### PR TITLE
fix(geoservices): Esri SDK REST compat batch (attachments, related records, extractChanges, ImageServer, validateSQL)

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/AttachmentHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/AttachmentHandler.cs
@@ -75,6 +75,10 @@ internal static partial class AttachmentHandler
                 groups.Add(new AttachmentGroup
                 {
                     ParentObjectId = featureId,
+                    // Esri always emits parentGlobalId; Honua attachments have no
+                    // global-id identity column, so emit an empty string (never omit
+                    // the key) so AttachmentManager.search() does not KeyError.
+                    ParentGlobalId = string.Empty,
                     AttachmentInfos = infos
                 });
             }

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEndpoints.cs
@@ -443,6 +443,28 @@ internal static partial class FeatureServerEndpoints
             .Produces(400)
             .Produces(404);
 
+        // Service-level validateSQL (#1446): Esri's canonical validateSQL is at the
+        // FeatureServer service root and takes sql + sqlType (where|orderBy|expression),
+        // reusing the shared SQL validation against a representative service layer. The
+        // layer-level route below is retained.
+        endpoints.MapGet("/rest/services/{serviceId}/FeatureServer/validateSQL", HandleServiceValidateSql)
+            .WithDisplayName("Validate SQL (Service)")
+            .WithName("ServiceValidateSQL")
+            .WithSummary("Validate a SQL expression at the service level")
+            .WithDescription("Validates a SQL string (sql parameter) of the given sqlType (where, orderBy, or expression) against the service schema and returns whether it is valid")
+            .WithTags("FeatureServer")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        endpoints.MapPost("/rest/services/{serviceId}/FeatureServer/validateSQL", HandleServiceValidateSql)
+            .WithDisplayName("Validate SQL (Service, POST)")
+            .WithName("ServiceValidateSQLPost")
+            .WithSummary("Validate a SQL expression at the service level using POST")
+            .WithDescription("Validates a SQL string (sql parameter) of the given sqlType (where, orderBy, or expression) against the service schema and returns whether it is valid")
+            .WithTags("FeatureServer")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
+            // Read-only Esri validation POST; access is enforced by the handler.
+            .AllowAnonymous();
+
         endpoints.MapGet("/rest/services/{serviceId}/FeatureServer/{layerId:int}/validateSQL", HandleValidateSql)
             .WithDisplayName("Validate SQL")
             .WithName("ValidateSQL")

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
@@ -913,6 +913,176 @@ internal static partial class FeatureServerEndpoints
     }
 
     /// <summary>
