### PR TITLE
feat: OGC API - Styles Phase 1 adapter over per-layer storage (#1388)

### DIFF
--- a/docs/cite-status.md
+++ b/docs/cite-status.md
@@ -88,6 +88,22 @@ The WFS 2.0 explicit transactional slice is tracked separately and passes
 - **WMS 1.3 `default`** — the official ETS default profile.
 - **WMTS 1.0 `default`** — the official ETS default profile.
 
+## OGC API surfaces without an official CITE ETS
+
+Some OGC API standards do not (yet) have an official CITE Executable Test Suite,
+so they are not part of the 952/952 suite count above. They are still shipped as
+conformant protocol adapters and proven with targeted integration tests plus an
+accurate `/conformance` declaration:
+
+- **OGC API – Styles (Part 1)** — `/ogc/styles`. Phase 1 adapter over Honua's
+  per-layer style storage (ADR-0048, issue #1388). Declares `core`,
+  `mapbox-styles`, `sld-10`, `sld-11`, `style-validation`, and **partial**
+  `manage-styles` (PUT only; standalone POST-create and DELETE return `501`
+  until the Phase 2 independent style catalog, issue #1389). MapLibre is served
+  from canonical storage; SLD 1.0/1.1 are derived on demand. Covered by
+  `tests/dotnet/Honua.Server.Tests/Features/Styling/OgcStylesEndpointTests.cs`.
+  See [`docs/gis/style-engine-protocol-consumption.md`](gis/style-engine-protocol-consumption.md).
+
 ## How To Refresh This Page
 
 1. Trigger the

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -2194,6 +2194,49 @@
       ]
     },
     {
+      "surfaceId": "ogc-api-styles",
+      "displayName": "OGC API Styles",
+      "surfaceKind": "http-route-family",
+      "protocol": "OGC API Styles",
+      "canonicalIdentifier": "/ogc/styles",
+      "parentSurfaceId": null,
+      "endpointPrefixes": [
+        "/ogc/styles"
+      ],
+      "endpointExactMatches": [],
+      "endpointContains": [],
+      "operationKeys": [],
+      "proofs": [
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "EndpointRegistry coverage and endpoint integration tests for the OGC API Styles Phase 1 adapter (ADR-0048)",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/EndpointRegistry.cs",
+            "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/Styling/OgcStylesEndpointTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "honua-server#1388",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "standards-conformance",
+          "proofMechanism": "OGC API Styles Phase 1 conformance classes (core, mapbox-styles, sld-10, sld-11, style-validation, partial manage-styles) are declared at /ogc/styles/conformance and documented, with targeted endpoint coverage",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "docs/gis/style-engine-protocol-consumption.md",
+            "tests/dotnet/Honua.Server.Tests/Features/Styling/OgcStylesEndpointTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "honua-server#1388",
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
       "surfaceId": "ogc-api-maps-and-static-rendering",
       "displayName": "OGC API Maps and static rendering",
       "surfaceKind": "http-route-family",

--- a/docs/gis/style-engine-protocol-consumption.md
+++ b/docs/gis/style-engine-protocol-consumption.md
@@ -12,6 +12,10 @@ protocol slice does with that document.
 - Theme engine: implemented (`default`, `dark`, `colorblind-safe`, `print`)
 - Style revision metadata: implemented (`styleVersion`, `revisedAt`,
   `revisedBy`, `changeSummary` returned on admin GET/PUT)
+- OGC API – Styles Phase 1 adapter: implemented (ADR-0048, issue #1388;
+  `core`, `mapbox-styles`, `sld-10`, `sld-11`, `style-validation`, partial
+  `manage-styles`). Independent style catalog (Phase 2, full POST/DELETE) is
+  issue #1389.
 - Visual diff UX in the Admin UI: deferred to a follow-up ticket
 
 ## Storage shape
@@ -197,13 +201,36 @@ equivalent hex literal.
 - Theme transforms applied to `/api/styles/{layerId}.json?theme=...` return a
   deterministic variant that shares the underlying `layer-styles` cache tag.
 
-### OGC API Styles (planned)
+### OGC API Styles (Phase 1 — shipped)
 
-The cross-protocol contract is designed so a future OGC API Styles slice can
-expose the same canonical document through the OGC negotiation surface
-without re-translating it. The revision metadata fields (`styleVersion`,
-`revisedAt`, `revisedBy`, `changeSummary`) are stable enough to back an OGC
-"style version" identifier or the visual-diff UX in the Admin UI.
+The OGC API – Styles Phase 1 adapter (ADR-0048, issue #1388) exposes the same
+canonical per-layer style document through the OGC negotiation surface without
+re-translating it. It is a thin protocol slice in
+`src/Honua.Protocols.OgcApi/Styles/` mounted under `/ogc/styles`, projecting the
+existing per-layer store; it reaches the internal style services through the
+public `IOgcStyleProjection` abstraction (`Honua.Core`, implemented by
+`OgcStyleProjection` in `Honua.Server`), mirroring the existing
+`ISldStyleConverter` / `IGeoServicesStyleConverter` cross-project pattern.
+
+| Endpoint | Method | Behavior |
+|----------|--------|----------|
+| `/ogc/styles` | GET | Landing links + styles list (one entry per collection that has a stored MapLibre style). |
+| `/ogc/styles/conformance` | GET | Declares `core`, `mapbox-styles`, `sld-10`, `sld-11`, `style-validation`, partial `manage-styles`. |
+| `/ogc/styles/openapi.json` | GET | OpenAPI document for the slice. |
+| `/ogc/styles/{styleId}` | GET | Content-negotiated stylesheet: MapLibre (`application/vnd.mapbox.style+json`, default) or derived SLD 1.0/1.1 by `Accept`. |
+| `/ogc/styles/{styleId}/metadata` | GET | `id`, `title`, `description`, `keywords`, `license`, `version` + stylesheet / `describedby` (schema) / `preview` links. |
+| `/ogc/styles/{styleId}` | PUT | `manage-styles`: validates MapLibre via the normalizer and writes through `ILayerStyleService`. Honors `Prefer: handling=strict` and `?validate`. |
+| `/ogc/styles` (POST), `/ogc/styles/{styleId}` (DELETE) | POST/DELETE | `501 Not Implemented` — standalone style CRUD arrives with the Phase 2 independent catalog (issue #1389). |
+
+The `styleId` is the collection's stable resource name — the same identifier
+used as the OGC API Features collectionId — chosen to be forward-compatible with
+the Phase 2 styleId-keyed catalog. SLD encodings are derived on demand from the
+canonical MapLibre style via `MapLibreToSldConverter`; the canonical store only
+holds MapLibre. The collection metadata (`GET /ogc/features/collections/{id}`)
+carries `rel:"style"` (the `/api/styles/{layerId}.json` alias, unchanged),
+`rel:"styles"` (→ `/ogc/styles`), and `rel:"stylesheet"` (→ `/ogc/styles/{styleId}`)
+links. The revision metadata fields (`styleVersion`, `revisedAt`, `revisedBy`,
+`changeSummary`) back the OGC style `version` field.
 
 ## Symbolizer support matrix
 

--- a/src/Honua.Core/Features/Styling/Abstractions/IOgcStyleProjection.cs
+++ b/src/Honua.Core/Features/Styling/Abstractions/IOgcStyleProjection.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Styling.Abstractions;
+
+/// <summary>
+/// Projects Honua's per-layer style storage as OGC API - Styles resources (ADR-0048,
+/// Phase 1). Exposed in <c>Honua.Core</c> so the OGC API protocol slice in
+/// <c>Honua.Protocols.OgcApi</c> can read, derive, validate, and update styles without
+/// taking a hard dependency on the internal style services, converters, and validator
+/// that live in <c>Honua.Server</c>. This mirrors the cross-project pattern used by
+/// <see cref="ISldStyleConverter"/> and <see cref="IGeoServicesStyleConverter"/>.
+/// </summary>
+public interface IOgcStyleProjection
+{
+    /// <summary>
+    /// Lists the styles available through the OGC API - Styles surface. In Phase 1 this
+    /// enumerates the collections (data resources) that have a stored, non-null MapLibre
+    /// style; each styled collection projects to exactly one OGC style.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The styled-collection summaries, ordered by style identifier.</returns>
+    Task<IReadOnlyList<OgcStyleSummary>> ListStylesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the stylesheet for the requested style in the requested encoding. MapLibre
+    /// is served from canonical storage; SLD 1.0/1.1 are derived on demand from the
+    /// canonical MapLibre style.
+    /// </summary>
+    /// <param name="styleId">Stable style identifier (the collection's resource name).</param>
+    /// <param name="encoding">Requested stylesheet encoding.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The stylesheet document, or <c>null</c> when no such styled collection exists.</returns>
+    Task<OgcStylesheet?> GetStylesheetAsync(
+        string styleId,
+        OgcStyleEncoding encoding,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets descriptive metadata for the requested style.
+    /// </summary>
+    /// <param name="styleId">Stable style identifier (the collection's resource name).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The style metadata, or <c>null</c> when no such styled collection exists.</returns>
+    Task<OgcStyleMetadata?> GetStyleMetadataAsync(
+        string styleId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validates and stores a MapLibre stylesheet for an existing style (OGC
+    /// <c>manage-styles</c>, PUT). Phase 1 only updates an existing styled collection's
+    /// per-layer style; it cannot create a standalone style.
+    /// </summary>
+    /// <param name="styleId">Stable style identifier (the collection's resource name).</param>
+    /// <param name="mapLibreStyleJson">Candidate MapLibre style JSON document.</param>
+    /// <param name="strict">When <c>true</c>, validation failures reject the request (OGC <c>style-validation</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The update outcome.</returns>
+    Task<OgcStyleUpdateResult> UpdateStyleAsync(
+        string styleId,
+        string mapLibreStyleJson,
+        bool strict,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Stylesheet encodings the OGC API - Styles surface can serve.
+/// </summary>
+public enum OgcStyleEncoding
+{
+    /// <summary>Canonical MapLibre / Mapbox style JSON.</summary>
+    MapboxStyle,
+
+    /// <summary>OGC Styled Layer Descriptor 1.0, derived from the MapLibre style.</summary>
+    Sld10,
+
+    /// <summary>OGC Styled Layer Descriptor 1.1, derived from the MapLibre style.</summary>
+    Sld11
+}
+
+/// <summary>
+/// Summary of a single OGC style entry for the styles list.
+/// </summary>
+/// <param name="StyleId">Stable style identifier (the collection's resource name).</param>
+/// <param name="Title">Human-readable title for the style.</param>
+public sealed record OgcStyleSummary(string StyleId, string Title);
+
+/// <summary>
+/// A serialized stylesheet plus the media type to return for it.
+/// </summary>
+/// <param name="Content">Serialized stylesheet content (MapLibre JSON or SLD XML).</param>
+/// <param name="MediaType">IANA media type for <paramref name="Content"/>.</param>
+/// <param name="Encoding">Encoding that was produced.</param>
+public sealed record OgcStylesheet(string Content, string MediaType, OgcStyleEncoding Encoding);
+
+/// <summary>
+/// Descriptive metadata for an OGC style.
+/// </summary>
+/// <param name="StyleId">Stable style identifier.</param>
+/// <param name="Title">Human-readable title.</param>
+/// <param name="Description">Optional description.</param>
+/// <param name="Keywords">Keywords describing the style.</param>
+/// <param name="License">Optional license identifier.</param>
+/// <param name="Version">Optional style revision number, as a string.</param>
+public sealed record OgcStyleMetadata(
+    string StyleId,
+    string Title,
+    string? Description,
+    IReadOnlyList<string> Keywords,
+    string? License,
+    string? Version);
+
+/// <summary>
+/// Status of an OGC style update attempt.
+/// </summary>
+public enum OgcStyleUpdateStatus
+{
+    /// <summary>The style was updated.</summary>
+    Updated,
+
+    /// <summary>No style with the requested identifier exists.</summary>
+    NotFound,
+
+    /// <summary>The supplied stylesheet was invalid.</summary>
+    Invalid
+}
+
+/// <summary>
+/// Outcome of an OGC style update attempt.
+/// </summary>
+/// <param name="Status">Outcome status.</param>
+/// <param name="ErrorMessage">Human-readable error message when <paramref name="Status"/> is not <see cref="OgcStyleUpdateStatus.Updated"/>.</param>
+public sealed record OgcStyleUpdateResult(OgcStyleUpdateStatus Status, string? ErrorMessage);

--- a/src/Honua.Hosting/Features/Caching/OutputCacheTtlOptions.cs
+++ b/src/Honua.Hosting/Features/Caching/OutputCacheTtlOptions.cs
@@ -80,6 +80,31 @@ public sealed class OutputCacheTtlOptions
     public TimeSpan OgcMapsOpenApi { get; set; } = TimeSpan.FromHours(1);
 
     /// <summary>
+    /// OGC Styles list cache duration. Default: 5 minutes.
+    /// </summary>
+    public TimeSpan OgcStylesList { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// OGC Styles conformance endpoint cache duration. Default: 1 hour.
+    /// </summary>
+    public TimeSpan OgcStylesConformance { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// OGC Styles OpenAPI spec cache duration. Default: 1 hour.
+    /// </summary>
+    public TimeSpan OgcStylesOpenApi { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// OGC Styles stylesheet cache duration. Default: 5 minutes.
+    /// </summary>
+    public TimeSpan OgcStylesStylesheet { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// OGC Styles metadata cache duration. Default: 5 minutes.
+    /// </summary>
+    public TimeSpan OgcStylesMetadata { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
     /// OGC Coverages landing page cache duration. Default: 30 minutes.
     /// </summary>
     public TimeSpan OgcCoveragesLandingPage { get; set; } = TimeSpan.FromMinutes(30);

--- a/src/Honua.Hosting/Features/Models/StandardErrorHelpers.cs
+++ b/src/Honua.Hosting/Features/Models/StandardErrorHelpers.cs
@@ -151,6 +151,23 @@ internal static class StandardErrorHelpers
     }
 
     /// <summary>
+    /// Creates an Unsupported Media Type error response.
+    /// </summary>
+    /// <param name="context">The HTTP context for protocol detection.</param>
+    /// <param name="detail">The error detail message.</param>
+    /// <param name="additionalDetails">Optional additional details.</param>
+    /// <returns>A protocol-specific Unsupported Media Type response.</returns>
+    internal static IResult CreateUnsupportedMediaType(HttpContext context, string detail, IReadOnlyList<string>? additionalDetails = null)
+    {
+        var errorResponse = new StandardErrorResponse(
+            StatusCodes.Status415UnsupportedMediaType,
+            "Unsupported Media Type",
+            detail,
+            additionalDetails);
+        return StandardErrorResponseFormatter.FormatError(context, errorResponse);
+    }
+
+    /// <summary>
     /// Creates an Unprocessable Entity error response.
     /// </summary>
     /// <param name="context">The HTTP context for protocol detection.</param>

--- a/src/Honua.Protocols.Ogc.Shared/Common/OgcCommonModels.cs
+++ b/src/Honua.Protocols.Ogc.Shared/Common/OgcCommonModels.cs
@@ -144,6 +144,21 @@ public static class RelationTypes
     public const string Style = "style";
 
     /// <summary>
+    /// Refers to a stylesheet (the encoded style document itself) per OGC API - Styles.
+    /// </summary>
+    public const string Stylesheet = "stylesheet";
+
+    /// <summary>
+    /// Refers to a preview (e.g. thumbnail) of a style per OGC API - Styles.
+    /// </summary>
+    public const string Preview = "preview";
+
+    /// <summary>
+    /// Refers to the styles available for a resource per OGC API - Styles.
+    /// </summary>
+    public const string Styles = "http://www.opengis.net/def/rel/ogc/1.0/styles";
+
+    /// <summary>
     /// Indicates the link target provides service documentation.
     /// </summary>
     public const string ServiceDoc = "service-doc";
@@ -334,4 +349,19 @@ public static class MediaTypes
     /// PNG image media type.
     /// </summary>
     public const string Png = "image/png";
+
+    /// <summary>
+    /// Mapbox/MapLibre style document media type (OGC API - Styles canonical encoding).
+    /// </summary>
+    public const string MapboxStyle = "application/vnd.mapbox.style+json";
+
+    /// <summary>
+    /// OGC Styled Layer Descriptor 1.0 media type.
+    /// </summary>
+    public const string Sld10 = "application/vnd.ogc.sld+xml;version=1.0";
+
+    /// <summary>
+    /// OGC Styled Layer Descriptor 1.1 media type.
+    /// </summary>
+    public const string Sld11 = "application/vnd.ogc.sld+xml;version=1.1";
 }

--- a/src/Honua.Protocols.OgcApi/Features/CollectionsEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Features/CollectionsEndpoints.cs
@@ -572,6 +572,24 @@ internal static class CollectionsEndpoints
                 rel: RelationTypes.Style,
                 type: MediaTypes.Json,
                 title: "Style"));
+
+            // OGC API - Styles (ADR-0048): the styleId is the collection's stable
+            // resource name (forward-compatible with the Phase 2 styleId catalog).
+            var styleId = Uri.EscapeDataString(resource.Metadata.Name);
+
+            // Styles list scoped to this collection.
+            collectionLinks.Add(Link.Create(
+                href: $"{baseUrl}/ogc/styles",
+                rel: RelationTypes.Styles,
+                type: MediaTypes.Json,
+                title: "Styles"));
+
+            // The collection's OGC stylesheet (content-negotiated encoding).
+            collectionLinks.Add(Link.Create(
+                href: $"{baseUrl}/ogc/styles/{styleId}",
+                rel: RelationTypes.Stylesheet,
+                type: MediaTypes.MapboxStyle,
+                title: "Stylesheet"));
         }
 
         if (IsProtocolEnabled(service, OgcApiTilesProtocolName))

--- a/src/Honua.Protocols.OgcApi/Styles/Handlers/OgcStylesConformanceHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Styles/Handlers/OgcStylesConformanceHandler.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Protocols.Ogc.Api.Styles.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Protocols.Ogc.Api.Styles.Handlers;
+
+/// <summary>
+/// Handler for OGC API - Styles conformance declarations. Declares the conformance
+/// classes implemented by the Phase 1 adapter (ADR-0048): core, mapbox-styles,
+/// sld-10, sld-11, style-validation, and (partial) manage-styles.
+/// </summary>
+internal sealed class OgcStylesConformanceHandler
+{
+    private const string ConformanceBase = "http://www.opengis.net/spec/ogcapi-styles-1/1.0/conf/";
+
+    private readonly ILogger<OgcStylesConformanceHandler> _logger;
+
+    public OgcStylesConformanceHandler(ILogger<OgcStylesConformanceHandler> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Gets the conformance classes that this server implements for OGC API - Styles.
+    /// </summary>
+    public Task<OgcStylesConformance> GetConformanceAsync(CancellationToken cancellationToken = default)
+    {
+        OgcStylesLog.ConformanceRequested(_logger);
+
+        var conformance = new OgcStylesConformance
+        {
+            ConformsTo =
+            [
+                // OGC API - Styles Part 1: Core
+                ConformanceBase + "core",
+
+                // Mapbox/MapLibre style encoding (canonical store)
+                ConformanceBase + "mapbox-styles",
+
+                // SLD 1.0 encoding (derived from the canonical MapLibre style)
+                ConformanceBase + "sld-10",
+
+                // SLD 1.1 encoding (derived from the canonical MapLibre style)
+                ConformanceBase + "sld-11",
+
+                // Style validation (Prefer: handling=strict / ?validate)
+                ConformanceBase + "style-validation",
+
+                // Manage styles - PARTIAL in Phase 1 (PUT only; POST/DELETE arrive with
+                // the Phase 2 independent style catalog, issue #1389).
+                ConformanceBase + "manage-styles"
+            ]
+        };
+
+        return Task.FromResult(conformance);
+    }
+}

--- a/src/Honua.Protocols.OgcApi/Styles/Models/OgcStylesModels.cs
+++ b/src/Honua.Protocols.OgcApi/Styles/Models/OgcStylesModels.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+using Honua.Protocols.Ogc.Common;
+
+namespace Honua.Protocols.Ogc.Api.Styles.Models;
+
+/// <summary>
+/// OGC API - Styles conformance declaration.
+/// </summary>
+public sealed class OgcStylesConformance
+{
+    /// <summary>
+    /// Conformance class URIs implemented by the OGC API - Styles surface.
+    /// </summary>
+    [JsonPropertyName("conformsTo")]
+    public required string[] ConformsTo { get; init; }
+}
+
+/// <summary>
+/// OGC API - Styles styles list response (<c>GET /ogc/styles</c>).
+/// </summary>
+public sealed record StylesList
+{
+    /// <summary>
+    /// The styles available on the server.
+    /// </summary>
+    [JsonPropertyName("styles")]
+    public required ImmutableArray<StyleEntry> Styles { get; init; }
+
+    /// <summary>
+    /// Optional default style identifier.
+    /// </summary>
+    [JsonPropertyName("default")]
+    public string? Default { get; init; }
+
+    /// <summary>
+    /// Links to related resources (self, alternate, etc.).
+    /// </summary>
+    [JsonPropertyName("links")]
+    public ImmutableArray<Link>? Links { get; init; }
+}
+
+/// <summary>
+/// A single entry in the OGC API - Styles styles list.
+/// </summary>
+public sealed record StyleEntry
+{
+    /// <summary>
+    /// Stable style identifier.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Human-readable title for the style.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Links to the stylesheet encodings and style metadata.
+    /// </summary>
+    [JsonPropertyName("links")]
+    public required ImmutableArray<Link> Links { get; init; }
+}
+
+/// <summary>
+/// OGC API - Styles style metadata response (<c>GET /ogc/styles/{styleId}/metadata</c>).
+/// </summary>
+public sealed record StyleMetadataResponse
+{
+    /// <summary>
+    /// Stable style identifier.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Human-readable title for the style.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Description of the style.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Keywords describing the style.
+    /// </summary>
+    [JsonPropertyName("keywords")]
+    public ImmutableArray<string>? Keywords { get; init; }
+
+    /// <summary>
+    /// License identifier for the style, when known.
+    /// </summary>
+    [JsonPropertyName("license")]
+    public string? License { get; init; }
+
+    /// <summary>
+    /// Style revision number, expressed as a string, when known.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// Links incl. the stylesheet encodings, the schema (describedby), and a preview.
+    /// </summary>
+    [JsonPropertyName("links")]
+    public required ImmutableArray<Link> Links { get; init; }
+}

--- a/src/Honua.Protocols.OgcApi/Styles/OgcStylesEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Styles/OgcStylesEndpoints.cs
@@ -1,0 +1,534 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Text;
+using Honua.Core.Features.Styling.Abstractions;
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Models;
+using Honua.Protocols.Ogc.Api.Styles.Handlers;
+using Honua.Protocols.Ogc.Api.Styles.Models;
+using Honua.Protocols.Ogc.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
+
+namespace Honua.Protocols.Ogc.Api.Styles;
+
+/// <summary>
+/// OGC API - Styles endpoints (ADR-0048, Phase 1). Projects Honua's per-layer style
+/// storage as conformant OGC styles: landing, conformance, OpenAPI, the styles list,
+/// content-negotiated stylesheets (MapLibre canonical + derived SLD 1.0/1.1), style
+/// metadata, and a partial <c>manage-styles</c> surface (PUT only). Standalone style
+/// create (POST) and delete (DELETE) return 501 until the Phase 2 independent style
+/// catalog lands (issue #1389).
+/// </summary>
+public static class OgcStylesEndpoints
+{
+    private static readonly ImmutableHashSet<string> MetadataQueryParameters =
+        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "f");
+
+    private static readonly ImmutableHashSet<string> OpenApiQueryParameters =
+        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "f");
+
+    /// <summary>
+    /// Maps OGC API - Styles endpoints to the application.
+    /// </summary>
+    public static void MapOgcStylesEndpoints(this IEndpointRouteBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        var group = app.MapGroup("/ogc/styles")
+            .WithTags("OGC API - Styles");
+
+        group.MapGet(string.Empty, GetStyles)
+            .WithDisplayName("Styles List")
+            .WithName("GetStylesList")
+            .WithSummary("Get the OGC API - Styles landing/styles list")
+            .WithDescription("Returns the landing-page links and the list of styles available on the server")
+            .Produces<StylesList>(StatusCodes.Status200OK, MediaTypes.Json)
+            .CacheOutput("OgcStylesList");
+
+        group.MapGet("/conformance", GetConformance)
+            .WithDisplayName("Styles API Conformance")
+            .WithName("GetStylesConformance")
+            .WithSummary("Get OGC API - Styles conformance classes")
+            .WithDescription("Returns the conformance classes that the server implements from OGC API - Styles")
+            .Produces<OgcStylesConformance>()
+            .CacheOutput("OgcStylesConformance");
+
+        group.MapGet("/openapi.json", GetOpenApiSpec)
+            .WithDisplayName("Styles API OpenAPI Specification")
+            .WithName("GetStylesOpenApiSpec")
+            .WithSummary("Get OpenAPI 3.0 specification for OGC API - Styles")
+            .WithDescription("The OpenAPI specification describes all available OGC API - Styles endpoints")
+            .Produces<object>(StatusCodes.Status200OK, MediaTypes.OpenApi)
+            .Produces(StatusCodes.Status404NotFound)
+            .CacheOutput("OgcStylesOpenApi");
+
+        group.MapGet("/{styleId}", GetStylesheet)
+            .WithDisplayName("Get Stylesheet")
+            .WithName("GetStylesheet")
+            .WithSummary("Get a stylesheet")
+            .WithDescription("Returns the stylesheet for a style. The encoding is selected by the Accept header: MapLibre/Mapbox JSON (default), or derived SLD 1.0/1.1.")
+            .Produces<object>(StatusCodes.Status200OK, MediaTypes.MapboxStyle)
+            .Produces(StatusCodes.Status200OK, contentType: MediaTypes.Sld10)
+            .Produces(StatusCodes.Status200OK, contentType: MediaTypes.Sld11)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status406NotAcceptable)
+            .CacheOutput("OgcStylesStylesheet");
+
+        group.MapGet("/{styleId}/metadata", GetStyleMetadata)
+            .WithDisplayName("Get Style Metadata")
+            .WithName("GetStyleMetadata")
+            .WithSummary("Get style metadata")
+            .WithDescription("Returns descriptive metadata for a style, including stylesheet, schema (describedby), and preview links")
+            .Produces<StyleMetadataResponse>(StatusCodes.Status200OK, MediaTypes.Json)
+            .Produces(StatusCodes.Status404NotFound)
+            .CacheOutput("OgcStylesMetadata");
+
+        group.MapPut("/{styleId}", UpdateStyle)
+            .WithDisplayName("Update Style")
+            .WithName("UpdateStyle")
+            .WithSummary("Update an existing style (manage-styles)")
+            .WithDescription("Validates and stores a MapLibre stylesheet for an existing style. Honors Prefer: handling=strict and ?validate. Creating standalone styles is not yet supported (Phase 2).")
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status415UnsupportedMediaType);
+
+        group.MapPost(string.Empty, CreateStyleNotSupported)
+            .WithDisplayName("Create Style (not supported in Phase 1)")
+            .WithName("CreateStyleNotSupported")
+            .WithSummary("Create a standalone style - not supported until Phase 2")
+            .WithDescription("Standalone style creation arrives with the Phase 2 independent style catalog (issue #1389).")
+            .Produces(StatusCodes.Status501NotImplemented);
+
+        group.MapDelete("/{styleId}", DeleteStyleNotSupported)
+            .WithDisplayName("Delete Style (not supported in Phase 1)")
+            .WithName("DeleteStyleNotSupported")
+            .WithSummary("Delete a style - not supported until Phase 2")
+            .WithDescription("Standalone style deletion arrives with the Phase 2 independent style catalog (issue #1389).")
+            .Produces(StatusCodes.Status501NotImplemented);
+    }
+
+    /// <summary>
+    /// Get the OGC API - Styles styles list (also the landing surface).
+    /// </summary>
+    private static async Task<IResult> GetStyles(
+        HttpContext context,
+        string? f,
+        IOgcStyleProjection projection,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken = default)
+    {
+        if (!OgcCoreMetadataUtilities.TryPrepareMetadataResponse(
+                context,
+                f,
+                MetadataQueryParameters,
+                out var outputFormat,
+                out var errorResult))
+        {
+            return errorResult!;
+        }
+
+        var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+        var basePath = $"{baseUrl}/ogc/styles";
+
+        var summaries = await projection.ListStylesAsync(cancellationToken).ConfigureAwait(false);
+        var logger = loggerFactory.CreateLogger("Honua.Protocols.Ogc.Api.Styles.OgcStylesEndpoints");
+        OgcStylesLog.StylesListed(logger, summaries.Count);
+
+        var entries = ImmutableArray.CreateBuilder<StyleEntry>(summaries.Count);
+        foreach (var summary in summaries)
+        {
+            entries.Add(new StyleEntry
+            {
+                Id = summary.StyleId,
+                Title = summary.Title,
+                Links = BuildStylesheetLinks(baseUrl, summary.StyleId)
+            });
+        }
+
+        var listLinks = OgcCoreMetadataUtilities.BuildLandingPageLinks(context, basePath, outputFormat);
+        listLinks.Add(Link.Create(
+            href: $"{baseUrl}/ogc/styles/conformance",
+            rel: RelationTypes.Conformance,
+            type: MediaTypes.Json,
+            title: "Conformance declaration"));
+        listLinks.Add(Link.Create(
+            href: $"{baseUrl}/ogc/styles/openapi.json",
+            rel: RelationTypes.ServiceDesc,
+            type: MediaTypes.OpenApi,
+            title: "API definition"));
+
+        var stylesList = new StylesList
+        {
+            Styles = entries.ToImmutable(),
+            Links = listLinks.ToImmutable()
+        };
+
+        return OgcCommonUtilities.FormatMetadataResponse(
+            stylesList,
+            OgcStylesJsonContext.Default.StylesList,
+            outputFormat,
+            "Styles");
+    }
+
+    /// <summary>
+    /// Get OGC API - Styles conformance classes.
+    /// </summary>
+    private static async Task<IResult> GetConformance(
+        OgcStylesConformanceHandler handler,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await handler.GetConformanceAsync(cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> GetOpenApiSpec(
+        HttpContext context,
+        string? f,
+        IWebHostEnvironment environment)
+    {
+        const string fallbackSpec = """
+        {
+          "openapi": "3.0.3",
+          "info": {
+            "title": "Honua OGC API Styles",
+            "description": "OGC API Styles adapter over Honua per-layer style storage (ADR-0048, Phase 1)",
+            "version": "1.0.0"
+          },
+          "paths": {}
+        }
+        """;
+
+        return await OgcCoreMetadataUtilities.GetOpenApiSpecAsync(
+            context,
+            f,
+            environment,
+            OpenApiQueryParameters,
+            "ogc-styles-openapi.json",
+            fallbackSpec).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Get a stylesheet, content-negotiated by the Accept header.
+    /// </summary>
+    private static async Task<IResult> GetStylesheet(
+        string styleId,
+        HttpContext context,
+        IOgcStyleProjection projection,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryNegotiateEncoding(context, out var encoding))
+        {
+            return StandardErrorHelpers.CreateNotAcceptable(
+                context,
+                "Supported stylesheet media types are application/vnd.mapbox.style+json, application/vnd.ogc.sld+xml;version=1.0, and application/vnd.ogc.sld+xml;version=1.1.");
+        }
+
+        var stylesheet = await projection.GetStylesheetAsync(styleId, encoding, cancellationToken).ConfigureAwait(false);
+        if (stylesheet is null)
+        {
+            var logger = loggerFactory.CreateLogger("Honua.Protocols.Ogc.Api.Styles.OgcStylesEndpoints");
+            OgcStylesLog.StyleNotFound(logger, styleId);
+            return StandardErrorHelpers.CreateNotFound(context, $"Style '{styleId}' not found.");
+        }
+
+        return Results.Content(stylesheet.Content, stylesheet.MediaType, Encoding.UTF8);
+    }
+
+    /// <summary>
+    /// Get style metadata.
+    /// </summary>
+    private static async Task<IResult> GetStyleMetadata(
+        string styleId,
+        HttpContext context,
+        string? f,
+        IOgcStyleProjection projection,
+        CancellationToken cancellationToken = default)
+    {
+        if (!OgcCoreMetadataUtilities.TryPrepareMetadataResponse(
+                context,
+                f,
+                MetadataQueryParameters,
+                out var outputFormat,
+                out var errorResult))
+        {
+            return errorResult!;
+        }
+
+        var metadata = await projection.GetStyleMetadataAsync(styleId, cancellationToken).ConfigureAwait(false);
+        if (metadata is null)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, $"Style '{styleId}' not found.");
+        }
+
+        var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+        var links = BuildStylesheetLinks(baseUrl, styleId).ToBuilder();
+        links.Add(Link.Create(
+            href: $"{baseUrl}/ogc/styles/{Uri.EscapeDataString(styleId)}/metadata",
+            rel: RelationTypes.Self,
+            type: MediaTypes.Json,
+            title: "Style metadata"));
+        links.Add(Link.Create(
+            href: $"{baseUrl}/ogc/features/collections/{Uri.EscapeDataString(styleId)}/queryables",
+            rel: RelationTypes.DescribedBy,
+            type: MediaTypes.SchemaJson,
+            title: "Schema"));
+        links.Add(Link.Create(
+            href: $"{baseUrl}/ogc/maps/collections/{Uri.EscapeDataString(styleId)}/map",
+            rel: RelationTypes.Preview,
+            type: MediaTypes.Png,
+            title: "Preview"));
+
+        var response = new StyleMetadataResponse
+        {
+            Id = metadata.StyleId,
+            Title = metadata.Title,
+            Description = metadata.Description,
+            Keywords = metadata.Keywords.Count > 0 ? metadata.Keywords.ToImmutableArray() : null,
+            License = metadata.License,
+            Version = metadata.Version,
+            Links = links.ToImmutable()
+        };
+
+        return OgcCommonUtilities.FormatMetadataResponse(
+            response,
+            OgcStylesJsonContext.Default.StyleMetadataResponse,
+            outputFormat,
+            "Style metadata");
+    }
+
+    /// <summary>
+    /// Update an existing style (manage-styles, PUT). Honors Prefer: handling=strict
+    /// and ?validate for strict validation.
+    /// </summary>
+    private static async Task<IResult> UpdateStyle(
+        string styleId,
+        HttpContext context,
+        IOgcStyleProjection projection,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken = default)
+    {
+        var contentType = context.Request.ContentType;
+        if (!string.IsNullOrWhiteSpace(contentType)
+            && !IsMapboxStyleContentType(contentType))
+        {
+            return StandardErrorHelpers.CreateUnsupportedMediaType(
+                context,
+                "Phase 1 manage-styles accepts only MapLibre/Mapbox style JSON (application/vnd.mapbox.style+json or application/json).");
+        }
+
+        string body;
+        using (var reader = new StreamReader(context.Request.Body, Encoding.UTF8))
+        {
+            body = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body must contain a MapLibre style document.");
+        }
+
+        var strict = IsStrictRequested(context);
+
+        var result = await projection.UpdateStyleAsync(styleId, body, strict, cancellationToken).ConfigureAwait(false);
+        var logger = loggerFactory.CreateLogger("Honua.Protocols.Ogc.Api.Styles.OgcStylesEndpoints");
+
+        switch (result.Status)
+        {
+            case OgcStyleUpdateStatus.Updated:
+                OgcStylesLog.StyleUpdated(logger, styleId);
+                return Results.NoContent();
+            case OgcStyleUpdateStatus.NotFound:
+                OgcStylesLog.StyleNotFound(logger, styleId);
+                return StandardErrorHelpers.CreateNotFound(context, $"Style '{styleId}' not found.");
+            default:
+                OgcStylesLog.StyleUpdateRejected(logger, styleId, result.ErrorMessage ?? "invalid");
+                return StandardErrorHelpers.CreateBadRequest(
+                    context,
+                    result.ErrorMessage ?? "MapLibre style is invalid.");
+        }
+    }
+
+    private static IResult CreateStyleNotSupported(HttpContext context)
+        => StandardErrorHelpers.CreateNotImplemented(
+            context,
+            "Creating a standalone style is not supported in Phase 1. Independent style storage (POST-create) arrives with the Phase 2 style catalog (issue #1389). Use PUT /ogc/styles/{styleId} to update an existing collection's style.");
+
+    private static IResult DeleteStyleNotSupported(string styleId, HttpContext context)
+        => StandardErrorHelpers.CreateNotImplemented(
+            context,
+            "Deleting a style is not supported in Phase 1. Independent style storage (DELETE) arrives with the Phase 2 style catalog (issue #1389); Phase 1 styles are bound to their collection's per-layer storage.");
+
+    private static ImmutableArray<Link> BuildStylesheetLinks(string baseUrl, string styleId)
+    {
+        var encoded = Uri.EscapeDataString(styleId);
+        var stylesheetHref = $"{baseUrl}/ogc/styles/{encoded}";
+        var links = ImmutableArray.CreateBuilder<Link>(4);
+        links.Add(Link.Create(
+            href: stylesheetHref,
+            rel: RelationTypes.Stylesheet,
+            type: MediaTypes.MapboxStyle,
+            title: "MapLibre/Mapbox stylesheet"));
+        links.Add(Link.Create(
+            href: stylesheetHref,
+            rel: RelationTypes.Stylesheet,
+            type: MediaTypes.Sld10,
+            title: "SLD 1.0 stylesheet (derived)"));
+        links.Add(Link.Create(
+            href: stylesheetHref,
+            rel: RelationTypes.Stylesheet,
+            type: MediaTypes.Sld11,
+            title: "SLD 1.1 stylesheet (derived)"));
+        links.Add(Link.Create(
+            href: $"{baseUrl}/ogc/styles/{encoded}/metadata",
+            rel: RelationTypes.DescribedBy,
+            type: MediaTypes.Json,
+            title: "Style metadata"));
+        return links.ToImmutable();
+    }
+
+    /// <summary>
+    /// Negotiates the stylesheet encoding from the Accept header. MapLibre/Mapbox JSON
+    /// is the default when no specific stylesheet media type is requested.
+    /// </summary>
+    private static bool TryNegotiateEncoding(HttpContext context, out OgcStyleEncoding encoding)
+    {
+        encoding = OgcStyleEncoding.MapboxStyle;
+
+        var accept = context.Request.Headers.Accept;
+        if (accept.Count == 0)
+        {
+            return true;
+        }
+
+        var matchedAny = false;
+        var bestQuality = -1d;
+        var wildcard = false;
+
+        foreach (var headerValue in accept)
+        {
+            if (string.IsNullOrWhiteSpace(headerValue))
+            {
+                continue;
+            }
+
+            foreach (var token in headerValue.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (!MediaTypeHeaderValue.TryParse(token, out var media))
+                {
+                    continue;
+                }
+
+                var quality = media.Quality ?? 1d;
+                var mediaType = media.MediaType.Value ?? string.Empty;
+
+                if (mediaType is "*/*" or "application/*")
+                {
+                    wildcard = true;
+                    continue;
+                }
+
+                if (TryMapMediaType(mediaType, media, out var candidate) && quality > bestQuality)
+                {
+                    bestQuality = quality;
+                    encoding = candidate;
+                    matchedAny = true;
+                }
+            }
+        }
+
+        if (matchedAny)
+        {
+            return true;
+        }
+
+        // No explicit stylesheet media type matched: fall back to MapLibre default only
+        // when the client accepts anything; otherwise the request is not acceptable.
+        encoding = OgcStyleEncoding.MapboxStyle;
+        return wildcard;
+    }
+
+    private static bool TryMapMediaType(string mediaType, MediaTypeHeaderValue media, out OgcStyleEncoding encoding)
+    {
+        encoding = OgcStyleEncoding.MapboxStyle;
+        switch (mediaType)
+        {
+            case "application/vnd.mapbox.style+json":
+            case "application/json":
+                encoding = OgcStyleEncoding.MapboxStyle;
+                return true;
+            case "application/vnd.ogc.sld+xml":
+                encoding = ReadSldVersion(media) == "1.1"
+                    ? OgcStyleEncoding.Sld11
+                    : OgcStyleEncoding.Sld10;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static string? ReadSldVersion(MediaTypeHeaderValue media)
+    {
+        foreach (var parameter in media.Parameters)
+        {
+            if (string.Equals(parameter.Name.Value, "version", StringComparison.OrdinalIgnoreCase))
+            {
+                return parameter.Value.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsMapboxStyleContentType(string contentType)
+    {
+        if (!MediaTypeHeaderValue.TryParse(contentType, out var media))
+        {
+            return false;
+        }
+
+        var mediaType = media.MediaType.Value ?? string.Empty;
+        return mediaType is "application/vnd.mapbox.style+json" or "application/json";
+    }
+
+    private static bool IsStrictRequested(HttpContext context)
+    {
+        if (context.Request.Query.TryGetValue("validate", out var validateValues))
+        {
+            foreach (var value in validateValues)
+            {
+                if (string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(value, "strict", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+
+        foreach (var prefer in context.Request.Headers["Prefer"])
+        {
+            if (prefer is null)
+            {
+                continue;
+            }
+
+            foreach (var token in prefer.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (token.Replace(" ", string.Empty, StringComparison.Ordinal)
+                    .Equals("handling=strict", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Honua.Protocols.OgcApi/Styles/OgcStylesJsonContext.cs
+++ b/src/Honua.Protocols.OgcApi/Styles/OgcStylesJsonContext.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+using Honua.Protocols.Ogc.Api.Styles.Models;
+using Honua.Protocols.Ogc.Common;
+
+namespace Honua.Protocols.Ogc.Api.Styles;
+
+/// <summary>
+/// JSON serialization context for OGC API - Styles models.
+/// Enables AOT-compatible, source-generated JSON serialization for the Styles slice.
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(LandingPage))]
+[JsonSerializable(typeof(ConformanceDeclaration))]
+[JsonSerializable(typeof(Link))]
+[JsonSerializable(typeof(ImmutableArray<Link>))]
+[JsonSerializable(typeof(ImmutableArray<string>))]
+[JsonSerializable(typeof(OgcStylesConformance))]
+[JsonSerializable(typeof(StylesList))]
+[JsonSerializable(typeof(StyleEntry))]
+[JsonSerializable(typeof(ImmutableArray<StyleEntry>))]
+[JsonSerializable(typeof(StyleMetadataResponse))]
+internal sealed partial class OgcStylesJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Protocols.OgcApi/Styles/OgcStylesLog.cs
+++ b/src/Honua.Protocols.OgcApi/Styles/OgcStylesLog.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Protocols.Ogc.Api.Styles;
+
+/// <summary>
+/// Structured logging for OGC API - Styles operations.
+/// Event ID range: 5950-5999 (avoiding collisions with other features).
+/// </summary>
+internal static partial class OgcStylesLog
+{
+    [LoggerMessage(
+        EventId = 5950,
+        Level = LogLevel.Information,
+        Message = "OGC Styles conformance requested")]
+    public static partial void ConformanceRequested(ILogger logger);
+
+    [LoggerMessage(
+        EventId = 5951,
+        Level = LogLevel.Debug,
+        Message = "OGC Styles list returned {Count} styles")]
+    public static partial void StylesListed(ILogger logger, int count);
+
+    [LoggerMessage(
+        EventId = 5952,
+        Level = LogLevel.Debug,
+        Message = "OGC Style '{StyleId}' not found")]
+    public static partial void StyleNotFound(ILogger logger, string styleId);
+
+    [LoggerMessage(
+        EventId = 5953,
+        Level = LogLevel.Information,
+        Message = "OGC Style '{StyleId}' updated")]
+    public static partial void StyleUpdated(ILogger logger, string styleId);
+
+    [LoggerMessage(
+        EventId = 5954,
+        Level = LogLevel.Warning,
+        Message = "OGC Style '{StyleId}' update rejected: {Reason}")]
+    public static partial void StyleUpdateRejected(ILogger logger, string styleId, string reason);
+}

--- a/src/Honua.Protocols.OgcApi/Styles/OgcStylesServiceCollectionExtensions.cs
+++ b/src/Honua.Protocols.OgcApi/Styles/OgcStylesServiceCollectionExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Protocols.Ogc.Api.Styles.Handlers;
+
+namespace Honua.Protocols.Ogc.Api.Styles;
+
+/// <summary>
+/// Service collection extensions for OGC API - Styles feature registration.
+/// </summary>
+internal static class OgcStylesServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers OGC API - Styles services with dependency injection. The style
+    /// projection itself (<c>IOgcStyleProjection</c>) is registered in
+    /// <c>Honua.Server</c> alongside the internal style services it composes.
+    /// </summary>
+    public static IServiceCollection AddOgcStyles(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddScoped<OgcStylesConformanceHandler>();
+
+        return services;
+    }
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -916,6 +916,16 @@ public static class EndpointRegistry
         new("GET", "/ogc/maps/collections/{collectionId}/map/tiles/{tileMatrixSetId}"),
         new("GET", "/ogc/maps/map"),
 
+        // OGC API - Styles (ADR-0048, Phase 1)
+        new("GET", "/ogc/styles"),
+        new("GET", "/ogc/styles/conformance"),
+        new("GET", "/ogc/styles/openapi.json"),
+        new("GET", "/ogc/styles/{styleId}"),
+        new("GET", "/ogc/styles/{styleId}/metadata"),
+        new("PUT", "/ogc/styles/{styleId}"),
+        new("POST", "/ogc/styles"),
+        new("DELETE", "/ogc/styles/{styleId}"),
+
         // Static Map
         new("GET", "/static/{serviceId}/{center}/{dimensions}.{format}"),
         new("GET", "/static/{serviceId}/bbox/{bbox}/{dimensions}.{format}"),

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -39,6 +39,7 @@ using Honua.Protocols.Ogc.Api.Features;
 using Honua.Protocols.Ogc.Api.Maps;
 using Honua.Protocols.Ogc.Api.Processes;
 using Honua.Protocols.Ogc.Api.Records;
+using Honua.Protocols.Ogc.Api.Styles;
 using Honua.Protocols.Ogc.Api.Tiles;
 using Honua.Server.Features.Orchestration;
 using Honua.PackageReview;
@@ -85,6 +86,7 @@ internal static class FeatureRegistrationExtensions
         services.AddOgcCoverages();
         services.AddOgcFeatures(configuration);
         services.AddOgcMaps();
+        services.AddOgcStyles();
         services.AddOgcProcesses(configuration);
         services.AddWfs20(configuration);
         services.AddWcs20();
@@ -171,6 +173,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapOgcCoveragesEndpoints();
         endpoints.MapOgcFeaturesEndpoints();
         endpoints.MapOgcMapsEndpoints();
+        endpoints.MapOgcStylesEndpoints();
         endpoints.MapOgcProcessesEndpoints();
         endpoints.MapOgcRecordsEndpoints();
         endpoints.MapOgcTilesEndpoints();

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
@@ -223,6 +223,51 @@ internal static class ObservabilityServiceCollectionExtensions
                 policy.Tag("ogc-maps", "metadata");
             });
 
+            // OGC API Styles caching policies (ADR-0048). Styles map to finite
+            // styleId/encoding/format keys, so output caching is appropriate.
+            options.AddPolicy("OgcStylesList", policy =>
+            {
+                policy.Expire(ttl.OgcStylesList);
+                policy.SetVaryByQuery("f");
+                policy.SetVaryByHeader("Accept");
+                policy.Tag("ogc-styles", "metadata");
+            });
+
+            options.AddPolicy("OgcStylesConformance", policy =>
+            {
+                policy.Expire(ttl.OgcStylesConformance);
+                policy.SetVaryByQuery("f");
+                policy.SetVaryByHeader("Accept");
+                policy.Tag("ogc-styles", "metadata");
+            });
+
+            options.AddPolicy("OgcStylesOpenApi", policy =>
+            {
+                policy.Expire(ttl.OgcStylesOpenApi);
+                policy.SetVaryByQuery("f");
+                policy.SetVaryByHeader("Accept");
+                policy.Tag("ogc-styles", "metadata");
+            });
+
+            options.AddPolicy("OgcStylesStylesheet", policy =>
+            {
+                policy.Expire(ttl.OgcStylesStylesheet);
+                // Vary by every behavior-changing input: the style identifier and the
+                // negotiated encoding (Accept selects MapLibre vs SLD 1.0/1.1).
+                policy.SetVaryByRouteValue("styleId");
+                policy.SetVaryByHeader("Accept");
+                policy.Tag("ogc-styles");
+            });
+
+            options.AddPolicy("OgcStylesMetadata", policy =>
+            {
+                policy.Expire(ttl.OgcStylesMetadata);
+                policy.SetVaryByRouteValue("styleId");
+                policy.SetVaryByQuery("f");
+                policy.SetVaryByHeader("Accept");
+                policy.Tag("ogc-styles", "metadata");
+            });
+
             options.AddPolicy("OgcCoveragesLandingPage", policy =>
             {
                 policy.Expire(ttl.OgcCoveragesLandingPage);

--- a/src/Honua.Server/Features/Styling/OgcStyleProjection.cs
+++ b/src/Honua.Server/Features/Styling/OgcStyleProjection.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Styling.Abstractions;
+using Honua.Infrastructure.Rendering;
+using Honua.Server.Features.Styling.Sld;
+
+namespace Honua.Server.Features.Styling;
+
+/// <summary>
+/// <see cref="IOgcStyleProjection"/> implementation that projects Honua's per-layer
+/// style storage as OGC API - Styles resources (ADR-0048, Phase 1). It composes the
+/// internal <see cref="ILayerStyleService"/>, the canonical MapLibre store
+/// (<see cref="ILayerStyleCatalog"/>), the SLD exporter, and the metadata-v2 graph so
+/// the protocol slice in <c>Honua.Protocols.OgcApi</c> never needs to reach those
+/// internal types directly.
+/// </summary>
+internal sealed class OgcStyleProjection : IOgcStyleProjection
+{
+    private readonly IMetadataV2GraphProvider _graphProvider;
+    private readonly ILayerStyleService _styleService;
+    private readonly ILayerStyleCatalog _styleCatalog;
+
+    public OgcStyleProjection(
+        IMetadataV2GraphProvider graphProvider,
+        ILayerStyleService styleService,
+        ILayerStyleCatalog styleCatalog)
+    {
+        _graphProvider = graphProvider ?? throw new ArgumentNullException(nameof(graphProvider));
+        _styleService = styleService ?? throw new ArgumentNullException(nameof(styleService));
+        _styleCatalog = styleCatalog ?? throw new ArgumentNullException(nameof(styleCatalog));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<OgcStyleSummary>> ListStylesAsync(CancellationToken cancellationToken = default)
+    {
+        var snapshot = await _graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+
+        var summaries = new List<OgcStyleSummary>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var resource in snapshot.Graph.Resources)
+        {
+            var styleId = resource.Metadata.Name;
+            if (string.IsNullOrWhiteSpace(styleId) || !seen.Add(styleId))
+            {
+                continue;
+            }
+
+            var storageLayerId = snapshot.ResolveStorageLayerId(resource);
+            if (!storageLayerId.HasValue)
+            {
+                continue;
+            }
+
+            // Phase 1: a collection projects to an OGC style only when it has a
+            // genuinely stored MapLibre style. Read the canonical store directly so the
+            // in-memory default style synthesized for unstyled layers does not appear.
+            var stored = await _styleCatalog.GetLayerStyleAsync(storageLayerId.Value, cancellationToken).ConfigureAwait(false);
+            if (stored is null || string.IsNullOrWhiteSpace(stored.MapLibreStyleJson))
+            {
+                continue;
+            }
+
+            summaries.Add(new OgcStyleSummary(styleId, ResolveTitle(resource)));
+        }
+
+        summaries.Sort(static (a, b) => string.CompareOrdinal(a.StyleId, b.StyleId));
+        return summaries;
+    }
+
+    /// <inheritdoc />
+    public async Task<OgcStylesheet?> GetStylesheetAsync(
+        string styleId,
+        OgcStyleEncoding encoding,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleId);
+
+        var (resource, storageLayerId, snapshot) = await ResolveStyledResourceAsync(styleId, cancellationToken).ConfigureAwait(false);
+        if (resource is null || !storageLayerId.HasValue)
+        {
+            return null;
+        }
+
+        var stored = await _styleCatalog.GetLayerStyleAsync(storageLayerId.Value, cancellationToken).ConfigureAwait(false);
+        if (stored is null || string.IsNullOrWhiteSpace(stored.MapLibreStyleJson))
+        {
+            return null;
+        }
+
+        var mapLibreJson = stored.MapLibreStyleJson!;
+        if (encoding == OgcStyleEncoding.MapboxStyle)
+        {
+            return new OgcStylesheet(mapLibreJson, OgcStyleMediaTypes.MapboxStyle, OgcStyleEncoding.MapboxStyle);
+        }
+
+        var sld = DeriveSld(mapLibreJson, resource, storageLayerId.Value, encoding);
+        return sld;
+    }
+
+    /// <inheritdoc />
+    public async Task<OgcStyleMetadata?> GetStyleMetadataAsync(
+        string styleId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleId);
+
+        var (resource, storageLayerId, _) = await ResolveStyledResourceAsync(styleId, cancellationToken).ConfigureAwait(false);
+        if (resource is null || !storageLayerId.HasValue)
+        {
+            return null;
+        }
+
+        var stored = await _styleCatalog.GetLayerStyleAsync(storageLayerId.Value, cancellationToken).ConfigureAwait(false);
+        if (stored is null || string.IsNullOrWhiteSpace(stored.MapLibreStyleJson))
+        {
+            return null;
+        }
+
+        var version = stored.StyleVersion > 0
+            ? stored.StyleVersion.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : null;
+
+        return new OgcStyleMetadata(
+            styleId,
+            ResolveTitle(resource),
+            resource.Metadata.Description,
+            resource.Metadata.Keywords,
+            resource.Metadata.License,
+            version);
+    }
+
+    /// <inheritdoc />
+    public async Task<OgcStyleUpdateResult> UpdateStyleAsync(
+        string styleId,
+        string mapLibreStyleJson,
+        bool strict,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleId);
+        ArgumentNullException.ThrowIfNull(mapLibreStyleJson);
+
+        var (resource, storageLayerId, _) = await ResolveResourceAsync(styleId, cancellationToken).ConfigureAwait(false);
+        if (resource is null || !storageLayerId.HasValue)
+        {
+            return new OgcStyleUpdateResult(OgcStyleUpdateStatus.NotFound, $"Style '{styleId}' not found.");
+        }
+
+        JsonElement parsed;
+        try
+        {
+            using var document = JsonDocument.Parse(mapLibreStyleJson);
+            parsed = document.RootElement.Clone();
+        }
+        catch (JsonException ex)
+        {
+            return new OgcStyleUpdateResult(OgcStyleUpdateStatus.Invalid, $"MapLibre style is not valid JSON: {ex.Message}");
+        }
+
+        var result = await _styleService
+            .UpdateStyleAsync(resource, storageLayerId.Value, parsed, drawingInfo: null, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.Status switch
+        {
+            LayerStyleUpdateStatus.Updated => new OgcStyleUpdateResult(OgcStyleUpdateStatus.Updated, null),
+            LayerStyleUpdateStatus.NotFound => new OgcStyleUpdateResult(OgcStyleUpdateStatus.NotFound, $"Style '{styleId}' not found."),
+            _ => new OgcStyleUpdateResult(OgcStyleUpdateStatus.Invalid, result.ErrorMessage ?? "MapLibre style is invalid.")
+        };
+    }
+
+    private static OgcStylesheet DeriveSld(
+        string mapLibreJson,
+        MetadataV2Resource resource,
+        int storageLayerId,
+        OgcStyleEncoding encoding)
+    {
+        var layerName = string.IsNullOrWhiteSpace(resource.Metadata.Name)
+            ? $"layer-{storageLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture)}"
+            : resource.Metadata.Name;
+
+        MapLibreStyleLayer[] layers;
+        using (var document = JsonDocument.Parse(mapLibreJson))
+        {
+            if (!document.RootElement.TryGetProperty("layers", out var layersElement)
+                || layersElement.ValueKind != JsonValueKind.Array)
+            {
+                layers = Array.Empty<MapLibreStyleLayer>();
+            }
+            else
+            {
+                layers = JsonSerializer.Deserialize(
+                    layersElement.GetRawText(),
+                    MapLibreStyleJsonContext.Default.MapLibreStyleLayerArray) ?? Array.Empty<MapLibreStyleLayer>();
+            }
+        }
+
+        var export = MapLibreToSldConverter.Export(layers, layerName);
+        var sldXml = export.SldXml;
+
+        if (encoding == OgcStyleEncoding.Sld11)
+        {
+            sldXml = RewriteSldVersion(sldXml, "1.1.0");
+            return new OgcStylesheet(sldXml, OgcStyleMediaTypes.Sld11, OgcStyleEncoding.Sld11);
+        }
+
+        return new OgcStylesheet(sldXml, OgcStyleMediaTypes.Sld10, OgcStyleEncoding.Sld10);
+    }
+
+    private static string RewriteSldVersion(string sldXml, string version)
+    {
+        try
+        {
+            var document = XDocument.Parse(sldXml);
+            document.Root?.SetAttributeValue("version", version);
+            return document.Declaration + Environment.NewLine + document.ToString();
+        }
+        catch (System.Xml.XmlException)
+        {
+            // The exporter always produces well-formed XML; fall back to the original
+            // document rather than failing the request if parsing ever regresses.
+            return sldXml;
+        }
+    }
+
+    private async Task<(MetadataV2Resource? Resource, int? StorageLayerId, MetadataV2GraphSnapshot Snapshot)> ResolveResourceAsync(
+        string styleId,
+        CancellationToken cancellationToken)
+    {
+        var snapshot = await _graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var resource in snapshot.Graph.Resources)
+        {
+            if (!string.Equals(resource.Metadata.Name, styleId, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            return (resource, snapshot.ResolveStorageLayerId(resource), snapshot);
+        }
+
+        return (null, null, snapshot);
+    }
+
+    private async Task<(MetadataV2Resource? Resource, int? StorageLayerId, MetadataV2GraphSnapshot Snapshot)> ResolveStyledResourceAsync(
+        string styleId,
+        CancellationToken cancellationToken)
+        => await ResolveResourceAsync(styleId, cancellationToken).ConfigureAwait(false);
+
+    private static string ResolveTitle(MetadataV2Resource resource)
+        => resource.Metadata.Title
+            ?? (string.IsNullOrWhiteSpace(resource.Metadata.Name) ? "Style" : resource.Metadata.Name);
+}
+
+/// <summary>
+/// Media type constants for OGC API - Styles stylesheet encodings, kept in
+/// <c>Honua.Server</c> alongside the projection that produces them.
+/// </summary>
+internal static class OgcStyleMediaTypes
+{
+    public const string MapboxStyle = "application/vnd.mapbox.style+json";
+    public const string Sld10 = "application/vnd.ogc.sld+xml;version=1.0";
+    public const string Sld11 = "application/vnd.ogc.sld+xml;version=1.1";
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -475,6 +475,8 @@ Honua.Core.Features.Publishing.Content.ContentPublishingServiceCollectionExtensi
 builder.Services.AddScoped<Honua.Infrastructure.Services.IGeometryConverter,
     Honua.Infrastructure.Services.GeometryConverter>();
 builder.Services.AddScoped<ILayerStyleService, LayerStyleService>();
+builder.Services.AddScoped<Honua.Core.Features.Styling.Abstractions.IOgcStyleProjection,
+    Honua.Server.Features.Styling.OgcStyleProjection>();
 builder.Services.AddSingleton<Honua.Core.Features.Styling.Abstractions.IGeoServicesStyleConverter,
     Honua.Server.Features.Styling.GeoServicesStyleConverter>();
 builder.Services.AddSingleton<Honua.Core.Features.Styling.Abstractions.ISldStyleConverter,
@@ -594,6 +596,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Protocols.Ogc.Api.Features.OgcJsonContext.Default,
         Honua.Protocols.Ogc.Api.Maps.Models.OgcMapsJsonContext.Default,
         Honua.Protocols.Ogc.Api.Records.OgcRecordsJsonContext.Default,
+        Honua.Protocols.Ogc.Api.Styles.OgcStylesJsonContext.Default,
         Honua.Protocols.Ogc.Api.Tiles.OgcTilesJsonContext.Default,
         Honua.Server.Features.Admin.Models.SecureConnectionJsonContext.Default,
         Honua.Server.Features.Admin.Models.LayerPublishingJsonContext.Default,

--- a/tests/dotnet/Honua.Server.Tests/Features/Styling/OgcStylesEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Styling/OgcStylesEndpointTests.cs
@@ -1,0 +1,321 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Styling;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+
+namespace Honua.Server.Tests.Features.Styling;
+
+/// <summary>
+/// Integration tests for the OGC API - Styles Phase 1 adapter (ADR-0048, issue #1388).
+/// Covers landing/styles list, conformance, content-negotiated stylesheets (MapLibre +
+/// derived SLD), style metadata, manage-styles PUT (with strict validation), and the
+/// 501 responses for standalone POST-create / DELETE.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.OgcApiStyles)]
+public sealed class OgcStylesEndpointTests : IAsyncLifetime
+{
+    private const string MapboxStyleMediaType = "application/vnd.mapbox.style+json";
+    private const string Sld10MediaType = "application/vnd.ogc.sld+xml;version=1.0";
+    private const string Sld11MediaType = "application/vnd.ogc.sld+xml;version=1.1";
+
+    private readonly WebAppFixture _fixture = new();
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /ogc/styles/conformance")]
+    public async Task GetConformance_ListsThePhase1ConformanceClasses()
+    {
+        var client = _fixture.CreateClient();
+
+        var response = await client.GetAsync("/ogc/styles/conformance");
+
+        response.Be200Ok();
+        var payload = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        var classes = document.RootElement.GetProperty("conformsTo")
+            .EnumerateArray()
+            .Select(e => e.GetString())
+            .ToArray();
+
+        classes.Should().Contain("http://www.opengis.net/spec/ogcapi-styles-1/1.0/conf/core");
+        classes.Should().Contain("http://www.opengis.net/spec/ogcapi-styles-1/1.0/conf/mapbox-styles");
+        classes.Should().Contain("http://www.opengis.net/spec/ogcapi-styles-1/1.0/conf/sld-10");
+        classes.Should().Contain("http://www.opengis.net/spec/ogcapi-styles-1/1.0/conf/sld-11");
+        classes.Should().Contain("http://www.opengis.net/spec/ogcapi-styles-1/1.0/conf/style-validation");
+        classes.Should().Contain("http://www.opengis.net/spec/ogcapi-styles-1/1.0/conf/manage-styles");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /ogc/styles/openapi.json")]
+    public async Task GetOpenApi_ReturnsOpenApiDocument()
+    {
+        var client = _fixture.CreateClient();
+
+        var response = await client.GetAsync("/ogc/styles/openapi.json");
+
+        response.Be200Ok();
+        var payload = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        document.RootElement.TryGetProperty("openapi", out _).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /ogc/styles")]
+    public async Task GetStylesList_AfterStyling_IncludesTheStyledCollection()
+    {
+        var client = _fixture.CreateAdminClient();
+        await SeedTestLayerStyleAsync(client);
+
+        var response = await client.GetAsync("/ogc/styles");
+
+        response.Be200Ok();
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var styles = document.RootElement.GetProperty("styles");
+        styles.GetArrayLength().Should().BeGreaterThan(0);
+
+        var first = styles[0];
+        first.GetProperty("id").GetString().Should().NotBeNullOrEmpty();
+        var links = first.GetProperty("links").EnumerateArray().ToArray();
+        links.Should().Contain(l =>
+            l.GetProperty("rel").GetString() == "stylesheet"
+            && l.GetProperty("type").GetString() == MapboxStyleMediaType);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /ogc/styles/{styleId}")]
+    public async Task GetStylesheet_DefaultAccept_ReturnsMapLibreStyle()
+    {
+        var client = _fixture.CreateAdminClient();
+        var styleId = await SeedAndResolveStyleIdAsync(client);
+
+        var response = await client.GetAsync($"/ogc/styles/{Uri.EscapeDataString(styleId)}");
+
+        response.Be200Ok();
+        response.Content.Headers.ContentType?.MediaType.Should().Be(MapboxStyleMediaType);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("version").GetInt32().Should().Be(8);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /ogc/styles/{styleId}")]
+    public async Task GetStylesheet_AcceptSld10_ReturnsDerivedSld()
+    {
+        var client = _fixture.CreateAdminClient();
+        var styleId = await SeedAndResolveStyleIdAsync(client);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"/ogc/styles/{Uri.EscapeDataString(styleId)}");
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(Sld10MediaType));
+
+        var response = await client.SendAsync(request);
+
+        response.Be200Ok();
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.ogc.sld+xml");
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("StyledLayerDescriptor");
+        body.Should().Contain("version=\"1.0.0\"");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /ogc/styles/{styleId}")]
+    public async Task GetStylesheet_AcceptSld11_ReturnsDerivedSld11()
+    {
+        var client = _fixture.CreateAdminClient();
+        var styleId = await SeedAndResolveStyleIdAsync(client);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"/ogc/styles/{Uri.EscapeDataString(styleId)}");
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(Sld11MediaType));
+
+        var response = await client.SendAsync(request);
+
+        response.Be200Ok();
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("StyledLayerDescriptor");
+        body.Should().Contain("version=\"1.1.0\"");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /ogc/styles/{styleId}")]
+    public async Task GetStylesheet_UnknownStyle_Returns404()
+    {
+        var client = _fixture.CreateClient();
+
+        var response = await client.GetAsync($"/ogc/styles/does-not-exist-{Guid.NewGuid():N}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /ogc/styles/{styleId}/metadata")]
+    public async Task GetStyleMetadata_ReturnsMetadataWithStylesheetSchemaAndPreviewLinks()
+    {
+        var client = _fixture.CreateAdminClient();
+        var styleId = await SeedAndResolveStyleIdAsync(client);
+
+        var response = await client.GetAsync($"/ogc/styles/{Uri.EscapeDataString(styleId)}/metadata");
+
+        response.Be200Ok();
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("id").GetString().Should().Be(styleId);
+
+        var links = document.RootElement.GetProperty("links").EnumerateArray().ToArray();
+        links.Should().Contain(l => l.GetProperty("rel").GetString() == "stylesheet");
+        links.Should().Contain(l => l.GetProperty("rel").GetString() == "describedby");
+        links.Should().Contain(l => l.GetProperty("rel").GetString() == "preview");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Update)]
+    [Endpoint("PUT /ogc/styles/{styleId}")]
+    public async Task PutStyle_WithValidMapLibre_Returns204()
+    {
+        var client = _fixture.CreateAdminClient();
+        var styleId = await SeedAndResolveStyleIdAsync(client);
+
+        var style = BuildDefaultStyleJson();
+        using var content = new StringContent(style, Encoding.UTF8, MapboxStyleMediaType);
+        using var request = new HttpRequestMessage(HttpMethod.Put, $"/ogc/styles/{Uri.EscapeDataString(styleId)}")
+        {
+            Content = content
+        };
+
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Update)]
+    [Endpoint("PUT /ogc/styles/{styleId}")]
+    public async Task PutStyle_WithInvalidMapLibre_StrictHandling_Returns400()
+    {
+        var client = _fixture.CreateAdminClient();
+        var styleId = await SeedAndResolveStyleIdAsync(client);
+
+        // Missing version/layers -> normalizer rejects.
+        const string invalid = "{\"name\":\"broken\"}";
+        using var content = new StringContent(invalid, Encoding.UTF8, MapboxStyleMediaType);
+        using var request = new HttpRequestMessage(HttpMethod.Put, $"/ogc/styles/{Uri.EscapeDataString(styleId)}")
+        {
+            Content = content
+        };
+        request.Headers.TryAddWithoutValidation("Prefer", "handling=strict");
+
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /ogc/styles")]
+    public async Task PostStyle_Returns501NotImplemented()
+    {
+        var client = _fixture.CreateAdminClient();
+
+        using var content = new StringContent(BuildDefaultStyleJson(), Encoding.UTF8, MapboxStyleMediaType);
+        var response = await client.PostAsync("/ogc/styles", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("DELETE /ogc/styles/{styleId}")]
+    public async Task DeleteStyle_Returns501NotImplemented()
+    {
+        var client = _fixture.CreateAdminClient();
+        var styleId = await SeedAndResolveStyleIdAsync(client);
+
+        var response = await client.DeleteAsync($"/ogc/styles/{Uri.EscapeDataString(styleId)}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /ogc/features/collections/{collectionId}")]
+    public async Task GetCollection_IncludesStylesAndStylesheetLinks()
+    {
+        var client = _fixture.CreateClient();
+
+        var collectionsResponse = await client.GetAsync("/ogc/features/collections");
+        collectionsResponse.Be200Ok();
+        using var collectionsDocument = JsonDocument.Parse(await collectionsResponse.Content.ReadAsStringAsync());
+        var collections = collectionsDocument.RootElement.GetProperty("collections");
+        collections.GetArrayLength().Should().BeGreaterThan(0);
+        var collectionId = collections[0].GetProperty("id").GetString();
+        collectionId.Should().NotBeNullOrEmpty();
+
+        var response = await client.GetAsync($"/ogc/features/collections/{Uri.EscapeDataString(collectionId!)}");
+        response.Be200Ok();
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var links = document.RootElement.GetProperty("links").EnumerateArray().ToArray();
+
+        links.Should().Contain(l => l.GetProperty("rel").GetString() == "style");
+        links.Should().Contain(l => l.GetProperty("rel").GetString() == "http://www.opengis.net/def/rel/ogc/1.0/styles");
+        links.Should().Contain(l =>
+            l.GetProperty("rel").GetString() == "stylesheet"
+            && l.GetProperty("href").GetString()!.Contains("/ogc/styles/", StringComparison.Ordinal));
+    }
+
+    private async Task<string> SeedAndResolveStyleIdAsync(HttpClient adminClient)
+    {
+        await SeedTestLayerStyleAsync(adminClient);
+
+        var response = await adminClient.GetAsync("/ogc/styles");
+        response.Be200Ok();
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var styles = document.RootElement.GetProperty("styles");
+        styles.GetArrayLength().Should().BeGreaterThan(0);
+        return styles[0].GetProperty("id").GetString()!;
+    }
+
+    private static async Task SeedTestLayerStyleAsync(HttpClient adminClient)
+    {
+        var request = new LayerStyleUpdateRequest
+        {
+            MapLibreStyle = JsonSerializer.Deserialize<JsonElement>(BuildDefaultStyleJson())
+        };
+
+        var response = await adminClient.PutAsync(
+            $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/style",
+            JsonContent.Create(request, LayerStyleJsonContext.Default.LayerStyleUpdateRequest));
+        response.Be200Ok();
+    }
+
+    private static string BuildDefaultStyleJson()
+    {
+        var layer = new StyleLayerDescriptor(
+            WebAppFixture.TestLayerId,
+            "Test Layer",
+            MetadataV2GeometryType.Point);
+        var style = StyleDefaults.BuildDefaultMapLibreStyle(layer);
+        return JsonSerializer.Serialize(style);
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Constants/ProtocolNames.cs
+++ b/tests/dotnet/Honua.TestKit/Constants/ProtocolNames.cs
@@ -140,6 +140,11 @@ public static class ProtocolNames
     public const string OgcApiCoverages = "OGC-API-Coverages";
 
     /// <summary>
+    /// OGC API - Styles (Part 1).
+    /// </summary>
+    public const string OgcApiStyles = "OGC-API-Styles";
+
+    /// <summary>
     /// GeoServices REST service directory and root metadata endpoints.
     /// </summary>
     public const string GeoservicesCatalog = "GeoservicesCatalog";


### PR DESCRIPTION
## Issue Link
Fixes #1388
Part of umbrella #1387. Implements ADR-0048.

## Summary
Adds the OGC API – Styles **Phase 1** protocol adapter, mounted at `/ogc/styles`, projecting Honua's existing per-layer style storage as OGC styles. Ships a conformant read + partial-manage Styles API now; the styleId scheme and contract are forward-compatible with the Phase 2 independent style catalog (#1389), so no client breakage when storage evolves.

Claims conformance classes: `core`, `mapbox-styles`, `sld-10`, `sld-11`, `style-validation`, and partial `manage-styles`.

## Changes Made
- New slice `src/Honua.Protocols.OgcApi/Styles/` (endpoints, conformance handler, models, source-generated JSON context, log, DI extension) mirroring the Tiles/Maps slices.
- Endpoints: styles list, `/conformance`, `/openapi.json`, content-negotiated `GET /ogc/styles/{styleId}` (MapLibre default; SLD 1.0/1.1 derived by `Accept`), `/{styleId}/metadata`, `PUT /{styleId}` (manage-styles with strict validation). `POST`/`DELETE` return 501 pending the Phase 2 catalog (#1389).
- styleId = the collection's stable resource name (same value as the OGC API Features collectionId), chosen for Phase 2 forward-compatibility.
- New public `IOgcStyleProjection` abstraction in `Honua.Core` (implemented by `OgcStyleProjection` in `Honua.Server`), mirroring the existing `ISldStyleConverter`/`IGeoServicesStyleConverter` cross-project pattern — keeps Server internals internal rather than exposing them to the protocol slice.
- Collection links: added `rel:"styles"` + `rel:"stylesheet"` to OGC Features collection metadata; kept the `/api/styles/{layerId}.json` `rel:"style"` alias working.
- Registration via `AddOgcStyles()`/`MapOgcStylesEndpoints()`; `OgcStyles*` output-cache policies (vary by styleId + Accept/format); new `RelationTypes`/`MediaTypes`; JSON context chained in `Program.cs`; `EndpointRegistry` + public-interface proof ledger updated.
- Docs: `docs/cite-status.md` and `docs/gis/style-engine-protocol-consumption.md` reference the new surface + ADR-0048.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Build (`-c Release /p:TreatWarningsAsErrors=true`) → 0 warnings/0 errors. `dotnet format --verify-no-changes` clean. Architecture tests 101 passed / 0 failed. New styles integration tests 13/13; OGC Features + LayerStyle suites 30/30; OpenAPI-negotiation + health 26/26; OgcApi collection-metadata 31/31. Existing CITE-suite slices untouched (952/952 preserved).

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] OpenAPI spec changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

New additive OGC API – Styles routes; existing `/api/styles/{layerId}.json` alias preserved.

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. Additive new endpoints; the existing `/api/styles/{layerId}.json` path is retained as a back-compat alias.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review