### PR TITLE
feat: post-import reconciliation & parity gate (#1247, #1379, #1380, #1381)

### DIFF
--- a/src/Honua.Core/Features/Migration/Abstractions/GeoservicesImportProgress.cs
+++ b/src/Honua.Core/Features/Migration/Abstractions/GeoservicesImportProgress.cs
@@ -146,6 +146,19 @@ public sealed record GeoservicesImportProgress : IOperationProgress, ICancellabl
     /// </summary>
     public string? CurrentPhase { get; init; }
 
+    /// <summary>
+    /// Per-layer data-reconciliation artifact produced by the <see cref="GeoservicesImportStatus.Validating"/>
+    /// phase, when reconciliation ran. <c>null</c> until the Validating phase completes (or when the
+    /// import did not publish a queryable layer to reconcile against).
+    /// </summary>
+    public MigrationReconciliationArtifact? ReconciliationArtifact { get; init; }
+
+    /// <summary>
+    /// Catalog parity report produced by the <see cref="GeoservicesImportStatus.Validating"/> phase,
+    /// when a published Metadata v2 entry was available to reconcile against. <c>null</c> otherwise.
+    /// </summary>
+    public MigrationCatalogReconciliationReport? CatalogReconciliationReport { get; init; }
+
     // IOperationProgress implementation
     string IOperationProgress.OperationId => JobId;
     OperationType IOperationProgress.Type => OperationType.ExternalImport;
@@ -158,7 +171,13 @@ public sealed record GeoservicesImportProgress : IOperationProgress, ICancellabl
         GeoservicesImportStatus.InsertingFeatures => OperationStatus.Processing,
         GeoservicesImportStatus.Publishing => OperationStatus.Processing,
         GeoservicesImportStatus.CopyingAttachments => OperationStatus.Processing,
+        GeoservicesImportStatus.Validating => OperationStatus.Processing,
         GeoservicesImportStatus.Completed => OperationStatus.Completed,
+        // NeedsReview is a terminal, non-success outcome: the run published data but a hard
+        // reconciliation finding blocked completion. The generic operation surface has no
+        // dedicated "needs review" state, so it projects as Failed (did not succeed); migration
+        // -aware clients read the precise GeoservicesImportStatus.NeedsReview instead.
+        GeoservicesImportStatus.NeedsReview => OperationStatus.Failed,
         GeoservicesImportStatus.Failed => OperationStatus.Failed,
         GeoservicesImportStatus.Cancelled => OperationStatus.Cancelled,
         _ => OperationStatus.Queued
@@ -238,9 +257,22 @@ public enum GeoservicesImportStatus
     CopyingAttachments,
 
     /// <summary>
+    /// Post-publish reconciliation is comparing the published layer against the source snapshot.
+    /// </summary>
+    Validating,
+
+    /// <summary>
     /// Import completed successfully.
     /// </summary>
     Completed,
+
+    /// <summary>
+    /// The import published data but a hard reconciliation finding (count/geometry/content/extent
+    /// or catalog parity) routed the run to operator review before it can be declared complete. The
+    /// imported data and layer are left in place; an operator audits the discrepancy and decides
+    /// whether to accept, re-import, or roll back.
+    /// </summary>
+    NeedsReview,
 
     /// <summary>
     /// Import failed with errors.

--- a/src/Honua.Core/Features/Migration/Abstractions/ILayerReconciliationService.cs
+++ b/src/Honua.Core/Features/Migration/Abstractions/ILayerReconciliationService.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Migration.Domain;
+
+namespace Honua.Core.Features.Migration.Abstractions;
+
+/// <summary>
+/// Runs per-layer reconciliation checks (count, geometry validity, content/schema, extent)
+/// against published Honua catalog layers immediately after the apply step of a migration
+/// run and emits a deterministic <see cref="MigrationReconciliationArtifact"/> describing
+/// each layer's outcome.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This service is the server-side counterpart to the SDK <c>reconcile.ts</c> probe: it
+/// confirms that what landed on the Honua target lines up with the source inventory before
+/// a migration run is allowed to transition to <c>Completed</c>. Hard-check failures gate
+/// the run to <c>NeedsReview</c> so an operator can audit the discrepancy before claiming
+/// success.
+/// </para>
+/// <para>
+/// Source-side facts (counts, extents, field names, snapshot filter) must be captured by
+/// the caller from the migration inventory or apply-time snapshot. The service does not
+/// re-issue source HTTP calls — this keeps the reconciliation deterministic against the
+/// apply-time snapshot and avoids drift-induced false positives.
+/// </para>
+/// </remarks>
+public interface ILayerReconciliationService
+{
+    /// <summary>
+    /// Run reconciliation checks for every layer in the request and aggregate the result.
+    /// </summary>
+    /// <param name="request">Per-run reconciliation request including the per-layer source snapshot.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Deterministic reconciliation artifact for the run.</returns>
+    Task<MigrationReconciliationArtifact> ReconcileAsync(
+        LayerReconciliationRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Migration/Abstractions/IMigrationRunCatalog.cs
+++ b/src/Honua.Core/Features/Migration/Abstractions/IMigrationRunCatalog.cs
@@ -114,6 +114,31 @@ public interface IMigrationRunCatalog
     Task<string?> GetEvidencePackAsync(
         string runId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Record the signed reconciliation scorecard (issue #1381) for an existing run. Persists the
+    /// scorecard fingerprint on the run row and the scorecard JSON body for later retrieval via
+    /// <see cref="GetScorecardAsync"/>. Returns the updated record, or <c>null</c> if the run-id is
+    /// unknown. Recording is independent of <see cref="RecordCompletedAsync"/> so a scorecard can be
+    /// attached whether the run completed or was routed to review.
+    /// </summary>
+    /// <param name="runId">Run identifier to attach the scorecard to.</param>
+    /// <param name="scorecardFingerprint">Signed scorecard fingerprint (<c>sha256:&lt;hex&gt;</c>).</param>
+    /// <param name="scorecardBody">Scorecard JSON body to persist.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<MigrationRunRecord?> RecordScorecardAsync(
+        string runId,
+        string scorecardFingerprint,
+        string scorecardBody,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Return the reconciliation-scorecard JSON body recorded for the given run, or <c>null</c> if
+    /// the run is unknown or no scorecard has been recorded yet.
+    /// </summary>
+    Task<string?> GetScorecardAsync(
+        string runId,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Migration/Domain/GeoservicesImportRequest.cs
+++ b/src/Honua.Core/Features/Migration/Domain/GeoservicesImportRequest.cs
@@ -373,6 +373,27 @@ public sealed record GeoservicesImportResult
     public int FailedAttachments { get; init; }
 
     /// <summary>
+    /// True when the import published data but a hard post-publish reconciliation finding routed
+    /// the run to operator review instead of completion (parity gate, issue #1380). When set,
+    /// <see cref="Success"/> is <c>false</c> even though data was published, and
+    /// <see cref="ReconciliationArtifact"/> / <see cref="CatalogReconciliationReport"/> carry the
+    /// blocking findings.
+    /// </summary>
+    public bool NeedsReview { get; init; }
+
+    /// <summary>
+    /// Per-layer data-reconciliation artifact produced by the Validating phase, when reconciliation
+    /// ran. <c>null</c> when the import did not publish a queryable layer to reconcile against.
+    /// </summary>
+    public MigrationReconciliationArtifact? ReconciliationArtifact { get; init; }
+
+    /// <summary>
+    /// Catalog parity report produced by the Validating phase, when a published Metadata v2 entry
+    /// was available to reconcile against. <c>null</c> otherwise.
+    /// </summary>
+    public MigrationCatalogReconciliationReport? CatalogReconciliationReport { get; init; }
+
+    /// <summary>
     /// Create successful import result.
     /// </summary>
     public static GeoservicesImportResult CreateSuccess(
@@ -387,7 +408,9 @@ public sealed record GeoservicesImportResult
         TimeSpan duration = default,
         IReadOnlyList<string>? warnings = null,
         int attachmentCount = 0,
-        int failedAttachments = 0) =>
+        int failedAttachments = 0,
+        MigrationReconciliationArtifact? reconciliationArtifact = null,
+        MigrationCatalogReconciliationReport? catalogReconciliationReport = null) =>
         new()
         {
             Success = true,
@@ -402,7 +425,50 @@ public sealed record GeoservicesImportResult
             Duration = duration,
             Warnings = warnings ?? [],
             AttachmentCount = attachmentCount,
-            FailedAttachments = failedAttachments
+            FailedAttachments = failedAttachments,
+            ReconciliationArtifact = reconciliationArtifact,
+            CatalogReconciliationReport = catalogReconciliationReport
+        };
+
+    /// <summary>
+    /// Create a result for an import that published data but was routed to operator review by the
+    /// post-publish parity gate (issue #1380). Data and the published layer are left in place.
+    /// </summary>
+    public static GeoservicesImportResult CreateNeedsReview(
+        string tableName,
+        string sourceServiceUrl,
+        int sourceLayerId,
+        int featureCount,
+        int failedFeatures,
+        int? publishedLayerId,
+        string? serviceName,
+        string? sourceLayerName,
+        TimeSpan duration,
+        IReadOnlyList<string>? warnings,
+        int attachmentCount,
+        int failedAttachments,
+        MigrationReconciliationArtifact? reconciliationArtifact,
+        MigrationCatalogReconciliationReport? catalogReconciliationReport,
+        string reviewReason) =>
+        new()
+        {
+            Success = false,
+            NeedsReview = true,
+            TableName = tableName,
+            SourceServiceUrl = sourceServiceUrl,
+            SourceLayerId = sourceLayerId,
+            SourceLayerName = sourceLayerName,
+            FeatureCount = featureCount,
+            FailedFeatures = failedFeatures,
+            PublishedLayerId = publishedLayerId,
+            ServiceName = serviceName,
+            Duration = duration,
+            Warnings = warnings ?? [],
+            AttachmentCount = attachmentCount,
+            FailedAttachments = failedAttachments,
+            ReconciliationArtifact = reconciliationArtifact,
+            CatalogReconciliationReport = catalogReconciliationReport,
+            ErrorMessage = reviewReason
         };
 
     /// <summary>

--- a/src/Honua.Core/Features/Migration/Domain/LayerReconciliationRequest.cs
+++ b/src/Honua.Core/Features/Migration/Domain/LayerReconciliationRequest.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Shared.Models;
+
+namespace Honua.Core.Features.Migration.Domain;
+
+/// <summary>
+/// Per-run input to <see cref="Abstractions.ILayerReconciliationService"/>. Carries the
+/// per-layer source-side snapshot collected during apply so the service does not have to
+/// re-issue source HTTP calls (which would risk drift-induced false positives).
+/// </summary>
+public sealed record LayerReconciliationRequest
+{
+    /// <summary>
+    /// Stable identifier for the originating migration run.
+    /// </summary>
+    public required string RunId { get; init; }
+
+    /// <summary>
+    /// Source kind that produced the layers being reconciled, for example
+    /// <c>geoserver-rest</c> or <c>arcgis-geoservices-rest</c>.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Per-layer reconciliation inputs. Empty when the apply produced no
+    /// successfully published layers (the artifact still records the run with no probes).
+    /// </summary>
+    public IReadOnlyList<LayerReconciliationLayerInput> Layers { get; init; } = [];
+
+    /// <summary>
+    /// Tolerances and sampling options. Defaults preserve the proven
+    /// <c>reconcile.ts</c> behavior with conservative count/geometry bands.
+    /// </summary>
+    public LayerReconciliationOptions Options { get; init; } = new();
+}
+
+/// <summary>
+/// Single-layer reconciliation input.
+/// </summary>
+public sealed record LayerReconciliationLayerInput
+{
+    /// <summary>
+    /// Stable source-side identifier, for example a GeoServer
+    /// <c>workspace:layer</c> id or an ArcGIS resource id. Used in the artifact
+    /// to correlate per-layer results back to source intent.
+    /// </summary>
+    public required string SourceLayerId { get; init; }
+
+    /// <summary>
+    /// Human-readable source layer label. Falls back to <see cref="SourceLayerId"/>
+    /// when the upstream pipeline does not carry a separate display name.
+    /// </summary>
+    public string? SourceLayerName { get; init; }
+
+    /// <summary>
+    /// Honua catalog layer id assigned by publish. Reconciliation is skipped when this is
+    /// <c>null</c> (the apply did not produce a queryable layer for this source).
+    /// </summary>
+    public required int? TargetHonuaLayerId { get; init; }
+
+    /// <summary>
+    /// Source-side feature count snapshot recorded at apply time. <c>null</c> when the
+    /// source did not advertise a count; the count probe will record a <c>warn</c> with
+    /// a "no baseline" reason.
+    /// </summary>
+    public long? SourceFeatureCount { get; init; }
+
+    /// <summary>
+    /// Source-side bounding box snapshot. <c>null</c> when the source did not advertise an
+    /// extent; the extent probe will record a <c>warn</c> with a "no baseline" reason.
+    /// </summary>
+    public BoundingBox? SourceExtent { get; init; }
+
+    /// <summary>
+    /// Source-advertised field names (deduplicated). Empty when the source did not advertise
+    /// any schema; the content probe will record <c>pass</c> with a "no baseline" note.
+    /// </summary>
+    public IReadOnlyList<string> SourceFieldNames { get; init; } = [];
+
+    /// <summary>
+    /// Optional secret-safe filter mirror applied at apply time (e.g. CQL or GeoServices
+    /// <c>where</c>) so the count probe can be filter-mirrored. <c>null</c> means the apply
+    /// imported all features and the probe issues an unfiltered count.
+    /// </summary>
+    public string? FilterMirror { get; init; }
+}
+
+/// <summary>
+/// Tunable tolerances applied across every probe. Defaults mirror the proven
+/// <c>reconcile.ts</c> bands and the ArcGIS parity runner's conservative thresholds.
+/// </summary>
+public sealed record LayerReconciliationOptions
+{
+    /// <summary>
+    /// Default sample size for the geometry-validity and content probes.
+    /// </summary>
+    public const int DefaultSampleSize = 100;
+
+    /// <summary>
+    /// Default count delta-ratio at or below which the count probe records <c>pass</c>.
+    /// </summary>
+    public const double DefaultCountWarnRatio = 0.05;
+
+    /// <summary>
+    /// Default count delta-ratio above which the count probe records <c>fail</c>.
+    /// </summary>
+    public const double DefaultCountFailRatio = 0.20;
+
+    /// <summary>
+    /// Default geometry validity ratio at or above which the geometry probe records <c>pass</c>.
+    /// </summary>
+    public const double DefaultGeometryPassRatio = 0.99;
+
+    /// <summary>
+    /// Default geometry validity ratio below the pass band but at or above which the geometry
+    /// probe records <c>warn</c> (rather than <c>fail</c>).
+    /// </summary>
+    public const double DefaultGeometryWarnRatio = 0.95;
+
+    /// <summary>
+    /// Default extent dimension tolerance, expressed as a ratio of the source dimension. Allows
+    /// for sub-meter reprojection / rounding noise around an otherwise identical bbox.
+    /// </summary>
+    public const double DefaultExtentTolerance = 0.001;
+
+    /// <summary>
+    /// Sample size used for geometry validity and attribute schema probes. Clamped to <c>[1, 10000]</c>.
+    /// </summary>
+    public int SampleSize { get; init; } = DefaultSampleSize;
+
+    /// <summary>
+    /// Count delta-ratio at or below which the count probe records <c>pass</c>.
+    /// </summary>
+    public double CountWarnRatio { get; init; } = DefaultCountWarnRatio;
+
+    /// <summary>
+    /// Count delta-ratio above which the count probe records <c>fail</c>.
+    /// </summary>
+    public double CountFailRatio { get; init; } = DefaultCountFailRatio;
+
+    /// <summary>
+    /// Geometry validity ratio at or above which the geometry probe records <c>pass</c>.
+    /// </summary>
+    public double GeometryPassRatio { get; init; } = DefaultGeometryPassRatio;
+
+    /// <summary>
+    /// Geometry validity ratio at or above which the geometry probe records <c>warn</c>
+    /// (when it is below <see cref="GeometryPassRatio"/>).
+    /// </summary>
+    public double GeometryWarnRatio { get; init; } = DefaultGeometryWarnRatio;
+
+    /// <summary>
+    /// Extent dimension tolerance, expressed as a ratio of the source dimension. Smaller
+    /// deltas are treated as projection / rounding noise and recorded as <c>pass</c>.
+    /// </summary>
+    public double ExtentTolerance { get; init; } = DefaultExtentTolerance;
+}

--- a/src/Honua.Core/Features/Migration/Domain/MigrationCatalogReconciliationReport.cs
+++ b/src/Honua.Core/Features/Migration/Domain/MigrationCatalogReconciliationReport.cs
@@ -177,6 +177,14 @@ public sealed record MigrationCatalogReconciliationInput
     /// alongside each outcome so reports can cross-reference the catalog entry.
     /// </summary>
     public string? TargetResourceId { get; init; }
+
+    /// <summary>
+    /// Optional source-side subtype set captured for this resource (for ArcGIS GeoServices imports
+    /// this is the layer's canonical <c>subtypes</c> block). The inventory resource itself does not
+    /// carry subtype metadata, so callers that captured subtypes supply them here to drive the
+    /// subtype reconciliation collector. <c>null</c> skips subtype reconciliation.
+    /// </summary>
+    public Honua.Core.Features.Metadata.Domain.V2.MetadataV2Subtypes? ExpectedSubtypes { get; init; }
 }
 
 /// <summary>
@@ -225,6 +233,29 @@ public static class MigrationCatalogReconciliationCodes
 
     /// <summary>A relationship captured at manifest time is missing from the published resource.</summary>
     public const string RelationshipMissing = "catalog.relationship.missing";
+
+    /// <summary>
+    /// The source resource advertised attachments but the published resource does not declare
+    /// attachment support (<c>Editing.SupportsAttachments</c> is <c>false</c>).
+    /// </summary>
+    public const string AttachmentMissing = "catalog.attachment.missing";
+
+    /// <summary>
+    /// The source resource advertised a subtype set but the published resource declares no
+    /// subtypes (<see cref="Honua.Core.Features.Metadata.Domain.V2.MetadataV2Resource.Subtypes"/>
+    /// is <c>null</c> or empty).
+    /// </summary>
+    public const string SubtypeMissing = "catalog.subtype.missing";
+
+    /// <summary>
+    /// The published subtype set is keyed on a different subtype field than the source advertised.
+    /// </summary>
+    public const string SubtypeFieldMismatch = "catalog.subtype.field-mismatch";
+
+    /// <summary>
+    /// One or more source subtype codes are missing from the published subtype set.
+    /// </summary>
+    public const string SubtypeCodeMissing = "catalog.subtype.code-missing";
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Migration/Domain/MigrationReconciliationArtifact.cs
+++ b/src/Honua.Core/Features/Migration/Domain/MigrationReconciliationArtifact.cs
@@ -1,0 +1,266 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Migration.Domain;
+
+/// <summary>
+/// Stable classification values reused across every reconciliation probe so reports stay
+/// machine-readable. Matches the existing parity-runner vocabulary (pass / warn / fail) so
+/// downstream UI and admin endpoints can render them consistently.
+/// </summary>
+public static class MigrationReconciliationClassifications
+{
+    /// <summary>The probe is inside its pass band.</summary>
+    public const string Pass = "pass";
+
+    /// <summary>The probe is outside the pass band but inside the warn band; operator review suggested.</summary>
+    public const string Warn = "warn";
+
+    /// <summary>The probe is outside the warn band; the run cannot transition to Completed.</summary>
+    public const string Fail = "fail";
+
+    /// <summary>The probe was skipped because the input was missing or unsupported. Treated as warn for aggregation.</summary>
+    public const string Skipped = "skipped";
+}
+
+/// <summary>
+/// Deterministic per-run reconciliation artifact persisted by the Validating phase.
+/// </summary>
+public sealed record MigrationReconciliationArtifact
+{
+    /// <summary>
+    /// Stable artifact kind identifier. Used by the evidence pack and admin endpoints to
+    /// discriminate this artifact from the apply-execution / parity artifacts.
+    /// </summary>
+    public string ArtifactKind { get; init; } = "honua.migration.reconciliation";
+
+    /// <summary>
+    /// Artifact schema version.
+    /// </summary>
+    public string ArtifactVersion { get; init; } = "1.0";
+
+    /// <summary>
+    /// Originating migration run identifier.
+    /// </summary>
+    public required string RunId { get; init; }
+
+    /// <summary>
+    /// Source kind that produced the layers.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Aggregate classification across every layer. Worst probe classification wins:
+    /// any <c>fail</c> → <c>fail</c>; any <c>warn</c> → <c>warn</c>; otherwise <c>pass</c>.
+    /// </summary>
+    public required string Classification { get; init; }
+
+    /// <summary>
+    /// UTC instant the reconciliation began.
+    /// </summary>
+    public required DateTimeOffset StartedAt { get; init; }
+
+    /// <summary>
+    /// UTC instant the reconciliation completed.
+    /// </summary>
+    public required DateTimeOffset CompletedAt { get; init; }
+
+    /// <summary>
+    /// Aggregate counts across every per-layer report. Useful for badge rendering in the
+    /// admin UI and for the run summary line.
+    /// </summary>
+    public required MigrationReconciliationSummary Summary { get; init; }
+
+    /// <summary>
+    /// Per-layer reconciliation reports. Ordered by source layer id for deterministic
+    /// fingerprinting.
+    /// </summary>
+    public MigrationReconciliationLayerReport[] Layers { get; init; } = [];
+
+    /// <summary>
+    /// Sorted, deduplicated, secret-safe reason strings rolled up from every per-probe
+    /// failure across every layer. Empty when the run is <c>pass</c>.
+    /// </summary>
+    public string[] Reasons { get; init; } = [];
+
+    /// <summary>
+    /// Tolerances applied to this run. Persisted so an audit can replay the same gate.
+    /// </summary>
+    public required LayerReconciliationOptions Options { get; init; }
+}
+
+/// <summary>
+/// Aggregate counts for a <see cref="MigrationReconciliationArtifact"/>.
+/// </summary>
+public sealed record MigrationReconciliationSummary
+{
+    /// <summary>Total per-layer reports.</summary>
+    public int LayerCount { get; init; }
+
+    /// <summary>Number of layers classified <c>pass</c>.</summary>
+    public int PassCount { get; init; }
+
+    /// <summary>Number of layers classified <c>warn</c>.</summary>
+    public int WarnCount { get; init; }
+
+    /// <summary>Number of layers classified <c>fail</c>.</summary>
+    public int FailCount { get; init; }
+
+    /// <summary>Number of layers classified <c>skipped</c> (e.g. missing target id).</summary>
+    public int SkippedCount { get; init; }
+}
+
+/// <summary>
+/// Per-layer reconciliation report (one per source layer in the run).
+/// </summary>
+public sealed record MigrationReconciliationLayerReport
+{
+    /// <summary>Source-side layer identifier.</summary>
+    public required string SourceLayerId { get; init; }
+
+    /// <summary>Optional source-side layer display name.</summary>
+    public string? SourceLayerName { get; init; }
+
+    /// <summary>
+    /// Honua catalog layer id (when the apply produced one). <c>null</c> when the apply did
+    /// not publish a queryable layer; the report is recorded with <c>skipped</c>.
+    /// </summary>
+    public int? TargetHonuaLayerId { get; init; }
+
+    /// <summary>Aggregate classification across the four probes for this layer.</summary>
+    public required string Classification { get; init; }
+
+    /// <summary>Feature-count probe.</summary>
+    public required MigrationReconciliationCountProbe Count { get; init; }
+
+    /// <summary>Geometry-validity probe.</summary>
+    public required MigrationReconciliationGeometryProbe Geometry { get; init; }
+
+    /// <summary>Content / attribute-keys probe.</summary>
+    public required MigrationReconciliationContentProbe Content { get; init; }
+
+    /// <summary>Extent probe.</summary>
+    public required MigrationReconciliationExtentProbe Extent { get; init; }
+}
+
+/// <summary>
+/// Feature-count probe result.
+/// </summary>
+public sealed record MigrationReconciliationCountProbe
+{
+    /// <summary>Source-side count snapshot at apply time. <c>null</c> when the source did not advertise.</summary>
+    public long? SourceCount { get; init; }
+
+    /// <summary>Target-side count returned by Honua post-apply.</summary>
+    public long? TargetCount { get; init; }
+
+    /// <summary>Target - Source. <c>null</c> when either side is unavailable.</summary>
+    public long? Delta { get; init; }
+
+    /// <summary>|Delta| / Source. <c>null</c> when source is <c>0</c> or unavailable.</summary>
+    public double? DeltaRatio { get; init; }
+
+    /// <summary>Secret-safe filter mirror used on the count query, when one was supplied.</summary>
+    public string? FilterMirror { get; init; }
+
+    /// <summary>Pass / warn / fail / skipped.</summary>
+    public required string Classification { get; init; }
+
+    /// <summary>Operator-visible explanation. <c>null</c> when the probe passed.</summary>
+    public string? Reason { get; init; }
+}
+
+/// <summary>
+/// Geometry-validity probe result.
+/// </summary>
+public sealed record MigrationReconciliationGeometryProbe
+{
+    /// <summary>Number of features sampled (clamped by available rows).</summary>
+    public int Sampled { get; init; }
+
+    /// <summary>Number of sampled features whose geometry was present and well-formed.</summary>
+    public int Valid { get; init; }
+
+    /// <summary>Valid / Sampled, or <c>1</c> when nothing was sampled.</summary>
+    public double Ratio { get; init; }
+
+    /// <summary>Pass / warn / fail / skipped.</summary>
+    public required string Classification { get; init; }
+
+    /// <summary>Operator-visible explanation. <c>null</c> when the probe passed.</summary>
+    public string? Reason { get; init; }
+}
+
+/// <summary>
+/// Content / attribute-keys probe result.
+/// </summary>
+public sealed record MigrationReconciliationContentProbe
+{
+    /// <summary>Sorted source-side field names (snapshot).</summary>
+    public string[] SourceFieldNames { get; init; } = [];
+
+    /// <summary>Sorted target-side field names sampled from the published layer.</summary>
+    public string[] TargetFieldNames { get; init; } = [];
+
+    /// <summary>
+    /// Source field names that were not present on the target. Hard-failure trigger.
+    /// </summary>
+    public string[] MissingOnTarget { get; init; } = [];
+
+    /// <summary>Target field names that were not present in the source (e.g. ObjectID remap).</summary>
+    public string[] ExtraOnTarget { get; init; } = [];
+
+    /// <summary>Pass / warn / fail / skipped.</summary>
+    public required string Classification { get; init; }
+
+    /// <summary>Operator-visible explanation. <c>null</c> when the probe passed.</summary>
+    public string? Reason { get; init; }
+}
+
+/// <summary>
+/// Spatial-extent probe result.
+/// </summary>
+public sealed record MigrationReconciliationExtentProbe
+{
+    /// <summary>Source-side extent snapshot at apply time. <c>null</c> when none was advertised.</summary>
+    public ExtentBox? Source { get; init; }
+
+    /// <summary>Target-side extent returned by Honua post-apply.</summary>
+    public ExtentBox? Target { get; init; }
+
+    /// <summary>
+    /// Absolute differences between source and target extents normalized by source dimension.
+    /// <c>null</c> when either side is unavailable or source has zero width/height.
+    /// </summary>
+    public double? MaxDimensionDelta { get; init; }
+
+    /// <summary>Pass / warn / fail / skipped.</summary>
+    public required string Classification { get; init; }
+
+    /// <summary>Operator-visible explanation. <c>null</c> when the probe passed.</summary>
+    public string? Reason { get; init; }
+}
+
+/// <summary>
+/// Minimal flat extent representation used by the reconciliation artifact so the schema
+/// does not pull in <see cref="Honua.Core.Features.Shared.Models.BoundingBox"/>'s richer
+/// type surface (CRS uri, axis order, etc.) — those concerns belong to the catalog layer,
+/// not to the reconciliation evidence.
+/// </summary>
+public readonly record struct ExtentBox
+{
+    /// <summary>Minimum X coordinate.</summary>
+    public required double MinX { get; init; }
+
+    /// <summary>Minimum Y coordinate.</summary>
+    public required double MinY { get; init; }
+
+    /// <summary>Maximum X coordinate.</summary>
+    public required double MaxX { get; init; }
+
+    /// <summary>Maximum Y coordinate.</summary>
+    public required double MaxY { get; init; }
+
+    /// <summary>Spatial reference SRID (default <c>4326</c> when unknown).</summary>
+    public required int Srid { get; init; }
+}

--- a/src/Honua.Core/Features/Migration/Domain/MigrationReconciliationScorecard.cs
+++ b/src/Honua.Core/Features/Migration/Domain/MigrationReconciliationScorecard.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Migration.Domain;
+
+/// <summary>
+/// Signed, deterministic roll-up of a migration run's reconciliation outcome (issue #1381). The
+/// scorecard deliberately keeps two distinct dimensions of "did the migration succeed?" separate so
+/// operators never conflate them:
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// <b>Data reconciliation</b> (<see cref="DataReconciliation"/>): did the bytes land — feature
+/// counts, geometry validity, attribute keys, and spatial extent of the published layer matched the
+/// apply-time source snapshot. Sourced from <see cref="MigrationReconciliationArtifact"/> and the
+/// catalog parity report (<see cref="MigrationCatalogReconciliationReport"/>).
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <b>Capability parity</b> (<see cref="CapabilityParity"/>): could the construct be expressed at
+/// all on Honua — the per-construct automation/fidelity assessment from the Esri construct
+/// capability registry / fidelity matrix. A construct can be unsupported (low capability parity)
+/// while the data that <i>was</i> imported reconciles perfectly, and vice versa; the scorecard keeps
+/// the two scores side by side rather than averaging them into a single misleading number.
+/// </description>
+/// </item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// The scorecard is fingerprinted with the same SHA-256-over-canonical-JSON mechanism used by the
+/// evidence pack (<see cref="MigrationReconciliationScorecard.Fingerprint"/>). The fingerprint is
+/// computed over the unsigned body so a verifier can recompute it independently.
+/// </remarks>
+public sealed record MigrationReconciliationScorecard
+{
+    /// <summary>Stable artifact kind identifier.</summary>
+    public string ArtifactKind { get; init; } = "honua.migration.reconciliation-scorecard";
+
+    /// <summary>Artifact schema version.</summary>
+    public string ArtifactVersion { get; init; } = "1.0";
+
+    /// <summary>Originating migration run identifier.</summary>
+    public required string RunId { get; init; }
+
+    /// <summary>Source kind that produced the layers, for example <c>arcgis-geoservices-rest</c>.</summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>UTC instant the scorecard was generated.</summary>
+    public required DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>
+    /// Overall gate verdict for the run: <c>pass</c>, <c>warn</c>, or <c>fail</c>. Derived from the
+    /// data-reconciliation dimension only — capability parity is advisory and never gates a run by
+    /// itself (an unsupported construct that was deliberately skipped is not a faithless import).
+    /// </summary>
+    public required string Verdict { get; init; }
+
+    /// <summary>Data-reconciliation dimension (count/geometry/content/extent + catalog parity).</summary>
+    public required MigrationScorecardDataReconciliation DataReconciliation { get; init; }
+
+    /// <summary>Capability-parity dimension (per-construct automation/fidelity), kept distinct.</summary>
+    public required MigrationScorecardCapabilityParity CapabilityParity { get; init; }
+
+    /// <summary>
+    /// SHA-256 fingerprint of the scorecard body (every field except this one), formatted
+    /// <c>sha256:&lt;hex&gt;</c>. Reuses the evidence-pack fingerprint mechanism so downstream
+    /// verifiers can prove the scorecard was not altered. <c>null</c> on an unsigned body; set by the
+    /// builder/signer.
+    /// </summary>
+    public string? Fingerprint { get; init; }
+}
+
+/// <summary>
+/// Data-reconciliation dimension of a <see cref="MigrationReconciliationScorecard"/>. Aggregates the
+/// per-layer data-reconciliation outcomes (count/geometry/content/extent) and, when available, the
+/// deeper catalog-parity findings (schema/domain/identifier/relationship/attachment/subtype).
+/// </summary>
+public sealed record MigrationScorecardDataReconciliation
+{
+    /// <summary>Aggregate data-reconciliation classification: <c>pass</c>, <c>warn</c>, or <c>fail</c>.</summary>
+    public required string Classification { get; init; }
+
+    /// <summary>Total layers covered by data reconciliation.</summary>
+    public int LayerCount { get; init; }
+
+    /// <summary>Layers whose data reconciled cleanly.</summary>
+    public int PassCount { get; init; }
+
+    /// <summary>Layers with warn-level data-reconciliation findings.</summary>
+    public int WarnCount { get; init; }
+
+    /// <summary>Layers with at least one hard data-reconciliation finding.</summary>
+    public int FailCount { get; init; }
+
+    /// <summary>Layers skipped (e.g. no published target to reconcile against).</summary>
+    public int SkippedCount { get; init; }
+
+    /// <summary>
+    /// Number of catalog-parity findings folded into this dimension (0 when no catalog report was
+    /// supplied). Catalog findings are part of data reconciliation, not capability parity.
+    /// </summary>
+    public int CatalogFindingCount { get; init; }
+
+    /// <summary>Per-layer scorecard rows, ordered deterministically by source layer id.</summary>
+    public MigrationScorecardLayer[] Layers { get; init; } = [];
+
+    /// <summary>Sorted, deduplicated, secret-safe blocking/advisory reasons rolled up across all layers.</summary>
+    public string[] Reasons { get; init; } = [];
+}
+
+/// <summary>
+/// One per-layer row in the data-reconciliation dimension of the scorecard.
+/// </summary>
+public sealed record MigrationScorecardLayer
+{
+    /// <summary>Source-side layer identifier.</summary>
+    public required string SourceLayerId { get; init; }
+
+    /// <summary>Optional source-side layer display name.</summary>
+    public string? SourceLayerName { get; init; }
+
+    /// <summary>Honua catalog layer id, when a queryable layer was published.</summary>
+    public int? TargetHonuaLayerId { get; init; }
+
+    /// <summary>Aggregate per-layer data-reconciliation classification.</summary>
+    public required string Classification { get; init; }
+}
+
+/// <summary>
+/// Capability-parity dimension of a <see cref="MigrationReconciliationScorecard"/>. Summarizes how
+/// many source constructs could be expressed automatically / with assistance / not at all on Honua.
+/// Kept strictly separate from data reconciliation: this answers "could we express it?" not "did the
+/// bytes land?".
+/// </summary>
+public sealed record MigrationScorecardCapabilityParity
+{
+    /// <summary>Total source constructs assessed for capability parity.</summary>
+    public int ConstructCount { get; init; }
+
+    /// <summary>Constructs Honua can express without operator involvement.</summary>
+    public int AutomatedCount { get; init; }
+
+    /// <summary>Constructs Honua can express with operator assistance.</summary>
+    public int AssistedCount { get; init; }
+
+    /// <summary>Constructs requiring manual review to express.</summary>
+    public int ManualReviewCount { get; init; }
+
+    /// <summary>Constructs Honua cannot express (no capability parity).</summary>
+    public int UnsupportedCount { get; init; }
+
+    /// <summary>
+    /// Capability-parity ratio in <c>[0, 1]</c>: (automated + assisted) / construct count, or
+    /// <c>1</c> when no constructs were assessed. Advisory only — never gates the run.
+    /// </summary>
+    public double ParityRatio { get; init; }
+}

--- a/src/Honua.Core/Features/Migration/Domain/MigrationRunRecord.cs
+++ b/src/Honua.Core/Features/Migration/Domain/MigrationRunRecord.cs
@@ -91,6 +91,15 @@ public sealed record MigrationRunRecord
     /// secrets expected.
     /// </summary>
     public string? StatusNote { get; init; }
+
+    /// <summary>
+    /// Fingerprint of the signed reconciliation scorecard recorded for this run
+    /// (<see cref="MigrationReconciliationScorecard.Fingerprint"/>, issue #1381),
+    /// when one has been persisted. Returned to API callers so they can prove
+    /// they received the same scorecard later. <c>null</c> until a scorecard is
+    /// recorded.
+    /// </summary>
+    public string? ReconciliationScorecardFingerprint { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Migration/Services/LayerReconciliationService.cs
+++ b/src/Honua.Core/Features/Migration/Services/LayerReconciliationService.cs
@@ -1,0 +1,739 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Globalization;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Shared.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.Migration.Services;
+
+/// <summary>
+/// Default <see cref="ILayerReconciliationService"/> implementation. Drives the
+/// post-apply Validating phase by issuing target-only probes against the catalog
+/// <see cref="IFeatureReader"/> and comparing them with the per-layer source snapshot
+/// supplied in the request. Source-side facts (count, extent, field names) are read from
+/// the snapshot so the gate remains deterministic against the apply moment and is not
+/// vulnerable to source-side drift.
+/// </summary>
+public sealed partial class LayerReconciliationService : ILayerReconciliationService
+{
+    private const int MinSampleSize = 1;
+    private const int MaxSampleSize = 10_000;
+
+    private readonly IFeatureReader _featureReader;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<LayerReconciliationService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LayerReconciliationService"/> class.
+    /// </summary>
+    /// <param name="featureReader">Target catalog feature reader.</param>
+    /// <param name="timeProvider">Time provider used to stamp the artifact.</param>
+    /// <param name="logger">Logger.</param>
+    public LayerReconciliationService(
+        IFeatureReader featureReader,
+        TimeProvider timeProvider,
+        ILogger<LayerReconciliationService> logger)
+    {
+        _featureReader = featureReader ?? throw new ArgumentNullException(nameof(featureReader));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<MigrationReconciliationArtifact> ReconcileAsync(
+        LayerReconciliationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.RunId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.SourceKind);
+
+        var options = NormalizeOptions(request.Options);
+        var startedAt = _timeProvider.GetUtcNow();
+        var stopwatch = Stopwatch.StartNew();
+
+        var reports = new List<MigrationReconciliationLayerReport>(request.Layers.Count);
+        foreach (var layer in request.Layers
+            .OrderBy(static l => l.SourceLayerId, StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            reports.Add(await ReconcileLayerAsync(layer, options, cancellationToken).ConfigureAwait(false));
+        }
+
+        var summary = BuildSummary(reports);
+        var classification = AggregateClassification(reports.Select(static r => r.Classification));
+        var reasons = CollectReasons(reports);
+
+        stopwatch.Stop();
+        Log.ReconciliationCompleted(
+            _logger,
+            request.RunId,
+            request.SourceKind,
+            reports.Count,
+            summary.FailCount,
+            summary.WarnCount,
+            summary.PassCount,
+            stopwatch.ElapsedMilliseconds);
+
+        return new MigrationReconciliationArtifact
+        {
+            RunId = request.RunId,
+            SourceKind = request.SourceKind,
+            Classification = classification,
+            StartedAt = startedAt,
+            CompletedAt = _timeProvider.GetUtcNow(),
+            Summary = summary,
+            Layers = reports.ToArray(),
+            Reasons = reasons,
+            Options = options
+        };
+    }
+
+    private async Task<MigrationReconciliationLayerReport> ReconcileLayerAsync(
+        LayerReconciliationLayerInput layer,
+        LayerReconciliationOptions options,
+        CancellationToken cancellationToken)
+    {
+        if (layer.TargetHonuaLayerId is null)
+        {
+            return BuildSkippedReport(
+                layer,
+                reason: "Apply step did not produce a Honua catalog layer; reconciliation skipped.");
+        }
+
+        var targetLayerId = layer.TargetHonuaLayerId.Value;
+        long? targetCount = null;
+        FeatureExtent? targetExtent = null;
+        QueryResult<Feature>? sample = null;
+        string? readerFailure = null;
+
+        try
+        {
+            // Count and extent probes are cheap aggregates; pull them up-front so we can fall back
+            // to skipped probes when the target catalog itself errors out.
+            targetCount = await _featureReader
+                .CountAsync(targetLayerId, BuildCountQuery(layer), cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            readerFailure = "Target catalog count query failed; manual review required.";
+            Log.ProbeFailed(_logger, layer.SourceLayerId, "count", ex);
+        }
+
+        try
+        {
+            targetExtent = await _featureReader
+                .GetExtentAsync(targetLayerId, BuildCountQuery(layer), cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            readerFailure ??= "Target catalog extent query failed; manual review required.";
+            Log.ProbeFailed(_logger, layer.SourceLayerId, "extent", ex);
+        }
+
+        try
+        {
+            sample = await _featureReader
+                .QueryAsync(targetLayerId, BuildSampleQuery(layer, options), cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            readerFailure ??= "Target catalog sample query failed; manual review required.";
+            Log.ProbeFailed(_logger, layer.SourceLayerId, "sample", ex);
+        }
+
+        var count = BuildCountProbe(layer, options, targetCount, readerFailure);
+        var geometry = BuildGeometryProbe(sample, options, readerFailure);
+        var content = BuildContentProbe(layer, sample, readerFailure);
+        var extent = BuildExtentProbe(layer, targetExtent, options, readerFailure);
+
+        return new MigrationReconciliationLayerReport
+        {
+            SourceLayerId = layer.SourceLayerId,
+            SourceLayerName = layer.SourceLayerName,
+            TargetHonuaLayerId = targetLayerId,
+            Classification = AggregateClassification(
+            [
+                count.Classification,
+                geometry.Classification,
+                content.Classification,
+                extent.Classification
+            ]),
+            Count = count,
+            Geometry = geometry,
+            Content = content,
+            Extent = extent
+        };
+    }
+
+    private static FeatureQuery BuildCountQuery(LayerReconciliationLayerInput layer)
+    {
+        // Filter mirror keeps the count "apples to apples" when the apply step only imported a
+        // subset of source features (e.g. CQL/where snapshot). When no filter was supplied the
+        // probe falls back to the catalog default of "all features".
+        var where = string.IsNullOrWhiteSpace(layer.FilterMirror) ? null : layer.FilterMirror;
+        return where is null ? default : new FeatureQuery { Where = where };
+    }
+
+    private static FeatureQuery BuildSampleQuery(LayerReconciliationLayerInput layer, LayerReconciliationOptions options)
+    {
+        var sampleSize = Math.Clamp(options.SampleSize, MinSampleSize, MaxSampleSize);
+        return new FeatureQuery
+        {
+            Where = string.IsNullOrWhiteSpace(layer.FilterMirror) ? null : layer.FilterMirror,
+            Limit = sampleSize
+        };
+    }
+
+    private static MigrationReconciliationCountProbe BuildCountProbe(
+        LayerReconciliationLayerInput layer,
+        LayerReconciliationOptions options,
+        long? targetCount,
+        string? readerFailure)
+    {
+        if (readerFailure is not null && targetCount is null)
+        {
+            return new MigrationReconciliationCountProbe
+            {
+                SourceCount = layer.SourceFeatureCount,
+                TargetCount = null,
+                FilterMirror = layer.FilterMirror,
+                Classification = MigrationReconciliationClassifications.Fail,
+                Reason = readerFailure
+            };
+        }
+
+        var source = layer.SourceFeatureCount;
+        if (source is null)
+        {
+            return new MigrationReconciliationCountProbe
+            {
+                SourceCount = null,
+                TargetCount = targetCount,
+                FilterMirror = layer.FilterMirror,
+                Classification = MigrationReconciliationClassifications.Warn,
+                Reason = "Source did not advertise a feature count snapshot; cannot prove count parity without a baseline."
+            };
+        }
+
+        var delta = (targetCount ?? 0L) - source.Value;
+        if (source.Value == 0L)
+        {
+            return delta == 0L
+                ? new MigrationReconciliationCountProbe
+                {
+                    SourceCount = source,
+                    TargetCount = targetCount,
+                    Delta = 0L,
+                    DeltaRatio = 0d,
+                    FilterMirror = layer.FilterMirror,
+                    Classification = MigrationReconciliationClassifications.Pass
+                }
+                : new MigrationReconciliationCountProbe
+                {
+                    SourceCount = source,
+                    TargetCount = targetCount,
+                    Delta = delta,
+                    FilterMirror = layer.FilterMirror,
+                    Classification = MigrationReconciliationClassifications.Fail,
+                    Reason = $"Source advertised 0 features but target reports {targetCount}; reject the apply."
+                };
+        }
+
+        var ratio = Math.Abs((double)delta) / source.Value;
+        var classification = ratio <= options.CountWarnRatio
+            ? MigrationReconciliationClassifications.Pass
+            : ratio <= options.CountFailRatio
+                ? MigrationReconciliationClassifications.Warn
+                : MigrationReconciliationClassifications.Fail;
+
+        string? reason = classification switch
+        {
+            MigrationReconciliationClassifications.Pass => null,
+            MigrationReconciliationClassifications.Warn =>
+                $"Feature-count delta {delta} ({FormatPercent(ratio)}) is outside the {FormatPercent(options.CountWarnRatio)} pass band; investigate before cutover.",
+            _ =>
+                $"Feature-count delta {delta} ({FormatPercent(ratio)}) exceeds the {FormatPercent(options.CountFailRatio)} fail band; reject the apply."
+        };
+
+        return new MigrationReconciliationCountProbe
+        {
+            SourceCount = source,
+            TargetCount = targetCount,
+            Delta = delta,
+            DeltaRatio = ratio,
+            FilterMirror = layer.FilterMirror,
+            Classification = classification,
+            Reason = reason
+        };
+    }
+
+    private static MigrationReconciliationGeometryProbe BuildGeometryProbe(
+        QueryResult<Feature>? sample,
+        LayerReconciliationOptions options,
+        string? readerFailure)
+    {
+        if (sample is null)
+        {
+            return new MigrationReconciliationGeometryProbe
+            {
+                Sampled = 0,
+                Valid = 0,
+                Ratio = 0d,
+                Classification = MigrationReconciliationClassifications.Fail,
+                Reason = readerFailure ?? "Target sample query returned no result; cannot inspect geometry validity."
+            };
+        }
+
+        var features = sample.Value.Items;
+        if (features.Length == 0)
+        {
+            // No features to inspect — treat as pass (the count probe already records the empty
+            // table). Source-side reconcile.ts uses the same "empty is healthy" convention.
+            return new MigrationReconciliationGeometryProbe
+            {
+                Sampled = 0,
+                Valid = 0,
+                Ratio = 1d,
+                Classification = MigrationReconciliationClassifications.Pass
+            };
+        }
+
+        var valid = 0;
+        foreach (var feature in features)
+        {
+            if (IsGeometryWellFormed(feature.Geometry))
+            {
+                valid++;
+            }
+        }
+
+        var ratio = (double)valid / features.Length;
+        var classification = ratio >= options.GeometryPassRatio
+            ? MigrationReconciliationClassifications.Pass
+            : ratio >= options.GeometryWarnRatio
+                ? MigrationReconciliationClassifications.Warn
+                : MigrationReconciliationClassifications.Fail;
+
+        string? reason = classification == MigrationReconciliationClassifications.Pass
+            ? null
+            : $"Target geometry-validity ratio {FormatRatio(ratio)} is below the {FormatRatio(options.GeometryPassRatio)} pass band ({valid} of {features.Length} sampled features had a well-formed geometry).";
+
+        return new MigrationReconciliationGeometryProbe
+        {
+            Sampled = features.Length,
+            Valid = valid,
+            Ratio = ratio,
+            Classification = classification,
+            Reason = reason
+        };
+    }
+
+    private static MigrationReconciliationContentProbe BuildContentProbe(
+        LayerReconciliationLayerInput layer,
+        QueryResult<Feature>? sample,
+        string? readerFailure)
+    {
+        var sourceFields = layer.SourceFieldNames
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Select(static name => name.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        if (sample is null)
+        {
+            return new MigrationReconciliationContentProbe
+            {
+                SourceFieldNames = sourceFields,
+                TargetFieldNames = [],
+                MissingOnTarget = sourceFields,
+                ExtraOnTarget = [],
+                Classification = sourceFields.Length == 0
+                    ? MigrationReconciliationClassifications.Pass
+                    : MigrationReconciliationClassifications.Fail,
+                Reason = sourceFields.Length == 0
+                    ? null
+                    : readerFailure ?? "Target sample query returned no result; cannot inspect attribute keys."
+            };
+        }
+
+        var features = sample.Value.Items;
+        var targetFields = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var feature in features)
+        {
+            if (feature.Attributes is null)
+            {
+                continue;
+            }
+
+            foreach (var key in feature.Attributes.Keys)
+            {
+                if (!string.IsNullOrWhiteSpace(key))
+                {
+                    targetFields.Add(key.Trim());
+                }
+            }
+        }
+
+        var targetFieldArray = targetFields
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        if (sourceFields.Length == 0)
+        {
+            return new MigrationReconciliationContentProbe
+            {
+                SourceFieldNames = [],
+                TargetFieldNames = targetFieldArray,
+                MissingOnTarget = [],
+                ExtraOnTarget = targetFieldArray,
+                Classification = MigrationReconciliationClassifications.Pass,
+                Reason = "Source did not advertise attribute keys; recording target attributes without comparison."
+            };
+        }
+
+        var missing = sourceFields.Where(name => !targetFields.Contains(name))
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+        var sourceSet = new HashSet<string>(sourceFields, StringComparer.Ordinal);
+        var extra = targetFieldArray.Where(name => !sourceSet.Contains(name))
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        return new MigrationReconciliationContentProbe
+        {
+            SourceFieldNames = sourceFields,
+            TargetFieldNames = targetFieldArray,
+            MissingOnTarget = missing,
+            ExtraOnTarget = extra,
+            Classification = missing.Length == 0
+                ? MigrationReconciliationClassifications.Pass
+                : MigrationReconciliationClassifications.Fail,
+            Reason = missing.Length == 0
+                ? null
+                : $"Target is missing {missing.Length} source attribute key(s): {string.Join(", ", missing)}."
+        };
+    }
+
+    private static MigrationReconciliationExtentProbe BuildExtentProbe(
+        LayerReconciliationLayerInput layer,
+        FeatureExtent? targetExtent,
+        LayerReconciliationOptions options,
+        string? readerFailure)
+    {
+        var source = layer.SourceExtent is { } s
+            ? new ExtentBox
+            {
+                MinX = s.MinX,
+                MinY = s.MinY,
+                MaxX = s.MaxX,
+                MaxY = s.MaxY,
+                Srid = s.SpatialReferenceId ?? 4326
+            }
+            : (ExtentBox?)null;
+
+        var target = targetExtent is { } t
+            ? new ExtentBox
+            {
+                MinX = t.MinX,
+                MinY = t.MinY,
+                MaxX = t.MaxX,
+                MaxY = t.MaxY,
+                Srid = t.SpatialReference
+            }
+            : (ExtentBox?)null;
+
+        if (target is null)
+        {
+            return new MigrationReconciliationExtentProbe
+            {
+                Source = source,
+                Target = null,
+                Classification = source is null
+                    ? MigrationReconciliationClassifications.Pass
+                    : MigrationReconciliationClassifications.Fail,
+                Reason = source is null
+                    ? null
+                    : readerFailure ?? "Target catalog reported no extent for the published layer; cannot prove extent parity."
+            };
+        }
+
+        if (source is null)
+        {
+            return new MigrationReconciliationExtentProbe
+            {
+                Source = null,
+                Target = target,
+                Classification = MigrationReconciliationClassifications.Warn,
+                Reason = "Source did not advertise an extent snapshot; cannot prove extent parity without a baseline."
+            };
+        }
+
+        var sourceBox = source.Value;
+        var targetBox = target.Value;
+        var width = Math.Abs(sourceBox.MaxX - sourceBox.MinX);
+        var height = Math.Abs(sourceBox.MaxY - sourceBox.MinY);
+
+        // Degenerate sources (point geometries) cannot use a width-relative tolerance; require an
+        // exact match instead, otherwise we would always pass.
+        if (width == 0d && height == 0d)
+        {
+            var matches =
+                sourceBox.MinX == targetBox.MinX &&
+                sourceBox.MinY == targetBox.MinY &&
+                sourceBox.MaxX == targetBox.MaxX &&
+                sourceBox.MaxY == targetBox.MaxY;
+            return new MigrationReconciliationExtentProbe
+            {
+                Source = source,
+                Target = target,
+                MaxDimensionDelta = matches ? 0d : null,
+                Classification = matches
+                    ? MigrationReconciliationClassifications.Pass
+                    : MigrationReconciliationClassifications.Fail,
+                Reason = matches
+                    ? null
+                    : "Degenerate source extent did not match target extent exactly."
+            };
+        }
+
+        var widthDenom = width == 0d ? height : width;
+        var heightDenom = height == 0d ? width : height;
+        var dx = Math.Max(
+            Math.Abs(targetBox.MinX - sourceBox.MinX),
+            Math.Abs(targetBox.MaxX - sourceBox.MaxX));
+        var dy = Math.Max(
+            Math.Abs(targetBox.MinY - sourceBox.MinY),
+            Math.Abs(targetBox.MaxY - sourceBox.MaxY));
+        var ratio = Math.Max(dx / widthDenom, dy / heightDenom);
+
+        var tolerance = options.ExtentTolerance;
+        var warnTolerance = tolerance * 10d;
+        var classification = ratio <= tolerance
+            ? MigrationReconciliationClassifications.Pass
+            : ratio <= warnTolerance
+                ? MigrationReconciliationClassifications.Warn
+                : MigrationReconciliationClassifications.Fail;
+
+        string? reason = classification switch
+        {
+            MigrationReconciliationClassifications.Pass => null,
+            MigrationReconciliationClassifications.Warn =>
+                $"Target extent differs from source by up to {FormatRatio(ratio)} of source dimension; within reprojection tolerance band but worth a manual look.",
+            _ =>
+                $"Target extent differs from source by up to {FormatRatio(ratio)} of source dimension; outside the configured {FormatRatio(warnTolerance)} warn band."
+        };
+
+        return new MigrationReconciliationExtentProbe
+        {
+            Source = source,
+            Target = target,
+            MaxDimensionDelta = ratio,
+            Classification = classification,
+            Reason = reason
+        };
+    }
+
+    private static MigrationReconciliationLayerReport BuildSkippedReport(
+        LayerReconciliationLayerInput layer,
+        string reason) =>
+        new()
+        {
+            SourceLayerId = layer.SourceLayerId,
+            SourceLayerName = layer.SourceLayerName,
+            TargetHonuaLayerId = layer.TargetHonuaLayerId,
+            Classification = MigrationReconciliationClassifications.Skipped,
+            Count = new MigrationReconciliationCountProbe
+            {
+                SourceCount = layer.SourceFeatureCount,
+                TargetCount = null,
+                FilterMirror = layer.FilterMirror,
+                Classification = MigrationReconciliationClassifications.Skipped,
+                Reason = reason
+            },
+            Geometry = new MigrationReconciliationGeometryProbe
+            {
+                Sampled = 0,
+                Valid = 0,
+                Ratio = 0d,
+                Classification = MigrationReconciliationClassifications.Skipped,
+                Reason = reason
+            },
+            Content = new MigrationReconciliationContentProbe
+            {
+                SourceFieldNames = layer.SourceFieldNames.OrderBy(static name => name, StringComparer.Ordinal).ToArray(),
+                TargetFieldNames = [],
+                MissingOnTarget = [],
+                ExtraOnTarget = [],
+                Classification = MigrationReconciliationClassifications.Skipped,
+                Reason = reason
+            },
+            Extent = new MigrationReconciliationExtentProbe
+            {
+                Source = layer.SourceExtent is { } s
+                    ? new ExtentBox
+                    {
+                        MinX = s.MinX,
+                        MinY = s.MinY,
+                        MaxX = s.MaxX,
+                        MaxY = s.MaxY,
+                        Srid = s.SpatialReferenceId ?? 4326
+                    }
+                    : (ExtentBox?)null,
+                Target = null,
+                Classification = MigrationReconciliationClassifications.Skipped,
+                Reason = reason
+            }
+        };
+
+    private static MigrationReconciliationSummary BuildSummary(List<MigrationReconciliationLayerReport> reports)
+    {
+        var passCount = 0;
+        var warnCount = 0;
+        var failCount = 0;
+        var skippedCount = 0;
+        foreach (var report in reports)
+        {
+            switch (report.Classification)
+            {
+                case MigrationReconciliationClassifications.Pass:
+                    passCount++;
+                    break;
+                case MigrationReconciliationClassifications.Warn:
+                    warnCount++;
+                    break;
+                case MigrationReconciliationClassifications.Fail:
+                    failCount++;
+                    break;
+                default:
+                    skippedCount++;
+                    break;
+            }
+        }
+
+        return new MigrationReconciliationSummary
+        {
+            LayerCount = reports.Count,
+            PassCount = passCount,
+            WarnCount = warnCount,
+            FailCount = failCount,
+            SkippedCount = skippedCount
+        };
+    }
+
+    private static string AggregateClassification(IEnumerable<string> classifications)
+    {
+        var seenWarn = false;
+        var seenSkipped = false;
+        foreach (var classification in classifications)
+        {
+            switch (classification)
+            {
+                case MigrationReconciliationClassifications.Fail:
+                    return MigrationReconciliationClassifications.Fail;
+                case MigrationReconciliationClassifications.Warn:
+                    seenWarn = true;
+                    break;
+                case MigrationReconciliationClassifications.Skipped:
+                    seenSkipped = true;
+                    break;
+            }
+        }
+
+        if (seenWarn)
+        {
+            return MigrationReconciliationClassifications.Warn;
+        }
+
+        // A skip alone keeps the run aggregate at "warn" so the operator notices the unverified
+        // layer; the per-report classification still reads as "skipped" so the UI can render it.
+        return seenSkipped
+            ? MigrationReconciliationClassifications.Warn
+            : MigrationReconciliationClassifications.Pass;
+    }
+
+    private static string[] CollectReasons(IEnumerable<MigrationReconciliationLayerReport> reports) =>
+        reports
+            .SelectMany(static report => new[]
+            {
+                report.Count.Reason,
+                report.Geometry.Reason,
+                report.Content.Reason,
+                report.Extent.Reason
+            })
+            .Where(static reason => !string.IsNullOrWhiteSpace(reason))
+            .Select(static reason => reason!.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static reason => reason, StringComparer.Ordinal)
+            .ToArray();
+
+    private static LayerReconciliationOptions NormalizeOptions(LayerReconciliationOptions? options)
+    {
+        options ??= new LayerReconciliationOptions();
+        return new LayerReconciliationOptions
+        {
+            SampleSize = Math.Clamp(options.SampleSize, MinSampleSize, MaxSampleSize),
+            CountWarnRatio = Math.Max(0d, options.CountWarnRatio),
+            CountFailRatio = Math.Max(options.CountWarnRatio, options.CountFailRatio),
+            GeometryPassRatio = Math.Clamp(options.GeometryPassRatio, 0d, 1d),
+            GeometryWarnRatio = Math.Clamp(Math.Min(options.GeometryWarnRatio, options.GeometryPassRatio), 0d, 1d),
+            ExtentTolerance = Math.Max(0d, options.ExtentTolerance)
+        };
+    }
+
+    /// <summary>
+    /// Cheap, NTS-free geometry well-formedness check. Mirrors the SDK <c>reconcile.ts</c>
+    /// "geometry is present" heuristic: a non-empty WKB payload with a byte-order byte and a
+    /// type marker is good enough to distinguish "feature copied" from "geometry dropped".
+    /// </summary>
+    private static bool IsGeometryWellFormed(byte[]? wkb)
+    {
+        if (wkb is null || wkb.Length < 5)
+        {
+            return false;
+        }
+
+        // First byte is byte-order (0 = big-endian, 1 = little-endian); next four bytes are the
+        // geometry type. Any other byte-order value is malformed.
+        return wkb[0] is 0 or 1;
+    }
+
+    private static string FormatPercent(double ratio)
+        => (ratio * 100d).ToString("0.##", CultureInfo.InvariantCulture) + "%";
+
+    private static string FormatRatio(double ratio)
+        => ratio.ToString("0.###", CultureInfo.InvariantCulture);
+
+    private static partial class Log
+    {
+        [LoggerMessage(8020, LogLevel.Information,
+            "Layer reconciliation completed for run {RunId} ({SourceKind}): {LayerCount} layers (fail={FailCount}, warn={WarnCount}, pass={PassCount}) in {DurationMs}ms")]
+        public static partial void ReconciliationCompleted(
+            ILogger logger,
+            string runId,
+            string sourceKind,
+            int layerCount,
+            int failCount,
+            int warnCount,
+            int passCount,
+            long durationMs);
+
+        [LoggerMessage(8021, LogLevel.Warning,
+            "Layer reconciliation probe '{Probe}' failed for source layer '{SourceLayerId}'")]
+        public static partial void ProbeFailed(
+            ILogger logger,
+            string sourceLayerId,
+            string probe,
+            Exception exception);
+    }
+}

--- a/src/Honua.Core/Features/Migration/Services/MigrationCatalogReconciler.cs
+++ b/src/Honua.Core/Features/Migration/Services/MigrationCatalogReconciler.cs
@@ -64,7 +64,8 @@ public static class MigrationCatalogReconciler
                     input.PublishedResource,
                     input.ExpectedRelationships,
                     input.SourceBbox,
-                    input.TargetResourceId);
+                    input.TargetResourceId,
+                    input.ExpectedSubtypes);
             })
             .OrderBy(static outcome => outcome.SourceResourceId, StringComparer.Ordinal)
             .ToArray();
@@ -87,11 +88,12 @@ public static class MigrationCatalogReconciler
         MetadataV2Resource? publishedResource,
         IEnumerable<MigrationManifestRelationshipRecord>? expectedRelationships = null,
         double[]? sourceBbox = null,
-        string? targetResourceId = null)
+        string? targetResourceId = null,
+        MetadataV2Subtypes? expectedSubtypes = null)
     {
         ArgumentNullException.ThrowIfNull(resource);
         var expected = expectedRelationships?.ToArray() ?? [];
-        return ReconcileResourceInternal(resource, publishedResource, expected, sourceBbox, targetResourceId);
+        return ReconcileResourceInternal(resource, publishedResource, expected, sourceBbox, targetResourceId, expectedSubtypes);
     }
 
     private static MigrationCatalogReconciliationResource ReconcileResourceInternal(
@@ -99,7 +101,8 @@ public static class MigrationCatalogReconciler
         MetadataV2Resource? published,
         MigrationManifestRelationshipRecord[] expectedRelationships,
         double[]? sourceBbox,
-        string? targetResourceId)
+        string? targetResourceId,
+        MetadataV2Subtypes? expectedSubtypes)
     {
         if (published is null)
         {
@@ -127,6 +130,8 @@ public static class MigrationCatalogReconciler
         CollectSpatialFindings(resource, published, sourceBbox, findings);
         CollectIdentifierFindings(resource, published, findings);
         CollectRelationshipFindings(expectedRelationships, published, findings);
+        CollectAttachmentFindings(resource, published, findings);
+        CollectSubtypeFindings(expectedSubtypes, published, findings);
 
         var ordered = findings
             .OrderBy(static finding => finding.Code, StringComparer.Ordinal)
@@ -447,6 +452,119 @@ public static class MigrationCatalogReconciler
     private static bool IsRelationshipExpectedToPersist(string classification)
         => string.Equals(classification, MigrationManifestRelationshipClassifications.Automated, StringComparison.Ordinal)
         || string.Equals(classification, MigrationManifestRelationshipClassifications.Assisted, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Assert that a source resource advertising attachments was published with attachment support.
+    /// Trunk now imports source attachments (#1257); this collector proves the published catalog
+    /// entry declares attachment support so the imported attachments are actually reachable.
+    /// </summary>
+    /// <param name="resource">Source inventory resource.</param>
+    /// <param name="published">Published Metadata v2 catalog entry.</param>
+    /// <param name="findings">Sink for emitted findings.</param>
+    internal static void CollectAttachmentFindings(
+        MigrationInventoryResource resource,
+        MetadataV2Resource published,
+        List<MigrationCatalogReconciliationFinding> findings)
+    {
+        // Only assert when the source explicitly reported attachment support. A null
+        // HasAttachments means the source did not advertise attachment state, so we cannot
+        // distinguish "no attachments" from "unknown" and must not false-fail.
+        if (resource.HasAttachments != true)
+        {
+            return;
+        }
+
+        if (published.Editing?.SupportsAttachments == true)
+        {
+            return;
+        }
+
+        findings.Add(new MigrationCatalogReconciliationFinding
+        {
+            Code = MigrationCatalogReconciliationCodes.AttachmentMissing,
+            Severity = MigrationCatalogReconciliationSeverities.Fail,
+            Subject = "attachments",
+            Expected = "supportsAttachments=true",
+            Actual = "supportsAttachments=false",
+            Summary = "Source resource advertised attachments but the published catalog entry does not declare attachment support."
+        });
+    }
+
+    /// <summary>
+    /// Assert that a source-captured subtype set was persisted onto the published catalog entry.
+    /// Trunk now persists Esri subtypes (#1378); this collector proves the published resource keeps
+    /// the same subtype field and that every source subtype code is present.
+    /// </summary>
+    /// <param name="expectedSubtypes">Source-captured subtype set, or <c>null</c> to skip.</param>
+    /// <param name="published">Published Metadata v2 catalog entry.</param>
+    /// <param name="findings">Sink for emitted findings.</param>
+    internal static void CollectSubtypeFindings(
+        MetadataV2Subtypes? expectedSubtypes,
+        MetadataV2Resource published,
+        List<MigrationCatalogReconciliationFinding> findings)
+    {
+        if (expectedSubtypes is null || expectedSubtypes.Subtypes.Count == 0)
+        {
+            return;
+        }
+
+        var publishedSubtypes = published.Subtypes;
+        if (publishedSubtypes is null || publishedSubtypes.Subtypes.Count == 0)
+        {
+            findings.Add(new MigrationCatalogReconciliationFinding
+            {
+                Code = MigrationCatalogReconciliationCodes.SubtypeMissing,
+                Severity = MigrationCatalogReconciliationSeverities.Fail,
+                Subject = "subtypes",
+                Expected = expectedSubtypes.SubtypeField,
+                Summary = "Source resource advertised a subtype set but the published catalog entry declares no subtypes."
+            });
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(expectedSubtypes.SubtypeField) &&
+            !string.IsNullOrWhiteSpace(publishedSubtypes.SubtypeField) &&
+            !string.Equals(expectedSubtypes.SubtypeField, publishedSubtypes.SubtypeField, StringComparison.OrdinalIgnoreCase))
+        {
+            findings.Add(new MigrationCatalogReconciliationFinding
+            {
+                Code = MigrationCatalogReconciliationCodes.SubtypeFieldMismatch,
+                Severity = MigrationCatalogReconciliationSeverities.Fail,
+                Subject = "subtypes",
+                Expected = expectedSubtypes.SubtypeField,
+                Actual = publishedSubtypes.SubtypeField,
+                Summary = "Published subtype field differs from the source-captured subtype field."
+            });
+        }
+
+        var publishedCodes = publishedSubtypes.Subtypes
+            .Select(static subtype => CodeToString(subtype.Code))
+            .Where(static code => code is not null)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missingCodes = expectedSubtypes.Subtypes
+            .Select(static subtype => CodeToString(subtype.Code))
+            .Where(code => code is not null && !publishedCodes.Contains(code))
+            .Select(static code => code!)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static code => code, StringComparer.Ordinal)
+            .ToArray();
+
+        if (missingCodes.Length > 0)
+        {
+            findings.Add(new MigrationCatalogReconciliationFinding
+            {
+                Code = MigrationCatalogReconciliationCodes.SubtypeCodeMissing,
+                Severity = MigrationCatalogReconciliationSeverities.Fail,
+                Subject = "subtypes",
+                Expected = string.Join(",", expectedSubtypes.Subtypes
+                    .Select(static subtype => CodeToString(subtype.Code))
+                    .Where(static code => code is not null)),
+                Actual = string.Join(",", publishedCodes.OrderBy(static code => code, StringComparer.Ordinal)),
+                Summary = $"Source subtype codes are missing from the published subtype set: {string.Join(",", missingCodes)}."
+            });
+        }
+    }
 
     private static MigrationCatalogReconciliationSummary BuildSummary(
         MigrationCatalogReconciliationResource[] outcomes)

--- a/src/Honua.Core/Features/Migration/Services/MigrationReconciliationScorecardBuilder.cs
+++ b/src/Honua.Core/Features/Migration/Services/MigrationReconciliationScorecardBuilder.cs
@@ -1,0 +1,212 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Cryptography;
+using System.Text.Json;
+using Honua.Core.Features.Migration.Domain;
+
+namespace Honua.Core.Features.Migration.Services;
+
+/// <summary>
+/// Pure, deterministic builder for <see cref="MigrationReconciliationScorecard"/> (issue #1381).
+/// Aggregates the per-layer data-reconciliation artifact (and optional catalog parity report) into
+/// the data-reconciliation dimension, folds the per-construct automation statuses into the distinct
+/// capability-parity dimension, and signs the body with the evidence-pack fingerprint mechanism.
+/// </summary>
+public static class MigrationReconciliationScorecardBuilder
+{
+    /// <summary>
+    /// Build and sign a scorecard from a completed reconciliation run.
+    /// </summary>
+    /// <param name="runId">Stable migration run identifier.</param>
+    /// <param name="sourceKind">Source kind, e.g. <c>arcgis-geoservices-rest</c>.</param>
+    /// <param name="generatedAt">UTC instant the scorecard is generated.</param>
+    /// <param name="dataArtifact">
+    /// Per-layer data-reconciliation artifact (count/geometry/content/extent). Required: this is the
+    /// gating dimension.
+    /// </param>
+    /// <param name="catalogReport">
+    /// Optional deeper catalog parity report (schema/domain/identifier/relationship/attachment/
+    /// subtype). Its findings are folded into the data-reconciliation dimension when supplied.
+    /// </param>
+    /// <param name="capabilityAutomationStatuses">
+    /// Per-construct automation statuses from the Esri construct capability registry / fidelity
+    /// matrix (see <see cref="MigrationFidelityAutomationStatuses"/>). Drives the capability-parity
+    /// dimension, which is kept strictly separate from data reconciliation and never gates the run.
+    /// </param>
+    /// <returns>A signed scorecard whose <see cref="MigrationReconciliationScorecard.Fingerprint"/> is set.</returns>
+    public static MigrationReconciliationScorecard Build(
+        string runId,
+        string sourceKind,
+        DateTimeOffset generatedAt,
+        MigrationReconciliationArtifact dataArtifact,
+        MigrationCatalogReconciliationReport? catalogReport,
+        IEnumerable<string> capabilityAutomationStatuses)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceKind);
+        ArgumentNullException.ThrowIfNull(dataArtifact);
+        ArgumentNullException.ThrowIfNull(capabilityAutomationStatuses);
+
+        var data = BuildDataReconciliation(dataArtifact, catalogReport);
+        var capability = BuildCapabilityParity(capabilityAutomationStatuses);
+
+        // The verdict is derived from the data-reconciliation dimension ONLY. Capability parity is
+        // advisory: a construct that Honua cannot express (and was therefore not imported) is not a
+        // faithless import of the data that DID land.
+        var verdict = data.Classification;
+
+        var unsigned = new MigrationReconciliationScorecard
+        {
+            RunId = runId,
+            SourceKind = sourceKind,
+            GeneratedAt = generatedAt,
+            Verdict = verdict,
+            DataReconciliation = data,
+            CapabilityParity = capability,
+            Fingerprint = null
+        };
+
+        return unsigned with { Fingerprint = ComputeFingerprint(unsigned) };
+    }
+
+    /// <summary>
+    /// Compute the deterministic SHA-256 fingerprint over the unsigned scorecard body (i.e. with
+    /// <see cref="MigrationReconciliationScorecard.Fingerprint"/> set to <c>null</c>). Mirrors the
+    /// evidence-pack fingerprint mechanism (<c>sha256:&lt;lowercase-hex&gt;</c>) so downstream
+    /// verifiers can recompute it independently. Exposed for tests and verifiers.
+    /// </summary>
+    public static string ComputeFingerprint(MigrationReconciliationScorecard scorecard)
+    {
+        ArgumentNullException.ThrowIfNull(scorecard);
+        var body = scorecard.Fingerprint is null ? scorecard : scorecard with { Fingerprint = null };
+        var payload = JsonSerializer.SerializeToUtf8Bytes(
+            body,
+            MigrationReconciliationScorecardJsonContext.Default.MigrationReconciliationScorecard);
+        var hash = SHA256.HashData(payload);
+        return $"sha256:{Convert.ToHexString(hash).ToLowerInvariant()}";
+    }
+
+    private static MigrationScorecardDataReconciliation BuildDataReconciliation(
+        MigrationReconciliationArtifact dataArtifact,
+        MigrationCatalogReconciliationReport? catalogReport)
+    {
+        var layers = dataArtifact.Layers
+            .Select(static layer => new MigrationScorecardLayer
+            {
+                SourceLayerId = layer.SourceLayerId,
+                SourceLayerName = layer.SourceLayerName,
+                TargetHonuaLayerId = layer.TargetHonuaLayerId,
+                Classification = layer.Classification
+            })
+            .OrderBy(static layer => layer.SourceLayerId, StringComparer.Ordinal)
+            .ToArray();
+
+        var catalogFindingCount = catalogReport?.Summary.FindingCount ?? 0;
+        var catalogReasons = catalogReport is null
+            ? []
+            : catalogReport.Resources
+                .SelectMany(static resource => resource.Findings)
+                .Select(static finding => finding.Summary)
+                .Where(static summary => !string.IsNullOrWhiteSpace(summary))
+                .Select(static summary => summary.Trim());
+
+        var reasons = dataArtifact.Reasons
+            .Concat(catalogReasons)
+            .Where(static reason => !string.IsNullOrWhiteSpace(reason))
+            .Select(static reason => reason.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static reason => reason, StringComparer.Ordinal)
+            .ToArray();
+
+        // Fold catalog parity into the same dimension: a hard catalog finding escalates the data
+        // classification to fail, a warn escalates pass to warn.
+        var classification = EscalateClassification(dataArtifact.Classification, catalogReport);
+
+        return new MigrationScorecardDataReconciliation
+        {
+            Classification = classification,
+            LayerCount = dataArtifact.Summary.LayerCount,
+            PassCount = dataArtifact.Summary.PassCount,
+            WarnCount = dataArtifact.Summary.WarnCount,
+            FailCount = dataArtifact.Summary.FailCount,
+            SkippedCount = dataArtifact.Summary.SkippedCount,
+            CatalogFindingCount = catalogFindingCount,
+            Layers = layers,
+            Reasons = reasons
+        };
+    }
+
+    private static string EscalateClassification(
+        string dataClassification,
+        MigrationCatalogReconciliationReport? catalogReport)
+    {
+        if (catalogReport is null)
+        {
+            return dataClassification;
+        }
+
+        if (catalogReport.Summary.FailResourceCount > 0 ||
+            string.Equals(dataClassification, MigrationReconciliationClassifications.Fail, StringComparison.Ordinal))
+        {
+            return MigrationReconciliationClassifications.Fail;
+        }
+
+        if (catalogReport.Summary.WarnResourceCount > 0 ||
+            string.Equals(dataClassification, MigrationReconciliationClassifications.Warn, StringComparison.Ordinal))
+        {
+            return MigrationReconciliationClassifications.Warn;
+        }
+
+        return MigrationReconciliationClassifications.Pass;
+    }
+
+    private static MigrationScorecardCapabilityParity BuildCapabilityParity(
+        IEnumerable<string> capabilityAutomationStatuses)
+    {
+        var automated = 0;
+        var assisted = 0;
+        var manualReview = 0;
+        var unsupported = 0;
+        var total = 0;
+
+        foreach (var status in capabilityAutomationStatuses)
+        {
+            if (string.IsNullOrWhiteSpace(status))
+            {
+                continue;
+            }
+
+            total++;
+            switch (status.Trim().ToLowerInvariant())
+            {
+                case MigrationFidelityAutomationStatuses.Automated:
+                    automated++;
+                    break;
+                case MigrationFidelityAutomationStatuses.Assisted:
+                    assisted++;
+                    break;
+                case MigrationFidelityAutomationStatuses.ManualReview:
+                    manualReview++;
+                    break;
+                default:
+                    // Treat any unrecognized status as unsupported so the parity ratio stays
+                    // conservative rather than silently inflating.
+                    unsupported++;
+                    break;
+            }
+        }
+
+        var parityRatio = total == 0 ? 1d : (double)(automated + assisted) / total;
+
+        return new MigrationScorecardCapabilityParity
+        {
+            ConstructCount = total,
+            AutomatedCount = automated,
+            AssistedCount = assisted,
+            ManualReviewCount = manualReview,
+            UnsupportedCount = unsupported,
+            ParityRatio = parityRatio
+        };
+    }
+}

--- a/src/Honua.Core/Features/Migration/Services/MigrationReconciliationScorecardJsonContext.cs
+++ b/src/Honua.Core/Features/Migration/Services/MigrationReconciliationScorecardJsonContext.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Migration.Domain;
+
+namespace Honua.Core.Features.Migration.Services;
+
+/// <summary>
+/// AOT-safe JSON serialization context for the reconciliation scorecard (issue #1381). Used to
+/// produce the deterministic, canonical byte payload that
+/// <see cref="MigrationReconciliationScorecardBuilder.ComputeFingerprint"/> hashes, so the
+/// fingerprint is stable across runs and recomputable by verifiers without reflection.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    WriteIndented = false)]
+[JsonSerializable(typeof(MigrationReconciliationScorecard))]
+[JsonSerializable(typeof(MigrationScorecardDataReconciliation))]
+[JsonSerializable(typeof(MigrationScorecardCapabilityParity))]
+[JsonSerializable(typeof(MigrationScorecardLayer))]
+[JsonSerializable(typeof(MigrationScorecardLayer[]))]
+public sealed partial class MigrationReconciliationScorecardJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Import/Features/Migration/MigrationRunAdminEndpoints.cs
+++ b/src/Honua.Import/Features/Migration/MigrationRunAdminEndpoints.cs
@@ -57,6 +57,10 @@ internal static class MigrationRunAdminEndpoints
             .WithName("GetMigrationRunEvidencePack")
             .WithSummary("Download the slice-4 evidence pack JSON for a migration run");
 
+        _ = group.MapGet("/{runId}/scorecard", HandleGetScorecardAsync)
+            .WithName("GetMigrationRunScorecard")
+            .WithSummary("Download the signed reconciliation scorecard JSON for a migration run");
+
         _ = group.MapPost("/{runId}/cancel", HandleCancelAsync)
             .WithName("CancelMigrationRun")
             .WithSummary("Mark a running migration run as cancelled");
@@ -149,6 +153,50 @@ internal static class MigrationRunAdminEndpoints
             // Quoted ETag per RFC 7232 so HTTP caches treat the fingerprint
             // as opaque rather than weak.
             context.Response.Headers.ETag = $"\"{record.EvidencePackFingerprint}\"";
+        }
+
+        await context.Response.Body.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task HandleGetScorecardAsync(HttpContext context)
+    {
+        var cancellationToken = context.RequestAborted;
+        var runId = context.Request.RouteValues["runId"]?.ToString();
+        if (string.IsNullOrWhiteSpace(runId))
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Run id is required.", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var catalog = context.RequestServices.GetRequiredService<IMigrationRunCatalog>();
+        var record = await catalog.GetAsync(runId, cancellationToken).ConfigureAwait(false);
+        if (record is null)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, $"Migration run '{runId}' was not found.", StatusCodes.Status404NotFound);
+            return;
+        }
+
+        var body = await catalog.GetScorecardAsync(runId, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(body))
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                $"Migration run '{runId}' has no reconciliation scorecard persisted yet (status={MigrationRunSerialization.StatusToText(record.Status)}).",
+                StatusCodes.Status404NotFound);
+            return;
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(body);
+        var filename = $"migration-run-{MigrationScannerEndpoints.SanitizeFilenameSlug(record.RunId)}-reconciliation-scorecard.json";
+
+        context.Response.StatusCode = StatusCodes.Status200OK;
+        context.Response.ContentType = "application/json; charset=utf-8";
+        context.Response.Headers["Content-Disposition"] = $"attachment; filename=\"{filename}\"";
+        context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+        if (!string.IsNullOrEmpty(record.ReconciliationScorecardFingerprint))
+        {
+            // Quoted ETag per RFC 7232 so HTTP caches treat the fingerprint as opaque.
+            context.Response.Headers.ETag = $"\"{record.ReconciliationScorecardFingerprint}\"";
         }
 
         await context.Response.Body.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
