### PR TITLE
feat: wire MigrationCatalogReconciler into Validating phase + feed scorecard (#1379, #1381)

### DIFF
--- a/src/Honua.Core/Features/Migration/Domain/MigrationReconciliationArtifact.cs
+++ b/src/Honua.Core/Features/Migration/Domain/MigrationReconciliationArtifact.cs
@@ -87,6 +87,15 @@ public sealed record MigrationReconciliationArtifact
     /// Tolerances applied to this run. Persisted so an audit can replay the same gate.
     /// </summary>
     public required LayerReconciliationOptions Options { get; init; }
+
+    /// <summary>
+    /// Deeper catalog-parity report produced by the Validating phase when a published Metadata v2
+    /// catalog entry was available to reconcile against (issue #1379). Carries the per-resource
+    /// schema/domain/identifier/relationship/attachment/subtype findings that the count/geometry/
+    /// content/extent probes above intentionally do not cover (counts can match while the schema is
+    /// wrong). <c>null</c> when no published catalog entry was available to reconcile against.
+    /// </summary>
+    public MigrationCatalogReconciliationReport? CatalogReconciliation { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Migration/Services/MigrationCatalogReconciler.cs
+++ b/src/Honua.Core/Features/Migration/Services/MigrationCatalogReconciler.cs
@@ -222,6 +222,21 @@ public static class MigrationCatalogReconciler
             return;
         }
 
+        // Respect the capture-time coded-value cap (EsriFieldDomainParser.CodedValueDomainCap). A
+        // coded-value domain that exceeded the cap at scan time is captured with its type/name but
+        // NO coded values (DomainValues is null/empty) and is deliberately omitted from the publish
+        // path (it would otherwise materialize as a misleading partial lookup). Reconciling such a
+        // capped domain against the published field would false-fail as DomainMissing/DomainValues-
+        // Mismatch even though the omission is intentional, so skip the missing/values probes for
+        // it. We can only faithfully reconcile a coded-value domain whose values we actually captured.
+        var isCappedCodedValueDomain =
+            string.Equals(inventoryField.DomainType, "codedValue", StringComparison.OrdinalIgnoreCase) &&
+            (inventoryField.DomainValues is null || inventoryField.DomainValues.Length == 0);
+        if (isCappedCodedValueDomain && publishedField.Domain is null)
+        {
+            return;
+        }
+
         if (publishedField.Domain is null)
         {
             findings.Add(new MigrationCatalogReconciliationFinding

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Reconciliation.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Reconciliation.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Migration.Abstractions;
 using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
 using Honua.Core.Features.Shared.Models;
 
 namespace Honua.Postgres.Features.Migration;
@@ -59,6 +62,24 @@ internal sealed partial class GeoservicesImportService
                 .ReconcileAsync(reconciliationRequest, cancellationToken)
                 .ConfigureAwait(false);
 
+            // Catalog reconciliation (issue #1379): reconcile the published Metadata v2 catalog entry
+            // against the apply-time source layer definition. This is the deeper "counts can match
+            // while the schema is wrong" pass (schema/domain/identifier/relationship/attachment/
+            // subtype). It is recorded on the artifact and surfaced separately; it does NOT change
+            // the #1380 gate verdict, which stays driven by the data-movement artifact below.
+            var catalogReport = await RunCatalogReconciliationAsync(
+                jobId,
+                layerInfo,
+                publishedLayer,
+                cancellationToken).ConfigureAwait(false);
+
+            // Bind the catalog report to the artifact so both travel together through persistence,
+            // the evidence pack, and the admin surfaces (#1379 AC).
+            if (catalogReport is not null)
+            {
+                artifact = artifact with { CatalogReconciliation = catalogReport };
+            }
+
             // Parity gate (issue #1380): a hard (fail) finding blocks Completed and routes the run to
             // NeedsReview. Warn and skipped classifications are recorded on the artifact but do not
             // block — they surface to operators without halting the import.
@@ -70,7 +91,7 @@ internal sealed partial class GeoservicesImportService
             return new ReconciliationGateOutcome
             {
                 Artifact = artifact,
-                CatalogReport = null,
+                CatalogReport = catalogReport,
                 NeedsReview = needsReview,
                 ReviewReason = needsReview ? BuildReviewReason(artifact) : null
             };
@@ -147,4 +168,158 @@ internal sealed partial class GeoservicesImportService
 
         return $"Post-publish reconciliation reported {artifact.Summary.FailCount} blocking finding(s).";
     }
+
+    /// <summary>
+    /// Catalog reconciliation pass for issue #1379. Reads the published Metadata v2 catalog entry
+    /// that the AutoPublish step materialized for <paramref name="publishedLayer"/> back out of the
+    /// persisted graph, builds a source inventory resource from the apply-time
+    /// <paramref name="layerInfo"/> snapshot, and runs the deterministic
+    /// <see cref="MigrationCatalogReconciler"/> over the pair. Returns <c>null</c> (skipping the
+    /// pass without failing the import) when no read-back seam is available or the published entry
+    /// cannot be located — a reconciliation-infrastructure gap is not evidence of a faithless import.
+    /// </summary>
+    private async Task<MigrationCatalogReconciliationReport?> RunCatalogReconciliationAsync(
+        string jobId,
+        GeoservicesLayerInfo layerInfo,
+        PublishedLayerSummary publishedLayer,
+        CancellationToken cancellationToken)
+    {
+        if (_metadataWriteBaseReader is null)
+        {
+            return null;
+        }
+
+        var snapshot = await _metadataWriteBaseReader
+            .TryGetPersistedCurrentAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (snapshot is null)
+        {
+            // No activated snapshot (fresh DB / serving straight from the V1 catalog). There is no
+            // canonical published entry to reconcile against, so skip rather than false-fail.
+            return null;
+        }
+
+        // AutoPublish materializes the data resource with the stable id res-layer-{layerId}.
+        var resourceId = $"res-layer-{publishedLayer.LayerId.ToString(CultureInfo.InvariantCulture)}";
+        var published = snapshot.Graph.Resources
+            .FirstOrDefault(resource => string.Equals(resource.Metadata.Id, resourceId, StringComparison.Ordinal));
+        if (published is null)
+        {
+            return null;
+        }
+
+        var inventoryResource = BuildInventoryResourceFromLayerInfo(layerInfo);
+        var sourceBbox = layerInfo.Extent is { } extent
+            ? new[] { extent.Xmin, extent.Ymin, extent.Xmax, extent.Ymax }
+            : null;
+
+        return MigrationCatalogReconciler.BuildReport(
+            jobId,
+            "arcgis-geoservices-rest",
+            [
+                new MigrationCatalogReconciliationInput
+                {
+                    Resource = inventoryResource,
+                    PublishedResource = published,
+                    SourceBbox = sourceBbox,
+                    TargetResourceId = published.Metadata.Id,
+                    // The per-layer geoservices import path does not currently translate relationship
+                    // classes here (relationship apply is a separate flow); pass none so relationship
+                    // findings are not asserted against this single-layer publish.
+                    ExpectedRelationships = [],
+                    ExpectedSubtypes = layerInfo.Subtypes
+                }
+            ]);
+    }
+
+    /// <summary>
+    /// Projects the apply-time <see cref="GeoservicesLayerInfo"/> snapshot into the
+    /// <see cref="MigrationInventoryResource"/> shape the catalog reconciler consumes. Only the facts
+    /// the reconciler probes are mapped (fields + types + captured domains, geometry type, declared
+    /// SRID, attachment advertisement). Coded-value domains that exceeded the capture cap surface
+    /// with no captured values so the reconciler's cap guard does not false-fail them.
+    /// </summary>
+    private static MigrationInventoryResource BuildInventoryResourceFromLayerInfo(GeoservicesLayerInfo layerInfo)
+    {
+        var srid = layerInfo.SpatialReferenceWkid
+            ?? layerInfo.Extent?.SpatialReferenceWkid;
+
+        var spatialReferences = srid.HasValue
+            ? new[]
+            {
+                new MigrationSpatialReferenceInfo
+                {
+                    Role = "declared",
+                    Srid = srid,
+                    CrsUri = $"EPSG:{srid.Value.ToString(CultureInfo.InvariantCulture)}"
+                }
+            }
+            : [];
+
+        var fields = layerInfo.Fields
+            .Select(BuildInventoryField)
+            .ToArray();
+
+        return new MigrationInventoryResource
+        {
+            Id = $"{layerInfo.Id.ToString(CultureInfo.InvariantCulture)}",
+            ContainerId = "geoservices-import",
+            Kind = "layer",
+            Name = layerInfo.Name,
+            GeometryType = layerInfo.GeometryType,
+            FeatureCount = layerInfo.FeatureCount,
+            HasAttachments = layerInfo.HasAttachments,
+            SpatialReferences = spatialReferences,
+            Fields = fields,
+            Compatibility = new MigrationCompatibilityAssessment
+            {
+                Level = "compatible",
+                Reason = "Imported via the GeoServices apply path."
+            }
+        };
+    }
+
+    private static MigrationInventoryField BuildInventoryField(GeoservicesFieldInfo field)
+    {
+        var domain = field.Domain;
+        string? domainType = domain?.Type;
+        string? domainName = domain?.Name;
+        MigrationInventoryCodedValue[]? domainValues = null;
+
+        if (domain is { } captured &&
+            string.Equals(captured.Type, "codedValue", StringComparison.OrdinalIgnoreCase) &&
+            captured.CodedValues.Count > 0)
+        {
+            domainValues = captured.CodedValues
+                .Select(static coded => new MigrationInventoryCodedValue
+                {
+                    Code = CodedValueToString(coded.Code) ?? string.Empty,
+                    Name = string.IsNullOrWhiteSpace(coded.Name) ? CodedValueToString(coded.Code) ?? string.Empty : coded.Name
+                })
+                .Where(static value => value.Code.Length > 0)
+                .ToArray();
+        }
+
+        return new MigrationInventoryField
+        {
+            Name = field.Name,
+            Alias = string.Equals(field.Alias, field.Name, StringComparison.Ordinal) ? null : field.Alias,
+            FieldType = field.Type,
+            Nullable = field.Nullable,
+            DomainType = domainType,
+            DomainName = domainName,
+            DomainValues = domainValues
+        };
+    }
+
+    private static string? CodedValueToString(System.Text.Json.JsonElement element)
+        => element.ValueKind switch
+        {
+            System.Text.Json.JsonValueKind.String => element.GetString(),
+            System.Text.Json.JsonValueKind.Number => element.GetRawText(),
+            System.Text.Json.JsonValueKind.True => "true",
+            System.Text.Json.JsonValueKind.False => "false",
+            System.Text.Json.JsonValueKind.Null or System.Text.Json.JsonValueKind.Undefined => null,
+            _ => element.GetRawText()
+        };
 }

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.cs
@@ -10,11 +10,13 @@ using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Resilience;
+using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Shared.Models;
 using Honua.Core.Features.Styling.Abstractions;
 using Honua.Core.Features.Styling.Domain;
 using Honua.Postgres.Features.Infrastructure;
+using Honua.Postgres.Features.Metadata;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 using Honua.Core.Features.Migration.Abstractions;
@@ -43,6 +45,7 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
     private readonly IAttachmentStore? _attachmentStore;
     private readonly IMigrationCatalogWriter? _catalogWriter;
     private readonly ILayerReconciliationService? _reconciliationService;
+    private readonly IMetadataV2GraphWriteBaseReader? _metadataWriteBaseReader;
     private readonly ILogger<GeoservicesImportService> _logger;
     private readonly PostgresSchemaConfiguration _schemaConfiguration;
 
@@ -58,6 +61,7 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
         IAttachmentStore? attachmentStore = null,
         IMigrationCatalogWriter? catalogWriter = null,
         ILayerReconciliationService? reconciliationService = null,
+        IMetadataV2GraphStore? metadataGraphStore = null,
         PostgresSchemaConfiguration? schemaConfiguration = null)
     {
         _restClient = restClient ?? throw new ArgumentNullException(nameof(restClient));
@@ -70,6 +74,11 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
         _attachmentStore = attachmentStore;
         _catalogWriter = catalogWriter;
         _reconciliationService = reconciliationService;
+        // The catalog-reconciliation read-back (issue #1379) needs the genuinely-persisted current
+        // graph (where AutoPublish materialized res-layer-{layerId}), never the V1-catalog compat
+        // synthesis. The Postgres store implements this seam; a non-implementing test double leaves
+        // the reader null and catalog reconciliation is skipped.
+        _metadataWriteBaseReader = metadataGraphStore as IMetadataV2GraphWriteBaseReader;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _schemaConfiguration = schemaConfiguration ?? new PostgresSchemaConfiguration(
             PostgresSchemaConfiguration.DefaultMetadataSchema,

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationCatalogReconcilerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationCatalogReconcilerTests.cs
@@ -545,6 +545,87 @@ public sealed class MigrationCatalogReconcilerTests
             f.Code == MigrationCatalogReconciliationCodes.SubtypeCodeMissing);
     }
 
