### PR TITLE
fix(scene): centralize scene URL construction + enclose 3D Tiles descendant heights

### DIFF
--- a/src/Honua.Protocols.Scene/SceneDiscoveryEndpoints.cs
+++ b/src/Honua.Protocols.Scene/SceneDiscoveryEndpoints.cs
@@ -442,23 +442,13 @@ internal static partial class SceneDiscoveryEndpoints
             };
 
     private static string BuildSceneApiUrl(string baseUrl, string sceneId)
-        => BuildUrl(baseUrl, "/api/scenes/", sceneId, suffix: null);
+        => Honua.Scene.SceneUrls.AbsoluteSceneApiUrl(baseUrl, sceneId);
 
     private static string BuildSceneResolveUrl(string baseUrl, string sceneId)
-        => BuildUrl(baseUrl, "/api/scenes/", sceneId, "/resolve");
+        => Honua.Scene.SceneUrls.AbsoluteSceneResolveUrl(baseUrl, sceneId);
 
     private static string BuildTilesetUrl(string baseUrl, string sceneId)
-        => BuildUrl(baseUrl, "/scenes/", sceneId, "/tileset.json");
-
-    private static string BuildUrl(string baseUrl, string prefix, string sceneId, string? suffix)
-    {
-        var escapedSceneId = Uri.EscapeDataString(sceneId);
-        return string.Concat(
-            baseUrl.AsSpan().TrimEnd('/'),
-            prefix.AsSpan(),
-            escapedSceneId.AsSpan(),
-            suffix.AsSpan());
-    }
+        => Honua.Scene.SceneUrls.AbsoluteTilesetUrl(baseUrl, sceneId);
 
     private static string[] ParseRequestedCapabilities(string? raw)
         => string.IsNullOrWhiteSpace(raw)

--- a/src/Honua.Protocols.Scene/SceneEndpoints.cs
+++ b/src/Honua.Protocols.Scene/SceneEndpoints.cs
@@ -660,14 +660,7 @@ internal static partial class SceneEndpoints
     }
 
     private static string BuildSceneUrl(string baseUrl, string sceneId, string suffix)
-    {
-        var escapedSceneId = Uri.EscapeDataString(sceneId);
-        return string.Concat(
-            baseUrl.AsSpan().TrimEnd('/'),
-            "/scenes/",
-            escapedSceneId.AsSpan(),
-            suffix.AsSpan());
-    }
+        => Honua.Scene.SceneUrls.AbsoluteSceneUrl(baseUrl, sceneId, suffix);
 
     // EventIds 8404-8408 reserved here. 8401-8403 are owned by
     // Honua.Core's MonitoredCacheLog; 8410-8419 are reserved by SceneAccessLog

--- a/src/Honua.Scene/Generation/TilesetDocumentWriter.cs
+++ b/src/Honua.Scene/Generation/TilesetDocumentWriter.cs
@@ -148,23 +148,22 @@ public static class TilesetDocumentWriter
         // 3D Tiles 1.1 requires a tile's boundingVolume to spatially enclose
         // every descendant's bounding volume. The lon/lat bounds come from the
         // node envelope (which already encloses its children), but the vertical
-        // extent must too. A content-bearing node uses its own emitted
-        // [min,max]; a content-less interior node (e.g. when interior sampling
-        // is disabled) would otherwise default to [0,0], which fails to enclose
-        // its content-bearing descendants and lets a conformant client cull
-        // visible geometry — so derive its vertical extent from the union of all
-        // content-bearing descendants instead.
+        // extent must too. Derive it from the union of this node's own content
+        // and every content-bearing descendant rather than the node's own
+        // emitted [min,max]: a content-bearing interior node's height comes from
+        // a thinned representative sample of its subtree (SampleFeatures strides
+        // by key order, not height), so the sample can exclude the leaf carrying
+        // the subtree's extreme height — leaving the node's own extent narrower
+        // than its descendants. A content-less interior node (interior sampling
+        // disabled) has no own extent at all. Either way the node's own [min,max]
+        // can fail to enclose descendants and let a conformant client cull
+        // visible geometry, so always union over the whole subtree.
         double minHeight;
         double maxHeight;
