### PR TITLE
feat: OGC API – Styles Phase 2 catalog + styled vector maps (#1389, #1390)

### DIFF
--- a/src/Honua.Core.Abstractions/Features/Metadata/Abstractions/IMetadataV2StyleGraphSync.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Abstractions/IMetadataV2StyleGraphSync.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Abstractions;
+
+/// <summary>
+/// Synchronizes the canonical Metadata v2 graph with the independent style catalog
+/// (ADR-0048, Phase 2, issue #1389). Called after a style is created, updated, deleted,
+/// or (dis)associated from a layer so the graph's <c>Type=Style</c> resources and the
+/// data resources' <c>StyleResourceIds</c> reflect the catalog without waiting for a
+/// re-publish. Implemented where graph-store write access lives (the provider project),
+/// and exposed as a Core abstraction so the server-side style services can invoke it
+/// without taking a hard provider dependency.
+/// </summary>
+public interface IMetadataV2StyleGraphSync
+{
+    /// <summary>
+    /// Reconciles the <c>Type=Style</c> resources and <c>StyleResourceIds</c> for a layer
+    /// against the current style-catalog associations for that layer. Adds or refreshes
+    /// the layer's style resources, points the data resource's <c>StyleResourceIds</c> at
+    /// them (primary first), and prunes any orphaned style resources no longer referenced
+    /// by any resource. A no-op when the graph has no resource for the layer.
+    /// </summary>
+    /// <param name="layerId">Integer storage-layer identifier whose styles changed.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SyncLayerStylesAsync(int layerId, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2StyleResourceFactory.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2StyleResourceFactory.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Builds <see cref="MetadataV2ResourceType.Style"/> resources for the canonical graph
+/// from independent-catalog style bytes (ADR-0048, Phase 2, issue #1389). Kept in
+/// <c>Honua.Core.Abstractions</c> so both the publish-time graph producer and the
+/// style-update graph sync produce identical Style resources without duplicating the
+/// encoding-projection logic.
+/// </summary>
+public static class MetadataV2StyleResourceFactory
+{
+    /// <summary>The canonical resource id prefix for a style resource.</summary>
+    public const string StyleResourceIdPrefix = "style-";
+
+    /// <summary>
+    /// Builds the canonical resource id for a catalog style id.
+    /// </summary>
+    /// <param name="styleId">Stable catalog style identifier.</param>
+    /// <returns>The sanitized style resource id.</returns>
+    public static string BuildStyleResourceId(string styleId)
+        => StyleResourceIdPrefix + SanitizeId(styleId);
+
+    /// <summary>
+    /// Builds a <see cref="MetadataV2ResourceType.Style"/> resource from catalog style
+    /// bytes. The canonical MapLibre body is always emitted as a <c>mapbox-style</c>
+    /// encoding; a cached drawingInfo, when present, is emitted as
+    /// <c>esri-drawing-info</c>. Other encodings (SLD) are derived on demand by the
+    /// read path, so they are not pre-materialized here.
+    /// </summary>
+    /// <param name="styleId">Stable catalog style identifier (becomes the resource name).</param>
+    /// <param name="mapLibreStyleJson">Canonical MapLibre style JSON.</param>
+    /// <param name="title">Optional title.</param>
+    /// <param name="description">Optional description.</param>
+    /// <param name="drawingInfoJson">Optional cached GeoServices drawingInfo JSON.</param>
+    /// <param name="styleVersion">Author-managed integer style version.</param>
+    /// <param name="createdAt">Resource created timestamp.</param>
+    /// <param name="updatedAt">Resource updated timestamp.</param>
+    /// <returns>The style resource.</returns>
+    public static MetadataV2Resource BuildStyleResource(
+        string styleId,
+        string mapLibreStyleJson,
+        string? title,
+        string? description,
+        string? drawingInfoJson,
+        int styleVersion,
+        DateTimeOffset createdAt,
+        DateTimeOffset updatedAt)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(mapLibreStyleJson);
+
+        var encodings = new List<MetadataV2StyleEncoding>(2)
+        {
+            new()
+            {
+                Encoding = "mapbox-style",
+                Body = mapLibreStyleJson,
+                ContentType = "application/vnd.mapbox.style+json"
+            }
+        };
+
+        if (!string.IsNullOrWhiteSpace(drawingInfoJson))
+        {
+            encodings.Add(new MetadataV2StyleEncoding
+            {
+                Encoding = "esri-drawing-info",
+                Body = drawingInfoJson,
+                ContentType = "application/json"
+            });
+        }
+
+        var resolvedTitle = string.IsNullOrWhiteSpace(title) ? styleId : title;
+        return new MetadataV2Resource
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = BuildStyleResourceId(styleId),
+                Name = styleId,
+                Title = resolvedTitle,
+                Description = description,
+                CreatedAt = createdAt,
+                UpdatedAt = updatedAt
+            },
+            Type = MetadataV2ResourceType.Style,
+            Style = new MetadataV2ResourceStyle
+            {
+                Title = resolvedTitle,
+                Abstract = description,
+                StyleVersion = styleVersion,
+                Encodings = encodings
+            },
+            Status = new MetadataV2Status
+            {
+                Lifecycle = MetadataV2LifecycleStatus.Active,
+                State = MetadataV2OperationalState.Ready,
+                ObservedAt = updatedAt
+            }
+        };
+    }
+
+    private static string SanitizeId(string value)
+    {
+        var trimmed = value.Trim();
+        var chars = trimmed.Select(ch =>
+            char.IsLetterOrDigit(ch) || ch is '-' or '_' or '.'
+                ? ch
+                : '-');
+        var sanitized = new string(chars.ToArray()).Trim('-');
+        return string.IsNullOrWhiteSpace(sanitized) ? "default" : sanitized;
+    }
+}

