### PR TITLE
feat: render styled vector maps for OGC API Maps via Skia pipeline (#1390)

### DIFF
--- a/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs
+++ b/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs
@@ -208,6 +208,151 @@ internal static class RasterMapRenderingPipeline
         var imageBytes = SkiaMapRenderer.EncodeSurface(surface, "png");
         return RasterTileRenderResult.Success(imageBytes, totalFeatureCount);
     }
+    /// <summary>
+    /// Result of a single-collection vector render through the Skia pipeline.
+    /// </summary>
+    internal readonly record struct VectorCollectionRenderResult(
+        bool IsSuccess,
+        byte[] ImageBytes,
+        int FeatureCount,
+        IResult? Error)
+    {
+        public static VectorCollectionRenderResult Success(byte[] imageBytes, int featureCount)
+            => new(true, imageBytes, featureCount, null);
+
+        public static VectorCollectionRenderResult Failure(IResult error)
+            => new(false, [], 0, error);
+    }
+
+    /// <summary>
+    /// Renders a single vector collection to an encoded image using the shared Skia
+    /// pipeline and an explicit MapLibre style document. This is the vector counterpart
+    /// to the raster-coverage renderer used by OGC API Maps styled-map requests: the
+    /// caller resolves the style (e.g. from a styleId-keyed projection) and supplies the
+    /// already-validated request extent. Reprojection, capacity limiting, feature
+    /// querying, and drawing all reuse the same helpers WMS GetMap and MapServer export
+    /// invoke, so no rendering or geodesy logic is duplicated.
+    /// </summary>
+    /// <param name="context">The current HTTP context (used to resolve request-scoped services).</param>
+    /// <param name="layerId">Storage layer identifier for the collection.</param>
+    /// <param name="geometryType">Geometry type used to drive default styling and the point fast-path.</param>
+    /// <param name="serviceSrid">Storage CRS the feature geometries are stored in.</param>
+    /// <param name="mapLibreStyleJson">Resolved MapLibre style JSON to apply, or <c>null</c> for default styling.</param>
+    /// <param name="requestExtent">Requested map extent in <paramref name="requestSrid"/>.</param>
+    /// <param name="requestSrid">CRS the requested extent (and output image) is expressed in.</param>
+    /// <param name="imageWidth">Output image width in pixels.</param>
+    /// <param name="imageHeight">Output image height in pixels.</param>
+    /// <param name="format">Output image format string (e.g. <c>png</c>, <c>jpeg</c>).</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="backgroundColor">Background fill used when not transparent (defaults to white).</param>
+    /// <param name="temporalFilter">Optional temporal filter for time-enabled collections.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    internal static async Task<VectorCollectionRenderResult> RenderVectorCollectionAsync(
+        HttpContext context,
+        int layerId,
+        MetadataV2GeometryType geometryType,
+        int serviceSrid,
+        string? mapLibreStyleJson,
+        SkiaMapRenderer.RenderExtent requestExtent,
+        int requestSrid,
+        int imageWidth,
+        int imageHeight,
+        string format,
+        bool transparent,
+        SKColor? backgroundColor,
+        TemporalFilter? temporalFilter,
+        CancellationToken cancellationToken)
+    {
+        await using var renderLease = await context.RequestServices
+            .GetRequiredService<RasterRenderCapacityLimiter>()
+            .TryAcquireAsync(imageWidth, imageHeight, cancellationToken)
+            .ConfigureAwait(false);
+        if (renderLease is null)
+        {
+            return VectorCollectionRenderResult.Failure(StandardErrorHelpers.CreateServiceUnavailable(
+                context,
+                RasterRenderCapacityLimiter.CapacityExceededMessage,
+                RasterRenderCapacityLimiter.RetryAfterSeconds));
+        }
+
+        // Reproject the request extent into the storage CRS the feature reader expects,
+        // mirroring WMS GetMap's per-layer handling.
+        var queryExtent = requestExtent;
+        if (requestSrid != serviceSrid)
+        {
+            var extentTransformResult = await TryTransformExtentAsync(
+                context,
+                requestExtent,
+                requestSrid,
+                serviceSrid,
+                cancellationToken).ConfigureAwait(false);
+            if (!extentTransformResult.IsSuccess)
+            {
+                return VectorCollectionRenderResult.Failure(
+                    StandardErrorHelpers.CreateBadRequest(context, extentTransformResult.Error ?? InvalidSpatialReferenceMessage));
+            }
+
+            queryExtent = extentTransformResult.Extent;
+        }
+
+        using var surface = SKSurface.Create(new SKImageInfo(imageWidth, imageHeight, SKColorType.Rgba8888, SKAlphaType.Premul));
+        if (surface is null)
+        {
+            return VectorCollectionRenderResult.Failure(
+                StandardErrorHelpers.CreateInternalServerError(context, "Failed to allocate render surface."));
+        }
+
+        var canvas = surface.Canvas;
+        var effectiveTransparent = transparent && string.Equals(format, "png", StringComparison.OrdinalIgnoreCase);
+        canvas.Clear(effectiveTransparent ? SKColors.Transparent : backgroundColor ?? SKColors.White);
+
+        var totalFeatureCount = 0;
+        if (geometryType != MetadataV2GeometryType.None)
+        {
+            var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
+            var transform = SkiaMapRenderer.BuildTransform(requestExtent, imageWidth, imageHeight);
+            var stylePlan = BuildRasterStylePlanFromJson(mapLibreStyleJson);
+            var spatialFilter = CreateBboxSpatialFilter(queryExtent, serviceSrid);
+            var featureQuery = CreateRasterFeatureQuery(
+                stylePlan,
+                spatialFilter,
+                serviceSrid,
+                requestSrid,
+                MaxFeaturesPerLayer,
+                temporalFilter: temporalFilter);
+
+            var renderedPointCount = await TryRenderRasterPointFastPathAsync(
+                canvas,
+                featureReader,
+                layerId,
+                geometryType,
+                stylePlan,
+                featureQuery,
+                requestExtent,
+                imageWidth,
+                imageHeight,
+                transform,
+                cancellationToken).ConfigureAwait(false);
+            if (renderedPointCount >= 0)
+            {
+                totalFeatureCount += renderedPointCount;
+            }
+            else
+            {
+                var features = await QueryRasterFeaturesAsync(featureReader, layerId, featureQuery, cancellationToken)
+                    .ConfigureAwait(false);
+                if (features.Length > 0)
+                {
+                    totalFeatureCount += features.Length;
+                    RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transform, geometryType);
+                }
+            }
+        }
+
+        var imageBytes = SkiaMapRenderer.EncodeSurface(surface, format);
+        return VectorCollectionRenderResult.Success(imageBytes, totalFeatureCount);
+    }
+
     internal static void RenderLayerToCanvas(
         SKCanvas canvas,
         ImmutableArray<Feature> features,
@@ -620,8 +765,17 @@ internal static class RasterMapRenderingPipeline
     }
 
     private static RasterStylePlan BuildRasterStylePlan(LayerStyleDefinition? style)
