### PR TITLE
fix: resolve OAPIF feature reads to feature publication and honor editable default (#1463)

### DIFF
--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2Common.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2Common.cs
@@ -404,11 +404,27 @@ public sealed record MetadataV2Field
     public string? Alias { get; init; }
 
     /// <summary>
-    /// True when the field is editable through edit-capable services.
-    /// Defaults to true to preserve existing behaviour.
+    /// Serialized editable flag. Nullable so an absent value round-trips as "unspecified"
+    /// rather than <see langword="false"/>: System.Text.Json source-generated deserialization
+    /// of an all-<c>init</c> record materializes absent value-type members as their CLR
+    /// default (<see langword="false"/>) and does not run a <c>= true</c> property
+    /// initializer, so a plain <c>bool</c> property would silently deserialize to
+    /// non-editable. Consumers read <see cref="Editable"/>, which applies the true default.
     /// </summary>
     [JsonPropertyName("editable")]
-    public bool Editable { get; init; } = true;
+    public bool? EditableValue { get; init; }
+
+    /// <summary>
+    /// True when the field is editable through edit-capable services.
+    /// Defaults to true (when <see cref="EditableValue"/> is unspecified) to preserve
+    /// existing behaviour.
+    /// </summary>
+    [JsonIgnore]
+    public bool Editable
+    {
+        get => EditableValue ?? true;
+        init => EditableValue = value;
+    }
 
     /// <summary>
     /// Maximum length for VARCHAR-typed fields. Null for non-string or

--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/ServiceProtocols.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/ServiceProtocols.cs
@@ -109,4 +109,71 @@ public static class ServiceProtocols
 
         return false;
     }
+
+    /// <summary>
+    /// Indicates whether a publication of <paramref name="publicationType"/> is the canonical
+    /// surface for <paramref name="protocol"/>. Used to disambiguate collection/layer routing
+    /// when a single local identifier is published through several protocol surfaces (for
+    /// example, the same layer index exposed as both an OGC feature collection and an Esri
+    /// image layer). A protocol whose preferred publication types are unknown returns
+    /// <see langword="false"/> so callers fall back to their generic match order.
+    /// </summary>
+    /// <param name="protocol">The protocol identifier the request targets.</param>
+    /// <param name="publicationType">The candidate publication's type.</param>
+    /// <returns><see langword="true"/> when the publication type is the preferred surface for the protocol.</returns>
+    public static bool IsPreferredPublicationType(string? protocol, MetadataV2PublicationType publicationType)
+    {
+        if (string.IsNullOrWhiteSpace(protocol))
+        {
+            return false;
+        }
+
+        if (string.Equals(protocol, OgcFeatures, StringComparison.OrdinalIgnoreCase))
+        {
+            return publicationType == MetadataV2PublicationType.OgcCollection;
+        }
+
+        if (string.Equals(protocol, Stac, StringComparison.OrdinalIgnoreCase))
+        {
+            return publicationType == MetadataV2PublicationType.StacCollection;
+        }
+
+        if (string.Equals(protocol, Wfs20, StringComparison.OrdinalIgnoreCase))
+        {
+            return publicationType == MetadataV2PublicationType.WfsFeatureType;
+        }
+
+        if (string.Equals(protocol, FeatureServer, StringComparison.OrdinalIgnoreCase))
+        {
+            return publicationType == MetadataV2PublicationType.EsriFeatureLayer;
+        }
+
+        if (string.Equals(protocol, MapServer, StringComparison.OrdinalIgnoreCase))
+        {
+            return publicationType == MetadataV2PublicationType.EsriMapLayer;
+        }
+
+        if (string.Equals(protocol, ImageServer, StringComparison.OrdinalIgnoreCase))
+        {
+            return publicationType == MetadataV2PublicationType.EsriImageLayer;
+        }
+
+        if (string.Equals(protocol, OData, StringComparison.OrdinalIgnoreCase))
+        {
+            return publicationType == MetadataV2PublicationType.ODataEntitySet;
+        }
+
+        if (string.Equals(protocol, Wms, StringComparison.OrdinalIgnoreCase))
+        {
+            return publicationType == MetadataV2PublicationType.WmsLayer;
+        }
+
+        if (string.Equals(protocol, Wmts, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(protocol, OgcApiTiles, StringComparison.OrdinalIgnoreCase))
+        {
+            return publicationType == MetadataV2PublicationType.WmtsLayer;
+        }
+
+        return false;
+    }
 }