@@ -276,7 +324,9 @@ internal static class MigrationRunAdminEndpoints
         EvidencePackRef = record.EvidencePackRef,
         EvidencePackFingerprint = record.EvidencePackFingerprint,
         StatusNote = record.StatusNote,
-        HasEvidencePack = !string.IsNullOrEmpty(record.EvidencePackFingerprint)
+        HasEvidencePack = !string.IsNullOrEmpty(record.EvidencePackFingerprint),
+        ReconciliationScorecardFingerprint = record.ReconciliationScorecardFingerprint,
+        HasReconciliationScorecard = !string.IsNullOrEmpty(record.ReconciliationScorecardFingerprint)
     };
 }
 
@@ -320,6 +370,12 @@ public sealed record MigrationRunDto
 
     /// <summary>True when the evidence pack is available for download.</summary>
     public bool HasEvidencePack { get; init; }
+
+    /// <summary>Fingerprint of the signed reconciliation scorecard (issue #1381), when recorded.</summary>
+    public string? ReconciliationScorecardFingerprint { get; init; }
+
+    /// <summary>True when the reconciliation scorecard is available for download.</summary>
+    public bool HasReconciliationScorecard { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.ImportSteps.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.ImportSteps.cs
@@ -187,7 +187,61 @@ internal sealed partial class GeoservicesImportService
                     "Layer advertises attachments, but no attachment store is registered; attachments were not copied.");
             }
 