-        if (hasContent)
+        if (TryGetDescendantHeightExtent(node, content, out var subtreeMin, out var subtreeMax))
         {
-            minHeight = nodeContent.MinHeightMeters;
-            maxHeight = nodeContent.MaxHeightMeters;
-        }
-        else if (TryGetDescendantHeightExtent(node, content, out var descMin, out var descMax))
-        {
-            minHeight = descMin;
-            maxHeight = descMax;
+            minHeight = subtreeMin;
+            maxHeight = subtreeMax;
         }
         else
         {

--- a/src/Honua.Scene/Generation/TilesetDocumentWriter.cs
+++ b/src/Honua.Scene/Generation/TilesetDocumentWriter.cs
@@ -145,14 +145,43 @@ public static class TilesetDocumentWriter
     {
         var hasContent = content.TryGetValue(node, out var nodeContent);
 
+        // 3D Tiles 1.1 requires a tile's boundingVolume to spatially enclose
+        // every descendant's bounding volume. The lon/lat bounds come from the
+        // node envelope (which already encloses its children), but the vertical
+        // extent must too. A content-bearing node uses its own emitted
+        // [min,max]; a content-less interior node (e.g. when interior sampling
+        // is disabled) would otherwise default to [0,0], which fails to enclose
+        // its content-bearing descendants and lets a conformant client cull
+        // visible geometry — so derive its vertical extent from the union of all
+        // content-bearing descendants instead.
+        double minHeight;
+        double maxHeight;
+        if (hasContent)
+        {
+            minHeight = nodeContent.MinHeightMeters;
+            maxHeight = nodeContent.MaxHeightMeters;
+        }
+        else if (TryGetDescendantHeightExtent(node, content, out var descMin, out var descMax))
+        {
+            minHeight = descMin;
+            maxHeight = descMax;
+        }
+        else
+        {
+            // No content anywhere in this subtree; a degenerate [0,0] slab is
+            // the only meaningful vertical extent and encloses nothing real.
+            minHeight = 0.0;
+            maxHeight = 0.0;
+        }
+
         var region = new[]
         {
             node.West * Math.PI / 180.0,
             node.South * Math.PI / 180.0,
             node.East * Math.PI / 180.0,
             node.North * Math.PI / 180.0,
-            hasContent ? nodeContent.MinHeightMeters : 0.0,
-            hasContent ? nodeContent.MaxHeightMeters : 0.0
+            minHeight,
+            maxHeight
         };
 
         List<TileNode>? children = null;
@@ -175,6 +204,44 @@ public static class TilesetDocumentWriter
             Content = hasContent ? new TileContent { Uri = nodeContent.Uri } : null,
             Children = children
         };
+    }
+
+    /// <summary>
+    /// Unions the vertical extent (meters) of every content-bearing node in the
+    /// subtree rooted at <paramref name="node"/>. Returns <c>false</c> when no
+    /// descendant carries content, so callers can fall back to a degenerate
+    /// extent rather than producing an inverted [+inf,-inf] region.
+    /// </summary>
+    private static bool TryGetDescendantHeightExtent(
+        SceneTileNode node,
+        IReadOnlyDictionary<SceneTileNode, SceneTileContent> content,
+        out double minHeight,
+        out double maxHeight)
+    {
+        var found = false;
+        var min = double.PositiveInfinity;
+        var max = double.NegativeInfinity;
+
+        if (content.TryGetValue(node, out var nodeContent))
+        {
+            found = true;
+            min = nodeContent.MinHeightMeters;
+            max = nodeContent.MaxHeightMeters;
+        }
+
+        foreach (var child in node.Children)
+        {
+            if (TryGetDescendantHeightExtent(child, content, out var childMin, out var childMax))
+            {
+                found = true;
+                if (childMin < min) min = childMin;
+                if (childMax > max) max = childMax;
+            }
+        }
+
+        minHeight = found ? min : 0.0;
+        maxHeight = found ? max : 0.0;
+        return found;
     }
 
     /// <summary>

--- a/src/Honua.Scene/Grpc/SceneGrpcMapping.cs
+++ b/src/Honua.Scene/Grpc/SceneGrpcMapping.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
-using System.Globalization;
 using Honua.Core.Features.Raster.Domain;
 using Honua.Core.Features.Scene.Domain;
 using Proto = Geospatial.V1;
@@ -224,5 +223,5 @@ internal static class SceneGrpcMapping
     }
 
     private static string BuildTilesetPath(string sceneId)
-        => string.Create(CultureInfo.InvariantCulture, $"/scenes/{sceneId}/tileset.json");
+        => Honua.Scene.SceneUrls.TilesetRelativePath(sceneId);
 }

--- a/src/Honua.Scene/PointCloud/PointCloudTilesetBuilder.cs
+++ b/src/Honua.Scene/PointCloud/PointCloudTilesetBuilder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using Honua.Core.Features.Scene.Domain;
 using Honua.Core.Features.Scene.Generation;
 
@@ -52,15 +53,32 @@ public static class PointCloudTilesetBuilder
             throw new ArgumentException("At least one point is required to build a point-cloud tileset.", nameof(points));
         }
 
+        // Hard cap on total points enforced BEFORE the O(N) ProjectedPoint[]
+        // allocation below, so a malformed/oversized LAS cannot drive an
+        // unbounded multi-GB buffer. Rejected with the stable scene error code
+        // (the same surface LasPointCloudReader uses) rather than an OOM.
+        if (points.Count > options.MaxPointCount)
+        {
+            throw new LasFormatException(
+                SceneGenerationErrorCodes.ModelAssetInvalid,
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Point cloud has {0} points, exceeding the maximum of {1}.",
+                    points.Count,
+                    options.MaxPointCount));
+        }
+
         // Perf follow-up: the builder buffers the whole cloud into a
         // ProjectedPoint[] and the quadtree recursion allocates a fresh
         // List<int> per node plus members.ToArray() per child, so index storage
         // is duplicated at each depth. A bounded improvement would partition a
         // single reusable index buffer in place (range-based (begin,end) splits
