### PR TITLE
fix(geoservices): Esri f=json field conformance — string length + date epoch-ms

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
@@ -251,9 +251,13 @@ internal static partial class FeatureServerEndpoints
             Type = geoServicesType,
             SqlType = sqlType,
             Alias = field.Alias ?? field.Title ?? field.Name,
-            // V2 has no length slot on the canonical field model (length lives in the
-            // storage binding when needed). Pass null so the response omits the key.
-            Length = null,
+            // Esri clients require a positive length on string fields (a null length is
+            // mapped to 0 and breaks inserts/updates). String fields source their length
+            // from the canonical field's declared varchar length, falling back to the
+            // Esri-conventional default; non-string fields report their declared length.
+            Length = !isObjectId && field.Type == MetadataV2FieldType.String
+                ? GeoServicesFieldConventions.ResolveStringFieldLength(field.Length)
+                : field.Length,
             Nullable = field.Nullable && !isObjectId,
             Editable = !isGeometry && !isObjectId,
             // V2 has no default-value slot on the canonical field; the catalog/admin layer

--- a/src/Honua.Protocols.GeoServices/FeatureServer/GeoServicesFieldConventions.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/GeoServicesFieldConventions.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+
+namespace Honua.Protocols.GeoServices.FeatureServer;
+
+/// <summary>
+/// Shared Esri GeoServices field-metadata conventions used by the FeatureServer and
+/// MapServer field-info projections.
+/// </summary>
+internal static class GeoServicesFieldConventions
+{
+    /// <summary>
+    /// Esri-conventional default <c>length</c> emitted for <c>esriFieldTypeString</c>
+    /// fields whose backing column declares no explicit varchar length.
+    /// </summary>
+    /// <remarks>
+    /// A real Esri FeatureServer always reports a positive <c>length</c> for string
+    /// fields. arcpy maps a null/absent length to 0 and then rejects every insert/update
+    /// with "Field length exceeded", so the f=json metadata must never emit a null or
+    /// non-positive length for a string field.
+    /// </remarks>
+    internal const int DefaultStringFieldLength = 256;
+
+    /// <summary>
+    /// Resolves the <c>length</c> to report for a string field. Uses the column's
+    /// declared varchar length when it is a positive value; otherwise falls back to the
+    /// Esri-conventional <see cref="DefaultStringFieldLength"/>.
+    /// </summary>
+    /// <param name="declaredLength">The declared varchar length, when known.</param>
+    internal static int ResolveStringFieldLength(int? declaredLength)
+        => declaredLength is int length and > 0 ? length : DefaultStringFieldLength;
+
+    /// <summary>
+    /// Converts a <see cref="DateTime"/> to epoch milliseconds (UTC). Values with an
+    /// unspecified kind are treated as UTC.
+    /// </summary>
+    internal static long ToEpochMilliseconds(DateTime value)
+        => new DateTimeOffset(DateTime.SpecifyKind(
+            value,
+            value.Kind == DateTimeKind.Unspecified ? DateTimeKind.Utc : value.Kind)).ToUnixTimeMilliseconds();
+
+    /// <summary>
+    /// Converts a <see cref="DateOnly"/> to epoch milliseconds at midnight UTC.
+    /// </summary>
+    internal static long ToEpochMilliseconds(DateOnly value)
+        => new DateTimeOffset(value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
+
+    /// <summary>
+    /// Coerces a value known to belong to an <c>esriFieldTypeDate</c> field into an
+    /// epoch-millisecond (UTC) integer. Handles <see cref="DateTime"/>,
+    /// <see cref="DateTimeOffset"/>, <see cref="DateOnly"/>, already-numeric epoch values,
+    /// <see cref="JsonElement"/>, and ISO-8601 / date-only strings. Date-only values are
+    /// treated as midnight UTC. Already-numeric epoch values pass through unchanged so the
+    /// conversion is idempotent.
+    /// </summary>
+    internal static bool TryConvertToEpochMilliseconds(object value, out long epochMilliseconds)
+    {
+        switch (value)
+        {
+            case DateTimeOffset dto:
+                epochMilliseconds = dto.ToUnixTimeMilliseconds();
+                return true;
+            case DateTime dt:
+                epochMilliseconds = ToEpochMilliseconds(dt);
+                return true;
+            case DateOnly dateOnly:
+                epochMilliseconds = ToEpochMilliseconds(dateOnly);
+                return true;
+            case long l:
+                epochMilliseconds = l;
+                return true;
+            case int i:
+                epochMilliseconds = i;
+                return true;
+            case JsonElement element:
+                return TryConvertJsonElementToEpochMilliseconds(element, out epochMilliseconds);
+            case string text:
+                return TryParseDateStringToEpochMilliseconds(text, out epochMilliseconds);
+        }
+
+        epochMilliseconds = 0;
+        return false;
+    }
+
+    private static bool TryConvertJsonElementToEpochMilliseconds(JsonElement element, out long epochMilliseconds)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Number when element.TryGetInt64(out var epoch):
+                epochMilliseconds = epoch;
+                return true;
+            case JsonValueKind.String:
+                return TryParseDateStringToEpochMilliseconds(element.GetString(), out epochMilliseconds);
+        }
+
+        epochMilliseconds = 0;
+        return false;
+    }
+
+    private static bool TryParseDateStringToEpochMilliseconds(string? text, out long epochMilliseconds)
+    {
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            // Already an epoch-ms integer encoded as a string.
+            if (long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var epoch))
+            {
+                epochMilliseconds = epoch;
+                return true;
+            }
+
+            if (DateTimeOffset.TryParse(
+                    text,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                    out var parsedOffset))
+            {
+                epochMilliseconds = parsedOffset.ToUnixTimeMilliseconds();
+                return true;
+            }
+
+            // Date-only string (no time component) -> midnight UTC.
+            if (DateOnly.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate))
+            {
+                epochMilliseconds = ToEpochMilliseconds(parsedDate);
+                return true;
+            }
+        }
+
+        epochMilliseconds = 0;
+        return false;
+    }
+}

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/QueryFormatters.cs
@@ -175,6 +175,11 @@ internal sealed class QueryFormatter : IQueryFormatter
         var runtimeFieldNames = runtimeFields
             .Select(field => field.Name)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        // esriFieldTypeDate fields must serialize as epoch-ms integers per the Esri f=json spec.