+            // Phase 5: Validating — reconcile the published layer against the apply-time source
+            // snapshot before declaring the import complete. A hard finding routes the run to
+            // NeedsReview (issue #1380) instead of Completed; warn findings are recorded but do
+            // not block. Reconciliation runs outside the import transaction (which is already
+            // committed) because it probes the published, queryable layer.
+            ReconciliationGateOutcome reconciliation = ReconciliationGateOutcome.Skipped;
+            if (publishedLayer is not null && _reconciliationService is not null)
+            {
+                ReportProgress(progress, jobId, startedAt, GeoservicesImportStatus.Validating, request,
+                    "Reconciling published layer against source snapshot",
+                    featuresProcessed, featuresProcessed, layerInfo.Name, publishedLayer.LayerId,
+                    attachmentsProcessed: attachmentCount, failedAttachments: failedAttachments);
+
+                reconciliation = await RunReconciliationGateAsync(
+                    request,
+                    jobId,
+                    layerInfo,
+                    publishedLayer,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
             stopwatch.Stop();
+
+            if (reconciliation.NeedsReview)
+            {
+                Log.ReconciliationGateBlocked(_logger, request.TableName, reconciliation.ReviewReason ?? "reconciliation failed");
+
+                ReportProgress(progress, jobId, startedAt, GeoservicesImportStatus.NeedsReview, request,
+                    "Import published but requires operator review (reconciliation gate)",
+                    featuresProcessed,
+                    featuresProcessed,
+                    layerInfo.Name,
+                    publishedLayer?.LayerId,
+                    attachmentsProcessed: attachmentCount,
+                    failedAttachments: failedAttachments,
+                    reconciliationArtifact: reconciliation.Artifact,
+                    catalogReconciliationReport: reconciliation.CatalogReport);
+
+                return GeoservicesImportResult.CreateNeedsReview(
+                    request.TableName,
+                    request.ServiceUrl,
+                    request.LayerId,
+                    featuresProcessed,
+                    failedFeatures,
+                    publishedLayer?.LayerId,
+                    publishedLayer?.ServiceName ?? request.ServiceName,
+                    layerInfo.Name,
+                    stopwatch.Elapsed,
+                    warnings,
+                    attachmentCount,
+                    failedAttachments,
+                    reconciliation.Artifact,
+                    reconciliation.CatalogReport,
+                    reconciliation.ReviewReason ?? "Post-publish reconciliation reported a blocking discrepancy.");
+            }
 
             Log.ImportCompleted(_logger, request.TableName, featuresProcessed, failedFeatures,
                 stopwatch.Elapsed.TotalSeconds);
@@ -200,7 +254,9 @@ internal sealed partial class GeoservicesImportService
                 layerInfo.Name,
                 publishedLayer?.LayerId,
                 attachmentsProcessed: attachmentCount,
-                failedAttachments: failedAttachments);
+                failedAttachments: failedAttachments,
+                reconciliationArtifact: reconciliation.Artifact,
+                catalogReconciliationReport: reconciliation.CatalogReport);
 
             return GeoservicesImportResult.CreateSuccess(
                 request.TableName,
@@ -214,7 +270,9 @@ internal sealed partial class GeoservicesImportService
                 duration: stopwatch.Elapsed,
                 warnings: warnings,
                 attachmentCount: attachmentCount,
-                failedAttachments: failedAttachments);
+                failedAttachments: failedAttachments,
+                reconciliationArtifact: reconciliation.Artifact,
+                catalogReconciliationReport: reconciliation.CatalogReport);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Reconciliation.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Reconciliation.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Shared.Models;
+
+namespace Honua.Postgres.Features.Migration;
+
+internal sealed partial class GeoservicesImportService
+{
+    /// <summary>
+    /// Outcome of the post-publish reconciliation gate (issues #1247, #1380). Carries the
+    /// data-reconciliation artifact, the optional catalog-parity report, and the aggregated verdict
+    /// the import pipeline uses to decide between <see cref="GeoservicesImportStatus.Completed"/> and
+    /// <see cref="GeoservicesImportStatus.NeedsReview"/>.
+    /// </summary>
+    private readonly record struct ReconciliationGateOutcome
+    {
+        /// <summary>A gate outcome for runs where reconciliation did not run (no publish or no service registered).</summary>
+        public static ReconciliationGateOutcome Skipped => default;
+
+        /// <summary>Per-layer data-reconciliation artifact, when reconciliation ran.</summary>
+        public MigrationReconciliationArtifact? Artifact { get; init; }
+
+        /// <summary>Catalog parity report, when one was produced. Always <c>null</c> on the per-layer geoservices path today.</summary>
+        public MigrationCatalogReconciliationReport? CatalogReport { get; init; }
+
+        /// <summary>True when a hard finding routes the run to operator review.</summary>
+        public bool NeedsReview { get; init; }
+
+        /// <summary>Operator-visible reason the run was routed to review. <c>null</c> when the gate passed.</summary>
+        public string? ReviewReason { get; init; }
+    }
+
+    /// <summary>
+    /// Runs the post-publish reconciliation gate for a single imported + published layer. Builds the
+    /// reconciliation request from the apply-time source snapshot (<paramref name="layerInfo"/>) so
+    /// the gate is deterministic against the apply moment, runs the
+    /// <see cref="ILayerReconciliationService"/>, and aggregates the verdict.
+    /// </summary>
+    private async Task<ReconciliationGateOutcome> RunReconciliationGateAsync(
+        GeoservicesImportRequest request,
+        string jobId,
+        GeoservicesLayerInfo layerInfo,
+        PublishedLayerSummary publishedLayer,
+        CancellationToken cancellationToken)
+    {
+        if (_reconciliationService is null)
+        {
+            return ReconciliationGateOutcome.Skipped;
+        }
+
+        try
+        {
+            var reconciliationRequest = BuildReconciliationRequest(request, jobId, layerInfo, publishedLayer);
+            var artifact = await _reconciliationService
+                .ReconcileAsync(reconciliationRequest, cancellationToken)
+                .ConfigureAwait(false);
+
+            // Parity gate (issue #1380): a hard (fail) finding blocks Completed and routes the run to
+            // NeedsReview. Warn and skipped classifications are recorded on the artifact but do not
+            // block — they surface to operators without halting the import.
+            var needsReview = string.Equals(
+                artifact.Classification,
+                MigrationReconciliationClassifications.Fail,
+                StringComparison.Ordinal);
+
+            return new ReconciliationGateOutcome
+            {
+                Artifact = artifact,
+                CatalogReport = null,
+                NeedsReview = needsReview,
+                ReviewReason = needsReview ? BuildReviewReason(artifact) : null
+            };
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // The data was already committed and published. If reconciliation itself errors out we do
+            // not fail the import — we record the gate as unavailable and let the run complete, since
+            // a reconciliation-infrastructure failure is not evidence of a faithless import. Operators
+            // can re-run reconciliation out of band.
+            Log.ReconciliationGateUnavailable(_logger, request.TableName, ex);
+            return ReconciliationGateOutcome.Skipped;
+        }
+    }
+
+    /// <summary>
+    /// Builds the per-run reconciliation request from the apply-time source snapshot. The source
+    /// facts (feature count, extent, field names, where-clause mirror) are read from
+    /// <paramref name="layerInfo"/> and the import request so the gate does not re-issue source HTTP
+    /// calls and stays deterministic against the apply moment.
+    /// </summary>
+    private static LayerReconciliationRequest BuildReconciliationRequest(
+        GeoservicesImportRequest request,
+        string jobId,
+        GeoservicesLayerInfo layerInfo,
+        PublishedLayerSummary publishedLayer)
+    {
+        var sourceFieldNames = layerInfo.Fields
+            .Where(static field => !field.IsObjectId && !IsGeometryField(field))
+            .Select(static field => field.Name.SanitizeFieldName())
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .ToArray();
+
+        BoundingBox? sourceExtent = layerInfo.Extent is { } extent
+            ? BoundingBox.Create(
+                extent.Xmin,
+                extent.Ymin,
+                extent.Xmax,
+                extent.Ymax,
+                extent.SpatialReferenceWkid ?? layerInfo.SpatialReferenceWkid ?? request.TargetSrid)
+            : null;
+
+        var layerInput = new LayerReconciliationLayerInput
+        {
+            SourceLayerId = $"{request.ServiceUrl}#{request.LayerId}",
+            SourceLayerName = string.IsNullOrWhiteSpace(layerInfo.Name) ? request.TableName : layerInfo.Name,
+            TargetHonuaLayerId = publishedLayer.LayerId,
+            SourceFeatureCount = layerInfo.FeatureCount,
+            SourceExtent = sourceExtent,
+            SourceFieldNames = sourceFieldNames,
+            // The where-clause supplied to the import is mirrored onto the reconciliation count
+            // probe so a partial import (subset of source features) is reconciled apples-to-apples.
+            FilterMirror = string.IsNullOrWhiteSpace(request.WhereClause) ? null : request.WhereClause
+        };
+
+        return new LayerReconciliationRequest
+        {
+            RunId = jobId,
+            SourceKind = "arcgis-geoservices-rest",
+            Layers = [layerInput]
+        };
+    }
+
+    private static string BuildReviewReason(MigrationReconciliationArtifact artifact)
+    {
+        if (artifact.Reasons.Length > 0)
+        {
+            return $"Post-publish reconciliation reported {artifact.Summary.FailCount} blocking finding(s): {string.Join(" ", artifact.Reasons)}";
+        }
+
+        return $"Post-publish reconciliation reported {artifact.Summary.FailCount} blocking finding(s).";
+    }
+}

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.cs
@@ -42,6 +42,7 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
     private readonly ILayerStyleCatalog? _styleCatalog;
     private readonly IAttachmentStore? _attachmentStore;
     private readonly IMigrationCatalogWriter? _catalogWriter;
