### PR TITLE
feat: migrate Portal-facade + GP-translation lanes onto IEsriConstructCapabilityRegistry (#1382)

### DIFF
--- a/src/Honua.Core/Features/Migration/Services/EsriConstructCapabilityRegistry.cs
+++ b/src/Honua.Core/Features/Migration/Services/EsriConstructCapabilityRegistry.cs
@@ -56,6 +56,46 @@ public sealed class EsriConstructCapabilityRegistry : IEsriConstructCapabilityRe
 
         /// <summary>Resource temporal/time metadata.</summary>
         public const string ResourceTimeMetadata = "resource.time-metadata";
+
+        // --- Portal-facade serve lane (#1382) -------------------------------
+        // The Portal facade re-exposes imported Esri-shaped Metadata v2 services
+        // as ArcGIS Portal items. These keys carry the per-service-construct
+        // "can this construct be served through the facade?" verdict so the
+        // facade lane resolves from the shared registry instead of a private
+        // protocol→item-type table.
+
+        /// <summary>Feature service exposed through the Portal facade as a feature-service item.</summary>
+        public const string FacadeFeatureService = "facade.feature-service";
+
+        /// <summary>Map service exposed through the Portal facade as a map-service item.</summary>
+        public const string FacadeMapService = "facade.map-service";
+
+        /// <summary>Image service exposed through the Portal facade as an image-service item.</summary>
+        public const string FacadeImageService = "facade.image-service";
+
+        // --- GP-translation lane (#1382) ------------------------------------
+        // The geoprocessing migration evidence classifier groups built-in
+        // processes into construct families. These keys carry the per-family
+        // automation verdict so the GP lane resolves from the shared registry
+        // instead of a private process-id/category table.
+
+        /// <summary>First-slice deterministic vector geoprocessing family.</summary>
+        public const string GpVectorDeterministic = "gp.vector-deterministic";
+
+        /// <summary>Destructive data-management geoprocessing family (approval-gated).</summary>
+        public const string GpDestructiveDataManagement = "gp.destructive-data-management";
+
+        /// <summary>Heavyweight raster/surface geoprocessing family.</summary>
+        public const string GpRasterSurface = "gp.raster-surface";
+
+        /// <summary>Heavyweight raster-producing conversion geoprocessing family.</summary>
+        public const string GpRasterConversion = "gp.raster-conversion";
+
+        /// <summary>Non-destructive data-management geoprocessing family.</summary>
+        public const string GpDataManagement = "gp.data-management";
+
+        /// <summary>Geoprocessing family not included in the first migration evidence slice.</summary>
+        public const string GpUnsupported = "gp.unsupported";
     }
 
     /// <summary>
@@ -206,6 +246,101 @@ public sealed class EsriConstructCapabilityRegistry : IEsriConstructCapabilityRe
             CanTransform = false,
             CanServe = false,
             RequiresCheck = true
