### PR TITLE
feat: import Esri attachments + persist relationship classes (#1257, #1256)

### DIFF
--- a/src/Honua.Core/Features/Migration/Abstractions/GeoservicesImportProgress.cs
+++ b/src/Honua.Core/Features/Migration/Abstractions/GeoservicesImportProgress.cs
@@ -54,6 +54,17 @@ public sealed record GeoservicesImportProgress : IOperationProgress, ICancellabl
     public int FailedFeatures { get; init; }
 
     /// <summary>
+    /// Number of feature attachments copied so far while the import is in the
+    /// <see cref="GeoservicesImportStatus.CopyingAttachments"/> phase.
+    /// </summary>
+    public int AttachmentsProcessed { get; init; }
+
+    /// <summary>
+    /// Number of source attachments that failed to copy.
+    /// </summary>
+    public int FailedAttachments { get; init; }
+
+    /// <summary>
     /// Progress percentage (0-100), null if total is unknown.
     /// </summary>
     public double? PercentComplete => EstimatedTotalFeatures > 0
@@ -146,6 +157,7 @@ public sealed record GeoservicesImportProgress : IOperationProgress, ICancellabl
         GeoservicesImportStatus.CreatingTable => OperationStatus.Processing,
         GeoservicesImportStatus.InsertingFeatures => OperationStatus.Processing,
         GeoservicesImportStatus.Publishing => OperationStatus.Processing,
+        GeoservicesImportStatus.CopyingAttachments => OperationStatus.Processing,
         GeoservicesImportStatus.Completed => OperationStatus.Completed,
         GeoservicesImportStatus.Failed => OperationStatus.Failed,
         GeoservicesImportStatus.Cancelled => OperationStatus.Cancelled,
@@ -219,6 +231,11 @@ public enum GeoservicesImportStatus
     /// Publishing the imported layer.
     /// </summary>
     Publishing,
+
+    /// <summary>
+    /// Copying source feature attachments into the Honua attachment store.
+    /// </summary>
+    CopyingAttachments,
 
     /// <summary>
     /// Import completed successfully.

--- a/src/Honua.Core/Features/Migration/Abstractions/IGeoservicesImportService.cs
+++ b/src/Honua.Core/Features/Migration/Abstractions/IGeoservicesImportService.cs
@@ -3,6 +3,7 @@
 
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Migration.Abstractions;
 using Honua.Core.Features.Migration.Domain;
 using Honua.Core.Features.Migration.Services;
@@ -57,5 +58,31 @@ public interface IGeoservicesImportService
     Task<GeoservicesImportResult> ImportLayerAsync(
         GeoservicesImportRequest request,
         IProgress<GeoservicesImportProgress>? progress,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Apply the simple relationship classes captured in a migration manifest
+    /// to the Honua catalog so the GeoServices <c>queryRelatedRecords</c> path
+    /// can resolve related features for imported ArcGIS layers (issue #1256).
+    /// </summary>
+    /// <remarks>
+    /// The caller provides a <paramref name="publishedLayerMap"/> mapping each
+    /// source resource id from the manifest (e.g.
+    /// <c>resource:Inspections:layer:0</c>) to the Honua layer id assigned at
+    /// publish time. Relationships whose origin or related resource is not in
+    /// the map are recorded as <see cref="MigrationCatalogWriteOutcome.AlreadyExists"/>
+    /// with a manual-review-style message so re-running after the missing layer
+    /// is imported converges. Composite, attributed, many-to-many, and
+    /// manual-review relationships are skipped here per the slice contract.
+    /// </remarks>
+    /// <param name="manifest">Manifest emitted by the manifest translator. Must originate from an ArcGIS source.</param>
+    /// <param name="publishedLayerMap">Resolved Honua layer ids per manifest source resource id. Keys are the manifest's <c>SourceResourceId</c> values.</param>
+    /// <param name="graphStore">Optional read-write Metadata v2 graph store. When <c>null</c>, only the v1 <c>honua.relationships</c> rows are written.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Per-relationship outcomes ordered by origin layer id then source relationship id.</returns>
+    Task<MigrationRelationshipApplyOutcome[]> ApplyRelationshipsAsync(
+        MigrationManifestArtifact manifest,
+        IReadOnlyDictionary<string, int> publishedLayerMap,
+        IMetadataV2GraphStore? graphStore,
         CancellationToken cancellationToken = default);
 }

--- a/src/Honua.Core/Features/Migration/Abstractions/IMigrationCatalogWriter.cs
+++ b/src/Honua.Core/Features/Migration/Abstractions/IMigrationCatalogWriter.cs
@@ -3,6 +3,7 @@
 
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Migration.Abstractions;
 using Honua.Core.Features.Migration.Domain;
 using Honua.Core.Features.Migration.Services;
@@ -86,6 +87,32 @@ public interface IMigrationCatalogWriter
     Task<MigrationCatalogWriteOutcome> EnsureStyleAsync(
         string connectionString,
         MigrationStyleRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Idempotently persist relationship metadata for an imported layer set
+    /// (issue #1256). Writes both the canonical Metadata v2 graph entry
+    /// (<see cref="Honua.Core.Features.Metadata.Domain.V2.MetadataV2Resource.Relationships"/>
+    /// on the origin resource) and the v1 <c>honua.relationships</c> row used by
+    /// the GeoServices FeatureServer <c>queryRelatedRecords</c> path.
+    /// </summary>
+    /// <remarks>
+    /// All requests in a single call MUST target the same target database. Per
+    /// request, both writes are idempotent: the v2 graph append checks for an
+    /// existing relationship by stable id, and the v1 insert uses
+    /// <c>ON CONFLICT (layer_id, relationship_id) DO NOTHING</c>. Relationships
+    /// that already exist on either side return
+    /// <see cref="MigrationCatalogWriteOutcome.AlreadyExists"/>.
+    /// </remarks>
+    /// <param name="connectionString">PostgreSQL connection string for the target catalog.</param>
+    /// <param name="graphStore">Read-write graph store used to mutate the v2 graph snapshot. May be <c>null</c>; when null the v2 graph write is skipped and only the v1 row is written.</param>
+    /// <param name="requests">Per-relationship apply requests.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Per-relationship outcomes ordered by source relationship id.</returns>
+    Task<MigrationRelationshipApplyOutcome[]> EnsureRelationshipsAsync(
+        string connectionString,
+        IMetadataV2GraphStore? graphStore,
+        MigrationRelationshipApplyRequest[] requests,
         CancellationToken cancellationToken = default);
 }
 
@@ -315,4 +342,94 @@ public sealed record MigrationStyleRequest
     /// the manifest translator already marked the source style as unsupported.
     /// </summary>
     public string ReviewDisposition { get; init; } = "applied";
+}
+
+/// <summary>
+/// Request payload for <see cref="IMigrationCatalogWriter.EnsureRelationshipsAsync"/>
+/// (issue #1256). Carries a single source-side relationship class plus the
+/// resolved Honua layer ids for both sides. Multiple requests can be passed
+/// in a single call so the writer can batch v2 graph mutations.
+/// </summary>
+public sealed record MigrationRelationshipApplyRequest
+{
+    /// <summary>
+    /// Stable identifier derived from the source fidelity record (for example
+    /// <c>classification:resource:Inspections:layer:0:relationship:2</c>). Used
+    /// for outcome correlation and step-result reporting.
+    /// </summary>
+    public required string SourceRelationshipId { get; init; }
+
+    /// <summary>
+    /// Optional original integer relationship id advertised by the ArcGIS
+    /// service. Persisted to <c>honua.relationships.relationship_id</c> and
+    /// surfaced as <see cref="Honua.Core.Features.Metadata.Domain.V2.MetadataV2Relationship.EsriRelationshipId"/>
+    /// so Esri-style clients can call <c>queryRelatedRecords</c> with the same
+    /// integer the source service advertised.
+    /// </summary>
+    public int? EsriRelationshipId { get; init; }
+
+    /// <summary>
+    /// Optional display name for the relationship.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Resolved Honua layer id of the origin (source) layer in the relationship.
+    /// </summary>
+    public required int OriginLayerId { get; init; }
+
+    /// <summary>
+    /// Resolved Honua layer id of the destination (related) layer.
+    /// </summary>
+    public required int RelatedLayerId { get; init; }
+
+    /// <summary>
+    /// Foreign-key field name on the origin layer.
+    /// </summary>
+    public required string OriginKeyField { get; init; }
+
+    /// <summary>
+    /// Primary/foreign-key field name on the destination layer.
+    /// </summary>
+    public required string DestinationKeyField { get; init; }
+
+    /// <summary>
+    /// Normalized relationship role (<c>origin</c> or <c>destination</c>). Used to
+    /// pick the v1 <c>relationship_type</c> column value and the v2
+    /// <see cref="Honua.Core.Features.Metadata.Domain.V2.MetadataV2Relationship.Role"/>.
+    /// </summary>
+    public required string Role { get; init; }
+
+    /// <summary>
+    /// Normalized relationship cardinality (<c>1:1</c>, <c>1:N</c>, or <c>M:N</c>).
+    /// </summary>
+    public required string Cardinality { get; init; }
+}
+
+/// <summary>
+/// Outcome of a single <see cref="MigrationRelationshipApplyRequest"/>.
+/// </summary>
+public sealed record MigrationRelationshipApplyOutcome
+{
+    /// <summary>
+    /// Source relationship id from the original request.
+    /// </summary>
+    public required string SourceRelationshipId { get; init; }
+
+    /// <summary>
+    /// Per-relationship outcome.
+    /// </summary>
+    public required MigrationCatalogWriteOutcome Outcome { get; init; }
+
+    /// <summary>
+    /// Operator-facing summary describing what was written, skipped, or
+    /// re-applied.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// Stable target relationship reference (<c>rel:{originLayerId}:{esriRelationshipId}</c>)
+    /// that the apply step should record on its manifest manifest <c>TargetRelationshipRef</c>.
+    /// </summary>
+    public required string TargetRelationshipRef { get; init; }
 }

--- a/src/Honua.Core/Features/Migration/Domain/GeoservicesImportRequest.cs
+++ b/src/Honua.Core/Features/Migration/Domain/GeoservicesImportRequest.cs
@@ -267,6 +267,15 @@ public sealed record GeoservicesImportRequest
     /// not plaintext token or password values.
     /// </summary>
     public GeoservicesCredentialDescriptor? Credentials { get; init; }
+
+    /// <summary>
+    /// Whether to copy feature attachments advertised by the source layer
+    /// (<c>hasAttachments == true</c>) into the Honua attachment store after
+    /// features have been inserted and the layer auto-published. Skipped when
+    /// auto-publish is disabled, no published layer was registered, or no
+    /// attachment store is configured.
+    /// </summary>
+    public bool ImportAttachments { get; init; } = true;
 }
 
 /// <summary>
@@ -350,6 +359,20 @@ public sealed record GeoservicesImportResult
     public IReadOnlyList<string> Warnings { get; init; } = [];
 
     /// <summary>
+    /// Number of attachments successfully copied into the Honua attachment store.
+    /// Zero when the source layer does not advertise attachments, the attachment
+    /// copy step was disabled, or no attachment store was registered.
+    /// </summary>
+    public int AttachmentCount { get; init; }
+
+    /// <summary>
+    /// Number of source attachments that could not be copied. Includes per-attachment
+    /// download/upload errors and skipped attachments whose parent ObjectId could not
+    /// be mapped to an inserted Honua feature.
+    /// </summary>
+    public int FailedAttachments { get; init; }
+
+    /// <summary>
     /// Create successful import result.
     /// </summary>
     public static GeoservicesImportResult CreateSuccess(
@@ -362,7 +385,9 @@ public sealed record GeoservicesImportResult
         string? serviceName = null,
         string? sourceLayerName = null,
         TimeSpan duration = default,
-        IReadOnlyList<string>? warnings = null) =>
+        IReadOnlyList<string>? warnings = null,
+        int attachmentCount = 0,
+        int failedAttachments = 0) =>
         new()
         {
             Success = true,
@@ -375,7 +400,9 @@ public sealed record GeoservicesImportResult
             PublishedLayerId = publishedLayerId,
             ServiceName = serviceName,
             Duration = duration,
-            Warnings = warnings ?? []
+            Warnings = warnings ?? [],
+            AttachmentCount = attachmentCount,
+            FailedAttachments = failedAttachments
         };
 
     /// <summary>

--- a/src/Honua.Core/Features/Migration/Domain/MigrationManifestArtifact.cs
+++ b/src/Honua.Core/Features/Migration/Domain/MigrationManifestArtifact.cs
@@ -522,6 +522,34 @@ public sealed record MigrationManifestRelationshipRecord
     public string[] RelatedLayerIds { get; init; } = [];
 
     /// <summary>
+    /// Optional relationship role on this resource (e.g. <c>esriRelRoleOrigin</c>,
+    /// <c>esriRelRoleDestination</c>). Drives the V2 graph write direction for
+    /// simple relationships: only origin-role records produce a
+    /// <c>MetadataV2Resource.Relationships</c> entry on the origin resource.
+    /// </summary>
+    public string? Role { get; init; }
+
+    /// <summary>
+    /// Foreign key field name on the origin (source) layer. For simple ArcGIS
+    /// relationships, this is the same field name as
+    /// <see cref="DestinationKeyField"/> because both sides use a shared
+    /// <c>keyField</c> value.
+    /// </summary>
+    public string? OriginKeyField { get; init; }
+
+    /// <summary>
+    /// Primary or foreign key field name on the destination (related) layer.
+    /// </summary>
+    public string? DestinationKeyField { get; init; }
+
+    /// <summary>
+    /// Optional original integer relationship id advertised by the source ArcGIS
+    /// service. Used to construct stable Esri-style relationship identifiers in
+    /// the target catalog.
+    /// </summary>
+    public int? EsriRelationshipId { get; init; }
+
+    /// <summary>
     /// Automation classification. One of
     /// <see cref="MigrationManifestRelationshipClassifications.Automated"/>,
     /// <see cref="MigrationManifestRelationshipClassifications.Assisted"/>,

--- a/src/Honua.Core/Features/Migration/Services/ArcGisRestClient.cs
+++ b/src/Honua.Core/Features/Migration/Services/ArcGisRestClient.cs
@@ -192,6 +192,100 @@ internal sealed partial class ArcGisRestClient
     }
 
     /// <summary>
