### PR TITLE
feat: import & enforce Esri attribute rules on the edit path (#1271)

### DIFF
--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2Common.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2Common.cs
@@ -603,3 +603,84 @@ public sealed record MetadataV2SubtypeFieldOverride
     [JsonPropertyName("domain")]
     public MetadataV2FieldDomain? Domain { get; init; }
 }
+
+/// <summary>
+/// Esri-style attribute rule attached to a resource. Attribute rules are the modern
+/// sibling to coded-value/range domains: they fire on the edit path to either compute
+/// a field value (<c>calculation</c>), reject a violating edit (<c>constraint</c>), or
+/// flag a non-conforming row (<c>validation</c>). The rule's logic is expressed as an
+/// Arcade expression. Honua evaluates a deliberately small, safe subset of Arcade on
+/// the edit path; expressions outside that subset are routed out of scope (skipped with
+/// a logged warning) rather than failing the edit, so importing a layer that uses
+/// complex Arcade never breaks editing. See <c>AttributeRuleEvaluator</c> for the
+/// supported subset.
+/// </summary>
+public sealed record MetadataV2AttributeRule
+{
+    /// <summary>
+    /// Stable rule name (unique within the resource).
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Rule kind. Canonical values: <c>calculation</c>, <c>constraint</c>, or
+    /// <c>validation</c>.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public MetadataV2AttributeRuleType Type { get; init; } = MetadataV2AttributeRuleType.Calculation;
+
+    /// <summary>
+    /// Target field that a <see cref="MetadataV2AttributeRuleType.Calculation"/> rule
+    /// writes its computed value into. References a declared
+    /// <see cref="MetadataV2Resource.SchemaFields"/> entry. Ignored for constraint and
+    /// validation rules.
+    /// </summary>
+    [JsonPropertyName("fieldName")]
+    public string? FieldName { get; init; }
+
+    /// <summary>
+    /// Arcade expression text. For calculation rules this evaluates to the value written
+    /// into <see cref="FieldName"/>; for constraint/validation rules it evaluates to a
+    /// boolean where <c>false</c> indicates a violation.
+    /// </summary>
+    [JsonPropertyName("scriptExpression")]
+    public string ScriptExpression { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Edit events that trigger the rule. Canonical values: <c>insert</c>, <c>update</c>,
+    /// <c>delete</c>. An empty set is treated as "all editing events" to match Esri's
+    /// default of firing on every edit.
+    /// </summary>
+    [JsonPropertyName("triggeringEvents")]
+    public IReadOnlyList<string> TriggeringEvents { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Operator-facing message surfaced when a constraint/validation rule reports a
+    /// violation. Falls back to a generic message when unset.
+    /// </summary>
+    [JsonPropertyName("errorMessage")]
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Whether the rule is active. Inactive rules are imported for fidelity but never
+    /// fire on the edit path. Defaults to true.
+    /// </summary>
+    [JsonPropertyName("isEnabled")]
+    public bool IsEnabled { get; init; } = true;
+}
+
+/// <summary>
+/// Canonical attribute-rule kinds. String-encoded in JSON for snapshot readability.
+/// </summary>
+public enum MetadataV2AttributeRuleType
+{
+    /// <summary>Computes a target field value when the rule's triggering event fires.</summary>
+    Calculation,
+
+    /// <summary>Rejects an edit when the rule's boolean expression evaluates to false.</summary>
+    Constraint,
+
+    /// <summary>Flags a non-conforming row; evaluated like a constraint on the edit path.</summary>
+    Validation
+}

--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2Graph.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2Graph.cs
@@ -140,6 +140,7 @@ public sealed record MetadataV2Resource
     private IReadOnlyList<string>? _policyIds;
     private IReadOnlyList<MetadataV2Relationship>? _relationships;
     private IReadOnlyList<string>? _styleResourceIds;
+    private IReadOnlyList<MetadataV2AttributeRule>? _attributeRules;
     private IReadOnlyDictionary<string, JsonElement>? _extensions;
 
     /// <summary>
@@ -252,6 +253,20 @@ public sealed record MetadataV2Resource
     /// </summary>
     [JsonPropertyName("subtypes")]
     public MetadataV2Subtypes? Subtypes { get; init; }
+
+    /// <summary>
+    /// Esri-style attribute rules (calculation / constraint / validation) attached to
+    /// this resource. Imported alongside domains and subtypes from an Esri source layer
+    /// and enforced on the shared edit path: calculation rules populate their target
+    /// field before write, constraint/validation rules reject violating edits. Empty for
+    /// resources with no attribute rules.
+    /// </summary>
+    [JsonPropertyName("attributeRules")]
+    public IReadOnlyList<MetadataV2AttributeRule> AttributeRules
+    {
+        get => _attributeRules ?? Array.Empty<MetadataV2AttributeRule>();
+        init => _attributeRules = value;
+    }
 
     /// <summary>
     /// Optional extrusion metadata used by FeatureServer layer metadata and 3D Tiles generation.

--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2GraphValidation.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2GraphValidation.cs
@@ -148,6 +148,7 @@ public static class MetadataV2GraphValidator
             ValidateResourceSchemaFields(errors, resource);
             ValidateResourceDisplayEditing(errors, resource);
             ValidateResourceSubtypes(errors, resource);
+            ValidateResourceAttributeRules(errors, resource);
             ValidateResourceExtrusion(errors, resource);
             ValidateResourceSymbology3D(errors, resource);
         }
@@ -177,6 +178,48 @@ public static class MetadataV2GraphValidator
             foreach (var fieldName in subtype.FieldOverrides.Keys)
             {
                 EnsureFieldDeclared(errors, resource, fieldName, "subtypes.subtypes.fieldOverrides");
+            }
+        }
+    }
+
+    private static void ValidateResourceAttributeRules(List<string> errors, MetadataV2Resource resource)
+    {
+        var rules = resource.AttributeRules;
+        if (rules.Count == 0)
+        {
+            return;
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var rule in rules)
+        {
+            if (string.IsNullOrWhiteSpace(rule.Name))
+            {
+                errors.Add($"resource '{resource.Metadata.Id}' attributeRules.name is required.");
+            }
+            else if (!seen.Add(rule.Name))
+            {
+                errors.Add($"resource '{resource.Metadata.Id}' attributeRules.name '{rule.Name}' is duplicated.");
+            }
+
+            if (string.IsNullOrWhiteSpace(rule.ScriptExpression))
+            {
+                errors.Add($"resource '{resource.Metadata.Id}' attributeRule '{rule.Name}' scriptExpression is required.");
+            }
+
+            // A calculation rule writes its computed value into a declared field; a rule
+            // pointing at an undeclared field could never be applied, so reject it at the
+            // graph level rather than silently dropping the write at edit time.
+            if (rule.Type == MetadataV2AttributeRuleType.Calculation)
+            {
+                if (string.IsNullOrWhiteSpace(rule.FieldName))
+                {
+                    errors.Add($"resource '{resource.Metadata.Id}' calculation attributeRule '{rule.Name}' requires fieldName.");
+                }
+                else
+                {
+                    EnsureFieldDeclared(errors, resource, rule.FieldName, "attributeRules.fieldName");
+                }
             }
         }
     }

--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2JsonContext.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2JsonContext.cs
@@ -38,6 +38,7 @@ namespace Honua.Core.Features.Metadata.Domain.V2;
 [JsonSerializable(typeof(MetadataV2Subtypes))]
 [JsonSerializable(typeof(MetadataV2Subtype))]
 [JsonSerializable(typeof(MetadataV2SubtypeFieldOverride))]
+[JsonSerializable(typeof(MetadataV2AttributeRule))]
 [JsonSerializable(typeof(MetadataV2Relationship))]
 [JsonSerializable(typeof(MetadataV2PublicationIdentifier))]
 [JsonSerializable(typeof(MetadataV2SpatialReference))]

--- a/src/Honua.Core/Features/Admin/Domain/LayerPublishingModels.cs
+++ b/src/Honua.Core/Features/Admin/Domain/LayerPublishingModels.cs
@@ -88,6 +88,15 @@ public sealed class LayerPublishRequest
     /// Null when the source layer declared no subtypes.
     /// </summary>
     public Honua.Core.Features.Metadata.Domain.V2.MetadataV2Subtypes? Subtypes { get; init; }
