### PR TITLE
feat: add ArcGIS Portal/Sharing REST read surface (#1243)

### DIFF
--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -1147,7 +1147,9 @@
       "protocol": "ArcGIS Portal Sharing",
       "canonicalIdentifier": "/sharing/rest/generateToken",
       "parentSurfaceId": null,
-      "endpointPrefixes": [],
+      "endpointPrefixes": [
+        "/sharing/rest/"
+      ],
       "endpointExactMatches": [
         "/sharing/rest/generateToken"
       ],

--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -118,6 +118,8 @@ public static class FeatureCatalog
         // Identity — Community (ArcGIS Portal interop)
         new("identity.portal-token", "ArcGIS Portal Token Issuance", Categories.Identity,
             HonuaEdition.Community, "Expose POST/GET /sharing/rest/generateToken so Esri clients can authenticate against Honua-secured /rest/services."),
+        new("identity.portal-sharing", "ArcGIS Portal Sharing Read Surface", Categories.Identity,
+            HonuaEdition.Community, "Expose the read-only /sharing/rest Portal facade (info, portals/self, search, content/items) so Esri clients can discover Honua content as portal items."),
 
         // Identity — Enterprise
         new("identity.oidc", "OIDC Authentication", Categories.Identity,

--- a/src/Honua.Hosting/Features/Models/ProtocolRequestClassifier.cs
+++ b/src/Honua.Hosting/Features/Models/ProtocolRequestClassifier.cs
@@ -106,5 +106,7 @@ internal static class ProtocolRequestClassifier
 
     internal static bool IsGeoServices(PathString path) =>
         path.StartsWithSegments("/rest/services") ||
-        path.StartsWithSegments("/tiles");
+        path.StartsWithSegments("/tiles") ||
+        path.StartsWithSegments("/sharing/rest") ||
+        path.StartsWithSegments("/rest/info");
 }

--- a/src/Honua.Protocols.GeoServices/Sharing/SharingRestEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/Sharing/SharingRestEndpoints.cs
@@ -3,14 +3,20 @@
 
 using System.Globalization;
 using System.Net;
+using System.Security.Claims;
 using Honua.Core.Features.Authorization.Abstractions;
 using Honua.Core.Features.Infrastructure.Logging;
+using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.MultiTenancy.Abstractions;
+using Honua.Core.Features.Portal.Abstractions;
+using Honua.Core.Features.Portal.Domain;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Helpers;
 using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Protocols.GeoServices.Sharing;
@@ -25,7 +31,16 @@ public static class SharingRestEndpoints
     internal const string EntitlementKey = "identity.portal-token";
     internal const string EntitlementFeatureName = "ArcGIS Portal Token Issuance";
 
+    /// <summary>Entitlement key gating the read-only Portal/Sharing discovery surface.</summary>
+    internal const string ReadEntitlementKey = "identity.portal-sharing";
+    internal const string ReadEntitlementFeatureName = "ArcGIS Portal Sharing Read Surface";
+
     private const string JsonContentType = "application/json";
+
+    // The Portal facade only accepts the ArcGIS family of services as items, so
+    // the search result page size is bounded to a sane default/maximum.
+    private const int DefaultSearchPageSize = 10;
+    private const int MaxSearchPageSize = 100;
 
     /// <summary>
     /// Maps the <c>/sharing/rest/generateToken</c> POST and GET endpoints.
@@ -60,6 +75,83 @@ public static class SharingRestEndpoints
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status402PaymentRequired);
+
+        endpoints.MapSharingRestReadEndpoints();
+
+        return endpoints;
+    }
+
+    /// <summary>
+    /// Maps the read-only Portal/Sharing REST discovery surface (#1243):
+    /// <c>info</c>, <c>portals/self</c>, <c>community/self</c>, <c>search</c>, and
+    /// <c>content/items/{id}</c> (+ <c>/data</c>). All routes are off-by-default
+    /// and entitlement-gated; the whole surface returns 404 when disabled so it is
+    /// never a silent discovery surface.
+    /// </summary>
+    /// <param name="endpoints">Endpoint route builder to extend.</param>
+    /// <returns>The original builder, to support fluent chaining.</returns>
+    private static IEndpointRouteBuilder MapSharingRestReadEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/sharing/rest/info", HandleInfoAsync)
+            .WithDisplayName("ArcGIS Portal Sharing Info")
+            .WithName("SharingRestInfo")
+            .WithSummary("Portal version and authentication info")
+            .WithTags("GeoServices Sharing")
+            .AllowAnonymous()
+            .Produces<SharingInfoResponse>(StatusCodes.Status200OK, JsonContentType)
+            .Produces(StatusCodes.Status404NotFound);
+
+        // The /rest/info alias is already served by the GeoServices catalog
+        // endpoint (GeoservicesCatalogEndpoints.HandleGetRestInfo) with an
+        // equivalent authInfo shape; we do not re-map it here to avoid an
+        // ambiguous route. The Portal-specific authInfo lives at
+        // /sharing/rest/info.
+        endpoints.MapGet("/sharing/rest/portals/self", HandlePortalSelfAsync)
+            .WithDisplayName("ArcGIS Portal Self")
+            .WithName("SharingRestPortalsSelf")
+            .WithSummary("RBAC-scoped portal/user self description")
+            .WithTags("GeoServices Sharing")
+            .AllowAnonymous()
+            .Produces<PortalSelfResponse>(StatusCodes.Status200OK, JsonContentType)
+            .Produces(StatusCodes.Status404NotFound);
+
+        endpoints.MapGet("/sharing/rest/community/self", HandleCommunitySelfAsync)
+            .WithDisplayName("ArcGIS Portal Community Self")
+            .WithName("SharingRestCommunitySelf")
+            .WithSummary("RBAC-scoped user self description")
+            .WithTags("GeoServices Sharing")
+            .AllowAnonymous()
+            .Produces<CommunitySelfResponse>(StatusCodes.Status200OK, JsonContentType)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+
+        endpoints.MapGet("/sharing/rest/search", HandleSearchAsync)
+            .WithDisplayName("ArcGIS Portal Search")
+            .WithName("SharingRestSearch")
+            .WithSummary("Search visible portal items with paging")
+            .WithTags("GeoServices Sharing")
+            .AllowAnonymous()
+            .Produces<SearchResponse>(StatusCodes.Status200OK, JsonContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status404NotFound);
+
+        endpoints.MapGet("/sharing/rest/content/items/{id}", HandleContentItemAsync)
+            .WithDisplayName("ArcGIS Portal Content Item")
+            .WithName("SharingRestContentItem")
+            .WithSummary("Fetch a single portal item by id")
+            .WithTags("GeoServices Sharing")
+            .AllowAnonymous()
+            .Produces<PortalItem>(StatusCodes.Status200OK, JsonContentType)
+            .Produces(StatusCodes.Status404NotFound);
+
+        endpoints.MapGet("/sharing/rest/content/items/{id}/data", HandleContentItemDataAsync)
+            .WithDisplayName("ArcGIS Portal Content Item Data")
+            .WithName("SharingRestContentItemData")
+            .WithSummary("Fetch a single portal item's data document by id")
+            .WithTags("GeoServices Sharing")
+            .AllowAnonymous()
+            .Produces<PortalItem>(StatusCodes.Status200OK, JsonContentType)
+            .Produces(StatusCodes.Status404NotFound);
 
         return endpoints;
     }
