### PR TITLE
feat(scene): quadtree LOD partitioning + LAS point-cloud ingest (#1200, #1201)

### DIFF
--- a/docs/gis/scene-generation.md
+++ b/docs/gis/scene-generation.md
@@ -42,7 +42,7 @@ an admin-request timeout. Asynchronous job tracking through a durable
 | `displayName` | no | Human-readable name (≤ 128 characters). When omitted, defaults to `"{layer.Name} ({sceneId})"` (truncated to fit), so repeated generations from the same layer never collide on the registry's name uniqueness constraint. Provide an explicit value to override. |
 | `description` | no | Optional description text. |
 | `includeAttributes` | no | Allowlist of attribute fields to project into the tileset's metadata schema. Empty means all numeric/string attributes. |
-| `maxFeatureCount` | no | Per-job override of the v1 50 000-feature cap; the smaller of the two values wins. |
+| `maxFeatureCount` | no | Per-job override of the server feature cap; the smaller of the two values wins. |
 | `cacheMaxAgeSeconds` | no | Cache directive applied to the registered scene dataset. Bounded to `[0, 86400]` (24 hours); values above the ceiling are rejected with `SCENE_OPTIONS_INVALID`. |
 | `editionGate` | no | Optional licensing gate forwarded to the scene record. Must be a lowercase slug (letters, digits, hyphens). |
 
@@ -66,7 +66,9 @@ Once the response returns, the tileset is discoverable via the existing
 hosted serving routes:
 
 - `GET /scenes/{sceneId}/tileset.json` — root document.
-- `GET /scenes/{sceneId}/tile_0000.glb` — single tile content.
+- `GET /scenes/{sceneId}/tile_0000.glb` — tile content (single-tile output, or
+  the first node of a quadtree LOD tileset; LOD jobs emit `tile_0001.glb`, … and
+  point-cloud jobs emit `points_0000.pnts`, …).
 
 #### Response warnings
 
@@ -212,13 +214,27 @@ problem-detail helpers:
 | `SCENE_REGISTRATION_CONFLICT` | 409 | The requested scene id or display name collides with an existing dataset (active OR inactive). The executor preflights against the registry and stages every generation under an intent-scoped `.staging-{intentId}` directory before promoting to `{sceneId}/`; the registry INSERT remains the canonical collision authority, and a losing request's staging bytes are deleted without ever touching the winner's final-path files. If a prior generation failed during staging promotion (e.g. permission denied on `Directory.Move`), the executor compensates by deactivating the inserted registry record so the serving path returns 404, but the inactive record still occupies the slug/name until the operator deletes the record via the admin scene CRUD path (#844). |
 | `SCENE_OPTIONS_INVALID` | 400 | Generation options failed validation. The executor runs the canonical `SceneDatasetValidator` checks (`sceneId`, `displayName`, `cacheMaxAgeSeconds`, `editionGate`) before doing any I/O so invalid input never produces a partial output directory. The executor also rejects an explicit `cacheMaxAgeSeconds` that is non-numeric or negative and an explicit `maxFeatureCount` that is non-numeric or non-positive, rather than silently falling back to the server defaults. |
 
-## Limits and known v1 limitations
+## Tiling, LOD, and limits
 
-- **Hard 50 000 feature cap.** Layers exceeding the cap are rejected; raise
-  the `SceneGeneration:MaxFeatureCount` configuration value with care.
-- **Single-tile output.** v1 emits one tile per generation job and does not
-  spatially partition large datasets. Enterprise-scale tiling and LOD
-  optimization are deferred.
+- **Quadtree LOD partitioning (#1200).** Datasets at or above
+  `SceneGeneration:LodFeatureThreshold` (default 50 000) are partitioned into a
+  quadtree of tiles with per-level geometric error and a coarse interior LOD
+  sample, instead of one oversized tile. Smaller datasets keep the byte-stable
+  single-tile layout. The hierarchy uses `REPLACE` refinement so a 3D Tiles
+  client (CesiumJS) swaps a coarse parent tile for its finer children as the
+  camera approaches. Tile content files are named `tile_0000.glb`,
+  `tile_0001.glb`, … in a deterministic pre-order walk.
+- **Feature cap.** The hard per-job cap is `SceneGeneration:MaxFeatureCount`
+  (default 1 000 000, raised from the v1 single-tile 50 000). Layers exceeding
+  the cap are rejected with `SCENE_FEATURE_LIMIT_EXCEEDED`.
+- **LOD tuning knobs.** `SceneGeneration:MaxFeaturesPerTile` (leaf split
+  threshold, default 2 000), `SceneGeneration:MaxLodDepth` (default 12), and
+  `SceneGeneration:InteriorSampleCount` (coarse-LOD sample size, default 256)
+  control the partition shape. Output stays deterministic for any fixed
+  configuration.
+- **Per-LOD feature thinning.** Interior nodes carry a deterministic strided
+  sample of the features beneath them as their coarse level of detail. Leaf
+  tiles carry their full membership; every feature appears in exactly one leaf.
 - **Fan triangulation for polygons.** Convex polygons render correctly;
   non-convex rings produce visually imperfect fills (the topology is
   still deterministic and the mesh remains parsable).
@@ -236,12 +252,34 @@ problem-detail helpers:
   `SCENE_REGISTRATION_CONFLICT` after its staging bytes are deleted — the winner's
   final-path files are never overwritten.
 
+## Point-cloud ingest (#1201)
+
+The scene module includes a pure-managed LAS point-cloud ingest pipeline that
+converts an uncompressed ASPRS LAS file into a deterministic 3D Tiles point
+tileset (a quadtree of Cesium `.pnts` tiles plus a `tileset.json` tree):
+
+- **Supported formats.** Uncompressed LAS 1.1–1.4, point data record formats
+  0, 1, 2, 3, 6, 7, and 8. Position is descaled with the header scale/offset;
+  classification, intensity, and (for colour-bearing formats) per-point RGB are
+  preserved into the `.pnts` feature/batch tables.
+- **Output.** `points_0000.pnts`, `points_0001.pnts`, … with positions
+  ECEF-encoded relative to a per-tile `RTC_CENTER`, RGB as `UNSIGNED_BYTE`, and a
+  batch table carrying `INTENSITY` (UNSIGNED_SHORT) and `CLASSIFICATION`
+  (UNSIGNED_BYTE). The tileset serves through the existing scene endpoints.
+- **Limits / deferred.** LAZ (LASzip) and Cloud-Optimized Point Cloud (COPC)
+  inputs are detected and rejected with `SCENE_MODEL_ASSET_INVALID` rather than
+  mis-parsed; native LAZ/COPC decompression is a tracked follow-up. Malformed
+  or truncated inputs surface a problem-detail error code without leaking
+  parser internals.
+
 ## Deferred enterprise-scale work
 
-- Quadtree/oct-tree spatial partitioning for medium/large datasets.
-- LOD generation with automatic mesh decimation.
+- Octree spatial partitioning (the quadtree path landed in #1200).
+- Mesh decimation / vertex-welding per LOD (current LOD thins by feature
+  sampling, not geometry simplification).
 - Streaming/incremental tile production for million-feature datasets.
 - Distributed tiling for parallel pipelines.
+- Native LAZ/COPC point-cloud decompression (#1201 ships uncompressed LAS).
 - glTF/GLB model-asset substitution (rooftops, tree instances).
 - CityGML/IFC ingestion.
 - Native I3S output (informed by #843).
@@ -378,13 +416,12 @@ follow-on under #842; the v1 demo does not require it.
 
 ### Upgrade path
 
-This demo slice is deliberately small. The following limits documented
-in this file apply unchanged: 50 000-feature cap, single-tile output,
-fan triangulation, no inner-ring or model-asset support, and no streaming
-LOD. The full producer roadmap that lifts these limits — quadtree
-partitioning, mesh decimation, distributed tiling, glTF model assets,
-CityGML/IFC ingestion — is tracked in #842. Drone and point-cloud paths
-are tracked separately in #900.
+This demo slice is deliberately small. It stays under the LOD threshold so it
+keeps single-tile output, but the broader pipeline now supports quadtree LOD
+partitioning (#1200) and LAS point-cloud ingest (#1201). The remaining producer
+roadmap — mesh decimation, octree partitioning, distributed tiling, glTF model
+assets, CityGML/IFC ingestion, and native LAZ/COPC — is tracked in #842 and the
+deferred-work list above.
 
 ## Related
 

--- a/src/Honua.Scene/Generation/SceneLodModel.cs
+++ b/src/Honua.Scene/Generation/SceneLodModel.cs
@@ -1,0 +1,169 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Domain;
+
+namespace Honua.Core.Features.Scene.Generation;
+
+/// <summary>
+/// Thresholds controlling the quadtree LOD partitioning performed by
+/// <see cref="SceneQuadtreePartitioner"/> (#1200).
+/// </summary>
+public sealed record SceneLodOptions
+{
+    /// <summary>
+    /// Maximum number of features a leaf tile may hold before the partitioner
+    /// subdivides it. Smaller values produce deeper trees and smaller tile
+    /// payloads at the cost of more tile requests.
+    /// </summary>
+    public int MaxFeaturesPerTile { get; init; } = 2_000;
+
+    /// <summary>
+    /// Hard cap on quadtree depth. Bounds the tree even for pathologically
+    /// clustered datasets where subdivision never separates features.
+    /// </summary>
+    public int MaxDepth { get; init; } = 12;
+
+    /// <summary>
+    /// Number of representative features each interior node carries as its
+    /// coarse LOD (REPLACE refinement). Zero disables interior content (the
+    /// tileset then only carries leaf geometry).
+    /// </summary>
+    public int InteriorSampleCount { get; init; } = 256;
+
+    /// <summary>
+    /// Returns the canonical single-tile options used when LOD is disabled:
+    /// every feature in one leaf, no interior sampling.
+    /// </summary>
+    public static SceneLodOptions SingleTile { get; } = new()
+    {
+        MaxFeaturesPerTile = int.MaxValue,
+        MaxDepth = 0,
+        InteriorSampleCount = 0
+    };
+}
+
+/// <summary>
+/// A deterministic quadtree of scene tiles produced by
+/// <see cref="SceneQuadtreePartitioner"/>. Each node owns a feature subset
+/// (the leaf's full membership or an interior node's thinned sample) and a
+/// geographic envelope, from which the executor builds GLB content and the
+/// <c>tileset.json</c> tree.
+/// </summary>
+public sealed class SceneTileTree
+{
+    /// <summary>Creates a tile tree.</summary>
+    /// <param name="root">Root node of the hierarchy.</param>
+    /// <param name="rootGeometricError">Geometric error declared on the root, in meters.</param>
+    public SceneTileTree(SceneTileNode root, double rootGeometricError)
+    {
+        Root = root ?? throw new ArgumentNullException(nameof(root));
+        RootGeometricError = rootGeometricError;
+    }
+
+    /// <summary>Root node of the quadtree.</summary>
+    public SceneTileNode Root { get; }
+
+    /// <summary>Geometric error declared on the root tile, in meters.</summary>
+    public double RootGeometricError { get; }
+
+    /// <summary>
+    /// Total number of nodes that carry tile content (every node with at least
+    /// one feature). Equals the number of GLB files the executor writes.
+    /// </summary>
+    public int ContentNodeCount => CountContentNodes(Root);
+
+    /// <summary>Maximum depth reached by any leaf in the tree.</summary>
+    public int MaxDepthReached => ComputeMaxDepth(Root);
+
+    private static int CountContentNodes(SceneTileNode node)
+    {
+        var count = node.Features.Count > 0 ? 1 : 0;
+        foreach (var child in node.Children)
+        {
+            count += CountContentNodes(child);
+        }
+        return count;
+    }
+
+    private static int ComputeMaxDepth(SceneTileNode node)
+    {
+        var max = node.Depth;
+        foreach (var child in node.Children)
+        {
+            var childMax = ComputeMaxDepth(child);
+            if (childMax > max)
+            {
+                max = childMax;
+            }
+        }
+        return max;
+    }
+}
+
+/// <summary>
+/// A single node in a <see cref="SceneTileTree"/>. Carries the node's
+/// geographic envelope (WGS-84 degrees), geometric error, depth, the feature
+/// subset rendered into its GLB content, and its ordered child nodes.
+/// </summary>
+public sealed class SceneTileNode
+{
+    /// <summary>Creates a tile node.</summary>
+    /// <param name="west">Western envelope bound, degrees.</param>
+    /// <param name="south">Southern envelope bound, degrees.</param>
+    /// <param name="east">Eastern envelope bound, degrees.</param>
+    /// <param name="north">Northern envelope bound, degrees.</param>
+    /// <param name="geometricError">Geometric error of this node, meters (0 at leaves).</param>
+    /// <param name="depth">Zero-based depth (root = 0).</param>
+    /// <param name="features">Features rendered into this node's content.</param>
+    /// <param name="children">Ordered child nodes.</param>
+    public SceneTileNode(
+        double west,
+        double south,
+        double east,
+        double north,
+        double geometricError,
+        int depth,
+        IReadOnlyList<SceneFeature> features,
+        IReadOnlyList<SceneTileNode> children)
+    {
+        West = west;
+        South = south;
+        East = east;
+        North = north;
+        GeometricError = geometricError;
+        Depth = depth;
+        Features = features ?? throw new ArgumentNullException(nameof(features));
+        Children = children ?? throw new ArgumentNullException(nameof(children));
+    }
+
+    /// <summary>Western envelope bound, degrees.</summary>
+    public double West { get; }
+
+    /// <summary>Southern envelope bound, degrees.</summary>
+    public double South { get; }
+
+    /// <summary>Eastern envelope bound, degrees.</summary>
+    public double East { get; }
+
+    /// <summary>Northern envelope bound, degrees.</summary>
+    public double North { get; }
+
+    /// <summary>Geometric error of this node, meters. Leaves declare 0.</summary>
+    public double GeometricError { get; }
+
+    /// <summary>Zero-based depth in the tree (root = 0).</summary>
+    public int Depth { get; }
+
+    /// <summary>Features rendered into this node's GLB content (may be empty).</summary>
+    public IReadOnlyList<SceneFeature> Features { get; }
+
+    /// <summary>Ordered child nodes (empty at leaves).</summary>
+    public IReadOnlyList<SceneTileNode> Children { get; }
+
+    /// <summary>True when this node is a leaf (no children).</summary>
+    public bool IsLeaf => Children.Count == 0;
+
+    /// <summary>Envelope as a [west, south, east, north] degree array.</summary>
+    public double[] BoundsDegrees => [West, South, East, North];
+}

--- a/src/Honua.Scene/Generation/SceneQuadtreePartitioner.cs
+++ b/src/Honua.Scene/Generation/SceneQuadtreePartitioner.cs
@@ -1,0 +1,301 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Domain;
+
+namespace Honua.Core.Features.Scene.Generation;
+
+/// <summary>
+/// Deterministic quadtree spatial partitioner for the 3D Tiles generation
+/// pipeline (#1200). Splits an ordered, homogeneous feature set into a
+/// hierarchy of tiles with bounding volumes and a per-level geometric error,
+/// enabling progressive LOD streaming for city-scale datasets.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The partitioner assigns every feature to a leaf by recursively subdividing
+/// the dataset's geographic envelope into four equal lon/lat quadrants
+/// (NW, NE, SW, SE) until either a leaf holds at most
+/// <see cref="SceneLodOptions.MaxFeaturesPerTile"/> features or the tree reaches
+/// <see cref="SceneLodOptions.MaxDepth"/>. Feature-to-quadrant assignment uses
+/// each feature's geometric centroid so a feature lands in exactly one leaf.
+/// </para>
+/// <para>
+/// Refinement is "REPLACE": every interior node carries a thinned representative
+/// sample of the features beneath it (a coarse LOD), and the geometric error
+/// strictly decreases from root to leaf so a 3D Tiles client refines as the
+/// camera approaches. Sampling is a deterministic stride over the
+/// primary-key-ordered features, so the output is byte-stable across runs given
+/// identical input.
+/// </para>
+/// <para>
+/// The partition is purely combinatorial — it does not project coordinates or
+/// build GLB content. The executor walks the resulting <see cref="SceneTileTree"/>,
+/// builds one GLB per node from <see cref="SceneTileNode.Features"/>, and emits a
+/// matching <c>tileset.json</c> tree via <see cref="TilesetDocumentWriter"/>.
+/// </para>
+/// </remarks>
+public static class SceneQuadtreePartitioner
+{
+    /// <summary>
+    /// Partitions the supplied features into a quadtree LOD hierarchy.
+    /// </summary>
+    /// <param name="features">
+    /// Ordered, homogeneous-geometry features. Ordering (typically by primary
+    /// key) is the determinism contract; the partitioner never reorders within
+    /// a leaf.
+    /// </param>
+    /// <param name="boundsDegrees">
+    /// Dataset envelope in WGS-84 degrees: [west, south, east, north]. Must
+    /// enclose every feature centroid.
+    /// </param>
+    /// <param name="rootGeometricError">
+    /// Geometric error (meters) declared on the root tile — typically the
+    /// dataset's bounding-diagonal length. Child errors are derived by halving
+    /// at each level so error decreases monotonically with depth.
+    /// </param>
+    /// <param name="options">Partitioning thresholds.</param>
+    /// <returns>A deterministic <see cref="SceneTileTree"/>.</returns>
+    public static SceneTileTree Partition(
+        IReadOnlyList<SceneFeature> features,
+        double[] boundsDegrees,
+        double rootGeometricError,
+        SceneLodOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+        ArgumentNullException.ThrowIfNull(boundsDegrees);
+        ArgumentNullException.ThrowIfNull(options);
+        if (boundsDegrees.Length != 4)
+        {
+            throw new ArgumentException("boundsDegrees must have exactly 4 elements.", nameof(boundsDegrees));
+        }
+        if (features.Count == 0)
+        {
+            throw new ArgumentException("At least one feature is required to partition.", nameof(features));
+        }
+
+        // Index features by their assigned leaf path during recursion. We carry
+        // the original index so feature ordering inside any node is a stable
+        // ascending sequence (preserving the caller's primary-key order).
+        var indices = new int[features.Count];
+        for (var i = 0; i < features.Count; i++)
+        {
+            indices[i] = i;
+        }
+
+        var centroids = new (double Lon, double Lat)[features.Count];
+        for (var i = 0; i < features.Count; i++)
+        {
+            centroids[i] = ComputeCentroid(features[i].Geometry.Vertices);
+        }
+
+        var root = BuildNode(
+            features,
+            centroids,
+            indices,
+            west: boundsDegrees[0],
+            south: boundsDegrees[1],
+            east: boundsDegrees[2],
+            north: boundsDegrees[3],
+            depth: 0,
+            geometricError: rootGeometricError,
+            options);
+
+        return new SceneTileTree(root, rootGeometricError);
+    }
+
+    private static SceneTileNode BuildNode(
+        IReadOnlyList<SceneFeature> features,
+        (double Lon, double Lat)[] centroids,
+        int[] memberIndices,
+        double west,
+        double south,
+        double east,
+        double north,
+        int depth,
+        double geometricError,
+        SceneLodOptions options)
+    {
+        var leafThresholdReached = memberIndices.Length <= options.MaxFeaturesPerTile;
+        var depthLimitReached = depth >= options.MaxDepth;
+
+        if (leafThresholdReached || depthLimitReached)
+        {
+            // Leaf: carries every member feature in ascending original order.
+            var leafFeatures = MaterializeFeatures(features, memberIndices);
+            return new SceneTileNode(
+                west, south, east, north,
+                geometricError: 0.0,
+                depth,
+                leafFeatures,
+                children: Array.Empty<SceneTileNode>());
+        }
+
+        // Interior node: split into four lon/lat quadrants about the envelope
+        // midpoint. A feature is assigned to the quadrant containing its
+        // centroid; midpoint ties bias toward the lower/left quadrant so the
+        // assignment is total and deterministic.
+        var midLon = (west + east) * 0.5;
+        var midLat = (south + north) * 0.5;
+
+        var sw = new List<int>();
+        var se = new List<int>();
+        var nw = new List<int>();
+        var ne = new List<int>();
+
+        foreach (var index in memberIndices)
+        {
+            var (lon, lat) = centroids[index];
+            var isEast = lon > midLon;
+            var isNorth = lat > midLat;
+            if (isNorth)
+            {
+                (isEast ? ne : nw).Add(index);
+            }
+            else
+            {
+                (isEast ? se : sw).Add(index);
+            }
+        }
+
+        // If the split fails to separate features (all centroids coincide, or
+        // every feature falls into one quadrant past the depth budget), emit a
+        // leaf rather than recursing forever.
+        var nonEmptyQuadrants =
+            (sw.Count > 0 ? 1 : 0) +
+            (se.Count > 0 ? 1 : 0) +
+            (nw.Count > 0 ? 1 : 0) +
+            (ne.Count > 0 ? 1 : 0);
+        if (nonEmptyQuadrants <= 1)
+        {
+            var leafFeatures = MaterializeFeatures(features, memberIndices);
+            return new SceneTileNode(
+                west, south, east, north,
+                geometricError: 0.0,
+                depth,
+                leafFeatures,
+                children: Array.Empty<SceneTileNode>());
+        }
+
+        var childError = geometricError * 0.5;
+        var children = new List<SceneTileNode>(4);
+
+        // Children are emitted in a fixed quadrant order (SW, SE, NW, NE) so the
+        // tileset tree shape and content uris are deterministic.
+        AddChild(children, features, centroids, sw, west, south, midLon, midLat, depth + 1, childError, options);
+        AddChild(children, features, centroids, se, midLon, south, east, midLat, depth + 1, childError, options);
+        AddChild(children, features, centroids, nw, west, midLat, midLon, north, depth + 1, childError, options);
+        AddChild(children, features, centroids, ne, midLon, midLat, east, north, depth + 1, childError, options);
+
+        // The interior node itself carries a thinned representative sample as a
+        // coarse LOD (REPLACE refinement). Sampling strides the member set so
+        // the sample is deterministic and spatially spread.
+        var sample = SampleFeatures(features, memberIndices, options.InteriorSampleCount);
+
+        return new SceneTileNode(
+            west, south, east, north,
+            geometricError,
+            depth,
+            sample,
+            children);
+    }
+
+    private static void AddChild(
+        List<SceneTileNode> children,
+        IReadOnlyList<SceneFeature> features,
+        (double Lon, double Lat)[] centroids,
+        List<int> members,
+        double west,
+        double south,
+        double east,
+        double north,
+        int depth,
+        double geometricError,
+        SceneLodOptions options)
+    {
+        if (members.Count == 0)
+        {
+            return;
+        }
+
+        children.Add(BuildNode(
+            features,
+            centroids,
+            members.ToArray(),
+            west, south, east, north,
+            depth,
+            geometricError,
+            options));
+    }
+
+    private static SceneFeature[] MaterializeFeatures(
+        IReadOnlyList<SceneFeature> features,
+        int[] memberIndices)
+    {
+        // memberIndices preserves ascending original order by construction
+        // (recursion partitions an already-ascending slice into ascending
+        // sub-slices), so no sort is needed.
+        var result = new SceneFeature[memberIndices.Length];
+        for (var i = 0; i < memberIndices.Length; i++)
+        {
+            result[i] = features[memberIndices[i]];
+        }
+        return result;
+    }
+
+    private static SceneFeature[] SampleFeatures(
+        IReadOnlyList<SceneFeature> features,
+        int[] memberIndices,
+        int sampleCount)
+    {
+        if (sampleCount <= 0 || memberIndices.Length <= sampleCount)
+        {
+            return MaterializeFeatures(features, memberIndices);
+        }
+
+        // Deterministic uniform stride over the ascending member set. Using a
+        // fixed-point accumulator avoids floating-point drift and yields a
+        // spatially spread, primary-key-ordered representative subset.
+        var sample = new SceneFeature[sampleCount];
+        for (var i = 0; i < sampleCount; i++)
+        {
+            var sourceIndex = (int)((long)i * memberIndices.Length / sampleCount);
+            sample[i] = features[memberIndices[sourceIndex]];
+        }
+        return sample;
+    }
+
+    private static (double Lon, double Lat) ComputeCentroid(IReadOnlyList<SceneVertex> vertices)
+    {
+        if (vertices.Count == 0)
+        {
+            return (0.0, 0.0);
+        }
+        if (vertices.Count == 1)
+        {
+            return (vertices[0].Longitude, vertices[0].Latitude);
+        }
+
+        // Arithmetic mean of the ring/line vertices. For a closed ring whose
+        // first and last vertex coincide we drop the duplicate so the centroid
+        // is not biased toward the closing vertex.
+        var count = vertices.Count;
+        var first = vertices[0];
+        var last = vertices[count - 1];
+        if (count > 2
+            && first.Longitude == last.Longitude
+            && first.Latitude == last.Latitude)
+        {
+            count--;
+        }
+
+        var sumLon = 0.0;
+        var sumLat = 0.0;
+        for (var i = 0; i < count; i++)
+        {
+            sumLon += vertices[i].Longitude;
+            sumLat += vertices[i].Latitude;
+        }
+        return (sumLon / count, sumLat / count);
+    }
+}

--- a/src/Honua.Scene/Generation/TilesetDocumentWriter.cs
+++ b/src/Honua.Scene/Generation/TilesetDocumentWriter.cs
@@ -94,6 +94,84 @@ public static class TilesetDocumentWriter
     }
 
     /// <summary>
+    /// Builds a multi-level tileset document from a quadtree LOD partition
+    /// (#1200). Every <see cref="SceneTileNode"/> that carries content becomes a
+    /// <see cref="TileNode"/> with its own bounding region and tile content; the
+    /// tree refinement is "REPLACE" so a client swaps a coarse interior tile for
+    /// its finer children as the camera approaches.
+    /// </summary>
+    /// <param name="tree">The partition produced by <see cref="SceneQuadtreePartitioner"/>.</param>
+    /// <param name="content">
+    /// Maps a content-bearing node to its emitted content (relative GLB uri plus
+    /// the node's vertical extent in meters). Nodes with no features are skipped.
+    /// </param>
+    /// <param name="generatorTag">Optional generator label written into the asset block.</param>
+    /// <param name="styleReference">Optional style-metadata contract reference advertised under <c>extras</c>.</param>
+    public static TilesetDocument BuildTree(
+        SceneTileTree tree,
+        IReadOnlyDictionary<SceneTileNode, SceneTileContent> content,
+        string? generatorTag = null,
+        TilesetStyleReference? styleReference = null)
+    {
+        ArgumentNullException.ThrowIfNull(tree);
+        ArgumentNullException.ThrowIfNull(content);
+
+        var root = BuildTileNode(tree.Root, content);
+
+        return new TilesetDocument
+        {
+            Asset = new TilesetAsset
+            {
+                Version = "1.1",
+                Generator = string.IsNullOrEmpty(generatorTag) ? null : generatorTag
+            },
+            GeometricError = tree.RootGeometricError,
+            Root = root,
+            Extras = styleReference is null
+                ? null
+                : new TilesetExtras { Style = styleReference }
+        };
+    }
+
+    private static TileNode BuildTileNode(
+        SceneTileNode node,
+        IReadOnlyDictionary<SceneTileNode, SceneTileContent> content)
+    {
+        var hasContent = content.TryGetValue(node, out var nodeContent);
+
+        var region = new[]
+        {
+            node.West * Math.PI / 180.0,
+            node.South * Math.PI / 180.0,
+            node.East * Math.PI / 180.0,
+            node.North * Math.PI / 180.0,
+            hasContent ? nodeContent.MinHeightMeters : 0.0,
+            hasContent ? nodeContent.MaxHeightMeters : 0.0
+        };
+
+        List<TileNode>? children = null;
+        if (node.Children.Count > 0)
+        {
+            children = new List<TileNode>(node.Children.Count);
+            foreach (var child in node.Children)
+            {
+                children.Add(BuildTileNode(child, content));
+            }
+        }
+
+        return new TileNode
+        {
+            BoundingVolume = new BoundingVolume { Region = region },
+            GeometricError = node.GeometricError,
+            // REPLACE so a parent's coarse LOD is swapped for its children's
+            // finer geometry as the client refines toward the leaves.
+            Refine = "REPLACE",
+            Content = hasContent ? new TileContent { Uri = nodeContent.Uri } : null,
+            Children = children
+        };
+    }
+
+    /// <summary>
     /// Serializes the tileset document to a deterministic UTF-8 byte sequence.
     /// </summary>
     public static byte[] Serialize(TilesetDocument document)
@@ -102,3 +180,12 @@ public static class TilesetDocumentWriter
         return JsonSerializer.SerializeToUtf8Bytes(document, TilesetJsonContext.Default.TilesetDocument);
     }
 }
+
+/// <summary>
+/// Content emitted for a single quadtree tile node: the relative GLB uri plus
+/// the node's vertical extent (meters) used to size its bounding region.
+/// </summary>
+/// <param name="Uri">Relative content uri (e.g. <c>tile_0003.glb</c>).</param>
+/// <param name="MinHeightMeters">Minimum vertex height in the node, meters.</param>
+/// <param name="MaxHeightMeters">Maximum vertex height in the node, meters.</param>
+public readonly record struct SceneTileContent(string Uri, double MinHeightMeters, double MaxHeightMeters);

--- a/src/Honua.Scene/PointCloud/LasModel.cs
+++ b/src/Honua.Scene/PointCloud/LasModel.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Scene.PointCloud;
+
+/// <summary>
+/// Decoded ASPRS LAS public header block fields needed by the point-cloud
+/// ingest pipeline (#1201).
+/// </summary>
+public sealed record LasHeader
+{
+    /// <summary>LAS major version (1).</summary>
+    public required byte VersionMajor { get; init; }
+
+    /// <summary>LAS minor version (1-4).</summary>
+    public required byte VersionMinor { get; init; }
+
+    /// <summary>Point data record format (0-10; only supported formats reach callers).</summary>
+    public required byte PointDataRecordFormat { get; init; }
+
+    /// <summary>Length in bytes of a single point record.</summary>
+    public required ushort PointRecordLength { get; init; }
+
+    /// <summary>Byte offset from the start of the file to the first point record.</summary>
+    public required uint OffsetToPointData { get; init; }
+
+    /// <summary>Total number of point records.</summary>
+    public required ulong PointCount { get; init; }
+
+    /// <summary>Declared public header size in bytes.</summary>
+    public required ushort HeaderSize { get; init; }
+
+    /// <summary>X scale factor applied to the stored integer X.</summary>
+    public required double ScaleX { get; init; }
+
+    /// <summary>Y scale factor applied to the stored integer Y.</summary>
+    public required double ScaleY { get; init; }
+
+    /// <summary>Z scale factor applied to the stored integer Z.</summary>
+    public required double ScaleZ { get; init; }
+
+    /// <summary>X offset added after scaling.</summary>
+    public required double OffsetXValue { get; init; }
+
+    /// <summary>Y offset added after scaling.</summary>
+    public required double OffsetYValue { get; init; }
+
+    /// <summary>Z offset added after scaling.</summary>
+    public required double OffsetZValue { get; init; }
+
+    /// <summary>Minimum descaled X across the cloud.</summary>
+    public required double MinX { get; init; }
+
+    /// <summary>Minimum descaled Y across the cloud.</summary>
+    public required double MinY { get; init; }
+
+    /// <summary>Minimum descaled Z across the cloud.</summary>
+    public required double MinZ { get; init; }
+
+    /// <summary>Maximum descaled X across the cloud.</summary>
+    public required double MaxX { get; init; }
+
+    /// <summary>Maximum descaled Y across the cloud.</summary>
+    public required double MaxY { get; init; }
+
+    /// <summary>Maximum descaled Z across the cloud.</summary>
+    public required double MaxZ { get; init; }
+
+    /// <summary>True when the point format carries per-point RGB.</summary>
+    public bool HasColor => PointDataRecordFormat is 2 or 3 or 7 or 8;
+}
+
+/// <summary>
+/// One decoded LAS point: descaled position plus the preserved attributes the
+/// ingest pipeline carries into the output tileset (#1201).
+/// </summary>
+/// <param name="X">Descaled X in the file's horizontal units.</param>
+/// <param name="Y">Descaled Y in the file's horizontal units.</param>
+/// <param name="Z">Descaled Z (elevation) in meters.</param>
+/// <param name="Intensity">Pulse return intensity (0-65535).</param>
+/// <param name="Classification">ASPRS classification code.</param>
+/// <param name="HasColor">True when <paramref name="Red"/>/<paramref name="Green"/>/<paramref name="Blue"/> are meaningful.</param>
+/// <param name="Red">16-bit red channel (0 when the format has no colour).</param>
+/// <param name="Green">16-bit green channel.</param>
+/// <param name="Blue">16-bit blue channel.</param>
+public readonly record struct LasPoint(
+    double X,
+    double Y,
+    double Z,
+    ushort Intensity,
+    byte Classification,
+    bool HasColor,
+    ushort Red,
+    ushort Green,
+    ushort Blue);

--- a/src/Honua.Scene/PointCloud/LasPointCloudReader.cs
+++ b/src/Honua.Scene/PointCloud/LasPointCloudReader.cs
@@ -1,0 +1,269 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using System.Globalization;
+using Honua.Core.Features.Scene.Domain;
+
+namespace Honua.Core.Features.Scene.PointCloud;
+
+/// <summary>
+/// Pure-managed reader for ASPRS LAS point-cloud files (#1201). Parses the LAS
+/// public header block and streams point records, decoding position
+/// (descaled to the file's CRS units), intensity, classification, and — for
+/// colour-bearing point data record formats — per-point RGB.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Supports the uncompressed LAS 1.1-1.4 point data record formats 0, 1, 2, 3,
+/// 6, 7, and 8 (the formats produced by the overwhelming majority of LiDAR and
+/// drone-photogrammetry exporters). Compressed LAZ and Cloud-Optimized Point
+/// Cloud (COPC) inputs are detected and rejected with a clear error so callers
+/// can surface a problem-detail rather than mis-parsing chunked data; native
+/// LAZ/COPC decompression is a tracked follow-up.
+/// </para>
+/// <para>
+/// The reader is deterministic and allocation-conscious: it reads point records
+/// sequentially in file order, applies the header scale/offset, and yields a
+/// <see cref="LasPoint"/> per record without buffering the whole cloud. Position
+/// is returned in the file's stored horizontal units; the tiling pipeline is
+/// responsible for any datum/CRS interpretation.
+/// </para>
+/// </remarks>
+public static class LasPointCloudReader
+{
+    private const int PublicHeaderMinLength = 227; // LAS 1.2 public header size.
+
+    /// <summary>
+    /// Reads the LAS public header block from <paramref name="source"/> and
+    /// validates that the file is a supported, uncompressed LAS.
+    /// </summary>
+    /// <exception cref="LasFormatException">The stream is not a supported LAS file.</exception>
+    public static LasHeader ReadHeader(ReadOnlySpan<byte> source)
+    {
+        if (source.Length < PublicHeaderMinLength)
+        {
+            throw new LasFormatException(
+                SceneGenerationErrorCodes.ModelAssetInvalid,
+                "LAS file is shorter than the minimum public header block.");
+        }
+
+        if (source[0] != (byte)'L' || source[1] != (byte)'A' || source[2] != (byte)'S' || source[3] != (byte)'F')
+        {
+            throw new LasFormatException(
+                SceneGenerationErrorCodes.ModelAssetInvalid,
+                "LAS signature 'LASF' not found; the file is not a LAS point cloud.");
+        }
+
+        var versionMajor = source[24];
+        var versionMinor = source[25];
+
+        var headerSize = BinaryPrimitives.ReadUInt16LittleEndian(source.Slice(94, 2));
+        var offsetToPointData = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(96, 4));
+        var rawPointFormat = source[104];
+
+        // Bit 7 (0x80) of the point data record format byte is the LAZ
+        // compression flag set by laszip. We do not decode the arithmetic-coded
+        // chunk table, so reject compressed inputs explicitly.
+        var isCompressed = (rawPointFormat & 0x80) != 0 || (rawPointFormat & 0x40) != 0;
+        if (isCompressed)
+        {
+            throw new LasFormatException(
+                SceneGenerationErrorCodes.ModelAssetInvalid,
+                "LAZ-compressed point clouds are not yet supported; supply an uncompressed LAS file.");
+        }
+
+        var pointFormat = (byte)(rawPointFormat & 0x3F);
+        if (!IsSupportedFormat(pointFormat))
+        {
+            throw new LasFormatException(
+                SceneGenerationErrorCodes.UnsupportedGeometryType,
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "LAS point data record format {0} is not supported.",
+                    pointFormat));
+        }
+
+        var pointRecordLength = BinaryPrimitives.ReadUInt16LittleEndian(source.Slice(105, 2));
+
+        // Legacy 32-bit point count (LAS <=1.3). LAS 1.4 also carries a 64-bit
+        // count at offset 247 which supersedes the legacy field when non-zero.
+        ulong pointCount = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(107, 4));
+        if (versionMajor == 1 && versionMinor >= 4 && source.Length >= 255)
+        {
+            var extended = BinaryPrimitives.ReadUInt64LittleEndian(source.Slice(247, 8));
+            if (extended != 0)
+            {
+                pointCount = extended;
+            }
+        }
+
+        var scaleX = BinaryPrimitives.ReadDoubleLittleEndian(source.Slice(131, 8));
+        var scaleY = BinaryPrimitives.ReadDoubleLittleEndian(source.Slice(139, 8));
+        var scaleZ = BinaryPrimitives.ReadDoubleLittleEndian(source.Slice(147, 8));
+        var offsetX = BinaryPrimitives.ReadDoubleLittleEndian(source.Slice(155, 8));
+        var offsetY = BinaryPrimitives.ReadDoubleLittleEndian(source.Slice(163, 8));
+        var offsetZ = BinaryPrimitives.ReadDoubleLittleEndian(source.Slice(171, 8));
+        var maxX = BinaryPrimitives.ReadDoubleLittleEndian(source.Slice(179, 8));
+        var minX = BinaryPrimitives.ReadDoubleLittleEndian(source.Slice(187, 8));
+        var maxY = BinaryPrimitives.ReadDoubleLittleEndian(source.Slice(195, 8));
+        var minY = BinaryPrimitives.ReadDoubleLittleEndian(source.Slice(203, 8));
+        var maxZ = BinaryPrimitives.ReadDoubleLittleEndian(source.Slice(211, 8));
+        var minZ = BinaryPrimitives.ReadDoubleLittleEndian(source.Slice(219, 8));
+
+        if (pointRecordLength < MinRecordLength(pointFormat))
+        {
+            throw new LasFormatException(
+                SceneGenerationErrorCodes.ModelAssetInvalid,
+                "LAS point record length is smaller than the declared point format requires.");
+        }
+
+        return new LasHeader
+        {
+            VersionMajor = versionMajor,
+            VersionMinor = versionMinor,
+            PointDataRecordFormat = pointFormat,
+            PointRecordLength = pointRecordLength,
+            OffsetToPointData = offsetToPointData,
+            PointCount = pointCount,
+            HeaderSize = headerSize,
+            ScaleX = scaleX,
+            ScaleY = scaleY,
+            ScaleZ = scaleZ,
+            OffsetXValue = offsetX,
+            OffsetYValue = offsetY,
+            OffsetZValue = offsetZ,
+            MinX = minX,
+            MinY = minY,
+            MinZ = minZ,
+            MaxX = maxX,
+            MaxY = maxY,
+            MaxZ = maxZ
+        };
+    }
+
+    /// <summary>
+    /// Streams the decoded points from a LAS buffer in file order. The header is
+    /// parsed first; each yielded <see cref="LasPoint"/> carries descaled
+    /// position plus the preserved intensity, classification, and (when present)
+    /// RGB attributes.
+    /// </summary>
+    public static IEnumerable<LasPoint> ReadPoints(byte[] source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var header = ReadHeader(source);
+        return ReadPoints(source, header);
+    }
+
+    /// <summary>
+    /// Streams the decoded points using a pre-parsed <paramref name="header"/>,
+    /// avoiding a second header parse when the caller already has it.
+    /// </summary>
+    public static IEnumerable<LasPoint> ReadPoints(byte[] source, LasHeader header)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(header);
+
+        var recordLength = header.PointRecordLength;
+        var format = header.PointDataRecordFormat;
+        var hasColor = FormatHasColor(format);
+        var hasIntensity = true; // every supported format carries intensity.
+        var colorOffset = ColorByteOffset(format);
+        var classificationOffset = ClassificationByteOffset(format);
+
+        var start = checked((int)header.OffsetToPointData);
+        for (ulong i = 0; i < header.PointCount; i++)
+        {
+            var recordStart = start + checked((int)(i * (ulong)recordLength));
+            if (recordStart + recordLength > source.Length)
+            {
+                throw new LasFormatException(
+                    SceneGenerationErrorCodes.ModelAssetInvalid,
+                    "LAS point data is truncated relative to the declared point count.");
+            }
+
+            var record = source.AsSpan(recordStart, recordLength);
+
+            var xi = BinaryPrimitives.ReadInt32LittleEndian(record.Slice(0, 4));
+            var yi = BinaryPrimitives.ReadInt32LittleEndian(record.Slice(4, 4));
+            var zi = BinaryPrimitives.ReadInt32LittleEndian(record.Slice(8, 4));
+
+            var x = xi * header.ScaleX + header.OffsetXValue;
+            var y = yi * header.ScaleY + header.OffsetYValue;
+            var z = zi * header.ScaleZ + header.OffsetZValue;
+
+            var intensity = hasIntensity
+                ? BinaryPrimitives.ReadUInt16LittleEndian(record.Slice(12, 2))
+                : (ushort)0;
+
+            var classification = record[classificationOffset];
+
+            ushort r = 0, g = 0, b = 0;
+            if (hasColor)
+            {
+                r = BinaryPrimitives.ReadUInt16LittleEndian(record.Slice(colorOffset, 2));
+                g = BinaryPrimitives.ReadUInt16LittleEndian(record.Slice(colorOffset + 2, 2));
+                b = BinaryPrimitives.ReadUInt16LittleEndian(record.Slice(colorOffset + 4, 2));
+            }
+
+            yield return new LasPoint(x, y, z, intensity, classification, hasColor, r, g, b);
+        }
+    }
+
+    private static bool IsSupportedFormat(byte format) => format is 0 or 1 or 2 or 3 or 6 or 7 or 8;
+
+    private static bool FormatHasColor(byte format) => format is 2 or 3 or 7 or 8;
+
+    /// <summary>
+    /// Minimum record length for each supported point data record format.
+    /// </summary>
+    private static int MinRecordLength(byte format) => format switch
+    {
+        0 => 20,
+        1 => 28,
+        2 => 26,
+        3 => 34,
+        6 => 30,
+        7 => 36,
+        8 => 38,
+        _ => int.MaxValue
+    };
+
+    /// <summary>
+    /// Byte offset of the classification field within a point record. Formats
+    /// 0-5 pack it at offset 15; the extended formats 6-10 move it to offset 16.
+    /// </summary>
+    private static int ClassificationByteOffset(byte format) => format >= 6 ? 16 : 15;
+
+    /// <summary>
+    /// Byte offset of the first RGB channel within a colour-bearing record.
+    /// </summary>
+    private static int ColorByteOffset(byte format) => format switch
+    {
+        2 => 20, // base record (20 bytes) + RGB.
+        3 => 28, // base + GPS time (8) + RGB.
+        7 => 30, // extended base (30 bytes) + RGB.
+        8 => 30, // extended base + RGB (+ NIR after).
+        _ => -1
+    };
+}
+
+/// <summary>
+/// Raised when a LAS buffer is malformed or uses an unsupported format. Carries
+/// a stable <see cref="SceneGenerationErrorCodes"/> code so the ingest executor
+/// can surface a problem-detail without leaking parser internals.
+/// </summary>
+public sealed class LasFormatException : Exception
+{
+    /// <summary>Creates a <see cref="LasFormatException"/>.</summary>
+    /// <param name="code">Stable scene error code (see <see cref="SceneGenerationErrorCodes"/>).</param>
+    /// <param name="message">Human-readable, non-sensitive description.</param>
+    public LasFormatException(string code, string message)
+        : base(message)
+    {
+        Code = code;
+    }
+
+    /// <summary>Stable error code forwarded through problem-detail helpers.</summary>
+    public string Code { get; }
+}

