### PR TITLE
fix(ci): provision PostGIS for security-nightly runtime test (follow-up to #1457)

### DIFF
--- a/.github/workflows/security-nightly.yml
+++ b/.github/workflows/security-nightly.yml
@@ -315,8 +315,35 @@ jobs:
 
       - name: Start container for runtime security analysis
         run: |
+          set -euo pipefail
+
+          # The published image runs a Production cold start that performs the
+          # PostGIS preflight compatibility check before migrations, so a
+          # reachable PostGIS database is required even when migrations are
+          # skipped. Provision one on a dedicated network and point the
+          # hardened app container at it by service name.
+          docker network create honua-runtime-net
+
+          docker run -d \
+            --name honua-runtime-db \
+            --network honua-runtime-net \
+            -e POSTGRES_DB=honua \
+            -e POSTGRES_USER=honua \
+            -e POSTGRES_PASSWORD=honua_password \
+            postgis/postgis:16-3.4
+
+          echo "Waiting for PostGIS to accept connections..."
+          for _ in $(seq 1 60); do
+            if docker exec honua-runtime-db pg_isready -U honua -d honua >/dev/null 2>&1; then
+              break
+            fi
+            sleep 2
+          done
+          docker exec honua-runtime-db pg_isready -U honua -d honua
+
           docker run -d \
             --name honua-runtime-test \
+            --network honua-runtime-net \
             --read-only \
             --tmpfs /tmp \
             --cap-drop ALL \
@@ -324,7 +351,7 @@ jobs:
             -e HONUA_SKIP_MIGRATIONS=true \
             -e HONUA_ADMIN_PASSWORD="Security-Nightly-Admin-Pass1!" \
             -e Security__ConnectionEncryption__MasterKey="security-nightly-master-key-at-least-32-chars" \
-            -e ConnectionStrings__DefaultConnection="Host=localhost;Port=5432;Database=honua;Username=honua;Password=honua_password" \
+            -e ConnectionStrings__DefaultConnection="Host=honua-runtime-db;Port=5432;Database=honua;Username=honua;Password=honua_password" \
             -p 8080:8080 \
             ${{ env.IMAGE_NAME }}:security-test
 
@@ -359,6 +386,9 @@ jobs:
         run: |
           docker stop honua-runtime-test || true
           docker rm honua-runtime-test || true
+          docker stop honua-runtime-db || true
+          docker rm honua-runtime-db || true
+          docker network rm honua-runtime-net || true
 
       - name: Generate container security summary
         if: always()


### PR DESCRIPTION
Related to #943 (security-nightly maintenance)

## Summary
Follow-up to #1457. That PR was squash-merged before its second commit landed, so trunk got the env-var fix but **not** the PostGIS provisioning that was the actual fix. Without a reachable database, the Production cold-start PostGIS preflight check aborts the hardened runtime-test container before the security assertions run.

## Changes Made
- Provision a `postgis/postgis:16-3.4` container on a dedicated docker network in the Container Security Scan job.
- Wait for `pg_isready` before starting the hardened app container; point it at the DB by service name via `ConnectionStrings__DefaultConnection`.
- Tear down the DB container and network in cleanup (`if: always()`). The app container retains all hardening flags (read-only, non-root).

## Breaking Changes
None — workflow-only change to a nightly CI job.

## Testing
- [x] This exact branch state was dispatch-validated in #1457's work: Container Security Scan job `success`, assertions confirmed in logs (PostGIS accepting connections, `whoami` -> `honua`, `/healthz/live` -> Healthy).

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent (workflow-only change; validated via dispatch run 26890056067 = green)