### PR TITLE
fix: round-trip gml:identifier codeSpace on WFS-T Replace (#1433)

### DIFF
--- a/src/Honua.Hosting/Features/Validation/ValidationExtensions.cs
+++ b/src/Honua.Hosting/Features/Validation/ValidationExtensions.cs
@@ -12,6 +12,7 @@ namespace Honua.Infrastructure.Validation;
 public static class ValidationExtensions
 {
     internal const string WfsGmlIdentifierAttributeName = "__honua_wfs_gml_identifier";
+    internal const string WfsGmlIdentifierCodeSpaceAttributeName = "__honua_wfs_gml_identifier_codespace";
     internal const string WfsGmlNameAttributeName = "__honua_wfs_gml_name";
     internal const string WfsGmlDescriptionAttributeName = "__honua_wfs_gml_description";
 
@@ -27,6 +28,7 @@ public static class ValidationExtensions
     internal static bool IsReservedMutationAttribute(string attributeName)
     {
         return attributeName.Equals(WfsGmlIdentifierAttributeName, StringComparison.Ordinal) ||
+               attributeName.Equals(WfsGmlIdentifierCodeSpaceAttributeName, StringComparison.Ordinal) ||
                attributeName.Equals(WfsGmlNameAttributeName, StringComparison.Ordinal) ||
                attributeName.Equals(WfsGmlDescriptionAttributeName, StringComparison.Ordinal);
     }

--- a/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Transaction.cs
+++ b/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Transaction.cs
@@ -723,6 +723,12 @@ internal sealed partial class Wfs20Handler
                 out var reservedAttributeName))
             {
                 attributes[reservedAttributeName] = ParseTransactionReservedAttributeValue(propertyElement);
+                if (reservedAttributeName.Equals(ValidationExtensions.WfsGmlIdentifierAttributeName, StringComparison.Ordinal))
+                {
+                    attributes[ValidationExtensions.WfsGmlIdentifierCodeSpaceAttributeName] =
+                        ParseTransactionGmlCodeSpace(propertyElement);
+                }
+
                 continue;
             }
 
@@ -813,6 +819,13 @@ internal sealed partial class Wfs20Handler
                 attributes[reservedAttributeName] = valueElement == null
                     ? null
                     : ParseTransactionReservedAttributeValue(valueElement);
+                if (reservedAttributeName.Equals(ValidationExtensions.WfsGmlIdentifierAttributeName, StringComparison.Ordinal))
+                {
+                    attributes[ValidationExtensions.WfsGmlIdentifierCodeSpaceAttributeName] = valueElement == null
+                        ? null
+                        : ParseTransactionGmlCodeSpace(valueElement);
+                }
+
                 continue;
             }
 
@@ -1173,6 +1186,34 @@ internal sealed partial class Wfs20Handler
         }
 
         return valueElement.Value.Trim();
+    }
+
+
+    /// <summary>
+    /// Extracts the <c>codeSpace</c> attribute carried by a <c>gml:identifier</c> property so it can
+    /// be persisted and round-tripped. <c>gml:identifier</c> is of type
+    /// <c>gml:CodeWithAuthorityType</c>, for which <c>codeSpace</c> is mandatory; the WFS 2.0 ETS
+    /// asserts the standard property survives a Replace round-trip and validates it against the GML
+    /// schema, so dropping the authority would emit schema-invalid GML on read-back.
+    /// </summary>
+    private static string? ParseTransactionGmlCodeSpace(XElement valueElement)
+    {
+        var direct = valueElement.Attributes()
+            .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, "codeSpace", StringComparison.OrdinalIgnoreCase))
+            ?.Value;
+        if (!string.IsNullOrWhiteSpace(direct))
+        {
+            return direct.Trim();
+        }
+
+        // For Update payloads the identifier may be wrapped inside a gml:identifier child of wfs:Value.
+        var nested = valueElement.Elements()
+            .FirstOrDefault(element => string.Equals(element.Name.LocalName, "identifier", StringComparison.OrdinalIgnoreCase))
+            ?.Attributes()
+            .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, "codeSpace", StringComparison.OrdinalIgnoreCase))
+            ?.Value;
+
+        return string.IsNullOrWhiteSpace(nested) ? null : nested.Trim();
     }
 
 