--- a/src/Honua.Scene/PointCloud/PntsTileWriter.cs
+++ b/src/Honua.Scene/PointCloud/PntsTileWriter.cs
@@ -1,0 +1,257 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using System.Text;
+using System.Text.Json;
+
+namespace Honua.Core.Features.Scene.PointCloud;
+
+/// <summary>
+/// Deterministic writer for the Cesium 3D Tiles Point Cloud (<c>.pnts</c>) tile
+/// format (#1201). Emits POSITION and RGB feature-table semantics plus a batch
+/// table carrying the preserved INTENSITY and CLASSIFICATION attributes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Positions are encoded as <c>Float32</c> XYZ relative to an
+/// <c>RTC_CENTER</c> (the tile's ECEF centroid) so the 32-bit mantissa retains
+/// centimetre precision regardless of the cloud's global ECEF magnitude. RGB is
+/// emitted as <c>UNSIGNED_BYTE</c> per channel (LAS 16-bit colour is scaled to
+/// 8-bit). When the source has no colour the writer omits the RGB semantic and
+/// the client falls back to a uniform point colour.
+/// </para>
+/// <para>
+/// The byte layout — header, padded feature-table JSON, feature-table binary,
+/// batch-table JSON, batch-table binary — follows the PNTS spec exactly and is
+/// produced in a fixed property order, so identical input yields byte-identical
+/// output.
+/// </para>
+/// </remarks>
+public static class PntsTileWriter
+{
+    private const uint Magic = 0x73746E70; // "pnts" little-endian.
+    private const uint Version = 1;
+    private const int HeaderLength = 28;
+
+    /// <summary>
+    /// Builds a <c>.pnts</c> tile from the supplied projected points.
+    /// </summary>
+    /// <param name="points">
+    /// Points to write, each carrying an ECEF position and preserved attributes.
+    /// Must be non-empty.
+    /// </param>
+    /// <returns>A deterministic PNTS byte sequence.</returns>
+    public static byte[] Build(IReadOnlyList<PntsPoint> points)
+    {
+        ArgumentNullException.ThrowIfNull(points);
+        if (points.Count == 0)
+        {
+            throw new ArgumentException("At least one point is required to build a .pnts tile.", nameof(points));
+        }
+
+        var count = points.Count;
+        var hasColor = points[0].HasColor;
+
+        // RTC center = arithmetic mean of ECEF positions. Subtracting it keeps
+        // the Float32 positions small and precise.
+        double cx = 0, cy = 0, cz = 0;
+        for (var i = 0; i < count; i++)
+        {
+            cx += points[i].EcefX;
+            cy += points[i].EcefY;
+            cz += points[i].EcefZ;
+        }
+        cx /= count;
+        cy /= count;
+        cz /= count;
+
+        // Feature-table binary: POSITION (VEC3 float32) then optional RGB (3 x uint8).
+        var positionBytes = new byte[count * 12];
+        for (var i = 0; i < count; i++)
+        {
+            var p = points[i];
+            BinaryPrimitives.WriteSingleLittleEndian(positionBytes.AsSpan(i * 12, 4), (float)(p.EcefX - cx));
+            BinaryPrimitives.WriteSingleLittleEndian(positionBytes.AsSpan(i * 12 + 4, 4), (float)(p.EcefY - cy));
+            BinaryPrimitives.WriteSingleLittleEndian(positionBytes.AsSpan(i * 12 + 8, 4), (float)(p.EcefZ - cz));
+        }
+
+        byte[]? rgbBytes = null;
+        if (hasColor)
+        {
+            rgbBytes = new byte[count * 3];
+            for (var i = 0; i < count; i++)
+            {
+                var p = points[i];
+                // LAS stores 16-bit colour; >>8 maps to 8-bit deterministically.
+                rgbBytes[i * 3] = (byte)(p.Red >> 8);
+                rgbBytes[i * 3 + 1] = (byte)(p.Green >> 8);
+                rgbBytes[i * 3 + 2] = (byte)(p.Blue >> 8);
+            }
+        }
+
+        var featureBinary = new List<byte>(positionBytes.Length + (rgbBytes?.Length ?? 0));
+        featureBinary.AddRange(positionBytes);
+        var rgbByteOffset = -1;
+        if (rgbBytes is not null)
+        {
+            rgbByteOffset = featureBinary.Count;
+            featureBinary.AddRange(rgbBytes);
+        }
+
+        // Batch-table binary: INTENSITY (uint16) and CLASSIFICATION (uint8).
+        var intensityBytes = new byte[count * 2];
+        var classificationBytes = new byte[count];
+        for (var i = 0; i < count; i++)
+        {
+            BinaryPrimitives.WriteUInt16LittleEndian(intensityBytes.AsSpan(i * 2, 2), points[i].Intensity);
+            classificationBytes[i] = points[i].Classification;
+        }
+
+        var batchBinary = new List<byte>(intensityBytes.Length + classificationBytes.Length);
+        var intensityOffset = 0;
+        batchBinary.AddRange(intensityBytes);
+        var classificationOffset = batchBinary.Count;
+        batchBinary.AddRange(classificationBytes);
+
+        var featureTableJson = BuildFeatureTableJson(count, cx, cy, cz, hasColor, rgbByteOffset);
+        var batchTableJson = BuildBatchTableJson(intensityOffset, classificationOffset);
+
+        // Pad each JSON section to an 8-byte boundary (PNTS spec) with spaces.
+        var featureJsonPadded = PadJson(featureTableJson, HeaderLength);
+        var featureBinaryArray = featureBinary.ToArray();
+        // The feature-table binary must start 8-byte aligned within the tile.
+        var batchJsonPadded = PadJson(batchTableJson, HeaderLength + featureJsonPadded.Length + featureBinaryArray.Length);
+        var batchBinaryArray = batchBinary.ToArray();
+
+        var totalLength = HeaderLength
+            + featureJsonPadded.Length + featureBinaryArray.Length
+            + batchJsonPadded.Length + batchBinaryArray.Length;
+
+        var tile = new byte[totalLength];
+        BinaryPrimitives.WriteUInt32LittleEndian(tile.AsSpan(0, 4), Magic);
+        BinaryPrimitives.WriteUInt32LittleEndian(tile.AsSpan(4, 4), Version);
+        BinaryPrimitives.WriteUInt32LittleEndian(tile.AsSpan(8, 4), (uint)totalLength);
+        BinaryPrimitives.WriteUInt32LittleEndian(tile.AsSpan(12, 4), (uint)featureJsonPadded.Length);
+        BinaryPrimitives.WriteUInt32LittleEndian(tile.AsSpan(16, 4), (uint)featureBinaryArray.Length);
+        BinaryPrimitives.WriteUInt32LittleEndian(tile.AsSpan(20, 4), (uint)batchJsonPadded.Length);
+        BinaryPrimitives.WriteUInt32LittleEndian(tile.AsSpan(24, 4), (uint)batchBinaryArray.Length);
+
+        var offset = HeaderLength;
+        featureJsonPadded.CopyTo(tile.AsSpan(offset));
+        offset += featureJsonPadded.Length;
+        featureBinaryArray.CopyTo(tile.AsSpan(offset));
+        offset += featureBinaryArray.Length;
+        batchJsonPadded.CopyTo(tile.AsSpan(offset));
+        offset += batchJsonPadded.Length;
+        batchBinaryArray.CopyTo(tile.AsSpan(offset));
+
+        return tile;
+    }
+
+    private static byte[] BuildFeatureTableJson(
+        int count,
+        double cx,
+        double cy,
+        double cz,
+        bool hasColor,
+        int rgbByteOffset)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = false, SkipValidation = true }))
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("POINTS_LENGTH", count);
+
+            writer.WriteStartArray("RTC_CENTER");
+            writer.WriteNumberValue(cx);
+            writer.WriteNumberValue(cy);
+            writer.WriteNumberValue(cz);
+            writer.WriteEndArray();
+
+            writer.WriteStartObject("POSITION");
+            writer.WriteNumber("byteOffset", 0);
+            writer.WriteEndObject();
+
+            if (hasColor)
+            {
+                writer.WriteStartObject("RGB");
+                writer.WriteNumber("byteOffset", rgbByteOffset);
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndObject();
+        }
+        return stream.ToArray();
+    }
+
+    private static byte[] BuildBatchTableJson(int intensityOffset, int classificationOffset)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = false, SkipValidation = true }))
+        {
+            writer.WriteStartObject();
+
+            writer.WriteStartObject("INTENSITY");
+            writer.WriteNumber("byteOffset", intensityOffset);
+            writer.WriteString("componentType", "UNSIGNED_SHORT");
+            writer.WriteString("type", "SCALAR");
+            writer.WriteEndObject();
+
+            writer.WriteStartObject("CLASSIFICATION");
+            writer.WriteNumber("byteOffset", classificationOffset);
+            writer.WriteString("componentType", "UNSIGNED_BYTE");
+            writer.WriteString("type", "SCALAR");
+            writer.WriteEndObject();
+
+            writer.WriteEndObject();
+        }
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Pads a JSON section with trailing spaces so the byte that follows it
+    /// (<paramref name="precedingLength"/> bytes into the tile) lands on an
+    /// 8-byte boundary, per the PNTS spec.
+    /// </summary>
+    private static byte[] PadJson(byte[] json, int precedingLength)
+    {
+        var end = precedingLength + json.Length;
+        var pad = (8 - (end & 7)) & 7;
+        if (pad == 0)
+        {
+            return json;
+        }
+        var padded = new byte[json.Length + pad];
+        json.CopyTo(padded, 0);
+        for (var i = 0; i < pad; i++)
+        {
+            padded[json.Length + i] = (byte)' ';
+        }
+        return padded;
+    }
+}
+
+/// <summary>
+/// A single point ready for PNTS encoding: ECEF position plus preserved
+/// attributes (#1201).
+/// </summary>
+/// <param name="EcefX">ECEF X in meters.</param>
+/// <param name="EcefY">ECEF Y in meters.</param>
+/// <param name="EcefZ">ECEF Z in meters.</param>
+/// <param name="Intensity">Preserved pulse intensity.</param>
+/// <param name="Classification">Preserved ASPRS classification.</param>
+/// <param name="HasColor">True when RGB channels are meaningful.</param>
+/// <param name="Red">16-bit red channel.</param>
+/// <param name="Green">16-bit green channel.</param>
+/// <param name="Blue">16-bit blue channel.</param>
+public readonly record struct PntsPoint(
+    double EcefX,
+    double EcefY,
+    double EcefZ,
+    ushort Intensity,
+    byte Classification,
+    bool HasColor,
+    ushort Red,
+    ushort Green,
+    ushort Blue);

