### PR TITLE
fix(geoservices): final Esri cert gaps — extractChanges layers JSON-array + ImageServer conf.json

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -1061,8 +1061,12 @@ internal static partial class FeatureServerEndpoints
 
         var layerById = ResolveServiceReplicaLayersV2(service, snapshot)
             .ToDictionary(layer => layer.PublicLayerId);
-        var tokens = layersParam.Split(',', StringSplitOptions.TrimEntries);
-        if (tokens.Any(token => token.Length == 0))
+
+        // Accept both the comma-separated form (layers=0 / layers=0,1) and the Esri
+        // JSON-array form (layers=[0] / layers=[0,1]) that the ArcGIS API for Python
+        // (FeatureLayerCollection.extract_changes / create_replica) sends.
+        var tokens = StripLayerListBrackets(layersParam).Split(',', StringSplitOptions.TrimEntries);
+        if (tokens.Length == 0 || tokens.Any(token => token.Length == 0))
         {
             error = StandardErrorHelpers.CreateBadRequest(
                 context,

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.cs
@@ -367,6 +367,24 @@ internal static partial class FeatureServerEndpoints
         };
     }
 
+    /// <summary>
+    /// Normalizes the GeoServices <c>layers</c> parameter to its inner token list,
+    /// accepting both the comma-separated form (<c>0</c> / <c>0,1</c>) and the Esri
+    /// JSON-array form (<c>[0]</c> / <c>[0,1]</c>) the ArcGIS API for Python sends.
+    /// </summary>
+    internal static string StripLayerListBrackets(string rawValue)
+    {
+        var normalized = rawValue.Trim();
+        if (normalized.Length >= 2 &&
+            normalized.StartsWith('[') &&
+            normalized.EndsWith(']'))
+        {
+            normalized = normalized[1..^1];
+        }
+
+        return normalized;
+    }
+
     internal static bool TryParseLayerIdList(string rawValue, out int[] layerIds, out string? error)
     {
         layerIds = [];
@@ -378,15 +396,7 @@ internal static partial class FeatureServerEndpoints
             return false;
         }
 
-        var normalized = rawValue.Trim();
-        if (normalized.StartsWith('[') &&
-            normalized.EndsWith(']') &&
-            normalized.Length >= 2)
-        {
-            normalized = normalized[1..^1];
-        }
-
-        var tokens = normalized.Split(',', StringSplitOptions.TrimEntries);
+        var tokens = StripLayerListBrackets(rawValue).Split(',', StringSplitOptions.TrimEntries);
         if (tokens.Length == 0 || tokens.Any(static token => token.Length == 0))
         {
             error = "layers parameter must contain only numeric layer IDs.";

--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerMetadataHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerMetadataHandler.cs
@@ -201,6 +201,85 @@ internal sealed class ImageServerMetadataHandler
         }
     }
 