+    private readonly ILayerReconciliationService? _reconciliationService;
     private readonly ILogger<GeoservicesImportService> _logger;
     private readonly PostgresSchemaConfiguration _schemaConfiguration;
 
@@ -56,6 +57,7 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
         ILayerStyleCatalog? styleCatalog = null,
         IAttachmentStore? attachmentStore = null,
         IMigrationCatalogWriter? catalogWriter = null,
+        ILayerReconciliationService? reconciliationService = null,
         PostgresSchemaConfiguration? schemaConfiguration = null)
     {
         _restClient = restClient ?? throw new ArgumentNullException(nameof(restClient));
@@ -67,6 +69,7 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
         _styleCatalog = styleCatalog;
         _attachmentStore = attachmentStore;
         _catalogWriter = catalogWriter;
+        _reconciliationService = reconciliationService;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _schemaConfiguration = schemaConfiguration ?? new PostgresSchemaConfiguration(
             PostgresSchemaConfiguration.DefaultMetadataSchema,
@@ -359,7 +362,9 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
         string? layerName = null,
         int? publishedLayerId = null,
         int attachmentsProcessed = 0,
-        int failedAttachments = 0)
+        int failedAttachments = 0,
+        MigrationReconciliationArtifact? reconciliationArtifact = null,
+        MigrationCatalogReconciliationReport? catalogReconciliationReport = null)
     {
         progress?.Report(new GeoservicesImportProgress
         {
@@ -376,7 +381,9 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
             StartedAt = startedAt,
             CurrentPhase = phase,
             AttachmentsProcessed = attachmentsProcessed,
-            FailedAttachments = failedAttachments
+            FailedAttachments = failedAttachments,
+            ReconciliationArtifact = reconciliationArtifact,
+            CatalogReconciliationReport = catalogReconciliationReport
         });
     }
 