+        },
+
+        // --- Portal-facade serve lane (#1382) -------------------------------
+        new EsriConstructCapabilityDescriptor
+        {
+            ConstructKey = Keys.FacadeFeatureService,
+            AutomationStatus = MigrationFidelityAutomationStatuses.Automated,
+            Code = ImportCompatibilityCodes.Compatible,
+            Reason = "FeatureServer services are re-exposed through the Portal facade as feature-service items.",
+            CanTransform = true,
+            CanServe = true,
+            RequiresCheck = false
+        },
+        new EsriConstructCapabilityDescriptor
+        {
+            ConstructKey = Keys.FacadeMapService,
+            AutomationStatus = MigrationFidelityAutomationStatuses.Automated,
+            Code = ImportCompatibilityCodes.Compatible,
+            Reason = "MapServer services are re-exposed through the Portal facade as map-service items.",
+            CanTransform = true,
+            CanServe = true,
+            RequiresCheck = false
+        },
+        new EsriConstructCapabilityDescriptor
+        {
+            ConstructKey = Keys.FacadeImageService,
+            AutomationStatus = MigrationFidelityAutomationStatuses.Automated,
+            Code = ImportCompatibilityCodes.Compatible,
+            Reason = "ImageServer services are re-exposed through the Portal facade as image-service items.",
+            CanTransform = true,
+            CanServe = true,
+            RequiresCheck = false
+        },
+
+        // --- GP-translation lane (#1382) ------------------------------------
+        new EsriConstructCapabilityDescriptor
+        {
+            ConstructKey = Keys.GpVectorDeterministic,
+            AutomationStatus = MigrationFidelityAutomationStatuses.Automated,
+            Code = ImportCompatibilityCodes.Compatible,
+            Reason = "First-slice deterministic vector process evidence.",
+            CanTransform = true,
+            CanServe = true,
+            RequiresCheck = false
+        },
+        new EsriConstructCapabilityDescriptor
+        {
+            ConstructKey = Keys.GpDestructiveDataManagement,
+            AutomationStatus = MigrationFidelityAutomationStatuses.ManualReview,
+            Code = ImportCompatibilityCodes.ManualReview,
+            Reason = "Destructive data-management process; execution requires operator approval.",
+            ManualSteps = ["Obtain operator approval before executing this destructive process."],
+            CanTransform = false,
+            CanServe = false,
+            RequiresCheck = true
+        },
+        new EsriConstructCapabilityDescriptor
+        {
+            ConstructKey = Keys.GpRasterSurface,
+            AutomationStatus = MigrationFidelityAutomationStatuses.Assisted,
+            Code = ImportCompatibilityCodes.ManualReview,
+            Reason = "Heavyweight raster/surface family; native-profile execution routed to the GDAL worker image, validation-only in the lean image.",
+            CanTransform = false,
+            CanServe = false,
+            RequiresCheck = false
+        },
+        new EsriConstructCapabilityDescriptor
+        {
+            ConstructKey = Keys.GpRasterConversion,
+            AutomationStatus = MigrationFidelityAutomationStatuses.Assisted,
+            Code = ImportCompatibilityCodes.ManualReview,
+            Reason = "Heavyweight raster conversion family; catalog and validation only in this evidence slice.",
+            CanTransform = false,
+            CanServe = false,
+            RequiresCheck = false
+        },
+        new EsriConstructCapabilityDescriptor
+        {
+            ConstructKey = Keys.GpDataManagement,
+            AutomationStatus = MigrationFidelityAutomationStatuses.Assisted,
+            Code = ImportCompatibilityCodes.ManualReview,
+            Reason = "Data-management process is inventoried for migration review, not projected as automated runtime evidence.",
+            CanTransform = false,
+            CanServe = false,
+            RequiresCheck = false
+        },
+        new EsriConstructCapabilityDescriptor
+        {
+            ConstructKey = Keys.GpUnsupported,
+            AutomationStatus = MigrationFidelityAutomationStatuses.Unsupported,
+            Code = ImportCompatibilityCodes.ManualReview,
+            Reason = "Not included in the first process migration evidence slice.",
+            CanTransform = false,
+            CanServe = false,
+            RequiresCheck = false
         }
     ];
 

--- a/src/Honua.Core/Features/Portal/PortalServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Portal/PortalServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Services;
 using Honua.Core.Features.Portal.Abstractions;
 using Honua.Core.Features.Portal.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,14 +18,19 @@ public static class PortalServiceCollectionExtensions
 {
     /// <summary>
     /// Registers the RBAC-aware <see cref="IPortalItemProjector"/>. The projector
-    /// depends on the shared <c>IAccessPolicyEvaluator</c>, which the host registers
-    /// as part of the authentication/RBAC pipeline.
+    /// depends on the shared <c>IAccessPolicyEvaluator</c> (registered by the
+    /// authentication/RBAC pipeline) and the shared
+    /// <see cref="IEsriConstructCapabilityRegistry"/> (#1382), which is registered
+    /// here defensively so the facade lane always has the capability registry even
+    /// when the import feature is not otherwise wired.
     /// </summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <returns>The same service collection for chaining.</returns>
     public static IServiceCollection AddPortalItemProjection(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
+        services.TryAddSingleton<IEsriConstructCapabilityRegistry>(
+            _ => new EsriConstructCapabilityRegistry(EsriConstructCapabilityRegistry.BuiltInDescriptors));
         services.TryAddSingleton<IPortalItemProjector, PortalItemProjector>();
         return services;
     }

--- a/src/Honua.Core/Features/Portal/Services/PortalItemProjector.cs
+++ b/src/Honua.Core/Features/Portal/Services/PortalItemProjector.cs
@@ -4,6 +4,8 @@
 using System.Globalization;
 using System.Security.Claims;
 using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Services;
 using Honua.Core.Features.Portal.Abstractions;
 using Honua.Core.Features.Portal.Domain;
 using Honua.Core.Features.Security.Abstractions;
@@ -28,6 +30,7 @@ public sealed class PortalItemProjector : IPortalItemProjector
         new(new ClaimsIdentity(authenticationType: "PortalAccessProbe"));
 
     private readonly IAccessPolicyEvaluator _accessPolicyEvaluator;
+    private readonly IEsriConstructCapabilityRegistry _capabilityRegistry;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PortalItemProjector"/> class.
@@ -38,10 +41,20 @@ public sealed class PortalItemProjector : IPortalItemProjector
     /// through, so the Portal <c>access</c> tier cannot drift from the real RBAC
     /// decision.
     /// </param>
-    public PortalItemProjector(IAccessPolicyEvaluator accessPolicyEvaluator)
+    /// <param name="capabilityRegistry">
+    /// The shared Esri construct capability/fidelity registry (#1382). The facade
+    /// lane resolves the "can this service construct be served through the Portal
+    /// facade?" verdict from the registry instead of a private table, so the
+    /// facade, importer, and GP lanes stay aligned on one source of truth.
+    /// </param>
+    public PortalItemProjector(
+        IAccessPolicyEvaluator accessPolicyEvaluator,
+        IEsriConstructCapabilityRegistry capabilityRegistry)
     {
         ArgumentNullException.ThrowIfNull(accessPolicyEvaluator);
+        ArgumentNullException.ThrowIfNull(capabilityRegistry);
         _accessPolicyEvaluator = accessPolicyEvaluator;
+        _capabilityRegistry = capabilityRegistry;
     }
 
     /// <inheritdoc />
@@ -103,7 +116,15 @@ public sealed class PortalItemProjector : IPortalItemProjector
         ClaimsPrincipal principal,
         string baseUrl)
     {
-        if (!TryMapItemType(service.PrimaryProtocol, out var itemType, out var urlType))
+        if (!TryMapItemType(service.PrimaryProtocol, out var itemType, out var urlType, out var constructKey))
+        {
+            return null;
+        }
+
+        // The facade only serves constructs the shared capability registry marks
+        // as servable. Unknown protocols resolve to the manual-review fallback
+        // (CanServe == false) and are therefore not surfaced as Portal items.
+        if (!_capabilityRegistry.ResolveOrUnknown(constructKey).CanServe)
         {
             return null;
         }
@@ -219,29 +240,39 @@ public sealed class PortalItemProjector : IPortalItemProjector
     }
 
     /// <summary>