--- a/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.cs
+++ b/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.cs
@@ -1181,9 +1181,17 @@ internal sealed partial class Wfs20Handler
             writer.WriteElementString("gml", "description", Wfs20Utilities.GmlNamespace, gmlDescription);
         }
 
-        if (TryGetGmlIdentifierValue(feature.Attributes, out var gmlIdentifier))
+        if (TryGetGmlIdentifierValue(feature.Attributes, out var gmlIdentifier, out var gmlIdentifierCodeSpace))
         {
-            writer.WriteElementString("gml", "identifier", Wfs20Utilities.GmlNamespace, gmlIdentifier);
+            writer.WriteStartElement("gml", "identifier", Wfs20Utilities.GmlNamespace);
+            // codeSpace is mandatory on gml:CodeWithAuthorityType; fall back to the WFS namespace
+            // URI when a transaction supplied an identifier without an explicit authority so the
+            // emitted GML stays schema-valid.
+            writer.WriteAttributeString(
+                "codeSpace",
+                string.IsNullOrWhiteSpace(gmlIdentifierCodeSpace) ? FeatureNamespaceUri : gmlIdentifierCodeSpace);
+            writer.WriteString(gmlIdentifier);
+            writer.WriteEndElement();
         }
 
         if (!includeMemberWrapper &&
@@ -1264,12 +1272,23 @@ internal sealed partial class Wfs20Handler
 
     private static bool TryGetGmlIdentifierValue(
         ImmutableDictionary<string, object?> attributes,
-        out string? gmlIdentifier)
+        out string? gmlIdentifier,
+        out string? gmlIdentifierCodeSpace)
     {
-        return TryGetReservedTransactionValue(
+        if (TryGetReservedTransactionValue(
             attributes,
             ValidationExtensions.WfsGmlIdentifierAttributeName,
-            out gmlIdentifier);
+            out gmlIdentifier))
+        {
+            TryGetReservedTransactionValue(
+                attributes,
+                ValidationExtensions.WfsGmlIdentifierCodeSpaceAttributeName,
+                out gmlIdentifierCodeSpace);
+            return true;
+        }
+
+        gmlIdentifierCodeSpace = null;
+        return false;
     }
 
     private static bool TryGetTransactionMappedValue(

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wfs20/Wfs20EndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wfs20/Wfs20EndpointsTests.cs
@@ -1326,7 +1326,63 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
         queryContent.Should().Contain("<honua:test_layer");
         queryContent.Should().Contain("WFS Replace Name");
         queryContent.Should().Contain("WFS Replace Description");
-        queryContent.Should().Contain($"<gml:identifier>{replacementIdentifier}</gml:identifier>");
+        // gml:identifier is gml:CodeWithAuthorityType; codeSpace is mandatory. When the transaction
+        // omits an authority the serializer falls back to the feature namespace URI so the emitted
+        // GML remains schema-valid.
+        queryContent.Should().Contain(
+            $"<gml:identifier codeSpace=\"http://honua.io/wfs\">{replacementIdentifier}</gml:identifier>");
+        queryContent.Should().NotContain("FeatureCollection");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(TestProtocols.Wfs20, "Transaction")]
+    public async Task Wfs_Transaction_Replace_RoundTripsGmlDescriptionAndIdentifierCodeSpace()
+    {
+        // Mirrors the WFS 2.0 ETS ReplaceTests flow (#1433): the harness replaces a feature with
+        // standard gml:description / gml:identifier properties (the identifier carrying a CITE
+        // codeSpace) and then asserts they survive a GetFeatureById read-back. gml:identifier is
+        // gml:CodeWithAuthorityType, so the codeSpace authority must round-trip too.
+        var featureId = await _fixture.InsertFeatureAsync(WebAppFixture.TestLayerId, "WFS Replace CodeSpace Original");
+        var replacementIdentifier = Guid.NewGuid().ToString();
+        const string codeSpace = "http://cite.opengeospatial.org/";
+
+        var requestBody = $$"""
+            <wfs:Transaction service="WFS" version="2.0.0"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:fes="http://www.opengis.net/fes/2.0"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:honua="http://honua.io/wfs">
+              <wfs:Replace>
+                <honua:test_layer gml:id="test_layer.{{featureId}}">
+                  <gml:description>Lorem ipsum dolor sit amet.</gml:description>
+                  <gml:identifier codeSpace="{{codeSpace}}">{{replacementIdentifier}}</gml:identifier>
+                  <gml:name>WFS Replace CodeSpace Name</gml:name>
+                  <honua:name>WFS Replace CodeSpace Name</honua:name>
+                </honua:test_layer>
+                <fes:Filter>
+                  <fes:ResourceId rid="test_layer.{{featureId}}" />
+                </fes:Filter>
+              </wfs:Replace>
+            </wfs:Transaction>
+            """;
+
+        using var requestContent = new StringContent(requestBody, Encoding.UTF8, "application/xml");
+        var response = await _fixture.Client.PostAsync("/wfs", requestContent);
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        content.Should().Contain("<wfs:totalReplaced>1</wfs:totalReplaced>");
+
+        var queryResponse = await _fixture.Client.GetAsync(
+            $"/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&STOREDQUERY_ID={Uri.EscapeDataString(GetFeatureByIdStoredQueryId)}&ID=test_layer.{featureId}");
+        var queryContent = await queryResponse.Content.ReadAsStringAsync();
+
+        queryResponse.StatusCode.Should().Be(HttpStatusCode.OK, queryContent);
+        queryContent.Should().Contain("<gml:description>Lorem ipsum dolor sit amet.</gml:description>");
+        queryContent.Should().Contain(
+            $"<gml:identifier codeSpace=\"{codeSpace}\">{replacementIdentifier}</gml:identifier>");
         queryContent.Should().NotContain("FeatureCollection");
     }
 