-        // with an in-array swap) and stream/spool the source points, capping the
-        // point count to avoid a malformed LAS exhausting memory. Deferred to
-        // avoid destabilizing the current deterministic layout; this method's
-        // IReadOnlyList contract already requires random access.
+        // with an in-array swap) and stream/spool the source points. The total
+        // point count is already capped above (PointCloudTilingOptions.MaxPointCount)
+        // so a malformed LAS cannot exhaust memory; the remaining work is the
+        // in-place index partitioning, deferred to avoid destabilizing the
+        // current deterministic layout (this method's IReadOnlyList contract
+        // already requires random access).
 
         // 1. Project every point once; track the geographic envelope.
         var projected = new ProjectedPoint[points.Count];
@@ -129,7 +147,7 @@ public static class PointCloudTilesetBuilder
         for (var i = 0; i < contentNodes.Count; i++)
         {
             var node = contentNodes[i];
-            var uri = $"points_{i:0000}.pnts";
+            var uri = string.Create(CultureInfo.InvariantCulture, $"points_{i:0000}.pnts");
             var pnts = PntsTileWriter.Build(node.Points, eightBitColor);
             tiles[uri] = pnts;
             content[node.SceneNode] = new SceneTileContent(uri, node.MinHeight, node.MaxHeight);
@@ -393,6 +411,15 @@ public sealed record PointCloudTilingOptions
 
     /// <summary>Representative points carried by each interior node as a coarse LOD.</summary>
     public int InteriorSampleCount { get; init; } = 8_192;
+
+    /// <summary>
+    /// Hard cap on the total number of points the builder will accept. Enforced
+    /// before any per-point buffer is allocated so a malformed or hostile LAS
+    /// cannot drive an unbounded multi-GB allocation; a larger cloud is rejected
+    /// with a stable scene error. The default (250 million) comfortably exceeds
+    /// realistic single-tileset ingests while bounding worst-case memory.
+    /// </summary>
+    public long MaxPointCount { get; init; } = 250_000_000L;
 }
 
 /// <summary>

--- a/src/Honua.Scene/Publishing/SceneTilesPublishExecutor.cs
+++ b/src/Honua.Scene/Publishing/SceneTilesPublishExecutor.cs
@@ -84,7 +84,7 @@ internal sealed partial class SceneTilesPublishExecutor : IPublishExecutor
         var record = PublishedServiceRecord.CreateFromIntent(
             serviceId: $"scene:{outcome.Result.SceneId}",
             intent: intent,
-            endpoint: $"/scenes/{outcome.Result.SceneId}/tileset.json");
+            endpoint: Honua.Scene.SceneUrls.TilesetRelativePath(outcome.Result.SceneId));
         return record with { Warnings = outcome.Result.Warnings };
     }
 