--- a/src/Honua.Scene/PointCloud/PointCloudTilesetBuilder.cs
+++ b/src/Honua.Scene/PointCloud/PointCloudTilesetBuilder.cs
@@ -1,0 +1,375 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Domain;
+using Honua.Core.Features.Scene.Generation;
+
+namespace Honua.Core.Features.Scene.PointCloud;
+
+/// <summary>
+/// Converts a decoded LAS point cloud into a deterministic 3D Tiles point
+/// tileset: a quadtree of <c>.pnts</c> tiles plus a <c>tileset.json</c> tree
+/// servable through the existing scene infrastructure (#1201).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Points are projected to geographic coordinates by a caller-supplied
+/// <see cref="PointCloudGeoTransform"/> (which interprets the LAS file's CRS),
+/// partitioned by their lon/lat into a quadtree via the same deterministic
+/// scheme used for feature tiling (#1200), and each content node is written as a
+/// <c>.pnts</c> tile whose positions are ECEF-encoded with an RTC center.
+/// Classification, intensity, and RGB are preserved per point.
+/// </para>
+/// <para>
+/// Output is byte-stable: points keep their LAS file order, tile uris are
+/// assigned in a fixed pre-order walk, and the writer emits fixed property
+/// orders, so identical input produces identical bytes across runs.
+/// </para>
+/// </remarks>
+public static class PointCloudTilesetBuilder
+{
+    /// <summary>
+    /// Builds the in-memory artifacts (tile uris -> bytes, plus the tileset
+    /// document bytes) for a LAS point cloud. The caller writes the returned
+    /// blobs under the scene asset root.
+    /// </summary>
+    /// <param name="points">Decoded LAS points in file order. Must be non-empty.</param>
+    /// <param name="transform">Projects a LAS (x, y, z) to (lon°, lat°, heightMeters).</param>
+    /// <param name="options">Tiling thresholds (max points per tile, depth).</param>
+    /// <param name="generatorTag">Optional generator label for the tileset asset block.</param>
+    /// <returns>The deterministic point-cloud tileset artifacts.</returns>
+    public static PointCloudTilesetResult Build(
+        IReadOnlyList<LasPoint> points,
+        PointCloudGeoTransform transform,
+        PointCloudTilingOptions options,
+        string? generatorTag = null)
+    {
+        ArgumentNullException.ThrowIfNull(points);
+        ArgumentNullException.ThrowIfNull(transform);
+        ArgumentNullException.ThrowIfNull(options);
+        if (points.Count == 0)
+        {
+            throw new ArgumentException("At least one point is required to build a point-cloud tileset.", nameof(points));
+        }
+
+        // 1. Project every point once; track the geographic envelope.
+        var projected = new ProjectedPoint[points.Count];
+        var west = double.PositiveInfinity;
+        var south = double.PositiveInfinity;
+        var east = double.NegativeInfinity;
+        var north = double.NegativeInfinity;
+        var minHeight = double.PositiveInfinity;
+        var maxHeight = double.NegativeInfinity;
+
+        for (var i = 0; i < points.Count; i++)
+        {
+            var p = points[i];
+            var (lon, lat, height) = transform(p.X, p.Y, p.Z);
+            var (ex, ey, ez) = EcefCoordinateTransform.ToEcef(lon, lat, height);
+            projected[i] = new ProjectedPoint(lon, lat, height, ex, ey, ez, p);
+
+            if (lon < west) west = lon;
+            if (lat < south) south = lat;
+            if (lon > east) east = lon;
+            if (lat > north) north = lat;
+            if (height < minHeight) minHeight = height;
+            if (height > maxHeight) maxHeight = height;
+        }
+
+        var boundsDegrees = new[] { west, south, east, north };
+        var rootGeometricError = ComputeRootGeometricError(boundsDegrees, minHeight, maxHeight);
+
+        // 2. Partition by lon/lat into a quadtree of point indices.
+        var indices = new int[projected.Length];
+        for (var i = 0; i < indices.Length; i++)
+        {
+            indices[i] = i;
+        }
+
+        var root = BuildNode(
+            projected,
+            indices,
+            west, south, east, north,
+            depth: 0,
+            geometricError: rootGeometricError,
+            options);
+
+        // 3. Walk pre-order, emit one .pnts per content-bearing node.
+        var contentNodes = new List<PointTileNode>();
+        CollectContentNodes(root, contentNodes);
+
+        var tiles = new Dictionary<string, byte[]>(contentNodes.Count, StringComparer.Ordinal);
+        var content = new Dictionary<SceneTileNode, SceneTileContent>(contentNodes.Count);
+
+        for (var i = 0; i < contentNodes.Count; i++)
+        {
+            var node = contentNodes[i];
+            var uri = $"points_{i:0000}.pnts";
+            var pnts = PntsTileWriter.Build(node.Points);
+            tiles[uri] = pnts;
+            content[node.SceneNode] = new SceneTileContent(uri, node.MinHeight, node.MaxHeight);
+        }
+
+        var tree = new SceneTileTree(BuildSceneNode(root), rootGeometricError);
+        var tileset = TilesetDocumentWriter.BuildTree(tree, content, generatorTag);
+        var tilesetBytes = TilesetDocumentWriter.Serialize(tileset);
+
+        return new PointCloudTilesetResult(tilesetBytes, tiles, boundsDegrees, contentNodes.Count, points.Count);
+    }
+
+    private static PointTileNode BuildNode(
+        ProjectedPoint[] projected,
+        int[] memberIndices,
+        double west,
+        double south,
+        double east,
+        double north,
+        int depth,
+        double geometricError,
+        PointCloudTilingOptions options)
+    {
+        var sceneNode = new SceneTileNode(west, south, east, north, geometricError, depth, Array.Empty<SceneFeature>(), Array.Empty<SceneTileNode>());
+
+        var leafReached = memberIndices.Length <= options.MaxPointsPerTile;
+        var depthReached = depth >= options.MaxDepth;
+        if (leafReached || depthReached)
+        {
+            return MakeLeaf(projected, memberIndices, west, south, east, north, depth, sceneNode);
+        }
+
+        var midLon = (west + east) * 0.5;
+        var midLat = (south + north) * 0.5;
+        var sw = new List<int>();
+        var se = new List<int>();
+        var nw = new List<int>();
+        var ne = new List<int>();
+        foreach (var index in memberIndices)
+        {
+            var p = projected[index];
+            var isEast = p.Lon > midLon;
+            var isNorth = p.Lat > midLat;
+            if (isNorth)
+            {
+                (isEast ? ne : nw).Add(index);
+            }
+            else
+            {
+                (isEast ? se : sw).Add(index);
+            }
+        }
+
+        var nonEmpty =
+            (sw.Count > 0 ? 1 : 0) + (se.Count > 0 ? 1 : 0) +
+            (nw.Count > 0 ? 1 : 0) + (ne.Count > 0 ? 1 : 0);
+        if (nonEmpty <= 1)
+        {
+            return MakeLeaf(projected, memberIndices, west, south, east, north, depth, sceneNode);
+        }
+
+        var childError = geometricError * 0.5;
+        var children = new List<PointTileNode>(4);
+        AddChild(children, projected, sw, west, south, midLon, midLat, depth + 1, childError, options);
+        AddChild(children, projected, se, midLon, south, east, midLat, depth + 1, childError, options);
+        AddChild(children, projected, nw, west, midLat, midLon, north, depth + 1, childError, options);
+        AddChild(children, projected, ne, midLon, midLat, east, north, depth + 1, childError, options);
+
+        // Interior coarse LOD: deterministic strided sample of the member points.
+        var sample = SamplePoints(projected, memberIndices, options.InteriorSampleCount);
+        var (sampleMin, sampleMax) = HeightExtent(projected, memberIndices);
+
+        var sceneChildren = new SceneTileNode[children.Count];
+        for (var i = 0; i < children.Count; i++)
+        {
+            sceneChildren[i] = children[i].SceneNode;
+        }
+        var interiorSceneNode = new SceneTileNode(west, south, east, north, geometricError, depth, Array.Empty<SceneFeature>(), sceneChildren);
+
+        return new PointTileNode
+        {
+            SceneNode = interiorSceneNode,
+            Points = sample,
+            Children = children,
+            MinHeight = sampleMin,
+            MaxHeight = sampleMax
+        };
+    }
+
+    private static void AddChild(
+        List<PointTileNode> children,
+        ProjectedPoint[] projected,
+        List<int> members,
+        double west,
+        double south,
+        double east,
+        double north,
+        int depth,
+        double geometricError,
+        PointCloudTilingOptions options)
+    {
+        if (members.Count == 0)
+        {
+            return;
+        }
+        children.Add(BuildNode(projected, members.ToArray(), west, south, east, north, depth, geometricError, options));
+    }
+
+    private static PointTileNode MakeLeaf(
+        ProjectedPoint[] projected,
+        int[] memberIndices,
+        double west,
+        double south,
+        double east,
+        double north,
+        int depth,
+        SceneTileNode sceneNode)
+    {
+        var pts = MaterializePoints(projected, memberIndices);
+        var (min, max) = HeightExtent(projected, memberIndices);
+        return new PointTileNode
+        {
+            SceneNode = sceneNode,
+            Points = pts,
+            Children = new List<PointTileNode>(),
+            MinHeight = min,
+            MaxHeight = max
+        };
+    }
+
+    private static PntsPoint[] MaterializePoints(ProjectedPoint[] projected, int[] memberIndices)
+    {
+        var result = new PntsPoint[memberIndices.Length];
+        for (var i = 0; i < memberIndices.Length; i++)
+        {
+            result[i] = projected[memberIndices[i]].ToPnts();
+        }
+        return result;
+    }
+
+    private static PntsPoint[] SamplePoints(ProjectedPoint[] projected, int[] memberIndices, int sampleCount)
+    {
+        if (sampleCount <= 0 || memberIndices.Length <= sampleCount)
+        {
+            return MaterializePoints(projected, memberIndices);
+        }
+        var sample = new PntsPoint[sampleCount];
+        for (var i = 0; i < sampleCount; i++)
+        {
+            var sourceIndex = (int)((long)i * memberIndices.Length / sampleCount);
+            sample[i] = projected[memberIndices[sourceIndex]].ToPnts();
+        }
+        return sample;
+    }
+
+    private static (double Min, double Max) HeightExtent(ProjectedPoint[] projected, int[] memberIndices)
+    {
+        if (memberIndices.Length == 0)
+        {
+            return (0.0, 0.0);
+        }
+        var min = double.PositiveInfinity;
+        var max = double.NegativeInfinity;
+        foreach (var index in memberIndices)
+        {
+            var h = projected[index].Height;
+            if (h < min) min = h;
+            if (h > max) max = h;
+        }
+        return (min, max);
+    }
+
+    private static SceneTileNode BuildSceneNode(PointTileNode node) => node.SceneNode;
+
+    private static void CollectContentNodes(PointTileNode node, List<PointTileNode> sink)
+    {
+        if (node.Points.Length > 0)
+        {
+            sink.Add(node);
+        }
+        foreach (var child in node.Children)
+        {
+            CollectContentNodes(child, sink);
+        }
+    }
+
+    private static double ComputeRootGeometricError(double[] boundsDegrees, double minHeight, double maxHeight)
+    {
+        var lonSpanRad = (boundsDegrees[2] - boundsDegrees[0]) * Math.PI / 180.0;
+        var latSpanRad = (boundsDegrees[3] - boundsDegrees[1]) * Math.PI / 180.0;
+        var lonMeters = Math.Abs(lonSpanRad) * EcefCoordinateTransform.WgsSemiMajorAxis
+            * Math.Cos((boundsDegrees[1] + boundsDegrees[3]) * 0.5 * Math.PI / 180.0);
+        var latMeters = Math.Abs(latSpanRad) * EcefCoordinateTransform.WgsSemiMajorAxis;
+        var heightMeters = Math.Max(0.0, maxHeight - minHeight);
+        var diagonal = Math.Sqrt(lonMeters * lonMeters + latMeters * latMeters + heightMeters * heightMeters);
+        return Math.Round(diagonal, 6, MidpointRounding.AwayFromZero);
+    }
+
+    private readonly record struct ProjectedPoint(
+        double Lon,
+        double Lat,
+        double Height,
+        double EcefX,
+        double EcefY,
+        double EcefZ,
+        LasPoint Source)
+    {
+        public PntsPoint ToPnts() => new(
+            EcefX, EcefY, EcefZ,
+            Source.Intensity,
+            Source.Classification,
+            Source.HasColor,
+            Source.Red,
+            Source.Green,
+            Source.Blue);
+    }
+
+    private sealed class PointTileNode
+    {
+        public required SceneTileNode SceneNode { get; init; }
+        public required PntsPoint[] Points { get; init; }
+        public required List<PointTileNode> Children { get; init; }
+        public required double MinHeight { get; init; }
+        public required double MaxHeight { get; init; }
+    }
+}
+
+/// <summary>
+/// Projects a LAS (x, y, z) coordinate to (longitude°, latitude°, height m).
+/// Implementations interpret the LAS file's CRS.
+/// </summary>
+/// <param name="x">LAS X in the file's horizontal units.</param>
+/// <param name="y">LAS Y in the file's horizontal units.</param>
+/// <param name="z">LAS Z (elevation) in meters.</param>
+/// <returns>Geographic longitude/latitude in degrees and ellipsoidal height in meters.</returns>
+public delegate (double Longitude, double Latitude, double Height) PointCloudGeoTransform(double x, double y, double z);
+
+/// <summary>
+/// Tiling thresholds for the point-cloud quadtree (#1201).
+/// </summary>
+public sealed record PointCloudTilingOptions
+{
+    /// <summary>Maximum points a leaf tile may hold before subdivision.</summary>
+    public int MaxPointsPerTile { get; init; } = 50_000;
+
+    /// <summary>Hard cap on quadtree depth.</summary>
+    public int MaxDepth { get; init; } = 16;
+
+    /// <summary>Representative points carried by each interior node as a coarse LOD.</summary>
+    public int InteriorSampleCount { get; init; } = 8_192;
+}
+
+/// <summary>
+/// Deterministic artifacts produced from a LAS point cloud (#1201): the
+/// serialized <c>tileset.json</c> bytes plus a map of relative <c>.pnts</c> uris
+/// to their bytes, and dataset summary fields.
+/// </summary>
+/// <param name="TilesetJsonBytes">Serialized tileset document.</param>
+/// <param name="Tiles">Map of relative <c>.pnts</c> uri to tile bytes.</param>
+/// <param name="BoundsDegrees">Dataset envelope [west, south, east, north] in degrees.</param>
+/// <param name="TileCount">Number of <c>.pnts</c> tiles written.</param>
+/// <param name="PointCount">Total points ingested.</param>
+public readonly record struct PointCloudTilesetResult(
+    byte[] TilesetJsonBytes,
+    IReadOnlyDictionary<string, byte[]> Tiles,
+    double[] BoundsDegrees,
+    int TileCount,
+    int PointCount);