+    [Fact]
+    public void Reconcile_WhenCappedCodedValueDomainHasNoCapturedValuesAndPublishedOmitsDomain_DoesNotFalseFail()
+    {
+        // A coded-value domain that exceeded the capture cap is captured with its type/name but NO
+        // values (DomainValues == null) and is intentionally omitted from publish. Reconciliation
+        // must not report DomainMissing/DomainValuesMismatch against the omitted published domain.
+        var inventory = BuildInventoryResource() with
+        {
+            Fields =
+            [
+                new MigrationInventoryField { Name = "OBJECTID", FieldType = "esriFieldTypeOID", Nullable = false },
+                new MigrationInventoryField { Name = "GLOBALID", FieldType = "esriFieldTypeGlobalID", Nullable = false },
+                new MigrationInventoryField
+                {
+                    Name = "TYPE",
+                    FieldType = "esriFieldTypeString",
+                    Nullable = true,
+                    DomainType = "codedValue",
+                    DomainName = "HugeParcelType",
+                    DomainValues = null // capped: over the CodedValueDomainCap, no values captured
+                }
+            ]
+        };
+
+        // Published field carries no domain (publish dropped the over-cap domain).
+        var published = BuildPublishedResource() with
+        {
+            SchemaFields = BuildPublishedResource().SchemaFields
+                .Select(field => field.Name == "TYPE" ? field with { Domain = null } : field)
+                .ToArray()
+        };
+
+        var outcome = MigrationCatalogReconciler.ReconcileResource(inventory, published);
+
+        outcome.Findings.Should().NotContain(f =>
+            f.Code == MigrationCatalogReconciliationCodes.DomainMissing ||
+            f.Code == MigrationCatalogReconciliationCodes.DomainValuesMismatch);
+        outcome.Classification.Should().Be(MigrationCatalogReconciliationClassifications.Pass);
+    }
+
+    [Fact]
+    public void Reconcile_WhenCappedCodedValueDomainButPublishedRetainsDomain_StillChecksDomainName()
+    {
+        // When the published field DID retain a domain, a capped (valueless) inventory domain can
+        // still meaningfully reconcile the domain NAME — only the missing/values probes are skipped.
+        var inventory = BuildInventoryResource() with
+        {
+            Fields =
+            [
+                new MigrationInventoryField { Name = "OBJECTID", FieldType = "esriFieldTypeOID", Nullable = false },
+                new MigrationInventoryField { Name = "GLOBALID", FieldType = "esriFieldTypeGlobalID", Nullable = false },
+                new MigrationInventoryField
+                {
+                    Name = "TYPE",
+                    FieldType = "esriFieldTypeString",
+                    Nullable = true,
+                    DomainType = "codedValue",
+                    DomainName = "ParcelType",
+                    DomainValues = null
+                }
+            ]
+        };
+
+        var published = BuildPublishedResource() with
+        {
+            SchemaFields = BuildPublishedResource().SchemaFields
+                .Select(field => field.Name == "TYPE"
+                    ? field with { Domain = field.Domain! with { Name = "RenamedParcelType" } }
+                    : field)
+                .ToArray()
+        };
+
+        var outcome = MigrationCatalogReconciler.ReconcileResource(inventory, published);
+
+        // Missing/values probes skipped, but the name-mismatch warn still fires.
+        outcome.Findings.Should().NotContain(f =>
+            f.Code == MigrationCatalogReconciliationCodes.DomainMissing ||
+            f.Code == MigrationCatalogReconciliationCodes.DomainValuesMismatch);
+        outcome.Findings.Should().ContainSingle(f => f.Code == MigrationCatalogReconciliationCodes.DomainNameMismatch);
+    }
+
     private static MetadataV2Subtypes BuildSubtypes(string subtypeField, params (string Code, string Name)[] subtypes)
         => new()
         {

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportCatalogReconciliationTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportCatalogReconciliationTests.cs
@@ -1,0 +1,282 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
+using Honua.Postgres.Features.Admin;
+using Honua.Postgres.Features.Infrastructure;
+using Honua.Postgres.Features.Metadata;
+using Honua.Postgres.Features.Migration;
+using Honua.TestKit;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+/// <summary>
+/// Integration coverage for issue #1379: the Validating phase invokes
+/// <see cref="MigrationCatalogReconciler"/> against the published Metadata v2 catalog entry that the
+/// AutoPublish step materialized, and binds the resulting catalog-parity report to the per-layer
+/// <see cref="MigrationReconciliationArtifact"/>. A faithfully imported layer must yield an all-green
+/// catalog reconciliation (no fail findings, <c>pass</c> classification).
+/// </summary>
+[Collection("Database")]
+public sealed class GeoservicesImportCatalogReconciliationTests(PostgresFixture fixture)
+{
+    [Fact]
+    public async Task ImportLayerAsync_WhenLayerImportedFaithfully_ProducesAllGreenCatalogReconciliation()
+    {
+        const string tableName = "geoservices_catalog_recon";
+        var serviceName = $"catrecon_{Guid.NewGuid():N}";
+        var schemaName = await fixture.CreateIsolatedSchemaAsync("ImportCatalogRecon");
+        var environment = $"CatalogReconTest-{Guid.NewGuid():N}";
+
+        await EnsureCatalogSchemaAsync();
+
+        var graphStore = new PostgresMetadataV2GraphStore(
+            new FixtureConnectionProvider(fixture),
+            environment);
+
+        try
+        {
+            var service = CreateService(graphStore, schemaName);
+
+            var result = await service.ImportLayerAsync(new GeoservicesImportRequest
+            {
+                ServiceUrl = "https://example.com/arcgis/rest/services/Faithful/FeatureServer",
+                LayerId = 0,
+                TableName = tableName,
+                TargetSchema = schemaName,
+                TargetSrid = 4326,
+                BatchSize = 10,
+                RequestTimeoutSeconds = 5,
+                MaxRetries = 0,
+                AutoPublish = true,
+                ServiceName = serviceName,
+                ImportAttachments = false
+            });
+
+            result.Success.Should().BeTrue();
+            result.NeedsReview.Should().BeFalse();
+
+            // #1379: the catalog reconciliation report must be produced and bound to the artifact.
+            result.ReconciliationArtifact.Should().NotBeNull();
+            var catalog = result.ReconciliationArtifact!.CatalogReconciliation;
+            catalog.Should().NotBeNull("the Validating phase must run the catalog reconciler against the published entry");
+
+            // The report is also surfaced as a sibling on the result for the scorecard/gate path.
+            result.CatalogReconciliationReport.Should().BeSameAs(catalog);
+
+            catalog!.Resources.Should().ContainSingle();
+            var resource = catalog.Resources[0];
+            resource.Classification.Should().Be(
+                MigrationCatalogReconciliationClassifications.Pass,
+                "a faithfully imported layer must reconcile all-green; findings: {0}",
+                string.Join("; ", resource.Findings.Select(f => $"{f.Code}:{f.Summary}")));
+            resource.Findings.Should().BeEmpty();
+            catalog.Summary.FailResourceCount.Should().Be(0);
+            catalog.Summary.PassResourceCount.Should().Be(1);
+        }
+        finally
+        {
+            await CleanupCatalogAsync(serviceName);
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    private GeoservicesImportService CreateService(PostgresMetadataV2GraphStore graphStore, string dataSchema)
+    {
+        var restClient = new ArcGisRestClient(
+            new HttpClient(new FaithfulFeatureServerHandler()),
+            NullLogger<ArcGisRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+
+        var crsRegistry = new Mock<ICrsRegistry>(MockBehavior.Loose);
+        var connectionProvider = new FixtureConnectionProvider(fixture);
+
+        var schemaConfiguration = new PostgresSchemaConfiguration(
+            PostgresSchemaConfiguration.DefaultMetadataSchema,
+            dataSchema,
+            [dataSchema, "public"]);
+
+        var publishingService = new PostgreSqlLayerPublishingService(
+            new PostgreSqlTableDiscoveryService(
+                NullLogger<PostgreSqlTableDiscoveryService>.Instance,
+                schemaContext: null,
+                schemaConfiguration: schemaConfiguration),
+            graphStore,
+            NullLogger<PostgreSqlLayerPublishingService>.Instance);
+
+        return new GeoservicesImportService(
+            restClient,
+            connectionProvider,
+            crsRegistry.Object,
+            new EsriConstructCapabilityRegistry(EsriConstructCapabilityRegistry.BuiltInDescriptors),
+            NullLogger<GeoservicesImportService>.Instance,
+            layerPublishingService: publishingService,
+            // A pass-through data-reconciliation service so the gate reaches the catalog pass; the
+            // catalog reconciler reads the published entry back through the real graph store.
+            reconciliationService: new PassThroughReconciliationService(),
+            metadataGraphStore: graphStore);
+    }
+
+    private sealed class PassThroughReconciliationService : ILayerReconciliationService
+    {
+        public Task<MigrationReconciliationArtifact> ReconcileAsync(
+            LayerReconciliationRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new MigrationReconciliationArtifact
+            {
+                RunId = request.RunId,
+                SourceKind = request.SourceKind,
+                Classification = MigrationReconciliationClassifications.Pass,
+                StartedAt = DateTimeOffset.UtcNow,
+                CompletedAt = DateTimeOffset.UtcNow,
+                Summary = new MigrationReconciliationSummary { LayerCount = 1, PassCount = 1 },
+                Layers = [],
+                Reasons = [],
+                Options = new LayerReconciliationOptions()
+            });
+    }
+
+    private async Task EnsureCatalogSchemaAsync()
+    {
+        var sql = await File.ReadAllTextAsync(RepositoryPaths.Resolve("tests", "seed", "base-schema.sql"));
+        await using var connection = await fixture.GetConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"SET search_path TO honua, public;\n{sql}";
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private async Task CleanupCatalogAsync(string serviceName)
+    {
+        await using var connection = await fixture.GetConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            DELETE FROM honua.layer_fields
+            WHERE layer_id IN (
+                SELECT layer_id FROM honua.service_layers WHERE service_name = @serviceName);
+            DELETE FROM honua.service_layers WHERE service_name = @serviceName;
+            DELETE FROM honua.services WHERE service_name = @serviceName;
+            """;
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "serviceName";
+        parameter.Value = serviceName;
+        command.Parameters.Add(parameter);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    // Minimal faithful ArcGIS FeatureServer mock: a point layer in WKID 4326 with an OBJECTID, a
+    // string attribute, and a small coded-value domain. No subtypes, no attachments — everything the
+    // catalog reconciler probes (fields, types, geometry, SRID, identifier, domain) maps cleanly.
+    private sealed class FaithfulFeatureServerHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var pathAndQuery = request.RequestUri?.PathAndQuery ?? string.Empty;
+
+            var payload = pathAndQuery switch
+            {
+                "/arcgis/rest/services/Faithful/FeatureServer/0?f=json" => """
+                    {
+                      "id": 0,
+                      "name": "Faithful Layer",
+                      "geometryType": "esriGeometryPoint",
+                      "maxRecordCount": 10,
+                      "hasAttachments": false,
+                      "extent": { "xmin": -158, "ymin": 21, "xmax": -157, "ymax": 22, "spatialReference": { "wkid": 4326 } },
+                      "fields": [
+                        { "name": "OBJECTID", "type": "esriFieldTypeOID", "nullable": false },
+                        { "name": "Name", "type": "esriFieldTypeString", "nullable": true },
+                        {
+                          "name": "Status",
+                          "type": "esriFieldTypeString",
+                          "nullable": true,
+                          "domain": {
+                            "type": "codedValue",
+                            "name": "StatusDomain",
+                            "codedValues": [
+                              { "name": "Open", "code": "O" },
+                              { "name": "Closed", "code": "C" }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                    """,
+                "/arcgis/rest/services/Faithful/FeatureServer/0/query?where=1=1&returnCountOnly=true&f=json" => """{"count":1}""",
+                _ when pathAndQuery.Contains("resultOffset=0", StringComparison.Ordinal) => """
+                    {
+                      "features": [
+                        {
+                          "attributes": { "OBJECTID": 1, "Name": "Alpha", "Status": "O" },
+                          "geometry": { "x": -157.1, "y": 21.3 }
+                        }
+                      ],
+                      "exceededTransferLimit": false,
+                      "spatialReference": { "wkid": 4326 }
+                    }
+                    """,
+                _ when pathAndQuery.Contains("resultOffset=", StringComparison.Ordinal) => """
+                    {
+                      "features": [],
+                      "exceededTransferLimit": false,
+                      "spatialReference": { "wkid": 4326 }
+                    }
+                    """,
+                _ => throw new InvalidOperationException($"Unexpected ArcGIS request path: {pathAndQuery}")
+            };
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class FixtureConnectionProvider(PostgresFixture postgresFixture) : IDatabaseConnectionProvider
+    {
+        public string GetConnectionString()
+            => new Npgsql.NpgsqlConnectionStringBuilder(postgresFixture.ConnectionString)
+            {
+                SearchPath = "honua,public"
+            }.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+            => await postgresFixture.DataSource.OpenConnectionAsync(cancellationToken);
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var connection = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var transaction = await connection.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (connection, transaction);
+            }
+            catch
+            {
+                await connection.DisposeAsync();
+                throw;
+            }
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(
+            Func<Task<T>> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(
+            Func<Task> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #1379
Fixes #1381

## Summary
Closes the two coupled gaps left by PR #1483 in the post-import reconciliation gate (epic #1246): the schema/data-model reconciler (`MigrationCatalogReconciler`) is now actually invoked per layer during the `Validating` import phase, and its report is fed into the signed reconciliation scorecard's data-reconciliation dimension. Previously the reconciler and scorecard existed but nothing ran the per-layer catalog pass or supplied it a real report.

## Changes Made
- Invoke `MigrationCatalogReconciler` in the GeoServices import `Validating` phase, alongside the existing #1247 data-movement checks, reading the published Metadata v2 entry back through the existing `IMetadataV2GraphWriteBaseReader` seam; when no reader/snapshot is available the pass is skipped (never failed), so a reconciliation-infra gap is not treated as a faithless import.
- Project the apply-time `GeoservicesLayerInfo` into a `MigrationInventoryResource` (fields/types/captured domains, geometry, declared SRID, attachment advertisement) and supply the captured subtype set + source bbox to the reconciler.
- Add a `CatalogReconciliation` property to `MigrationReconciliationArtifact` and populate it so the catalog report travels with the per-layer artifact (still surfaced as the sibling `CatalogReconciliationReport` for the gate/scorecard path).
- Wire the pre-existing attachment/subtype finding collectors (added in #1483) end-to-end; fix `CollectFieldDomainFindings` so a capped coded-value domain (`CodedValueDomainCap`) is not false-failed as `DomainMissing`/`DomainValuesMismatch`.
- Feed the real catalog report into `MigrationReconciliationScorecardBuilder`, keeping capability-parity strictly distinct and non-gating from data-reconciliation.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Core unit: 31 passed (`MigrationCatalogReconcilerTests` incl. 2 new capped-domain cases + `MigrationReconciliationScorecardBuilderTests`). Postgres integration (Testcontainers + PostGIS): new `GeoservicesImportCatalogReconciliationTests` + existing gate/persistence tests green.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

(No new DB migration; reuses migration `044` from #1483.)

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent — full `Honua.sln` Release build with `TreatWarningsAsErrors=true` clean, `dotnet format --verify-no-changes` clean, Core + Postgres reconciliation tests green
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