--- a/src/Honua.Scene/SceneUrls.cs
+++ b/src/Honua.Scene/SceneUrls.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+
+namespace Honua.Scene;
+
+/// <summary>
+/// Single source of truth for the scene asset/discovery URL contract so the
+/// 3D Tiles asset surface, the HTTP discovery surface, and the gRPC scene
+/// metadata stay in lockstep. If the scene route prefix or the tileset filename
+/// ever changes it changes here once instead of drifting across the call sites
+/// that emit client-facing links (CLAUDE.md DRY rule for behaviour-bearing
+/// link/URL shape).
+/// </summary>
+public static class SceneUrls
+{
+    private const string ScenePrefix = "/scenes/";
+    private const string SceneApiPrefix = "/api/scenes/";
+    private const string TilesetSuffix = "/tileset.json";
+    private const string ResolveSuffix = "/resolve";
+
+    /// <summary>
+    /// The server-relative path at which a scene's <c>tileset.json</c> is
+    /// served (<c>/scenes/{sceneId}/tileset.json</c>). The scene id is inserted
+    /// verbatim (no URL escaping) to match the gRPC metadata contract; callers
+    /// emitting absolute, client-dereferenceable links use
+    /// <see cref="AbsoluteTilesetUrl"/> instead.
+    /// </summary>
+    /// <param name="sceneId">Stable scene identifier.</param>
+    public static string TilesetRelativePath(string sceneId)
+        => string.Create(CultureInfo.InvariantCulture, $"{ScenePrefix}{sceneId}{TilesetSuffix}");
+
+    /// <summary>
+    /// Absolute URL to a scene's <c>tileset.json</c>
+    /// (<c>{baseUrl}/scenes/{escapedSceneId}/tileset.json</c>). The scene id is
+    /// percent-escaped so the link is safe to hand to a client.
+    /// </summary>
+    /// <param name="baseUrl">Origin/base URL; a single trailing slash is trimmed.</param>
+    /// <param name="sceneId">Stable scene identifier.</param>
+    public static string AbsoluteTilesetUrl(string baseUrl, string sceneId)
+        => BuildAbsolute(baseUrl, ScenePrefix, sceneId, TilesetSuffix);
+
+    /// <summary>
+    /// Absolute URL to a scene asset under the scene route
+    /// (<c>{baseUrl}/scenes/{escapedSceneId}{suffix}</c>).
+    /// </summary>
+    /// <param name="baseUrl">Origin/base URL; a single trailing slash is trimmed.</param>
+    /// <param name="sceneId">Stable scene identifier.</param>
+    /// <param name="suffix">Trailing path segment (e.g. <c>/tileset.json</c>); may be empty.</param>
+    public static string AbsoluteSceneUrl(string baseUrl, string sceneId, string suffix)
+        => BuildAbsolute(baseUrl, ScenePrefix, sceneId, suffix);
+
+    /// <summary>
+    /// Absolute URL to a scene's metadata document under the scene API route
+    /// (<c>{baseUrl}/api/scenes/{escapedSceneId}</c>).
+    /// </summary>
+    /// <param name="baseUrl">Origin/base URL; a single trailing slash is trimmed.</param>
+    /// <param name="sceneId">Stable scene identifier.</param>
+    public static string AbsoluteSceneApiUrl(string baseUrl, string sceneId)
+        => BuildAbsolute(baseUrl, SceneApiPrefix, sceneId, suffix: null);
+
+    /// <summary>
+    /// Absolute URL to a scene's access-resolve endpoint under the scene API
+    /// route (<c>{baseUrl}/api/scenes/{escapedSceneId}/resolve</c>).
+    /// </summary>
+    /// <param name="baseUrl">Origin/base URL; a single trailing slash is trimmed.</param>
+    /// <param name="sceneId">Stable scene identifier.</param>
+    public static string AbsoluteSceneResolveUrl(string baseUrl, string sceneId)
+        => BuildAbsolute(baseUrl, SceneApiPrefix, sceneId, ResolveSuffix);
+
+    private static string BuildAbsolute(string baseUrl, string prefix, string sceneId, string? suffix)
+    {
+        var escapedSceneId = Uri.EscapeDataString(sceneId);
+        return string.Concat(
+            baseUrl.AsSpan().TrimEnd('/'),
+            prefix.AsSpan(),
+            escapedSceneId.AsSpan(),
+            suffix.AsSpan());
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/TilesetDocumentTreeWriterTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/TilesetDocumentTreeWriterTests.cs
@@ -122,6 +122,100 @@ public sealed class TilesetDocumentTreeWriterTests
         AssertRegionEnclosesDescendants(tree.Root, doc.Root, content);
     }
 
+    [UnitTest]
+    public void BuildTree_ContentBearingInteriorNode_RegionEnclosesDescendantHeights()
+    {
+        // Interior nodes DO carry content here (InteriorSampleCount > 0), but a
+        // content-bearing interior node's height comes from a thinned sample of
+        // its subtree, so its own [min,max] can be narrower than a descendant
+        // leaf's. The emitted region must union the whole subtree's extent rather
+        // than trust the node's own sampled span — otherwise it under-encloses
+        // and a conformant 3D Tiles client culls visible geometry.
+        var features = MakePointGrid(40, 40);
+        var options = new SceneLodOptions { MaxFeaturesPerTile = 80, MaxDepth = 8, InteriorSampleCount = 64 };
+        var tree = SceneQuadtreePartitioner.Partition(features, Bounds, 4096.0, options);
+
+        // Give every content-bearing node (interior samples included) a narrow,
+        // distinct height span...
+        var content = new Dictionary<SceneTileNode, SceneTileContent>();
+        var index = 0;
+        void AssignNarrow(SceneTileNode node)
+        {
+            if (node.Features.Count > 0)
+            {
+                var min = 100.0 + index;
+                content[node] = new SceneTileContent($"tile_{index:0000}.glb", min, min + 5.0);
+                index++;
+            }
+            foreach (var child in node.Children)
+            {
+                AssignNarrow(child);
+            }
+        }
+        AssignNarrow(tree.Root);
+
+        // ...then force the deepest content-bearing leaf to carry an extreme span
+        // that none of its narrow-span ancestors enclose on their own.
+        SceneTileNode? deepestLeaf = null;
+        var deepestDepth = -1;
+        void FindDeepestLeaf(SceneTileNode node, int depth)
+        {
+            if (node.Children.Count == 0 && content.ContainsKey(node) && depth > deepestDepth)
+            {
+                deepestLeaf = node;
+                deepestDepth = depth;
+            }
+            foreach (var child in node.Children)
+            {
+                FindDeepestLeaf(child, depth + 1);
+            }
+        }
+        FindDeepestLeaf(tree.Root, 0);
+        deepestLeaf.Should().NotBeNull("the fixture must contain a content-bearing leaf");
+        content[deepestLeaf!] = new SceneTileContent("tile_extreme.glb", -500.0, 1500.0);
+
+        // Sanity: at least one content-bearing INTERIOR node now fails to enclose
+        // its descendants on its own span — so the test exercises the
+        // content-bearing path and would fail if the writer trusted that span.
+        CountUnderEnclosingInteriorContentNodes(tree.Root, content).Should().BeGreaterThan(0);
+
+        var doc = TilesetDocumentWriter.BuildTree(tree, content, "honua-test");
+
+        AssertRegionEnclosesDescendants(tree.Root, doc.Root, content);
+    }
+
+    private static int CountUnderEnclosingInteriorContentNodes(
+        SceneTileNode node,
+        IReadOnlyDictionary<SceneTileNode, SceneTileContent> content)
+    {
+        var count = 0;
+        if (node.Children.Count > 0 && content.TryGetValue(node, out var own))
+        {
+            var childMin = double.PositiveInfinity;
+            var childMax = double.NegativeInfinity;
+            var childFound = false;
+            foreach (var child in node.Children)
+            {
+                var (found, min, max) = DescendantHeightExtent(child, content);
+                if (found)
+                {
+                    childFound = true;
+                    if (min < childMin) childMin = min;
+                    if (max > childMax) childMax = max;
+                }
+            }
+            if (childFound && (own.MinHeightMeters > childMin || own.MaxHeightMeters < childMax))
+            {
+                count = 1;
+            }
+        }
+        foreach (var child in node.Children)
+        {
+            count += CountUnderEnclosingInteriorContentNodes(child, content);
+        }
+        return count;
+    }
+
     private static int CountInteriorContentLessNodes(
         SceneTileNode node,
         IReadOnlyDictionary<SceneTileNode, SceneTileContent> content)

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/TilesetDocumentTreeWriterTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/TilesetDocumentTreeWriterTests.cs
@@ -80,6 +80,114 @@ public sealed class TilesetDocumentTreeWriterTests
         }
     }
 