+    /// Query attachment metadata for one or more features in a layer.
+    /// </summary>
+    /// <param name="serviceUrl">Service root URL (FeatureServer or MapServer).</param>
+    /// <param name="layerId">Layer identifier.</param>
+    /// <param name="objectIds">Source ObjectIds whose attachments should be enumerated.</param>
+    /// <param name="timeoutSeconds">Per-request timeout in seconds.</param>
+    /// <param name="maxRetries">Maximum HTTP retry attempts.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="credentials">Optional credential descriptor.</param>
+    /// <returns>Attachment groupings keyed by parent ObjectId. Empty when no objectIds are supplied.</returns>
+    public async Task<ArcGisAttachmentQueryResponse> QueryAttachmentsAsync(
+        string serviceUrl,
+        int layerId,
+        IReadOnlyCollection<long> objectIds,
+        int timeoutSeconds,
+        int maxRetries,
+        CancellationToken cancellationToken,
+        GeoservicesCredentialDescriptor? credentials = null)
+    {
+        ArgumentNullException.ThrowIfNull(objectIds);
+
+        if (objectIds.Count == 0)
+        {
+            return new ArcGisAttachmentQueryResponse { AttachmentGroups = [] };
+        }
+
+        var normalizedUrl = NormalizeServiceUrl(serviceUrl);
+        var objectIdCsv = string.Join(
+            ",",
+            objectIds.Select(id => id.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+        var queryUrl = $"{normalizedUrl}/{layerId}/queryAttachments?objectIds={Uri.EscapeDataString(objectIdCsv)}&returnUrl=false&f=json";
+
+        return await GetJsonAsync(
+            queryUrl,
+            ArcGisJsonContext.Default.ArcGisAttachmentQueryResponse,
+            maxRetries,
+            timeoutSeconds,
+            credentials,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Download a single attachment as a binary stream. The caller owns the returned stream
+    /// and the disposable wrapper that backs it.
+    /// </summary>
+    public async Task<ArcGisAttachmentDownload> DownloadAttachmentAsync(
+        string serviceUrl,
+        int layerId,
+        long featureObjectId,
+        long attachmentId,
+        int timeoutSeconds,
+        int maxRetries,
+        CancellationToken cancellationToken,
+        GeoservicesCredentialDescriptor? credentials = null)
+    {
+        var normalizedUrl = NormalizeServiceUrl(serviceUrl);
+        var url = $"{normalizedUrl}/{layerId}/{featureObjectId}/attachments/{attachmentId}";
+
+        await EnsureSafeOutboundUriAsync(url, cancellationToken).ConfigureAwait(false);
+
+        var options = BuildHttpOptions(maxRetries);
+        var policy = CreateHttpPolicy(options, maxRetries, cancellationToken);
+        var response = await policy.ExecuteAsync(
+            async ct =>
+            {
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                timeoutCts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+                using var request = CreateGetRequest(url, credentials);
+                return await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    timeoutCts.Token).ConfigureAwait(false);
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            ThrowIfAuthenticationFailure(response, url, credentials);
+            response.EnsureSuccessStatusCode();
+
+            var contentType = response.Content.Headers.ContentType?.MediaType
+                ?? "application/octet-stream";
+            var contentLength = response.Content.Headers.ContentLength;
+            var content = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            return new ArcGisAttachmentDownload(content, contentType, contentLength, response);
+        }
+        catch
+        {
+            response.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
     /// Query features from a layer with pagination support.
     /// </summary>
     public async Task<ArcGisQueryResult> QueryFeaturesAsync(
@@ -1079,7 +1173,93 @@ internal sealed record ArcGisError
     public string[]? Details { get; init; }
 }
 
+internal sealed record ArcGisAttachmentQueryResponse
+{
+    [JsonPropertyName("attachmentGroups")]
+    public ArcGisAttachmentGroup[]? AttachmentGroups { get; init; }
+}
+
+internal sealed record ArcGisAttachmentGroup
+{
+    [JsonPropertyName("parentObjectId")]
+    public long ParentObjectId { get; init; }
+
+    [JsonPropertyName("parentGlobalId")]
+    public string? ParentGlobalId { get; init; }
+
+    [JsonPropertyName("attachmentInfos")]
+    public ArcGisAttachmentInfo[]? AttachmentInfos { get; init; }
+}
+
+internal sealed record ArcGisAttachmentInfo
+{
+    [JsonPropertyName("id")]
+    public long Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("contentType")]
+    public string? ContentType { get; init; }
+
+    [JsonPropertyName("size")]
+    public long Size { get; init; }
+
+    [JsonPropertyName("keywords")]
+    public string? Keywords { get; init; }
+}
+
 #pragma warning restore CA1812
+
+/// <summary>
+/// Wraps a single ArcGIS attachment download: the binary content stream plus the
+/// underlying <see cref="HttpResponseMessage"/> whose lifetime the caller controls.
+/// </summary>
+internal sealed class ArcGisAttachmentDownload : IAsyncDisposable, IDisposable
+{
+    private readonly HttpResponseMessage _response;
+    private bool _disposed;
+
+    public ArcGisAttachmentDownload(
+        Stream content,
+        string contentType,
+        long? contentLength,
+        HttpResponseMessage response)
+    {
+        Content = content ?? throw new ArgumentNullException(nameof(content));
+        ContentType = string.IsNullOrWhiteSpace(contentType) ? "application/octet-stream" : contentType;
+        ContentLength = contentLength;
+        _response = response ?? throw new ArgumentNullException(nameof(response));
+    }
+
+    public Stream Content { get; }
+    public string ContentType { get; }
+    public long? ContentLength { get; }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        Content.Dispose();
+        _response.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        await Content.DisposeAsync().ConfigureAwait(false);
+        _response.Dispose();
+    }
+}
 
 /// <summary>
 /// JSON serialization context for ArcGIS REST API responses.
@@ -1088,6 +1268,7 @@ internal sealed record ArcGisError
 [JsonSerializable(typeof(ArcGisLayerResponse))]
 [JsonSerializable(typeof(ArcGisCountResponse))]
 [JsonSerializable(typeof(ArcGisFeatureResponse))]
+[JsonSerializable(typeof(ArcGisAttachmentQueryResponse))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class ArcGisJsonContext : JsonSerializerContext
 {

--- a/src/Honua.Core/Features/Migration/Services/MigrationManifestTranslator.cs
+++ b/src/Honua.Core/Features/Migration/Services/MigrationManifestTranslator.cs
@@ -690,6 +690,24 @@ public static partial class MigrationManifestTranslator
                                    !string.IsNullOrWhiteSpace(rt)
                 ? rt
                 : null;
+            var role = classification.Metadata.TryGetValue("role", out var roleValue) &&
+                       !string.IsNullOrWhiteSpace(roleValue)
+                ? roleValue
+                : null;
+            var originKeyField = classification.Metadata.TryGetValue("originKeyField", out var okf) &&
+                                 !string.IsNullOrWhiteSpace(okf)
+                ? okf
+                : null;
+            var destinationKeyField = classification.Metadata.TryGetValue("destinationKeyField", out var dkf) &&
+                                      !string.IsNullOrWhiteSpace(dkf)
+                ? dkf
+                : null;
+            int? esriRelationshipId = null;
+            if (classification.Metadata.TryGetValue("relationshipId", out var esriIdText) &&
+                int.TryParse(esriIdText, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsedEsriId))
+            {
+                esriRelationshipId = parsedEsriId;
+            }
             var relatedLayerIds = ExtractRelatedLayerIds(classification);
 
             var (cls, reason) = ClassifyRelationship(cardinality, relationshipType, relatedLayerIds);
@@ -709,6 +727,10 @@ public static partial class MigrationManifestTranslator
                 Cardinality = cardinality,
                 RelationshipType = relationshipType,
                 RelatedLayerIds = relatedLayerIds,
+                Role = role,
+                OriginKeyField = originKeyField,
+                DestinationKeyField = destinationKeyField,
+                EsriRelationshipId = esriRelationshipId,
                 Classification = cls,
                 TargetRelationshipRef = targetRef,
                 Reason = reason

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Attachments.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Attachments.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
+
+namespace Honua.Postgres.Features.Migration;
+
+internal sealed partial class GeoservicesImportService
+{
+    private const int AttachmentQueryBatchSize = 50;
+
+    private async Task<(int Copied, int Failed)> CopyAttachmentsAsync(
+        GeoservicesImportRequest request,
+        GeoservicesLayerInfo layerInfo,
+        int publishedLayerId,
+        Dictionary<long, long> objectIdMap,
+        List<string> warnings,
+        IProgress<GeoservicesImportProgress>? progress,
+        string jobId,
+        DateTimeOffset startedAt,
+        int featuresProcessed,
+        CancellationToken cancellationToken)
+    {
+        if (_attachmentStore == null || objectIdMap.Count == 0)
+        {
+            return (0, 0);
+        }
+
+        Log.AttachmentCopyStarting(_logger, request.LayerId, objectIdMap.Count);
+        ReportProgress(
+            progress,
+            jobId,
+            startedAt,
+            GeoservicesImportStatus.CopyingAttachments,
+            request,
+            "Copying source attachments",
+            featuresProcessed,
+            featuresProcessed,
+            layerInfo.Name,
+            publishedLayerId,
+            attachmentsProcessed: 0,
+            failedAttachments: 0);
+
+        var attachmentsCopied = 0;
+        var failedAttachments = 0;
+
+        // Stable batches of source ObjectIds keep attachment-group ordering deterministic for tests.
+        var sourceObjectIds = objectIdMap.Keys
+            .OrderBy(static value => value)
+            .ToArray();
+
+        for (var batchStart = 0; batchStart < sourceObjectIds.Length; batchStart += AttachmentQueryBatchSize)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var batchLength = Math.Min(AttachmentQueryBatchSize, sourceObjectIds.Length - batchStart);
+            var batch = new long[batchLength];
+            Array.Copy(sourceObjectIds, batchStart, batch, 0, batchLength);
+
+            ArcGisAttachmentQueryResponse queryResponse;
+            try
+            {
+                queryResponse = await _restClient.QueryAttachmentsAsync(
+                    request.ServiceUrl,
+                    request.LayerId,
+                    batch,
+                    request.RequestTimeoutSeconds,
+                    request.MaxRetries,
+                    cancellationToken,
+                    request.Credentials).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.AttachmentQueryBatchFailed(_logger, request.LayerId, batch.Length, ex);
+                warnings.Add(
+                    $"Attachment metadata query failed for {batch.Length} parent features; "
+                    + "this batch of attachments was skipped.");
+                continue;
+            }
+
+            if (queryResponse.AttachmentGroups == null || queryResponse.AttachmentGroups.Length == 0)
+            {
+                continue;
+            }
+
+            foreach (var group in queryResponse.AttachmentGroups)
+            {
+                if (group.AttachmentInfos == null || group.AttachmentInfos.Length == 0)
+                {
+                    continue;
+                }
+
+                if (!objectIdMap.TryGetValue(group.ParentObjectId, out var honuaFeatureId))
+                {
+                    // Parent feature was not inserted (filtered out or insert failed). Count
+                    // every advertised attachment as failed so reconciliation surfaces it.
+                    failedAttachments += group.AttachmentInfos.Length;
+                    warnings.Add(
+                        $"Source feature {group.ParentObjectId} has "
+                        + $"{group.AttachmentInfos.Length} attachment(s) but no matching imported feature.");
+                    continue;
+                }
+
+                foreach (var attachmentInfo in group.AttachmentInfos)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    try
+                    {
+                        await using var download = await _restClient.DownloadAttachmentAsync(
+                            request.ServiceUrl,
+                            request.LayerId,
+                            group.ParentObjectId,
+                            attachmentInfo.Id,
+                            request.RequestTimeoutSeconds,
+                            request.MaxRetries,
+                            cancellationToken,
+                            request.Credentials).ConfigureAwait(false);
+
+                        var filename = string.IsNullOrWhiteSpace(attachmentInfo.Name)
+                            ? $"attachment-{attachmentInfo.Id}"
+                            : attachmentInfo.Name!;
+                        var contentType = string.IsNullOrWhiteSpace(attachmentInfo.ContentType)
+                            ? download.ContentType
+                            : attachmentInfo.ContentType!;
+
+                        await _attachmentStore!.UploadAsync(
+                            publishedLayerId,
+                            honuaFeatureId,
+                            filename,
+                            contentType,
+                            download.Content,
+                            attachmentInfo.Keywords,
+                            cancellationToken).ConfigureAwait(false);
+
+                        attachmentsCopied++;
+
+                        ReportProgress(
+                            progress,
+                            jobId,
+                            startedAt,
+                            GeoservicesImportStatus.CopyingAttachments,
+                            request,
+                            $"Copied attachment {attachmentsCopied}",
+                            featuresProcessed,
+                            featuresProcessed,
+                            layerInfo.Name,
+                            publishedLayerId,
+                            attachmentsProcessed: attachmentsCopied,
+                            failedAttachments: failedAttachments);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        failedAttachments++;
+                        Log.AttachmentCopyFailed(
+                            _logger,
+                            attachmentInfo.Id,
+                            group.ParentObjectId,
+                            request.LayerId,
+                            ex);
+                    }
+                }
+            }
+        }
+
+        Log.AttachmentCopyCompleted(_logger, request.LayerId, attachmentsCopied, failedAttachments);
+
+        if (failedAttachments > 0)
+        {
+            warnings.Add(
+                $"Attachment copy completed with {failedAttachments} failure(s); the import succeeded "
+                + "but some attachments are missing from the target store.");
+        }
+
+        return (attachmentsCopied, failedAttachments);
+    }
+}

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Features.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Features.cs
@@ -20,7 +20,7 @@ namespace Honua.Postgres.Features.Migration;
 
 internal sealed partial class GeoservicesImportService
 {
-    private async Task<(int inserted, int failed)> InsertFeaturesAsync(
+    private async Task<InsertFeaturesResult> InsertFeaturesAsync(
         NpgsqlConnection connection,
         string schemaName,
         string tableName,
@@ -37,6 +37,8 @@ internal sealed partial class GeoservicesImportService
         // Build insert statement
         var fields = layerInfo.Fields.Where(f => !f.IsObjectId && !IsGeometryField(f)).ToArray();
         var hasGeometry = !string.IsNullOrEmpty(layerInfo.GeometryType);
+        var sourceObjectIdField = layerInfo.Fields.FirstOrDefault(f => f.IsObjectId)?.Name;
+        var objectIdMap = new Dictionary<long, long>(features.Length);
 
         var columnNames = string.Join(", ", fields.Select(f => $"\"{f.Name.SanitizeFieldName()}\""));
         if (hasGeometry)
@@ -50,7 +52,8 @@ internal sealed partial class GeoservicesImportService
             parameterPlaceholders += $", {BuildGeometryInsertExpression(layerInfo.GeometryType, targetSrid)}";
         }
 
-        var insertSql = $"INSERT INTO {QuoteIdentifier(schemaName)}.{QuoteIdentifier(tableName)} ({columnNames}) VALUES ({parameterPlaceholders})";
+        var insertSql =
+            $"INSERT INTO {QuoteIdentifier(schemaName)}.{QuoteIdentifier(tableName)} ({columnNames}) VALUES ({parameterPlaceholders}) RETURNING {FieldNames.ObjectId}";
 
         // Create the command once, add parameters with placeholder values, and prepare
         await using var cmd = connection.CreateCommand();
@@ -107,8 +110,16 @@ internal sealed partial class GeoservicesImportService
                     cmd.Parameters["geom"].Value = DBNull.Value;
                 }
 
-                await cmd.ExecuteNonQueryAsync(cancellationToken);
+                var rawInsertedId = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
                 inserted++;
+
+                if (sourceObjectIdField is not null
+                    && TryReadSourceObjectId(feature, sourceObjectIdField, out var sourceOid)
+                    && rawInsertedId is not null
+                    && rawInsertedId is not DBNull)
+                {
+                    objectIdMap[sourceOid] = Convert.ToInt64(rawInsertedId, System.Globalization.CultureInfo.InvariantCulture);
+                }
             }
             catch (Exception ex)
             {
@@ -128,8 +139,63 @@ internal sealed partial class GeoservicesImportService
             Log.HigherDimensionGeometryDetected(_logger, higherDimensionCount, tableName);
         }
 
-        return (inserted, failed);
+        return new InsertFeaturesResult(inserted, failed, objectIdMap);
     }
+
+    private static bool TryReadSourceObjectId(
+        ArcGisFeature feature,
+        string sourceObjectIdField,
+        out long sourceObjectId)
+    {
+        sourceObjectId = 0;
+        if (feature.Attributes is null)
+        {
+            return false;
+        }
+
+        if (!feature.Attributes.TryGetValue(sourceObjectIdField, out var element))
+        {
+            return false;
+        }
+
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Number:
+                if (element.TryGetInt64(out var int64))
+                {
+                    sourceObjectId = int64;
+                    return true;
+                }
+
+                if (element.TryGetDouble(out var dbl) && !double.IsNaN(dbl) && !double.IsInfinity(dbl))
+                {
+                    sourceObjectId = (long)dbl;
+                    return true;
+                }
+
+                return false;
+
+            case JsonValueKind.String:
+                return long.TryParse(
+                    element.GetString(),
+                    System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out sourceObjectId);
+
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Outcome of a single InsertFeaturesAsync batch: insert/fail counters plus a
+    /// mapping from source ObjectId to the BIGSERIAL identifier assigned by the
+    /// imported table. Used to link attachments back to the persisted features.
+    /// </summary>
+    internal readonly record struct InsertFeaturesResult(
+        int Inserted,
+        int Failed,
+        Dictionary<long, long> ObjectIdMap);
 
     private static string BuildGeometryInsertExpression(string? geometryType, int targetSrid)
     {

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Fidelity.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Fidelity.cs
@@ -156,20 +156,7 @@ internal sealed partial class GeoservicesImportService
                 subtypes.ManualSteps));
         }
 
-        if (HasRelationshipMetadata(resourceElement))
-        {
-            var relationships = _constructCapabilityRegistry.ResolveOrUnknown(EsriConstructCapabilityRegistry.Keys.ResourceRelationships);
-            records.Add(CreateFidelityRecord(
-                $"{resource.Id}:relationships",
-                resource.Id,
-                "relationship",
-                "relationships",
-                resource.Name,
-                relationships.AutomationStatus,
-                relationships.Code,
-                relationships.Reason,
-                relationships.ManualSteps));
-        }
+        records.AddRange(BuildRelationshipFidelityRecords(resource, resourceElement));
 
         if (resource.HasAttachments == true)
         {
@@ -276,9 +263,135 @@ internal sealed partial class GeoservicesImportService
             HasNonEmptyArray(resourceElement, "subtypes") ||
             !string.IsNullOrWhiteSpace(GetOptionalStringProperty(resourceElement, "subtypeField"));
 
-    private static bool HasRelationshipMetadata(JsonElement resourceElement)
-        => HasNonEmptyArray(resourceElement, "relationships") ||
-            HasNonEmptyArray(resourceElement, "relationshipInfos");
+    private static IEnumerable<MigrationFidelityClassificationRecord> BuildRelationshipFidelityRecords(
+        MigrationInventoryResource resource,
+        JsonElement resourceElement)
+    {
+        if (!TryGetRelationshipArray(resourceElement, out var relationships))
+        {
+            yield break;
+        }
+
+        foreach (var relationship in relationships.EnumerateArray())
+        {
+            if (relationship.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var relationshipId = GetOptionalIntProperty(relationship, "id");
+            var name = GetOptionalStringProperty(relationship, "name");
+            var cardinality = GetOptionalStringProperty(relationship, "cardinality");
+            var role = GetOptionalStringProperty(relationship, "role");
+            var keyField = GetOptionalStringProperty(relationship, "keyField");
+            var relatedTableId = GetOptionalIntProperty(relationship, "relatedTableId");
+            var relationshipType = GetOptionalStringProperty(relationship, "relationshipType");
+            var composite = GetOptionalBoolProperty(relationship, "composite");
+
+            var derivedType = relationshipType;
+            if (composite == true && string.IsNullOrWhiteSpace(derivedType))
+            {
+                derivedType = "composite";
+            }
+
+            var isComposite = composite == true ||
+                string.Equals(derivedType, "composite", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(derivedType, "attributed", StringComparison.OrdinalIgnoreCase);
+            var isManyToMany = !string.IsNullOrWhiteSpace(cardinality) &&
+                cardinality.Trim().Equals("esriRelCardinalityManyToMany", StringComparison.OrdinalIgnoreCase);
+
+            var automationStatus = isComposite || isManyToMany
+                ? MigrationFidelityAutomationStatuses.ManualReview
+                : MigrationFidelityAutomationStatuses.Automated;
+            var compatibilityCode = automationStatus == MigrationFidelityAutomationStatuses.Automated
+                ? ImportCompatibilityCodes.Compatible
+                : ImportCompatibilityCodes.ArcGisRelationshipsManualReview;
+
+            var reason = automationStatus == MigrationFidelityAutomationStatuses.Automated
+                ? "Simple relationship class captured for automated migration to honua.relationships and MetadataV2Resource.Relationships."
+                : isComposite
+                    ? $"Relationship type '{derivedType ?? "composite"}' carries side-effects (composite delete or junction attributes) that this slice does not recreate automatically."
+                    : isManyToMany
+                        ? "Many-to-many relationships require a junction table and are deferred from automated migration."
+                        : "Relationship metadata was detected and captured for operator review; automated relationship migration is not implemented.";
+
+            var manualSteps = automationStatus == MigrationFidelityAutomationStatuses.ManualReview
+                ? new[] { "Map related layers or tables to target relationship configuration before cutover." }
+                : Array.Empty<string>();
+
+            var metadata = new SortedDictionary<string, string>(StringComparer.Ordinal);
+            if (relationshipId.HasValue)
+            {
+                metadata["relationshipId"] = relationshipId.Value.ToString(CultureInfo.InvariantCulture);
+            }
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                metadata["name"] = name!;
+            }
+            if (!string.IsNullOrWhiteSpace(cardinality))
+            {
+                metadata["cardinality"] = cardinality!;
+            }
+            if (!string.IsNullOrWhiteSpace(role))
+            {
+                metadata["role"] = role!;
+            }
+            if (!string.IsNullOrWhiteSpace(keyField))
+            {
+                metadata["originKeyField"] = keyField!;
+                metadata["destinationKeyField"] = keyField!;
+            }
+            if (relatedTableId.HasValue)
+            {
+                metadata["relatedLayerIds"] = $"layer:{relatedTableId.Value}";
+            }
+            if (!string.IsNullOrWhiteSpace(derivedType))
+            {
+                metadata["relationshipType"] = derivedType!;
+            }
+
+            var idSuffix = relationshipId.HasValue
+                ? relationshipId.Value.ToString(CultureInfo.InvariantCulture)
+                : (string.IsNullOrWhiteSpace(name) ? "unknown" : name!);
+
+            yield return CreateFidelityRecord(
+                $"{resource.Id}:relationship:{idSuffix}",
+                resource.Id,
+                "relationship",
+                "relationships",
+                string.IsNullOrWhiteSpace(name) ? resource.Name : name,
+                automationStatus,
+                compatibilityCode,
+                reason,
+                manualSteps,
+                metadata: metadata);
+        }
+    }
+
+    private static bool TryGetRelationshipArray(JsonElement resourceElement, out JsonElement relationships)
+    {
+        // Prefer the non-empty array so MapServer documents that advertise an
+        // empty "relationships" alongside a populated "relationshipInfos" still
+        // surface per-relationship fidelity.
+        if (resourceElement.TryGetProperty("relationships", out var array) &&
+            array.ValueKind == JsonValueKind.Array &&
+            array.GetArrayLength() > 0)
+        {
+            relationships = array;
+            return true;
+        }
+
+        if (resourceElement.TryGetProperty("relationshipInfos", out array) &&
+            array.ValueKind == JsonValueKind.Array &&
+            array.GetArrayLength() > 0)
+        {
+            relationships = array;
+            return true;
+        }
+
+        relationships = default;
+        return false;
+    }
 
     private static bool HasNonEmptyArray(JsonElement element, string propertyName)
         => element.TryGetProperty(propertyName, out var property) &&

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Fidelity.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Fidelity.cs
@@ -173,7 +173,6 @@ internal sealed partial class GeoservicesImportService
 
         if (resource.HasAttachments == true)
         {
-            var attachments = _constructCapabilityRegistry.ResolveOrUnknown(EsriConstructCapabilityRegistry.Keys.ResourceAttachments);
             var attachmentDependencyIds = dependencies
                 .Where(static dependency => string.Equals(dependency.Kind, "attachments", StringComparison.Ordinal))
                 .Select(static dependency => dependency.Id)
@@ -184,10 +183,9 @@ internal sealed partial class GeoservicesImportService
                 "attachment",
                 "attachments",
                 resource.Name,
-                attachments.AutomationStatus,
-                attachments.Code,
-                attachments.Reason,
-                attachments.ManualSteps,
+                MigrationFidelityAutomationStatuses.Automated,
+                ImportCompatibilityCodes.Compatible,
+                "Attachments are automatically copied to the Honua attachment store during import when ImportAttachments is enabled and auto-publish succeeds.",
                 relatedIds: attachmentDependencyIds));
         }
 

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.ImportSteps.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.ImportSteps.cs
@@ -76,6 +76,7 @@ internal sealed partial class GeoservicesImportService
             var offset = 0;
             var batchNumber = 0;
             var hasMore = true;
+            var objectIdMap = new Dictionary<long, long>();
 
             while (hasMore && !cancellationToken.IsCancellationRequested)
             {
@@ -108,7 +109,7 @@ internal sealed partial class GeoservicesImportService
                     $"Inserting batch {batchNumber} ({queryResult.Features.Length} features)",
                     featuresProcessed, totalFeatures, layerInfo.Name);
 
-                var (inserted, failed) = await InsertFeaturesAsync(
+                var batchInsert = await InsertFeaturesAsync(
                     connection,
                     targetSchema,
                     request.TableName,
@@ -117,15 +118,20 @@ internal sealed partial class GeoservicesImportService
                     request.TargetSrid,
                     cancellationToken);
 
-                featuresProcessed += inserted;
-                failedFeatures += failed;
+                featuresProcessed += batchInsert.Inserted;
+                failedFeatures += batchInsert.Failed;
 
-                if (failed > 0)
+                foreach (var entry in batchInsert.ObjectIdMap)
                 {
-                    warnings.Add($"Batch {batchNumber}: {failed} features failed to insert");
+                    objectIdMap[entry.Key] = entry.Value;
                 }
 
-                Log.BatchCompleted(_logger, batchNumber, inserted, failed, featuresProcessed);
+                if (batchInsert.Failed > 0)
+                {
+                    warnings.Add($"Batch {batchNumber}: {batchInsert.Failed} features failed to insert");
+                }
+
+                Log.BatchCompleted(_logger, batchNumber, batchInsert.Inserted, batchInsert.Failed, featuresProcessed);
 
                 offset += queryResult.Features.Length;
                 hasMore = queryResult.ExceededTransferLimit || queryResult.Features.Length == batchSize;
@@ -155,6 +161,32 @@ internal sealed partial class GeoservicesImportService
                     cancellationToken).ConfigureAwait(false);
             }
 
+            var attachmentCount = 0;
+            var failedAttachments = 0;
+            if (layerInfo.HasAttachments
+                && request.ImportAttachments
+                && publishedLayer != null
+                && _attachmentStore != null
+                && objectIdMap.Count > 0)
+            {
+                (attachmentCount, failedAttachments) = await CopyAttachmentsAsync(
+                    request,
+                    layerInfo,
+                    publishedLayer.LayerId,
+                    objectIdMap,
+                    warnings,
+                    progress,
+                    jobId,
+                    startedAt,
+                    featuresProcessed,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            else if (layerInfo.HasAttachments && request.ImportAttachments && _attachmentStore == null)
+            {
+                warnings.Add(
+                    "Layer advertises attachments, but no attachment store is registered; attachments were not copied.");
+            }
+
             stopwatch.Stop();
 
             Log.ImportCompleted(_logger, request.TableName, featuresProcessed, failedFeatures,
@@ -166,7 +198,9 @@ internal sealed partial class GeoservicesImportService
                 featuresProcessed,
                 featuresProcessed,
                 layerInfo.Name,
-                publishedLayer?.LayerId);
+                publishedLayer?.LayerId,
+                attachmentsProcessed: attachmentCount,
+                failedAttachments: failedAttachments);
 
             return GeoservicesImportResult.CreateSuccess(
                 request.TableName,
@@ -178,7 +212,9 @@ internal sealed partial class GeoservicesImportService
                 publishedLayer?.ServiceName ?? request.ServiceName,
                 layerInfo.Name,
                 duration: stopwatch.Elapsed,
-                warnings: warnings);
+                warnings: warnings,
+                attachmentCount: attachmentCount,
+                failedAttachments: failedAttachments);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Inventory.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Inventory.cs
@@ -284,11 +284,10 @@ internal sealed partial class GeoservicesImportService
                     ["advertised"] = "true"
                 },
                 SpatialReferences = [],