--- a/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
+++ b/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
@@ -250,13 +250,23 @@ internal static class LayerValidationHelpers
         // When a protocol is specified, prefer the matching publication so a STAC
         // collection request that shares a serviceLocalId with another protocol's
         // publication (e.g. an Esri Feature Service publication with the same local id)
-        // doesn't get dispatched to the wrong protocol.
+        // doesn't get dispatched to the wrong protocol. Among protocol-enabled candidates,
+        // prefer the one whose publication type is the canonical surface for the protocol
+        // (e.g. an ogc-collection for OGC API Features); a single layer index is commonly
+        // published through several surfaces (feature, map, image, OGC, STAC) and every
+        // service enables every protocol, so without the publication-type preference the
+        // first publication in document order wins — which routes feature reads to the
+        // raster image binding and 500s.
         if (!string.IsNullOrWhiteSpace(requiredProtocol))
         {
-            publication = snapshot.Graph.Publications.FirstOrDefault(p =>
+            var protocolMatches = snapshot.Graph.Publications.Where(p =>
                 MatchesCollectionId(p) &&
                 snapshot.Index.ServicesById.TryGetValue(p.ServiceId, out var s) &&
                 MetadataV2ServiceProtocols.IsProtocolEnabled(s, requiredProtocol));
+            publication = protocolMatches
+                .OrderByDescending(p => MetadataV2ServiceProtocols.IsPreferredPublicationType(requiredProtocol, p.PublicationType))
+                .ThenByDescending(p => p.IsPrimary)
+                .FirstOrDefault();
         }
         publication ??= snapshot.Graph.Publications.FirstOrDefault(MatchesCollectionId);
 
@@ -416,6 +426,7 @@ internal static class LayerValidationHelpers
         var snapshot = await GetV2SnapshotAsync(context, cancellationToken).ConfigureAwait(false);
 
         MetadataV2Service? chosen = null;
+        var chosenIsPreferredType = false;
         foreach (var pub in snapshot.Graph.Publications)
         {
             if (pub.LayerIndex != layerId) continue;
@@ -427,10 +438,32 @@ internal static class LayerValidationHelpers
                 continue;
             }
 
-            if (chosen is null ||
+            // Prefer the publication whose type is the canonical surface for the protocol
+            // before falling back to the lexicographically earliest service name. Without
+            // this, a layer published through several protocol surfaces resolves to whichever
+            // service sorts first rather than the one actually serving the requested protocol.
+            var candidateIsPreferredType =
+                MetadataV2ServiceProtocols.IsPreferredPublicationType(requiredProtocol, pub.PublicationType);
+
+            if (chosen is null)
+            {
+                chosen = service;
+                chosenIsPreferredType = candidateIsPreferredType;
+                continue;
+            }
+
+            if (candidateIsPreferredType && !chosenIsPreferredType)
+            {
+                chosen = service;
+                chosenIsPreferredType = true;
+                continue;
+            }
+
+            if (candidateIsPreferredType == chosenIsPreferredType &&
                 string.Compare(service.Metadata.Name, chosen.Metadata.Name, StringComparison.OrdinalIgnoreCase) < 0)
             {
                 chosen = service;
+                chosenIsPreferredType = candidateIsPreferredType;
             }
         }
         return chosen?.Metadata.Name;
@@ -478,7 +511,8 @@ internal static class LayerValidationHelpers
                 .Where(p =>
                     snapshot.Index.ServicesById.TryGetValue(p.ServiceId, out var s) &&
                     MetadataV2ServiceProtocols.IsProtocolEnabled(s, requiredProtocol))
-                .OrderByDescending(p => p.IsPrimary)
+                .OrderByDescending(p => MetadataV2ServiceProtocols.IsPreferredPublicationType(requiredProtocol, p.PublicationType))
+                .ThenByDescending(p => p.IsPrimary)
                 .FirstOrDefault();
             if (preferred is not null)
             {

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
@@ -762,7 +762,7 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
             var clauses = new List<string>();
             foreach (var clause in query.OrderBy.Value)
             {
-                var column = ResolveColumnExpression(clause.Field);
+                var column = ResolveSortColumnExpression(clause.Field);
                 clauses.Add($"{column} {(clause.Ascending ? "ASC" : "DESC")}");
             }
 
@@ -904,6 +904,48 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
         }
 
         return ValidateAndQuoteIdentifier(field.Name);
+    }
+
+    /// <summary>
+    /// Resolves a field reference used in an ORDER BY clause. Scalar fields persisted inside
+    /// the attributes JSONB column are read with the text accessor (<c>-&gt;&gt;</c>), which
+    /// would otherwise sort numerically- and temporally-typed values lexicographically
+    /// (e.g. "10" before "9"). Cast those fields to their declared SQL type so sorting matches
+    /// the field's semantics; text/uuid fields keep the plain text accessor.
+    /// </summary>
+    private string ResolveSortColumnExpression(string fieldName)
+    {
+        var column = ResolveColumnExpression(fieldName);
+
+        // Only attributes-JSONB scalar accessors need a typed cast. The primary key and
+        // physical (non-JSONB) columns are already correctly typed, and geometry columns
+        // are not orderable here.
+        if (string.IsNullOrWhiteSpace(_mapping.AttributesColumn) ||
+            !column.StartsWith('(') ||
+            !column.Contains("->>", StringComparison.Ordinal))
+        {
+            return column;
+        }
+
+        var field = _resource.SchemaFields.FirstOrDefault(candidate =>
+            candidate.Name.Equals(fieldName, StringComparison.OrdinalIgnoreCase));
+        if (field is null)
+        {
+            return column;
+        }
+
+        var sortCast = field.Type switch
+        {
+            MetadataV2FieldType.Integer or MetadataV2FieldType.BigInteger => "::bigint",
+            MetadataV2FieldType.Double or MetadataV2FieldType.Float => "::double precision",
+            MetadataV2FieldType.Boolean => "::boolean",
+            MetadataV2FieldType.DateTime => "::timestamptz",
+            MetadataV2FieldType.Date => "::date",
+            MetadataV2FieldType.Time => "::time",
+            _ => null,
+        };
+
+        return sortCast is null ? column : $"{column}{sortCast}";
     }
 
     private MetadataV2Field ResolveFieldDefinition(string fieldName)

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
@@ -611,6 +611,74 @@ public sealed class MetadataV2ModelTests
             "resource 'resource.buildings' symbology3D.rules.attribute 'missing_height' is not declared in schemaFields.");
     }
 
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void MetadataV2Field_Deserialize_AbsentEditable_DefaultsToTrue()
+    {
+        // Snapshots produced without an explicit "editable" key must read as editable so
+        // edit-capable services do not reject updates to ordinary fields. Source-generated
+        // deserialization of an all-init record materializes absent value-type members as
+        // their CLR default, so the default-true contract must survive a missing key.
+        const string json = """{"name":"name","type":"string","nullable":true}""";
+
+        var field = JsonSerializer.Deserialize(json, MetadataV2JsonContext.Default.MetadataV2Field);
+
+        field.Should().NotBeNull();
+        field!.EditableValue.Should().BeNull();
+        field.Editable.Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void MetadataV2Field_Deserialize_ExplicitEditableFalse_IsHonoured()
+    {
+        const string json = """{"name":"objectid","type":"integer","editable":false}""";
+
+        var field = JsonSerializer.Deserialize(json, MetadataV2JsonContext.Default.MetadataV2Field);
+
+        field.Should().NotBeNull();
+        field!.EditableValue.Should().BeFalse();
+        field.Editable.Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void MetadataV2Field_Editable_RoundTripsThroughInitializer()
+    {
+        var editable = new MetadataV2Field { Name = "name", Editable = true };
+        var nonEditable = new MetadataV2Field { Name = "objectid", Editable = false };
+
+        editable.Editable.Should().BeTrue();
+        editable.EditableValue.Should().BeTrue();
+        nonEditable.Editable.Should().BeFalse();
+        nonEditable.EditableValue.Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void IsPreferredPublicationType_MatchesCanonicalSurfacePerProtocol()
+    {
+        ServiceProtocols.IsPreferredPublicationType(
+            ServiceProtocols.OgcFeatures, MetadataV2PublicationType.OgcCollection).Should().BeTrue();
+        ServiceProtocols.IsPreferredPublicationType(
+            ServiceProtocols.OgcFeatures, MetadataV2PublicationType.EsriImageLayer).Should().BeFalse();
+
+        ServiceProtocols.IsPreferredPublicationType(
+            ServiceProtocols.Stac, MetadataV2PublicationType.StacCollection).Should().BeTrue();
+        ServiceProtocols.IsPreferredPublicationType(
+            ServiceProtocols.FeatureServer, MetadataV2PublicationType.EsriFeatureLayer).Should().BeTrue();
+        ServiceProtocols.IsPreferredPublicationType(
+            ServiceProtocols.ImageServer, MetadataV2PublicationType.EsriImageLayer).Should().BeTrue();
+        ServiceProtocols.IsPreferredPublicationType(
+            ServiceProtocols.Wfs20, MetadataV2PublicationType.WfsFeatureType).Should().BeTrue();
+
+        // Unknown / unspecified protocols leave callers on their generic match order.
+        ServiceProtocols.IsPreferredPublicationType(
+            null, MetadataV2PublicationType.OgcCollection).Should().BeFalse();
+        ServiceProtocols.IsPreferredPublicationType(
+            "Grpc", MetadataV2PublicationType.OgcCollection).Should().BeFalse();
+    }
+
     private static MetadataV2Graph CreateValidGraph()
     {
         return new MetadataV2Graph

--- a/tests/python/feature_server/test_auxiliary_services.py
+++ b/tests/python/feature_server/test_auxiliary_services.py
@@ -68,7 +68,7 @@ class TestImageServer:
         assert response.status_code == 400
 
     @pytest.mark.integration
-    def test_compute_statistics_histograms_valid_request_returns_not_implemented(
+    def test_compute_statistics_histograms_valid_request_returns_statistics(
         self, http_client: httpx.Client, test_layer_id: int
     ):
         response = http_client.get(
@@ -87,7 +87,14 @@ class TestImageServer:
             },
         )
 
-        assert response.status_code == 501
+        # computeStatisticsHistograms is implemented and returns per-band statistics and
+        # histograms computed from the registered raster for the requested geometry.
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert "statistics" in data
+        assert "histograms" in data
+        assert isinstance(data["statistics"], list)
+        assert isinstance(data["histograms"], list)
 
     @pytest.mark.integration
     def test_compute_class_statistics_valid_request_returns_not_implemented(

--- a/tests/python/shared/postgis.py
+++ b/tests/python/shared/postgis.py
@@ -539,6 +539,37 @@ class PostGISFixture:
                     """
                 )
 
+                # Multidimensional coverage catalog (server migration 025). The ImageServer
+                # metadata builder lists registered coverages for the layer; with migrations
+                # skipped the table is absent and the metadata endpoint 500s on 42P01. The
+                # table can be empty - ListByLayerAsync simply returns no coverages.
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS honua.multidim_coverage_catalog (
+                        id                  BIGSERIAL PRIMARY KEY,
+                        layer_id            INTEGER NOT NULL,
+                        name                VARCHAR(255) NOT NULL,
+                        description         TEXT,
+                        format              VARCHAR(50) NOT NULL,
+                        provider            VARCHAR(50) NOT NULL,
+                        bucket              VARCHAR(255) NOT NULL,
+                        object_key          VARCHAR(1024) NOT NULL,
+                        variables           JSONB NOT NULL DEFAULT '[]'::jsonb,
+                        metadata            JSONB,
+                        metadata_scanned_at TIMESTAMPTZ,
+                        created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                        updated_at          TIMESTAMPTZ,
+                        CONSTRAINT uq_multidim_coverage_object UNIQUE (layer_id, provider, bucket, object_key),
+                        CONSTRAINT ck_multidim_coverage_format
+                            CHECK (format IN ('CloudOptimizedHdf5', 'NetCdf4'))
+                    );
+                    """
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_multidim_coverage_layer "
+                    "ON honua.multidim_coverage_catalog(layer_id);"
+                )
+
                 conn.execute(
                     """
                     CREATE TABLE IF NOT EXISTS honua.raster_data (


### PR DESCRIPTION
## Issue Link
Fixes #1463

## Summary
The Python Integration Tests lane was failing 106 / 335 on `trunk`. Reproducing against a locally-run server traced the failures to a small set of systemic causes in shared/canonical server code plus two test-harness gaps. After the fixes the runnable suites (ogc_features, feature_server, image_server, gp_server) pass: **404 passed, 1 skipped** locally (up from ~97 failing across these suites).

The dominant cause: the integration seed publishes one layer index through several protocol surfaces (OGC collection, Esri feature/map/image, STAC) sharing one local id, and every service enables every protocol. Collection/layer resolution gated only on service-protocol enablement and `IsPrimary`, so the first publication in document order won — the raster ImageServer binding. Every OGC API Features read 500'd (`column "objectid" does not exist` against `honua.raster_data`) and every attribute/CQL2 filter 400'd as a downstream effect. Fixing resolution to prefer the canonical publication type for the requested protocol fixed the bulk of the lane.

## Changes Made
- **Server (OAPIF/all protocols):** `LayerValidationHelpers` collection and layer resolution now prefers the publication whose `PublicationType` is the canonical surface for the requested protocol (`IsPreferredPublicationType` in `ServiceProtocols`), before falling back to `IsPrimary` / earliest service name.
- **Server (metadata-v2 model):** `MetadataV2Field` honors the documented default-true `editable` contract. Source-generated deserialization of an all-`init` record materializes an absent value-type member as its CLR default (`false`), silently breaking the default; backed by a nullable serialized `EditableValue` with a default-true `Editable` accessor.
- **Server (Postgres storage-mapped reader):** ORDER BY on JSONB-stored numeric/temporal attributes now casts to the declared type so sorting is by value, not lexicographic text.
- **Test harness:** seed creates `honua.multidim_coverage_catalog` (mirrors migration 025) so ImageServer metadata does not 500 with migrations skipped; updated the stale `computeStatisticsHistograms` test (which is implemented) to assert its 200 statistics/histograms response.

## Testing
- [x] Unit tests added/updated — `MetadataV2ModelTests` (editable default deserialization + `IsPreferredPublicationType`); 20/20 pass.
- [x] Integration tests added/updated — Python lane runnable suites: 404 passed, 1 skipped locally.
- [ ] Architecture tests pass
- [x] Manual testing performed — reproduced each 500/400/sort failure pre-fix and verified the fixed responses.

Not run locally: `gdal_ogr` suite requires the `ogr2ogr` CLI (not installable in this environment). Those tests consume the same OAPIF `/items`, `filter`, and `bbox` endpoints fixed here (verified returning valid GeoJSON) and are expected to pass in CI.

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] None — no nightly/release/deploy impact

## Docs or Contract Impact
- [ ] None — no public contract change beyond an additive nullable `editable` value field and a new pure helper.

## Release/Deploy Impact
- [x] None — standard merge-and-release flow. No migration (test seed mirrors existing migration 025).

## Breaking Changes
None

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` (Debug+Release build, warnings-as-errors 0 warnings, `dotnet format --verify-no-changes` clean, 20/20 new unit tests pass; full Python lane 404 passed/1 skipped locally)
