### PR TITLE
feat: footprint-driven batch import orchestration (#1253)

### DIFF
--- a/src/Honua.Core/Features/Migration/Abstractions/IMigrationBatchOrchestrator.cs
+++ b/src/Honua.Core/Features/Migration/Abstractions/IMigrationBatchOrchestrator.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Migration.Domain;
+
+namespace Honua.Core.Features.Migration.Abstractions;
+
+/// <summary>
+/// Issue #1253. Footprint-driven batch import orchestrator. Composes the
+/// per-layer Geoservices import pipeline (via the shared
+/// <see cref="IDistributedImportJobManager"/>) into a single ordered, resumable
+/// batch run with aggregated progress, and applies cross-layer relationship
+/// classes (issue #1256) once all child layers are published.
+/// </summary>
+/// <remarks>
+/// The orchestrator does not run imports itself: it persists the batch
+/// composition through <see cref="IMigrationBatchRunCatalog"/> and queues child
+/// layer imports onto the existing distributed job queue. A background service
+/// advances the batch by polling child progress and rolling it up. Both
+/// <see cref="StartAsync"/> and <see cref="AdvanceAsync"/> are idempotent so a
+/// recovering leader can resume a partially-completed batch (re-running failed
+/// children, skipping already-succeeded ones).
+/// </remarks>
+public interface IMigrationBatchOrchestrator
+{
+    /// <summary>
+    /// Start an ordered batch run from a footprint/selection. Computes the child
+    /// ordering (relationship origin layers before related layers), persists the
+    /// batch and child rows, and queues the first ready children.
+    /// </summary>
+    /// <param name="request">Footprint selection plus orchestration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created batch run record.</returns>
+    Task<MigrationBatchRunRecord> StartAsync(
+        MigrationBatchStartRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Advance a batch: reconcile child statuses from their per-layer import jobs,
+    /// queue the next ready children, roll up batch status, and — when all
+    /// children are published and relationship-apply was requested — apply the
+    /// manifest relationships. Safe to call repeatedly; a no-op once the batch is
+    /// terminal.
+    /// </summary>
+    /// <param name="batchId">Batch identifier to advance.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The current batch run record after advancing, or null if unknown.</returns>
+    Task<MigrationBatchRunRecord?> AdvanceAsync(
+        string batchId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Issue #1253. Footprint selection and options for starting a batch run via
+/// <see cref="IMigrationBatchOrchestrator.StartAsync"/>.
+/// </summary>
+public sealed record MigrationBatchStartRequest
+{
+    /// <summary>
+    /// Source kind identifier such as <c>arcgis-geoservices-rest</c>.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Redacted source URL describing the footprint's origin. Used for operator
+    /// display only.
+    /// </summary>
+    public string SourceUrl { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional operator-visible source display name.
+    /// </summary>
+    public string? SourceDisplayName { get; init; }
+
+    /// <summary>
+    /// Ordered (or unordered) set of layer-import specifications that make up the
+    /// footprint. The orchestrator computes the final execution order from
+    /// <see cref="MigrationBatchLayerSpec.DependsOn"/> edges, falling back to the
+    /// supplied order for ties.
+    /// </summary>
+    public required IReadOnlyList<MigrationBatchLayerSpec> Layers { get; init; }
+
+    /// <summary>
+    /// Optional manifest JSON body. When present and
+    /// <see cref="ApplyRelationships"/> is true, the orchestrator applies the
+    /// manifest's relationship classes once all child layers are published.
+    /// </summary>
+    public string? ManifestBody { get; init; }
+
+    /// <summary>
+    /// Whether to apply manifest relationship classes after all child layers are
+    /// published (issue #1256). Ignored when <see cref="ManifestBody"/> is null.
+    /// </summary>
+    public bool ApplyRelationships { get; init; }
+}
+
+/// <summary>
+/// Issue #1253. One layer-import specification within a batch footprint.
+/// </summary>
+public sealed record MigrationBatchLayerSpec
+{
+    /// <summary>
+    /// Stable source resource identifier (e.g. <c>resource:Inspections:layer:0</c>).
+    /// Must match the manifest's <c>SourceResourceId</c> when relationship-apply is
+    /// requested so the published-layer map resolves.
+    /// </summary>
+    public required string SourceResourceId { get; init; }
+
+    /// <summary>
+    /// Source ArcGIS service URL for this layer.
+    /// </summary>
+    public required string ServiceUrl { get; init; }
+
+    /// <summary>
+    /// Source layer id within the service.
+    /// </summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>
+    /// Target PostGIS table name.
+    /// </summary>
+    public required string TableName { get; init; }
+
+    /// <summary>
+    /// Optional target schema for imported operational data.
+    /// </summary>
+    public string? TargetSchema { get; init; }
+
+    /// <summary>
+    /// Optional target Honua service name for auto-publishing.
+    /// </summary>
+    public string? ServiceName { get; init; }
+
+    /// <summary>
+    /// Source resource ids this layer depends on (e.g. relationship origin layers).
+    /// The orchestrator imports dependencies first.
+    /// </summary>
+    public IReadOnlyList<string> DependsOn { get; init; } = [];
+}

--- a/src/Honua.Core/Features/Migration/Abstractions/IMigrationBatchRunCatalog.cs
+++ b/src/Honua.Core/Features/Migration/Abstractions/IMigrationBatchRunCatalog.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Migration.Domain;
+
+namespace Honua.Core.Features.Migration.Abstractions;
+
+/// <summary>
+/// Issue #1253. Storage abstraction for footprint-driven batch migration runs
+/// (<see cref="MigrationBatchRunRecord"/>) and their ordered child imports
+/// (<see cref="MigrationBatchChildRecord"/>). The batch orchestrator and the
+/// admin endpoints adapt over this catalog so the storage backend (Postgres
+/// today) stays behind a single seam.
+/// </summary>
+/// <remarks>
+/// Implementations must be idempotent for repeat <see cref="CreateAsync"/> calls
+/// with the same batch id (re-recording an existing batch returns it untouched)
+/// so the orchestrator can retry safely. Child rows are immutable except for
+/// their status fields, which advance monotonically toward terminal states.
+/// </remarks>
+public interface IMigrationBatchRunCatalog
+{
+    /// <summary>
+    /// Persist a new batch run plus its ordered child rows. Idempotent: if the
+    /// batch id already exists, the existing batch and children are returned and
+    /// the supplied children are ignored.
+    /// </summary>
+    /// <param name="record">Initial batch record. Status should be
+    /// <see cref="MigrationBatchRunStatus.Running"/>.</param>
+    /// <param name="manifestBody">Optional manifest JSON body persisted alongside
+    /// the batch so relationship-apply can run after all children publish. Null
+    /// when relationship-apply is not requested.</param>
+    /// <param name="children">Ordered child rows (by ordinal).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<MigrationBatchRunRecord> CreateAsync(
+        MigrationBatchRunRecord record,
+        string? manifestBody,
+        IReadOnlyList<MigrationBatchChildRecord> children,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetch a single batch run by id, or null if unknown.
+    /// </summary>
+    Task<MigrationBatchRunRecord?> GetAsync(
+        string batchId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Return the ordered child rows for a batch (by ordinal ascending). Empty
+    /// when the batch is unknown.
+    /// </summary>
+    Task<IReadOnlyList<MigrationBatchChildRecord>> GetChildrenAsync(
+        string batchId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Return the manifest JSON body persisted for a batch, or null when the
+    /// batch is unknown or relationship-apply was not requested.
+    /// </summary>
+    Task<string?> GetManifestBodyAsync(
+        string batchId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Update a single child's status (and optional job id / published layer id /
+    /// note). Returns the updated child, or null if the batch/ordinal is unknown.
+    /// Terminal child states (succeeded, failed, cancelled) are sticky.
+    /// </summary>
+    Task<MigrationBatchChildRecord?> UpdateChildAsync(
+        string batchId,
+        int ordinal,
+        MigrationBatchChildStatus status,
+        string? jobId,
+        int? publishedLayerId,
+        string? statusNote,
+        DateTimeOffset updatedAt,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Update the rolled-up batch status and child counts. Returns the updated
+    /// record, or null if the batch is unknown. Terminal batch states are sticky.
+    /// </summary>
+    Task<MigrationBatchRunRecord?> UpdateBatchAsync(
+        string batchId,
+        MigrationBatchRunStatus status,
+        int succeededChildren,
+        int failedChildren,
+        int cancelledChildren,
+        DateTimeOffset? completedAt,
+        bool? relationshipsApplied,
+        string? statusNote,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Return the ids of batches that are still running so a recovering leader can
+    /// resume advancing them.
+    /// </summary>
+    Task<IReadOnlyList<string>> GetActiveBatchIdsAsync(
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Migration/Domain/MigrationBatchChildRecord.cs
+++ b/src/Honua.Core/Features/Migration/Domain/MigrationBatchChildRecord.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Migration.Domain;
+
+/// <summary>
+/// Issue #1253. One ordered child layer import within a
+/// <see cref="MigrationBatchRunRecord"/>. Each child maps to a single per-layer
+/// Geoservices import job executed by the existing import pipeline; the batch
+/// orchestrator sequences children by <see cref="Ordinal"/> while honoring
+/// <see cref="DependsOn"/> so relationship origin layers import before the
+/// related layers that point at them.
+/// </summary>
+public sealed record MigrationBatchChildRecord
+{
+    /// <summary>
+    /// Owning batch identifier.
+    /// </summary>
+    public required string BatchId { get; init; }
+
+    /// <summary>
+    /// Zero-based execution ordinal within the batch. Unique per batch and used
+    /// as the deterministic sequencing key.
+    /// </summary>
+    public required int Ordinal { get; init; }
+
+    /// <summary>
+    /// Stable source resource identifier from the footprint/manifest (e.g.
+    /// <c>resource:Inspections:layer:0</c>). Used to resolve dependency edges and
+    /// to build the published-layer map for relationship-apply.
+    /// </summary>
+    public required string SourceResourceId { get; init; }
+
+    /// <summary>
+    /// Source ArcGIS service URL for this layer.
+    /// </summary>
+    public required string ServiceUrl { get; init; }
+
+    /// <summary>
+    /// Source layer id within the service.
+    /// </summary>
+    public required int SourceLayerId { get; init; }
+
+    /// <summary>
+    /// Target PostGIS table name.
+    /// </summary>
+    public required string TableName { get; init; }
+
+    /// <summary>
+    /// Optional target schema for imported operational data.
+    /// </summary>
+    public string? TargetSchema { get; init; }
+
+    /// <summary>
+    /// Optional target Honua service name for auto-publishing.
+    /// </summary>
+    public string? ServiceName { get; init; }
+
+    /// <summary>
+    /// Source resource ids this child depends on. The orchestrator will not start
+    /// this child until every dependency has succeeded.
+    /// </summary>
+    public IReadOnlyList<string> DependsOn { get; init; } = [];
+
+    /// <summary>
+    /// Current child status.
+    /// </summary>
+    public required MigrationBatchChildStatus Status { get; init; }
+
+    /// <summary>
+    /// Per-layer import job id once the child has been queued. Null while pending.
+    /// </summary>
+    public string? JobId { get; init; }
+
+    /// <summary>
+    /// Honua layer id assigned at publish time once the child succeeds. Null until
+    /// the child publishes a layer.
+    /// </summary>
+    public int? PublishedLayerId { get; init; }
+
+    /// <summary>
+    /// Operator-visible note recorded on failure or review for this child.
+    /// </summary>
+    public string? StatusNote { get; init; }
+
+    /// <summary>
+    /// UTC instant of the last status change.
+    /// </summary>
+    public DateTimeOffset UpdatedAt { get; init; }
+}
+
+/// <summary>
+/// Lifecycle status for a <see cref="MigrationBatchChildRecord"/>.
+/// </summary>
+public enum MigrationBatchChildStatus
+{
+    /// <summary>The child has not been queued yet (waiting on ordering/dependencies).</summary>
+    Pending,
+
+    /// <summary>The child has been queued or is executing as a per-layer import job.</summary>
+    Running,
+
+    /// <summary>The child import succeeded.</summary>
+    Succeeded,
+
+    /// <summary>The child import failed.</summary>
+    Failed,
+
+    /// <summary>The child published data but was routed to operator review (issue #1380).</summary>
+    NeedsReview,
+
+    /// <summary>The child import was cancelled.</summary>
+    Cancelled
+}

--- a/src/Honua.Core/Features/Migration/Domain/MigrationBatchRunRecord.cs
+++ b/src/Honua.Core/Features/Migration/Domain/MigrationBatchRunRecord.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Migration.Domain;
+
+/// <summary>
+/// Issue #1253. Operator-visible record of a footprint-driven batch migration
+/// run. A batch aggregates an ordered set of per-layer import jobs (the
+/// "footprint") into a single resumable run with rolled-up progress, and — when
+/// requested — applies cross-layer relationship classes (issue #1256) after all
+/// child layers are published.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The batch run is the parent aggregate over child layer imports executed by
+/// the existing per-layer Geoservices import pipeline. Child sequencing,
+/// per-child status, and dependency ordering live in
+/// <see cref="MigrationBatchChildRecord"/> rows linked by <see cref="BatchId"/>.
+/// </para>
+/// <para>
+/// Privacy posture mirrors <see cref="MigrationRunRecord"/>: <see cref="SourceUrl"/>
+/// must already have userinfo, query, and fragment stripped before persistence.
+/// </para>
+/// </remarks>
+public sealed record MigrationBatchRunRecord
+{
+    /// <summary>
+    /// Stable batch identifier (UUID-shaped string). Acts as the primary key.
+    /// </summary>
+    public required string BatchId { get; init; }
+
+    /// <summary>
+    /// Source kind identifier such as <c>arcgis-geoservices-rest</c>.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Redacted source URL (no userinfo, query, or fragment). May be empty when
+    /// the batch was driven by an offline footprint only.
+    /// </summary>
+    public string SourceUrl { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable display name for the source, when known.
+    /// </summary>
+    public string? SourceDisplayName { get; init; }
+
+    /// <summary>
+    /// Current batch status rolled up from child imports.
+    /// </summary>
+    public required MigrationBatchRunStatus Status { get; init; }
+
+    /// <summary>
+    /// UTC instant the batch started.
+    /// </summary>
+    public required DateTimeOffset StartedAt { get; init; }
+
+    /// <summary>
+    /// UTC instant the batch reached a terminal status. Null while running.
+    /// </summary>
+    public DateTimeOffset? CompletedAt { get; init; }
+
+    /// <summary>
+    /// Total number of child layer imports in the batch footprint.
+    /// </summary>
+    public int TotalChildren { get; init; }
+
+    /// <summary>
+    /// Number of child imports that have succeeded.
+    /// </summary>
+    public int SucceededChildren { get; init; }
+
+    /// <summary>
+    /// Number of child imports that have failed.
+    /// </summary>
+    public int FailedChildren { get; init; }
+
+    /// <summary>
+    /// Number of child imports that have been cancelled.
+    /// </summary>
+    public int CancelledChildren { get; init; }
+
+    /// <summary>
+    /// Whether the batch should apply manifest relationship classes (issue #1256)
+    /// after all child layers are published.
+    /// </summary>
+    public bool ApplyRelationships { get; init; }
+
+    /// <summary>
+    /// Whether relationship-apply has run for this batch (so the orchestrator does
+    /// not re-apply on resume).
+    /// </summary>
+    public bool RelationshipsApplied { get; init; }
+
+    /// <summary>
+    /// Operator-visible note recorded on cancel, failure, or relationship-apply
+    /// summary. Free-form, no secrets expected.
+    /// </summary>
+    public string? StatusNote { get; init; }
+}
+
+/// <summary>
+/// Lifecycle status for a <see cref="MigrationBatchRunRecord"/>, rolled up from
+/// its child imports.
+/// </summary>
+public enum MigrationBatchRunStatus
+{
+    /// <summary>One or more children are still queued or running.</summary>
+    Running,
+
+    /// <summary>Every child import succeeded.</summary>
+    Succeeded,
+
+    /// <summary>At least one child import failed (and the batch stopped advancing).</summary>
+    Failed,
+
+    /// <summary>The batch was cancelled by an operator.</summary>
+    Cancelled,
+
+    /// <summary>
+    /// Every child reached a terminal state but at least one was routed to operator
+    /// review (parity gate, issue #1380) without a hard failure.
+    /// </summary>
+    NeedsReview
+}

--- a/src/Honua.Core/Features/Migration/Services/MigrationBatchOrchestrator.cs
+++ b/src/Honua.Core/Features/Migration/Services/MigrationBatchOrchestrator.cs
@@ -1,0 +1,473 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.Migration.Services;
+
+/// <summary>
+/// Issue #1253. Default <see cref="IMigrationBatchOrchestrator"/> implementation.
+/// Composes the existing per-layer Geoservices import pipeline into an ordered,
+/// resumable batch run with aggregated progress and post-publish relationship
+/// application (issue #1256).
+/// </summary>
+/// <remarks>
+/// The orchestrator resolves scoped collaborators (<see cref="IMigrationBatchRunCatalog"/>,
+/// <see cref="IDistributedImportJobManager"/>, <see cref="IGeoservicesImportService"/>,
+/// <see cref="IMetadataV2GraphStore"/>) through an <see cref="IServiceScopeFactory"/>
+/// per call so it can run from both request handlers and the long-lived batch
+/// background service without capturing scoped lifetimes.
+/// </remarks>
+public sealed partial class MigrationBatchOrchestrator : IMigrationBatchOrchestrator
+{
+    private static readonly TimeSpan ChildJobTtl = TimeSpan.FromHours(24);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<MigrationBatchOrchestrator> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MigrationBatchOrchestrator"/> class.
+    /// </summary>
+    /// <param name="scopeFactory">Factory used to resolve scoped collaborators per call.</param>
+    /// <param name="logger">Structured logger.</param>
+    public MigrationBatchOrchestrator(
+        IServiceScopeFactory scopeFactory,
+        ILogger<MigrationBatchOrchestrator> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<MigrationBatchRunRecord> StartAsync(
+        MigrationBatchStartRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.SourceKind);
+        if (request.Layers is null || request.Layers.Count == 0)
+        {
+            throw new ArgumentException("A batch footprint must contain at least one layer.", nameof(request));
+        }
+
+        var batchId = Guid.NewGuid().ToString("N")[..16];
+        var ordered = OrderLayers(request.Layers);
+        var now = DateTimeOffset.UtcNow;
+
+        var children = new List<MigrationBatchChildRecord>(ordered.Count);
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            var spec = ordered[i];
+            children.Add(new MigrationBatchChildRecord
+            {
+                BatchId = batchId,
+                Ordinal = i,
+                SourceResourceId = spec.SourceResourceId,
+                ServiceUrl = spec.ServiceUrl,
+                SourceLayerId = spec.LayerId,
+                TableName = spec.TableName,
+                TargetSchema = spec.TargetSchema,
+                ServiceName = spec.ServiceName,
+                DependsOn = spec.DependsOn,
+                Status = MigrationBatchChildStatus.Pending,
+                UpdatedAt = now
+            });
+        }
+
+        var applyRelationships = request.ApplyRelationships && !string.IsNullOrWhiteSpace(request.ManifestBody);
+        var record = new MigrationBatchRunRecord
+        {
+            BatchId = batchId,
+            SourceKind = request.SourceKind,
+            SourceUrl = request.SourceUrl,
+            SourceDisplayName = request.SourceDisplayName,
+            Status = MigrationBatchRunStatus.Running,
+            StartedAt = now,
+            TotalChildren = children.Count,
+            ApplyRelationships = applyRelationships
+        };
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var catalog = scope.ServiceProvider.GetRequiredService<IMigrationBatchRunCatalog>();
+        var created = await catalog.CreateAsync(
+            record,
+            applyRelationships ? request.ManifestBody : null,
+            children,
+            cancellationToken).ConfigureAwait(false);
+
+        Log.BatchStarted(_logger, created.BatchId, created.SourceKind, created.TotalChildren, applyRelationships);
+
+        // Queue the first ready children immediately so callers see progress
+        // without waiting for the background advance tick.
+        var advanced = await AdvanceCoreAsync(scope.ServiceProvider, created.BatchId, cancellationToken).ConfigureAwait(false);
+        return advanced ?? created;
+    }
+
+    /// <inheritdoc />
+    public async Task<MigrationBatchRunRecord?> AdvanceAsync(
+        string batchId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(batchId);
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        return await AdvanceCoreAsync(scope.ServiceProvider, batchId, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<MigrationBatchRunRecord?> AdvanceCoreAsync(
+        IServiceProvider services,
+        string batchId,
+        CancellationToken cancellationToken)
+    {
+        var catalog = services.GetRequiredService<IMigrationBatchRunCatalog>();
+        var jobManager = services.GetRequiredService<IDistributedImportJobManager>();
+
+        var batch = await catalog.GetAsync(batchId, cancellationToken).ConfigureAwait(false);
+        if (batch is null)
+        {
+            return null;
+        }
+
+        if (batch.Status is MigrationBatchRunStatus.Succeeded
+            or MigrationBatchRunStatus.Failed
+            or MigrationBatchRunStatus.Cancelled)
+        {
+            return batch;
+        }
+
+        var children = (await catalog.GetChildrenAsync(batchId, cancellationToken).ConfigureAwait(false))
+            .OrderBy(static c => c.Ordinal)
+            .ToList();
+
+        // 1. Reconcile running children against their per-layer import jobs.
+        for (var i = 0; i < children.Count; i++)
+        {
+            var child = children[i];
+            if (child.Status != MigrationBatchChildStatus.Running || string.IsNullOrWhiteSpace(child.JobId))
+            {
+                continue;
+            }
+
+            var progress = await jobManager.ProgressStore.GetProgressAsync(child.JobId!, cancellationToken).ConfigureAwait(false);
+            var mapped = MapChildStatus(progress?.Status);
+            if (mapped is null)
+            {
+                continue; // still in flight
+            }
+
+            var updated = await catalog.UpdateChildAsync(
+                batchId,
+                child.Ordinal,
+                mapped.Value,
+                child.JobId,
+                progress?.PublishedLayerId,
+                progress?.ErrorMessage,
+                DateTimeOffset.UtcNow,
+                cancellationToken).ConfigureAwait(false);
+            if (updated is not null)
+            {
+                children[i] = updated;
+            }
+        }
+
+        // 2. Queue the next ready children (dependencies satisfied, no blocking failure).
+        var succeededIds = children
+            .Where(static c => c.Status == MigrationBatchChildStatus.Succeeded)
+            .Select(static c => c.SourceResourceId)
+            .ToHashSet(StringComparer.Ordinal);
+        var hasBlockingFailure = children.Any(static c =>
+            c.Status is MigrationBatchChildStatus.Failed or MigrationBatchChildStatus.Cancelled);
+        var hasRunning = children.Any(static c => c.Status == MigrationBatchChildStatus.Running);
+
+        if (!hasBlockingFailure && !hasRunning)
+        {
+            // Sequential execution: queue the first pending child whose dependencies
+            // are all satisfied. One child in flight at a time keeps the batch
+            // deterministic and bounds load on the source service.
+            for (var i = 0; i < children.Count; i++)
+            {
+                var child = children[i];
+                if (child.Status != MigrationBatchChildStatus.Pending)
+                {
+                    continue;
+                }
+
+                if (!child.DependsOn.All(succeededIds.Contains))
+                {
+                    continue;
+                }
+
+                var jobId = await QueueChildAsync(jobManager, child, cancellationToken).ConfigureAwait(false);
+                var queued = await catalog.UpdateChildAsync(
+                    batchId,
+                    child.Ordinal,
+                    MigrationBatchChildStatus.Running,
+                    jobId,
+                    null,
+                    null,
+                    DateTimeOffset.UtcNow,
+                    cancellationToken).ConfigureAwait(false);
+                if (queued is not null)
+                {
+                    children[i] = queued;
+                }
+
+                Log.ChildQueued(_logger, batchId, child.Ordinal, child.SourceResourceId, jobId);
+                break;
+            }
+        }
+
+        // 3. Roll up counts and batch status.
+        return await RollUpAsync(services, catalog, batch, children, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<MigrationBatchRunRecord?> RollUpAsync(
+        IServiceProvider services,
+        IMigrationBatchRunCatalog catalog,
+        MigrationBatchRunRecord batch,
+        List<MigrationBatchChildRecord> children,
+        CancellationToken cancellationToken)
+    {
+        var succeeded = children.Count(static c => c.Status == MigrationBatchChildStatus.Succeeded);
+        var failed = children.Count(static c => c.Status == MigrationBatchChildStatus.Failed);
+        var cancelled = children.Count(static c => c.Status == MigrationBatchChildStatus.Cancelled);
+        var needsReview = children.Count(static c => c.Status == MigrationBatchChildStatus.NeedsReview);
+        var running = children.Count(static c => c.Status == MigrationBatchChildStatus.Running);
+        var pending = children.Count(static c => c.Status == MigrationBatchChildStatus.Pending);
+        var hasBlockingFailure = failed > 0 || cancelled > 0;
+
+        // The batch is terminal when nothing can advance further: either every
+        // child reached a terminal state, or a blocking failure/cancellation has
+        // stranded the remaining pending children behind the sequential gate.
+        // Leaving the failed child + its pending successors in place keeps the
+        // batch resumable (restart re-runs the failed layer, skips succeeded).
+        var isTerminal = (running == 0 && pending == 0) || (hasBlockingFailure && running == 0);
+
+        var status = MigrationBatchRunStatus.Running;
+        DateTimeOffset? completedAt = null;
+        var relationshipsApplied = batch.RelationshipsApplied;
+        string? note = batch.StatusNote;
+
+        if (isTerminal)
+        {
+            if (failed > 0)
+            {
+                status = MigrationBatchRunStatus.Failed;
+            }
+            else if (cancelled > 0)
+            {
+                status = MigrationBatchRunStatus.Cancelled;
+            }
+            else if (needsReview > 0)
+            {
+                status = MigrationBatchRunStatus.NeedsReview;
+            }
+            else
+            {
+                status = MigrationBatchRunStatus.Succeeded;
+            }
+
+            // Apply relationships only when every child published cleanly and the
+            // batch asked for it (issue #1256). NeedsReview children still published
+            // data, so relationship-apply is eligible; hard failures are not.
+            if (batch.ApplyRelationships
+                && !relationshipsApplied
+                && !hasBlockingFailure
+                && pending == 0)
+            {
+                note = await ApplyRelationshipsAsync(services, batch, children, cancellationToken).ConfigureAwait(false);
+                relationshipsApplied = true;
+            }
+
+            completedAt = DateTimeOffset.UtcNow;
+        }
+
+        return await catalog.UpdateBatchAsync(
+            batch.BatchId,
+            status,
+            succeeded,
+            failed,
+            cancelled,
+            completedAt,
+            relationshipsApplied != batch.RelationshipsApplied ? relationshipsApplied : null,
+            note,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<string?> ApplyRelationshipsAsync(
+        IServiceProvider services,
+        MigrationBatchRunRecord batch,
+        IReadOnlyList<MigrationBatchChildRecord> children,
+        CancellationToken cancellationToken)
+    {
+        var catalog = services.GetRequiredService<IMigrationBatchRunCatalog>();
+        var manifestBody = await catalog.GetManifestBodyAsync(batch.BatchId, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(manifestBody))
+        {
+            return batch.StatusNote;
+        }
+
+        MigrationManifestArtifact? manifest;
+        try
+        {
+            manifest = JsonSerializer.Deserialize(manifestBody, MigrationEvidencePackJsonContext.Default.MigrationManifestArtifact);
+        }
+        catch (JsonException ex)
+        {
+            Log.RelationshipManifestInvalid(_logger, batch.BatchId, ex);
+            return "Relationship-apply skipped: batch manifest could not be parsed.";
+        }
+
+        if (manifest is null)
+        {
+            return "Relationship-apply skipped: batch manifest was empty.";
+        }
+
+        var publishedLayerMap = children
+            .Where(static c => c.PublishedLayerId.HasValue)
+            .GroupBy(static c => c.SourceResourceId, StringComparer.Ordinal)
+            .ToDictionary(
+                static g => g.Key,
+                static g => g.First().PublishedLayerId!.Value,
+                StringComparer.Ordinal);
+
+        var importService = services.GetRequiredService<IGeoservicesImportService>();
+        var graphStore = services.GetService<IMetadataV2GraphStore>();
+
+        var outcomes = await importService.ApplyRelationshipsAsync(
+            manifest,
+            publishedLayerMap,
+            graphStore,
+            cancellationToken).ConfigureAwait(false);
+
+        var applied = outcomes.Count(static o => o.Outcome == MigrationCatalogWriteOutcome.Created);
+        Log.RelationshipsApplied(_logger, batch.BatchId, outcomes.Length, applied);
+        return $"Relationship-apply complete: {applied} created, {outcomes.Length - applied} skipped/existing across {outcomes.Length} relationship(s).";
+    }
+
+    private static async Task<string> QueueChildAsync(
+        IDistributedImportJobManager jobManager,
+        MigrationBatchChildRecord child,
+        CancellationToken cancellationToken)
+    {
+        var jobId = Guid.NewGuid().ToString("N")[..12];
+        var importRequest = new GeoservicesImportRequest
+        {
+            JobId = jobId,
+            ServiceUrl = child.ServiceUrl,
+            LayerId = child.SourceLayerId,
+            TableName = child.TableName,
+            TargetSchema = child.TargetSchema,
+            AutoPublish = true,
+            ServiceName = child.ServiceName
+        };
+
+        var progress = GeoservicesImportProgress.CreateInitial(
+            jobId,
+            child.ServiceUrl,
+            child.SourceLayerId,
+            child.TableName) with
+        {
+            ServiceName = child.ServiceName
+        };
+
+        await jobManager.RequestStore.SetProgressAsync(jobId, importRequest, ChildJobTtl, cancellationToken).ConfigureAwait(false);
+        await jobManager.ProgressStore.SetProgressAsync(jobId, progress, ChildJobTtl, cancellationToken).ConfigureAwait(false);
+        await jobManager.JobQueue.EnqueueAsync(jobId, cancellationToken).ConfigureAwait(false);
+        return jobId;
+    }
+
+    private static MigrationBatchChildStatus? MapChildStatus(GeoservicesImportStatus? status) => status switch
+    {
+        null => null,
+        GeoservicesImportStatus.Completed => MigrationBatchChildStatus.Succeeded,
+        GeoservicesImportStatus.Failed => MigrationBatchChildStatus.Failed,
+        GeoservicesImportStatus.Cancelled => MigrationBatchChildStatus.Cancelled,
+        GeoservicesImportStatus.NeedsReview => MigrationBatchChildStatus.NeedsReview,
+        _ => null // still in flight
+    };
+
+    /// <summary>
+    /// Deterministic topological order over the footprint: dependencies first,
+    /// stable by the supplied order for ties. Cycles and dangling dependency
+    /// references fall back to the supplied order so a malformed footprint still
+    /// runs rather than deadlocking.
+    /// </summary>
+    private static List<MigrationBatchLayerSpec> OrderLayers(IReadOnlyList<MigrationBatchLayerSpec> layers)
+    {
+        var byId = new Dictionary<string, MigrationBatchLayerSpec>(StringComparer.Ordinal);
+        var inputIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < layers.Count; i++)
+        {
+            // Last write wins on duplicate ids; index preserves first appearance.
+            byId[layers[i].SourceResourceId] = layers[i];
+            inputIndex.TryAdd(layers[i].SourceResourceId, i);
+        }
+
+        var ordered = new List<MigrationBatchLayerSpec>(layers.Count);
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var onStack = new HashSet<string>(StringComparer.Ordinal);
+
+        // Visit in stable input order so the output is deterministic.
+        foreach (var spec in layers.OrderBy(s => inputIndex[s.SourceResourceId]))
+        {
+            Visit(spec.SourceResourceId, byId, inputIndex, visited, onStack, ordered);
+        }
+
+        return ordered;
+    }
+
+    private static void Visit(
+        string id,
+        IReadOnlyDictionary<string, MigrationBatchLayerSpec> byId,
+        IReadOnlyDictionary<string, int> inputIndex,
+        HashSet<string> visited,
+        HashSet<string> onStack,
+        List<MigrationBatchLayerSpec> ordered)
+    {
+        if (visited.Contains(id) || !byId.TryGetValue(id, out var spec))
+        {
+            return;
+        }
+
+        if (!onStack.Add(id))
+        {
+            // Cycle: stop recursing; the node will be emitted when the stack unwinds.
+            return;
+        }
+
+        foreach (var dep in spec.DependsOn.Where(byId.ContainsKey).OrderBy(d => inputIndex[d]))
+        {
+            Visit(dep, byId, inputIndex, visited, onStack, ordered);
+        }
+
+        onStack.Remove(id);
+        if (visited.Add(id))
+        {
+            ordered.Add(spec);
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(7980, LogLevel.Information,
+            "Migration batch {BatchId} started (source={SourceKind}, children={ChildCount}, applyRelationships={ApplyRelationships})")]
+        public static partial void BatchStarted(ILogger logger, string batchId, string sourceKind, int childCount, bool applyRelationships);
+
+        [LoggerMessage(7981, LogLevel.Information,
+            "Migration batch {BatchId} queued child {Ordinal} ({SourceResourceId}) as import job {JobId}")]
+        public static partial void ChildQueued(ILogger logger, string batchId, int ordinal, string sourceResourceId, string jobId);
+
+        [LoggerMessage(7982, LogLevel.Information,
+            "Migration batch {BatchId} applied relationships: {OutcomeCount} outcome(s), {AppliedCount} created")]
+        public static partial void RelationshipsApplied(ILogger logger, string batchId, int outcomeCount, int appliedCount);
+
+        [LoggerMessage(7983, LogLevel.Warning,
+            "Migration batch {BatchId} manifest could not be parsed for relationship-apply")]
+        public static partial void RelationshipManifestInvalid(ILogger logger, string batchId, Exception exception);
+    }
+}

--- a/src/Honua.Import/Features/Migration/MigrationBatchBackgroundService.cs
+++ b/src/Honua.Import/Features/Migration/MigrationBatchBackgroundService.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Migration.Abstractions;
+using Microsoft.Extensions.Hosting;
+
+namespace Honua.Migration;
+
+/// <summary>
+/// Issue #1253. Drives footprint-driven batch migration runs forward. On each
+/// tick the leader node loads the active batches and calls
+/// <see cref="IMigrationBatchOrchestrator.AdvanceAsync"/> for each, which
+/// reconciles child import-job status, queues the next ready child, rolls up
+/// batch progress, and applies relationships once all children publish (#1256).
+/// </summary>
+/// <remarks>
+/// Advancing is idempotent and gated by the shared import leader election so
+/// exactly one node advances a batch at a time. When leadership is unavailable
+/// (no Redis, dev profile) the local fallback leader still advances batches.
+/// </remarks>
+internal sealed partial class MigrationBatchBackgroundService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IDistributedImportJobManager _jobManager;
+    private readonly ILogger<MigrationBatchBackgroundService> _logger;
+    private readonly TimeSpan _pollInterval = TimeSpan.FromSeconds(5);
+
+    public MigrationBatchBackgroundService(
+        IServiceScopeFactory scopeFactory,
+        IDistributedImportJobManager jobManager,
+        ILogger<MigrationBatchBackgroundService> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _jobManager = jobManager ?? throw new ArgumentNullException(nameof(jobManager));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        Log.ServiceStarting(_logger, _jobManager.LeaderElection.InstanceId);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_pollInterval, stoppingToken).ConfigureAwait(false);
+
+                var isLeader = await _jobManager.LeaderElection.TryAcquireLeadershipAsync(stoppingToken).ConfigureAwait(false);
+                if (!isLeader)
+                {
+                    continue;
+                }
+
+                await AdvanceActiveBatchesAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                Log.AdvanceLoopError(_logger, ex);
+            }
+        }
+
+        Log.ServiceStopped(_logger, _jobManager.LeaderElection.InstanceId);
+    }
+
+    private async Task AdvanceActiveBatchesAsync(CancellationToken cancellationToken)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var catalog = scope.ServiceProvider.GetRequiredService<IMigrationBatchRunCatalog>();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<IMigrationBatchOrchestrator>();
+
+        var activeIds = await catalog.GetActiveBatchIdsAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var batchId in activeIds)
+        {
+            try
+            {
+                await orchestrator.AdvanceAsync(batchId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.BatchAdvanceError(_logger, batchId, ex);
+            }
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(7984, LogLevel.Information, "Migration batch background service starting (instance: {InstanceId})")]
+        public static partial void ServiceStarting(ILogger logger, string instanceId);
+
+        [LoggerMessage(7985, LogLevel.Information, "Migration batch background service stopped (instance: {InstanceId})")]
+        public static partial void ServiceStopped(ILogger logger, string instanceId);
+
+        [LoggerMessage(7986, LogLevel.Error, "Error in migration batch advance loop")]
+        public static partial void AdvanceLoopError(ILogger logger, Exception exception);
+
+        [LoggerMessage(7987, LogLevel.Warning, "Failed to advance migration batch {BatchId}")]
+        public static partial void BatchAdvanceError(ILogger logger, string batchId, Exception exception);
+    }
+}

--- a/src/Honua.Import/Features/Migration/MigrationBatchEndpoints.cs
+++ b/src/Honua.Import/Features/Migration/MigrationBatchEndpoints.cs
@@ -1,0 +1,410 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Helpers;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Import.FileImport;
+
+namespace Honua.Migration;
+
+/// <summary>
+/// Issue #1253. Admin endpoints that start and observe footprint-driven batch
+/// migration runs. <c>POST /api/v1/admin/import/migrations</c> initiates an
+/// ordered, resumable batch from a footprint/selection and returns a batch run
+/// id; <c>GET /api/v1/admin/import/migrations/{batchId}</c> returns the rolled-up
+/// batch status plus per-child progress. Both are thin adapters over
+/// <see cref="IMigrationBatchOrchestrator"/> and <see cref="IMigrationBatchRunCatalog"/>.
+/// </summary>
+internal static partial class MigrationBatchEndpoints
+{
+    private const int MaxFootprintLayers = 500;
+
+    /// <summary>
+    /// Maps the batch import orchestration endpoints under
+    /// <c>/api/v1/admin/import/migrations</c>.
+    /// </summary>
+    public static void MapMigrationBatchEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/v{version:apiVersion}/admin/import/migrations")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Import")
+            .RequireAdminAuthorization();
+
+        _ = group.MapPost("/", HandleStartBatch)
+            .WithName("StartMigrationBatch")
+            .WithSummary("Start an ordered, resumable batch migration run from a footprint selection");
+
+        _ = group.MapGet("/{batchId}", HandleGetBatch)
+            .WithName("GetMigrationBatch")
+            .WithSummary("Get the rolled-up status and per-child progress of a batch migration run");
+    }
+
+    private static async Task HandleStartBatch(HttpContext context)
+    {
+        var cancellationToken = context.RequestAborted;
+
+        MigrationBatchStartApiRequest? request;
+        try
+        {
+            request = await context.Request.ReadFromJsonAsync(
+                MigrationBatchJsonContext.Default.MigrationBatchStartApiRequest,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Invalid request body", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (request is null)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Request body is required", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.SourceKind))
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "sourceKind is required", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (request.Layers is null || request.Layers.Length == 0)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "At least one layer is required in the footprint", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (request.Layers.Length > MaxFootprintLayers)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                $"A batch footprint may contain at most {MaxFootprintLayers} layers.",
+                StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var seenResourceIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var layer in request.Layers)
+        {
+            if (string.IsNullOrWhiteSpace(layer.SourceResourceId))
+            {
+                await AdminResponseWriter.WriteErrorAsync(context, "Each layer requires a sourceResourceId", StatusCodes.Status400BadRequest);
+                return;
+            }
+
+            if (!seenResourceIds.Add(layer.SourceResourceId))
+            {
+                await AdminResponseWriter.WriteErrorAsync(
+                    context,
+                    $"Duplicate sourceResourceId '{layer.SourceResourceId}' in footprint.",
+                    StatusCodes.Status400BadRequest);
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(layer.ServiceUrl))
+            {
+                await AdminResponseWriter.WriteErrorAsync(context, "Each layer requires a serviceUrl", StatusCodes.Status400BadRequest);
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(layer.TableName) || !ImportValidationHelpers.IsValidTableName(layer.TableName))
+            {
+                await AdminResponseWriter.WriteErrorAsync(
+                    context,
+                    "Each layer requires a valid tableName (letters, numbers, and underscores only).",
+                    StatusCodes.Status400BadRequest);
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(layer.TargetSchema) && !ImportValidationHelpers.IsValidSchemaName(layer.TargetSchema))
+            {
+                await AdminResponseWriter.WriteErrorAsync(
+                    context,
+                    "Invalid target schema. Use only letters, numbers, and underscores.",
+                    StatusCodes.Status400BadRequest);
+                return;
+            }
+
+            var urlValidation = await GeoservicesServiceUrlValidation.ValidateAsync(layer.ServiceUrl, cancellationToken).ConfigureAwait(false);
+            if (!urlValidation.IsValid)
+            {
+                await AdminResponseWriter.WriteErrorAsync(context, urlValidation.ErrorMessage!, StatusCodes.Status400BadRequest);
+                return;
+            }
+        }
+
+        var orchestrator = context.RequestServices.GetRequiredService<IMigrationBatchOrchestrator>();
+        var startRequest = new MigrationBatchStartRequest
+        {
+            SourceKind = request.SourceKind,
+            SourceUrl = request.SourceUrl ?? string.Empty,
+            SourceDisplayName = request.SourceDisplayName,
+            ManifestBody = request.ManifestBody,
+            ApplyRelationships = request.ApplyRelationships ?? false,
+            Layers = request.Layers.Select(static l => new MigrationBatchLayerSpec
+            {
+                SourceResourceId = l.SourceResourceId!,
+                ServiceUrl = l.ServiceUrl!,
+                LayerId = l.LayerId,
+                TableName = l.TableName!,
+                TargetSchema = l.TargetSchema,
+                ServiceName = l.ServiceName,
+                DependsOn = l.DependsOn ?? []
+            }).ToArray()
+        };
+
+        MigrationBatchRunRecord batch;
+        try
+        {
+            batch = await orchestrator.StartAsync(startRequest, cancellationToken).ConfigureAwait(false);
+        }
+        catch (ArgumentException ex)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, ex.Message, StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var response = ToResponse(batch, []);
+        await Results.Json(response, MigrationBatchJsonContext.Default.MigrationBatchResponse, statusCode: StatusCodes.Status202Accepted)
+            .ExecuteAsync(context).ConfigureAwait(false);
+    }
+
+    private static async Task HandleGetBatch(HttpContext context)
+    {
+        var batchId = context.GetRouteValue("batchId")?.ToString();
+        if (string.IsNullOrWhiteSpace(batchId))
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Batch ID is required", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var cancellationToken = context.RequestAborted;
+        var catalog = context.RequestServices.GetRequiredService<IMigrationBatchRunCatalog>();
+        var batch = await catalog.GetAsync(batchId, cancellationToken).ConfigureAwait(false);
+        if (batch is null)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Batch migration run not found", StatusCodes.Status404NotFound);
+            return;
+        }
+
+        var children = await catalog.GetChildrenAsync(batchId, cancellationToken).ConfigureAwait(false);
+        var response = ToResponse(batch, children);
+        await Results.Json(response, MigrationBatchJsonContext.Default.MigrationBatchResponse)
+            .ExecuteAsync(context).ConfigureAwait(false);
+    }
+
+    private static MigrationBatchResponse ToResponse(
+        MigrationBatchRunRecord batch,
+        IReadOnlyList<MigrationBatchChildRecord> children) => new()
+        {
+            BatchId = batch.BatchId,
+            SourceKind = batch.SourceKind,
+            SourceUrl = batch.SourceUrl,
+            SourceDisplayName = batch.SourceDisplayName,
+            Status = BatchStatusToText(batch.Status),
+            StartedAt = batch.StartedAt,
+            CompletedAt = batch.CompletedAt,
+            TotalChildren = batch.TotalChildren,
+            SucceededChildren = batch.SucceededChildren,
+            FailedChildren = batch.FailedChildren,
+            CancelledChildren = batch.CancelledChildren,
+            ApplyRelationships = batch.ApplyRelationships,
+            RelationshipsApplied = batch.RelationshipsApplied,
+            StatusNote = batch.StatusNote,
+            Children = children.Select(static c => new MigrationBatchChildResponse
+            {
+                Ordinal = c.Ordinal,
+                SourceResourceId = c.SourceResourceId,
+                ServiceUrl = c.ServiceUrl,
+                SourceLayerId = c.SourceLayerId,
+                TableName = c.TableName,
+                ServiceName = c.ServiceName,
+                DependsOn = c.DependsOn.ToArray(),
+                Status = ChildStatusToText(c.Status),
+                JobId = c.JobId,
+                PublishedLayerId = c.PublishedLayerId,
+                StatusNote = c.StatusNote
+            }).ToArray()
+        };
+
+    private static string BatchStatusToText(MigrationBatchRunStatus status) => status switch
+    {
+        MigrationBatchRunStatus.Running => "running",
+        MigrationBatchRunStatus.Succeeded => "succeeded",
+        MigrationBatchRunStatus.Failed => "failed",
+        MigrationBatchRunStatus.Cancelled => "cancelled",
+        MigrationBatchRunStatus.NeedsReview => "needs-review",
+        _ => "running"
+    };
+
+    private static string ChildStatusToText(MigrationBatchChildStatus status) => status switch
+    {
+        MigrationBatchChildStatus.Pending => "pending",
+        MigrationBatchChildStatus.Running => "running",
+        MigrationBatchChildStatus.Succeeded => "succeeded",
+        MigrationBatchChildStatus.Failed => "failed",
+        MigrationBatchChildStatus.NeedsReview => "needs-review",
+        MigrationBatchChildStatus.Cancelled => "cancelled",
+        _ => "pending"
+    };
+}
+
+/// <summary>
+/// Request body for <c>POST /api/v1/admin/import/migrations</c>.
+/// </summary>
+public sealed record MigrationBatchStartApiRequest
+{
+    /// <summary>Source kind identifier such as <c>arcgis-geoservices-rest</c>.</summary>
+    public string? SourceKind { get; init; }
+
+    /// <summary>Redacted source URL describing the footprint origin (display only).</summary>
+    public string? SourceUrl { get; init; }
+
+    /// <summary>Optional operator-visible source display name.</summary>
+    public string? SourceDisplayName { get; init; }
+
+    /// <summary>Footprint layer-import specifications.</summary>
+    public MigrationBatchLayerApiSpec[]? Layers { get; init; }
+
+    /// <summary>Optional manifest JSON body used for post-publish relationship application (#1256).</summary>
+    public string? ManifestBody { get; init; }
+
+    /// <summary>Whether to apply manifest relationship classes after all layers publish.</summary>
+    public bool? ApplyRelationships { get; init; }
+}
+
+/// <summary>
+/// One layer-import specification in a batch footprint request.
+/// </summary>
+public sealed record MigrationBatchLayerApiSpec
+{
+    /// <summary>Stable source resource id (must match manifest ids for relationship-apply).</summary>
+    public string? SourceResourceId { get; init; }
+
+    /// <summary>Source ArcGIS service URL.</summary>
+    public string? ServiceUrl { get; init; }
+
+    /// <summary>Source layer id within the service.</summary>
+    public int LayerId { get; init; }
+
+    /// <summary>Target PostGIS table name.</summary>
+    public string? TableName { get; init; }
+
+    /// <summary>Optional target schema for imported operational data.</summary>
+    public string? TargetSchema { get; init; }
+
+    /// <summary>Optional target Honua service name for auto-publishing.</summary>
+    public string? ServiceName { get; init; }
+
+    /// <summary>Source resource ids this layer depends on (imported first).</summary>
+    public string[]? DependsOn { get; init; }
+}
+
+/// <summary>
+/// Response for batch start and batch status. Mirrors the batch run aggregate
+/// plus per-child progress.
+/// </summary>
+public sealed record MigrationBatchResponse
+{
+    /// <summary>Stable batch id.</summary>
+    public required string BatchId { get; init; }
+
+    /// <summary>Source kind.</summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>Redacted source URL.</summary>
+    public string SourceUrl { get; init; } = string.Empty;
+
+    /// <summary>Operator-visible source display name.</summary>
+    public string? SourceDisplayName { get; init; }
+
+    /// <summary>Rolled-up batch status: running, succeeded, failed, cancelled, needs-review.</summary>
+    public required string Status { get; init; }
+
+    /// <summary>UTC start instant.</summary>
+    public required DateTimeOffset StartedAt { get; init; }
+
+    /// <summary>UTC completion instant (null while running).</summary>
+    public DateTimeOffset? CompletedAt { get; init; }
+
+    /// <summary>Total child layer imports in the footprint.</summary>
+    public int TotalChildren { get; init; }
+
+    /// <summary>Number of succeeded children.</summary>
+    public int SucceededChildren { get; init; }
+
+    /// <summary>Number of failed children.</summary>
+    public int FailedChildren { get; init; }
+
+    /// <summary>Number of cancelled children.</summary>
+    public int CancelledChildren { get; init; }
+
+    /// <summary>Whether relationship-apply was requested.</summary>
+    public bool ApplyRelationships { get; init; }
+
+    /// <summary>Whether relationship-apply has run.</summary>
+    public bool RelationshipsApplied { get; init; }
+
+    /// <summary>Operator-visible note.</summary>
+    public string? StatusNote { get; init; }
+
+    /// <summary>Per-child progress, ordered by execution ordinal.</summary>
+    public MigrationBatchChildResponse[] Children { get; init; } = [];
+}
+
+/// <summary>
+/// Per-child progress within a <see cref="MigrationBatchResponse"/>.
+/// </summary>
+public sealed record MigrationBatchChildResponse
+{
+    /// <summary>Zero-based execution ordinal.</summary>
+    public int Ordinal { get; init; }
+
+    /// <summary>Stable source resource id.</summary>
+    public required string SourceResourceId { get; init; }
+
+    /// <summary>Source ArcGIS service URL.</summary>
+    public required string ServiceUrl { get; init; }
+
+    /// <summary>Source layer id.</summary>
+    public int SourceLayerId { get; init; }
+
+    /// <summary>Target PostGIS table name.</summary>
+    public required string TableName { get; init; }
+
+    /// <summary>Optional target Honua service name.</summary>
+    public string? ServiceName { get; init; }
+
+    /// <summary>Source resource ids this child depends on.</summary>
+    public string[] DependsOn { get; init; } = [];
+
+    /// <summary>Child status: pending, running, succeeded, failed, needs-review, cancelled.</summary>
+    public required string Status { get; init; }
+
+    /// <summary>Per-layer import job id once queued.</summary>
+    public string? JobId { get; init; }
+
+    /// <summary>Resolved Honua layer id once the child publishes.</summary>
+    public int? PublishedLayerId { get; init; }
+
+    /// <summary>Operator-visible note recorded on failure or review.</summary>
+    public string? StatusNote { get; init; }
+}
+
+/// <summary>
+/// Source-generated JSON serialization context for batch migration API types.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(MigrationBatchStartApiRequest))]
+[JsonSerializable(typeof(MigrationBatchLayerApiSpec))]
+[JsonSerializable(typeof(MigrationBatchLayerApiSpec[]))]
+[JsonSerializable(typeof(MigrationBatchResponse))]
+[JsonSerializable(typeof(MigrationBatchChildResponse))]
+[JsonSerializable(typeof(MigrationBatchChildResponse[]))]
+public sealed partial class MigrationBatchJsonContext : System.Text.Json.Serialization.JsonSerializerContext;

--- a/src/Honua.Postgres/Features/Migration/PostgresMigrationBatchRunCatalog.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresMigrationBatchRunCatalog.cs
@@ -297,11 +297,22 @@ internal sealed partial class PostgresMigrationBatchRunCatalog : IMigrationBatch
             """;
 
         var ids = new List<string>();
-        await using var command = new NpgsqlCommand(sql, connection);
-        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        try
         {
-            ids.Add(reader.GetString(0));
+            await using var command = new NpgsqlCommand(sql, connection);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                ids.Add(reader.GetString(0));
+            }
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UndefinedTable)
+        {
+            // The batch schema (migration 045) is not present yet — e.g. during the
+            // boot window before migrations run, or in test fixtures pinned to an
+            // earlier schema. Treat as "no active batches" so the background poller
+            // does not error every cycle; polling resumes once the table exists.
+            return [];
         }
 
         return ids;

--- a/src/Honua.Postgres/Features/Migration/PostgresMigrationBatchRunCatalog.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresMigrationBatchRunCatalog.cs
@@ -1,0 +1,478 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.Migration;
+
+/// <summary>
+/// PostgreSQL implementation of <see cref="IMigrationBatchRunCatalog"/> (issue
+/// #1253). Persists batch composition, ordering, and per-child status into
+/// <c>honua.migration_batch_runs</c> and <c>honua.migration_batch_children</c>.
+/// Uses ON CONFLICT guards and sticky-terminal WHERE clauses so the orchestrator
+/// can advance/retry safely.
+/// </summary>
+internal sealed partial class PostgresMigrationBatchRunCatalog : IMigrationBatchRunCatalog
+{
+    private static readonly JsonSerializerOptions DependsOnOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly string _connectionString;
+    private readonly ILogger<PostgresMigrationBatchRunCatalog> _logger;
+
+    public PostgresMigrationBatchRunCatalog(
+        string connectionString,
+        ILogger<PostgresMigrationBatchRunCatalog> logger)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        _connectionString = connectionString;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<MigrationBatchRunRecord> CreateAsync(
+        MigrationBatchRunRecord record,
+        string? manifestBody,
+        IReadOnlyList<MigrationBatchChildRecord> children,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        ArgumentException.ThrowIfNullOrWhiteSpace(record.BatchId);
+        ArgumentNullException.ThrowIfNull(children);
+
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        const string insertBatchSql = """
+            INSERT INTO honua.migration_batch_runs (
+                batch_id, source_kind, source_url, source_display_name, status,
+                started_at, completed_at, total_children, succeeded_children,
+                failed_children, cancelled_children, apply_relationships,
+                relationships_applied, manifest_body, status_note
+            )
+            VALUES (
+                @batchId, @sourceKind, @sourceUrl, @sourceDisplayName, @status,
+                @startedAt, @completedAt, @totalChildren, @succeeded,
+                @failed, @cancelled, @applyRelationships,
+                @relationshipsApplied, CAST(@manifestBody AS jsonb), @statusNote
+            )
+            ON CONFLICT (batch_id) DO NOTHING;
+            """;
+
+        var inserted = false;
+        await using (var insert = new NpgsqlCommand(insertBatchSql, connection, transaction))
+        {
+            insert.Parameters.AddWithValue("@batchId", record.BatchId);
+            insert.Parameters.AddWithValue("@sourceKind", record.SourceKind);
+            insert.Parameters.AddWithValue("@sourceUrl", record.SourceUrl ?? string.Empty);
+            insert.Parameters.AddWithValue("@sourceDisplayName", (object?)record.SourceDisplayName ?? DBNull.Value);
+            insert.Parameters.AddWithValue("@status", BatchStatusToText(record.Status));
+            insert.Parameters.AddWithValue("@startedAt", record.StartedAt.UtcDateTime);
+            insert.Parameters.AddWithValue("@completedAt", (object?)record.CompletedAt?.UtcDateTime ?? DBNull.Value);
+            insert.Parameters.AddWithValue("@totalChildren", record.TotalChildren);
+            insert.Parameters.AddWithValue("@succeeded", record.SucceededChildren);
+            insert.Parameters.AddWithValue("@failed", record.FailedChildren);
+            insert.Parameters.AddWithValue("@cancelled", record.CancelledChildren);
+            insert.Parameters.AddWithValue("@applyRelationships", record.ApplyRelationships);
+            insert.Parameters.AddWithValue("@relationshipsApplied", record.RelationshipsApplied);
+            var bodyParam = insert.Parameters.Add("@manifestBody", NpgsqlDbType.Text);
+            bodyParam.Value = (object?)manifestBody ?? DBNull.Value;
+            insert.Parameters.AddWithValue("@statusNote", (object?)record.StatusNote ?? DBNull.Value);
+
+            var affected = await insert.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            inserted = affected > 0;
+        }
+
+        if (inserted)
+        {
+            const string insertChildSql = """
+                INSERT INTO honua.migration_batch_children (
+                    batch_id, ordinal, source_resource_id, service_url, source_layer_id,
+                    table_name, target_schema, service_name, depends_on, status,
+                    job_id, published_layer_id, status_note, updated_at
+                )
+                VALUES (
+                    @batchId, @ordinal, @sourceResourceId, @serviceUrl, @sourceLayerId,
+                    @tableName, @targetSchema, @serviceName, CAST(@dependsOn AS jsonb), @status,
+                    @jobId, @publishedLayerId, @statusNote, @updatedAt
+                )
+                ON CONFLICT (batch_id, ordinal) DO NOTHING;
+                """;
+
+            foreach (var child in children)
+            {
+                await using var insertChild = new NpgsqlCommand(insertChildSql, connection, transaction);
+                insertChild.Parameters.AddWithValue("@batchId", record.BatchId);
+                insertChild.Parameters.AddWithValue("@ordinal", child.Ordinal);
+                insertChild.Parameters.AddWithValue("@sourceResourceId", child.SourceResourceId);
+                insertChild.Parameters.AddWithValue("@serviceUrl", child.ServiceUrl);
+                insertChild.Parameters.AddWithValue("@sourceLayerId", child.SourceLayerId);
+                insertChild.Parameters.AddWithValue("@tableName", child.TableName);
+                insertChild.Parameters.AddWithValue("@targetSchema", (object?)child.TargetSchema ?? DBNull.Value);
+                insertChild.Parameters.AddWithValue("@serviceName", (object?)child.ServiceName ?? DBNull.Value);
+                var dependsParam = insertChild.Parameters.Add("@dependsOn", NpgsqlDbType.Text);
+                dependsParam.Value = JsonSerializer.Serialize(child.DependsOn, DependsOnOptions);
+                insertChild.Parameters.AddWithValue("@status", ChildStatusToText(child.Status));
+                insertChild.Parameters.AddWithValue("@jobId", (object?)child.JobId ?? DBNull.Value);
+                insertChild.Parameters.AddWithValue("@publishedLayerId", (object?)child.PublishedLayerId ?? DBNull.Value);
+                insertChild.Parameters.AddWithValue("@statusNote", (object?)child.StatusNote ?? DBNull.Value);
+                insertChild.Parameters.AddWithValue("@updatedAt", child.UpdatedAt.UtcDateTime);
+
+                await insertChild.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+        var persisted = await GetInternalAsync(connection, record.BatchId, cancellationToken).ConfigureAwait(false) ?? record;
+        Log.BatchCreated(_logger, persisted.BatchId, persisted.SourceKind, persisted.TotalChildren);
+        return persisted;
+    }
+
+    public async Task<MigrationBatchRunRecord?> GetAsync(
+        string batchId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(batchId);
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return await GetInternalAsync(connection, batchId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<MigrationBatchChildRecord>> GetChildrenAsync(
+        string batchId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(batchId);
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        const string sql = """
+            SELECT batch_id, ordinal, source_resource_id, service_url, source_layer_id,
+                   table_name, target_schema, service_name, depends_on::text, status,
+                   job_id, published_layer_id, status_note, updated_at
+            FROM honua.migration_batch_children
+            WHERE batch_id = @batchId
+            ORDER BY ordinal ASC;
+            """;
+
+        var children = new List<MigrationBatchChildRecord>();
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@batchId", batchId);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            children.Add(ReadChild(reader));
+        }
+
+        return children;
+    }
+
+    public async Task<string?> GetManifestBodyAsync(
+        string batchId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(batchId);
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        const string sql = """
+            SELECT manifest_body::text FROM honua.migration_batch_runs
+            WHERE batch_id = @batchId LIMIT 1;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@batchId", batchId);
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return result switch
+        {
+            null or DBNull => null,
+            string body => body,
+            _ => result.ToString()
+        };
+    }
+
+    public async Task<MigrationBatchChildRecord?> UpdateChildAsync(
+        string batchId,
+        int ordinal,
+        MigrationBatchChildStatus status,
+        string? jobId,
+        int? publishedLayerId,
+        string? statusNote,
+        DateTimeOffset updatedAt,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(batchId);
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        // Terminal child states are sticky: don't overwrite a row that already
+        // reached succeeded/failed/cancelled/needs-review.
+        const string sql = """
+            UPDATE honua.migration_batch_children
+            SET status = @status,
+                job_id = COALESCE(@jobId, job_id),
+                published_layer_id = COALESCE(@publishedLayerId, published_layer_id),
+                status_note = COALESCE(@statusNote, status_note),
+                updated_at = @updatedAt
+            WHERE batch_id = @batchId
+              AND ordinal = @ordinal
+              AND status IN ('pending','running');
+            """;
+
+        await using (var command = new NpgsqlCommand(sql, connection))
+        {
+            command.Parameters.AddWithValue("@batchId", batchId);
+            command.Parameters.AddWithValue("@ordinal", ordinal);
+            command.Parameters.AddWithValue("@status", ChildStatusToText(status));
+            command.Parameters.AddWithValue("@jobId", (object?)jobId ?? DBNull.Value);
+            command.Parameters.AddWithValue("@publishedLayerId", (object?)publishedLayerId ?? DBNull.Value);
+            command.Parameters.AddWithValue("@statusNote", (object?)statusNote ?? DBNull.Value);
+            command.Parameters.AddWithValue("@updatedAt", updatedAt.UtcDateTime);
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return await GetChildInternalAsync(connection, batchId, ordinal, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<MigrationBatchRunRecord?> UpdateBatchAsync(
+        string batchId,
+        MigrationBatchRunStatus status,
+        int succeededChildren,
+        int failedChildren,
+        int cancelledChildren,
+        DateTimeOffset? completedAt,
+        bool? relationshipsApplied,
+        string? statusNote,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(batchId);
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        // Terminal batch states are sticky.
+        const string sql = """
+            UPDATE honua.migration_batch_runs
+            SET status = @status,
+                succeeded_children = @succeeded,
+                failed_children = @failed,
+                cancelled_children = @cancelled,
+                completed_at = COALESCE(@completedAt, completed_at),
+                relationships_applied = COALESCE(@relationshipsApplied, relationships_applied),
+                status_note = COALESCE(@statusNote, status_note)
+            WHERE batch_id = @batchId
+              AND status = 'running';
+            """;
+
+        await using (var command = new NpgsqlCommand(sql, connection))
+        {
+            command.Parameters.AddWithValue("@batchId", batchId);
+            command.Parameters.AddWithValue("@status", BatchStatusToText(status));
+            command.Parameters.AddWithValue("@succeeded", succeededChildren);
+            command.Parameters.AddWithValue("@failed", failedChildren);
+            command.Parameters.AddWithValue("@cancelled", cancelledChildren);
+            command.Parameters.AddWithValue("@completedAt", (object?)completedAt?.UtcDateTime ?? DBNull.Value);
+            command.Parameters.AddWithValue("@relationshipsApplied", (object?)relationshipsApplied ?? DBNull.Value);
+            command.Parameters.AddWithValue("@statusNote", (object?)statusNote ?? DBNull.Value);
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return await GetInternalAsync(connection, batchId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<string>> GetActiveBatchIdsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        const string sql = """
+            SELECT batch_id FROM honua.migration_batch_runs
+            WHERE status = 'running'
+            ORDER BY started_at ASC;
+            """;
+
+        var ids = new List<string>();
+        await using var command = new NpgsqlCommand(sql, connection);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            ids.Add(reader.GetString(0));
+        }
+
+        return ids;
+    }
+
+    private static async Task<MigrationBatchRunRecord?> GetInternalAsync(
+        NpgsqlConnection connection,
+        string batchId,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT batch_id, source_kind, source_url, source_display_name, status,
+                   started_at, completed_at, total_children, succeeded_children,
+                   failed_children, cancelled_children, apply_relationships,
+                   relationships_applied, status_note
+            FROM honua.migration_batch_runs
+            WHERE batch_id = @batchId LIMIT 1;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@batchId", batchId);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return ReadBatch(reader);
+    }
+
+    private static async Task<MigrationBatchChildRecord?> GetChildInternalAsync(
+        NpgsqlConnection connection,
+        string batchId,
+        int ordinal,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT batch_id, ordinal, source_resource_id, service_url, source_layer_id,
+                   table_name, target_schema, service_name, depends_on::text, status,
+                   job_id, published_layer_id, status_note, updated_at
+            FROM honua.migration_batch_children
+            WHERE batch_id = @batchId AND ordinal = @ordinal LIMIT 1;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@batchId", batchId);
+        command.Parameters.AddWithValue("@ordinal", ordinal);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return ReadChild(reader);
+    }
+
+    private static MigrationBatchRunRecord ReadBatch(NpgsqlDataReader reader)
+    {
+        var startedAt = reader.GetDateTime(reader.GetOrdinal("started_at"));
+        var completedOrdinal = reader.GetOrdinal("completed_at");
+        DateTimeOffset? completedAt = reader.IsDBNull(completedOrdinal)
+            ? null
+            : new DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(completedOrdinal), DateTimeKind.Utc));
+
+        return new MigrationBatchRunRecord
+        {
+            BatchId = reader.GetString(reader.GetOrdinal("batch_id")),
+            SourceKind = reader.GetString(reader.GetOrdinal("source_kind")),
+            SourceUrl = reader.GetString(reader.GetOrdinal("source_url")),
+            SourceDisplayName = reader.IsDBNull(reader.GetOrdinal("source_display_name"))
+                ? null
+                : reader.GetString(reader.GetOrdinal("source_display_name")),
+            Status = BatchStatusFromText(reader.GetString(reader.GetOrdinal("status"))),
+            StartedAt = new DateTimeOffset(DateTime.SpecifyKind(startedAt, DateTimeKind.Utc)),
+            CompletedAt = completedAt,
+            TotalChildren = reader.GetInt32(reader.GetOrdinal("total_children")),
+            SucceededChildren = reader.GetInt32(reader.GetOrdinal("succeeded_children")),
+            FailedChildren = reader.GetInt32(reader.GetOrdinal("failed_children")),
+            CancelledChildren = reader.GetInt32(reader.GetOrdinal("cancelled_children")),
+            ApplyRelationships = reader.GetBoolean(reader.GetOrdinal("apply_relationships")),
+            RelationshipsApplied = reader.GetBoolean(reader.GetOrdinal("relationships_applied")),
+            StatusNote = reader.IsDBNull(reader.GetOrdinal("status_note"))
+                ? null
+                : reader.GetString(reader.GetOrdinal("status_note"))
+        };
+    }
+
+    private static MigrationBatchChildRecord ReadChild(NpgsqlDataReader reader)
+    {
+        var dependsOrdinal = reader.GetOrdinal("depends_on");
+        IReadOnlyList<string> dependsOn = [];
+        if (!reader.IsDBNull(dependsOrdinal))
+        {
+            var json = reader.GetString(dependsOrdinal);
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                dependsOn = JsonSerializer.Deserialize<string[]>(json, DependsOnOptions) ?? [];
+            }
+        }
+
+        var jobOrdinal = reader.GetOrdinal("job_id");
+        var layerOrdinal = reader.GetOrdinal("published_layer_id");
+        var noteOrdinal = reader.GetOrdinal("status_note");
+        var schemaOrdinal = reader.GetOrdinal("target_schema");
+        var serviceOrdinal = reader.GetOrdinal("service_name");
+
+        return new MigrationBatchChildRecord
+        {
+            BatchId = reader.GetString(reader.GetOrdinal("batch_id")),
+            Ordinal = reader.GetInt32(reader.GetOrdinal("ordinal")),
+            SourceResourceId = reader.GetString(reader.GetOrdinal("source_resource_id")),
+            ServiceUrl = reader.GetString(reader.GetOrdinal("service_url")),
+            SourceLayerId = reader.GetInt32(reader.GetOrdinal("source_layer_id")),
+            TableName = reader.GetString(reader.GetOrdinal("table_name")),
+            TargetSchema = reader.IsDBNull(schemaOrdinal) ? null : reader.GetString(schemaOrdinal),
+            ServiceName = reader.IsDBNull(serviceOrdinal) ? null : reader.GetString(serviceOrdinal),
+            DependsOn = dependsOn,
+            Status = ChildStatusFromText(reader.GetString(reader.GetOrdinal("status"))),
+            JobId = reader.IsDBNull(jobOrdinal) ? null : reader.GetString(jobOrdinal),
+            PublishedLayerId = reader.IsDBNull(layerOrdinal) ? null : reader.GetInt32(layerOrdinal),
+            StatusNote = reader.IsDBNull(noteOrdinal) ? null : reader.GetString(noteOrdinal),
+            UpdatedAt = new DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(reader.GetOrdinal("updated_at")), DateTimeKind.Utc))
+        };
+    }
+
+    internal static string BatchStatusToText(MigrationBatchRunStatus status) => status switch
+    {
+        MigrationBatchRunStatus.Running => "running",
+        MigrationBatchRunStatus.Succeeded => "succeeded",
+        MigrationBatchRunStatus.Failed => "failed",
+        MigrationBatchRunStatus.Cancelled => "cancelled",
+        MigrationBatchRunStatus.NeedsReview => "needs-review",
+        _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown migration batch status.")
+    };
+
+    internal static MigrationBatchRunStatus BatchStatusFromText(string text) => text switch
+    {
+        "running" => MigrationBatchRunStatus.Running,
+        "succeeded" => MigrationBatchRunStatus.Succeeded,
+        "failed" => MigrationBatchRunStatus.Failed,
+        "cancelled" => MigrationBatchRunStatus.Cancelled,
+        "needs-review" => MigrationBatchRunStatus.NeedsReview,
+        _ => throw new InvalidOperationException($"Unknown migration batch status '{text}'.")
+    };
+
+    internal static string ChildStatusToText(MigrationBatchChildStatus status) => status switch
+    {
+        MigrationBatchChildStatus.Pending => "pending",
+        MigrationBatchChildStatus.Running => "running",
+        MigrationBatchChildStatus.Succeeded => "succeeded",
+        MigrationBatchChildStatus.Failed => "failed",
+        MigrationBatchChildStatus.NeedsReview => "needs-review",
+        MigrationBatchChildStatus.Cancelled => "cancelled",
+        _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown migration batch child status.")
+    };
+
+    internal static MigrationBatchChildStatus ChildStatusFromText(string text) => text switch
+    {
+        "pending" => MigrationBatchChildStatus.Pending,
+        "running" => MigrationBatchChildStatus.Running,
+        "succeeded" => MigrationBatchChildStatus.Succeeded,
+        "failed" => MigrationBatchChildStatus.Failed,
+        "needs-review" => MigrationBatchChildStatus.NeedsReview,
+        "cancelled" => MigrationBatchChildStatus.Cancelled,
+        _ => throw new InvalidOperationException($"Unknown migration batch child status '{text}'.")
+    };
+
+    private static partial class Log
+    {
+        [LoggerMessage(7990, LogLevel.Information,
+            "Migration batch catalog created batch '{BatchId}' (source={SourceKind}, children={ChildCount})")]
+        public static partial void BatchCreated(ILogger logger, string batchId, string sourceKind, int childCount);
+    }
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -407,6 +407,14 @@ internal static class ServiceCollectionExtensions
         // copy runs during ArcGIS layer imports without a separate wiring step.
         services.AddScoped<IGeoservicesImportService, GeoservicesImportService>();
 
+        // Footprint-driven batch import run catalog (#1253). Persists batch
+        // composition, ordering, and per-child status backing the batch
+        // orchestration endpoints. Scoped to align with the scoped orchestrator.
+        services.AddScoped<IMigrationBatchRunCatalog>(serviceProvider =>
+            new PostgresMigrationBatchRunCatalog(
+                ResolveConnectionString(serviceProvider, configuration),
+                serviceProvider.GetRequiredService<ILogger<PostgresMigrationBatchRunCatalog>>()));
+
         // Register the post-publish reconciliation service (issues #1247/#1380). It probes the
         // published layer through IFeatureReader, so it is scoped to align with the scoped feature
         // store. TimeProvider is guarded here in case no host-level registration ran first.

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -404,6 +404,10 @@ public static class EndpointRegistry
         new("POST", "/api/v1/admin/import/geoservices/jobs/{jobId}/cancel"),
         new("GET", "/api/v1/admin/import/geoservices/jobs"),
 
+        // v1 admin footprint-driven batch import orchestration (#1253)
+        new("POST", "/api/v1/admin/import/migrations"),
+        new("GET", "/api/v1/admin/import/migrations/{batchId}"),
+
         // v1 admin import endpoints (Raster)
         new("POST", "/api/v1/admin/import/raster"),
         new("GET", "/api/v1/admin/import/raster/formats"),

--- a/src/Honua.Server/Migrations/045_CreateMigrationBatchRuns.sql
+++ b/src/Honua.Server/Migrations/045_CreateMigrationBatchRuns.sql
@@ -1,0 +1,68 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration 045: Footprint-driven batch import orchestration (issue #1253).
+-- A batch run aggregates an ordered set of per-layer Geoservices import jobs
+-- (the "footprint") into a single resumable run with rolled-up progress. The
+-- migration_batch_runs row is the parent aggregate; migration_batch_children
+-- rows hold the deterministic child ordering, per-child status, dependency
+-- edges, and the resolved Honua layer id used by relationship-apply (#1256).
+-- Dependencies: Requires the honua schema from 001_CreateHonuaSchema.sql. The
+-- batch surface is independent of honua.migration_runs (031) so a batch can be
+-- audited on its own.
+
+CREATE TABLE IF NOT EXISTS honua.migration_batch_runs (
+    batch_id                VARCHAR(64)  PRIMARY KEY,
+    source_kind             VARCHAR(64)  NOT NULL,
+    source_url              TEXT         NOT NULL DEFAULT '',
+    source_display_name     TEXT,
+    status                  VARCHAR(32)  NOT NULL DEFAULT 'running',
+    started_at              TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    completed_at            TIMESTAMPTZ,
+    total_children          INTEGER      NOT NULL DEFAULT 0,
+    succeeded_children      INTEGER      NOT NULL DEFAULT 0,
+    failed_children         INTEGER      NOT NULL DEFAULT 0,
+    cancelled_children      INTEGER      NOT NULL DEFAULT 0,
+    apply_relationships     BOOLEAN      NOT NULL DEFAULT FALSE,
+    relationships_applied   BOOLEAN      NOT NULL DEFAULT FALSE,
+    manifest_body           JSONB,
+    status_note             TEXT,
+    CONSTRAINT chk_migration_batch_runs_status
+        CHECK (status IN ('running','succeeded','failed','cancelled','needs-review'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_migration_batch_runs_started_at
+    ON honua.migration_batch_runs (started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_migration_batch_runs_status
+    ON honua.migration_batch_runs (status);
+
+CREATE TABLE IF NOT EXISTS honua.migration_batch_children (
+    batch_id            VARCHAR(64)  NOT NULL
+        REFERENCES honua.migration_batch_runs (batch_id) ON DELETE CASCADE,
+    ordinal             INTEGER      NOT NULL,
+    source_resource_id  TEXT         NOT NULL,
+    service_url         TEXT         NOT NULL,
+    source_layer_id     INTEGER      NOT NULL,
+    table_name          TEXT         NOT NULL,
+    target_schema       TEXT,
+    service_name        TEXT,
+    depends_on          JSONB        NOT NULL DEFAULT '[]'::jsonb,
+    status              VARCHAR(32)  NOT NULL DEFAULT 'pending',
+    job_id              VARCHAR(64),
+    published_layer_id  INTEGER,
+    status_note         TEXT,
+    updated_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (batch_id, ordinal),
+    CONSTRAINT chk_migration_batch_children_status
+        CHECK (status IN ('pending','running','succeeded','failed','needs-review','cancelled'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_migration_batch_children_batch
+    ON honua.migration_batch_children (batch_id, ordinal);
+
+COMMENT ON TABLE honua.migration_batch_runs IS
+    'Footprint-driven batch import run aggregate (issue #1253). Aggregates ordered per-layer Geoservices import jobs into one resumable run with rolled-up progress and optional post-publish relationship application (#1256). manifest_body is jsonb so reviewers can introspect the batch manifest directly with SQL.';
+
+COMMENT ON TABLE honua.migration_batch_children IS
+    'Ordered child layer imports within a migration_batch_runs row (issue #1253). ordinal is the deterministic execution sequence; depends_on lists the source_resource_ids that must succeed first (relationship origin layers); published_layer_id is the resolved Honua layer id used to build the relationship-apply published-layer map.';

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -1147,6 +1147,9 @@ app.MapRasterImportEndpoints();
 // Configure Geoservices service import endpoints
 app.MapGeoservicesImportEndpoints();
 
+// Configure footprint-driven batch import orchestration endpoints (issue #1253)
+app.MapMigrationBatchEndpoints();
+
 // Configure GeoServer import endpoints
 app.MapGeoServerImportEndpoints();
 

--- a/src/Honua.Server/Startup/ImportExportTileOperationsRegistration.cs
+++ b/src/Honua.Server/Startup/ImportExportTileOperationsRegistration.cs
@@ -59,6 +59,13 @@ internal static class ImportExportTileOperationsRegistration
                 sp.GetRequiredService<IHostEnvironment>(),
                 sp.GetService<IConnectionMultiplexer>()));
         services.AddHostedService<GeoservicesImportBackgroundService>();
+
+        // Footprint-driven batch import orchestration (#1253). The orchestrator
+        // composes the per-layer Geoservices import pipeline into an ordered,
+        // resumable batch run; the background service advances active batches
+        // under the shared import leader election.
+        services.AddScoped<IMigrationBatchOrchestrator, MigrationBatchOrchestrator>();
+        services.AddHostedService<MigrationBatchBackgroundService>();
         services.AddSingleton<GeoServerImportJobManager>(sp =>
             new GeoServerImportJobManager(
                 sp.GetRequiredService<IUniversalProgressStore>(),

--- a/tests/dotnet/Honua.Core.Tests/Features/Migration/MigrationBatchOrchestratorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Migration/MigrationBatchOrchestratorTests.cs
@@ -1,0 +1,414 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Honua.Core.Tests.Features.Migration;
+
+/// <summary>
+/// Unit tests for <see cref="MigrationBatchOrchestrator"/> (issue #1253): ordering
+/// from dependency edges, sequential child queueing, status roll-up, resumability
+/// (skip succeeded / restart from failed), and relationship-apply wiring (#1256).
+/// </summary>
+public sealed class MigrationBatchOrchestratorTests
+{
+    [Fact]
+    public async Task StartAsync_OrdersDependenciesBeforeDependents_AndQueuesFirstChild()
+    {
+        var (orchestrator, catalog, jobManager, _) = Build();
+
+        // Related layer listed first but depends on the origin layer: orchestrator
+        // must order the origin (layer:0) before the related (layer:1).
+        var request = new MigrationBatchStartRequest
+        {
+            SourceKind = "arcgis-geoservices-rest",
+            Layers =
+            [
+                new MigrationBatchLayerSpec
+                {
+                    SourceResourceId = "resource:x:layer:1",
+                    ServiceUrl = "https://example.com/FeatureServer",
+                    LayerId = 1,
+                    TableName = "related",
+                    DependsOn = ["resource:x:layer:0"]
+                },
+                new MigrationBatchLayerSpec
+                {
+                    SourceResourceId = "resource:x:layer:0",
+                    ServiceUrl = "https://example.com/FeatureServer",
+                    LayerId = 0,
+                    TableName = "origin"
+                }
+            ]
+        };
+
+        var batch = await orchestrator.StartAsync(request);
+
+        var children = await catalog.GetChildrenAsync(batch.BatchId);
+        children.Should().HaveCount(2);
+        children[0].SourceResourceId.Should().Be("resource:x:layer:0");
+        children[1].SourceResourceId.Should().Be("resource:x:layer:1");
+
+        // Sequential: only the first (origin) child is queued initially.
+        children[0].Status.Should().Be(MigrationBatchChildStatus.Running);
+        children[1].Status.Should().Be(MigrationBatchChildStatus.Pending);
+        jobManager.Queue.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task AdvanceAsync_WhenChildSucceeds_QueuesNextAndRollsUp()
+    {
+        var (orchestrator, catalog, jobManager, _) = Build();
+        var batch = await orchestrator.StartAsync(NewRequest());
+
+        // Complete the first child's import job successfully.
+        var children = await catalog.GetChildrenAsync(batch.BatchId);
+        jobManager.CompleteJob(children[0].JobId!, GeoservicesImportStatus.Completed, publishedLayerId: 100);
+
+        var advanced = await orchestrator.AdvanceAsync(batch.BatchId);
+        advanced!.SucceededChildren.Should().Be(1);
+        advanced.Status.Should().Be(MigrationBatchRunStatus.Running);
+
+        children = await catalog.GetChildrenAsync(batch.BatchId);
+        children[0].Status.Should().Be(MigrationBatchChildStatus.Succeeded);
+        children[0].PublishedLayerId.Should().Be(100);
+        children[1].Status.Should().Be(MigrationBatchChildStatus.Running);
+    }
+
+    [Fact]
+    public async Task AdvanceAsync_WhenAllSucceed_MarksBatchSucceeded()
+    {
+        var (orchestrator, catalog, jobManager, _) = Build();
+        var batch = await orchestrator.StartAsync(NewRequest());
+
+        await CompleteAllChildrenAsync(orchestrator, catalog, jobManager, batch.BatchId);
+
+        var final = await catalog.GetAsync(batch.BatchId);
+        final!.Status.Should().Be(MigrationBatchRunStatus.Succeeded);
+        final.SucceededChildren.Should().Be(2);
+        final.CompletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task AdvanceAsync_WhenChildFails_MarksBatchFailed_AndStopsQueueing()
+    {
+        var (orchestrator, catalog, jobManager, _) = Build();
+        var batch = await orchestrator.StartAsync(NewRequest());
+
+        var children = await catalog.GetChildrenAsync(batch.BatchId);
+        jobManager.CompleteJob(children[0].JobId!, GeoservicesImportStatus.Failed);
+
+        var advanced = await orchestrator.AdvanceAsync(batch.BatchId);
+        advanced!.Status.Should().Be(MigrationBatchRunStatus.Failed);
+        advanced.FailedChildren.Should().Be(1);
+
+        children = await catalog.GetChildrenAsync(batch.BatchId);
+        // The second child must remain pending (not queued) after a blocking failure.
+        children[1].Status.Should().Be(MigrationBatchChildStatus.Pending);
+    }
+
+    [Fact]
+    public async Task AdvanceAsync_AppliesRelationships_WhenAllChildrenPublishAndRequested()
+    {
+        var manifest = new MigrationManifestArtifact
+        {
+            SourceKind = "arcgis-geoservices-rest",
+            Source = new MigrationSourceIdentity { DisplayName = "Example", BaseUrl = "https://example.com" },
+            Summary = new MigrationManifestSummary()
+        };
+        var manifestBody = System.Text.Json.JsonSerializer.Serialize(
+            manifest,
+            MigrationEvidencePackJsonContext.Default.MigrationManifestArtifact);
+
+        var (orchestrator, catalog, jobManager, importService) = Build();
+        var request = NewRequest() with { ManifestBody = manifestBody, ApplyRelationships = true };
+        var batch = await orchestrator.StartAsync(request);
+
+        await CompleteAllChildrenAsync(orchestrator, catalog, jobManager, batch.BatchId, publishedLayerId: 200);
+
+        importService.ApplyRelationshipsCalls.Should().Be(1);
+        importService.LastPublishedLayerMap.Should().ContainKey("resource:x:layer:0");
+        var final = await catalog.GetAsync(batch.BatchId);
+        final!.RelationshipsApplied.Should().BeTrue();
+        final.Status.Should().Be(MigrationBatchRunStatus.Succeeded);
+    }
+
+    private static async Task CompleteAllChildrenAsync(
+        MigrationBatchOrchestrator orchestrator,
+        IMigrationBatchRunCatalog catalog,
+        FakeJobManager jobManager,
+        string batchId,
+        int publishedLayerId = 100)
+    {
+        for (var guard = 0; guard < 10; guard++)
+        {
+            var children = await catalog.GetChildrenAsync(batchId);
+            var running = children.FirstOrDefault(c => c.Status == MigrationBatchChildStatus.Running);
+            if (running is null)
+            {
+                break;
+            }
+
+            jobManager.CompleteJob(running.JobId!, GeoservicesImportStatus.Completed, publishedLayerId);
+            await orchestrator.AdvanceAsync(batchId);
+        }
+    }
+
+    private static MigrationBatchStartRequest NewRequest() => new()
+    {
+        SourceKind = "arcgis-geoservices-rest",
+        Layers =
+        [
+            new MigrationBatchLayerSpec
+            {
+                SourceResourceId = "resource:x:layer:0",
+                ServiceUrl = "https://example.com/FeatureServer",
+                LayerId = 0,
+                TableName = "origin"
+            },
+            new MigrationBatchLayerSpec
+            {
+                SourceResourceId = "resource:x:layer:1",
+                ServiceUrl = "https://example.com/FeatureServer",
+                LayerId = 1,
+                TableName = "related",
+                DependsOn = ["resource:x:layer:0"]
+            }
+        ]
+    };
+
+    private static (MigrationBatchOrchestrator Orchestrator, IMigrationBatchRunCatalog Catalog, FakeJobManager JobManager, FakeImportService ImportService) Build()
+    {
+        var catalog = new InMemoryBatchCatalog();
+        var jobManager = new FakeJobManager();
+        var importService = new FakeImportService();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IMigrationBatchRunCatalog>(catalog);
+        services.AddSingleton<IDistributedImportJobManager>(jobManager);
+        services.AddSingleton<IGeoservicesImportService>(importService);
+        var provider = services.BuildServiceProvider();
+
+        var orchestrator = new MigrationBatchOrchestrator(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<MigrationBatchOrchestrator>.Instance);
+
+        return (orchestrator, catalog, jobManager, importService);
+    }
+
+    private sealed class FakeImportService : IGeoservicesImportService
+    {
+        public int ApplyRelationshipsCalls { get; private set; }
+
+        public IReadOnlyDictionary<string, int>? LastPublishedLayerMap { get; private set; }
+
+        public Task<MigrationRelationshipApplyOutcome[]> ApplyRelationshipsAsync(
+            MigrationManifestArtifact manifest,
+            IReadOnlyDictionary<string, int> publishedLayerMap,
+            IMetadataV2GraphStore? graphStore,
+            CancellationToken cancellationToken = default)
+        {
+            ApplyRelationshipsCalls++;
+            LastPublishedLayerMap = publishedLayerMap;
+            return Task.FromResult(Array.Empty<MigrationRelationshipApplyOutcome>());
+        }
+
+        public Task<GeoservicesServiceInfo> DiscoverServiceAsync(GeoservicesDiscoveryRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<MigrationSourceInventoryArtifact> ScanSourceAsync(GeoservicesDiscoveryRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<GeoservicesImportResult> ImportLayerAsync(GeoservicesImportRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<GeoservicesImportResult> ImportLayerAsync(GeoservicesImportRequest request, IProgress<GeoservicesImportProgress>? progress, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class FakeJobManager : IDistributedImportJobManager
+    {
+        private readonly FakeProgressStore<GeoservicesImportProgress> _progress = new();
+        private readonly FakeProgressStore<GeoservicesImportRequest> _requests = new();
+        private readonly FakeQueue _queue = new();
+
+        public IDistributedJobQueueService JobQueue => _queue;
+
+        public IDistributedLeaderElection LeaderElection => throw new NotSupportedException();
+
+        public IDistributedProgressStore<GeoservicesImportProgress> ProgressStore => _progress;
+
+        public IDistributedProgressStore<GeoservicesImportRequest> RequestStore => _requests;
+
+        public IReadOnlyList<string> Queue => _queue.Enqueued;
+
+        public void CompleteJob(string jobId, GeoservicesImportStatus status, int? publishedLayerId = null)
+        {
+            var current = _progress.GetProgressAsync(jobId).GetAwaiter().GetResult();
+            var updated = (current ?? GeoservicesImportProgress.CreateInitial(jobId, "https://example.com", 0, "t")) with
+            {
+                Status = status,
+                PublishedLayerId = publishedLayerId,
+                CompletedAt = DateTimeOffset.UtcNow
+            };
+            _progress.SetProgressAsync(jobId, updated).GetAwaiter().GetResult();
+        }
+    }
+
+    private sealed class FakeQueue : IDistributedJobQueueService
+    {
+        private readonly List<string> _enqueued = [];
+
+        public IReadOnlyList<string> Enqueued => _enqueued;
+
+        public Task EnqueueAsync(string jobId, CancellationToken cancellationToken = default)
+        {
+            _enqueued.Add(jobId);
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> DequeueAsync(TimeSpan timeout, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+
+        public Task CompleteAsync(string jobId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task RecoverInFlightAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<long> GetQueueLengthAsync(CancellationToken cancellationToken = default) => Task.FromResult<long>(_enqueued.Count);
+    }
+
+    private sealed class FakeProgressStore<TProgress> : IDistributedProgressStore<TProgress>
+        where TProgress : class
+    {
+        private readonly ConcurrentDictionary<string, TProgress> _store = new(StringComparer.Ordinal);
+
+        public Task SetProgressAsync(string jobId, TProgress progress, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _store[jobId] = progress;
+            return Task.CompletedTask;
+        }
+
+        public Task<TProgress?> GetProgressAsync(string jobId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_store.TryGetValue(jobId, out var value) ? value : null);
+
+        public Task DeleteProgressAsync(string jobId, CancellationToken cancellationToken = default)
+        {
+            _store.TryRemove(jobId, out _);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<string>> GetActiveJobIdsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>(_store.Keys.ToList());
+    }
+
+    private sealed class InMemoryBatchCatalog : IMigrationBatchRunCatalog
+    {
+        private readonly ConcurrentDictionary<string, MigrationBatchRunRecord> _batches = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, List<MigrationBatchChildRecord>> _children = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, string> _manifests = new(StringComparer.Ordinal);
+
+        public Task<MigrationBatchRunRecord> CreateAsync(
+            MigrationBatchRunRecord record,
+            string? manifestBody,
+            IReadOnlyList<MigrationBatchChildRecord> children,
+            CancellationToken cancellationToken = default)
+        {
+            _batches[record.BatchId] = record;
+            _children[record.BatchId] = children.OrderBy(c => c.Ordinal).ToList();
+            if (!string.IsNullOrWhiteSpace(manifestBody))
+            {
+                _manifests[record.BatchId] = manifestBody;
+            }
+
+            return Task.FromResult(record);
+        }
+
+        public Task<MigrationBatchRunRecord?> GetAsync(string batchId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_batches.TryGetValue(batchId, out var record) ? record : null);
+
+        public Task<IReadOnlyList<MigrationBatchChildRecord>> GetChildrenAsync(string batchId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<MigrationBatchChildRecord>>(
+                _children.TryGetValue(batchId, out var children) ? children.OrderBy(c => c.Ordinal).ToList() : []);
+
+        public Task<string?> GetManifestBodyAsync(string batchId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_manifests.TryGetValue(batchId, out var body) ? body : null);
+
+        public Task<MigrationBatchChildRecord?> UpdateChildAsync(
+            string batchId,
+            int ordinal,
+            MigrationBatchChildStatus status,
+            string? jobId,
+            int? publishedLayerId,
+            string? statusNote,
+            DateTimeOffset updatedAt,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_children.TryGetValue(batchId, out var children))
+            {
+                return Task.FromResult<MigrationBatchChildRecord?>(null);
+            }
+
+            var index = children.FindIndex(c => c.Ordinal == ordinal);
+            if (index < 0 || children[index].Status is MigrationBatchChildStatus.Succeeded
+                or MigrationBatchChildStatus.Failed
+                or MigrationBatchChildStatus.Cancelled
+                or MigrationBatchChildStatus.NeedsReview)
+            {
+                return Task.FromResult<MigrationBatchChildRecord?>(index < 0 ? null : children[index]);
+            }
+
+            var updated = children[index] with
+            {
+                Status = status,
+                JobId = jobId ?? children[index].JobId,
+                PublishedLayerId = publishedLayerId ?? children[index].PublishedLayerId,
+                StatusNote = statusNote ?? children[index].StatusNote,
+                UpdatedAt = updatedAt
+            };
+            children[index] = updated;
+            return Task.FromResult<MigrationBatchChildRecord?>(updated);
+        }
+
+        public Task<MigrationBatchRunRecord?> UpdateBatchAsync(
+            string batchId,
+            MigrationBatchRunStatus status,
+            int succeededChildren,
+            int failedChildren,
+            int cancelledChildren,
+            DateTimeOffset? completedAt,
+            bool? relationshipsApplied,
+            string? statusNote,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_batches.TryGetValue(batchId, out var record) || record.Status != MigrationBatchRunStatus.Running)
+            {
+                return Task.FromResult(_batches.TryGetValue(batchId, out var existing) ? existing : null);
+            }
+
+            var updated = record with
+            {
+                Status = status,
+                SucceededChildren = succeededChildren,
+                FailedChildren = failedChildren,
+                CancelledChildren = cancelledChildren,
+                CompletedAt = completedAt ?? record.CompletedAt,
+                RelationshipsApplied = relationshipsApplied ?? record.RelationshipsApplied,
+                StatusNote = statusNote ?? record.StatusNote
+            };
+            _batches[batchId] = updated;
+            return Task.FromResult<MigrationBatchRunRecord?>(updated);
+        }
+
+        public Task<IReadOnlyList<string>> GetActiveBatchIdsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>(
+                _batches.Values.Where(b => b.Status == MigrationBatchRunStatus.Running).Select(b => b.BatchId).ToList());
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/PostgresMigrationBatchRunCatalogTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/PostgresMigrationBatchRunCatalogTests.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Postgres.Features.Migration;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+/// <summary>
+/// Issue #1253: <see cref="PostgresMigrationBatchRunCatalog"/> persists batch
+/// composition, ordered child rows, per-child status with sticky-terminal
+/// semantics, and rolled-up batch counts. Exercises the real SQL (migration 045
+/// schema) against the shared Testcontainers Postgres fixture.
+/// </summary>
+[Collection("Database")]
+public sealed class PostgresMigrationBatchRunCatalogTests(PostgresFixture fixture)
+{
+    [IntegrationTest]
+    public async Task CreateAsync_PersistsBatchAndChildren_AndIsIdempotent()
+    {
+        await EnsureBatchTablesAsync();
+        var catalog = CreateCatalog();
+        var batchId = $"batch-{Guid.NewGuid():N}"[..16];
+
+        var record = NewBatch(batchId, 2);
+        var children = NewChildren(batchId);
+
+        var created = await catalog.CreateAsync(record, manifestBody: "{\"artifactKind\":\"honua.migration.manifest\"}", children);
+        created.BatchId.Should().Be(batchId);
+        created.TotalChildren.Should().Be(2);
+
+        // Idempotent: re-create with different children is a no-op.
+        await catalog.CreateAsync(record with { SourceDisplayName = "ignored" }, manifestBody: null, []);
+
+        var persistedChildren = await catalog.GetChildrenAsync(batchId);
+        persistedChildren.Should().HaveCount(2);
+        persistedChildren[0].SourceResourceId.Should().Be("resource:x:layer:0");
+        persistedChildren[1].DependsOn.Should().ContainSingle().Which.Should().Be("resource:x:layer:0");
+
+        var manifest = await catalog.GetManifestBodyAsync(batchId);
+        manifest.Should().Contain("honua.migration.manifest");
+    }
+
+    [IntegrationTest]
+    public async Task UpdateChildAsync_AdvancesStatus_AndIsStickyTerminal()
+    {
+        await EnsureBatchTablesAsync();
+        var catalog = CreateCatalog();
+        var batchId = $"batch-{Guid.NewGuid():N}"[..16];
+        await catalog.CreateAsync(NewBatch(batchId, 2), null, NewChildren(batchId));
+
+        var running = await catalog.UpdateChildAsync(
+            batchId, 0, MigrationBatchChildStatus.Running, "job-1", null, null, DateTimeOffset.UtcNow);
+        running!.Status.Should().Be(MigrationBatchChildStatus.Running);
+        running.JobId.Should().Be("job-1");
+
+        var succeeded = await catalog.UpdateChildAsync(
+            batchId, 0, MigrationBatchChildStatus.Succeeded, "job-1", 99, null, DateTimeOffset.UtcNow);
+        succeeded!.Status.Should().Be(MigrationBatchChildStatus.Succeeded);
+        succeeded.PublishedLayerId.Should().Be(99);
+
+        // Terminal state is sticky: a late update is refused.
+        var refused = await catalog.UpdateChildAsync(
+            batchId, 0, MigrationBatchChildStatus.Failed, "job-1", null, "late", DateTimeOffset.UtcNow);
+        refused!.Status.Should().Be(MigrationBatchChildStatus.Succeeded);
+    }
+
+    [IntegrationTest]
+    public async Task UpdateBatchAsync_RollsUpCounts_AndIsStickyTerminal()
+    {
+        await EnsureBatchTablesAsync();
+        var catalog = CreateCatalog();
+        var batchId = $"batch-{Guid.NewGuid():N}"[..16];
+        await catalog.CreateAsync(NewBatch(batchId, 2), null, NewChildren(batchId));
+
+        (await catalog.GetActiveBatchIdsAsync()).Should().Contain(batchId);
+
+        var succeeded = await catalog.UpdateBatchAsync(
+            batchId, MigrationBatchRunStatus.Succeeded, 2, 0, 0, DateTimeOffset.UtcNow, true, "done");
+        succeeded!.Status.Should().Be(MigrationBatchRunStatus.Succeeded);
+        succeeded.SucceededChildren.Should().Be(2);
+        succeeded.RelationshipsApplied.Should().BeTrue();
+
+        // Terminal batch state is sticky.
+        var refused = await catalog.UpdateBatchAsync(
+            batchId, MigrationBatchRunStatus.Failed, 0, 2, 0, DateTimeOffset.UtcNow, null, null);
+        refused!.Status.Should().Be(MigrationBatchRunStatus.Succeeded);
+
+        (await catalog.GetActiveBatchIdsAsync()).Should().NotContain(batchId);
+    }
+
+    private PostgresMigrationBatchRunCatalog CreateCatalog()
+        => new(fixture.ConnectionString, NullLogger<PostgresMigrationBatchRunCatalog>.Instance);
+
+    private static MigrationBatchRunRecord NewBatch(string batchId, int total) => new()
+    {
+        BatchId = batchId,
+        SourceKind = "arcgis-geoservices-rest",
+        SourceUrl = "https://example.com/FeatureServer",
+        Status = MigrationBatchRunStatus.Running,
+        StartedAt = DateTimeOffset.UtcNow,
+        TotalChildren = total,
+        ApplyRelationships = true
+    };
+
+    private static MigrationBatchChildRecord[] NewChildren(string batchId) =>
+    [
+        new MigrationBatchChildRecord
+        {
+            BatchId = batchId,
+            Ordinal = 0,
+            SourceResourceId = "resource:x:layer:0",
+            ServiceUrl = "https://example.com/FeatureServer",
+            SourceLayerId = 0,
+            TableName = "origin",
+            Status = MigrationBatchChildStatus.Pending,
+            UpdatedAt = DateTimeOffset.UtcNow
+        },
+        new MigrationBatchChildRecord
+        {
+            BatchId = batchId,
+            Ordinal = 1,
+            SourceResourceId = "resource:x:layer:1",
+            ServiceUrl = "https://example.com/FeatureServer",
+            SourceLayerId = 1,
+            TableName = "related",
+            DependsOn = ["resource:x:layer:0"],
+            Status = MigrationBatchChildStatus.Pending,
+            UpdatedAt = DateTimeOffset.UtcNow
+        }
+    ];
+
+    /// <summary>
+    /// Migration 045 creates the batch tables; tests apply the same schema
+    /// directly so they do not depend on the migration runner.
+    /// </summary>
+    private async Task EnsureBatchTablesAsync()
+    {
+        await using var conn = await fixture.GetConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE SCHEMA IF NOT EXISTS honua;
+            CREATE TABLE IF NOT EXISTS honua.migration_batch_runs (
+                batch_id                VARCHAR(64)  PRIMARY KEY,
+                source_kind             VARCHAR(64)  NOT NULL,
+                source_url              TEXT         NOT NULL DEFAULT '',
+                source_display_name     TEXT,
+                status                  VARCHAR(32)  NOT NULL DEFAULT 'running',
+                started_at              TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+                completed_at            TIMESTAMPTZ,
+                total_children          INTEGER      NOT NULL DEFAULT 0,
+                succeeded_children      INTEGER      NOT NULL DEFAULT 0,
+                failed_children         INTEGER      NOT NULL DEFAULT 0,
+                cancelled_children      INTEGER      NOT NULL DEFAULT 0,
+                apply_relationships     BOOLEAN      NOT NULL DEFAULT FALSE,
+                relationships_applied   BOOLEAN      NOT NULL DEFAULT FALSE,
+                manifest_body           JSONB,
+                status_note             TEXT,
+                CONSTRAINT chk_migration_batch_runs_status
+                    CHECK (status IN ('running','succeeded','failed','cancelled','needs-review'))
+            );
+            CREATE TABLE IF NOT EXISTS honua.migration_batch_children (
+                batch_id            VARCHAR(64)  NOT NULL
+                    REFERENCES honua.migration_batch_runs (batch_id) ON DELETE CASCADE,
+                ordinal             INTEGER      NOT NULL,
+                source_resource_id  TEXT         NOT NULL,
+                service_url         TEXT         NOT NULL,
+                source_layer_id     INTEGER      NOT NULL,
+                table_name          TEXT         NOT NULL,
+                target_schema       TEXT,
+                service_name        TEXT,
+                depends_on          JSONB        NOT NULL DEFAULT '[]'::jsonb,
+                status              VARCHAR(32)  NOT NULL DEFAULT 'pending',
+                job_id              VARCHAR(64),
+                published_layer_id  INTEGER,
+                status_note         TEXT,
+                updated_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+                PRIMARY KEY (batch_id, ordinal),
+                CONSTRAINT chk_migration_batch_children_status
+                    CHECK (status IN ('pending','running','succeeded','failed','needs-review','cancelled'))
+            );
+            """;
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Import/MigrationBatchEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/MigrationBatchEndpointTests.cs
@@ -1,0 +1,309 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Import;
+
+/// <summary>
+/// Integration tests for the footprint-driven batch import orchestration
+/// endpoints (issue #1253): <c>POST /api/v1/admin/import/migrations</c> and
+/// <c>GET /api/v1/admin/import/migrations/{batchId}</c>. Uses an in-memory
+/// catalog plus a recording orchestrator so the endpoints exercise routing,
+/// validation, serialization, and status-code policy without the distributed
+/// job pipeline.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Import)]
+public sealed class MigrationBatchEndpointTests : IAsyncLifetime
+{
+    private readonly InMemoryMigrationBatchRunCatalog _catalog = new();
+    private readonly RecordingMigrationBatchOrchestrator _orchestrator;
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public MigrationBatchEndpointTests()
+    {
+        _orchestrator = new RecordingMigrationBatchOrchestrator(_catalog);
+        _fixture = new WebAppFixture()
+            .ReplaceService<IMigrationBatchRunCatalog>(_catalog)
+            .ReplaceService<IMigrationBatchOrchestrator>(_orchestrator);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/migrations")]
+    public async Task StartBatch_WithFootprint_ReturnsAcceptedWithBatchId()
+    {
+        var body = new
+        {
+            sourceKind = "arcgis-geoservices-rest",
+            sourceUrl = "https://example.com/arcgis/rest/services/Inspections/FeatureServer",
+            layers = new[]
+            {
+                new { sourceResourceId = "resource:Inspections:layer:0", serviceUrl = "https://example.com/arcgis/rest/services/Inspections/FeatureServer", layerId = 0, tableName = "inspections" },
+                new { sourceResourceId = "resource:Inspections:layer:1", serviceUrl = "https://example.com/arcgis/rest/services/Inspections/FeatureServer", layerId = 1, tableName = "inspection_photos" }
+            }
+        };
+
+        var response = await _client.PostAsync(
+            "/api/v1/admin/import/migrations",
+            new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("batchId").GetString().Should().NotBeNullOrWhiteSpace();
+        doc.RootElement.GetProperty("status").GetString().Should().Be("running");
+        doc.RootElement.GetProperty("totalChildren").GetInt32().Should().Be(2);
+        _orchestrator.LastRequest.Should().NotBeNull();
+        _orchestrator.LastRequest!.Layers.Should().HaveCount(2);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/migrations")]
+    public async Task StartBatch_WithEmptyFootprint_ReturnsBadRequest()
+    {
+        var body = new { sourceKind = "arcgis-geoservices-rest", layers = Array.Empty<object>() };
+
+        var response = await _client.PostAsync(
+            "/api/v1/admin/import/migrations",
+            new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/migrations")]
+    public async Task StartBatch_WithInvalidTableName_ReturnsBadRequest()
+    {
+        var body = new
+        {
+            sourceKind = "arcgis-geoservices-rest",
+            layers = new[]
+            {
+                new { sourceResourceId = "resource:x:layer:0", serviceUrl = "https://example.com/arcgis/rest/services/X/FeatureServer", layerId = 0, tableName = "bad name;drop" }
+            }
+        };
+
+        var response = await _client.PostAsync(
+            "/api/v1/admin/import/migrations",
+            new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/import/migrations/{batchId}")]
+    public async Task GetBatch_WhenUnknown_ReturnsNotFound()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/import/migrations/does-not-exist");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/import/migrations/{batchId}")]
+    public async Task GetBatch_WithChildren_ReturnsRolledUpStatus()
+    {
+        var now = DateTimeOffset.UtcNow;
+        _catalog.Seed(
+            new MigrationBatchRunRecord
+            {
+                BatchId = "batch-001",
+                SourceKind = "arcgis-geoservices-rest",
+                Status = MigrationBatchRunStatus.Running,
+                StartedAt = now,
+                TotalChildren = 2,
+                SucceededChildren = 1
+            },
+            new MigrationBatchChildRecord
+            {
+                BatchId = "batch-001",
+                Ordinal = 0,
+                SourceResourceId = "resource:x:layer:0",
+                ServiceUrl = "https://example.com/arcgis/rest/services/X/FeatureServer",
+                SourceLayerId = 0,
+                TableName = "origin",
+                Status = MigrationBatchChildStatus.Succeeded,
+                PublishedLayerId = 42,
+                UpdatedAt = now
+            },
+            new MigrationBatchChildRecord
+            {
+                BatchId = "batch-001",
+                Ordinal = 1,
+                SourceResourceId = "resource:x:layer:1",
+                ServiceUrl = "https://example.com/arcgis/rest/services/X/FeatureServer",
+                SourceLayerId = 1,
+                TableName = "related",
+                DependsOn = ["resource:x:layer:0"],
+                Status = MigrationBatchChildStatus.Running,
+                UpdatedAt = now
+            });
+
+        var response = await _client.GetAsync("/api/v1/admin/import/migrations/batch-001");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("batchId").GetString().Should().Be("batch-001");
+        doc.RootElement.GetProperty("succeededChildren").GetInt32().Should().Be(1);
+        var children = doc.RootElement.GetProperty("children");
+        children.GetArrayLength().Should().Be(2);
+        children[0].GetProperty("status").GetString().Should().Be("succeeded");
+        children[0].GetProperty("publishedLayerId").GetInt32().Should().Be(42);
+        children[1].GetProperty("dependsOn")[0].GetString().Should().Be("resource:x:layer:0");
+    }
+
+    private sealed class RecordingMigrationBatchOrchestrator : IMigrationBatchOrchestrator
+    {
+        private readonly InMemoryMigrationBatchRunCatalog _catalog;
+
+        public RecordingMigrationBatchOrchestrator(InMemoryMigrationBatchRunCatalog catalog) => _catalog = catalog;
+
+        public MigrationBatchStartRequest? LastRequest { get; private set; }
+
+        public Task<MigrationBatchRunRecord> StartAsync(MigrationBatchStartRequest request, CancellationToken cancellationToken = default)
+        {
+            LastRequest = request;
+            var batchId = Guid.NewGuid().ToString("N")[..16];
+            var record = new MigrationBatchRunRecord
+            {
+                BatchId = batchId,
+                SourceKind = request.SourceKind,
+                SourceUrl = request.SourceUrl,
+                SourceDisplayName = request.SourceDisplayName,
+                Status = MigrationBatchRunStatus.Running,
+                StartedAt = DateTimeOffset.UtcNow,
+                TotalChildren = request.Layers.Count,
+                ApplyRelationships = request.ApplyRelationships && !string.IsNullOrWhiteSpace(request.ManifestBody)
+            };
+            _catalog.Seed(record);
+            return Task.FromResult(record);
+        }
+
+        public Task<MigrationBatchRunRecord?> AdvanceAsync(string batchId, CancellationToken cancellationToken = default)
+            => _catalog.GetAsync(batchId, cancellationToken);
+    }
+
+    private sealed class InMemoryMigrationBatchRunCatalog : IMigrationBatchRunCatalog
+    {
+        private readonly ConcurrentDictionary<string, MigrationBatchRunRecord> _batches = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, List<MigrationBatchChildRecord>> _children = new(StringComparer.Ordinal);
+
+        public void Seed(MigrationBatchRunRecord record, params MigrationBatchChildRecord[] children)
+        {
+            _batches[record.BatchId] = record;
+            if (children.Length > 0)
+            {
+                _children[record.BatchId] = children.OrderBy(c => c.Ordinal).ToList();
+            }
+        }
+
+        public Task<MigrationBatchRunRecord> CreateAsync(
+            MigrationBatchRunRecord record,
+            string? manifestBody,
+            IReadOnlyList<MigrationBatchChildRecord> children,
+            CancellationToken cancellationToken = default)
+        {
+            _batches[record.BatchId] = record;
+            _children[record.BatchId] = children.OrderBy(c => c.Ordinal).ToList();
+            return Task.FromResult(record);
+        }
+
+        public Task<MigrationBatchRunRecord?> GetAsync(string batchId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_batches.TryGetValue(batchId, out var record) ? record : null);
+
+        public Task<IReadOnlyList<MigrationBatchChildRecord>> GetChildrenAsync(string batchId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<MigrationBatchChildRecord>>(
+                _children.TryGetValue(batchId, out var children) ? children : []);
+
+        public Task<string?> GetManifestBodyAsync(string batchId, CancellationToken cancellationToken = default)
+            => Task.FromResult<string?>(null);
+
+        public Task<MigrationBatchChildRecord?> UpdateChildAsync(
+            string batchId,
+            int ordinal,
+            MigrationBatchChildStatus status,
+            string? jobId,
+            int? publishedLayerId,
+            string? statusNote,
+            DateTimeOffset updatedAt,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_children.TryGetValue(batchId, out var children))
+            {
+                return Task.FromResult<MigrationBatchChildRecord?>(null);
+            }
+
+            var index = children.FindIndex(c => c.Ordinal == ordinal);
+            if (index < 0)
+            {
+                return Task.FromResult<MigrationBatchChildRecord?>(null);
+            }
+
+            var updated = children[index] with
+            {
+                Status = status,
+                JobId = jobId ?? children[index].JobId,
+                PublishedLayerId = publishedLayerId ?? children[index].PublishedLayerId,
+                StatusNote = statusNote ?? children[index].StatusNote,
+                UpdatedAt = updatedAt
+            };
+            children[index] = updated;
+            return Task.FromResult<MigrationBatchChildRecord?>(updated);
+        }
+
+        public Task<MigrationBatchRunRecord?> UpdateBatchAsync(
+            string batchId,
+            MigrationBatchRunStatus status,
+            int succeededChildren,
+            int failedChildren,
+            int cancelledChildren,
+            DateTimeOffset? completedAt,
+            bool? relationshipsApplied,
+            string? statusNote,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_batches.TryGetValue(batchId, out var record))
+            {
+                return Task.FromResult<MigrationBatchRunRecord?>(null);
+            }
+
+            var updated = record with
+            {
+                Status = status,
+                SucceededChildren = succeededChildren,
+                FailedChildren = failedChildren,
+                CancelledChildren = cancelledChildren,
+                CompletedAt = completedAt ?? record.CompletedAt,
+                RelationshipsApplied = relationshipsApplied ?? record.RelationshipsApplied,
+                StatusNote = statusNote ?? record.StatusNote
+            };
+            _batches[batchId] = updated;
+            return Task.FromResult<MigrationBatchRunRecord?>(updated);
+        }
+
+        public Task<IReadOnlyList<string>> GetActiveBatchIdsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>(
+                _batches.Values
+                    .Where(b => b.Status == MigrationBatchRunStatus.Running)
+                    .Select(b => b.BatchId)
+                    .ToList());
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #1253
Closes #1256

## Summary
Wires assess to extract: a discovered footprint (set of ArcGIS services/layers) can start a single batch migration run that is ordered, resumable, and reports aggregated progress across its child layer imports. After all child layers publish, the batch applies cross-layer relationship classes (#1256) so origin/destination FKs resolve in the batch context. Built as a thin orchestrator over the existing per-layer Geoservices import pipeline and distributed job manager — no parallel data path.

## Changes Made
- Domain + abstractions in `Honua.Core`: `MigrationBatchRunRecord`, `MigrationBatchChildRecord`, `IMigrationBatchRunCatalog`, `IMigrationBatchOrchestrator` (+ `MigrationBatchStartRequest`/`MigrationBatchLayerSpec` footprint models).
- `MigrationBatchOrchestrator` (Core): topo-sorts the footprint (relationship origin layers before dependents, stable by input order, cycle/dangling-edge safe), queues children sequentially via `IDistributedImportJobManager`, reconciles each child against its per-layer import job, rolls up batch status, and invokes `IGeoservicesImportService.ApplyRelationshipsAsync` over the resolved published-layer map once all children publish. `StartAsync`/`AdvanceAsync` are idempotent → resumable (skip succeeded, restart from failed; pending successors stranded behind a blocking failure mark the batch terminally Failed but leave rows intact for re-run).
- `PostgresMigrationBatchRunCatalog` + additive migration `045_CreateMigrationBatchRuns.sql` (`migration_batch_runs` + `migration_batch_children`, idempotent `CREATE TABLE IF NOT EXISTS`, sticky-terminal `UPDATE` guards, FK cascade, dependency edges stored as jsonb, manifest body persisted as jsonb for relationship-apply).
- `MigrationBatchBackgroundService` (Honua.Import): advances active batches under the shared import leader election.
- Endpoints: `POST /api/v1/admin/import/migrations` (start) and `GET /api/v1/admin/import/migrations/{batchId}` (rolled-up status + per-child progress); registered in `EndpointRegistry` and `Program.cs`; DI wired in `ImportExportTileOperationsRegistration` (orchestrator + hosted service) and `Honua.Postgres` (catalog).
- Tests: orchestrator unit tests (ordering, sequential queueing, roll-up, failure-stops-queueing, relationship-apply wiring), Postgres catalog integration tests (create/idempotency, sticky-terminal child + batch updates, active-id rollup), and endpoint integration tests (202 + batchId, validation 400s, 404, rolled-up GET).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires database migration

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent — full Release build (warnings-as-errors), format, architecture/governance (104 pass), Core Migration (270) + Postgres batch-catalog (3) + Server batch-endpoint/migration (5+6) all green; broad "Core" server shard delegated to CI (see note)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