--- a/src/Honua.Scene/Publishing/SceneGenerationOptions.cs
+++ b/src/Honua.Scene/Publishing/SceneGenerationOptions.cs
@@ -26,7 +26,36 @@ internal sealed class SceneGenerationServerOptions
     /// Hard upper bound on features per generation job. Layers exceeding
     /// this count are rejected with <c>SCENE_FEATURE_LIMIT_EXCEEDED</c>.
     /// </summary>
-    public int MaxFeatureCount { get; set; } = 50_000;
+    /// <remarks>
+    /// Raised from the v1 single-tile 50 000 cap to 1 000 000 now that the
+    /// quadtree LOD pipeline (#1200) partitions large datasets into a tile
+    /// hierarchy instead of one oversized GLB.
+    /// </remarks>
+    public int MaxFeatureCount { get; set; } = 1_000_000;
+
+    /// <summary>
+    /// Feature-count threshold at or above which the generator switches from
+    /// single-tile output to quadtree LOD partitioning (#1200). Datasets below
+    /// the threshold keep the byte-stable single-tile layout.
+    /// </summary>
+    public int LodFeatureThreshold { get; set; } = 50_000;
+
+    /// <summary>
+    /// Maximum number of features a leaf tile may hold before the quadtree
+    /// partitioner subdivides it.
+    /// </summary>
+    public int MaxFeaturesPerTile { get; set; } = 2_000;
+
+    /// <summary>
+    /// Hard cap on quadtree depth for the LOD partitioner.
+    /// </summary>
+    public int MaxLodDepth { get; set; } = 12;
+
+    /// <summary>
+    /// Number of representative features each interior LOD node carries as its
+    /// coarse level of detail.
+    /// </summary>
+    public int InteriorSampleCount { get; set; } = 256;
 
     /// <summary>
     /// Generator label written into the GLB asset block for traceability.

