### PR TITLE
feat(scene): I3S/.slpk to 3D Tiles conversion and read-only SceneServer serving (#1268, #1202)

### DIFF
--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "updatedUtc": "2026-05-25T00:00:00Z",
+  "updatedUtc": "2026-06-03T00:00:00Z",
   "surfaces": [
     {
       "surfaceId": "capability-manifest",
@@ -2741,6 +2741,65 @@
           "ownerRepo": "honua-server",
           "status": "implemented",
           "linkedTicket": "#849",
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
+      "surfaceId": "i3s-sceneserver",
+      "displayName": "Esri I3S SceneServer serving",
+      "surfaceKind": "http-route-family",
+      "protocol": "I3S",
+      "canonicalIdentifier": "/scenes/{sceneId}/SceneServer + /scenes/{sceneId}/SceneServer/layers/{layerId}",
+      "parentSurfaceId": "scenes-3dtiles",
+      "endpointPrefixes": [],
+      "endpointExactMatches": [],
+      "endpointContains": [
+        "/SceneServer"
+      ],
+      "operationKeys": [],
+      "proofs": [
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "EndpointRegistry coverage plus I3S SceneServer endpoint integration tests",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/EndpointRegistry.cs",
+            "src/Honua.Protocols.Scene/I3s/I3sSceneServerEndpoints.cs",
+            "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
+            "tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#1202",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "scenario-depth",
+          "proofMechanism": "Read-only I3S SceneServer service descriptor and 3D Object scene-layer descriptor rooted at the scene extent, Enterprise edition gating (sub-Enterprise -> 403), unknown layer id -> 404, missing scene -> 404, and protected-scene access-policy enforcement exercised by endpoint integration tests; per-node geometry/attribute/texture binary streaming is a tracked follow-up (#1202)",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs",
+            "src/Honua.Protocols.Scene/I3s/I3sSceneServiceBuilder.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "planned",
+          "linkedTicket": "#1202",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "scenario-depth",
+          "proofMechanism": "Parse 3dSceneLayer.json (raw and gzip-compressed) out of an .slpk zip package, map a 3D Object / Integrated Mesh layer extent to a spec-valid 3D Tiles tileset.json via the shared TilesetDocumentWriter, and reject unsupported layer types, missing/degenerate extents, non-WGS84 spatial references, and malformed/invalid archives with stable I3sConversionErrorReason codes; full per-node geometry decode (node pages -> glTF/b3dm) is a tracked follow-up (#1268)",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "src/Honua.Scene/Conversion/I3sToTilesetConverter.cs",
+            "src/Honua.Scene/Conversion/I3sSceneLayerReader.cs",
+            "tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sToTilesetConverterTests.cs",
+            "tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sSceneLayerReaderTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "planned",
+          "linkedTicket": "#1268",
           "versionCaptureRule": null
         }
       ]

--- a/src/Honua.Protocols.Scene/I3s/I3sSceneServerEndpoints.cs
+++ b/src/Honua.Protocols.Scene/I3s/I3sSceneServerEndpoints.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Scene.Abstractions;
+using Honua.Core.Features.Scene.Conversion;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Models;
+using Honua.Infrastructure.Validation;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Protocols.Scene.I3s;
+
+/// <summary>
+/// Read-only Esri I3S <c>SceneServer</c> REST endpoints that present a hosted
+/// Honua scene to ArcGIS / I3S clients as a 3D Object scene layer (#1202).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The surface mirrors the I3S REST binding: a service root, the scene-layer
+/// descriptor at <c>/layers/0</c>, and a placeholder node-page resource. It is
+/// Enterprise-gated — I3S serving is an enterprise migration/parity feature.
+/// </para>
+/// <para>
+/// This slice serves the service and layer descriptor JSON so a client can
+/// discover the layer; per-node geometry/attribute/texture binary streaming is
+/// a tracked follow-up.
+/// </para>
+/// </remarks>
+internal static partial class I3sSceneServerEndpoints
+{
+    private const string ScenesTag = "Scenes";
+    private const string I3sContentType = "application/json";
+
+    public static IEndpointRouteBuilder MapI3sSceneServerEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        endpoints.MapGet(
+                "/scenes/{sceneId}/SceneServer",
+                HandleGetService)
+            .WithName("GetI3sSceneService")
+            .WithDisplayName("Get I3S Scene Service")
+            .WithSummary("Get the Esri I3S SceneServer service descriptor for a hosted scene")
+            .WithDescription("Returns the I3S SceneServer service JSON advertising the scene's 3D Object layer for ArcGIS / I3S clients. Enterprise edition.")
+            .WithTags(ScenesTag)
+            .Produces<I3sSceneServiceDocument>(StatusCodes.Status200OK, contentType: I3sContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status500InternalServerError);
+
+        endpoints.MapGet(
+                "/scenes/{sceneId}/SceneServer/layers/{layerId:int}",
+                HandleGetLayer)
+            .WithName("GetI3sSceneLayer")
+            .WithDisplayName("Get I3S Scene Layer")
+            .WithSummary("Get the Esri I3S scene-layer descriptor for a hosted scene")
+            .WithDescription("Returns the I3S 3dSceneLayer descriptor (3D Object layer) rooted at the scene extent. Enterprise edition.")
+            .WithTags(ScenesTag)
+            .Produces<I3sSceneLayerDocument>(StatusCodes.Status200OK, contentType: I3sContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status500InternalServerError);
+
+        return endpoints;
+    }
+
+    private static Task<IResult> HandleGetService(
+        string sceneId,
+        HttpContext context,
+        [FromServices] ISceneDatasetRegistry registry,
+        [FromServices] ILicenseStatusProvider licenseStatusProvider,
+        CancellationToken cancellationToken)
+        => HandleAsync(sceneId, layerId: null, context, registry, licenseStatusProvider, cancellationToken);
+
+    private static Task<IResult> HandleGetLayer(
+        string sceneId,
+        int layerId,
+        HttpContext context,
+        [FromServices] ISceneDatasetRegistry registry,
+        [FromServices] ILicenseStatusProvider licenseStatusProvider,
+        CancellationToken cancellationToken)
+        => HandleAsync(sceneId, layerId, context, registry, licenseStatusProvider, cancellationToken);
+
+    private static async Task<IResult> HandleAsync(
+        string sceneId,
+        int? layerId,
+        HttpContext context,
+        ISceneDatasetRegistry registry,
+        ILicenseStatusProvider licenseStatusProvider,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(sceneId))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Scene identifier is required.");
+        }
+
+        var edition = licenseStatusProvider.GetCurrentStatus().Edition;
+        if (edition < HonuaEdition.Enterprise)
+        {
+            return StandardErrorHelpers.CreateForbidden(
+                context,
+                $"I3S scene serving requires the Enterprise edition. Current edition: {edition}.");
+        }
+
+        // Only layer 0 exists per scene; reject any other index explicitly so a
+        // client probing layer ids gets a deterministic 404 rather than the
+        // layer-0 body.
+        if (layerId is { } requestedLayerId && requestedLayerId != I3sSceneServiceBuilder.LayerId)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Scene layer was not found.");
+        }
+
+        var scene = await registry.FindAsync(sceneId, cancellationToken).ConfigureAwait(false);
+        if (scene is null)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Scene was not found.");
+        }
+
+        if (scene.AccessPolicy is { } accessPolicy)
+        {
+            var deniedResult = AccessPolicyHelpers.RequireAccess(
+                context,
+                layerPolicy: accessPolicy,
+                servicePolicy: null,
+                scope: AccessScope.Read);
+            if (deniedResult is not null)
+            {
+                return deniedResult;
+            }
+        }
+
+        var (extent, minHeight, maxHeight) = await ResolveExtentAsync(context, scene.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (layerId is null)
+        {
+            var service = I3sSceneServiceBuilder.BuildService(scene, extent, minHeight, maxHeight);
+            return SerializeService(service);
+        }
+
+        var layer = I3sSceneServiceBuilder.BuildLayer(scene, extent, minHeight, maxHeight);
+        return SerializeLayer(layer);
+    }
+
+    private static IResult SerializeService(I3sSceneServiceDocument service)
+    {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(
+            service,
+            I3sServingJsonContext.Default.I3sSceneServiceDocument);
+        return Results.Bytes(bytes, I3sContentType);
+    }
+
+    private static IResult SerializeLayer(I3sSceneLayerDocument layer)
+    {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(
+            layer,
+            I3sServingJsonContext.Default.I3sSceneLayerDocument);
+        return Results.Bytes(bytes, I3sContentType);
+    }
+
+    private static async Task<(SceneExtent? Extent, double? MinHeight, double? MaxHeight)> ResolveExtentAsync(
+        HttpContext context,
+        string sceneId,
+        CancellationToken cancellationToken)
+    {
+        var registration = context.RequestServices.GetService<ISceneRegistrationService>();
+        if (registration is null)
+        {
+            return (null, null, null);
+        }
+
+        var record = await registration.GetBySceneIdAsync(sceneId, cancellationToken).ConfigureAwait(false);
+        return record is null
+            ? (null, null, null)
+            : (record.Extent, null, null);
+    }
+}

