### PR TITLE
fix: content publication policy-update NRE on default policy (#1239)

### DIFF
--- a/src/Honua.Core/Features/Publishing/Content/Domain/ContentPublicationPolicy.cs
+++ b/src/Honua.Core/Features/Publishing/Content/Domain/ContentPublicationPolicy.cs
@@ -42,6 +42,44 @@ public sealed record ContentPublicationPolicy
     public ContentPublicLinkPolicy PublicLink { get; init; } = new();
 }
 
+/// <summary>
+/// Normalizes a <see cref="ContentPublicationPolicy"/> so its nested members are
+/// never null. JSON deserialization (including the source-generated path) does not
+/// run record property initializers for members absent from the payload, so a
+/// minimal create body (for example <c>{"visibility":"organization"}</c>) can
+/// produce a policy with null <c>Share</c>/<c>Embed</c>/<c>Service</c>/<c>PublicLink</c>
+/// members. Callers that persist or mutate a policy run it through this normalizer
+/// first so downstream code can dereference nested members safely.
+/// </summary>
+public static class ContentPublicationPolicyNormalizer
+{
+    /// <summary>
+    /// Returns a policy whose nested members are guaranteed non-null, defaulting any
+    /// null member (or the policy itself) to its initialized default.
+    /// </summary>
+    /// <param name="policy">The policy to normalize, or null to produce a default policy.</param>
+    /// <returns>A policy with non-null nested members.</returns>
+    public static ContentPublicationPolicy Normalize(ContentPublicationPolicy? policy)
+    {
+        policy ??= new ContentPublicationPolicy();
+
+        // The nested members are declared non-null, but deserialization can leave them
+        // null when absent from the payload. Read through nullable views so the
+        // null-coalescing below is meaningful rather than a no-op the compiler flags.
+        var publicLink = (ContentPublicLinkPolicy?)policy.PublicLink is { } existingLink
+            ? existingLink with { Links = (IReadOnlyList<ContentPublicLink>?)existingLink.Links ?? [] }
+            : new ContentPublicLinkPolicy();
+
+        return policy with
+        {
+            Share = (ContentSharePolicy?)policy.Share ?? new ContentSharePolicy(),
+            Embed = (ContentEmbedPolicy?)policy.Embed ?? new ContentEmbedPolicy(),
+            Service = (ContentServicePolicy?)policy.Service ?? new ContentServicePolicy(),
+            PublicLink = publicLink,
+        };
+    }
+}
+
 /// <summary>Sharing policy for a published route.</summary>
 public sealed record ContentSharePolicy
 {

--- a/src/Honua.Core/Features/Publishing/Content/Services/ContentPublicationService.cs
+++ b/src/Honua.Core/Features/Publishing/Content/Services/ContentPublicationService.cs
@@ -88,7 +88,9 @@ public sealed class ContentPublicationService : IContentPublicationService
         var publicationId = Guid.NewGuid().ToString("D");
         var versionId = Guid.NewGuid().ToString("D");
         var routePath = RoutePathPrefix + slug;
-        var policy = request.Policy ?? new ContentPublicationPolicy();
+        // Normalize so the persisted policy always has non-null nested members, even
+        // when the create payload only supplies a subset (e.g. {"visibility":"..."}).
+        var policy = ContentPublicationPolicyNormalizer.Normalize(request.Policy);
         var contentHash = ResolveContentHash(request.ContentPayload, request.ContentHash);
 
         var version = new ContentPublicationVersion
@@ -353,7 +355,12 @@ public sealed class ContentPublicationService : IContentPublicationService
         }
 
         var now = _timeProvider.GetUtcNow();
-        var current = route.Policy;
+        // Normalize so nested policy members are never null. A route persisted from a
+        // minimal create payload (e.g. {"visibility":"organization"}) can round-trip
+        // with null nested objects because JSON deserialization does not run the record
+        // property initializers for absent members. Coalesce defensively here so the
+        // delta-apply logic below cannot dereference a null nested member.
+        var current = ContentPublicationPolicyNormalizer.Normalize(route.Policy);
 
         // Apply scalar policy deltas.
         var share = request.Share ?? current.Share;

