### PR TITLE
feat: harden ArcGIS Portal OAuth2 bridge (#1484)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,22 @@ HONUA_ADMIN_PASSWORD=
 # Authentication__ClientCertificates__ForwardedCertificate__Enabled=false
 # Authentication__ClientCertificates__ForwardedCertificate__TrustedProxyNetworks__0=10.0.0.0/24
 
+# ArcGIS Portal OAuth2 named-user bridge (#1242/#1484) — opt-in, off by default.
+# The /sharing/rest/oauth2/{authorize,callback,token} bridge brokers identity to a
+# configured OIDC provider (see Oidc__*). Hardening before enabling in production:
+#   - AllowedRedirectUris: per-deployment redirect_uri allow-list (open-redirect
+#     mitigation). Each entry is an exact absolute URI or an origin
+#     (scheme+host[:port] with no path). An EMPTY list rejects every redirect_uri,
+#     so register every trusted ArcGIS client redirect before enabling.
+#     The ArcGIS Pro native loopback (urn:ietf:wg:oauth:2.0:oob) is only honored
+#     when listed verbatim.
+#   - RequirePkce (default true): every authorization-code flow must use PKCE.
+#   - RotateRefreshTokens (default true): rotate the refresh token on each use.
+# Authentication__PortalToken__OAuth2__AllowedRedirectUris__0=https://arcgis.example.com/
+# Authentication__PortalToken__OAuth2__AllowedRedirectUris__1=https://app.example.com/oauth/redirect
+# Authentication__PortalToken__OAuth2__RequirePkce=true
+# Authentication__PortalToken__OAuth2__RotateRefreshTokens=true
+
 # Development authentication bypass (DO NOT USE IN PRODUCTION)
 # The bypass ONLY activates when ALL of the following are true:
 #   1. ASPNETCORE_ENVIRONMENT is exactly "Test" (NOT "Development", NOT "Staging")

--- a/docs/contributor/adr/0049-single-auth-identity-token-foundation.md
+++ b/docs/contributor/adr/0049-single-auth-identity-token-foundation.md
@@ -139,6 +139,65 @@ real (#1374 + #1375):
 
 Deferred to **#1242**: the OAuth2 bridge itself.
 
+## OAuth2 bridge hardening (#1484)
+
+The OAuth2 bridge (`/sharing/rest/oauth2/{authorize,callback,token}`) landed in
+#1242 and stays opt-in/off-by-default. Before it can be enabled in production the
+following hardening (#1484) is required and now lands with this ADR:
+
+- **`redirect_uri` allow-list (open-redirect mitigation).** `oauth2/authorize`
+  validates the client `redirect_uri` against a per-deployment allow-list
+  (`Authentication:PortalToken:OAuth2:AllowedRedirectUris`) via the shared
+  `PortalOAuthRedirectUriValidator` (exact-URI or same-origin match; the ArcGIS
+  Pro `urn:ietf:wg:oauth:2.0:oob` native redirect is only honored when listed
+  verbatim). An empty list rejects everything, and a non-allow-listed URI gets a
+  direct 400 and is **never** redirected to (RFC 6749 §4.1.2.1), so the bridge
+  cannot be used to bounce an authorization code to a hostile host.
+- **Hard-required PKCE.** With `OAuth2.RequirePkce` (default on), `authorize`
+  rejects a code flow with no `code_challenge`, and the token endpoint rejects an
+  `authorization_code` grant whose stored code carries no challenge — so every
+  code flow has had PKCE. (Previously PKCE was only verified when a challenge had
+  been registered.)
+- **Refresh-token rotation.** With `OAuth2.RotateRefreshTokens` (default on), a
+  `refresh_token` grant revokes the presented token and returns a fresh one,
+  bounding a leaked token's replay window to a single use. Refresh tokens remain
+  90-day, cache-backed, and revocable by cache eviction; rotation can be disabled
+  for clients that cannot persist a refreshed token.
+
+### CSRF posture: cookieless `idpState.brokerSessionId` binding
+
+ArcGIS Pro's embedded browser is hostile to cookies, so the bridge cannot use a
+cookie-bound CSRF/state for the IdP leg. Instead `PortalOAuthBroker` mints a
+high-entropy random `idpState` (32 chars) and a separate broker-session id (256
+bits of cache-key entropy) at `authorize` time, persists the ArcGIS client's
+pinned parameters (redirect_uri/state/PKCE challenge) plus the IdP PKCE verifier
+in the single-use, short-lived (15 min) broker session, and sends the IdP the
+**combined** `state = idpState.brokerSessionId`. At `callback` the broker
+splits the value, consumes the broker session by id (single-use; removed on
+read), and constant-time-compares the returned `idpState` against the stored one
+before proceeding.
+
+This was reviewed against the CSRF/authorization-fixation threat model and is
+judged adequate for the bridge:
+
+- The IdP leg's CSRF defense rests on (a) the unguessable, single-use
+  `brokerSessionId` (an attacker cannot forge or replay a valid session id) and
+  (b) the constant-time `idpState` equality check, which is the standard
+  state-parameter binding — the cookieless transport does not weaken it because
+  the secret lives server-side in the broker session, not in a cookie.
+- The authorization code returned to the ArcGIS client is independently bound to
+  that client's own PKCE `code_challenge` (now hard-required) plus the
+  allow-listed, exact-match `redirect_uri` and `client_id`, so a code obtained on
+  a victim's behalf cannot be redeemed by an attacker.
+- Broker sessions and codes are single-use and expire quickly (15 min / 5 min),
+  bounding any race or replay window.
+
+No stronger binding (for example a `PORTAL_OAUTH_STATE` cookie or a
+device/PKCE-bound state) is added: it would either break the embedded-browser
+flow or duplicate the protection the server-side single-use session already
+provides. The conclusion is captured here and in
+`PortalOAuthBroker.BeginAuthorizeAsync`.
+
 ## Cross-references
 
 - Complements ADR-0024 (Open-Core Edition Model) and the RBAC enforcement model.

--- a/src/Honua.Hosting/Features/Authentication/PortalOAuthBroker.cs
+++ b/src/Honua.Hosting/Features/Authentication/PortalOAuthBroker.cs
@@ -110,6 +110,17 @@ internal sealed class PortalOAuthBroker(
         // The IdP callback returns to Honua, carrying the broker session id in the
         // CSRF state so the callback can recover the pinned ArcGIS parameters
         // without a cookie (ArcGIS Pro's embedded browser is hostile to cookies).
+        //
+        // CSRF posture (#1484, see ADR-0049 "CSRF posture"): the cookieless binding
+        // is judged adequate. `idpState` (32 random chars) plus `brokerSessionId`
+        // (256-bit cache-key entropy) are both unguessable; the callback consumes the
+        // session single-use by id and constant-time-compares `idpState` before
+        // proceeding. The secret lives server-side in the single-use, 15-minute
+        // broker session, so the cookieless transport does not weaken the standard
+        // state-parameter binding. The ArcGIS-facing code is additionally bound to
+        // the client's hard-required PKCE challenge and allow-listed exact
+        // redirect_uri/client_id, so a code minted on a victim's behalf cannot be
+        // redeemed by an attacker.
         var combinedState = $"{idpState}.{brokerSessionId}";
         var callbackUri = callbackUriFactory(PortalOAuthRoutes.CallbackPath);
 

--- a/src/Honua.Hosting/Features/Authentication/PortalOAuthRedirectUriValidator.cs
+++ b/src/Honua.Hosting/Features/Authentication/PortalOAuthRedirectUriValidator.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Authentication;
+
+/// <summary>
+/// Validates an ArcGIS OAuth2 <c>redirect_uri</c> against the per-deployment
+/// allow-list (#1484). This is the open-redirect mitigation for the
+/// <c>oauth2/authorize</c> entrypoint: before this gate the bridge accepted any
+/// absolute URI, which an attacker could use to bounce a victim's authorization
+/// code (and, by extension, a freshly minted portal token) to an arbitrary host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Matching is deliberately conservative. An allow-list entry matches a candidate
+/// redirect URI when either:
+/// </para>
+/// <list type="bullet">
+/// <item><description>the candidate equals the entry exactly (ordinal, after a
+/// fragment is stripped — RFC 6749 §3.1.2 forbids fragments in redirect URIs), or</description></item>
+/// <item><description>the entry is an <em>origin</em> (an absolute http/https URI
+/// whose path is empty or <c>/</c> and which carries no query/fragment) and the
+/// candidate shares that exact scheme, host, and port.</description></item>
+/// </list>
+/// <para>
+/// Non-http(s) schemes (for example the ArcGIS Pro native
+/// <c>urn:ietf:wg:oauth:2.0:oob</c> redirect or a custom app scheme) only ever
+/// match by exact, verbatim equality so an operator must opt in to them
+/// explicitly. No substring, prefix, or wildcard matching is performed.
+/// </para>
+/// </remarks>
+public static class PortalOAuthRedirectUriValidator
+{
+    /// <summary>
+    /// Determines whether <paramref name="redirectUri"/> is permitted by the
+    /// configured <paramref name="allowList"/>.
+    /// </summary>
+    /// <param name="redirectUri">The client-supplied redirect URI.</param>
+    /// <param name="allowList">The configured allow-list entries. An empty or
+    /// <see langword="null"/> list permits nothing.</param>
+    /// <returns><see langword="true"/> when the redirect URI is allow-listed.</returns>
+    public static bool IsAllowed(string? redirectUri, IReadOnlyList<string>? allowList)
+    {
+        if (string.IsNullOrWhiteSpace(redirectUri) || allowList is null || allowList.Count == 0)
+        {
+            return false;
+        }
+
+        // A redirect_uri must be an absolute URI without a fragment (RFC 6749).
+        if (!Uri.TryCreate(redirectUri, UriKind.Absolute, out var candidate) ||
+            !string.IsNullOrEmpty(candidate.Fragment))
+        {
+            return false;
+        }
+
+        var canonicalCandidate = Canonicalize(candidate);
+
+        foreach (var entry in allowList)
+        {
+            if (string.IsNullOrWhiteSpace(entry))
+            {
+                continue;
+            }
+
+            var trimmed = entry.Trim();
+
+            // Exact, verbatim match (covers custom schemes and the ArcGIS oob URN).
+            if (string.Equals(trimmed, redirectUri.Trim(), StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var allowed))
+            {
+                continue;
+            }
+
+            // Canonical absolute-URI equality (normalizes default ports / casing of
+            // scheme+host) for http(s) entries.
+            if (IsHttpScheme(allowed) &&
+                string.Equals(Canonicalize(allowed), canonicalCandidate, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            // Origin match: an http(s) entry with no meaningful path matches any
+            // candidate sharing the same scheme/host/port.
+            if (IsOrigin(allowed) && SameOrigin(allowed, candidate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsHttpScheme(Uri uri)
+        => uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ||
+           uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsOrigin(Uri uri)
+        => IsHttpScheme(uri) &&
+           (string.IsNullOrEmpty(uri.AbsolutePath) || uri.AbsolutePath == "/") &&
+           string.IsNullOrEmpty(uri.Query) &&
+           string.IsNullOrEmpty(uri.Fragment);
+
+    private static bool SameOrigin(Uri a, Uri b)
+        => a.Scheme.Equals(b.Scheme, StringComparison.OrdinalIgnoreCase) &&
+           a.Host.Equals(b.Host, StringComparison.OrdinalIgnoreCase) &&
+           a.Port == b.Port;
+
+    private static string Canonicalize(Uri uri)
+        => string.Create(
+            System.Globalization.CultureInfo.InvariantCulture,
+            $"{uri.Scheme.ToLowerInvariant()}://{uri.Host.ToLowerInvariant()}:{uri.Port}{uri.AbsolutePath}{uri.Query}");
+}

--- a/src/Honua.Hosting/Features/Authentication/PortalOAuthTokenService.cs
+++ b/src/Honua.Hosting/Features/Authentication/PortalOAuthTokenService.cs
@@ -79,6 +79,16 @@ internal sealed class PortalOAuthTokenService(
             return PortalOAuthTokenResult.Failure("invalid_grant", "redirect_uri does not match the authorization request.");
         }
 
+        // Hard PKCE requirement (#1484): when enabled, an authorization code that was
+        // issued without a registered code_challenge is rejected outright. Combined
+        // with the authorize-endpoint guard this guarantees every code flow has had
+        // PKCE — closing the authorization-code interception window for native
+        // clients (ArcGIS Pro / Field Maps) that lack a confidential client secret.
+        if (_tokenOptions.OAuth2.RequirePkce && string.IsNullOrWhiteSpace(record.CodeChallenge))
+        {
+            return PortalOAuthTokenResult.Failure("invalid_grant", "PKCE is required: no code_challenge was registered for this authorization code.");
+        }
+
         if (!VerifyPkce(record.CodeChallenge, record.CodeChallengeMethod, request.CodeVerifier))
         {
             return PortalOAuthTokenResult.Failure("invalid_grant", "PKCE verification failed.");
@@ -115,15 +125,23 @@ internal sealed class PortalOAuthTokenService(
             return PortalOAuthTokenResult.Failure("invalid_grant", "Refresh token was issued to a different client.");
         }
 
-        // Refresh returns a fresh access token but reuses the existing refresh token
-        // (no rotation) so an ArcGIS client can keep refreshing for the refresh
-        // token's lifetime, matching ArcGIS behavior.
+        // Refresh-token rotation (#1484): when enabled (the default) the presented
+        // token is revoked and a fresh refresh token is minted and returned, bounding
+        // the replay window of a leaked token to a single use. The old token is
+        // removed before issuing so a concurrent reuse races to a revoked entry. When
+        // rotation is disabled the existing token is reused (legacy ArcGIS behavior).
+        var rotate = _tokenOptions.OAuth2.RotateRefreshTokens;
+        if (rotate)
+        {
+            await _store.RemoveRefreshTokenAsync(request.RefreshToken, cancellationToken).ConfigureAwait(false);
+        }
+
         return await IssueAsync(
             record.ClientId,
             record.Principal,
             requestedMinutes: null,
             requestBinding,
-            includeRefreshToken: false,
+            includeRefreshToken: rotate,
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -190,9 +208,10 @@ internal sealed class PortalOAuthTokenService(
     {
         if (string.IsNullOrWhiteSpace(challenge))
         {
-            // No challenge was registered at authorize time; nothing to verify.
-            // ArcGIS Pro always sends PKCE, so a missing challenge means the client
-            // opted out and we do not require a verifier.
+            // No challenge was registered at authorize time. This branch is only
+            // reachable when OAuth2.RequirePkce is disabled (the default-on hard
+            // requirement, #1484, rejects no-challenge codes before this call); in
+            // that explicit opt-out there is nothing to verify.
             return true;
         }
 

--- a/src/Honua.Hosting/Features/Authentication/PortalTokenAuthenticationOptions.cs
+++ b/src/Honua.Hosting/Features/Authentication/PortalTokenAuthenticationOptions.cs
@@ -49,4 +49,56 @@ public sealed class PortalTokenAuthenticationOptions
     /// Requests above this value are clamped to the maximum.
     /// </summary>
     public int MaxExpirationMinutes { get; set; } = DefaultMaxExpirationMinutesValue;
+
+    /// <summary>
+    /// Hardening options for the ArcGIS OAuth2 named-user bridge
+    /// (<c>/sharing/rest/oauth2/{authorize,callback,token}</c>, #1242/#1484).
+    /// </summary>
+    public PortalOAuth2Options OAuth2 { get; set; } = new();
+}
+
+/// <summary>
+/// Security-hardening options for the ArcGIS OAuth2 named-user bridge (#1484):
+/// the per-deployment <c>redirect_uri</c> allow-list (open-redirect mitigation)
+/// and the hard PKCE requirement toggle.
+/// </summary>
+public sealed class PortalOAuth2Options
+{
+    /// <summary>
+    /// Configuration section binding root, relative to
+    /// <see cref="PortalTokenAuthenticationOptions.SectionName"/>.
+    /// </summary>
+    public const string SectionName = "OAuth2";
+
+    /// <summary>
+    /// Per-deployment allow-list of redirect URIs the <c>oauth2/authorize</c>
+    /// endpoint will accept (#1484). Each entry is either an exact absolute URI or
+    /// an <em>origin</em> (scheme + host + optional port, with no path beyond
+    /// <c>/</c>); an origin entry matches any redirect URI sharing that exact
+    /// scheme/host/port. The ArcGIS Pro native loopback redirect
+    /// (<c>urn:ietf:wg:oauth:2.0:oob</c>) is only accepted when listed verbatim.
+    /// When the list is empty the authorize endpoint rejects every redirect URI,
+    /// so the bridge cannot be exploited as an open redirector before an operator
+    /// has explicitly registered its trusted clients.
+    /// </summary>
+    public string[] AllowedRedirectUris { get; set; } = [];
+
+    /// <summary>
+    /// When <see langword="true"/> (the default) every authorization-code flow
+    /// must carry a PKCE <c>code_challenge</c> at <c>authorize</c> time and a
+    /// matching <c>code_verifier</c> at <c>token</c> time (#1484). Set to
+    /// <see langword="false"/> only for a legacy client that genuinely cannot send
+    /// PKCE; doing so re-opens the authorization-code interception window.
+    /// </summary>
+    public bool RequirePkce { get; set; } = true;
+
+    /// <summary>
+    /// When <see langword="true"/> (the default) a successful <c>refresh_token</c>
+    /// grant rotates the refresh token: the presented token is revoked and a new one
+    /// is returned in the response (#1484). Rotation bounds the replay window of a
+    /// leaked refresh token to a single use. Set to <see langword="false"/> to
+    /// restore the non-rotating behavior for clients that cannot persist a
+    /// refreshed token.
+    /// </summary>
+    public bool RotateRefreshTokens { get; set; } = true;
 }

--- a/src/Honua.Protocols.GeoServices/Sharing/SharingOAuth2Endpoints.cs
+++ b/src/Honua.Protocols.GeoServices/Sharing/SharingOAuth2Endpoints.cs
@@ -113,6 +113,26 @@ internal static class SharingOAuth2Endpoints
             return StandardErrorHelpers.CreateBadRequest(context, "redirect_uri must be an absolute URI.");
         }
 
+        // Open-redirect mitigation (#1484): the redirect_uri must be registered in
+        // the per-deployment allow-list. A non-allow-listed redirect_uri is rejected
+        // with a direct 400 and is NEVER redirected to (RFC 6749 §4.1.2.1) so the
+        // bridge cannot be used to bounce an authorization code to a hostile host.
+        if (!PortalOAuthRedirectUriValidator.IsAllowed(redirectUri, tokenOptions.Value.OAuth2.AllowedRedirectUris))
+        {
+            SharingRestLog.OAuthRedirectUriRejected(logger);
+            return StandardErrorHelpers.CreateBadRequest(context, "redirect_uri is not registered for this deployment.");
+        }
+
+        // Hard PKCE requirement (#1484): when enabled, every authorization-code flow
+        // must register a PKCE code_challenge up front so the matching code_verifier
+        // is enforced at the token endpoint. Without this an intercepted code could
+        // be redeemed by an attacker.
+        if (tokenOptions.Value.OAuth2.RequirePkce && string.IsNullOrWhiteSpace(ReadFirst(query["code_challenge"])))
+        {
+            return RedirectError(context, redirectUri, ReadFirst(query["state"]),
+                "invalid_request", "code_challenge is required (PKCE).");
+        }
+
         var request = new PortalOAuthAuthorizeRequest(
             ClientId: clientId,
             RedirectUri: redirectUri,

--- a/src/Honua.Protocols.GeoServices/Sharing/SharingRestEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/Sharing/SharingRestEndpoints.cs
@@ -779,6 +779,9 @@ public static class SharingRestEndpoints
         bool FormatValid);
 }
 
-internal sealed class SharingRestLog
+internal sealed partial class SharingRestLog
 {
+    [LoggerMessage(EventId = 7120, Level = LogLevel.Warning,
+        Message = "Portal OAuth authorize rejected: redirect_uri is not registered in the deployment allow-list.")]
+    public static partial void OAuthRedirectUriRejected(ILogger logger);
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingOAuth2CallbackE2ETests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingOAuth2CallbackE2ETests.cs
@@ -1,0 +1,276 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Infrastructure.Authentication;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Honua.Server.Tests.Features.Sharing;
+
+/// <summary>
+/// End-to-end coverage for the ArcGIS OAuth2 bridge callback IdP round-trip
+/// (#1242/#1484). A mock OIDC provider is wired into the broker's named HTTP client
+/// (discovery + token endpoints) and a symmetric signing key validates the relayed
+/// id_token, so the test exercises the full authorize → IdP-redirect → callback →
+/// token path that previously only had the not-configured 404 gate.
+/// </summary>
+[Collection("Database")]
+[SecurityTest]
+[Protocol(TestProtocols.FeatureServer)]
+[Operation(Operations.Security)]
+public sealed class SharingOAuth2CallbackE2ETests : IAsyncLifetime
+{
+    private const string AdminPassword = WebAppFixture.SharedAdminPassword;
+    private const string ClientId = "arcgispro";
+    private const string RedirectUri = "https://app.example.com/oauth/redirect";
+
+    // Mock IdP coordinates. The broker derives the discovery URL from the provider
+    // Authority; the stub serves discovery + token regardless of host.
+    private const string IdpAuthority = "https://oidc.test";
+    private const string IdpClientId = "honua-confidential-client";
+    private const string IdpSigningKey = "OidcCallbackE2ESymmetricSigningKey-0123456789-abcdef";
+
+    private readonly WebAppFixture _fixture;
+
+    public SharingOAuth2CallbackE2ETests()
+    {
+        _fixture = new WebAppFixture()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+                builder.UseSetting("Authentication:PortalToken:RequireHttps", "false");
+
+                // Allow-list the ArcGIS client redirect (#1484 open-redirect mitigation).
+                builder.UseSetting("Authentication:PortalToken:OAuth2:AllowedRedirectUris:0", RedirectUri);
+
+                // Opt into the OIDC-backed credential verifier so the relayed id_token
+                // is validated by the shared OIDC core.
+                builder.UseSetting("Authentication:PortalCredentialVerifier:UseOidc", "true");
+
+                // A Generic OIDC provider with a static symmetric signing key: the
+                // verifier validates the id_token without JWKS discovery, and the
+                // broker treats Authority as the discovery base for the mock IdP.
+                builder.UseSetting("Oidc:Enabled", "true");
+                // RequireHttps stays true (the options validator enforces it); the
+                // mock IdP authority is https and the broker's HTTP calls are served
+                // by the in-process MockOidcProviderHandler, so no real TLS is needed.
+                builder.UseSetting("Oidc:Generic:Enabled", "true");
+                builder.UseSetting("Oidc:Generic:Authority", IdpAuthority);
+                builder.UseSetting("Oidc:Generic:ClientId", IdpClientId);
+                builder.UseSetting("Oidc:TokenValidation:SymmetricSigningKey", IdpSigningKey);
+            })
+            .ConfigureServices(services =>
+            {
+                // Intercept the broker's discovery/token HTTP calls with a mock IdP.
+                services.AddHttpClient(PortalOAuthBroker.HttpClientName)
+                    .ConfigurePrimaryHttpMessageHandler(() => new MockOidcProviderHandler());
+            });
+    }
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/oauth2/callback")]
+    public async Task Callback_FullIdpRoundTrip_IssuesArcGisCodeAndMintsToken()
+    {
+        using var client = _fixture.CreateClient(allowAutoRedirect: false);
+
+        // 1. authorize: creates a broker session and redirects to the (mock) IdP
+        //    authorize endpoint carrying the combined state.
+        var verifier = "callback-e2e-pkce-verifier-value-abcdefghijklmnopqrstuvwx";
+        var challenge = WebEncoders.Base64UrlEncode(
+            System.Security.Cryptography.SHA256.HashData(Encoding.ASCII.GetBytes(verifier)));
+        var authorizeUrl = QueryHelpers.AddQueryString("/sharing/rest/oauth2/authorize", new Dictionary<string, string?>
+        {
+            ["response_type"] = "code",
+            ["client_id"] = ClientId,
+            ["redirect_uri"] = RedirectUri,
+            ["state"] = "client-state-xyz",
+            ["code_challenge"] = challenge,
+            ["code_challenge_method"] = "S256",
+        });
+
+        using var authorizeResponse = await client.GetAsync(authorizeUrl);
+        authorizeResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        var idpRedirect = authorizeResponse.Headers.Location;
+        idpRedirect.Should().NotBeNull();
+        idpRedirect!.AbsoluteUri.Should().StartWith($"{IdpAuthority}/authorize");
+
+        var idpQuery = QueryHelpers.ParseQuery(idpRedirect.Query);
+        var combinedState = idpQuery["state"].ToString();
+        combinedState.Should().NotBeNullOrWhiteSpace();
+
+        // 2. callback: the mock IdP returns to Honua with a code + the combined state.
+        //    The broker exchanges the IdP code (stub returns a signed id_token),
+        //    verifies the principal, and redirects to the allow-listed ArcGIS
+        //    redirect_uri with a Honua-minted authorization code.
+        var callbackUrl = QueryHelpers.AddQueryString("/sharing/rest/oauth2/callback", new Dictionary<string, string?>
+        {
+            ["state"] = combinedState,
+            ["code"] = "mock-idp-authorization-code",
+        });
+
+        using var callbackResponse = await client.GetAsync(callbackUrl);
+        callbackResponse.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        var clientRedirect = callbackResponse.Headers.Location;
+        clientRedirect.Should().NotBeNull();
+        clientRedirect!.GetLeftPart(UriPartial.Path).Should().Be(RedirectUri);
+
+        var clientQuery = QueryHelpers.ParseQuery(clientRedirect.Query);
+        clientQuery["state"].ToString().Should().Be("client-state-xyz");
+        var arcgisCode = clientQuery["code"].ToString();
+        arcgisCode.Should().NotBeNullOrWhiteSpace();
+
+        // 3. token: exchange the Honua authorization code (with PKCE) for an access token.
+        using var tokenResponse = await client.PostAsync(
+            "/sharing/rest/oauth2/token",
+            new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("grant_type", "authorization_code"),
+                new KeyValuePair<string, string>("code", arcgisCode),
+                new KeyValuePair<string, string>("redirect_uri", RedirectUri),
+                new KeyValuePair<string, string>("client_id", ClientId),
+                new KeyValuePair<string, string>("code_verifier", verifier),
+            }));
+
+        tokenResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await tokenResponse.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("access_token").GetString().Should().NotBeNullOrWhiteSpace();
+        doc.RootElement.GetProperty("expires_in").GetInt64().Should().BeGreaterThan(0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/oauth2/authorize")]
+    public async Task Authorize_NonAllowListedRedirectUri_RejectsWithoutRedirect()
+    {
+        using var client = _fixture.CreateClient(allowAutoRedirect: false);
+        var url = QueryHelpers.AddQueryString("/sharing/rest/oauth2/authorize", new Dictionary<string, string?>
+        {
+            ["response_type"] = "code",
+            ["client_id"] = ClientId,
+            ["redirect_uri"] = "https://evil.example.com/steal",
+            ["state"] = "client-state-xyz",
+            ["code_challenge"] = "abc",
+            ["code_challenge_method"] = "S256",
+        });
+
+        using var response = await client.GetAsync(url);
+
+        // Open-redirect mitigation: a non-allow-listed redirect_uri is a direct 400
+        // and is NEVER redirected to.
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Headers.Location.Should().BeNull();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/oauth2/authorize")]
+    public async Task Authorize_MissingPkceChallenge_RedirectsErrorToClient()
+    {
+        using var client = _fixture.CreateClient(allowAutoRedirect: false);
+        var url = QueryHelpers.AddQueryString("/sharing/rest/oauth2/authorize", new Dictionary<string, string?>
+        {
+            ["response_type"] = "code",
+            ["client_id"] = ClientId,
+            ["redirect_uri"] = RedirectUri,
+            ["state"] = "client-state-xyz",
+            // No code_challenge: hard PKCE requirement rejects.
+        });
+
+        using var response = await client.GetAsync(url);
+
+        // The redirect_uri is allow-listed, so per RFC 6749 the error is delivered to
+        // the client redirect rather than as a bare 400.
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        var location = response.Headers.Location;
+        location.Should().NotBeNull();
+        location!.GetLeftPart(UriPartial.Path).Should().Be(RedirectUri);
+        QueryHelpers.ParseQuery(location.Query)["error"].ToString().Should().Be("invalid_request");
+    }
+
+    private static string CreateIdToken()
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(IdpSigningKey));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var claims = new List<Claim>
+        {
+            new("sub", "named.user@example.com"),
+            new("name", "Named User"),
+            new("email", "named.user@example.com"),
+            new("roles", "org_user"),
+            new(ClaimTypes.Role, "org_user"),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: IdpAuthority,
+            audience: IdpClientId,
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(10),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    /// <summary>
+    /// Minimal mock OIDC provider: serves the discovery document and the token
+    /// endpoint (returning a signed id_token) for the broker's IdP leg.
+    /// </summary>
+    private sealed class MockOidcProviderHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+
+            if (path.EndsWith("/.well-known/openid-configuration", StringComparison.Ordinal))
+            {
+                var discovery = JsonSerializer.Serialize(new
+                {
+                    authorization_endpoint = $"{IdpAuthority}/authorize",
+                    token_endpoint = $"{IdpAuthority}/token",
+                });
+                return Task.FromResult(Json(discovery));
+            }
+
+            if (path.EndsWith("/token", StringComparison.Ordinal))
+            {
+                var tokenResponse = JsonSerializer.Serialize(new
+                {
+                    access_token = "mock-idp-access-token",
+                    id_token = CreateIdToken(),
+                    token_type = "Bearer",
+                    expires_in = 600,
+                });
+                return Task.FromResult(Json(tokenResponse));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static HttpResponseMessage Json(string body)
+            => new(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingOAuth2Tests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingOAuth2Tests.cs
@@ -140,6 +140,75 @@ public sealed class SharingOAuth2Tests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Security)]
     [Endpoint("POST /sharing/rest/oauth2/token")]
+    public async Task Token_AuthorizationCodeWithoutRegisteredPkce_ReturnsInvalidGrant()
+    {
+        // Hard PKCE requirement (#1484): a code minted without a code_challenge is
+        // rejected by the token endpoint even if the client sends no verifier. This
+        // guards the seam directly (the authorize endpoint also blocks no-PKCE flows).
+        var code = await SeedAuthorizationCodeAsync(codeChallenge: null, method: null);
+
+        using var client = _fixture.CreateClient();
+        using var response = await PostFormAsync(
+            client,
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", RedirectUri),
+            ("client_id", ClientId));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var error = await ReadErrorAsync(response);
+        error.Error.Should().Be("invalid_grant");
+        error.ErrorDescription.Should().Contain("PKCE");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("POST /sharing/rest/oauth2/token")]
+    public async Task Token_RefreshTokenGrant_RotatesRefreshTokenAndRevokesOld()
+    {
+        // Refresh-token rotation (#1484): a refresh exchange returns a NEW refresh
+        // token and revokes the presented one, so reusing the old token fails.
+        var verifier = "rotation-pkce-verifier-value-abcdefghijklmnopqrstuv";
+        var challenge = WebEncoders.Base64UrlEncode(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)));
+        var code = await SeedAuthorizationCodeAsync(challenge, "S256");
+
+        using var client = _fixture.CreateClient();
+        using var first = await PostFormAsync(
+            client,
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", RedirectUri),
+            ("client_id", ClientId),
+            ("code_verifier", verifier));
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        var firstPayload = await ReadTokenAsync(first);
+        firstPayload.RefreshToken.Should().NotBeNullOrWhiteSpace();
+
+        using var rotated = await PostFormAsync(
+            client,
+            ("grant_type", "refresh_token"),
+            ("refresh_token", firstPayload.RefreshToken!),
+            ("client_id", ClientId));
+        rotated.StatusCode.Should().Be(HttpStatusCode.OK);
+        var rotatedPayload = await ReadTokenAsync(rotated);
+        rotatedPayload.RefreshToken.Should().NotBeNullOrWhiteSpace();
+        rotatedPayload.RefreshToken.Should().NotBe(firstPayload.RefreshToken,
+            "a rotated refresh token must differ from the one it replaces");
+
+        // The original refresh token is now revoked and must not be accepted again.
+        using var replay = await PostFormAsync(
+            client,
+            ("grant_type", "refresh_token"),
+            ("refresh_token", firstPayload.RefreshToken!),
+            ("client_id", ClientId));
+        replay.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var replayError = await ReadErrorAsync(replay);
+        replayError.Error.Should().Be("invalid_grant");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("POST /sharing/rest/oauth2/token")]
     public async Task Token_UnknownAuthorizationCode_ReturnsInvalidGrant()
     {
         using var client = _fixture.CreateClient();

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/PortalOAuthRedirectUriValidatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/PortalOAuthRedirectUriValidatorTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Infrastructure.Authentication;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Infrastructure.Authentication;
+
+/// <summary>
+/// Unit tests for the ArcGIS OAuth2 bridge redirect_uri allow-list (#1484), the
+/// open-redirect mitigation guarding <c>/sharing/rest/oauth2/authorize</c>.
+/// </summary>
+[Protocol(TestProtocols.FeatureServer)]
+[Operation(Operations.Security)]
+public sealed class PortalOAuthRedirectUriValidatorTests
+{
+    [UnitTest]
+    [Operation(Operations.Security)]
+    public void IsAllowed_EmptyAllowList_RejectsEverything()
+    {
+        PortalOAuthRedirectUriValidator.IsAllowed("https://app.example.com/cb", [])
+            .Should().BeFalse();
+        PortalOAuthRedirectUriValidator.IsAllowed("https://app.example.com/cb", null)
+            .Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Security)]
+    public void IsAllowed_ExactMatch_Allows()
+    {
+        var list = new[] { "https://app.example.com/oauth/redirect" };
+        PortalOAuthRedirectUriValidator.IsAllowed("https://app.example.com/oauth/redirect", list)
+            .Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Security)]
+    public void IsAllowed_DifferentPathUnderExactEntry_Rejects()
+    {
+        var list = new[] { "https://app.example.com/oauth/redirect" };
+        PortalOAuthRedirectUriValidator.IsAllowed("https://app.example.com/oauth/evil", list)
+            .Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Security)]
+    public void IsAllowed_OriginEntry_AllowsAnyPathOnSameOrigin()
+    {
+        var list = new[] { "https://arcgis.example.com/" };
+        PortalOAuthRedirectUriValidator.IsAllowed("https://arcgis.example.com/oauth/redirect", list)
+            .Should().BeTrue();
+        PortalOAuthRedirectUriValidator.IsAllowed("https://arcgis.example.com/anything?x=1", list)
+            .Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Security)]
+    public void IsAllowed_OriginEntry_RejectsDifferentHostSchemeOrPort()
+    {
+        var list = new[] { "https://arcgis.example.com/" };
+        PortalOAuthRedirectUriValidator.IsAllowed("https://evil.example.com/redirect", list)
+            .Should().BeFalse();
+        PortalOAuthRedirectUriValidator.IsAllowed("http://arcgis.example.com/redirect", list)
+            .Should().BeFalse();
+        PortalOAuthRedirectUriValidator.IsAllowed("https://arcgis.example.com:8443/redirect", list)
+            .Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Security)]
+    public void IsAllowed_NonAbsoluteOrFragmentUri_Rejects()
+    {
+        var list = new[] { "https://app.example.com/" };
+        PortalOAuthRedirectUriValidator.IsAllowed("/relative/path", list).Should().BeFalse();
+        PortalOAuthRedirectUriValidator.IsAllowed("https://app.example.com/cb#frag", list)
+            .Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Security)]
+    public void IsAllowed_OobUrn_OnlyMatchesWhenListedVerbatim()
+    {
+        const string oob = "urn:ietf:wg:oauth:2.0:oob";
+        PortalOAuthRedirectUriValidator.IsAllowed(oob, ["https://app.example.com/"])
+            .Should().BeFalse();
+        PortalOAuthRedirectUriValidator.IsAllowed(oob, [oob])
+            .Should().BeTrue();
+    }
+}

--- a/tests/dotnet/Honua.TestKit/WebAppFixture.cs
+++ b/tests/dotnet/Honua.TestKit/WebAppFixture.cs
@@ -533,6 +533,27 @@ public sealed class WebAppFixture : IAsyncLifetime
     }
 
     /// <summary>
+    /// Create a new HTTP client with control over automatic redirect following.
+    /// Pass <see langword="false"/> to inspect 3xx responses (their <c>Location</c>
+    /// header) instead of transparently following them — required when a redirect
+    /// target points off-server (for example the OAuth2 bridge IdP leg).
+    /// </summary>
+    public HttpClient CreateClient(bool allowAutoRedirect)
+    {
+        var client = ActiveFactory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = allowAutoRedirect,
+        });
+        client.Timeout = _defaultTestClientTimeout;
+        if (_useSharedServer && !string.IsNullOrWhiteSpace(_currentSchema))
+        {
+            client.DefaultRequestHeaders.Add("X-Honua-Test-Schema", _currentSchema);
+        }
+
+        return client;
+    }
+
+    /// <summary>
     /// Create a new HTTP client with admin authorization for testing admin endpoints.
     /// </summary>
     public HttpClient CreateAdminClient()


### PR DESCRIPTION
## Issue Link
Fixes #1484

## Summary
Hardens the ArcGIS Portal OAuth2 named-user bridge (`/sharing/rest/oauth2/{authorize,callback,token}`, landed in #1242) ahead of any production enablement of the Portal facade. The facade remains opt-in / off-by-default per epic #1240; these changes only affect deployments that have explicitly enabled it.

## Changes Made
- **redirect_uri allow-list:** `oauth2/authorize` validates `redirect_uri` against `Authentication:PortalToken:OAuth2:AllowedRedirectUris` via the new shared `PortalOAuthRedirectUriValidator` (exact-URI or same-origin; oob URN only when listed verbatim). Empty list rejects everything; non-allow-listed URIs return 400 and are never redirected to (RFC 6749 §4.1.2.1).
- **Hard-require PKCE:** new `OAuth2.RequirePkce` (default on); `authorize` rejects flows with no `code_challenge`, and the token endpoint rejects an authorization_code grant whose stored code carried no challenge.
- **Refresh-token rotation:** new `OAuth2.RotateRefreshTokens` (default on) revokes the presented refresh token and returns a fresh one per refresh; replay of the old token fails. Toggle restores legacy non-rotating behavior.
- **CSRF posture:** reviewed and documented as adequate (unguessable single-use broker session id + constant-time `idpState` compare, bound to the hard-required PKCE challenge and allow-listed exact redirect_uri/client_id) in `PortalOAuthBroker` and an ADR-0049 section; no weaker cookieless binding.
- **callback e2e:** new `SharingOAuth2CallbackE2ETests` drive the full authorize → IdP redirect → callback → token round-trip against a mock OIDC provider; added a non-redirecting `CreateClient(bool)` overload to `Honua.TestKit/WebAppFixture.cs` to inspect the off-server IdP redirect.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

22/22 Sharing OAuth2 + redirect-validator tests pass (incl. 3 new callback e2e + new PKCE/rotation/allow-list cases). Release build with `TreatWarningsAsErrors=true`: 0 warnings.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [x] Documentation updated

(New config keys; ADR-0049 updated. No SDK code changes required.)

## Release/Deploy Impact
- [x] Requires environment variable or secret changes

(Deployments enabling the Portal facade must set `Authentication:PortalToken:OAuth2:AllowedRedirectUris`; documented in `.env.example`.)

## Breaking Changes
None for default deployments (facade is off by default). For deployments that had already enabled the Portal OAuth2 facade: the new redirect_uri allow-list and hard-required PKCE will reject previously-accepted misconfigured clients until `AllowedRedirectUris` is configured; both are gated by config and default to the safe posture.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent — Release build with `TreatWarningsAsErrors=true` clean, `dotnet format --verify-no-changes` clean, OAuth2 unit + integration tests (Testcontainers) 22/22 green
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
