### PR TITLE
feat(scene): CityGML building ingest with Building Scene Layer semantics (#1207)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -40,6 +40,7 @@
 - [Hosted 3D Tiles Scenes](gis/scenes-3dtiles.md)
 - [OpenUSD and Omniverse Export Path](gis/openusd-omniverse-export-path.md)
 - [Point Cloud, Drone, and Reality-Capture Ingest](gis/point-cloud-reality-capture-ingest.md)
+- [CityGML / BIM Building Scene Layer Ingest](gis/citygml-bim-building-scene-layer-ingest.md)
 - [3D Tiles Generation Pipeline](gis/scene-generation.md)
 - [Elevation Query and Profile API](gis/elevation-api.md)
 - [Known Limitations](gis/MVP_COMPATIBILITY_CONTRACT.md)

--- a/docs/gis/citygml-bim-building-scene-layer-ingest.md
+++ b/docs/gis/citygml-bim-building-scene-layer-ingest.md
@@ -1,0 +1,93 @@
+# CityGML / BIM Building Scene Layer Ingest
+
+This page documents the CityGML → 3D Tiles ingest pipeline with Building Scene
+Layer (BSL) semantics added for `honua-server#1207`. It covers the supported
+CityGML subset, how the building/storey/component hierarchy and attributes map
+onto the existing Honua scene pipeline, and the bounded follow-ups deferred from
+this first slice.
+
+## What this slice delivers
+
+A **pure-managed CityGML building reader** plus a **Building Scene Layer
+builder** that maps parsed building geometry and semantics onto Honua's existing
+[3D Tiles generation pipeline](scene-generation.md):
+
+- `CityGmlReader` (`Honua.Core.Features.Scene.Bim`) parses `bldg:Building`
+  features, their boundary surfaces, and the generic/CityGML attributes attached
+  at the building and surface levels into a `CityGmlModel` carrying the
+  building → storey → component hierarchy.
+- `BuildingSceneLayerBuilder` projects each boundary surface to the WGS-84
+  ellipsoid (via a caller-supplied geo-transform, mirroring the point-cloud
+  pipeline), emits one `SceneFeature` polygon per surface, and reuses
+  `GeometryTileBuilder` + `TilesetDocumentWriter` to produce a deterministic,
+  servable `tileset.json` plus one GLB tile.
+- BSL semantics (building id, storey id, surface type, **discipline / sub-layer**,
+  component id, and the parsed generic attributes) are carried **per feature**
+  through the existing `EXT_mesh_features` + `EXT_structural_metadata` glTF path,
+  so identify flows attribute hits back to the correct building component and
+  discipline.
+
+The output is byte-stable: features keep document order, BSL attribute columns
+are emitted in a fixed schema order, and the GLB/tileset writers are
+deterministic, so identical input produces identical bytes across runs.
+
+## Supported CityGML subset
+
+| Aspect | Supported in this slice |
+| --- | --- |
+| CityGML versions | 1.0 and 2.0 (namespace-tolerant; matches on XML local names) |
+| Feature classes | `bldg:Building`, `bldg:BuildingPart` |
+| Boundary surfaces | `WallSurface`, `RoofSurface`, `GroundSurface`, `ClosureSurface`, `CeilingSurface`, `FloorSurface`, `OuterCeilingSurface`, `OuterFloorSurface`, `InteriorWallSurface` |
+| Geometry | Exterior `gml:LinearRing` rings at any LOD (`lod1`/`lod2` multi-surfaces); `gml:posList` and `gml:pos` coordinate encodings |
+| Building semantics | `gml:name`, `bldg:storeysAboveGround`, `bldg:storeysBelowGround` |
+| Attributes | `gen:stringAttribute` / `gen:intAttribute` / `gen:doubleAttribute` / `gen:genericAttribute` at building and surface level (nested `<gen:value>` or direct text) |
+| CRS | Document CRS captured from the `gml:Envelope` `srsName`; coordinates are **not** transformed in-reader — the builder takes a projection delegate |
+
+### Discipline / sub-layer mapping
+
+Each boundary surface is classified into a BIM discipline (the Building Scene
+Layer sub-layer) so AEC clients can filter by discipline:
+
+| CityGML surface type | Discipline / sub-layer |
+| --- | --- |
+| `GroundSurface`, `FloorSurface`, `CeilingSurface`, `OuterFloorSurface`, `OuterCeilingSurface` | `Structural` |
+| `WallSurface`, `RoofSurface`, `ClosureSurface`, `InteriorWallSurface` | `Architectural` |
+
+The discipline, surface type, building id, storey id, and component id are each
+emitted as a dedicated `bsl_*` metadata property on every feature.
+
+## Limits and non-goals (this slice)
+
+- **CityGML only.** IFC and native BIM (`.ifc`, vendor BIM) are **not** parsed.
+  IFC is a large STEP/EXPRESS schema with no mainstream pure-managed reader and
+  is deferred (see follow-ups).
+- **Storey hierarchy is synthetic.** CityGML 2.0 has no first-class storey, so a
+  single whole-building storey is synthesised. Per-room/per-storey decomposition
+  from `bldg:Room` is a follow-up.
+- **Exterior rings only.** Interior rings (holes) are skipped; surfaces are
+  fan-triangulated by the shared `GeometryTileBuilder` (correct for convex
+  rings, deterministic for non-convex — the same documented v1 limitation as the
+  feature-layer scene path).
+- **No textures/appearances.** CityGML `app:Appearance` (textures, materials) is
+  not read.
+- **No in-reader CRS transform.** A projected-CRS document needs the caller to
+  supply an inverse-projection geo-transform; geographic documents pass through.
+- **No ingest endpoint yet.** This slice ships the reader + builder library and
+  unit tests. Wiring it behind an admin ingest executor + endpoint (mirroring
+  the feature-layer publish executor) is a tracked follow-up so it lands with the
+  full endpoint/operation registry + proof-ledger gates.
+
+## Deferred follow-ups
+
+- **IFC / native BIM reader** — `.ifc` STEP parsing and property-set mapping.
+- **Ingest executor + admin endpoint** — `POST` ingest path that streams an
+  uploaded CityGML document through the reader/builder, registers the resulting
+  tileset in the scene dataset registry, and gates on the Enterprise edition.
+- **Storey decomposition** — derive real storeys from `bldg:Room` /
+  `bldg:storey` so the BSL level sub-layer reflects the model.
+- **Interior rings + robust triangulation** — honour holes and use a proper
+  polygon triangulator shared with the feature-layer scene path.
+- **Appearances** — CityGML textures/materials → glTF PBR materials.
+- **Quadtree LOD** — large city models should partition through the existing
+  `SceneQuadtreePartitioner` rather than emit a single tile.
+```

--- a/src/Honua.Scene/Bim/BuildingSceneLayerBuilder.cs
+++ b/src/Honua.Scene/Bim/BuildingSceneLayerBuilder.cs
@@ -1,0 +1,298 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Domain;
+using Honua.Core.Features.Scene.Generation;
+
+namespace Honua.Core.Features.Scene.Bim;
+
+/// <summary>
+/// Converts a parsed <see cref="CityGmlModel"/> into a deterministic 3D Tiles
+/// tileset with Building Scene Layer (BSL) semantics (#1207): one GLB tile whose
+/// triangulated boundary surfaces carry per-feature BSL attributes (building id,
+/// storey, surface type, discipline / sub-layer, and the parsed generic
+/// attributes) through the existing <c>EXT_structural_metadata</c> path, plus a
+/// servable <c>tileset.json</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each CityGML boundary surface (wall / roof / ground / ...) becomes one
+/// <see cref="SceneFeature"/> polygon. The model's source coordinates are placed
+/// on the WGS-84 ellipsoid by a caller-supplied <see cref="CityGmlGeoTransform"/>
+/// (which interprets the document CRS), exactly mirroring how the point-cloud
+/// pipeline projects LAS coordinates. The resulting features are handed to the
+/// shared <see cref="GeometryTileBuilder"/> so geometry &#8594; ECEF projection,
+/// triangulation, and the per-feature metadata table are reused rather than
+/// reimplemented.
+/// </para>
+/// <para>
+/// Output is byte-stable: features keep document order, BSL attribute columns
+/// are emitted in a fixed schema order, and the GLB/tileset writers are
+/// deterministic, so identical input produces identical bytes across runs.
+/// </para>
+/// </remarks>
+public static class BuildingSceneLayerBuilder
+{
+    /// <summary>BSL attribute: the owning building's <c>gml:id</c>.</summary>
+    public const string AttributeBuildingId = "bsl_building_id";
+
+    /// <summary>BSL attribute: the owning building's name (when present).</summary>
+    public const string AttributeBuildingName = "bsl_building_name";
+
+    /// <summary>BSL attribute: the owning storey identifier (the BSL level sub-layer).</summary>
+    public const string AttributeStoreyId = "bsl_storey_id";
+
+    /// <summary>BSL attribute: the CityGML surface type (WallSurface, RoofSurface, ...).</summary>
+    public const string AttributeSurfaceType = "bsl_surface_type";
+
+    /// <summary>BSL attribute: the BIM discipline / Building Scene Layer sub-layer.</summary>
+    public const string AttributeDiscipline = "bsl_discipline";
+
+    /// <summary>BSL attribute: the boundary-surface component <c>gml:id</c>.</summary>
+    public const string AttributeComponentId = "bsl_component_id";
+
+    /// <summary>
+    /// Builds the deterministic tileset artifacts (tileset.json bytes plus the
+    /// GLB tile bytes) for a CityGML building model with BSL attributes.
+    /// </summary>
+    /// <param name="model">The parsed CityGML model. Must contain at least one surface.</param>
+    /// <param name="transform">Projects a model (x, y, z) to (lon&#176;, lat&#176;, heightMeters), interpreting the document CRS.</param>
+    /// <param name="generatorTag">Optional generator label for the tileset/GLB asset blocks.</param>
+    /// <returns>The deterministic BSL tileset artifacts.</returns>
+    /// <exception cref="ArgumentException">The model carries no boundary surfaces.</exception>
+    public static BuildingSceneLayerResult Build(
+        CityGmlModel model,
+        CityGmlGeoTransform transform,
+        string? generatorTag = null)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+        ArgumentNullException.ThrowIfNull(transform);
+
+        // 1. Flatten the BSL hierarchy into ordered polygon features, projecting
+        //    every vertex once and tracking the geographic envelope + the set of
+        //    generic attribute keys that need a metadata column.
+        var features = new List<SceneFeature>();
+        var genericKeys = new List<string>();
+        var seenGenericKeys = new HashSet<string>(StringComparer.Ordinal);
+
+        var west = double.PositiveInfinity;
+        var south = double.PositiveInfinity;
+        var east = double.NegativeInfinity;
+        var north = double.NegativeInfinity;
+        var minHeight = double.PositiveInfinity;
+        var maxHeight = double.NegativeInfinity;
+
+        long featureId = 0;
+        var buildingCount = 0;
+        var surfaceCount = 0;
+        var disciplines = new SortedSet<string>(StringComparer.Ordinal);
+
+        foreach (var building in model.Buildings)
+        {
+            buildingCount++;
+            foreach (var storey in building.Storeys)
+            {
+                foreach (var surface in storey.Surfaces)
+                {
+                    if (surface.Ring.Count < 3)
+                    {
+                        continue;
+                    }
+
+                    var vertices = new List<SceneVertex>(surface.Ring.Count);
+                    foreach (var v in surface.Ring)
+                    {
+                        var (lon, lat, height) = transform(v.X, v.Y, v.Z);
+                        vertices.Add(new SceneVertex(lon, lat, height));
+
+                        if (lon < west) west = lon;
+                        if (lat < south) south = lat;
+                        if (lon > east) east = lon;
+                        if (lat > north) north = lat;
+                        if (height < minHeight) minHeight = height;
+                        if (height > maxHeight) maxHeight = height;
+                    }
+
+                    var attributes = BuildAttributeBag(
+                        building, storey, surface, genericKeys, seenGenericKeys);
+
+                    features.Add(new SceneFeature
+                    {
+                        Id = featureId++,
+                        Geometry = new SceneFeatureGeometry
+                        {
+                            Kind = SceneGeometryKind.Polygon,
+                            Vertices = vertices
+                        },
+                        Attributes = attributes
+                    });
+                    surfaceCount++;
+                    disciplines.Add(surface.Discipline);
+                }
+            }
+        }
+
+        if (features.Count == 0)
+        {
+            throw new ArgumentException(
+                "CityGML model contains no boundary surfaces with at least three vertices.",
+                nameof(model));
+        }
+
+        // 2. Build the metadata schema: fixed BSL columns first (stable order),
+        //    then a STRING column per discovered generic attribute in first-seen
+        //    order so the layout is byte-identical across runs.
+        var schemas = BuildSchemas(genericKeys);
+
+        // 3. Hand off to the shared GLB writer (geometry -> ECEF, triangulation,
+        //    EXT_structural_metadata table) and the shared tileset writer.
+        var warnings = new List<string>();
+        var glb = GeometryTileBuilder.BuildGlb(
+            features,
+            schemas,
+            extrusion: null,
+            generatorTag,
+            warnings);
+
+        var bounds = new[] { west, south, east, north };
+        if (double.IsPositiveInfinity(minHeight)) minHeight = 0.0;
+        if (double.IsNegativeInfinity(maxHeight)) maxHeight = 0.0;
+        var geometricError = ComputeGeometricError(bounds, minHeight, maxHeight);
+
+        const string tileUri = "building_0000.glb";
+        var tileset = TilesetDocumentWriter.Build(
+            bounds,
+            minHeight,
+            maxHeight,
+            geometricError,
+            tileContentUris: [tileUri],
+            generatorTag);
+        var tilesetBytes = TilesetDocumentWriter.Serialize(tileset);
+
+        var tiles = new Dictionary<string, byte[]>(1, StringComparer.Ordinal) { [tileUri] = glb };
+
+        return new BuildingSceneLayerResult(
+            tilesetBytes,
+            tiles,
+            bounds,
+            buildingCount,
+            surfaceCount,
+            disciplines.ToArray(),
+            warnings.AsReadOnly());
+    }
+
+    private static Dictionary<string, object?> BuildAttributeBag(
+        CityGmlBuilding building,
+        CityGmlStorey storey,
+        CityGmlBoundarySurface surface,
+        List<string> genericKeys,
+        HashSet<string> seenGenericKeys)
+    {
+        var bag = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            [AttributeBuildingId] = building.Id,
+            [AttributeBuildingName] = building.Name ?? string.Empty,
+            [AttributeStoreyId] = storey.Id,
+            [AttributeSurfaceType] = surface.SurfaceType,
+            [AttributeDiscipline] = surface.Discipline,
+            [AttributeComponentId] = surface.Id
+        };
+
+        // Building-level generic attributes apply to every component; surface
+        // attributes override on collision (most specific wins).
+        foreach (var (key, value) in building.Attributes)
+        {
+            var column = GenericColumnName(key);
+            bag[column] = value;
+            TrackGenericKey(column, genericKeys, seenGenericKeys);
+        }
+        foreach (var (key, value) in surface.Attributes)
+        {
+            var column = GenericColumnName(key);
+            bag[column] = value;
+            TrackGenericKey(column, genericKeys, seenGenericKeys);
+        }
+
+        return bag;
+    }
+
+    private static void TrackGenericKey(string column, List<string> genericKeys, HashSet<string> seen)
+    {
+        if (seen.Add(column))
+        {
+            genericKeys.Add(column);
+        }
+    }
+
+    private static string GenericColumnName(string key) => "attr_" + key;
+
+    private static List<SceneAttributeSchema> BuildSchemas(List<string> genericKeys)
+    {
+        var schemas = new List<SceneAttributeSchema>(6 + genericKeys.Count)
+        {
+            StringSchema(AttributeBuildingId),
+            StringSchema(AttributeBuildingName),
+            StringSchema(AttributeStoreyId),
+            StringSchema(AttributeSurfaceType),
+            StringSchema(AttributeDiscipline),
+            StringSchema(AttributeComponentId)
+        };
+        foreach (var key in genericKeys)
+        {
+            schemas.Add(StringSchema(key));
+        }
+        return schemas;
+    }
+
+    private static SceneAttributeSchema StringSchema(string fieldName) => new()
+    {
+        PropertyId = fieldName,
+        FieldName = fieldName,
+        SchemaType = "STRING",
+        SchemaComponentType = string.Empty
+    };
+
+    private static double ComputeGeometricError(double[] bounds, double minHeight, double maxHeight)
+    {
+        var lonSpanRad = (bounds[2] - bounds[0]) * Math.PI / 180.0;
+        var latSpanRad = (bounds[3] - bounds[1]) * Math.PI / 180.0;
+        var lonMeters = Math.Abs(lonSpanRad) * EcefCoordinateTransform.WgsSemiMajorAxis
+            * Math.Cos((bounds[1] + bounds[3]) * 0.5 * Math.PI / 180.0);
+        var latMeters = Math.Abs(latSpanRad) * EcefCoordinateTransform.WgsSemiMajorAxis;
+        var heightMeters = Math.Max(0.0, maxHeight - minHeight);
+        var diagonal = Math.Sqrt(lonMeters * lonMeters + latMeters * latMeters + heightMeters * heightMeters);
+        return Math.Round(diagonal, 6, MidpointRounding.AwayFromZero);
+    }
+}
+
+/// <summary>
+/// Projects a CityGML model coordinate to (longitude&#176;, latitude&#176;,
+/// height m). Implementations interpret the document CRS (geographic documents
+/// pass through; projected documents apply the inverse projection).
+/// </summary>
+/// <param name="x">Model X in the document's horizontal units.</param>
+/// <param name="y">Model Y in the document's horizontal units.</param>
+/// <param name="z">Model Z (elevation) in meters.</param>
+/// <returns>Geographic longitude/latitude in degrees and ellipsoidal height in meters.</returns>
+public delegate (double Longitude, double Latitude, double Height) CityGmlGeoTransform(double x, double y, double z);
+
+/// <summary>
+/// Deterministic artifacts produced from a CityGML building model (#1207): the
+/// serialized <c>tileset.json</c> bytes, the GLB tile bytes, and BSL summary
+/// fields (building / surface counts and the discovered discipline sub-layers).
+/// </summary>
+/// <param name="TilesetJsonBytes">Serialized tileset document.</param>
+/// <param name="Tiles">Map of relative GLB uri to tile bytes.</param>
+/// <param name="BoundsDegrees">Dataset envelope [west, south, east, north] in degrees.</param>
+/// <param name="BuildingCount">Number of buildings ingested.</param>
+/// <param name="SurfaceCount">Number of boundary-surface components emitted.</param>
+/// <param name="Disciplines">Distinct BSL disciplines / sub-layers present, in sorted order.</param>
+/// <param name="Warnings">Non-fatal coercion warnings raised by the metadata writer.</param>
+public readonly record struct BuildingSceneLayerResult(
+    byte[] TilesetJsonBytes,
+    IReadOnlyDictionary<string, byte[]> Tiles,
+    double[] BoundsDegrees,
+    int BuildingCount,
+    int SurfaceCount,
+    IReadOnlyList<string> Disciplines,
+    IReadOnlyList<string> Warnings);

--- a/src/Honua.Scene/Bim/CityGmlModel.cs
+++ b/src/Honua.Scene/Bim/CityGmlModel.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Scene.Bim;
+
+/// <summary>
+/// In-memory representation of a parsed CityGML building model with Building
+/// Scene Layer (BSL) semantics (#1207). The model preserves the
+/// building &#8594; storey &#8594; component (boundary surface) hierarchy and the
+/// generic/CityGML attributes attached at each level so the tiling stage can
+/// emit them as per-feature metadata.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The model is intentionally format-neutral above the CityGML reader: it holds
+/// only ordered geometry (planar polygon rings in the source CRS) plus a flat
+/// attribute bag per component. The Building Scene Layer "sub-layer / discipline"
+/// structure is carried as the <see cref="CityGmlBoundarySurface.Discipline"/>
+/// classification (Architectural, Structural, ...) and the
+/// <see cref="CityGmlBoundarySurface.SurfaceType"/> (WallSurface, RoofSurface,
+/// GroundSurface, ...), which the builder surfaces as BSL attributes.
+/// </para>
+/// </remarks>
+public sealed record CityGmlModel
+{
+    /// <summary>Source CRS identifier (e.g. <c>urn:ogc:def:crs:EPSG::4979</c>) when declared, else null.</summary>
+    public string? SourceCrs { get; init; }
+
+    /// <summary>Whether the source CRS axis order is latitude/longitude (EPSG geographic default) rather than longitude/latitude.</summary>
+    public bool LatitudeFirst { get; init; }
+
+    /// <summary>Ordered buildings parsed from the document.</summary>
+    public required IReadOnlyList<CityGmlBuilding> Buildings { get; init; }
+}
+
+/// <summary>
+/// One CityGML building (<c>bldg:Building</c> or a nested <c>bldg:BuildingPart</c>
+/// flattened into the same building) with its storey breakdown and the
+/// generic/CityGML attributes parsed from the source.
+/// </summary>
+public sealed record CityGmlBuilding
+{
+    /// <summary>Stable building identifier (<c>gml:id</c>) used for BSL grouping and feature ids.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Human-readable name (<c>gml:name</c>) when present.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Declared number of storeys above ground, when present.</summary>
+    public int? StoreysAboveGround { get; init; }
+
+    /// <summary>Declared number of storeys below ground, when present.</summary>
+    public int? StoreysBelowGround { get; init; }
+
+    /// <summary>Parsed generic/CityGML attributes attached at the building level.</summary>
+    public IReadOnlyDictionary<string, string> Attributes { get; init; }
+        = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>Ordered storeys (BSL sub-layer level). Buildings without explicit storeys carry a single synthetic storey.</summary>
+    public required IReadOnlyList<CityGmlStorey> Storeys { get; init; }
+}
+
+/// <summary>
+/// A storey grouping within a building (the BSL "level" sub-layer). CityGML 2.0
+/// has no first-class storey class, so storeys are derived from
+/// <c>bldg:Room</c> grouping or synthesised as a single whole-building storey
+/// when no room decomposition exists.
+/// </summary>
+public sealed record CityGmlStorey
+{
+    /// <summary>Stable storey identifier used for BSL grouping and feature ids.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Human-readable storey name when present.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Ordered boundary surfaces (BSL components) within the storey.</summary>
+    public required IReadOnlyList<CityGmlBoundarySurface> Surfaces { get; init; }
+}
+
+/// <summary>
+/// A single boundary surface (BSL component): a planar polygon ring classified
+/// by CityGML surface type and mapped to a BIM discipline / sub-layer.
+/// </summary>
+public sealed record CityGmlBoundarySurface
+{
+    /// <summary>Stable surface identifier (<c>gml:id</c>) used for feature ids.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>CityGML surface type (e.g. <c>WallSurface</c>, <c>RoofSurface</c>, <c>GroundSurface</c>).</summary>
+    public required string SurfaceType { get; init; }
+
+    /// <summary>BIM discipline / Building Scene Layer sub-layer (e.g. <c>Architectural</c>, <c>Structural</c>).</summary>
+    public required string Discipline { get; init; }
+
+    /// <summary>Parsed generic attributes attached at the surface level.</summary>
+    public IReadOnlyDictionary<string, string> Attributes { get; init; }
+        = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>Ordered exterior ring vertices (source CRS, 3D). Inner rings are ignored in this slice.</summary>
+    public required IReadOnlyList<CityGmlVertex> Ring { get; init; }
+}
+
+/// <summary>
+/// A single 3D vertex in the source CRS units (degrees or projected meters,
+/// depending on the document CRS), with an elevation in meters.
+/// </summary>
+/// <param name="X">First ordinate (longitude or easting, per source CRS).</param>
+/// <param name="Y">Second ordinate (latitude or northing, per source CRS).</param>
+/// <param name="Z">Elevation in meters.</param>
+public readonly record struct CityGmlVertex(double X, double Y, double Z);

--- a/src/Honua.Scene/Bim/CityGmlReader.cs
+++ b/src/Honua.Scene/Bim/CityGmlReader.cs
@@ -1,0 +1,455 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Xml.Linq;
+using Honua.Core.Features.Scene.Domain;
+
+namespace Honua.Core.Features.Scene.Bim;
+
+/// <summary>
+/// Pure-managed reader for the CityGML building subset (#1207). Parses
+/// <c>bldg:Building</c> features, their boundary surfaces (<c>WallSurface</c> /
+/// <c>RoofSurface</c> / <c>GroundSurface</c> / ...) and the generic/CityGML
+/// attributes attached at the building and surface levels into a
+/// <see cref="CityGmlModel"/> carrying Building Scene Layer semantics.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The reader is namespace-tolerant: it matches on XML local names so a
+/// document may use either CityGML 1.0 (<c>http://www.opengis.net/citygml/1.0</c>)
+/// or 2.0 (<c>http://www.opengis.net/citygml/2.0</c>) namespace prefixes, and it
+/// reads <c>gml:posList</c> as well as the older <c>gml:pos</c> coordinate
+/// encoding. Geometry is taken from the boundary surfaces' exterior
+/// <c>gml:LinearRing</c>s at any LOD; inner rings are skipped (a documented v1
+/// limitation).
+/// </para>
+/// <para>
+/// The reader does not transform CRS; the BSL builder takes a caller-supplied
+/// projection delegate so a projected-CRS document can be placed on the
+/// ellipsoid by the tiling stage, mirroring the point-cloud pipeline. Output is
+/// deterministic: features keep document order. Parsing is hardened against XXE
+/// (no DTD processing, no external entity resolution).
+/// </para>
+/// </remarks>
+public static class CityGmlReader
+{
+    /// <summary>
+    /// Parses a CityGML document from a UTF-8 byte buffer into a
+    /// <see cref="CityGmlModel"/>.
+    /// </summary>
+    /// <param name="source">The CityGML document bytes (UTF-8 or BOM-prefixed).</param>
+    /// <returns>The parsed building model with BSL hierarchy and attributes.</returns>
+    /// <exception cref="CityGmlFormatException">The document is malformed or contains no parseable building geometry.</exception>
+    public static CityGmlModel Read(byte[] source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        using var stream = new MemoryStream(source, writable: false);
+        return Read(stream);
+    }
+
+    /// <summary>
+    /// Parses a CityGML document from a stream into a <see cref="CityGmlModel"/>.
+    /// </summary>
+    /// <param name="source">The CityGML document stream.</param>
+    /// <returns>The parsed building model with BSL hierarchy and attributes.</returns>
+    /// <exception cref="CityGmlFormatException">The document is malformed or contains no parseable building geometry.</exception>
+    public static CityGmlModel Read(Stream source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        XDocument document;
+        try
+        {
+            // LoadOptions.None + the default safe reader settings (DTD disabled,
+            // no external resolver) harden the parse against XXE; CityGML never
+            // relies on a DTD.
+            using var reader = System.Xml.XmlReader.Create(source, new System.Xml.XmlReaderSettings
+            {
+                DtdProcessing = System.Xml.DtdProcessing.Prohibit,
+                XmlResolver = null,
+                IgnoreComments = true,
+                IgnoreProcessingInstructions = true
+            });
+            document = XDocument.Load(reader);
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            throw new CityGmlFormatException(
+                SceneGenerationErrorCodes.ModelAssetInvalid,
+                "CityGML document is not well-formed XML.",
+                ex);
+        }
+
+        var root = document.Root
+            ?? throw new CityGmlFormatException(
+                SceneGenerationErrorCodes.ModelAssetInvalid,
+                "CityGML document is empty.");
+
+        var sourceCrs = root.Descendants()
+            .FirstOrDefault(e => e.Name.LocalName == "Envelope")?
+            .Attribute("srsName")?.Value;
+        var latitudeFirst = IsLatitudeFirst(sourceCrs);
+
+        var buildings = new List<CityGmlBuilding>();
+        foreach (var element in root.Descendants())
+        {
+            if (element.Name.LocalName is not ("Building" or "BuildingPart"))
+            {
+                continue;
+            }
+
+            var building = ReadBuilding(element);
+            if (building is not null)
+            {
+                buildings.Add(building);
+            }
+        }
+
+        if (buildings.Count == 0)
+        {
+            throw new CityGmlFormatException(
+                SceneGenerationErrorCodes.ModelAssetInvalid,
+                "CityGML document contains no parseable bldg:Building geometry.");
+        }
+
+        return new CityGmlModel
+        {
+            SourceCrs = sourceCrs,
+            LatitudeFirst = latitudeFirst,
+            Buildings = buildings
+        };
+    }
+
+    private static CityGmlBuilding? ReadBuilding(XElement element)
+    {
+        var id = GmlId(element) ?? $"building-{Guid.NewGuid():N}";
+
+        string? name = null;
+        int? storeysAbove = null;
+        int? storeysBelow = null;
+        var attributes = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        // Direct (non-descendant) children give the building-level metadata; a
+        // nested BuildingPart's own surfaces are handled when the descendant
+        // walk reaches that BuildingPart element separately.
+        foreach (var child in element.Elements())
+        {
+            switch (child.Name.LocalName)
+            {
+                case "name" when name is null:
+                    name = Trim(child.Value);
+                    break;
+                case "storeysAboveGround":
+                    storeysAbove = ParseInt(child.Value);
+                    break;
+                case "storeysBelowGround":
+                    storeysBelow = ParseInt(child.Value);
+                    break;
+                case "stringAttribute":
+                case "intAttribute":
+                case "doubleAttribute":
+                case "genericAttribute":
+                    ReadGenericAttribute(child, attributes);
+                    break;
+            }
+        }
+
+        var surfaces = new List<CityGmlBoundarySurface>();
+        // Collect boundary surfaces owned by THIS building only — stop the walk
+        // at any nested Building/BuildingPart so a part's surfaces are not
+        // double-counted (the descendant pass over the document handles parts).
+        foreach (var surfaceElement in DescendantsUntilNestedBuilding(element))
+        {
+            if (IsBoundarySurfaceType(surfaceElement.Name.LocalName))
+            {
+                ReadBoundarySurface(surfaceElement, surfaces);
+            }
+        }
+
+        if (surfaces.Count == 0)
+        {
+            return null;
+        }
+
+        // CityGML 2.0 has no first-class storey; synthesise a single
+        // whole-building storey so the BSL hierarchy stays building -> storey ->
+        // component. Storey decomposition from bldg:Room is a tracked follow-up.
+        var storey = new CityGmlStorey
+        {
+            Id = $"{id}-storey-1",
+            Name = storeysAbove is { } above ? $"Storeys above ground: {above}" : null,
+            Surfaces = surfaces
+        };
+
+        return new CityGmlBuilding
+        {
+            Id = id,
+            Name = name,
+            StoreysAboveGround = storeysAbove,
+            StoreysBelowGround = storeysBelow,
+            Attributes = attributes,
+            Storeys = new[] { storey }
+        };
+    }
+
+    /// <summary>
+    /// Yields descendants of <paramref name="building"/> without crossing into a
+    /// nested <c>Building</c>/<c>BuildingPart</c> subtree (those are processed by
+    /// the top-level descendant walk so their surfaces are attributed to the
+    /// correct owner).
+    /// </summary>
+    private static IEnumerable<XElement> DescendantsUntilNestedBuilding(XElement building)
+    {
+        foreach (var child in building.Elements())
+        {
+            if (child.Name.LocalName is "Building" or "BuildingPart")
+            {
+                continue;
+            }
+            yield return child;
+            foreach (var nested in DescendantsUntilNestedBuilding(child))
+            {
+                yield return nested;
+            }
+        }
+    }
+
+    private static void ReadBoundarySurface(XElement element, List<CityGmlBoundarySurface> sink)
+    {
+        var surfaceType = element.Name.LocalName;
+        var discipline = MapDiscipline(surfaceType);
+        var baseId = GmlId(element) ?? $"{surfaceType}-{sink.Count}";
+
+        var attributes = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var child in element.Elements())
+        {
+            if (child.Name.LocalName is "stringAttribute" or "intAttribute"
+                or "doubleAttribute" or "genericAttribute")
+            {
+                ReadGenericAttribute(child, attributes);
+            }
+        }
+
+        // Each exterior LinearRing under the surface becomes one BSL component
+        // feature. gml:exterior selects the outer ring; interior holes are
+        // skipped in this slice.
+        var ringIndex = 0;
+        foreach (var ringElement in element.Descendants().Where(e => e.Name.LocalName == "LinearRing"))
+        {
+            if (IsInteriorRing(ringElement))
+            {
+                continue;
+            }
+
+            var ring = ReadLinearRing(ringElement);
+            if (ring.Count < 3)
+            {
+                continue;
+            }
+
+            sink.Add(new CityGmlBoundarySurface
+            {
+                Id = ringIndex == 0 ? baseId : $"{baseId}-{ringIndex}",
+                SurfaceType = surfaceType,
+                Discipline = discipline,
+                Attributes = attributes,
+                Ring = ring
+            });
+            ringIndex++;
+        }
+    }
+
+    private static bool IsInteriorRing(XElement ring)
+    {
+        // A LinearRing nested under a gml:interior is a hole; skip it.
+        for (var parent = ring.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (parent.Name.LocalName == "interior")
+            {
+                return true;
+            }
+            if (parent.Name.LocalName == "exterior" || parent.Name.LocalName == "Polygon")
+            {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private static List<CityGmlVertex> ReadLinearRing(XElement ring)
+    {
+        var vertices = new List<CityGmlVertex>();
+        foreach (var child in ring.Elements())
+        {
+            switch (child.Name.LocalName)
+            {
+                case "posList":
+                    var dim = ParseInt(child.Attribute("srsDimension")?.Value) ?? 3;
+                    AppendPosList(child.Value, dim, vertices);
+                    break;
+                case "pos":
+                    AppendPos(child.Value, vertices);
+                    break;
+            }
+        }
+        return vertices;
+    }
+
+    private static void AppendPosList(string? text, int dimension, List<CityGmlVertex> sink)
+    {
+        if (string.IsNullOrWhiteSpace(text) || dimension < 2)
+        {
+            return;
+        }
+
+        var tokens = text.Split(
+            (char[]?)null,
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        for (var i = 0; i + dimension - 1 < tokens.Length; i += dimension)
+        {
+            if (!TryParseDouble(tokens[i], out var x) || !TryParseDouble(tokens[i + 1], out var y))
+            {
+                continue;
+            }
+            var z = 0.0;
+            if (dimension >= 3)
+            {
+                _ = TryParseDouble(tokens[i + 2], out z);
+            }
+            sink.Add(new CityGmlVertex(x, y, z));
+        }
+    }
+
+    private static void AppendPos(string? text, List<CityGmlVertex> sink)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        var tokens = text.Split(
+            (char[]?)null,
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (tokens.Length < 2
+            || !TryParseDouble(tokens[0], out var x)
+            || !TryParseDouble(tokens[1], out var y))
+        {
+            return;
+        }
+        var z = 0.0;
+        if (tokens.Length >= 3)
+        {
+            _ = TryParseDouble(tokens[2], out z);
+        }
+        sink.Add(new CityGmlVertex(x, y, z));
+    }
+
+    private static void ReadGenericAttribute(XElement element, Dictionary<string, string> sink)
+    {
+        var name = element.Attribute("name")?.Value;
+        if (string.IsNullOrEmpty(name))
+        {
+            return;
+        }
+
+        // CityGML generic attributes carry their value either as a nested
+        // <gen:value> element (1.0 style) or as direct text content (the common
+        // gen:stringAttribute form). Prefer the nested value when present.
+        var valueElement = element.Elements().FirstOrDefault(e => e.Name.LocalName == "value");
+        var value = valueElement is not null ? Trim(valueElement.Value) : Trim(element.Value);
+        if (!string.IsNullOrEmpty(value))
+        {
+            sink[name] = value;
+        }
+    }
+
+    /// <summary>
+    /// Maps a CityGML surface type to a BIM discipline / Building Scene Layer
+    /// sub-layer. Architectural envelope surfaces map to <c>Architectural</c>;
+    /// load-bearing slabs (ground/floor/ceiling) map to <c>Structural</c>.
+    /// </summary>
+    private static string MapDiscipline(string surfaceType) => surfaceType switch
+    {
+        "GroundSurface" => "Structural",
+        "FloorSurface" => "Structural",
+        "CeilingSurface" => "Structural",
+        "OuterFloorSurface" => "Structural",
+        "OuterCeilingSurface" => "Structural",
+        _ => "Architectural"
+    };
+
+    private static bool IsBoundarySurfaceType(string localName) => localName switch
+    {
+        "WallSurface" => true,
+        "RoofSurface" => true,
+        "GroundSurface" => true,
+        "ClosureSurface" => true,
+        "OuterCeilingSurface" => true,
+        "OuterFloorSurface" => true,
+        "CeilingSurface" => true,
+        "FloorSurface" => true,
+        "InteriorWallSurface" => true,
+        _ => false
+    };
+
+    private static string? GmlId(XElement element)
+        => element.Attributes().FirstOrDefault(a => a.Name.LocalName == "id")?.Value;
+
+    private static bool IsLatitudeFirst(string? srsName)
+    {
+        if (string.IsNullOrEmpty(srsName))
+        {
+            return false;
+        }
+
+        // EPSG geographic CRS (4326/4979) declare latitude-first axis order in
+        // their authoritative definition; many CityGML producers honor that for
+        // urn-form srsName. EPSG:4326 short form and projected CRS stay
+        // longitude/easting-first.
+        return srsName.Contains("EPSG::4326", StringComparison.OrdinalIgnoreCase)
+            || srsName.Contains("EPSG::4979", StringComparison.OrdinalIgnoreCase)
+            || srsName.Contains("EPSG:4979", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Trim(string value) => value.Trim();
+
+    private static int? ParseInt(string? text)
+        => int.TryParse(text?.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+            ? value
+            : null;
+
+    private static bool TryParseDouble(string token, out double value)
+        => double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+}
+
+/// <summary>
+/// Raised when a CityGML buffer is malformed or carries no parseable building
+/// geometry. Carries a stable <see cref="SceneGenerationErrorCodes"/> code so an
+/// ingest executor can surface a problem-detail without leaking parser internals.
+/// </summary>
+public sealed class CityGmlFormatException : Exception
+{
+    /// <summary>Creates a <see cref="CityGmlFormatException"/>.</summary>
+    /// <param name="code">Stable scene error code (see <see cref="SceneGenerationErrorCodes"/>).</param>
+    /// <param name="message">Human-readable, non-sensitive description.</param>
+    public CityGmlFormatException(string code, string message)
+        : base(message)
+    {
+        Code = code;
+    }
+
+    /// <summary>Creates a <see cref="CityGmlFormatException"/> wrapping an inner cause.</summary>
+    /// <param name="code">Stable scene error code (see <see cref="SceneGenerationErrorCodes"/>).</param>
+    /// <param name="message">Human-readable, non-sensitive description.</param>
+    /// <param name="innerException">The underlying parse failure.</param>
+    public CityGmlFormatException(string code, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        Code = code;
+    }
+
+    /// <summary>Stable error code forwarded through problem-detail helpers.</summary>
+    public string Code { get; }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Bim/BuildingSceneLayerBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Bim/BuildingSceneLayerBuilderTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.Scene.Bim;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.Bim;
+
+/// <summary>
+/// End-to-end unit tests for the CityGML -> 3D Tiles Building Scene Layer
+/// pipeline (#1207): reader -> BSL builder -> tileset + GLB with per-feature
+/// BSL attributes carried through EXT_structural_metadata.
+/// </summary>
+public sealed class BuildingSceneLayerBuilderTests
+{
+    // Treat CityGML X/Y as longitude/latitude degrees directly so the test does
+    // not depend on a projected-CRS transform.
+    private static (double, double, double) IdentityGeo(double x, double y, double z) => (x, y, z);
+
+    [UnitTest]
+    public void Build_FixtureBuilding_ProducesServableTileset()
+    {
+        var model = CityGmlReader.Read(CityGmlFixtures.SingleBuilding());
+
+        var result = BuildingSceneLayerBuilder.Build(model, IdentityGeo, "honua-test");
+
+        result.BuildingCount.Should().Be(1);
+        result.SurfaceCount.Should().Be(4);
+        result.Disciplines.Should().BeEquivalentTo(["Architectural", "Structural"]);
+        result.Tiles.Should().ContainKey("building_0000.glb");
+
+        using var json = JsonDocument.Parse(Encoding.UTF8.GetString(result.TilesetJsonBytes));
+        json.RootElement.GetProperty("asset").GetProperty("version").GetString().Should().Be("1.1");
+        var uri = json.RootElement.GetProperty("root")
+            .GetProperty("children")[0].GetProperty("content").GetProperty("uri").GetString();
+        uri.Should().Be("building_0000.glb");
+        result.Tiles.Should().ContainKey(uri!);
+    }
+
+    [UnitTest]
+    public void Build_Glb_CarriesBslAttributeColumnsInStructuralMetadata()
+    {
+        var model = CityGmlReader.Read(CityGmlFixtures.SingleBuilding());
+        var result = BuildingSceneLayerBuilder.Build(model, IdentityGeo, "honua-test");
+
+        var schema = ExtractStructuralMetadataSchema(result.Tiles["building_0000.glb"]);
+        var properties = schema.GetProperty("classes")
+            .GetProperty("honua_feature_class")
+            .GetProperty("properties");
+
+        // Fixed BSL columns.
+        properties.TryGetProperty(BuildingSceneLayerBuilder.AttributeBuildingId, out _).Should().BeTrue();
+        properties.TryGetProperty(BuildingSceneLayerBuilder.AttributeStoreyId, out _).Should().BeTrue();
+        properties.TryGetProperty(BuildingSceneLayerBuilder.AttributeSurfaceType, out _).Should().BeTrue();
+        properties.TryGetProperty(BuildingSceneLayerBuilder.AttributeDiscipline, out _).Should().BeTrue();
+        properties.TryGetProperty(BuildingSceneLayerBuilder.AttributeComponentId, out _).Should().BeTrue();
+
+        // Discovered generic attributes are surfaced as attr_-prefixed columns.
+        properties.TryGetProperty("attr_usage", out _).Should().BeTrue();
+        properties.TryGetProperty("attr_material", out _).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Build_FeatureCount_MatchesBoundarySurfaceCount()
+    {
+        var model = CityGmlReader.Read(CityGmlFixtures.SingleBuilding());
+        var result = BuildingSceneLayerBuilder.Build(model, IdentityGeo);
+
+        var propertyTable = ExtractFirstPropertyTable(result.Tiles["building_0000.glb"]);
+        propertyTable.GetProperty("count").GetInt32().Should().Be(result.SurfaceCount);
+    }
+
+    [UnitTest]
+    public void Build_IsDeterministic_ByteIdenticalAcrossRuns()
+    {
+        var model = CityGmlReader.Read(CityGmlFixtures.SingleBuilding());
+
+        var a = BuildingSceneLayerBuilder.Build(model, IdentityGeo, "honua");
+        var b = BuildingSceneLayerBuilder.Build(model, IdentityGeo, "honua");
+
+        a.TilesetJsonBytes.Should().Equal(b.TilesetJsonBytes);
+        a.Tiles["building_0000.glb"].Should().Equal(b.Tiles["building_0000.glb"]);
+    }
+
+    [UnitTest]
+    public void Build_GlbHeader_IsValidGlb2()
+    {
+        var model = CityGmlReader.Read(CityGmlFixtures.SingleBuilding());
+        var result = BuildingSceneLayerBuilder.Build(model, IdentityGeo);
+
+        var glb = result.Tiles["building_0000.glb"];
+        glb.Length.Should().BeGreaterThan(12);
+        Encoding.ASCII.GetString(glb, 0, 4).Should().Be("glTF");
+        System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(glb.AsSpan(4, 4)).Should().Be(2u);
+    }
+
+    [UnitTest]
+    public void Build_BoundsDegrees_EncloseTheBuilding()
+    {
+        var model = CityGmlReader.Read(CityGmlFixtures.SingleBuilding());
+        var result = BuildingSceneLayerBuilder.Build(model, IdentityGeo);
+
+        result.BoundsDegrees.Should().Equal(0.0, 0.0, 0.001, 0.001);
+    }
+
+    // ---- GLB parsing helpers (JSON chunk only) ----
+
+    private static JsonDocument ParseGlbJsonChunk(byte[] glb)
+    {
+        // GLB: 12-byte header, then chunk header (4 length + 4 type) + chunk body.
+        var jsonLen = (int)System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(glb.AsSpan(12, 4));
+        var json = Encoding.UTF8.GetString(glb, 20, jsonLen).TrimEnd('\0', ' ');
+        return JsonDocument.Parse(json);
+    }
+
+    private static JsonElement ExtractStructuralMetadataSchema(byte[] glb)
+    {
+        using var doc = ParseGlbJsonChunk(glb);
+        return doc.RootElement
+            .GetProperty("extensions")
+            .GetProperty("EXT_structural_metadata")
+            .GetProperty("schema")
+            .Clone();
+    }
+
+    private static JsonElement ExtractFirstPropertyTable(byte[] glb)
+    {
+        using var doc = ParseGlbJsonChunk(glb);
+        return doc.RootElement
+            .GetProperty("extensions")
+            .GetProperty("EXT_structural_metadata")
+            .GetProperty("propertyTables")[0]
+            .Clone();
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Bim/CityGmlFixtures.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Bim/CityGmlFixtures.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+
+namespace Honua.Core.Tests.Features.Scene.Bim;
+
+/// <summary>
+/// Inline CityGML 2.0 documents for the building ingest tests (#1207). Kept in
+/// source (rather than as committed binary/large fixtures) so the exact XML the
+/// reader parses is visible alongside the assertions, mirroring the point-cloud
+/// LAS fixture builder.
+/// </summary>
+internal static class CityGmlFixtures
+{
+    /// <summary>
+    /// A minimal CityGML 2.0 city model with one building made of a ground, a
+    /// roof, and two wall surfaces, carrying both a building-level generic
+    /// attribute and storey counts. Coordinates are small lon/lat degrees near
+    /// the origin so an identity geo-transform places them on the ellipsoid.
+    /// </summary>
+    public static byte[] SingleBuilding()
+    {
+        const string xml = """
+<?xml version="1.0" encoding="UTF-8"?>
+<core:CityModel
+    xmlns:core="http://www.opengis.net/citygml/2.0"
+    xmlns:bldg="http://www.opengis.net/citygml/building/2.0"
+    xmlns:gen="http://www.opengis.net/citygml/generics/2.0"
+    xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326" srsDimension="3">
+      <gml:lowerCorner>0.0 0.0 0.0</gml:lowerCorner>
+      <gml:upperCorner>0.001 0.001 10.0</gml:upperCorner>
+    </gml:Envelope>
+  </gml:boundedBy>
+  <core:cityObjectMember>
+    <bldg:Building gml:id="BLDG_1">
+      <gml:name>Test Tower</gml:name>
+      <bldg:storeysAboveGround>3</bldg:storeysAboveGround>
+      <gen:stringAttribute name="usage">office</gen:stringAttribute>
+      <bldg:boundedBy>
+        <bldg:GroundSurface gml:id="GND_1">
+          <bldg:lod2MultiSurface>
+            <gml:MultiSurface>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList srsDimension="3">0.0 0.0 0.0 0.001 0.0 0.0 0.001 0.001 0.0 0.0 0.001 0.0 0.0 0.0 0.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+            </gml:MultiSurface>
+          </bldg:lod2MultiSurface>
+        </bldg:GroundSurface>
+      </bldg:boundedBy>
+      <bldg:boundedBy>
+        <bldg:RoofSurface gml:id="ROOF_1">
+          <gen:stringAttribute name="material">concrete</gen:stringAttribute>
+          <bldg:lod2MultiSurface>
+            <gml:MultiSurface>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList srsDimension="3">0.0 0.0 10.0 0.001 0.0 10.0 0.001 0.001 10.0 0.0 0.001 10.0 0.0 0.0 10.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+            </gml:MultiSurface>
+          </bldg:lod2MultiSurface>
+        </bldg:RoofSurface>
+      </bldg:boundedBy>
+      <bldg:boundedBy>
+        <bldg:WallSurface gml:id="WALL_1">
+          <bldg:lod2MultiSurface>
+            <gml:MultiSurface>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList srsDimension="3">0.0 0.0 0.0 0.001 0.0 0.0 0.001 0.0 10.0 0.0 0.0 10.0 0.0 0.0 0.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+            </gml:MultiSurface>
+          </bldg:lod2MultiSurface>
+        </bldg:WallSurface>
+      </bldg:boundedBy>
+      <bldg:boundedBy>
+        <bldg:WallSurface gml:id="WALL_2">
+          <bldg:lod2MultiSurface>
+            <gml:MultiSurface>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList srsDimension="3">0.001 0.0 0.0 0.001 0.001 0.0 0.001 0.001 10.0 0.001 0.0 10.0 0.001 0.0 0.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+            </gml:MultiSurface>
+          </bldg:lod2MultiSurface>
+        </bldg:WallSurface>
+      </bldg:boundedBy>
+    </bldg:Building>
+  </core:cityObjectMember>
+</core:CityModel>
+""";
+        return Encoding.UTF8.GetBytes(xml);
+    }
+
+    /// <summary>
+    /// A document using the older <c>gml:pos</c> coordinate encoding (one pos
+    /// element per vertex) to exercise that parse path.
+    /// </summary>
+    public static byte[] GmlPosEncoding()
+    {
+        const string xml = """
+<?xml version="1.0" encoding="UTF-8"?>
+<core:CityModel
+    xmlns:core="http://www.opengis.net/citygml/1.0"
+    xmlns:bldg="http://www.opengis.net/citygml/building/1.0"
+    xmlns:gml="http://www.opengis.net/gml">
+  <core:cityObjectMember>
+    <bldg:Building gml:id="BLDG_POS">
+      <bldg:boundedBy>
+        <bldg:GroundSurface gml:id="GND_POS">
+          <bldg:lod1MultiSurface>
+            <gml:MultiSurface>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:pos>0.0 0.0 0.0</gml:pos>
+                      <gml:pos>0.002 0.0 0.0</gml:pos>
+                      <gml:pos>0.002 0.002 0.0</gml:pos>
+                      <gml:pos>0.0 0.0 0.0</gml:pos>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+            </gml:MultiSurface>
+          </bldg:lod1MultiSurface>
+        </bldg:GroundSurface>
+      </bldg:boundedBy>
+    </bldg:Building>
+  </core:cityObjectMember>
+</core:CityModel>
+""";
+        return Encoding.UTF8.GetBytes(xml);
+    }
+
+    /// <summary>A document with no building geometry, to exercise the empty-input rejection.</summary>
+    public static byte[] NoBuildings()
+    {
+        const string xml = """
+<?xml version="1.0" encoding="UTF-8"?>
+<core:CityModel
+    xmlns:core="http://www.opengis.net/citygml/2.0"
+    xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"/>
+  </gml:boundedBy>
+</core:CityModel>
+""";
+        return Encoding.UTF8.GetBytes(xml);
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Bim/CityGmlReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Bim/CityGmlReaderTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Bim;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.Bim;
+
+/// <summary>
+/// Unit tests for the pure-managed CityGML building reader (#1207).
+/// </summary>
+public sealed class CityGmlReaderTests
+{
+    [UnitTest]
+    public void Read_SingleBuilding_ParsesHierarchyAndAttributes()
+    {
+        var model = CityGmlReader.Read(CityGmlFixtures.SingleBuilding());
+
+        model.SourceCrs.Should().Be("urn:ogc:def:crs:EPSG::4326");
+        model.Buildings.Should().HaveCount(1);
+
+        var building = model.Buildings[0];
+        building.Id.Should().Be("BLDG_1");
+        building.Name.Should().Be("Test Tower");
+        building.StoreysAboveGround.Should().Be(3);
+        building.Attributes.Should().ContainKey("usage").WhoseValue.Should().Be("office");
+
+        building.Storeys.Should().HaveCount(1);
+        var storey = building.Storeys[0];
+        storey.Surfaces.Should().HaveCount(4);
+        storey.Surfaces.Select(s => s.SurfaceType).Should()
+            .ContainInOrder("GroundSurface", "RoofSurface", "WallSurface", "WallSurface");
+    }
+
+    [UnitTest]
+    public void Read_GroundSurface_MapsToStructuralDiscipline()
+    {
+        var model = CityGmlReader.Read(CityGmlFixtures.SingleBuilding());
+        var surfaces = model.Buildings[0].Storeys[0].Surfaces;
+
+        var ground = surfaces.Single(s => s.SurfaceType == "GroundSurface");
+        ground.Discipline.Should().Be("Structural");
+
+        var walls = surfaces.Where(s => s.SurfaceType == "WallSurface");
+        walls.Should().OnlyContain(s => s.Discipline == "Architectural");
+    }
+
+    [UnitTest]
+    public void Read_SurfaceLevelGenericAttribute_IsParsed()
+    {
+        var model = CityGmlReader.Read(CityGmlFixtures.SingleBuilding());
+        var roof = model.Buildings[0].Storeys[0].Surfaces.Single(s => s.SurfaceType == "RoofSurface");
+
+        roof.Attributes.Should().ContainKey("material").WhoseValue.Should().Be("concrete");
+    }
+
+    [UnitTest]
+    public void Read_PosListRing_DecodesEveryVertex()
+    {
+        var model = CityGmlReader.Read(CityGmlFixtures.SingleBuilding());
+        var ground = model.Buildings[0].Storeys[0].Surfaces.Single(s => s.SurfaceType == "GroundSurface");
+
+        // The closed ring has 5 posList tuples; the reader keeps them verbatim.
+        ground.Ring.Should().HaveCount(5);
+        ground.Ring[0].Should().Be(new CityGmlVertex(0.0, 0.0, 0.0));
+        ground.Ring[2].Should().Be(new CityGmlVertex(0.001, 0.001, 0.0));
+    }
+
+    [UnitTest]
+    public void Read_GmlPosEncoding_ParsesIndividualPositions()
+    {
+        var model = CityGmlReader.Read(CityGmlFixtures.GmlPosEncoding());
+        var ground = model.Buildings[0].Storeys[0].Surfaces.Single();
+
+        ground.Ring.Should().HaveCount(4);
+        ground.Ring[1].Should().Be(new CityGmlVertex(0.002, 0.0, 0.0));
+    }
+
+    [UnitTest]
+    public void Read_NoBuildings_Throws()
+    {
+        var act = () => CityGmlReader.Read(CityGmlFixtures.NoBuildings());
+
+        act.Should().Throw<CityGmlFormatException>()
+            .Which.Code.Should().Be("SCENE_MODEL_ASSET_INVALID");
+    }
+
+    [UnitTest]
+    public void Read_MalformedXml_Throws()
+    {
+        var act = () => CityGmlReader.Read("<not-closed"u8.ToArray());
+
+        act.Should().Throw<CityGmlFormatException>()
+            .Which.Code.Should().Be("SCENE_MODEL_ASSET_INVALID");
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1207

## Summary
Delivers a coherent, fully-tested CityGML → 3D Tiles vertical slice with Building Scene Layer (BSL) semantics. Adds a pure-managed CityGML building reader and a BSL builder that maps parsed building geometry and semantics onto the existing `Honua.Scene` generation pipeline, emitting a deterministic servable tileset with per-feature BSL attributes (building / storey / component hierarchy, surface type, discipline / sub-layer) carried through the existing `EXT_structural_metadata` glTF path.

This is the most tractable input format from #1207 (CityGML is XML-based and parseable in pure-managed code). IFC / native BIM, the storey decomposition, and the admin ingest endpoint are deferred as tracked follow-ups (documented below), per the issue's XL realistic-scope guidance — hence `Related to #1207` rather than `Closes`.

Mirrors the structure of the existing point-cloud ingest (`PointCloud/`): added under the existing `Honua.Scene` module (no new project, no new endpoint/operation), so no EndpointRegistry / OperationRegistry / ModuleDependencyPolicy changes are required.

## Changes Made
- **`src/Honua.Scene/Bim/CityGmlModel.cs`** — BSL domain model (building → storey → component hierarchy with attributes and 3D rings).
- **`src/Honua.Scene/Bim/CityGmlReader.cs`** — namespace-tolerant CityGML 1.0/2.0 reader for `bldg:Building` features, boundary surfaces (wall/roof/ground/...), storey counts, and `gen:*` generic attributes; supports `gml:posList` and `gml:pos`; XXE-hardened (DTD prohibited, no external resolver); surfaces a stable `SCENE_MODEL_ASSET_INVALID` error code.
- **`src/Honua.Scene/Bim/BuildingSceneLayerBuilder.cs`** — projects each boundary surface via a caller-supplied geo-transform (mirroring the LAS pipeline), emits one `SceneFeature` polygon per surface, classifies each into a BIM discipline / sub-layer, and reuses `GeometryTileBuilder` + `TilesetDocumentWriter` to produce a byte-stable `tileset.json` + GLB with per-feature BSL metadata columns.
- **Tests** (`tests/dotnet/Honua.Core.Tests/Features/Scene/Bim/`) — inline CityGML fixtures + 13 unit tests covering reader hierarchy/attributes/encodings/errors and end-to-end builder output (tileset structure, BSL metadata columns, determinism, GLB header, bounds).
- **Docs** — `docs/gis/citygml-bim-building-scene-layer-ingest.md` (supported subset, discipline mapping, limits, follow-ups) + `docs/SUMMARY.md` TOC entry.

### Deferred follow-ups (tracked in the docs page)
- IFC / native BIM reader (large STEP/EXPRESS schema; no mainstream pure-managed reader).
- Admin ingest executor + endpoint with Enterprise edition gating (will land with the endpoint/operation registry + proof-ledger gates).
- Real storey decomposition from `bldg:Room` / `bldg:storey`.
- Interior rings + robust triangulation; CityGML appearances/textures; quadtree LOD for large city models.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (ran locally — build 0/0, format clean, architecture + affected unit/integration tests pass; AOT IL phase clean)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review


