### PR TITLE
fix(featureserver): accept returnAdvancedSymbols on metadata endpoints

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.cs
@@ -63,7 +63,12 @@ internal static partial class FeatureServerEndpoints
         private static readonly string[] EsriMetadataClientParameters =
         [
             "returnFieldGroups",
-            "returnPbfFeatureEncodings"
+            "returnPbfFeatureEncodings",
+            // The ArcGIS Maps SDK for .NET appends returnAdvancedSymbols to the
+            // layer/service metadata GET during ServiceFeatureTable.LoadAsync. #1455
+            // accepted it on the layer-query endpoint but not here, so LoadAsync
+            // returned 400 and the entire .NET FeatureServer client was blocked.
+            "returnAdvancedSymbols"
         ];
 
         public static readonly FrozenSet<string> ServiceMetadata =

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MetadataClientParameterTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MetadataClientParameterTests.cs
@@ -9,6 +9,12 @@
 // "does not exist or is not supported" (MakeFeatureLayer / Add Data failed). These
 // tests assert the metadata endpoints accept and ignore those standard client
 // parameters, returning the same payload as a plain f=json request.
+//
+// returnAdvancedSymbols is the same class of bug for a different client: the ArcGIS
+// Maps SDK for .NET appends it to the layer/service metadata GET during
+// ServiceFeatureTable.LoadAsync. #1455 accepted it on the layer-query endpoint but
+// not the metadata endpoints, so LoadAsync returned 400 and the entire .NET
+// FeatureServer client was blocked. It is folded into the parameter set below.
 
 using System.Net;
 using FluentAssertions;
@@ -28,7 +34,7 @@ public sealed class MetadataClientParameterTests : IAsyncLifetime
 {
     private const string TestServiceId = "test";
     private const int TestLayerId = 0;
-    private const string ArcGisProMetadataParameters = "returnFieldGroups=true&returnPbfFeatureEncodings=true";
+    private const string ArcGisProMetadataParameters = "returnFieldGroups=true&returnPbfFeatureEncodings=true&returnAdvancedSymbols=true";
 
     private readonly WebAppFixture _fixture = new();
 


### PR DESCRIPTION
## Issue Link
Related to #418

## Summary
Surfaced by the licensed Esri SDK certification (esri-dotnet lane, ArcGIS Maps SDK for .NET 200.6.0): the FeatureServer layer/service **metadata** endpoints reject `returnAdvancedSymbols` with HTTP 400 ("Unknown query parameter"). The .NET SDK appends `returnAdvancedSymbols=true` to the metadata GET during `ServiceFeatureTable.LoadAsync`, so the load fails and the **entire .NET FeatureServer client is blocked** (the certification lane went 0/23 on FeatureServer). #1455 accepted the param on the layer-**query** endpoint but not the metadata endpoints. This adds it to the metadata accept-and-ignore allowlist, mirroring the #1384 (`returnFieldGroups`/`returnPbfFeatureEncodings`) and #1276 precedents.

Reproduction (server logs + curl, deterministic 3/3):
- `GET /rest/services/{svc}/FeatureServer/{id}?f=json&returnAdvancedSymbols=true` → **400** (before) / **200** (after)
- `GET /rest/services/{svc}/FeatureServer/{id}/query?...&returnAdvancedSymbols=true` → 200 (already, via #1455)

## Changes Made
- `FeatureServerUtilities.cs` — add `returnAdvancedSymbols` to `EsriMetadataClientParameters` (feeds both the `ServiceMetadata` and `LayerMetadata` allowlists). Accept-and-ignore; does not change the metadata document.
- `MetadataClientParameterTests.cs` — fold `returnAdvancedSymbols=true` into the ArcGIS-client metadata parameter set, so the existing service- and layer-metadata regression tests assert it returns the same payload as a plain `f=json` request.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

`MetadataClientParameterTests` 2/2 green; Release `-p:TreatWarningsAsErrors=true` build 0/0. Manually reproduced the 400→200 fix against a running trunk image via the .NET SDK and curl.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

Behavior change is additive (a previously-rejected client param is now accepted-and-ignored); no response shape changes.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None — a previously-400'd query parameter is now accepted and ignored on the metadata endpoints.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