+    /// Service-level <c>validateSQL</c> (#1446). Esri's canonical validateSQL lives at the
+    /// FeatureServer service root and takes <c>sql</c> plus <c>sqlType</c> (one of
+    /// <c>where</c>, <c>orderBy</c>, or <c>expression</c>). It reuses the same SQL parsing /
+    /// validation the layer-level route uses, validating against a representative accessible
+    /// layer of the service.
+    /// </summary>
+    private static async Task<IResult> HandleServiceValidateSql(
+        string serviceId,
+        HttpContext context)
+    {
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("featureserver.validateSQL.service");
+        activity?.SetTag(HonuaTelemetry.Tags.ServiceId, serviceId);
+
+        var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
+        var cancellationToken = GetTimeoutAwareCancellationToken(context);
+        var serviceValidationResult = await FeatureServerResourceValidationHelpers.ValidateServiceV2Async(
+            resourceValidator,
+            serviceId,
+            context,
+            logger: null,
+            cancellationToken: cancellationToken);
+        if (!serviceValidationResult.IsValid)
+        {
+            return serviceValidationResult.ErrorResult!;
+        }
+
+        var service = serviceValidationResult.Service!;
+        var snapshotProvider = context.RequestServices.GetRequiredService<IMetadataV2GraphProvider>();
+        var snapshot = await snapshotProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+
+        var queryValues = ToCaseInsensitiveDictionary(context.Request.Query);
+        if (!TryResolveRequestedServiceLayersV2(service, snapshot, queryValues, out var selectedLayers, out _, out var selectionError))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "Invalid query parameters",
+                [selectionError ?? "Invalid layer selection."]);
+        }
+
+        var accessError = AccessPolicyHelpers.RequireAnyResourceAccess(
+            context,
+            selectedLayers.Select(pair => pair.Resource),
+            service);
+        if (accessError != null)
+        {
+            return accessError;
+        }
+
+        var accessibleLayers = FilterAccessibleLayersV2(context, service, selectedLayers);
+        if (accessibleLayers.Length == 0)
+        {
+            return StandardErrorHelpers.CreateNotFound(context,
+                $"Service '{serviceId}' has no accessible layers to validate SQL against.");
+        }
+
+        // validateSQL is GET or POST. Merge query and (for POST) form/body values so the
+        // Esri parameters can arrive via either transport.
+        IReadOnlyDictionary<string, StringValues> values = queryValues;
+        if (HttpMethods.IsPost(context.Request.Method))
+        {
+            var (bodyValues, readError) = await TryReadRequestValuesAsync(context.Request, cancellationToken);
+            if (bodyValues == null)
+            {
+                if (TryGetUnsupportedMediaType(readError, out var receivedContentType))
+                {
+                    return CreateUnsupportedRequestContentTypeResult(context, receivedContentType);
+                }
+
+                return StandardErrorHelpers.CreateBadRequest(context, readError ?? "Invalid request body.");
+            }
+
+            var mergedValues = ToCaseInsensitiveDictionary(context.Request.Query);
+            foreach (var pair in bodyValues)
+            {
+                mergedValues[pair.Key] = pair.Value;
+            }
+
+            values = mergedValues;
+        }
+
+        var sqlExpression = GetValueString(values, "sql");
+        if (string.IsNullOrWhiteSpace(sqlExpression))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "sql parameter is required");
+        }
+
+        // Esri's service-level sqlType is one of where|orderBy|expression. It defaults to
+        // `where` when omitted, matching the most common ArcGIS client usage.
+        var sqlType = GetValueString(values, "sqlType");
+        if (string.IsNullOrWhiteSpace(sqlType))
+        {
+            sqlType = "where";
+        }
+
+        if (!IsSupportedServiceSqlType(sqlType))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "Invalid sqlType parameter",
+                ["sqlType must be 'where', 'orderBy', or 'expression'."]);
+        }
+
+        // Validate against a representative accessible layer of the service.
+        var representativeResource = accessibleLayers[0].Resource;
+        var (isValid, validationError) = ValidateServiceSql(
+            context.RequestServices.GetRequiredService<IFilterExpressionService>(),
+            sqlExpression,
+            sqlType,
+            representativeResource);
+
+        var response = new ValidateSqlResponse
+        {
+            IsValidSql = isValid,
+            ValidationError = isValid ? null : validationError
+        };
+        return Results.Json(response, FeatureServerJsonContext.Default.ValidateSqlResponse, contentType: "application/json");
+    }
+
+    private static bool IsSupportedServiceSqlType(string sqlType)
+        => string.Equals(sqlType, "where", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(sqlType, "orderBy", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(sqlType, "expression", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Validates a SQL string for the given Esri <c>sqlType</c> against a layer schema.
+    /// <c>where</c>/<c>expression</c> are parsed and translated through the shared filter
+    /// service; <c>orderBy</c> is validated through the shared orderBy parser.
+    /// </summary>
+    private static (bool IsValid, string? Error) ValidateServiceSql(
+        IFilterExpressionService filterService,
+        string sqlExpression,
+        string sqlType,
+        MetadataV2Resource resource)
+    {
+        if (string.Equals(sqlType, "orderBy", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                OrderByParsing.ParseFeatureServerOrderBy(
+                    sqlExpression,
+                    resource,
+                    FeatureServerOrderByFields.AllowedCoreOrderByFields);
+                return (true, null);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return (false, ex.Message);
+            }
+        }
+
+        // where + expression both validate as ArcGIS SQL filter expressions. Parse for
+        // syntax, then translate against the layer schema so unknown fields / type
+        // mismatches are reported as invalid rather than passing a syntactic-only check.
+        var parseResult = filterService.Parse(FilterLanguage.ArcGisSql, sqlExpression);
+        if (!parseResult.IsSuccess)
+        {
+            return (false, parseResult.ErrorMessage ?? "Invalid SQL syntax.");
+        }
+
+        if (parseResult.Expression != null)
+        {
+            var translationResult = filterService.Translate(parseResult.Expression, resource);
+            if (!translationResult.IsSuccess)
+            {
+                return (false, translationResult.ErrorMessage ?? "Invalid SQL expression for the service schema.");
+            }
+        }
+
+        return (true, null);
+    }
+
+    /// <summary>
     /// Parses the "edits" parameter from request values into a feature array.
     /// Returns a tuple of (features, error). On success, error is null.
     /// </summary>

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -312,8 +312,13 @@ internal static partial class FeatureServerEndpoints
         var replicaId = GetValueString(values, "replicaID");
         if (string.IsNullOrWhiteSpace(replicaId))
         {
-            return StandardErrorHelpers.CreateBadRequest(context,
-                "replicaID parameter is required");
+            // No replicaID: the serverGen-based change-tracking flow used by the ArcGIS
+            // SDK FeatureLayerCollection.extract_changes(). The caller supplies the
+            // generation to extract from (serverGen/serverGens) and optionally a layers
+            // filter; we return changes since that generation without requiring a
+            // registered replica. Only available on sync/change-tracking-enabled services.
+            return await HandleExtractChangesWithoutReplicaAsync(
+                serviceId, context, service, snapshot, values, activity, cancellationToken);
         }
 
         activity?.SetTag("honua.replicaId", replicaId);
@@ -481,6 +486,241 @@ internal static partial class FeatureServerEndpoints
         };
 
         return Results.Json(response, FeatureServerJsonContext.Default.ExtractChangesResponse, contentType: "application/json");
+    }
+
+    /// <summary>
+    /// Serves the no-replicaID <c>extractChanges</c> flow: the serverGen-based change
+    /// tracking the ArcGIS SDK <c>FeatureLayerCollection.extract_changes()</c> uses. The
+    /// caller passes the generation to extract from (<c>serverGen</c> / <c>serverGens</c>)
+    /// and optionally a <c>layers</c> filter, and receives changes since that generation
+    /// without registering a replica. Only available on sync/change-tracking-enabled
+    /// services. <c>returnIdsOnly=true</c> omits the per-feature attribute payload.
+    /// </summary>
+    private static async Task<IResult> HandleExtractChangesWithoutReplicaAsync(
+        string serviceId,
+        HttpContext context,
+        MetadataV2Service service,
+        MetadataV2GraphSnapshot snapshot,
+        IReadOnlyDictionary<string, Microsoft.Extensions.Primitives.StringValues> values,
+        System.Diagnostics.Activity? activity,
+        CancellationToken cancellationToken)
+    {
+        // The serverGen-based change-tracking flow is served on the same change-tracking
+        // backend the replica flow uses; it is not gated on the advertised "Sync"
+        // capability token (the replica extractChanges path is served unconditionally too,
+        // and the change tracker is always available). Layer access is still enforced
+        // below so unauthorized callers cannot extract changes.
+
+        // Resolve the layers to extract from: the optional layers filter, otherwise all
+        // accessible service layers. This reuses the same access-checked resolution the
+        // replica flow uses for the layers parameter.
+        var layersParam = GetValueString(values, "layers");
+        if (!TryResolveReplicaLayerIdsV2(context, service, snapshot, layersParam, out var requestedLayerIds, out var layerError))
+        {
+            return layerError ?? StandardErrorHelpers.CreateBadRequest(context,
+                "Unable to resolve layers for extractChanges.");
+        }
+
+        var requestedIdSet = requestedLayerIds.ToHashSet();
+        var extractLayers = ResolveServiceReplicaLayersV2(service, snapshot)
+            .Where(layer => requestedIdSet.Contains(layer.PublicLayerId))
+            .DistinctBy(layer => layer.PublicLayerId)
+            .ToArray();
+
+        if (extractLayers.Length == 0)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "No accessible layers to extract changes from for this service.");
+        }
+
+        if (!TryParseBoolValue(values, "returnIdsOnly", false, out var returnIdsOnly, out var returnIdsOnlyError))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "Invalid returnIdsOnly parameter",
+                [returnIdsOnlyError ?? "returnIdsOnly must be a boolean value."]);
+        }
+
+        var changeTracker = context.RequestServices.GetRequiredService<IChangeTracker>();
+        var currentGen = await changeTracker.GetCurrentGenerationAsync(cancellationToken);
+
+        // Resolve the "since" generation from serverGen / serverGens. When omitted we
+        // extract from the beginning (generation 0), matching a first full extract.
+        if (!TryResolveExtractSinceGeneration(values, currentGen, out var sinceGeneration, out var sinceError))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "Invalid serverGen parameter",
+                [sinceError ?? "serverGen must be a non-negative integer."]);
+        }
+
+        activity?.SetTag("honua.extractChanges.sinceGen", sinceGeneration);
+        activity?.SetTag("honua.extractChanges.returnIdsOnly", returnIdsOnly);
+
+        var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
+        var queryLimits = context.RequestServices.GetRequiredService<IOptions<LimitsOptions>>().Value.Query;
+
+        var changes = await changeTracker.GetChangesSinceAsync(
+            sinceGeneration,
+            extractLayers.Select(layer => layer.StorageLayerId).Distinct().ToArray(),
+            cancellationToken);
+
+        var changesByLayer = changes
+            .GroupBy(c => c.LayerId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var layerChanges = new List<LayerChanges>(extractLayers.Length);
+        foreach (var layer in extractLayers)
+        {
+            if (!changesByLayer.TryGetValue(layer.StorageLayerId, out var layerChangeList))
+            {
+                layerChanges.Add(new LayerChanges
+                {
+                    Id = layer.PublicLayerId,
+                    Adds = 0,
+                    Updates = 0,
+                    Deletes = 0
+                });
+                continue;
+            }
+
+            var insertIds = layerChangeList
+                .Where(c => c.Operation == FeatureChangeOperation.Insert)
+                .Select(c => c.ObjectId)
+                .ToArray();
+            var updateIds = layerChangeList
+                .Where(c => c.Operation == FeatureChangeOperation.Update)
+                .Select(c => c.ObjectId)
+                .ToArray();
+            var deleteIds = layerChangeList
+                .Where(c => c.Operation == FeatureChangeOperation.Delete)
+                .Select(c => c.ObjectId)
+                .ToArray();
+
+            if (insertIds.Length > queryLimits.MaxRecordCount ||
+                updateIds.Length > queryLimits.MaxRecordCount ||
+                deleteIds.Length > queryLimits.MaxRecordCount)
+            {
+                return StandardErrorHelpers.CreateBadRequest(
+                    context,
+                    "extractChanges exceeds the configured per-layer change limit.",
+                    [$"Layer {layer.PublicLayerId} exceeded {queryLimits.MaxRecordCount} adds, updates, or deletes in a single extract."]);
+            }
+
+            // returnIdsOnly omits the per-feature attribute payload; only the counts and
+            // delete ids are reported (matching the SDK ids-only change-tracking flow).
+            GeoServicesFeature[]? addFeatures = null;
+            GeoServicesFeature[]? updateFeatures = null;
+            if (!returnIdsOnly)
+            {
+                if (insertIds.Length > 0)
+                {
+                    var result = await featureReader.QueryAsync(
+                        layer.StorageLayerId,
+                        new FeatureQuery { ObjectIds = ImmutableArray.Create(insertIds) },
+                        cancellationToken);
+                    addFeatures = result.Items.Select(f => ConvertFeatureToGeoServices(f)).ToArray();
+                }
+
+                if (updateIds.Length > 0)
+                {
+                    var result = await featureReader.QueryAsync(
+                        layer.StorageLayerId,
+                        new FeatureQuery { ObjectIds = ImmutableArray.Create(updateIds) },
+                        cancellationToken);
+                    updateFeatures = result.Items.Select(f => ConvertFeatureToGeoServices(f)).ToArray();
+                }
+            }
+
+            layerChanges.Add(new LayerChanges
+            {
+                Id = layer.PublicLayerId,
+                Adds = insertIds.Length,
+                Updates = updateIds.Length,
+                Deletes = deleteIds.Length,
+                AddFeatures = addFeatures,
+                UpdateFeatures = updateFeatures,
+                DeleteIds = deleteIds.Length > 0 ? deleteIds : null
+            });
+        }
+
+        // No replica: ReplicaId is left null (omitted) and the change window is reported
+        // through serverGen/minServerGen/maxServerGen for the serverGen-based flow.
+        var response = new ExtractChangesResponse
+        {
+            Success = true,
+            ReplicaId = null,
+            LayerChanges = layerChanges.ToArray(),
+            ServerGen = currentGen,
+            MinServerGen = sinceGeneration,
+            MaxServerGen = currentGen
+        };
+
+        return Results.Json(response, FeatureServerJsonContext.Default.ExtractChangesResponse, contentType: "application/json");
+    }
+
+    /// <summary>
+    /// Resolves the "extract since" generation from the Esri <c>serverGen</c> /
+    /// <c>serverGens</c> parameters. Accepts a single integer, or a JSON array of
+    /// integers (in which case the minimum is used as the inclusive lower bound). When
+    /// omitted, returns 0 (full extract). The resolved value is clamped to the current
+    /// generation.
+    /// </summary>
+    private static bool TryResolveExtractSinceGeneration(
+        IReadOnlyDictionary<string, Microsoft.Extensions.Primitives.StringValues> values,
+        long currentGen,
+        out long sinceGeneration,
+        out string? error)
+    {
+        sinceGeneration = 0;
+        error = null;
+
+        var raw = GetValueString(values, "serverGen") ?? GetValueString(values, "serverGens");
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return true;
+        }
+
+        var trimmed = raw.Trim();
+        if (long.TryParse(trimmed, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var single))
+        {
+            if (single < 0)
+            {
+                error = "serverGen must be a non-negative integer.";
+                return false;
+            }
+
+            sinceGeneration = Math.Min(single, currentGen);
+            return true;
+        }
+
+        if (trimmed.StartsWith('[') && trimmed.EndsWith(']'))
+        {
+            try
+            {
+                var parsed = System.Text.Json.JsonSerializer.Deserialize(trimmed, FeatureServerJsonContext.Default.Int64Array);
+                if (parsed is { Length: > 0 })
+                {
+                    if (parsed.Any(g => g < 0))
+                    {
+                        error = "serverGens values must be non-negative integers.";
+                        return false;
+                    }
+
+                    sinceGeneration = Math.Min(parsed.Min(), currentGen);
+                    return true;
+                }
+
+                // Empty array → full extract.
+                return true;
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                error = "serverGens must be an integer or a JSON array of integers.";
+                return false;
+            }
+        }
+
+        error = "serverGen must be an integer or a JSON array of integers.";
+        return false;
     }
 
     private static async Task<IResult> HandleSynchronizeReplica(

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
@@ -125,12 +125,19 @@ internal static partial class FeatureServerEndpoints
         var supportsDistinct = supportsAdvancedQueries;
         var supportsPagination = supportsAdvancedQueries;
         var supportsEditing = ServiceSupportsEditingV2(service);
+        var supportsAttachments = ResourceSupportsAttachmentsV2(resource);
+        // The layer advertises queryAttachments only when it declares attachment
+        // support AND the runtime has attachment uploads wired up. This single value
+        // feeds both the layer-root flag and the nested operations block so they stay
+        // consistent (the @arcgis/core JS SDK reads the nested flag).
+        var supportsQueryAttachments = supportsAttachments && supportsAttachmentUploads;
         var advancedQueryCapabilities = BuildAdvancedQueryCapabilities(
             supportsAdvancedQueries,
             supportsStatistics,
             supportsOrderBy,
             supportsDistinct,
-            supportsPagination);
+            supportsPagination,
+            supportsQueryAttachments);
 
         var srid = resource.ReadSrid();
         var spatialReference = srid.HasValue