-    /// Maps a Metadata v2 primary protocol to the Esri Portal item type and the
-    /// GeoServices URL route segment. Returns <see langword="false"/> for
-    /// non-Esri protocols (OGC API, STAC, OData, …) which are not Portal items.
+    /// Maps a Metadata v2 primary protocol to the Esri Portal item type, the
+    /// GeoServices URL route segment, and the shared capability-registry
+    /// construct key. Returns <see langword="false"/> for non-Esri protocols
+    /// (OGC API, STAC, OData, …) which are never Portal items. The servability
+    /// verdict for the mapped construct is owned by the registry, not this table.
     /// </summary>
-    private static bool TryMapItemType(string? primaryProtocol, out string itemType, out string urlType)
+    private static bool TryMapItemType(
+        string? primaryProtocol,
+        out string itemType,
+        out string urlType,
+        out string constructKey)
     {
         switch (primaryProtocol)
         {
             case ServiceProtocols.FeatureServer:
                 itemType = PortalItemTypes.FeatureService;
                 urlType = ServiceProtocols.FeatureServer;
+                constructKey = EsriConstructCapabilityRegistry.Keys.FacadeFeatureService;
                 return true;
             case ServiceProtocols.MapServer:
                 itemType = PortalItemTypes.MapService;
                 urlType = ServiceProtocols.MapServer;
+                constructKey = EsriConstructCapabilityRegistry.Keys.FacadeMapService;
                 return true;
             case ServiceProtocols.ImageServer:
                 itemType = PortalItemTypes.ImageService;
                 urlType = ServiceProtocols.ImageServer;
+                constructKey = EsriConstructCapabilityRegistry.Keys.FacadeImageService;
                 return true;
             default:
                 itemType = string.Empty;
                 urlType = string.Empty;
+                constructKey = string.Empty;
                 return false;
         }
     }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessMigrationEvidenceClassifier.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessMigrationEvidenceClassifier.cs
@@ -3,12 +3,23 @@
 
 using System.Collections.Frozen;
 using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
 
 namespace Honua.Geoprocessing;
 
 /// <summary>
 /// Classifies built-in processes for migration evidence claims.
 /// </summary>
+/// <remarks>
+/// The capability/fidelity verdict (automation tier) is sourced from the shared
+/// <see cref="IEsriConstructCapabilityRegistry"/> (#1382): the classifier maps a
+/// process onto a GP construct family key and the registry supplies the verdict,
+/// keeping the GP lane aligned with the importer and Portal-facade lanes rather
+/// than maintaining a private tier table. Unrecognised keys fall back to the
+/// shared <c>manual-review</c> descriptor.
+/// </remarks>
 internal static class ProcessMigrationEvidenceClassifier
 {
     private static readonly FrozenSet<string> FirstSliceAutomatedVectorProcessIds =
@@ -37,56 +48,79 @@ internal static class ProcessMigrationEvidenceClassifier
             "generalization.dissolve",
         }.ToFrozenSet(StringComparer.Ordinal);
 
