### PR TITLE
feat: canonical replica-sync conflict detection + upload cursor (#1272)

### DIFF
--- a/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/ReplicaRecord.cs
+++ b/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/ReplicaRecord.cs
@@ -47,4 +47,11 @@ public readonly record struct ReplicaRecord
     /// Generation number at last successful sync
     /// </summary>
     public required long LastSyncGeneration { get; init; }
+
+    /// <summary>
+    /// Server generation produced by the most recent upload sync. Used as the download "since"
+    /// cursor so a replica does not receive its own just-applied edits back on a subsequent
+    /// download delta. Defaults to 0 for replicas that have never uploaded (#1272).
+    /// </summary>
+    public long UploadBaseGeneration { get; init; }
 }

--- a/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/ReplicaSync.cs
+++ b/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/ReplicaSync.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+
+namespace Honua.Core.Features.FeatureStore.Domain;
+
+/// <summary>
+/// Direction of a replica synchronization. Mirrors the Esri <c>syncDirection</c> parameter but is
+/// exposed as a protocol-neutral canonical contract (#1272).
+/// </summary>
+public enum ReplicaSyncDirection
+{
+    /// <summary>Server-to-client only: server changes are returned, no client edits are applied.</summary>
+    Download = 0,
+
+    /// <summary>Client-to-server only: client edits are uploaded and applied, no download delta.</summary>
+    Upload = 1,
+
+    /// <summary>Bidirectional: client edits are uploaded and applied, then a download delta is returned.</summary>
+    Bidirectional = 2,
+}
+
+/// <summary>
+/// A single uploaded edit within a replica synchronization. Conveys only what the canonical conflict
+/// detector needs — the operation kind and (for update/delete) the conflict-detection object id —
+/// plus an opaque <see cref="Payload"/> the protocol adapter uses to recover the original wire
+/// feature when applying the edit through the shared edit pipeline. Geometry/attribute validation and
+/// persistence stay in that shared pipeline; this record never carries provider-specific feature
+/// shape into the canonical service.
+/// </summary>
+/// <param name="Kind">Operation kind (create/update/delete).</param>
+/// <param name="ObjectId">
+/// Stable object id for update/delete operations; null for create. Used as the conflict-detection
+/// key against the server change log.
+/// </param>
+/// <param name="Payload">
+/// Opaque protocol payload the adapter's replica edit applier casts back to its wire feature type.
+/// The canonical service treats it as an opaque token.
+/// </param>
+public readonly record struct ReplicaUploadEdit(
+    FeatureEditOperationKind Kind,
+    long? ObjectId,
+    object? Payload);
+
+/// <summary>
+/// The set of uploaded edits targeting a single service-local layer within a replica
+/// synchronization. The canonical sync service resolves conflicts and applies non-conflicting edits
+/// per layer.
+/// </summary>
+/// <param name="PublicLayerId">Service-local layer id the edits target.</param>
+/// <param name="StorageLayerId">Storage-layer id used for change-log conflict detection.</param>
+/// <param name="Edits">Uploaded edits for this layer.</param>
+public readonly record struct ReplicaUploadLayerEdits(
+    int PublicLayerId,
+    int StorageLayerId,
+    ImmutableArray<ReplicaUploadEdit> Edits);
+
+/// <summary>
+/// Canonical request to synchronize a replica. The GeoServices (and any other replica-capable
+/// protocol) adapter maps its wire parameters onto this request; the shared replica-sync service owns
+/// base-generation conflict detection, conflict-record writes, and the upload cursor (#1272).
+/// </summary>
+/// <param name="ReplicaId">Replica being synchronized.</param>
+/// <param name="ServiceId">Service the replica belongs to.</param>
+/// <param name="Direction">Requested sync direction.</param>
+/// <param name="BaseGeneration">
+/// The replica's last-known server generation cursor. Server changes to a feature after this cursor
+/// indicate a conflicting concurrent server edit.
+/// </param>
+/// <param name="LayerEdits">Per-layer uploaded edits (empty for download-only sync).</param>
+/// <param name="LastWriteWins">
+/// When true (the default for non-manual conflict strategies), conflicting edits are still applied
+/// (last-write-wins) but a durable conflict record is written when supported. When false, conflicting
+/// edits are skipped and only recorded.
+/// </param>
+/// <param name="SyncOperationId">Optional correlation id linking produced conflicts to this call.</param>
+/// <param name="DeviceId">Optional uploading device identifier (conflict audit evidence).</param>
+/// <param name="UserId">Optional uploading user identifier (conflict audit evidence).</param>
+public readonly record struct ReplicaSyncRequest(
+    string ReplicaId,
+    string ServiceId,
+    ReplicaSyncDirection Direction,
+    long BaseGeneration,
+    ImmutableArray<ReplicaUploadLayerEdits> LayerEdits,
+    bool LastWriteWins = true,
+    string? SyncOperationId = null,
+    string? DeviceId = null,
+    string? UserId = null);
+
+/// <summary>
+/// A conflict detected while applying an uploaded replica edit: the client edit and a server edit to
+/// the same <c>(layerId, objectId)</c> both occurred since the replica's base generation.
+/// </summary>
+/// <param name="PublicLayerId">Service-local layer id of the conflicting feature.</param>
+/// <param name="ObjectId">Stable object id of the conflicting feature.</param>
+/// <param name="ConflictType">Conflict classification.</param>
+/// <param name="ClientKind">The client operation kind that conflicted.</param>
+/// <param name="ServerOperation">The server operation that mutated the feature since base.</param>
+/// <param name="Applied">
+/// True when the client edit was still applied (last-write-wins); false when it was skipped.
+/// </param>
+/// <param name="ConflictId">
+/// Durable conflict-record id when a record was written; null when conflict review is unsupported.
+/// </param>
+public readonly record struct ReplicaSyncConflict(
+    int PublicLayerId,
+    long ObjectId,
+    ReplicaConflictType ConflictType,
+    FeatureEditOperationKind ClientKind,
+    FeatureChangeOperation ServerOperation,
+    bool Applied,
+    string? ConflictId);
+
+/// <summary>
+/// Outcome of applying the uploaded edits for a single layer through the shared edit pipeline.
+/// </summary>
+/// <param name="PublicLayerId">Service-local layer id.</param>
+/// <param name="AppliedAdds">Number of create operations applied.</param>
+/// <param name="AppliedUpdates">Number of update operations applied.</param>
+/// <param name="AppliedDeletes">Number of delete operations applied.</param>
+/// <param name="Failed">True when any non-conflict edit failed to apply.</param>
+/// <param name="FailureMessage">Sanitized failure message when <paramref name="Failed"/> is true.</param>
+public readonly record struct ReplicaLayerApplyResult(
+    int PublicLayerId,
+    int AppliedAdds,
+    int AppliedUpdates,
+    int AppliedDeletes,
+    bool Failed,
+    string? FailureMessage);
+
+/// <summary>
+/// Report produced by a replica upload/synchronize. Summarizes the applied edits, any detected
+/// conflicts, and the resulting server generation cursor that a subsequent download delta should use
+/// as its lower bound so the replica does not receive its own just-applied edits back (#1272).
+/// </summary>
+/// <param name="Success">
+/// True when all non-conflicting edits applied cleanly. Conflicts under last-write-wins do not by
+/// themselves fail the sync.
+/// </param>
+/// <param name="AppliedAdds">Total create operations applied across all layers.</param>
+/// <param name="AppliedUpdates">Total update operations applied across all layers.</param>
+/// <param name="AppliedDeletes">Total delete operations applied across all layers.</param>
+/// <param name="Conflicts">Detected conflicts.</param>
+/// <param name="LayerResults">Per-layer apply results.</param>
+/// <param name="ServerGeneration">Server generation after the upload applied.</param>
+/// <param name="FailureMessage">Sanitized failure message when <paramref name="Success"/> is false.</param>
+public readonly record struct ReplicaSyncUploadReport(
+    bool Success,
+    int AppliedAdds,
+    int AppliedUpdates,
+    int AppliedDeletes,
+    ImmutableArray<ReplicaSyncConflict> Conflicts,
+    ImmutableArray<ReplicaLayerApplyResult> LayerResults,
+    long ServerGeneration,
+    string? FailureMessage);

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IReplicaEditApplier.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IReplicaEditApplier.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.FeatureStore.Abstractions;
+
+/// <summary>
+/// Applies a resolved set of uploaded replica edits for a single layer through the shared edit
+/// pipeline. The concrete implementation is supplied by the protocol adapter so that uploaded edits
+/// reuse the same validation, authorization, geometry conversion, telemetry, and transactional
+/// outbox behavior as ordinary edits, rather than the replica path issuing its own data access.
+/// </summary>
+/// <remarks>
+/// The canonical <see cref="IReplicaSyncService"/> owns conflict detection and the upload cursor; it
+/// only decides <em>which</em> edits to apply and delegates the <em>how</em> to this applier so the
+/// shared edit pipeline remains the single write path (#1272).
+/// </remarks>
+public interface IReplicaEditApplier
+{
+    /// <summary>
+    /// Applies the supplied edits for a single layer through the shared edit pipeline.
+    /// </summary>
+    /// <param name="serviceId">Service the layer belongs to.</param>
+    /// <param name="publicLayerId">Service-local layer id the edits target.</param>
+    /// <param name="edits">Resolved edits to apply (conflicting edits already filtered when skipped).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The per-layer apply result.</returns>
+    Task<ReplicaLayerApplyResult> ApplyAsync(
+        string serviceId,
+        int publicLayerId,
+        ImmutableArray<ReplicaUploadEdit> edits,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IReplicaSyncService.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IReplicaSyncService.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.FeatureStore.Abstractions;
+
+/// <summary>
+/// Canonical replica-upload synchronization pipeline (#1272). Resolves uploaded edits against the
+/// replica's base generation cursor, detects server-side conflicts via the change log, applies
+/// non-conflicting edits through the shared edit pipeline (via <see cref="IReplicaEditApplier"/>),
+/// and writes durable conflict records when conflict review is supported. Protocol adapters
+/// (GeoServices <c>synchronizeReplica</c> and any future replica-capable protocol) map their wire
+/// parameters onto <see cref="ReplicaSyncRequest"/> and adapt the returned report; they do not
+/// reimplement conflict detection or the upload cursor.
+/// </summary>
+public interface IReplicaSyncService
+{
+    /// <summary>
+    /// Applies an uploaded replica synchronization: detects conflicts against the base generation,
+    /// applies non-conflicting (and, under last-write-wins, conflicting) edits through the supplied
+    /// applier, records durable conflicts when supported, and returns an upload report whose
+    /// <see cref="ReplicaSyncUploadReport.ServerGeneration"/> is the cursor a subsequent download
+    /// delta should use as its lower bound.
+    /// </summary>
+    /// <param name="request">Canonical sync request.</param>
+    /// <param name="editApplier">
+    /// Protocol-supplied applier that writes edits through the shared edit pipeline.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The upload report.</returns>
+    Task<ReplicaSyncUploadReport> ApplyUploadAsync(
+        ReplicaSyncRequest request,
+        IReplicaEditApplier editApplier,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/FeatureStore/Services/ReplicaSyncService.cs
+++ b/src/Honua.Core/Features/FeatureStore/Services/ReplicaSyncService.cs
@@ -1,0 +1,243 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.FeatureStore.Services;
+
+/// <summary>
+/// Canonical replica-upload synchronization pipeline (#1272). See <see cref="IReplicaSyncService"/>.
+/// </summary>
+/// <remarks>
+/// Conflict detection compares each uploaded update/delete against the server change log since the
+/// replica's base generation: a server-side mutation of the same <c>(layerId, objectId)</c> indicates
+/// a concurrent server edit and produces a conflict candidate. Non-conflicting edits (and, under
+/// last-write-wins, conflicting edits) are applied through <see cref="IReplicaEditApplier"/>, which
+/// the protocol adapter backs with the shared edit pipeline. Durable conflict records are written
+/// through <see cref="IReplicaConflictRepository"/> when <see cref="IReplicaConflictRepository.SupportsConflictReview"/>
+/// is true; when conflict review is unsupported the service falls back to last-write-wins so existing
+/// non-manual strategy behavior is preserved (conflict-record creation + resolution API is owned by
+/// #1287).
+/// </remarks>
+public sealed partial class ReplicaSyncService : IReplicaSyncService
+{
+    private readonly IChangeTracker _changeTracker;
+    private readonly IReplicaConflictRepository _conflictRepository;
+    private readonly ILogger<ReplicaSyncService> _logger;
+
+    /// <summary>
+    /// Initializes a new <see cref="ReplicaSyncService"/>.
+    /// </summary>
+    /// <param name="changeTracker">Change-log reader used for conflict detection.</param>
+    /// <param name="conflictRepository">Durable conflict-record store (#1287 owns the resolution API).</param>
+    /// <param name="logger">Logger.</param>
+    public ReplicaSyncService(
+        IChangeTracker changeTracker,
+        IReplicaConflictRepository conflictRepository,
+        ILogger<ReplicaSyncService> logger)
+    {
+        _changeTracker = changeTracker ?? throw new ArgumentNullException(nameof(changeTracker));
+        _conflictRepository = conflictRepository ?? throw new ArgumentNullException(nameof(conflictRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<ReplicaSyncUploadReport> ApplyUploadAsync(
+        ReplicaSyncRequest request,
+        IReplicaEditApplier editApplier,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(editApplier);
+
+        var layerEdits = request.LayerEdits;
+        if (layerEdits.IsDefaultOrEmpty)
+        {
+            var currentGen = await _changeTracker.GetCurrentGenerationAsync(cancellationToken).ConfigureAwait(false);
+            return new ReplicaSyncUploadReport(
+                Success: true,
+                AppliedAdds: 0,
+                AppliedUpdates: 0,
+                AppliedDeletes: 0,
+                Conflicts: ImmutableArray<ReplicaSyncConflict>.Empty,
+                LayerResults: ImmutableArray<ReplicaLayerApplyResult>.Empty,
+                ServerGeneration: currentGen,
+                FailureMessage: null);
+        }
+
+        // Conflict review is supported only when the provider can durably persist conflicts. When it
+        // cannot (read-only providers, or before #1287 lands), fall back to last-write-wins so the
+        // existing non-manual strategy behavior is preserved.
+        var canRecordConflicts = _conflictRepository.SupportsConflictReview;
+        var applyConflicting = request.LastWriteWins || !canRecordConflicts;
+
+        var conflicts = ImmutableArray.CreateBuilder<ReplicaSyncConflict>();
+        var layerResults = ImmutableArray.CreateBuilder<ReplicaLayerApplyResult>(layerEdits.Length);
+        var totalAdds = 0;
+        var totalUpdates = 0;
+        var totalDeletes = 0;
+        var anyFailure = false;
+        string? firstFailure = null;
+
+        foreach (var layer in layerEdits)
+        {
+            var edits = layer.Edits.IsDefault ? ImmutableArray<ReplicaUploadEdit>.Empty : layer.Edits;
+            if (edits.IsEmpty)
+            {
+                layerResults.Add(new ReplicaLayerApplyResult(layer.PublicLayerId, 0, 0, 0, Failed: false, FailureMessage: null));
+                continue;
+            }
+
+            // Map server-side mutations since the base generation for conflict detection. Only
+            // update/delete uploads can conflict; inserts use server-assigned ids and cannot collide
+            // on an existing (layerId, objectId) key here (duplicate-insert detection is owned by the
+            // edit pipeline's uniqueness handling and #1287).
+            var serverChanges = await _changeTracker
+                .GetChangesSinceAsync(request.BaseGeneration, [layer.StorageLayerId], cancellationToken)
+                .ConfigureAwait(false);
+            var serverByObjectId = new Dictionary<long, FeatureChangeOperation>();
+            foreach (var change in serverChanges)
+            {
+                serverByObjectId[change.ObjectId] = change.Operation;
+            }
+
+            var editsToApply = ImmutableArray.CreateBuilder<ReplicaUploadEdit>(edits.Length);
+            foreach (var edit in edits)
+            {
+                if (edit.Kind != FeatureEditOperationKind.Create &&
+                    edit.ObjectId is { } objectId &&
+                    serverByObjectId.TryGetValue(objectId, out var serverOp))
+                {
+                    var conflictType = ClassifyConflict(edit.Kind, serverOp);
+                    var conflictId = canRecordConflicts
+                        ? await RecordConflictAsync(request, layer.PublicLayerId, objectId, conflictType, cancellationToken).ConfigureAwait(false)
+                        : null;
+
+                    conflicts.Add(new ReplicaSyncConflict(
+                        layer.PublicLayerId,
+                        objectId,
+                        conflictType,
+                        edit.Kind,
+                        serverOp,
+                        Applied: applyConflicting,
+                        ConflictId: conflictId));
+
+                    if (!applyConflicting)
+                    {
+                        // Manual review: skip the conflicting edit. The conflict record carries the
+                        // client intent for later resolution.
+                        continue;
+                    }
+                }
+
+                editsToApply.Add(edit);
+            }
+
+            ReplicaLayerApplyResult applyResult;
+            if (editsToApply.Count == 0)
+            {
+                applyResult = new ReplicaLayerApplyResult(layer.PublicLayerId, 0, 0, 0, Failed: false, FailureMessage: null);
+            }
+            else
+            {
+                applyResult = await editApplier
+                    .ApplyAsync(request.ServiceId, layer.PublicLayerId, editsToApply.ToImmutable(), cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            totalAdds += applyResult.AppliedAdds;
+            totalUpdates += applyResult.AppliedUpdates;
+            totalDeletes += applyResult.AppliedDeletes;
+            if (applyResult.Failed)
+            {
+                anyFailure = true;
+                firstFailure ??= applyResult.FailureMessage;
+            }
+
+            layerResults.Add(applyResult);
+        }
+
+        if (conflicts.Count > 0)
+        {
+            Log.ConflictsDetected(_logger, request.ReplicaId, request.ServiceId, conflicts.Count, applyConflicting);
+        }
+
+        // The server generation produced once the uploaded edits applied. A subsequent download delta
+        // uses this as its lower bound so the replica does not receive its own edits back.
+        var serverGeneration = await _changeTracker.GetCurrentGenerationAsync(cancellationToken).ConfigureAwait(false);
+
+        return new ReplicaSyncUploadReport(
+            Success: !anyFailure,
+            AppliedAdds: totalAdds,
+            AppliedUpdates: totalUpdates,
+            AppliedDeletes: totalDeletes,
+            Conflicts: conflicts.ToImmutable(),
+            LayerResults: layerResults.ToImmutable(),
+            ServerGeneration: serverGeneration,
+            FailureMessage: firstFailure);
+    }
+
+    private static ReplicaConflictType ClassifyConflict(
+        FeatureEditOperationKind clientKind,
+        FeatureChangeOperation serverOperation)
+        => (clientKind, serverOperation) switch
+        {
+            (FeatureEditOperationKind.Delete, FeatureChangeOperation.Update) => ReplicaConflictType.DeleteUpdate,
+            (FeatureEditOperationKind.Update, FeatureChangeOperation.Delete) => ReplicaConflictType.UpdateDelete,
+            // Update vs concurrent server insert/update: an attribute-level conflict. Geometry-only
+            // classification requires a field-level diff that is owned by the conflict-resolution
+            // surface (#1287); the upload path records the coarser Attribute classification.
+            _ => ReplicaConflictType.Attribute,
+        };
+
+    private async Task<string?> RecordConflictAsync(
+        ReplicaSyncRequest request,
+        int publicLayerId,
+        long objectId,
+        ReplicaConflictType conflictType,
+        CancellationToken cancellationToken)
+    {
+        var conflictId = Guid.NewGuid().ToString("N");
+        var record = new ReplicaConflictRecord
+        {
+            ConflictId = conflictId,
+            ReplicaId = request.ReplicaId,
+            ServiceId = request.ServiceId,
+            LayerId = publicLayerId,
+            ObjectId = objectId,
+            ConflictType = conflictType,
+            Status = ReplicaConflictStatus.Pending,
+            SyncOperationId = request.SyncOperationId,
+            DeviceId = request.DeviceId,
+            UserId = request.UserId,
+            ServerGeneration = request.BaseGeneration,
+            DetectedAt = DateTimeOffset.UtcNow,
+        };
+
+        try
+        {
+            await _conflictRepository.UpsertAsync(record, cancellationToken).ConfigureAwait(false);
+            return conflictId;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A conflict-record write failure must not fail the sync; the edit is still applied under
+            // last-write-wins. Surface the failure in logs for operator follow-up.
+            Log.ConflictRecordFailed(_logger, request.ReplicaId, publicLayerId, objectId, ex);
+            return null;
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(EventId = 7740, Level = LogLevel.Information,
+            Message = "Replica {ReplicaId} sync for service {ServiceId} detected {ConflictCount} conflict(s); appliedConflicting={AppliedConflicting}")]
+        public static partial void ConflictsDetected(ILogger logger, string replicaId, string serviceId, int conflictCount, bool appliedConflicting);
+
+        [LoggerMessage(EventId = 7741, Level = LogLevel.Warning,
+            Message = "Failed to persist replica conflict record for replica {ReplicaId} layer {LayerId} objectId {ObjectId}")]
+        public static partial void ConflictRecordFailed(ILogger logger, string replicaId, int layerId, long objectId, Exception exception);
+    }
+}

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresReplicaRepository.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresReplicaRepository.cs
@@ -25,14 +25,15 @@ internal sealed class PostgresReplicaRepository : IReplicaRepository
     public async Task UpsertAsync(ReplicaRecord record, CancellationToken cancellationToken = default)
     {
         const string sql = """
-            INSERT INTO honua.replicas (replica_id, replica_name, service_id, sync_model, layer_ids, created_at, last_sync_time, last_sync_generation)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            INSERT INTO honua.replicas (replica_id, replica_name, service_id, sync_model, layer_ids, created_at, last_sync_time, last_sync_generation, upload_base_generation)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             ON CONFLICT (replica_id) DO UPDATE SET
                 replica_name = EXCLUDED.replica_name,
                 sync_model = EXCLUDED.sync_model,
                 layer_ids = EXCLUDED.layer_ids,
                 last_sync_time = EXCLUDED.last_sync_time,
-                last_sync_generation = EXCLUDED.last_sync_generation
+                last_sync_generation = EXCLUDED.last_sync_generation,
+                upload_base_generation = EXCLUDED.upload_base_generation
             """;
 
         await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
@@ -46,6 +47,7 @@ internal sealed class PostgresReplicaRepository : IReplicaRepository
         command.Parameters.AddWithValue(NpgsqlDbType.TimestampTz, record.CreatedAt);
         command.Parameters.AddWithValue(NpgsqlDbType.TimestampTz, record.LastSyncTime);
         command.Parameters.AddWithValue(NpgsqlDbType.Bigint, record.LastSyncGeneration);
+        command.Parameters.AddWithValue(NpgsqlDbType.Bigint, record.UploadBaseGeneration);
 
         await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -54,7 +56,7 @@ internal sealed class PostgresReplicaRepository : IReplicaRepository
     {
         const string sql = """
             SELECT replica_id, replica_name, service_id, sync_model, layer_ids,
-                   created_at, last_sync_time, last_sync_generation
+                   created_at, last_sync_time, last_sync_generation, upload_base_generation
             FROM honua.replicas
             WHERE replica_id = $1
             """;
@@ -78,7 +80,8 @@ internal sealed class PostgresReplicaRepository : IReplicaRepository
             LayerIds = (int[])reader.GetValue(4),
             CreatedAt = reader.GetFieldValue<DateTimeOffset>(5),
             LastSyncTime = reader.GetFieldValue<DateTimeOffset>(6),
-            LastSyncGeneration = reader.GetInt64(7)
+            LastSyncGeneration = reader.GetInt64(7),
+            UploadBaseGeneration = reader.GetInt64(8)
         };
     }
 
@@ -86,7 +89,7 @@ internal sealed class PostgresReplicaRepository : IReplicaRepository
     {
         const string sql = """
             SELECT replica_id, replica_name, service_id, sync_model, layer_ids,
-                   created_at, last_sync_time, last_sync_generation
+                   created_at, last_sync_time, last_sync_generation, upload_base_generation
             FROM honua.replicas
             WHERE service_id = $1
             ORDER BY created_at DESC, replica_id ASC
@@ -110,7 +113,8 @@ internal sealed class PostgresReplicaRepository : IReplicaRepository
                 LayerIds = (int[])reader.GetValue(4),
                 CreatedAt = reader.GetFieldValue<DateTimeOffset>(5),
                 LastSyncTime = reader.GetFieldValue<DateTimeOffset>(6),
-                LastSyncGeneration = reader.GetInt64(7)
+                LastSyncGeneration = reader.GetInt64(7),
+                UploadBaseGeneration = reader.GetInt64(8)
             });
         }
 

--- a/src/Honua.Protocols.GeoServices/FeatureServer/DistributedReplicaStore.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/DistributedReplicaStore.cs
@@ -222,4 +222,10 @@ internal sealed record ReplicaState(
     public DateTimeOffset LastSyncTime { get; init; } = CreatedAt;
 
     public long LastSyncGeneration { get; init; }
+
+    /// <summary>
+    /// Server generation produced by the most recent upload sync. Used as the download "since"
+    /// cursor so a replica does not receive its own just-applied edits back (#1272).
+    /// </summary>
+    public long UploadBaseGeneration { get; init; }
 }

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -6,6 +6,7 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
+using Honua.Core.Features.Shared.Models;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Core.Configuration;
 using System.Collections.Immutable;
@@ -806,62 +807,77 @@ internal static partial class FeatureServerEndpoints
 
         var syncDirection = GetValueString(values, "syncDirection") ?? "download";
         var editsJson = GetValueString(values, "edits");
+        var isUploadDirection = !string.Equals(syncDirection, "download", StringComparison.OrdinalIgnoreCase);
 
-        // If upload or bidirectional sync includes edits, apply them
-        if (!string.IsNullOrWhiteSpace(editsJson) &&
-            !string.Equals(syncDirection, "download", StringComparison.OrdinalIgnoreCase))
+        var changeTracker = context.RequestServices.GetRequiredService<IChangeTracker>();
+
+        SynchronizeReplicaConflict[]? conflicts = null;
+        int? appliedAdds = null;
+        int? appliedUpdates = null;
+        int? appliedDeletes = null;
+
+        // Upload/bidirectional sync with edits is applied through the canonical replica-sync
+        // pipeline: it detects server-side conflicts against the replica's base generation, applies
+        // non-conflicting edits via the shared edit pipeline, and writes durable conflict records
+        // when supported. Download-only syncs and empty uploads skip the pipeline entirely (#1272).
+        long uploadServerGen = 0;
+        var didUpload = false;
+        if (isUploadDirection && !string.IsNullOrWhiteSpace(editsJson))
         {
-            GeoServicesFeature[]? features;
-            try
+            if (!TryParseSynchronizeReplicaEdits(editsJson!, replicaLayers, out var layerEdits, out var parseError))
             {
-                features = System.Text.Json.JsonSerializer.Deserialize(
-                    editsJson, FeatureServerJsonContext.Default.GeoServicesFeatureArray);
-            }
-            catch (System.Text.Json.JsonException)
-            {
-                return StandardErrorHelpers.CreateBadRequest(context,
-                    "Invalid edits parameter",
-                    ["edits must be a valid JSON array of features."]);
+                return StandardErrorHelpers.CreateBadRequest(context, "Invalid edits parameter", [parseError!]);
             }
 
-            if (features is { Length: > 0 })
+            if (!layerEdits.IsDefaultOrEmpty)
             {
-                // Apply the incoming edits to the first replica layer
-                var targetLayerId = replicaLayers[0].PublicLayerId;
                 var editsHandler = context.RequestServices.GetRequiredService<FeatureServerEditsHandler>();
                 var limitsOptions = context.RequestServices
                     .GetRequiredService<Microsoft.Extensions.Options.IOptions<Honua.Core.Configuration.LimitsOptions>>();
+                var syncService = context.RequestServices.GetRequiredService<IReplicaSyncService>();
+                var applier = new FeatureServerReplicaEditApplier(editsHandler, limitsOptions.Value.Edits);
 
-                var editRequest = new ApplyEditsRequest { Adds = features, RollbackOnFailure = false };
-                var editResult = await editsHandler.HandleApplyEditsAsync(
-                    serviceId, targetLayerId, editRequest, limitsOptions.Value.Edits, cancellationToken);
+                var syncRequest = new ReplicaSyncRequest(
+                    ReplicaId: replicaId,
+                    ServiceId: serviceId,
+                    Direction: string.Equals(syncDirection, "upload", StringComparison.OrdinalIgnoreCase)
+                        ? ReplicaSyncDirection.Upload
+                        : ReplicaSyncDirection.Bidirectional,
+                    BaseGeneration: replica.LastSyncGeneration,
+                    LayerEdits: layerEdits,
+                    LastWriteWins: true,
+                    SyncOperationId: context.TraceIdentifier);
 
-                // If the edit handler returned an error, pass it through
-                if (editResult is not Microsoft.AspNetCore.Http.HttpResults.JsonHttpResult<ApplyEditsResponse> jsonResult)
-                {
-                    return editResult;
-                }
-
-                if (jsonResult.Value is not { } applyResponse ||
-                    !applyResponse.Success ||
-                    HasFailedEditResult(applyResponse.AddResults) ||
-                    HasFailedEditResult(applyResponse.UpdateResults) ||
-                    HasFailedEditResult(applyResponse.DeleteResults))
+                var report = await syncService.ApplyUploadAsync(syncRequest, applier, cancellationToken);
+                if (!report.Success)
                 {
                     return StandardErrorHelpers.CreateBadRequest(
                         context,
                         "Uploaded replica edits failed to apply.");
                 }
+
+                appliedAdds = report.AppliedAdds;
+                appliedUpdates = report.AppliedUpdates;
+                appliedDeletes = report.AppliedDeletes;
+                conflicts = MapSyncConflicts(report.Conflicts);
+                uploadServerGen = report.ServerGeneration;
+                didUpload = true;
             }
         }
 
-        // Update the last sync time and generation in distributed store.
-        var changeTracker = context.RequestServices.GetRequiredService<IChangeTracker>();
-        var currentGen = await changeTracker.GetCurrentGenerationAsync(cancellationToken);
+        // The server generation cursor recorded for the replica. After an upload we record the
+        // post-apply generation as both the last-sync and upload-base cursor so a subsequent download
+        // delta excludes the client's own just-applied edits. Download-only syncs simply advance the
+        // last-sync cursor to the current generation.
+        var currentGen = didUpload
+            ? uploadServerGen
+            : await changeTracker.GetCurrentGenerationAsync(cancellationToken);
+
         var updated = replica with
         {
             LastSyncTime = DateTimeOffset.UtcNow,
-            LastSyncGeneration = currentGen
+            LastSyncGeneration = currentGen,
+            UploadBaseGeneration = didUpload ? currentGen : replica.UploadBaseGeneration
         };
         await replicaStore.SetAsync(updated, cancellationToken: cancellationToken);
 
@@ -870,15 +886,195 @@ internal static partial class FeatureServerEndpoints
             Success = true,
             ReplicaId = replicaId,
             SyncDirection = syncDirection,
-            ServerGen = currentGen
+            ServerGen = currentGen,
+            AppliedAdds = appliedAdds,
+            AppliedUpdates = appliedUpdates,
+            AppliedDeletes = appliedDeletes,
+            Conflicts = conflicts
         };
 
         return Results.Json(response, FeatureServerJsonContext.Default.SynchronizeReplicaResponse, contentType: "application/json");
     }
 
-    private static bool HasFailedEditResult(EditResult[]? results)
+    /// <summary>
+    /// Maps canonical sync conflicts to the wire conflict summary.
+    /// </summary>
+    private static SynchronizeReplicaConflict[]? MapSyncConflicts(
+        ImmutableArray<ReplicaSyncConflict> conflicts)
     {
-        return results is not null && Array.Exists(results, static result => !result.Success);
+        if (conflicts.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        var result = new SynchronizeReplicaConflict[conflicts.Length];
+        for (var i = 0; i < conflicts.Length; i++)
+        {
+            var conflict = conflicts[i];
+            result[i] = new SynchronizeReplicaConflict
+            {
+                LayerId = conflict.PublicLayerId,
+                ObjectId = conflict.ObjectId,
+                ConflictType = (int)conflict.ConflictType,
+                Applied = conflict.Applied,
+                ConflictId = conflict.ConflictId
+            };
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Parses the <c>synchronizeReplica</c> <c>edits</c> parameter into canonical per-layer upload
+    /// edits. Accepts the ArcGIS per-layer form (a JSON array of
+    /// <c>{ id, adds, updates, deletes }</c> objects) and, for backward compatibility, the legacy flat
+    /// array of features (interpreted as adds against the replica's first layer). Edits referencing a
+    /// layer not in the replica are rejected.
+    /// </summary>
+    private static bool TryParseSynchronizeReplicaEdits(
+        string editsJson,
+        ReplicaLayerV2[] replicaLayers,
+        out ImmutableArray<ReplicaUploadLayerEdits> layerEdits,
+        out string? error)
+    {
+        layerEdits = ImmutableArray<ReplicaUploadLayerEdits>.Empty;
+        error = null;
+
+        var storageByPublicId = replicaLayers
+            .DistinctBy(layer => layer.PublicLayerId)
+            .ToDictionary(layer => layer.PublicLayerId, layer => layer.StorageLayerId);
+
+        var trimmed = editsJson.TrimStart();
+
+        // The per-layer form is an array of objects ("[{...}]"); the legacy flat form is an array of
+        // features which are also objects. Disambiguate by probing for the per-layer "id" shape.
+        SynchronizeReplicaLayerEdits[]? perLayer = null;
+        var parsedPerLayer = false;
+        if (trimmed.StartsWith('['))
+        {
+            try
+            {
+                perLayer = System.Text.Json.JsonSerializer.Deserialize(
+                    editsJson, FeatureServerJsonContext.Default.SynchronizeReplicaLayerEditsArray);
+                parsedPerLayer = perLayer is { Length: > 0 }
+                    && perLayer.All(static entry => entry is not null);
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                parsedPerLayer = false;
+            }
+        }
+
+        var builder = ImmutableArray.CreateBuilder<ReplicaUploadLayerEdits>();
+
+        if (parsedPerLayer && perLayer is not null &&
+            perLayer.Any(static entry =>
+                entry.Adds is { Length: > 0 } ||
+                entry.Updates is { Length: > 0 } ||
+                entry.Deletes is { Length: > 0 }))
+        {
+            foreach (var entry in perLayer)
+            {
+                if (!storageByPublicId.TryGetValue(entry.Id, out var storageLayerId))
+                {
+                    error = $"edits reference layer {entry.Id} which is not part of this replica.";
+                    return false;
+                }
+
+                var edits = ImmutableArray.CreateBuilder<ReplicaUploadEdit>();
+                if (entry.Adds is not null)
+                {
+                    foreach (var add in entry.Adds)
+                    {
+                        edits.Add(new ReplicaUploadEdit(FeatureEditOperationKind.Create, ObjectId: null, Payload: add));
+                    }
+                }
+
+                if (entry.Updates is not null)
+                {
+                    foreach (var update in entry.Updates)
+                    {
+                        edits.Add(new ReplicaUploadEdit(
+                            FeatureEditOperationKind.Update,
+                            ObjectId: TryReadObjectId(update),
+                            Payload: update));
+                    }
+                }
+
+                if (entry.Deletes is not null)
+                {
+                    foreach (var deleteId in entry.Deletes)
+                    {
+                        edits.Add(new ReplicaUploadEdit(FeatureEditOperationKind.Delete, ObjectId: deleteId, Payload: null));
+                    }
+                }
+
+                if (edits.Count > 0)
+                {
+                    builder.Add(new ReplicaUploadLayerEdits(entry.Id, storageLayerId, edits.ToImmutable()));
+                }
+            }
+
+            layerEdits = builder.ToImmutable();
+            return true;
+        }
+
+        // Legacy flat form: an array of features applied as adds to the first replica layer.
+        GeoServicesFeature[]? features;
+        try
+        {
+            features = System.Text.Json.JsonSerializer.Deserialize(
+                editsJson, FeatureServerJsonContext.Default.GeoServicesFeatureArray);
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            error = "edits must be a valid JSON array of features or per-layer edit objects.";
+            return false;
+        }
+
+        if (features is { Length: > 0 })
+        {
+            var firstLayer = replicaLayers[0];
+            var edits = ImmutableArray.CreateBuilder<ReplicaUploadEdit>(features.Length);
+            foreach (var feature in features)
+            {
+                edits.Add(new ReplicaUploadEdit(FeatureEditOperationKind.Create, ObjectId: null, Payload: feature));
+            }
+
+            builder.Add(new ReplicaUploadLayerEdits(firstLayer.PublicLayerId, firstLayer.StorageLayerId, edits.ToImmutable()));
+        }
+
+        layerEdits = builder.ToImmutable();
+        return true;
+    }
+
+    /// <summary>
+    /// Reads the object id attribute from an Esri-JSON update feature for conflict keying. Returns
+    /// null when no recognizable object id attribute is present; conflict detection then treats the
+    /// update as non-conflicting (the shared edit pipeline still rejects updates without an id).
+    /// </summary>
+    private static long? TryReadObjectId(GeoServicesFeature feature)
+    {
+        if (feature.Attributes is null)
+        {
+            return null;
+        }
+
+        foreach (var (key, value) in feature.Attributes)
+        {
+            if (key.Equals(FieldNames.ObjectId, StringComparison.OrdinalIgnoreCase) ||
+                key.Equals("objectid", StringComparison.OrdinalIgnoreCase) ||
+                key.Equals("oid", StringComparison.OrdinalIgnoreCase) ||
+                key.Equals("fid", StringComparison.OrdinalIgnoreCase))
+            {
+                if (FeatureServerValueParser.TryConvertToLong(value, out var objectId))
+                {
+                    return objectId;
+                }
+            }
+        }
+
+        return null;
     }
 
     private static async Task<IResult> HandleUnRegisterReplica(
@@ -1198,7 +1394,8 @@ internal static partial class FeatureServerEndpoints
         record.CreatedAt)
     {
         LastSyncTime = record.LastSyncTime,
-        LastSyncGeneration = record.LastSyncGeneration
+        LastSyncGeneration = record.LastSyncGeneration,
+        UploadBaseGeneration = record.UploadBaseGeneration
     };
 
     private static async Task<IResult?> RequireReplicaWriteAccessV2Async(

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Models/FeatureServerJsonContext.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Models/FeatureServerJsonContext.cs
@@ -120,6 +120,10 @@ namespace Honua.Protocols.GeoServices.FeatureServer.Models;
 [JsonSerializable(typeof(DistributedReplicaStore.ReplicaStateEnvelope))]
 [JsonSerializable(typeof(SynchronizeReplicaRequest))]
 [JsonSerializable(typeof(SynchronizeReplicaResponse))]
+[JsonSerializable(typeof(SynchronizeReplicaConflict))]
+[JsonSerializable(typeof(SynchronizeReplicaConflict[]))]
+[JsonSerializable(typeof(SynchronizeReplicaLayerEdits))]
+[JsonSerializable(typeof(SynchronizeReplicaLayerEdits[]), TypeInfoPropertyName = "SynchronizeReplicaLayerEditsArray")]
 [JsonSerializable(typeof(UnRegisterReplicaRequest))]
 [JsonSerializable(typeof(SuccessResponse))]
 // Maintenance models

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Models/ReplicationModels.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Models/ReplicationModels.cs
@@ -423,6 +423,91 @@ public sealed class SynchronizeReplicaResponse
     /// </summary>
     [JsonPropertyName("serverGen")]
     public long ServerGen { get; set; }
+
+    /// <summary>
+    /// Number of uploaded add operations applied during this synchronization. Omitted (null) for
+    /// download-only syncs that carry no upload.
+    /// </summary>
+    [JsonPropertyName("appliedAdds")]
+    public int? AppliedAdds { get; set; }
+
+    /// <summary>
+    /// Number of uploaded update operations applied during this synchronization.
+    /// </summary>
+    [JsonPropertyName("appliedUpdates")]
+    public int? AppliedUpdates { get; set; }
+
+    /// <summary>
+    /// Number of uploaded delete operations applied during this synchronization.
+    /// </summary>
+    [JsonPropertyName("appliedDeletes")]
+    public int? AppliedDeletes { get; set; }
+
+    /// <summary>
+    /// Conflicts detected while applying the uploaded edits, when any. A non-empty list does not by
+    /// itself fail the sync under last-write-wins; durable conflict records are written for review
+    /// when supported (#1287).
+    /// </summary>
+    [JsonPropertyName("conflicts")]
+    public SynchronizeReplicaConflict[]? Conflicts { get; set; }
+}
+
+/// <summary>
+/// Summary of a single conflict detected while applying uploaded replica edits.
+/// </summary>
+public sealed class SynchronizeReplicaConflict
+{
+    /// <summary>Service-local layer id of the conflicting feature.</summary>
+    [JsonPropertyName("layerId")]
+    public int LayerId { get; set; }
+
+    /// <summary>Stable object id of the conflicting feature.</summary>
+    [JsonPropertyName("objectId")]
+    public long ObjectId { get; set; }
+
+    /// <summary>
+    /// Conflict classification ordinal (see <c>ReplicaConflictType</c>): 0=attribute, 1=geometry,
+    /// 2=delete-update, 3=update-delete, 4=duplicate-insert, 5=attachment, 6=relationship.
+    /// </summary>
+    [JsonPropertyName("conflictType")]
+    public int ConflictType { get; set; }
+
+    /// <summary>
+    /// Whether the client edit was still applied (last-write-wins) despite the conflict.
+    /// </summary>
+    [JsonPropertyName("applied")]
+    public bool Applied { get; set; }
+
+    /// <summary>
+    /// Durable conflict-record id when a record was written for review; null when conflict review is
+    /// unsupported by the provider.
+    /// </summary>
+    [JsonPropertyName("conflictId")]
+    public string? ConflictId { get; set; }
+}
+
+/// <summary>
+/// A single layer's uploaded edits within the <c>synchronizeReplica</c> <c>edits</c> parameter. The
+/// ArcGIS sync <c>edits</c> payload is a JSON array of these per-layer objects; each carries Esri-JSON
+/// adds/updates and delete object ids for one layer.
+/// </summary>
+public sealed class SynchronizeReplicaLayerEdits
+{
+    /// <summary>Service-local layer id the edits target.</summary>
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    /// <summary>Features to add (Esri JSON).</summary>
+    [JsonPropertyName("adds")]
+    public GeoServicesFeature[]? Adds { get; set; }
+
+    /// <summary>Features to update (Esri JSON; each must carry its object id attribute).</summary>
+    [JsonPropertyName("updates")]
+    public GeoServicesFeature[]? Updates { get; set; }
+
+    /// <summary>Object ids to delete.</summary>
+    [JsonPropertyName("deletes")]
+    public long[]? Deletes { get; set; }
 }
 
 /// <summary>

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/CachingReplicaStore.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/CachingReplicaStore.cs
@@ -98,7 +98,8 @@ internal sealed partial class CachingReplicaStore : IReplicaStore
         LayerIds = state.LayerIds,
         CreatedAt = state.CreatedAt,
         LastSyncTime = state.LastSyncTime,
-        LastSyncGeneration = state.LastSyncGeneration
+        LastSyncGeneration = state.LastSyncGeneration,
+        UploadBaseGeneration = state.UploadBaseGeneration
     };
 
     private static ReplicaState ToState(ReplicaRecord record) => new(
@@ -110,7 +111,8 @@ internal sealed partial class CachingReplicaStore : IReplicaStore
         record.CreatedAt)
     {
         LastSyncTime = record.LastSyncTime,
-        LastSyncGeneration = record.LastSyncGeneration
+        LastSyncGeneration = record.LastSyncGeneration,
+        UploadBaseGeneration = record.UploadBaseGeneration
     };
 
     private static partial class Log

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureServerReplicaEditApplier.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureServerReplicaEditApplier.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Configuration;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Protocols.GeoServices.FeatureServer.Models;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Honua.Protocols.GeoServices.FeatureServer.Services;
+
+/// <summary>
+/// GeoServices-backed <see cref="IReplicaEditApplier"/> that applies resolved replica upload edits
+/// through the shared FeatureServer applyEdits pipeline (<see cref="FeatureServerEditsHandler"/>), so
+/// uploaded edits reuse the same validation, authorization, geometry conversion, telemetry, and
+/// transactional outbox behavior as ordinary edits rather than the replica path issuing its own data
+/// access (#1272).
+/// </summary>
+/// <remarks>
+/// The canonical <see cref="IReplicaSyncService"/> owns conflict detection and only passes the edits
+/// it decided to apply; this applier maps each <see cref="ReplicaUploadEdit"/> back to its GeoServices
+/// wire payload and dispatches a single <c>applyEdits</c> per layer. Edits are applied with
+/// <see cref="ApplyEditsRequest.RollbackOnFailure"/> set to <c>false</c> so a single bad row does not
+/// discard the rest of the upload (matching the prior synchronize behavior and Esri sync semantics).
+/// </remarks>
+internal sealed class FeatureServerReplicaEditApplier : IReplicaEditApplier
+{
+    private readonly FeatureServerEditsHandler _editsHandler;
+    private readonly EditLimits _editLimits;
+
+    public FeatureServerReplicaEditApplier(FeatureServerEditsHandler editsHandler, EditLimits editLimits)
+    {
+        _editsHandler = editsHandler ?? throw new ArgumentNullException(nameof(editsHandler));
+        _editLimits = editLimits;
+    }
+
+    public async Task<ReplicaLayerApplyResult> ApplyAsync(
+        string serviceId,
+        int publicLayerId,
+        ImmutableArray<ReplicaUploadEdit> edits,
+        CancellationToken cancellationToken = default)
+    {
+        if (edits.IsDefaultOrEmpty)
+        {
+            return new ReplicaLayerApplyResult(publicLayerId, 0, 0, 0, Failed: false, FailureMessage: null);
+        }
+
+        var adds = new List<GeoServicesFeature>();
+        var updates = new List<GeoServicesFeature>();
+        var deletes = new List<object>();
+
+        foreach (var edit in edits)
+        {
+            switch (edit.Kind)
+            {
+                case FeatureEditOperationKind.Create when edit.Payload is GeoServicesFeature add:
+                    adds.Add(add);
+                    break;
+                case FeatureEditOperationKind.Update when edit.Payload is GeoServicesFeature update:
+                    updates.Add(update);
+                    break;
+                case FeatureEditOperationKind.Delete when edit.ObjectId is { } objectId:
+                    deletes.Add(objectId);
+                    break;
+                default:
+                    // A payload that does not match its declared kind is a programming error in the
+                    // adapter; treat the layer apply as failed rather than silently dropping the edit.
+                    return new ReplicaLayerApplyResult(
+                        publicLayerId, 0, 0, 0, Failed: true,
+                        FailureMessage: "Uploaded replica edit payload did not match its operation kind.");
+            }
+        }
+
+        var request = new ApplyEditsRequest
+        {
+            Adds = adds.Count > 0 ? adds.ToArray() : null,
+            Updates = updates.Count > 0 ? updates.ToArray() : null,
+            Deletes = deletes.Count > 0 ? deletes.ToArray() : null,
+            RollbackOnFailure = false,
+        };
+
+        var editResult = await _editsHandler.HandleApplyEditsAsync(
+            serviceId, publicLayerId, request, _editLimits, cancellationToken).ConfigureAwait(false);
+
+        if (editResult is not JsonHttpResult<ApplyEditsResponse> { Value: { } response })
+        {
+            // The shared handler returned an error result (validation/auth/etc.). Report the layer as
+            // failed; the synchronize adapter maps this to a bad-request without leaking internals.
+            return new ReplicaLayerApplyResult(
+                publicLayerId, 0, 0, 0, Failed: true,
+                FailureMessage: "Uploaded replica edits failed to apply.");
+        }
+
+        var appliedAdds = CountSuccessful(response.AddResults);
+        var appliedUpdates = CountSuccessful(response.UpdateResults);
+        var appliedDeletes = CountSuccessful(response.DeleteResults);
+        var failed = !response.Success
+            || HasFailure(response.AddResults)
+            || HasFailure(response.UpdateResults)
+            || HasFailure(response.DeleteResults);
+
+        return new ReplicaLayerApplyResult(
+            publicLayerId,
+            appliedAdds,
+            appliedUpdates,
+            appliedDeletes,
+            Failed: failed,
+            FailureMessage: failed ? "Uploaded replica edits failed to apply." : null);
+    }
+
+    private static int CountSuccessful(EditResult[]? results)
+        => results is null ? 0 : results.Count(static r => r.Success);
+
+    private static bool HasFailure(EditResult[]? results)
+        => results is not null && Array.Exists(results, static r => !r.Success);
+}

--- a/src/Honua.Server/Migrations/046_AddReplicaUploadBaseGeneration.sql
+++ b/src/Honua.Server/Migrations/046_AddReplicaUploadBaseGeneration.sql
@@ -1,0 +1,17 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration: 046_AddReplicaUploadBaseGeneration.sql
+-- Description: Adds a per-replica upload base/target generation cursor so a download delta
+--              following an upload sync can exclude the client's own just-applied edits. The
+--              upload sync advances this cursor to the server generation produced once the
+--              uploaded edits have been applied; the subsequent download uses it as the
+--              "since" cursor instead of last_sync_generation, which would otherwise replay the
+--              client's own edits back to it (#1272).
+-- Dependencies: Requires honua.replicas (012_AddReplicationDurability.sql).
+
+ALTER TABLE honua.replicas
+    ADD COLUMN IF NOT EXISTS upload_base_generation BIGINT NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN honua.replicas.upload_base_generation IS
+    'Server generation produced by the most recent upload sync; used as the download "since" cursor so a replica does not receive its own just-applied edits back (#1272)';

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -542,6 +542,12 @@ builder.Services.AddScoped<Honua.Protocols.GeoServices.FeatureServer.IReplicaSto
     new Honua.Protocols.GeoServices.FeatureServer.Services.CachingReplicaStore(
         sp.GetRequiredService<Honua.Protocols.GeoServices.FeatureServer.DistributedReplicaStore>(),
         sp.GetRequiredService<Honua.Core.Features.FeatureStore.Abstractions.IReplicaRepository>()));
+// Canonical replica-upload synchronization pipeline (#1272). Conflict detection runs against the
+// provider's change log; conflict-record writes use the durable conflict store when supported and
+// otherwise fall back to last-write-wins. Available for all providers since IChangeTracker and
+// IReplicaConflictRepository are always registered (read-only providers register no-op stubs).
+builder.Services.AddScoped<Honua.Core.Features.FeatureStore.Abstractions.IReplicaSyncService,
+    Honua.Core.Features.FeatureStore.Services.ReplicaSyncService>();
 
 // ---- Extracted: import/export job managers, migration evidence, tile operations
 //      (Startup/ImportExportTileOperationsRegistration.cs)

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicaSyncTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicaSyncTests.cs
@@ -1,0 +1,278 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
+
+/// <summary>
+/// Track A (#1272) coverage for the canonical replica-upload synchronization pipeline:
+/// multi-layer uploads, upload+download round-trips that exclude the client's own edits,
+/// base-generation conflict detection with durable conflict records, and last-write-wins behavior.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.FeatureServer)]
+public sealed class FeatureServerReplicaSyncTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.SynchronizeReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/synchronizeReplica")]
+    public async Task SynchronizeReplica_MultiLayerUpload_AppliesPerLayerEdits()
+    {
+        var replicaId = await CreateReplicaAsync("MultiLayerUpload", "0,1");
+
+        // Per-layer edits payload: one add on layer 0, one add on layer 1.
+        var edits = JsonSerializer.Serialize(new object[]
+        {
+            new { id = 0, adds = new[] { new { attributes = new { name = "layer0-add" } } } },
+            new { id = 1, adds = new[] { new { attributes = new { name = "layer1-add" } } } }
+        });
+
+        var root = await SynchronizeUploadAsync(replicaId, edits);
+
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+        root.GetProperty("appliedAdds").GetInt32().Should().Be(2);
+        root.GetProperty("appliedUpdates").GetInt32().Should().Be(0);
+        root.GetProperty("appliedDeletes").GetInt32().Should().Be(0);
+        // No prior server edits to these new features: no conflicts (the property is omitted when null).
+        HasNoConflicts(root).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.SynchronizeReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/synchronizeReplica")]
+    public async Task SynchronizeReplica_UploadThenExtract_ExcludesOwnEdits()
+    {
+        var replicaId = await CreateReplicaAsync("RoundTrip", "0");
+
+        // Establish a download baseline so the replica's cursor is at the current generation.
+        await SynchronizeDownloadAsync(replicaId);
+
+        // Upload an add through the replica.
+        var edits = JsonSerializer.Serialize(new object[]
+        {
+            new { id = 0, adds = new[] { new { attributes = new { name = "roundtrip-add" } } } }
+        });
+        var uploadRoot = await SynchronizeUploadAsync(replicaId, edits);
+        uploadRoot.GetProperty("appliedAdds").GetInt32().Should().Be(1);
+
+        // A subsequent extractChanges (download delta) must not return the client's own just-applied
+        // edit, because the upload advanced the replica's sync cursor past it.
+        var extractPayload = JsonSerializer.Serialize(new { replicaID = replicaId, f = "json" });
+        var extractResponse = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/extractChanges",
+            new StringContent(extractPayload, Encoding.UTF8, "application/json"));
+        extractResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var extractDoc = JsonDocument.Parse(await extractResponse.Content.ReadAsStringAsync());
+        var layerChanges = extractDoc.RootElement.GetProperty("layerChanges");
+        foreach (var layer in layerChanges.EnumerateArray())
+        {
+            layer.GetProperty("adds").GetInt32().Should().Be(0, "the replica must not receive its own just-applied edits back");
+            layer.GetProperty("updates").GetInt32().Should().Be(0);
+            layer.GetProperty("deletes").GetInt32().Should().Be(0);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.SynchronizeReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/synchronizeReplica")]
+    public async Task SynchronizeReplica_ConcurrentServerEdit_RecordsConflictAndAppliesLastWriteWins()
+    {
+        // Seed a feature the client and server will both edit.
+        var objectId = await AddFeatureAsync("conflict-base");
+
+        // Create the replica AFTER the seed and establish a base cursor at the current generation.
+        var replicaId = await CreateReplicaAsync("ConflictTest", "0");
+        await SynchronizeDownloadAsync(replicaId);
+
+        // Server-side concurrent edit to the same feature (advances the change log past the base).
+        await UpdateFeatureAsync(objectId, "server-wins-attempt");
+
+        // Client uploads a conflicting update to the same feature.
+        var edits = JsonSerializer.Serialize(new object[]
+        {
+            new
+            {
+                id = 0,
+                updates = new[]
+                {
+                    new { attributes = new Dictionary<string, object?> { ["objectid"] = objectId, ["name"] = "client-wins" } }
+                }
+            }
+        });
+        var root = await SynchronizeUploadAsync(replicaId, edits);
+
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+
+        // A conflict is reported and, under the default last-write-wins strategy, still applied.
+        root.TryGetProperty("conflicts", out var conflicts).Should().BeTrue();
+        conflicts.ValueKind.Should().Be(JsonValueKind.Array);
+        conflicts.GetArrayLength().Should().Be(1);
+        var conflict = conflicts[0];
+        conflict.GetProperty("layerId").GetInt32().Should().Be(0);
+        conflict.GetProperty("objectId").GetInt64().Should().Be(objectId);
+        conflict.GetProperty("applied").GetBoolean().Should().BeTrue();
+
+        // A durable conflict record was written (conflict review supported on Postgres).
+        var conflictId = conflict.GetProperty("conflictId").GetString();
+        conflictId.Should().NotBeNullOrWhiteSpace();
+        var conflictRepo = _fixture.GetService<IReplicaConflictRepository>();
+        var record = await conflictRepo.GetAsync(conflictId!);
+        record.Should().NotBeNull();
+        record!.Value.ReplicaId.Should().Be(replicaId);
+        record.Value.ObjectId.Should().Be(objectId);
+        record.Value.Status.Should().Be(ReplicaConflictStatus.Pending);
+
+        // Last-write-wins: the client's value is the committed server state.
+        var serverName = await ReadFeatureNameAsync(objectId);
+        serverName.Should().Be("client-wins");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.SynchronizeReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/synchronizeReplica")]
+    public async Task SynchronizeReplica_NoConcurrentServerEdit_AppliesWithoutConflict()
+    {
+        var objectId = await AddFeatureAsync("no-conflict-base");
+        var replicaId = await CreateReplicaAsync("NoConflictTest", "0");
+        await SynchronizeDownloadAsync(replicaId);
+
+        // No server-side edit between base and upload: the client's update is conflict-free.
+        var edits = JsonSerializer.Serialize(new object[]
+        {
+            new
+            {
+                id = 0,
+                updates = new[]
+                {
+                    new { attributes = new Dictionary<string, object?> { ["objectid"] = objectId, ["name"] = "client-only" } }
+                }
+            }
+        });
+        var root = await SynchronizeUploadAsync(replicaId, edits);
+
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+        root.GetProperty("appliedUpdates").GetInt32().Should().Be(1);
+        HasNoConflicts(root).Should().BeTrue();
+
+        var serverName = await ReadFeatureNameAsync(objectId);
+        serverName.Should().Be("client-only");
+    }
+
+    private static bool HasNoConflicts(JsonElement root)
+        => !root.TryGetProperty("conflicts", out var conflicts)
+           || conflicts.ValueKind == JsonValueKind.Null
+           || conflicts.GetArrayLength() == 0;
+
+    private async Task<string> CreateReplicaAsync(string name, string layers)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            replicaName = name,
+            layers,
+            syncModel = "perReplica",
+            f = "json"
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/createReplica",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("replicaID").GetString()!;
+    }
+
+    private async Task SynchronizeDownloadAsync(string replicaId)
+    {
+        var payload = JsonSerializer.Serialize(new { replicaID = replicaId, syncDirection = "download", f = "json" });
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/synchronizeReplica",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private async Task<JsonElement> SynchronizeUploadAsync(string replicaId, string editsJson)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            replicaID = replicaId,
+            syncDirection = "upload",
+            edits = editsJson,
+            f = "json"
+        });
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/synchronizeReplica",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonDocument.Parse(content).RootElement.Clone();
+    }
+
+    private async Task<long> AddFeatureAsync(string name)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            adds = new[] { new { attributes = new { name } } },
+            f = "json"
+        });
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/applyEdits",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var addResults = doc.RootElement.GetProperty("addResults");
+        addResults.GetArrayLength().Should().Be(1);
+        addResults[0].GetProperty("success").GetBoolean().Should().BeTrue();
+        return addResults[0].GetProperty("objectId").GetInt64();
+    }
+
+    private async Task UpdateFeatureAsync(long objectId, string name)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            updates = new[]
+            {
+                new { attributes = new Dictionary<string, object?> { ["objectid"] = objectId, ["name"] = name } }
+            },
+            f = "json"
+        });
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/applyEdits",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("updateResults")[0].GetProperty("success").GetBoolean().Should().BeTrue();
+    }
+
+    private async Task<string?> ReadFeatureNameAsync(long objectId)
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query" +
+            $"?where=objectid={objectId}&outFields=*&returnGeometry=false&f=json");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var features = doc.RootElement.GetProperty("features");
+        features.GetArrayLength().Should().Be(1);
+        return features[0].GetProperty("attributes").GetProperty("name").GetString();
+    }
+}

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -861,6 +861,7 @@ sql:
           CONSTRAINT replicas_valid_service CHECK(LENGTH(service_id) > 0),
           CONSTRAINT replicas_valid_sync_model CHECK(sync_model IN ('none', 'perLayer', 'perReplica'))
       );
+  - "ALTER TABLE honua.replicas ADD COLUMN IF NOT EXISTS upload_base_generation BIGINT NOT NULL DEFAULT 0;"
   - |
       CREATE TABLE IF NOT EXISTS honua.feature_changes (
           change_id BIGSERIAL PRIMARY KEY,


### PR DESCRIPTION
## Issue Link
Fixes #1272

## Summary
Track A of #1272 hardens the offline-replica / change-tracking sync path. Previously `HandleSynchronizeReplica` blindly applied uploaded edits to `replicaLayers[0]` as adds only, did no base-generation conflict check, and never wrote conflict records. This PR introduces a canonical replica-sync pipeline that resolves uploaded edits per-layer with full add/update/delete typing, detects server-side conflicts against the replica's base generation via the change log, applies non-conflicting edits through the shared edit pipeline, and writes durable conflict records when supported (falling back to last-write-wins otherwise). A per-replica upload cursor ensures a subsequent download delta excludes the client's own just-applied edits.

This is the first of two PRs for #1272. Track B (branch versioning + `gdbVersion` routing, XL) is a separate follow-up PR.

## Changes Made
- Added canonical `IReplicaSyncService`/`ReplicaSyncService` (`Honua.Core`) that takes the replica's `LastSyncGeneration` as the base cursor, types incoming edits per-layer, queries `IChangeTracker.GetChangesSinceAsync(base, layers)` to detect server-side mutation of the same `(layer_id, objectid)` since base, applies non-conflicting (and, under last-write-wins, conflicting) edits, and returns an upload report (applied add/update/delete counts, conflicts[], serverGen).
- Added `IReplicaEditApplier` abstraction so the canonical service applies edits through the protocol's shared edit pipeline rather than issuing its own data access; GeoServices supplies `FeatureServerReplicaEditApplier` backed by `FeatureServerEditsHandler` (preserves validation/auth/geometry/telemetry/outbox).
- Rewrote `HandleSynchronizeReplica` as a thin adapter: parses the `edits` parameter (ArcGIS per-layer form `[{id,adds,updates,deletes}]` plus the legacy flat feature-array form for backward compatibility), maps to the canonical `ReplicaSyncRequest`, and returns applied counts + a conflict summary.
- Conflict records are written via `IReplicaConflictRepository.UpsertAsync` (base/client/server classification) gated behind `SupportsConflictReview`; when unsupported, behavior falls back to last-write-wins. Conflict-record creation-on-upload + the resolution API remain owned by #1287 — this PR only writes pending records and does not add the review/resolution surface.
- Added a per-replica `upload_base_generation` cursor (additive `ALTER TABLE honua.replicas`, migration `046_AddReplicaUploadBaseGeneration.sql` + matching idempotent ALTER in `tests/seed/server.yaml`); the upload sync advances the replica's sync cursor to the post-apply generation so a subsequent download delta excludes the client's own edits.
- Registered new DTOs (`SynchronizeReplicaConflict`, `SynchronizeReplicaLayerEdits`) in the source-generated `FeatureServerJsonContext`; extended `SynchronizeReplicaResponse` with `appliedAdds/Updates/Deletes` and `conflicts`.
- Added Testcontainers + PostGIS integration tests: multi-layer upload, upload+extract round-trip excludes own edits, concurrent server edit records a conflict and applies last-write-wins, conflict-free update.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

New tests (Testcontainers + PostGIS): 4/4 passing. Existing replication regression suite (ReplicationDurabilityTests, FeatureServerReplicationTests, MobileOfflineDemoFixtureReplicationTests): 34/34 passing. Architecture tests: 104 passed / 1 skipped. Release build with `TreatWarningsAsErrors=true` clean across Honua.Core, Honua.Postgres, Honua.Protocols.GeoServices, Honua.Server. `dotnet format Honua.sln` clean.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

The `synchronizeReplica` response gains additive, optional fields (`appliedAdds/Updates/Deletes`, `conflicts`); existing fields are unchanged.

## Release/Deploy Impact
- [x] Requires database migration

Migration `046_AddReplicaUploadBaseGeneration.sql` is additive and idempotent (`ADD COLUMN IF NOT EXISTS ... DEFAULT 0`).

## Breaking Changes
None. `gdbVersion` rejection behavior is unchanged (branch versioning is Track B). Upload edits now flow through the canonical conflict-aware path, but the legacy flat-array `edits` form is still accepted and existing behavior (including upload-failure non-advancement of generation) is preserved.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review