+    [UnitTest]
+    public void BuildTree_ContentLessInteriorNode_RegionEnclosesDescendantHeights()
+    {
+        // InteriorSampleCount = 0 disables interior content, so every interior
+        // node is absent from the content map. Its region vertical extent must
+        // still enclose the [min,max] of its content-bearing leaf descendants,
+        // or a conformant 3D Tiles client can cull visible geometry.
+        var features = MakePointGrid(40, 40);
+        var options = new SceneLodOptions { MaxFeaturesPerTile = 80, MaxDepth = 8, InteriorSampleCount = 0 };
+        var tree = SceneQuadtreePartitioner.Partition(features, Bounds, 4096.0, options);
+
+        // Assign each content-bearing (leaf) node a DISTINCT, nonzero height
+        // span so a naive [0,0] interior region is detectably wrong.
+        var content = new Dictionary<SceneTileNode, SceneTileContent>();
+        var index = 0;
+        void AssignLeafHeights(SceneTileNode node)
+        {
+            if (node.Features.Count > 0)
+            {
+                var min = 100.0 + (index * 10.0);
+                var max = min + 25.0 + index;
+                content[node] = new SceneTileContent($"tile_{index:0000}.glb", min, max);
+                index++;
+            }
+            foreach (var child in node.Children)
+            {
+                AssignLeafHeights(child);
+            }
+        }
+        AssignLeafHeights(tree.Root);
+
+        // Sanity: the configuration actually produced content-less interior
+        // nodes (otherwise the test would vacuously pass).
+        CountInteriorContentLessNodes(tree.Root, content).Should().BeGreaterThan(0);
+
+        var doc = TilesetDocumentWriter.BuildTree(tree, content, "honua-test");
+
+        // Pair the domain tree with the emitted TileNode tree (same pre-order
+        // structure) and assert the enclosure invariant on every node.
+        AssertRegionEnclosesDescendants(tree.Root, doc.Root, content);
+    }
+
+    private static int CountInteriorContentLessNodes(
+        SceneTileNode node,
+        IReadOnlyDictionary<SceneTileNode, SceneTileContent> content)
+    {
+        var count = !content.ContainsKey(node) && node.Children.Count > 0 ? 1 : 0;
+        foreach (var child in node.Children)
+        {
+            count += CountInteriorContentLessNodes(child, content);
+        }
+        return count;
+    }
+
+    private static void AssertRegionEnclosesDescendants(
+        SceneTileNode node,
+        TileNode emitted,
+        IReadOnlyDictionary<SceneTileNode, SceneTileContent> content)
+    {
+        var (hasDescendant, descMin, descMax) = DescendantHeightExtent(node, content);
+        if (hasDescendant)
+        {
+            // Region layout is [west, south, east, north, minHeight, maxHeight].
+            emitted.BoundingVolume.Region[4].Should().BeLessThanOrEqualTo(
+                descMin,
+                "the node region floor must enclose every content-bearing descendant");
+            emitted.BoundingVolume.Region[5].Should().BeGreaterThanOrEqualTo(
+                descMax,
+                "the node region ceiling must enclose every content-bearing descendant");
+        }
+
+        if (node.Children.Count > 0)
+        {
+            emitted.Children.Should().NotBeNull();
+            emitted.Children!.Count.Should().Be(node.Children.Count);
+            for (var i = 0; i < node.Children.Count; i++)
+            {
+                AssertRegionEnclosesDescendants(node.Children[i], emitted.Children[i], content);
+            }
+        }
+    }
+
+    private static (bool Found, double Min, double Max) DescendantHeightExtent(
+        SceneTileNode node,
+        IReadOnlyDictionary<SceneTileNode, SceneTileContent> content)
+    {
+        var found = false;
+        var min = double.PositiveInfinity;
+        var max = double.NegativeInfinity;
+        if (content.TryGetValue(node, out var c))
+        {
+            found = true;
+            min = c.MinHeightMeters;
+            max = c.MaxHeightMeters;
+        }
+        foreach (var child in node.Children)
+        {
+            var (childFound, childMin, childMax) = DescendantHeightExtent(child, content);
+            if (childFound)
+            {
+                found = true;
+                if (childMin < min) min = childMin;
+                if (childMax > max) max = childMax;
+            }
+        }
+        return (found, min, max);
+    }
+
     private static Dictionary<SceneTileNode, SceneTileContent> AssignContent(SceneTileTree tree)
     {
         var content = new Dictionary<SceneTileNode, SceneTileContent>();

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/PointCloud/PointCloudTilesetBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/PointCloud/PointCloudTilesetBuilderTests.cs
@@ -170,6 +170,107 @@ public sealed class PointCloudTilesetBuilderTests
             "the dataset-wide colour decision must encode raw 200 as 200>>8 == 0 in every tile");
     }
 