+    /// <summary>
+    /// Serves the <c>/ImageServer/conf.json</c> storage/configuration descriptor.
+    /// The ArcGIS Maps SDK for .NET native runtime probes this resource when loading
+    /// an <c>ImageServiceRaster</c>; returning a 404 makes the runtime report "could
+    /// not read the ImageServer conf". For the dynamic (non-cached) image service this
+    /// returns a well-formed descriptor that explicitly advertises no fused tile cache.
+    /// </summary>
+    public async Task<IResult> GetServiceConfAsync(
+        HttpContext context,
+        int layerId,
+        CancellationToken cancellationToken = default)
+    {
+        Activity? featureActivity = null;
+
+        try
+        {
+            var snapshot = await _graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+            if (ImageServerV2Lookups.FindByLayerIndex(snapshot, layerId) is not { } resolved)
+            {
+                ImageServerLog.LayerNotFound(_logger, layerId);
+                return StandardErrorHelpers.CreateNotFound(context, "Layer not found.");
+            }
+
+            featureActivity = HonuaTelemetry.StartFeatureActivity(
+                "metadata",
+                HonuaTelemetry.Protocols.ImageServer,
+                layerId.ToString(CultureInfo.InvariantCulture));
+            featureActivity?.SetTag(HonuaTelemetry.Tags.Operation, "get-service-conf");
+
+            var rasters = await _rasterStore.ListRastersAsync(layerId, cancellationToken);
+            if (rasters.Length == 0)
+            {
+                ImageServerLog.NoRastersFound(_logger, layerId);
+                return StandardErrorHelpers.CreateNotFound(context, "No rasters found for layer.");
+            }
+
+            var aggregateExtent = ImageServerMosaicHelpers.ComputeAggregateExtent(rasters);
+            var referenceRaster = CreateMosaicReferenceRaster(rasters, aggregateExtent);
+
+            var extent = aggregateExtent;
+            if (extent == null)
+            {
+                ImageServerLog.ExtentNotAvailable(_logger, layerId);
+                return StandardErrorHelpers.CreateInternalServerError(context, "Unable to determine raster extent.");
+            }
+
+            var conf = new ImageServerConfInfo
+            {
+                // Dynamic (non-cached) image service: no fused tile cache.
+                SingleFusedMapCache = false,
+                TileInfo = null,
+                StorageInfo = BuildStorageInfo(),
+                BlockWidth = BlockWidth,
+                BlockHeight = BlockHeight,
+                SpatialReference = CreateSpatialReference(referenceRaster.Srid),
+                FullExtent = BuildExtent(extent.Value),
+                PixelType = MapPixelType(referenceRaster.PixelType),
+                BandCount = referenceRaster.BandCount
+            };
+
+            HonuaTelemetry.SetSuccess(featureActivity, 1);
+            return Results.Json(conf, ImageServerJsonContext.Default.ImageServerConfInfo);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            ImageServerLog.ServiceInfoFailed(_logger, ex, layerId);
+            HonuaTelemetry.RecordException(featureActivity, ex);
+            return StandardErrorHelpers.CreateInternalServerError(context, "An error occurred while retrieving service configuration.");
+        }
+        finally
+        {
+            featureActivity?.Dispose();
+        }
+    }
+
     private static SpatialReference CreateSpatialReference(int? srid)
     {
         return new SpatialReference

--- a/src/Honua.Protocols.GeoServices/ImageServer/ImageServerEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/ImageServerEndpoints.cs
@@ -59,6 +59,17 @@ internal static class ImageServerEndpoints
             .Produces<ImageServerServiceInfo>()
             .Produces(404);
 
+        // The ArcGIS Maps SDK for .NET native runtime probes conf.json when loading an
+        // ImageServiceRaster. A 404 is reported as "could not read the ImageServer conf",
+        // so serve the dynamic-service storage descriptor here.
+        group.MapGet("/conf.json", GetServiceConf)
+            .WithDisplayName("Get Image Service Configuration")
+            .WithName("GetImageServiceConf")
+            .WithSummary("Get Image Server configuration descriptor")
+            .WithDescription("Returns the storage/configuration descriptor (storageInfo, extent, spatial reference) the native ImageServiceRaster runtime probes when loading the service")
+            .Produces<ImageServerConfInfo>()
+            .Produces(404);
+
         // Export image endpoint - core rendering capability
         group.MapGet("/exportImage", ExportImage)
             .WithDisplayName("Export Image")
@@ -366,6 +377,14 @@ internal static class ImageServerEndpoints
             .Produces<ImageServerServiceInfo>()
             .Produces(404);
 
+        serviceGroup.MapGet("/conf.json", GetServiceConfByService)
+            .WithDisplayName("Get Image Service Configuration by Service")
+            .WithName("GetImageServiceConfByService")
+            .WithSummary("Get Image Server configuration descriptor")
+            .WithDescription("Returns the storage/configuration descriptor the native ImageServiceRaster runtime probes when loading the named service")
+            .Produces<ImageServerConfInfo>()
+            .Produces(404);
+
         serviceGroup.MapGet("/exportImage", ExportImageByService)
             .WithDisplayName("Export Image by Service")
             .WithName("ExportImageByService")
@@ -635,6 +654,41 @@ internal static class ImageServerEndpoints
     {
         var resolution = await ResolveImageServiceLayerIdAsync(serviceId, context, cancellationToken);
         return resolution.ErrorResult ?? await GetServiceInfo(resolution.LayerId, f, context, handler, cancellationToken);
+    }
+
+    /// <summary>
+    /// Serve the conf.json storage/configuration descriptor for the native runtime.
+    /// </summary>
+    private static async Task<IResult> GetServiceConf(
+        int id,
+        string? f,
+        HttpContext context,
+        ImageServerMetadataHandler handler,
+        CancellationToken cancellationToken = default)
+    {
+        if (!IsSupportedJsonResponseFormat(f))
+        {
+            return CreateUnsupportedJsonFormatResult(context);
+        }
+
+        var layerError = await ValidateImageLayerAsync(id, context, cancellationToken);
+        if (layerError is not null)
+        {
+            return layerError;
+        }
+
+        return await handler.GetServiceConfAsync(context, id, cancellationToken);
+    }
+
+    private static async Task<IResult> GetServiceConfByService(
+        string serviceId,
+        string? f,
+        HttpContext context,
+        ImageServerMetadataHandler handler,
+        CancellationToken cancellationToken = default)
+    {
+        var resolution = await ResolveImageServiceLayerIdAsync(serviceId, context, cancellationToken);
+        return resolution.ErrorResult ?? await GetServiceConf(resolution.LayerId, f, context, handler, cancellationToken);
     }
 
     /// <summary>

--- a/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerJsonContext.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerJsonContext.cs
@@ -27,6 +27,7 @@ namespace Honua.Protocols.GeoServices.ImageServer.Models;
 [JsonSerializable(typeof(SpatialReference))]
 [JsonSerializable(typeof(ImageServerExtent))]
 [JsonSerializable(typeof(ImageServerStorageInfo))]
+[JsonSerializable(typeof(ImageServerConfInfo))]
 [JsonSerializable(typeof(Field))]
 [JsonSerializable(typeof(TileInfo))]
 [JsonSerializable(typeof(Point))]

--- a/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerModels.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerModels.cs
@@ -536,6 +536,55 @@ public sealed class ImageServerStorageInfo
 }
 
 /// <summary>