@@ -511,5 +518,13 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
 
         [LoggerMessage(7839, LogLevel.Debug, "Relationship apply skipped: {Reason}")]
         public static partial void RelationshipApplySkipped(ILogger logger, string reason);
+
+        [LoggerMessage(7840, LogLevel.Warning,
+            "Reconciliation gate routed import of table {TableName} to NeedsReview: {Reason}")]
+        public static partial void ReconciliationGateBlocked(ILogger logger, string tableName, string reason);
+
+        [LoggerMessage(7841, LogLevel.Warning,
+            "Reconciliation gate could not run for table {TableName}; import completed without a reconciliation verdict")]
+        public static partial void ReconciliationGateUnavailable(ILogger logger, string tableName, Exception exception);
     }
 }

--- a/src/Honua.Postgres/Features/Migration/PostgresMigrationRunCatalog.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresMigrationRunCatalog.cs
@@ -255,6 +255,7 @@ internal sealed partial class PostgresMigrationRunCatalog : IMigrationRunCatalog
                    completed_at,
                    evidence_pack_ref,
                    evidence_pack_fingerprint,
+                   reconciliation_scorecard_fingerprint,
                    status_note
             FROM honua.migration_runs
             WHERE (@sourceKind::text IS NULL OR LOWER(source_kind) = @sourceKind::text)
