### PR TITLE
fix(imageserver): serve conf.json + Esri-shaped config so ArcGIS .NET SDK loads ImageServiceRaster (#1456)

### DIFF
--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerMetadataHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerMetadataHandler.cs
@@ -39,12 +39,6 @@ internal sealed class ImageServerMetadataHandler
     /// <summary>Maximum number of records returned in catalog queries.</summary>
     private const int MaxRecordCount = 1000;
 
-    /// <summary>Pixel-block width advertised in <c>storageInfo</c> (standard Esri tile size).</summary>
-    private const int BlockWidth = 128;
-
-    /// <summary>Pixel-block height advertised in <c>storageInfo</c> (standard Esri tile size).</summary>
-    private const int BlockHeight = 128;
-
     private readonly IMetadataV2GraphProvider _graphProvider;
     private readonly IRasterStore _rasterStore;
     private readonly IImageServerMultidimensionalInfoBuilder _multidimensionalInfoBuilder;
@@ -143,12 +137,14 @@ internal sealed class ImageServerMetadataHandler
                 // without them it fails "Failed to read configuration data" (#1456).
                 FullExtent = BuildExtent(extent.Value),
                 InitialExtent = BuildExtent(extent.Value),
-                StorageInfo = BuildStorageInfo(),
-                // Esri's ImageServer root surfaces blockWidth/blockHeight both at the top
-                // level AND inside storageInfo. The ArcGIS Maps SDK for .NET
-                // ImageServiceRaster reads them from the root, so mirror them there (#1456).
-                BlockWidth = BlockWidth,
-                BlockHeight = BlockHeight,
+                // A real dynamic (non-fused-cache) Esri ImageServer omits storageInfo
+                // entirely (verified against a public Esri ImageServer). Emitting it
+                // makes the ArcGIS Maps SDK for .NET native runtime treat the service
+                // as cached and reject the config; honua serves dynamic imagery via
+                // exportImage, so omit storageInfo and the root block size (#1456).
+                StorageInfo = null,
+                BlockWidth = null,
+                BlockHeight = null,
                 SpatialReference = CreateSpatialReference(referenceRaster.Srid),
                 PixelSizeX = CalculatePixelSize(extent.Value, referenceRaster.Width),
                 PixelSizeY = CalculatePixelSize(extent.Value, referenceRaster.Height, isHeight: true),
@@ -217,18 +213,6 @@ internal sealed class ImageServerMetadataHandler
         XMax = extent.XMax,
         YMax = extent.YMax,
         SpatialReference = CreateSpatialReference(extent.Srid)
-    };
-
-    /// <summary>
-    /// Builds the pixel-block <c>storageInfo</c> block. Honua's ImageServer is a
-    /// dynamic (non-tiled) service, so we advertise the standard 128x128 pixel-block
-    /// size that lets <c>ImageServiceRaster.LoadAsync</c> read configuration data
-    /// without ever requesting a tile-cache <c>conf.json</c> (#1456).
-    /// </summary>
-    private static ImageServerStorageInfo BuildStorageInfo() => new()
-    {
-        BlockWidth = BlockWidth,
-        BlockHeight = BlockHeight
     };
 
     private static double CalculatePixelSize(Core.Features.Raster.Domain.RasterExtent extent, int pixelCount, bool isHeight = false)

--- a/src/Honua.Protocols.GeoServices/ImageServer/ImageServerEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/ImageServerEndpoints.cs
@@ -59,6 +59,20 @@ internal static class ImageServerEndpoints
             .Produces<ImageServerServiceInfo>()
             .Produces(404);
 