+    // Single shared registry instance built from the same descriptor set the DI
+    // container seeds, so the static GP classifier resolves identical verdicts.
+    private static readonly IEsriConstructCapabilityRegistry Registry =
+        new EsriConstructCapabilityRegistry(EsriConstructCapabilityRegistry.BuiltInDescriptors);
+
     public static ProcessMigrationEvidenceClassification Classify(ProcessDefinition definition)
+        => Classify(definition, Registry);
+
+    /// <summary>
+    /// Classifies <paramref name="definition"/> using the supplied capability
+    /// registry. The construct-family mapping stays local (it is the lane's
+    /// parsing job); the registry owns the per-family capability/fidelity verdict.
+    /// </summary>
+    public static ProcessMigrationEvidenceClassification Classify(
+        ProcessDefinition definition,
+        IEsriConstructCapabilityRegistry registry)
     {
         ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(registry);
 
+        var constructKey = ResolveConstructKey(definition);
+        var descriptor = registry.ResolveOrUnknown(constructKey);
+
+        var tier = ToAutomationTier(descriptor.AutomationStatus);
+        var requiresApproval = string.Equals(
+            constructKey,
+            EsriConstructCapabilityRegistry.Keys.GpDestructiveDataManagement,
+            StringComparison.Ordinal);
+
+        return new ProcessMigrationEvidenceClassification(
+            tier,
+            RequiresApproval: requiresApproval,
+            IsProjectedThroughOgcApiProcesses: descriptor.CanServe,
+            descriptor.Reason);
+    }
+
+    /// <summary>
+    /// Maps a process to its GP construct family registry key. Every process maps
+    /// to a registered family (including the explicit <c>gp.unsupported</c> catch
+    /// for processes outside the first evidence slice), so the shared unknown
+    /// fallback only fires when the registry itself lacks the key.
+    /// </summary>
+    private static string ResolveConstructKey(ProcessDefinition definition)
+    {
         var processId = definition.ProcessId;
         if (FirstSliceAutomatedVectorProcessIds.Contains(processId))
         {
-            return new ProcessMigrationEvidenceClassification(
-                ProcessMigrationAutomationTier.Automated,
-                RequiresApproval: false,
-                IsProjectedThroughOgcApiProcesses: true,
-                "First-slice deterministic vector process evidence.");
+            return EsriConstructCapabilityRegistry.Keys.GpVectorDeterministic;
         }
 
         if (ProcessDestructiveClassifier.IsDestructive(processId))
         {
-            return new ProcessMigrationEvidenceClassification(
-                ProcessMigrationAutomationTier.ManualReview,
-                RequiresApproval: true,
-                IsProjectedThroughOgcApiProcesses: false,
-                "Destructive data-management process; execution requires operator approval.");
+            return EsriConstructCapabilityRegistry.Keys.GpDestructiveDataManagement;
         }
 
         return definition.Category switch
         {
-            "surface" or "raster" => new ProcessMigrationEvidenceClassification(
-                ProcessMigrationAutomationTier.Assisted,
-                RequiresApproval: false,
-                IsProjectedThroughOgcApiProcesses: false,
-                "Heavyweight raster/surface family; native-profile execution routed to the GDAL worker image, validation-only in the lean image."),
-
-            "conversion" when definition.OutputArtifactKinds.Contains(ArtifactKind.Raster) => new ProcessMigrationEvidenceClassification(
-                ProcessMigrationAutomationTier.Assisted,
-                RequiresApproval: false,
-                IsProjectedThroughOgcApiProcesses: false,
-                "Heavyweight raster conversion family; catalog and validation only in this evidence slice."),
-
-            "data-management" => new ProcessMigrationEvidenceClassification(
-                ProcessMigrationAutomationTier.Assisted,
-                RequiresApproval: false,
-                IsProjectedThroughOgcApiProcesses: false,
-                "Data-management process is inventoried for migration review, not projected as automated runtime evidence."),
-
-            _ => new ProcessMigrationEvidenceClassification(
-                ProcessMigrationAutomationTier.Unsupported,
-                RequiresApproval: false,
-                IsProjectedThroughOgcApiProcesses: false,
-                "Not included in the first process migration evidence slice.")
+            "surface" or "raster" => EsriConstructCapabilityRegistry.Keys.GpRasterSurface,
+            "conversion" when definition.OutputArtifactKinds.Contains(ArtifactKind.Raster) =>
+                EsriConstructCapabilityRegistry.Keys.GpRasterConversion,
+            "data-management" => EsriConstructCapabilityRegistry.Keys.GpDataManagement,
+            _ => EsriConstructCapabilityRegistry.Keys.GpUnsupported
         };
     }
