### PR TITLE
fix: align storage-mapped within/contains and seed GPServer protocol (#1460)

### DIFF
--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
@@ -682,8 +682,16 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
 
         return filter.SpatialRelationship switch
         {
-            SpatialRelationship.Within => $"ST_Within({geometryColumn}, {filterGeometry})",
-            SpatialRelationship.Contains => $"ST_Contains({geometryColumn}, {filterGeometry})",
+            // Esri semantics (mirroring the canonical FeatureQueryBuilder path):
+            // esriSpatialRelWithin  => filter geometry is within the feature geometry
+            //                          => ST_Within(filter, feature).
+            // esriSpatialRelContains => filter geometry contains the feature geometry
+            //                          => ST_Contains(filter, feature).
+            // The operands must lead with the filter geometry; reversing them (feature, filter)
+            // makes an envelope/feature .within(bounds) query return 0 because a point feature
+            // can never ST_Contains an enclosing envelope.
+            SpatialRelationship.Within => $"ST_Within({filterGeometry}, {geometryColumn})",
+            SpatialRelationship.Contains => $"ST_Contains({filterGeometry}, {geometryColumn})",
             SpatialRelationship.EnvelopeIntersects => $"{geometryColumn} && {filterGeometry}",
             SpatialRelationship.Crosses => $"ST_Crosses({geometryColumn}, {filterGeometry})",
             SpatialRelationship.Touches => $"ST_Touches({geometryColumn}, {filterGeometry})",

--- a/src/Honua.Postgres/Features/Metadata/MetadataV2CompatSnapshotSql.cs
+++ b/src/Honua.Postgres/Features/Metadata/MetadataV2CompatSnapshotSql.cs
@@ -338,9 +338,10 @@ internal static class MetadataV2CompatSnapshotSql
                         -- production publish path does (PostgreSqlLayerPublishingService.MetadataV2Graph
                         -- sets MetadataV2ServiceProtocols.All on a single service). Without Wcs here
                         -- the WCS GetCapabilities preflight 404s with OperationNotSupported even
-                        -- though the raster-backed layers exist. (honua-server#1412.)
-                        'protocols', to_jsonb(ARRAY['FeatureServer', 'MapServer', 'ImageServer', 'OData', 'Grpc', 'OgcFeatures', 'Wfs20', 'Wms', 'Wmts', 'Wcs', 'OGC-API-Maps', 'OGC-API-Tiles', 'OGC-API-Coverages']::text[]),
-                        'enabledProtocols', to_jsonb(ARRAY['FeatureServer', 'MapServer', 'ImageServer', 'OData', 'Grpc', 'OgcFeatures', 'Wfs20', 'Wms', 'Wmts', 'Wcs', 'OGC-API-Maps', 'OGC-API-Tiles', 'OGC-API-Coverages']::text[]),
+                        -- though the raster-backed layers exist; without GPServer the GeoServices
+                        -- GPServer service/task routes 404 with "GPServer is not enabled". (honua-server#1412.)
+                        'protocols', to_jsonb(ARRAY['FeatureServer', 'MapServer', 'ImageServer', 'GPServer', 'OData', 'Grpc', 'OgcFeatures', 'Wfs20', 'Wms', 'Wmts', 'Wcs', 'OGC-API-Maps', 'OGC-API-Tiles', 'OGC-API-Coverages']::text[]),
+                        'enabledProtocols', to_jsonb(ARRAY['FeatureServer', 'MapServer', 'ImageServer', 'GPServer', 'OData', 'Grpc', 'OgcFeatures', 'Wfs20', 'Wms', 'Wmts', 'Wcs', 'OGC-API-Maps', 'OGC-API-Tiles', 'OGC-API-Coverages']::text[]),
                         'options', '{}'::jsonb,
                         'accessPolicy', service_access_policy,
                         'status', (SELECT value FROM status_doc),

--- a/tests/seed/base-schema.sql
+++ b/tests/seed/base-schema.sql
@@ -651,11 +651,14 @@ BEGIN
                     'publicationIds', '[]'::jsonb,
                     -- Name-based service routing (ServicesByName / FindService) is first-wins on
                     -- the lowest service id 'svc-<part>-feature', so the feature service must carry
-                    -- the full protocol union (including Wcs / OGC API Coverages / ImageServer) the
-                    -- way the production publish path does. Otherwise WCS GetCapabilities 404s with
-                    -- OperationNotSupported. Mirrors MetadataV2CompatSnapshotSql. (honua-server#1412.)
-                    'protocols', to_jsonb(ARRAY['FeatureServer', 'MapServer', 'ImageServer', 'OData', 'Grpc', 'OgcFeatures', 'Wfs20', 'Wms', 'Wmts', 'Wcs', 'OGC-API-Maps', 'OGC-API-Tiles', 'OGC-API-Coverages']::text[]),
-                    'enabledProtocols', to_jsonb(ARRAY['FeatureServer', 'MapServer', 'ImageServer', 'OData', 'Grpc', 'OgcFeatures', 'Wfs20', 'Wms', 'Wmts', 'Wcs', 'OGC-API-Maps', 'OGC-API-Tiles', 'OGC-API-Coverages']::text[]),
+                    -- the full protocol union (including Wcs / OGC API Coverages / ImageServer /
+                    -- GPServer) the way the production publish path does (which sets
+                    -- MetadataV2ServiceProtocols.All). Otherwise WCS GetCapabilities 404s with
+                    -- OperationNotSupported and GPServer service/task routes 404 with
+                    -- "GPServer is not enabled". Mirrors MetadataV2CompatSnapshotSql.
+                    -- (honua-server#1412.)
+                    'protocols', to_jsonb(ARRAY['FeatureServer', 'MapServer', 'ImageServer', 'GPServer', 'OData', 'Grpc', 'OgcFeatures', 'Wfs20', 'Wms', 'Wmts', 'Wcs', 'OGC-API-Maps', 'OGC-API-Tiles', 'OGC-API-Coverages']::text[]),
+                    'enabledProtocols', to_jsonb(ARRAY['FeatureServer', 'MapServer', 'ImageServer', 'GPServer', 'OData', 'Grpc', 'OgcFeatures', 'Wfs20', 'Wms', 'Wmts', 'Wcs', 'OGC-API-Maps', 'OGC-API-Tiles', 'OGC-API-Coverages']::text[]),
                     'options', '{}'::jsonb,
                     'accessPolicy', service_access_policy,
                     'status', (SELECT value FROM status_doc),


### PR DESCRIPTION
## Issue Link
Fixes #1460

## Summary
The **JavaScript Integration Tests** and **Esri Leaflet Browser Tests** lanes were red on `trunk`. Pulling the actual job logs for scheduled run 26887061444 showed the server does start and reach readiness — the visible curl "connection refused" lines are just the first readiness-loop iterations during boot. The real failures were two protocol regressions that only surface once the lanes run their tests:

- JS lane: 3 `feature-server/gpserver-smoke.test.ts` cases failed because `/rest/services/test_service/GPServer` (and the task/submitJob routes) returned `404` ("GPServer is not enabled for this service").
- Esri Leaflet lane: `[CERT-QFLT-02] Spatial bbox filter via .within(bounds)` returned 0 features (seeded SF-area points are inside the bbox).

## Changes Made
- **Storage-mapped reader spatial operand order** (`PostgresStorageMappedFeatureReader.BuildSpatialFilter`): mapped `esriSpatialRelWithin`/`esriSpatialRelContains` as `ST_Within`/`ST_Contains(feature, filter)` — the inverse of the canonical `FeatureQueryBuilder.Spatial` path. esri-leaflet `.within(bounds)` emits `esriSpatialRelContains`, so the generated SQL was `ST_Contains("geometry"::geometry, ST_MakeEnvelope(...))` (feature-contains-envelope), which a point can never satisfy → 0 rows. Fixed to lead with the filter geometry (`ST_Contains(filter, feature)`), matching the canonical reader and documented ArcGIS/esri-leaflet semantics.
- **GPServer in the compat-snapshot protocol union**: name-based routing (`ServicesByName`, first-wins) resolves `test_service` to the synthesized `svc-<part>-feature` service, whose protocol list omitted `GPServer`, so `IsProtocolEnabled` returned false → 404. The real publish path (`PostgreSqlLayerPublishingService.MetadataV2Graph`) sets `ServiceProtocols.All` (which includes GPServer). Added `GPServer` to the feature-service union in both the test seed (`tests/seed/base-schema.sql`) and the production compat SQL (`MetadataV2CompatSnapshotSql.cs`) so they stay in sync.

GPServer-smoke outcome: a real server-side gap (the compat snapshot under-advertised protocols vs the real publish path), not a test bug. The submitJob smoke already accepts `503` for the no-Redis CI environment, and it returns exactly that.

## Testing
- [x] Integration tests added/updated
- [x] Manual testing performed

Local validation against a fresh PostGIS + seeded `test_service`:
- Full JS integration vitest suite: **350/350 pass** (was 347 pass / 3 fail). GPServer smoke: 3/3.
- `esriSpatialRelContains` envelope query (esri-leaflet `.within(bounds)`): **9 features** (was 0). `esriSpatialRelWithin` envelope-vs-points correctly returns 0.
- GPServer root/task: 200; submitJob: 503 with "Redis-backed durable storage" (matches the smoke contract).
- The Esri Leaflet Playwright spec wraps the same FeatureServer query verified above; the browser binary can't install on this WSL distro, so the browser harness is validated by the underlying HTTP query.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None


---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