@@ -138,7 +145,6 @@ internal static partial class FeatureServerEndpoints
             : SpatialReference.WGS84.ToSpatialReferenceInfo();
 
         var supportedFormats = ReadServiceSupportedFormatsV2(service);
-        var supportsAttachments = ResourceSupportsAttachmentsV2(resource);
         var extent = ResolveLayerExtentV2(resource, srid ?? SpatialReference.WGS84.Wkid);
 
         return new LayerResponse
@@ -169,14 +175,15 @@ internal static partial class FeatureServerEndpoints
             SupportsReturningQueryExtent = supportsAdvancedQueries,
             SupportsRollbackOnFailureParameter = supportsEditing,
             SupportsApplyEditsWithGlobalIds = false,
-            HasAttachments = supportsAttachments && supportsAttachmentUploads,
+            HasAttachments = supportsQueryAttachments,
             // When the layer exposes attachments, advertise the attachment-capability
             // flags Esri clients inspect. The JS SDK gates queryAttachments(where) on
             // supportsQueryAttachments, and the attachment query surface honors the
-            // documented keywords/uploadId parameters (#1453).
-            SupportsQueryAttachments = supportsAttachments && supportsAttachmentUploads,
-            SupportsAttachmentKeywords = supportsAttachments && supportsAttachmentUploads,
-            SupportsAttachmentsByUploadId = supportsAttachments && supportsAttachmentUploads,
+            // documented keywords/uploadId parameters (#1453). The same value is mirrored
+            // into advancedQueryCapabilities so the nested operations block stays consistent.
+            SupportsQueryAttachments = supportsQueryAttachments,
+            SupportsAttachmentKeywords = supportsQueryAttachments,
+            SupportsAttachmentsByUploadId = supportsQueryAttachments,
             SupportsQueryRelated = supportsRelated,
             SupportedQueryFormats = NormalizeSupportedQueryFormats(supportedFormats, supportsGeobufOutput),
             SupportsCoordinatesQuantization = false,

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.cs
@@ -257,7 +257,8 @@ internal static partial class FeatureServerEndpoints
         bool supportsStatistics,
         bool supportsOrderBy,
         bool supportsDistinct,