+    [UnitTest]
+    public void Build_InteriorSampleCountZero_InteriorRegionEnclosesDescendantHeights()
+    {
+        // With InteriorSampleCount = 0 every interior node is content-less and is
+        // dropped from the content map; its region vertical extent must still
+        // enclose the [min,max] heights of its content-bearing leaf descendants,
+        // or a conformant 3D Tiles client can cull visible geometry. GridPoints
+        // assigns z = 1 + r + c, so leaf heights vary across the quadtree and a
+        // naive [0,0] interior slab would be detectably wrong.
+        var las = LasFixtureBuilder.BuildFormat3(GridPoints(24, 24), scale: 1e-7);
+        var points = LasPointCloudReader.ReadPoints(las).ToList();
+
+        var result = PointCloudTilesetBuilder.Build(
+            points, IdentityGeo,
+            new PointCloudTilingOptions { MaxPointsPerTile = 30, MaxDepth = 8, InteriorSampleCount = 0 });
+
+        using var json = JsonDocument.Parse(Encoding.UTF8.GetString(result.TilesetJsonBytes));
+        var root = json.RootElement.GetProperty("root");
+
+        // The configuration must actually produce content-less interior nodes.
+        CountContentLessInteriorNodes(root).Should().BeGreaterThan(0);
+
+        AssertRegionEnclosesDescendantHeights(root);
+    }
+
+    private static int CountContentLessInteriorNodes(JsonElement node)
+    {
+        var hasChildren = node.TryGetProperty("children", out var children)
+            && children.GetArrayLength() > 0;
+        var hasContent = node.TryGetProperty("content", out _);
+        var count = hasChildren && !hasContent ? 1 : 0;
+        if (hasChildren)
+        {
+            foreach (var child in children.EnumerateArray())
+            {
+                count += CountContentLessInteriorNodes(child);
+            }
+        }
+        return count;
+    }
+
+    // Returns the union [min,max] height of every content-bearing node in the
+    // subtree (Region layout: [west, south, east, north, minHeight, maxHeight]).
+    private static (bool Found, double Min, double Max) AssertRegionEnclosesDescendantHeights(JsonElement node)
+    {
+        var found = false;
+        var min = double.PositiveInfinity;
+        var max = double.NegativeInfinity;
+
+        var hasContent = node.TryGetProperty("content", out _);
+        if (hasContent)
+        {
+            var region = node.GetProperty("boundingVolume").GetProperty("region");
+            found = true;
+            min = region[4].GetDouble();
+            max = region[5].GetDouble();
+        }
+
+        if (node.TryGetProperty("children", out var children))
+        {
+            foreach (var child in children.EnumerateArray())
+            {
+                var (childFound, childMin, childMax) = AssertRegionEnclosesDescendantHeights(child);
+                if (childFound)
+                {
+                    found = true;
+                    if (childMin < min) min = childMin;
+                    if (childMax > max) max = childMax;
+                }
+            }
+        }
+
+        if (found)
+        {
+            var region = node.GetProperty("boundingVolume").GetProperty("region");
+            region[4].GetDouble().Should().BeLessThanOrEqualTo(
+                min, "the node region floor must enclose every content-bearing descendant");
+            region[5].GetDouble().Should().BeGreaterThanOrEqualTo(
+                max, "the node region ceiling must enclose every content-bearing descendant");
+        }
+
+        return (found, min, max);
+    }
+
+    [UnitTest]
+    public void Build_PointCountOverCap_ThrowsLasFormatException()
+    {
+        // A tiny cap rejects the cloud BEFORE the per-point buffer is allocated,
+        // so a malformed/oversized LAS cannot drive an unbounded allocation.
+        var las = LasFixtureBuilder.BuildFormat3(GridPoints(4, 4), scale: 1e-7);
+        var points = LasPointCloudReader.ReadPoints(las).ToList();
+        points.Count.Should().Be(16);
+
+        var act = () => PointCloudTilesetBuilder.Build(
+            points, IdentityGeo,
+            new PointCloudTilingOptions { MaxPointCount = 8 });
+
+        act.Should().Throw<LasFormatException>()
+            .Which.Code.Should().Be(Honua.Core.Features.Scene.Domain.SceneGenerationErrorCodes.ModelAssetInvalid);
+    }
+
     private static List<(byte R, byte G, byte B)> ExtractRgb(byte[] tile)
     {
         var featureJsonLen = (int)System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(tile.AsSpan(12, 4));

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/SceneGrpcIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/SceneGrpcIntegrationTests.cs
@@ -39,6 +39,11 @@ public sealed class SceneGrpcIntegrationTests : IAsyncLifetime
     private const string MissingTilesetSceneId = "missing-tileset-scene";
     private const string MalformedTilesetSceneId = "malformed-tileset-scene";
 
+    // A scene whose root content uri points at a file larger than the gRPC tile
+    // service's MaxTileContentBytes cap (256 MiB), exercising the
+    // ResourceExhausted oversized-tile rejection branch.
+    private const string OversizedTileSceneId = "oversized-tile-scene";
+
     // A database-backed scene carrying a small WGS-84 extent near the prime
     // meridian, used to exercise the ListScenes spatial extent filter (config
     // scenes have no persisted extent and so cannot be excluded by it).
@@ -52,6 +57,7 @@ public sealed class SceneGrpcIntegrationTests : IAsyncLifetime
     private readonly string _missingContentRoot;
     private readonly string _missingTilesetRoot;
     private readonly string _malformedTilesetRoot;
+    private readonly string _oversizedTileRoot;
     private GrpcChannel? _channel;
     private Proto.SceneService.SceneServiceClient? _sceneClient;
     private Proto.TileService.TileServiceClient? _tileClient;
@@ -64,6 +70,7 @@ public sealed class SceneGrpcIntegrationTests : IAsyncLifetime
         _missingContentRoot = CreateMissingContentTilesetRoot();
         _missingTilesetRoot = CreateMissingTilesetRoot();
         _malformedTilesetRoot = CreateMalformedTilesetRoot();
+        _oversizedTileRoot = CreateOversizedTileRoot();
         _fixture = new WebAppFixture()
             .ConfigureWebHost(builder =>
             {
@@ -94,6 +101,13 @@ public sealed class SceneGrpcIntegrationTests : IAsyncLifetime
                         ["Scenes:Datasets:3:Id"] = MalformedTilesetSceneId,
                         ["Scenes:Datasets:3:Name"] = "Malformed Tileset",
                         ["Scenes:Datasets:3:AssetRoot"] = _malformedTilesetRoot,
+
+                        // A scene whose root content uri points at a file larger
+                        // than MaxTileContentBytes, exercising the GetTile/
+                        // StreamTiles ResourceExhausted oversized-tile branch.
+                        ["Scenes:Datasets:4:Id"] = OversizedTileSceneId,
+                        ["Scenes:Datasets:4:Name"] = "Oversized Tile",
+                        ["Scenes:Datasets:4:AssetRoot"] = _oversizedTileRoot,
                     });
                 });
             });