+
+    private static ProcessMigrationAutomationTier ToAutomationTier(string automationStatus)
+        => automationStatus switch
+        {
+            MigrationFidelityAutomationStatuses.Automated => ProcessMigrationAutomationTier.Automated,
+            MigrationFidelityAutomationStatuses.Assisted => ProcessMigrationAutomationTier.Assisted,
+            MigrationFidelityAutomationStatuses.ManualReview => ProcessMigrationAutomationTier.ManualReview,
+            _ => ProcessMigrationAutomationTier.Unsupported
+        };
 
     public static bool IsFirstSliceOgcProcess(ProcessDefinition definition)
         => Classify(definition).IsProjectedThroughOgcApiProcesses;

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/EsriConstructCapabilityRegistryTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/EsriConstructCapabilityRegistryTests.cs
@@ -22,6 +22,15 @@ public sealed class EsriConstructCapabilityRegistryTests
     [InlineData(EsriConstructCapabilityRegistry.Keys.ResourceAttachments, MigrationFidelityAutomationStatuses.ManualReview, ImportCompatibilityCodes.ArcGisAttachments, false, false, true)]
     [InlineData(EsriConstructCapabilityRegistry.Keys.ResourceRenderers, MigrationFidelityAutomationStatuses.ManualReview, ImportCompatibilityCodes.ManualReview, false, false, true)]
     [InlineData(EsriConstructCapabilityRegistry.Keys.ResourceTimeMetadata, MigrationFidelityAutomationStatuses.ManualReview, ImportCompatibilityCodes.ArcGisTimeMetadataManualReview, false, false, true)]
+    [InlineData(EsriConstructCapabilityRegistry.Keys.FacadeFeatureService, MigrationFidelityAutomationStatuses.Automated, ImportCompatibilityCodes.Compatible, true, true, false)]
+    [InlineData(EsriConstructCapabilityRegistry.Keys.FacadeMapService, MigrationFidelityAutomationStatuses.Automated, ImportCompatibilityCodes.Compatible, true, true, false)]
+    [InlineData(EsriConstructCapabilityRegistry.Keys.FacadeImageService, MigrationFidelityAutomationStatuses.Automated, ImportCompatibilityCodes.Compatible, true, true, false)]
+    [InlineData(EsriConstructCapabilityRegistry.Keys.GpVectorDeterministic, MigrationFidelityAutomationStatuses.Automated, ImportCompatibilityCodes.Compatible, true, true, false)]
+    [InlineData(EsriConstructCapabilityRegistry.Keys.GpDestructiveDataManagement, MigrationFidelityAutomationStatuses.ManualReview, ImportCompatibilityCodes.ManualReview, false, false, true)]
+    [InlineData(EsriConstructCapabilityRegistry.Keys.GpRasterSurface, MigrationFidelityAutomationStatuses.Assisted, ImportCompatibilityCodes.ManualReview, false, false, false)]
+    [InlineData(EsriConstructCapabilityRegistry.Keys.GpRasterConversion, MigrationFidelityAutomationStatuses.Assisted, ImportCompatibilityCodes.ManualReview, false, false, false)]
+    [InlineData(EsriConstructCapabilityRegistry.Keys.GpDataManagement, MigrationFidelityAutomationStatuses.Assisted, ImportCompatibilityCodes.ManualReview, false, false, false)]
+    [InlineData(EsriConstructCapabilityRegistry.Keys.GpUnsupported, MigrationFidelityAutomationStatuses.Unsupported, ImportCompatibilityCodes.ManualReview, false, false, false)]
     public void ResolveOrUnknown_KnownConstructKey_ReturnsSeededDescriptor(
         string constructKey,
         string expectedAutomationStatus,
@@ -96,7 +105,16 @@ public sealed class EsriConstructCapabilityRegistryTests
             EsriConstructCapabilityRegistry.Keys.ResourceRelationships,
             EsriConstructCapabilityRegistry.Keys.ResourceAttachments,
             EsriConstructCapabilityRegistry.Keys.ResourceRenderers,
-            EsriConstructCapabilityRegistry.Keys.ResourceTimeMetadata
+            EsriConstructCapabilityRegistry.Keys.ResourceTimeMetadata,
+            EsriConstructCapabilityRegistry.Keys.FacadeFeatureService,
+            EsriConstructCapabilityRegistry.Keys.FacadeMapService,
+            EsriConstructCapabilityRegistry.Keys.FacadeImageService,
+            EsriConstructCapabilityRegistry.Keys.GpVectorDeterministic,
+            EsriConstructCapabilityRegistry.Keys.GpDestructiveDataManagement,
+            EsriConstructCapabilityRegistry.Keys.GpRasterSurface,
+            EsriConstructCapabilityRegistry.Keys.GpRasterConversion,
+            EsriConstructCapabilityRegistry.Keys.GpDataManagement,
+            EsriConstructCapabilityRegistry.Keys.GpUnsupported
         ]);
     }
 