+
+    /// <summary>
+    /// Optional Esri-style attribute rules (calculation / constraint / validation)
+    /// captured from the migration source. Calculation rules whose target field is
+    /// published, and constraint/validation rules, are carried into the Metadata v2
+    /// resource so they fire on the shared edit path (FeatureServer <c>applyEdits</c>).
+    /// Null when the source layer declared none.
+    /// </summary>
+    public IReadOnlyList<Honua.Core.Features.Metadata.Domain.V2.MetadataV2AttributeRule>? AttributeRules { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/AttributeRules/AttributeRuleEngine.cs
+++ b/src/Honua.Core/Features/AttributeRules/AttributeRuleEngine.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Core.Features.AttributeRules;
+
+/// <summary>
+/// Editing event that can trigger an attribute rule. Mirrors the canonical Esri
+/// triggering-event vocabulary (<c>insert</c> / <c>update</c> / <c>delete</c>).
+/// </summary>
+public enum AttributeRuleEditEvent
+{
+    /// <summary>A feature is being inserted.</summary>
+    Insert,
+
+    /// <summary>An existing feature is being updated.</summary>
+    Update,
+
+    /// <summary>A feature is being deleted.</summary>
+    Delete
+}
+
+/// <summary>
+/// A single constraint/validation violation produced while applying attribute rules to
+/// a feature on the edit path.
+/// </summary>
+/// <param name="RuleName">Name of the violated rule.</param>
+/// <param name="Message">Operator-facing message describing the violation.</param>
+public readonly record struct AttributeRuleViolation(string RuleName, string Message);
+
+/// <summary>
+/// Result of applying a resource's attribute rules to one feature's attributes for a
+/// given edit event.
+/// </summary>
+/// <param name="Attributes">
+/// The (possibly updated) attribute dictionary after calculation rules have populated
+/// their target fields. Always non-null; equals the input map when no calculation rule
+/// fired.
+/// </param>
+/// <param name="Violations">
+/// Constraint/validation violations. Empty when every applicable rule passed (or was
+/// routed out of scope as unsupported).
+/// </param>
+public readonly record struct AttributeRuleApplicationResult(
+    IReadOnlyDictionary<string, object?> Attributes,
+    IReadOnlyList<AttributeRuleViolation> Violations)
+{
+    /// <summary>True when no constraint/validation rule was violated.</summary>
+    public bool IsValid => Violations.Count == 0;
+}
+
+/// <summary>
+/// Shared, provider-agnostic engine that applies a resource's
+/// <see cref="MetadataV2AttributeRule"/> set to a feature's attributes on the edit path.
+/// Calculation rules compute and write their target field before the write; constraint
+/// and validation rules evaluate a boolean expression and surface a violation when it is
+/// false. Expressions outside the supported safe subset (see
+/// <see cref="AttributeRuleExpression"/>) are routed out of scope via the supplied
+/// <see cref="IUnsupportedExpressionSink"/> rather than failing the edit, keeping full
+/// Arcade parity an explicit non-goal of this path.
+/// </summary>
+public static class AttributeRuleEngine
+{
+    /// <summary>
+    /// Applies the resource's enabled attribute rules for <paramref name="editEvent"/> to
+    /// <paramref name="attributes"/>.
+    /// </summary>
+    /// <param name="resource">The resource whose attribute rules apply.</param>
+    /// <param name="attributes">
+    /// Case-insensitive feature attributes. Calculation outputs are written into a copy;
+    /// the input map is never mutated.
+    /// </param>
+    /// <param name="editEvent">The triggering edit event.</param>
+    /// <param name="unsupported">
+    /// Optional sink notified when a rule's expression is outside the supported subset
+    /// (routed out of scope). May be <c>null</c> to silently skip.
+    /// </param>
+    /// <returns>The application result carrying updated attributes and any violations.</returns>
+    public static AttributeRuleApplicationResult Apply(
+        MetadataV2Resource resource,
+        IReadOnlyDictionary<string, object?> attributes,
+        AttributeRuleEditEvent editEvent,
+        IUnsupportedExpressionSink? unsupported = null)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentNullException.ThrowIfNull(attributes);
+
+        var rules = resource.AttributeRules;
+        if (rules.Count == 0)
+        {
+            return new AttributeRuleApplicationResult(attributes, Array.Empty<AttributeRuleViolation>());
+        }
+
+        Dictionary<string, object?>? working = null;
+        List<AttributeRuleViolation>? violations = null;
+
+        // The evaluation snapshot a rule reads from. Calculation rules can feed later
+        // rules, so we read from the working copy once one exists.
+        IReadOnlyDictionary<string, object?> Current() => working ?? attributes;
+
+        foreach (var rule in rules)
+        {
+            if (!rule.IsEnabled || !AppliesTo(rule, editEvent))
+            {
+                continue;
+            }
+
+            switch (rule.Type)
+            {
+                case MetadataV2AttributeRuleType.Calculation:
+                    {
+                        if (string.IsNullOrWhiteSpace(rule.FieldName))
+                        {
+                            continue;
+                        }
+
+                        var result = AttributeRuleExpression.Evaluate(rule.ScriptExpression, Current(), expectBoolean: false);
+                        if (result.Status == AttributeRuleExpressionStatus.Unsupported)
+                        {
+                            unsupported?.OnUnsupported(resource, rule);
+                            continue;
+                        }
+
+                        working ??= new Dictionary<string, object?>(attributes, StringComparer.OrdinalIgnoreCase);
+                        working[rule.FieldName] = result.Value;
+                        break;
+                    }
+
+                case MetadataV2AttributeRuleType.Constraint:
+                case MetadataV2AttributeRuleType.Validation:
+                    {
+                        var result = AttributeRuleExpression.Evaluate(rule.ScriptExpression, Current(), expectBoolean: true);
+                        switch (result.Status)
+                        {
+                            case AttributeRuleExpressionStatus.Unsupported:
+                                unsupported?.OnUnsupported(resource, rule);
+                                break;
+                            case AttributeRuleExpressionStatus.Violated:
+                                violations ??= new List<AttributeRuleViolation>();
+                                violations.Add(new AttributeRuleViolation(
+                                    rule.Name,
+                                    string.IsNullOrWhiteSpace(rule.ErrorMessage)
+                                        ? $"Attribute rule '{rule.Name}' was violated."
+                                        : rule.ErrorMessage!));
+                                break;
+                            case AttributeRuleExpressionStatus.Satisfied:
+                            case AttributeRuleExpressionStatus.Computed:
+                            default:
+                                break;
+                        }
+
+                        break;
+                    }
+
+                default:
+                    break;
+            }
+        }
+
+        return new AttributeRuleApplicationResult(
+            working ?? attributes,
+            (IReadOnlyList<AttributeRuleViolation>?)violations ?? Array.Empty<AttributeRuleViolation>());
+    }
+
+    private static bool AppliesTo(MetadataV2AttributeRule rule, AttributeRuleEditEvent editEvent)
+    {
+        // An empty triggering-events set fires on every editing event (Esri default).
+        if (rule.TriggeringEvents.Count == 0)
+        {
+            return editEvent != AttributeRuleEditEvent.Delete || rule.Type != MetadataV2AttributeRuleType.Calculation;
+        }
+
+        var token = editEvent switch
+        {
+            AttributeRuleEditEvent.Insert => "insert",
+            AttributeRuleEditEvent.Update => "update",
+            AttributeRuleEditEvent.Delete => "delete",
+            _ => string.Empty
+        };
+
+        foreach (var configured in rule.TriggeringEvents)
+        {
+            if (string.Equals(configured, token, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+/// <summary>
+/// Sink notified when an attribute-rule expression falls outside the supported safe
+/// subset and is routed out of scope (full Arcade parity is a non-goal of the edit
+/// path). Implementations typically log a structured warning identifying the resource
+/// and rule.
+/// </summary>
+public interface IUnsupportedExpressionSink
+{
+    /// <summary>
+    /// Invoked when <paramref name="rule"/> on <paramref name="resource"/> uses an
+    /// expression Honua does not evaluate on the edit path.
+    /// </summary>
+    /// <param name="resource">The resource owning the rule.</param>
+    /// <param name="rule">The rule whose expression was unsupported.</param>
+    void OnUnsupported(MetadataV2Resource resource, MetadataV2AttributeRule rule);
+}

--- a/src/Honua.Core/Features/AttributeRules/AttributeRuleExpression.cs
+++ b/src/Honua.Core/Features/AttributeRules/AttributeRuleExpression.cs
@@ -1,0 +1,598 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+
+namespace Honua.Core.Features.AttributeRules;
+
+/// <summary>
+/// Outcome of evaluating an attribute-rule expression.
+/// </summary>
+/// <param name="Status">Whether the expression produced a value, reported a constraint violation, or was unsupported.</param>
+/// <param name="Value">
+/// The computed value for a successful calculation expression. <c>null</c> for boolean
+/// constraint evaluations and for unsupported/skipped expressions.
+/// </param>
+public readonly record struct AttributeRuleExpressionResult(
+    AttributeRuleExpressionStatus Status,
+    object? Value)
+{
+    /// <summary>Creates a result for a successfully computed value (calculation).</summary>
+    /// <param name="value">The computed value.</param>
+    /// <returns>A success result carrying <paramref name="value"/>.</returns>
+    public static AttributeRuleExpressionResult Computed(object? value)
+        => new(AttributeRuleExpressionStatus.Computed, value);
+
+    /// <summary>Creates a result for a boolean constraint that passed.</summary>
+    public static AttributeRuleExpressionResult Satisfied { get; } =
+        new(AttributeRuleExpressionStatus.Satisfied, true);
+
+    /// <summary>Creates a result for a boolean constraint that was violated.</summary>
+    public static AttributeRuleExpressionResult Violated { get; } =
+        new(AttributeRuleExpressionStatus.Violated, false);
+
+    /// <summary>
+    /// Creates a result for an expression outside the supported safe subset. The caller
+    /// routes these out of scope (skips with a logged warning) rather than failing the edit.
+    /// </summary>
+    public static AttributeRuleExpressionResult Unsupported { get; } =
+        new(AttributeRuleExpressionStatus.Unsupported, null);
+}
+
+/// <summary>
+/// Status of an evaluated attribute-rule expression.
+/// </summary>
+public enum AttributeRuleExpressionStatus
+{
+    /// <summary>The calculation expression produced a value (carried in the result).</summary>
+    Computed,
+
+    /// <summary>The boolean constraint expression evaluated to true (no violation).</summary>
+    Satisfied,
+
+    /// <summary>The boolean constraint expression evaluated to false (violation).</summary>
+    Violated,
+
+    /// <summary>
+    /// The expression is outside the supported safe subset and must be routed out of
+    /// scope (skipped) rather than enforced.
+    /// </summary>
+    Unsupported
+}
+
+/// <summary>
+/// Evaluates the deliberately small, safe subset of Arcade that Honua enforces on the
+/// edit path for attribute rules. The evaluator is parameterized over a feature's
+/// attributes only; it performs no I/O, no reflection, no SQL, and no arbitrary code
+/// execution. Expressions outside the subset return
+/// <see cref="AttributeRuleExpressionStatus.Unsupported"/> so callers can route them to
+/// an out-of-scope path (AI resolver / skip-with-warning) without failing the edit.
+/// <para>
+/// Supported grammar (whitespace-insensitive):
+/// <list type="bullet">
+///   <item>Literals: numbers (<c>42</c>, <c>3.5</c>), single/double-quoted strings, <c>true</c>/<c>false</c>/<c>null</c>.</item>
+///   <item>Field references: <c>$feature.FieldName</c> or <c>$feature["Field Name"]</c>.</item>
+///   <item>Arithmetic over numbers: <c>+ - * /</c> (left-to-right, no precedence beyond grouping is required since callers use simple expressions; <c>*</c>/<c>/</c> bind tighter than <c>+</c>/<c>-</c>).</item>
+///   <item>Comparisons: <c>== != &lt; &lt;= &gt; &gt;=</c>.</item>
+///   <item>Boolean combination: <c>&amp;&amp;</c> and <c>||</c>.</item>
+///   <item>Parentheses for grouping.</item>
+///   <item>Optional trailing semicolon and a leading <c>return</c> keyword (Esri wraps calc scripts as <c>return &lt;expr&gt;;</c>).</item>
+/// </list>
+/// Anything else — function calls, <c>if</c>/<c>var</c>/multi-statement scripts, member
+/// access beyond <c>$feature</c>, string concatenation semantics, etc. — is treated as
+/// unsupported.
+/// </para>
+/// </summary>
+public static class AttributeRuleExpression
+{
+    /// <summary>
+    /// Evaluates <paramref name="expression"/> against the supplied feature attributes.
+    /// </summary>
+    /// <param name="expression">The Arcade expression text.</param>
+    /// <param name="attributes">Case-insensitive feature attribute lookup.</param>
+    /// <param name="expectBoolean">
+    /// True for constraint/validation rules (the result is interpreted as a pass/fail
+    /// boolean); false for calculation rules (the result is the computed value).
+    /// </param>
+    /// <returns>The evaluation outcome.</returns>
+    public static AttributeRuleExpressionResult Evaluate(
+        string? expression,
+        IReadOnlyDictionary<string, object?> attributes,
+        bool expectBoolean)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+
+        if (string.IsNullOrWhiteSpace(expression))
+        {
+            return AttributeRuleExpressionResult.Unsupported;
+        }
+
+        var normalized = Normalize(expression);
+        if (normalized is null)
+        {
+            return AttributeRuleExpressionResult.Unsupported;
+        }
+
+        var parser = new Parser(normalized, attributes);
+        if (!parser.TryParse(out var value))
+        {
+            return AttributeRuleExpressionResult.Unsupported;
+        }
+
+        if (expectBoolean)
+        {
+            if (value is bool boolean)
+            {
+                return boolean ? AttributeRuleExpressionResult.Satisfied : AttributeRuleExpressionResult.Violated;
+            }
+
+            // A constraint expression that did not reduce to a boolean is not something we
+            // can safely enforce; route it out of scope rather than guessing truthiness.
+            return AttributeRuleExpressionResult.Unsupported;
+        }
+
+        return AttributeRuleExpressionResult.Computed(value);
+    }
+
+    // Strips an optional leading 'return' and a single trailing ';'. Rejects (returns null)
+    // anything that still contains a ';' afterwards (multi-statement script) or other
+    // tokens we don't support, leaving fine-grained rejection to the parser.
+    private static string? Normalize(string expression)
+    {
+        var trimmed = expression.Trim();
+        if (trimmed.StartsWith("return ", StringComparison.Ordinal) ||
+            trimmed.StartsWith("return\t", StringComparison.Ordinal))
+        {
+            trimmed = trimmed["return".Length..].TrimStart();
+        }
+
+        if (trimmed.EndsWith(';'))
+        {
+            trimmed = trimmed[..^1].TrimEnd();
+        }
+
+        if (trimmed.Length == 0 || trimmed.Contains(';', StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return trimmed;
+    }
+
+    // Recursive-descent parser/evaluator for the supported subset. Returns false from
+    // TryParse for any token or construct outside the grammar.
+    private ref struct Parser(string text, IReadOnlyDictionary<string, object?> attributes)
+    {
+        private readonly string _text = text;
+        private readonly IReadOnlyDictionary<string, object?> _attributes = attributes;
+        private int _pos;
+        private bool _failed;
+
+        public bool TryParse(out object? value)
+        {
+            value = ParseOr();
+            SkipWhitespace();
+            if (_failed || _pos != _text.Length)
+            {
+                value = null;
+                return false;
+            }
+
+            return true;
+        }
+
+        private object? ParseOr()
+        {
+            var left = ParseAnd();
+            while (!_failed && Match("||"))
+            {
+                var right = ParseAnd();
+                left = AsBool(left) || AsBool(right);
+            }
+
+            return left;
+        }
+
+        private object? ParseAnd()
+        {
+            var left = ParseComparison();
+            while (!_failed && Match("&&"))
+            {
+                var right = ParseComparison();
+                left = AsBool(left) && AsBool(right);
+            }
+
+            return left;
+        }
+
+        private object? ParseComparison()
+        {
+            var left = ParseAdditive();
+            SkipWhitespace();
+            foreach (var op in ComparisonOperators)
+            {
+                if (Match(op))
+                {
+                    var right = ParseAdditive();
+                    return Compare(left, right, op);
+                }
+            }
+
+            return left;
+        }
+
+        private object? ParseAdditive()
+        {
+            var left = ParseMultiplicative();
+            while (!_failed)
+            {
+                SkipWhitespace();
+                if (Match("+"))
+                {
+                    left = Arithmetic(left, ParseMultiplicative(), '+');
+                }
+                else if (Match("-"))
+                {
+                    left = Arithmetic(left, ParseMultiplicative(), '-');
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return left;
+        }
+
+        private object? ParseMultiplicative()
+        {
+            var left = ParsePrimary();
+            while (!_failed)
+            {
+                SkipWhitespace();
+                if (Match("*"))
+                {
+                    left = Arithmetic(left, ParsePrimary(), '*');
+                }
+                else if (Match("/"))
+                {
+                    left = Arithmetic(left, ParsePrimary(), '/');
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return left;
+        }
+
+        private object? ParsePrimary()
+        {
+            SkipWhitespace();
+            if (_pos >= _text.Length)
+            {
+                return Fail();
+            }
+
+            var c = _text[_pos];
+            if (c == '(')
+            {
+                _pos++;
+                var inner = ParseOr();
+                SkipWhitespace();
+                if (!Match(")"))
+                {
+                    return Fail();
+                }
+
+                return inner;
+            }
+
+            if (c is '\'' or '"')
+            {
+                return ParseString(c);
+            }
+
+            if (char.IsDigit(c) || (c == '-' && _pos + 1 < _text.Length && char.IsDigit(_text[_pos + 1])))
+            {
+                return ParseNumber();
+            }
+
+            if (c == '$')
+            {
+                return ParseFeatureReference();
+            }
+
+            if (char.IsLetter(c))
+            {
+                return ParseKeyword();
+            }
+
+            return Fail();
+        }
+
+        private object? ParseKeyword()
+        {
+            var start = _pos;
+            while (_pos < _text.Length && (char.IsLetterOrDigit(_text[_pos]) || _text[_pos] == '_'))
+            {
+                _pos++;
+            }
+
+            var word = _text[start.._pos];
+            return word switch
+            {
+                "true" => true,
+                "false" => false,
+                "null" => null,
+                _ => Fail()
+            };
+        }
+
+        private object? ParseFeatureReference()
+        {
+            // Consume "$feature"
+            const string FeatureToken = "$feature";
+            if (!Match(FeatureToken))
+            {
+                return Fail();
+            }
+
+            SkipWhitespace();
+            string fieldName;
+            if (_pos < _text.Length && _text[_pos] == '.')
+            {
+                _pos++;
+                var start = _pos;
+                while (_pos < _text.Length && (char.IsLetterOrDigit(_text[_pos]) || _text[_pos] == '_'))
+                {
+                    _pos++;
+                }
+
+                if (_pos == start)
+                {
+                    return Fail();
+                }
+
+                fieldName = _text[start.._pos];
+            }
+            else if (_pos < _text.Length && _text[_pos] == '[')
+            {
+                _pos++;
+                SkipWhitespace();
+                if (_pos >= _text.Length || (_text[_pos] != '\'' && _text[_pos] != '"'))
+                {
+                    return Fail();
+                }
+
+                var quote = _text[_pos];
+                var name = ParseString(quote);
+                if (_failed || name is not string nameString)
+                {
+                    return Fail();
+                }
+
+                SkipWhitespace();
+                if (!Match("]"))
+                {
+                    return Fail();
+                }
+
+                fieldName = nameString;
+            }
+            else
+            {
+                return Fail();
+            }
+
+            return _attributes.TryGetValue(fieldName, out var fieldValue) ? fieldValue : null;
+        }
+
+        private object? ParseString(char quote)
+        {
+            _pos++; // opening quote
+            var sb = new System.Text.StringBuilder();
+            while (_pos < _text.Length)
+            {
+                var c = _text[_pos];
+                if (c == quote)
+                {
+                    _pos++;
+                    return sb.ToString();
+                }
+
+                // No escape-sequence support — a backslash means an unsupported expression.
+                if (c == '\\')
+                {
+                    return Fail();
+                }
+
+                sb.Append(c);
+                _pos++;
+            }
+
+            return Fail();
+        }
+
+        private object? ParseNumber()
+        {
+            var start = _pos;
+            if (_text[_pos] == '-')
+            {
+                _pos++;
+            }
+
+            var hasDot = false;
+            while (_pos < _text.Length)
+            {
+                var c = _text[_pos];
+                if (char.IsDigit(c))
+                {
+                    _pos++;
+                }
+                else if (c == '.' && !hasDot)
+                {
+                    hasDot = true;
+                    _pos++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            var slice = _text[start.._pos];
+            if (!double.TryParse(slice, NumberStyles.Float, CultureInfo.InvariantCulture, out var number))
+            {
+                return Fail();
+            }
+
+            return number;
+        }
+
+        private object? Fail()
+        {
+            _failed = true;
+            return null;
+        }
+
+        private bool Match(string token)
+        {
+            SkipWhitespace();
+            if (_pos + token.Length > _text.Length)
+            {
+                return false;
+            }
+
+            if (string.CompareOrdinal(_text, _pos, token, 0, token.Length) != 0)
+            {
+                return false;
+            }
+
+            _pos += token.Length;
+            return true;
+        }
+
+        private void SkipWhitespace()
+        {
+            while (_pos < _text.Length && char.IsWhiteSpace(_text[_pos]))
+            {
+                _pos++;
+            }
+        }
+
+        private bool AsBool(object? value) => value is bool b ? b : Fail() is null && false;
+
+        private object? Arithmetic(object? left, object? right, char op)
+        {
+            if (_failed)
+            {
+                return null;
+            }
+
+            if (!TryToDouble(left, out var l) || !TryToDouble(right, out var r))
+            {
+                return Fail();
+            }
+
+            return op switch
+            {
+                '+' => l + r,
+                '-' => l - r,
+                '*' => l * r,
+                '/' => r == 0 ? Fail() : l / r,
+                _ => Fail()
+            };
+        }
+
+        private object? Compare(object? left, object? right, string op)
+        {
+            if (_failed)
+            {
+                return null;
+            }
+
+            if (op is "==" or "!=")
+            {
+                var equal = ValuesEqual(left, right);
+                return op == "==" ? equal : !equal;
+            }
+
+            if (!TryToDouble(left, out var l) || !TryToDouble(right, out var r))
+            {
+                return Fail();
+            }
+
+            return op switch
+            {
+                "<" => l < r,
+                "<=" => l <= r,
+                ">" => l > r,
+                ">=" => l >= r,
+                _ => Fail()
+            };
+        }
+
+        private static bool ValuesEqual(object? left, object? right)
+        {
+            if (left is null || right is null)
+            {
+                return left is null && right is null;
+            }
+
+            if (TryToDouble(left, out var l) && TryToDouble(right, out var r))
+            {
+                return l.Equals(r);
+            }
+
+            if (left is bool lb && right is bool rb)
+            {
+                return lb == rb;
+            }
+
+            return string.Equals(
+                Convert.ToString(left, CultureInfo.InvariantCulture),
+                Convert.ToString(right, CultureInfo.InvariantCulture),
+                StringComparison.Ordinal);
+        }
+
+        private static bool TryToDouble(object? value, out double result)
+        {
+            switch (value)
+            {
+                case double d:
+                    result = d;
+                    return true;
+                case float f:
+                    result = f;
+                    return true;
+                case decimal m:
+                    result = (double)m;
+                    return true;
+                case long l:
+                    result = l;
+                    return true;
+                case int i:
+                    result = i;
+                    return true;
+                case short s:
+                    result = s;
+                    return true;
+                case byte b:
+                    result = b;
+                    return true;
+                case string str when double.TryParse(str, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed):
+                    result = parsed;
+                    return true;
+                default:
+                    result = 0;
+                    return false;
+            }
+        }
+
+        // Two-character comparison operators are matched before single-character ones so
+        // ">=" is not mis-read as ">".
+        private static readonly string[] ComparisonOperators = ["==", "!=", "<=", ">=", "<", ">"];
+    }
+}

--- a/src/Honua.Core/Features/Migration/Domain/GeoservicesServiceInfo.cs
+++ b/src/Honua.Core/Features/Migration/Domain/GeoservicesServiceInfo.cs
@@ -151,6 +151,14 @@ public sealed record GeoservicesLayerInfo
     /// <c>defaultSubtypeCode</c>).
     /// </summary>
     public Honua.Core.Features.Metadata.Domain.V2.MetadataV2Subtypes? Subtypes { get; init; }
+
+    /// <summary>
+    /// Canonical Esri attribute rules (calculation / constraint / validation) captured
+    /// from the source layer, or <c>null</c> when the layer declares none. Carried through
+    /// the auto-publish pipeline so the rules persist into the Metadata v2 graph and fire
+    /// on the shared edit path (FeatureServer <c>applyEdits</c>).
+    /// </summary>
+    public IReadOnlyList<Honua.Core.Features.Metadata.Domain.V2.MetadataV2AttributeRule>? AttributeRules { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Migration/Services/ArcGisRestClient.cs
+++ b/src/Honua.Core/Features/Migration/Services/ArcGisRestClient.cs
@@ -187,7 +187,11 @@ internal sealed partial class ArcGisRestClient
             Subtypes = EsriSubtypeParser.Parse(
                 layerResponse.SubtypeField,
                 layerResponse.DefaultSubtypeCode,
-                layerResponse.Subtypes).Subtypes
+                layerResponse.Subtypes).Subtypes,
+            // Persisted through publish so calculation/constraint/validation rules survive
+            // to the served FeatureServer surface and fire on applyEdits. An over-cap rule
+            // set is reported via the inventory warning path and intentionally not persisted.
+            AttributeRules = EsriAttributeRuleParser.Parse(layerResponse.AttributeRules).Rules
         };
     }
 
@@ -1081,6 +1085,9 @@ internal sealed record ArcGisLayerResponse
 
     [JsonPropertyName("subtypes")]
     public JsonElement? Subtypes { get; init; }
+
+    [JsonPropertyName("attributeRules")]
+    public JsonElement? AttributeRules { get; init; }
 }
 
 internal sealed record ArcGisSpatialReference

--- a/src/Honua.Core/Features/Migration/Services/EsriAttributeRuleParser.cs
+++ b/src/Honua.Core/Features/Migration/Services/EsriAttributeRuleParser.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Core.Features.Migration.Services;
+
+/// <summary>
+/// Shared, deterministic parser that converts an Esri layer's <c>attributeRules</c> JSON
+/// into the canonical <see cref="MetadataV2AttributeRule"/> list. Mirrors
+/// <see cref="EsriSubtypeParser"/>: it is the single source of truth for attribute-rule
+/// capture so the migration inventory artifact and the import/publish projection agree.
+/// <para>
+/// Attribute rules are imported for fidelity regardless of whether their Arcade
+/// expression is one Honua can evaluate on the edit path — unsupported expressions are
+/// routed out of scope at edit time, not dropped at import. The number of captured rules
+/// is bounded by <see cref="AttributeRuleCap"/> for determinism.
+/// </para>
+/// </summary>
+public static class EsriAttributeRuleParser
+{
+    /// <summary>
+    /// Maximum number of attribute rules captured for a single layer. Layers exceeding
+    /// this cap are reported as truncated and not persisted, keeping the artifact bounded.
+    /// </summary>
+    public const int AttributeRuleCap = 200;
+
+    /// <summary>
+    /// Parses the Esri attribute-rule metadata on a layer element into the canonical
+    /// <see cref="MetadataV2AttributeRule"/> list.
+    /// </summary>
+    /// <param name="layerElement">The Esri layer element carrying <c>attributeRules</c>.</param>
+    /// <returns>The parse result describing the captured rules and whether they were truncated.</returns>
+    public static EsriAttributeRuleParseResult Parse(JsonElement layerElement)
+    {
+        if (layerElement.ValueKind != JsonValueKind.Object)
+        {
+            return EsriAttributeRuleParseResult.None;
+        }
+
+        var rulesElement = layerElement.TryGetProperty("attributeRules", out var rules)
+            ? rules
+            : (JsonElement?)null;
+        return Parse(rulesElement);
+    }
+
+    /// <summary>
+    /// Parses the Esri <c>attributeRules</c> array element into the canonical model.
+    /// </summary>
+    /// <param name="attributeRulesElementOrNull">The Esri <c>attributeRules</c> array element, or <c>null</c>.</param>
+    /// <returns>The parse result; <see cref="EsriAttributeRuleParseResult.None"/> when there are no usable rules.</returns>
+    public static EsriAttributeRuleParseResult Parse(JsonElement? attributeRulesElementOrNull)
+    {
+        if (attributeRulesElementOrNull is not { ValueKind: JsonValueKind.Array } rulesElement ||
+            rulesElement.GetArrayLength() == 0)
+        {
+            return EsriAttributeRuleParseResult.None;
+        }
+
+        if (rulesElement.GetArrayLength() > AttributeRuleCap)
+        {
+            return EsriAttributeRuleParseResult.OverCap;
+        }
+
+        var parsed = new List<MetadataV2AttributeRule>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in rulesElement.EnumerateArray())
+        {
+            if (entry.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var name = GetString(entry, "name");
+            if (string.IsNullOrWhiteSpace(name) || !seen.Add(name!))
+            {
+                continue;
+            }
+
+            if (!TryMapType(GetString(entry, "type"), out var type))
+            {
+                continue;
+            }
+
+            var script = GetString(entry, "scriptExpression");
+            if (string.IsNullOrWhiteSpace(script))
+            {
+                continue;
+            }
+
+            var fieldName = GetString(entry, "fieldName");
+            if (type == MetadataV2AttributeRuleType.Calculation && string.IsNullOrWhiteSpace(fieldName))
+            {
+                // A calculation rule with no target field can never be applied; skip it
+                // rather than persist an un-appliable rule.
+                continue;
+            }
+
+            parsed.Add(new MetadataV2AttributeRule
+            {
+                Name = name!,
+                Type = type,
+                FieldName = fieldName,
+                ScriptExpression = script!,
+                TriggeringEvents = ParseTriggeringEvents(entry),
+                ErrorMessage = GetString(entry, "errorMessage"),
+                IsEnabled = GetBool(entry, "isEnabled") ?? true
+            });
+        }
+
+        if (parsed.Count == 0)
+        {
+            return EsriAttributeRuleParseResult.None;
+        }
+
+        var ordered = parsed
+            .OrderBy(static rule => rule.Name, StringComparer.Ordinal)
+            .ToArray();
+
+        return new EsriAttributeRuleParseResult(ordered, Truncated: false);
+    }
+
+    private static IReadOnlyList<string> ParseTriggeringEvents(JsonElement ruleElement)
+    {
+        if (!ruleElement.TryGetProperty("triggeringEvents", out var events) ||
+            events.ValueKind != JsonValueKind.Array)
+        {
+            return Array.Empty<string>();
+        }
+
+        var result = new List<string>();
+        foreach (var item in events.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var value = item.GetString();
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            // Esri uses 'Insert'/'Update'/'Delete'; normalize to lowercase canonical tokens.
+            result.Add(value.Trim().ToLowerInvariant());
+        }
+
+        return result.Count == 0 ? Array.Empty<string>() : result;
+    }
+
+    private static bool TryMapType(string? esriType, out MetadataV2AttributeRuleType type)
+    {
+        switch (esriType?.Trim().ToLowerInvariant())
+        {
+            case "calculation":
+            case "esriarcalculation":
+                type = MetadataV2AttributeRuleType.Calculation;
+                return true;
+            case "constraint":
+            case "esriarconstraint":
+                type = MetadataV2AttributeRuleType.Constraint;
+                return true;
+            case "validation":
+            case "esriarvalidation":
+                type = MetadataV2AttributeRuleType.Validation;
+                return true;
+            default:
+                type = MetadataV2AttributeRuleType.Calculation;
+                return false;
+        }
+    }
+
+    private static string? GetString(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static bool? GetBool(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var value))
+        {
+            return null;
+        }
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => null
+        };
+    }
+}
+
+/// <summary>
+/// Outcome of parsing an Esri layer's attribute-rule metadata into the canonical model.
+/// </summary>
+/// <param name="Rules">The parsed canonical rules, or <c>null</c> when there are none or they were truncated.</param>
+/// <param name="Truncated">True when the rule set exceeded <see cref="EsriAttributeRuleParser.AttributeRuleCap"/> and was omitted.</param>
+public readonly record struct EsriAttributeRuleParseResult(
+    IReadOnlyList<MetadataV2AttributeRule>? Rules,
+    bool Truncated)
+{
+    /// <summary>Shared result for a layer that carries no attribute rules.</summary>
+    public static readonly EsriAttributeRuleParseResult None = new(Rules: null, Truncated: false);
+
+    /// <summary>Shared result for a layer whose rule set exceeded the cap and was omitted.</summary>
+    public static readonly EsriAttributeRuleParseResult OverCap = new(Rules: null, Truncated: true);
+}

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.MetadataV2Graph.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.MetadataV2Graph.cs
@@ -347,8 +347,38 @@ internal sealed partial class PostgreSqlLayerPublishingService
             // the compat-compile snapshot and are served on the FeatureServer layer
             // metadata (subtypeField / subtypes / defaultSubtypeCode) (honua-server#1378).
             Subtypes = ResolveSubtypesForPublish(request.Subtypes, fields),
+            // Carry the captured Esri attribute rules into the canonical graph so they
+            // fire on the shared edit path (FeatureServer applyEdits). Calculation rules
+            // whose target column was not published are dropped (honua-server#1271).
+            AttributeRules = ResolveAttributeRulesForPublish(request.AttributeRules, fields),
             Status = ActiveReadyStatus(now)
         };
+    }
+
+    // Attaches captured attribute rules, dropping calculation rules whose target field
+    // was not published. A calculation rule pointing at a column the layer did not publish
+    // could never be applied and would fail graph validation, so it is omitted rather than
+    // persisted against a missing field. Constraint/validation rules are carried as-is;
+    // their expressions are evaluated against the published attribute set at edit time and
+    // unsupported expressions are routed out of scope, so a stale field reference simply
+    // skips rather than breaking the edit.
+    private static MetadataV2AttributeRule[] ResolveAttributeRulesForPublish(
+        IReadOnlyList<MetadataV2AttributeRule>? attributeRules,
+        IReadOnlyList<LayerFieldInsert> fields)
+    {
+        if (attributeRules is null || attributeRules.Count == 0)
+        {
+            return [];
+        }
+
+        var publishedNames = new HashSet<string>(
+            fields.Select(field => field.Name),
+            StringComparer.OrdinalIgnoreCase);
+
+        return attributeRules
+            .Where(rule => rule.Type != MetadataV2AttributeRuleType.Calculation
+                || (!string.IsNullOrWhiteSpace(rule.FieldName) && publishedNames.Contains(rule.FieldName!)))
+            .ToArray();
     }
 
     // Attaches the captured subtype set only when its subtype field was actually

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.cs
@@ -195,7 +195,12 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
                 // is the canonical 'type' column on the imported layer; the publish path
                 // only attaches the subtypes when that column is actually published, so a
                 // subtype set referencing a dropped column never false-fails reconciliation.
-                Subtypes = layerInfo.Subtypes
+                Subtypes = layerInfo.Subtypes,
+                // Carry the captured Esri attribute rules through publish so calculation /
+                // constraint / validation rules fire on applyEdits. Calculation rules whose
+                // target column is not published are pruned in the projection so a rule
+                // referencing a dropped field never fails graph validation.
+                AttributeRules = layerInfo.AttributeRules
             };
 
             var published = await _layerPublishingService.PublishLayerAsync(

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using System.Globalization;
+using Honua.Core.Features.AttributeRules;
 using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
@@ -247,7 +248,7 @@ internal sealed class FeatureServerEditsHandler(
                 // request's, but using request.Adds[i].Geometry directly keeps the rule
                 // identical to the update path.
                 var requestHasGeometry = request.Adds[i].Geometry != null;
-                var newFeature = await BuildFeatureFromGeoServicesAsync(request.Adds[i], 0, resource, cancellationToken);
+                var newFeature = await BuildFeatureFromGeoServicesAsync(request.Adds[i], 0, resource, AttributeRuleEditEvent.Insert, cancellationToken);
                 context.CreateFeatures.Add(newFeature);
                 context.CreateIndexes.Add(i);
                 context.CreateGeometryChanged.Add(requestHasGeometry);
@@ -322,6 +323,7 @@ internal sealed class FeatureServerEditsHandler(
                     update,
                     internalObjectId,
                     resource,
+                    AttributeRuleEditEvent.Update,
                     cancellationToken,
                     existingFeature).ConfigureAwait(false);
                 context.UpdateFeatures.Add(updateFeature);
@@ -730,6 +732,7 @@ internal sealed class FeatureServerEditsHandler(
         GeoServicesFeature feature,
         long objectId,
         MetadataV2Resource resource,
+        AttributeRuleEditEvent editEvent,
         CancellationToken cancellationToken,
         Feature? existingFeature = null)
     {
@@ -816,7 +819,55 @@ internal sealed class FeatureServerEditsHandler(
             attributes.Remove(objectIdFieldName);
         }
 
+        // Esri attribute rules fire on the shared edit path after attribute validation
+        // and merge: calculation rules populate their target field, constraint/validation
+        // rules reject violating edits. Expressions outside the supported safe subset are
+        // routed out of scope (skipped with a logged warning) by the engine, keeping full
+        // Arcade parity a non-goal of this path. Throwing ArgumentException lets the
+        // surrounding per-feature try/catch convert a violation into a clean edit failure
+        // result rather than a 500.
+        var ruleResult = AttributeRuleEngine.Apply(
+            resource,
+            attributes,
+            editEvent,
+            new UnsupportedExpressionLogger(_logger));
+        if (!ruleResult.IsValid)
+        {
+            var message = ruleResult.Violations[0].Message;
+            throw new ArgumentException(SanitizeEditErrorMessage(message, "Attribute rule violation."));
+        }
+
+        if (!ReferenceEquals(ruleResult.Attributes, (IReadOnlyDictionary<string, object?>)attributes))
+        {
+            attributes = ImmutableDictionary.CreateBuilder<string, object?>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (key, value) in ruleResult.Attributes)
+            {
+                attributes[key] = value;
+            }
+        }
+
         return Feature.Create(objectId, geometry, attributes.ToImmutable());
+    }
+
+    /// <summary>
+    /// Routes attribute-rule expressions outside the supported safe subset out of scope by
+    /// emitting a structured warning identifying the layer and rule. The edit is allowed to
+    /// proceed (full Arcade parity is a non-goal of the edit path).
+    /// </summary>
+    private sealed class UnsupportedExpressionLogger(ILogger logger) : IUnsupportedExpressionSink
+    {
+        public void OnUnsupported(MetadataV2Resource resource, MetadataV2AttributeRule rule)
+        {
+            var resourceId = string.IsNullOrEmpty(resource.Metadata.Id)
+                ? (string.IsNullOrEmpty(resource.Metadata.Name) ? "unknown" : resource.Metadata.Name)
+                : resource.Metadata.Id;
+            FeatureServerLog.AttributeRuleExpressionUnsupported(
+                logger,
+                resourceId,
+                0,
+                rule.Name,
+                rule.Type.ToString());
+        }
     }
 
     /// <summary>

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerLog.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerLog.cs
@@ -283,6 +283,21 @@ internal static partial class FeatureServerLog
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to delete feature {Index}: {ErrorMessage}")]
     public static partial void FeatureDeleteFailed(ILogger logger, int index, string errorMessage, Exception exception);
 
+    /// <summary>
+    /// Logs when an attribute rule's Arcade expression is outside the supported safe
+    /// subset and is routed out of scope (skipped) on the edit path rather than enforced.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="serviceId">The service identifier.</param>
+    /// <param name="layerId">The layer identifier.</param>
+    /// <param name="ruleName">The attribute rule whose expression was unsupported.</param>
+    /// <param name="ruleType">The attribute-rule type (calculation/constraint/validation).</param>
+    [LoggerMessage(
+        EventId = 2310,
+        Level = LogLevel.Warning,
+        Message = "Attribute rule '{RuleName}' ({RuleType}) on {ServiceId}/FeatureServer/{LayerId} uses an unsupported Arcade expression; routed out of scope (skipped)")]
+    public static partial void AttributeRuleExpressionUnsupported(ILogger logger, string serviceId, int layerId, string ruleName, string ruleType);
+
     // Related records query events (2400-2499)
 
     /// <summary>

--- a/tests/dotnet/Honua.Core.Tests/Features/AttributeRules/AttributeRuleEngineTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/AttributeRules/AttributeRuleEngineTests.cs
@@ -1,0 +1,206 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.AttributeRules;
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Core.Tests.Features.AttributeRules;
+
+/// <summary>
+/// Unit coverage for the shared attribute-rule engine and safe Arcade-subset evaluator
+/// (honua-server#1271). Verifies that calculation rules populate their target field,
+/// constraint/validation rules reject violations, triggering events gate firing, and
+/// expressions outside the supported subset are routed out of scope (skipped) rather
+/// than failing the edit.
+/// </summary>
+public sealed class AttributeRuleEngineTests
+{
+    [Fact]
+    public void Apply_CalculationConstantRule_PopulatesTargetField()
+    {
+        var resource = ResourceWithRules(new MetadataV2AttributeRule
+        {
+            Name = "SetStatus",
+            Type = MetadataV2AttributeRuleType.Calculation,
+            FieldName = "status",
+            ScriptExpression = "return 'active';"
+        });
+
+        var result = AttributeRuleEngine.Apply(
+            resource,
+            Attributes(("qty", 5)),
+            AttributeRuleEditEvent.Insert);
+
+        result.IsValid.Should().BeTrue();
+        result.Attributes["status"].Should().Be("active");
+        result.Attributes["qty"].Should().Be(5);
+    }
+
+    [Fact]
+    public void Apply_CalculationArithmeticRule_ComputesFromFields()
+    {
+        var resource = ResourceWithRules(new MetadataV2AttributeRule
+        {
+            Name = "Total",
+            Type = MetadataV2AttributeRuleType.Calculation,
+            FieldName = "total",
+            ScriptExpression = "$feature.qty * $feature.price"
+        });
+
+        var result = AttributeRuleEngine.Apply(
+            resource,
+            Attributes(("qty", 3), ("price", 4)),
+            AttributeRuleEditEvent.Update);
+
+        result.IsValid.Should().BeTrue();
+        result.Attributes["total"].Should().Be(12d);
+    }
+
+    [Fact]
+    public void Apply_ConstraintViolated_ReportsViolationWithMessage()
+    {
+        var resource = ResourceWithRules(new MetadataV2AttributeRule
+        {
+            Name = "PositiveQty",
+            Type = MetadataV2AttributeRuleType.Constraint,
+            ScriptExpression = "$feature.qty > 0",
+            ErrorMessage = "Quantity must be positive"
+        });
+
+        var result = AttributeRuleEngine.Apply(
+            resource,
+            Attributes(("qty", -1)),
+            AttributeRuleEditEvent.Insert);
+
+        result.IsValid.Should().BeFalse();
+        result.Violations.Should().ContainSingle();
+        result.Violations[0].Message.Should().Be("Quantity must be positive");
+    }
+
+    [Fact]
+    public void Apply_ConstraintSatisfied_NoViolation()
+    {
+        var resource = ResourceWithRules(new MetadataV2AttributeRule
+        {
+            Name = "PositiveQty",
+            Type = MetadataV2AttributeRuleType.Constraint,
+            ScriptExpression = "$feature.qty > 0"
+        });
+
+        var result = AttributeRuleEngine.Apply(
+            resource,
+            Attributes(("qty", 10)),
+            AttributeRuleEditEvent.Insert);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Apply_TriggeringEventMismatch_RuleDoesNotFire()
+    {
+        var resource = ResourceWithRules(new MetadataV2AttributeRule
+        {
+            Name = "InsertOnly",
+            Type = MetadataV2AttributeRuleType.Constraint,
+            ScriptExpression = "$feature.qty > 0",
+            TriggeringEvents = ["insert"]
+        });
+
+        // An update-time edit must not fire an insert-only rule even when it would violate.
+        var result = AttributeRuleEngine.Apply(
+            resource,
+            Attributes(("qty", -5)),
+            AttributeRuleEditEvent.Update);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Apply_DisabledRule_DoesNotFire()
+    {
+        var resource = ResourceWithRules(new MetadataV2AttributeRule
+        {
+            Name = "Off",
+            Type = MetadataV2AttributeRuleType.Constraint,
+            ScriptExpression = "$feature.qty > 0",
+            IsEnabled = false
+        });
+
+        var result = AttributeRuleEngine.Apply(
+            resource,
+            Attributes(("qty", -5)),
+            AttributeRuleEditEvent.Insert);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Apply_UnsupportedExpression_RoutedOutOfScopeNotFailed()
+    {
+        var resource = ResourceWithRules(new MetadataV2AttributeRule
+        {
+            Name = "ComplexArcade",
+            Type = MetadataV2AttributeRuleType.Constraint,
+            // A function call is outside the supported safe subset.
+            ScriptExpression = "Count($feature.parts) > 0"
+        });
+
+        var sink = new RecordingSink();
+        var result = AttributeRuleEngine.Apply(
+            resource,
+            Attributes(("qty", 1)),
+            AttributeRuleEditEvent.Insert,
+            sink);
+
+        // Unsupported expressions skip rather than fail the edit, and notify the sink.
+        result.IsValid.Should().BeTrue();
+        sink.Unsupported.Should().ContainSingle().Which.Should().Be("ComplexArcade");
+    }
+
+    [Fact]
+    public void Apply_UnsupportedCalculation_DoesNotWriteTargetField()
+    {
+        var resource = ResourceWithRules(new MetadataV2AttributeRule
+        {
+            Name = "ComplexCalc",
+            Type = MetadataV2AttributeRuleType.Calculation,
+            FieldName = "status",
+            ScriptExpression = "DomainName($feature, 'status')"
+        });
+
+        var result = AttributeRuleEngine.Apply(
+            resource,
+            Attributes(("qty", 1)),
+            AttributeRuleEditEvent.Insert);
+
+        result.IsValid.Should().BeTrue();
+        result.Attributes.ContainsKey("status").Should().BeFalse();
+    }
+
+    private static MetadataV2Resource ResourceWithRules(params MetadataV2AttributeRule[] rules)
+        => new()
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "res", Name = "Test" },
+            AttributeRules = rules
+        };
+
+    private static Dictionary<string, object?> Attributes(params (string Key, object? Value)[] pairs)
+    {
+        var dictionary = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in pairs)
+        {
+            dictionary[key] = value;
+        }
+
+        return dictionary;
+    }
+
+    private sealed class RecordingSink : IUnsupportedExpressionSink
+    {
+        public List<string> Unsupported { get; } = new();
+
+        public void OnUnsupported(MetadataV2Resource resource, MetadataV2AttributeRule rule)
+            => Unsupported.Add(rule.Name);
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/EsriAttributeRuleParserTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/EsriAttributeRuleParserTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Migration.Services;
+
+namespace Honua.Core.Tests.Features.Import;
+
+/// <summary>
+/// Unit coverage for the shared Esri attribute-rule parser (honua-server#1271). The
+/// parser is the single source of truth for attribute-rule capture: it maps Esri
+/// calculation/constraint/validation rules into the canonical model, normalizes
+/// triggering events, drops un-appliable calculation rules (no target field), and bounds
+/// the rule set by the cap.
+/// </summary>
+public sealed class EsriAttributeRuleParserTests
+{
+    [Fact]
+    public void Parse_CalculationAndConstraintRules_ProducesCanonicalRules()
+    {
+        var layer = ParseLayer("""
+            {
+              "attributeRules": [
+                {
+                  "name": "SetStatus",
+                  "type": "calculation",
+                  "fieldName": "status",
+                  "scriptExpression": "return 'active';",
+                  "triggeringEvents": ["Insert", "Update"],
+                  "isEnabled": true
+                },
+                {
+                  "name": "PositiveQty",
+                  "type": "constraint",
+                  "scriptExpression": "$feature.qty > 0",
+                  "errorMessage": "Quantity must be positive",
+                  "triggeringEvents": ["Insert"]
+                }
+              ]
+            }
+            """);
+
+        var result = EsriAttributeRuleParser.Parse(layer);
+
+        result.Truncated.Should().BeFalse();
+        result.Rules.Should().NotBeNull();
+        result.Rules!.Should().HaveCount(2);
+
+        // Deterministically ordered by name.
+        var calc = result.Rules.Single(r => r.Name == "SetStatus");
+        calc.Type.Should().Be(MetadataV2AttributeRuleType.Calculation);
+        calc.FieldName.Should().Be("status");
+        calc.TriggeringEvents.Should().ContainInOrder("insert", "update");
+
+        var constraint = result.Rules.Single(r => r.Name == "PositiveQty");
+        constraint.Type.Should().Be(MetadataV2AttributeRuleType.Constraint);
+        constraint.ErrorMessage.Should().Be("Quantity must be positive");
+        constraint.TriggeringEvents.Should().ContainInOrder("insert");
+    }
+
+    [Fact]
+    public void Parse_CalculationWithoutFieldName_IsDropped()
+    {
+        var layer = ParseLayer("""
+            {
+              "attributeRules": [
+                { "name": "NoTarget", "type": "calculation", "scriptExpression": "return 1;" }
+              ]
+            }
+            """);
+
+        var result = EsriAttributeRuleParser.Parse(layer);
+
+        // A calculation rule with no target field can never be applied; the parser drops it.
+        result.Rules.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_NoAttributeRules_ReturnsNone()
+    {
+        var layer = ParseLayer("""{ "name": "Layer" }""");
+
+        var result = EsriAttributeRuleParser.Parse(layer);
+
+        result.Should().Be(EsriAttributeRuleParseResult.None);
+    }
+
+    [Fact]
+    public void Parse_OverCap_ReportsTruncatedAndOmits()
+    {
+        var builder = new StringBuilder("{ \"attributeRules\": [");
+        for (var i = 0; i <= EsriAttributeRuleParser.AttributeRuleCap; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append("{ \"name\": \"r")
+                .Append(i.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .Append("\", \"type\": \"constraint\", \"scriptExpression\": \"$feature.x > 0\" }");
+        }
+
+        builder.Append("] }");
+        var layer = ParseLayer(builder.ToString());
+
+        var result = EsriAttributeRuleParser.Parse(layer);
+
+        result.Truncated.Should().BeTrue();
+        result.Rules.Should().BeNull();
+    }
+
+    private static JsonElement ParseLayer(string json)
+        => JsonDocument.Parse(json).RootElement.Clone();
+}

--- a/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -2788,6 +2788,170 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.ApplyEdits)]
     [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_WithCalculationRule_PopulatesTargetFieldOnAdd()
+    {
+        // honua-server#1271: a calculation attribute rule attached to the resource must
+        // fire on applyEdits and populate its target field before write. The 'description'
+        // string field is part of the seeded test layer schema, so we drive a constant
+        // assignment into it and read it back via a query.
+        var rule = new MetadataV2AttributeRule
+        {
+            Name = "SetDescription",
+            Type = MetadataV2AttributeRuleType.Calculation,
+            FieldName = "description",
+            ScriptExpression = "return 'calculated-by-rule';",
+        };
+
+        try
+        {
+            _fixture.UpdateV2ResourceAttributeRules(TestLayerId, [rule]);
+
+            var editsRequest = new ApplyEditsRequest
+            {
+                Adds =
+                [
+                    new GeoServicesFeature
+                    {
+                        Attributes = new Dictionary<string, object?>
+                        {
+                            ["name"] = "Calc Rule Feature",
+                            // No description supplied: the calculation rule must populate it.
+                        },
+                        Geometry = new GeoServicesGeometry { X = -122.41, Y = 37.77 },
+                    },
+                ],
+            };
+
+            var json = JsonSerializer.Serialize(editsRequest, FeatureServerJsonContext.Default.ApplyEditsRequest);
+            var response = await _fixture.Client.PostAsync(
+                $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/applyEdits",
+                new StringContent(json, Encoding.UTF8, "application/json"));
+
+            response.Be200Ok();
+            var applyEditsResponse = JsonSerializer.Deserialize<ApplyEditsResponse>(
+                await response.Content.ReadAsStringAsync(), FeatureServerJsonContext.Default.ApplyEditsResponse);
+            applyEditsResponse.Should().NotBeNull();
+            applyEditsResponse!.Success.Should().BeTrue();
+            applyEditsResponse.AddResults.Should().ContainSingle();
+            applyEditsResponse.AddResults![0].Success.Should().BeTrue();
+
+            // The stored description must reflect the rule's computed value.
+            var query = await _fixture.Client.GetAsync(
+                $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=name='Calc Rule Feature'&outFields=*&f=json");
+            query.Be200Ok();
+            var body = await query.Content.ReadAsStringAsync();
+            body.Should().Contain("calculated-by-rule");
+        }
+        finally
+        {
+            _fixture.UpdateV2ResourceAttributeRules(TestLayerId, null);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_WithConstraintRule_RejectsViolatingEditWithCleanError()
+    {
+        // honua-server#1271: a constraint attribute rule that evaluates to false must
+        // reject the edit through the standard per-feature edit-error shape (not a 500).
+        var rule = new MetadataV2AttributeRule
+        {
+            Name = "NameNotReject",
+            Type = MetadataV2AttributeRuleType.Constraint,
+            ScriptExpression = "$feature.name != 'reject'",
+            ErrorMessage = "Name 'reject' is not allowed",
+        };
+
+        try
+        {
+            _fixture.UpdateV2ResourceAttributeRules(TestLayerId, [rule]);
+
+            var editsRequest = new ApplyEditsRequest
+            {
+                Adds =
+                [
+                    new GeoServicesFeature
+                    {
+                        Attributes = new Dictionary<string, object?> { ["name"] = "reject" },
+                        Geometry = new GeoServicesGeometry { X = -122.41, Y = 37.77 },
+                    },
+                ],
+            };
+
+            var json = JsonSerializer.Serialize(editsRequest, FeatureServerJsonContext.Default.ApplyEditsRequest);
+            var response = await _fixture.Client.PostAsync(
+                $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/applyEdits",
+                new StringContent(json, Encoding.UTF8, "application/json"));
+
+            // The request is well-formed (HTTP 200) but the feature edit fails per-feature
+            // with the rule's message, matching the domain-validation failure pattern.
+            response.Be200Ok();
+            var applyEditsResponse = JsonSerializer.Deserialize<ApplyEditsResponse>(
+                await response.Content.ReadAsStringAsync(), FeatureServerJsonContext.Default.ApplyEditsResponse);
+            applyEditsResponse.Should().NotBeNull();
+            applyEditsResponse!.AddResults.Should().ContainSingle();
+            applyEditsResponse.AddResults![0].Success.Should().BeFalse();
+            applyEditsResponse.AddResults[0].Error.Should().NotBeNull();
+            applyEditsResponse.AddResults[0].Error!.Description.Should().Contain("Name 'reject' is not allowed");
+        }
+        finally
+        {
+            _fixture.UpdateV2ResourceAttributeRules(TestLayerId, null);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_WithUnsupportedRuleExpression_DoesNotFailEdit()
+    {
+        // honua-server#1271: a constraint whose Arcade expression is outside the supported
+        // safe subset must be routed out of scope (skipped) rather than failing the edit.
+        var rule = new MetadataV2AttributeRule
+        {
+            Name = "ComplexArcade",
+            Type = MetadataV2AttributeRuleType.Constraint,
+            ScriptExpression = "Count($feature.parts) > 0",
+        };
+
+        try
+        {
+            _fixture.UpdateV2ResourceAttributeRules(TestLayerId, [rule]);
+
+            var editsRequest = new ApplyEditsRequest
+            {
+                Adds =
+                [
+                    new GeoServicesFeature
+                    {
+                        Attributes = new Dictionary<string, object?> { ["name"] = "Unsupported Rule Feature" },
+                        Geometry = new GeoServicesGeometry { X = -122.41, Y = 37.77 },
+                    },
+                ],
+            };
+
+            var json = JsonSerializer.Serialize(editsRequest, FeatureServerJsonContext.Default.ApplyEditsRequest);
+            var response = await _fixture.Client.PostAsync(
+                $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/applyEdits",
+                new StringContent(json, Encoding.UTF8, "application/json"));
+
+            response.Be200Ok();
+            var applyEditsResponse = JsonSerializer.Deserialize<ApplyEditsResponse>(
+                await response.Content.ReadAsStringAsync(), FeatureServerJsonContext.Default.ApplyEditsResponse);
+            applyEditsResponse.Should().NotBeNull();
+            applyEditsResponse!.AddResults.Should().ContainSingle();
+            applyEditsResponse.AddResults![0].Success.Should().BeTrue();
+        }
+        finally
+        {
+            _fixture.UpdateV2ResourceAttributeRules(TestLayerId, null);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
     public async Task ApplyEdits_WithAddOperationAndCallerObjectId_ReturnsGeneratedObjectId()
     {
         var editsRequest = new ApplyEditsRequest

--- a/tests/dotnet/Honua.TestKit/Mixins/WebAppFixtureMetadataV2GraphMutationMixin.cs
+++ b/tests/dotnet/Honua.TestKit/Mixins/WebAppFixtureMetadataV2GraphMutationMixin.cs
@@ -242,6 +242,56 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
     }
 
     /// <summary>
+    /// Sets (or clears) the Esri attribute-rule set on the resource published at
+    /// <paramref name="layerIndex"/> so the shared edit path's calculation/constraint
+    /// enforcement can be exercised end-to-end against the served graph
+    /// (honua-server#1271).
+    /// </summary>
+    internal static void UpdateResourceAttributeRules(
+        WebAppFixture fixture,
+        int layerIndex,
+        IReadOnlyList<MetadataV2AttributeRule>? attributeRules)
+    {
+        var provider = RequireProvider(fixture);
+
+        var snapshot = provider.GetCurrentAsync().AsTask().GetAwaiter().GetResult();
+        var pub = snapshot.Graph.Publications.FirstOrDefault(p => p.LayerIndex == layerIndex);
+        if (pub is null)
+        {
+            throw new InvalidOperationException(
+                $"No publication for layer {layerIndex} in the test V2 graph.");
+        }
+
+        var resources = snapshot.Graph.Resources.ToArray();
+        var mutated = false;
+        for (var i = 0; i < resources.Length; i++)
+        {
+            if (!string.Equals(resources[i].Metadata.Id, pub.ResourceId, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            resources[i] = resources[i] with
+            {
+                AttributeRules = attributeRules ?? Array.Empty<MetadataV2AttributeRule>()
+            };
+            mutated = true;
+        }
+
+        if (!mutated)
+        {
+            return;
+        }
+
+        var updatedGraph = snapshot.Graph with
+        {
+            Resources = resources,
+            Revision = snapshot.Graph.Revision + 1,
+        };
+        provider.SetGraph(updatedGraph);
+    }
+
+    /// <summary>
     /// Renames the resource bound to the publication with <paramref name="layerIndex"/>.
     /// Mirrors the v1 layer-rename behaviour CITE-conformance tests depend on.
     /// </summary>

--- a/tests/dotnet/Honua.TestKit/WebAppFixture.cs
+++ b/tests/dotnet/Honua.TestKit/WebAppFixture.cs
@@ -251,6 +251,14 @@ public sealed class WebAppFixture : IAsyncLifetime
         => Honua.TestKit.Mixins.WebAppFixtureMetadataV2GraphMutationMixin.UpdateResourceSubtypes(this, layerIndex, subtypes);
 
     /// <summary>
+    /// Sets (or clears with <c>null</c>) the Esri attribute-rule set on the resource
+    /// published at <paramref name="layerIndex"/>. Delegates to
+    /// <see cref="Mixins.WebAppFixtureMetadataV2GraphMutationMixin"/>.
+    /// </summary>
+    public void UpdateV2ResourceAttributeRules(int layerIndex, IReadOnlyList<MetadataV2AttributeRule>? attributeRules)
+        => Honua.TestKit.Mixins.WebAppFixtureMetadataV2GraphMutationMixin.UpdateResourceAttributeRules(this, layerIndex, attributeRules);
+
+    /// <summary>
     /// V2-aware helper that renames the canonical resource bound to the publication with
     /// <paramref name="layerIndex"/>. Delegates to
     /// <see cref="Mixins.WebAppFixtureMetadataV2GraphMutationMixin"/>.


### PR DESCRIPTION
## Issue Link
Closes #1271

## Summary
Implements the minimal viable slice of Esri attribute-rule support (the modern sibling to coded-value domains): import attribute-rule definitions and enforce calculation/constraint/validation rules on the edit path. Completes epic #1270 alongside #1271's sibling work.

Enforcement is hooked at the existing domain-validation chokepoint in `FeatureServerEditsHandler.BuildFeatureFromGeoServicesAsync` — right after `_mutationValidator.ValidateAttributes(...)` — so rules reuse the same per-feature `EditError` shape (clean error, not a 500) and honor `rollbackOnFailure`. The evaluation engine itself is protocol-agnostic in `Honua.Core`, ready for reuse by other edit adapters.

## Changes Made
- Model attribute rules as `MetadataV2AttributeRule` (+ `MetadataV2AttributeRuleType`) on `MetadataV2Resource.AttributeRules`, mirroring how `Subtypes` are modeled/registered/validated/imported/projected.
- New `AttributeRuleEngine` + `AttributeRuleExpression` evaluator in `Honua.Core` supporting a safe expression subset: literals, `$feature.Field`/`$feature["Field"]` refs, arithmetic, comparisons, boolean ops, parens, optional `return …;`. Anything else is reported `Unsupported`.
- Import: `EsriAttributeRuleParser` + wiring through `ArcGisRestClient`, `GeoservicesServiceInfo`, `LayerPublishingModels`, `GeoservicesImportService`, `PostgreSqlLayerPublishingService.MetadataV2Graph.cs`.
- Enforcement on the FeatureServer `applyEdits` path (`FeatureServerEditsHandler`, `FeatureServerLog`); unsupported expressions routed to the AI-resolver hook (`IUnsupportedExpressionSink`) and skipped with a warning — never failing the edit.
- Deferred (documented): full Arcade parity, and extending the engine call into OGC API Features / WFS-T / OData / gRPC edit adapters (engine is protocol-agnostic and ready).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

8 engine + 4 parser unit tests (12/12). 3 PostGIS integration tests: calculation populates the field; constraint rejects a violating applyEdits with a clean error; unsupported expression skipped (3/3). Release build `TreatWarningsAsErrors=true`: 0 warnings; `dotnet format --verify-no-changes`: exit 0; architecture tests 104 pass.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