@@ -149,7 +163,7 @@ public sealed class SceneGrpcIntegrationTests : IAsyncLifetime
         _channel?.Dispose();
         await _fixture.DisposeAsync();
 
-        foreach (var root in new[] { _missingContentRoot, _missingTilesetRoot, _malformedTilesetRoot })
+        foreach (var root in new[] { _missingContentRoot, _missingTilesetRoot, _malformedTilesetRoot, _oversizedTileRoot })
         {
             try
             {
@@ -683,6 +697,44 @@ public sealed class SceneGrpcIntegrationTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("POST /geospatial.v1.TileService/GetTile")]
+    public async Task GetTile_ForOversizedContentFile_ThrowsResourceExhausted()
+    {
+        // The root content file is one byte over MaxTileContentBytes (256 MiB),
+        // so the tile service rejects it with ResourceExhausted before buffering
+        // it, rather than attempting an unbounded ~2x allocation.
+        var act = async () => await _tileClient!.GetTileAsync(
+            new Proto.GetTileRequest { SceneId = OversizedTileSceneId, NodeId = "0" },
+            _headers);
+
+        (await act.Should().ThrowAsync<RpcException>())
+            .Which.StatusCode.Should().Be(StatusCode.ResourceExhausted);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Streaming)]
+    [Endpoint("POST /geospatial.v1.TileService/StreamTiles")]
+    public async Task StreamTiles_ForOversizedContentFile_ThrowsResourceExhausted()
+    {
+        // The oversized-tile guard is shared by GetTile and StreamTiles; pin the
+        // ResourceExhausted branch on the streaming path too.
+        using var call = _tileClient!.StreamTiles(
+            new Proto.StreamTilesRequest { SceneId = OversizedTileSceneId },
+            _headers);
+
+        var act = async () =>
+        {
+            await foreach (var _ in call.ResponseStream.ReadAllAsync())
+            {
+            }
+        };
+
+        (await act.Should().ThrowAsync<RpcException>())
+            .Which.StatusCode.Should().Be(StatusCode.ResourceExhausted);
+    }
+
+    [IntegrationTest]
     [Operation(Operations.Streaming)]
     [Endpoint("POST /geospatial.v1.TileService/StreamTiles")]
     public async Task StreamTiles_WithOverlappingExtent_StreamsMatchingTiles()