--- a/src/Honua.Core/Features/Styling/Abstractions/IOgcStyleProjection.cs
+++ b/src/Honua.Core/Features/Styling/Abstractions/IOgcStyleProjection.cs
@@ -61,6 +61,37 @@ public interface IOgcStyleProjection
         string mapLibreStyleJson,
         bool strict,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a new standalone style in the independent style catalog (OGC
+    /// <c>manage-styles</c>, POST). Available from Phase 2 (ADR-0048, issue #1389).
+    /// The new style is decoupled from any layer; it can later be associated with
+    /// data resources to render them.
+    /// </summary>
+    /// <param name="styleId">
+    /// Requested stable style identifier. When <c>null</c> or blank the server assigns one.
+    /// </param>
+    /// <param name="mapLibreStyleJson">Candidate MapLibre style JSON document.</param>
+    /// <param name="strict">When <c>true</c>, validation failures reject the request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The create outcome, including the assigned style identifier on success.</returns>
+    Task<OgcStyleCreateResult> CreateStyleAsync(
+        string? styleId,
+        string mapLibreStyleJson,
+        bool strict,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a style from the independent style catalog (OGC <c>manage-styles</c>,
+    /// DELETE). Available from Phase 2. Default per-layer styles (those still backing a
+    /// Phase 1 collection) cannot be deleted through this surface.
+    /// </summary>
+    /// <param name="styleId">Stable style identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The delete outcome.</returns>
+    Task<OgcStyleDeleteResult> DeleteStyleAsync(
+        string styleId,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -131,3 +162,48 @@ public enum OgcStyleUpdateStatus
 /// <param name="Status">Outcome status.</param>
 /// <param name="ErrorMessage">Human-readable error message when <paramref name="Status"/> is not <see cref="OgcStyleUpdateStatus.Updated"/>.</param>
 public sealed record OgcStyleUpdateResult(OgcStyleUpdateStatus Status, string? ErrorMessage);
+
+/// <summary>
+/// Status of an OGC style create attempt.
+/// </summary>
+public enum OgcStyleCreateStatus
+{
+    /// <summary>The style was created.</summary>
+    Created,
+
+    /// <summary>A style with the requested identifier already exists.</summary>
+    Conflict,
+
+    /// <summary>The supplied stylesheet was invalid.</summary>
+    Invalid
+}
+
+/// <summary>
+/// Outcome of an OGC style create attempt.
+/// </summary>
+/// <param name="Status">Outcome status.</param>
+/// <param name="StyleId">Assigned style identifier when <paramref name="Status"/> is <see cref="OgcStyleCreateStatus.Created"/>.</param>
+/// <param name="ErrorMessage">Human-readable error message when creation did not succeed.</param>
+public sealed record OgcStyleCreateResult(OgcStyleCreateStatus Status, string? StyleId, string? ErrorMessage);
+
+/// <summary>
+/// Status of an OGC style delete attempt.
+/// </summary>
+public enum OgcStyleDeleteStatus
+{
+    /// <summary>The style was deleted.</summary>
+    Deleted,
+
+    /// <summary>No style with the requested identifier exists in the catalog.</summary>
+    NotFound,
+
+    /// <summary>The style cannot be deleted through this surface (e.g. a Phase 1 default per-layer style).</summary>
+    Forbidden
+}
+
+/// <summary>
+/// Outcome of an OGC style delete attempt.
+/// </summary>
+/// <param name="Status">Outcome status.</param>
+/// <param name="ErrorMessage">Human-readable error message when deletion did not succeed.</param>
+public sealed record OgcStyleDeleteResult(OgcStyleDeleteStatus Status, string? ErrorMessage);

--- a/src/Honua.Core/Features/Styling/Abstractions/IStyleCatalog.cs
+++ b/src/Honua.Core/Features/Styling/Abstractions/IStyleCatalog.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Styling.Domain;
+
+namespace Honua.Core.Features.Styling.Abstractions;
+
+/// <summary>
+/// Independent, styleId-keyed style store (ADR-0048, Phase 2, issue #1389).
+/// Unlike <see cref="ILayerStyleCatalog"/> — which keys style bytes by an integer
+/// storage-layer id and binds one style to exactly one layer — this catalog stores
+/// styles by a stable string <c>styleId</c> decoupled from any layer, and maintains an
+/// ordered many-to-many association so one style can render many layers. It is the
+/// backing store for the OGC API - Styles <c>manage-styles</c> create/delete surface and
+/// for the <c>Type=Style</c> metadata-v2 graph producer.
+/// </summary>
+public interface IStyleCatalog
+{
+    /// <summary>
+    /// Gets a single catalog style by its stable identifier.
+    /// </summary>
+    /// <param name="styleId">Stable style identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The style, or <c>null</c> when no such style exists.</returns>
+    Task<StyleCatalogRecord?> GetStyleAsync(string styleId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists every catalog style, ordered by style identifier.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>All catalog styles.</returns>
+    Task<IReadOnlyList<StyleCatalogRecord>> ListStylesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists the catalog styles associated with a layer, ordered by ordinal
+    /// (<c>0</c> = primary).
+    /// </summary>
+    /// <param name="layerId">Integer storage-layer identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The associated styles, primary first.</returns>
+    Task<IReadOnlyList<StyleCatalogRecord>> GetStylesForLayerAsync(int layerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists every layer/style association in the catalog. Used by the graph producer
+    /// to populate <c>StyleResourceIds</c> across all data resources.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>All associations.</returns>
+    Task<IReadOnlyList<StyleLayerAssociation>> ListAssociationsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a new standalone catalog style. Fails when a style with the same
+    /// identifier already exists.
+    /// </summary>
+    /// <param name="styleId">Stable style identifier.</param>
+    /// <param name="mapLibreStyleJson">Canonical MapLibre style JSON.</param>
+    /// <param name="title">Optional title.</param>
+    /// <param name="description">Optional description.</param>
+    /// <param name="drawingInfoJson">Optional cached GeoServices drawingInfo JSON.</param>
+    /// <param name="revisedBy">Optional author or source identifier.</param>
+    /// <param name="changeSummary">Optional change summary.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created style, or <c>null</c> when the identifier already exists.</returns>
+    Task<StyleCatalogRecord?> CreateStyleAsync(
+        string styleId,
+        string mapLibreStyleJson,
+        string? title = null,
+        string? description = null,
+        string? drawingInfoJson = null,
+        string? revisedBy = null,
+        string? changeSummary = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Inserts or updates a catalog style (upsert by <c>styleId</c>). On update the
+    /// canonical MapLibre style is replaced and the version is incremented.
+    /// </summary>
+    /// <param name="styleId">Stable style identifier.</param>
+    /// <param name="mapLibreStyleJson">Canonical MapLibre style JSON.</param>
+    /// <param name="title">Optional title.</param>
+    /// <param name="description">Optional description.</param>
+    /// <param name="drawingInfoJson">Optional cached GeoServices drawingInfo JSON.</param>
+    /// <param name="revisedBy">Optional author or source identifier.</param>
+    /// <param name="changeSummary">Optional change summary.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The upserted style.</returns>
+    Task<StyleCatalogRecord> UpsertStyleAsync(
+        string styleId,
+        string mapLibreStyleJson,
+        string? title = null,
+        string? description = null,
+        string? drawingInfoJson = null,
+        string? revisedBy = null,
+        string? changeSummary = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a catalog style and all of its layer associations.
+    /// </summary>
+    /// <param name="styleId">Stable style identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><c>true</c> when a style was deleted; <c>false</c> when none existed.</returns>
+    Task<bool> DeleteStyleAsync(string styleId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Associates a style with a layer at the given ordinal (idempotent upsert of the
+    /// association). Used so one style can render many layers.
+    /// </summary>
+    /// <param name="layerId">Integer storage-layer identifier.</param>
+    /// <param name="styleId">Stable style identifier.</param>
+    /// <param name="ordinal">Zero-based reference ordinal; 0 is primary.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><c>true</c> when the association was applied; <c>false</c> when the style or layer does not exist.</returns>
+    Task<bool> AssociateLayerAsync(int layerId, string styleId, int ordinal = 0, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Styling/Domain/StyleCatalogRecord.cs
+++ b/src/Honua.Core/Features/Styling/Domain/StyleCatalogRecord.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Styling.Domain;
+
+/// <summary>
+/// A first-class, styleId-keyed style record from the independent style catalog
+/// (ADR-0048, Phase 2). Decoupled from any single layer: one style may render many
+/// layers through <see cref="StyleLayerAssociation"/> entries.
+/// </summary>
+public sealed record StyleCatalogRecord
+{
+    /// <summary>Stable string style identifier (<c>honua://styles/{StyleId}</c>).</summary>
+    public required string StyleId { get; init; }
+
+    /// <summary>Optional human-readable title.</summary>
+    public string? Title { get; init; }
+
+    /// <summary>Optional free-form description / abstract.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Canonical MapLibre/Mapbox style JSON.</summary>
+    public required string MapLibreStyleJson { get; init; }
+
+    /// <summary>Optional cached GeoServices drawingInfo JSON.</summary>
+    public string? DrawingInfoJson { get; init; }
+
+    /// <summary>Author-managed integer style version, incremented on canonical updates.</summary>
+    public int StyleVersion { get; init; }
+
+    /// <summary>UTC timestamp the style was created.</summary>
+    public DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>UTC timestamp of the last canonical update.</summary>
+    public DateTimeOffset UpdatedAt { get; init; }
+
+    /// <summary>Optional author or source identifier of the most recent revision.</summary>
+    public string? RevisedBy { get; init; }
+
+    /// <summary>Optional operator-supplied description of the most recent revision.</summary>
+    public string? ChangeSummary { get; init; }
+}
+
+/// <summary>
+/// An ordered association between a layer (integer storage-layer id) and a catalog
+/// style. <see cref="Ordinal"/> <c>0</c> is the primary style, matching
+/// <c>MetadataV2Resource.StyleResourceIds[0]</c>.
+/// </summary>
+/// <param name="LayerId">Integer storage-layer identifier.</param>
+/// <param name="StyleId">Catalog style identifier.</param>
+/// <param name="Ordinal">Zero-based reference ordinal; 0 is primary.</param>
+public sealed record StyleLayerAssociation(int LayerId, string StyleId, int Ordinal);

--- a/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs
+++ b/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs
@@ -208,6 +208,151 @@ internal static class RasterMapRenderingPipeline
         var imageBytes = SkiaMapRenderer.EncodeSurface(surface, "png");
         return RasterTileRenderResult.Success(imageBytes, totalFeatureCount);
     }
+    /// <summary>
+    /// Result of a single-collection vector render through the Skia pipeline.
+    /// </summary>
+    internal readonly record struct VectorCollectionRenderResult(
+        bool IsSuccess,
+        byte[] ImageBytes,
+        int FeatureCount,
+        IResult? Error)
+    {
+        public static VectorCollectionRenderResult Success(byte[] imageBytes, int featureCount)
+            => new(true, imageBytes, featureCount, null);
+
+        public static VectorCollectionRenderResult Failure(IResult error)
+            => new(false, [], 0, error);
+    }
+
+    /// <summary>
+    /// Renders a single vector collection to an encoded image using the shared Skia
+    /// pipeline and an explicit MapLibre style document. This is the vector counterpart
+    /// to the raster-coverage renderer used by OGC API Maps styled-map requests: the
+    /// caller resolves the style (e.g. from a styleId-keyed projection) and supplies the
+    /// already-validated request extent. Reprojection, capacity limiting, feature
+    /// querying, and drawing all reuse the same helpers WMS GetMap and MapServer export
+    /// invoke, so no rendering or geodesy logic is duplicated.
+    /// </summary>
+    /// <param name="context">The current HTTP context (used to resolve request-scoped services).</param>
+    /// <param name="layerId">Storage layer identifier for the collection.</param>
+    /// <param name="geometryType">Geometry type used to drive default styling and the point fast-path.</param>
+    /// <param name="serviceSrid">Storage CRS the feature geometries are stored in.</param>
+    /// <param name="mapLibreStyleJson">Resolved MapLibre style JSON to apply, or <c>null</c> for default styling.</param>
+    /// <param name="requestExtent">Requested map extent in <paramref name="requestSrid"/>.</param>
+    /// <param name="requestSrid">CRS the requested extent (and output image) is expressed in.</param>
+    /// <param name="imageWidth">Output image width in pixels.</param>
+    /// <param name="imageHeight">Output image height in pixels.</param>
+    /// <param name="format">Output image format string (e.g. <c>png</c>, <c>jpeg</c>).</param>
+    /// <param name="transparent">Whether the background should be transparent.</param>
+    /// <param name="backgroundColor">Background fill used when not transparent (defaults to white).</param>
+    /// <param name="temporalFilter">Optional temporal filter for time-enabled collections.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    internal static async Task<VectorCollectionRenderResult> RenderVectorCollectionAsync(
+        HttpContext context,
+        int layerId,
+        MetadataV2GeometryType geometryType,
+        int serviceSrid,
+        string? mapLibreStyleJson,
+        SkiaMapRenderer.RenderExtent requestExtent,
+        int requestSrid,
+        int imageWidth,
+        int imageHeight,
+        string format,
+        bool transparent,
+        SKColor? backgroundColor,
+        TemporalFilter? temporalFilter,
+        CancellationToken cancellationToken)
+    {
+        await using var renderLease = await context.RequestServices
+            .GetRequiredService<RasterRenderCapacityLimiter>()
+            .TryAcquireAsync(imageWidth, imageHeight, cancellationToken)
+            .ConfigureAwait(false);
+        if (renderLease is null)
+        {
+            return VectorCollectionRenderResult.Failure(StandardErrorHelpers.CreateServiceUnavailable(
+                context,
+                RasterRenderCapacityLimiter.CapacityExceededMessage,
+                RasterRenderCapacityLimiter.RetryAfterSeconds));
+        }
+
+        // Reproject the request extent into the storage CRS the feature reader expects,
+        // mirroring WMS GetMap's per-layer handling.
+        var queryExtent = requestExtent;
+        if (requestSrid != serviceSrid)
+        {
+            var extentTransformResult = await TryTransformExtentAsync(
+                context,
+                requestExtent,
+                requestSrid,
+                serviceSrid,
+                cancellationToken).ConfigureAwait(false);
+            if (!extentTransformResult.IsSuccess)
+            {
+                return VectorCollectionRenderResult.Failure(
+                    StandardErrorHelpers.CreateBadRequest(context, extentTransformResult.Error ?? InvalidSpatialReferenceMessage));
+            }
+
+            queryExtent = extentTransformResult.Extent;
+        }
+
+        using var surface = SKSurface.Create(new SKImageInfo(imageWidth, imageHeight, SKColorType.Rgba8888, SKAlphaType.Premul));
+        if (surface is null)
+        {
+            return VectorCollectionRenderResult.Failure(
+                StandardErrorHelpers.CreateInternalServerError(context, "Failed to allocate render surface."));
+        }
+
+        var canvas = surface.Canvas;
+        var effectiveTransparent = transparent && string.Equals(format, "png", StringComparison.OrdinalIgnoreCase);
+        canvas.Clear(effectiveTransparent ? SKColors.Transparent : backgroundColor ?? SKColors.White);
+
+        var totalFeatureCount = 0;
+        if (geometryType != MetadataV2GeometryType.None)
+        {
+            var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
+            var transform = SkiaMapRenderer.BuildTransform(requestExtent, imageWidth, imageHeight);
+            var stylePlan = BuildRasterStylePlanFromJson(mapLibreStyleJson);
+            var spatialFilter = CreateBboxSpatialFilter(queryExtent, serviceSrid);
+            var featureQuery = CreateRasterFeatureQuery(
+                stylePlan,
+                spatialFilter,
+                serviceSrid,
+                requestSrid,
+                MaxFeaturesPerLayer,
+                temporalFilter: temporalFilter);
+
+            var renderedPointCount = await TryRenderRasterPointFastPathAsync(
+                canvas,
+                featureReader,
+                layerId,
+                geometryType,
+                stylePlan,
+                featureQuery,
+                requestExtent,
+                imageWidth,
+                imageHeight,
+                transform,
+                cancellationToken).ConfigureAwait(false);
+            if (renderedPointCount >= 0)
+            {
+                totalFeatureCount += renderedPointCount;
+            }
+            else
+            {
+                var features = await QueryRasterFeaturesAsync(featureReader, layerId, featureQuery, cancellationToken)
+                    .ConfigureAwait(false);
+                if (features.Length > 0)
+                {
+                    totalFeatureCount += features.Length;
+                    RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transform, geometryType);
+                }
+            }
+        }
+
+        var imageBytes = SkiaMapRenderer.EncodeSurface(surface, format);
+        return VectorCollectionRenderResult.Success(imageBytes, totalFeatureCount);
+    }
+
     internal static void RenderLayerToCanvas(
         SKCanvas canvas,
         ImmutableArray<Feature> features,
@@ -620,8 +765,17 @@ internal static class RasterMapRenderingPipeline
     }
 
     private static RasterStylePlan BuildRasterStylePlan(LayerStyleDefinition? style)
+        => BuildRasterStylePlanFromJson(style?.MapLibreStyleJson);
+
+    /// <summary>
+    /// Builds a render-time style plan directly from an explicit MapLibre style JSON
+    /// document, bypassing the per-layer style catalog. Used by callers (such as OGC API
+    /// Maps styled-map rendering) that resolve the style from an external source — e.g. a
+    /// styleId-keyed projection — rather than the layer's stored default style.
+    /// </summary>
+    internal static RasterStylePlan BuildRasterStylePlanFromJson(string? mapLibreStyleJson)
     {
-        var styleLayers = StyleTranslator.ParseStyleLayers(style?.MapLibreStyleJson);
+        var styleLayers = StyleTranslator.ParseStyleLayers(mapLibreStyleJson);
         var referencedFields = StyleTranslator.CollectReferencedFields(styleLayers);
 
         return new RasterStylePlan

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.MetadataV2Graph.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.MetadataV2Graph.cs
@@ -94,12 +94,30 @@ internal sealed partial class PostgreSqlLayerPublishingService
                 .ToArray()
         };
 
+        // ADR-0048 Phase 2 (#1389): project the independent style catalog into the
+        // canonical graph. Emit a Type=Style resource per associated catalog style and
+        // point the data resource's StyleResourceIds at them ([0] = primary), so the
+        // FeatureServer/MapServer StyleResourceIds read path lights up with real data
+        // and one style can be shared by many resources.
+        var (styleResources, styleResourceIds) =
+            await BuildStyleResourcesForLayerAsync(layerId, now, cancellationToken).ConfigureAwait(false);
+        if (styleResourceIds.Count > 0)
+        {
+            resource = resource with { StyleResourceIds = styleResourceIds };
+        }
+
+        var resourcesWithStyles = UpsertById(graph.Resources, resource, static item => item.Metadata.Id);
+        foreach (var styleResource in styleResources)
+        {
+            resourcesWithStyles = UpsertById(resourcesWithStyles, styleResource, static item => item.Metadata.Id);
+        }
+
         var updatedGraph = graph with
         {
             Revision = Math.Max(graph.Revision + 1, 1),
             GeneratedAt = now,
             Services = UpsertById(graph.Services, service, static item => item.Metadata.Id),
-            Resources = UpsertById(graph.Resources, resource, static item => item.Metadata.Id),
+            Resources = resourcesWithStyles,
             StorageBindings = UpsertById(graph.StorageBindings, binding, static item => item.Metadata.Id),
             Publications = UpsertPublication(graph.Publications, publication),
             Connections = connection is null
@@ -621,6 +639,45 @@ internal sealed partial class PostgreSqlLayerPublishingService
         }
 
         return result;
+    }
+
+    // Builds the Type=Style graph resources for a layer's associated catalog styles
+    // and the ordered StyleResourceIds the data resource should reference. Returns
+    // empty when the style catalog is unavailable or the layer has no associations
+    // (e.g. a freshly published, not-yet-styled layer), so the publish path degrades
+    // gracefully and the data resource simply carries no StyleResourceIds.
+    private async Task<(IReadOnlyList<MetadataV2Resource> Styles, IReadOnlyList<string> StyleResourceIds)>
+        BuildStyleResourcesForLayerAsync(int layerId, DateTimeOffset now, CancellationToken cancellationToken)
+    {
+        if (_styleCatalog is null)
+        {
+            return (Array.Empty<MetadataV2Resource>(), Array.Empty<string>());
+        }
+
+        var styles = await _styleCatalog.GetStylesForLayerAsync(layerId, cancellationToken).ConfigureAwait(false);
+        if (styles.Count == 0)
+        {
+            return (Array.Empty<MetadataV2Resource>(), Array.Empty<string>());
+        }
+
+        var resources = new List<MetadataV2Resource>(styles.Count);
+        var ids = new List<string>(styles.Count);
+        foreach (var style in styles)
+        {
+            var resourceId = MetadataV2StyleResourceFactory.BuildStyleResourceId(style.StyleId);
+            resources.Add(MetadataV2StyleResourceFactory.BuildStyleResource(
+                style.StyleId,
+                style.MapLibreStyleJson,
+                style.Title,
+                style.Description,
+                style.DrawingInfoJson,
+                style.StyleVersion,
+                style.CreatedAt == default ? now : style.CreatedAt,
+                style.UpdatedAt == default ? now : style.UpdatedAt));
+            ids.Add(resourceId);
+        }
+
+        return (resources, ids);
     }
 
     private static string BuildResourceId(int layerId)

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
@@ -28,7 +28,8 @@ internal sealed partial class PostgreSqlLayerPublishingService(
     ITableDiscoveryService tableDiscoveryService,
     IMetadataV2GraphStore metadataGraphStore,
     ILogger<PostgreSqlLayerPublishingService> logger,
-    string? metadataSchema = null) : ILayerPublishingService
+    string? metadataSchema = null,
+    Honua.Core.Features.Styling.Abstractions.IStyleCatalog? styleCatalog = null) : ILayerPublishingService
 {
     private const string DefaultServiceName = "default";
     private const int CatalogExtentSrid = 4326;
@@ -47,6 +48,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
     private readonly ITableDiscoveryService _tableDiscoveryService = tableDiscoveryService;
     private readonly IMetadataV2GraphStore _metadataGraphStore = metadataGraphStore;
     private readonly ILogger<PostgreSqlLayerPublishingService> _logger = logger;
+    private readonly Honua.Core.Features.Styling.Abstractions.IStyleCatalog? _styleCatalog = styleCatalog;
 
     // The Honua-managed metadata schema that owns the shared `features` table
     // (default 'honua', overridable via Database:Schema). Only a `features` table in

--- a/src/Honua.Postgres/Features/Metadata/PostgresMetadataV2StyleGraphSync.cs
+++ b/src/Honua.Postgres/Features/Metadata/PostgresMetadataV2StyleGraphSync.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Styling.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Postgres.Features.Metadata;
+
+/// <summary>
+/// PostgreSQL-backed <see cref="IMetadataV2StyleGraphSync"/> (ADR-0048, Phase 2,
+/// issue #1389). Reconciles the canonical graph's <c>Type=Style</c> resources and
+/// <c>StyleResourceIds</c> against the independent style catalog whenever a layer's
+/// styles change, so the FeatureServer/MapServer style read path reflects edits
+/// immediately rather than waiting for a re-publish.
+/// </summary>
+internal sealed class PostgresMetadataV2StyleGraphSync : IMetadataV2StyleGraphSync
+{
+    private readonly IMetadataV2GraphStore _graphStore;
+    private readonly IStyleCatalog _styleCatalog;
+    private readonly ILogger<PostgresMetadataV2StyleGraphSync> _logger;
+
+    public PostgresMetadataV2StyleGraphSync(
+        IMetadataV2GraphStore graphStore,
+        IStyleCatalog styleCatalog,
+        ILogger<PostgresMetadataV2StyleGraphSync> logger)
+    {
+        _graphStore = graphStore ?? throw new ArgumentNullException(nameof(graphStore));
+        _styleCatalog = styleCatalog ?? throw new ArgumentNullException(nameof(styleCatalog));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task SyncLayerStylesAsync(int layerId, CancellationToken cancellationToken = default)
+    {
+        MetadataV2GraphSnapshot snapshot;
+        try
+        {
+            snapshot = await _graphStore.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or KeyNotFoundException)
+        {
+            // No activated snapshot yet (fresh DB); nothing to reconcile.
+            PostgresMetadataV2StyleGraphSyncLog.NoSnapshot(_logger, layerId);
+            return;
+        }
+
+        var graph = snapshot.Graph;
+        if (!snapshot.Index.ResourcesByStorageLayerId.TryGetValue(layerId, out var dataResource))
+        {
+            // The layer is not (yet) represented in the graph; the publish path will
+            // pick up its styles when it next runs.
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var styles = await _styleCatalog.GetStylesForLayerAsync(layerId, cancellationToken).ConfigureAwait(false);
+
+        var styleResources = new List<MetadataV2Resource>(styles.Count);
+        var styleResourceIds = new List<string>(styles.Count);
+        foreach (var style in styles)
+        {
+            styleResources.Add(MetadataV2StyleResourceFactory.BuildStyleResource(
+                style.StyleId,
+                style.MapLibreStyleJson,
+                style.Title,
+                style.Description,
+                style.DrawingInfoJson,
+                style.StyleVersion,
+                style.CreatedAt == default ? now : style.CreatedAt,
+                style.UpdatedAt == default ? now : style.UpdatedAt));
+            styleResourceIds.Add(MetadataV2StyleResourceFactory.BuildStyleResourceId(style.StyleId));
+        }
+
+        // Replace the data resource's StyleResourceIds with the current catalog order.
+        var updatedDataResource = dataResource with { StyleResourceIds = styleResourceIds };
+
+        var resources = new List<MetadataV2Resource>(graph.Resources.Count + styleResources.Count);
+        foreach (var resource in graph.Resources)
+        {
+            if (string.Equals(resource.Metadata.Id, updatedDataResource.Metadata.Id, StringComparison.Ordinal))
+            {
+                resources.Add(updatedDataResource);
+            }
+            else
+            {
+                resources.Add(resource);
+            }
+        }
+
+        // Upsert (add or refresh) the layer's style resources.
+        foreach (var styleResource in styleResources)
+        {
+            var index = resources.FindIndex(r =>
+                string.Equals(r.Metadata.Id, styleResource.Metadata.Id, StringComparison.Ordinal));
+            if (index >= 0)
+            {
+                resources[index] = styleResource;
+            }
+            else
+            {
+                resources.Add(styleResource);
+            }
+        }
+
+        // Prune Type=Style resources that are no longer referenced by any resource so
+        // a deleted/disassociated style does not linger and trip referential checks.
+        var referencedStyleIds = resources
+            .SelectMany(r => r.StyleResourceIds)
+            .ToHashSet(StringComparer.Ordinal);
+        resources.RemoveAll(r =>
+            r.Type == MetadataV2ResourceType.Style
+            && !referencedStyleIds.Contains(r.Metadata.Id));
+
+        var updatedGraph = graph with
+        {
+            Revision = Math.Max(graph.Revision + 1, 1),
+            GeneratedAt = now,
+            Resources = resources
+        };
+
+        var validation = MetadataV2GraphValidator.Validate(updatedGraph);
+        if (!validation.IsValid)
+        {
+            PostgresMetadataV2StyleGraphSyncLog.ValidationFailed(
+                _logger,
+                layerId,
+                string.Join("; ", validation.Errors));
+            return;
+        }
+
+        await _graphStore.SaveAsync(updatedGraph, snapshot.Etag, cancellationToken).ConfigureAwait(false);
+        PostgresMetadataV2StyleGraphSyncLog.Synced(_logger, layerId, styleResourceIds.Count);
+    }
+}
+
+internal static partial class PostgresMetadataV2StyleGraphSyncLog
+{
+    [LoggerMessage(EventId = 6100, Level = LogLevel.Debug,
+        Message = "No activated metadata-v2 snapshot; skipping style graph sync for layer {LayerId}.")]
+    public static partial void NoSnapshot(ILogger logger, int layerId);
+
+    [LoggerMessage(EventId = 6101, Level = LogLevel.Warning,
+        Message = "Style graph sync produced an invalid graph for layer {LayerId}: {Errors}")]
+    public static partial void ValidationFailed(ILogger logger, int layerId, string errors);
+
+    [LoggerMessage(EventId = 6102, Level = LogLevel.Debug,
+        Message = "Synced {StyleCount} style resource(s) into the graph for layer {LayerId}.")]
+    public static partial void Synced(ILogger logger, int layerId, int styleCount);
+}

--- a/src/Honua.Postgres/Features/Styling/PostgresStyleCatalog.cs
+++ b/src/Honua.Postgres/Features/Styling/PostgresStyleCatalog.cs
@@ -1,0 +1,315 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Styling.Abstractions;
+using Honua.Core.Features.Styling.Domain;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.Styling;
+
+/// <summary>
+/// PostgreSQL implementation of the independent, styleId-keyed style catalog
+/// (ADR-0048, Phase 2). Backed by <c>honua.styles</c> and the ordered
+/// <c>honua.layer_style_refs</c> association table (migration 042).
+/// </summary>
+internal sealed class PostgresStyleCatalog : IStyleCatalog
+{
+    private const string SelectColumns = """
+        style_id,
+        title,
+        description,
+        maplibre_style,
+        drawing_info,
+        style_version,
+        created_at,
+        updated_at,
+        revised_by,
+        change_summary
+        """;
+
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly string _stylesTable;
+    private readonly string _refsTable;
+    private readonly string _layersTable;
+
+    public PostgresStyleCatalog(IDatabaseConnectionProvider connectionProvider, string? schemaName = null)
+    {
+        _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+        _stylesTable = Infrastructure.SchemaSearchPath.QualifyTable("styles", schemaName);
+        _refsTable = Infrastructure.SchemaSearchPath.QualifyTable("layer_style_refs", schemaName);
+        _layersTable = Infrastructure.SchemaSearchPath.QualifyTable("layers", schemaName);
+    }
+
+    /// <inheritdoc />
+    public async Task<StyleCatalogRecord?> GetStyleAsync(string styleId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleId);
+
+        var sql = $"""
+            SELECT {SelectColumns}
+            FROM {_stylesTable}
+            WHERE style_id = @styleId
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        _ = command.Parameters.AddWithValue("@styleId", styleId);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return ReadStyle(reader);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<StyleCatalogRecord>> ListStylesAsync(CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SELECT {SelectColumns}
+            FROM {_stylesTable}
+            ORDER BY style_id
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+
+        var results = new List<StyleCatalogRecord>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            results.Add(ReadStyle(reader));
+        }
+
+        return results;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<StyleCatalogRecord>> GetStylesForLayerAsync(int layerId, CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SELECT {QualifiedSelectColumns("s")}
+            FROM {_refsTable} r
+            JOIN {_stylesTable} s ON s.style_id = r.style_id
+            WHERE r.layer_id = @layerId
+            ORDER BY r.ordinal, s.style_id
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        _ = command.Parameters.AddWithValue("@layerId", layerId);
+
+        var results = new List<StyleCatalogRecord>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            results.Add(ReadStyle(reader));
+        }
+
+        return results;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<StyleLayerAssociation>> ListAssociationsAsync(CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SELECT layer_id, style_id, ordinal
+            FROM {_refsTable}
+            ORDER BY layer_id, ordinal, style_id
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+
+        var results = new List<StyleLayerAssociation>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            results.Add(new StyleLayerAssociation(reader.GetInt32(0), reader.GetString(1), reader.GetInt32(2)));
+        }
+
+        return results;
+    }
+
+    /// <inheritdoc />
+    public async Task<StyleCatalogRecord?> CreateStyleAsync(
+        string styleId,
+        string mapLibreStyleJson,
+        string? title = null,
+        string? description = null,
+        string? drawingInfoJson = null,
+        string? revisedBy = null,
+        string? changeSummary = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(mapLibreStyleJson);
+
+        var sql = $"""
+            INSERT INTO {_stylesTable}
+                (style_id, title, description, maplibre_style, drawing_info,
+                 style_version, created_at, updated_at, revised_by, change_summary)
+            VALUES
+                (@styleId, @title, @description, @mapLibreStyle, @drawingInfo,
+                 1, NOW(), NOW(), @revisedBy, @changeSummary)
+            ON CONFLICT (style_id) DO NOTHING
+            RETURNING {SelectColumns}
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        _ = command.Parameters.AddWithValue("@styleId", styleId);
+        AddNullableText(command, "@title", title);
+        AddNullableText(command, "@description", description);
+        AddJsonb(command, "@mapLibreStyle", mapLibreStyleJson);
+        AddNullableJsonb(command, "@drawingInfo", drawingInfoJson);
+        AddNullableText(command, "@revisedBy", revisedBy);
+        AddNullableText(command, "@changeSummary", changeSummary);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return ReadStyle(reader);
+    }
+
+    /// <inheritdoc />
+    public async Task<StyleCatalogRecord> UpsertStyleAsync(
+        string styleId,
+        string mapLibreStyleJson,
+        string? title = null,
+        string? description = null,
+        string? drawingInfoJson = null,
+        string? revisedBy = null,
+        string? changeSummary = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(mapLibreStyleJson);
+
+        var sql = $"""
+            INSERT INTO {_stylesTable}
+                (style_id, title, description, maplibre_style, drawing_info,
+                 style_version, created_at, updated_at, revised_by, change_summary)
+            VALUES
+                (@styleId, @title, @description, @mapLibreStyle, @drawingInfo,
+                 1, NOW(), NOW(), @revisedBy, @changeSummary)
+            ON CONFLICT (style_id) DO UPDATE SET
+                title = COALESCE(EXCLUDED.title, {_stylesTable}.title),
+                description = COALESCE(EXCLUDED.description, {_stylesTable}.description),
+                maplibre_style = EXCLUDED.maplibre_style,
+                drawing_info = EXCLUDED.drawing_info,
+                style_version = {_stylesTable}.style_version + 1,
+                updated_at = NOW(),
+                revised_by = EXCLUDED.revised_by,
+                change_summary = EXCLUDED.change_summary
+            RETURNING {SelectColumns}
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        _ = command.Parameters.AddWithValue("@styleId", styleId);
+        AddNullableText(command, "@title", title);
+        AddNullableText(command, "@description", description);
+        AddJsonb(command, "@mapLibreStyle", mapLibreStyleJson);
+        AddNullableJsonb(command, "@drawingInfo", drawingInfoJson);
+        AddNullableText(command, "@revisedBy", revisedBy);
+        AddNullableText(command, "@changeSummary", changeSummary);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        _ = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+        return ReadStyle(reader);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteStyleAsync(string styleId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleId);
+
+        // layer_style_refs cascades on delete (FK ON DELETE CASCADE).
+        var sql = $"""
+            DELETE FROM {_stylesTable}
+            WHERE style_id = @styleId
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        _ = command.Parameters.AddWithValue("@styleId", styleId);
+
+        var affected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return affected > 0;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> AssociateLayerAsync(int layerId, string styleId, int ordinal = 0, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleId);
+
+        var sql = $"""
+            INSERT INTO {_refsTable} (layer_id, style_id, ordinal)
+            SELECT @layerId, @styleId, @ordinal
+            WHERE EXISTS (SELECT 1 FROM {_stylesTable} WHERE style_id = @styleId)
+              AND EXISTS (SELECT 1 FROM {_layersTable} WHERE layer_id = @layerId)
+            ON CONFLICT (layer_id, style_id) DO UPDATE SET ordinal = EXCLUDED.ordinal
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        _ = command.Parameters.AddWithValue("@layerId", layerId);
+        _ = command.Parameters.AddWithValue("@styleId", styleId);
+        _ = command.Parameters.AddWithValue("@ordinal", ordinal);
+
+        var affected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return affected > 0;
+    }
+
+    private static string QualifiedSelectColumns(string alias) =>
+        string.Join(
+            ",\n",
+            SelectColumns
+                .Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                .Select(column => $"{alias}.{column.TrimEnd(',')}"));
+
+    private static void AddJsonb(NpgsqlCommand command, string name, string value) =>
+        command.Parameters.Add(new NpgsqlParameter(name, NpgsqlDbType.Jsonb) { Value = value });
+
+    private static void AddNullableJsonb(NpgsqlCommand command, string name, string? value) =>
+        command.Parameters.Add(new NpgsqlParameter(name, NpgsqlDbType.Jsonb)
+        {
+            Value = string.IsNullOrWhiteSpace(value) ? DBNull.Value : value
+        });
+
+    private static void AddNullableText(NpgsqlCommand command, string name, string? value) =>
+        command.Parameters.Add(new NpgsqlParameter(name, NpgsqlDbType.Text)
+        {
+            Value = string.IsNullOrWhiteSpace(value) ? DBNull.Value : value
+        });
+
+    private static StyleCatalogRecord ReadStyle(NpgsqlDataReader reader)
+    {
+        return new StyleCatalogRecord
+        {
+            StyleId = reader.GetString(0),
+            Title = reader.IsDBNull(1) ? null : reader.GetString(1),
+            Description = reader.IsDBNull(2) ? null : reader.GetString(2),
+            MapLibreStyleJson = reader.GetString(3),
+            DrawingInfoJson = reader.IsDBNull(4) ? null : reader.GetString(4),
+            StyleVersion = reader.IsDBNull(5) ? 0 : reader.GetInt32(5),
+            CreatedAt = ReadUtc(reader, 6),
+            UpdatedAt = ReadUtc(reader, 7),
+            RevisedBy = reader.IsDBNull(8) ? null : reader.GetString(8),
+            ChangeSummary = reader.IsDBNull(9) ? null : reader.GetString(9)
+        };
+    }
+
+    private static DateTimeOffset ReadUtc(NpgsqlDataReader reader, int ordinal) =>
+        reader.IsDBNull(ordinal)
+            ? default
+            : new DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(ordinal), DateTimeKind.Utc));
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -217,6 +217,15 @@ internal static class ServiceCollectionExtensions
                 serviceProvider.GetRequiredService<IDatabaseConnectionProvider>(),
                 configuration["Database:Schema"]));
 
+        // Register the independent, styleId-keyed style catalog (ADR-0048 Phase 2, #1389)
+        services.AddScoped<IStyleCatalog>(serviceProvider =>
+            new PostgresStyleCatalog(
+                serviceProvider.GetRequiredService<IDatabaseConnectionProvider>(),
+                configuration["Database:Schema"]));
+
+        // Reconciles Type=Style graph resources + StyleResourceIds with the style catalog
+        services.AddScoped<IMetadataV2StyleGraphSync, Features.Metadata.PostgresMetadataV2StyleGraphSync>();
+
         // Register field profiling service for style suggestions (#400)
         services.AddScoped<IFieldProfilingService>(serviceProvider =>
             new PostgresFieldProfilingService(
@@ -233,7 +242,8 @@ internal static class ServiceCollectionExtensions
                 serviceProvider.GetRequiredService<ITableDiscoveryService>(),
                 serviceProvider.GetRequiredService<IMetadataV2GraphStore>(),
                 serviceProvider.GetRequiredService<ILogger<PostgreSqlLayerPublishingService>>(),
-                configuration["Database:Schema"]));
+                configuration["Database:Schema"],
+                serviceProvider.GetService<IStyleCatalog>()));
 
         // Register health checker
         services.AddScoped<IDatabaseHealthChecker, PostgresDatabaseHealthChecker>();

--- a/src/Honua.Protocols.OgcApi/Maps/Handlers/OgcMapsConformanceHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Maps/Handlers/OgcMapsConformanceHandler.cs
@@ -35,6 +35,9 @@ internal sealed class OgcMapsConformanceHandler
                 // Collection maps support
                 "https://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/collection-map",
 
+                // Styled maps support (styleId-resolved MapLibre styling of vector collections, ADR-0048)
+                "https://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/styled-map",
+
                 // Dataset-wide maps support
                 "https://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/dataset-map",
 

--- a/src/Honua.Protocols.OgcApi/Maps/Handlers/OgcMapsRenderingHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Maps/Handlers/OgcMapsRenderingHandler.cs
@@ -9,6 +9,7 @@ using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
 using Honua.Core.Features.Shared.Models;
+using Honua.Core.Features.Styling.Abstractions;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Rendering;
@@ -56,15 +57,18 @@ internal sealed class OgcMapsRenderingHandler
 
     private readonly IMetadataV2GraphProvider _graphProvider;
     private readonly IRasterMapRenderer _mapRenderer;
+    private readonly IOgcStyleProjection _styleProjection;
     private readonly ILogger<OgcMapsRenderingHandler> _logger;
 
     public OgcMapsRenderingHandler(
         IMetadataV2GraphProvider graphProvider,
         IRasterMapRenderer mapRenderer,
+        IOgcStyleProjection styleProjection,
         ILogger<OgcMapsRenderingHandler> logger)
     {
         _graphProvider = graphProvider ?? throw new ArgumentNullException(nameof(graphProvider));
         _mapRenderer = mapRenderer ?? throw new ArgumentNullException(nameof(mapRenderer));
+        _styleProjection = styleProjection ?? throw new ArgumentNullException(nameof(styleProjection));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -453,7 +457,24 @@ internal sealed class OgcMapsRenderingHandler
 
             OgcMapsLog.StyledMapRenderStarted(_logger, layerId, styleId, renderRequest.Value.Width, renderRequest.Value.Height);
 
-            // Render the styled map
+            // Renderer dispatch (ADR-0048): vector collections render through the shared
+            // Skia pipeline with an explicit styleId-resolved MapLibre style (the same path
+            // WMS GetMap / MapServer export use). Raster coverages keep the raster-only
+            // renderer, which reports an honest 501 for styled requests.
+            if (ResourceHasGeometry(resource))
+            {
+                return await RenderStyledVectorMapAsync(
+                    layerId,
+                    styleId,
+                    resource,
+                    service,
+                    renderRequest.Value,
+                    context,
+                    scope,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            // Render the styled map (raster path)
             var result = await _mapRenderer.RenderStyledMapAsync(layerId, styleId, renderRequest.Value, cancellationToken);
             if (result.Data.Length == 0)
             {
@@ -485,6 +506,109 @@ internal sealed class OgcMapsRenderingHandler
             scope.RecordException(ex);
             return CreateErrorResult(context, "An error occurred while rendering the styled map.");
         }
+    }
+
+    /// <summary>
+    /// Renders a styled map for a vector collection through the shared Skia pipeline,
+    /// resolving the MapLibre style for <paramref name="styleId"/> via the OGC API - Styles
+    /// projection (ADR-0048). Falls back to default styling when the styleId does not
+    /// resolve to a stored style for the collection.
+    /// </summary>
+    private async Task<IResult> RenderStyledVectorMapAsync(
+        int layerId,
+        string styleId,
+        MetadataV2Resource resource,
+        MetadataV2Service? service,
+        MapRenderRequest renderRequest,
+        HttpContext? context,
+        HonuaTelemetryScope scope,
+        CancellationToken cancellationToken)
+    {
+        // The Skia pipeline resolves request-scoped services (feature reader, capacity
+        // limiter, coordinate transform) from the HTTP context, so styled vector rendering
+        // requires a live request. Without one we surface the same honest 501 as raster.
+        if (context is null)
+        {
+            return Results.Problem(
+                title: "Styled vector map rendering requires an active request context.",
+                statusCode: StatusCodes.Status501NotImplemented);
+        }
+
+        // Resolve the requested style (canonical MapLibre). A missing/unknown style renders
+        // with the collection's default styling rather than failing the request.
+        string? mapLibreStyleJson = null;
+        var stylesheet = await _styleProjection
+            .GetStylesheetAsync(styleId, OgcStyleEncoding.MapboxStyle, cancellationToken)
+            .ConfigureAwait(false);
+        if (stylesheet is not null)
+        {
+            mapLibreStyleJson = stylesheet.Content;
+        }
+
+        var geometryType = resource.ReadGeometryType();
+        var serviceSrid = service?.SpatialReference?.ResolveSrid()
+            ?? resource.ReadSrid()
+            ?? DefaultBboxCrsSrid;
+        var requestSrid = renderRequest.BoundingBoxCrs ?? renderRequest.Crs ?? DefaultBboxCrsSrid;
+        var requestExtent = new SkiaMapRenderer.RenderExtent(
+            renderRequest.BoundingBox[0],
+            renderRequest.BoundingBox[1],
+            renderRequest.BoundingBox[2],
+            renderRequest.BoundingBox[3]);
+        var format = renderRequest.Format switch
+        {
+            RasterFormat.JPEG => "jpeg",
+            RasterFormat.TIFF => "tiff",
+            _ => "png"
+        };
+
+        var renderResult = await RasterMapRenderingPipeline.RenderVectorCollectionAsync(
+            context,
+            layerId,
+            geometryType,
+            serviceSrid,
+            mapLibreStyleJson,
+            requestExtent,
+            requestSrid,
+            renderRequest.Width,
+            renderRequest.Height,
+            format,
+            renderRequest.Transparent,
+            backgroundColor: null,
+            temporalFilter: null,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!renderResult.IsSuccess)
+        {
+            return renderResult.Error!;
+        }
+
+        OgcMapsLog.StyledMapRenderCompleted(_logger, layerId, styleId, renderResult.ImageBytes.Length);
+        scope.SetSuccess(renderResult.FeatureCount);
+
+        var result = new RasterResult
+        {
+            Data = renderResult.ImageBytes,
+            ContentType = renderRequest.Format.ToContentType(),
+            Width = renderRequest.Width,
+            Height = renderRequest.Height,
+            Srid = requestSrid
+        };
+
+        return CreateMapFileResult(context, result, renderRequest);
+    }
+
+    private static bool ResourceHasGeometry(MetadataV2Resource resource)
+    {
+        if (resource.ReadGeometryType() != MetadataV2GeometryType.None)
+        {
+            return true;
+        }
+
+        // V2 graphs that don't fill in the typed Spatial slot still surface geometry through
+        // the schema (Geometry/Geography field). Match the WMS/WMTS V2 ports — both treat
+        // such a layer as renderable.
+        return resource.FindPrimaryGeometryField() is not null;
     }
 
     /// <summary>

--- a/src/Honua.Protocols.OgcApi/Styles/OgcStylesEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Styles/OgcStylesEndpoints.cs
@@ -98,19 +98,23 @@ public static class OgcStylesEndpoints
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status415UnsupportedMediaType);
 
-        group.MapPost(string.Empty, CreateStyleNotSupported)
-            .WithDisplayName("Create Style (not supported in Phase 1)")
-            .WithName("CreateStyleNotSupported")
-            .WithSummary("Create a standalone style - not supported until Phase 2")
-            .WithDescription("Standalone style creation arrives with the Phase 2 independent style catalog (issue #1389).")
-            .Produces(StatusCodes.Status501NotImplemented);
+        group.MapPost(string.Empty, CreateStyle)
+            .WithDisplayName("Create Style")
+            .WithName("CreateStyle")
+            .WithSummary("Create a standalone style (manage-styles)")
+            .WithDescription("Validates and stores a MapLibre stylesheet as a new standalone style in the independent style catalog (ADR-0048 Phase 2). The new style's stable identifier is returned in the Location header. Honors Prefer: handling=strict and ?validate.")
+            .Produces(StatusCodes.Status201Created)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status409Conflict)
+            .Produces(StatusCodes.Status415UnsupportedMediaType);
 
-        group.MapDelete("/{styleId}", DeleteStyleNotSupported)
-            .WithDisplayName("Delete Style (not supported in Phase 1)")
-            .WithName("DeleteStyleNotSupported")
-            .WithSummary("Delete a style - not supported until Phase 2")
-            .WithDescription("Standalone style deletion arrives with the Phase 2 independent style catalog (issue #1389).")
-            .Produces(StatusCodes.Status501NotImplemented);
+        group.MapDelete("/{styleId}", DeleteStyle)
+            .WithDisplayName("Delete Style")
+            .WithName("DeleteStyle")
+            .WithSummary("Delete a style (manage-styles)")
+            .WithDescription("Deletes a standalone style from the independent style catalog (ADR-0048 Phase 2).")
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status404NotFound);
     }
 
     /// <summary>
@@ -355,15 +359,100 @@ public static class OgcStylesEndpoints
         }
     }
 
-    private static IResult CreateStyleNotSupported(HttpContext context)
-        => StandardErrorHelpers.CreateNotImplemented(
-            context,
-            "Creating a standalone style is not supported in Phase 1. Independent style storage (POST-create) arrives with the Phase 2 style catalog (issue #1389). Use PUT /ogc/styles/{styleId} to update an existing collection's style.");
+    /// <summary>
+    /// Create a standalone style (manage-styles, POST). Stores a MapLibre stylesheet in
+    /// the independent style catalog (ADR-0048 Phase 2). The optional desired identifier
+    /// is read from the X-Style-Id header; otherwise the server assigns one.
+    /// </summary>
+    private static async Task<IResult> CreateStyle(
+        HttpContext context,
+        IOgcStyleProjection projection,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken = default)
+    {
+        var contentType = context.Request.ContentType;
+        if (!string.IsNullOrWhiteSpace(contentType)
+            && !IsMapboxStyleContentType(contentType))
+        {
+            return StandardErrorHelpers.CreateUnsupportedMediaType(
+                context,
+                "manage-styles create accepts only MapLibre/Mapbox style JSON (application/vnd.mapbox.style+json or application/json).");
+        }
 
-    private static IResult DeleteStyleNotSupported(string styleId, HttpContext context)
-        => StandardErrorHelpers.CreateNotImplemented(
-            context,
-            "Deleting a style is not supported in Phase 1. Independent style storage (DELETE) arrives with the Phase 2 style catalog (issue #1389); Phase 1 styles are bound to their collection's per-layer storage.");
+        string body;
+        using (var reader = new StreamReader(context.Request.Body, Encoding.UTF8))
+        {
+            body = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body must contain a MapLibre style document.");
+        }
+
+        string? requestedStyleId = null;
+        if (context.Request.Headers.TryGetValue("X-Style-Id", out var styleIdHeader))
+        {
+            requestedStyleId = styleIdHeader.ToString();
+        }
+
+        var strict = IsStrictRequested(context);
+        var result = await projection.CreateStyleAsync(requestedStyleId, body, strict, cancellationToken).ConfigureAwait(false);
+        var logger = loggerFactory.CreateLogger("Honua.Protocols.Ogc.Api.Styles.OgcStylesEndpoints");
+
+        switch (result.Status)
+        {
+            case OgcStyleCreateStatus.Created:
+                var styleId = result.StyleId!;
+                OgcStylesLog.StyleCreated(logger, styleId);
+                var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+                var location = $"{baseUrl}/ogc/styles/{Uri.EscapeDataString(styleId)}";
+                context.Response.Headers.Location = location;
+                var entry = new StyleEntry
+                {
+                    Id = styleId,
+                    Links = BuildStylesheetLinks(baseUrl, styleId)
+                };
+                return Results.Json(
+                    entry,
+                    OgcStylesJsonContext.Default.StyleEntry,
+                    contentType: MediaTypes.Json,
+                    statusCode: StatusCodes.Status201Created);
+            case OgcStyleCreateStatus.Conflict:
+                OgcStylesLog.StyleCreateRejected(logger, result.ErrorMessage ?? "conflict");
+                return StandardErrorHelpers.CreateConflict(context, result.ErrorMessage ?? "A style with that identifier already exists.");
+            default:
+                OgcStylesLog.StyleCreateRejected(logger, result.ErrorMessage ?? "invalid");
+                return StandardErrorHelpers.CreateBadRequest(context, result.ErrorMessage ?? "MapLibre style is invalid.");
+        }
+    }
+
+    /// <summary>
+    /// Delete a standalone style (manage-styles, DELETE) from the independent style
+    /// catalog (ADR-0048 Phase 2).
+    /// </summary>
+    private static async Task<IResult> DeleteStyle(
+        string styleId,
+        HttpContext context,
+        IOgcStyleProjection projection,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await projection.DeleteStyleAsync(styleId, cancellationToken).ConfigureAwait(false);
+        var logger = loggerFactory.CreateLogger("Honua.Protocols.Ogc.Api.Styles.OgcStylesEndpoints");
+
+        switch (result.Status)
+        {
+            case OgcStyleDeleteStatus.Deleted:
+                OgcStylesLog.StyleDeleted(logger, styleId);
+                return Results.NoContent();
+            case OgcStyleDeleteStatus.Forbidden:
+                return StandardErrorHelpers.CreateBadRequest(context, result.ErrorMessage ?? $"Style '{styleId}' cannot be deleted through this surface.");
+            default:
+                OgcStylesLog.StyleNotFound(logger, styleId);
+                return StandardErrorHelpers.CreateNotFound(context, result.ErrorMessage ?? $"Style '{styleId}' not found.");
+        }
+    }
 
     private static ImmutableArray<Link> BuildStylesheetLinks(string baseUrl, string styleId)
     {

--- a/src/Honua.Protocols.OgcApi/Styles/OgcStylesLog.cs
+++ b/src/Honua.Protocols.OgcApi/Styles/OgcStylesLog.cs
@@ -40,4 +40,22 @@ internal static partial class OgcStylesLog
         Level = LogLevel.Warning,
         Message = "OGC Style '{StyleId}' update rejected: {Reason}")]
     public static partial void StyleUpdateRejected(ILogger logger, string styleId, string reason);
+
+    [LoggerMessage(
+        EventId = 5955,
+        Level = LogLevel.Information,
+        Message = "OGC Style '{StyleId}' created")]
+    public static partial void StyleCreated(ILogger logger, string styleId);
+
+    [LoggerMessage(
+        EventId = 5956,
+        Level = LogLevel.Warning,
+        Message = "OGC Style create rejected: {Reason}")]
+    public static partial void StyleCreateRejected(ILogger logger, string reason);
+
+    [LoggerMessage(
+        EventId = 5957,
+        Level = LogLevel.Information,
+        Message = "OGC Style '{StyleId}' deleted")]
+    public static partial void StyleDeleted(ILogger logger, string styleId);
 }

--- a/src/Honua.Server/Features/Styling/LayerStyleLog.cs
+++ b/src/Honua.Server/Features/Styling/LayerStyleLog.cs
@@ -33,4 +33,10 @@ internal static partial class LayerStyleLog
         Level = LogLevel.Debug,
         Message = "Theme transform for layer {LayerId} skipped property '{Property}' due to malformed color '{Color}'.")]
     public static partial void ThemeColorParseFailure(ILogger logger, int layerId, string property, string color);
+
+    [LoggerMessage(
+        EventId = 6404,
+        Level = LogLevel.Warning,
+        Message = "Failed to mirror layer {LayerId} style into the independent style catalog/graph. The per-layer style update succeeded; StyleResourceIds may lag until the next publish.")]
+    public static partial void StyleCatalogSyncFailed(ILogger logger, int layerId, Exception exception);
 }

--- a/src/Honua.Server/Features/Styling/LayerStyleService.cs
+++ b/src/Honua.Server/Features/Styling/LayerStyleService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using System.Text.Json;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
@@ -21,15 +22,21 @@ internal sealed class LayerStyleService : ILayerStyleService
     private readonly ILayerStyleCatalog _styleCatalog;
     private readonly ILogger<LayerStyleService> _logger;
     private readonly IMetadataV2GraphProvider? _metadataV2GraphProvider;
+    private readonly IStyleCatalog? _independentStyleCatalog;
+    private readonly IMetadataV2StyleGraphSync? _styleGraphSync;
 
     public LayerStyleService(
         ILayerStyleCatalog styleCatalog,
         ILogger<LayerStyleService> logger,
-        IMetadataV2GraphProvider? metadataV2GraphProvider = null)
+        IMetadataV2GraphProvider? metadataV2GraphProvider = null,
+        IStyleCatalog? independentStyleCatalog = null,
+        IMetadataV2StyleGraphSync? styleGraphSync = null)
     {
         _styleCatalog = styleCatalog ?? throw new ArgumentNullException(nameof(styleCatalog));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _metadataV2GraphProvider = metadataV2GraphProvider;
+        _independentStyleCatalog = independentStyleCatalog;
+        _styleGraphSync = styleGraphSync;
     }
 
     /// <inheritdoc />
@@ -126,6 +133,15 @@ internal sealed class LayerStyleService : ILayerStyleService
 
             var generatedDrawingInfoJson = MapLibreToGeoServicesConverter.Convert(normalized, styleLayer);
 
+            await SyncIndependentStyleCatalogAsync(
+                styleLayer.Id,
+                resource,
+                normalized,
+                generatedDrawingInfoJson,
+                revisedBy,
+                changeSummary,
+                cancellationToken).ConfigureAwait(false);
+
             return new LayerStyleUpdateResult(
                 LayerStyleUpdateStatus.Updated,
                 BuildSnapshot(updated, normalized, generatedDrawingInfoJson),
@@ -151,11 +167,72 @@ internal sealed class LayerStyleService : ILayerStyleService
             return new LayerStyleUpdateResult(LayerStyleUpdateStatus.NotFound, null, null);
         }
 
+        await SyncIndependentStyleCatalogAsync(
+            styleLayer.Id,
+            resource,
+            mapLibreJson,
+            drawingInfoJson,
+            revisedBy,
+            changeSummary,
+            cancellationToken).ConfigureAwait(false);
+
         return new LayerStyleUpdateResult(
             LayerStyleUpdateStatus.Updated,
             BuildSnapshot(saved, mapLibreJson, drawingInfoJson),
             null,
             conversion.Unsupported);
+    }
+
+    // ADR-0048 Phase 2 (#1389): mirror the per-layer style update into the independent
+    // styleId-keyed catalog as the layer's default style ("style-layer-{id}"), associate
+    // it at the primary ordinal, then reconcile the canonical graph so the Type=Style
+    // resource and the data resource's StyleResourceIds reflect the edit immediately.
+    // Best-effort: a failure here must not fail the per-layer style update (Phase 1
+    // contract), so exceptions are logged and swallowed.
+    private async Task SyncIndependentStyleCatalogAsync(
+        int storageLayerId,
+        MetadataV2Resource resource,
+        string mapLibreStyleJson,
+        string? drawingInfoJson,
+        string? revisedBy,
+        string? changeSummary,
+        CancellationToken cancellationToken)
+    {
+        if (_independentStyleCatalog is null)
+        {
+            return;
+        }
+
+        var styleId = $"style-layer-{storageLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+        var title = resource.Metadata.Title ?? resource.Metadata.Name;
+
+        try
+        {
+            _ = await _independentStyleCatalog
+                .UpsertStyleAsync(
+                    styleId,
+                    mapLibreStyleJson,
+                    title,
+                    resource.Metadata.Description,
+                    drawingInfoJson,
+                    revisedBy,
+                    changeSummary,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await _independentStyleCatalog
+                .AssociateLayerAsync(storageLayerId, styleId, ordinal: 0, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (_styleGraphSync is not null)
+            {
+                await _styleGraphSync.SyncLayerStylesAsync(storageLayerId, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            LayerStyleLog.StyleCatalogSyncFailed(_logger, storageLayerId, ex);
+        }
     }
 
     private async ValueTask<StyleLayerDescriptor> ResolveStyleLayerAsync(

--- a/src/Honua.Server/Features/Styling/OgcStyleProjection.cs
+++ b/src/Honua.Server/Features/Styling/OgcStyleProjection.cs
@@ -25,15 +25,18 @@ internal sealed class OgcStyleProjection : IOgcStyleProjection
     private readonly IMetadataV2GraphProvider _graphProvider;
     private readonly ILayerStyleService _styleService;
     private readonly ILayerStyleCatalog _styleCatalog;
+    private readonly IStyleCatalog? _independentStyleCatalog;
 
     public OgcStyleProjection(
         IMetadataV2GraphProvider graphProvider,
         ILayerStyleService styleService,
-        ILayerStyleCatalog styleCatalog)
+        ILayerStyleCatalog styleCatalog,
+        IStyleCatalog? independentStyleCatalog = null)
     {
         _graphProvider = graphProvider ?? throw new ArgumentNullException(nameof(graphProvider));
         _styleService = styleService ?? throw new ArgumentNullException(nameof(styleService));
         _styleCatalog = styleCatalog ?? throw new ArgumentNullException(nameof(styleCatalog));
+        _independentStyleCatalog = independentStyleCatalog;
     }
 
     /// <inheritdoc />
@@ -69,6 +72,24 @@ internal sealed class OgcStyleProjection : IOgcStyleProjection
             summaries.Add(new OgcStyleSummary(styleId, ResolveTitle(resource)));
         }
 
+        // Phase 2: also surface standalone catalog styles that are not already
+        // represented as a Phase 1 collection-keyed style.
+        if (_independentStyleCatalog is not null)
+        {
+            var catalogStyles = await _independentStyleCatalog.ListStylesAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var style in catalogStyles)
+            {
+                if (!seen.Add(style.StyleId))
+                {
+                    continue;
+                }
+
+                summaries.Add(new OgcStyleSummary(
+                    style.StyleId,
+                    string.IsNullOrWhiteSpace(style.Title) ? style.StyleId : style.Title!));
+            }
+        }
+
         summaries.Sort(static (a, b) => string.CompareOrdinal(a.StyleId, b.StyleId));
         return summaries;
     }
@@ -84,13 +105,15 @@ internal sealed class OgcStyleProjection : IOgcStyleProjection
         var (resource, storageLayerId, snapshot) = await ResolveStyledResourceAsync(styleId, cancellationToken).ConfigureAwait(false);
         if (resource is null || !storageLayerId.HasValue)
         {
-            return null;
+            // Phase 2: the styleId may identify a standalone catalog style rather than a
+            // Phase 1 collection-keyed style. Serve it from the independent catalog.
+            return await GetCatalogStylesheetAsync(styleId, encoding, cancellationToken).ConfigureAwait(false);
         }
 
         var stored = await _styleCatalog.GetLayerStyleAsync(storageLayerId.Value, cancellationToken).ConfigureAwait(false);
         if (stored is null || string.IsNullOrWhiteSpace(stored.MapLibreStyleJson))
         {
-            return null;
+            return await GetCatalogStylesheetAsync(styleId, encoding, cancellationToken).ConfigureAwait(false);
         }
 
         var mapLibreJson = stored.MapLibreStyleJson!;
@@ -103,6 +126,30 @@ internal sealed class OgcStyleProjection : IOgcStyleProjection
         return sld;
     }
 
+    private async Task<OgcStylesheet?> GetCatalogStylesheetAsync(
+        string styleId,
+        OgcStyleEncoding encoding,
+        CancellationToken cancellationToken)
+    {
+        if (_independentStyleCatalog is null)
+        {
+            return null;
+        }
+
+        var style = await _independentStyleCatalog.GetStyleAsync(styleId, cancellationToken).ConfigureAwait(false);
+        if (style is null || string.IsNullOrWhiteSpace(style.MapLibreStyleJson))
+        {
+            return null;
+        }
+
+        if (encoding == OgcStyleEncoding.MapboxStyle)
+        {
+            return new OgcStylesheet(style.MapLibreStyleJson, OgcStyleMediaTypes.MapboxStyle, OgcStyleEncoding.MapboxStyle);
+        }
+
+        return DeriveSldFromMapLibre(style.MapLibreStyleJson, style.StyleId, encoding);
+    }
+
     /// <inheritdoc />
     public async Task<OgcStyleMetadata?> GetStyleMetadataAsync(
         string styleId,
@@ -113,13 +160,13 @@ internal sealed class OgcStyleProjection : IOgcStyleProjection
         var (resource, storageLayerId, _) = await ResolveStyledResourceAsync(styleId, cancellationToken).ConfigureAwait(false);
         if (resource is null || !storageLayerId.HasValue)
         {
-            return null;
+            return await GetCatalogStyleMetadataAsync(styleId, cancellationToken).ConfigureAwait(false);
         }
 
         var stored = await _styleCatalog.GetLayerStyleAsync(storageLayerId.Value, cancellationToken).ConfigureAwait(false);
         if (stored is null || string.IsNullOrWhiteSpace(stored.MapLibreStyleJson))
         {
-            return null;
+            return await GetCatalogStyleMetadataAsync(styleId, cancellationToken).ConfigureAwait(false);
         }
 
         var version = stored.StyleVersion > 0
@@ -132,6 +179,32 @@ internal sealed class OgcStyleProjection : IOgcStyleProjection
             resource.Metadata.Description,
             resource.Metadata.Keywords,
             resource.Metadata.License,
+            version);
+    }
+
+    private async Task<OgcStyleMetadata?> GetCatalogStyleMetadataAsync(string styleId, CancellationToken cancellationToken)
+    {
+        if (_independentStyleCatalog is null)
+        {
+            return null;
+        }
+
+        var style = await _independentStyleCatalog.GetStyleAsync(styleId, cancellationToken).ConfigureAwait(false);
+        if (style is null)
+        {
+            return null;
+        }
+
+        var version = style.StyleVersion > 0
+            ? style.StyleVersion.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : null;
+
+        return new OgcStyleMetadata(
+            style.StyleId,
+            string.IsNullOrWhiteSpace(style.Title) ? style.StyleId : style.Title!,
+            style.Description,
+            Array.Empty<string>(),
+            License: null,
             version);
     }
 
@@ -174,6 +247,112 @@ internal sealed class OgcStyleProjection : IOgcStyleProjection
         };
     }
 
+    /// <inheritdoc />
+    public async Task<OgcStyleCreateResult> CreateStyleAsync(
+        string? styleId,
+        string mapLibreStyleJson,
+        bool strict,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(mapLibreStyleJson);
+
+        if (_independentStyleCatalog is null)
+        {
+            return new OgcStyleCreateResult(
+                OgcStyleCreateStatus.Invalid,
+                null,
+                "Standalone style creation requires the independent style catalog, which is not configured.");
+        }
+
+        if (!TryValidateStandaloneMapLibre(mapLibreStyleJson, strict, out var error))
+        {
+            return new OgcStyleCreateResult(OgcStyleCreateStatus.Invalid, null, error);
+        }
+
+        var resolvedStyleId = string.IsNullOrWhiteSpace(styleId)
+            ? $"style-{Guid.NewGuid():N}"
+            : styleId.Trim();
+
+        var created = await _independentStyleCatalog
+            .CreateStyleAsync(resolvedStyleId, mapLibreStyleJson, title: resolvedStyleId, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        if (created is null)
+        {
+            return new OgcStyleCreateResult(
+                OgcStyleCreateStatus.Conflict,
+                null,
+                $"A style with identifier '{resolvedStyleId}' already exists.");
+        }
+
+        return new OgcStyleCreateResult(OgcStyleCreateStatus.Created, created.StyleId, null);
+    }
+
+    /// <inheritdoc />
+    public async Task<OgcStyleDeleteResult> DeleteStyleAsync(
+        string styleId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleId);
+
+        if (_independentStyleCatalog is null)
+        {
+            return new OgcStyleDeleteResult(
+                OgcStyleDeleteStatus.NotFound,
+                "Standalone style deletion requires the independent style catalog, which is not configured.");
+        }
+
+        var deleted = await _independentStyleCatalog.DeleteStyleAsync(styleId, cancellationToken).ConfigureAwait(false);
+        return deleted
+            ? new OgcStyleDeleteResult(OgcStyleDeleteStatus.Deleted, null)
+            : new OgcStyleDeleteResult(OgcStyleDeleteStatus.NotFound, $"Style '{styleId}' not found.");
+    }
+
+    // Lightweight validation for a standalone (not-yet-layer-bound) MapLibre style.
+    // Unlike the per-layer normalizer, it does not require a Honua tile source binding,
+    // since a standalone catalog style is decoupled from any layer; binding (and the
+    // stricter normalization) happens when the style is associated with a layer.
+    private static bool TryValidateStandaloneMapLibre(string mapLibreStyleJson, bool strict, out string? error)
+    {
+        error = null;
+        try
+        {
+            using var document = JsonDocument.Parse(mapLibreStyleJson);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                error = "MapLibre style must be a JSON object.";
+                return false;
+            }
+
+            if (strict)
+            {
+                if (!root.TryGetProperty("version", out var version)
+                    || version.ValueKind != JsonValueKind.Number
+                    || version.GetInt32() != 8)
+                {
+                    error = "MapLibre style must include version 8.";
+                    return false;
+                }
+
+                if (!root.TryGetProperty("layers", out var layers)
+                    || layers.ValueKind != JsonValueKind.Array
+                    || layers.GetArrayLength() == 0)
+                {
+                    error = "MapLibre style must include at least one layer.";
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            error = $"MapLibre style is not valid JSON: {ex.Message}";
+            return false;
+        }
+    }
+
     private static OgcStylesheet DeriveSld(
         string mapLibreJson,
         MetadataV2Resource resource,
@@ -183,6 +362,19 @@ internal sealed class OgcStyleProjection : IOgcStyleProjection
         var layerName = string.IsNullOrWhiteSpace(resource.Metadata.Name)
             ? $"layer-{storageLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture)}"
             : resource.Metadata.Name;
+
+        return DeriveSldFromMapLibre(mapLibreJson, layerName, encoding);
+    }
+
+    private static OgcStylesheet DeriveSldFromMapLibre(
+        string mapLibreJson,
+        string layerName,
+        OgcStyleEncoding encoding)
+    {
+        if (string.IsNullOrWhiteSpace(layerName))
+        {
+            layerName = "style";
+        }
 
         MapLibreStyleLayer[] layers;
         using (var document = JsonDocument.Parse(mapLibreJson))

--- a/src/Honua.Server/Migrations/042_CreateStyleCatalog.sql
+++ b/src/Honua.Server/Migrations/042_CreateStyleCatalog.sql
@@ -1,0 +1,87 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Independent, styleId-keyed style catalog (ADR-0048, Phase 2, issue #1389).
+--
+-- Phase 1 stored style bytes strictly per-layer (honua.layers.maplibre_style,
+-- keyed by the integer storage-layer id) so one style could never be shared by
+-- many layers. Phase 2 introduces a first-class style store keyed by a stable
+-- string styleId, decoupled from any single layer, plus an ordered many-to-many
+-- association table so a single style can render many data resources.
+--
+-- honua.layers.maplibre_style remains the canonical per-layer Phase 1 store and
+-- is NOT dropped here: the catalog is additive (per ADR-0048 "trade-offs
+-- accepted"), and existing per-layer styles are backfilled into a default style
+-- per styled layer so nothing regresses.
+
+CREATE TABLE IF NOT EXISTS honua.styles
+(
+    style_id            TEXT PRIMARY KEY,
+    title               TEXT,
+    description         TEXT,
+    maplibre_style      JSONB NOT NULL,
+    drawing_info        JSONB,
+    style_version       INT NOT NULL DEFAULT 1,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revised_by          TEXT,
+    change_summary      TEXT,
+    CONSTRAINT styles_style_id_not_blank_check
+        CHECK (length(btrim(style_id)) > 0),
+    CONSTRAINT styles_change_summary_length_check
+        CHECK (change_summary IS NULL OR char_length(change_summary) <= 1000)
+);
+
+COMMENT ON TABLE honua.styles IS
+    'Independent styleId-keyed style catalog (ADR-0048 Phase 2). One style may render many layers.';
+COMMENT ON COLUMN honua.styles.style_id IS 'Stable string style identifier (honua://styles/{style_id}).';
+COMMENT ON COLUMN honua.styles.maplibre_style IS 'Canonical MapLibre/Mapbox style JSON. Derived encodings (SLD, drawingInfo) are produced on demand.';
+COMMENT ON COLUMN honua.styles.drawing_info IS 'Optional cached GeoServices drawingInfo JSON for FeatureServer/MapServer.';
+COMMENT ON COLUMN honua.styles.style_version IS 'Author-managed integer style version, incremented on canonical updates.';
+
+-- Ordered many-to-many association: a layer references styles by ordinal
+-- (ordinal 0 = primary, matching MetadataV2Resource.StyleResourceIds[0]).
+CREATE TABLE IF NOT EXISTS honua.layer_style_refs
+(
+    layer_id    INT NOT NULL REFERENCES honua.layers (layer_id) ON DELETE CASCADE,
+    style_id    TEXT NOT NULL REFERENCES honua.styles (style_id) ON DELETE CASCADE,
+    ordinal     INT NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (layer_id, style_id)
+);
+
+COMMENT ON TABLE honua.layer_style_refs IS
+    'Ordered association between layers and catalog styles (ADR-0048 Phase 2). ordinal 0 is the primary style.';
+
+CREATE INDEX IF NOT EXISTS layer_style_refs_layer_idx
+    ON honua.layer_style_refs (layer_id, ordinal);
+CREATE INDEX IF NOT EXISTS layer_style_refs_style_idx
+    ON honua.layer_style_refs (style_id);
+
+-- Backfill: migrate every existing per-layer MapLibre style into a default
+-- catalog style (styleId "style-layer-{layer_id}") and a primary association,
+-- so the Type=Style graph producer lights up StyleResourceIds with real data
+-- without operator action. Idempotent: re-running skips rows already present.
+INSERT INTO honua.styles
+    (style_id, title, description, maplibre_style, drawing_info, style_version,
+     created_at, updated_at, revised_by, change_summary)
+SELECT
+    'style-layer-' || l.layer_id::text,
+    l.layer_name,
+    NULL,
+    l.maplibre_style,
+    l.geoservices_drawing_info,
+    GREATEST(COALESCE(l.style_version, 1), 1),
+    COALESCE(l.style_revised_at, NOW()),
+    COALESCE(l.style_revised_at, NOW()),
+    l.style_revised_by,
+    l.style_change_summary
+FROM honua.layers l
+WHERE l.maplibre_style IS NOT NULL
+ON CONFLICT (style_id) DO NOTHING;
+
+INSERT INTO honua.layer_style_refs (layer_id, style_id, ordinal)
+SELECT l.layer_id, 'style-layer-' || l.layer_id::text, 0
+FROM honua.layers l
+WHERE l.maplibre_style IS NOT NULL
+ON CONFLICT (layer_id, style_id) DO NOTHING;

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2StyleResourceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2StyleResourceTests.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Core.Tests.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Tests for the ADR-0048 Phase 2 (#1389) first-class style resources: the
+/// <see cref="MetadataV2StyleResourceFactory"/> producer output, the
+/// <c>StyleResourceIds → Type=Style</c> graph validation exercised with real data, and
+/// the one-style-many-resources reverse index.
+/// </summary>
+[Protocol(ProtocolNames.TestQuality)]
+public sealed class MetadataV2StyleResourceTests
+{
+    private const string MapLibreBody =
+        "{\"version\":8,\"name\":\"test\",\"sources\":{},\"layers\":[]}";
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void BuildStyleResource_EmitsMapboxEncodingAndStyleType()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var resource = MetadataV2StyleResourceFactory.BuildStyleResource(
+            "style-layer-7",
+            MapLibreBody,
+            title: "Parcels Style",
+            description: "Primary parcel symbology",
+            drawingInfoJson: "{\"renderer\":{}}",
+            styleVersion: 3,
+            createdAt: now,
+            updatedAt: now);
+
+        resource.Type.Should().Be(MetadataV2ResourceType.Style);
+        resource.Metadata.Id.Should().Be("style-style-layer-7");
+        resource.Metadata.Name.Should().Be("style-layer-7");
+        resource.Style.Should().NotBeNull();
+        resource.Style!.StyleVersion.Should().Be(3);
+        resource.Style.Encodings.Should().Contain(e => e.Encoding == "mapbox-style" && e.Body == MapLibreBody);
+        resource.Style.Encodings.Should().Contain(e => e.Encoding == "esri-drawing-info");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void BuildStyleResource_WithoutDrawingInfo_OmitsEsriEncoding()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var resource = MetadataV2StyleResourceFactory.BuildStyleResource(
+            "s1", MapLibreBody, null, null, drawingInfoJson: null, styleVersion: 1, now, now);
+
+        resource.Style!.Encodings.Should().ContainSingle();
+        resource.Style.Encodings[0].Encoding.Should().Be("mapbox-style");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Validate_StyleResourceIdsReferencingRealStyle_IsValid()
+    {
+        var graph = BuildGraphWithSharedStyle();
+
+        var result = MetadataV2GraphValidator.Validate(graph);
+
+        result.IsValid.Should().BeTrue(string.Join("; ", result.Errors));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Validate_StyleResourceIdsReferencingNonStyle_ReturnsError()
+    {
+        // Point a data resource's StyleResourceIds at a non-Style resource.
+        var graph = BuildGraphWithSharedStyle() with { };
+        var broken = graph with
+        {
+            Resources = graph.Resources
+                .Select(r => r.Metadata.Id == "resource.a"
+                    ? r with { StyleResourceIds = ["resource.b"] }
+                    : r)
+                .ToArray()
+        };
+
+        var result = MetadataV2GraphValidator.Validate(broken);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.Contains("styleResourceIds", StringComparison.Ordinal)
+            && e.Contains("not a declared resource of type Style", StringComparison.Ordinal));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Index_OneStyle_ReferencedByManyResources()
+    {
+        var graph = BuildGraphWithSharedStyle();
+
+        var index = MetadataV2GraphIndex.Build(graph);
+
+        var referencing = index.ResourcesByStyleResourceId["style-shared"].ToArray();
+        referencing.Should().HaveCount(2);
+        referencing.Select(r => r.Metadata.Id).Should().BeEquivalentTo("resource.a", "resource.b");
+    }
+
+    // Builds a minimal valid graph where ONE Type=Style resource ("style-shared") is
+    // referenced by TWO distinct data resources, exercising one-style-many-layers reuse.
+    private static MetadataV2Graph BuildGraphWithSharedStyle()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var styleResource = MetadataV2StyleResourceFactory.BuildStyleResource(
+            "shared", MapLibreBody, "Shared", null, null, 1, now, now)
+            with
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "style-shared", Name = "shared" }
+        };
+
+        return new MetadataV2Graph
+        {
+            Resources =
+            [
+                new MetadataV2Resource
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "resource.a" },
+                    StorageBindingIds = ["storage.a"],
+                    StyleResourceIds = ["style-shared"]
+                },
+                new MetadataV2Resource
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "resource.b" },
+                    StorageBindingIds = ["storage.b"],
+                    StyleResourceIds = ["style-shared"]
+                },
+                styleResource
+            ],
+            Connections =
+            [
+                new MetadataV2Connection
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "connection.pg" }
+                }
+            ],
+            StorageBindings =
+            [
+                new MetadataV2StorageBinding
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "storage.a" },
+                    ResourceId = "resource.a",
+                    ConnectionId = "connection.pg",
+                    StorageLayerId = 0
+                },
+                new MetadataV2StorageBinding
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "storage.b" },
+                    ResourceId = "resource.b",
+                    ConnectionId = "connection.pg",
+                    StorageLayerId = 1
+                }
+            ]
+        };
+    }
+}

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsBasicTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsBasicTests.cs
@@ -260,6 +260,34 @@ public class OgcMapsBasicTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("GET /ogc/maps/collections/{collectionId}/styles/{styleId}/map")]
+    [Operation(Operations.Render)]
+    public async Task GetStyledMap_VectorCollection_RendersPngInsteadOf501()
+    {
+        // The styled-map endpoint routes vector collections through the Skia rendering
+        // pipeline (ADR-0048) instead of the raster-only path that returns 501. Layer 0
+        // is a seeded vector (Point) collection, so a styled request must produce a PNG.
+        var queryParams = "?bbox=-180,-90,180,90&width=256&height=256&f=png";
+
+        var response = await _fixture.Client.GetAsync(
+            $"/ogc/maps/collections/{TestLayerId}/styles/default/map{queryParams}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().NotBe(HttpStatusCode.NotImplemented);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("image/png");
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        bytes.Should().NotBeEmpty();
+
+        // PNG signature: 89 50 4E 47 0D 0A 1A 0A.
+        bytes.Should().HaveCountGreaterThan(8);
+        bytes[0].Should().Be(0x89);
+        bytes[1].Should().Be(0x50);
+        bytes[2].Should().Be(0x4E);
+        bytes[3].Should().Be(0x47);
+    }
+
+    [IntegrationTest]
     [Endpoint("GET /ogc/maps/collections/{collectionId}/map/tiles")]
     [Operation(Operations.GetTileMetadata)]
     public async Task GetMapTileSets_ValidCollection_ReturnsTileSetMetadata()

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsConformanceHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsConformanceHandlerTests.cs
@@ -50,6 +50,16 @@ public class OgcMapsConformanceHandlerTests
 
     [UnitTest]
     [Operation(Operations.Metadata)]
+    public async Task GetConformanceAsync_IncludesStyledMapConformance()
+    {
+        var result = await _handler.GetConformanceAsync();
+
+        result.ConformsTo.Should().Contain(
+            "https://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/styled-map");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
     public async Task GetConformanceAsync_IncludesDatasetMapConformance()
     {
         var result = await _handler.GetConformanceAsync();

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsConformanceTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsConformanceTests.cs
@@ -129,12 +129,12 @@ public class OgcMapsConformanceTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Metadata)]
     [Endpoint("GET /ogc/maps/conformance")]
-    public async Task GetConformance_DoesNotClaimStyledMapConformance()
+    public async Task GetConformance_ClaimsStyledMapConformance()
     {
         var classes = await GetConformanceClassesAsync();
 
-        classes.Should().NotContain("https://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/styled-map",
-            "the full styled-map conformance class is not claimed by this service");
+        classes.Should().Contain("https://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/styled-map",
+            "styled-map rendering of vector collections is now supported via the Skia pipeline (ADR-0048)");
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Styling/OgcStylesEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Styling/OgcStylesEndpointTests.cs
@@ -234,27 +234,80 @@ public sealed class OgcStylesEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Create)]
     [Endpoint("POST /ogc/styles")]
-    public async Task PostStyle_Returns501NotImplemented()
+    public async Task PostStyle_WithValidMapLibre_Returns201AndIsRetrievable()
     {
         var client = _fixture.CreateAdminClient();
 
+        var styleId = $"created-{Guid.NewGuid():N}";
         using var content = new StringContent(BuildDefaultStyleJson(), Encoding.UTF8, MapboxStyleMediaType);
-        var response = await client.PostAsync("/ogc/styles", content);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/ogc/styles") { Content = content };
+        request.Headers.TryAddWithoutValidation("X-Style-Id", styleId);
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.ToString().Should().Contain(Uri.EscapeDataString(styleId));
+
+        // The newly created standalone style is retrievable through the read path.
+        var fetched = await client.GetAsync($"/ogc/styles/{Uri.EscapeDataString(styleId)}");
+        fetched.Be200Ok();
+        fetched.Content.Headers.ContentType?.MediaType.Should().Be(MapboxStyleMediaType);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /ogc/styles")]
+    public async Task PostStyle_DuplicateId_Returns409Conflict()
+    {
+        var client = _fixture.CreateAdminClient();
+
+        var styleId = $"dup-{Guid.NewGuid():N}";
+
+        using var first = new StringContent(BuildDefaultStyleJson(), Encoding.UTF8, MapboxStyleMediaType);
+        using var firstRequest = new HttpRequestMessage(HttpMethod.Post, "/ogc/styles") { Content = first };
+        firstRequest.Headers.TryAddWithoutValidation("X-Style-Id", styleId);
+        (await client.SendAsync(firstRequest)).StatusCode.Should().Be(HttpStatusCode.Created);
+
+        using var second = new StringContent(BuildDefaultStyleJson(), Encoding.UTF8, MapboxStyleMediaType);
+        using var secondRequest = new HttpRequestMessage(HttpMethod.Post, "/ogc/styles") { Content = second };
+        secondRequest.Headers.TryAddWithoutValidation("X-Style-Id", styleId);
+
+        var response = await client.SendAsync(secondRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 
     [IntegrationTest]
     [Operation(Operations.Delete)]
     [Endpoint("DELETE /ogc/styles/{styleId}")]
-    public async Task DeleteStyle_Returns501NotImplemented()
+    public async Task DeleteStyle_AfterCreate_Returns204ThenNotFound()
     {
         var client = _fixture.CreateAdminClient();
-        var styleId = await SeedAndResolveStyleIdAsync(client);
 
-        var response = await client.DeleteAsync($"/ogc/styles/{Uri.EscapeDataString(styleId)}");
+        var styleId = $"del-{Guid.NewGuid():N}";
+        using var content = new StringContent(BuildDefaultStyleJson(), Encoding.UTF8, MapboxStyleMediaType);
+        using var createRequest = new HttpRequestMessage(HttpMethod.Post, "/ogc/styles") { Content = content };
+        createRequest.Headers.TryAddWithoutValidation("X-Style-Id", styleId);
+        (await client.SendAsync(createRequest)).StatusCode.Should().Be(HttpStatusCode.Created);
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        var deleteResponse = await client.DeleteAsync($"/ogc/styles/{Uri.EscapeDataString(styleId)}");
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var getResponse = await client.GetAsync($"/ogc/styles/{Uri.EscapeDataString(styleId)}");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("DELETE /ogc/styles/{styleId}")]
+    public async Task DeleteStyle_Unknown_Returns404()
+    {
+        var client = _fixture.CreateAdminClient();
+
+        var response = await client.DeleteAsync($"/ogc/styles/missing-{Guid.NewGuid():N}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Styling/StyleCatalogPhase2Tests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Styling/StyleCatalogPhase2Tests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Styling.Abstractions;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Styling;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Features.Styling;
+
+/// <summary>
+/// Integration tests for the ADR-0048 Phase 2 (#1389) independent style catalog: the
+/// styleId-keyed store and its many-to-many associations, the <c>Type=Style</c> graph
+/// producer lighting up <c>StyleResourceIds</c> with real data, and one-style-many
+/// resource reuse.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.OgcApiStyles)]
+public sealed class StyleCatalogPhase2Tests : IAsyncLifetime
+{
+    private const string MapboxStyleMediaType = "application/vnd.mapbox.style+json";
+
+    private readonly WebAppFixture _fixture = new();
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Update)]
+    [Endpoint("PUT /api/v1/admin/metadata/layers/{layerId}/style")]
+    public async Task UpdatingLayerStyle_PopulatesStyleResourceIdsWithTypeStyleResource()
+    {
+        var client = _fixture.CreateAdminClient();
+        await SeedTestLayerStyleAsync(client);
+
+        using var scope = _fixture.Services.CreateScope();
+
+        // The independent catalog now has the layer's default style.
+        var catalog = scope.ServiceProvider.GetRequiredService<IStyleCatalog>();
+        var styles = await catalog.GetStylesForLayerAsync(WebAppFixture.TestLayerId);
+        styles.Should().NotBeEmpty();
+        var styleId = styles[0].StyleId;
+        styleId.Should().Be($"style-layer-{WebAppFixture.TestLayerId}");
+
+        // The canonical graph references it via StyleResourceIds → a real Type=Style resource.
+        var graphProvider = scope.ServiceProvider.GetRequiredService<IMetadataV2GraphProvider>();
+        var snapshot = await graphProvider.GetCurrentAsync();
+
+        snapshot.Index.ResourcesByStorageLayerId.TryGetValue(WebAppFixture.TestLayerId, out var dataResource)
+            .Should().BeTrue();
+        dataResource!.StyleResourceIds.Should().NotBeEmpty();
+
+        var styleResourceId = dataResource.StyleResourceIds[0];
+        snapshot.Index.ResourcesById.TryGetValue(styleResourceId, out var styleResource).Should().BeTrue();
+        styleResource!.Type.Should().Be(MetadataV2ResourceType.Style);
+        styleResource.Style.Should().NotBeNull();
+        styleResource.Style!.Encodings.Should().Contain(e => e.Encoding == "mapbox-style");
+
+        // The graph stays valid with the populated StyleResourceIds.
+        MetadataV2GraphValidator.Validate(snapshot.Graph).IsValid.Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Update)]
+    [Endpoint("PUT /api/v1/admin/metadata/layers/{layerId}/style")]
+    public async Task OneCatalogStyle_CanBeReferencedByManyLayers()
+    {
+        var client = _fixture.CreateAdminClient();
+        await SeedTestLayerStyleAsync(client);
+
+        using var scope = _fixture.Services.CreateScope();
+        var catalog = scope.ServiceProvider.GetRequiredService<IStyleCatalog>();
+
+        var styleId = $"shared-{Guid.NewGuid():N}";
+        var created = await catalog.CreateStyleAsync(styleId, BuildDefaultStyleJson(), title: "Shared");
+        created.Should().NotBeNull();
+
+        // Associate the SAME style with the test layer (one style -> many layers).
+        var associated = await catalog.AssociateLayerAsync(WebAppFixture.TestLayerId, styleId, ordinal: 1);
+        associated.Should().BeTrue();
+
+        var forLayer = await catalog.GetStylesForLayerAsync(WebAppFixture.TestLayerId);
+        forLayer.Select(s => s.StyleId).Should().Contain(styleId);
+
+        // The shared style is one record; the association table records the reuse.
+        var associations = await catalog.ListAssociationsAsync();
+        associations.Count(a => a.StyleId == styleId).Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    private static async Task SeedTestLayerStyleAsync(HttpClient adminClient)
+    {
+        var request = new LayerStyleUpdateRequest
+        {
+            MapLibreStyle = JsonSerializer.Deserialize<JsonElement>(BuildDefaultStyleJson())
+        };
+
+        var response = await adminClient.PutAsync(
+            $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/style",
+            JsonContent.Create(request, LayerStyleJsonContext.Default.LayerStyleUpdateRequest));
+        response.Be200Ok();
+    }
+
+    private static string BuildDefaultStyleJson()
+    {
+        var layer = new StyleLayerDescriptor(
+            WebAppFixture.TestLayerId,
+            "Test Layer",
+            MetadataV2GeometryType.Point);
+        var style = StyleDefaults.BuildDefaultMapLibreStyle(layer);
+        return JsonSerializer.Serialize(style);
+    }
+}

--- a/tests/seed/base-schema.sql
+++ b/tests/seed/base-schema.sql
@@ -106,6 +106,34 @@ ALTER TABLE IF EXISTS honua.layers
 ALTER TABLE IF EXISTS honua.layers
     ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE;
 
+-- Independent styleId-keyed style catalog (ADR-0048 Phase 2, migration 042, #1389).
+CREATE TABLE IF NOT EXISTS honua.styles (
+    style_id            TEXT PRIMARY KEY,
+    title               TEXT,
+    description         TEXT,
+    maplibre_style      JSONB NOT NULL,
+    drawing_info        JSONB,
+    style_version       INT NOT NULL DEFAULT 1,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revised_by          TEXT,
+    change_summary      TEXT,
+    CONSTRAINT styles_style_id_not_blank_check CHECK (length(btrim(style_id)) > 0),
+    CONSTRAINT styles_change_summary_length_check
+        CHECK (change_summary IS NULL OR char_length(change_summary) <= 1000)
+);
+
+CREATE TABLE IF NOT EXISTS honua.layer_style_refs (
+    layer_id    INT NOT NULL REFERENCES honua.layers (layer_id) ON DELETE CASCADE,
+    style_id    TEXT NOT NULL REFERENCES honua.styles (style_id) ON DELETE CASCADE,
+    ordinal     INT NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (layer_id, style_id)
+);
+
+CREATE INDEX IF NOT EXISTS layer_style_refs_layer_idx ON honua.layer_style_refs (layer_id, ordinal);
+CREATE INDEX IF NOT EXISTS layer_style_refs_style_idx ON honua.layer_style_refs (style_id);
+
 CREATE TABLE IF NOT EXISTS honua.service_layers (
     service_name VARCHAR(64) NOT NULL REFERENCES honua.services(service_name) ON DELETE CASCADE,
     layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -53,6 +53,29 @@ sql:
   - "ALTER TABLE IF EXISTS honua.layers ADD COLUMN IF NOT EXISTS style_revised_by TEXT;"
   - "ALTER TABLE IF EXISTS honua.layers ADD COLUMN IF NOT EXISTS style_change_summary TEXT;"
   - |
+      CREATE TABLE IF NOT EXISTS honua.styles (
+          style_id            TEXT PRIMARY KEY,
+          title               TEXT,
+          description         TEXT,
+          maplibre_style      JSONB NOT NULL,
+          drawing_info        JSONB,
+          style_version       INT NOT NULL DEFAULT 1,
+          created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          revised_by          TEXT,
+          change_summary      TEXT
+      );
+  - |
+      CREATE TABLE IF NOT EXISTS honua.layer_style_refs (
+          layer_id    INT NOT NULL REFERENCES honua.layers (layer_id) ON DELETE CASCADE,
+          style_id    TEXT NOT NULL REFERENCES honua.styles (style_id) ON DELETE CASCADE,
+          ordinal     INT NOT NULL DEFAULT 0,
+          created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          PRIMARY KEY (layer_id, style_id)
+      );
+  - "CREATE INDEX IF NOT EXISTS layer_style_refs_layer_idx ON honua.layer_style_refs (layer_id, ordinal);"
+  - "CREATE INDEX IF NOT EXISTS layer_style_refs_style_idx ON honua.layer_style_refs (style_id);"
+  - |
       CREATE TABLE IF NOT EXISTS honua.service_layers (
           service_name VARCHAR(64) NOT NULL REFERENCES honua.services(service_name) ON DELETE CASCADE,
           layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,


### PR DESCRIPTION
## Issue Link
Fixes #1389
Fixes #1390
Part of umbrella #1387. Implements ADR-0048. Consolidates the two Phase-2 styles changes into one PR to avoid running the honua-server CI matrix twice.

## Summary
Two related OGC API – Styles changes, merged into one branch (zero conflicts — disjoint areas):
- **#1389 Phase 2 — independent styleId-keyed style catalog**: styles become first-class and reusable (one style → many layers), promoting the dormant `Type=Style`/`StyleResourceIds` scaffolding to a real, populated graph.
- **#1390 Styled vector maps**: OGC API Maps `…/styles/{styleId}/map` now renders vector collections via the shared Skia pipeline (was a 501 stub).

## Changes Made
- Migration **042** (`042_CreateStyleCatalog.sql`): `honua.styles` (styleId-keyed, layer-independent) + `honua.layer_style_refs` (ordered M2M, ordinal 0 = primary); backfills existing per-layer MapLibre styles into a default style per layer. Idempotent.
- `IStyleCatalog` (Honua.Core) + `PostgresStyleCatalog`; `MetadataV2StyleResourceFactory` graph producer emitting `Type=Style` resources and populating `StyleResourceIds`; `IMetadataV2StyleGraphSync`/`PostgresMetadataV2StyleGraphSync` reconciles + prunes; `LayerStyleService` mirrors per-layer edits into the catalog (best-effort, never fails the Phase 1 update).
- OGC `manage-styles` full write surface: `POST /ogc/styles` (201+Location, 409 on dup) and `DELETE /ogc/styles/{styleId}` (204/404) replace the Phase 1 501 stubs; GET/PUT contract preserved; list/metadata now also surface standalone catalog styles.
- The dormant FeatureServer/MapServer `StyleResourceIds → Type=Style` read path now lights up with real data.
- Styled-map: `OgcMapsRenderingHandler.RenderStyledMapAsync` dispatches vector collections to `RasterMapRenderingPipeline.RenderVectorCollectionAsync` with a `styleId`-resolved MapLibre style (via the Phase 1 `IOgcStyleProjection`); raster coverages keep the honest 501; `…/conf/styled-map` claimed in `OgcMapsConformanceHandler`. No rendering/geodesy logic duplicated (reuses the WMS/MapServer pipeline path).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Combined branch: `dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true` → 0 warnings/0 errors. Per-change suites verified green on their source branches (catalog/endpoint tests, MetadataV2 style-resource tests, Maps styled-map render test, architecture tests 101). CITE suites untouched.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] OpenAPI spec changed
- [ ] None — no docs or contract impact

OGC API – Styles `manage-styles` POST/DELETE added; OGC API Maps styled-map conformance class claimed. Additive.

## Release/Deploy Impact
- [x] Requires database migration
- [ ] None — standard merge-and-release flow

## Breaking Changes
None. Additive. Phase 1 `/ogc/styles` GET/PUT contract and the per-layer style backing are preserved (catalog is additive, not a cutover).

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review