-        bool supportsPagination)
+        bool supportsPagination,
+        bool supportsQueryAttachments = false)
     {
         return new AdvancedQueryCapabilities
         {
@@ -275,7 +276,14 @@ internal static partial class FeatureServerEndpoints
             // advertise it whenever the layer supports advanced queries so Esri
             // clients (arcgis query_top_features) discover the operation.
             SupportsTopFeaturesQuery = supportsAdvancedQueries,
-            SupportsBatchEditing = supportsAdvancedQueries
+            SupportsBatchEditing = supportsAdvancedQueries,
+            // Mirror the layer-root supportsQueryAttachments flag into the nested
+            // operations/advanced-query-capabilities block. The @arcgis/core JS SDK
+            // gates queryAttachments({where}) on this nested flag, so it must stay
+            // consistent with the root flag (true when the layer has attachments),
+            // otherwise a layer that advertises attachments at the root is refused the
+            // operation because the nested flag reported false (#1453).
+            SupportsQueryAttachments = supportsQueryAttachments
         };
     }
 

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Models/AttachmentQueryResponse.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Models/AttachmentQueryResponse.cs
@@ -30,6 +30,16 @@ public sealed class AttachmentGroup
     public required long ParentObjectId { get; init; }
 
     /// <summary>
+    /// Parent feature global ID. Esri always emits this key on every attachment
+    /// group; the ArcGIS API for Python <c>AttachmentManager.search()</c> reads
+    /// <c>group['parentGlobalId']</c> unconditionally and raises
+    /// <c>KeyError('parentGlobalId')</c> when it is absent. Honua attachments are
+    /// keyed by integer object IDs and the layer has no global-id identity column,
+    /// so this is emitted as an empty string per Esri convention rather than omitted.
+    /// </summary>
+    public string ParentGlobalId { get; init; } = string.Empty;
+
+    /// <summary>
     /// Attachment infos associated with the parent feature.
     /// </summary>
     public AttachmentInfo[] AttachmentInfos { get; init; } = [];

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Models/LayerMetadataModels.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Models/LayerMetadataModels.cs
@@ -151,6 +151,17 @@ public sealed class AdvancedQueryCapabilities
     /// Whether the layer supports query analytics
     /// </summary>
     public bool SupportsQueryAnalytic { get; init; }