+        => BuildRasterStylePlanFromJson(style?.MapLibreStyleJson);
+
+    /// <summary>
+    /// Builds a render-time style plan directly from an explicit MapLibre style JSON
+    /// document, bypassing the per-layer style catalog. Used by callers (such as OGC API
+    /// Maps styled-map rendering) that resolve the style from an external source — e.g. a
+    /// styleId-keyed projection — rather than the layer's stored default style.
+    /// </summary>
+    internal static RasterStylePlan BuildRasterStylePlanFromJson(string? mapLibreStyleJson)
     {
-        var styleLayers = StyleTranslator.ParseStyleLayers(style?.MapLibreStyleJson);
+        var styleLayers = StyleTranslator.ParseStyleLayers(mapLibreStyleJson);
         var referencedFields = StyleTranslator.CollectReferencedFields(styleLayers);
 
         return new RasterStylePlan

--- a/src/Honua.Protocols.OgcApi/Maps/Handlers/OgcMapsConformanceHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Maps/Handlers/OgcMapsConformanceHandler.cs
@@ -35,6 +35,9 @@ internal sealed class OgcMapsConformanceHandler
                 // Collection maps support
                 "https://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/collection-map",
 
+                // Styled maps support (styleId-resolved MapLibre styling of vector collections, ADR-0048)
+                "https://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/styled-map",
+
                 // Dataset-wide maps support
                 "https://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/dataset-map",
 

--- a/src/Honua.Protocols.OgcApi/Maps/Handlers/OgcMapsRenderingHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Maps/Handlers/OgcMapsRenderingHandler.cs
@@ -9,6 +9,7 @@ using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
 using Honua.Core.Features.Shared.Models;
+using Honua.Core.Features.Styling.Abstractions;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Rendering;
@@ -56,15 +57,18 @@ internal sealed class OgcMapsRenderingHandler
 
     private readonly IMetadataV2GraphProvider _graphProvider;
     private readonly IRasterMapRenderer _mapRenderer;
+    private readonly IOgcStyleProjection _styleProjection;
     private readonly ILogger<OgcMapsRenderingHandler> _logger;
 
     public OgcMapsRenderingHandler(
         IMetadataV2GraphProvider graphProvider,
         IRasterMapRenderer mapRenderer,
+        IOgcStyleProjection styleProjection,
         ILogger<OgcMapsRenderingHandler> logger)
     {
         _graphProvider = graphProvider ?? throw new ArgumentNullException(nameof(graphProvider));
         _mapRenderer = mapRenderer ?? throw new ArgumentNullException(nameof(mapRenderer));
+        _styleProjection = styleProjection ?? throw new ArgumentNullException(nameof(styleProjection));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -453,7 +457,24 @@ internal sealed class OgcMapsRenderingHandler
 
             OgcMapsLog.StyledMapRenderStarted(_logger, layerId, styleId, renderRequest.Value.Width, renderRequest.Value.Height);
 
-            // Render the styled map
+            // Renderer dispatch (ADR-0048): vector collections render through the shared
+            // Skia pipeline with an explicit styleId-resolved MapLibre style (the same path
+            // WMS GetMap / MapServer export use). Raster coverages keep the raster-only
+            // renderer, which reports an honest 501 for styled requests.
+            if (ResourceHasGeometry(resource))
+            {
+                return await RenderStyledVectorMapAsync(
+                    layerId,
+                    styleId,
+                    resource,
+                    service,
+                    renderRequest.Value,
+                    context,
+                    scope,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            // Render the styled map (raster path)
             var result = await _mapRenderer.RenderStyledMapAsync(layerId, styleId, renderRequest.Value, cancellationToken);
             if (result.Data.Length == 0)
             {
@@ -485,6 +506,109 @@ internal sealed class OgcMapsRenderingHandler
             scope.RecordException(ex);
             return CreateErrorResult(context, "An error occurred while rendering the styled map.");
         }
+    }
+
+    /// <summary>
+    /// Renders a styled map for a vector collection through the shared Skia pipeline,
+    /// resolving the MapLibre style for <paramref name="styleId"/> via the OGC API - Styles
+    /// projection (ADR-0048). Falls back to default styling when the styleId does not
+    /// resolve to a stored style for the collection.
+    /// </summary>
+    private async Task<IResult> RenderStyledVectorMapAsync(
+        int layerId,
+        string styleId,
+        MetadataV2Resource resource,
+        MetadataV2Service? service,
+        MapRenderRequest renderRequest,
+        HttpContext? context,
+        HonuaTelemetryScope scope,
+        CancellationToken cancellationToken)
+    {
+        // The Skia pipeline resolves request-scoped services (feature reader, capacity
+        // limiter, coordinate transform) from the HTTP context, so styled vector rendering
+        // requires a live request. Without one we surface the same honest 501 as raster.
+        if (context is null)
+        {
+            return Results.Problem(
+                title: "Styled vector map rendering requires an active request context.",
+                statusCode: StatusCodes.Status501NotImplemented);
+        }
+
+        // Resolve the requested style (canonical MapLibre). A missing/unknown style renders
+        // with the collection's default styling rather than failing the request.
+        string? mapLibreStyleJson = null;
+        var stylesheet = await _styleProjection
+            .GetStylesheetAsync(styleId, OgcStyleEncoding.MapboxStyle, cancellationToken)
+            .ConfigureAwait(false);
+        if (stylesheet is not null)
+        {
+            mapLibreStyleJson = stylesheet.Content;
+        }
+
+        var geometryType = resource.ReadGeometryType();
+        var serviceSrid = service?.SpatialReference?.ResolveSrid()
+            ?? resource.ReadSrid()
+            ?? DefaultBboxCrsSrid;
+        var requestSrid = renderRequest.BoundingBoxCrs ?? renderRequest.Crs ?? DefaultBboxCrsSrid;
+        var requestExtent = new SkiaMapRenderer.RenderExtent(
+            renderRequest.BoundingBox[0],
+            renderRequest.BoundingBox[1],
+            renderRequest.BoundingBox[2],
+            renderRequest.BoundingBox[3]);
+        var format = renderRequest.Format switch
+        {
+            RasterFormat.JPEG => "jpeg",
+            RasterFormat.TIFF => "tiff",
+            _ => "png"
+        };
+
+        var renderResult = await RasterMapRenderingPipeline.RenderVectorCollectionAsync(
+            context,
+            layerId,
+            geometryType,
+            serviceSrid,
+            mapLibreStyleJson,
+            requestExtent,
+            requestSrid,
+            renderRequest.Width,
+            renderRequest.Height,
+            format,
+            renderRequest.Transparent,
+            backgroundColor: null,
+            temporalFilter: null,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!renderResult.IsSuccess)
+        {
+            return renderResult.Error!;
+        }
+
+        OgcMapsLog.StyledMapRenderCompleted(_logger, layerId, styleId, renderResult.ImageBytes.Length);
+        scope.SetSuccess(renderResult.FeatureCount);
+
+        var result = new RasterResult
+        {
+            Data = renderResult.ImageBytes,
+            ContentType = renderRequest.Format.ToContentType(),
+            Width = renderRequest.Width,
+            Height = renderRequest.Height,
+            Srid = requestSrid
+        };
+
+        return CreateMapFileResult(context, result, renderRequest);
+    }
+
+    private static bool ResourceHasGeometry(MetadataV2Resource resource)
+    {
+        if (resource.ReadGeometryType() != MetadataV2GeometryType.None)
+        {
+            return true;
+        }
+
+        // V2 graphs that don't fill in the typed Spatial slot still surface geometry through
+        // the schema (Geometry/Geography field). Match the WMS/WMTS V2 ports — both treat
+        // such a layer as renderable.
+        return resource.FindPrimaryGeometryField() is not null;
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsBasicTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsBasicTests.cs
@@ -260,6 +260,34 @@ public class OgcMapsBasicTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("GET /ogc/maps/collections/{collectionId}/styles/{styleId}/map")]
+    [Operation(Operations.Render)]
+    public async Task GetStyledMap_VectorCollection_RendersPngInsteadOf501()
+    {
+        // The styled-map endpoint routes vector collections through the Skia rendering
+        // pipeline (ADR-0048) instead of the raster-only path that returns 501. Layer 0
+        // is a seeded vector (Point) collection, so a styled request must produce a PNG.
+        var queryParams = "?bbox=-180,-90,180,90&width=256&height=256&f=png";
+
+        var response = await _fixture.Client.GetAsync(
+            $"/ogc/maps/collections/{TestLayerId}/styles/default/map{queryParams}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().NotBe(HttpStatusCode.NotImplemented);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("image/png");
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        bytes.Should().NotBeEmpty();
+
+        // PNG signature: 89 50 4E 47 0D 0A 1A 0A.
+        bytes.Should().HaveCountGreaterThan(8);
+        bytes[0].Should().Be(0x89);
+        bytes[1].Should().Be(0x50);
+        bytes[2].Should().Be(0x4E);
+        bytes[3].Should().Be(0x47);
+    }
+
+    [IntegrationTest]
     [Endpoint("GET /ogc/maps/collections/{collectionId}/map/tiles")]
     [Operation(Operations.GetTileMetadata)]
     public async Task GetMapTileSets_ValidCollection_ReturnsTileSetMetadata()

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsConformanceHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsConformanceHandlerTests.cs
@@ -50,6 +50,16 @@ public class OgcMapsConformanceHandlerTests
 
     [UnitTest]
     [Operation(Operations.Metadata)]
+    public async Task GetConformanceAsync_IncludesStyledMapConformance()
+    {
+        var result = await _handler.GetConformanceAsync();
+
+        result.ConformsTo.Should().Contain(
+            "https://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/styled-map");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
     public async Task GetConformanceAsync_IncludesDatasetMapConformance()
     {
         var result = await _handler.GetConformanceAsync();

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsConformanceTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsConformanceTests.cs
@@ -129,12 +129,12 @@ public class OgcMapsConformanceTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Metadata)]
     [Endpoint("GET /ogc/maps/conformance")]
-    public async Task GetConformance_DoesNotClaimStyledMapConformance()
+    public async Task GetConformance_ClaimsStyledMapConformance()
     {
         var classes = await GetConformanceClassesAsync();
 
-        classes.Should().NotContain("https://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/styled-map",
-            "the full styled-map conformance class is not claimed by this service");
+        classes.Should().Contain("https://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/styled-map",
+            "styled-map rendering of vector collections is now supported via the Skia pipeline (ADR-0048)");
     }
 
     [IntegrationTest]


### PR DESCRIPTION
## Issue Link
Fixes #1390
(umbrella: #1387)

## Summary
`GET /ogc/maps/collections/{id}/styles/{styleId}/map` previously routed every collection to the raster-only `IRasterMapRenderer.RenderStyledMapAsync`, whose only implementation (`PostgresRasterMapRenderer`) throws `NotSupportedException` (501) for vector features. This PR adds a renderer-dispatch path (ADR-0048) so vector collections render through the existing Skia `RasterMapRenderingPipeline` with an explicit `styleId`-resolved MapLibre style, while raster coverages keep the honest 501. The OGC API Maps styled-map conformance class is now claimed.

## Changes Made
- Add `RasterMapRenderingPipeline.RenderVectorCollectionAsync` (Honua.Hosting): a reusable single-collection vector renderer that takes an explicit MapLibre style JSON and reuses the same reprojection, capacity-limiting, feature-query, point fast-path, and drawing helpers WMS GetMap and MapServer export already use — no rendering or geodesy logic is duplicated. Also adds `BuildRasterStylePlanFromJson` to build a style plan from a raw style document instead of the per-layer catalog.
- Dispatch in `OgcMapsRenderingHandler.RenderStyledMapAsync`: vector resources resolve the `styleId` to a canonical MapLibre style via `IOgcStyleProjection` (the same abstraction the merged Styles Phase 1 slice uses) and render via the Skia pipeline; unresolved styles fall back to default styling; raster resources keep the existing 501 path.
- Claim `…/conf/styled-map` in `OgcMapsConformanceHandler`.
- Tests updated/added accordingly.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

`dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true` → 0 warnings, 0 errors.
`dotnet format Honua.sln --verify-no-changes` → clean.
`Honua.Protocols.OgcApi.Tests` (filter `~Maps`) → 116/116 passed, including the new `GetStyledMap_VectorCollection_RendersPngInsteadOf501` integration test (asserts a 200 PNG with the PNG signature, not 501) and the inverted styled-map conformance assertions.
`Honua.Architecture.Tests` → 101 passed / 1 skipped.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact
<!-- The styled-map endpoint already documented a 200 image response in ogc-maps-openapi.json; the 501 remains valid for raster coverages. Conformance declaration now matches runtime behavior. -->

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