@@ -1146,6 +1198,47 @@ public sealed class SceneGrpcIntegrationTests : IAsyncLifetime
         var root = Path.Combine(Path.GetTempPath(), "honua-grpc-malformed-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         File.WriteAllText(Path.Combine(root, "tileset.json"), "null");
+        return root;
+    }
+
+    /// <summary>
+    /// Creates a temporary scene asset root whose <c>tileset.json</c> root
+    /// content uri points at a file just over the gRPC tile service's
+    /// MaxTileContentBytes cap (256 MiB). The oversized payload is a sparse,
+    /// zero-filled file produced via <see cref="FileStream.SetLength"/> so it
+    /// consumes no real disk and the test stays CI-fast, exercising the
+    /// ResourceExhausted oversized-tile rejection branch.
+    /// </summary>
+    private static string CreateOversizedTileRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "honua-grpc-oversized-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        const string tilesetJson = """
+        {
+          "asset": { "version": "1.1" },
+          "geometricError": 100.0,
+          "root": {
+            "boundingVolume": { "region": [-1.31970, 0.69886, -1.31965, 0.69890, 0.0, 20.0] },
+            "geometricError": 100.0,
+            "refine": "REPLACE",
+            "content": { "uri": "tiles/oversized.b3dm" }
+          }
+        }
+        """;
+        File.WriteAllText(Path.Combine(root, "tileset.json"), tilesetJson);
+
+        var tilesDir = Path.Combine(root, "tiles");
+        Directory.CreateDirectory(tilesDir);
+        // 256 MiB + 1 byte: one byte over MaxTileContentBytes. SetLength on a
+        // fresh file produces a sparse extent on the platforms CI runs on, so no
+        // bytes are actually written.
+        const long oversized = (256L * 1024 * 1024) + 1;
+        using (var fs = new FileStream(Path.Combine(tilesDir, "oversized.b3dm"), FileMode.CreateNew, FileAccess.Write))
+        {
+            fs.SetLength(oversized);
+        }
+
         return root;
     }
 


### PR DESCRIPTION
## Issue Link
Related to #530 (Epic: 3D scene services — I3S, 3D Tiles, and 3D visualization)

## Summary
Follow-up hardening on the 3D scene tileset path (post-#1481): centralizes scene
URL construction behind one helper and fixes a 3D Tiles 1.1 `boundingVolume`
enclosure bug for interior tile nodes.

## Changes Made
- Add `SceneUrls` as the single source of truth for scene asset/discovery URL construction and route every emitter (`SceneDiscoveryEndpoints`, `SceneEndpoints`, `SceneGrpcMapping`, `SceneTilesPublishExecutor`) through it. Behavior-preserving at each call site: absolute links stay percent-escaped, the relative gRPC/publish path stays verbatim.
- Fix `TilesetDocumentWriter` so an interior tile node derives its vertical extent from the union over its whole subtree. Previously content-less interior nodes emitted a degenerate `[0,0]` slab, and content-bearing interior nodes used a thinned-sample span that could exclude the extreme-height leaf — both violate the 3D Tiles 1.1 rule that a tile's `boundingVolume` enclose every descendant, letting a conformant client cull visible geometry.
- Add tests asserting the enclosure invariant on both content-less and content-bearing interior nodes (the content-bearing case fails without the fix), plus point-cloud builder and scene gRPC integration coverage.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

> **Local verification note:** full Release build (warnings-as-errors), `dotnet format --verify-no-changes`, all unit tests (`Honua.Core` 2475/0, `Honua.Postgres` 602/0), and the scene gRPC integration tests (70/0) pass locally. `pre-pr-check.sh` exited non-zero only because the bundled local "Operator Eval Harness" server shard (an LLM-eval suite unrelated to scene code) exceeded its 20-minute wall-clock budget; CI runs that suite as its own properly-budgeted shard.

This change was refined via an independent code-review pass — the content-bearing interior enclosure gap was caught in review, not in the original change.
