### PR TITLE
chore: deprecate layerId style aliases, record OGC Styles conformance, fix stale style docs (#1417)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,8 @@ Use this map when deciding where code, issues, PRs, and cross-repo coordination 
 |---|---|---|
 | `honua-server` | Public | Server runtime, protocol adapters, canonical pipelines, API governance, conformance/test infrastructure. |
 | `Honua.Server` | Private | Archived legacy server/reference implementation only. It is not an active development target; do not open issues or PRs there and do not copy code from it. Use it only to understand historical behavior. |
-| `honua-server-admin` | Public | Web administration UI for Honua Server, built with Blazor WebAssembly and MudBlazor. |
+| `honua-server-admin` | Public | **Archived/dead — not an active target.** Former Blazor WebAssembly + MudBlazor admin UI. All admin/console UI work has moved to `honua-console`. Do not open issues/PRs or route new work here. |
+| `honua-console` | Public | **Active admin/console UI home.** Hosts the Studio map builder and the styleId-keyed style editor (dual-mode: MapLibre/Maputnik + Esri-renderer `drawingInfo` authoring over `/ogc/styles`; ADR-0007/ADR-0048). |
 | `honua-sdk-js` | Public | JavaScript/TypeScript SDKs for Honua, including the MCP server package. |
 | `honua-sdk-dotnet` | Public | .NET SDKs for Honua. |
 | `honua-sdk-python` | Public | Python SDK for Honua. |

--- a/docs/cite-status.md
+++ b/docs/cite-status.md
@@ -97,11 +97,24 @@ accurate `/conformance` declaration:
 
 - **OGC API – Styles (Part 1)** — `/ogc/styles`. Phase 1 adapter over Honua's
   per-layer style storage (ADR-0048, issue #1388). Declares `core`,
-  `mapbox-styles`, `sld-10`, `sld-11`, `style-validation`, and **partial**
-  `manage-styles` (PUT only; standalone POST-create and DELETE return `501`
-  until the Phase 2 independent style catalog, issue #1389). MapLibre is served
-  from canonical storage; SLD 1.0/1.1 are derived on demand. Covered by
+  `mapbox-styles`, `sld-10`, `sld-11`, `style-validation`, and
+  `manage-styles` (Phase 2 promoted POST-create / DELETE to full CRUD; the
+  Phase 1 disclosure that POST/DELETE returned `501` no longer applies).
+  MapLibre is served from canonical storage; SLD 1.0/1.1 are derived on demand.
+  **Conformance status: there is no official OGC API – Styles CITE/ETS
+  executable test suite yet**, so this surface is not part of the 952/952 count
+  above and there is no external pass-rate to report. Honua's status is proven
+  by internal integration tests that exercise every claimed conformance class —
+  `GetConformance_ListsThePhase1ConformanceClasses` asserts all six classes are
+  declared, and sibling tests cover the read path (MapLibre + derived SLD
+  1.0/1.1), `/metadata`, `style-validation` (`Prefer: handling=strict`), and the
+  `manage-styles` PUT/POST/DELETE lifecycle — in
   `tests/dotnet/Honua.Server.Tests/Features/Styling/OgcStylesEndpointTests.cs`.
+  When the official OGC Styles ETS becomes available it will be wired in like the
+  other suites and reflected here (issue #1417 item 3). The canonical `styleId`
+  surface supersedes the deprecated layerId-keyed style aliases
+  (`/api/styles/{layerId}.json`, admin `…/layers/{layerId}/style`), which remain
+  working but emit advisory `Deprecation`/`Sunset` headers pending removal.
   See [`docs/gis/style-engine-protocol-consumption.md`](gis/style-engine-protocol-consumption.md).
 
 ## How To Refresh This Page

--- a/docs/contributor/adr/0007-embedded-maputnik.md
+++ b/docs/contributor/adr/0007-embedded-maputnik.md
@@ -1,11 +1,23 @@
 # ADR-0007: Embedded Maputnik Style Editor
 
 ## Status
-Accepted; implementation tracked in `honua-server-admin#80` (admin embed)
-and `honua-portal#39` (portal saved-map style overrides). The honua-server
-side of this ADR has no remaining work — server delivers MapLibre style
-JSON via the existing endpoints; the iframe integration lives in the admin
-and portal repositories.
+Accepted; the embedded editor is re-homed to **honua-console** (the active
+admin/console UI home). The earlier routing to `honua-server-admin#80` is
+**stale** — `honua-server-admin` is archived/dead and is no longer an active
+target. Portal saved-map style overrides remain tracked in `honua-portal#39`
+(the portal is a separate end-user surface). The honua-server side of this ADR
+has no remaining work — the server delivers the canonical style via the OGC
+API – Styles surface (`/ogc/styles/{styleId}`, ADR-0048) and the legacy
+`/api/styles/{layerId}.json` alias; the editor integration lives in
+honua-console.
+
+**Product decision — dual-mode editor.** The honua-console style editor is
+**dual-mode**: it supports both **MapLibre/Maputnik** visual authoring and
+**Esri-renderer (`drawingInfo`)** authoring (simple / unique-value /
+class-breaks) for users familiar with the Esri model. Both modes author the
+single canonical style over `/ogc/styles`; the server round-trips MapLibre ↔
+Esri `drawingInfo` (ADR-0002), so there is one source of truth regardless of
+the authoring mode the user chooses.
 
 ## Context
 MVP needs a visual style editor for MapLibre styles. Options:
@@ -14,9 +26,12 @@ MVP needs a visual style editor for MapLibre styles. Options:
 - No visual editor (JSON only)
 
 ## Decision
-Embed Maputnik in the admin UI via iframe with postMessage API for style exchange.
-
-Current source still exposes JSON text editing in `honua-server-admin`; the active implementation work is tracked in `honua-server-admin#80`. Portal saved-map style overrides are tracked separately in `honua-portal#39`.
+Embed Maputnik in **honua-console** via iframe with postMessage API for style
+exchange, as one mode of the dual-mode (MapLibre/Maputnik + Esri-renderer)
+editor described in Status. The original framing targeted the now-archived
+`honua-server-admin`; that target is dead and the editor re-homes to
+honua-console (which already hosts the styleId-picker foundation). Portal
+saved-map style overrides are tracked separately in `honua-portal#39`.
 
 **Integration:**
 ```html

--- a/docs/contributor/adr/0048-ogc-api-styles-and-cross-repo-style-coherence.md
+++ b/docs/contributor/adr/0048-ogc-api-styles-and-cross-repo-style-coherence.md
@@ -49,7 +49,7 @@ The same concept — "the style for this thing" — is addressed differently in 
 | Public read endpoint (`/api/styles/{id}.json`) | **layerId** (int) |
 | honua-sdk-dotnet / honua-sdk-python admin clients | **layerId** (int) |
 | honua-sdk-js runtime (`styleRefs`) | **styleId** (string) |
-| honua-console (Studio map builder) | opaque per-layer **string** |
+| honua-console (Studio map builder; the admin/console UI home) | opaque per-layer **string** |
 | geospatial-grpc | **no style message** — 2D style is an opaque `style_artifact` ArtifactRef |
 | geospatial-mcp spec | defines `honua://styles/{style_id}` URIs that **nothing implements** |
 
@@ -133,7 +133,12 @@ API before the storage is fully first-class:
   promote `manage-styles` to full POST/DELETE; enable one-style-many-layers reuse. The Phase 1
   API contract is preserved.
 - **Phase 3: cross-repo rollout.** geospatial-grpc `StyleRef` (proto-first) → SDK styleId clients
-  → console styleId picker → MCP `honua://styles/{styleId}` resources/tools. Mobile annotation
+  → **honua-console** styleId picker + editor → MCP `honua://styles/{styleId}` resources/tools.
+  The style editor is re-homed to **honua-console** (the active admin/console UI home;
+  `honua-server-admin` is archived/dead, so ADR-0007's original `honua-server-admin#80` routing is
+  stale). The console editor is **dual-mode**: MapLibre/Maputnik visual authoring **and**
+  Esri-renderer (`drawingInfo`) authoring for Esri-familiar users, both writing the one canonical
+  style over `/ogc/styles` (the server round-trips MapLibre ↔ Esri per ADR-0002). Mobile annotation
   styling stays intentionally orthogonal (documented, not unified).
 - **Parallel: OGC API Maps styled-map for vector layers** — separate from the Styles API; tracked
   as its own issue against the renderer-dispatch architecture.
@@ -165,8 +170,9 @@ API before the storage is fully first-class:
 ## Related ADRs
 - **ADR-0002** (MapLibre as Canonical Style Format) — canonical-format decision stands; its
   one-style-per-layer *storage* framing is superseded by the first-class model as the target.
-- **ADR-0007** (Embedded Maputnik Style Editor) — the console styleId picker / editor consumes
-  `/ogc/styles`.
+- **ADR-0007** (Embedded Maputnik Style Editor) — the editor is re-homed to **honua-console**
+  (not the archived `honua-server-admin`) and is **dual-mode**: MapLibre/Maputnik + Esri-renderer
+  (`drawingInfo`) authoring. The console styleId picker / editor consumes `/ogc/styles`.
 - **ADR-0040** (Metadata v2 Canonical Graph) — this ADR resolves its open design question #8;
   the producer + storage for `Type=Style` / `StyleResourceIds` is the Phase 2 epic.
 

--- a/docs/developer/api-specs/admin-api.json
+++ b/docs/developer/api-specs/admin-api.json
@@ -1499,8 +1499,9 @@
           "Styles"
         ],
         "summary": "Get Layer Style",
-        "description": "Get the canonical MapLibre style document for a layer plus revision metadata (styleVersion, revisedAt, revisedBy, changeSummary). The cached drawingInfo conversion is included when available.",
+        "description": "DEPRECATED layerId-keyed alias. The canonical style identifier is styleId via GET /ogc/styles/{styleId} (ADR-0048). This alias is kept working for back-compat and returns advisory Deprecation/Sunset response headers; it will be removed only after downstream styleId migration completes. Get the canonical MapLibre style document for a layer plus revision metadata (styleVersion, revisedAt, revisedBy, changeSummary). The cached drawingInfo conversion is included when available.",
         "operationId": "getAdminLayerStyle",
+        "deprecated": true,
         "parameters": [
           {
             "name": "layerId",
@@ -1540,7 +1541,8 @@
           "Styles"
         ],
         "summary": "Update Layer Style",
-        "description": "Update the canonical MapLibre style for a layer. Supply mapLibreStyle directly or a GeoServices drawingInfo payload that the engine converts. Optional changedBy and changeSummary populate the layer's revision metadata; changeSummary longer than 1000 characters returns 400. The response includes the persisted style, the incremented styleVersion, the new revisedAt timestamp, and unsupportedSymbolizers[] entries with stable StyleErrorCodes for any symbolizers that could not be losslessly translated. Style intent is never silently dropped: a best-effort MapLibre fallback is still returned alongside the unsupported list.",
+        "deprecated": true,
+        "description": "DEPRECATED layerId-keyed alias. The canonical style identifier is styleId via PUT /ogc/styles/{styleId} (ADR-0048). This alias is kept working for back-compat and returns advisory Deprecation/Sunset response headers; it will be removed only after downstream styleId migration completes. Update the canonical MapLibre style for a layer. Supply mapLibreStyle directly or a GeoServices drawingInfo payload that the engine converts. Optional changedBy and changeSummary populate the layer's revision metadata; changeSummary longer than 1000 characters returns 400. The response includes the persisted style, the incremented styleVersion, the new revisedAt timestamp, and unsupportedSymbolizers[] entries with stable StyleErrorCodes for any symbolizers that could not be losslessly translated. Style intent is never silently dropped: a best-effort MapLibre fallback is still returned alongside the unsupported list.",
         "operationId": "updateAdminLayerStyle",
         "parameters": [
           {

--- a/docs/gis/style-engine-protocol-consumption.md
+++ b/docs/gis/style-engine-protocol-consumption.md
@@ -12,10 +12,12 @@ protocol slice does with that document.
 - Theme engine: implemented (`default`, `dark`, `colorblind-safe`, `print`)
 - Style revision metadata: implemented (`styleVersion`, `revisedAt`,
   `revisedBy`, `changeSummary` returned on admin GET/PUT)
-- OGC API – Styles Phase 1 adapter: implemented (ADR-0048, issue #1388;
-  `core`, `mapbox-styles`, `sld-10`, `sld-11`, `style-validation`, partial
-  `manage-styles`). Independent style catalog (Phase 2, full POST/DELETE) is
-  issue #1389.
+- OGC API – Styles adapter: implemented (ADR-0048, issue #1388;
+  `core`, `mapbox-styles`, `sld-10`, `sld-11`, `style-validation`,
+  `manage-styles`). The independent style catalog (Phase 2, full POST/DELETE,
+  issue #1389) is implemented. No official OGC Styles CITE/ETS exists yet; the
+  surface is proven by the integration tests in
+  `tests/dotnet/Honua.Server.Tests/Features/Styling/OgcStylesEndpointTests.cs`.
 - Visual diff UX in the Admin UI: deferred to a follow-up ticket
 
 ## Storage shape
@@ -60,7 +62,29 @@ newly-published row increments `0 -> 1` deterministically.
 | Submit MapLibre style | `PUT /api/v1/admin/metadata/layers/{layerId}/style` body `{ "mapLibreStyle": { ... } }` | Validated by `MapLibreStyleNormalizer`; rejected with 400 on schema errors. |
 | Submit GeoServices drawingInfo | `PUT /api/v1/admin/metadata/layers/{layerId}/style` body `{ "drawingInfo": { ... } }` | Converted to MapLibre by `GeoServicesToMapLibreConverter`. Unsupported renderer/symbol types are reported in the response body via `unsupportedSymbolizers[]` with stable codes from `StyleErrorCodes`. |
 | Read canonical style | `GET /api/v1/admin/metadata/layers/{layerId}/style` | Returns the canonical MapLibre document plus revision metadata. |
-| Read public style | `GET /api/styles/{layerId}.json[?theme=dark|colorblind-safe|print]` | Public read endpoint with output cache; theme transforms applied deterministically per query key. |
+| Read public style | `GET /api/styles/{layerId}.json[?theme=dark|colorblind-safe|print]` | **Deprecated layerId alias** — prefer `GET /ogc/styles/{styleId}` (see below). Still working with output cache; theme transforms applied deterministically per query key. Emits advisory `Deprecation`/`Sunset` headers. |
+
+## Canonical style identifier and deprecated layerId aliases
+
+The canonical style identifier is **`styleId`**, addressed through the OGC
+API – Styles surface (`/ogc/styles`, ADR-0048). `GET /ogc/styles/{styleId}`
+serves the MapLibre style and, via content negotiation, derived SLD 1.0/1.1;
+`PUT /ogc/styles/{styleId}` writes it.
+
+The older **layerId-keyed paths are deprecated aliases** that are kept working
+for back-compat:
+
+| Deprecated layerId alias | Canonical styleId replacement |
+|--------------------------|-------------------------------|
+| `GET /api/styles/{layerId}.json` | `GET /ogc/styles/{styleId}` (content-negotiated MapLibre/SLD) |
+| `GET /api/v1/admin/metadata/layers/{layerId}/style` | `GET /ogc/styles/{styleId}` (+ `/metadata`) |
+| `PUT /api/v1/admin/metadata/layers/{layerId}/style` | `PUT /ogc/styles/{styleId}` |
+
+Each alias returns advisory `Deprecation: true` and `Sunset` response headers
+plus a `Link: rel="successor-version"` pointing at `/ogc/styles`, and is marked
+`deprecated` in its OpenAPI metadata. Behavior is otherwise identical. Per
+ADR-0048 the aliases are **not removed yet**: hard removal (Phase 3) is gated on
+the SDK / console / MCP consumers migrating to `styleId`.
 
 ## Unsupported symbolizers
 
@@ -215,19 +239,20 @@ public `IOgcStyleProjection` abstraction (`Honua.Core`, implemented by
 | Endpoint | Method | Behavior |
 |----------|--------|----------|
 | `/ogc/styles` | GET | Landing links + styles list (one entry per collection that has a stored MapLibre style). |
-| `/ogc/styles/conformance` | GET | Declares `core`, `mapbox-styles`, `sld-10`, `sld-11`, `style-validation`, partial `manage-styles`. |
+| `/ogc/styles/conformance` | GET | Declares `core`, `mapbox-styles`, `sld-10`, `sld-11`, `style-validation`, `manage-styles`. |
 | `/ogc/styles/openapi.json` | GET | OpenAPI document for the slice. |
 | `/ogc/styles/{styleId}` | GET | Content-negotiated stylesheet: MapLibre (`application/vnd.mapbox.style+json`, default) or derived SLD 1.0/1.1 by `Accept`. |
 | `/ogc/styles/{styleId}/metadata` | GET | `id`, `title`, `description`, `keywords`, `license`, `version` + stylesheet / `describedby` (schema) / `preview` links. |
 | `/ogc/styles/{styleId}` | PUT | `manage-styles`: validates MapLibre via the normalizer and writes through `ILayerStyleService`. Honors `Prefer: handling=strict` and `?validate`. |
-| `/ogc/styles` (POST), `/ogc/styles/{styleId}` (DELETE) | POST/DELETE | `501 Not Implemented` — standalone style CRUD arrives with the Phase 2 independent catalog (issue #1389). |
+| `/ogc/styles` (POST) | POST | `manage-styles`: creates a standalone style in the Phase 2 independent style catalog (issue #1389); the new stable identifier is returned in `Location`. Honors `Prefer: handling=strict` and `?validate`. |
+| `/ogc/styles/{styleId}` (DELETE) | DELETE | `manage-styles`: deletes a standalone style from the Phase 2 independent catalog. |
 
 The `styleId` is the collection's stable resource name — the same identifier
 used as the OGC API Features collectionId — chosen to be forward-compatible with
 the Phase 2 styleId-keyed catalog. SLD encodings are derived on demand from the
 canonical MapLibre style via `MapLibreToSldConverter`; the canonical store only
 holds MapLibre. The collection metadata (`GET /ogc/features/collections/{id}`)
-carries `rel:"style"` (the `/api/styles/{layerId}.json` alias, unchanged),
+carries `rel:"style"` (the deprecated `/api/styles/{layerId}.json` alias, retained),
 `rel:"styles"` (→ `/ogc/styles`), and `rel:"stylesheet"` (→ `/ogc/styles/{styleId}`)
 links. The revision metadata fields (`styleVersion`, `revisedAt`, `revisedBy`,
 `changeSummary`) back the OGC style `version` field.

--- a/src/Honua.Server/Features/Admin/AdminLayerStyleEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AdminLayerStyleEndpoints.cs
@@ -14,6 +14,14 @@ namespace Honua.Server.Features.Admin;
 /// <summary>
 /// Admin endpoints for layer style metadata management.
 /// </summary>
+/// <remarks>
+/// The <c>…/layers/{layerId}/style</c> GET/PUT routes are <b>deprecated</b>
+/// layerId-keyed aliases. The canonical style identifier is <c>styleId</c> via
+/// the OGC API – Styles surface (<c>GET/PUT /ogc/styles/{styleId}</c>,
+/// ADR-0048). These admin aliases remain working for back-compat and emit
+/// advisory <c>Deprecation</c>/<c>Sunset</c> response headers; per ADR-0048
+/// they are retired only after the cross-repo styleId rollout (Phase 3).
+/// </remarks>
 internal static class AdminLayerStyleEndpoints
 {
     /// <summary>
@@ -29,12 +37,14 @@ internal static class AdminLayerStyleEndpoints
 
         _ = group.MapGet("/{layerId:int}/style", HandleGetLayerStyle)
             .WithName("GetAdminLayerStyle")
-            .WithSummary("Get layer style metadata")
+            .WithSummary("[Deprecated] Get layer style metadata by layerId")
+            .WithDescription("DEPRECATED layerId-keyed alias. Use the canonical styleId surface GET /ogc/styles/{styleId} (ADR-0048). Kept working for back-compat; emits advisory Deprecation/Sunset headers.")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
 
         _ = group.MapPut("/{layerId:int}/style", HandleUpdateLayerStyle)
             .WithName("UpdateAdminLayerStyle")
-            .WithSummary("Update layer style metadata")
+            .WithSummary("[Deprecated] Update layer style metadata by layerId")
+            .WithDescription("DEPRECATED layerId-keyed alias. Use the canonical styleId surface PUT /ogc/styles/{styleId} (ADR-0048). Kept working for back-compat; emits advisory Deprecation/Sunset headers.")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Put }));
     }
 
@@ -44,6 +54,9 @@ internal static class AdminLayerStyleEndpoints
         [FromServices] ILayerStyleService styleService,
         CancellationToken cancellationToken)
     {
+        // Advisory deprecation signaling for the layerId-keyed admin alias.
+        StyleDeprecationHeaders.Apply(context, "/ogc/styles");
+
         if (layerId < 0)
         {
             return ProblemDetailsHelpers.CreateAdminProblem(
@@ -84,6 +97,9 @@ internal static class AdminLayerStyleEndpoints
         [FromServices] OutputCacheInvalidationService cacheInvalidator,
         CancellationToken cancellationToken)
     {
+        // Advisory deprecation signaling for the layerId-keyed admin alias.
+        StyleDeprecationHeaders.Apply(context, "/ogc/styles");
+
         if (layerId < 0)
         {
             return ProblemDetailsHelpers.CreateAdminProblem(

--- a/src/Honua.Server/Features/Styling/StyleDeprecationHeaders.cs
+++ b/src/Honua.Server/Features/Styling/StyleDeprecationHeaders.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Honua.Server.Features.Styling;
+
+/// <summary>
+/// Emits advisory deprecation signaling for the legacy layerId-keyed style
+/// aliases. The canonical style identifier is <c>styleId</c> via
+/// <c>/ogc/styles/{styleId}</c> (ADR-0048); the layerId-keyed paths
+/// (<c>/api/styles/{layerId}.json</c> and the admin
+/// <c>…/layers/{layerId}/style</c> endpoints) remain working back-compat
+/// aliases until consumers migrate. Per ADR-0048 the aliases are retired only
+/// after the SDK/console/MCP styleId rollout completes (Phase 3); removing them
+/// now would break clients before they migrate.
+/// </summary>
+internal static class StyleDeprecationHeaders
+{
+    /// <summary>
+    /// The RFC 8594 <c>Deprecation</c> header. The presence/<c>true</c> value
+    /// signals the resource is deprecated.
+    /// </summary>
+    public const string DeprecationHeader = "Deprecation";
+
+    /// <summary>
+    /// The RFC 8594 <c>Sunset</c> header advertising when the alias may stop
+    /// responding. The exact date is gated on downstream styleId adoption, so
+    /// the value is intentionally advisory rather than a hard commitment.
+    /// </summary>
+    public const string SunsetHeader = "Sunset";
+
+    /// <summary>
+    /// The <c>Link</c> header pointing clients at the canonical replacement.
+    /// </summary>
+    public const string LinkHeader = "Link";
+
+    /// <summary>
+    /// Adds the advisory deprecation response headers for a layerId-keyed style
+    /// alias. Behavior is otherwise unchanged; this only signals deprecation.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <param name="successorRelativePath">
+    /// The canonical successor path (e.g. <c>/ogc/styles</c>) advertised to the
+    /// client via the <c>Link: rel="successor-version"</c> relation.
+    /// </param>
+    public static void Apply(HttpContext context, string successorRelativePath)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var headers = context.Response.Headers;
+        headers[DeprecationHeader] = "true";
+
+        // Advisory sunset: the layerId aliases are retired only after the
+        // cross-repo styleId rollout (ADR-0048 Phase 3). The date is a
+        // non-binding signal that the alias is on a deprecation track and may
+        // move once downstream consumers have migrated to styleId.
+        headers[SunsetHeader] = "Thu, 31 Dec 2026 23:59:59 GMT";
+
+        headers.Append(LinkHeader, $"<{successorRelativePath}>; rel=\"successor-version\"");
+    }
+}

--- a/src/Honua.Server/Features/Styling/StyleEndpoints.cs
+++ b/src/Honua.Server/Features/Styling/StyleEndpoints.cs
@@ -12,6 +12,22 @@ using Microsoft.Extensions.Logging;
 
 namespace Honua.Server.Features.Styling;
 
+/// <summary>
+/// Public read endpoint for the canonical MapLibre style of a layer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The route <c>GET /api/styles/{layerId}.json</c> is a <b>deprecated</b>
+/// layerId-keyed alias. The canonical style identifier is <c>styleId</c> via
+/// <c>GET /ogc/styles/{styleId}</c> (ADR-0048), which serves MapLibre and
+/// derived SLD encodings through content negotiation.
+/// </para>
+/// <para>
+/// The alias is kept working for back-compat and emits advisory
+/// <c>Deprecation</c>/<c>Sunset</c> response headers. Per ADR-0048 it is
+/// retired only after the cross-repo styleId rollout (Phase 3) completes.
+/// </para>
+/// </remarks>
 internal static class StyleEndpoints
 {
     /// <summary>
@@ -24,10 +40,10 @@ internal static class StyleEndpoints
     public static IEndpointRouteBuilder MapStyleEndpoints(this IEndpointRouteBuilder endpoints)
     {
         endpoints.MapGet("/api/styles/{layerId:int}.json", HandleGetStyle)
-            .WithDisplayName("Get MapLibre Style")
+            .WithDisplayName("Get MapLibre Style (deprecated layerId alias)")
             .WithName("GetMapLibreStyle")
-            .WithSummary("Get MapLibre style for a layer")
-            .WithDescription("Returns a MapLibre style JSON document for the requested layer. Pass ?theme=dark|colorblind-safe|print for theme transforms.")
+            .WithSummary("[Deprecated] Get MapLibre style for a layer by layerId")
+            .WithDescription("DEPRECATED layerId-keyed alias. The canonical style identifier is styleId via GET /ogc/styles/{styleId} (ADR-0048); content negotiation there serves MapLibre and derived SLD. This endpoint keeps working as a back-compat alias and returns advisory Deprecation/Sunset response headers; it will be removed only after downstream styleId migration completes. Returns a MapLibre style JSON document for the requested layer. Pass ?theme=dark|colorblind-safe|print for theme transforms.")
             .WithTags("Styles")
             .CacheOutput("LayerStyle")
             .WithETag()
@@ -48,6 +64,10 @@ internal static class StyleEndpoints
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
+        // Advisory deprecation signaling for the layerId-keyed alias. Behavior is
+        // unchanged; the canonical identifier is styleId via /ogc/styles/{styleId}.
+        StyleDeprecationHeaders.Apply(context, "/ogc/styles");
+
         if (!TryParseTheme(theme, out var themeProfile))
         {
             return StandardErrorHelpers.CreateBadRequest(

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/LayerStyleEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/LayerStyleEndpointsTests.cs
@@ -57,6 +57,29 @@ public sealed class LayerStyleEndpointsTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Metadata)]
     [Endpoint("GET /api/v1/admin/metadata/layers/{layerId}/style")]
+    public async Task GetLayerStyle_DeprecatedLayerIdAlias_EmitsDeprecationHeaders()
+    {
+        var client = _fixture.CreateAdminClient();
+
+        var response = await client.GetAsync(
+            $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/style");
+
+        response.Be200Ok();
+
+        // The layerId-keyed admin alias is deprecated in favour of the canonical
+        // styleId surface /ogc/styles/{styleId} (ADR-0048) but kept working.
+        response.Headers.TryGetValues("Deprecation", out var deprecation).Should().BeTrue();
+        deprecation!.Should().Contain("true");
+        response.Headers.Contains("Sunset").Should().BeTrue();
+        response.Headers.TryGetValues("Link", out var link).Should().BeTrue();
+        link!.Should().Contain(value =>
+            value.Contains("/ogc/styles", StringComparison.Ordinal)
+            && value.Contains("successor-version", StringComparison.Ordinal));
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /api/v1/admin/metadata/layers/{layerId}/style")]
     [Endpoint("PUT /api/v1/admin/metadata/layers/{layerId}/style")]
     public async Task UnstyledLayer_ReadsAtVersionZero_AndFirstPutLandsAsRevisionOne()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Tiles/TileJsonEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Tiles/TileJsonEndpointTests.cs
@@ -151,6 +151,26 @@ public sealed class TileJsonEndpointTests : IAsyncLifetime
         root.GetProperty("layers").GetArrayLength().Should().BeGreaterThan(0);
     }
 
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /api/styles/{layerId}.json")]
+    public async Task GetStyle_DeprecatedLayerIdAlias_EmitsDeprecationHeaders()
+    {
+        var response = await _fixture.Client.GetAsync($"/api/styles/{WebAppFixture.TestLayerId}.json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // The layerId-keyed alias is deprecated in favour of /ogc/styles/{styleId}
+        // (ADR-0048) but kept working; it must advertise advisory deprecation.
+        response.Headers.TryGetValues("Deprecation", out var deprecation).Should().BeTrue();
+        deprecation!.Should().Contain("true");
+        response.Headers.Contains("Sunset").Should().BeTrue();
+        response.Headers.TryGetValues("Link", out var link).Should().BeTrue();
+        link!.Should().Contain(value =>
+            value.Contains("/ogc/styles", StringComparison.Ordinal)
+            && value.Contains("successor-version", StringComparison.Ordinal));
+    }
+
     private Task<HttpResponseMessage> GetStyleFromTileJsonAsync(string styleUrl)
     {
         if (Uri.TryCreate(styleUrl, UriKind.Absolute, out var absolute))


### PR DESCRIPTION
## Issue Link
Related to #1417

## Summary
Three grouped honua-server styles follow-ups (one PR per the grouping convention): deprecate the layerId-keyed style aliases in favor of styleId `/ogc/styles`, record OGC API – Styles conformance status, and fix stale style docs now that honua-server-admin is archived and the editor re-homes to honua-console with dual-mode (MapLibre/Maputnik + Esri-renderer) authoring (ADR-0048).

## Changes Made
- Deprecate (keep working) the layerId style paths `/api/styles/{layerId}.json` (`Features/Styling/StyleEndpoints.cs`) and admin `…/layers/{layerId}/style` (`Features/Admin/AdminLayerStyleEndpoints.cs`) — deprecation signaling + OpenAPI deprecated flag + docs pointing to `/ogc/styles/{styleId}`; behavior unchanged. Hard removal is gated on consumer migration (ADR-0048 Phase 3).
- Record OGC API – Styles conformance status in `docs/cite-status.md` (internal conformance tests cover the claimed classes; no official OGC Styles ETS exists yet — stated honestly).
- Re-home the embedded style editor from the archived `honua-server-admin` to `honua-console`, and record the dual-mode MapLibre/Maputnik + Esri-renderer (`drawingInfo`) authoring decision — `docs/contributor/adr/0007-embedded-maputnik.md`, `docs/contributor/adr/0048-...md`.
- Update the repo map in `AGENTS.md` (= `CLAUDE.md`): mark `honua-server-admin` archived, add `honua-console` as the active admin/console UI home.
- Updated `docs/gis/style-engine-protocol-consumption.md`, `docs/developer/api-specs/admin-api.json`, and affected tests.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

`dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true` → 0 warnings/0 errors. `dotnet format Honua.sln --verify-no-changes` clean.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] OpenAPI spec changed
- [x] Documentation updated

Adds `deprecated` signaling to the layerId style endpoints; no behavior change.

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. The layerId style paths are marked deprecated but continue to work; removal is a later, separately-gated step (Phase 3).

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review