+
+    /// <summary>
+    /// Whether the layer supports the <c>queryAttachments</c> operation. Mirrors the
+    /// layer-root <c>supportsQueryAttachments</c> flag. The ArcGIS Maps SDK for
+    /// JavaScript reads this off the nested operations/advanced-query-capabilities
+    /// block when deciding whether <c>queryAttachments({where})</c> is permitted, and
+    /// it must stay consistent with the root flag (true when the layer has
+    /// attachments) so a layer that advertises attachments at the root is not refused
+    /// the operation because the nested flag reported false.
+    /// </summary>
+    public bool SupportsQueryAttachments { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Models/RelatedRecordGroup.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Models/RelatedRecordGroup.cs
@@ -19,8 +19,11 @@ public sealed class RelatedRecordGroup
     public required long ObjectId { get; init; }
 
     /// <summary>
-    /// Flat array of related records for this source feature. Omitted when the
-    /// source feature has no related records.
+    /// Flat array of related records for this source feature. Always emitted as an
+    /// array (empty when the source feature has no related rows) for the standard
+    /// queryRelatedRecords flow, because the @arcgis/core JS SDK reads
+    /// <c>group.relatedRecords.length</c> unconditionally. Omitted only for
+    /// <c>returnCountOnly=true</c> responses, which carry <see cref="Count"/> instead.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public GeoServicesFeature[]? RelatedRecords { get; init; }

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/RelatedRecordsService.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/RelatedRecordsService.cs
@@ -308,6 +308,11 @@ internal sealed class RelatedRecordsService : IRelatedRecordsService
             return new RelatedRecordGroup
             {
                 ObjectId = objectId,
+                // Always emit relatedRecords as an array (empty when the source object
+                // has no related rows). The @arcgis/core JS SDK reads
+                // group.relatedRecords.length unconditionally and throws
+                // "Cannot read properties of undefined (reading 'length')" when the key
+                // is absent, so an empty group must still carry relatedRecords: [].
                 RelatedRecords = hasRelatedFeatures && relatedCount > 0
                     ?
                     [
@@ -320,7 +325,7 @@ internal sealed class RelatedRecordsService : IRelatedRecordsService
                             outFieldSet,
                             effectiveGeometryLimits))
                     ]
-                    : null
+                    : []
             };
         }).ToArray();
 

--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerMetadataHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerMetadataHandler.cs
@@ -144,6 +144,11 @@ internal sealed class ImageServerMetadataHandler
                 FullExtent = BuildExtent(extent.Value),
                 InitialExtent = BuildExtent(extent.Value),
                 StorageInfo = BuildStorageInfo(),
+                // Esri's ImageServer root surfaces blockWidth/blockHeight both at the top
+                // level AND inside storageInfo. The ArcGIS Maps SDK for .NET
+                // ImageServiceRaster reads them from the root, so mirror them there (#1456).
+                BlockWidth = BlockWidth,
+                BlockHeight = BlockHeight,
                 SpatialReference = CreateSpatialReference(referenceRaster.Srid),
                 PixelSizeX = CalculatePixelSize(extent.Value, referenceRaster.Width),
                 PixelSizeY = CalculatePixelSize(extent.Value, referenceRaster.Height, isHeight: true),

--- a/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerModels.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerModels.cs
@@ -147,6 +147,25 @@ public sealed class ImageServerServiceInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ImageServerStorageInfo? StorageInfo { get; init; }
 
