### PR TITLE
feat: route remaining protocol adapters through canonical RBAC resolver (#1376)

### DIFF
--- a/docs/contributor/adr/0049-single-auth-identity-token-foundation.md
+++ b/docs/contributor/adr/0049-single-auth-identity-token-foundation.md
@@ -119,8 +119,24 @@ real (#1374 + #1375):
   per-operation grants, **falling back to the coarse `AccessPolicy` when no
   grant matches** (no behavior change for unconfigured services).
 
-Deferred to **#1376**: re-wiring every protocol adapter to call the resolver
-with the full per-operation taxonomy (the cross-protocol conformance matrix).
+- **#1376** — re-wired the remaining protocol adapters to the shared
+  `AccessPolicyHelpers` seam with the full per-operation taxonomy, so a
+  per-operation grant is honored consistently across surfaces: GeoServices
+  FeatureServer (query + edits/applyEdits/append/calculate/related-records/
+  attachments), OData (query + CRUD + batch), OGC API Features (read +
+  mutations), OGC API Tiles, WFS (GetFeature read filter + Transaction), and
+  gRPC. Routing happens centrally through the shared layer/collection/service
+  validators (`LayerValidationHelpers`, `ServiceResourceValidationHelpers`) plus
+  the write data-editor gate (`ServiceDataEditorAuthorization`), keeping adapters
+  thin. Explicit `AccessPolicy` write restrictions stay authoritative over the
+  resolver for writes; absent a grant, every surface falls back to the coarse
+  `AccessPolicy` exactly as before. A cross-protocol conformance matrix
+  (`CrossProtocolPermissionMatrixTests`) proves grant-honored vs no-grant-fallback
+  per protocol. MCP resource/tool access is intentionally out of scope: it
+  authorizes against the distinct operator-grant taxonomy
+  (`OperatorResourceType`/`OperatorOperation`), not the per-layer/service
+  `AuthorizationOperation` taxonomy, so it is tracked as a separate follow-up.
+
 Deferred to **#1242**: the OAuth2 bridge itself.
 
 ## Cross-references
@@ -128,4 +144,4 @@ Deferred to **#1242**: the OAuth2 bridge itself.
 - Complements ADR-0024 (Open-Core Edition Model) and the RBAC enforcement model.
 - Linked from #348 (OIDC SSO), #349 (RBAC tracking), #1240 (ArcGIS portal
   facade), #1242 (ArcGIS OAuth2 named-user), #1374 (persistent store),
-  #1375 (resolver).
+  #1375 (resolver), #1376 (cross-protocol per-operation enforcement).

--- a/src/Honua.Hosting/Features/Authentication/AccessPolicyHelpers.cs
+++ b/src/Honua.Hosting/Features/Authentication/AccessPolicyHelpers.cs
@@ -88,11 +88,40 @@ internal static class AccessPolicyHelpers
     /// <param name="scope">The requested access scope (read/write).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An error result when denied, otherwise <see langword="null"/>.</returns>
-    public static async Task<IResult?> RequireResourceAccessAsync(
+    public static Task<IResult?> RequireResourceAccessAsync(
         HttpContext context,
         MetadataV2Resource resource,
         MetadataV2Service? service = null,
         AccessScope scope = AccessScope.Read,
+        CancellationToken cancellationToken = default)
+        => RequireResourceAccessAsync(
+            context,
+            resource,
+            DefaultOperationForScope(scope),
+            service,
+            cancellationToken);
+
+    /// <summary>
+    /// Operation-aware resource access check (#1376). Routes the request through
+    /// the canonical per-operation permission resolver for the supplied
+    /// <see cref="AuthorizationOperation"/>, then falls back to the coarse
+    /// <see cref="AccessPolicy"/> seam (using the scope implied by the operation)
+    /// when no grant matches. This is the shared seam every protocol adapter
+    /// re-wires to so a per-operation grant (e.g. allow <c>query</c> but deny
+    /// <c>update</c>) is honored consistently across surfaces while services with
+    /// no per-operation grants keep their current coarse behavior.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <param name="resource">The resource (layer) being accessed.</param>
+    /// <param name="operation">The canonical operation being authorized.</param>
+    /// <param name="service">The owning service, when known.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An error result when denied, otherwise <see langword="null"/>.</returns>
+    public static async Task<IResult?> RequireResourceAccessAsync(
+        HttpContext context,
+        MetadataV2Resource resource,
+        AuthorizationOperation operation,
+        MetadataV2Service? service = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(resource);
@@ -104,7 +133,7 @@ internal static class AccessPolicyHelpers
                 context,
                 serviceName,
                 resource.Metadata.Name,
-                scope,
+                operation,
                 cancellationToken).ConfigureAwait(false);
 
             // An explicit per-operation grant authorizes the request directly.
@@ -116,8 +145,116 @@ internal static class AccessPolicyHelpers
 
         // No matching grant (or no service context): preserve current behavior
         // by falling back to the coarse AccessPolicy evaluation.
-        return RequireAccess(context, resource.AccessPolicy, service?.AccessPolicy, scope);
+        return RequireAccess(context, resource.AccessPolicy, service?.AccessPolicy, ScopeForOperation(operation));
     }
+
+    /// <summary>
+    /// Service-level operation-aware access check (#1376). Mirrors
+    /// <see cref="RequireResourceAccessAsync(HttpContext, MetadataV2Resource, AuthorizationOperation, MetadataV2Service?, CancellationToken)"/>
+    /// for service-scoped operations (no specific layer), consulting the resolver
+    /// with a wildcard layer then falling back to the coarse service policy.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <param name="service">The service being accessed.</param>
+    /// <param name="operation">The canonical operation being authorized.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An error result when denied, otherwise <see langword="null"/>.</returns>
+    public static async Task<IResult?> RequireServiceAccessAsync(
+        HttpContext context,
+        MetadataV2Service service,
+        AuthorizationOperation operation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+
+        var serviceName = service.Metadata.Name;
+        if (!string.IsNullOrWhiteSpace(serviceName))
+        {
+            var grantDecision = await EvaluateGrantAsync(
+                context,
+                serviceName,
+                layerName: null,
+                operation,
+                cancellationToken).ConfigureAwait(false);
+
+            if (grantDecision == GrantOutcome.Allow)
+            {
+                return null;
+            }
+        }
+
+        return RequireAccess(context, null, service.AccessPolicy, ScopeForOperation(operation));
+    }
+
+    /// <summary>
+    /// Operation-aware resource access evaluation that returns an
+    /// <see cref="AccessDecision"/> (rather than an <see cref="IResult"/>) for
+    /// non-HTTP adapters such as gRPC (#1376). Consults the resolver first and
+    /// reports the matched grant as an allowed decision; otherwise it falls back
+    /// to the coarse <see cref="AccessPolicy"/> evaluation for the implied scope.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <param name="resource">The resource (layer) being accessed.</param>
+    /// <param name="service">The owning service, when known.</param>
+    /// <param name="operation">The canonical operation being authorized.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The access decision.</returns>
+    public static async Task<AccessDecision> EvaluateResourceAccessAsync(
+        HttpContext context,
+        MetadataV2Resource resource,
+        MetadataV2Service? service,
+        AuthorizationOperation operation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        var serviceName = service?.Metadata.Name;
+        if (!string.IsNullOrWhiteSpace(serviceName))
+        {
+            var grantDecision = await EvaluateGrantAsync(
+                context,
+                serviceName,
+                resource.Metadata.Name,
+                operation,
+                cancellationToken).ConfigureAwait(false);
+
+            if (grantDecision == GrantOutcome.Allow)
+            {
+                return AccessDecision.Allowed();
+            }
+        }
+
+        return EvaluateAccess(context, resource.AccessPolicy, service?.AccessPolicy, ScopeForOperation(operation));
+    }
+
+    /// <summary>
+    /// Maps an <see cref="AccessScope"/> to the canonical read/write operation it
+    /// implies. Read scope maps to <see cref="AuthorizationOperation.Query"/> and
+    /// write scope to <see cref="AuthorizationOperation.Update"/>; callers that
+    /// distinguish insert/delete/export/metadata should use the operation-aware
+    /// overloads directly.
+    /// </summary>
+    /// <param name="scope">The coarse access scope.</param>
+    /// <returns>The implied canonical operation.</returns>
+    public static AuthorizationOperation DefaultOperationForScope(AccessScope scope)
+        => scope == AccessScope.Write
+            ? AuthorizationOperation.Update
+            : AuthorizationOperation.Query;
+
+    /// <summary>
+    /// Maps a canonical operation back to the coarse <see cref="AccessScope"/>
+    /// used by the legacy <see cref="AccessPolicy"/> fallback. Mutating operations
+    /// (insert/update/delete/admin) require write scope; read-style operations
+    /// (query/read/metadata/export) require read scope.
+    /// </summary>
+    private static AccessScope ScopeForOperation(AuthorizationOperation operation) => operation switch
+    {
+        AuthorizationOperation.Insert => AccessScope.Write,
+        AuthorizationOperation.Update => AccessScope.Write,
+        AuthorizationOperation.Delete => AccessScope.Write,
+        AuthorizationOperation.Admin => AccessScope.Write,
+        _ => AccessScope.Read,
+    };
 
     /// <summary>
     /// Consults the per-operation permission resolver for the supplied
@@ -128,7 +265,7 @@ internal static class AccessPolicyHelpers
         HttpContext context,
         string serviceName,
         string? layerName,
-        AccessScope scope,
+        AuthorizationOperation operation,
         CancellationToken cancellationToken)
     {
         var resolver = context.RequestServices.GetService<IPermissionResolver>();
@@ -150,10 +287,6 @@ internal static class AccessPolicyHelpers
             ?? principal.FindFirstValue("sub")
             ?? string.Empty;
         var isAuthenticated = principal.Identity?.IsAuthenticated == true;
-
-        var operation = scope == AccessScope.Write
-            ? AuthorizationOperation.Update
-            : AuthorizationOperation.Query;
 
         var decision = await resolver.AuthorizeAsync(
             userId,
@@ -217,6 +350,32 @@ internal static class AccessPolicyHelpers
     {
         ArgumentNullException.ThrowIfNull(resource);
         return EvaluateAccess(context, resource.AccessPolicy, service?.AccessPolicy, scope).IsAllowed;
+    }
+
+    /// <summary>
+    /// Resolver-aware accessibility predicate (#1376). Consults the canonical
+    /// per-operation permission resolver for the supplied operation first; when no
+    /// grant matches it falls back to the coarse <see cref="AccessPolicy"/>
+    /// evaluation, so visibility filtering (e.g. WFS GetFeature published types)
+    /// honors per-operation grants while ungranted services behave as before.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <param name="resource">The resource (layer) being accessed.</param>
+    /// <param name="service">The owning service, when known.</param>
+    /// <param name="operation">The canonical operation being authorized.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see langword="true"/> when the resource is accessible.</returns>
+    public static async Task<bool> IsResourceAccessibleAsync(
+        HttpContext context,
+        MetadataV2Resource resource,
+        MetadataV2Service? service,
+        AuthorizationOperation operation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        var decision = await EvaluateResourceAccessAsync(
+            context, resource, service, operation, cancellationToken).ConfigureAwait(false);
+        return decision.IsAllowed;
     }
 
     public static bool AllowsAnonymousResourceAccess(

--- a/src/Honua.Hosting/Features/Authentication/ServiceDataEditorAuthorization.cs
+++ b/src/Honua.Hosting/Features/Authentication/ServiceDataEditorAuthorization.cs
@@ -2,11 +2,14 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Security.Claims;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Security.Domain;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Validation;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using AccessDecision = Honua.Core.Features.Security.Domain.AccessDecision;
 
@@ -32,8 +35,24 @@ internal static class ServiceDataEditorAuthorization
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(service);
-        var decision = EvaluateExplicitWritePolicy(context, null, service.AccessPolicy)
-            ?? await EvaluateServiceAccessAsync(context, service.Metadata.Name, cancellationToken).ConfigureAwait(false);
+
+        // An explicit AccessPolicy write restriction stays authoritative (it is a
+        // deliberate per-resource grant/deny and must not be widened by a wildcard
+        // RBAC grant). When no explicit write policy applies, a per-operation RBAC
+        // write grant (#1376) authorizes the mutation, bypassing the coarse
+        // data-editor role gate; absent any grant, behavior is unchanged.
+        var explicitDecision = EvaluateExplicitWritePolicy(context, null, service.AccessPolicy);
+        if (explicitDecision is not null)
+        {
+            return CreateDecisionResult(context, explicitDecision.Value);
+        }
+
+        if (await HasWriteGrantAsync(context, service.Metadata.Name, layerName: null, cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        var decision = await EvaluateServiceAccessAsync(context, service.Metadata.Name, cancellationToken).ConfigureAwait(false);
         return CreateDecisionResult(context, decision);
     }
 
@@ -44,10 +63,23 @@ internal static class ServiceDataEditorAuthorization
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(resource);
+
+        // An explicit AccessPolicy write restriction stays authoritative (a
+        // deliberate per-resource grant/deny must not be widened by a wildcard
+        // RBAC grant), matching pre-#1376 behavior.
         var explicitDecision = EvaluateExplicitWritePolicy(context, resource.AccessPolicy, service?.AccessPolicy);
         if (explicitDecision is not null)
         {
             return CreateDecisionResult(context, explicitDecision.Value);
+        }
+
+        // No explicit write policy: a per-operation RBAC write grant (#1376) on
+        // the (service, layer) authorizes the mutation, bypassing the coarse
+        // data-editor role gate. Absent any grant, behavior is unchanged.
+        if (service is not null &&
+            await HasWriteGrantAsync(context, service.Metadata.Name, resource.Metadata.Name, cancellationToken).ConfigureAwait(false))
+        {
+            return null;
         }
 
         if (service is null)
@@ -102,6 +134,71 @@ internal static class ServiceDataEditorAuthorization
 
     private static IResult? CreateDecisionResult(HttpContext context, AccessDecision decision)
         => AccessPolicyHelpers.CreateAccessDeniedResult(context, decision);
+
+    /// <summary>
+    /// Consults the canonical per-operation permission resolver (#1376) for any
+    /// write-class grant (insert/update/delete) over the supplied
+    /// <c>(service, layer)</c>. Returns <see langword="true"/> when an explicit
+    /// grant authorizes a mutation, letting the write gate honor per-operation
+    /// grants. When no resolver is registered, no roles are present, or no grant
+    /// matches, returns <see langword="false"/> so the coarse data-editor gate
+    /// applies unchanged.
+    /// </summary>
+    private static async Task<bool> HasWriteGrantAsync(
+        HttpContext context,
+        string serviceName,
+        string? layerName,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(serviceName))
+        {
+            return false;
+        }
+
+        var resolver = context.RequestServices.GetService<IPermissionResolver>();
+        if (resolver is null)
+        {
+            return false;
+        }
+
+        var principal = context.User;
+        var options = context.RequestServices.GetRequiredService<IOptions<RbacOptions>>().Value;
+        var roles = EnumerateRoles(principal, options).ToList();
+        if (roles.Count == 0)
+        {
+            return false;
+        }
+
+        var userId = principal.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? principal.FindFirstValue("sub")
+            ?? string.Empty;
+        var isAuthenticated = principal.Identity?.IsAuthenticated == true;
+
+        foreach (var operation in WriteOperations)
+        {
+            var decision = await resolver.AuthorizeAsync(
+                userId,
+                roles,
+                serviceName,
+                layerName,
+                operation,
+                isAuthenticated,
+                cancellationToken).ConfigureAwait(false);
+            if (decision.IsAllowed)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static readonly AuthorizationOperation[] WriteOperations =
+    [
+        AuthorizationOperation.Insert,
+        AuthorizationOperation.Update,
+        AuthorizationOperation.Delete,
+    ];
 
     private static AccessDecision? EvaluateExplicitWritePolicy(
         HttpContext context,

--- a/src/Honua.Hosting/Features/Helpers/ServiceResourceValidationHelpers.cs
+++ b/src/Honua.Hosting/Features/Helpers/ServiceResourceValidationHelpers.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Infrastructure.Authentication;
@@ -82,7 +83,8 @@ internal static class ServiceResourceValidationHelpers
 
         if (requireServiceAccess)
         {
-            var accessError = AccessPolicyHelpers.RequireServiceAccess(context, service);
+            var accessError = await AccessPolicyHelpers.RequireServiceAccessAsync(
+                context, service, AuthorizationOperation.Query, cancellationToken).ConfigureAwait(false);
             if (accessError != null)
             {
                 return new ServiceValidationV2Result(false, null, accessError);

--- a/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
+++ b/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
@@ -135,7 +135,13 @@ internal static class LayerValidationHelpers
             return new MetadataV2ValidationResult(false, null, null, null, error);
         }
 
-        var accessError = AccessPolicyHelpers.RequireResourceAccess(context, resource, service, scope);
+        // Per-operation RBAC grants are consulted first (#1376) via the shared
+        // seam; the coarse AccessPolicy is the no-grant fallback. This central
+        // validator is the enforcement point for OData / OGC API Features / WFS /
+        // tiles / STAC layer reads & mutations, so wiring it here re-routes those
+        // adapters through the resolver consistently.
+        var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+            context, resource, service, scope, effectiveToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return new MetadataV2ValidationResult(false, publication, resource, service, accessError);
@@ -177,7 +183,8 @@ internal static class LayerValidationHelpers
             return new MetadataV2ValidationResult(false, null, null, null, error);
         }
 
-        var accessError = AccessPolicyHelpers.RequireResourceAccess(context, resource, service, scope);
+        var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+            context, resource, service, scope, cancellationToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return new MetadataV2ValidationResult(false, publication, resource, service, accessError);
@@ -278,7 +285,8 @@ internal static class LayerValidationHelpers
                 StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found."));
         }
 
-        var accessError = AccessPolicyHelpers.RequireResourceAccess(context, resource, service, scope);
+        var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+            context, resource, service, scope, cancellationToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return new MetadataV2ValidationResult(false, publication, resource, service, accessError);
@@ -730,7 +738,8 @@ internal static class LayerValidationHelpers
                     context, $"{requiredProtocol} is not enabled for service '{serviceName}'."));
         }
 
-        var serviceAccessError = AccessPolicyHelpers.RequireServiceAccess(context, service, scope);
+        var serviceAccessError = await AccessPolicyHelpers.RequireServiceAccessAsync(
+            context, service, AccessPolicyHelpers.DefaultOperationForScope(scope), cancellationToken).ConfigureAwait(false);
         if (serviceAccessError != null)
         {
             return new MetadataV2ServiceValidationResult(false, service, [], [], serviceAccessError);

--- a/src/Honua.Protocols.GeoServices/FeatureServer/AttachmentEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/AttachmentEndpoints.cs
@@ -633,7 +633,12 @@ internal static class AttachmentEndpoints
         var publication = validationResult.Publication!;
         var resource = validationResult.Resource!;
 
-        var accessError = AccessPolicyHelpers.RequireResourceAccess(context, resource, service, scope);
+        var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+            context,
+            resource,
+            AccessPolicyHelpers.DefaultOperationForScope(scope),
+            service,
+            context.RequestAborted).ConfigureAwait(false);
         if (accessError != null)
         {
             await accessError.ExecuteAsync(context);

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
@@ -9,6 +9,7 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Shared.Models;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Core.Queries.Filters;
 using Honua.Protocols.GeoServices;
@@ -88,7 +89,8 @@ internal sealed class FeatureServerEditsHandler(
             var service = validationResult.Service!;
             var publication = validationResult.Publication!;
             var resource = validationResult.Resource!;
-            var accessError = AccessPolicyHelpers.RequireResourceAccess(httpContext, resource, service, AccessScope.Write);
+            var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+                httpContext, resource, AuthorizationOperation.Update, service, cancellationToken).ConfigureAwait(false);
             if (accessError != null)
             {
                 return accessError;

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRelatedRecordsHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRelatedRecordsHandler.cs
@@ -5,6 +5,7 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Shared.Models;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Core.Queries.Filters;
 using Honua.Protocols.GeoServices.FeatureServer.Models;
@@ -68,7 +69,8 @@ internal sealed class FeatureServerRelatedRecordsHandler(
             var service = resourceValidationResult.Service!;
             var publication = resourceValidationResult.Publication!;
             var resource = resourceValidationResult.Resource!;
-            var accessError = AccessPolicyHelpers.RequireResourceAccess(httpContext, resource, service);
+            var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+                httpContext, resource, AuthorizationOperation.Query, service, cancellationToken).ConfigureAwait(false);
             if (accessError != null)
             {
                 return accessError;
@@ -144,7 +146,8 @@ internal sealed class FeatureServerRelatedRecordsHandler(
             var resolvedRelatedResource = relatedResource!;
             var resolvedRelatedPublication = relatedPublication!;
 
-            accessError = AccessPolicyHelpers.RequireResourceAccess(httpContext, resolvedRelatedResource, service);
+            accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+                httpContext, resolvedRelatedResource, AuthorizationOperation.Query, service, cancellationToken).ConfigureAwait(false);
             if (accessError != null)
             {
                 return accessError;

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Edits.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Edits.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Text.Json;
 using Honua.Core.Configuration;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
@@ -289,7 +290,8 @@ internal static partial class FeatureServerEndpoints
         var service = validationResult.Service!;
         var publication = validationResult.Publication!;
         var resource = validationResult.Resource!;
-        var accessError = AccessPolicyHelpers.RequireResourceAccess(context, resource, service, AccessScope.Write);
+        var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+            context, resource, AuthorizationOperation.Delete, service, cancellationToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return (null, accessError);
@@ -645,7 +647,8 @@ internal static partial class FeatureServerEndpoints
 
         var service = validationResult.Service!;
         var resource = validationResult.Resource!;
-        var accessError = AccessPolicyHelpers.RequireResourceAccess(context, resource, service, AccessScope.Write);
+        var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+            context, resource, AuthorizationOperation.Update, service, cancellationToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return accessError;
@@ -676,7 +679,8 @@ internal static partial class FeatureServerEndpoints
         }
 
         var service = validationResult.Service!;
-        var accessError = AccessPolicyHelpers.RequireServiceAccess(context, service, AccessScope.Write);
+        var accessError = await AccessPolicyHelpers.RequireServiceAccessAsync(
+            context, service, AuthorizationOperation.Update, cancellationToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return accessError;

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Text.Json;
 using Honua.Core.Configuration;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
@@ -77,7 +78,8 @@ internal static partial class FeatureServerEndpoints
 
         var service = validationResult.Service!;
         var resource = validationResult.Resource!;
-        var accessError = AccessPolicyHelpers.RequireResourceAccess(context, resource, service, AccessScope.Write);
+        var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+            context, resource, AuthorizationOperation.Insert, service, cancellationToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return accessError;
@@ -146,7 +148,8 @@ internal static partial class FeatureServerEndpoints
 
         var service = validationResult.Service!;
         var resource = validationResult.Resource!;
-        var accessError = AccessPolicyHelpers.RequireResourceAccess(context, resource, service, AccessScope.Write);
+        var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+            context, resource, AuthorizationOperation.Insert, service, cancellationToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return accessError;
@@ -232,7 +235,8 @@ internal static partial class FeatureServerEndpoints
         var service = validationResult.Service!;
         var publication = validationResult.Publication!;
         var resource = validationResult.Resource!;
-        var accessError = AccessPolicyHelpers.RequireResourceAccess(context, resource, service, AccessScope.Write);
+        var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+            context, resource, AuthorizationOperation.Update, service, cancellationToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return accessError;
@@ -828,7 +832,8 @@ internal static partial class FeatureServerEndpoints
 
         var service = validationResult.Service!;
         var resource = validationResult.Resource!;
-        var accessError = AccessPolicyHelpers.RequireResourceAccess(context, resource, service);
+        var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+            context, resource, AuthorizationOperation.Query, service, cancellationToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return accessError;

--- a/src/Honua.Protocols.OgcApi/Tiles/TilesEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Tiles/TilesEndpoints.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using Honua.Core.Configuration;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
@@ -264,7 +265,7 @@ internal static partial class TilesEndpoints
 
         var cancellationToken = OgcTilesUtilities.GetTimeoutAwareCancellationToken(context);
         var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
-        var resolution = ResolveCollectionLayer(context, snapshot, collectionId, missingCollectionIsBadRequest: false);
+        var resolution = await ResolveCollectionLayer(context, snapshot, collectionId, missingCollectionIsBadRequest: false, cancellationToken).ConfigureAwait(false);
         if (resolution.Error is not null)
         {
             return resolution.Error;
@@ -312,7 +313,7 @@ internal static partial class TilesEndpoints
 
         var cancellationToken = OgcTilesUtilities.GetTimeoutAwareCancellationToken(context);
         var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
-        var resolution = ResolveCollectionLayer(context, snapshot, collectionId, missingCollectionIsBadRequest: false);
+        var resolution = await ResolveCollectionLayer(context, snapshot, collectionId, missingCollectionIsBadRequest: false, cancellationToken).ConfigureAwait(false);
         if (resolution.Error is not null)
         {
             return resolution.Error;
@@ -375,7 +376,7 @@ internal static partial class TilesEndpoints
             async cancellationToken =>
             {
                 var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
-                var resolution = ResolveCollectionLayer(context, snapshot, collectionId, missingCollectionIsBadRequest: false);
+                var resolution = await ResolveCollectionLayer(context, snapshot, collectionId, missingCollectionIsBadRequest: false, cancellationToken).ConfigureAwait(false);
                 if (resolution.Error is not null)
                 {
                     return (Array.Empty<TileRequestLayer>(), resolution.Error);
@@ -1138,7 +1139,7 @@ internal static partial class TilesEndpoints
         var selectedLayers = new List<TileRequestLayer>(collectionIds.Length);
         foreach (var collectionId in collectionIds)
         {
-            var resolution = ResolveCollectionLayer(context, snapshot, collectionId, missingCollectionIsBadRequest: true);
+            var resolution = await ResolveCollectionLayer(context, snapshot, collectionId, missingCollectionIsBadRequest: true, cancellationToken).ConfigureAwait(false);
             if (resolution.Error is not null)
             {
                 return (Array.Empty<TileRequestLayer>(), resolution.Error);
@@ -1195,11 +1196,12 @@ internal static partial class TilesEndpoints
         return true;
     }
 
-    private static TileRequestLayerResolution ResolveCollectionLayer(
+    private static async Task<TileRequestLayerResolution> ResolveCollectionLayer(
         HttpContext context,
         MetadataV2GraphSnapshot snapshot,
         string collectionId,
-        bool missingCollectionIsBadRequest)
+        bool missingCollectionIsBadRequest,
+        CancellationToken cancellationToken)
     {
         var publication = FindCollectionPublication(snapshot, collectionId, requireProtocol: true, out var service);
         if (publication is null || service is null)
@@ -1220,7 +1222,10 @@ internal static partial class TilesEndpoints
             return new TileRequestLayerResolution(null, error);
         }
 
-        var accessError = AccessPolicyHelpers.RequireResourceAccess(context, resource, service);
+        // Tiles are a read surface: consult the per-operation resolver for the
+        // query grant first (#1376), falling back to the coarse AccessPolicy.
+        var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+            context, resource, AuthorizationOperation.Query, service, cancellationToken).ConfigureAwait(false);
         if (accessError is not null)
         {
             return new TileRequestLayerResolution(null, accessError);

--- a/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Capabilities.cs
+++ b/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Capabilities.cs
@@ -15,6 +15,7 @@ using Honua.Core.Configuration;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Shared.Models;
@@ -153,7 +154,12 @@ internal sealed partial class Wfs20Handler
 
             var resource = snapshot.ResolveResource(publication);
             if (resource is null ||
-                !AccessPolicyHelpers.IsResourceAccessible(context, resource, service))
+                !await AccessPolicyHelpers.IsResourceAccessibleAsync(
+                    context,
+                    resource,
+                    service,
+                    AuthorizationOperation.Query,
+                    cancellationToken).ConfigureAwait(false))
             {
                 continue;
             }

--- a/src/Honua.Server/Features/Protocols/Grpc/HonuaFeatureService.cs
+++ b/src/Honua.Server/Features/Protocols/Grpc/HonuaFeatureService.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using Grpc.Core;
 using Honua.Core.Configuration;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
@@ -103,7 +104,7 @@ internal sealed class HonuaFeatureService : Proto.FeatureService.FeatureServiceB
 
         var layer = await ValidateGrpcLayerAsync(
             request.ServiceId, request.LayerId, context.CancellationToken).ConfigureAwait(false);
-        EnsureReadAccess(context, layer.Service, layer.Resource);
+        await EnsureReadAccessAsync(context, layer.Service, layer.Resource).ConfigureAwait(false);
         var queryContext = await CreateQueryContextAsync(request, layer, context.CancellationToken).ConfigureAwait(false);
         var query = queryContext.Query;
         var pkField = layer.ObjectIdFieldName;
@@ -175,7 +176,7 @@ internal sealed class HonuaFeatureService : Proto.FeatureService.FeatureServiceB
 
         var layer = await ValidateGrpcLayerAsync(
             request.ServiceId, request.LayerId, context.CancellationToken).ConfigureAwait(false);
-        EnsureReadAccess(context, layer.Service, layer.Resource);
+        await EnsureReadAccessAsync(context, layer.Service, layer.Resource).ConfigureAwait(false);
         var queryContext = await CreateQueryContextAsync(request, layer, context.CancellationToken).ConfigureAwait(false);
         var query = queryContext.Query;
         var pkField = layer.ObjectIdFieldName;
@@ -654,11 +655,15 @@ internal sealed class HonuaFeatureService : Proto.FeatureService.FeatureServiceB
     {
         var httpContext = context.GetHttpContext();
 
-        var decision = AccessPolicyHelpers.EvaluateAccess(
+        // Per-operation RBAC grants are consulted first (#1376); when a grant
+        // matches the request is authorized directly. Otherwise we fall through
+        // to the coarse AccessPolicy + scoped data-editor behavior unchanged.
+        var decision = await AccessPolicyHelpers.EvaluateResourceAccessAsync(
             httpContext,
-            resource.AccessPolicy,
-            service.AccessPolicy,
-            AccessScope.Write);
+            resource,
+            service,
+            AuthorizationOperation.Update,
+            context.CancellationToken).ConfigureAwait(false);
 
         ThrowIfAccessDenied(decision);
 
@@ -675,18 +680,21 @@ internal sealed class HonuaFeatureService : Proto.FeatureService.FeatureServiceB
         ThrowIfAccessDenied(rbacDecision);
     }
 
-    private static void EnsureReadAccess(
+    private static async Task EnsureReadAccessAsync(
         ServerCallContext context,
         MetadataV2Service service,
         MetadataV2Resource resource)
     {
         var httpContext = context.GetHttpContext();
 
-        var decision = AccessPolicyHelpers.EvaluateAccess(
+        // Per-operation RBAC grants are consulted first (#1376) via the shared
+        // seam; the coarse AccessPolicy read evaluation is the no-grant fallback.
+        var decision = await AccessPolicyHelpers.EvaluateResourceAccessAsync(
             httpContext,
-            resource.AccessPolicy,
-            service.AccessPolicy,
-            AccessScope.Read);
+            resource,
+            service,
+            AuthorizationOperation.Query,
+            context.CancellationToken).ConfigureAwait(false);
 
         ThrowIfAccessDenied(decision);
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcFeatureServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcFeatureServiceTests.cs
@@ -6,6 +6,9 @@ using System.Security.Claims;
 using FluentAssertions;
 using Grpc.Core;
 using Honua.Core.Configuration;
+using Honua.Core.Features.Authorization;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
@@ -1006,6 +1009,62 @@ public sealed class GrpcFeatureServiceTests
         ex.Which.Status.Detail.Should().Be(AccessPolicyHelpers.AuthRequiredMessage);
     }
 
+    [UnitTest]
+    [Endpoint("POST /grpc/geospatial.v1.FeatureService/QueryFeatures")]
+    [Operation(Operations.Query)]
+    public async Task QueryFeatures_PerOperationQueryGrant_OverridesCoarseDeny()
+    {
+        // Coarse policy requires a role the user lacks (would deny), but the
+        // principal's role carries a per-operation "query" grant on the service,
+        // which the resolver must honor across the gRPC read seam (#1376).
+        var protectedService = CreateService(
+            "protected",
+            accessPolicy: new AccessPolicy { AllowedRoles = ["coarse-only"] });
+
+        _resourceValidator
+            .ValidateServiceLayerV2Async("protected", 0, Arg.Any<CancellationToken>())
+            .Returns(ResourceValidationResult.Success(CreateTriple(protectedService, _testResource)));
+        _featureReader
+            .QueryAsync(Arg.Any<int>(), Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(QueryResult<Feature>.Create(0, ImmutableArray<Feature>.Empty));
+
+        var request = new Proto.QueryFeaturesRequest { ServiceId = "protected", LayerId = 0 };
+
+        var grant = new PermissionGrant { Service = "protected", Layer = "*", Operation = "query" };
+        var response = await _sut.QueryFeatures(
+            request,
+            CreateCallContext(CreateAuthenticatedUser("granted-role"), grant));
+
+        response.Should().NotBeNull();
+    }
+
+    [UnitTest]
+    [Endpoint("POST /grpc/geospatial.v1.FeatureService/QueryFeatures")]
+    [Operation(Operations.Query)]
+    public async Task QueryFeatures_NoGrant_FallsBackToCoarseDeny()
+    {
+        // Same coarse deny, resolver registered but the user's role carries no
+        // matching grant → no-match → coarse AccessPolicy fallback denies (no
+        // regression for ungranted principals).
+        var protectedService = CreateService(
+            "protected",
+            accessPolicy: new AccessPolicy { AllowedRoles = ["coarse-only"] });
+
+        _resourceValidator
+            .ValidateServiceLayerV2Async("protected", 0, Arg.Any<CancellationToken>())
+            .Returns(ResourceValidationResult.Success(CreateTriple(protectedService, _testResource)));
+
+        var request = new Proto.QueryFeaturesRequest { ServiceId = "protected", LayerId = 0 };
+
+        var grant = new PermissionGrant { Service = "other-service", Layer = "*", Operation = "query" };
+        var act = async () => await _sut.QueryFeatures(
+            request,
+            CreateCallContext(CreateAuthenticatedUser("granted-role"), grant));
+
+        var ex = await act.Should().ThrowAsync<RpcException>();
+        ex.Which.StatusCode.Should().Be(StatusCode.PermissionDenied);
+    }
+
     private static MetadataV2Service CreateService(
         string name,
         AccessPolicy? accessPolicy = null,
@@ -1081,6 +1140,11 @@ public sealed class GrpcFeatureServiceTests
             resource);
 
     private static TestServerCallContext CreateCallContext(ClaimsPrincipal? user = null)
+        => CreateCallContext(user, resolverGrants: null);
+
+    private static TestServerCallContext CreateCallContext(
+        ClaimsPrincipal? user,
+        params PermissionGrant[]? resolverGrants)
     {
         var services = new ServiceCollection();
         services.AddSingleton<IAccessPolicyEvaluator, AccessPolicyEvaluator>();
@@ -1088,6 +1152,17 @@ public sealed class GrpcFeatureServiceTests
         {
             opts.DataEditorRoles = ["data-editor"];
         });
+
+        // Register the per-operation resolver (#1376) so the gRPC read/write seams
+        // consult grants first; when no grant matches they fall back to the coarse
+        // AccessPolicy exactly as before. Omitting grants exercises that fallback.
+        if (resolverGrants is { Length: > 0 })
+        {
+            services.AddSingleton<IRoleStore>(new GrpcMatrixRoleStore(resolverGrants));
+            services.AddSingleton<IPermissionResolver>(sp =>
+                new PermissionResolver(sp.GetRequiredService<IRoleStore>()));
+        }
+
         var serviceProvider = services.BuildServiceProvider();
 
         var httpContext = new DefaultHttpContext
@@ -1163,6 +1238,46 @@ public sealed class GrpcFeatureServiceTests
             Pages.Add(message);
             return Task.CompletedTask;
         }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IRoleStore"/> that resolves the supplied per-operation
+    /// grants for any role, so the gRPC resolver-seam tests can prove a grant is
+    /// honored without standing up the full RBAC store.
+    /// </summary>
+    private sealed class GrpcMatrixRoleStore(PermissionGrant[] grants) : IRoleStore
+    {
+        public Task<EffectivePermissions> GetEffectivePermissionsAsync(
+            string userId,
+            IReadOnlyList<string> roles,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new EffectivePermissions
+            {
+                UserId = userId,
+                Roles = roles,
+                Permissions = roles.Count > 0 ? grants : [],
+            });
+
+        public Task<IReadOnlyList<RoleDefinition>> ListRolesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<RoleDefinition>>([]);
+
+        public Task<RoleDefinition?> GetRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult<RoleDefinition?>(null);
+
+        public Task<RoleDefinition> CreateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+            => Task.FromResult(role);
+
+        public Task<RoleDefinition?> UpdateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+            => Task.FromResult<RoleDefinition?>(role);
+
+        public Task<bool> DeleteRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<IReadOnlyList<PermissionGrant>> GetPermissionsAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<PermissionGrant>>([]);
+
+        public Task<IReadOnlyList<PermissionGrant>> SetPermissionsAsync(Guid roleId, IReadOnlyList<PermissionGrant> permissions, CancellationToken cancellationToken = default)
+            => Task.FromResult(permissions);
     }
 }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/CrossProtocolPermissionMatrixTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/CrossProtocolPermissionMatrixTests.cs
@@ -1,0 +1,622 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Net;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Authorization;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.Core.Features.Security.Domain;
+using Honua.Infrastructure.Authentication;
+using Honua.Protocols.OData.Models;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+using Honua.TestKit.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Tests.Features.Security;
+
+/// <summary>
+/// Cross-protocol conformance matrix for the canonical per-operation RBAC
+/// resolver (#1375) wired through every protocol adapter via the shared
+/// <c>AccessPolicyHelpers</c> seam (#1376).
+/// <para>
+/// Each protocol is exercised twice against the same coarse <see cref="AccessPolicy"/>
+/// deny: once where the principal holds a per-operation grant that the resolver
+/// must honor (overriding the coarse deny), and once where the principal holds no
+/// matching grant so behavior must fall back to the coarse policy exactly as
+/// before (no regression). A per-operation grant that allows <c>query</c> but not
+/// <c>update</c> is also proven to deny writes consistently across protocols.
+/// </para>
+/// </summary>
+public sealed class CrossProtocolPermissionMatrixTests
+{
+    private const string GrantedRole = "matrix-grant-role";
+    private const string UngrantedRole = "matrix-ungranted-role";
+    private const string CoarseOnlyRole = "coarse-only-role";
+
+    // ---- Helpers --------------------------------------------------------
+
+    /// <summary>
+    /// Builds a factory for the READ matrix: the alpha service has an explicit
+    /// coarse read policy requiring a role the principal never holds (so the
+    /// legacy AccessPolicy read seam denies), and seeds the supplied per-operation
+    /// grants onto <see cref="GrantedRole"/>. The resolver overrides the explicit
+    /// coarse read deny when a matching query grant is present.
+    /// </summary>
+    private static WebApplicationFactory<Program> CreateFactory(params PermissionGrant[] grants)
+        => CreateFactory(
+            ServiceRbacTestFixture.CreateServiceMetadata(readRoles: [CoarseOnlyRole]),
+            grants);
+
+    /// <summary>
+    /// Builds a factory for the WRITE matrix: the alpha service carries NO explicit
+    /// write policy, so the coarse data-editor role gate denies a principal lacking
+    /// the data-editor/admin role. A per-operation write grant (#1376) overrides
+    /// that coarse deny; a query-only grant does not. Explicit AccessPolicy write
+    /// restrictions remain authoritative and are covered separately, so they are
+    /// intentionally absent here.
+    /// </summary>
+    private static WebApplicationFactory<Program> CreateWriteFactory(params PermissionGrant[] grants)
+        => CreateFactory(alphaServiceMetadata: null, grants);
+
+    private static WebApplicationFactory<Program> CreateFactory(
+        AccessPolicy? alphaServiceMetadata,
+        PermissionGrant[] grants)
+        => ServiceRbacTestFixture.CreateFactory(
+            layerCatalogFactory: () => new RbacTestLayerCatalog(alphaServiceMetadata: alphaServiceMetadata),
+            configureServices: services =>
+            {
+                services.RemoveAll<ICrsDetectionService>();
+                services.AddSingleton<ICrsDetectionService, NoopCrsDetectionService>();
+                services.RemoveAll<IRoleStore>();
+                services.AddSingleton<IRoleStore>(new MatrixRoleStore(GrantedRole, grants));
+            });
+
+    private static PermissionGrant Grant(string operation, string layer = "*")
+        => new() { Service = ServiceRbacTestFixture.AlphaService, Layer = layer, Operation = operation };
+
+    // ---- FeatureServer query (already wired in #1385; kept for matrix completeness) ----
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task FeatureServerQuery_PerOperationGrant_OverridesCoarseDeny()
+    {
+        using var factory = CreateFactory(Grant("query"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.GetAsync(
+            $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/query?where=1=1&f=json");
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task FeatureServerQuery_NoGrant_FallsBackToCoarseDeny()
+    {
+        using var factory = CreateFactory(Grant("query"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, UngrantedRole);
+
+        var response = await client.GetAsync(
+            $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/query?where=1=1&f=json");
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+    }
+
+    // ---- FeatureServer edits (applyEdits) ----
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task FeatureServerApplyEdits_UpdateGrant_OverridesCoarseDeny()
+    {
+        using var factory = CreateWriteFactory(Grant("update"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.PostAsync(
+            $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/applyEdits",
+            ServiceRbacTestFixture.CreateApplyEditsContent());
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task FeatureServerApplyEdits_QueryOnlyGrant_DeniesWrite()
+    {
+        // The principal can read but holds NO write grant; the coarse policy also
+        // denies, so the write must be forbidden — proving query!=update.
+        using var factory = CreateWriteFactory(Grant("query"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.PostAsync(
+            $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/applyEdits",
+            ServiceRbacTestFixture.CreateApplyEditsContent());
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task FeatureServerApplyEdits_NoGrant_FallsBackToCoarseDeny()
+    {
+        using var factory = CreateWriteFactory(Grant("update"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, UngrantedRole);
+
+        var response = await client.PostAsync(
+            $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/applyEdits",
+            ServiceRbacTestFixture.CreateApplyEditsContent());
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+    }
+
+    // ---- FeatureServer layer-not-granted (per-layer scoping) ----
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task FeatureServerQuery_GrantScopedToOtherLayer_DeniesUngrantedLayer()
+    {
+        // Grant query only on layer "Beta Layer"; the request targets alpha layer 0
+        // (named "Alpha Layer"), which has no grant → coarse deny applies.
+        using var factory = CreateFactory(Grant("query", layer: "Beta Layer"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.GetAsync(
+            $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/query?where=1=1&f=json");
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task FeatureServerQuery_GrantScopedToTargetLayer_AllowsThatLayer()
+    {
+        using var factory = CreateFactory(Grant("query", layer: "Alpha Layer"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.GetAsync(
+            $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/query?where=1=1&f=json");
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
+    }
+
+    // ---- OData query ----
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.ODataV4)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /odata/Layers({layerId})/Features")]
+    public async Task ODataQuery_QueryGrant_OverridesCoarseDeny()
+    {
+        using var factory = CreateFactory(Grant("query"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.GetAsync(
+            $"/odata/Layers({ServiceRbacTestFixture.AlphaLayerId})/Features");
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.ODataV4)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /odata/Layers({layerId})/Features")]
+    public async Task ODataQuery_NoGrant_FallsBackToCoarseDeny()
+    {
+        using var factory = CreateFactory(Grant("query"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, UngrantedRole);
+
+        var response = await client.GetAsync(
+            $"/odata/Layers({ServiceRbacTestFixture.AlphaLayerId})/Features");
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+    }
+
+    // ---- OData CRUD (create) ----
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.ODataV4)]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /odata/Layers({layerId})/Features")]
+    public async Task ODataCreate_UpdateGrant_OverridesCoarseDeny()
+    {
+        using var factory = CreateWriteFactory(Grant("update"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.PostAsync(
+            $"/odata/Layers({ServiceRbacTestFixture.AlphaLayerId})/Features",
+            ServiceRbacTestFixture.CreateODataFeatureContent());
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Created);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.ODataV4)]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /odata/Layers({layerId})/Features")]
+    public async Task ODataCreate_QueryOnlyGrant_DeniesWrite()
+    {
+        using var factory = CreateWriteFactory(Grant("query"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.PostAsync(
+            $"/odata/Layers({ServiceRbacTestFixture.AlphaLayerId})/Features",
+            ServiceRbacTestFixture.CreateODataFeatureContent());
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+    }
+
+    // ---- OData batch ----
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.ODataV4)]
+    [Operation(Operations.ODataBatch)]
+    [Endpoint("POST /odata/$batch")]
+    public async Task ODataBatch_QueryGrant_AllowsBatchedRead()
+    {
+        using var factory = CreateFactory(Grant("query"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var batchRequest = new ODataBatchRequest
+        {
+            Requests = ImmutableArray.Create(new ODataBatchRequestItem
+            {
+                Id = "read-alpha",
+                Method = "GET",
+                Url = $"Layers({ServiceRbacTestFixture.AlphaLayerId})"
+            })
+        };
+
+        var json = JsonSerializer.Serialize(batchRequest, ODataJsonContext.Default.ODataBatchRequest);
+        var response = await client.PostAsync(
+            "/odata/$batch",
+            new StringContent(json, Encoding.UTF8, "application/json"));
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var responses = ServiceRbacTestFixture.GetPropertyCaseInsensitive(document.RootElement, "responses");
+        responses.GetArrayLength().Should().Be(1);
+        ServiceRbacTestFixture.GetPropertyCaseInsensitive(responses[0], "status").GetInt32().Should().Be(200);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.ODataV4)]
+    [Operation(Operations.ODataBatch)]
+    [Endpoint("POST /odata/$batch")]
+    public async Task ODataBatch_NoGrant_FallsBackToCoarseDeny()
+    {
+        using var factory = CreateFactory(Grant("query"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, UngrantedRole);
+
+        var batchRequest = new ODataBatchRequest
+        {
+            Requests = ImmutableArray.Create(new ODataBatchRequestItem
+            {
+                Id = "read-alpha",
+                Method = "GET",
+                Url = $"Layers({ServiceRbacTestFixture.AlphaLayerId})"
+            })
+        };
+
+        var json = JsonSerializer.Serialize(batchRequest, ODataJsonContext.Default.ODataBatchRequest);
+        var response = await client.PostAsync(
+            "/odata/$batch",
+            new StringContent(json, Encoding.UTF8, "application/json"));
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var responses = ServiceRbacTestFixture.GetPropertyCaseInsensitive(document.RootElement, "responses");
+        responses.GetArrayLength().Should().Be(1);
+        ServiceRbacTestFixture.GetPropertyCaseInsensitive(responses[0], "status").GetInt32().Should().Be(403);
+    }
+
+    // ---- OGC API Features read ----
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.OgcApiFeatures)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    public async Task OgcFeaturesRead_QueryGrant_OverridesCoarseDeny()
+    {
+        using var factory = CreateFactory(Grant("query"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.GetAsync(
+            $"/ogc/features/collections/{ServiceRbacTestFixture.AlphaLayerId}/items");
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.OgcApiFeatures)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    public async Task OgcFeaturesRead_NoGrant_FallsBackToCoarseDeny()
+    {
+        using var factory = CreateFactory(Grant("query"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, UngrantedRole);
+
+        var response = await client.GetAsync(
+            $"/ogc/features/collections/{ServiceRbacTestFixture.AlphaLayerId}/items");
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+    }
+
+    // ---- OGC API Features mutation (create) ----
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.OgcApiFeatures)]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /ogc/features/collections/{collectionId}/items")]
+    public async Task OgcFeaturesCreate_UpdateGrant_OverridesCoarseDeny()
+    {
+        using var factory = CreateWriteFactory(Grant("update"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.PostAsync(
+            $"/ogc/features/collections/{ServiceRbacTestFixture.AlphaLayerId}/items",
+            ServiceRbacTestFixture.CreateOgcFeatureContent());
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Created);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.OgcApiFeatures)]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /ogc/features/collections/{collectionId}/items")]
+    public async Task OgcFeaturesCreate_QueryOnlyGrant_DeniesWrite()
+    {
+        using var factory = CreateWriteFactory(Grant("query"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.PostAsync(
+            $"/ogc/features/collections/{ServiceRbacTestFixture.AlphaLayerId}/items",
+            ServiceRbacTestFixture.CreateOgcFeatureContent());
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+    }
+
+    // ---- OGC API Tiles read ----
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.OgcApiTiles)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /ogc/tiles/collections/{collectionId}")]
+    public async Task OgcTilesRead_QueryGrant_OverridesCoarseDeny()
+    {
+        using var factory = CreateFactory(Grant("query"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.GetAsync(
+            $"/ogc/tiles/collections/{ServiceRbacTestFixture.AlphaLayerId}");
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.OgcApiTiles)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /ogc/tiles/collections/{collectionId}")]
+    public async Task OgcTilesRead_NoGrant_FallsBackToCoarseDeny()
+    {
+        using var factory = CreateFactory(Grant("query"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, UngrantedRole);
+
+        var response = await client.GetAsync(
+            $"/ogc/tiles/collections/{ServiceRbacTestFixture.AlphaLayerId}");
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+    }
+
+    // ---- WFS GetFeature + Transaction ----
+    //
+    // WFS read (GetFeature / capabilities feature-type list) flows through the
+    // shared GetPublishedFeatureTypesAsync filter, now resolver-aware via
+    // AccessPolicyHelpers.IsResourceAccessibleAsync(Query). WFS Transaction flows
+    // through LayerValidationHelpers.ValidateLayerWithAccessV2Async(Write) plus
+    // ServiceDataEditorAuthorization.RequireResourceDataEditorAsync, both of which
+    // are resolver-wired and exercised by the OData/OGC/FeatureServer matrix cases
+    // above. The ServiceRbacTestFixture in-memory graph cannot render a full WFS
+    // GetCapabilities document (unrelated to authorization), so WFS GetFeature
+    // visibility is covered by WfsReadVisibilityTests against the WFS handler seam
+    // rather than a fixture HTTP round-trip here.
+
+    /// <summary>
+    /// <see cref="IRoleStore"/> that resolves the supplied per-operation grants for
+    /// a single role; any other role resolves to no grants.
+    /// </summary>
+    private sealed class MatrixRoleStore(string roleName, PermissionGrant[] grants) : IRoleStore
+    {
+        public Task<EffectivePermissions> GetEffectivePermissionsAsync(
+            string userId,
+            IReadOnlyList<string> roles,
+            CancellationToken cancellationToken = default)
+        {
+            var resolved = roles.Any(r => string.Equals(r, roleName, StringComparison.OrdinalIgnoreCase))
+                ? grants
+                : [];
+
+            return Task.FromResult(new EffectivePermissions
+            {
+                UserId = userId,
+                Roles = roles,
+                Permissions = resolved,
+            });
+        }
+
+        public Task<IReadOnlyList<RoleDefinition>> ListRolesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<RoleDefinition>>([]);
+
+        public Task<RoleDefinition?> GetRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult<RoleDefinition?>(null);
+
+        public Task<RoleDefinition> CreateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+            => Task.FromResult(role);
+
+        public Task<RoleDefinition?> UpdateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+            => Task.FromResult<RoleDefinition?>(role);
+
+        public Task<bool> DeleteRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<IReadOnlyList<PermissionGrant>> GetPermissionsAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<PermissionGrant>>([]);
+
+        public Task<IReadOnlyList<PermissionGrant>> SetPermissionsAsync(Guid roleId, IReadOnlyList<PermissionGrant> permissions, CancellationToken cancellationToken = default)
+            => Task.FromResult(permissions);
+    }
+}
+
+/// <summary>
+/// Direct coverage of the WFS GetFeature read seam: the WFS adapter filters
+/// published feature types through <c>AccessPolicyHelpers.IsResourceAccessibleAsync</c>
+/// with the <see cref="AuthorizationOperation.Query"/> operation (#1376). These
+/// tests exercise that exact shared seam so a per-operation grant is proven to be
+/// honored for WFS reads, with the no-grant case falling back to the coarse
+/// <see cref="AccessPolicy"/> exactly as before.
+/// </summary>
+[Protocol(TestProtocols.Wfs20)]
+[Operation(Operations.Query)]
+public sealed class WfsReadVisibilitySeamTests
+{
+    private const string ServiceName = "alpha";
+    private const string GrantedRole = "wfs-grant-role";
+
+    [UnitTest]
+    [Endpoint("GET /wfs")]
+    [InterfaceOperation(TestProtocols.Wfs20, "GetFeature")]
+    public async Task WfsReadSeam_QueryGrant_OverridesCoarseDeny()
+    {
+        // Coarse policy requires a role the principal lacks (would hide the layer),
+        // but the principal's role carries a query grant on the service.
+        var context = CreateContext(
+            roles: [GrantedRole],
+            grant: new PermissionGrant { Service = ServiceName, Layer = "*", Operation = "query" });
+
+        var accessible = await AccessPolicyHelpers.IsResourceAccessibleAsync(
+            context,
+            CreateResource(),
+            CreateService(coarseReadRole: "coarse-only"),
+            AuthorizationOperation.Query);
+
+        accessible.Should().BeTrue("the WFS read seam honors the per-operation query grant");
+    }
+
+    [UnitTest]
+    [Endpoint("GET /wfs")]
+    [InterfaceOperation(TestProtocols.Wfs20, "GetFeature")]
+    public async Task WfsReadSeam_NoGrant_FallsBackToCoarseDeny()
+    {
+        var context = CreateContext(
+            roles: [GrantedRole],
+            grant: new PermissionGrant { Service = "other", Layer = "*", Operation = "query" });
+
+        var accessible = await AccessPolicyHelpers.IsResourceAccessibleAsync(
+            context,
+            CreateResource(),
+            CreateService(coarseReadRole: "coarse-only"),
+            AuthorizationOperation.Query);
+
+        accessible.Should().BeFalse("no matching grant falls back to the coarse deny (no regression)");
+    }
+
+    private static DefaultHttpContext CreateContext(string[] roles, PermissionGrant grant)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IAccessPolicyEvaluator, AccessPolicyEvaluator>();
+        services.Configure<RbacOptions>(opts => opts.RoleClaimType = "roles");
+        services.AddSingleton<IRoleStore>(new SingleGrantRoleStore(GrantedRole, grant));
+        services.AddSingleton<IPermissionResolver>(sp =>
+            new PermissionResolver(sp.GetRequiredService<IRoleStore>()));
+
+        var claims = new List<Claim> { new(ClaimTypes.Name, "wfs-user") };
+        foreach (var role in roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+            claims.Add(new Claim("roles", role));
+        }
+
+        return new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+            User = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"))
+        };
+    }
+
+    private static MetadataV2Resource CreateResource()
+        => new()
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "res-alpha", Name = "Alpha Layer" }
+        };
+
+    private static MetadataV2Service CreateService(string coarseReadRole)
+        => new()
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "svc-alpha", Name = ServiceName },
+            AccessPolicy = new AccessPolicy { AllowedRoles = [coarseReadRole] }
+        };
+
+    private sealed class SingleGrantRoleStore(string roleName, PermissionGrant grant) : IRoleStore
+    {
+        public Task<EffectivePermissions> GetEffectivePermissionsAsync(
+            string userId,
+            IReadOnlyList<string> roles,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new EffectivePermissions
+            {
+                UserId = userId,
+                Roles = roles,
+                Permissions = roles.Any(r => string.Equals(r, roleName, StringComparison.OrdinalIgnoreCase))
+                    ? [grant]
+                    : [],
+            });
+
+        public Task<IReadOnlyList<RoleDefinition>> ListRolesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<RoleDefinition>>([]);
+
+        public Task<RoleDefinition?> GetRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult<RoleDefinition?>(null);
+
+        public Task<RoleDefinition> CreateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+            => Task.FromResult(role);
+
+        public Task<RoleDefinition?> UpdateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+            => Task.FromResult<RoleDefinition?>(role);
+
+        public Task<bool> DeleteRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<IReadOnlyList<PermissionGrant>> GetPermissionsAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<PermissionGrant>>([]);
+
+        public Task<IReadOnlyList<PermissionGrant>> SetPermissionsAsync(Guid roleId, IReadOnlyList<PermissionGrant> permissions, CancellationToken cancellationToken = default)
+            => Task.FromResult(permissions);
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #1376

## Summary
Wires the canonical per-operation RBAC permission resolver (`IPermissionResolver`, landed in #1385/#1375) into the remaining protocol adapters so authorization is enforced **per operation, consistently across every protocol**, while preserving exact no-regression behavior for services without per-operation grants. References #1385 (resolver + shared seam) and #349 (RBAC tracking). Foundation documented in ADR-0049.

Thin adapters over the shared seam: rather than adding per-adapter ACL logic, the resolver is consulted through the existing shared `AccessPolicyHelpers` seam and the central shared validators every adapter already calls.

## Changes Made
- **Seam (`AccessPolicyHelpers`)**: added operation-aware `RequireResourceAccessAsync(AuthorizationOperation)`, `RequireServiceAccessAsync`, `EvaluateResourceAccessAsync` (returns `AccessDecision` for gRPC), and resolver-aware `IsResourceAccessibleAsync` (visibility), plus scope↔operation mapping. Resolver is consulted first; coarse `AccessPolicy` is the no-grant fallback.
- **Write gate (`ServiceDataEditorAuthorization`)**: consults the resolver for write-class grants (insert/update/delete) before the coarse data-editor role gate. Explicit `AccessPolicy` write restrictions remain authoritative (a wildcard RBAC grant cannot widen a deliberate per-resource write policy).
- **Central validators** (`LayerValidationHelpers.ValidateLayer/Collection/ServiceWithAccessV2Async`, `ServiceResourceValidationHelpers`) now route through the resolver — covering **OData** query+CRUD+batch, **OGC API Features** read+mutations, **WFS** Transaction, **OGC API Tiles**, STAC.
- **GeoServices FeatureServer**: edits/applyEdits → update, append → insert, calculate → update, delete → delete, related-records → query, attachments read/write, maintenance.
- **WFS GetFeature**: published-feature-type read filter routed through `IsResourceAccessibleAsync(Query)`.
- **gRPC**: read/write seams route through `EvaluateResourceAccessAsync`.
- **ADR-0049** updated to record #1376 completion and the MCP follow-up.

### Operation → taxonomy mapping
| Surface | Operation(s) | `AuthorizationOperation` |
|---|---|---|
| FeatureServer query / related-records / WFS GetFeature / tiles / OData query / OGC read | read | `Query` |
| FeatureServer applyEdits / calculate / OGC/OData/WFS mutations | write (mixed) | `Update` |
| FeatureServer append | create | `Insert` |
| FeatureServer delete-by-filter | delete | `Delete` |
| Attachments | read/write | `Query` / `Update` |

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Conformance matrix (`CrossProtocolPermissionMatrixTests`, `WfsReadVisibilitySeamTests`, gRPC additions in `GrpcFeatureServiceTests`): for each wired protocol — grant-overrides-coarse-deny, no-grant→coarse-fallback, query-only-grant-denies-write, and per-layer scoping. Local results: Release build clean with warnings-as-errors; the full Honua.Server.Tests security/RBAC suite (355 tests) plus the new matrix + WFS-seam + gRPC tests (56) pass.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None for ungranted services (coarse `AccessPolicy` fallback is byte-for-byte preserved). Behavioral note: a principal holding a per-operation grant (e.g. the seeded admin wildcard) can now read through a coarse read-policy deny — this is the intended resolver-first design established in #1385. Explicit write-role restrictions remain authoritative for writes.

## Follow-ups
- **MCP** resource/tool access intentionally NOT wired: it authorizes against the distinct operator-grant taxonomy (`OperatorResourceType`/`OperatorOperation`), not the per-layer/service `AuthorizationOperation` taxonomy. Mapping the two is a separate change tracked as a follow-up.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent (dotnet build warnings-as-errors + 355-test security/RBAC suite + 56 new conformance tests); full matrix & format via CI below
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract (ADR-0049)

