### PR TITLE
fix(featurestore): preserve numeric attribute types from JSONB-backed layers

### DIFF
--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
@@ -436,13 +436,19 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
         {
             parts.Add($"'{EscapeSqlLiteral(field.Name)}'");
             // When the resource declares an attributes JSONB column (a single column holding
-            // the per-field values), pull the field via {attributes}->>'name' instead of
-            // expecting a column-per-field on the table — the seed-driven test fixture's
-            // shared 'features' table follows that shape, and v1 catalog readers used the
-            // same projection before the cutover.
+            // the per-field values), pull the field from that column instead of expecting a
+            // column-per-field on the table — the seed-driven test fixture's shared 'features'
+            // table follows that shape, and v1 catalog readers used the same projection before
+            // the cutover.
+            //
+            // Use the jsonb-preserving accessor (->) for numeric/boolean/json fields so the
+            // value round-trips with its declared type (an integer field returns a JSON
+            // number, not a string). Text-like types keep the text accessor (->>) so existing
+            // string/date formatting is unchanged.
             if (jsonbAccessor is not null)
             {
-                parts.Add($"{jsonbAccessor} ->> '{EscapeSqlLiteral(field.Name)}'");
+                var accessor = PreservesJsonType(field.Type) ? "->" : "->>";
+                parts.Add($"{jsonbAccessor} {accessor} '{EscapeSqlLiteral(field.Name)}'");
             }
             else
             {
@@ -452,6 +458,19 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
 
         return $"jsonb_build_object({string.Join(", ", parts)})";
     }
+
+    /// <summary>
+    /// Whether a field's value should be projected with the jsonb-preserving
+    /// accessor (<c>-&gt;</c>) so its declared numeric/boolean/json type survives,
+    /// rather than the text accessor (<c>-&gt;&gt;</c>) which stringifies it.
+    /// </summary>
+    private static bool PreservesJsonType(MetadataV2FieldType type)
+        => type is MetadataV2FieldType.Integer
+            or MetadataV2FieldType.BigInteger
+            or MetadataV2FieldType.Double
+            or MetadataV2FieldType.Float
+            or MetadataV2FieldType.Boolean
+            or MetadataV2FieldType.Json;
 
     private MetadataV2Field[] ResolveAttributeFields(FeatureQuery query)
     {

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/PostgresStorageMappedFeatureReaderSqlTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/PostgresStorageMappedFeatureReaderSqlTests.cs
@@ -62,4 +62,38 @@ public sealed class PostgresStorageMappedFeatureReaderSqlTests
         expression.Should().Contain("'field_1', \"field_1\"");
         expression.Should().Contain("'field_51', \"field_51\"");
     }
+
+    [Fact]
+    public void BuildAttributesExpressionText_WithJsonbColumn_PreservesNumericTypeButStringifiesText()
+    {
+        var fields = new[]
+        {
+            new MetadataV2Field { Name = "site_name", Type = MetadataV2FieldType.String },
+            new MetadataV2Field { Name = "sync_version", Type = MetadataV2FieldType.Integer },
+            new MetadataV2Field { Name = "elevation", Type = MetadataV2FieldType.Double },
+            new MetadataV2Field { Name = "serviceable", Type = MetadataV2FieldType.Boolean },
+            new MetadataV2Field { Name = "inspected", Type = MetadataV2FieldType.Date },
+        };
+
+        var method = typeof(PostgresStorageMappedFeatureReader).GetMethod(
+            "BuildAttributesExpressionText",
+            BindingFlags.NonPublic | BindingFlags.Static,
+            binder: null,
+            types: [typeof(MetadataV2Field[]), typeof(string)],
+            modifiers: null);
+
+        method.Should().NotBeNull();
+
+        var expression = (string)method!.Invoke(null, [fields, "attributes"])!;
+
+        // Numeric/boolean fields use the jsonb-preserving accessor (->) so they
+        // round-trip as JSON numbers/booleans, not strings.
+        expression.Should().Contain("'sync_version', \"attributes\" -> 'sync_version'");
+        expression.Should().Contain("'elevation', \"attributes\" -> 'elevation'");
+        expression.Should().Contain("'serviceable', \"attributes\" -> 'serviceable'");
+
+        // Text/date fields keep the text accessor (->>) — formatting unchanged.
+        expression.Should().Contain("'site_name', \"attributes\" ->> 'site_name'");
+        expression.Should().Contain("'inspected', \"attributes\" ->> 'inspected'");
+    }
 }


### PR DESCRIPTION
## Issue Link
N/A — found by Honua Collect's feature-sync end-to-end tests (cross-repo).

## Summary
Integer (and other numeric) attributes on layers stored on the shared `features`
JSONB table round-tripped through the FeatureServer query response as **strings**
(`"7"` instead of `7`), even though the field is declared `esriFieldTypeInteger`.

## Changes Made
- `PostgresStorageMappedFeatureReader`: the attribute projection built
  `jsonb_build_object('field', "attributes" ->> 'field', ...)` for every field;
  `->>` returns text, stringifying numbers. Now uses the jsonb-preserving
  accessor `->` for numeric/boolean/json field types, keeping `->>` for
  text/date/uuid/binary so string and date formatting are unchanged.
- Unit test asserting numeric fields project with `->` and text fields with `->>`.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — output is more correct (numbers serialize as JSON numbers); text/date unchanged.

## Root cause
Captured against a live server: the executed SQL was
`jsonb_build_object('sync_version', "attributes" ->> 'sync_version', ...)::text`
while the stored JSONB value was a number (`jsonb_typeof` = `number`) and the
snapshot field type was `integer`. So the `->>` text extraction was the sole
cause. Verified: full server build succeeds; the new unit test asserts the
corrected projection.

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Tests added for new functionality