--- a/tests/dotnet/Honua.Core.Tests/Features/Portal/PortalItemProjectorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Portal/PortalItemProjectorTests.cs
@@ -3,7 +3,11 @@
 
 using System.Security.Claims;
 using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
 using Honua.Core.Features.Portal.Domain;
 using Honua.Core.Features.Portal.Services;
 using Honua.Core.Features.Security.Abstractions;
@@ -31,7 +35,7 @@ public sealed class PortalItemProjectorTests
         var snapshot = BuildSnapshot(
             BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: true),
             resourceAccess: AnonymousPolicy());
-        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+        var projector = CreateProjector();
 
         var items = projector.ProjectVisibleItems(snapshot, Anonymous(), ProxyBaseUrl);
 
@@ -52,7 +56,7 @@ public sealed class PortalItemProjectorTests
         var snapshot = BuildSnapshot(
             BuildService("service.basemap", "City Basemap", ServiceProtocols.MapServer, publicAccess: true),
             resourceAccess: AnonymousPolicy());
-        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+        var projector = CreateProjector();
 
         var items = projector.ProjectVisibleItems(snapshot, Anonymous(), ProxyBaseUrl + "/");
 
@@ -83,7 +87,7 @@ public sealed class PortalItemProjectorTests
         var snapshot = BuildSnapshotWithResource(
             BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: true),
             resource);
-        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+        var projector = CreateProjector();
 
         var item = projector.ProjectVisibleItems(snapshot, Anonymous(), ProxyBaseUrl).Single();
 
@@ -100,7 +104,7 @@ public sealed class PortalItemProjectorTests
         var snapshot = BuildSnapshot(
             BuildService("service.ogc", "OgcFeatures", ServiceProtocols.OgcFeatures, publicAccess: true),
             resourceAccess: AnonymousPolicy());
-        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+        var projector = CreateProjector();
 
         var items = projector.ProjectVisibleItems(snapshot, Anonymous(), ProxyBaseUrl);
 
@@ -115,7 +119,7 @@ public sealed class PortalItemProjectorTests
         var snapshot = BuildSnapshot(
             BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: false),
             resourceAccess: new AccessPolicy { AllowAnonymous = false });
-        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+        var projector = CreateProjector();
 
         var item = projector.ProjectVisibleItems(snapshot, AuthenticatedUser("editor"), ProxyBaseUrl).Single();
 
@@ -129,7 +133,7 @@ public sealed class PortalItemProjectorTests
         var snapshot = BuildSnapshot(
             BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: false),
             resourceAccess: new AccessPolicy { AllowedRoles = ["admin"] });
-        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+        var projector = CreateProjector();
 
         var item = projector.ProjectVisibleItems(snapshot, AuthenticatedUser("admin"), ProxyBaseUrl).Single();
 
@@ -144,7 +148,7 @@ public sealed class PortalItemProjectorTests
         var snapshot = BuildSnapshot(
             BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: false),
             resourceAccess: new AccessPolicy { AllowedRoles = ["admin"] });
-        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+        var projector = CreateProjector();
 
         var items = projector.ProjectVisibleItems(snapshot, AuthenticatedUser("viewer"), ProxyBaseUrl);
 
@@ -158,7 +162,7 @@ public sealed class PortalItemProjectorTests
         var snapshot = BuildSnapshot(
             BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: false),
             resourceAccess: new AccessPolicy { AllowedRoles = ["admin"] });
-        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+        var projector = CreateProjector();
 
         var item = projector.ProjectItem(snapshot, AuthenticatedUser("viewer"), "service.parcels", ProxyBaseUrl);
 
@@ -172,7 +176,7 @@ public sealed class PortalItemProjectorTests
         var snapshot = BuildSnapshot(
             BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: false),
             resourceAccess: new AccessPolicy { AllowedRoles = ["admin"] });
-        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+        var projector = CreateProjector();
 
         var item = projector.ProjectItem(snapshot, AuthenticatedUser("admin"), "service.parcels", ProxyBaseUrl);
 