+        // Tile-cache configuration document. Honua's ImageServer is a dynamic
+        // (non-fused-cache) service, but the ArcGIS Maps SDK for .NET native
+        // runtime (ImageServiceRaster.LoadAsync) unconditionally probes
+        // `conf.json` while reading raster configuration and treats a bare/empty
+        // 404 as a fatal "Failed to read configuration data". Serving the
+        // Esri-shaped "no fused cache" document here lets LoadAsync proceed down
+        // the dynamic path instead of erroring (#1456).
+        group.MapGet("/conf.json", GetTileCacheConf)
+            .WithDisplayName("Get Image Service Tile Cache Configuration")
+            .WithName("GetImageServiceConf")
+            .WithSummary("Get the tile-cache configuration document")
+            .Produces(200, contentType: JsonContentType)
+            .AllowAnonymous();
+
         // Export image endpoint - core rendering capability
         group.MapGet("/exportImage", ExportImage)
             .WithDisplayName("Export Image")
@@ -366,6 +380,14 @@ internal static class ImageServerEndpoints
             .Produces<ImageServerServiceInfo>()
             .Produces(404);
 
+        // See the {id:int} group's conf.json route for why this exists (#1456).
+        serviceGroup.MapGet("/conf.json", GetTileCacheConfByService)
+            .WithDisplayName("Get Image Service Tile Cache Configuration by Service")
+            .WithName("GetImageServiceConfByService")
+            .WithSummary("Get the tile-cache configuration document")
+            .Produces(200, contentType: JsonContentType)
+            .AllowAnonymous();
+
         serviceGroup.MapGet("/exportImage", ExportImageByService)
             .WithDisplayName("Export Image by Service")
             .WithName("ExportImageByService")
@@ -635,6 +657,39 @@ internal static class ImageServerEndpoints
     {
         var resolution = await ResolveImageServiceLayerIdAsync(serviceId, context, cancellationToken);
         return resolution.ErrorResult ?? await GetServiceInfo(resolution.LayerId, f, context, handler, cancellationToken);
+    }
+
+    // On a real Esri ImageServer, `…/ImageServer/conf.json` returns the SAME
+    // service-descriptor document as `…/ImageServer?f=json` (verified against a
+    // public Esri ImageServer: conf.json yields currentVersion/extent/
+    // spatialReference/… — the service info, not a tile-cache schema). The ArcGIS
+    // Maps SDK for .NET native runtime reads this while loading an
+    // ImageServiceRaster; honua previously 404'd here, so LoadAsync failed with
+    // "could not read configuration data". Serve the service descriptor (always
+    // JSON, the runtime does not send f=json) so the dynamic load proceeds (#1456).
+    private static async Task<IResult> GetTileCacheConf(
+        int id,
+        HttpContext context,
+        ImageServerMetadataHandler handler,
+        CancellationToken cancellationToken = default)
+    {
+        var layerError = await ValidateImageLayerAsync(id, context, cancellationToken);
+        if (layerError is not null)
+        {
+            return layerError;
+        }
+
+        return await handler.GetServiceInfoAsync(context, id, cancellationToken);
+    }
+
+    private static async Task<IResult> GetTileCacheConfByService(
+        string serviceId,
+        HttpContext context,
+        ImageServerMetadataHandler handler,
+        CancellationToken cancellationToken = default)
+    {
+        var resolution = await ResolveImageServiceLayerIdAsync(serviceId, context, cancellationToken);
+        return resolution.ErrorResult ?? await GetTileCacheConf(resolution.LayerId, context, handler, cancellationToken);
     }
 
     /// <summary>

--- a/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerJsonContext.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerJsonContext.cs
@@ -9,7 +9,13 @@ namespace Honua.Protocols.GeoServices.ImageServer.Models;
 /// JSON serialization context for Image Server models.
 /// Enables AOT-compatible JSON serialization for Image Server endpoints.
 /// </summary>
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+// Esri omits null-valued fields from ImageServer documents (descriptor /
+// conf.json). The ArcGIS Maps SDK for .NET native runtime reads these with a
+// strict parser that rejects nulls where it expects a string/array/object, so
+// match Esri and drop nulls on the wire (#1456).
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(ImageServerServiceInfo))]
 [JsonSerializable(typeof(ImageServerTimeInfo))]
 [JsonSerializable(typeof(ImageServerTimeReference))]

--- a/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerModels.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerModels.cs
@@ -98,8 +98,12 @@ public sealed class ImageServerServiceInfo
     [JsonPropertyName("defaultMosaicMethod")]
     public string DefaultMosaicMethod { get; init; } = "esriMosaicNorthwest";
 