+/// Storage/configuration descriptor served at the <c>/ImageServer/conf.json</c>
+/// resource. The ArcGIS Maps SDK for .NET native runtime probes <c>conf.json</c>
+/// when loading an <c>ImageServiceRaster</c>; for a dynamic (non-cached) image
+/// service it must receive a well-formed descriptor (200) rather than a 404, which
+/// the native runtime reports as "could not read the ImageServer conf". This block
+/// explicitly advertises no fused tile cache (<c>singleFusedMapCache=false</c>,
+/// <c>tileInfo=null</c>) and surfaces the pixel-block <c>storageInfo</c>, extent, and
+/// spatial reference the runtime uses to plan chunked pixel reads.
+/// </summary>
+public sealed class ImageServerConfInfo
+{
+    /// <summary>Whether the service is backed by a single fused tile cache.</summary>
+    [JsonPropertyName("singleFusedMapCache")]
+    public bool SingleFusedMapCache { get; init; }
+
+    /// <summary>Tile cache scheme; null for a dynamic (non-cached) image service.</summary>
+    [JsonPropertyName("tileInfo")]
+    public TileInfo? TileInfo { get; init; }
+
+    /// <summary>Pixel-block storage information describing chunked pixel reads.</summary>
+    [JsonPropertyName("storageInfo")]
+    public required ImageServerStorageInfo StorageInfo { get; init; }
+
+    /// <summary>Width, in pixels, of a stored pixel block (mirrors storageInfo).</summary>
+    [JsonPropertyName("blockWidth")]
+    public required int BlockWidth { get; init; }
+
+    /// <summary>Height, in pixels, of a stored pixel block (mirrors storageInfo).</summary>
+    [JsonPropertyName("blockHeight")]
+    public required int BlockHeight { get; init; }
+
+    /// <summary>Spatial reference of the image service.</summary>
+    [JsonPropertyName("spatialReference")]
+    public required SpatialReference SpatialReference { get; init; }
+
+    /// <summary>Full extent of the image service.</summary>
+    [JsonPropertyName("fullExtent")]
+    public required ImageServerExtent FullExtent { get; init; }
+
+    /// <summary>Esri pixel type advertised by the service (e.g. U8, F32).</summary>
+    [JsonPropertyName("pixelType")]
+    public required string PixelType { get; init; }
+
+    /// <summary>Number of bands in the source raster mosaic.</summary>
+    [JsonPropertyName("bandCount")]
+    public required int BandCount { get; init; }
+}
+
+/// <summary>
 /// Field definition for image services.
 /// </summary>
 public sealed class Field

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -757,6 +757,7 @@ public static class EndpointRegistry
 
         new("GET", "/rest/services/{id}/ImageServer"),
         new("POST", "/rest/services/{id}/ImageServer"),
