### PR TITLE
feat: branch-versioning storage + canonical abstraction foundation (#1272 Track B)

### DIFF
--- a/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/GdbVersion.cs
+++ b/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/GdbVersion.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.FeatureStore.Domain;
+
+/// <summary>
+/// Access level of a branch version. Mirrors the Esri version access taxonomy but is exposed as a
+/// Honua product contract (#1272 Track B).
+/// </summary>
+public enum VersionAccess
+{
+    /// <summary>Only the owner may read or edit the version.</summary>
+    Private = 0,
+
+    /// <summary>Anyone may read; only the owner may edit.</summary>
+    Protected = 1,
+
+    /// <summary>Anyone may read or edit the version.</summary>
+    Public = 2,
+}
+
+/// <summary>
+/// Lifecycle state of a branch version.
+/// </summary>
+public enum VersionState
+{
+    /// <summary>Version is editable and queryable.</summary>
+    Active = 0,
+
+    /// <summary>A reconcile is in progress; the version is locked.</summary>
+    Reconciling = 1,
+
+    /// <summary>A post is in progress; the version is locked.</summary>
+    Posting = 2,
+
+    /// <summary>Version has been deleted.</summary>
+    Deleted = 3,
+}
+
+/// <summary>
+/// A branch version: a named branch off DEFAULT that accumulates isolated edits which are later
+/// reconciled against and posted back to DEFAULT. The DEFAULT version is implicit (represented by a
+/// null version context everywhere) and is never materialized as a <see cref="GdbVersion"/> row, so
+/// existing non-versioned read/write paths stay byte-identical (#1272 Track B).
+/// </summary>
+public readonly record struct GdbVersion
+{
+    /// <summary>Unique version identifier.</summary>
+    public required Guid VersionId { get; init; }
+
+    /// <summary>Esri-style <c>owner.name</c> version identity.</summary>
+    public required string VersionName { get; init; }
+
+    /// <summary>Version owner.</summary>
+    public required string Owner { get; init; }
+
+    /// <summary>Parent version this branch was created from; null when branched from DEFAULT.</summary>
+    public Guid? ParentVersion { get; init; }
+
+    /// <summary>Access level.</summary>
+    public required VersionAccess Access { get; init; }
+
+    /// <summary>Lifecycle state.</summary>
+    public required VersionState State { get; init; }
+
+    /// <summary>
+    /// DEFAULT generation the branch last reconciled against (its merge base). Reconcile pulls
+    /// DEFAULT changes since this cursor into the version.
+    /// </summary>
+    public required long CommonAncestorGeneration { get; init; }
+
+    /// <summary>Latest generation produced by edits within this version.</summary>
+    public required long BranchGeneration { get; init; }
+
+    /// <summary>Optional human-readable description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Timestamp (UTC) when the version was created.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>Timestamp (UTC) when the version was last modified.</summary>
+    public required DateTimeOffset ModifiedAt { get; init; }
+}
+
+/// <summary>
+/// The version a read or edit operation targets, threaded through the shared query/edit pipeline. A
+/// null <see cref="VersionContext"/> (or <see cref="IsDefault"/>) means the DEFAULT version, which is
+/// byte-identical to the non-versioned base path. Reads overlay the version's deltas onto the
+/// DEFAULT base; writes set the transaction-scoped version GUC so the change-tracking trigger tags
+/// produced changes with the version (#1272 Track B).
+/// </summary>
+public readonly record struct VersionContext
+{
+    /// <summary>
+    /// The DEFAULT version context. Read/write paths must treat this exactly as the non-versioned
+    /// base path (no overlay, no GUC).
+    /// </summary>
+    public static VersionContext Default => new() { VersionId = null };
+
+    /// <summary>Target version id; null for DEFAULT.</summary>
+    public Guid? VersionId { get; init; }
+
+    /// <summary>Esri-style <c>owner.name</c> identity, for diagnostics/links; null for DEFAULT.</summary>
+    public string? VersionName { get; init; }
+
+    /// <summary>
+    /// The branch's merge base (DEFAULT generation last reconciled against). Used by the read overlay
+    /// to bound the version-delta scan; meaningless for DEFAULT.
+    /// </summary>
+    public long CommonAncestorGeneration { get; init; }
+
+    /// <summary>True when this context targets the DEFAULT version.</summary>
+    public bool IsDefault => VersionId is null;
+
+    /// <summary>Creates a version context for a specific branch version.</summary>
+    /// <param name="version">The resolved branch version.</param>
+    /// <returns>A version context targeting <paramref name="version"/>.</returns>
+    public static VersionContext ForVersion(GdbVersion version) => new()
+    {
+        VersionId = version.VersionId,
+        VersionName = version.VersionName,
+        CommonAncestorGeneration = version.CommonAncestorGeneration,
+    };
+}

--- a/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/VersionOperations.cs
+++ b/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/VersionOperations.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+
+namespace Honua.Core.Features.FeatureStore.Domain;
+
+/// <summary>
+/// Request to create a branch version off a parent (DEFAULT when <see cref="ParentVersion"/> is null).
+/// </summary>
+/// <param name="VersionName">Esri-style <c>owner.name</c> identity.</param>
+/// <param name="Owner">Version owner.</param>
+/// <param name="Access">Access level.</param>
+/// <param name="ParentVersion">Parent version id; null branches from DEFAULT.</param>
+/// <param name="Description">Optional description.</param>
+public readonly record struct CreateVersionRequest(
+    string VersionName,
+    string Owner,
+    VersionAccess Access,
+    Guid? ParentVersion = null,
+    string? Description = null);
+
+/// <summary>
+/// Request to alter a version's mutable metadata. Null fields are left unchanged.
+/// </summary>
+/// <param name="VersionId">Version to alter.</param>
+/// <param name="VersionName">New name, or null to leave unchanged.</param>
+/// <param name="Access">New access level, or null to leave unchanged.</param>
+/// <param name="Description">New description, or null to leave unchanged.</param>
+public readonly record struct AlterVersionRequest(
+    Guid VersionId,
+    string? VersionName = null,
+    VersionAccess? Access = null,
+    string? Description = null);
+
+/// <summary>
+/// Classification of an unresolved reconcile conflict between version edits and DEFAULT edits made
+/// since the version's merge base. Reuses the disconnected-sync conflict taxonomy (#1272 Track B).
+/// </summary>
+/// <param name="LayerId">Storage-layer id of the conflicting feature.</param>
+/// <param name="ObjectId">Stable object id of the conflicting feature.</param>
+/// <param name="ConflictType">Conflict classification.</param>
+public readonly record struct VersionReconcileConflict(
+    int LayerId,
+    long ObjectId,
+    ReplicaConflictType ConflictType);
+
+/// <summary>
+/// Result of a reconcile: the conflicts detected between the version and DEFAULT since the merge
+/// base, and whether the version is clear to post. A reconcile pulls DEFAULT changes since
+/// <see cref="GdbVersion.CommonAncestorGeneration"/> into the version, applies auto-resolution
+/// policies (owned by #371), and reports any remaining conflicts that block <c>Post</c>.
+/// </summary>
+/// <param name="Conflicts">Unresolved conflicts; non-empty blocks post.</param>
+/// <param name="CanPost">True when the version reconciled cleanly and may be posted.</param>
+/// <param name="NewCommonAncestorGeneration">The DEFAULT generation the version is now reconciled to.</param>
+public readonly record struct VersionReconcileResult(
+    ImmutableArray<VersionReconcileConflict> Conflicts,
+    bool CanPost,
+    long NewCommonAncestorGeneration);
+
+/// <summary>
+/// Result of a post: after a clean reconcile, the version's net changes are replayed onto DEFAULT in
+/// a single transaction and the generation advances.
+/// </summary>
+/// <param name="Posted">True when the post committed.</param>
+/// <param name="AppliedChanges">Number of net feature changes replayed onto DEFAULT.</param>
+/// <param name="ServerGeneration">DEFAULT generation produced by the post.</param>
+/// <param name="BlockedByConflicts">True when the post was refused because unresolved conflicts remain.</param>
+public readonly record struct VersionPostResult(
+    bool Posted,
+    int AppliedChanges,
+    long ServerGeneration,
+    bool BlockedByConflicts);

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IVersionManager.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IVersionManager.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.FeatureStore.Abstractions;
+
+/// <summary>
+/// Canonical branch-versioning manager (#1272 Track B). Owns the lifecycle of gdb versions
+/// (create/delete/alter/list), version read/edit sessions (which set the version lock and the
+/// transaction-scoped version GUC), and the reconcile/post merge workflow. A null
+/// <see cref="VersionContext"/> always denotes the DEFAULT version and must be handled exactly as the
+/// non-versioned base path so existing reads/writes and CITE conformance stay byte-identical.
+/// </summary>
+/// <remarks>
+/// Branch versioning is Postgres-only and gated behind the Enterprise entitlement; other providers
+/// return not-supported. Reconcile detects conflicts between the version and DEFAULT since the merge
+/// base (reusing the disconnected-sync conflict classification), applies #371's auto-policies, and
+/// blocks <see cref="PostAsync"/> while unresolved conflicts remain. Post replays the version's net
+/// changes onto DEFAULT through the shared edit pipeline in one transaction and advances the
+/// generation. Large reconcile/post runs are expected to execute through the canonical job runtime,
+/// and the version is locked (Redis-backed) for the duration of a reconcile or post.
+/// </remarks>
+public interface IVersionManager
+{
+    /// <summary>Whether this provider supports branch versioning. Non-Postgres providers return false.</summary>
+    bool SupportsVersioning { get; }
+
+    /// <summary>Creates a new branch version.</summary>
+    /// <param name="request">Create request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created version.</returns>
+    Task<GdbVersion> CreateAsync(CreateVersionRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes a branch version. DEFAULT cannot be deleted.</summary>
+    /// <param name="versionId">Version to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True when the version existed and was deleted.</returns>
+    Task<bool> DeleteAsync(Guid versionId, CancellationToken cancellationToken = default);
+
+    /// <summary>Alters a version's mutable metadata.</summary>
+    /// <param name="request">Alter request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated version, or null when not found.</returns>
+    Task<GdbVersion?> AlterAsync(AlterVersionRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Lists all branch versions (excluding the implicit DEFAULT).</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The known branch versions.</returns>
+    Task<IReadOnlyList<GdbVersion>> ListAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves a <c>gdbVersion</c> parameter to a <see cref="VersionContext"/>. An absent/empty value
+    /// or the DEFAULT sentinel (e.g. <c>SDE.DEFAULT</c>) resolves to <see cref="VersionContext.Default"/>;
+    /// an unknown name yields null so the caller can return a not-found error.
+    /// </summary>
+    /// <param name="gdbVersion">Requested version identity, or null/empty for DEFAULT.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resolved context, or null when the named version does not exist.</returns>
+    Task<VersionContext?> ResolveAsync(string? gdbVersion, CancellationToken cancellationToken = default);
+
+    /// <summary>Reconciles a version against DEFAULT, detecting conflicts since the merge base.</summary>
+    /// <param name="versionId">Version to reconcile.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The reconcile result.</returns>
+    Task<VersionReconcileResult> ReconcileAsync(Guid versionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Posts a reconciled version's net changes onto DEFAULT. Refused while unresolved conflicts
+    /// remain (the version must be reconciled clean first).
+    /// </summary>
+    /// <param name="versionId">Version to post.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The post result.</returns>
+    Task<VersionPostResult> PostAsync(Guid versionId, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Server/Migrations/047_CreateGdbVersions.sql
+++ b/src/Honua.Server/Migrations/047_CreateGdbVersions.sql
@@ -1,0 +1,54 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration: 047_CreateGdbVersions.sql
+-- Description: Adds the branch-versioning version dimension (#1272 Track B). A gdb version is a
+--              named branch off DEFAULT that accumulates isolated edits which are later reconciled
+--              against and posted back to DEFAULT. This migration creates only the version registry;
+--              the change-log version dimension and version-aware trigger are added in 048. The
+--              DEFAULT version is implicit (NULL version_id everywhere) and is intentionally NOT
+--              represented as a row so existing NULL-version read/write paths stay byte-identical.
+-- Dependencies: Requires honua schema (001) and honua.sync_generation (012_AddReplicationDurability).
+
+CREATE TABLE IF NOT EXISTS honua.gdb_versions (
+    version_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Esri-style "owner.name" identity (e.g. "sde.QA"). Unique per owner+name.
+    version_name TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    -- Parent version this branch was created from. NULL parent == branched from DEFAULT.
+    parent_version UUID REFERENCES honua.gdb_versions(version_id) ON DELETE SET NULL,
+    -- Access level (VersionAccess ordinal): 0=private, 1=protected, 2=public.
+    access SMALLINT NOT NULL DEFAULT 0,
+    -- Lifecycle state (VersionState ordinal): 0=active, 1=reconciling, 2=posting, 3=deleted.
+    state SMALLINT NOT NULL DEFAULT 0,
+    -- Generation pointers used by reconcile/post. common_ancestor_gen is the DEFAULT generation the
+    -- branch last reconciled against (its merge base); branch_gen is the latest generation produced
+    -- by edits within this version. Both advance through the version-aware change log (048).
+    common_ancestor_gen BIGINT NOT NULL DEFAULT 0,
+    branch_gen BIGINT NOT NULL DEFAULT 0,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    modified_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT gdb_versions_valid_name CHECK(LENGTH(version_name) > 0 AND LENGTH(version_name) <= 256),
+    CONSTRAINT gdb_versions_valid_owner CHECK(LENGTH(owner) > 0),
+    CONSTRAINT gdb_versions_valid_access CHECK(access BETWEEN 0 AND 2),
+    CONSTRAINT gdb_versions_valid_state CHECK(state BETWEEN 0 AND 3)
+);
+
+-- Version identity is unique per owner+name (case-insensitive, matching Esri "owner.name" lookup).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_gdb_versions_owner_name
+    ON honua.gdb_versions(LOWER(owner), LOWER(version_name));
+
+-- Parent traversal for reconcile-base resolution and version-tree listing.
+CREATE INDEX IF NOT EXISTS idx_gdb_versions_parent
+    ON honua.gdb_versions(parent_version);
+
+COMMENT ON TABLE honua.gdb_versions IS 'Branch-versioning version registry; DEFAULT is implicit NULL (#1272)';
+COMMENT ON COLUMN honua.gdb_versions.version_id IS 'Unique version identifier';
+COMMENT ON COLUMN honua.gdb_versions.version_name IS 'Esri-style owner.name version identity';
+COMMENT ON COLUMN honua.gdb_versions.owner IS 'Version owner';
+COMMENT ON COLUMN honua.gdb_versions.parent_version IS 'Parent version; NULL == branched from DEFAULT';
+COMMENT ON COLUMN honua.gdb_versions.access IS 'Access level (0=private,1=protected,2=public)';
+COMMENT ON COLUMN honua.gdb_versions.state IS 'Lifecycle state (0=active,1=reconciling,2=posting,3=deleted)';
+COMMENT ON COLUMN honua.gdb_versions.common_ancestor_gen IS 'DEFAULT generation the branch last reconciled against (merge base)';
+COMMENT ON COLUMN honua.gdb_versions.branch_gen IS 'Latest generation produced by edits within this version';

--- a/src/Honua.Server/Migrations/048_AddVersionToChangeLog.sql
+++ b/src/Honua.Server/Migrations/048_AddVersionToChangeLog.sql
@@ -1,0 +1,69 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration: 048_AddVersionToChangeLog.sql
+-- Description: Adds the version dimension to the change log and makes the change-tracking trigger
+--              version-aware (#1272 Track B). A nullable version_id column tags each recorded change
+--              with the gdb version that produced it; the trigger reads a transaction-scoped GUC
+--              (honua.gdb_version) set by the edit session. When the GUC is unset or empty (the
+--              DEFAULT version), version_id stays NULL and the recorded change is byte-identical to
+--              the pre-migration behavior, so existing replication/change-tracking and CITE paths are
+--              unaffected.
+-- Dependencies: Requires honua.feature_changes + honua.track_feature_changes (012) and
+--               honua.gdb_versions (047).
+
+ALTER TABLE honua.feature_changes
+    ADD COLUMN IF NOT EXISTS version_id UUID;
+
+-- Version-scoped delta scans (extractChanges/reconcile within a version).
+CREATE INDEX IF NOT EXISTS idx_feature_changes_version_generation
+    ON honua.feature_changes(version_id, generation, layer_id);
+
+-- Version-aware trigger: records the producing version from the transaction-scoped GUC. The GUC is
+-- read with the missing_ok=true form so an unset GUC yields NULL (DEFAULT version) without error.
+CREATE OR REPLACE FUNCTION honua.track_feature_changes()
+RETURNS TRIGGER AS $$
+DECLARE
+    gen BIGINT;
+    lid INT;
+    oid BIGINT;
+    op SMALLINT;
+    ver TEXT;
+    ver_uuid UUID;
+BEGIN
+    gen := nextval('honua.sync_generation');
+
+    IF TG_OP = 'INSERT' THEN
+        lid := NEW.layer_id;
+        oid := NEW.objectid;
+        op := 1;
+    ELSIF TG_OP = 'UPDATE' THEN
+        lid := NEW.layer_id;
+        oid := NEW.objectid;
+        op := 2;
+    ELSIF TG_OP = 'DELETE' THEN
+        lid := OLD.layer_id;
+        oid := OLD.objectid;
+        op := 3;
+    END IF;
+
+    -- Resolve the producing version from the transaction-scoped GUC. Unset/empty == DEFAULT (NULL).
+    ver := current_setting('honua.gdb_version', true);
+    IF ver IS NULL OR ver = '' THEN
+        ver_uuid := NULL;
+    ELSE
+        ver_uuid := ver::UUID;
+    END IF;
+
+    INSERT INTO honua.feature_changes (generation, layer_id, objectid, operation, version_id)
+    VALUES (gen, lid, oid, op, ver_uuid);
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON COLUMN honua.feature_changes.version_id IS
+    'Branch version that produced the change; NULL == DEFAULT version (byte-identical to pre-versioning) (#1272)';

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -904,6 +904,29 @@ sql:
   - "CREATE INDEX IF NOT EXISTS idx_feature_changes_generation_layer ON honua.feature_changes(generation, layer_id);"
   - "CREATE INDEX IF NOT EXISTS idx_feature_changes_changed_at ON honua.feature_changes(changed_at);"
   - "CREATE INDEX IF NOT EXISTS idx_feature_changes_layer_objectid ON honua.feature_changes(layer_id, objectid, generation);"
+  # Branch-versioning foundation (#1272 Track B): version registry + change-log version dimension.
+  - |
+      CREATE TABLE IF NOT EXISTS honua.gdb_versions (
+          version_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          version_name TEXT NOT NULL,
+          owner TEXT NOT NULL,
+          parent_version UUID REFERENCES honua.gdb_versions(version_id) ON DELETE SET NULL,
+          access SMALLINT NOT NULL DEFAULT 0,
+          state SMALLINT NOT NULL DEFAULT 0,
+          common_ancestor_gen BIGINT NOT NULL DEFAULT 0,
+          branch_gen BIGINT NOT NULL DEFAULT 0,
+          description TEXT,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          modified_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          CONSTRAINT gdb_versions_valid_name CHECK(LENGTH(version_name) > 0 AND LENGTH(version_name) <= 256),
+          CONSTRAINT gdb_versions_valid_owner CHECK(LENGTH(owner) > 0),
+          CONSTRAINT gdb_versions_valid_access CHECK(access BETWEEN 0 AND 2),
+          CONSTRAINT gdb_versions_valid_state CHECK(state BETWEEN 0 AND 3)
+      );
+  - "CREATE UNIQUE INDEX IF NOT EXISTS idx_gdb_versions_owner_name ON honua.gdb_versions(LOWER(owner), LOWER(version_name));"
+  - "CREATE INDEX IF NOT EXISTS idx_gdb_versions_parent ON honua.gdb_versions(parent_version);"
+  - "ALTER TABLE honua.feature_changes ADD COLUMN IF NOT EXISTS version_id UUID;"
+  - "CREATE INDEX IF NOT EXISTS idx_feature_changes_version_generation ON honua.feature_changes(version_id, generation, layer_id);"
   - |
       CREATE OR REPLACE FUNCTION honua.track_feature_changes()
       RETURNS TRIGGER AS $$
@@ -912,6 +935,8 @@ sql:
           lid INT;
           oid BIGINT;
           op SMALLINT;
+          ver TEXT;
+          ver_uuid UUID;
       BEGIN
           gen := nextval('honua.sync_generation');
           IF TG_OP = 'INSERT' THEN
@@ -927,8 +952,14 @@ sql:
               oid := OLD.objectid;
               op := 3;
           END IF;
-          INSERT INTO honua.feature_changes (generation, layer_id, objectid, operation)
-          VALUES (gen, lid, oid, op);
+          ver := current_setting('honua.gdb_version', true);
+          IF ver IS NULL OR ver = '' THEN
+              ver_uuid := NULL;
+          ELSE
+              ver_uuid := ver::UUID;
+          END IF;
+          INSERT INTO honua.feature_changes (generation, layer_id, objectid, operation, version_id)
+          VALUES (gen, lid, oid, op, ver_uuid);
           IF TG_OP = 'DELETE' THEN
               RETURN OLD;
           END IF;


### PR DESCRIPTION
## Issue Link
Refs #1272, #371

## Summary
Track B foundation of #1272 (branch versioning + `gdbVersion` routing). This PR lands the **storage dimension and the canonical version-manager contract only**, kept fully additive and inert for the DEFAULT (null-version) path so existing reads/writes, replication/change-tracking, and OGC CITE conformance (952/952) stay byte-identical. It coordinates with #371 (which owns the named-version/reconcile-post UX and auto-resolution policies) and does not duplicate it.

**This is a foundation PR. The version read/write wiring and the protocol surface are explicitly deferred** (see Breaking Changes / deferred list below) to avoid shipping half-wired version routing and to protect CITE. `gdbVersion` continues to be hard-rejected exactly as today — branch versioning is not yet reachable end-to-end.

Stacked on Track A (#1499). Review/merge #1499 first.

## Changes Made
- `047_CreateGdbVersions.sql`: `honua.gdb_versions` registry (version_id, `owner.name` identity, parent_version, access, state, `common_ancestor_gen`/`branch_gen` generation pointers). DEFAULT is implicit and never materialized as a row.
- `048_AddVersionToChangeLog.sql`: nullable `version_id` on `honua.feature_changes` and a version-aware `track_feature_changes()` trigger that reads a transaction-scoped GUC (`honua.gdb_version`). When the GUC is unset/empty (DEFAULT), `version_id` stays NULL and the recorded change is byte-identical to the pre-versioning trigger.
- Mirrored 047/048 into `tests/seed/server.yaml` so the existing change-tracking/replication suites exercise the new trigger. All 11 change-tracking + Track-A sync tests stay green, proving the NULL-version path is inert.
- Canonical domain types (`Honua.Core.Abstractions`): `GdbVersion`, `VersionContext` (with `Default`/`ForVersion`), `VersionAccess`/`VersionState`, `CreateVersionRequest`/`AlterVersionRequest`, `VersionReconcileConflict`/`VersionReconcileResult`, `VersionPostResult`.
- Canonical `IVersionManager` (`Honua.Core`): `Create`/`Delete`/`Alter`/`List`, `ResolveAsync` (`gdbVersion` → `VersionContext`; absent/`SDE.DEFAULT` → DEFAULT), `Reconcile`, `Post`. Documents Postgres-only (`SupportsVersioning`), Enterprise gating, reuse of the disconnected-sync conflict classification, and #371 auto-policy coordination.

## Deferred to a clearly-scoped follow-up (NOT in this PR)
To avoid half-wired version routing and protect CITE 952/952, the following Track B work is intentionally not included and should land in a subsequent PR:
- `PostgresVersionManager` implementation + DI registration (and not-supported stubs for other providers).
- `FeatureQueryBuilder.Version.cs` read overlay (overlay version deltas onto the DEFAULT base), mirroring `FeatureQueryBuilder.Temporal.cs`.
- Threading `VersionContext` through the shared `FeatureQuery` (read) and `FeatureEditBatch` (write, setting the edit-session GUC).
- Redis-locked reconcile/post executed through `Honua.Jobs`; temporal checkpoint interop (#1285) on post.
- The `src/Honua.Protocols.GeoServices/VersionManagementServer/` protocol slice and its `create`/`delete`/`alter`/`startReading`/`startEditing`/`stopReading`/`stopEditing`/`reconcile`/`post`/`versions`/`versionInfo` endpoints (each needs an `[InterfaceOperation]` for the OperationRegistry gate and an integration test for the EndpointRegistry gate).
- Replacing the hard `gdbVersion is not supported` rejections in `FeatureServerRequestHandlers.Edits.cs` with `VersionContext` resolution.
- Advertising `hasVersionedData`/`supportsBranchVersioning` + the VersionManagementServer URL in FeatureServer metadata via the shared capability service.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

The version-aware trigger is validated by running the existing change-tracking + Track-A sync suites against the updated seed: 11/11 passing, confirming the NULL-version (DEFAULT) path is byte-identical. Release build with `TreatWarningsAsErrors=true` clean (Honua.Core, Honua.Server). `dotnet format Honua.sln` clean. No new endpoints or operations are added, so EndpointRegistry/OperationRegistry gates are unaffected.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

No public protocol surface changes (no endpoints/operations added in this PR).

## Release/Deploy Impact
- [x] Requires database migration

Migrations 047/048 are additive and idempotent (`CREATE TABLE/INDEX IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`). The trigger replacement preserves DEFAULT-path behavior exactly.

## Breaking Changes
None. `gdbVersion` remains hard-rejected exactly as before this PR — branch versioning is not yet reachable end-to-end (the version read/write pipeline and the VersionManagementServer protocol slice are deferred, see above). The change-tracking trigger gains a version dimension but is byte-identical for the DEFAULT (NULL) version, so replication, change tracking, and CITE conformance are unaffected.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review