-                Compatibility = MigrationInventoryHelpers.Partial(
-                    "Attachments require a separate migration path.",
+                Compatibility = MigrationInventoryHelpers.Compatible(
+                    "Attachments are migrated automatically when ImportAttachments is enabled and the layer auto-publishes.",
                     ["The source resource advertises attachments."],
-                    ["Plan a separate attachment migration alongside the core data import."],
-                    code: ImportCompatibilityCodes.ArcGisAttachments)
+                    code: ImportCompatibilityCodes.Compatible)
             });
         }
 

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.RelationshipApply.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.RelationshipApply.cs
@@ -1,0 +1,191 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Postgres.Features.Migration;
+
+internal sealed partial class GeoservicesImportService
+{
+    private const string ArcGisSourceKind = "arcgis-geoservices-rest";
+
+    /// <inheritdoc />
+    public async Task<MigrationRelationshipApplyOutcome[]> ApplyRelationshipsAsync(
+        MigrationManifestArtifact manifest,
+        IReadOnlyDictionary<string, int> publishedLayerMap,
+        IMetadataV2GraphStore? graphStore,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(publishedLayerMap);
+
+        if (!string.Equals(manifest.SourceKind, ArcGisSourceKind, StringComparison.Ordinal))
+        {
+            // Other source kinds (geoserver-rest, ogc-wfs, etc.) do not currently
+            // emit per-relationship records into the manifest. Returning an empty
+            // outcome set is intentional: callers can treat it as "nothing to apply".
+            return [];
+        }
+
+        if (_catalogWriter == null)
+        {
+            // Catalog writer is not wired up (e.g. in a discovery-only deployment).
+            // Skip rather than failing so the import path remains usable for scans.
+            Log.RelationshipApplySkipped(_logger, "catalog-writer-unavailable");
+            return [];
+        }
+
+        var sourceTargets = manifest.TargetResources
+            .ToDictionary(static r => r.SourceResourceId, StringComparer.Ordinal);
+
+        var requests = new List<MigrationRelationshipApplyRequest>();
+        var skipped = new List<MigrationRelationshipApplyOutcome>();
+
+        foreach (var target in manifest.TargetResources.OrderBy(static r => r.SourceResourceId, StringComparer.Ordinal))
+        {
+            foreach (var relationship in target.Relationships)
+            {
+                if (!IsApplyEligible(relationship.Classification))
+                {
+                    continue;
+                }
+
+                // Origin: the current target resource.
+                if (!publishedLayerMap.TryGetValue(target.SourceResourceId, out var originLayerId))
+                {
+                    skipped.Add(BuildSkippedOutcome(
+                        relationship.SourceRelationshipId,
+                        $"Origin layer for resource '{target.SourceResourceId}' is not in the published layer map; relationship persistence deferred until the layer is imported.",
+                        originLayerId: null,
+                        relationship));
+                    continue;
+                }
+
+                // Related: must be resolved through the manifest's source layer ids.
+                if (!TryResolveRelatedSource(relationship, sourceTargets, out var relatedSourceResourceId))
+                {
+                    skipped.Add(BuildSkippedOutcome(
+                        relationship.SourceRelationshipId,
+                        "Related layer is not present in the manifest target resources; relationship persistence deferred until the related layer is imported.",
+                        originLayerId,
+                        relationship));
+                    continue;
+                }
+
+                if (!publishedLayerMap.TryGetValue(relatedSourceResourceId, out var relatedLayerId))
+                {
+                    skipped.Add(BuildSkippedOutcome(
+                        relationship.SourceRelationshipId,
+                        $"Related layer '{relatedSourceResourceId}' is not in the published layer map; relationship persistence deferred until the related layer is imported.",
+                        originLayerId,
+                        relationship));
+                    continue;
+                }
+
+                var originKeyField = relationship.OriginKeyField;
+                var destinationKeyField = relationship.DestinationKeyField;
+                if (string.IsNullOrWhiteSpace(originKeyField) || string.IsNullOrWhiteSpace(destinationKeyField))
+                {
+                    skipped.Add(BuildSkippedOutcome(
+                        relationship.SourceRelationshipId,
+                        "Source did not advertise origin/destination key fields for the relationship; operator must populate the foreign-key fields before automated migration.",
+                        originLayerId,
+                        relationship));
+                    continue;
+                }
+
+                requests.Add(new MigrationRelationshipApplyRequest
+                {
+                    SourceRelationshipId = relationship.SourceRelationshipId,
+                    EsriRelationshipId = relationship.EsriRelationshipId,
+                    Name = relationship.Name,
+                    OriginLayerId = originLayerId,
+                    RelatedLayerId = relatedLayerId,
+                    OriginKeyField = originKeyField!,
+                    DestinationKeyField = destinationKeyField!,
+                    Role = string.IsNullOrWhiteSpace(relationship.Role) ? "origin" : relationship.Role!,
+                    Cardinality = relationship.Cardinality ?? "1:N"
+                });
+            }
+        }
+
+        if (requests.Count == 0)
+        {
+            return skipped.ToArray();
+        }
+
+        var connectionString = _connectionProvider.GetConnectionString();
+        var applied = await _catalogWriter.EnsureRelationshipsAsync(
+                connectionString,
+                graphStore,
+                requests.ToArray(),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return applied
+            .Concat(skipped)
+            .OrderBy(static o => o.SourceRelationshipId, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static bool IsApplyEligible(string classification)
+        => string.Equals(classification, MigrationManifestRelationshipClassifications.Automated, StringComparison.Ordinal) ||
+           string.Equals(classification, MigrationManifestRelationshipClassifications.Assisted, StringComparison.Ordinal);
+
+    private static bool TryResolveRelatedSource(
+        MigrationManifestRelationshipRecord relationship,
+        Dictionary<string, MigrationManifestTargetResource> sourceTargets,
+        out string relatedSourceResourceId)
+    {
+        // The fidelity record carries the related layer's local identifier as
+        // "layer:{id}"; the manifest target resource ids follow the inventory
+        // convention "resource:{service}:{kind}:{id}". Resolve by suffix match
+        // against the manifest's target resources so unrelated services in the
+        // same graph snapshot are ignored.
+        foreach (var related in relationship.RelatedLayerIds)
+        {
+            if (string.IsNullOrWhiteSpace(related))
+            {
+                continue;
+            }
+
+            var local = related.Trim();
+            foreach (var (sourceResourceId, _) in sourceTargets)
+            {
+                if (sourceResourceId.EndsWith(":" + local, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(sourceResourceId, local, StringComparison.OrdinalIgnoreCase))
+                {
+                    relatedSourceResourceId = sourceResourceId;
+                    return true;
+                }
+            }
+        }
+
+        relatedSourceResourceId = string.Empty;
+        return false;
+    }
+
+    private static MigrationRelationshipApplyOutcome BuildSkippedOutcome(
+        string sourceRelationshipId,
+        string message,
+        int? originLayerId,
+        MigrationManifestRelationshipRecord relationship)
+    {
+        // A skipped relationship still needs a TargetRelationshipRef so the
+        // parity probe can report missing origin-side persistence as a manual
+        // review record rather than a zero-coverage hole.
+        var refValue = originLayerId.HasValue
+            ? $"rel-{originLayerId.Value}-{(relationship.EsriRelationshipId?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "deferred")}"
+            : relationship.TargetRelationshipRef ?? sourceRelationshipId;
+        return new MigrationRelationshipApplyOutcome
+        {
+            SourceRelationshipId = sourceRelationshipId,
+            Outcome = MigrationCatalogWriteOutcome.AlreadyExists,
+            Message = message,
+            TargetRelationshipRef = refValue
+        };
+    }
+}

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using Honua.Core.Features.Admin.Abstractions;
 using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.Attachments.Abstractions;
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
@@ -39,6 +40,7 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
     private readonly ILayerPublishingService? _layerPublishingService;
     private readonly IGeoServicesStyleConverter? _styleConverter;
     private readonly ILayerStyleCatalog? _styleCatalog;
+    private readonly IAttachmentStore? _attachmentStore;
     private readonly ILogger<GeoservicesImportService> _logger;
     private readonly PostgresSchemaConfiguration _schemaConfiguration;
 
@@ -51,6 +53,7 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
         ILayerPublishingService? layerPublishingService = null,
         IGeoServicesStyleConverter? styleConverter = null,
         ILayerStyleCatalog? styleCatalog = null,
+        IAttachmentStore? attachmentStore = null,
         PostgresSchemaConfiguration? schemaConfiguration = null)
     {
         _restClient = restClient ?? throw new ArgumentNullException(nameof(restClient));
@@ -60,6 +63,7 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
         _layerPublishingService = layerPublishingService;
         _styleConverter = styleConverter;
         _styleCatalog = styleCatalog;
+        _attachmentStore = attachmentStore;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _schemaConfiguration = schemaConfiguration ?? new PostgresSchemaConfiguration(
             PostgresSchemaConfiguration.DefaultMetadataSchema,
@@ -350,7 +354,9 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
         int featuresProcessed,
         int? totalFeatures,
         string? layerName = null,
-        int? publishedLayerId = null)
+        int? publishedLayerId = null,
+        int attachmentsProcessed = 0,
+        int failedAttachments = 0)
     {
         progress?.Report(new GeoservicesImportProgress
         {
@@ -365,7 +371,9 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
             ServiceName = request.ServiceName,
             PublishedLayerId = publishedLayerId,
             StartedAt = startedAt,
-            CurrentPhase = phase
+            CurrentPhase = phase,
+            AttachmentsProcessed = attachmentsProcessed,
+            FailedAttachments = failedAttachments
         });
     }
 
@@ -478,5 +486,24 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
             int layerId,
             string code,
             string symbolizerType);
+
+        [LoggerMessage(7835, LogLevel.Information,
+            "Starting attachment copy for layer {LayerId}: {FeatureCount} parent features in scope")]
+        public static partial void AttachmentCopyStarting(ILogger logger, int layerId, int featureCount);
+
+        [LoggerMessage(7836, LogLevel.Information,
+            "Attachment copy completed for layer {LayerId}: {AttachmentCount} copied, {FailedCount} failed")]
+        public static partial void AttachmentCopyCompleted(
+            ILogger logger, int layerId, int attachmentCount, int failedCount);
+
+        [LoggerMessage(7837, LogLevel.Warning,
+            "Failed to copy attachment {AttachmentId} for source feature {SourceObjectId} in layer {LayerId}")]
+        public static partial void AttachmentCopyFailed(
+            ILogger logger, long attachmentId, long sourceObjectId, int layerId, Exception exception);
+
+        [LoggerMessage(7838, LogLevel.Warning,
+            "Attachment metadata query failed for layer {LayerId} batch of {BatchSize} ObjectIds")]
+        public static partial void AttachmentQueryBatchFailed(
+            ILogger logger, int layerId, int batchSize, Exception exception);
     }
 }

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.cs
@@ -41,6 +41,7 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
     private readonly IGeoServicesStyleConverter? _styleConverter;
     private readonly ILayerStyleCatalog? _styleCatalog;
     private readonly IAttachmentStore? _attachmentStore;