@@ -188,10 +192,63 @@ public sealed class PortalItemProjectorTests
         var snapshot = BuildSnapshot(
             BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: true),
             resourceAccess: AnonymousPolicy());
-        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+        var projector = CreateProjector();
 
         projector.ProjectItem(snapshot, Anonymous(), "service.missing", ProxyBaseUrl).Should().BeNull();
     }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void ProjectVisibleItems_RegistryMarksConstructUnservable_OmitsItem()
+    {
+        // The facade serve decision is sourced from the shared capability
+        // registry (#1382). A registry whose feature-service descriptor is not
+        // servable must omit the item even though the protocol→item-type table
+        // still recognises FeatureServer — proving the verdict comes from the
+        // registry, not the private mapping table.
+        var snapshot = BuildSnapshot(
+            BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: true),
+            resourceAccess: AnonymousPolicy());
+        var projector = new PortalItemProjector(
+            new FakeAccessPolicyEvaluator(),
+            new EsriConstructCapabilityRegistry(NonServableFacadeDescriptors()));
+
+        var items = projector.ProjectVisibleItems(snapshot, Anonymous(), ProxyBaseUrl);
+
+        items.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void ProjectVisibleItems_BuiltInRegistry_ServesAllFacadeServiceTypes()
+    {
+        // Behaviour-preservation guard: every Esri service construct the private
+        // table used to accept is served by the built-in registry descriptors.
+        var registry = new EsriConstructCapabilityRegistry(EsriConstructCapabilityRegistry.BuiltInDescriptors);
+        registry.ResolveOrUnknown(EsriConstructCapabilityRegistry.Keys.FacadeFeatureService).CanServe.Should().BeTrue();
+        registry.ResolveOrUnknown(EsriConstructCapabilityRegistry.Keys.FacadeMapService).CanServe.Should().BeTrue();
+        registry.ResolveOrUnknown(EsriConstructCapabilityRegistry.Keys.FacadeImageService).CanServe.Should().BeTrue();
+    }
+
+    private static PortalItemProjector CreateProjector()
+        => new(
+            new FakeAccessPolicyEvaluator(),
+            new EsriConstructCapabilityRegistry(EsriConstructCapabilityRegistry.BuiltInDescriptors));
+
+    private static EsriConstructCapabilityDescriptor[] NonServableFacadeDescriptors()
+        =>
+        [
+            new EsriConstructCapabilityDescriptor
+            {
+                ConstructKey = EsriConstructCapabilityRegistry.Keys.FacadeFeatureService,
+                AutomationStatus = MigrationFidelityAutomationStatuses.ManualReview,
+                Code = ImportCompatibilityCodes.ManualReview,
+                Reason = "Test override: feature-service facade construct is not servable.",
+                CanTransform = false,
+                CanServe = false,
+                RequiresCheck = true
+            }
+        ];
 
     private static MetadataV2Service BuildService(string id, string name, string protocol, bool publicAccess)
         => new()

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessMigrationEvidenceClassifierTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessMigrationEvidenceClassifierTests.cs
@@ -2,6 +2,11 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using FluentAssertions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
 using Honua.Geoprocessing;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -72,5 +77,73 @@ public sealed class ProcessMigrationEvidenceClassifierTests
             classification.RequiresApproval.Should().BeTrue();
             classification.IsProjectedThroughOgcApiProcesses.Should().BeFalse();
         }