+    /// <summary>
+    /// Pixel-block width at the ImageServer metadata root. Esri's ImageServer root
+    /// surfaces <c>blockWidth</c> both at the top level AND inside <c>storageInfo</c>.
+    /// The ArcGIS Maps SDK for .NET <c>ImageServiceRaster</c> reads it from the root,
+    /// so it must be emitted there too, not only nested under <c>storageInfo</c> (#1456).
+    /// </summary>
+    [JsonPropertyName("blockWidth")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? BlockWidth { get; init; }
+
+    /// <summary>
+    /// Pixel-block height at the ImageServer metadata root. Mirrors the value inside
+    /// <c>storageInfo</c> for the ArcGIS Maps SDK for .NET <c>ImageServiceRaster</c>,
+    /// which reads it from the root (#1456).
+    /// </summary>
+    [JsonPropertyName("blockHeight")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? BlockHeight { get; init; }
+
     [JsonPropertyName("cacheType")]
     public string? CacheType { get; init; }
 

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -613,6 +613,8 @@ public static class EndpointRegistry
         new("POST", "/rest/services/{serviceId}/FeatureServer/{layerId}/calculate"),
         new("GET", "/rest/services/{serviceId}/FeatureServer/queryDomains"),
         new("GET", "/rest/services/{serviceId}/FeatureServer/relationships"),
+        new("GET", "/rest/services/{serviceId}/FeatureServer/validateSQL"),
+        new("POST", "/rest/services/{serviceId}/FeatureServer/validateSQL"),
         new("GET", "/rest/services/{serviceId}/FeatureServer/{layerId}/validateSQL"),
         new("POST", "/rest/services/{serviceId}/FeatureServer/{layerId}/validateSQL"),
         new("GET", "/rest/services/{serviceId}/FeatureServer/{layerId}/getEstimates"),

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerAccessFilteringTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerAccessFilteringTests.cs
@@ -122,6 +122,16 @@ public sealed class FeatureServerAccessFilteringTests
         root.GetProperty("supportsQueryAttachments").GetBoolean().Should().BeTrue();
         root.GetProperty("supportsAttachmentKeywords").GetBoolean().Should().BeTrue();
         root.GetProperty("supportsAttachmentsByUploadId").GetBoolean().Should().BeTrue();
+
+        // Regression for the operations-block inconsistency: the @arcgis/core JS SDK
+        // reads supportsQueryAttachments off the nested advancedQueryCapabilities
+        // (operations) block, not the root, when deciding whether queryAttachments({where})
+        // is permitted. The nested flag must match the root flag, otherwise a layer that
+        // advertises attachments at the root is refused the operation.
+        root.GetProperty("advancedQueryCapabilities")
+            .GetProperty("supportsQueryAttachments")
+            .GetBoolean()
+            .Should().BeTrue();
     }
 
     private static WebApplicationFactory<Program> CreateFactory()

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerMaintenanceTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerMaintenanceTests.cs
@@ -400,4 +400,112 @@ public sealed class FeatureServerMaintenanceTests : IAsyncLifetime
         using var document = JsonDocument.Parse(body);
         document.RootElement.GetProperty("isValidSQL").GetBoolean().Should().BeTrue();
     }
+
+    // #1446: Esri's canonical validateSQL is at the SERVICE level (no layerId) and takes
+    // sql + sqlType (one of where, orderBy, expression).
+    [IntegrationTest]
+    [Operation(Operations.ValidateSql)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/validateSQL")]
+    public async Task ServiceValidateSql_WhereType_ReturnsIsValid()
+    {
+        var content = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("sql", "objectid > 0"),
+            new KeyValuePair<string, string>("sqlType", "where"),
+            new KeyValuePair<string, string>("f", "json"),
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/validateSQL",
+            content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("isValidSQL").GetBoolean().Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ValidateSql)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/validateSQL")]
+    public async Task ServiceValidateSql_OrderByType_ReturnsIsValid()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/validateSQL?sql={Uri.EscapeDataString("objectid DESC")}&sqlType=orderBy&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("isValidSQL").GetBoolean().Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ValidateSql)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/validateSQL")]
+    public async Task ServiceValidateSql_ExpressionType_ReturnsIsValid()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/validateSQL?sql={Uri.EscapeDataString("objectid = 1")}&sqlType=expression&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("isValidSQL").GetBoolean().Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ValidateSql)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/validateSQL")]
+    public async Task ServiceValidateSql_DefaultsToWhenSqlTypeOmitted_ReturnsIsValid()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/validateSQL?sql={Uri.EscapeDataString("objectid > 0")}&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("isValidSQL").GetBoolean().Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ValidateSql)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/validateSQL")]
+    public async Task ServiceValidateSql_InvalidSqlType_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/validateSQL?sql={Uri.EscapeDataString("objectid > 0")}&sqlType=bogus&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ValidateSql)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/validateSQL")]
+    public async Task ServiceValidateSql_MissingSql_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/validateSQL?sqlType=where&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ValidateSql)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/validateSQL")]
+    public async Task ServiceValidateSql_InvalidWhere_ReturnsIsValidFalse()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/validateSQL?sql={Uri.EscapeDataString("INVALID %%%")}&sqlType=where&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("isValidSQL").GetBoolean().Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ValidateSql)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/validateSQL")]
+    public async Task ServiceValidateSql_NonExistentService_ReturnsNotFound()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/nonexistent/FeatureServer/validateSQL?sql={Uri.EscapeDataString("objectid > 0")}&sqlType=where&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicationTests.cs
@@ -302,21 +302,83 @@ public sealed class FeatureServerReplicationTests : IAsyncLifetime
         layerChanges.GetArrayLength().Should().BeGreaterThanOrEqualTo(1);
     }
 
+    // The serverGen-based change-tracking flow the ArcGIS SDK
+    // FeatureLayerCollection.extract_changes() uses calls extractChanges WITHOUT a
+    // replicaID. On a sync-enabled service this must return a valid changes envelope
+    // (since the provided serverGen) rather than 400.
     [IntegrationTest]
     [Operation(Operations.ExtractChanges)]
     [Endpoint("POST /rest/services/{serviceId}/FeatureServer/extractChanges")]