--- a/src/Honua.Scene/Publishing/SceneTilesPublishExecutor.cs
+++ b/src/Honua.Scene/Publishing/SceneTilesPublishExecutor.cs
@@ -249,23 +249,10 @@ internal sealed partial class SceneTilesPublishExecutor : IPublishExecutor
                 // the layer has no symbology (legacy white-material output).
                 var perFeatureSymbology = ResolvePerFeatureSymbology(symbology, collected.Features);
 
-                var glb = GeometryTileBuilder.BuildGlb(
-                    collected.Features,
-                    attributeSchemas,
-                    extrusion,
-                    serverOptions.GeneratorTag,
-                    collected.Warnings,
-                    perFeatureSymbology);
-
-                var tileFileName = "tile_0000.glb";
-                await File.WriteAllBytesAsync(
-                    Path.Combine(stagingDirectory, tileFileName),
-                    glb,
-                    cancellationToken).ConfigureAwait(false);
-
                 // Emit the style-metadata contract sidecar and advertise it from
                 // the tileset's extras so the JS client can apply the
-                // attribute-driven 3D Tiles Styling expressions at runtime.
+                // attribute-driven 3D Tiles Styling expressions at runtime. The
+                // sidecar is shared across all tiles in an LOD hierarchy.
                 TilesetStyleReference? styleReference = null;
                 if (symbology is not null)
                 {
@@ -284,19 +271,58 @@ internal sealed partial class SceneTilesPublishExecutor : IPublishExecutor
                 }
 
                 var geometricError = ComputeGeometricError(bounds, minHeight, maxHeight);