+    // Esri serializes allowedMosaicMethods as a comma-separated STRING, not an
+    // array. The ArcGIS Maps SDK for .NET native runtime parses the ImageServer
+    // config with a strict reader that rejects an array here ("Invalid
+    // configuration file"), so emit the Esri string form (#1456).
     [JsonPropertyName("allowedMosaicMethods")]
-    public string[] AllowedMosaicMethods { get; init; } = ["esriMosaicNorthwest", "esriMosaicCenter"];
+    public string AllowedMosaicMethods { get; init; } = "esriMosaicNorthwest,esriMosaicCenter";
 
     [JsonPropertyName("sortField")]
     public string? SortField { get; init; }
@@ -134,7 +138,11 @@ public sealed class ImageServerServiceInfo
     [JsonPropertyName("singleFusedMapCache")]
     public bool SingleFusedMapCache { get; init; } = false;
 
+    // Dynamic (non-fused-cache) services have no tile scheme. Esri omits tileInfo
+    // entirely in that case; emitting "tileInfo":null trips the native .NET
+    // runtime's strict ImageServer config parser, so omit when unset (#1456).
     [JsonPropertyName("tileInfo")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public TileInfo? TileInfo { get; init; }
 
     /// <summary>
@@ -478,7 +486,12 @@ public sealed class SpatialReference
     [JsonPropertyName("latestWkid")]
     public int? LatestWkid { get; init; }
 
+    // Esri omits wkt entirely when a well-known id is present. The ArcGIS Maps
+    // SDK for .NET native runtime reads the ImageServer config (descriptor /
+    // conf.json) with a strict parser that rejects a null wkt, so omit it when
+    // unset rather than emitting "wkt":null (#1456).
     [JsonPropertyName("wkt")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Wkt { get; init; }
 }
 

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -776,6 +776,7 @@ public static class EndpointRegistry
 
         new("GET", "/rest/services/{id}/ImageServer"),
         new("POST", "/rest/services/{id}/ImageServer"),
+        new("GET", "/rest/services/{id}/ImageServer/conf.json"),
         new("GET", "/rest/services/{id}/ImageServer/WCS"),
         new("GET", "/rest/services/{id}/ImageServer/exportImage"),
         new("POST", "/rest/services/{id}/ImageServer/exportImage"),
@@ -810,6 +811,7 @@ public static class EndpointRegistry
 
         new("GET", "/rest/services/{serviceId}/ImageServer"),
         new("POST", "/rest/services/{serviceId}/ImageServer"),
+        new("GET", "/rest/services/{serviceId}/ImageServer/conf.json"),
         new("GET", "/rest/services/{serviceId}/ImageServer/exportImage"),
         new("POST", "/rest/services/{serviceId}/ImageServer/exportImage"),
         new("GET", "/rest/services/{serviceId}/ImageServer/identify"),

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerBasicTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerBasicTests.cs
@@ -291,6 +291,7 @@ public class ImageServerBasicTests : IAsyncLifetime
     [Endpoint("POST /rest/services/{serviceId}/ImageServer/multidimensionalInfo")]
     [Endpoint("GET /rest/services/{serviceId}/ImageServer/slices")]
     [Endpoint("POST /rest/services/{serviceId}/ImageServer/slices")]
+    [Endpoint("GET /rest/services/{serviceId}/ImageServer/conf.json")]
     [Operation(Operations.Metadata)]
     public async Task ServiceNameRoutes_DispatchToImageServerSurface()
     {
@@ -315,6 +316,7 @@ public class ImageServerBasicTests : IAsyncLifetime
             $"/rest/services/{serviceId}/ImageServer/computeClassStatistics?f=json&classDescriptions={classDescriptions}",
             $"/rest/services/{serviceId}/ImageServer/multidimensionalInfo?f=json",
             $"/rest/services/{serviceId}/ImageServer/slices?f=json",
+            $"/rest/services/{serviceId}/ImageServer/conf.json",
         };
 
         foreach (var uri in getUris)

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
@@ -852,4 +852,43 @@ public class ImageServerEndpointsTests
             await fixture.DisposeAsync();
         }
     }