-    public async Task ExtractChanges_MissingReplicaId_ReturnsBadRequest()
+    public async Task ExtractChanges_WithoutReplicaId_ServerGenFlow_ReturnsChanges()
     {
-        var payload = JsonSerializer.Serialize(new { f = "json" });
+        var payload = JsonSerializer.Serialize(new
+        {
+            serverGen = 0,
+            layers = "0",
+            f = "json"
+        });
 
         var response = await _fixture.Client.PostAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/extractChanges",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
-        content.Should().Contain("replicaID");
+        using var document = JsonDocument.Parse(content);
+        var root = document.RootElement;
+
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+        // No replica was registered, so replicaID must be absent (or null).
+        if (root.TryGetProperty("replicaID", out var replicaIdElement))
+        {
+            replicaIdElement.ValueKind.Should().Be(JsonValueKind.Null);
+        }
+
+        root.TryGetProperty("layerChanges", out var layerChanges).Should().BeTrue();
+        layerChanges.ValueKind.Should().Be(JsonValueKind.Array);
+        layerChanges.GetArrayLength().Should().BeGreaterThanOrEqualTo(1);
+
+        // The change window is reported through serverGen/min/max for the serverGen flow.
+        root.TryGetProperty("serverGen", out _).Should().BeTrue();
+        root.TryGetProperty("minServerGen", out _).Should().BeTrue();
+        root.TryGetProperty("maxServerGen", out _).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ExtractChanges)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/extractChanges")]
+    public async Task ExtractChanges_WithoutReplicaId_ReturnIdsOnly_OmitsFeaturePayload()
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            serverGen = 0,
+            layers = "0",
+            returnIdsOnly = true,
+            f = "json"
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/extractChanges",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(content);
+        var root = document.RootElement;
+
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+        var layerChanges = root.GetProperty("layerChanges");
+        layerChanges.GetArrayLength().Should().BeGreaterThanOrEqualTo(1);
+
+        // returnIdsOnly suppresses the per-feature attribute payload; no addFeatures /
+        // updateFeatures arrays should be present.
+        foreach (var layer in layerChanges.EnumerateArray())
+        {
+            layer.TryGetProperty("addFeatures", out _).Should().BeFalse();
+            layer.TryGetProperty("updateFeatures", out _).Should().BeFalse();
+        }
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/RelatedRecordsServiceTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/RelatedRecordsServiceTests.cs
@@ -208,6 +208,59 @@ public sealed class RelatedRecordsServiceTests
         withoutRecords.RelatedRecords.Should().BeNull();
     }
 