+        var dateFieldNames = resource.SchemaFields
+            .Where(static field => field.Type is MetadataV2FieldType.DateTime or MetadataV2FieldType.Date)
+            .Select(static field => field.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
         GeoServicesFeature[] features = result.Items
             .Select(f => ConvertToGeoServicesFeature(
                 f,
@@ -183,6 +188,7 @@ internal sealed class QueryFormatter : IQueryFormatter
                 outFields,
                 visibleDeclaredAttributeFields,
                 runtimeFieldNames,
+                dateFieldNames,
                 objectIdFieldName,
                 returnZ,
                 returnM,
@@ -263,6 +269,7 @@ internal sealed class QueryFormatter : IQueryFormatter
         string[]? outFields,
         IReadOnlySet<string> declaredAttributeFields,
         IReadOnlySet<string> runtimeAttributeFields,
+        HashSet<string> dateFieldNames,
         string objectIdFieldName,
         bool returnZ,
         bool returnM,
@@ -277,6 +284,22 @@ internal sealed class QueryFormatter : IQueryFormatter
                 objectIdFieldName,
                 GeoServicesObjectIdFieldResolver.ResolveObjectIdValue(feature, objectIdFieldName),
                 suppressObjectId);
+
+        // esriFieldTypeDate attributes must serialize as epoch-ms integers (the object/non-
+        // streaming serialization path has no field-type context downstream, so coerce here
+        // where the layer's date fields are known).
+        if (dateFieldNames.Count > 0)
+        {
+            foreach (var fieldName in dateFieldNames)
+            {
+                if (attributes.TryGetValue(fieldName, out var dateValue)
+                    && dateValue is not null
+                    && GeoServicesFieldConventions.TryConvertToEpochMilliseconds(dateValue, out var epochMs))
+                {
+                    attributes[fieldName] = epochMs;
+                }
+            }
+        }
 
         return new GeoServicesFeature
         {
@@ -541,7 +564,11 @@ internal sealed class QueryFormatter : IQueryFormatter
             TimeOnly or TimeSpan => CreateRuntimeFieldInfo(name, "esriFieldTypeString", "TIME"),
             Guid => CreateRuntimeFieldInfo(name, "esriFieldTypeGUID", "UUID"),
             byte[] => CreateRuntimeFieldInfo(name, "esriFieldTypeBlob", "BYTEA"),
-            string text => CreateRuntimeFieldInfo(name, "esriFieldTypeString", "TEXT", text.Length),
+            string => CreateRuntimeFieldInfo(
+                name,
+                "esriFieldTypeString",
+                "TEXT",
+                GeoServicesFieldConventions.DefaultStringFieldLength),
             _ => null
         };
     }
@@ -589,13 +616,17 @@ internal sealed class QueryFormatter : IQueryFormatter
         // The layer's object-id field must be typed esriFieldTypeOID regardless of its
         // SQL type so Esri clients can locate the OID field by type (see issue #1299).
         var isObjectId = field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase);
