### PR TITLE
fix: resolve OGC CQL2 temporal 500 and integration-lane server readiness (#1414)

### DIFF
--- a/.github/actions/setup-honua-server/action.yml
+++ b/.github/actions/setup-honua-server/action.yml
@@ -59,14 +59,26 @@ runs:
     - name: Start Honua Server
       shell: bash
       run: |
+        # Always capture stdout/stderr to a log so a failed readiness wait is
+        # diagnosable. When the caller supplies an explicit log-path we honour it;
+        # otherwise fall back to a runner-temp log that the timeout branch dumps.
         if [ -n "$LOG_PATH" ]; then
           mkdir -p "$(dirname "$LOG_PATH")"
-          dotnet run --project src/Honua.Server --configuration Release --no-build --no-launch-profile > "$LOG_PATH" 2>&1 &
+          SERVER_LOG="$LOG_PATH"
         else
-          dotnet run --project src/Honua.Server --configuration Release --no-build --no-launch-profile &
+          SERVER_LOG="${RUNNER_TEMP:-/tmp}/honua-server-setup.log"
         fi
 
-        for _ in $(seq 1 15); do
+        dotnet run --project src/Honua.Server --configuration Release --no-build --no-launch-profile > "$SERVER_LOG" 2>&1 &
+
+        # A cold `dotnet run --no-build` start runs the PostGIS preflight check,
+        # the full database migration set, and high-frequency query preparation
+        # before /healthz/ready reports 200. On CI runners seeding a fresh
+        # database this routinely exceeds the previous 30s budget and left the
+        # server unbound when the JS/Esri-Leaflet lanes began polling
+        # http://localhost:5000 (curl: (7) connection refused). Budget generously
+        # (90 iterations x 2s = 180s), mirroring load-soak-nightly's readiness wait.
+        for _ in $(seq 1 90); do
           if curl -fsS http://localhost:5000/healthz/ready >/dev/null; then
             exit 0
           fi
@@ -74,6 +86,9 @@ runs:
           sleep 2
         done
 
+        echo "Honua Server did not become ready within the readiness budget." >&2
+        echo "----- server log (${SERVER_LOG}) -----" >&2
+        cat "$SERVER_LOG" >&2 || true
         exit 1
       env:
         ConnectionStrings__DefaultConnection: "Host=localhost;Database=honua_test;Username=honua;Password=honua"

--- a/src/Honua.Postgres/Queries/Filters/PostgresSqlFilterTranslator.cs
+++ b/src/Honua.Postgres/Queries/Filters/PostgresSqlFilterTranslator.cs
@@ -746,8 +746,16 @@ internal sealed class PostgresSqlFilterTranslator : SqlFilterExpressionVisitorBa
             return true;
         }
 
-        if (propertyName.Equals("created_at", StringComparison.OrdinalIgnoreCase) ||
-            propertyName.Equals("updated_at", StringComparison.OrdinalIgnoreCase))
+        // Audit-trail system columns are physically named "created"/"updated" on
+        // managed feature tables (see DatabaseSchema.CreatedColumn/UpdatedColumn).
+        // Only map them when the resource actually exposes them as queryable
+        // fields; otherwise fall through to normal schema resolution so unknown or
+        // attribute-backed temporal fields (e.g. a "created_at" defined in the
+        // layer schema and stored in the JSONB attributes column) are not rewritten
+        // into a bare column reference that does not exist on the table.
+        if ((propertyName.Equals(DatabaseSchema.CreatedColumn, StringComparison.OrdinalIgnoreCase) ||
+             propertyName.Equals(DatabaseSchema.UpdatedColumn, StringComparison.OrdinalIgnoreCase)) &&
+            context.TryGetField(propertyName) is null)
         {
             expression = QuoteIdentifier(propertyName.ToLowerInvariant());
             return true;

--- a/tests/dotnet/Honua.Postgres.Tests/Queries/Filters/PostgresSqlFilterTranslatorTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Queries/Filters/PostgresSqlFilterTranslatorTests.cs
@@ -416,6 +416,70 @@ public class PostgresSqlFilterTranslatorTests
     }
 
     [Fact]