@@ -315,6 +316,67 @@ internal sealed partial class PostgresMigrationRunCatalog : IMigrationRunCatalog
         };
     }
 
+    public async Task<MigrationRunRecord?> RecordScorecardAsync(
+        string runId,
+        string scorecardFingerprint,
+        string scorecardBody,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scorecardFingerprint);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scorecardBody);
+
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        const string updateSql = """
+            UPDATE honua.migration_runs
+            SET reconciliation_scorecard_fingerprint = @fingerprint,
+                reconciliation_scorecard_body = CAST(@body AS jsonb)
+            WHERE run_id = @runId;
+            """;
+
+        await using (var update = new NpgsqlCommand(updateSql, connection))
+        {
+            update.Parameters.AddWithValue("@runId", runId);
+            update.Parameters.AddWithValue("@fingerprint", scorecardFingerprint);
+            var bodyParam = update.Parameters.Add("@body", NpgsqlDbType.Text);
+            bodyParam.Value = scorecardBody;
+
+            await update.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return await GetInternalAsync(connection, runId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<string?> GetScorecardAsync(
+        string runId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        const string sql = """
+            SELECT reconciliation_scorecard_body::text
+            FROM honua.migration_runs
+            WHERE run_id = @runId
+            LIMIT 1;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@runId", runId);
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return result switch
+        {
+            null => null,
+            DBNull => null,
+            string body => body,
+            _ => result.ToString()
+        };
+    }
+
     private static async Task<MigrationRunRecord?> GetInternalAsync(
         NpgsqlConnection connection,
         string runId,
@@ -330,6 +392,7 @@ internal sealed partial class PostgresMigrationRunCatalog : IMigrationRunCatalog
                    completed_at,
                    evidence_pack_ref,
                    evidence_pack_fingerprint,
+                   reconciliation_scorecard_fingerprint,
                    status_note
             FROM honua.migration_runs
             WHERE run_id = @runId
@@ -372,6 +435,9 @@ internal sealed partial class PostgresMigrationRunCatalog : IMigrationRunCatalog
             EvidencePackFingerprint = reader.IsDBNull(reader.GetOrdinal("evidence_pack_fingerprint"))
                 ? null
                 : reader.GetString(reader.GetOrdinal("evidence_pack_fingerprint")),
+            ReconciliationScorecardFingerprint = reader.IsDBNull(reader.GetOrdinal("reconciliation_scorecard_fingerprint"))
+                ? null
+                : reader.GetString(reader.GetOrdinal("reconciliation_scorecard_fingerprint")),
             StatusNote = reader.IsDBNull(reader.GetOrdinal("status_note"))
                 ? null
                 : reader.GetString(reader.GetOrdinal("status_note"))

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -407,6 +407,12 @@ internal static class ServiceCollectionExtensions
         // copy runs during ArcGIS layer imports without a separate wiring step.
         services.AddScoped<IGeoservicesImportService, GeoservicesImportService>();
 
+        // Register the post-publish reconciliation service (issues #1247/#1380). It probes the
+        // published layer through IFeatureReader, so it is scoped to align with the scoped feature
+        // store. TimeProvider is guarded here in case no host-level registration ran first.
+        services.TryAddSingleton(TimeProvider.System);
+        services.TryAddScoped<ILayerReconciliationService, LayerReconciliationService>();
+
         // Register Core-level services via their own extensions
         services.AddImportSuggestionsCore();
         services.AddAutoDocsCore();

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -426,6 +426,7 @@ public static class EndpointRegistry
         new("GET", "/api/v1/admin/migration/runs"),
         new("GET", "/api/v1/admin/migration/runs/{runId}"),
         new("GET", "/api/v1/admin/migration/runs/{runId}/evidence-pack"),
+        new("GET", "/api/v1/admin/migration/runs/{runId}/scorecard"),
         new("POST", "/api/v1/admin/migration/runs/{runId}/cancel"),
 
         // v1 admin import endpoints (OGC WMTS tile cache export #1016 slice 4)

--- a/src/Honua.Server/Migrations/044_AddMigrationRunReconciliationScorecard.sql
+++ b/src/Honua.Server/Migrations/044_AddMigrationRunReconciliationScorecard.sql
@@ -1,0 +1,22 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration 044: Add reconciliation-scorecard columns to migration_runs
+-- Issue #1381. The signed reconciliation scorecard aggregates a run's
+-- per-layer data-reconciliation outcome (kept distinct from capability
+-- parity) and is fingerprinted with the same SHA-256-over-canonical-JSON
+-- mechanism as the slice-4 evidence pack. These columns let the admin
+-- orchestration endpoints stream the scorecard back and prove it was not
+-- altered, mirroring the evidence_pack_ref/fingerprint/body columns added
+-- in migration 031.
+-- Dependencies: Requires honua.migration_runs from 031_CreateMigrationRunCatalog.sql.
+
+ALTER TABLE honua.migration_runs
+    ADD COLUMN IF NOT EXISTS reconciliation_scorecard_fingerprint VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS reconciliation_scorecard_body        JSONB;
+
+COMMENT ON COLUMN honua.migration_runs.reconciliation_scorecard_fingerprint IS
+    'SHA-256 fingerprint (sha256:<hex>) of the signed reconciliation scorecard for this run (issue #1381). Returned as an ETag so callers can prove they received the same scorecard later.';
+
+COMMENT ON COLUMN honua.migration_runs.reconciliation_scorecard_body IS
+    'Signed reconciliation scorecard JSON body (issue #1381). jsonb so reviewers can introspect the per-layer data-reconciliation and capability-parity roll-up directly with SQL when triaging a NeedsReview run.';

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/LayerReconciliationServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/LayerReconciliationServiceTests.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
+using Honua.Core.Features.Shared.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Core.Tests.Features.Import;
+
+/// <summary>
+/// Exercises the post-publish data-reconciliation service (issue #1247): count/geometry/content/
+/// extent probes and the pass/warn/fail/skipped classification bands that the parity gate (#1380)
+/// consumes.
+/// </summary>
+public sealed class LayerReconciliationServiceTests
+{
+    [Fact]
+    public async Task Reconcile_WhenTargetMatchesSourceSnapshot_ClassifiesPass()
+    {
+        var reader = new StubFeatureReader
+        {
+            Count = 100,
+            Extent = FeatureExtent.Create(0, 0, 10, 10, 4326),
+            Sample = BuildSample(("OBJECTID", "NAME"), validGeometry: true, rows: 5)
+        };
+        var service = NewService(reader);
+
+        var artifact = await service.ReconcileAsync(BuildRequest(
+            sourceCount: 100,
+            sourceExtent: BoundingBox.Create(0, 0, 10, 10, 4326),
+            sourceFields: ["OBJECTID", "NAME"]));
+
+        artifact.Classification.Should().Be(MigrationReconciliationClassifications.Pass);
+        artifact.Summary.PassCount.Should().Be(1);
+        artifact.Layers.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Reconcile_WhenTargetCountFarBelowSource_ClassifiesFail()
+    {
+        // 100 source vs 10 target = 90% delta, well past the 20% fail band → fail (NeedsReview).
+        var reader = new StubFeatureReader
+        {
+            Count = 10,
+            Extent = FeatureExtent.Create(0, 0, 10, 10, 4326),
+            Sample = BuildSample(("OBJECTID", "NAME"), validGeometry: true, rows: 5)
+        };
+        var service = NewService(reader);
+
+        var artifact = await service.ReconcileAsync(BuildRequest(
+            sourceCount: 100,
+            sourceExtent: BoundingBox.Create(0, 0, 10, 10, 4326),
+            sourceFields: ["OBJECTID", "NAME"]));
+
+        artifact.Classification.Should().Be(MigrationReconciliationClassifications.Fail);
+        artifact.Summary.FailCount.Should().Be(1);
+        artifact.Reasons.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Reconcile_WhenSourceFieldMissingOnTarget_ClassifiesFail()
+    {
+        var reader = new StubFeatureReader
+        {
+            Count = 100,
+            Extent = FeatureExtent.Create(0, 0, 10, 10, 4326),
+            Sample = BuildSampleInternal(["OBJECTID"], validGeometry: true, rows: 5) // NAME dropped on target
+        };
+        var service = NewService(reader);
+
+        var artifact = await service.ReconcileAsync(BuildRequest(
+            sourceCount: 100,
+            sourceExtent: BoundingBox.Create(0, 0, 10, 10, 4326),
+            sourceFields: ["OBJECTID", "NAME"]));
+
+        artifact.Classification.Should().Be(MigrationReconciliationClassifications.Fail);
+        artifact.Layers[0].Content.Classification.Should().Be(MigrationReconciliationClassifications.Fail);
+        artifact.Layers[0].Content.MissingOnTarget.Should().Contain("NAME");
+    }
+
+    [Fact]
+    public async Task Reconcile_WhenNoTargetLayerPublished_ClassifiesSkipped()
+    {
+        var service = NewService(new StubFeatureReader());
+
+        var artifact = await service.ReconcileAsync(new LayerReconciliationRequest
+        {
+            RunId = "run",
+            SourceKind = "arcgis-geoservices-rest",
+            Layers =
+            [
+                new LayerReconciliationLayerInput
+                {
+                    SourceLayerId = "svc#0",
+                    TargetHonuaLayerId = null,
+                    SourceFeatureCount = 100
+                }
+            ]
+        });
+
+        artifact.Summary.SkippedCount.Should().Be(1);
+        artifact.Layers[0].Classification.Should().Be(MigrationReconciliationClassifications.Skipped);
+    }
+
+    private static LayerReconciliationService NewService(IFeatureReader reader)
+        => new(reader, TimeProvider.System, NullLogger<LayerReconciliationService>.Instance);
+
+    private static LayerReconciliationRequest BuildRequest(
+        long sourceCount,
+        BoundingBox sourceExtent,
+        string[] sourceFields)
+        => new()
+        {
+            RunId = "run",
+            SourceKind = "arcgis-geoservices-rest",
+            Layers =
+            [
+                new LayerReconciliationLayerInput
+                {
+                    SourceLayerId = "svc#0",
+                    SourceLayerName = "Layer",
+                    TargetHonuaLayerId = 1,
+                    SourceFeatureCount = sourceCount,
+                    SourceExtent = sourceExtent,
+                    SourceFieldNames = sourceFields
+                }
+            ]
+        };
+
+    private static QueryResult<Feature> BuildSample(
+        (string, string) fieldsTwo,
+        bool validGeometry,
+        int rows)
+        => BuildSampleInternal([fieldsTwo.Item1, fieldsTwo.Item2], validGeometry, rows);
+
+    private static QueryResult<Feature> BuildSampleInternal(string[] fields, bool validGeometry, int rows)
+    {
+        var attrs = fields.ToImmutableDictionary(f => f, _ => (object?)"x");
+        // WKB byte-order byte of 1 (little-endian) marks a well-formed geometry per the probe.
+        byte[]? geom = validGeometry ? [1, 1, 0, 0, 0] : null;
+        var items = Enumerable.Range(0, rows)
+            .Select(i => Feature.Create(i, geom, attrs))
+            .ToImmutableArray();
+        return QueryResult<Feature>.Create(rows, items);
+    }
+
+    private sealed class StubFeatureReader : IFeatureReader
+    {
+        public long Count { get; init; }
+        public FeatureExtent? Extent { get; init; }
+        public QueryResult<Feature> Sample { get; init; } = QueryResult<Feature>.Empty();
+
+        public Task<long> CountAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
+            => Task.FromResult(Count);
+
+        public Task<FeatureExtent?> GetExtentAsync(int layerId, FeatureQuery? query = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(Extent);
+
+        public Task<QueryResult<Feature>> QueryAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
+            => Task.FromResult(Sample);
+
+        public Task<Feature?> GetAsync(int layerId, long featureId, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<byte[]?> QueryFlatGeobufAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<ImmutableArray<long>> QueryObjectIdsAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryStatisticsAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<TemporalExtentResult?> GetTemporalExtentAsync(int layerId, string fieldName, TemporalPropertyType propertyType, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<EstimateResult> GetEstimatesAsync(int layerId, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<QueryResult<Feature>> QueryTopFeaturesAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryDateBinsAsync(int layerId, FeatureQuery query, DateBinDefinition dateBin, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryBinsAsync(int layerId, FeatureQuery query, BinDefinition binDefinition, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryH3Async(int layerId, FeatureQuery query, H3AggregationQuery h3Query, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationCatalogReconcilerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationCatalogReconcilerTests.cs
@@ -437,4 +437,124 @@ public sealed class MigrationCatalogReconcilerTests
             },
             Editing = new MetadataV2ResourceEditing { GlobalIdField = "GLOBALID" }
         };
+
+    [Fact]
+    public void Reconcile_WhenSourceAdvertisesAttachmentsButPublishedDoesNot_EmitsAttachmentMissingFinding()
+    {
+        var inventory = BuildInventoryResource() with { HasAttachments = true };
+        var published = BuildPublishedResource() with
+        {
+            Editing = new MetadataV2ResourceEditing { GlobalIdField = "GLOBALID", SupportsAttachments = false }
+        };
+
+        var outcome = MigrationCatalogReconciler.ReconcileResource(inventory, published);
+
+        outcome.Classification.Should().Be(MigrationCatalogReconciliationClassifications.Fail);
+        outcome.Findings.Should().ContainSingle(f => f.Code == MigrationCatalogReconciliationCodes.AttachmentMissing)
+            .Which.Severity.Should().Be(MigrationCatalogReconciliationSeverities.Fail);
+    }
+
+    [Fact]
+    public void Reconcile_WhenSourceAndPublishedBothSupportAttachments_EmitsNoAttachmentFinding()
+    {
+        var inventory = BuildInventoryResource() with { HasAttachments = true };
+        var published = BuildPublishedResource() with
+        {
+            Editing = new MetadataV2ResourceEditing { GlobalIdField = "GLOBALID", SupportsAttachments = true }
+        };
+
+        var outcome = MigrationCatalogReconciler.ReconcileResource(inventory, published);
+
+        outcome.Findings.Should().NotContain(f => f.Code == MigrationCatalogReconciliationCodes.AttachmentMissing);
+    }
+
+    [Fact]
+    public void Reconcile_WhenSourceDidNotAdvertiseAttachments_DoesNotFalseFailOnMissingAttachmentSupport()
+    {
+        // HasAttachments == null means "source did not report" — must not be treated as a fail.
+        var inventory = BuildInventoryResource() with { HasAttachments = null };
+        var published = BuildPublishedResource() with { Editing = null };
+
+        var outcome = MigrationCatalogReconciler.ReconcileResource(inventory, published);
+
+        outcome.Findings.Should().NotContain(f => f.Code == MigrationCatalogReconciliationCodes.AttachmentMissing);
+    }
+
+    [Fact]
+    public void Reconcile_WhenSourceSubtypesMissingFromPublished_EmitsSubtypeMissingFinding()
+    {
+        var inventory = BuildInventoryResource();
+        var published = BuildPublishedResource() with { Subtypes = null };
+        var expectedSubtypes = BuildSubtypes("STATUS", ("1", "Active"), ("2", "Retired"));
+
+        var outcome = MigrationCatalogReconciler.ReconcileResource(
+            inventory, published, expectedSubtypes: expectedSubtypes);
+
+        outcome.Classification.Should().Be(MigrationCatalogReconciliationClassifications.Fail);
+        outcome.Findings.Should().ContainSingle(f => f.Code == MigrationCatalogReconciliationCodes.SubtypeMissing)
+            .Which.Expected.Should().Be("STATUS");
+    }
+
+    [Fact]
+    public void Reconcile_WhenPublishedSubtypeFieldDiffers_EmitsSubtypeFieldMismatchFinding()
+    {
+        var inventory = BuildInventoryResource();
+        var published = BuildPublishedResource() with
+        {
+            Subtypes = BuildSubtypes("KIND", ("1", "Active"), ("2", "Retired"))
+        };
+        var expectedSubtypes = BuildSubtypes("STATUS", ("1", "Active"), ("2", "Retired"));
+
+        var outcome = MigrationCatalogReconciler.ReconcileResource(
+            inventory, published, expectedSubtypes: expectedSubtypes);
+
+        outcome.Findings.Should().ContainSingle(f => f.Code == MigrationCatalogReconciliationCodes.SubtypeFieldMismatch)
+            .Which.Actual.Should().Be("KIND");
+    }
+
+    [Fact]
+    public void Reconcile_WhenPublishedMissingSubtypeCode_EmitsSubtypeCodeMissingFinding()
+    {
+        var inventory = BuildInventoryResource();
+        var published = BuildPublishedResource() with
+        {
+            Subtypes = BuildSubtypes("STATUS", ("1", "Active"))
+        };
+        var expectedSubtypes = BuildSubtypes("STATUS", ("1", "Active"), ("2", "Retired"));
+
+        var outcome = MigrationCatalogReconciler.ReconcileResource(
+            inventory, published, expectedSubtypes: expectedSubtypes);
+
+        outcome.Findings.Should().ContainSingle(f => f.Code == MigrationCatalogReconciliationCodes.SubtypeCodeMissing)
+            .Which.Summary.Should().Contain("2");
+    }
+
+    [Fact]
+    public void Reconcile_WhenSubtypesMatch_EmitsNoSubtypeFindings()
+    {
+        var inventory = BuildInventoryResource();
+        var subtypes = BuildSubtypes("STATUS", ("1", "Active"), ("2", "Retired"));
+        var published = BuildPublishedResource() with { Subtypes = subtypes };
+
+        var outcome = MigrationCatalogReconciler.ReconcileResource(
+            inventory, published, expectedSubtypes: subtypes);
+
+        outcome.Findings.Should().NotContain(f =>
+            f.Code == MigrationCatalogReconciliationCodes.SubtypeMissing ||
+            f.Code == MigrationCatalogReconciliationCodes.SubtypeFieldMismatch ||
+            f.Code == MigrationCatalogReconciliationCodes.SubtypeCodeMissing);
+    }
+
+    private static MetadataV2Subtypes BuildSubtypes(string subtypeField, params (string Code, string Name)[] subtypes)
+        => new()
+        {
+            SubtypeField = subtypeField,
+            Subtypes = subtypes
+                .Select(s => new MetadataV2Subtype
+                {
+                    Code = JsonDocument.Parse($"\"{s.Code}\"").RootElement,
+                    Name = s.Name
+                })
+                .ToArray()
+        };
 }

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationReconciliationScorecardBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationReconciliationScorecardBuilderTests.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
+
+namespace Honua.Core.Tests.Features.Import;
+
+/// <summary>
+/// Exercises the signed reconciliation scorecard builder (issue #1381): aggregation of per-layer
+/// data-reconciliation outcomes, strict separation of the capability-parity dimension, and the
+/// deterministic evidence-pack-style fingerprint.
+/// </summary>
+public sealed class MigrationReconciliationScorecardBuilderTests
+{
+    private static readonly DateTimeOffset GeneratedAt = new(2026, 6, 4, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Build_AggregatesPerLayerOutcomes_AndDerivesVerdictFromDataReconciliation()
+    {
+        var artifact = BuildArtifact(
+            MigrationReconciliationClassifications.Warn,
+            passCount: 2,
+            warnCount: 1,
+            failCount: 0,
+            skippedCount: 1,
+            layerClassifications:
+            [
+                MigrationReconciliationClassifications.Pass,
+                MigrationReconciliationClassifications.Pass,
+                MigrationReconciliationClassifications.Warn,
+                MigrationReconciliationClassifications.Skipped
+            ],
+            reasons: ["Feature-count delta 3 (1%) is outside the pass band; investigate."]);
+
+        var scorecard = MigrationReconciliationScorecardBuilder.Build(
+            "run-1", "arcgis-geoservices-rest", GeneratedAt, artifact, catalogReport: null,
+            capabilityAutomationStatuses: ["automated", "automated", "unsupported"]);
+
+        scorecard.Verdict.Should().Be(MigrationReconciliationClassifications.Warn);
+        scorecard.DataReconciliation.LayerCount.Should().Be(4);
+        scorecard.DataReconciliation.PassCount.Should().Be(2);
+        scorecard.DataReconciliation.WarnCount.Should().Be(1);
+        scorecard.DataReconciliation.SkippedCount.Should().Be(1);
+        scorecard.DataReconciliation.Layers.Should().HaveCount(4);
+        scorecard.DataReconciliation.Reasons.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Build_KeepsCapabilityParityDistinctFromDataReconciliation()
+    {
+        // Data reconciles cleanly, but only half the constructs can be expressed on Honua. The two
+        // dimensions must stay separate: the verdict (data) is pass while capability parity is 0.5.
+        var artifact = BuildArtifact(
+            MigrationReconciliationClassifications.Pass,
+            passCount: 1, warnCount: 0, failCount: 0, skippedCount: 0,
+            layerClassifications: [MigrationReconciliationClassifications.Pass],
+            reasons: []);
+
+        var scorecard = MigrationReconciliationScorecardBuilder.Build(
+            "run-2", "arcgis-geoservices-rest", GeneratedAt, artifact, catalogReport: null,
+            capabilityAutomationStatuses: ["automated", "unsupported", "manual-review", "assisted"]);
+
+        scorecard.Verdict.Should().Be(MigrationReconciliationClassifications.Pass);
+        scorecard.DataReconciliation.Classification.Should().Be(MigrationReconciliationClassifications.Pass);
+
+        scorecard.CapabilityParity.ConstructCount.Should().Be(4);
+        scorecard.CapabilityParity.AutomatedCount.Should().Be(1);
+        scorecard.CapabilityParity.AssistedCount.Should().Be(1);
+        scorecard.CapabilityParity.ManualReviewCount.Should().Be(1);
+        scorecard.CapabilityParity.UnsupportedCount.Should().Be(1);
+        // (automated + assisted) / total = 2/4. Capability parity does NOT change the verdict.
+        scorecard.CapabilityParity.ParityRatio.Should().Be(0.5);
+    }
+
+    [Fact]
+    public void Build_WhenCatalogReportHasFailFinding_EscalatesDataClassificationToFail()
+    {
+        var artifact = BuildArtifact(
+            MigrationReconciliationClassifications.Pass,
+            passCount: 1, warnCount: 0, failCount: 0, skippedCount: 0,
+            layerClassifications: [MigrationReconciliationClassifications.Pass],
+            reasons: []);
+
+        var catalogReport = new MigrationCatalogReconciliationReport
+        {
+            RunId = "run-3",
+            SourceKind = "arcgis-geoservices-rest",
+            Summary = new MigrationCatalogReconciliationSummary
+            {
+                ResourceCount = 1,
+                FailResourceCount = 1,
+                FindingCount = 1
+            },
+            Resources =
+            [
+                new MigrationCatalogReconciliationResource
+                {
+                    SourceResourceId = "layer:parcels",
+                    Classification = MigrationCatalogReconciliationClassifications.Fail,
+                    Findings =
+                    [
+                        new MigrationCatalogReconciliationFinding
+                        {
+                            Code = MigrationCatalogReconciliationCodes.SubtypeMissing,
+                            Severity = MigrationCatalogReconciliationSeverities.Fail,
+                            Summary = "Published subtype set is missing."
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var scorecard = MigrationReconciliationScorecardBuilder.Build(
+            "run-3", "arcgis-geoservices-rest", GeneratedAt, artifact, catalogReport,
+            capabilityAutomationStatuses: []);
+
+        scorecard.Verdict.Should().Be(MigrationReconciliationClassifications.Fail);
+        scorecard.DataReconciliation.Classification.Should().Be(MigrationReconciliationClassifications.Fail);
+        scorecard.DataReconciliation.CatalogFindingCount.Should().Be(1);
+        scorecard.DataReconciliation.Reasons.Should().Contain("Published subtype set is missing.");
+    }
+
+    [Fact]
+    public void Build_SetsDeterministicFingerprint_ThatRecomputesOverUnsignedBody()
+    {
+        var artifact = BuildArtifact(
+            MigrationReconciliationClassifications.Pass,
+            passCount: 1, warnCount: 0, failCount: 0, skippedCount: 0,
+            layerClassifications: [MigrationReconciliationClassifications.Pass],
+            reasons: []);
+
+        var first = MigrationReconciliationScorecardBuilder.Build(
+            "run-4", "arcgis-geoservices-rest", GeneratedAt, artifact, null, ["automated"]);
+        var second = MigrationReconciliationScorecardBuilder.Build(
+            "run-4", "arcgis-geoservices-rest", GeneratedAt, artifact, null, ["automated"]);
+
+        first.Fingerprint.Should().StartWith("sha256:");
+        first.Fingerprint.Should().Be(second.Fingerprint);
+
+        // Recomputing the fingerprint over the signed scorecard (which clears Fingerprint first)
+        // reproduces the embedded value — proving the signature is over the unsigned body.
+        MigrationReconciliationScorecardBuilder.ComputeFingerprint(first).Should().Be(first.Fingerprint);
+    }
+
+    [Fact]
+    public void Build_WhenNoConstructsAssessed_ReportsFullCapabilityParity()
+    {
+        var artifact = BuildArtifact(
+            MigrationReconciliationClassifications.Pass,
+            passCount: 1, warnCount: 0, failCount: 0, skippedCount: 0,
+            layerClassifications: [MigrationReconciliationClassifications.Pass],
+            reasons: []);
+
+        var scorecard = MigrationReconciliationScorecardBuilder.Build(
+            "run-5", "arcgis-geoservices-rest", GeneratedAt, artifact, null, []);
+
+        scorecard.CapabilityParity.ConstructCount.Should().Be(0);
+        scorecard.CapabilityParity.ParityRatio.Should().Be(1d);
+    }
+
+    private static MigrationReconciliationArtifact BuildArtifact(
+        string classification,
+        int passCount,
+        int warnCount,
+        int failCount,
+        int skippedCount,
+        string[] layerClassifications,
+        string[] reasons)
+    {
+        var layers = layerClassifications
+            .Select((c, i) => new MigrationReconciliationLayerReport
+            {
+                SourceLayerId = $"layer-{i}",
+                SourceLayerName = $"Layer {i}",
+                TargetHonuaLayerId = i + 1,
+                Classification = c,
+                Count = new MigrationReconciliationCountProbe { Classification = c },
+                Geometry = new MigrationReconciliationGeometryProbe { Classification = c },
+                Content = new MigrationReconciliationContentProbe { Classification = c },
+                Extent = new MigrationReconciliationExtentProbe { Classification = c }
+            })
+            .ToArray();
+
+        return new MigrationReconciliationArtifact
+        {
+            RunId = "run",
+            SourceKind = "arcgis-geoservices-rest",
+            Classification = classification,
+            StartedAt = GeneratedAt,
+            CompletedAt = GeneratedAt,
+            Summary = new MigrationReconciliationSummary
+            {
+                LayerCount = layerClassifications.Length,
+                PassCount = passCount,
+                WarnCount = warnCount,
+                FailCount = failCount,
+                SkippedCount = skippedCount
+            },
+            Layers = layers,
+            Reasons = reasons,
+            Options = new LayerReconciliationOptions()
+        };
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportReconciliationGateTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportReconciliationGateTests.cs
@@ -1,0 +1,286 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.Admin.Abstractions;
+using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
+using Honua.Core.Features.Shared.Models;
+using Honua.Postgres.Features.Migration;
+using Honua.TestKit;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+/// <summary>
+/// Drives the post-publish reconciliation gate wired into the Geoservices import Validating phase
+/// (issues #1247/#1380). A reconciliation verdict of <c>fail</c> must route the run to
+/// <see cref="GeoservicesImportStatus.NeedsReview"/> and block completion; a faithful import must
+/// reach <see cref="GeoservicesImportStatus.Completed"/>.
+/// </summary>
+[Collection("Database")]
+public sealed class GeoservicesImportReconciliationGateTests(PostgresFixture fixture)
+{
+    [Fact]
+    public async Task ImportLayerAsync_WhenReconciliationReportsFail_RoutesToNeedsReviewAndBlocksCompleted()
+    {
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(GeoservicesImportReconciliationGateTests) + "_fail");
+        var reconciliation = new StubReconciliationService(MigrationReconciliationClassifications.Fail, failCount: 1);
+        var progress = new RecordingProgress();
+        var service = CreateService(new SimpleFeatureServerHandler(), publishedLayerId: 100, reconciliation);
+
+        try
+        {
+            var result = await service.ImportLayerAsync(BuildRequest("recon_gate_fail", schemaName), progress);
+
+            result.Success.Should().BeFalse();
+            result.NeedsReview.Should().BeTrue();
+            result.ReconciliationArtifact.Should().NotBeNull();
+            result.ReconciliationArtifact!.Classification.Should().Be(MigrationReconciliationClassifications.Fail);
+
+            progress.Statuses.Should().Contain(GeoservicesImportStatus.Validating);
+            progress.Statuses.Should().Contain(GeoservicesImportStatus.NeedsReview);
+            progress.Statuses.Should().NotContain(GeoservicesImportStatus.Completed);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    [Fact]
+    public async Task ImportLayerAsync_WhenReconciliationPasses_ReachesCompleted()
+    {
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(GeoservicesImportReconciliationGateTests) + "_pass");
+        var reconciliation = new StubReconciliationService(MigrationReconciliationClassifications.Pass, failCount: 0);
+        var progress = new RecordingProgress();
+        var service = CreateService(new SimpleFeatureServerHandler(), publishedLayerId: 101, reconciliation);
+
+        try
+        {
+            var result = await service.ImportLayerAsync(BuildRequest("recon_gate_pass", schemaName), progress);
+
+            result.Success.Should().BeTrue();
+            result.NeedsReview.Should().BeFalse();
+            result.ReconciliationArtifact.Should().NotBeNull();
+            result.ReconciliationArtifact!.Classification.Should().Be(MigrationReconciliationClassifications.Pass);
+
+            progress.Statuses.Should().Contain(GeoservicesImportStatus.Validating);
+            progress.Statuses.Should().Contain(GeoservicesImportStatus.Completed);
+            progress.Statuses.Should().NotContain(GeoservicesImportStatus.NeedsReview);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    private static GeoservicesImportRequest BuildRequest(string tableName, string schemaName) => new()
+    {
+        ServiceUrl = "https://example.com/arcgis/rest/services/Inspections/FeatureServer",
+        LayerId = 0,
+        TableName = tableName,
+        TargetSchema = schemaName,
+        TargetSrid = 4326,
+        BatchSize = 10,
+        RequestTimeoutSeconds = 5,
+        MaxRetries = 0,
+        AutoPublish = true,
+        ServiceName = "default",
+        ImportAttachments = false
+    };
+
+    private GeoservicesImportService CreateService(
+        HttpMessageHandler handler,
+        int publishedLayerId,
+        ILayerReconciliationService reconciliationService)
+    {
+        var restClient = new ArcGisRestClient(
+            new HttpClient(handler),
+            NullLogger<ArcGisRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+
+        var crsRegistry = new Mock<ICrsRegistry>(MockBehavior.Loose);
+
+        return new GeoservicesImportService(
+            restClient,
+            new FixtureConnectionProvider(fixture),
+            crsRegistry.Object,
+            new EsriConstructCapabilityRegistry(EsriConstructCapabilityRegistry.BuiltInDescriptors),
+            NullLogger<GeoservicesImportService>.Instance,
+            layerPublishingService: new StubLayerPublishingService(publishedLayerId),
+            reconciliationService: reconciliationService);
+    }
+
+    private sealed class StubReconciliationService(string classification, int failCount) : ILayerReconciliationService
+    {
+        public Task<MigrationReconciliationArtifact> ReconcileAsync(
+            LayerReconciliationRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var artifact = new MigrationReconciliationArtifact
+            {
+                RunId = request.RunId,
+                SourceKind = request.SourceKind,
+                Classification = classification,
+                StartedAt = DateTimeOffset.UtcNow,
+                CompletedAt = DateTimeOffset.UtcNow,
+                Summary = new MigrationReconciliationSummary
+                {
+                    LayerCount = 1,
+                    PassCount = failCount == 0 ? 1 : 0,
+                    FailCount = failCount
+                },
+                Layers = [],
+                Reasons = failCount > 0 ? ["Injected data loss for gate test."] : [],
+                Options = new LayerReconciliationOptions()
+            };
+            return Task.FromResult(artifact);
+        }
+    }
+
+    private sealed class RecordingProgress : IProgress<GeoservicesImportProgress>
+    {
+        public List<GeoservicesImportStatus> Statuses { get; } = [];
+        public void Report(GeoservicesImportProgress value) => Statuses.Add(value.Status);
+    }
+
+    private sealed class StubLayerPublishingService(int publishedLayerId) : ILayerPublishingService
+    {
+        public Task<IReadOnlyList<PublishedLayerSummary>> ListPublishedLayersAsync(
+            string connectionString, string serviceName, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<PublishedLayerSummary>>([]);
+
+        public Task<PublishedLayerSummary> PublishLayerAsync(
+            string connectionString, LayerPublishRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new PublishedLayerSummary
+            {
+                LayerId = publishedLayerId,
+                LayerName = request.LayerName,
+                Schema = request.Schema,
+                Table = request.Table,
+                GeometryType = request.GeometryType ?? "Point",
+                Srid = request.Srid ?? 4326,
+                PrimaryKey = request.PrimaryKey,
+                FieldCount = 2,
+                Enabled = true,
+                ServiceName = request.ServiceName ?? "default"
+            });
+
+        public Task<PublishedLayerSummary?> LinkExistingLayerToServiceAsync(
+            string connectionString, int layerId, string serviceName, bool enabled, CancellationToken cancellationToken = default)
+            => Task.FromResult<PublishedLayerSummary?>(null);
+
+        public Task<TablePublishValidationResult> ValidateTableForPublishAsync(
+            string connectionString, TablePublishValidationRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new TablePublishValidationResult
+            {
+                IsValid = true,
+                Status = "valid",
+                Schema = request.Schema,
+                Table = request.Table,
+                ServiceName = request.ServiceName ?? "default"
+            });
+
+        public Task<PublishedLayerSummary?> SetLayerEnabledAsync(
+            string connectionString, int layerId, string serviceName, bool enabled, CancellationToken cancellationToken = default)
+            => Task.FromResult<PublishedLayerSummary?>(null);
+
+        public Task<IReadOnlyList<PublishedLayerSummary>> SetServiceLayersEnabledAsync(
+            string connectionString, string serviceName, bool enabled, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<PublishedLayerSummary>>([]);
+
+        public Task<LayerExtentRefreshResult?> RefreshLayerExtentsAsync(
+            string connectionString, string serviceName, CancellationToken cancellationToken = default)
+            => Task.FromResult<LayerExtentRefreshResult?>(null);
+    }
+
+    private sealed class SimpleFeatureServerHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var pathAndQuery = request.RequestUri?.PathAndQuery ?? string.Empty;
+            return pathAndQuery switch
+            {
+                "/arcgis/rest/services/Inspections/FeatureServer/0?f=json" => Task.FromResult(JsonResponse("""
+                    {
+                      "id": 0,
+                      "name": "Inspections",
+                      "geometryType": "esriGeometryPoint",
+                      "maxRecordCount": 10,
+                      "hasAttachments": false,
+                      "extent": { "xmin": -158, "ymin": 21, "xmax": -157, "ymax": 22, "spatialReference": { "wkid": 4326 } },
+                      "fields": [
+                        { "name": "OBJECTID", "type": "esriFieldTypeOID", "nullable": false },
+                        { "name": "Name", "type": "esriFieldTypeString", "nullable": true }
+                      ]
+                    }
+                    """)),
+                "/arcgis/rest/services/Inspections/FeatureServer/0/query?where=1=1&returnCountOnly=true&f=json" =>
+                    Task.FromResult(JsonResponse("""{"count":2}""")),
+                "/arcgis/rest/services/Inspections/FeatureServer/0/query?f=json&where=1%3D1&outFields=%2A&returnGeometry=true&resultOffset=0&resultRecordCount=10&outSR=4326" =>
+                    Task.FromResult(JsonResponse("""
+                        {
+                          "features": [
+                            { "attributes": { "OBJECTID": 1, "Name": "Alpha" }, "geometry": { "x": -157.1, "y": 21.3 } },
+                            { "attributes": { "OBJECTID": 2, "Name": "Beta" }, "geometry": { "x": -157.2, "y": 21.4 } }
+                          ],
+                          "exceededTransferLimit": false,
+                          "spatialReference": { "wkid": 4326 }
+                        }
+                        """)),
+                "/arcgis/rest/services/Inspections/FeatureServer/0/query?f=json&where=1%3D1&outFields=%2A&returnGeometry=true&resultOffset=2&resultRecordCount=10&outSR=4326" =>
+                    Task.FromResult(JsonResponse("""
+                        { "features": [], "exceededTransferLimit": false, "spatialReference": { "wkid": 4326 } }
+                        """)),
+                _ => throw new InvalidOperationException($"Unexpected ArcGIS request path: {pathAndQuery}")
+            };
+        }
+
+        private static HttpResponseMessage JsonResponse(string body)
+            => new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private sealed class FixtureConnectionProvider(PostgresFixture postgresFixture) : IDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => postgresFixture.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+            => await postgresFixture.DataSource.OpenConnectionAsync(cancellationToken);
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var connection = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var transaction = await connection.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (connection, transaction);
+            }
+            catch
+            {
+                await connection.DisposeAsync();
+                throw;
+            }
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(
+            Func<Task<T>> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(
+            Func<Task> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/PostgresMigrationRunCatalogTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/PostgresMigrationRunCatalogTests.cs
@@ -87,6 +87,41 @@ public sealed class PostgresMigrationRunCatalogTests(PostgresFixture fixture)
     }
 
     [IntegrationTest]
+    public async Task RecordScorecardAsync_PersistsFingerprintAndBody_AndRoundTrips()
+    {
+        await EnsureMigrationRunsTableAsync();
+        var catalog = CreateCatalog();
+        var runId = $"run-scorecard-{Guid.NewGuid():N}";
+        await catalog.RecordStartedAsync(NewRecord(runId, MigrationRunStatus.Running));
+
+        var updated = await catalog.RecordScorecardAsync(
+            runId,
+            "sha256:scorecard-fingerprint",
+            "{\"artifactKind\":\"honua.migration.reconciliation-scorecard\"}");
+
+        updated.Should().NotBeNull();
+        updated!.ReconciliationScorecardFingerprint.Should().Be("sha256:scorecard-fingerprint");
+
+        var fetched = await catalog.GetAsync(runId);
+        fetched!.ReconciliationScorecardFingerprint.Should().Be("sha256:scorecard-fingerprint");
+
+        var body = await catalog.GetScorecardAsync(runId);
+        body.Should().Contain("honua.migration.reconciliation-scorecard");
+    }
+
+    [IntegrationTest]
+    public async Task GetScorecardAsync_WhenNoScorecardRecorded_ReturnsNull()
+    {
+        await EnsureMigrationRunsTableAsync();
+        var catalog = CreateCatalog();
+        var runId = $"run-noscorecard-{Guid.NewGuid():N}";
+        await catalog.RecordStartedAsync(NewRecord(runId, MigrationRunStatus.Running));
+
+        var body = await catalog.GetScorecardAsync(runId);
+        body.Should().BeNull();
+    }
+
+    [IntegrationTest]
     public async Task CancelAsync_OnlyAffectsRunningRows()
     {
         await EnsureMigrationRunsTableAsync();
@@ -166,9 +201,14 @@ public sealed class PostgresMigrationRunCatalogTests(PostgresFixture fixture)
                 evidence_pack_fingerprint   VARCHAR(128),
                 evidence_pack_body          JSONB,
                 status_note                 TEXT,
+                reconciliation_scorecard_fingerprint VARCHAR(128),
+                reconciliation_scorecard_body        JSONB,
                 CONSTRAINT chk_migration_runs_status
                     CHECK (status IN ('running','succeeded','failed','cancelled'))
             );
+            ALTER TABLE honua.migration_runs
+                ADD COLUMN IF NOT EXISTS reconciliation_scorecard_fingerprint VARCHAR(128),
+                ADD COLUMN IF NOT EXISTS reconciliation_scorecard_body        JSONB;
             CREATE INDEX IF NOT EXISTS idx_migration_runs_started_at
                 ON honua.migration_runs (started_at DESC);
             CREATE INDEX IF NOT EXISTS idx_migration_runs_status

--- a/tests/dotnet/Honua.Server.Tests/Import/MigrationRunAdminEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/MigrationRunAdminEndpointTests.cs
@@ -167,6 +167,44 @@ public sealed class MigrationRunAdminEndpointTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/migration/runs/{runId}/scorecard")]
+    public async Task Scorecard_WhenAbsent_ReturnsNotFound()
+    {
+        _catalog.Seed(new MigrationRunRecord
+        {
+            RunId = "run-no-scorecard",
+            SourceKind = "geoserver-rest",
+            Status = MigrationRunStatus.Succeeded,
+            StartedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            CompletedAt = DateTimeOffset.UtcNow
+        });
+
+        var response = await _client.GetAsync("/api/v1/admin/migration/runs/run-no-scorecard/scorecard");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/migration/runs/{runId}/scorecard")]
+    public async Task Scorecard_WhenPresent_ReturnsSignedScorecardJson()
+    {
+        const string body = "{\"artifactKind\":\"honua.migration.reconciliation-scorecard\"}";
+        _catalog.Seed(new MigrationRunRecord
+        {
+            RunId = "run-with-scorecard",
+            SourceKind = "geoserver-rest",
+            Status = MigrationRunStatus.Succeeded,
+            StartedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            CompletedAt = DateTimeOffset.UtcNow
+        });
+        await _catalog.RecordScorecardAsync("run-with-scorecard", "sha256:scorecard-abc", body);
+
+        var response = await _client.GetAsync("/api/v1/admin/migration/runs/run-with-scorecard/scorecard");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.ETag!.Tag.Should().Contain("sha256:scorecard-abc");
+        (await response.Content.ReadAsStringAsync()).Should().Contain("honua.migration.reconciliation-scorecard");
+    }
+
+    [IntegrationTest]
     [Endpoint("POST /api/v1/admin/migration/runs/{runId}/cancel")]
     public async Task Cancel_WithUnknownRunId_ReturnsNotFound()
     {

--- a/tests/dotnet/Honua.Server.Tests/Import/MigrationRunAdminEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/MigrationRunAdminEndpointTests.cs
@@ -221,6 +221,7 @@ public sealed class MigrationRunAdminEndpointTests : IAsyncLifetime
     private sealed class InMemoryMigrationRunCatalog : IMigrationRunCatalog
     {
         private readonly ConcurrentDictionary<string, (MigrationRunRecord Record, string? Body)> _rows = new();
+        private readonly ConcurrentDictionary<string, string> _scorecards = new();
 
         public void Seed(MigrationRunRecord record, string? evidencePackBody = null)
         {
@@ -313,6 +314,27 @@ public sealed class MigrationRunAdminEndpointTests : IAsyncLifetime
         public Task<string?> GetEvidencePackAsync(string runId, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(_rows.TryGetValue(runId, out var existing) ? existing.Body : null);
+        }
+
+        public Task<MigrationRunRecord?> RecordScorecardAsync(
+            string runId,
+            string scorecardFingerprint,
+            string scorecardBody,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_rows.TryGetValue(runId, out var existing))
+            {
+                return Task.FromResult<MigrationRunRecord?>(null);
+            }
+            var updated = existing.Record with { ReconciliationScorecardFingerprint = scorecardFingerprint };
+            _rows[runId] = (updated, existing.Body);
+            _scorecards[runId] = scorecardBody;
+            return Task.FromResult<MigrationRunRecord?>(updated);
+        }
+
+        public Task<string?> GetScorecardAsync(string runId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_scorecards.TryGetValue(runId, out var body) ? body : null);
         }
     }
 }


### PR DESCRIPTION
## Issue Link
Fixes #1247, #1380
Advances #1379, #1381 (catalog collectors + signed scorecard implemented & unit-tested; per-layer auto-invocation needs a MetadataV2 read-back seam / apply-run caller — documented follow-up)

## Summary
Implements the Esri-migration "post-import reconciliation & parity gate" epic (#1246). After the Geoservices import publishes a layer it now runs a deterministic reconciliation pass against the apply-time source snapshot; a hard discrepancy routes the run to a new `NeedsReview` state instead of `Completed`, and a signed scorecard rolls up the verdict while keeping data-reconciliation distinct from capability-parity.

## Changes Made
- **#1247** — `ILayerReconciliationService` + `LayerReconciliationService` (count/geometry/content/extent probes, pass/warn/fail/skipped), `MigrationReconciliationArtifact`, `LayerReconciliationRequest`. Registered in Postgres DI; a new **Validating** phase in `GeoservicesImportService.ImportSteps` runs reconciliation after Publishing and before Completed, building the request from `GeoservicesLayerInfo` + the import where-clause mirror and probing the published layer via `IFeatureReader`. Artifact persisted onto the import progress/result.
- **#1379** — `MigrationCatalogReconciler.CollectAttachmentFindings()` and `CollectSubtypeFindings()` with new stable finding codes (`catalog.attachment.missing`, `catalog.subtype.missing`, `catalog.subtype.field-mismatch`, `catalog.subtype.code-missing`) and an `ExpectedSubtypes` reconciliation input. Reconciles trunk's imported attachments (#1257) and persisted subtypes (#1378) against the published Metadata v2 graph.
- **#1380** — `NeedsReview` added to `GeoservicesImportStatus`. The Validating phase aggregates the verdict: a `fail` classification routes to `NeedsReview` and blocks `Completed`; `warn`/`skipped` are recorded but non-blocking. A reconciliation-infrastructure error does not fail an already-published import.
- **#1381** — `MigrationReconciliationScorecard` + signed `MigrationReconciliationScorecardBuilder` (SHA-256-over-canonical-JSON fingerprint, reusing the evidence-pack mechanism), keeping capability-parity and data-reconciliation as separate dimensions with the verdict derived from data reconciliation only. Persistence via migration `044`, `IMigrationRunCatalog.RecordScorecardAsync`/`GetScorecardAsync`, a `ReconciliationScorecardFingerprint` reference on `MigrationRunRecord`, and a `GET /api/v1/admin/migration/runs/{runId}/scorecard` admin endpoint.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Core unit tests: reconciliation service classification bands, attachment/subtype collectors, scorecard aggregation/separation/fingerprint (Core Migration suite 265/265 green). Postgres integration tests: Validating-phase gate (injected fail → NeedsReview + blocks Completed; faithful import → Completed) and scorecard round-trip through the run catalog (Reconcil/Migration/Import suite 239/239 green). `MigrationRunAdminEndpoint` Server tests 10/10 green. Full Core server shard was intentionally not run locally (CI parallel runners cover it).

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [ ] None — no docs or contract impact

(New admin endpoint + `MigrationRunDto` scorecard fields; SDK typed models intentionally out of scope per the epic.)

## Release/Deploy Impact
- [x] Requires database migration

(Migration `044_AddMigrationRunReconciliationScorecard.sql` adds two nullable columns to `honua.migration_runs`; additive and idempotent.)

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent — build (Release, warnings-as-errors), format, Core Migration (265) + Postgres reconcil/migration/import (239) + MigrationRunAdminEndpoint (10) all green; broad "Core" server shard delegated to CI (see note)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