+    // Regression: in the standard (non-count) queryRelatedRecords flow, a source object
+    // with no related rows must still carry relatedRecords as an empty array rather than
+    // null/omitted. The @arcgis/core JS SDK reads group.relatedRecords.length and throws
+    // "Cannot read properties of undefined (reading 'length')" otherwise.
+    [Fact]
+    public void GroupRelatedRecords_WithNoRelatedRows_EmitsEmptyRelatedRecordsArray()
+    {
+        var sut = CreateSut(Substitute.For<IRelationshipStore>());
+
+        var relationship = new MetadataV2Relationship
+        {
+            Id = "rel-1",
+            RelatedResourceId = "child",
+            OriginField = "objectid",
+            DestinationField = "parent_id"
+        };
+
+        // One related row belongs to object 1; object 2 has none.
+        var relatedFeature = Feature.Create(
+            10,
+            geometry: null,
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 10L,
+                ["parent_id"] = 1L,
+                ["label"] = "child-a"
+            }.ToImmutableDictionary());
+
+        var result = QueryResult<Feature>.Create(1, [relatedFeature]);
+
+        var grouped = sut.GroupRelatedRecords(
+            result,
+            objectIds: [1, 2],
+            relationship,
+            objectIdFieldName: "objectid",
+            returnGeometry: false,
+            outputSrid: null,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null,
+            outFields: null,
+            relatedResource: CreateRelatedResource());
+
+        var withRecords = grouped.Groups.Single(g => g.ObjectId == 1L);
+        withRecords.RelatedRecords.Should().NotBeNull();
+        withRecords.RelatedRecords!.Should().ContainSingle();
+
+        var withoutRecords = grouped.Groups.Single(g => g.ObjectId == 2L);
+        withoutRecords.RelatedRecords.Should().NotBeNull();
+        withoutRecords.RelatedRecords!.Should().BeEmpty();
+    }
+
     private static MetadataV2Resource CreateRelatedResource()
         => new()
         {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMetadataHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMetadataHandlerTests.cs
@@ -269,6 +269,12 @@ public class ImageServerMetadataHandlerTests
         info.StorageInfo!.BlockWidth.Should().BeGreaterThan(0);
         info.StorageInfo.BlockHeight.Should().BeGreaterThan(0);
 
+        // #1456: blockWidth/blockHeight must ALSO be surfaced at the metadata root, not
+        // only nested under storageInfo. The ArcGIS Maps SDK for .NET ImageServiceRaster
+        // reads them from the root, and the root values must match the storageInfo values.
+        info.BlockWidth.Should().Be(info.StorageInfo.BlockWidth);
+        info.BlockHeight.Should().Be(info.StorageInfo.BlockHeight);
+
         // Non-tiled service: no fused cache, so the SDK never requests conf.json.
         info.SingleFusedMapCache.Should().BeFalse();
         info.TileInfo.Should().BeNull();

--- a/tests/dotnet/Honua.Server.Tests/AttachmentEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/AttachmentEndpointTests.cs
@@ -71,6 +71,33 @@ public sealed class AttachmentEndpointTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.QueryAttachments)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryAttachments")]
+    public async Task QueryAttachments_AlwaysEmitsParentGlobalIdKey()
+    {
+        // Regression: the ArcGIS API for Python AttachmentManager.search() reads
+        // group['parentGlobalId'] unconditionally and raises KeyError when the key
+        // is absent. Esri always emits the key (empty string when there is no
+        // global-id column). Assert the raw JSON carries the key on every group,
+        // including groups with no attachments.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryAttachments?objectIds={TestFeatureId},999");
+
+        response.BeSuccessful();
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(content);
+        var groups = document.RootElement.GetProperty("attachmentGroups");
+        groups.GetArrayLength().Should().Be(2);
+        foreach (var group in groups.EnumerateArray())
+        {
+            group.TryGetProperty("parentGlobalId", out var parentGlobalId).Should().BeTrue(
+                "every attachment group must carry the parentGlobalId key");
+            parentGlobalId.ValueKind.Should().Be(JsonValueKind.String);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryAttachments)]
     [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/queryAttachments")]
     public async Task QueryAttachments_WithPost_ReturnsAttachments()
     {

--- a/tests/dotnet/Honua.Server.Tests/QueryRelatedRecordsEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/QueryRelatedRecordsEndpointTests.cs
@@ -758,7 +758,41 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
         queryResponse.Should().NotBeNull();
         queryResponse!.RelatedRecordGroups.Should().HaveCount(1);
         queryResponse.RelatedRecordGroups[0].ObjectId.Should().Be(999L);
-        queryResponse.RelatedRecordGroups[0].RelatedRecords.Should().BeNull();
+        // Even for a source object with no related rows, relatedRecords must be an empty
+        // array rather than null/absent.
+        queryResponse.RelatedRecordGroups[0].RelatedRecords.Should().NotBeNull();
+        queryResponse.RelatedRecordGroups[0].RelatedRecords.Should().BeEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryRelatedRecords)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryRelatedRecords")]
+    public async Task QueryRelatedRecords_EmptyGroupAlwaysEmitsRelatedRecordsArray()
+    {
+        // Regression: the @arcgis/core JS SDK reads group.relatedRecords.length
+        // unconditionally and throws "Cannot read properties of undefined (reading
+        // 'length')" when the key is absent. Every group (including objectIds with no
+        // related rows) must carry relatedRecords as an array. Mix an object with
+        // related rows (1) and one without (999) and assert the raw JSON.
+        var response = await GetWithRetryAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds=1,999&relationshipId={TestRelationshipId}");
+
+        response.Be200Ok();
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var jsonDoc = JsonDocument.Parse(content);
+        var groups = jsonDoc.RootElement.GetProperty("relatedRecordGroups");
+        groups.GetArrayLength().Should().Be(2);
+
+        foreach (var group in groups.EnumerateArray())
+        {
+            group.TryGetProperty("relatedRecords", out var relatedRecords).Should().BeTrue(
+                "every group must carry the relatedRecords key so group.relatedRecords.length is safe");
+            relatedRecords.ValueKind.Should().Be(JsonValueKind.Array);
+        }
+
+        var emptyGroup = groups.EnumerateArray().Single(g => g.GetProperty("objectId").GetInt64() == 999L);
+        emptyGroup.GetProperty("relatedRecords").GetArrayLength().Should().Be(0);
     }
 
     #endregion


### PR DESCRIPTION
## Issue Link
Related to #418
Fixes #1446
Fixes #1456

## Summary
Batch of six Esri GeoServices REST compatibility bugs surfaced by a real licensed Esri SDK certification run (ArcGIS API for Python, @arcgis/core JS, ArcGIS Maps SDK for .NET). Grouped into one PR to reduce CI congestion. Each was reproduced through a real Esri SDK and is fixed with regression tests.

## Changes Made
- **queryAttachments omits `parentGlobalId`** — the arcgis Python `AttachmentManager.search()` does `group['parentGlobalId']` and threw `KeyError`. `AttachmentGroup` now always emits `parentGlobalId` (empty string when the layer has no global-id column; the key is never omitted, per Esri convention).
- **queryAttachments capability-flag inconsistency** — layer-root `supportsQueryAttachments:true` but the nested `advancedQueryCapabilities` block reported `false`, so the @arcgis/core JS SDK refused `queryAttachments({where})`. The operations-block flag is now consistent with the root flag.
- **queryRelatedRecords empty groups omit `relatedRecords`** — the JS SDK did `group.relatedRecords.length` → `Cannot read properties of undefined`. Empty groups now always emit `relatedRecords: []` (count-only path unchanged).
- **extractChanges serverGen-only flow** — `POST …/FeatureServer/extractChanges` 400'd without a `replicaID`, but the ArcGIS SDK `extract_changes()` uses the no-replica serverGen flow. It now resolves layers (access-checked), reads the since-generation from `serverGen`/`serverGens`, runs the same incremental delta extraction, honors `returnIdsOnly`, and returns a valid envelope (replica path unchanged; no new route).
- **#1456 ImageServer `blockWidth`/`blockHeight` at root** — the ArcGIS Maps SDK for .NET `ImageServiceRaster` needs them at the top level of the ImageServer metadata, not only under `storageInfo`. Both are now surfaced at the root (and still in `storageInfo`).
- **#1446 service-level `validateSQL`** — Esri's canonical `validateSQL` is service-level with `sql`+`sqlType` (`where`/`orderBy`/`expression`); honua only had the layer-level `where` form. Added `GET`+`POST /rest/services/{serviceId}/FeatureServer/validateSQL` reusing the shared filter/orderBy validation; layer-level route retained. Registered both in `EndpointRegistry.cs`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Per-fix regression tests added across `Honua.Protocols.GeoServices.Tests` and `Honua.Server.Tests` (attachments parentGlobalId key, advancedQueryCapabilities flag, empty relatedRecords array, extractChanges serverGen flow + returnIdsOnly, ImageServer root block dims, service validateSQL per sqlType + error cases). Full-solution Release build `-p:TreatWarningsAsErrors=true` = **0/0**. Affected test classes green (ImageServer/RelatedRecords 23, AccessFiltering 4, Replication 19, Attachment/QueryRelatedRecords/Maintenance 60, governance drift/coverage 8). Bugs originally reproduced live through the Esri SDKs during certification.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

Additive GeoServices REST surface: one new service-level route + additional response fields (`parentGlobalId`, root `blockWidth`/`blockHeight`, empty `relatedRecords[]`). No existing response shapes change incompatibly.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None — all changes are additive (new accepted route, new/always-present response fields).

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