+    public void Translate_TemporalPredicateOnAttributeBackedTimestampField_UsesAttributesJsonPath()
+    {
+        // Regression: a schema field literally named "created_at"/"updated_at" is
+        // stored in the JSONB attributes column on managed feature tables and must
+        // be resolved through the schema, not rewritten to a bare physical column
+        // (which previously produced invalid SQL and a 500 from the OGC pipeline).
+        var jsonTranslator = new PostgresSqlFilterTranslator(useJsonAttributes: true);
+        var resource = CreateResource() with
+        {
+            SchemaFields = [.. CreateResource().SchemaFields, Field("created_at", MetadataV2FieldType.DateTime)],
+        };
+
+        var predicate = new TemporalPredicate(
+            TemporalOperator.After,
+            new PropertyReference("created_at"),
+            new Literal(new DateTimeOffset(2024, 01, 01, 0, 0, 0, TimeSpan.Zero), LiteralType.DateTime));
+
+        var result = jsonTranslator.Translate(predicate, resource);
+
+        result.Sql.Should().Contain("\"attributes\" ->> 'created_at'");
+        result.Sql.Should().NotContain("\"created_at\"");
+    }
+
+    [Fact]
+    public void Translate_TemporalPredicateOnUndefinedField_ThrowsArgumentException()
+    {
+        // Regression: T_BEFORE(updated_at, ...) on a layer that does not define an
+        // "updated_at" queryable previously emitted a bare column reference and
+        // failed at the database (500). It must surface a client error (400) via
+        // an ArgumentException instead.
+        var jsonTranslator = new PostgresSqlFilterTranslator(useJsonAttributes: true);
+
+        var predicate = new TemporalPredicate(
+            TemporalOperator.Before,
+            new PropertyReference("updated_at"),
+            new Literal(new DateTimeOffset(2024, 12, 31, 23, 59, 59, TimeSpan.Zero), LiteralType.DateTime));
+
+        var action = () => jsonTranslator.Translate(predicate, _resource);
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Translate_ArrayPredicateOnJsonField_WithJsonAttributes_ReturnsAttributesJsonPath()
+    {
+        // Regression coverage for the CQL2-text array operators (A_CONTAINS /
+        // A_OVERLAPS) over a JSON-backed attribute field in the OGC pipeline mode.
+        var jsonTranslator = new PostgresSqlFilterTranslator(useJsonAttributes: true);
+        var array = new ArrayLiteral([
+            new Literal("red", LiteralType.Text),
+            new Literal("blue", LiteralType.Text)
+        ]);
+
+        var predicate = new ArrayPredicate(
+            ArrayOperator.Contains,
+            new PropertyReference("tags"),
+            array);
+
+        var result = jsonTranslator.Translate(predicate, _resource);
+
+        result.Sql.Should().Be("\"attributes\" -> 'tags' @> @p0::jsonb");
+    }
+
+    [Fact]
     public void Translate_CaseInsensitiveFunction_ReturnsLoweredSQL()
     {
         // Arrange

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesEnhancementsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesEnhancementsTests.cs
@@ -1160,4 +1160,57 @@ public sealed class OgcFeaturesEnhancementsTests : IAsyncLifetime
     }
 
     #endregion
+
+    #region CQL2-Text Temporal Filter Tests (regression: attribute-backed timestamp fields)
+
+    [IntegrationTest]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    public async Task GetItems_WithCql2TextTemporalInstantOnAttributeField_Returns200()
+    {
+        // Regression: a CQL2-text T_AFTER against an attribute-backed timestamp
+        // field literally named "created_at" previously triggered a special-case
+        // in the SQL filter translator that emitted a bare column reference. In
+        // the JSONB-attributes storage model that produced
+        // "operator does not exist: text > timestamp with time zone" (PostgreSQL
+        // 42883) and surfaced as a 500. The field must instead resolve through the
+        // schema to the typed attributes JSON path and return 200.
+        _fixture.UpdateV2ResourceSchemaField(
+            WebAppFixture.TestLayerId,
+            new Honua.Core.Features.Metadata.Domain.V2.MetadataV2Field
+            {
+                Name = "created_at",
+                Type = Honua.Core.Features.Metadata.Domain.V2.MetadataV2FieldType.DateTime,
+                Nullable = true,
+                Description = "Created timestamp",
+            });
+
+        var filter = Uri.EscapeDataString("T_AFTER(created_at, TIMESTAMP('2024-01-01T00:00:00Z'))");
+
+        var response = await _fixture.Client.GetAsync(
+            $"/ogc/features/collections/{TestCollectionId}/items?filter={filter}&limit=1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    public async Task GetItems_WithCql2TextTemporalOnUndefinedField_Returns400()
+    {
+        // Regression: T_BEFORE against an undefined queryable (e.g. "updated_at"
+        // on a layer that does not expose it) previously emitted a bare column
+        // reference that failed at the database and surfaced as a 500. It must be
+        // a client error (400) instead, with no parser/syntax detail leaked.
+        var filter = Uri.EscapeDataString("T_BEFORE(updated_at, TIMESTAMP('2024-12-31T23:59:59Z'))");
+
+        var response = await _fixture.Client.GetAsync(
+            $"/ogc/features/collections/{TestCollectionId}/items?filter={filter}&limit=1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.ToLowerInvariant().Should().NotContain("syntax");
+        body.ToLowerInvariant().Should().NotContain("parse error");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Issue Link
Fixes #1414

## Summary
Fixes two pre-existing red integration lanes on `trunk`.

**A — OGC API Features CQL2-text temporal 500s.** The shared Postgres SQL filter translator (`PostgresSqlFilterTranslator.TryMapCoreField`) special-cased the literal field names `created_at`/`updated_at` to a bare physical column reference. In the canonical JSONB-attributes storage model that produced PostgreSQL `42883: operator does not exist: text > timestamp with time zone` (HTTP 500) for `T_AFTER`/`T_BEFORE` on attribute-backed timestamp fields, and referenced a non-existent column for fields a layer does not define. Verified at the HTTP level against a locally-run, CI-base-schema-seeded server (reverting the fix reproduced `42883`/500 for both `after_instant` and `before_instant`).

**B — JS + Esri-Leaflet lanes: server never ready.** The shared `setup-honua-server` composite action budgeted only 15×2s=30s for readiness. A cold `dotnet run --no-build` start runs the PostGIS preflight, the full 51-migration set, and query prep against a fresh CI database before `/healthz/ready` returns 200 — exceeding 30s — so the loop `exit 1`d before the server bound and the JS tests then hit `curl: (7) connection refused`. Same class as the load-soak-nightly readiness fix (already 180s).

## Changes Made
- `PostgresSqlFilterTranslator`: stop short-circuiting `created_at`/`updated_at` to bare columns; resolve them through the schema (defined attribute field → typed `attributes ->> '...'::<type>` JSON path → 200; undefined → `ArgumentException` → 400). Only map the real audit system columns (`created`/`updated`) to bare columns, and only when the resource does not expose them as queryables.
- `setup-honua-server` action: raise readiness budget to 90×2s=180s (matching load-soak-nightly); always capture stdout/stderr to a log and dump it on readiness timeout.
- Tests: 3 translator-level tests (attribute-backed timestamp → JSON path; undefined field → throw; array op on JSON field) and 2 OGC API Features endpoint integration tests (`T_AFTER(created_at,…)` → 200; `T_BEFORE(updated_at,…)` undefined → 400).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Local results: `Honua.Postgres.Tests` translator suite 45/45; `Honua.Protocols.OgcApi.Tests` `OgcFeaturesEnhancementsTests` 52/52 (incl. the 2 new). HTTP-level: full 23-case CQL2-text matrix + temporal-instant + datetime open intervals all 200/expected against a locally-run server; server boots and serves the JS-lane endpoints. Could not run the full pytest/Playwright harnesses locally (QGIS/Playwright/testcontainers orchestration); validated the underlying HTTP behavior and server boot directly.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None



## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent (dotnet build warnings-as-errors + targeted tests 45/45 + 52/52 + dotnet format --verify-no-changes); full matrix via CI below