+        new("GET", "/rest/services/{id}/ImageServer/conf.json"),
         new("GET", "/rest/services/{id}/ImageServer/WCS"),
         new("GET", "/rest/services/{id}/ImageServer/exportImage"),
         new("POST", "/rest/services/{id}/ImageServer/exportImage"),
@@ -791,6 +792,7 @@ public static class EndpointRegistry
 
         new("GET", "/rest/services/{serviceId}/ImageServer"),
         new("POST", "/rest/services/{serviceId}/ImageServer"),
+        new("GET", "/rest/services/{serviceId}/ImageServer/conf.json"),
         new("GET", "/rest/services/{serviceId}/ImageServer/exportImage"),
         new("POST", "/rest/services/{serviceId}/ImageServer/exportImage"),
         new("GET", "/rest/services/{serviceId}/ImageServer/identify"),

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerLayerListParsingTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerLayerListParsingTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Protocols.GeoServices.FeatureServer;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
+
+/// <summary>
+/// The GeoServices <c>layers</c> parameter (createReplica / extractChanges) is a JSON
+/// array per the Esri spec. The ArcGIS API for Python
+/// (<c>FeatureLayerCollection.extract_changes</c> / <c>create_replica</c>) sends the
+/// bracketed JSON-array form (<c>[0]</c> / <c>[0,1]</c>), while the comma-separated
+/// form (<c>0</c> / <c>0,1</c>) is also widely used. Both forms must parse identically.
+/// </summary>
+public sealed class FeatureServerLayerListParsingTests
+{
+    [Theory]
+    [InlineData("0")]
+    [InlineData("[0]")]
+    [InlineData(" [0] ")]
+    [InlineData("[ 0 ]")]
+    public void TryParseLayerIdList_SingleLayer_AcceptsCommaAndJsonArrayForms(string raw)
+    {
+        var ok = FeatureServerEndpoints.TryParseLayerIdList(raw, out var ids, out var error);
+
+        ok.Should().BeTrue();
+        error.Should().BeNull();
+        ids.Should().Equal(0);
+    }
+
+    [Theory]
+    [InlineData("0,1")]
+    [InlineData("[0,1]")]
+    [InlineData("[0, 1]")]
+    [InlineData(" [ 0 , 1 ] ")]
+    public void TryParseLayerIdList_MultipleLayers_AcceptsCommaAndJsonArrayForms(string raw)
+    {
+        var ok = FeatureServerEndpoints.TryParseLayerIdList(raw, out var ids, out var error);
+
+        ok.Should().BeTrue();
+        error.Should().BeNull();
+        ids.Should().BeEquivalentTo([0, 1]);
+    }
+
+    [Theory]
+    [InlineData("a")]
+    [InlineData("[a]")]
+    [InlineData("[0,a]")]
+    [InlineData("[0,]")]
+    [InlineData("[]")]
+    public void TryParseLayerIdList_NonNumericOrEmpty_ReturnsError(string raw)
+    {
+        var ok = FeatureServerEndpoints.TryParseLayerIdList(raw, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData("0", "0")]
+    [InlineData("[0]", "0")]
+    [InlineData("[0,1]", "0,1")]
+    [InlineData(" [ 0 , 1 ] ", " 0 , 1 ")]
+    public void StripLayerListBrackets_RemovesOuterBrackets(string raw, string expected)
+    {
+        FeatureServerEndpoints.StripLayerListBrackets(raw).Should().Be(expected);
+    }
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicationTests.cs
@@ -96,6 +96,37 @@ public sealed class FeatureServerReplicationTests : IAsyncLifetime
         creationDate.GetInt64().Should().BeGreaterThan(0);
     }
 
+    // The ArcGIS API for Python (FeatureLayerCollection.create_replica /
+    // extract_changes) sends the `layers` parameter as the Esri JSON-array form
+    // (layers=[0] / layers=[0,1]) rather than the comma-separated form. Both forms
+    // must be accepted identically.
+    [IntegrationTest]
+    [Operation(Operations.CreateReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/createReplica")]
+    public async Task CreateReplica_LayersAsJsonArray_ReturnsReplicaId()
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            replicaName = "JsonArrayReplica",
+            layers = "[0]",
+            syncModel = "perReplica",
+            f = "json"
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/createReplica",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(content);
+        var root = document.RootElement;
+
+        root.TryGetProperty("layers", out var layers).Should().BeTrue();
+        layers.EnumerateArray().Should().Contain(item => item.GetProperty("id").GetInt32() == 0);
+    }
+
     [IntegrationTest]
     [Operation(Operations.ListReplicas)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/replicas")]
@@ -343,6 +374,37 @@ public sealed class FeatureServerReplicationTests : IAsyncLifetime
         root.TryGetProperty("serverGen", out _).Should().BeTrue();
         root.TryGetProperty("minServerGen", out _).Should().BeTrue();
         root.TryGetProperty("maxServerGen", out _).Should().BeTrue();
+    }
+
+    // The ArcGIS API for Python sends layers as a JSON array (layers=[0,1]). The
+    // serverGen-based extractChanges flow must accept it identically to the
+    // comma-separated form (layers=0,1).
+    [IntegrationTest]
+    [Operation(Operations.ExtractChanges)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/extractChanges")]
+    public async Task ExtractChanges_LayersAsJsonArray_ReturnsChanges()
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            serverGen = 0,
+            layers = "[0]",
+            f = "json"
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/extractChanges",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(content);
+        var root = document.RootElement;
+
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+        root.TryGetProperty("layerChanges", out var layerChanges).Should().BeTrue();
+        layerChanges.ValueKind.Should().Be(JsonValueKind.Array);
+        layerChanges.GetArrayLength().Should().BeGreaterThanOrEqualTo(1);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerBasicTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerBasicTests.cs
@@ -269,6 +269,7 @@ public class ImageServerBasicTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("GET /rest/services/{serviceId}/ImageServer")]
+    [Endpoint("GET /rest/services/{serviceId}/ImageServer/conf.json")]
     [Endpoint("GET /rest/services/{serviceId}/ImageServer/exportImage")]
     [Endpoint("POST /rest/services/{serviceId}/ImageServer/exportImage")]
     [Endpoint("GET /rest/services/{serviceId}/ImageServer/identify")]
@@ -303,6 +304,7 @@ public class ImageServerBasicTests : IAsyncLifetime
         var getUris = new[]
         {
             $"/rest/services/{serviceId}/ImageServer?f=json",
+            $"/rest/services/{serviceId}/ImageServer/conf.json?f=json",
             $"/rest/services/{serviceId}/ImageServer/exportImage?bbox=-180,-90,180,90&size=256,256&format=png&f=json",
             $"/rest/services/{serviceId}/ImageServer/identify?geometry=0,0&geometryType=esriGeometryPoint&f=json",
             $"/rest/services/{serviceId}/ImageServer/tile/0/0/0?format=png",

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerClientCompatibilityTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerClientCompatibilityTests.cs
@@ -53,6 +53,48 @@ public sealed class ImageServerClientCompatibilityTests
         }
     }
 
+    // The ArcGIS Maps SDK for .NET native runtime probes /ImageServer/conf.json when
+    // loading an ImageServiceRaster; a 404 is reported as "could not read the
+    // ImageServer conf". The dynamic (non-cached) service serves a storage descriptor.
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{id}/ImageServer/conf.json")]
+    public async Task NativeRuntime_ReadsImageServerConfJson()
+    {
+        var fixture = await CreateFixtureAsync();
+        try
+        {
+            using var response = await fixture.Client.GetAsync($"/rest/services/{TestLayerId}/ImageServer/conf.json?f=json");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var root = doc.RootElement;
+
+            root.GetProperty("singleFusedMapCache").GetBoolean().Should().BeFalse();
+            root.TryGetProperty("tileInfo", out var tileInfo).Should().BeTrue();
+            tileInfo.ValueKind.Should().Be(JsonValueKind.Null);
+
+            root.TryGetProperty("storageInfo", out var storageInfo).Should().BeTrue();
+            storageInfo.GetProperty("blockWidth").GetInt32().Should().BeGreaterThan(0);
+            storageInfo.GetProperty("blockHeight").GetInt32().Should().BeGreaterThan(0);
+
+            root.GetProperty("blockWidth").GetInt32()
+                .Should().Be(storageInfo.GetProperty("blockWidth").GetInt32());
+            root.GetProperty("blockHeight").GetInt32()
+                .Should().Be(storageInfo.GetProperty("blockHeight").GetInt32());
+
+            root.TryGetProperty("fullExtent", out _).Should().BeTrue();
+            root.TryGetProperty("spatialReference", out _).Should().BeTrue();
+            root.GetProperty("bandCount").GetInt32().Should().Be(1);
+            root.GetProperty("pixelType").GetString().Should().Be("U8");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
     [IntegrationTest]
     [Operation(Operations.Export)]
     [Endpoint("GET /rest/services/{id}/ImageServer/exportImage")]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMetadataHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMetadataHandlerTests.cs
@@ -282,6 +282,68 @@ public class ImageServerMetadataHandlerTests
 
     [UnitTest]
     [Operation(Operations.GetServiceInfo)]
+    public async Task GetServiceConfAsync_ReturnsDynamicStorageDescriptor()
+    {
+        // The ArcGIS Maps SDK for .NET native runtime probes /ImageServer/conf.json
+        // when loading an ImageServiceRaster; a 404 is reported as "could not read the
+        // ImageServer conf". The dynamic (non-cached) service must return a well-formed
+        // descriptor that advertises no fused tile cache and carries the pixel-block
+        // storageInfo, extent, and spatial reference the runtime needs.
+        SetupSuccessfulMetadata();
+
+        var context = CreateImageServerContext();
+        var result = await _handler.GetServiceConfAsync(context, 1);
+
+        var jsonResult = result as JsonHttpResult<ImageServerConfInfo>;
+        jsonResult.Should().NotBeNull();
+        var conf = jsonResult!.Value!;
+
+        conf.SingleFusedMapCache.Should().BeFalse();
+        conf.TileInfo.Should().BeNull();
+
+        conf.StorageInfo.Should().NotBeNull();
+        conf.StorageInfo.BlockWidth.Should().BeGreaterThan(0);
+        conf.StorageInfo.BlockHeight.Should().BeGreaterThan(0);
+
+        // Block dimensions are mirrored at the root for the native runtime.
+        conf.BlockWidth.Should().Be(conf.StorageInfo.BlockWidth);
+        conf.BlockHeight.Should().Be(conf.StorageInfo.BlockHeight);
+
+        conf.FullExtent.Should().NotBeNull();
+        conf.FullExtent.XMin.Should().Be(-180);
+        conf.FullExtent.YMax.Should().Be(90);
+        conf.SpatialReference.Wkid.Should().Be(4326);
+        conf.BandCount.Should().BeGreaterThan(0);
+        conf.PixelType.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [UnitTest]
+    [Operation(Operations.GetServiceInfo)]
+    public async Task GetServiceConfAsync_LayerNotFound_ReturnsNotFound()
+    {
+        var context = CreateImageServerContext();
+        var result = await _handler.GetServiceConfAsync(context, 99);
+        await result.ExecuteAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [UnitTest]
+    [Operation(Operations.GetServiceInfo)]
+    public async Task GetServiceConfAsync_NoRasters_ReturnsNotFound()
+    {
+        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<RasterInfo>());
+
+        var context = CreateImageServerContext();
+        var result = await _handler.GetServiceConfAsync(context, 1);
+        await result.ExecuteAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [UnitTest]
+    [Operation(Operations.GetServiceInfo)]
     public async Task GetServiceInfoAsync_EmptyStatistics_ReturnsOk()
     {
         SetupLayerAndRasters();


### PR DESCRIPTION
## Issue Link
Related to #418

## Summary
Final server-side Esri GeoServices REST certification gaps found by the licensed Esri SDK certification run (ArcGIS API for Python + ArcGIS Maps SDK for .NET). Two real fixes (the other two candidate gaps — GeometryServer trimExtend and batch geocode — were already implemented on trunk via #1449).

## Changes Made
- **extractChanges / createReplica `layers` JSON-array form** — the ArcGIS API for Python `FeatureLayerCollection.extract_changes()` sends `layers=[0]` (the Esri-spec JSON-array form), which `TryResolveReplicaLayerIdsV2` rejected with 400 "layers parameter must contain only numeric layer IDs" because it split on `,` without stripping the brackets. Extracted a shared `StripLayerListBrackets` helper so both the extractChanges/createReplica path and the existing list parser accept `[0]`/`[0,1]` identically to `0`/`0,1`.
- **ImageServer `conf.json`** — the ArcGIS Maps SDK for .NET `ImageServiceRaster.LoadAsync` probes `/ImageServer/conf.json` and a 404 was surfaced as "could not read the ImageServer conf", blocking the .NET ImageServer client. Added a `conf.json` resource returning the dynamic-service storage descriptor (`singleFusedMapCache:false`, `tileInfo:null`, `storageInfo`, root-mirrored `blockWidth`/`blockHeight`, `fullExtent`, `spatialReference`, `pixelType`, `bandCount`) on both ImageServer route groups — without misrepresenting the dynamic service as cached.

## Changes Made (bullets)
- `FeatureServerUtilities.cs`, `FeatureServerRequestHandlers.Replication.cs` — shared bracket-stripping for the `layers` param.
- `ImageServer/Handlers/ImageServerMetadataHandler.cs`, `ImageServerEndpoints.cs`, `Models/ImageServerModels.cs`, `Models/ImageServerJsonContext.cs` — `conf.json` resource + route.
- `EndpointRegistry.cs` — registered `GET .../ImageServer/conf.json` (layer-id and service-name route groups).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

`FeatureServerLayerListParsingTests` 17/17; `ImageServerMetadataHandlerTests` 20/20; replication JSON-array integration 4/4; `ImageServerClientCompatibilityTests` 4/4; governance `EndpointRegistryDriftTests`/`ApiSurfaceCoverageTests`/`OpenApiDriftTests` green. Full-solution Release `-p:TreatWarningsAsErrors=true` 0/0. Bugs reproduced live via the Esri SDKs during certification.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — additive (a previously-rejected `layers` form is accepted; a new read-only `conf.json` resource). OGC/GeoJSON untouched.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