+    private readonly IMigrationCatalogWriter? _catalogWriter;
     private readonly ILogger<GeoservicesImportService> _logger;
     private readonly PostgresSchemaConfiguration _schemaConfiguration;
 
@@ -54,6 +55,7 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
         IGeoServicesStyleConverter? styleConverter = null,
         ILayerStyleCatalog? styleCatalog = null,
         IAttachmentStore? attachmentStore = null,
+        IMigrationCatalogWriter? catalogWriter = null,
         PostgresSchemaConfiguration? schemaConfiguration = null)
     {
         _restClient = restClient ?? throw new ArgumentNullException(nameof(restClient));
@@ -64,6 +66,7 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
         _styleConverter = styleConverter;
         _styleCatalog = styleCatalog;
         _attachmentStore = attachmentStore;
+        _catalogWriter = catalogWriter;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _schemaConfiguration = schemaConfiguration ?? new PostgresSchemaConfiguration(
             PostgresSchemaConfiguration.DefaultMetadataSchema,
@@ -505,5 +508,8 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
             "Attachment metadata query failed for layer {LayerId} batch of {BatchSize} ObjectIds")]
         public static partial void AttachmentQueryBatchFailed(
             ILogger logger, int layerId, int batchSize, Exception exception);
+
+        [LoggerMessage(7839, LogLevel.Debug, "Relationship apply skipped: {Reason}")]
+        public static partial void RelationshipApplySkipped(ILogger logger, string reason);
     }
 }

--- a/src/Honua.Postgres/Features/Migration/PostgresMigrationCatalogWriter.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresMigrationCatalogWriter.cs
@@ -5,6 +5,8 @@ using Honua.Core.Features.Import.Abstractions;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Migration.Abstractions;
 using Honua.Core.Features.Migration.Domain;
 using Honua.Core.Features.Migration.Services;
@@ -323,6 +325,360 @@ internal sealed partial class PostgresMigrationCatalogWriter : IMigrationCatalog
         return outcome;
     }
 