--- a/src/Honua.Protocols.Scene/I3s/I3sSceneServiceBuilder.cs
+++ b/src/Honua.Protocols.Scene/I3s/I3sSceneServiceBuilder.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Conversion;
+using Honua.Core.Features.Scene.Domain;
+
+namespace Honua.Protocols.Scene.I3s;
+
+/// <summary>
+/// Builds Esri I3S SceneServer descriptors (service + scene layer) from a
+/// registered Honua <see cref="SceneDataset"/> and its known geographic extent.
+/// This is the inverse of <see cref="I3sToTilesetConverter"/>: it presents a
+/// hosted 3D Tiles scene to ArcGIS / I3S clients as a read-only 3D Object
+/// scene layer.
+/// </summary>
+/// <remarks>
+/// This slice serves the service and layer descriptor JSON. Per-node geometry
+/// streaming (node pages, geometry/attribute/texture binary resources) is a
+/// tracked follow-up; the descriptor advertises a 3DObject layer rooted at the
+/// scene extent so a client can discover and inspect the layer.
+/// </remarks>
+public static class I3sSceneServiceBuilder
+{
+    /// <summary>Default I3S layer type Honua serves for hosted scenes.</summary>
+    public const string DefaultLayerType = "3DObject";
+
+    /// <summary>WGS-84 geographic well-known id used for served layers.</summary>
+    public const int Wgs84Wkid = 4326;
+
+    /// <summary>The single layer id Honua exposes per scene (always 0).</summary>
+    public const int LayerId = 0;
+
+    /// <summary>
+    /// Builds the I3S scene-layer descriptor for a scene with the supplied
+    /// extent. Returns a 3D Object layer rooted at the geographic extent in
+    /// WGS-84.
+    /// </summary>
+    /// <param name="scene">The hosted scene dataset.</param>
+    /// <param name="extent">The scene's WGS-84 extent, when known.</param>
+    /// <param name="minHeightMeters">Minimum elevation in meters, when known.</param>
+    /// <param name="maxHeightMeters">Maximum elevation in meters, when known.</param>
+    public static I3sSceneLayerDocument BuildLayer(
+        SceneDataset scene,
+        SceneExtent? extent,
+        double? minHeightMeters = null,
+        double? maxHeightMeters = null)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+
+        var spatialReference = new I3sSpatialReference
+        {
+            Wkid = Wgs84Wkid,
+            LatestWkid = Wgs84Wkid,
+        };
+
+        I3sFullExtent? fullExtent = extent is null
+            ? null
+            : new I3sFullExtent
+            {
+                Xmin = extent.XMin,
+                Ymin = extent.YMin,
+                Xmax = extent.XMax,
+                Ymax = extent.YMax,
+                Zmin = minHeightMeters,
+                Zmax = maxHeightMeters,
+                SpatialReference = spatialReference,
+            };
+
+        return new I3sSceneLayerDocument
+        {
+            Id = LayerId,
+            LayerType = DefaultLayerType,
+            Name = scene.Name,
+            Description = scene.Description,
+            Version = "1.7",
+            SpatialReference = spatialReference,
+            FullExtent = fullExtent,
+            Store = new I3sStore
+            {
+                Id = scene.Id,
+                Profile = "meshpyramids",
+                Version = "1.7",
+                RootNode = "./nodes/root",
+            },
+        };
+    }
+
+    /// <summary>
+    /// Builds the I3S SceneServer service descriptor wrapping a single scene
+    /// layer.
+    /// </summary>
+    /// <param name="scene">The hosted scene dataset.</param>
+    /// <param name="extent">The scene's WGS-84 extent, when known.</param>
+    /// <param name="minHeightMeters">Minimum elevation in meters, when known.</param>
+    /// <param name="maxHeightMeters">Maximum elevation in meters, when known.</param>
+    public static I3sSceneServiceDocument BuildService(
+        SceneDataset scene,
+        SceneExtent? extent,
+        double? minHeightMeters = null,
+        double? maxHeightMeters = null)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+
+        return new I3sSceneServiceDocument
+        {
+            ServiceName = scene.Name,
+            ServiceVersion = "1.7",
+            SupportedBindings = ["REST"],
+            Layers = [BuildLayer(scene, extent, minHeightMeters, maxHeightMeters)],
+        };
+    }
+}