--- a/tests/dotnet/Honua.Core.Tests/Features/Publishing/Content/ContentPublicationServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Publishing/Content/ContentPublicationServiceTests.cs
@@ -209,6 +209,74 @@ public sealed class ContentPublicationServiceTests
 
     [UnitTest]
     [Operation(Operations.Update)]
+    public async Task UpdatePolicy_OnPolicyWithNullNestedMembers_DoesNotThrow_AndAppliesDeltas()
+    {
+        // Regression for #1239: a publication created from a minimal policy whose nested
+        // members deserialize to null must not NRE on a subsequent policy update. Simulate
+        // the deserialized state (null embed/share/service/publicLink) explicitly.
+        var (service, _) = CreateService();
+        var nullNestedPolicy = new ContentPublicationPolicy
+        {
+            Visibility = ContentPublicationVisibility.Organization,
+            Share = null!,
+            Embed = null!,
+            Service = null!,
+            PublicLink = null!,
+        };
+        var published = await service.PublishAsync(
+            new PublishContentRequest { Kind = ContentPublicationKind.Report, RouteSlug = "rpt-smoke", ContentPayload = "a", Policy = nullNestedPolicy },
+            Actor,
+            null);
+
+        var result = await service.UpdatePolicyAsync(published.Route.PublicationId, new UpdatePublicationPolicyRequest
+        {
+            Visibility = ContentPublicationVisibility.Public,
+            Embed = new ContentEmbedPolicy { AllowEmbedding = false },
+        }, Actor, null);
+
+        result.Detail.Route.Policy.Visibility.Should().Be(ContentPublicationVisibility.Public);
+        result.Detail.Route.Policy.Embed.AllowEmbedding.Should().BeFalse();
+        result.Detail.Route.Policy.PublicLink.Links.Should().BeEmpty();
+        result.CreatedPublicLinkId.Should().BeNull();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    public void Normalize_NullNestedMembers_ReturnsNonNullDefaults()
+    {
+        var normalized = ContentPublicationPolicyNormalizer.Normalize(new ContentPublicationPolicy
+        {
+            Visibility = ContentPublicationVisibility.Organization,
+            Share = null!,
+            Embed = null!,
+            Service = null!,
+            PublicLink = null!,
+        });
+
+        normalized.Visibility.Should().Be(ContentPublicationVisibility.Organization);
+        normalized.Share.Should().NotBeNull();
+        normalized.Embed.Should().NotBeNull();
+        normalized.Service.Should().NotBeNull();
+        normalized.PublicLink.Should().NotBeNull();
+        normalized.PublicLink.Links.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    public void Normalize_NullPolicy_ReturnsFullyInitializedDefault()
+    {
+        var normalized = ContentPublicationPolicyNormalizer.Normalize(null);
+
+        normalized.Should().NotBeNull();
+        normalized.Share.Should().NotBeNull();
+        normalized.Embed.Should().NotBeNull();
+        normalized.Service.Should().NotBeNull();
+        normalized.PublicLink.Should().NotBeNull();
+        normalized.PublicLink.Links.Should().NotBeNull();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
     public async Task UpdatePolicy_WithUndefinedVisibility_ThrowsValidation()
     {
         var (service, _) = CreateService();

--- a/tests/dotnet/Honua.Server.Tests/Features/Console/Publications/ContentPublicationEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Console/Publications/ContentPublicationEndpointsTests.cs
@@ -204,6 +204,54 @@ public sealed class ContentPublicationEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("POST /api/v1/console/publications")]
+    [Endpoint("PATCH /api/v1/console/publications/{publicationId}/policy")]
+    public async Task UpdatePolicy_OnDefaultPolicyRoute_ChangesVisibilityAndEmbed_Returns200()
+    {
+        // Regression for #1239: a publication created with a minimal default policy
+        // ({"visibility":"organization"}) leaves the nested policy members (embed/share/
+        // service/publicLink) absent from the JSON body, so they deserialize to null. A
+        // subsequent minimal policy PATCH that only touches visibility + embed must
+        // succeed (200) rather than NRE while dereferencing those nested members.
+        const string createBody = """
+            {
+              "kind": "report",
+              "routeSlug": "rpt-smoke",
+              "title": "Smoke",
+              "contentPayload": "a",
+              "policy": { "visibility": "organization" }
+            }
+            """;
+
+        var createResponse = await _client.PostAsync("/api/v1/console/publications", JsonContent(createBody));
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await DeserializeAsync(createResponse, ContentPublicationJsonContext.Default.ContentPublicationDetail);
+        created.Should().NotBeNull();
+        var publicationId = created!.Route.PublicationId;
+
+        const string patchBody = """
+            {
+              "visibility": "public",
+              "embed": { "allowEmbedding": false }
+            }
+            """;
+
+        var patchResponse = await _client.PatchAsync(
+            $"/api/v1/console/publications/{publicationId}/policy",
+            JsonContent(patchBody));
+
+        patchResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await DeserializeAsync(patchResponse, ContentPublicationJsonContext.Default.ContentPublicationPolicyUpdateResponse);
+        result.Should().NotBeNull();
+        result!.Route.RouteSlug.Should().Be("rpt-smoke");
+        result.Route.Policy.Visibility.Should().Be(ContentPublicationVisibility.Public);
+        result.Route.Policy.Embed.AllowEmbedding.Should().BeFalse();
+        // No public link was created or revoked by this update.
+        result.CreatedPublicLinkId.Should().BeNull();
+        result.Route.Policy.PublicLink.Links.Should().BeEmpty();
+    }
+
+    [IntegrationTest]
     [Endpoint("PATCH /api/v1/console/publications/{publicationId}/policy")]
     public async Task UpdatePolicy_WithNumericUndefinedVisibility_ReturnsBadRequest()
     {


### PR DESCRIPTION
## Issue Link
Closes #1239

## Summary
`PATCH /api/v1/console/publications/{publicationId}/policy` returned HTTP 500 (`NullReferenceException`) on the first policy update for any publication created with a minimal default policy such as `{"visibility":"organization"}`. Publish/get/republish/rollback never faulted because only the policy-update path dereferenced the nested policy members.

Root cause: the nested members on `ContentPublicationPolicy` (`Embed`, `Share`, `Service`, `PublicLink`) are declared with record initializers (`= new()`), but System.Text.Json (both the source-generated request-binding path and the Postgres jsonb round-trip) does not run those initializers for members absent from the payload. A create body that only supplies `visibility` therefore persisted a policy with **null** nested members, and `UpdatePolicyAsync` then dereferenced `current.PublicLink.Links.ToList()` → NRE.

## Changes Made
- Add `ContentPublicationPolicyNormalizer.Normalize`, which coalesces a null policy and any null nested member to non-null defaults.
- Normalize at the publish/create boundary (`PublishAsync`) so every persisted policy is fully initialized (root-cause fix).
- Defensively normalize the stored policy at the start of `UpdatePolicyAsync` so legacy/round-tripped rows with null nested members cannot fault.
- No public API shape change.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Server integration `UpdatePolicy_OnDefaultPolicyRoute_ChangesVisibilityAndEmbed_Returns200` (exact issue repro: minimal create then visibility+embed PATCH → 200, Testcontainers + PostGIS, 15/0). Core: service test with explicitly null-nested policy + two normalizer unit tests (26/0). Release build `TreatWarningsAsErrors=true`: 0 warnings; `dotnet format --verify-no-changes`: clean.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