@@ -170,6 +262,387 @@ public static class SharingRestEndpoints
 
         return Results.Json(response, SharingRestJsonContext.Default.GenerateTokenResponse, contentType: JsonContentType);
     }
+
+    private static IResult HandleInfoAsync(
+        HttpContext context,
+        string? f,
+        [FromServices] IOptions<PortalTokenAuthenticationOptions> tokenOptions,
+        [FromServices] ILogger<SharingRestLog> logger)
+    {
+        var gate = GateReadSurface(context, f, logger);
+        if (gate is not null)
+        {
+            return gate;
+        }
+
+        var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+        var response = new SharingInfoResponse
+        {
+            AuthInfo = new SharingAuthInfo
+            {
+                IsTokenBasedSecurity = tokenOptions.Value.Enabled,
+                TokenServicesUrl = $"{baseUrl.TrimEnd('/')}/sharing/rest/generateToken",
+            },
+        };
+
+        return Results.Json(response, SharingRestJsonContext.Default.SharingInfoResponse, contentType: JsonContentType);
+    }
+
+    private static IResult HandlePortalSelfAsync(
+        HttpContext context,
+        string? f,
+        [FromServices] ILogger<SharingRestLog> logger)
+    {
+        var gate = GateReadSurface(context, f, logger);
+        if (gate is not null)
+        {
+            return gate;
+        }
+
+        var principal = context.User;
+        var user = principal.Identity?.IsAuthenticated == true
+            ? new PortalUser
+            {
+                Username = ResolveUsername(principal),
+                FullName = ResolveDisplayName(principal),
+            }
+            : null;
+
+        var response = new PortalSelfResponse
+        {
+            Id = "0123456789ABCDEF",
+            Name = "Honua",
+            User = user,
+        };
+
+        return Results.Json(response, SharingRestJsonContext.Default.PortalSelfResponse, contentType: JsonContentType);
+    }
+
+    private static IResult HandleCommunitySelfAsync(
+        HttpContext context,
+        string? f,
+        [FromServices] ILogger<SharingRestLog> logger)
+    {
+        var gate = GateReadSurface(context, f, logger);
+        if (gate is not null)
+        {
+            return gate;
+        }
+
+        var principal = context.User;
+        if (principal.Identity?.IsAuthenticated != true)
+        {
+            // community/self describes the *authenticated* user; anonymous callers
+            // get the Esri-shaped 401 rather than an anonymous user document.
+            return StandardErrorHelpers.CreateUnauthorized(
+                context,
+                "Authentication is required to describe the current user.");
+        }
+
+        var response = new CommunitySelfResponse
+        {
+            Username = ResolveUsername(principal),
+            FullName = ResolveDisplayName(principal),
+        };
+
+        return Results.Json(response, SharingRestJsonContext.Default.CommunitySelfResponse, contentType: JsonContentType);
+    }
+
+    private static async Task<IResult> HandleSearchAsync(
+        HttpContext context,
+        string? f,
+        [FromServices] IMetadataV2GraphProvider graphProvider,
+        [FromServices] IPortalItemProjector projector,
+        [FromServices] ILogger<SharingRestLog> logger)
+    {
+        var gate = GateReadSurface(context, f, logger);
+        if (gate is not null)
+        {
+            return gate;
+        }
+
+        var query = ReadFirst(context.Request.Query["q"]) ?? string.Empty;
+        var (start, num) = ResolvePaging(context.Request.Query);
+
+        var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+        var snapshot = await graphProvider.GetCurrentAsync(context.RequestAborted).ConfigureAwait(false);
+        var visible = projector.ProjectVisibleItems(snapshot, context.User, baseUrl);
+
+        var filtered = ApplyQuery(visible, query);
+        var sorted = ApplySort(filtered, context.Request.Query);
+
+        var total = sorted.Count;
+        // Esri start is 1-based; clamp the slice to the available range.
+        var skip = Math.Max(0, start - 1);
+        var page = skip >= total
+            ? Array.Empty<PortalItem>()
+            : sorted.Skip(skip).Take(num).ToArray();
+        var nextStart = skip + page.Length < total ? skip + page.Length + 1 : -1;
+
+        var response = new SearchResponse
+        {
+            Query = query,
+            Total = total,
+            Start = total == 0 ? 0 : start,
+            Num = page.Length,
+            NextStart = nextStart,
+            Results = page,
+        };
+
+        return Results.Json(response, SharingRestJsonContext.Default.SearchResponse, contentType: JsonContentType);
+    }
+
+    private static Task<IResult> HandleContentItemAsync(
+        HttpContext context,
+        string id,
+        string? f,
+        [FromServices] IMetadataV2GraphProvider graphProvider,
+        [FromServices] IPortalItemProjector projector,
+        [FromServices] ILogger<SharingRestLog> logger)
+        => ResolveItemAsync(context, id, f, graphProvider, projector, logger);
+
+    private static Task<IResult> HandleContentItemDataAsync(
+        HttpContext context,
+        string id,
+        string? f,
+        [FromServices] IMetadataV2GraphProvider graphProvider,
+        [FromServices] IPortalItemProjector projector,
+        [FromServices] ILogger<SharingRestLog> logger)
+        => ResolveItemAsync(context, id, f, graphProvider, projector, logger);
+
+    private static async Task<IResult> ResolveItemAsync(
+        HttpContext context,
+        string id,
+        string? f,
+        IMetadataV2GraphProvider graphProvider,
+        IPortalItemProjector projector,
+        ILogger<SharingRestLog> logger)
+    {
+        var gate = GateReadSurface(context, f, logger);
+        if (gate is not null)
+        {
+            return gate;
+        }
+
+        var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+        var snapshot = await graphProvider.GetCurrentAsync(context.RequestAborted).ConfigureAwait(false);
+        var item = projector.ProjectItem(snapshot, context.User, id, baseUrl);
+        if (item is null)
+        {
+            // The projector returns null both for unknown ids and for items the
+            // principal cannot read, so the facade never leaks hidden items.
+            return StandardErrorHelpers.CreateNotFound(context, "Item does not exist or is inaccessible.");
+        }
+
+        return Results.Json(item, SharingRestJsonContext.Default.PortalItem, contentType: JsonContentType);
+    }
+
+    /// <summary>
+    /// Configuration key that explicitly disables the read-only Portal/Sharing
+    /// discovery surface independent of licensing. Defaults to enabled; operators
+    /// opt out by setting it to <c>false</c>.
+    /// </summary>
+    internal const string ReadSurfaceEnabledKey = "Sharing:ReadSurface:Enabled";
+
+    /// <summary>
+    /// Gates the read surface in priority order: (1) the operator enable flag,
+    /// (2) the read-surface entitlement, then (3) the response format. When the
+    /// surface is disabled or unlicensed the whole surface 404s — it is never a
+    /// silent discovery surface and never reveals itself via a 400. Returns an
+    /// error result to short-circuit the request, or <see langword="null"/> when
+    /// the request may proceed.
+    /// </summary>
+    private static IResult? GateReadSurface(HttpContext context, string? format, ILogger<SharingRestLog> logger)
+    {
+        var configuration = context.RequestServices.GetRequiredService<IConfiguration>();
+        var enabled = configuration.GetValue(ReadSurfaceEnabledKey, true);
+        if (!enabled || !LicenseGate.IsEntitlementActive(context.RequestServices, ReadEntitlementKey))
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Portal sharing read surface is not available.");
+        }
+
+        if (!IsSupportedFormat(format))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Output format must be 'json' or 'pjson'.");
+        }
+
+        return null;
+    }
+
+    private static (int Start, int Num) ResolvePaging(IQueryCollection query)
+    {
+        var start = 1;
+        if (int.TryParse(ReadFirst(query["start"]), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedStart) &&
+            parsedStart > 0)
+        {
+            start = parsedStart;
+        }
+
+        var num = DefaultSearchPageSize;
+        if (int.TryParse(ReadFirst(query["num"]), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedNum) &&
+            parsedNum > 0)
+        {
+            num = Math.Min(parsedNum, MaxSearchPageSize);
+        }
+
+        return (start, num);
+    }
+
+    /// <summary>
+    /// Applies a coarse, case-insensitive Portal <c>q</c> filter over the projected
+    /// items. Supports the common <c>type:</c>, <c>owner:</c>, and <c>tags:</c>
+    /// field qualifiers plus free-text matching against title/snippet/tags; any
+    /// other qualifier degrades to free-text so unsupported syntax never errors.
+    /// </summary>
+    private static List<PortalItem> ApplyQuery(IReadOnlyList<PortalItem> items, string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return items.ToList();
+        }
+
+        var terms = TokenizeQuery(query);
+        if (terms.Count == 0)
+        {
+            return items.ToList();
+        }
+
+        var result = new List<PortalItem>(items.Count);
+        foreach (var item in items)
+        {
+            if (terms.All(term => MatchesTerm(item, term)))
+            {
+                result.Add(item);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Splits a Portal <c>q</c> expression into terms on whitespace while keeping
+    /// double-quoted phrases (including the common <c>field:"two words"</c> form)
+    /// intact, so multi-word qualifier values survive tokenizing.
+    /// </summary>
+    private static List<string> TokenizeQuery(string query)
+    {
+        var terms = new List<string>();
+        var current = new System.Text.StringBuilder();
+        var inQuotes = false;
+
+        foreach (var ch in query)
+        {
+            if (ch == '"')
+            {
+                inQuotes = !inQuotes;
+                current.Append(ch);
+            }
+            else if (char.IsWhiteSpace(ch) && !inQuotes)
+            {
+                if (current.Length > 0)
+                {
+                    terms.Add(current.ToString());
+                    current.Clear();
+                }
+            }
+            else
+            {
+                current.Append(ch);
+            }
+        }
+
+        if (current.Length > 0)
+        {
+            terms.Add(current.ToString());
+        }
+
+        return terms;
+    }
+
+    private static bool MatchesTerm(PortalItem item, string term)
+    {
+        var separator = term.IndexOf(':', StringComparison.Ordinal);
+        if (separator > 0 && separator < term.Length - 1)
+        {
+            var field = term[..separator];
+            var value = term[(separator + 1)..].Trim('"');
+            switch (field.ToLowerInvariant())
+            {
+                case "type":
+                    return item.Type.Contains(value, StringComparison.OrdinalIgnoreCase);
+                case "owner":
+                    return string.Equals(item.Owner, value, StringComparison.OrdinalIgnoreCase);
+                case "tags":
+                    return item.Tags.Any(tag => string.Equals(tag, value, StringComparison.OrdinalIgnoreCase));
+                case "id":
+                    return string.Equals(item.Id, value, StringComparison.OrdinalIgnoreCase);
+                case "title":
+                    return item.Title.Contains(value, StringComparison.OrdinalIgnoreCase);
+                default:
+                    return FreeTextMatch(item, term);
+            }
+        }
+
+        return FreeTextMatch(item, term);
+    }
+
+    private static bool FreeTextMatch(PortalItem item, string term)
+    {
+        var trimmed = term.Trim('"');
+        return item.Title.Contains(trimmed, StringComparison.OrdinalIgnoreCase) ||
+            (item.Snippet?.Contains(trimmed, StringComparison.OrdinalIgnoreCase) ?? false) ||
+            (item.Description?.Contains(trimmed, StringComparison.OrdinalIgnoreCase) ?? false) ||
+            item.Tags.Any(tag => tag.Contains(trimmed, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Applies the Portal <c>sortField</c>/<c>sortOrder</c> options over the
+    /// projected items. The projector already returns items title-sorted; this
+    /// honours explicit overrides for <c>title</c>, <c>created</c>, and
+    /// <c>modified</c>.
+    /// </summary>
+    private static List<PortalItem> ApplySort(List<PortalItem> items, IQueryCollection query)
+    {
+        var sortField = ReadFirst(query["sortField"]);
+        if (string.IsNullOrWhiteSpace(sortField))
+        {
+            return items;
+        }
+
+        var descending = string.Equals(ReadFirst(query["sortOrder"]), "desc", StringComparison.OrdinalIgnoreCase);
+        Comparison<PortalItem> comparison = sortField.ToLowerInvariant() switch
+        {
+            "created" => static (a, b) => a.Created.CompareTo(b.Created),
+            "modified" => static (a, b) => a.Modified.CompareTo(b.Modified),
+            "owner" => static (a, b) => string.Compare(a.Owner, b.Owner, StringComparison.OrdinalIgnoreCase),
+            _ => static (a, b) => string.Compare(a.Title, b.Title, StringComparison.OrdinalIgnoreCase),
+        };
+
+        items.Sort(comparison);
+        if (descending)
+        {
+            items.Reverse();
+        }
+
+        return items;
+    }
+
+    private static string ResolveUsername(ClaimsPrincipal principal)
+        => principal.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? principal.FindFirstValue("preferred_username")
+            ?? principal.FindFirstValue("sub")
+            ?? principal.Identity?.Name
+            ?? "user";
+
+    private static string ResolveDisplayName(ClaimsPrincipal principal)
+        => principal.FindFirstValue("name")
+            ?? principal.Identity?.Name
+            ?? ResolveUsername(principal);
+
+    private static bool IsSupportedFormat(string? format)
+        => string.IsNullOrWhiteSpace(format) ||
+            string.Equals(format, "json", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(format, "pjson", StringComparison.OrdinalIgnoreCase);
 
     private static async Task<GenerateTokenInputs> ReadParametersAsync(HttpContext context)
     {

--- a/src/Honua.Protocols.GeoServices/Sharing/SharingRestJsonContext.cs
+++ b/src/Honua.Protocols.GeoServices/Sharing/SharingRestJsonContext.cs
@@ -2,11 +2,17 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Text.Json.Serialization;
+using Honua.Core.Features.Portal.Domain;
 
 namespace Honua.Protocols.GeoServices.Sharing;
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.Unspecified)]
 [JsonSerializable(typeof(GenerateTokenResponse))]
+[JsonSerializable(typeof(SharingInfoResponse))]
+[JsonSerializable(typeof(PortalSelfResponse))]
+[JsonSerializable(typeof(CommunitySelfResponse))]
+[JsonSerializable(typeof(SearchResponse))]
+[JsonSerializable(typeof(PortalItem))]
 internal sealed partial class SharingRestJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Protocols.GeoServices/Sharing/SharingRestReadModels.cs
+++ b/src/Honua.Protocols.GeoServices/Sharing/SharingRestReadModels.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Portal.Domain;
+
+namespace Honua.Protocols.GeoServices.Sharing;
+
+/// <summary>
+/// Response body for <c>/sharing/rest/info</c> (and the <c>/rest/info</c> alias).
+/// Mirrors the ArcGIS Portal <c>info</c> document so packaged Esri clients can
+/// discover the portal version and the supported authentication scheme.
+/// </summary>
+internal sealed record SharingInfoResponse
+{
+    /// <summary>
+    /// Portal short version (e.g. <c>10.81</c>), matching the GeoServices catalog
+    /// version so the Portal facade and services directory stay aligned.
+    /// </summary>
+    [JsonPropertyName("currentVersion")]
+    public double CurrentVersion { get; init; } = 10.81;
+
+    /// <summary>
+    /// Portal full version string.
+    /// </summary>
+    [JsonPropertyName("fullVersion")]
+    public string FullVersion { get; init; } = "10.81";
+
+    /// <summary>
+    /// Authentication metadata advertising token-based security and the
+    /// token-issuance endpoint.
+    /// </summary>
+    [JsonPropertyName("authInfo")]
+    public required SharingAuthInfo AuthInfo { get; init; }
+}
+
+/// <summary>
+/// Authentication metadata block embedded in <see cref="SharingInfoResponse"/>.
+/// </summary>
+internal sealed record SharingAuthInfo
+{
+    /// <summary>
+    /// Whether the portal uses token-based security.
+    /// </summary>
+    [JsonPropertyName("isTokenBasedSecurity")]
+    public bool IsTokenBasedSecurity { get; init; } = true;
+
+    /// <summary>
+    /// Absolute URL of the token-issuance endpoint (<c>/sharing/rest/generateToken</c>),
+    /// honouring the forwarded scheme/host.
+    /// </summary>
+    [JsonPropertyName("tokenServicesUrl")]
+    public string TokenServicesUrl { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Response body for <c>/sharing/rest/portals/self</c>. A minimal, RBAC-scoped
+/// projection of the portal the caller is connected to.
+/// </summary>
+internal sealed record PortalSelfResponse
+{
+    /// <summary>Stable portal identifier.</summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>Whether the caller authenticated.</summary>
+    [JsonPropertyName("isPortal")]
+    public bool IsPortal { get; init; } = true;
+
+    /// <summary>Portal display name.</summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>Portal short name / URL key.</summary>
+    [JsonPropertyName("portalName")]
+    public string PortalName { get; init; } = "Honua";
+
+    /// <summary>
+    /// Authenticated user document, or <see langword="null"/> for anonymous callers.
+    /// </summary>
+    [JsonPropertyName("user")]
+    public PortalUser? User { get; init; }
+
+    /// <summary>Default basemap gallery group (empty — out of scope per #1243).</summary>
+    [JsonPropertyName("currentVersion")]
+    public string CurrentVersion { get; init; } = "10.81";
+}
+
+/// <summary>
+/// Response body for <c>/sharing/rest/community/self</c>. The RBAC-scoped user
+/// document for the calling principal.
+/// </summary>
+internal sealed record CommunitySelfResponse
+{
+    /// <summary>Username of the calling principal.</summary>
+    [JsonPropertyName("username")]
+    public required string Username { get; init; }
+
+    /// <summary>Display name of the calling principal.</summary>
+    [JsonPropertyName("fullName")]
+    public string FullName { get; init; } = string.Empty;
+
+    /// <summary>Roles granted to the calling principal.</summary>
+    [JsonPropertyName("role")]
+    public string Role { get; init; } = "org_user";
+}
+
+/// <summary>
+/// The user sub-document embedded in <see cref="PortalSelfResponse"/>.
+/// </summary>
+internal sealed record PortalUser
+{
+    /// <summary>Username of the calling principal.</summary>
+    [JsonPropertyName("username")]
+    public required string Username { get; init; }
+
+    /// <summary>Display name of the calling principal.</summary>
+    [JsonPropertyName("fullName")]
+    public string FullName { get; init; } = string.Empty;
+
+    /// <summary>Coarse role string for the calling principal.</summary>
+    [JsonPropertyName("role")]
+    public string Role { get; init; } = "org_user";
+}
+
+/// <summary>
+/// Response envelope for <c>/sharing/rest/search</c>. Matches the ArcGIS Portal
+/// search result shape (<c>total</c>/<c>start</c>/<c>num</c>/<c>nextStart</c>/
+/// <c>results</c>) so Esri clients can page through visible items.
+/// </summary>
+internal sealed record SearchResponse
+{
+    /// <summary>The search query echoed back to the caller.</summary>
+    [JsonPropertyName("query")]
+    public string Query { get; init; } = string.Empty;
+
+    /// <summary>Total number of items matching the (access-filtered) query.</summary>
+    [JsonPropertyName("total")]
+    public int Total { get; init; }
+
+    /// <summary>1-based index of the first returned result.</summary>
+    [JsonPropertyName("start")]
+    public int Start { get; init; }
+
+    /// <summary>Number of results in this page.</summary>
+    [JsonPropertyName("num")]
+    public int Num { get; init; }
+
+    /// <summary>
+    /// 1-based index of the next page's first result, or <c>-1</c> when this is the
+    /// last page (the Esri sentinel).
+    /// </summary>
+    [JsonPropertyName("nextStart")]
+    public int NextStart { get; init; }
+
+    /// <summary>The projected, access-filtered items in this page.</summary>
+    [JsonPropertyName("results")]
+    public IReadOnlyList<PortalItem> Results { get; init; } = Array.Empty<PortalItem>();
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -560,6 +560,14 @@ public static class EndpointRegistry
         new("POST", "/sharing/rest/generateToken"),
         new("GET", "/sharing/rest/generateToken"),
 
+        // ArcGIS Portal Sharing read surface (#1243).
+        new("GET", "/sharing/rest/info"),
+        new("GET", "/sharing/rest/portals/self"),
+        new("GET", "/sharing/rest/community/self"),
+        new("GET", "/sharing/rest/search"),
+        new("GET", "/sharing/rest/content/items/{id}"),
+        new("GET", "/sharing/rest/content/items/{id}/data"),
+
         new("GET", "/rest/services"),
         new("GET", "/rest/info"),
         new("GET", "/rest/services/{locatorName}/GeocodeServer"),

--- a/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
@@ -107,7 +107,8 @@ public sealed class FeatureCatalogTests
             "styling.defaults",
             "temporal.filtering",
             "temporal.extent-discovery",
-            "identity.portal-token"
+            "identity.portal-token",
+            "identity.portal-sharing"
         ]);
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingRestReadTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingRestReadTests.cs
@@ -1,0 +1,311 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Security.Domain;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests.Features.Sharing;
+
+/// <summary>
+/// Integration tests for the read-only ArcGIS Portal/Sharing REST surface (#1243):
+/// <c>info</c>, <c>portals/self</c>, <c>community/self</c>, <c>search</c>, and
+/// <c>content/items/{id}</c>. Verifies the Esri response shapes, RBAC-scoped
+/// visibility through <c>IPortalItemProjector</c>, paging, and entitlement gating.
+/// </summary>
+[Collection("Database")]
+[SecurityTest]
+[Protocol(TestProtocols.FeatureServer)]
+[Operation(Operations.Security)]
+public sealed class SharingRestReadTests : IAsyncLifetime
+{
+    private const string AdminPassword = WebAppFixture.SharedAdminPassword;
+    private const string PublicServiceId = "public-svc";
+    private const string PrivateServiceId = "private-svc";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly WebAppFixture _fixture;
+
+    public SharingRestReadTests()
+    {
+        _fixture = CreateFixture();
+    }
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    /// <summary>
+    /// Builds a fixture with a fixed Metadata v2 graph: one anonymously-readable
+    /// FeatureServer, one role-restricted FeatureServer, and one non-Esri (OGC)
+    /// service that must never project to a portal item.
+    /// </summary>
+    private static WebAppFixture CreateFixture()
+    {
+        var graph = new TestMetadataV2GraphBuilder()
+            .AddService(
+                PublicServiceId,
+                "Public Roads",
+                protocols: [ServiceProtocols.FeatureServer],
+                accessPolicy: new AccessPolicy { AllowAnonymous = true })
+            .AddService(
+                PrivateServiceId,
+                "Private Parcels",
+                protocols: [ServiceProtocols.FeatureServer],
+                accessPolicy: new AccessPolicy { AllowedRoles = ["parcel-admin"] })
+            .AddService(
+                "ogc-only",
+                "Coverage Catalog",
+                protocols: ["OgcApiFeatures"],
+                accessPolicy: new AccessPolicy { AllowAnonymous = true })
+            .Build();
+
+        var fixture = new WebAppFixture()
+            .ReplaceService<IMetadataV2GraphProvider>(new TestMetadataV2GraphProvider(graph))
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+                builder.UseSetting("Authentication:PortalToken:RequireHttps", "false");
+            });
+
+        return fixture;
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/info")]
+    public async Task Info_Anonymous_ReturnsAuthInfoShape()
+    {
+        using var client = _fixture.CreateClient();
+        using var response = await client.GetAsync("/sharing/rest/info?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        root.GetProperty("currentVersion").GetDouble().Should().BeGreaterThan(0);
+        var authInfo = root.GetProperty("authInfo");
+        authInfo.GetProperty("isTokenBasedSecurity").GetBoolean().Should().BeTrue();
+        authInfo.GetProperty("tokenServicesUrl").GetString().Should().EndWith("/sharing/rest/generateToken");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/portals/self")]
+    public async Task PortalsSelf_Anonymous_OmitsUser()
+    {
+        using var client = _fixture.CreateClient();
+        using var response = await client.GetAsync("/sharing/rest/portals/self?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        root.GetProperty("name").GetString().Should().NotBeNullOrWhiteSpace();
+        root.TryGetProperty("user", out var user).Should().BeTrue();
+        (user.ValueKind == JsonValueKind.Null).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/community/self")]
+    public async Task CommunitySelf_Anonymous_Returns401()
+    {
+        using var client = _fixture.CreateClient();
+        using var response = await client.GetAsync("/sharing/rest/community/self?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/search")]
+    public async Task Search_Anonymous_ReturnsOnlyPublicItemsWithPagingShape()
+    {
+        using var client = _fixture.CreateClient();
+        using var response = await client.GetAsync("/sharing/rest/search?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await ReadSearchAsync(response);
+
+        payload.Total.Should().Be(1);
+        payload.Start.Should().Be(1);
+        payload.Num.Should().Be(1);
+        payload.NextStart.Should().Be(-1);
+        payload.Results.Should().ContainSingle();
+        payload.Results[0].Id.Should().Be(PublicServiceId);
+        payload.Results[0].Access.Should().Be("public");
+        payload.Results[0].Type.Should().Be("Feature Service");
+        // The role-restricted and non-Esri services must never surface to anon.
+        payload.Results.Should().NotContain(r => r.Id == PrivateServiceId);
+        payload.Results.Should().NotContain(r => r.Id == "ogc-only");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/search")]
+    public async Task Search_WithPaging_HonorsStartAndNum()
+    {
+        using var client = _fixture.CreateClient();
+        // num=0 is invalid -> default; request the second page of a single-item set.
+        using var response = await client.GetAsync("/sharing/rest/search?f=json&start=2&num=10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await ReadSearchAsync(response);
+        payload.Total.Should().Be(1);
+        payload.Num.Should().Be(0);
+        payload.Results.Should().BeEmpty();
+        payload.NextStart.Should().Be(-1);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/search")]
+    public async Task Search_WithTypeQualifier_FiltersByType()
+    {
+        using var client = _fixture.CreateClient();
+        using var response = await client.GetAsync("/sharing/rest/search?f=json&q=type:Feature");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await ReadSearchAsync(response);
+        payload.Results.Should().NotBeEmpty();
+        payload.Results.Should().OnlyContain(r => r.Type == "Feature Service");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/content/items/{id}")]
+    public async Task ContentItem_PublicItem_RoundTrips()
+    {
+        using var client = _fixture.CreateClient();
+        using var response = await client.GetAsync($"/sharing/rest/content/items/{PublicServiceId}?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        root.GetProperty("id").GetString().Should().Be(PublicServiceId);
+        root.GetProperty("title").GetString().Should().Be("Public Roads");
+        root.GetProperty("url").GetString().Should().Contain("/rest/services/");
+        root.GetProperty("url").GetString().Should().EndWith("/FeatureServer");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/content/items/{id}/data")]
+    public async Task ContentItemData_PublicItem_RoundTrips()
+    {
+        using var client = _fixture.CreateClient();
+        using var response = await client.GetAsync($"/sharing/rest/content/items/{PublicServiceId}/data?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("id").GetString().Should().Be(PublicServiceId);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/content/items/{id}")]
+    public async Task ContentItem_RoleRestrictedItem_AnonymousGets404()
+    {
+        using var client = _fixture.CreateClient();
+        using var response = await client.GetAsync($"/sharing/rest/content/items/{PrivateServiceId}?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        // Esri-shaped error envelope: { error: { code, message, details } }.
+        var error = doc.RootElement.GetProperty("error");
+        error.GetProperty("code").GetInt32().Should().Be(404);
+        error.TryGetProperty("message", out _).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/content/items/{id}")]
+    public async Task ContentItem_UnknownId_Returns404()
+    {
+        using var client = _fixture.CreateClient();
+        using var response = await client.GetAsync("/sharing/rest/content/items/does-not-exist?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/search")]
+    public async Task ReadSurface_WhenEntitlementDisabled_Returns404()
+    {
+        var fixture = new WebAppFixture()
+            .ReplaceService<IMetadataV2GraphProvider>(new TestMetadataV2GraphProvider(
+                new TestMetadataV2GraphBuilder()
+                    .AddService(PublicServiceId, "Public Roads",
+                        protocols: [ServiceProtocols.FeatureServer],
+                        accessPolicy: new AccessPolicy { AllowAnonymous = true })
+                    .Build()))
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+                builder.UseSetting("Authentication:PortalToken:RequireHttps", "false");
+                // Disable the read surface -> whole surface 404s.
+                builder.UseSetting("Sharing:ReadSurface:Enabled", "false");
+            });
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateClient();
+            using var searchResponse = await client.GetAsync("/sharing/rest/search?f=json");
+            using var infoResponse = await client.GetAsync("/sharing/rest/info?f=json");
+            using var itemResponse = await client.GetAsync($"/sharing/rest/content/items/{PublicServiceId}?f=json");
+
+            searchResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            infoResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            itemResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    private static async Task<SearchPayload> ReadSearchAsync(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<SearchPayload>(json, JsonOptions)
+            ?? throw new InvalidOperationException("Empty search response body.");
+    }
+
+    private sealed record SearchPayload
+    {
+        public int Total { get; init; }
+
+        public int Start { get; init; }
+
+        public int Num { get; init; }
+
+        public int NextStart { get; init; }
+
+        public ItemPayload[] Results { get; init; } = Array.Empty<ItemPayload>();
+    }
+
+    private sealed record ItemPayload
+    {
+        public string Id { get; init; } = string.Empty;
+
+        public string Type { get; init; } = string.Empty;
+
+        public string Access { get; init; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #1243

## Summary
Adds the read-only ArcGIS Portal/Sharing REST facade alongside the existing `generateToken` endpoint (#1241), implemented as a thin Minimal-API adapter over the trunk dependencies: the RBAC-aware `IPortalItemProjector` (#1393), the access/visibility seam (#1392), and the shared metadata graph + base-URL/error helpers. No new metadata or ACL logic is introduced.

## Changes Made
- Read endpoints in `SharingRestEndpoints.cs`:
  - `GET /sharing/rest/info` — portal version + token auth info (`tokenServicesUrl` honours forwarded scheme/host via `BaseUrlResolver`).
  - `GET /sharing/rest/portals/self` and `community/self` — RBAC-scoped self; anonymous `community/self` returns Esri 401.
  - `GET /sharing/rest/search` — projects visible items through `IPortalItemProjector.ProjectVisibleItems`, with Esri paging (`total`/`start`/`num`/`nextStart`/`results`), quote-aware `q` filtering (`type:`/`owner:`/`tags:`/`title:`/`id:` + free text) and `sortField`/`sortOrder`.
  - `GET /sharing/rest/content/items/{id}` and `/data` — single item via `ProjectItem`; 404 (Esri envelope) when unknown or not visible, so hidden items never leak.
- Esri response shapes in `SharingRestReadModels.cs`; registered in `SharingRestJsonContext`.
- Visibility/entitlement gating: surface 404s when the `identity.portal-sharing` entitlement is inactive or `Sharing:ReadSurface:Enabled=false` (off-switch, never a silent discovery surface). New `identity.portal-sharing` feature (Community) in `FeatureCatalog`.
- Classified `/sharing/rest` (and `/rest/info`) as GeoServices in `ProtocolRequestClassifier` so error responses use the `{error:{code,message,details}}` envelope.
- Registered the new routes in `EndpointRegistry`. The `/rest/info` alias is intentionally left to the existing catalog endpoint to avoid an ambiguous route.

## Testing
- [x] Integration tests added/updated
- [x] Architecture tests pass

`SharingRestReadTests` (11 tests, all green): info/portals-self/community-self shapes, anonymous search returns only public items with correct paging, paging beyond range, `type:` qualifier filtering, item + `/data` round-trip, unpermitted principal 404 with Esri error envelope, unknown-id 404, and whole-surface 404 when disabled. Existing `SharingRestTokenTests` (12) and architecture drift/coverage tests pass; no regressions.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent (dotnet build warnings-as-errors + targeted tests + dotnet format verified); full matrix via CI below
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract

References #1240, #1392, #1393, #1241. OAuth2 named-user bridge deferred to #1242.