+        var isString = !isObjectId && field.Type == MetadataV2FieldType.String;
         return new GeoServicesFieldInfo
         {
             Name = field.Name,
             Type = isObjectId ? "esriFieldTypeOID" : MapFieldTypeToGeoServices(field.Type),
             SqlType = field.SqlType ?? MapFieldTypeToSql(field.Type),
             Alias = field.Alias ?? field.Title ?? field.Name,
-            Length = field.Length,
+            // Esri clients (arcpy/.NET SDK) require a positive length on string fields;
+            // a null length is mapped to 0 and breaks inserts. Fall back to the
+            // Esri-conventional default when the column declares none.
+            Length = isString ? GeoServicesFieldConventions.ResolveStringFieldLength(field.Length) : field.Length,
             Nullable = field.Nullable && !isObjectId,
             Editable = field.Editable && !isGeometry && !isObjectId,
             DefaultValue = field.DefaultValue.HasValue ? ConvertJsonElement(field.DefaultValue.Value) : null,
@@ -912,6 +943,13 @@ internal sealed class StreamingQueryFormatter
                                    field.Type is not (MetadataV2FieldType.Geometry or MetadataV2FieldType.Geography))
             .Select(static field => field.Name)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        // esriFieldTypeDate fields must be written as epoch-ms integers per the Esri f=json
+        // spec. Capture their names so the value writer can coerce dates regardless of the
+        // CLR type they arrive in (DateTime/DateTimeOffset/DateOnly/ISO string).
+        var dateFieldNames = resource.SchemaFields
+            .Where(static field => field.Type is MetadataV2FieldType.DateTime or MetadataV2FieldType.Date)
+            .Select(static field => field.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
         var displayFieldName = QueryFormatter.ResolveDisplayFieldName(queryFields, objectIdFieldName);
         var geometryType = resource.ReadGeometryType();
         var hasGeometry = geometryType != MetadataV2GeometryType.None || resource.FindPrimaryGeometryField() is not null;
@@ -957,6 +995,7 @@ internal sealed class StreamingQueryFormatter
                 outFieldLookup,
                 allDeclaredAttributeFields,
                 visibleDeclaredAttributeFields,
+                dateFieldNames,
                 objectIdFieldName,
                 returnZ,
                 returnM,
@@ -1062,6 +1101,7 @@ internal sealed class StreamingQueryFormatter
         HashSet<string>? outFieldLookup,
         IReadOnlySet<string> allDeclaredAttributeFields,
         IReadOnlySet<string> visibleDeclaredAttributeFields,
+        IReadOnlySet<string> dateFieldNames,
         string objectIdFieldName,
         bool returnZ,
         bool returnM,
@@ -1097,7 +1137,7 @@ internal sealed class StreamingQueryFormatter
                     objectIdWritten = true;
                 }
 