### PR DESCRIPTION
## Issue Link
Fixes #1433

## Summary
The WFS 2.0 transactional CITE slice (`ReplaceTests`, plus the dependent `DeleteTests` fixture state) failed because a WFS-T Replace did not round-trip the standard GML `gml:identifier` authority. The ETS replaces a feature with `gml:description` and `gml:identifier` (the identifier carrying a CITE `codeSpace`), then reads it back via the `GetFeatureById` stored query and validates the feature against the GML application schema.

`gml:identifier` is of type `gml:CodeWithAuthorityType`, for which the `codeSpace` attribute is **mandatory**. The serializer emitted `gml:identifier` with no `codeSpace`, and the transaction parser discarded the submitted authority — so the read-back GML was schema-invalid and the assertion failed. (`gml:description`/`gml:name` already round-tripped via the existing reserved-attribute mapping; the missing `codeSpace` was the remaining gap.)

## Changes Made
- Persist the `codeSpace` authority of `gml:identifier` on WFS-T Insert/Replace/Update into a companion reserved attribute (`__honua_wfs_gml_identifier_codespace`), parsed from the property element (and from a nested `gml:identifier` inside `wfs:Value` for Update payloads).
- Emit the `codeSpace` attribute on `gml:identifier` during GML serialization, falling back to the feature namespace URI when a transaction supplies an identifier without an explicit authority, so the emitted GML stays schema-valid.
- Treat the new companion attribute as a reserved mutation attribute so it bypasses schema-field validation.

## Testing
- [x] Integration tests added/updated
- [x] Manual testing performed

Added `Wfs_Transaction_Replace_RoundTripsGmlDescriptionAndIdentifierCodeSpace` mirroring the ETS Replace -> GetFeatureById flow (identifier carries the CITE `codeSpace`), and updated the existing Replace test to assert the mandatory `codeSpace` is now emitted. Full `Wfs20EndpointsTests` class: 71/71 passing against Testcontainers PostGIS (no WFS read/stored-query regressions).

Live verification of the broader round-trip (`gml:description`/`gml:name`/`gml:identifier`) was confirmed against the WFS 2.0 CITE compose. Driving the full local transactional ETS to green additionally requires the CITE transactional harness (anonymous-write layer config and the Test-environment metadata-v2 snapshot bootstrap), which is tracked separately on PR #1412 and is not present on `trunk`; this PR is the independent serializer fix.

## Gate Impact
- [x] Nightly gates (conformance, performance, security)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None