-                var tileset = TilesetDocumentWriter.Build(
-                    bounds,
-                    minHeight,
-                    maxHeight,
-                    geometricError,
-                    tileContentUris: [tileFileName],
-                    serverOptions.GeneratorTag,
-                    styleReference);
-                var tilesetBytes = TilesetDocumentWriter.Serialize(tileset);
-                await File.WriteAllBytesAsync(
-                    Path.Combine(stagingDirectory, "tileset.json"),
-                    tilesetBytes,
-                    cancellationToken).ConfigureAwait(false);
+
+                // Choose single-tile (byte-stable v1 layout) or quadtree LOD
+                // partitioning (#1200). The LOD path activates once the dataset
+                // crosses the configured threshold so existing small/medium
+                // datasets keep their deterministic single-tile output.
+                int tileCount;
+                if (collected.Features.Count >= serverOptions.LodFeatureThreshold)
+                {
+                    tileCount = await WriteLodTilesetAsync(
+                        collected.Features,
+                        attributeSchemas,
+                        extrusion,
+                        symbology,
+                        bounds,
+                        geometricError,
+                        serverOptions,
+                        styleReference,
+                        stagingDirectory,
+                        collected.Warnings,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    var glb = GeometryTileBuilder.BuildGlb(
+                        collected.Features,
+                        attributeSchemas,
+                        extrusion,
+                        serverOptions.GeneratorTag,
+                        collected.Warnings,
+                        perFeatureSymbology);
+
+                    var tileFileName = "tile_0000.glb";
+                    await File.WriteAllBytesAsync(
+                        Path.Combine(stagingDirectory, tileFileName),
+                        glb,
+                        cancellationToken).ConfigureAwait(false);
+
+                    var tileset = TilesetDocumentWriter.Build(
+                        bounds,
+                        minHeight,
+                        maxHeight,
+                        geometricError,
+                        tileContentUris: [tileFileName],
+                        serverOptions.GeneratorTag,
+                        styleReference);
+                    var tilesetBytes = TilesetDocumentWriter.Serialize(tileset);
+                    await File.WriteAllBytesAsync(
+                        Path.Combine(stagingDirectory, "tileset.json"),
+                        tilesetBytes,
+                        cancellationToken).ConfigureAwait(false);
+                    tileCount = 1;
+                }
 
                 var registeredDatasetId = await TryRegisterSceneAsync(
                     sceneId,
@@ -336,7 +362,7 @@ internal sealed partial class SceneTilesPublishExecutor : IPublishExecutor
 
                 stopwatch.Stop();
                 activity?.SetTag(HonuaTelemetry.Tags.FeatureCount, collected.Features.Count);
-                activity?.SetTag("honua.scene.tile_count", 1);
+                activity?.SetTag("honua.scene.tile_count", tileCount);
                 activity?.SetTag("honua.scene.id", sceneId);
                 SceneGenerationLog.Completed(_logger, intent.IntentId, sceneId, collected.Features.Count, stopwatch.ElapsedMilliseconds);
 
@@ -348,7 +374,7 @@ internal sealed partial class SceneTilesPublishExecutor : IPublishExecutor
                 var summary = new SceneGenerationSummary
                 {
                     FeatureCount = collected.Features.Count,
-                    TileCount = 1,
+                    TileCount = tileCount,
                     BoundingRegionDegrees = bounds,
                     GeometricError = geometricError,
                     Warnings = collected.Warnings.AsReadOnly()
@@ -399,6 +425,139 @@ internal sealed partial class SceneTilesPublishExecutor : IPublishExecutor
                 $"{SceneGenerationErrorCodes.OptionsInvalid}: Scene generation failed; see server logs for diagnostic detail.",
                 ex);
         }
+    }
+
+    /// <summary>
+    /// Partitions the collected features into a quadtree LOD hierarchy (#1200),
+    /// writes one GLB per content-bearing node, and emits the multi-level
+    /// <c>tileset.json</c> tree. Node content uris are assigned in a stable
+    /// pre-order walk (<c>tile_0000.glb</c>, <c>tile_0001.glb</c>, ...) so the
+    /// output is byte-identical across runs for identical input. Returns the
+    /// number of GLB tiles written.
+    /// </summary>
+    private static async Task<int> WriteLodTilesetAsync(
+        IReadOnlyList<SceneFeature> features,
+        IReadOnlyList<SceneAttributeSchema> attributeSchemas,
+        MetadataV2ExtrusionInfo? extrusion,
+        Symbology3D? symbology,
+        double[] bounds,
+        double rootGeometricError,
+        SceneGenerationServerOptions serverOptions,
+        TilesetStyleReference? styleReference,
+        string stagingDirectory,
+        List<string> warnings,
+        CancellationToken cancellationToken)
+    {
+        var lodOptions = new SceneLodOptions
+        {
+            MaxFeaturesPerTile = serverOptions.MaxFeaturesPerTile,
+            MaxDepth = serverOptions.MaxLodDepth,
+            InteriorSampleCount = serverOptions.InteriorSampleCount
+        };
+
+        var tree = SceneQuadtreePartitioner.Partition(features, bounds, rootGeometricError, lodOptions);
+
+        // Pre-order walk: collect content-bearing nodes in a stable order so
+        // both the uri assignment and the GLB write order are deterministic.
+        var contentNodes = new List<SceneTileNode>(tree.ContentNodeCount);
+        CollectContentNodes(tree.Root, contentNodes);
+
+        var content = new Dictionary<SceneTileNode, SceneTileContent>(contentNodes.Count);
+        for (var i = 0; i < contentNodes.Count; i++)
+        {
+            var node = contentNodes[i];
+            var perFeatureSymbology = ResolvePerFeatureSymbology(symbology, node.Features);
+            var glb = GeometryTileBuilder.BuildGlb(
+                node.Features,
+                attributeSchemas,
+                extrusion,
+                serverOptions.GeneratorTag,
+                warnings,
+                perFeatureSymbology);
+
+            var uri = string.Create(
+                CultureInfo.InvariantCulture,
+                $"tile_{i:0000}.glb");
+            await File.WriteAllBytesAsync(
+                Path.Combine(stagingDirectory, uri),
+                glb,
+                cancellationToken).ConfigureAwait(false);
+
+            var (nodeMin, nodeMax) = ComputeNodeHeightExtent(node.Features, extrusion);
+            content[node] = new SceneTileContent(uri, nodeMin, nodeMax);
+        }
+
+        var tileset = TilesetDocumentWriter.BuildTree(
+            tree,
+            content,
+            serverOptions.GeneratorTag,
+            styleReference);
+        var tilesetBytes = TilesetDocumentWriter.Serialize(tileset);
+        await File.WriteAllBytesAsync(
+            Path.Combine(stagingDirectory, "tileset.json"),
+            tilesetBytes,
+            cancellationToken).ConfigureAwait(false);
+
+        return contentNodes.Count;
+    }
+
+    private static void CollectContentNodes(SceneTileNode node, List<SceneTileNode> sink)
+    {
+        if (node.Features.Count > 0)
+        {
+            sink.Add(node);
+        }
+        foreach (var child in node.Children)
+        {
+            CollectContentNodes(child, sink);
+        }
+    }
+
+    /// <summary>
+    /// Computes a node's vertical extent (meters) for its bounding region.
+    /// Mirrors the extrusion-aware min/max-Z accounting used for the whole
+    /// dataset so each LOD tile's region encloses both prism faces.
+    /// </summary>
+    private static (double Min, double Max) ComputeNodeHeightExtent(
+        IReadOnlyList<SceneFeature> features,
+        MetadataV2ExtrusionInfo? extrusion)
+    {
+        var min = double.PositiveInfinity;
+        var max = double.NegativeInfinity;
+        var sawAny = false;
+
+        foreach (var feature in features)
+        {
+            if (extrusion is not null && feature.Geometry.Kind == SceneGeometryKind.Polygon)
+            {
+                var baseHeight = ResolveExtrusionBase(feature, extrusion);
+                var topZ = baseHeight + ResolveExtrusionMax(feature, extrusion);
+                var fMin = Math.Min(baseHeight, topZ);
+                var fMax = Math.Max(baseHeight, topZ);
+                if (fMax > max) max = fMax;
+                if (fMin < min) min = fMin;
+                sawAny = true;
+                continue;
+            }
+
+            foreach (var vertex in feature.Geometry.Vertices)
+            {
+                if (vertex.Height is { } z)
+                {
+                    sawAny = true;
+                    if (z < min) min = z;
+                    if (z > max) max = z;
+                }
+            }
+        }
+
+        if (!sawAny)
+        {
+            return (0.0, 0.0);
+        }
+        if (double.IsPositiveInfinity(min)) min = 0.0;
+        if (double.IsNegativeInfinity(max)) max = 0.0;
+        return (min, max);
     }
 
     private async Task<CollectedFeatures> CollectFeaturesAsync(
@@ -634,7 +793,7 @@ internal sealed partial class SceneTilesPublishExecutor : IPublishExecutor
     /// </summary>
     private static ResolvedSymbology[]? ResolvePerFeatureSymbology(
         Symbology3D? symbology,
-        List<SceneFeature> features)
+        IReadOnlyList<SceneFeature> features)
     {
         if (symbology is null)
         {

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/SceneQuadtreePartitionerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/SceneQuadtreePartitionerTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Domain;
+using Honua.Core.Features.Scene.Generation;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.Generation;
+
+/// <summary>
+/// Unit tests for the deterministic quadtree LOD partitioner (#1200).
+/// </summary>
+public sealed class SceneQuadtreePartitionerTests
+{
+    private static readonly double[] Bounds = [-122.5, 37.7, -122.4, 37.8];
+
+    [UnitTest]
+    public void Partition_SmallSet_ProducesSingleLeaf()
+    {
+        var features = MakePointGrid(4, 4); // 16 features.
+        var options = new SceneLodOptions { MaxFeaturesPerTile = 100, MaxDepth = 8, InteriorSampleCount = 8 };
+
+        var tree = SceneQuadtreePartitioner.Partition(features, Bounds, 1000.0, options);
+
+        tree.Root.IsLeaf.Should().BeTrue();
+        tree.Root.Features.Should().HaveCount(16);
+        tree.MaxDepthReached.Should().Be(0);
+    }
+
+    [UnitTest]
+    public void Partition_LargeSet_SubdividesIntoMultipleTiles()
+    {
+        var features = MakePointGrid(40, 40); // 1600 features.
+        var options = new SceneLodOptions { MaxFeaturesPerTile = 200, MaxDepth = 8, InteriorSampleCount = 64 };
+
+        var tree = SceneQuadtreePartitioner.Partition(features, Bounds, 1000.0, options);
+
+        tree.Root.IsLeaf.Should().BeFalse();
+        tree.ContentNodeCount.Should().BeGreaterThan(1);
+        tree.MaxDepthReached.Should().BeGreaterThan(0);
+    }
+
+    [UnitTest]
+    public void Partition_GeometricError_DecreasesMonotonicallyWithDepth()
+    {
+        var features = MakePointGrid(60, 60);
+        var options = new SceneLodOptions { MaxFeaturesPerTile = 150, MaxDepth = 10, InteriorSampleCount = 64 };
+
+        var tree = SceneQuadtreePartitioner.Partition(features, Bounds, 4096.0, options);
+
+        AssertErrorDecreases(tree.Root);
+    }
+
+    [UnitTest]
+    public void Partition_EveryFeatureAssignedExactlyOnce()
+    {
+        var features = MakePointGrid(30, 30); // 900 features.
+        var options = new SceneLodOptions { MaxFeaturesPerTile = 50, MaxDepth = 10, InteriorSampleCount = 0 };
+
+        var tree = SceneQuadtreePartitioner.Partition(features, Bounds, 1000.0, options);
+
+        // With InteriorSampleCount = 0 interior nodes still sample (0 disables
+        // thinning => full membership), so leaves alone cover the dataset.
+        var leafIds = new List<long>();
+        CollectLeafFeatureIds(tree.Root, leafIds);
+
+        leafIds.Should().HaveCount(900);
+        leafIds.Distinct().Should().HaveCount(900);
+    }
+
+    [UnitTest]
+    public void Partition_InteriorNodesCarryThinnedSample()
+    {
+        var features = MakePointGrid(50, 50); // 2500 features.
+        var options = new SceneLodOptions { MaxFeaturesPerTile = 100, MaxDepth = 8, InteriorSampleCount = 64 };
+
+        var tree = SceneQuadtreePartitioner.Partition(features, Bounds, 1000.0, options);
+
+        tree.Root.IsLeaf.Should().BeFalse();
+        tree.Root.Features.Count.Should().BeLessThanOrEqualTo(64);
+        tree.Root.Features.Should().NotBeEmpty();
+    }
+
+    [UnitTest]
+    public void Partition_IsDeterministic_SameTreeShapeAndOrder()
+    {
+        var features = MakePointGrid(45, 45);
+        var options = new SceneLodOptions { MaxFeaturesPerTile = 120, MaxDepth = 9, InteriorSampleCount = 32 };
+
+        var a = SceneQuadtreePartitioner.Partition(features, Bounds, 2048.0, options);
+        var b = SceneQuadtreePartitioner.Partition(features, Bounds, 2048.0, options);
+
+        Flatten(a.Root).Should().Equal(Flatten(b.Root));
+    }
+
+    [UnitTest]
+    public void Partition_ClusteredFeatures_RespectsDepthCapWithoutInfiniteRecursion()
+    {
+        // 500 features all at the same coordinate: subdivision can never
+        // separate them, so the partitioner must fall back to a leaf.
+        var features = new List<SceneFeature>();
+        for (var i = 0; i < 500; i++)
+        {
+            features.Add(MakePoint(i, -122.45, 37.75));
+        }
+        var options = new SceneLodOptions { MaxFeaturesPerTile = 10, MaxDepth = 12, InteriorSampleCount = 8 };
+
+        var tree = SceneQuadtreePartitioner.Partition(features, Bounds, 1000.0, options);
+
+        // Degenerate split collapses to a single leaf at the root.
+        tree.Root.IsLeaf.Should().BeTrue();
+        tree.Root.Features.Should().HaveCount(500);
+    }
+
+    private static void AssertErrorDecreases(SceneTileNode node)
+    {
+        foreach (var child in node.Children)
+        {
+            child.GeometricError.Should().BeLessThan(node.GeometricError,
+                "child geometric error must be strictly less than its parent's so a client refines correctly");
+            AssertErrorDecreases(child);
+        }
+    }
+
+    private static void CollectLeafFeatureIds(SceneTileNode node, List<long> sink)
+    {
+        if (node.IsLeaf)
+        {
+            foreach (var f in node.Features)
+            {
+                sink.Add(f.Id);
+            }
+            return;
+        }
+        foreach (var child in node.Children)
+        {
+            CollectLeafFeatureIds(child, sink);
+        }
+    }
+
+    private static List<string> Flatten(SceneTileNode node)
+    {
+        var lines = new List<string>();
+        void Walk(SceneTileNode n)
+        {
+            lines.Add($"d{n.Depth}:ge{n.GeometricError:F4}:fc{n.Features.Count}:ch{n.Children.Count}:[{n.West:F4},{n.South:F4},{n.East:F4},{n.North:F4}]");
+            foreach (var c in n.Children)
+            {
+                Walk(c);
+            }
+        }
+        Walk(node);
+        return lines;
+    }
+
+    private static List<SceneFeature> MakePointGrid(int cols, int rows)
+    {
+        var features = new List<SceneFeature>(cols * rows);
+        var west = Bounds[0];
+        var south = Bounds[1];
+        var lonStep = (Bounds[2] - Bounds[0]) / (cols + 1);
+        var latStep = (Bounds[3] - Bounds[1]) / (rows + 1);
+        var id = 0;
+        for (var r = 0; r < rows; r++)
+        {
+            for (var c = 0; c < cols; c++)
+            {
+                var lon = west + lonStep * (c + 1);
+                var lat = south + latStep * (r + 1);
+                features.Add(MakePoint(id++, lon, lat));
+            }
+        }
+        return features;
+    }
+
+    private static SceneFeature MakePoint(int id, double lon, double lat) => new()
+    {
+        Id = id,
+        Geometry = new SceneFeatureGeometry
+        {
+            Kind = SceneGeometryKind.Point,
+            Vertices = [new SceneVertex(lon, lat, 10.0)]
+        }
+    };
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/TilesetDocumentTreeWriterTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/TilesetDocumentTreeWriterTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Core.Features.Scene.Generation;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.Generation;
+
+/// <summary>
+/// Unit tests for the multi-level (quadtree LOD) tileset writer path (#1200).
+/// </summary>
+public sealed class TilesetDocumentTreeWriterTests
+{
+    private static readonly double[] Bounds = [-122.5, 37.7, -122.4, 37.8];
+
+    [UnitTest]
+    public void BuildTree_EmitsRefineReplaceAndNestedChildren()
+    {
+        var features = MakePointGrid(40, 40);
+        var options = new SceneLodOptions { MaxFeaturesPerTile = 200, MaxDepth = 8, InteriorSampleCount = 64 };
+        var tree = SceneQuadtreePartitioner.Partition(features, Bounds, 4096.0, options);
+        var content = AssignContent(tree);
+
+        var doc = TilesetDocumentWriter.BuildTree(tree, content, "honua-test");
+
+        doc.Asset.Version.Should().Be("1.1");
+        doc.GeometricError.Should().Be(tree.RootGeometricError);
+        doc.Root.Refine.Should().Be("REPLACE");
+        doc.Root.Children.Should().NotBeNull();
+        doc.Root.Children!.Count.Should().BeGreaterThan(0);
+    }
+
+    [UnitTest]
+    public void BuildTree_RegionMatchesNodeBoundsInRadians()
+    {
+        var features = MakePointGrid(40, 40);
+        var options = new SceneLodOptions { MaxFeaturesPerTile = 200, MaxDepth = 8, InteriorSampleCount = 64 };
+        var tree = SceneQuadtreePartitioner.Partition(features, Bounds, 4096.0, options);
+        var content = AssignContent(tree);
+
+        var doc = TilesetDocumentWriter.BuildTree(tree, content, "honua-test");
+
+        doc.Root.BoundingVolume.Region[0].Should().BeApproximately(tree.Root.West * Math.PI / 180.0, 1e-12);
+        doc.Root.BoundingVolume.Region[3].Should().BeApproximately(tree.Root.North * Math.PI / 180.0, 1e-12);
+    }
+
+    [UnitTest]
+    public void BuildTree_Serialize_IsByteIdenticalAcrossRuns()
+    {
+        var features = MakePointGrid(45, 45);
+        var options = new SceneLodOptions { MaxFeaturesPerTile = 120, MaxDepth = 9, InteriorSampleCount = 32 };
+
+        var treeA = SceneQuadtreePartitioner.Partition(features, Bounds, 2048.0, options);
+        var treeB = SceneQuadtreePartitioner.Partition(features, Bounds, 2048.0, options);
+
+        var bytesA = TilesetDocumentWriter.Serialize(TilesetDocumentWriter.BuildTree(treeA, AssignContent(treeA), "honua"));
+        var bytesB = TilesetDocumentWriter.Serialize(TilesetDocumentWriter.BuildTree(treeB, AssignContent(treeB), "honua"));
+
+        bytesA.Should().Equal(bytesB);
+    }
+
+    [UnitTest]
+    public void BuildTree_ChildGeometricError_DecreasesInSerializedJson()
+    {
+        var features = MakePointGrid(50, 50);
+        var options = new SceneLodOptions { MaxFeaturesPerTile = 100, MaxDepth = 10, InteriorSampleCount = 32 };
+        var tree = SceneQuadtreePartitioner.Partition(features, Bounds, 4096.0, options);
+
+        var bytes = TilesetDocumentWriter.Serialize(TilesetDocumentWriter.BuildTree(tree, AssignContent(tree), "honua"));
+        using var json = JsonDocument.Parse(Encoding.UTF8.GetString(bytes));
+
+        var root = json.RootElement.GetProperty("root");
+        var rootError = root.GetProperty("geometricError").GetDouble();
+        foreach (var child in root.GetProperty("children").EnumerateArray())
+        {
+            child.GetProperty("geometricError").GetDouble().Should().BeLessThan(rootError);
+        }
+    }
+
+    private static Dictionary<SceneTileNode, SceneTileContent> AssignContent(SceneTileTree tree)
+    {
+        var content = new Dictionary<SceneTileNode, SceneTileContent>();
+        var index = 0;
+        void Walk(SceneTileNode node)
+        {
+            if (node.Features.Count > 0)
+            {
+                content[node] = new SceneTileContent($"tile_{index:0000}.glb", 0.0, 10.0);
+                index++;
+            }
+            foreach (var child in node.Children)
+            {
+                Walk(child);
+            }
+        }
+        Walk(tree.Root);
+        return content;
+    }
+
+    private static List<SceneFeature> MakePointGrid(int cols, int rows)
+    {
+        var features = new List<SceneFeature>(cols * rows);
+        var lonStep = (Bounds[2] - Bounds[0]) / (cols + 1);
+        var latStep = (Bounds[3] - Bounds[1]) / (rows + 1);
+        var id = 0;
+        for (var r = 0; r < rows; r++)
+        {
+            for (var c = 0; c < cols; c++)
+            {
+                var lon = Bounds[0] + lonStep * (c + 1);
+                var lat = Bounds[1] + latStep * (r + 1);
+                features.Add(new SceneFeature
+                {
+                    Id = id++,
+                    Geometry = new SceneFeatureGeometry
+                    {
+                        Kind = SceneGeometryKind.Point,
+                        Vertices = [new SceneVertex(lon, lat, 10.0)]
+                    }
+                });
+            }
+        }
+        return features;
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/PointCloud/LasFixtureBuilder.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/PointCloud/LasFixtureBuilder.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+
+namespace Honua.Core.Tests.Features.Scene.PointCloud;
+
+/// <summary>
+/// Synthesizes minimal, valid uncompressed LAS 1.2 buffers in memory for the
+/// point-cloud ingest tests (#1201). Avoids committing a binary fixture while
+/// exercising the real header/point-record byte layout.
+/// </summary>
+internal static class LasFixtureBuilder
+{
+    /// <summary>A single point to encode into a LAS 1.2 point data record format 3 file.</summary>
+    internal readonly record struct Point(
+        double X,
+        double Y,
+        double Z,
+        ushort Intensity,
+        byte Classification,
+        ushort Red,
+        ushort Green,
+        ushort Blue);
+
+    private const int HeaderSize = 227;       // LAS 1.2 public header block.
+    private const int RecordLengthFormat3 = 34; // base 28 + RGB 6.
+
+    /// <summary>
+    /// Builds a LAS 1.2, point data record format 3 (XYZ + GPS time + RGB)
+    /// buffer from the supplied points with the given scale/offset.
+    /// </summary>
+    internal static byte[] BuildFormat3(
+        IReadOnlyList<Point> points,
+        double scale = 0.01,
+        double offsetX = 0.0,
+        double offsetY = 0.0,
+        double offsetZ = 0.0)
+    {
+        var pointDataOffset = HeaderSize;
+        var total = pointDataOffset + points.Count * RecordLengthFormat3;
+        var buffer = new byte[total];
+        var span = buffer.AsSpan();
+
+        span[0] = (byte)'L';
+        span[1] = (byte)'A';
+        span[2] = (byte)'S';
+        span[3] = (byte)'F';
+        span[24] = 1; // version major
+        span[25] = 2; // version minor
+
+        BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(94, 2), HeaderSize);
+        BinaryPrimitives.WriteUInt32LittleEndian(span.Slice(96, 4), (uint)pointDataOffset);
+        span[104] = 3; // point data record format 3
+        BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(105, 2), RecordLengthFormat3);
+        BinaryPrimitives.WriteUInt32LittleEndian(span.Slice(107, 4), (uint)points.Count);
+
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(131, 8), scale);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(139, 8), scale);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(147, 8), scale);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(155, 8), offsetX);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(163, 8), offsetY);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(171, 8), offsetZ);
+
+        double minX = double.PositiveInfinity, minY = double.PositiveInfinity, minZ = double.PositiveInfinity;
+        double maxX = double.NegativeInfinity, maxY = double.NegativeInfinity, maxZ = double.NegativeInfinity;
+
+        var offset = pointDataOffset;
+        foreach (var p in points)
+        {
+            var xi = (int)Math.Round((p.X - offsetX) / scale);
+            var yi = (int)Math.Round((p.Y - offsetY) / scale);
+            var zi = (int)Math.Round((p.Z - offsetZ) / scale);
+
+            BinaryPrimitives.WriteInt32LittleEndian(span.Slice(offset, 4), xi);
+            BinaryPrimitives.WriteInt32LittleEndian(span.Slice(offset + 4, 4), yi);
+            BinaryPrimitives.WriteInt32LittleEndian(span.Slice(offset + 8, 4), zi);
+            BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(offset + 12, 2), p.Intensity);
+            // bytes 14 (return/flags), 15 (classification), 16 (scan angle),
+            // 17 (user data), 18-19 (point source id), 20-27 (GPS time).
+            span[offset + 15] = p.Classification;
+            // RGB starts at base record length (28) for format 3.
+            BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(offset + 28, 2), p.Red);
+            BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(offset + 30, 2), p.Green);
+            BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(offset + 32, 2), p.Blue);
+
+            if (p.X < minX) minX = p.X;
+            if (p.Y < minY) minY = p.Y;
+            if (p.Z < minZ) minZ = p.Z;
+            if (p.X > maxX) maxX = p.X;
+            if (p.Y > maxY) maxY = p.Y;
+            if (p.Z > maxZ) maxZ = p.Z;
+
+            offset += RecordLengthFormat3;
+        }
+
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(179, 8), maxX);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(187, 8), minX);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(195, 8), maxY);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(203, 8), minY);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(211, 8), maxZ);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(219, 8), minZ);
+
+        return buffer;
+    }
+
+    /// <summary>Marks a format-3 buffer as LAZ-compressed (sets bit 7 of the format byte).</summary>
+    internal static byte[] MarkCompressed(byte[] lasBuffer)
+    {
+        var copy = (byte[])lasBuffer.Clone();
+        copy[104] = (byte)(copy[104] | 0x80);
+        return copy;
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/PointCloud/LasPointCloudReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/PointCloud/LasPointCloudReaderTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.PointCloud;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.PointCloud;
+
+/// <summary>
+/// Unit tests for the pure-managed LAS reader (#1201).
+/// </summary>
+public sealed class LasPointCloudReaderTests
+{
+    [UnitTest]
+    public void ReadHeader_ParsesVersionFormatAndCounts()
+    {
+        var las = LasFixtureBuilder.BuildFormat3(SamplePoints());
+
+        var header = LasPointCloudReader.ReadHeader(las);
+
+        header.VersionMajor.Should().Be(1);
+        header.VersionMinor.Should().Be(2);
+        header.PointDataRecordFormat.Should().Be(3);
+        header.PointCount.Should().Be(3UL);
+        header.HasColor.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void ReadPoints_DescalesPositionAndPreservesAttributes()
+    {
+        var points = SamplePoints();
+        var las = LasFixtureBuilder.BuildFormat3(points, scale: 0.01, offsetX: 100.0, offsetY: 200.0, offsetZ: 5.0);
+
+        var decoded = LasPointCloudReader.ReadPoints(las).ToList();
+
+        decoded.Should().HaveCount(3);
+        decoded[0].X.Should().BeApproximately(points[0].X, 0.01);
+        decoded[0].Y.Should().BeApproximately(points[0].Y, 0.01);
+        decoded[0].Z.Should().BeApproximately(points[0].Z, 0.01);
+        decoded[0].Classification.Should().Be(points[0].Classification);
+        decoded[0].Intensity.Should().Be(points[0].Intensity);
+        decoded[0].Red.Should().Be(points[0].Red);
+        decoded[0].Green.Should().Be(points[0].Green);
+        decoded[0].Blue.Should().Be(points[0].Blue);
+        decoded[0].HasColor.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void ReadHeader_NonLasSignature_Throws()
+    {
+        var garbage = new byte[300];
+        garbage[0] = (byte)'N';
+
+        var act = () => LasPointCloudReader.ReadHeader(garbage);
+
+        act.Should().Throw<LasFormatException>().Which.Code.Should().Be("SCENE_MODEL_ASSET_INVALID");
+    }
+
+    [UnitTest]
+    public void ReadHeader_TooShort_Throws()
+    {
+        var act = () => LasPointCloudReader.ReadHeader(new byte[10]);
+
+        act.Should().Throw<LasFormatException>();
+    }
+
+    [UnitTest]
+    public void ReadHeader_CompressedLaz_RejectsWithClearError()
+    {
+        var laz = LasFixtureBuilder.MarkCompressed(LasFixtureBuilder.BuildFormat3(SamplePoints()));
+
+        var act = () => LasPointCloudReader.ReadHeader(laz);
+
+        act.Should().Throw<LasFormatException>()
+            .WithMessage("*LAZ*");
+    }
+
+    [UnitTest]
+    public void ReadPoints_TruncatedData_Throws()
+    {
+        var las = LasFixtureBuilder.BuildFormat3(SamplePoints());
+        var truncated = las[..^10];
+
+        var act = () => LasPointCloudReader.ReadPoints(truncated).ToList();
+
+        act.Should().Throw<LasFormatException>();
+    }
+
+    private static List<LasFixtureBuilder.Point> SamplePoints() =>
+    [
+        new(100.5, 200.5, 5.5, 1200, 2, 60000, 30000, 10000),
+        new(101.0, 201.0, 6.0, 800, 6, 40000, 50000, 20000),
+        new(102.25, 202.75, 7.5, 4000, 1, 10000, 10000, 65000),
+    ];
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/PointCloud/PntsTileWriterTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/PointCloud/PntsTileWriterTests.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.Scene.PointCloud;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.PointCloud;
+
+/// <summary>
+/// Unit tests for the deterministic PNTS point-tile writer (#1201).
+/// </summary>
+public sealed class PntsTileWriterTests
+{
+    [UnitTest]
+    public void Build_EmitsValidPntsHeaderWithAlignedSections()
+    {
+        var tile = PntsTileWriter.Build(SamplePoints());
+
+        Encoding.ASCII.GetString(tile, 0, 4).Should().Be("pnts");
+        BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(4, 4)).Should().Be(1u);
+        BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(8, 4)).Should().Be((uint)tile.Length);
+
+        var featureJsonLen = BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(12, 4));
+        var featureBinLen = BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(16, 4));
+        var batchJsonLen = BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(20, 4));
+        var batchBinLen = BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(24, 4));
+
+        (28 + featureJsonLen).Should().Match(v => v % 8 == 0, "feature-table JSON must pad to an 8-byte boundary");
+        (28 + featureJsonLen + featureBinLen + batchJsonLen).Should().Match(v => v % 8 == 0);
+        (28 + featureJsonLen + featureBinLen + batchJsonLen + batchBinLen).Should().Be((uint)tile.Length);
+    }
+
+    [UnitTest]
+    public void Build_FeatureTableAdvertisesPositionRgbAndRtcCenter()
+    {
+        var tile = PntsTileWriter.Build(SamplePoints());
+        var featureJsonLen = (int)BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(12, 4));
+        var json = Encoding.UTF8.GetString(tile, 28, featureJsonLen);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("POINTS_LENGTH").GetInt32().Should().Be(3);
+        doc.RootElement.GetProperty("RTC_CENTER").GetArrayLength().Should().Be(3);
+        doc.RootElement.TryGetProperty("POSITION", out _).Should().BeTrue();
+        doc.RootElement.TryGetProperty("RGB", out _).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Build_BatchTablePreservesIntensityAndClassification()
+    {
+        var tile = PntsTileWriter.Build(SamplePoints());
+        var featureJsonLen = (int)BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(12, 4));
+        var featureBinLen = (int)BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(16, 4));
+        var batchJsonLen = (int)BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(20, 4));
+
+        var batchJsonStart = 28 + featureJsonLen + featureBinLen;
+        var json = Encoding.UTF8.GetString(tile, batchJsonStart, batchJsonLen);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("INTENSITY").GetProperty("componentType").GetString().Should().Be("UNSIGNED_SHORT");
+        doc.RootElement.GetProperty("CLASSIFICATION").GetProperty("componentType").GetString().Should().Be("UNSIGNED_BYTE");
+    }
+
+    [UnitTest]
+    public void Build_IsByteIdenticalAcrossRuns()
+    {
+        var a = PntsTileWriter.Build(SamplePoints());
+        var b = PntsTileWriter.Build(SamplePoints());
+
+        a.Should().Equal(b);
+    }
+
+    [UnitTest]
+    public void Build_NoColor_OmitsRgbSemantic()
+    {
+        var points = new List<PntsPoint>
+        {
+            new(6_378_137.0, 0.0, 0.0, 100, 2, HasColor: false, 0, 0, 0),
+            new(6_378_138.0, 1.0, 1.0, 200, 5, HasColor: false, 0, 0, 0),
+        };
+
+        var tile = PntsTileWriter.Build(points);
+        var featureJsonLen = (int)BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(12, 4));
+        var json = Encoding.UTF8.GetString(tile, 28, featureJsonLen);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.TryGetProperty("RGB", out _).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void Build_EmptyPoints_Throws()
+    {
+        var act = () => PntsTileWriter.Build(Array.Empty<PntsPoint>());
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    private static List<PntsPoint> SamplePoints() =>
+    [
+        new(6_378_137.0, 10.0, 20.0, 1200, 2, HasColor: true, 60000, 30000, 10000),
+        new(6_378_137.5, 11.0, 21.0, 800, 6, HasColor: true, 40000, 50000, 20000),
+        new(6_378_138.0, 12.0, 22.0, 4000, 1, HasColor: true, 10000, 10000, 65000),
+    ];
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/PointCloud/PointCloudTilesetBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/PointCloud/PointCloudTilesetBuilderTests.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.Scene.PointCloud;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.PointCloud;
+
+/// <summary>
+/// End-to-end unit tests for the LAS -> 3D Tiles point-cloud pipeline (#1201).
+/// </summary>
+public sealed class PointCloudTilesetBuilderTests
+{
+    // Treat the LAS X/Y as longitude/latitude degrees directly (a geographic
+    // LAS) so the test does not depend on a projected-CRS transform.
+    private static (double, double, double) IdentityGeo(double x, double y, double z) => (x, y, z);
+
+    [UnitTest]
+    public void Build_FixtureLas_ProducesValidPointTileset()
+    {
+        var las = LasFixtureBuilder.BuildFormat3(GridPoints(20, 20), scale: 1e-7);
+        var points = LasPointCloudReader.ReadPoints(las).ToList();
+
+        var result = PointCloudTilesetBuilder.Build(
+            points,
+            IdentityGeo,
+            new PointCloudTilingOptions { MaxPointsPerTile = 50, MaxDepth = 8, InteriorSampleCount = 16 },
+            "honua-test");
+
+        result.PointCount.Should().Be(400);
+        result.TileCount.Should().BeGreaterThan(1);
+        result.Tiles.Should().NotBeEmpty();
+
+        using var json = JsonDocument.Parse(Encoding.UTF8.GetString(result.TilesetJsonBytes));
+        json.RootElement.GetProperty("asset").GetProperty("version").GetString().Should().Be("1.1");
+        json.RootElement.GetProperty("root").GetProperty("refine").GetString().Should().Be("REPLACE");
+    }
+
+    [UnitTest]
+    public void Build_EveryTilesetContentUri_HasMatchingTileBlob()
+    {
+        var las = LasFixtureBuilder.BuildFormat3(GridPoints(16, 16), scale: 1e-7);
+        var points = LasPointCloudReader.ReadPoints(las).ToList();
+
+        var result = PointCloudTilesetBuilder.Build(
+            points, IdentityGeo,
+            new PointCloudTilingOptions { MaxPointsPerTile = 40, MaxDepth = 8, InteriorSampleCount = 16 });
+
+        using var json = JsonDocument.Parse(Encoding.UTF8.GetString(result.TilesetJsonBytes));
+        var uris = new List<string>();
+        CollectContentUris(json.RootElement.GetProperty("root"), uris);
+
+        uris.Should().NotBeEmpty();
+        foreach (var uri in uris)
+        {
+            result.Tiles.Should().ContainKey(uri);
+            PntsHeaderIsValid(result.Tiles[uri]).Should().BeTrue();
+        }
+    }
+
+    [UnitTest]
+    public void Build_IsDeterministic_ByteIdenticalAcrossRuns()
+    {
+        var las = LasFixtureBuilder.BuildFormat3(GridPoints(18, 18), scale: 1e-7);
+        var points = LasPointCloudReader.ReadPoints(las).ToList();
+        var options = new PointCloudTilingOptions { MaxPointsPerTile = 45, MaxDepth = 8, InteriorSampleCount = 16 };
+
+        var a = PointCloudTilesetBuilder.Build(points, IdentityGeo, options, "honua");
+        var b = PointCloudTilesetBuilder.Build(points, IdentityGeo, options, "honua");
+
+        a.TilesetJsonBytes.Should().Equal(b.TilesetJsonBytes);
+        a.Tiles.Keys.Should().BeEquivalentTo(b.Tiles.Keys);
+        foreach (var key in a.Tiles.Keys)
+        {
+            a.Tiles[key].Should().Equal(b.Tiles[key]);
+        }
+    }
+
+    [UnitTest]
+    public void Build_PreservesClassificationAndRgbInPntsBatchTable()
+    {
+        // Single tile so every source point lands in one leaf and we can read
+        // its batch-table classification back.
+        var sourcePoints = new List<LasFixtureBuilder.Point>
+        {
+            new(0.001, 0.001, 1.0, 1000, 2, 60000, 0, 0),
+            new(0.002, 0.002, 2.0, 2000, 6, 0, 60000, 0),
+        };
+        var las = LasFixtureBuilder.BuildFormat3(sourcePoints);
+        var points = LasPointCloudReader.ReadPoints(las).ToList();
+
+        var result = PointCloudTilesetBuilder.Build(
+            points, IdentityGeo,
+            new PointCloudTilingOptions { MaxPointsPerTile = 100, MaxDepth = 4, InteriorSampleCount = 0 });
+
+        result.TileCount.Should().Be(1);
+        var tile = result.Tiles.Values.Single();
+        // Classification bytes live in the batch-table binary; assert the two
+        // ASPRS codes survive the round trip.
+        ExtractClassifications(tile).Should().Contain([(byte)2, (byte)6]);
+    }
+
+    [UnitTest]
+    public void Build_EmptyPoints_Throws()
+    {
+        var act = () => PointCloudTilesetBuilder.Build(
+            Array.Empty<LasPoint>(), IdentityGeo, new PointCloudTilingOptions());
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    private static void CollectContentUris(JsonElement node, List<string> sink)
+    {
+        if (node.TryGetProperty("content", out var content))
+        {
+            sink.Add(content.GetProperty("uri").GetString()!);
+        }
+        if (node.TryGetProperty("children", out var children))
+        {
+            foreach (var child in children.EnumerateArray())
+            {
+                CollectContentUris(child, sink);
+            }
+        }
+    }
+
+    private static bool PntsHeaderIsValid(byte[] tile)
+        => tile.Length >= 28 && Encoding.ASCII.GetString(tile, 0, 4) == "pnts";
+
+    private static List<byte> ExtractClassifications(byte[] tile)
+    {
+        var featureJsonLen = (int)System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(12, 4));
+        var featureBinLen = (int)System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(16, 4));
+        var batchJsonLen = (int)System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(20, 4));
+        var batchBinStart = 28 + featureJsonLen + featureBinLen + batchJsonLen;
+
+        var batchJson = Encoding.UTF8.GetString(tile, 28 + featureJsonLen + featureBinLen, batchJsonLen);
+        using var doc = JsonDocument.Parse(batchJson);
+        var classificationOffset = doc.RootElement.GetProperty("CLASSIFICATION").GetProperty("byteOffset").GetInt32();
+        var intensityCount = doc.RootElement.GetProperty("INTENSITY").GetProperty("byteOffset").GetInt32();
+        _ = intensityCount;
+
+        // CLASSIFICATION is UNSIGNED_BYTE; the column runs to the end of the
+        // batch binary. Read every byte from its offset onward.
+        var result = new List<byte>();
+        for (var i = batchBinStart + classificationOffset; i < tile.Length; i++)
+        {
+            result.Add(tile[i]);
+        }
+        return result;
+    }
+
+    private static List<LasFixtureBuilder.Point> GridPoints(int cols, int rows)
+    {
+        var points = new List<LasFixtureBuilder.Point>(cols * rows);
+        // Keep coordinates as small longitude/latitude degrees near the origin.
+        for (var r = 0; r < rows; r++)
+        {
+            for (var c = 0; c < cols; c++)
+            {
+                var lon = 0.0001 * (c + 1);
+                var lat = 0.0001 * (r + 1);
+                points.Add(new LasFixtureBuilder.Point(
+                    lon, lat, 1.0 + r + c,
+                    Intensity: (ushort)(100 + c),
+                    Classification: (byte)((r + c) % 4),
+                    Red: 50000, Green: 40000, Blue: 30000));
+            }
+        }
+        return points;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/SceneTilesPublishExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/SceneTilesPublishExecutorTests.cs
@@ -88,6 +88,88 @@ public sealed class SceneTilesPublishExecutorTests : IDisposable
     }
 
     [UnitTest]