-                WriteJsonValue(writer, fieldName, kvp.Value, cancellationToken);
+                WriteJsonValue(writer, fieldName, kvp.Value, cancellationToken, dateFieldNames);
             }
         }
 
@@ -1216,14 +1256,34 @@ internal sealed class StreamingQueryFormatter
     }
 
     /// <summary>
-    /// Writes a JSON value with proper type handling
+    /// Writes a JSON value with proper type handling for the Esri GeoServices f=json
+    /// response. When <paramref name="dateFieldNames"/> contains <paramref name="propertyName"/>
+    /// the value is coerced to an epoch-millisecond integer (UTC) regardless of whether it
+    /// arrives as a <see cref="DateTime"/>, <see cref="DateTimeOffset"/>, <see cref="DateOnly"/>,
+    /// a numeric epoch, or an ISO/date string — matching the Esri spec's requirement that
+    /// <c>esriFieldTypeDate</c> values are epoch-millisecond integers.
     /// </summary>
     private static void WriteJsonValue(
         Utf8JsonWriter writer,
         string propertyName,
         object? value,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IReadOnlySet<string>? dateFieldNames = null)
     {
+        // Field-type-aware date coercion: the layer metadata knows this field is
+        // esriFieldTypeDate, so emit epoch-ms even when the value reaches us as a string
+        // (the canonical attribute pipeline can round-trip DateTime -> ISO string via JSON)
+        // or DateOnly. Numeric epoch values are passed through without double-conversion.
+        if (value is not null
+            && dateFieldNames is not null
+            && dateFieldNames.Contains(propertyName)
+            && GeoServicesFieldConventions.TryConvertToEpochMilliseconds(value, out var epochMs))
+        {
+            writer.WriteNumber(propertyName, epochMs);
+            cancellationToken.ThrowIfCancellationRequested();
+            return;
+        }
+
         switch (value)
         {
             case null:
@@ -1251,11 +1311,13 @@ internal sealed class StreamingQueryFormatter
                 writer.WriteBoolean(propertyName, b);
                 break;
             case DateTime dt:
-                writer.WriteNumber(propertyName, new DateTimeOffset(DateTime.SpecifyKind(
-                    dt, dt.Kind == DateTimeKind.Unspecified ? DateTimeKind.Utc : dt.Kind)).ToUnixTimeMilliseconds());
+                writer.WriteNumber(propertyName, GeoServicesFieldConventions.ToEpochMilliseconds(dt));
                 break;
             case DateTimeOffset dto:
                 writer.WriteNumber(propertyName, dto.ToUnixTimeMilliseconds());
+                break;
+            case DateOnly dateOnly:
+                writer.WriteNumber(propertyName, GeoServicesFieldConventions.ToEpochMilliseconds(dateOnly));
                 break;
             default:
                 // For complex objects, serialize to JSON and write as raw JSON

--- a/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Metadata.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Metadata.cs
@@ -13,6 +13,7 @@ using Honua.Core.Features.Validation.Abstractions;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Helpers;
 using Honua.Infrastructure.Models;
+using Honua.Protocols.GeoServices.FeatureServer;
 using Honua.Protocols.GeoServices.MapServer.Models;
 using Honua.ServiceDefaults;
 using Microsoft.Extensions.Options;
@@ -548,7 +549,12 @@ internal static partial class MapServerEndpoints
             Name = field.Name,
             Type = isObjectId ? "esriFieldTypeOID" : MapFieldTypeToGeoServicesV2(field.Type),
             Alias = field.Alias ?? field.Title ?? field.Name,
-            Length = field.Length,
+            // Esri clients require a positive length on string fields (a null length is
+            // mapped to 0 and breaks inserts/updates). Fall back to the Esri-conventional
+            // default when the column declares none.
+            Length = !isObjectId && field.Type == MetadataV2FieldType.String
+                ? GeoServicesFieldConventions.ResolveStringFieldLength(field.Length)
+                : field.Length,
             Nullable = field.Nullable && !isObjectId,
             Editable = field.Editable && !isObjectId
                 && field.Type is not MetadataV2FieldType.Geometry and not MetadataV2FieldType.Geography,

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/GeoServicesFieldSerializationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/GeoServicesFieldSerializationTests.cs
@@ -1,0 +1,353 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.IO.Pipelines;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Configuration;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Shared.Models;
+using Honua.Protocols.GeoServices.FeatureServer.Models;
+using Honua.Protocols.GeoServices.FeatureServer.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.Services;
+
+/// <summary>
+/// Esri GeoServices f=json serialization-compatibility regression tests:
+/// (1) esriFieldTypeString fields must report a positive <c>length</c>;
+/// (2) esriFieldTypeDate values must serialize as epoch-millisecond integers (not ISO strings).
+/// </summary>
+public sealed class GeoServicesFieldSerializationTests
+{
+    private const int DefaultStringLength = 256;
+
+    // ----- Bug 1: string field length -----
+
+    [Fact]
+    public async Task Json_StringFieldWithoutDeclaredLength_ReportsDefaultPositiveLength()
+    {
+        var (formatter, _) = CreateFormatter();
+        var resource = CreateResource(
+            new MetadataV2Field { Name = FieldNames.ObjectId, Type = MetadataV2FieldType.Integer, Nullable = false },
+            new MetadataV2Field { Name = "name", Type = MetadataV2FieldType.String },
+            new MetadataV2Field { Name = "description", Type = MetadataV2FieldType.String },
+            new MetadataV2Field { Name = "category", Type = MetadataV2FieldType.String });
+
+        var (response, _) = await formatter.FormatQueryResultAsync(
+            QueryResult<Feature>.Create(0, []),
+            resource,
+            format: "json",
+            returnGeometry: false,
+            outputSrid: null,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        var queryResponse = response.Should().BeOfType<QueryResponse>().Subject;
+        foreach (var fieldName in new[] { "name", "description", "category" })
+        {
+            var field = queryResponse.Fields!.Single(f => f.Name == fieldName);
+            field.Type.Should().Be("esriFieldTypeString");
+            field.Length.Should().Be(DefaultStringLength,
+                "string fields must report a positive length so arcpy does not map null -> 0");
+        }
+    }
+
+    [Fact]
+    public async Task Json_StringFieldWithDeclaredLength_PreservesDeclaredLength()
+    {
+        var (formatter, _) = CreateFormatter();
+        var resource = CreateResource(
+            new MetadataV2Field { Name = FieldNames.ObjectId, Type = MetadataV2FieldType.Integer, Nullable = false },
+            new MetadataV2Field { Name = "code", Type = MetadataV2FieldType.String, Length = 32 });
+
+        var (response, _) = await formatter.FormatQueryResultAsync(
+            QueryResult<Feature>.Create(0, []),
+            resource,
+            format: "json",
+            returnGeometry: false,
+            outputSrid: null,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        var queryResponse = response.Should().BeOfType<QueryResponse>().Subject;
+        queryResponse.Fields!.Single(f => f.Name == "code").Length.Should().Be(32);
+    }
+
+    [Fact]
+    public async Task Json_RuntimeStringField_ReportsPositiveLength()
+    {
+        var (formatter, _) = CreateFormatter();
+        var resource = CreateResource(
+            new MetadataV2Field { Name = FieldNames.ObjectId, Type = MetadataV2FieldType.Integer, Nullable = false });
+
+        var feature = Feature.Create(
+            1,
+            geometry: null,
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                // Undeclared runtime string attribute -> inferred field metadata.
+                ["runtime_label"] = "hello"
+            }.ToImmutableDictionary());
+
+        var (response, _) = await formatter.FormatQueryResultAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            resource,
+            format: "json",
+            returnGeometry: false,
+            outputSrid: null,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        var queryResponse = response.Should().BeOfType<QueryResponse>().Subject;
+        var runtimeField = queryResponse.Fields!.Single(f => f.Name == "runtime_label");
+        runtimeField.Type.Should().Be("esriFieldTypeString");
+        runtimeField.Length.Should().Be(DefaultStringLength);
+    }
+
+    // ----- Bug 2: date as epoch-ms (streaming f=json path) -----
+
+    [Fact]
+    public async Task Streaming_Json_DateFields_AreEmittedAsEpochMilliseconds()
+    {
+        var formatter = new StreamingQueryFormatter(Options.Create(new LimitsOptions()));
+        var resource = CreateResource(
+            new MetadataV2Field { Name = FieldNames.ObjectId, Type = MetadataV2FieldType.Integer, Nullable = false },
+            new MetadataV2Field { Name = "timestamp", Type = MetadataV2FieldType.DateTime },
+            new MetadataV2Field { Name = "created_date", Type = MetadataV2FieldType.Date });
+
+        var expectedTimestamp = new DateTimeOffset(2023, 1, 2, 0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        var expectedCreated = new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        // Arrives the way the canonical attribute pipeline delivers it after a JSON round-trip:
+        // the datetime as an ISO string, the date as a date-only string.
+        var feature = Feature.Create(
+            1,
+            geometry: null,
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["timestamp"] = "2023-01-02T00:00:00Z",
+                ["created_date"] = "2024-06-15"
+            }.ToImmutableDictionary());
+
+        var json = await StreamGeoServicesJsonAsync(formatter, feature, resource);
+        using var document = JsonDocument.Parse(json);
+        var attributes = document.RootElement.GetProperty("features")[0].GetProperty("attributes");
+
+        attributes.GetProperty("timestamp").ValueKind.Should().Be(JsonValueKind.Number);
+        attributes.GetProperty("timestamp").GetInt64().Should().Be(expectedTimestamp);
+        attributes.GetProperty("created_date").ValueKind.Should().Be(JsonValueKind.Number);
+        attributes.GetProperty("created_date").GetInt64().Should().Be(expectedCreated);
+    }
+
+    [Fact]
+    public async Task Streaming_Json_DateValues_HandleDateTimeAndDateOnlyClrTypes()
+    {
+        var formatter = new StreamingQueryFormatter(Options.Create(new LimitsOptions()));
+        var resource = CreateResource(
+            new MetadataV2Field { Name = FieldNames.ObjectId, Type = MetadataV2FieldType.Integer, Nullable = false },
+            new MetadataV2Field { Name = "timestamp", Type = MetadataV2FieldType.DateTime },
+            new MetadataV2Field { Name = "created_date", Type = MetadataV2FieldType.Date });
+
+        var dt = new DateTime(2023, 1, 2, 0, 0, 0, DateTimeKind.Utc);
+        var dateOnly = new DateOnly(2024, 6, 15);
+        var expectedTimestamp = new DateTimeOffset(dt).ToUnixTimeMilliseconds();
+        var expectedCreated = new DateTimeOffset(dateOnly.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
+
+        var feature = Feature.Create(
+            1,
+            geometry: null,
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["timestamp"] = dt,
+                ["created_date"] = dateOnly
+            }.ToImmutableDictionary());
+
+        var json = await StreamGeoServicesJsonAsync(formatter, feature, resource);
+        using var document = JsonDocument.Parse(json);
+        var attributes = document.RootElement.GetProperty("features")[0].GetProperty("attributes");
+
+        attributes.GetProperty("timestamp").GetInt64().Should().Be(expectedTimestamp);
+        attributes.GetProperty("created_date").GetInt64().Should().Be(expectedCreated);
+    }
+
+    [Fact]
+    public async Task Streaming_Json_AlreadyEpochValue_IsNotDoubleConverted()
+    {
+        var formatter = new StreamingQueryFormatter(Options.Create(new LimitsOptions()));
+        var resource = CreateResource(
+            new MetadataV2Field { Name = FieldNames.ObjectId, Type = MetadataV2FieldType.Integer, Nullable = false },
+            new MetadataV2Field { Name = "timestamp", Type = MetadataV2FieldType.DateTime });
+
+        var epoch = new DateTimeOffset(2023, 1, 2, 0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        var feature = Feature.Create(
+            1,
+            geometry: null,
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["timestamp"] = epoch
+            }.ToImmutableDictionary());
+
+        var json = await StreamGeoServicesJsonAsync(formatter, feature, resource);
+        using var document = JsonDocument.Parse(json);
+        var attributes = document.RootElement.GetProperty("features")[0].GetProperty("attributes");
+
+        attributes.GetProperty("timestamp").GetInt64().Should().Be(epoch);
+    }
+
+    // ----- Bug 2: object (non-streaming) f=json path -----
+
+    [Fact]
+    public async Task Json_ObjectPath_DateFields_AreEmittedAsEpochMilliseconds()
+    {
+        var (formatter, _) = CreateFormatter();
+        var resource = CreateResource(
+            new MetadataV2Field { Name = FieldNames.ObjectId, Type = MetadataV2FieldType.Integer, Nullable = false },
+            new MetadataV2Field { Name = "timestamp", Type = MetadataV2FieldType.DateTime },
+            new MetadataV2Field { Name = "created_date", Type = MetadataV2FieldType.Date });
+
+        var expectedTimestamp = new DateTimeOffset(2023, 1, 2, 0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        var expectedCreated = new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        var feature = Feature.Create(
+            1,
+            geometry: null,
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["timestamp"] = "2023-01-02T00:00:00Z",
+                ["created_date"] = "2024-06-15"
+            }.ToImmutableDictionary());
+
+        var (response, _) = await formatter.FormatQueryResultAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            resource,
+            format: "json",
+            returnGeometry: false,
+            outputSrid: null,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        var json = JsonSerializer.Serialize(response, FeatureServerJsonContext.Default.QueryResponse);
+        using var document = JsonDocument.Parse(json);
+        var attributes = document.RootElement.GetProperty("features")[0].GetProperty("attributes");
+
+        attributes.GetProperty("timestamp").ValueKind.Should().Be(JsonValueKind.Number);
+        attributes.GetProperty("timestamp").GetInt64().Should().Be(expectedTimestamp);
+        attributes.GetProperty("created_date").GetInt64().Should().Be(expectedCreated);
+    }
+
+    // ----- Bug 2 negative: GeoServices f=geojson keeps ISO date strings -----
+
+    [Fact]
+    public async Task Streaming_GeoJson_DateStrings_RemainIso()
+    {
+        var formatter = new StreamingQueryFormatter(Options.Create(new LimitsOptions()));
+        var resource = CreateResource(
+            new MetadataV2Field { Name = FieldNames.ObjectId, Type = MetadataV2FieldType.Integer, Nullable = false },
+            new MetadataV2Field { Name = "timestamp", Type = MetadataV2FieldType.DateTime });
+
+        var feature = Feature.Create(
+            1,
+            geometry: null,
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["timestamp"] = "2023-01-02T00:00:00Z"
+            }.ToImmutableDictionary());
+
+        var json = await StreamGeoJsonAsync(formatter, feature, resource);
+        using var document = JsonDocument.Parse(json);
+        var properties = document.RootElement.GetProperty("features")[0].GetProperty("properties");
+
+        properties.GetProperty("timestamp").ValueKind.Should().Be(JsonValueKind.String);
+        properties.GetProperty("timestamp").GetString().Should().Be("2023-01-02T00:00:00Z");
+    }
+
+    private static (QueryFormatter Formatter, LimitsOptions Limits) CreateFormatter()
+    {
+        var limitsOptions = Options.Create(new LimitsOptions());
+        var formatter = new QueryFormatter(
+            limitsOptions,
+            new PbfQueryFormatter(limitsOptions),
+            NullLogger<QueryFormatter>.Instance);
+        return (formatter, limitsOptions.Value);
+    }
+
+    private static async Task<string> StreamGeoServicesJsonAsync(
+        StreamingQueryFormatter formatter,
+        Feature feature,
+        MetadataV2Resource resource)
+    {
+        using var stream = new MemoryStream();
+        var pipe = PipeWriter.Create(stream);
+        await formatter.StreamAsGeoServicesJsonAsync(
+            ToAsyncEnumerable(feature),
+            resource,
+            returnGeometry: false,
+            outputSrid: null,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null,
+            outFields: null,
+            hasMoreResults: false,
+            outputStream: pipe);
+        await pipe.FlushAsync();
+        await pipe.CompleteAsync();
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static async Task<string> StreamGeoJsonAsync(
+        StreamingQueryFormatter formatter,
+        Feature feature,
+        MetadataV2Resource resource)
+    {
+        using var stream = new MemoryStream();
+        var pipe = PipeWriter.Create(stream);
+        await formatter.StreamAsGeoJsonAsync(
+            ToAsyncEnumerable(feature),
+            resource,
+            returnGeometry: false,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null,
+            outFields: null,
+            hasMoreResults: false,
+            outputStream: pipe);
+        await pipe.FlushAsync();
+        await pipe.CompleteAsync();
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static async IAsyncEnumerable<Feature> ToAsyncEnumerable(Feature feature)
+    {
+        yield return feature;
+        await Task.CompletedTask;
+    }
+
+    private static MetadataV2Resource CreateResource(params MetadataV2Field[] fields)
+        => new()
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "test-layer", Name = "test-layer" },
+            SchemaFields = [.. fields]
+        };
+}


### PR DESCRIPTION
## Issue Link
Related to #418

## Summary
Two Esri GeoServices `f=json` serialization conformance bugs found by the licensed Esri SDK certification run (they break the ArcGIS Maps SDK for .NET and ArcGIS Pro arcpy editing/reading; the ArcGIS API for Python tolerates them but they violate the Esri spec).

1. **`esriFieldTypeString` fields emitted `length: null`.** A real Esri FeatureServer always reports a positive `length`; arcpy maps null→0 and every value insert/update then fails client-side with "Field length exceeded".
2. **`esriFieldTypeDate` values returned as ISO-8601 strings instead of epoch-milliseconds.** The Esri `f=json` spec returns date values as epoch-ms integers (UTC); arcpy raises ERROR 010273 and .NET clients mis-handle the strings. (Date values were lost through a JSON round-trip in the canonical pipeline and reached the writer as strings, bypassing the existing `DateTime`→epoch-ms case.)

## Changes Made
- **String length** — emit a positive `length` for string fields (declared varchar length when known, else Esri-conventional 256) across all four projection sites: `QueryFormatters.MapFieldInfo`, `QueryFormatters.MapRuntimeFieldInfo`, `FeatureServerUtilities.V2.MapFieldInfoV2`, `MapServerRequestHandlers.Metadata.MapFieldInfoV2`.
- **Date epoch-ms** — the `f=json` value writer is now **field-type-aware**: fields whose layer metadata type is `esriFieldTypeDate` are coerced to epoch-ms (UTC) whether the value arrives as `DateTime`, `DateTimeOffset`, `DateOnly`, a numeric epoch (idempotent), or an ISO/date-only string. Added the missing `case DateOnly`. Applied to both `f=json` paths (streaming `WriteGeoServicesFeature` and the object path); MapServer query inherits it via the shared dispatcher/formatter.
- Shared helpers extracted to `GeoServicesFieldConventions.cs`.
- **Unchanged by design:** GeoServices `f=geojson` keeps ISO dates; OGC API Features / WFS use separate code paths and are untouched (still ISO); PBF/Arrow/Parquet unchanged.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

New `GeoServicesFieldSerializationTests` (8: string default/declared/runtime length; streaming date epoch-ms from ISO/DateTime/DateOnly; idempotent epoch; object-path epoch-ms; geojson stays ISO). Full GeoServices suite **687 passed/0 failed**; OGC API suite **301 passed/0 failed** (ISO dates confirmed unchanged). Full-solution Release `-p:TreatWarningsAsErrors=true` build **0/0**. Bugs originally reproduced live via arcpy/.NET during certification.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

The Esri `f=json` date representation changes from ISO string to epoch-ms (this is the Esri-conformant behavior; GeoJSON/OGC unchanged) and string fields gain a `length`. Both align Honua with the Esri spec.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None to Esri clients (this aligns with the Esri spec; Esri SDKs expect epoch-ms dates and string lengths). GeoJSON/OGC consumers are unaffected (still ISO).

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