+
+    [IntegrationTest]
+    [Endpoint("GET /rest/services/{id}/ImageServer/conf.json")]
+    [Operation(Operations.GetServiceInfo)]
+    public async Task ConfJson_ReturnsServiceDescriptor_InArcGisRuntimeCompatibleShape()
+    {
+        // Regression for #1456: the ArcGIS Maps SDK for .NET ImageServiceRaster
+        // unconditionally fetches conf.json while loading and parses it strictly.
+        // conf.json must return the service descriptor (like a real Esri ImageServer),
+        // and that descriptor must use the Esri wire shape the native parser accepts:
+        // allowedMosaicMethods as a comma-separated STRING (not an array) and no
+        // tile-cache storageInfo for a dynamic service. Any of these tripped
+        // LoadAsync with "could not read configuration data" / "Invalid configuration file".
+        var fixture = await CreateFixtureAsync(CreateRasterStoreSubstitute());
+        try
+        {
+            var response = await fixture.Client.GetAsync(
+                $"/rest/services/{TestLayerId}/ImageServer/conf.json");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+            var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+
+            // conf.json returns the service descriptor.
+            root.TryGetProperty("currentVersion", out _).Should().BeTrue();
+            root.TryGetProperty("extent", out _).Should().BeTrue();
+
+            // allowedMosaicMethods must serialize as a string, not an array.
+            root.GetProperty("allowedMosaicMethods").ValueKind.Should().Be(JsonValueKind.String);
+
+            // Dynamic service: no tile-cache storage block.
+            root.TryGetProperty("storageInfo", out _).Should().BeFalse();
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMetadataHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMetadataHandlerTests.cs
@@ -240,13 +240,18 @@ public class ImageServerMetadataHandlerTests
 
     [UnitTest]
     [Operation(Operations.GetServiceInfo)]
-    public async Task GetServiceInfoAsync_PopulatesFullExtentInitialExtentAndStorageInfo()
+    public async Task GetServiceInfoAsync_DynamicService_MatchesEsriShapeForArcGisRuntime()
     {
-        // Regression for #1456: the native .NET ImageServiceRaster.LoadAsync reads
-        // fullExtent/initialExtent and storageInfo (blockWidth/blockHeight) and fails
-        // "Failed to read configuration data" when they are null. The service is a
-        // dynamic (non-tiled) image service, so it must not advertise a tile cache
-        // (singleFusedMapCache=false, tileInfo=null) and never trigger a conf.json fetch.
+        // #1456: the native .NET ImageServiceRaster.LoadAsync ALWAYS fetches the
+        // ImageServer config (served at both the root descriptor and conf.json) and
+        // parses it with a strict reader. Verified against a public Esri ImageServer,
+        // a dynamic (non-fused-cache) service:
+        //   * populates fullExtent/initialExtent,
+        //   * OMITS storageInfo and the root blockWidth/blockHeight (those belong to a
+        //     tile cache; emitting them made the runtime reject the config),
+        //   * omits a tile scheme (singleFusedMapCache=false, tileInfo=null), and
+        //   * serializes allowedMosaicMethods as a comma-separated STRING (an array
+        //     trips the runtime with "Invalid configuration file").
         SetupSuccessfulMetadata();
 
         var context = CreateImageServerContext();
@@ -265,19 +270,16 @@ public class ImageServerMetadataHandlerTests
         info.InitialExtent!.XMin.Should().Be(-180);
         info.InitialExtent.YMax.Should().Be(90);
 
-        info.StorageInfo.Should().NotBeNull();
-        info.StorageInfo!.BlockWidth.Should().BeGreaterThan(0);
-        info.StorageInfo.BlockHeight.Should().BeGreaterThan(0);
-
-        // #1456: blockWidth/blockHeight must ALSO be surfaced at the metadata root, not
-        // only nested under storageInfo. The ArcGIS Maps SDK for .NET ImageServiceRaster
-        // reads them from the root, and the root values must match the storageInfo values.
-        info.BlockWidth.Should().Be(info.StorageInfo.BlockWidth);
-        info.BlockHeight.Should().Be(info.StorageInfo.BlockHeight);
-
-        // Non-tiled service: no fused cache, so the SDK never requests conf.json.
+        // Dynamic service: no fused cache, no tile-cache storage block (matches Esri).
         info.SingleFusedMapCache.Should().BeFalse();
         info.TileInfo.Should().BeNull();
+        info.StorageInfo.Should().BeNull();
+        info.BlockWidth.Should().BeNull();
+        info.BlockHeight.Should().BeNull();
+
+        // Esri serializes allowedMosaicMethods as a comma-separated string, not an array.
+        info.AllowedMosaicMethods.Should().BeOfType<string>();
+        info.AllowedMosaicMethods.Should().Contain("esriMosaic");
     }
 
     [UnitTest]


### PR DESCRIPTION
## Issue Link
Closes #1456

## Summary
The ArcGIS Maps SDK for .NET (`ImageServiceRaster.LoadAsync`) could not load honua's ImageServer. The native runtime **unconditionally** fetches the ImageServer config (the root descriptor and `…/ImageServer/conf.json`) and parses it with a strict reader. honua's output diverged from a real Esri ImageServer in three ways, each of which made `LoadAsync` throw. Verified end-to-end against the real ArcGIS Maps SDK for .NET 200.6: `ImageServiceRaster.LoadAsync` now returns `LoadStatus=Loaded` (was: failed).

This completes the remaining half of #1456 — the metadata fields were added previously, but the `conf.json` half was never implemented, and the prior attempt had the mechanism backwards (it *added* `storageInfo` believing that would suppress the `conf.json` fetch; that fetch is unconditional and `storageInfo` is a tile-cache signal that made the runtime reject the config).

## Changes Made
- **Serve `…/ImageServer/conf.json`** (both `{id:int}` and named-service route groups) returning the service descriptor — exactly what a real Esri ImageServer returns there. honua previously 404'd → `"could not read configuration data"`.
- **`allowedMosaicMethods` is now a comma-separated string**, not a JSON array. Esri serializes it as a string; the array tripped the native parser with `"Invalid configuration file"` (the decisive fix).
- **Match Esri's dynamic-service shape:** omit null-valued fields on the wire (`DefaultIgnoreCondition = WhenWritingNull` on the ImageServer JSON context) and drop `storageInfo` / root `blockWidth`/`blockHeight` for dynamic (non-fused-cache) services. A real dynamic Esri ImageServer omits these.
- Removed the now-orphaned `BuildStorageInfo()` helper and `BlockWidth`/`BlockHeight` constants.
- Registered both `conf.json` routes in `EndpointRegistry` (governance).
- Rewrote `ImageServerMetadataHandlerTests` (it codified the disproven "storageInfo present / never fetches conf.json" assumption) and added an integration regression test for `conf.json`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact (ImageServer wire shape now matches real Esri output)

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None to client behavior. The ImageServer descriptor wire shape changes to match real Esri (string `allowedMosaicMethods`; omitted `storageInfo`/`blockWidth`/`blockHeight` and null fields on dynamic services) — these align honua with what the official Esri SDKs expect.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

<sub>Validation note: `pre-pr-check.sh` was run; its only local failures were two known Windows-working-tree artifacts that are LF-clean in the committed blob and pass on CI/Linux — (1) `check-instructions-sync.sh` flags `CLAUDE.md` (materialized plain file vs. symlink on Windows), and (2) the format step reports CRLF (the working tree is CRLF via `core.autocrlf`; the committed blob is LF). Substantive checks verified directly: Release build `-p:TreatWarningsAsErrors=true` = 0 warnings / 0 errors; `Honua.Protocols.GeoServices.Tests` ImageServer = 270 pass; new conf.json integration test = pass; `EndpointRegistryDrift` governance = 5 pass.</sub>