+    public async Task Execute_LargeFixtureAboveLodThreshold_ProducesMultiTileLodTileset()
+    {
+        // #1200 acceptance: a feature set at/above the LOD threshold must
+        // generate a multi-tile, multi-LOD tileset (REPLACE refinement, a
+        // nested tile tree, more than one GLB) instead of one oversized tile.
+        BuildLayer();
+        _featureSource.Features = PointGrid(260, 260); // 67 600 features.
+
+        var executor = BuildExecutor(new SceneGenerationServerOptions
+        {
+            OutputRoot = _outputRoot,
+            MaxFeatureCount = 1_000_000,
+            LodFeatureThreshold = 50_000,
+            MaxFeaturesPerTile = 2_000,
+            MaxLodDepth = 12,
+            InteriorSampleCount = 128,
+            GeneratorTag = "honua-test-generator/1.0"
+        });
+
+        var outcome = await executor.RunDirectAsync(BuildIntent(sceneId: "large-lod"), CancellationToken.None);
+
+        outcome.Result.Summary.TileCount.Should().BeGreaterThan(1,
+            "a >50k dataset must partition into multiple tiles.");
+
+        var root = outcome.Result.AssetRoot;
+        var glbCount = Directory.GetFiles(root, "tile_*.glb").Length;
+        glbCount.Should().Be(outcome.Result.Summary.TileCount);
+        glbCount.Should().BeGreaterThan(1);
+
+        var tilesetBytes = await File.ReadAllBytesAsync(Path.Combine(root, "tileset.json"));
+        using var doc = JsonDocument.Parse(tilesetBytes);
+        var rootTile = doc.RootElement.GetProperty("root");
+        rootTile.GetProperty("refine").GetString().Should().Be("REPLACE");
+        rootTile.GetProperty("children").GetArrayLength().Should().BeGreaterThan(0);
+
+        // Geometric error refines: each child error is strictly less than root.
+        var rootError = rootTile.GetProperty("geometricError").GetDouble();
+        rootError.Should().BeGreaterThan(0.0);
+        foreach (var child in rootTile.GetProperty("children").EnumerateArray())
+        {
+            child.GetProperty("geometricError").GetDouble().Should().BeLessThan(rootError);
+        }
+    }
+
+    [UnitTest]
+    public async Task Execute_LodOutput_IsDeterministicAcrossRuns()
+    {
+        BuildLayer();
+        _featureSource.Features = PointGrid(80, 80); // 6 400 features.
+
+        var serverOptions = new SceneGenerationServerOptions
+        {
+            OutputRoot = _outputRoot,
+            MaxFeatureCount = 1_000_000,
+            LodFeatureThreshold = 1_000, // force the LOD path for a small fixture.
+            MaxFeaturesPerTile = 500,
+            MaxLodDepth = 10,
+            InteriorSampleCount = 64,
+            GeneratorTag = "honua-test-generator/1.0"
+        };
+        var executorA = BuildExecutor(serverOptions);
+        var executorB = BuildExecutor(serverOptions);
+
+        var a = await executorA.RunDirectAsync(BuildIntent(sceneId: "lod-determ-a"), CancellationToken.None);
+        var b = await executorB.RunDirectAsync(BuildIntent(sceneId: "lod-determ-b"), CancellationToken.None);
+
+        a.Result.Summary.TileCount.Should().Be(b.Result.Summary.TileCount).And.BeGreaterThan(1);
+
+        var tilesetA = await File.ReadAllBytesAsync(Path.Combine(a.Result.AssetRoot, "tileset.json"));
+        var tilesetB = await File.ReadAllBytesAsync(Path.Combine(b.Result.AssetRoot, "tileset.json"));
+        tilesetA.Should().Equal(tilesetB);
+
+        for (var i = 0; i < a.Result.Summary.TileCount; i++)
+        {
+            var name = $"tile_{i:0000}.glb";
+            var glbA = await File.ReadAllBytesAsync(Path.Combine(a.Result.AssetRoot, name));
+            var glbB = await File.ReadAllBytesAsync(Path.Combine(b.Result.AssetRoot, name));
+            glbA.Should().Equal(glbB, "LOD tile {0} must be byte-identical across runs.", name);
+        }
+    }
+
+    [UnitTest]
     public async Task Execute_PreservesAttributesInGlbStructuralMetadata()
     {
         BuildLayer();
@@ -1017,6 +1099,50 @@ public sealed class SceneTilesPublishExecutorTests : IDisposable
             new MetadataV2Field { Name = "height", Type = MetadataV2FieldType.Integer, Length = null, Nullable = true }
         };
         _metadataProvider.SetGraph(BuildSceneGraph(srid: sr.Wkid, accessPolicy: accessPolicy, fields: fields));