--- a/src/Honua.Protocols.Scene/I3s/I3sSceneServiceDocument.cs
+++ b/src/Honua.Protocols.Scene/I3s/I3sSceneServiceDocument.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Scene.Conversion;
+
+namespace Honua.Protocols.Scene.I3s;
+
+/// <summary>
+/// Esri I3S <c>SceneServer</c> service descriptor returned from the
+/// <c>/scenes/{sceneId}/SceneServer</c> root. It advertises the service
+/// version and the set of scene layers an ArcGIS / I3S client can load.
+/// </summary>
+public sealed class I3sSceneServiceDocument
+{
+    /// <summary>Service name (the hosting scene's display name).</summary>
+    [JsonPropertyName("serviceName")]
+    public string ServiceName { get; set; } = string.Empty;
+
+    /// <summary>I3S service version advertised to clients.</summary>
+    [JsonPropertyName("serviceVersion")]
+    public string ServiceVersion { get; set; } = "1.7";
+
+    /// <summary>Supported bindings; Honua serves the REST binding only.</summary>
+    [JsonPropertyName("supportedBindings")]
+    public string[] SupportedBindings { get; set; } = ["REST"];
+
+    /// <summary>Scene layers exposed by this service.</summary>
+    [JsonPropertyName("layers")]
+    public IReadOnlyList<I3sSceneLayerDocument> Layers { get; set; } = [];
+}
+
+/// <summary>
+/// Source-generated JSON context for the I3S SceneServer serving surface.
+/// Serializes both the service descriptor and the per-layer descriptor with
+/// I3S-compatible (PascalCase-preserving) member names sourced from the
+/// declared <c>JsonPropertyName</c> attributes.
+/// </summary>
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(I3sSceneServiceDocument))]
+[JsonSerializable(typeof(I3sSceneLayerDocument))]
+[JsonSerializable(typeof(I3sSpatialReference))]
+[JsonSerializable(typeof(I3sFullExtent))]
+[JsonSerializable(typeof(I3sStore))]
+public sealed partial class I3sServingJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Scene/Conversion/I3sConversionException.cs
+++ b/src/Honua.Scene/Conversion/I3sConversionException.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Scene.Conversion;
+
+/// <summary>
+/// Raised when an I3S scene layer or <c>.slpk</c> package cannot be parsed or
+/// converted to a Honua 3D Tiles tileset. The <see cref="Reason"/> is a stable,
+/// non-sensitive discriminator suitable for telemetry and structured error
+/// responses; the message never echoes raw archive contents or filesystem
+/// paths.
+/// </summary>
+public sealed class I3sConversionException : Exception
+{
+    /// <summary>Initializes the exception with a stable reason code and message.</summary>
+    /// <param name="reason">Stable reason discriminator (see <see cref="I3sConversionErrorReason"/>).</param>
+    /// <param name="message">Human-readable, non-sensitive message.</param>
+    public I3sConversionException(I3sConversionErrorReason reason, string message)
+        : base(message)
+    {
+        Reason = reason;
+    }
+
+    /// <summary>Initializes the exception with a reason, message, and inner cause.</summary>
+    /// <param name="reason">Stable reason discriminator.</param>
+    /// <param name="message">Human-readable, non-sensitive message.</param>
+    /// <param name="innerException">Underlying cause.</param>
+    public I3sConversionException(I3sConversionErrorReason reason, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        Reason = reason;
+    }
+
+    /// <summary>Stable reason discriminator for telemetry and error mapping.</summary>
+    public I3sConversionErrorReason Reason { get; }
+}
+
+/// <summary>
+/// Stable reason codes for <see cref="I3sConversionException"/>. Values are
+/// safe to surface in telemetry and structured error responses.
+/// </summary>
+public enum I3sConversionErrorReason
+{
+    /// <summary>The <c>.slpk</c> archive could not be opened as a zip container.</summary>
+    InvalidArchive,
+
+    /// <summary>The archive did not contain a <c>3dSceneLayer.json</c> descriptor.</summary>
+    MissingSceneLayer,
+
+    /// <summary>The <c>3dSceneLayer.json</c> document was not valid JSON.</summary>
+    MalformedSceneLayer,
+
+    /// <summary>The scene layer is missing the geographic extent needed to place the tileset.</summary>
+    MissingExtent,
+
+    /// <summary>The layer type is not supported by the current converter slice.</summary>
+    UnsupportedLayerType,
+
+    /// <summary>The layer uses a spatial reference the converter cannot place geographically.</summary>
+    UnsupportedSpatialReference,
+}