+    }
+
+    [UnitTest]
+    [Operation(Operations.ProcessDiscovery)]
+    public void Classify_ReadsVerdictFromInjectedRegistry()
+    {
+        // The GP lane sources the automation verdict from the shared capability
+        // registry (#1382). A registry whose deterministic-vector descriptor is
+        // overridden to manual-review must flip the lane's verdict — proving the
+        // verdict comes from the registry, not a private tier table.
+        var overridden = new EsriConstructCapabilityRegistry(
+        [
+            new EsriConstructCapabilityDescriptor
+            {
+                ConstructKey = EsriConstructCapabilityRegistry.Keys.GpVectorDeterministic,
+                AutomationStatus = MigrationFidelityAutomationStatuses.ManualReview,
+                Code = ImportCompatibilityCodes.ManualReview,
+                Reason = "Test override: deterministic vector process requires review.",
+                CanTransform = false,
+                CanServe = false,
+                RequiresCheck = true
+            }
+        ]);
+
+        var classification = ProcessMigrationEvidenceClassifier.Classify(
+            _catalog.GetProcess("geometry.buffer")!,
+            overridden);
+
+        classification.AutomationTier.Should().Be(ProcessMigrationAutomationTier.ManualReview);
+        classification.IsProjectedThroughOgcApiProcesses.Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.ProcessDiscovery)]
+    public void Classify_BuiltInRegistry_MatchesKnownConstructVerdicts()
+    {
+        // Behaviour-preservation guard: the built-in registry reproduces the
+        // exact verdicts the private table emitted for known GP constructs.
+        var registry = new EsriConstructCapabilityRegistry(EsriConstructCapabilityRegistry.BuiltInDescriptors);
+
+        registry.ResolveOrUnknown(EsriConstructCapabilityRegistry.Keys.GpVectorDeterministic)
+            .AutomationStatus.Should().Be(MigrationFidelityAutomationStatuses.Automated);
+        registry.ResolveOrUnknown(EsriConstructCapabilityRegistry.Keys.GpDestructiveDataManagement)
+            .AutomationStatus.Should().Be(MigrationFidelityAutomationStatuses.ManualReview);
+        registry.ResolveOrUnknown(EsriConstructCapabilityRegistry.Keys.GpRasterSurface)
+            .AutomationStatus.Should().Be(MigrationFidelityAutomationStatuses.Assisted);
+        registry.ResolveOrUnknown(EsriConstructCapabilityRegistry.Keys.GpRasterConversion)
+            .AutomationStatus.Should().Be(MigrationFidelityAutomationStatuses.Assisted);
+        registry.ResolveOrUnknown(EsriConstructCapabilityRegistry.Keys.GpDataManagement)
+            .AutomationStatus.Should().Be(MigrationFidelityAutomationStatuses.Assisted);
+        registry.ResolveOrUnknown(EsriConstructCapabilityRegistry.Keys.GpUnsupported)
+            .AutomationStatus.Should().Be(MigrationFidelityAutomationStatuses.Unsupported);
+    }
+
+    [UnitTest]
+    [Operation(Operations.ProcessDiscovery)]
+    public void Classify_RegistryMissingGpKey_FallsBackToManualReview()
+    {
+        // When the lane maps a process onto a key the registry does not know, the
+        // shared UnknownDescriptor manual-review fallback governs the verdict.
+        var emptyRegistry = new EsriConstructCapabilityRegistry([]);
+
+        var classification = ProcessMigrationEvidenceClassifier.Classify(
+            _catalog.GetProcess("geometry.buffer")!,
+            emptyRegistry);
+
+        classification.AutomationTier.Should().Be(ProcessMigrationAutomationTier.ManualReview);
+        classification.IsProjectedThroughOgcApiProcesses.Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Issue Link
Fixes #1382

## Summary
Migrates the Portal-facade and GP-translation lanes onto the shared `IEsriConstructCapabilityRegistry` (the CSM spine) so all three migration surfaces — importer, facade, and GP — resolve capability/fidelity verdicts from one declarative source of truth instead of private classification tables. This satisfies epic #1244's "importer, facade, and GP lanes consume the registry" acceptance criterion.

## Changes Made
- **Portal-facade lane** (`src/Honua.Core/Features/Portal/Services/PortalItemProjector.cs`): the serve verdict now comes from `IEsriConstructCapabilityRegistry.ResolveOrUnknown(...).CanServe` instead of a private `TryMapItemType` switch; the protocol→item-type/url-type mapping stays local (wire-format only). Registry injected via DI.
- **GP-translation lane** (`src/Honua.Geoprocessing/Features/Geoprocessing/ProcessMigrationEvidenceClassifier.cs`): the automation tier is now derived from the resolved registry descriptor (via a GP construct-family key) instead of a private id set + category switch; added a `Classify(definition, registry)` overload.
- Added registry keys + descriptors to `EsriConstructCapabilityRegistry`: facade (`facade.feature-service`, `facade.map-service`, `facade.image-service`) and GP (`gp.vector-deterministic`, `gp.destructive-data-management`, `gp.raster-surface`, `gp.raster-conversion`, `gp.data-management`, `gp.unsupported`), with reason strings copied verbatim to preserve evidence text.
- Both lanes route unknown keys to the shared `UnknownDescriptor` manual-review fallback; `AddPortalItemProjection` now `TryAddSingleton`s the registry.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Unit: registry + `PortalItemProjectorTests` 41/41; GP classifier + fixture tests 8/8. (One OGC-Processes integration test was an environmental Testcontainers host-startup timeout, not a logic regression — 76/77 host-backed siblings passed; CI will re-run the full shard.)

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent — Release build with `TreatWarningsAsErrors=true` (0 warnings/0 errors), `dotnet format --verify-no-changes` clean, affected unit tests green
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