+    }
+
+    private SceneTilesPublishExecutor BuildExecutor(SceneGenerationServerOptions serverOptions)
+        => new(
+            _featureSource,
+            _metadataProvider,
+            new TestHostEnvironment(),
+            Options.Create(serverOptions),
+            NullLogger<SceneTilesPublishExecutor>.Instance,
+            _registration);
+
+    private static List<SceneFeature> PointGrid(int cols, int rows)
+    {
+        // Distinct single-vertex point features spread across the layer bounds
+        // so the quadtree subdivides into many leaves.
+        const double west = -122.5, south = 37.7, east = -122.4, north = 37.8;
+        var lonStep = (east - west) / (cols + 1);
+        var latStep = (north - south) / (rows + 1);
+        var features = new List<SceneFeature>(cols * rows);
+        var id = 1;
+        for (var r = 0; r < rows; r++)
+        {
+            for (var c = 0; c < cols; c++)
+            {
+                var lon = west + lonStep * (c + 1);
+                var lat = south + latStep * (r + 1);
+                features.Add(new SceneFeature
+                {
+                    Id = id,
+                    Geometry = new SceneFeatureGeometry
+                    {
+                        Kind = SceneGeometryKind.Point,
+                        Vertices = [new SceneVertex(lon, lat, 10.0)]
+                    },
+                    Attributes = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["name"] = "p" + id.ToString(CultureInfo.InvariantCulture),
+                        ["height"] = 10
+                    }
+                });
+                id++;
+            }
+        }
+        return features;
     }
 
     private void SetResourceExtrusion(MetadataV2ExtrusionInfo extrusion)


### PR DESCRIPTION
## Issue Link
Closes #1200
Refs #1201 (engine landed; LAZ/COPC decompression + live point-cloud job endpoint tracked as follow-up — issue stays open)

## Summary
Extends the `Honua.Scene` 3D Tiles pipeline in two ways, in one PR to minimize CI cycles:

- **#1200 (quadtree LOD + spatial partitioning):** the generator no longer emits a single oversized tile. Datasets at/above a configurable threshold are partitioned into a deterministic quadtree with per-level geometric error and a coarse interior LOD sample, emitted as a multi-tile `REPLACE`-refinement `tileset.json` tree so CesiumJS refines LODs as the camera approaches. The hard feature cap rises from 50k to 1,000,000.
- **#1201 (point-cloud ingest):** a pure-managed LAS reader → quadtree → Cesium `.pnts` + `tileset.json` pipeline that preserves classification, intensity, and RGB. LAZ/COPC are detected and rejected with a clear error (native decompression is a tracked follow-up).

Both paths are deterministic / byte-stable for fixed inputs, matching the existing generator's contract.

## Changes Made
- Add `SceneQuadtreePartitioner` + `SceneTileTree`/`SceneTileNode`/`SceneLodOptions` (deterministic quadtree, monotonic geometric error, strided coarse-LOD sampling).
- Extend `TilesetDocumentWriter` with `BuildTree` to emit a multi-level tileset tree with per-node bounding regions and `REPLACE` refinement.
- Wire LOD into `SceneTilesPublishExecutor` (threshold-gated; single-tile layout preserved below threshold; raised `MaxFeatureCount`; new LOD tuning options).
- Add `LasPointCloudReader` (uncompressed LAS 1.1–1.4 formats 0/1/2/3/6/7/8; descale + preserve attributes; reject LAZ/COPC), `PntsTileWriter` (POSITION + RGB + INTENSITY/CLASSIFICATION batch table, ECEF + `RTC_CENTER`), and `PointCloudTilesetBuilder` (LAS → `.pnts` quadtree + tileset).
- Tests: partitioner (shape/error-monotonicity/determinism/clustering), tree writer, executor >50k multi-tile LOD + determinism, LAS reader (incl. invalid/truncated/LAZ inputs), PNTS writer, end-to-end point-cloud builder.
- Docs: `docs/gis/scene-generation.md` updated for LOD tiling, raised cap, tuning knobs, and a new point-cloud ingest section.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed (Cesium visual refinement smoke deferred — server-side suite only)

Local results: full `dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true` → 0 warnings / 0 errors; `dotnet format --verify-no-changes` clean; Architecture tests 102 passed / 1 skipped; Core.Tests scene suite 157 passed; `SceneTilesPublishExecutorTests` 43 passed (incl. the 67,600-feature multi-tile LOD test).

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. The single-tile output layout is preserved for datasets below the LOD threshold; the default `MaxFeatureCount` increases (more permissive, not breaking).

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (SMART mode: build 0/0, format clean, Architecture 102 passed, targeted server shard 705 passed; AOT IL/ILC phase clean — native link step skipped locally, no clang in sandbox, CI confirms)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Deferred scope (called out, not silently skipped)
- **Native LAZ/COPC decompression** — #1201 ships uncompressed LAS; compressed inputs are detected and rejected with `SCENE_MODEL_ASSET_INVALID`.
- **Point-cloud HTTP/gRPC job endpoint** — the ingest engine (read → tile → write) is complete and fully tested at the library level; the thin job-endpoint adapter (with its EndpointRegistry/OperationRegistry/proof-ledger gate wiring) is deferred to a focused follow-up to keep this PR's surface reviewable.
- **Per-LOD mesh decimation** — current LOD thins by deterministic feature sampling, not geometry simplification.