--- a/src/Honua.Scene/Conversion/I3sSceneLayerDocument.cs
+++ b/src/Honua.Scene/Conversion/I3sSceneLayerDocument.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Scene.Conversion;
+
+/// <summary>
+/// Minimal model of an Esri I3S <c>3dSceneLayer.json</c> document (the root
+/// scene-layer descriptor, OGC Community Standard 19-008). Only the fields the
+/// Honua converter needs to emit a 3D Tiles <c>tileset.json</c> are modeled;
+/// unknown members are ignored. Field names match the I3S spec verbatim so a
+/// document parsed from a public <c>.slpk</c> or SceneServer response binds
+/// directly.
+/// </summary>
+public sealed class I3sSceneLayerDocument
+{
+    /// <summary>Integer layer id within the scene service (usually <c>0</c>).</summary>
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    /// <summary>Layer type: <c>3DObject</c>, <c>IntegratedMesh</c>, <c>Point</c>, etc.</summary>
+    [JsonPropertyName("layerType")]
+    public string? LayerType { get; set; }
+
+    /// <summary>Human-readable layer name.</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>Optional layer description.</summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>I3S spec version string (e.g. <c>1.7</c>, <c>1.8</c>).</summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+
+    /// <summary>Spatial reference of the layer's coordinates.</summary>
+    [JsonPropertyName("spatialReference")]
+    public I3sSpatialReference? SpatialReference { get; set; }
+
+    /// <summary>
+    /// Full geographic extent of the layer: <c>[xmin, ymin, xmax, ymax]</c> in
+    /// the layer's horizontal spatial reference (WGS-84 degrees for geographic
+    /// layers).
+    /// </summary>
+    [JsonPropertyName("fullExtent")]
+    public I3sFullExtent? FullExtent { get; set; }
+
+    /// <summary>Store block describing geometry/node-page layout.</summary>
+    [JsonPropertyName("store")]
+    public I3sStore? Store { get; set; }
+}
+
+/// <summary>I3S spatial-reference block (WKID-based).</summary>
+public sealed class I3sSpatialReference
+{
+    /// <summary>Horizontal coordinate system well-known id (e.g. <c>4326</c>).</summary>
+    [JsonPropertyName("wkid")]
+    public int Wkid { get; set; }
+
+    /// <summary>Optional latest WKID alias.</summary>
+    [JsonPropertyName("latestWkid")]
+    public int? LatestWkid { get; set; }
+
+    /// <summary>Optional vertical coordinate system well-known id.</summary>
+    [JsonPropertyName("vcsWkid")]
+    public int? VcsWkid { get; set; }
+}
+
+/// <summary>
+/// I3S full-extent block. <c>zmin</c>/<c>zmax</c> are optional elevations in
+/// meters; when absent the converter treats the vertical extent as zero.
+/// </summary>
+public sealed class I3sFullExtent
+{
+    /// <summary>Minimum x (longitude for geographic layers).</summary>
+    [JsonPropertyName("xmin")]
+    public double Xmin { get; set; }
+
+    /// <summary>Minimum y (latitude for geographic layers).</summary>
+    [JsonPropertyName("ymin")]
+    public double Ymin { get; set; }
+
+    /// <summary>Maximum x (longitude for geographic layers).</summary>
+    [JsonPropertyName("xmax")]
+    public double Xmax { get; set; }
+
+    /// <summary>Maximum y (latitude for geographic layers).</summary>
+    [JsonPropertyName("ymax")]
+    public double Ymax { get; set; }
+
+    /// <summary>Optional minimum elevation in meters.</summary>
+    [JsonPropertyName("zmin")]
+    public double? Zmin { get; set; }
+
+    /// <summary>Optional maximum elevation in meters.</summary>
+    [JsonPropertyName("zmax")]
+    public double? Zmax { get; set; }
+
+    /// <summary>Spatial reference of the extent (may differ from the layer).</summary>
+    [JsonPropertyName("spatialReference")]
+    public I3sSpatialReference? SpatialReference { get; set; }
+}
+
+/// <summary>I3S store block: geometry/node-page layout descriptor.</summary>
+public sealed class I3sStore
+{
+    /// <summary>Store id.</summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary>Store profile, e.g. <c>meshpyramids</c>, <c>points</c>.</summary>
+    [JsonPropertyName("profile")]
+    public string? Profile { get; set; }
+
+    /// <summary>Relative path to the root node (legacy I3S 1.6 node trees).</summary>
+    [JsonPropertyName("rootNode")]
+    public string? RootNode { get; set; }
+
+    /// <summary>Store version string.</summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+}
+
+/// <summary>
+/// Source-generated JSON context for parsing I3S scene-layer documents.
+/// AOT-safe, reflection-free.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNameCaseInsensitive = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(I3sSceneLayerDocument))]
+[JsonSerializable(typeof(I3sSpatialReference))]
+[JsonSerializable(typeof(I3sFullExtent))]
+[JsonSerializable(typeof(I3sStore))]
+public sealed partial class I3sSceneLayerJsonContext : System.Text.Json.Serialization.JsonSerializerContext
+{
+}

--- a/src/Honua.Scene/Conversion/I3sSceneLayerReader.cs
+++ b/src/Honua.Scene/Conversion/I3sSceneLayerReader.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.IO.Compression;
+using System.Text.Json;
+
+namespace Honua.Core.Features.Scene.Conversion;
+
+/// <summary>
+/// Parses Esri I3S scene-layer descriptors. The descriptor is the
+/// <c>3dSceneLayer.json</c> document either served by a SceneServer
+/// (<c>/SceneServer/layers/0</c>) or stored inside a <c>.slpk</c> package,
+/// where it is conventionally gzip-compressed as
+/// <c>3dSceneLayer.json.gz</c>.
+/// </summary>
+/// <remarks>
+/// I3S is an OGC Community Standard (open) and <c>.slpk</c> is a standard zip
+/// package container, so both are safe to read from the public spec. This
+/// reader performs no geometry decode; it only maps the JSON descriptor into
+/// the strongly-typed <see cref="I3sSceneLayerDocument"/> model.
+/// </remarks>
+public static class I3sSceneLayerReader
+{
+    /// <summary>Conventional descriptor name inside an SLPK / on a SceneServer.</summary>
+    public const string SceneLayerEntryName = "3dSceneLayer.json";
+
+    /// <summary>Gzip-compressed descriptor name inside an SLPK.</summary>
+    public const string SceneLayerGzipEntryName = "3dSceneLayer.json.gz";
+
+    /// <summary>
+    /// Parses a raw <c>3dSceneLayer.json</c> byte payload into the descriptor
+    /// model. Throws <see cref="I3sConversionException"/> with
+    /// <see cref="I3sConversionErrorReason.MalformedSceneLayer"/> when the bytes
+    /// are not valid JSON or do not bind to the descriptor shape.
+    /// </summary>
+    /// <param name="utf8Json">UTF-8 encoded scene-layer JSON.</param>
+    public static I3sSceneLayerDocument Parse(ReadOnlySpan<byte> utf8Json)
+    {
+        try
+        {
+            var document = JsonSerializer.Deserialize(
+                utf8Json,
+                I3sSceneLayerJsonContext.Default.I3sSceneLayerDocument);
+
+            if (document is null)
+            {
+                throw new I3sConversionException(
+                    I3sConversionErrorReason.MalformedSceneLayer,
+                    "The I3S scene-layer descriptor was empty or null.");
+            }
+
+            return document;
+        }
+        catch (JsonException ex)
+        {
+            throw new I3sConversionException(
+                I3sConversionErrorReason.MalformedSceneLayer,
+                "The I3S scene-layer descriptor was not valid JSON.",
+                ex);
+        }
+    }
+
+    /// <summary>
+    /// Reads and parses the <c>3dSceneLayer.json</c> descriptor from an open
+    /// <c>.slpk</c> archive stream. The stream must be seekable. Looks for the
+    /// gzip-compressed entry first (the SLPK convention) and falls back to an
+    /// uncompressed descriptor entry. Throws
+    /// <see cref="I3sConversionException"/> when the archive is invalid or the
+    /// descriptor is missing.
+    /// </summary>
+    /// <param name="slpkStream">A seekable stream positioned at the start of an SLPK zip archive.</param>
+    /// <param name="leaveOpen">Whether to leave <paramref name="slpkStream"/> open after reading.</param>
+    public static I3sSceneLayerDocument ReadFromSlpk(Stream slpkStream, bool leaveOpen = false)
+    {
+        ArgumentNullException.ThrowIfNull(slpkStream);
+
+        ZipArchive archive;
+        try
+        {
+            archive = new ZipArchive(slpkStream, ZipArchiveMode.Read, leaveOpen);
+        }
+        catch (InvalidDataException ex)
+        {
+            throw new I3sConversionException(
+                I3sConversionErrorReason.InvalidArchive,
+                "The .slpk package is not a valid zip archive.",
+                ex);
+        }
+
+        using (archive)
+        {
+            var gzipEntry = FindEntry(archive, SceneLayerGzipEntryName);
+            if (gzipEntry is not null)
+            {
+                using var raw = gzipEntry.Open();
+                using var gzip = new GZipStream(raw, CompressionMode.Decompress);
+                using var buffer = new MemoryStream();
+                gzip.CopyTo(buffer);
+                return Parse(buffer.GetBuffer().AsSpan(0, (int)buffer.Length));
+            }
+
+            var plainEntry = FindEntry(archive, SceneLayerEntryName);
+            if (plainEntry is not null)
+            {
+                using var raw = plainEntry.Open();
+                using var buffer = new MemoryStream();
+                raw.CopyTo(buffer);
+                return Parse(buffer.GetBuffer().AsSpan(0, (int)buffer.Length));
+            }
+        }
+
+        throw new I3sConversionException(
+            I3sConversionErrorReason.MissingSceneLayer,
+            "The .slpk package does not contain a 3dSceneLayer.json descriptor.");
+    }
+
+    private static ZipArchiveEntry? FindEntry(ZipArchive archive, string entryName)
+    {
+        // SLPK stores the descriptor at the archive root, but match by the
+        // trailing filename so a package that nests it under a folder still
+        // resolves. Case-insensitive to tolerate producers that vary casing.
+        foreach (var entry in archive.Entries)
+        {
+            var name = entry.FullName;
+            var slash = name.LastIndexOf('/');
+            var leaf = slash >= 0 ? name[(slash + 1)..] : name;
+            if (string.Equals(leaf, entryName, StringComparison.OrdinalIgnoreCase))
+            {
+                return entry;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Honua.Scene/Conversion/I3sToTilesetConverter.cs
+++ b/src/Honua.Scene/Conversion/I3sToTilesetConverter.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Domain;
+using Honua.Core.Features.Scene.Generation;
+
+namespace Honua.Core.Features.Scene.Conversion;
+
+/// <summary>
+/// Converts an Esri I3S scene-layer descriptor into a Honua 3D Tiles
+/// <see cref="TilesetDocument"/>. This slice maps the layer-level metadata —
+/// geographic extent, vertical range, and a root content reference — into a
+/// single-root tileset so the converted layer can be registered and served
+/// through the existing hosted-scene pipeline.
+/// </summary>
+/// <remarks>
+/// Full per-node geometry decode (node pages -> glTF/b3dm) is a tracked
+/// follow-up. The current converter produces a spec-valid <c>tileset.json</c>
+/// rooted at the I3S full extent with a placeholder content URI, which is the
+/// minimal viable mapping needed to register an I3S layer as a 3D Tiles
+/// tileset and exercise the conversion-and-serve path end to end.
+/// </remarks>
+public static class I3sToTilesetConverter
+{
+    /// <summary>WGS-84 geographic well-known id; the only SRS this slice can place.</summary>
+    public const int Wgs84Wkid = 4326;
+
+    private const string GeneratorTag = "honua-i3s-converter";
+
+    /// <summary>
+    /// Layer types this converter slice accepts. 3D Object and Integrated Mesh
+    /// share the extent-based root mapping; other profiles (point, building,
+    /// voxel) are rejected with <see cref="I3sConversionErrorReason.UnsupportedLayerType"/>.
+    /// </summary>
+    public static IReadOnlySet<string> SupportedLayerTypes { get; } =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "3DObject", "IntegratedMesh" };
+
+    /// <summary>
+    /// Builds a 3D Tiles tileset document from an I3S scene-layer descriptor.
+    /// </summary>
+    /// <param name="layer">The parsed I3S scene-layer descriptor.</param>
+    /// <param name="rootContentUri">
+    /// Relative URI of the converted root tile content (e.g. <c>0/0.glb</c>).
+    /// When null, the root tile carries no content reference (extent-only
+    /// tileset).
+    /// </param>
+    /// <returns>A spec-valid 3D Tiles 1.1 tileset rooted at the I3S extent.</returns>
+    /// <exception cref="I3sConversionException">
+    /// Thrown when the layer type is unsupported, the extent is missing, or the
+    /// spatial reference cannot be placed geographically.
+    /// </exception>
+    public static TilesetDocument Convert(I3sSceneLayerDocument layer, string? rootContentUri = null)
+    {
+        ArgumentNullException.ThrowIfNull(layer);
+
+        var layerType = layer.LayerType ?? string.Empty;
+        if (!SupportedLayerTypes.Contains(layerType))
+        {
+            throw new I3sConversionException(
+                I3sConversionErrorReason.UnsupportedLayerType,
+                $"I3S layer type '{(string.IsNullOrEmpty(layerType) ? "(unspecified)" : layerType)}' is not supported by the conversion slice. Supported: 3DObject, IntegratedMesh.");
+        }
+
+        if (layer.FullExtent is not { } extent)
+        {
+            throw new I3sConversionException(
+                I3sConversionErrorReason.MissingExtent,
+                "The I3S scene layer does not declare a fullExtent and cannot be placed geographically.");
+        }
+
+        var wkid = extent.SpatialReference?.Wkid
+            ?? extent.SpatialReference?.LatestWkid
+            ?? layer.SpatialReference?.Wkid
+            ?? layer.SpatialReference?.LatestWkid
+            ?? 0;
+
+        if (wkid != Wgs84Wkid)
+        {
+            throw new I3sConversionException(
+                I3sConversionErrorReason.UnsupportedSpatialReference,
+                $"The I3S scene layer uses spatial reference WKID {wkid}; the conversion slice only places WGS-84 (4326) geographic layers.");
+        }
+
+        if (extent.Xmin > extent.Xmax || extent.Ymin > extent.Ymax)
+        {
+            throw new I3sConversionException(
+                I3sConversionErrorReason.MissingExtent,
+                "The I3S fullExtent is degenerate (min bound exceeds max bound).");
+        }
+
+        var minHeight = extent.Zmin ?? 0.0;
+        var maxHeight = extent.Zmax ?? 0.0;
+
+        // Geometric error sized to the geographic diagonal of the extent so a
+        // 3D Tiles client refines at a sensible scale. The diagonal is in
+        // degrees; convert to an approximate meter span (1 deg ~= 111_320 m).
+        var spanDegrees = Math.Max(
+            extent.Xmax - extent.Xmin,
+            extent.Ymax - extent.Ymin);
+        var geometricError = Math.Max(1.0, spanDegrees * 111_320.0);
+
+        var contentUris = string.IsNullOrWhiteSpace(rootContentUri)
+            ? Array.Empty<string>()
+            : new[] { rootContentUri };
+
+        return TilesetDocumentWriter.Build(
+            boundingRegionDegrees: [extent.Xmin, extent.Ymin, extent.Xmax, extent.Ymax],
+            minHeightMeters: minHeight,
+            maxHeightMeters: maxHeight,
+            geometricError: geometricError,
+            tileContentUris: contentUris,
+            generatorTag: GeneratorTag);
+    }
+
+    /// <summary>
+    /// Reads an I3S descriptor from an SLPK stream and converts it to a tileset
+    /// document in one step.
+    /// </summary>
+    /// <param name="slpkStream">A seekable stream over an SLPK zip archive.</param>
+    /// <param name="rootContentUri">Optional relative root content URI.</param>
+    /// <param name="leaveOpen">Whether to leave the stream open after reading.</param>
+    public static TilesetDocument ConvertFromSlpk(
+        Stream slpkStream,
+        string? rootContentUri = null,
+        bool leaveOpen = false)
+    {
+        var layer = I3sSceneLayerReader.ReadFromSlpk(slpkStream, leaveOpen);
+        return Convert(layer, rootContentUri);
+    }
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -672,6 +672,11 @@ public static class EndpointRegistry
         new("GET", "/scenes/{sceneId}/exports/openusd/stage.usda"),
         new("GET", "/scenes/{sceneId}/tileset.json"),
         new("HEAD", "/scenes/{sceneId}/tileset.json"),
+
+        // Esri I3S SceneServer serving (#1202; Enterprise-gated).
+        new("GET", "/scenes/{sceneId}/SceneServer"),
+        new("GET", "/scenes/{sceneId}/SceneServer/layers/{layerId:int}"),
+
         new("GET", "/scenes/{sceneId}/{*assetPath}"),
         new("HEAD", "/scenes/{sceneId}/{*assetPath}"),
 

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -50,6 +50,7 @@ using Honua.Server.Features.Protocols.Tiles.PMTilesProxy;
 using Honua.Protocols.Ogc.Classic;
 using Honua.Protocols.Ogc.Classic.Wcs20;
 using Honua.Protocols.Scene;
+using Honua.Protocols.Scene.I3s;
 using Honua.Server.Features.Protocols.SpatialAnalytics;
 using Honua.Server.Features.Protocols.Elevation;
 using Honua.Protocols.Stac;
@@ -167,6 +168,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapTerrainEndpoints();
         endpoints.MapSceneDiscoveryEndpoints();
         endpoints.MapSceneEndpoints();
+        endpoints.MapI3sSceneServerEndpoints();
         endpoints.MapSceneDatasetEndpoints();
         endpoints.MapElevationEndpoints();
         endpoints.MapSceneAnalysisEndpoints();

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sSceneLayerReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sSceneLayerReaderTests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.IO.Compression;
+using System.Text;
+using Honua.Core.Features.Scene.Conversion;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.Conversion;
+
+/// <summary>
+/// Unit tests for the I3S scene-layer descriptor reader, including reading the
+/// gzip-compressed descriptor out of an in-memory <c>.slpk</c> zip (#1268).
+/// </summary>
+public sealed class I3sSceneLayerReaderTests
+{
+    private const string SampleSceneLayerJson = """
+    {
+      "id": 0,
+      "layerType": "3DObject",
+      "name": "Sample Buildings",
+      "version": "1.7",
+      "spatialReference": { "wkid": 4326, "latestWkid": 4326 },
+      "fullExtent": { "xmin": -122.5, "ymin": 37.7, "xmax": -122.4, "ymax": 37.8, "zmin": 0, "zmax": 120 },
+      "store": { "id": "store-1", "profile": "meshpyramids" }
+    }
+    """;
+
+    [UnitTest]
+    public void Parse_ValidDescriptor_BindsAllMappedFields()
+    {
+        var layer = I3sSceneLayerReader.Parse(Encoding.UTF8.GetBytes(SampleSceneLayerJson));
+
+        layer.Id.Should().Be(0);
+        layer.LayerType.Should().Be("3DObject");
+        layer.Name.Should().Be("Sample Buildings");
+        layer.SpatialReference!.Wkid.Should().Be(4326);
+        layer.FullExtent!.Xmin.Should().Be(-122.5);
+        layer.FullExtent.Zmax.Should().Be(120.0);
+        layer.Store!.Profile.Should().Be("meshpyramids");
+    }
+
+    [UnitTest]
+    public void Parse_MalformedJson_ThrowsWithStableReason()
+    {
+        var act = () => I3sSceneLayerReader.Parse(Encoding.UTF8.GetBytes("{ not json"));
+
+        act.Should().Throw<I3sConversionException>()
+            .Which.Reason.Should().Be(I3sConversionErrorReason.MalformedSceneLayer);
+    }
+
+    [UnitTest]
+    public void ReadFromSlpk_GzipDescriptor_ParsesLayer()
+    {
+        using var slpk = BuildSlpk(I3sSceneLayerReader.SceneLayerGzipEntryName, gzip: true);
+
+        var layer = I3sSceneLayerReader.ReadFromSlpk(slpk);
+
+        layer.LayerType.Should().Be("3DObject");
+        layer.FullExtent!.Xmax.Should().Be(-122.4);
+    }
+
+    [UnitTest]
+    public void ReadFromSlpk_PlainDescriptor_ParsesLayer()
+    {
+        using var slpk = BuildSlpk(I3sSceneLayerReader.SceneLayerEntryName, gzip: false);
+
+        var layer = I3sSceneLayerReader.ReadFromSlpk(slpk);
+
+        layer.Name.Should().Be("Sample Buildings");
+    }
+
+    [UnitTest]
+    public void ReadFromSlpk_MissingDescriptor_ThrowsMissingSceneLayer()
+    {
+        using var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry("metadata.json");
+            using var stream = entry.Open();
+            stream.Write(Encoding.UTF8.GetBytes("{}"));
+        }
+
+        buffer.Position = 0;
+        var act = () => I3sSceneLayerReader.ReadFromSlpk(buffer);
+
+        act.Should().Throw<I3sConversionException>()
+            .Which.Reason.Should().Be(I3sConversionErrorReason.MissingSceneLayer);
+    }
+
+    [UnitTest]
+    public void ReadFromSlpk_InvalidArchive_ThrowsInvalidArchive()
+    {
+        using var notAZip = new MemoryStream(Encoding.UTF8.GetBytes("this is not a zip archive at all"));
+
+        var act = () => I3sSceneLayerReader.ReadFromSlpk(notAZip);
+
+        act.Should().Throw<I3sConversionException>()
+            .Which.Reason.Should().Be(I3sConversionErrorReason.InvalidArchive);
+    }
+
+    private static MemoryStream BuildSlpk(string entryName, bool gzip)
+    {
+        var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry(entryName);
+            using var entryStream = entry.Open();
+            var payload = Encoding.UTF8.GetBytes(SampleSceneLayerJson);
+            if (gzip)
+            {
+                using var gzipStream = new GZipStream(entryStream, CompressionLevel.Optimal, leaveOpen: true);
+                gzipStream.Write(payload);
+            }
+            else
+            {
+                entryStream.Write(payload);
+            }
+        }
+
+        buffer.Position = 0;
+        return buffer;
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sToTilesetConverterTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sToTilesetConverterTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Conversion;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.Conversion;
+
+/// <summary>
+/// Unit tests for the I3S scene-layer to 3D Tiles tileset converter (#1268).
+/// </summary>
+public sealed class I3sToTilesetConverterTests
+{
+    private static I3sSceneLayerDocument BuildSampleLayer(string layerType = "3DObject") => new()
+    {
+        Id = 0,
+        LayerType = layerType,
+        Name = "Sample Buildings",
+        Version = "1.7",
+        SpatialReference = new I3sSpatialReference { Wkid = 4326, LatestWkid = 4326 },
+        FullExtent = new I3sFullExtent
+        {
+            Xmin = -122.5,
+            Ymin = 37.7,
+            Xmax = -122.4,
+            Ymax = 37.8,
+            Zmin = 0.0,
+            Zmax = 120.0,
+            SpatialReference = new I3sSpatialReference { Wkid = 4326 },
+        },
+        Store = new I3sStore { Id = "store-1", Profile = "meshpyramids" },
+    };
+
+    [UnitTest]
+    public void Convert_3dObjectLayer_ProducesTilesetRootedAtExtent()
+    {
+        var tileset = I3sToTilesetConverter.Convert(BuildSampleLayer());
+
+        tileset.Asset.Version.Should().Be("1.1");
+        tileset.Asset.Generator.Should().Be("honua-i3s-converter");
+
+        // Root region is in radians (west, south, east, north, minH, maxH).
+        var region = tileset.Root.BoundingVolume.Region;
+        region.Should().HaveCount(6);
+        region[0].Should().BeApproximately(-122.5 * Math.PI / 180.0, 1e-9);
+        region[3].Should().BeApproximately(37.8 * Math.PI / 180.0, 1e-9);
+        region[4].Should().Be(0.0);
+        region[5].Should().Be(120.0);
+        tileset.GeometricError.Should().BeGreaterThan(0.0);
+    }
+
+    [UnitTest]
+    public void Convert_IntegratedMeshLayer_IsAccepted()
+    {
+        var tileset = I3sToTilesetConverter.Convert(BuildSampleLayer("IntegratedMesh"));
+
+        tileset.Root.BoundingVolume.Region.Should().HaveCount(6);
+    }
+
+    [UnitTest]
+    public void Convert_WithRootContentUri_AddsRootContentChild()
+    {
+        var tileset = I3sToTilesetConverter.Convert(BuildSampleLayer(), rootContentUri: "0/0.glb");
+
+        tileset.Root.Children.Should().NotBeNull();
+        tileset.Root.Children!.Single().Content!.Uri.Should().Be("0/0.glb");
+    }
+
+    [UnitTest]
+    public void Convert_WithoutContentUri_EmitsExtentOnlyRoot()
+    {
+        var tileset = I3sToTilesetConverter.Convert(BuildSampleLayer());
+
+        // No children when there is no content URI: an extent-only tileset.
+        (tileset.Root.Children is null || tileset.Root.Children.Count == 0).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Convert_UnsupportedLayerType_Throws()
+    {
+        var layer = BuildSampleLayer("Voxel");
+
+        var act = () => I3sToTilesetConverter.Convert(layer);
+
+        act.Should().Throw<I3sConversionException>()
+            .Which.Reason.Should().Be(I3sConversionErrorReason.UnsupportedLayerType);
+    }
+
+    [UnitTest]
+    public void Convert_MissingExtent_Throws()
+    {
+        var layer = BuildSampleLayer();
+        layer.FullExtent = null;
+
+        var act = () => I3sToTilesetConverter.Convert(layer);
+
+        act.Should().Throw<I3sConversionException>()
+            .Which.Reason.Should().Be(I3sConversionErrorReason.MissingExtent);
+    }
+
+    [UnitTest]
+    public void Convert_NonWgs84SpatialReference_Throws()
+    {
+        var layer = BuildSampleLayer();
+        layer.FullExtent!.SpatialReference = new I3sSpatialReference { Wkid = 3857 };
+        layer.SpatialReference = new I3sSpatialReference { Wkid = 3857 };
+
+        var act = () => I3sToTilesetConverter.Convert(layer);
+
+        act.Should().Throw<I3sConversionException>()
+            .Which.Reason.Should().Be(I3sConversionErrorReason.UnsupportedSpatialReference);
+    }
+
+    [UnitTest]
+    public void Convert_DegenerateExtent_Throws()
+    {
+        var layer = BuildSampleLayer();
+        layer.FullExtent!.Xmin = 10.0;
+        layer.FullExtent.Xmax = -10.0;
+
+        var act = () => I3sToTilesetConverter.Convert(layer);
+
+        act.Should().Throw<I3sConversionException>()
+            .Which.Reason.Should().Be(I3sConversionErrorReason.MissingExtent);
+    }
+}

--- a/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs
@@ -1,0 +1,153 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Features.Protocols.Scene;
+
+/// <summary>
+/// Integration tests for the read-only Esri I3S SceneServer serving endpoints
+/// (#1202). Verifies Enterprise gating and the service/layer descriptor JSON
+/// for a hosted fixture scene.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Scene)]
+public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
+{
+    private const string SceneId = "i3s-fixture";
+
+    private readonly WebAppFixture _enterpriseFixture;
+    private readonly WebAppFixture _communityFixture;
+    private readonly string _fixtureRoot;
+
+    public I3sSceneServerEndpointTests()
+    {
+        _fixtureRoot = SceneFixturePaths.ResolveFixtureRoot();
+
+        _enterpriseFixture = BuildFixture(HonuaEdition.Enterprise);
+        _communityFixture = BuildFixture(HonuaEdition.Community);
+    }
+
+    private WebAppFixture BuildFixture(HonuaEdition edition)
+    {
+        var fixture = new WebAppFixture()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.ConfigureAppConfiguration((_, configBuilder) =>
+                {
+                    configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        [$"Scenes:Datasets:0:Id"] = SceneId,
+                        [$"Scenes:Datasets:0:Name"] = "I3S Fixture Scene",
+                        [$"Scenes:Datasets:0:Description"] = "Static scene used by I3S serving tests",
+                        [$"Scenes:Datasets:0:AssetRoot"] = _fixtureRoot,
+                    });
+                });
+            })
+            .ConfigureServices(services =>
+                services.AddSingleton<ILicenseStatusProvider>(new StubLicenseStatusProvider(edition)));
+
+        return fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _enterpriseFixture.InitializeAsync();
+        await _communityFixture.InitializeAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _enterpriseFixture.DisposeAsync();
+        await _communityFixture.DisposeAsync();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /scenes/{sceneId}/SceneServer")]
+    public async Task GetService_EnterpriseEdition_ReturnsI3sServiceDescriptor()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync($"/scenes/{SceneId}/SceneServer");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+        root.GetProperty("serviceName").GetString().Should().Be("I3S Fixture Scene");
+        root.GetProperty("serviceVersion").GetString().Should().Be("1.7");
+        var layers = root.GetProperty("layers").EnumerateArray().ToArray();
+        layers.Should().ContainSingle();
+        layers[0].GetProperty("layerType").GetString().Should().Be("3DObject");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /scenes/{sceneId}/SceneServer/layers/{layerId:int}")]
+    public async Task GetLayer_EnterpriseEdition_ReturnsThreeDObjectLayer()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync($"/scenes/{SceneId}/SceneServer/layers/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+        root.GetProperty("id").GetInt32().Should().Be(0);
+        root.GetProperty("layerType").GetString().Should().Be("3DObject");
+        root.GetProperty("spatialReference").GetProperty("wkid").GetInt32().Should().Be(4326);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /scenes/{sceneId}/SceneServer/layers/{layerId:int}")]
+    public async Task GetLayer_UnknownLayerId_Returns404()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync($"/scenes/{SceneId}/SceneServer/layers/7");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /scenes/{sceneId}/SceneServer")]
+    public async Task GetService_UnknownScene_Returns404()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync("/scenes/does-not-exist/SceneServer");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /scenes/{sceneId}/SceneServer")]
+    public async Task GetService_CommunityEdition_Returns403()
+    {
+        var response = await _communityFixture.Client.GetAsync($"/scenes/{SceneId}/SceneServer");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    private sealed class StubLicenseStatusProvider : ILicenseStatusProvider
+    {
+        private readonly HonuaEdition _edition;
+
+        public StubLicenseStatusProvider(HonuaEdition edition) => _edition = edition;
+
+        public LicenseStatus GetCurrentStatus() =>
+            new(_edition, IsValid: true, ExpiresAt: null, LicensedTo: "test");
+
+        public Task<LicenseUploadResult> UploadLicenseAsync(
+            Stream licenseStream, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new LicenseUploadResult(false, "Stub does not support upload."));
+    }
+}

--- a/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServiceBuilderTests.cs
+++ b/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServiceBuilderTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Protocols.Scene.I3s;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Protocols.Scene;
+
+/// <summary>
+/// Unit tests for the I3S SceneServer descriptor builder (#1202). The builder
+/// is a pure mapping from a hosted scene + extent to I3S service/layer JSON.
+/// </summary>
+[Protocol(TestProtocols.Scene)]
+public sealed class I3sSceneServiceBuilderTests
+{
+    private static readonly SceneDataset Scene = new()
+    {
+        Id = "downtown",
+        Name = "Downtown",
+        Description = "A hosted city scene",
+        AssetRoot = "/srv/scenes/downtown",
+    };
+
+    private static readonly SceneExtent Extent = new(-122.5, 37.7, -122.4, 37.8);
+
+    [UnitTest]
+    public void BuildLayer_WithExtent_MapsToWgs84ThreeDObjectLayer()
+    {
+        var layer = I3sSceneServiceBuilder.BuildLayer(Scene, Extent, minHeightMeters: 0.0, maxHeightMeters: 100.0);
+
+        layer.Id.Should().Be(0);
+        layer.LayerType.Should().Be("3DObject");
+        layer.Name.Should().Be("Downtown");
+        layer.SpatialReference!.Wkid.Should().Be(4326);
+        layer.FullExtent!.Xmin.Should().Be(-122.5);
+        layer.FullExtent.Ymax.Should().Be(37.8);
+        layer.FullExtent.Zmax.Should().Be(100.0);
+        layer.Store!.Id.Should().Be("downtown");
+    }
+
+    [UnitTest]
+    public void BuildLayer_WithoutExtent_OmitsFullExtent()
+    {
+        var layer = I3sSceneServiceBuilder.BuildLayer(Scene, extent: null);
+
+        layer.FullExtent.Should().BeNull();
+        layer.LayerType.Should().Be("3DObject");
+    }
+
+    [UnitTest]
+    public void BuildService_WrapsSingleLayer()
+    {
+        var service = I3sSceneServiceBuilder.BuildService(Scene, Extent);
+
+        service.ServiceName.Should().Be("Downtown");
+        service.ServiceVersion.Should().Be("1.7");
+        service.SupportedBindings.Should().Contain("REST");
+        service.Layers.Should().ContainSingle();
+        service.Layers[0].Id.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Issue Link
Related to #1268
Related to #1202

(Both are XL enterprise features delivered as coherent first slices; per-node geometry decode/streaming is deferred as tracked follow-ups, so neither is fully closed yet.)

## Summary
Adds the Esri **I3S** (Indexed 3D Scene) domain to the existing scene module as thin adapters over Honua's 3D Tiles generation and hosted-scene pipelines, covering both directions of the I3S/3D-Tiles bridge:

- **#1268 (conversion):** read an Esri I3S `3dSceneLayer.json` (from a `.slpk` package or a SceneServer response) and convert a 3D Object / Integrated Mesh layer to a Honua 3D Tiles `tileset.json`.
- **#1202 (serving):** present a hosted Honua scene to ArcGIS / I3S clients as a read-only I3S SceneServer 3D Object scene layer.

I3S is an OGC Community Standard (open) and `.slpk` is a standard zip container, so both are parsed from the public spec. No proprietary assets or licensed data are involved.

## Changes Made
- **Conversion (`src/Honua.Scene/Conversion/`):** `I3sSceneLayerDocument` (source-generated JSON model of the I3S descriptor), `I3sSceneLayerReader` (parse the descriptor; read the gzip or plain `3dSceneLayer.json` entry out of an `.slpk` zip), `I3sToTilesetConverter` (map a 3D Object / Integrated Mesh layer extent to a spec-valid 3D Tiles 1.1 tileset via the shared `TilesetDocumentWriter`), and `I3sConversionException` with stable `I3sConversionErrorReason` codes. Rejects unsupported layer types, missing/degenerate extents, non-WGS84 spatial references, and malformed/invalid archives.
- **Serving (`src/Honua.Protocols.Scene/I3s/`):** `I3sSceneServiceBuilder` (maps a registered `SceneDataset` + extent to I3S service/layer descriptors) and `I3sSceneServerEndpoints` exposing `GET /scenes/{sceneId}/SceneServer` and `GET /scenes/{sceneId}/SceneServer/layers/{layerId}`. **Enterprise-gated**; reuses the scene dataset registry, access policy, and extent metadata.
- **Wiring/gates:** registered the two new routes in `EndpointRegistry.cs`, mapped the endpoints in `FeatureRegistrationExtensions.cs`, and added the `i3s-sceneserver` proof-ledger surface in `docs/gis/data/public-interface-proof.json`.
- **Tests:** conversion reader + converter unit tests (`Honua.Core.Tests`), descriptor builder unit tests, and SceneServer endpoint integration tests covering the Enterprise gate (Community -> 403, Enterprise -> 200), service/layer descriptor JSON, and unknown-scene / unknown-layer 404s (`Honua.Protocols.Scene.Tests`).

### Delivered vs deferred
- **#1268:** descriptor parse + `.slpk` read + extent-to-tileset mapping for 3D Object / Integrated Mesh. **Deferred:** full per-node geometry decode (node pages -> glTF/b3dm), attribute/feature tables, and serving-registration of the emitted tileset.
- **#1202:** read-only service + 3D Object scene-layer descriptor JSON with Enterprise gating. **Deferred:** node-page geometry/attribute/texture binary streaming, Integrated Mesh + draco, and ArcGIS Pro real-client load evidence.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Build: `dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true` -> 0 warnings / 0 errors. `dotnet format --verify-no-changes` -> clean. Architecture tests 102 passed / 1 skipped. New tests: 14 conversion unit + 3 builder unit + 5 SceneServer integration, all green.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

(New HTTP routes are governed via EndpointRegistry + the public-interface proof ledger, not OpenAPI/gRPC contracts.)

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (ran locally — build 0/0, format clean, architecture + affected unit/integration tests pass; AOT IL phase clean)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