+    public async Task<MigrationRelationshipApplyOutcome[]> EnsureRelationshipsAsync(
+        string connectionString,
+        IMetadataV2GraphStore? graphStore,
+        MigrationRelationshipApplyRequest[] requests,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        ArgumentNullException.ThrowIfNull(requests);
+        if (requests.Length == 0)
+        {
+            return [];
+        }
+
+        var orderedRequests = requests
+            .OrderBy(static r => r.OriginLayerId)
+            .ThenBy(static r => r.SourceRelationshipId, StringComparer.Ordinal)
+            .ToArray();
+
+        var graphOutcomes = graphStore == null
+            ? new Dictionary<string, GraphRelationshipOutcome>(StringComparer.Ordinal)
+            : await ApplyRelationshipGraphPatchAsync(graphStore, orderedRequests, cancellationToken).ConfigureAwait(false);
+
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        var results = new List<MigrationRelationshipApplyOutcome>(orderedRequests.Length);
+        var v1Created = 0;
+        var v1AlreadyExists = 0;
+
+        foreach (var request in orderedRequests)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // V1 honua.relationships row: required for the FeatureServer
+            // queryRelatedRecords path that reads from honua.relationships via the
+            // shared IRelationshipStore. The unique key (layer_id, relationship_id)
+            // keeps re-apply idempotent.
+            var v1Outcome = await InsertRelationshipRowAsync(connection, request, cancellationToken).ConfigureAwait(false);
+            if (v1Outcome == MigrationCatalogWriteOutcome.Created)
+            {
+                v1Created++;
+            }
+            else
+            {
+                v1AlreadyExists++;
+            }
+
+            graphOutcomes.TryGetValue(request.SourceRelationshipId, out var graphOutcome);
+            var combined = CombineRelationshipOutcomes(graphOutcome, v1Outcome, graphStore != null);
+            results.Add(new MigrationRelationshipApplyOutcome
+            {
+                SourceRelationshipId = request.SourceRelationshipId,
+                Outcome = combined.Outcome,
+                Message = combined.Message,
+                TargetRelationshipRef = BuildTargetRelationshipRef(request)
+            });
+        }
+
+        Log.RelationshipsPersisted(_logger, v1Created, v1AlreadyExists, graphStore == null ? "skipped" : "applied");
+        return results.ToArray();
+    }
+
+    private static async Task<Dictionary<string, GraphRelationshipOutcome>> ApplyRelationshipGraphPatchAsync(
+        IMetadataV2GraphStore graphStore,
+        MigrationRelationshipApplyRequest[] orderedRequests,
+        CancellationToken cancellationToken)
+    {
+        // Group requests by origin layer so each resource's relationships list is
+        // patched once per save instead of saving per relationship. Each save
+        // increments the graph revision, so coalescing keeps the snapshot small
+        // and avoids needless cache churn.
+        const int MaxAttempts = 2;
+        var outcomes = new Dictionary<string, GraphRelationshipOutcome>(StringComparer.Ordinal);
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var snapshot = await graphStore.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+            var graph = snapshot.Graph;
+            var requestsByOrigin = orderedRequests
+                .GroupBy(static r => r.OriginLayerId)
+                .OrderBy(static g => g.Key);
+
+            var updatedResources = graph.Resources.ToList();
+            var resourcesById = updatedResources
+                .Select(static (resource, index) => (resource, index))
+                .ToDictionary(item => item.resource.Metadata.Id, item => item.index, StringComparer.Ordinal);
+
+            var graphChanged = false;
+            var perRequestOutcomes = new Dictionary<string, GraphRelationshipOutcome>(StringComparer.Ordinal);
+
+            foreach (var group in requestsByOrigin)
+            {
+                var originResourceId = BuildResourceId(group.Key);
+                if (!resourcesById.TryGetValue(originResourceId, out var index))
+                {
+                    foreach (var req in group)
+                    {
+                        perRequestOutcomes[req.SourceRelationshipId] = new GraphRelationshipOutcome(
+                            MigrationCatalogWriteOutcome.AlreadyExists,
+                            $"Origin resource '{originResourceId}' not present in the Metadata v2 graph; v2 relationship entry skipped.");
+                    }
+                    continue;
+                }
+
+                var origin = updatedResources[index];
+                var existingRelationships = origin.Relationships.ToList();
+                var existingIds = new HashSet<string>(existingRelationships.Select(static r => r.Id), StringComparer.Ordinal);
+
+                foreach (var req in group)
+                {
+                    var relationshipId = BuildRelationshipId(req);
+                    if (existingIds.Contains(relationshipId))
+                    {
+                        perRequestOutcomes[req.SourceRelationshipId] = new GraphRelationshipOutcome(
+                            MigrationCatalogWriteOutcome.AlreadyExists,
+                            $"Relationship '{relationshipId}' already present on resource '{originResourceId}'; v2 graph entry unchanged.");
+                        continue;
+                    }
+
+                    existingRelationships.Add(BuildRelationshipMetadata(req, relationshipId));
+                    existingIds.Add(relationshipId);
+                    perRequestOutcomes[req.SourceRelationshipId] = new GraphRelationshipOutcome(
+                        MigrationCatalogWriteOutcome.Created,
+                        $"Appended relationship '{relationshipId}' to resource '{originResourceId}' in the Metadata v2 graph.");
+                    graphChanged = true;
+                }
+
+                if (graphChanged)
+                {
+                    updatedResources[index] = origin with { Relationships = existingRelationships };
+                }
+            }
+
+            if (!graphChanged)
+            {
+                foreach (var kv in perRequestOutcomes)
+                {
+                    outcomes[kv.Key] = kv.Value;
+                }
+                return outcomes;
+            }
+
+            var updatedGraph = graph with
+            {
+                Revision = Math.Max(graph.Revision + 1, 1),
+                GeneratedAt = graph.GeneratedAt,
+                Resources = updatedResources
+            };
+
+            try
+            {
+                await graphStore.SaveAsync(updatedGraph, snapshot.Etag, cancellationToken).ConfigureAwait(false);
+                foreach (var kv in perRequestOutcomes)
+                {
+                    outcomes[kv.Key] = kv.Value;
+                }
+                return outcomes;
+            }
+            catch (InvalidOperationException) when (attempt < MaxAttempts)
+            {
+                // Optimistic concurrency conflict: another writer beat us. Re-read
+                // the snapshot and rebuild the patch. We retry once; if a second
+                // attempt also fails the exception surfaces to the caller so the
+                // apply step can record a failed outcome.
+            }
+        }
+
+        return outcomes;
+    }
+
+    private static async Task<MigrationCatalogWriteOutcome> InsertRelationshipRowAsync(
+        NpgsqlConnection connection,
+        MigrationRelationshipApplyRequest request,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            INSERT INTO honua.relationships (
+                layer_id,
+                relationship_id,
+                name,
+                related_layer_id,
+                relationship_type,
+                origin_foreign_key,
+                destination_foreign_key,
+                description
+            )
+            VALUES (@layerId, @relationshipId, @name, @relatedLayerId, @relationshipType,
+                    @originForeignKey, @destinationForeignKey, NULL)
+            ON CONFLICT (layer_id, relationship_id) DO NOTHING
+            RETURNING relationship_id;
+            """;
+
+        // honua.relationships has CHECK constraints on relationship_id > 0 and
+        // relationship_type ∈ {esriRelRoleOrigin, esriRelRoleDestination,
+        // esriRelRoleAny}. Stable-hash the source identifier when the source did
+        // not advertise an integer id so the row still satisfies the schema.
+        var relationshipId = request.EsriRelationshipId ?? DeriveStableRelationshipId(request.SourceRelationshipId);
+        var relationshipType = NormalizeRelationshipRole(request.Role);
+        var name = string.IsNullOrWhiteSpace(request.Name)
+            ? $"rel-{relationshipId.ToString(System.Globalization.CultureInfo.InvariantCulture)}"
+            : request.Name!;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@layerId", request.OriginLayerId);
+        command.Parameters.AddWithValue("@relationshipId", relationshipId);
+        command.Parameters.AddWithValue("@name", name);
+        command.Parameters.AddWithValue("@relatedLayerId", request.RelatedLayerId);
+        command.Parameters.AddWithValue("@relationshipType", relationshipType);
+        command.Parameters.AddWithValue("@originForeignKey", request.OriginKeyField);
+        command.Parameters.AddWithValue("@destinationForeignKey", request.DestinationKeyField);
+
+        var inserted = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return inserted is null
+            ? MigrationCatalogWriteOutcome.AlreadyExists
+            : MigrationCatalogWriteOutcome.Created;
+    }
+
+    private static (MigrationCatalogWriteOutcome Outcome, string Message) CombineRelationshipOutcomes(
+        GraphRelationshipOutcome? graphOutcome,
+        MigrationCatalogWriteOutcome v1Outcome,
+        bool graphRequested)
+    {
+        var v1Message = v1Outcome == MigrationCatalogWriteOutcome.Created
+            ? "Inserted honua.relationships row."
+            : "honua.relationships row already present.";
+
+        if (!graphRequested)
+        {
+            return (
+                v1Outcome,
+                $"{v1Message} Metadata v2 graph write skipped (no graph store provided).");
+        }
+
+        if (graphOutcome is null)
+        {
+            return (
+                MigrationCatalogWriteOutcome.AlreadyExists,
+                $"{v1Message} Metadata v2 graph write skipped: no matching origin resource.");
+        }
+
+        var combinedOutcome = graphOutcome.Outcome == MigrationCatalogWriteOutcome.Created ||
+                              v1Outcome == MigrationCatalogWriteOutcome.Created
+            ? MigrationCatalogWriteOutcome.Created
+            : MigrationCatalogWriteOutcome.AlreadyExists;
+
+        return (combinedOutcome, $"{graphOutcome.Message} {v1Message}");
+    }
+
+    private static MetadataV2Relationship BuildRelationshipMetadata(
+        MigrationRelationshipApplyRequest request,
+        string relationshipId)
+    {
+        return new MetadataV2Relationship
+        {
+            Id = relationshipId,
+            Name = string.IsNullOrWhiteSpace(request.Name) ? relationshipId : request.Name!,
+            RelatedResourceId = BuildResourceId(request.RelatedLayerId),
+            Role = string.IsNullOrWhiteSpace(request.Role) ? "origin" : request.Role!,
+            Cardinality = MapCardinalityToV2(request.Cardinality),
+            OriginField = request.OriginKeyField,
+            DestinationField = request.DestinationKeyField,
+            EsriRelationshipId = request.EsriRelationshipId
+        };
+    }
+
+    private static string BuildRelationshipId(MigrationRelationshipApplyRequest request)
+    {
+        var idPart = request.EsriRelationshipId.HasValue
+            ? request.EsriRelationshipId.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : SanitizeRelationshipIdSuffix(request.SourceRelationshipId);
+        return $"rel-{request.OriginLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture)}-{idPart}";
+    }
+
+    private static string BuildTargetRelationshipRef(MigrationRelationshipApplyRequest request)
+        => BuildRelationshipId(request);
+
+    private static string BuildResourceId(int layerId)
+        => $"res-layer-{layerId.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+
+    private static string MapCardinalityToV2(string normalizedCardinality)
+    {
+        return normalizedCardinality switch
+        {
+            "1:1" => "one-to-one",
+            "1:N" => "one-to-many",
+            "M:N" => "many-to-many",
+            _ => "one-to-many"
+        };
+    }
+
+    private static string NormalizeRelationshipRole(string? role)
+    {
+        if (string.IsNullOrWhiteSpace(role))
+        {
+            return "esriRelRoleOrigin";
+        }
+
+        var trimmed = role.Trim();
+        if (trimmed.Equals("origin", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.Equals("esriRelRoleOrigin", StringComparison.OrdinalIgnoreCase))
+        {
+            return "esriRelRoleOrigin";
+        }
+        if (trimmed.Equals("destination", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.Equals("esriRelRoleDestination", StringComparison.OrdinalIgnoreCase))
+        {
+            return "esriRelRoleDestination";
+        }
+        if (trimmed.Equals("any", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.Equals("esriRelRoleAny", StringComparison.OrdinalIgnoreCase))
+        {
+            return "esriRelRoleAny";
+        }
+
+        return "esriRelRoleOrigin";
+    }
+
+    private static int DeriveStableRelationshipId(string sourceRelationshipId)
+    {
+        // honua.relationships CHECK requires relationship_id > 0; the FNV-1a 32-bit
+        // hash gives us a deterministic positive integer when the source did not
+        // advertise an integer relationship id.
+        const uint Prime = 16777619;
+        var hash = 2166136261u;
+        foreach (var ch in sourceRelationshipId)
+        {
+            hash ^= ch;
+            hash *= Prime;
+        }
+
+        var shifted = (int)(hash & 0x7FFFFFFFu);
+        return shifted == 0 ? 1 : shifted;
+    }
+
+    private static string SanitizeRelationshipIdSuffix(string sourceRelationshipId)
+    {
+        var builder = new System.Text.StringBuilder(sourceRelationshipId.Length);
+        foreach (var ch in sourceRelationshipId)
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                builder.Append(ch);
+            }
+            else if (builder.Length > 0 && builder[^1] != '-')
+            {
+                builder.Append('-');
+            }
+        }
+        var result = builder.ToString().Trim('-');
+        return string.IsNullOrEmpty(result) ? "unknown" : result;
+    }
+
+    private sealed record GraphRelationshipOutcome(MigrationCatalogWriteOutcome Outcome, string Message);
+
     private static async Task<long> CountRowsAsync(NpgsqlConnection connection, string identifier, CancellationToken cancellationToken)
     {
         await using var countCmd = new NpgsqlCommand($"SELECT COUNT(*) FROM {identifier};", connection);
@@ -372,5 +728,8 @@ internal sealed partial class PostgresMigrationCatalogWriter : IMigrationCatalog
 
         [LoggerMessage(7965, LogLevel.Information, "Migration catalog writer ensured {SourceFormat} style '{SourceId}' (disposition={Disposition}, {Outcome})")]
         public static partial void StylePersisted(ILogger logger, string sourceFormat, string sourceId, string disposition, string outcome);
+
+        [LoggerMessage(7966, LogLevel.Information, "Migration catalog writer ensured relationships: created={Created}, already-exists={AlreadyExists}, v2-graph={GraphStatus}")]
+        public static partial void RelationshipsPersisted(ILogger logger, int created, int alreadyExists, string graphStatus);
     }
 }

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -402,7 +402,9 @@ internal static class ServiceCollectionExtensions
             configureHandler: static () => ArcGisRestClient.CreatePinnedDnsHttpMessageHandler())
             .AddHttpMessageHandler<MigrationRequestCountingHandler>();
 
-        // Register Geoservices import service
+        // Register Geoservices import service. The optional IAttachmentStore parameter is
+        // automatically resolved from the container when registered above so attachment
+        // copy runs during ArcGIS layer imports without a separate wiring step.
         services.AddScoped<IGeoservicesImportService, GeoservicesImportService>();
 
         // Register Core-level services via their own extensions

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationArtifactSchemaSnapshots/honua.migration.manifest.schema.json
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationArtifactSchemaSnapshots/honua.migration.manifest.schema.json
@@ -1386,8 +1386,32 @@
                   "Nullable": false
                 },
                 {
+                  "JsonName": "destinationKeyField",
+                  "ClrName": "DestinationKeyField",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "esriRelationshipId",
+                  "ClrName": "EsriRelationshipId",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
                   "JsonName": "name",
                   "ClrName": "Name",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "originKeyField",
+                  "ClrName": "OriginKeyField",
                   "Container": "scalar",
                   "ElementType": "string",
                   "Required": false,
@@ -1412,6 +1436,14 @@
                 {
                   "JsonName": "relationshipType",
                   "ClrName": "RelationshipType",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "role",
+                  "ClrName": "Role",
                   "Container": "scalar",
                   "ElementType": "string",
                   "Required": false,

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationManifestTranslatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationManifestTranslatorTests.cs
@@ -696,6 +696,41 @@ public sealed class MigrationManifestTranslatorTests
     }
 
     [Fact]
+    public void Translate_WithArcGisRelationshipKeyFields_PropagatesOriginAndDestinationFields()
+    {
+        // Issue #1256: simple ArcGIS relationships use the same keyField on
+        // both sides; the fidelity scanner now records originKeyField and
+        // destinationKeyField metadata. The translator surfaces them on the
+        // emitted MigrationManifestRelationshipRecord so the apply pass can
+        // build foreign-key references without re-fetching the source JSON.
+        var inventory = CreateArcGisRelationshipInventory(
+            classifications:
+            [
+                CreateRelationshipClassification(
+                    sourceId: "resource:Inspections:layer:0",
+                    name: "InspectionToPhotos",
+                    metadata: new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["relationshipId"] = "3",
+                        ["cardinality"] = "1:N",
+                        ["relationshipType"] = "simple",
+                        ["relatedLayerIds"] = "layer:1",
+                        ["originKeyField"] = "INSPECTION_ID",
+                        ["destinationKeyField"] = "INSPECTION_ID",
+                        ["role"] = "esriRelRoleOrigin"
+                    })
+            ]);
+
+        var record = MigrationManifestTranslator.Translate(inventory)
+            .TargetResources.Should().ContainSingle().Subject
+            .Relationships.Should().ContainSingle().Subject;
+        record.OriginKeyField.Should().Be("INSPECTION_ID");
+        record.DestinationKeyField.Should().Be("INSPECTION_ID");
+        record.Role.Should().Be("esriRelRoleOrigin");
+        record.EsriRelationshipId.Should().Be(3);
+    }
+
+    [Fact]
     public void Translate_WithArcGisOneToManyRelationship_ClassifiesAsAssisted()
     {
         var inventory = CreateArcGisRelationshipInventory(

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceApplyPlanTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceApplyPlanTests.cs
@@ -676,5 +676,15 @@ public sealed class GeoServerImportServiceApplyPlanTests
             MigrationStyleRequest request,
             CancellationToken cancellationToken = default)
             => Task.FromResult(MigrationCatalogWriteOutcome.Created);
+
+        // Issue #1256: GeoServer apply tests do not exercise relationship
+        // persistence; return an empty outcome set so the interface remains
+        // satisfied.
+        public Task<MigrationRelationshipApplyOutcome[]> EnsureRelationshipsAsync(
+            string connectionString,
+            Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphStore? graphStore,
+            MigrationRelationshipApplyRequest[] requests,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<MigrationRelationshipApplyOutcome>());
     }
 }

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceDataSourceApplyTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceDataSourceApplyTests.cs
@@ -773,5 +773,12 @@ public sealed class GeoServerImportServiceDataSourceApplyTests
             MigrationStyleRequest request,
             CancellationToken cancellationToken = default)
             => Task.FromResult(MigrationCatalogWriteOutcome.Created);
+
+        public Task<MigrationRelationshipApplyOutcome[]> EnsureRelationshipsAsync(
+            string connectionString,
+            Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphStore? graphStore,
+            MigrationRelationshipApplyRequest[] requests,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<MigrationRelationshipApplyOutcome>());
     }
 }

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceStyleApplyTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceStyleApplyTests.cs
@@ -431,5 +431,12 @@ public sealed class GeoServerImportServiceStyleApplyTests
                 : MigrationCatalogWriteOutcome.AlreadyExists;
             return Task.FromResult(outcome);
         }
+
+        public Task<MigrationRelationshipApplyOutcome[]> EnsureRelationshipsAsync(
+            string connectionString,
+            Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphStore? graphStore,
+            MigrationRelationshipApplyRequest[] requests,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<MigrationRelationshipApplyOutcome>());
     }
 }

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportWorkspaceScopingTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportWorkspaceScopingTests.cs
@@ -574,6 +574,13 @@ public sealed class GeoServerImportWorkspaceScopingTests
             MigrationStyleRequest request,
             CancellationToken cancellationToken = default)
             => Task.FromResult(MigrationCatalogWriteOutcome.Created);
+
+        public Task<MigrationRelationshipApplyOutcome[]> EnsureRelationshipsAsync(
+            string connectionString,
+            Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphStore? graphStore,
+            MigrationRelationshipApplyRequest[] requests,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<MigrationRelationshipApplyOutcome>());
     }
 
     private sealed class RecordingLogger : ILogger<GeoServerImportService>

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesArcGisInventoryBaselineTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesArcGisInventoryBaselineTests.cs
@@ -185,8 +185,8 @@ public sealed class GeoservicesArcGisInventoryBaselineTests
         artifact.FidelityClassifications.Should().Contain(record =>
             record.SourceId == resource.Id &&
             record.Category == "attachments" &&
-            record.Code == ImportCompatibilityCodes.ArcGisAttachments &&
-            record.AutomationStatus == MigrationFidelityAutomationStatuses.ManualReview);
+            record.Code == ImportCompatibilityCodes.Compatible &&
+            record.AutomationStatus == MigrationFidelityAutomationStatuses.Automated);
         artifact.FidelityClassifications.Should().Contain(record =>
             record.Category == "renderers" &&
             record.AutomationStatus == MigrationFidelityAutomationStatuses.ManualReview);
@@ -198,9 +198,9 @@ public sealed class GeoservicesArcGisInventoryBaselineTests
 
         artifact.FidelityMatrix.Should().NotBeNull();
         artifact.FidelityMatrix!.Summary.Should().Match<MigrationFidelityMatrixSummary>(summary =>
-            summary.AutomatedCount >= 4 &&
+            summary.AutomatedCount >= 5 &&
             summary.AssistedCount >= 1 &&
-            summary.ManualReviewCount >= 5 &&
+            summary.ManualReviewCount >= 4 &&
             summary.UnsupportedCount == 0);
         artifact.FidelityMatrix.Cells.Should().Contain(cell =>
             cell.Category == "domains" &&

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesArcGisInventoryBaselineTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesArcGisInventoryBaselineTests.cs
@@ -177,11 +177,16 @@ public sealed class GeoservicesArcGisInventoryBaselineTests
             record.Category == "subtypes" &&
             record.Code == ImportCompatibilityCodes.ArcGisSubtypesManualReview &&
             record.AutomationStatus == MigrationFidelityAutomationStatuses.ManualReview);
-        artifact.FidelityClassifications.Should().Contain(record =>
-            record.SourceId == resource.Id &&
-            record.Category == "relationships" &&
-            record.Code == ImportCompatibilityCodes.ArcGisRelationshipsManualReview &&
-            record.AutomationStatus == MigrationFidelityAutomationStatuses.ManualReview);
+        // Issue #1256: per-relationship fidelity records now classify simple
+        // (non-composite, non-attributed, non-many-to-many) relationships as
+        // Automated so the apply path can recreate them deterministically.
+        var relationshipRecord = artifact.FidelityClassifications.Should().ContainSingle(record =>
+            record.SourceId == resource.Id && record.Category == "relationships").Subject;
+        relationshipRecord.Code.Should().Be(ImportCompatibilityCodes.Compatible);
+        relationshipRecord.AutomationStatus.Should().Be(MigrationFidelityAutomationStatuses.Automated);
+        relationshipRecord.Metadata["relationshipId"].Should().Be("2");
+        relationshipRecord.Metadata["name"].Should().Be("InspectionPhotos");
+        relationshipRecord.Metadata["relatedLayerIds"].Should().Be("layer:3");
         artifact.FidelityClassifications.Should().Contain(record =>
             record.SourceId == resource.Id &&
             record.Category == "attachments" &&
@@ -197,10 +202,13 @@ public sealed class GeoservicesArcGisInventoryBaselineTests
             record.AutomationStatus == MigrationFidelityAutomationStatuses.ManualReview);
 
         artifact.FidelityMatrix.Should().NotBeNull();
+        // Manual-review categories on current trunk are subtypes, renderers, and
+        // time-metadata (domains classify as Assisted; #1256 reclassifies the simple
+        // relationship as Automated), so the matrix carries exactly three manual-review cells.
         artifact.FidelityMatrix!.Summary.Should().Match<MigrationFidelityMatrixSummary>(summary =>
             summary.AutomatedCount >= 5 &&
             summary.AssistedCount >= 1 &&
-            summary.ManualReviewCount >= 4 &&
+            summary.ManualReviewCount >= 3 &&
             summary.UnsupportedCount == 0);
         artifact.FidelityMatrix.Cells.Should().Contain(cell =>
             cell.Category == "domains" &&
@@ -208,8 +216,8 @@ public sealed class GeoservicesArcGisInventoryBaselineTests
             cell.SourceIds.SequenceEqual(new[] { resource.Id }));
         artifact.FidelityMatrix.Cells.Should().Contain(cell =>
             cell.Category == "relationships" &&
-            cell.AutomationStatus == MigrationFidelityAutomationStatuses.ManualReview &&
-            cell.Codes.SequenceEqual(new[] { ImportCompatibilityCodes.ArcGisRelationshipsManualReview }));
+            cell.AutomationStatus == MigrationFidelityAutomationStatuses.Automated &&
+            cell.Codes.SequenceEqual(new[] { ImportCompatibilityCodes.Compatible }));
         artifact.FidelityMatrix.Cells.Should().Contain(cell =>
             cell.Category == "renderers" &&
             cell.AutomationStatus == MigrationFidelityAutomationStatuses.ManualReview &&

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesArcGisRelationshipFidelityTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesArcGisRelationshipFidelityTests.cs
@@ -1,0 +1,236 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.FileImport.Domain;
+using Honua.Core.Features.Migration.Services;
+using Honua.Core.Features.FileImport.Services;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Shared.Models;
+using Honua.Postgres.Features.Migration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+/// <summary>
+/// Targeted fixtures for the per-relationship fidelity extraction added by
+/// issue #1256. The High Fidelity baseline asserts the simple (id,name,relatedTableId)
+/// case; these fixtures cover the explicit metadata-rich cases that drive the
+/// translator+apply pipeline:
+/// <list type="bullet">
+///   <item>Simple relationship with cardinality + role + keyField yields Automated</item>
+///   <item>Composite relationship downgrades to ManualReview</item>
+///   <item>Many-to-many relationship downgrades to ManualReview</item>
+/// </list>
+/// </summary>
+public sealed class GeoservicesArcGisRelationshipFidelityTests
+{
+    [Fact]
+    public async Task ScanSourceAsync_SimpleRelationshipWithCardinalityAndKeyField_EmitsAutomatedFidelity()
+    {
+        var responses = BuildResponses(
+            relationshipsJson: "[{\"id\":2,\"name\":\"InspectionPhotos\",\"cardinality\":\"esriRelCardinalityOneToMany\",\"role\":\"esriRelRoleOrigin\",\"keyField\":\"INSPECTION_ID\",\"relatedTableId\":3}]");
+        var service = CreateService(new FixtureHttpHandler(responses));
+
+        var artifact = await service.ScanSourceAsync(new GeoservicesDiscoveryRequest
+        {
+            ServiceUrl = "https://example.com/arcgis/rest/services/Inspections/FeatureServer",
+            TimeoutSeconds = 5
+        });
+
+        var resource = artifact.Resources.Should().ContainSingle().Subject;
+        var record = artifact.FidelityClassifications.Should().ContainSingle(r =>
+            r.SourceId == resource.Id && r.Category == "relationships").Subject;
+        record.AutomationStatus.Should().Be(MigrationFidelityAutomationStatuses.Automated);
+        record.Code.Should().Be(ImportCompatibilityCodes.Compatible);
+        record.Id.Should().Be($"classification:{resource.Id}:relationship:2");
+        record.Metadata["relationshipId"].Should().Be("2");
+        record.Metadata["name"].Should().Be("InspectionPhotos");
+        record.Metadata["cardinality"].Should().Be("esriRelCardinalityOneToMany");
+        record.Metadata["role"].Should().Be("esriRelRoleOrigin");
+        record.Metadata["originKeyField"].Should().Be("INSPECTION_ID");
+        record.Metadata["destinationKeyField"].Should().Be("INSPECTION_ID");
+        record.Metadata["relatedLayerIds"].Should().Be("layer:3");
+    }
+
+    [Fact]
+    public async Task ScanSourceAsync_CompositeRelationship_EmitsManualReviewFidelity()
+    {
+        var responses = BuildResponses(
+            relationshipsJson: "[{\"id\":4,\"name\":\"OwnsParts\",\"cardinality\":\"esriRelCardinalityOneToMany\",\"role\":\"esriRelRoleOrigin\",\"keyField\":\"PARENT_ID\",\"relatedTableId\":5,\"composite\":true}]");
+        var service = CreateService(new FixtureHttpHandler(responses));
+
+        var artifact = await service.ScanSourceAsync(new GeoservicesDiscoveryRequest
+        {
+            ServiceUrl = "https://example.com/arcgis/rest/services/Inspections/FeatureServer",
+            TimeoutSeconds = 5
+        });
+
+        var resource = artifact.Resources.Should().ContainSingle().Subject;
+        var record = artifact.FidelityClassifications.Should().ContainSingle(r =>
+            r.SourceId == resource.Id && r.Category == "relationships").Subject;
+        record.AutomationStatus.Should().Be(MigrationFidelityAutomationStatuses.ManualReview);
+        record.Code.Should().Be(ImportCompatibilityCodes.ArcGisRelationshipsManualReview);
+        record.Metadata["relationshipType"].Should().Be("composite");
+    }
+
+    [Fact]
+    public async Task ScanSourceAsync_ManyToManyRelationship_EmitsManualReviewFidelity()
+    {
+        var responses = BuildResponses(
+            relationshipsJson: "[{\"id\":6,\"name\":\"JunctionLink\",\"cardinality\":\"esriRelCardinalityManyToMany\",\"role\":\"esriRelRoleOrigin\",\"keyField\":\"LINK_ID\",\"relatedTableId\":7}]");
+        var service = CreateService(new FixtureHttpHandler(responses));
+
+        var artifact = await service.ScanSourceAsync(new GeoservicesDiscoveryRequest
+        {
+            ServiceUrl = "https://example.com/arcgis/rest/services/Inspections/FeatureServer",
+            TimeoutSeconds = 5
+        });
+
+        var resource = artifact.Resources.Should().ContainSingle().Subject;
+        var record = artifact.FidelityClassifications.Should().ContainSingle(r =>
+            r.SourceId == resource.Id && r.Category == "relationships").Subject;
+        record.AutomationStatus.Should().Be(MigrationFidelityAutomationStatuses.ManualReview);
+        record.Code.Should().Be(ImportCompatibilityCodes.ArcGisRelationshipsManualReview);
+        record.Metadata["cardinality"].Should().Be("esriRelCardinalityManyToMany");
+    }
+
+    [Fact]
+    public async Task ScanSourceAsync_MultipleRelationshipsOnSameLayer_EmitsOneRecordPerEntry()
+    {
+        var responses = BuildResponses(
+            relationshipsJson:
+                "[{\"id\":2,\"name\":\"Photos\",\"cardinality\":\"esriRelCardinalityOneToMany\",\"role\":\"esriRelRoleOrigin\",\"keyField\":\"INSPECTION_ID\",\"relatedTableId\":3}," +
+                "{\"id\":4,\"name\":\"OwnsParts\",\"cardinality\":\"esriRelCardinalityOneToMany\",\"role\":\"esriRelRoleOrigin\",\"keyField\":\"PARENT_ID\",\"relatedTableId\":5,\"composite\":true}]");
+        var service = CreateService(new FixtureHttpHandler(responses));
+
+        var artifact = await service.ScanSourceAsync(new GeoservicesDiscoveryRequest
+        {
+            ServiceUrl = "https://example.com/arcgis/rest/services/Inspections/FeatureServer",
+            TimeoutSeconds = 5
+        });
+
+        var resource = artifact.Resources.Should().ContainSingle().Subject;
+        var records = artifact.FidelityClassifications
+            .Where(r => r.SourceId == resource.Id && r.Category == "relationships")
+            .OrderBy(r => r.Id, StringComparer.Ordinal)
+            .ToArray();
+        records.Should().HaveCount(2);
+        records[0].Id.Should().Be($"classification:{resource.Id}:relationship:2");
+        records[0].AutomationStatus.Should().Be(MigrationFidelityAutomationStatuses.Automated);
+        records[1].Id.Should().Be($"classification:{resource.Id}:relationship:4");
+        records[1].AutomationStatus.Should().Be(MigrationFidelityAutomationStatuses.ManualReview);
+    }
+
+    [Fact]
+    public async Task ScanSourceAsync_RelationshipInfosArray_IsHonouredAsAlternateSpelling()
+    {
+        // Some MapServer layers expose relationships under "relationshipInfos"
+        // instead of "relationships"; the scanner accepts both.
+        var responses = BuildResponses(
+            relationshipsJson: "[]",
+            relationshipInfosJson: "[{\"id\":9,\"name\":\"Lineage\",\"cardinality\":\"esriRelCardinalityOneToOne\",\"role\":\"esriRelRoleOrigin\",\"keyField\":\"PREDECESSOR_ID\",\"relatedTableId\":4}]");
+        var service = CreateService(new FixtureHttpHandler(responses));
+
+        var artifact = await service.ScanSourceAsync(new GeoservicesDiscoveryRequest
+        {
+            ServiceUrl = "https://example.com/arcgis/rest/services/Inspections/FeatureServer",
+            TimeoutSeconds = 5
+        });
+
+        var resource = artifact.Resources.Should().ContainSingle().Subject;
+        var record = artifact.FidelityClassifications.Should().ContainSingle(r =>
+            r.SourceId == resource.Id && r.Category == "relationships").Subject;
+        record.Metadata["relationshipId"].Should().Be("9");
+        record.Metadata["cardinality"].Should().Be("esriRelCardinalityOneToOne");
+        record.AutomationStatus.Should().Be(MigrationFidelityAutomationStatuses.Automated);
+    }
+
+    private static Dictionary<string, string> BuildResponses(
+        string relationshipsJson,
+        string? relationshipInfosJson = null)
+    {
+        var rootJson = "{" +
+            "\"currentVersion\":11.2," +
+            "\"serviceDescription\":\"Relationships Test\"," +
+            "\"capabilities\":\"Query\"," +
+            "\"layers\":[{\"id\":0,\"name\":\"Inspections\"}]" +
+            "}";
+
+        var relationshipFragment = relationshipInfosJson == null
+            ? $"\"relationships\":{relationshipsJson}"
+            : $"\"relationships\":{relationshipsJson},\"relationshipInfos\":{relationshipInfosJson}";
+
+        var layerJson = "{" +
+            "\"id\":0,\"name\":\"Inspections\"," +
+            "\"geometryType\":\"esriGeometryPoint\"," +
+            "\"capabilities\":\"Query\"," +
+            "\"spatialReference\":{\"wkid\":3857}," +
+            relationshipFragment + "," +
+            "\"drawingInfo\":{\"renderer\":{\"type\":\"simple\"}}," +
+            "\"fields\":[{\"name\":\"OBJECTID\",\"type\":\"esriFieldTypeOID\"}]" +
+            "}";
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["/arcgis/rest/services/Inspections/FeatureServer?f=json"] = rootJson,
+            ["/arcgis/rest/services/Inspections/FeatureServer/0?f=json"] = layerJson,
+            ["/arcgis/rest/services/Inspections/FeatureServer/0/query?where=1%3D1&returnCountOnly=true&f=json"] = "{\"count\":1}"
+        };
+    }
+
+    private static GeoservicesImportService CreateService(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler);
+        var restClient = new ArcGisRestClient(
+            httpClient,
+            NullLogger<ArcGisRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+        var connectionProvider = new Mock<IDatabaseConnectionProvider>(MockBehavior.Loose);
+        var crsRegistry = new Mock<ICrsRegistry>(MockBehavior.Loose);
+        crsRegistry.Setup(registry => registry.ResolveBySridAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns((int srid, CancellationToken _) => new ValueTask<CrsDefinition?>(
+                srid == 3857
+                    ? new CrsDefinition("http://www.opengis.net/def/crs/EPSG/0/3857", 3857, AxisOrder.EastNorth, false)
+                    : null));
+
+        return new GeoservicesImportService(
+            restClient,
+            connectionProvider.Object,
+            crsRegistry.Object,
+            new EsriConstructCapabilityRegistry(EsriConstructCapabilityRegistry.BuiltInDescriptors),
+            NullLogger<GeoservicesImportService>.Instance);
+    }
+
+    private sealed class FixtureHttpHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, string> _responses;
+
+        public FixtureHttpHandler(Dictionary<string, string> responses)
+        {
+            _responses = responses;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var pathAndQuery = request.RequestUri?.PathAndQuery ?? string.Empty;
+            if (!_responses.TryGetValue(pathAndQuery, out var body))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    Content = new StringContent("{\"error\":{\"code\":404,\"message\":\"no fixture\"}}")
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportServiceAttachmentImportTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportServiceAttachmentImportTests.cs
@@ -1,0 +1,463 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.Admin.Abstractions;
+using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.Attachments.Abstractions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
+using Honua.Core.Features.Shared.Models;
+using Honua.Postgres.Features.Migration;
+using Honua.TestKit;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+[Collection("Database")]
+public sealed class GeoservicesImportServiceAttachmentImportTests(PostgresFixture fixture)
+{
+    [Fact]
+    public async Task ImportLayerAsync_WhenLayerAdvertisesAttachments_CopiesAttachmentsIntoStoreAndReportsCounts()
+    {
+        const string tableName = "geoservices_attachment_import";
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(GeoservicesImportServiceAttachmentImportTests));
+        var handler = new AttachmentFeatureServerHandler();
+        var attachmentStore = new RecordingAttachmentStore();
+        var publishingService = new StubLayerPublishingService(publishedLayerId: 42);
+        var service = CreateService(handler, attachmentStore, publishingService);
+
+        try
+        {
+            var result = await service.ImportLayerAsync(new GeoservicesImportRequest
+            {
+                ServiceUrl = "https://example.com/arcgis/rest/services/Inspections/FeatureServer",
+                LayerId = 0,
+                TableName = tableName,
+                TargetSchema = schemaName,
+                TargetSrid = 4326,
+                BatchSize = 10,
+                RequestTimeoutSeconds = 5,
+                MaxRetries = 0,
+                AutoPublish = true,
+                ServiceName = "default"
+            });
+
+            result.Success.Should().BeTrue();
+            result.FeatureCount.Should().Be(2);
+            result.PublishedLayerId.Should().Be(42);
+            result.AttachmentCount.Should().Be(3);
+            result.FailedAttachments.Should().Be(0);
+
+            attachmentStore.Uploaded.Should().HaveCount(3);
+            attachmentStore.Uploaded.Select(static a => a.LayerId).Should().AllBeEquivalentTo(42);
+            attachmentStore.Uploaded.Select(static a => a.Filename).Should()
+                .BeEquivalentTo("photo1.jpg", "photo2.jpg", "notes.txt");
+
+            // Source OBJECTID 1 (Alpha) -> 2 attachments, OBJECTID 2 (Beta) -> 1 attachment.
+            var honuaFeatureIds = attachmentStore.Uploaded
+                .Select(static a => a.FeatureId)
+                .Distinct()
+                .OrderBy(static id => id)
+                .ToArray();
+            honuaFeatureIds.Should().HaveCount(2);
+            attachmentStore.Uploaded
+                .Where(a => a.FeatureId == honuaFeatureIds[0])
+                .Select(static a => a.Filename)
+                .OrderBy(static n => n)
+                .Should()
+                .BeEquivalentTo(["notes.txt", "photo1.jpg"]);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    [Fact]
+    public async Task ImportLayerAsync_WhenAttachmentDownloadFails_CountsFailureAndContinues()
+    {
+        const string tableName = "geoservices_attachment_partial";
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(
+            nameof(GeoservicesImportServiceAttachmentImportTests) + "_Failure");
+        var handler = new AttachmentFeatureServerHandler(failAttachmentId: 1001);
+        var attachmentStore = new RecordingAttachmentStore();
+        var publishingService = new StubLayerPublishingService(publishedLayerId: 7);
+        var service = CreateService(handler, attachmentStore, publishingService);
+
+        try
+        {
+            var result = await service.ImportLayerAsync(new GeoservicesImportRequest
+            {
+                ServiceUrl = "https://example.com/arcgis/rest/services/Inspections/FeatureServer",
+                LayerId = 0,
+                TableName = tableName,
+                TargetSchema = schemaName,
+                TargetSrid = 4326,
+                BatchSize = 10,
+                RequestTimeoutSeconds = 5,
+                MaxRetries = 0,
+                AutoPublish = true,
+                ServiceName = "default"
+            });
+
+            result.Success.Should().BeTrue();
+            result.AttachmentCount.Should().Be(2);
+            result.FailedAttachments.Should().Be(1);
+            result.Warnings.Should().Contain(static w => w.Contains("failure", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    [Fact]
+    public async Task ImportLayerAsync_WhenImportAttachmentsDisabled_SkipsAttachmentCopy()
+    {
+        const string tableName = "geoservices_attachment_disabled";
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(
+            nameof(GeoservicesImportServiceAttachmentImportTests) + "_Disabled");
+        var handler = new AttachmentFeatureServerHandler();
+        var attachmentStore = new RecordingAttachmentStore();
+        var publishingService = new StubLayerPublishingService(publishedLayerId: 9);
+        var service = CreateService(handler, attachmentStore, publishingService);
+
+        try
+        {
+            var result = await service.ImportLayerAsync(new GeoservicesImportRequest
+            {
+                ServiceUrl = "https://example.com/arcgis/rest/services/Inspections/FeatureServer",
+                LayerId = 0,
+                TableName = tableName,
+                TargetSchema = schemaName,
+                TargetSrid = 4326,
+                BatchSize = 10,
+                RequestTimeoutSeconds = 5,
+                MaxRetries = 0,
+                AutoPublish = true,
+                ServiceName = "default",
+                ImportAttachments = false
+            });
+
+            result.Success.Should().BeTrue();
+            result.AttachmentCount.Should().Be(0);
+            result.FailedAttachments.Should().Be(0);
+            attachmentStore.Uploaded.Should().BeEmpty();
+            handler.AttachmentRequestPaths.Should().BeEmpty();
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    private GeoservicesImportService CreateService(
+        HttpMessageHandler handler,
+        IAttachmentStore attachmentStore,
+        ILayerPublishingService publishingService)
+    {
+        var restClient = new ArcGisRestClient(
+            new HttpClient(handler),
+            NullLogger<ArcGisRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+
+        var crsRegistry = new Mock<ICrsRegistry>(MockBehavior.Strict);
+        crsRegistry.Setup(registry => registry.ResolveBySridAsync(4326, It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<CrsDefinition?>(new CrsDefinition(
+                "http://www.opengis.net/def/crs/EPSG/0/4326",
+                4326,
+                AxisOrder.EastNorth,
+                true)));
+
+        return new GeoservicesImportService(
+            restClient,
+            new FixtureConnectionProvider(fixture),
+            crsRegistry.Object,
+            NullLogger<GeoservicesImportService>.Instance,
+            layerPublishingService: publishingService,
+            attachmentStore: attachmentStore);
+    }
+
+    private sealed class RecordingAttachmentStore : IAttachmentStore
+    {
+        public List<UploadedAttachment> Uploaded { get; } = [];
+        private long _nextId = 1;
+
+        public async Task<Honua.Core.Features.Attachments.Domain.Attachment> UploadAsync(
+            int layerId,
+            long featureId,
+            string filename,
+            string contentType,
+            Stream content,
+            string? keywords = null,
+            CancellationToken cancellationToken = default)
+        {
+            using var buffer = new MemoryStream();
+            await content.CopyToAsync(buffer, cancellationToken);
+            var bytes = buffer.ToArray();
+            var id = _nextId++;
+            Uploaded.Add(new UploadedAttachment(layerId, featureId, filename, contentType, bytes, keywords));
+            return Honua.Core.Features.Attachments.Domain.Attachment.CreateForUpload(
+                id,
+                featureId,
+                layerId,
+                filename,
+                contentType,
+                bytes.LongLength,
+                $"test/{layerId}/{featureId}/{Guid.NewGuid():N}",
+                keywords);
+        }
+
+        public Task<Honua.Core.Features.Attachments.Domain.Attachment?> GetAsync(
+            int layerId, long featureId, long attachmentId, CancellationToken cancellationToken = default)
+            => Task.FromResult<Honua.Core.Features.Attachments.Domain.Attachment?>(null);
+
+        public Task<Honua.Core.Features.Attachments.Domain.Attachment[]> ListAsync(
+            int layerId, long featureId, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<Honua.Core.Features.Attachments.Domain.Attachment>());
+
+        public Task<Honua.Core.Features.Attachments.Domain.Attachment> CreateAsync(
+            int layerId,
+            long featureId,
+            Honua.Core.Features.Attachments.Domain.Attachment attachment,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<Honua.Core.Features.Attachments.Domain.Attachment> UpdateAsync(
+            int layerId,
+            long featureId,
+            Honua.Core.Features.Attachments.Domain.Attachment attachment,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<Honua.Core.Features.Attachments.Domain.Attachment> ReplaceAsync(
+            int layerId,
+            long featureId,
+            long attachmentId,
+            string filename,
+            string contentType,
+            Stream content,
+            string? keywords = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<bool> DeleteAsync(
+            int layerId, long featureId, long attachmentId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<Honua.Core.Features.Attachments.Domain.AttachmentContent?> DownloadAsync(
+            int layerId, long featureId, long attachmentId, CancellationToken cancellationToken = default)
+            => Task.FromResult<Honua.Core.Features.Attachments.Domain.AttachmentContent?>(null);
+
+        public sealed record UploadedAttachment(
+            int LayerId,
+            long FeatureId,
+            string Filename,
+            string ContentType,
+            byte[] Content,
+            string? Keywords);
+    }
+
+    private sealed class StubLayerPublishingService(int publishedLayerId) : ILayerPublishingService
+    {
+        public Task<IReadOnlyList<PublishedLayerSummary>> ListPublishedLayersAsync(
+            string connectionString, string serviceName, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<PublishedLayerSummary>>([]);
+
+        public Task<PublishedLayerSummary> PublishLayerAsync(
+            string connectionString,
+            LayerPublishRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new PublishedLayerSummary
+            {
+                LayerId = publishedLayerId,
+                LayerName = request.LayerName,
+                Schema = request.Schema,
+                Table = request.Table,
+                Description = request.Description,
+                GeometryType = request.GeometryType ?? "Point",
+                Srid = request.Srid ?? 4326,
+                PrimaryKey = request.PrimaryKey,
+                FieldCount = 2,
+                Enabled = true,
+                ServiceName = request.ServiceName ?? "default"
+            });
+
+        public Task<PublishedLayerSummary?> LinkExistingLayerToServiceAsync(
+            string connectionString,
+            int layerId,
+            string serviceName,
+            bool enabled,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<PublishedLayerSummary?>(null);
+
+        public Task<TablePublishValidationResult> ValidateTableForPublishAsync(
+            string connectionString,
+            TablePublishValidationRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new TablePublishValidationResult
+            {
+                IsValid = true,
+                Status = "valid",
+                Schema = request.Schema,
+                Table = request.Table,
+                ServiceName = request.ServiceName ?? "default"
+            });
+
+        public Task<PublishedLayerSummary?> SetLayerEnabledAsync(
+            string connectionString,
+            int layerId,
+            string serviceName,
+            bool enabled,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<PublishedLayerSummary?>(null);
+
+        public Task<IReadOnlyList<PublishedLayerSummary>> SetServiceLayersEnabledAsync(
+            string connectionString,
+            string serviceName,
+            bool enabled,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<PublishedLayerSummary>>([]);
+
+        public Task<LayerExtentRefreshResult?> RefreshLayerExtentsAsync(
+            string connectionString,
+            string serviceName,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<LayerExtentRefreshResult?>(null);
+    }
+
+    private sealed class AttachmentFeatureServerHandler(long? failAttachmentId = null) : HttpMessageHandler
+    {
+        public List<string> AttachmentRequestPaths { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var pathAndQuery = request.RequestUri?.PathAndQuery ?? string.Empty;
+
+            // Attachment paths
+            if (pathAndQuery.Contains("/attachments/", StringComparison.Ordinal))
+            {
+                AttachmentRequestPaths.Add(pathAndQuery);
+                if (failAttachmentId.HasValue && pathAndQuery.EndsWith($"/{failAttachmentId.Value}", StringComparison.Ordinal))
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+                }
+
+                var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(Encoding.UTF8.GetBytes("binary-payload"))
+                };
+                resp.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
+                return Task.FromResult(resp);
+            }
+
+            if (pathAndQuery.Contains("/queryAttachments", StringComparison.Ordinal))
+            {
+                AttachmentRequestPaths.Add(pathAndQuery);
+                return Task.FromResult(JsonResponse("""
+                    {
+                      "attachmentGroups": [
+                        {
+                          "parentObjectId": 1,
+                          "attachmentInfos": [
+                            { "id": 1001, "name": "photo1.jpg", "contentType": "image/jpeg", "size": 14 },
+                            { "id": 1002, "name": "notes.txt", "contentType": "text/plain", "size": 14 }
+                          ]
+                        },
+                        {
+                          "parentObjectId": 2,
+                          "attachmentInfos": [
+                            { "id": 1003, "name": "photo2.jpg", "contentType": "image/jpeg", "size": 14 }
+                          ]
+                        }
+                      ]
+                    }
+                    """));
+            }
+
+            return pathAndQuery switch
+            {
+                "/arcgis/rest/services/Inspections/FeatureServer/0?f=json" => Task.FromResult(JsonResponse("""
+                    {
+                      "id": 0,
+                      "name": "Inspections",
+                      "geometryType": "esriGeometryPoint",
+                      "maxRecordCount": 10,
+                      "hasAttachments": true,
+                      "fields": [
+                        { "name": "OBJECTID", "type": "esriFieldTypeOID", "nullable": false },
+                        { "name": "Name", "type": "esriFieldTypeString", "nullable": true }
+                      ]
+                    }
+                    """)),
+                "/arcgis/rest/services/Inspections/FeatureServer/0/query?where=1=1&returnCountOnly=true&f=json" =>
+                    Task.FromResult(JsonResponse("""{"count":2}""")),
+                "/arcgis/rest/services/Inspections/FeatureServer/0/query?f=json&where=1%3D1&outFields=%2A&returnGeometry=true&resultOffset=0&resultRecordCount=10&outSR=4326" =>
+                    Task.FromResult(JsonResponse("""
+                        {
+                          "features": [
+                            { "attributes": { "OBJECTID": 1, "Name": "Alpha" }, "geometry": { "x": -157.1, "y": 21.3 } },
+                            { "attributes": { "OBJECTID": 2, "Name": "Beta" }, "geometry": { "x": -157.2, "y": 21.4 } }
+                          ],
+                          "exceededTransferLimit": false,
+                          "spatialReference": { "wkid": 4326 }
+                        }
+                        """)),
+                "/arcgis/rest/services/Inspections/FeatureServer/0/query?f=json&where=1%3D1&outFields=%2A&returnGeometry=true&resultOffset=2&resultRecordCount=10&outSR=4326" =>
+                    Task.FromResult(JsonResponse("""
+                        {
+                          "features": [],
+                          "exceededTransferLimit": false,
+                          "spatialReference": { "wkid": 4326 }
+                        }
+                        """)),
+                _ => throw new InvalidOperationException($"Unexpected ArcGIS request path: {pathAndQuery}")
+            };
+        }
+
+        private static HttpResponseMessage JsonResponse(string body)
+            => new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private sealed class FixtureConnectionProvider(PostgresFixture postgresFixture) : IDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => postgresFixture.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+            => await postgresFixture.DataSource.OpenConnectionAsync(cancellationToken);
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var connection = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var transaction = await connection.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (connection, transaction);
+            }
+            catch
+            {
+                await connection.DisposeAsync();
+                throw;
+            }
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(
+            Func<Task<T>> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(
+            Func<Task> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportServiceAttachmentImportTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportServiceAttachmentImportTests.cs
@@ -180,6 +180,7 @@ public sealed class GeoservicesImportServiceAttachmentImportTests(PostgresFixtur
             restClient,
             new FixtureConnectionProvider(fixture),
             crsRegistry.Object,
+            new EsriConstructCapabilityRegistry(EsriConstructCapabilityRegistry.BuiltInDescriptors),
             NullLogger<GeoservicesImportService>.Instance,
             layerPublishingService: publishingService,
             attachmentStore: attachmentStore);

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesRelationshipApplyTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesRelationshipApplyTests.cs
@@ -1,0 +1,255 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.FileImport.Domain;
+using Honua.Core.Features.Migration.Services;
+using Honua.Core.Features.FileImport.Services;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Shared.Models;
+using Honua.Postgres.Features.Migration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+/// <summary>
+/// Verifies the manifest-to-apply-request translation in
+/// <see cref="GeoservicesImportService.ApplyRelationshipsAsync"/> (issue #1256).
+/// The actual persistence is exercised by the writer integration tests; here we
+/// mock the catalog writer and assert that the apply step routes the right
+/// Honua layer ids, foreign-key fields, and skip outcomes through it.
+/// </summary>
+public sealed class GeoservicesRelationshipApplyTests
+{
+    [Fact]
+    public async Task ApplyRelationshipsAsync_AutomatedRelationshipWithResolvedLayers_RoutesApplyRequest()
+    {
+        MigrationRelationshipApplyRequest[]? captured = null;
+        var writer = new Mock<IMigrationCatalogWriter>(MockBehavior.Strict);
+        writer.Setup(w => w.EnsureRelationshipsAsync(
+                It.IsAny<string>(),
+                It.IsAny<IMetadataV2GraphStore?>(),
+                It.IsAny<MigrationRelationshipApplyRequest[]>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, IMetadataV2GraphStore?, MigrationRelationshipApplyRequest[], CancellationToken>(
+                (_, _, requests, _) =>
+                {
+                    captured = requests;
+                    return Task.FromResult(requests.Select(r => new MigrationRelationshipApplyOutcome
+                    {
+                        SourceRelationshipId = r.SourceRelationshipId,
+                        Outcome = MigrationCatalogWriteOutcome.Created,
+                        Message = "applied",
+                        TargetRelationshipRef = $"rel-{r.OriginLayerId}-{r.EsriRelationshipId ?? 0}"
+                    }).ToArray());
+                });
+
+        var service = CreateService(writer.Object);
+        var manifest = BuildManifestWithRelationship(
+            originResourceId: "resource:Inspections:layer:0",
+            relatedSourceLayerToken: "layer:1",
+            cardinality: "1:N",
+            esriRelationshipId: 3,
+            classification: MigrationManifestRelationshipClassifications.Assisted);
+
+        var outcomes = await service.ApplyRelationshipsAsync(
+            manifest,
+            new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                ["resource:Inspections:layer:0"] = 200,
+                ["resource:Inspections:layer:1"] = 201
+            },
+            graphStore: null,
+            CancellationToken.None);
+
+        outcomes.Should().ContainSingle().Which.Outcome.Should().Be(MigrationCatalogWriteOutcome.Created);
+        captured.Should().NotBeNull();
+        var request = captured!.Should().ContainSingle().Subject;
+        request.OriginLayerId.Should().Be(200);
+        request.RelatedLayerId.Should().Be(201);
+        request.OriginKeyField.Should().Be("INSPECTION_ID");
+        request.DestinationKeyField.Should().Be("INSPECTION_ID");
+        request.EsriRelationshipId.Should().Be(3);
+        request.Cardinality.Should().Be("1:N");
+        request.Role.Should().Be("esriRelRoleOrigin");
+    }
+
+    [Fact]
+    public async Task ApplyRelationshipsAsync_RelatedLayerNotInPublishedMap_RecordsSkippedOutcome()
+    {
+        var writer = new Mock<IMigrationCatalogWriter>(MockBehavior.Strict);
+        // Strict: the writer must NOT be called when both sides cannot be resolved.
+
+        var service = CreateService(writer.Object);
+        var manifest = BuildManifestWithRelationship(
+            originResourceId: "resource:Inspections:layer:0",
+            relatedSourceLayerToken: "layer:99",
+            cardinality: "1:N",
+            esriRelationshipId: 3,
+            classification: MigrationManifestRelationshipClassifications.Assisted);
+
+        var outcomes = await service.ApplyRelationshipsAsync(
+            manifest,
+            new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                ["resource:Inspections:layer:0"] = 200
+            },
+            graphStore: null,
+            CancellationToken.None);
+
+        outcomes.Should().ContainSingle()
+            .Which.Message.Should().Contain("Related layer", "the related layer was not in the published map");
+        writer.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ApplyRelationshipsAsync_ManualReviewClassification_IsSkipped()
+    {
+        var writer = new Mock<IMigrationCatalogWriter>(MockBehavior.Strict);
+        var service = CreateService(writer.Object);
+        var manifest = BuildManifestWithRelationship(
+            originResourceId: "resource:Inspections:layer:0",
+            relatedSourceLayerToken: "layer:1",
+            cardinality: "1:N",
+            esriRelationshipId: 5,
+            classification: MigrationManifestRelationshipClassifications.ManualReview);
+
+        var outcomes = await service.ApplyRelationshipsAsync(
+            manifest,
+            new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                ["resource:Inspections:layer:0"] = 200,
+                ["resource:Inspections:layer:1"] = 201
+            },
+            graphStore: null,
+            CancellationToken.None);
+
+        outcomes.Should().BeEmpty();
+        writer.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ApplyRelationshipsAsync_NonArcGisSource_ReturnsEmpty()
+    {
+        var writer = new Mock<IMigrationCatalogWriter>(MockBehavior.Strict);
+        var service = CreateService(writer.Object);
+        var manifest = new MigrationManifestArtifact
+        {
+            SourceKind = "geoserver-rest",
+            Source = new MigrationSourceIdentity { DisplayName = "GeoServer", BaseUrl = "http://example.com/geoserver" },
+            Summary = new MigrationManifestSummary()
+        };
+
+        var outcomes = await service.ApplyRelationshipsAsync(
+            manifest,
+            new Dictionary<string, int>(StringComparer.Ordinal),
+            graphStore: null,
+            CancellationToken.None);
+
+        outcomes.Should().BeEmpty();
+        writer.VerifyNoOtherCalls();
+    }
+
+    private static MigrationManifestArtifact BuildManifestWithRelationship(
+        string originResourceId,
+        string relatedSourceLayerToken,
+        string cardinality,
+        int esriRelationshipId,
+        string classification)
+    {
+        var compatibility = new MigrationCompatibilityAssessment
+        {
+            Level = "compatible",
+            Reason = "Test"
+        };
+        var origin = new MigrationManifestTargetResource
+        {
+            SourceResourceId = originResourceId,
+            SourceKind = "layer",
+            Action = "publish",
+            TargetResourceId = "target:resource:inspections:inspection-points",
+            TargetServiceName = "inspections",
+            TargetResourceName = "inspection-points",
+            Relationships =
+            [
+                new MigrationManifestRelationshipRecord
+                {
+                    SourceRelationshipId = esriRelationshipId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    SourceResourceId = originResourceId,
+                    Name = "Photos",
+                    Cardinality = cardinality,
+                    RelationshipType = "simple",
+                    RelatedLayerIds = [relatedSourceLayerToken],
+                    Role = "esriRelRoleOrigin",
+                    OriginKeyField = "INSPECTION_ID",
+                    DestinationKeyField = "INSPECTION_ID",
+                    EsriRelationshipId = esriRelationshipId,
+                    Classification = classification,
+                    TargetRelationshipRef = classification != MigrationManifestRelationshipClassifications.ManualReview
+                        ? $"target:relationship:inspections:inspection-points:{esriRelationshipId}"
+                        : null
+                }
+            ],
+            Compatibility = compatibility
+        };
+        var related = new MigrationManifestTargetResource
+        {
+            SourceResourceId = "resource:Inspections:layer:1",
+            SourceKind = "table",
+            Action = "publish",
+            TargetResourceId = "target:resource:inspections:inspection-photos",
+            TargetServiceName = "inspections",
+            TargetResourceName = "inspection-photos",
+            Compatibility = compatibility
+        };
+
+        return new MigrationManifestArtifact
+        {
+            SourceKind = "arcgis-geoservices-rest",
+            Source = new MigrationSourceIdentity
+            {
+                DisplayName = "Inspections",
+                BaseUrl = "https://example.com/arcgis/rest/services/Inspections/FeatureServer"
+            },
+            Summary = new MigrationManifestSummary
+            {
+                SourceResourceCount = 2,
+                TargetResourceCount = 2
+            },
+            TargetResources = [origin, related]
+        };
+    }
+
+    private static GeoservicesImportService CreateService(IMigrationCatalogWriter catalogWriter)
+    {
+        var httpClient = new HttpClient(new NoopHandler());
+        var restClient = new ArcGisRestClient(
+            httpClient,
+            NullLogger<ArcGisRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+        var connectionProvider = new Mock<IDatabaseConnectionProvider>(MockBehavior.Loose);
+        connectionProvider.Setup(p => p.GetConnectionString()).Returns("Host=localhost;Database=test");
+        var crsRegistry = new Mock<ICrsRegistry>(MockBehavior.Loose);
+
+        return new GeoservicesImportService(
+            restClient,
+            connectionProvider.Object,
+            crsRegistry.Object,
+            new EsriConstructCapabilityRegistry(EsriConstructCapabilityRegistry.BuiltInDescriptors),
+            NullLogger<GeoservicesImportService>.Instance,
+            layerPublishingService: null,
+            catalogWriter: catalogWriter);
+    }
+
+    private sealed class NoopHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotImplemented));
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Import/GeoservicesImportEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/GeoservicesImportEndpointTests.cs
@@ -849,6 +849,13 @@ internal sealed class TestGeoservicesImportService(TimeSpan delay) : IGeoservice
             sourceLayerName: "Test Layer",
             serviceName: request.ServiceName);
     }
+
+    public Task<MigrationRelationshipApplyOutcome[]> ApplyRelationshipsAsync(
+        MigrationManifestArtifact manifest,
+        IReadOnlyDictionary<string, int> publishedLayerMap,
+        Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphStore? graphStore,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(Array.Empty<MigrationRelationshipApplyOutcome>());
 }
 
 internal sealed class DegradedImportJobManager : IDistributedImportJobManager, IImportCoordinationHealth

--- a/tests/dotnet/Honua.Server.Tests/Import/ImportBackgroundServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/ImportBackgroundServiceTests.cs
@@ -727,6 +727,13 @@ public sealed class ImportBackgroundServiceTests
 
             throw new InvalidOperationException("unreachable");
         }
+
+        public Task<MigrationRelationshipApplyOutcome[]> ApplyRelationshipsAsync(
+            MigrationManifestArtifact manifest,
+            IReadOnlyDictionary<string, int> publishedLayerMap,
+            Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphStore? graphStore,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
     }
 
     private sealed class SuccessfulGeoservicesImportService : IGeoservicesImportService
@@ -775,6 +782,13 @@ public sealed class ImportBackgroundServiceTests
                 serviceName: request.ServiceName,
                 sourceLayerName: "Roads"));
         }
+
+        public Task<MigrationRelationshipApplyOutcome[]> ApplyRelationshipsAsync(
+            MigrationManifestArtifact manifest,
+            IReadOnlyDictionary<string, int> publishedLayerMap,
+            Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphStore? graphStore,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<MigrationRelationshipApplyOutcome>());
     }
 
     private sealed class ThrowingGeoServerImportService(ThrowingBehavior behavior) : IGeoServerImportService

--- a/tests/dotnet/Honua.Server.Tests/Import/MigrationScannerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/MigrationScannerEndpointTests.cs
@@ -684,6 +684,13 @@ public sealed class MigrationScannerEndpointTests : IAsyncLifetime
                 request.ServiceUrl,
                 request.LayerId,
                 featureCount: 0));
+
+        public Task<MigrationRelationshipApplyOutcome[]> ApplyRelationshipsAsync(
+            MigrationManifestArtifact manifest,
+            IReadOnlyDictionary<string, int> publishedLayerMap,
+            Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphStore? graphStore,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<MigrationRelationshipApplyOutcome>());
     }
 
     private sealed class FakeOgcScanService : IOgcServiceMigrationScanner


### PR DESCRIPTION
## Issue Link
Fixes #1257
Advances #1256 (relationship-apply capability + tests landed; pipeline auto-invocation lands with #1253 batch orchestration)

## Summary
Lands two stale Esri-migration feature branches onto current trunk as one consolidated change:

- **#1257 (attachments, production-ready):** ArcGIS feature attachments are copied into the Honua attachment store during Geoservices imports when `ImportAttachments` is enabled and auto-publish succeeds. Includes an attachment-metadata REST path on `ArcGisRestClient`, the `CopyAttachmentsAsync` import step wired into the import pipeline, progress reporting, and an Automated fidelity classification for attachments.
- **#1256 (relationship classes, WIP integrated):** Per-relationship fidelity classification (simple relationships are Automated; composite/attributed/many-to-many are flagged for manual review), the `IMigrationCatalogWriter` abstraction with a Postgres implementation that ensures related tables/FKs, manifest/translator relationship records, and an `ApplyRelationshipsAsync` service entrypoint.

Both features were cherry-picked onto a fresh branch off `origin/trunk` (not merged) and integrated with trunk's evolved import pipeline: the registry-driven fidelity path (#1289), domains (#1255), and subtypes (#1378) behavior is preserved.

## Changes Made
- Layered the attachment-copy step (#1257) into the current registry-consuming import pipeline.
- Integrated #1256's richer per-relationship fidelity records (`BuildRelationshipFidelityRecords`), replacing trunk's single registry-based relationship classification while keeping the registry path for all other constructs.
- Combined both features' constructor dependencies on `GeoservicesImportService` (`IAttachmentStore`, style converter/catalog from #1257; `IMigrationCatalogWriter` from #1256) alongside trunk's required `IEsriConstructCapabilityRegistry`.
- Renumbered #1256's source-generated `LoggerMessage` event id (7833 -> 7839) to avoid collision with #1257's new attachment log events (7833-7838).
- Added `IMigrationCatalogWriter` + `PostgresMigrationCatalogWriter` (relationship table/FK ensure), manifest relationship records, and `MigrationManifestTranslator` relationship translation.
- Updated migration manifest schema snapshot and baseline fidelity-count expectations to match the integrated trunk classification (manual-review categories are now subtypes/renderers/time-metadata; domains are Assisted; the simple relationship is Automated).
- Fixed #1256 test constructors to pass `IEsriConstructCapabilityRegistry` (matching trunk's required ctor parameter).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

`dotnet test tests/dotnet/Honua.Postgres.Tests` (Import/Relationship/Attachment/Fidelity/Migration filter): 234 passed, 0 failed, 0 skipped.
`dotnet test tests/dotnet/Honua.Core.Tests --filter FullyQualifiedName~Migration`: 253 passed, 0 failed, 0 skipped.
Full `dotnet build Honua.sln --configuration Release /p:TreatWarningsAsErrors=true`: succeeded, 0 warnings, 0 errors.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires database migration

The relationship-apply path provisions related tables/FKs via `PostgresMigrationCatalogWriter` at import time.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` (build, format, unit + Postgres integration green; broad "Core" server shard delegated to CI — see note)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Notes for Reviewer
- **#1256 is integrated but not fully wired end-to-end.** `ApplyRelationshipsAsync` is exposed on `IGeoservicesImportService` and unit-tested directly, but it is not yet invoked from the main import flow (`ImportSteps`). This matches the upstream "WIP ~90%" status; auto-invocation during import is the remaining follow-up. The capability is correct and tested as a discrete unit.
- The baseline fidelity-count threshold change (manual-review `>= 4` -> `>= 3`) reflects trunk's evolved classification (domains became Assisted), not a regression; all per-category assertions still hold and the three manual-review categories are subtypes, renderers, and time-metadata.


