### PR TITLE
docs: ADR-0051 branch-versioning storage model (overlay/moment) (#1272)

### DIFF
--- a/docs/contributor/adr/0051-branch-versioning-storage-model.md
+++ b/docs/contributor/adr/0051-branch-versioning-storage-model.md
@@ -1,0 +1,187 @@
+# ADR-0051: Branch-Versioning Storage Model (Overlay/Moment Over the Live Base Table)
+
+## Status
+
+Accepted
+
+## Context
+
+Esri-style **branch versioning** (issue #1272, epic #1270) requires Honua to serve
+and edit named versions that diverge from the published `DEFAULT` data, then
+`reconcile`/`post` those edits back. The open architectural question is **how
+versioned edits are physically stored and read**, and which **native PostgreSQL
+features** to lean on. This decision is the substrate the deferred wiring in
+PR #1500 will build on, and it must coexist with #371 (named versions /
+reconcile-post UX), #1285 (temporal "as-of" history), and #1287 (durable
+disconnected-sync conflict records).
+
+Three facts about the existing implementation constrain the choice:
+
+- **`DEFAULT` data is the live base `features` table — never copied.** A layer is
+  a logical, `layer_id`-discriminated slice of one physical `features` table
+  (`objectid`, `layer_id`, `geometry` with `GIST`, `attributes JSONB` with `GIN`).
+  The read pipeline selects directly `FROM features WHERE layer_id = $1`
+  (`FeatureQueryBuilder.Build.cs`). Any version model must **overlay onto this
+  live table, not fork it.**
+- **The change log is OID-only.** `honua.feature_changes`
+  (`012_AddReplicationDurability.sql`) records *that* an `(layer_id, objectid)`
+  changed at a monotonic `honua.sync_generation`, via the `track_feature_changes()`
+  AFTER-ROW trigger — it does **not** store the row's geometry/attribute image.
+  `PostgresChangeTracker.GetChangesSinceAsync` collapses this log into a net op
+  (the reusable kernel for reconcile/post). #1285 temporal reads are a *projection
+  over this same generation cursor*, not a separate store. Consequence: the change
+  log can tell you *which* OIDs a version touched but **cannot reconstruct the
+  version's row values** — so any model must answer *where branch row values live*.
+- **Track B foundation already landed the storage dimension + contracts
+  (PR #1500, inert for `DEFAULT`).** `047_CreateGdbVersions.sql` (the
+  `honua.gdb_versions` registry with `common_ancestor_gen`/`branch_gen` pointers),
+  `048_AddVersionToChangeLog.sql` (nullable `feature_changes.version_id` + a
+  version-aware trigger driven by a transaction-scoped `honua.gdb_version` GUC —
+  **GUC unset ⇒ NULL ⇒ byte-identical to pre-versioning**), and the canonical
+  `GdbVersion`/`VersionContext`/`IVersionManager` contracts. This implicitly
+  commits to an overlay/moment direction; this ADR confirms it and specifies the
+  storage mechanics #1500 deferred.
+
+A hard non-negotiable: the **`DEFAULT` read/edit path must remain byte-identical**
+so the 952/952 OGC CITE baseline cannot regress when `gdbVersion` is absent.
+
+### Approaches weighed
+
+1. **Overlay / moment model.** `DEFAULT` stays the live base table; branch row
+   *values* live in a shared, version-discriminated overlay table; a version read
+   replays the overlay onto `DEFAULT` at a generation "moment."
+2. **Per-version physical delta tables.** One `features_v<id>` table set per version
+   (DDL per version), overlaid on `DEFAULT`.
+3. **Bitemporal / system-versioned rows in the base table.** Valid-time/txn-time
+   rows in `features`; a branch is a named view over row history.
+4. **Hybrid.** Overlay by default; promote a hot/long-lived version to its own
+   indexed delta table.
+
+| Axis | 1 Overlay | 2 Per-version tables | 3 Bitemporal base |
+|---|---|---|---|
+| `DEFAULT` byte-identical (CITE) | ✅ emits today's exact SQL | ✅ | ❌ adds temporal predicate to every `DEFAULT` read |
+| Scales with | edits (small) | edits + per-table catalog churn | whole-table history (taxes primary workload) |
+| Create/drop version | O(1) registry row | **DDL per version** (locks, catalog churn) | cheap pointer, but write-amplifies forever |
+| Isolation | strong (physical overlay) | strong | weak (predicate-only; leak risk) |
+| Storage | only edited rows | only edits + N× table/index overhead | full history in the primary table |
+| Reuse of foundation | maximal (rides `feature_changes`, collapse kernel, conflict classifier, `IFeatureWriter`) | needs DDL/registry/dynamic SQL | rebuilds temporal + replication on a new substrate |
+| Rollback | drop one table | migrate N tables | rewrites base-table contract |
+
+Per-version DDL tables are strictly dominated by the overlay (same benefits, DDL
+churn cost). Bitemporal is the "purest" history model and natively solves the
+OID-only gap, but it moves version state into the `DEFAULT` hot path and **cannot
+guarantee the byte-identical `DEFAULT` query** — disqualifying for #1272.
+
+## Decision
+
+**Adopt the overlay / moment model (Approach 1)** for v1, adding the one piece
+`047/048` left open: a shared, version-discriminated overlay table that stores
+branch row *values*.
+
+- **New migration `049_CreateVersionEdits.sql`** (additive, inert for `DEFAULT`):
+  `honua.version_edits(version_id UUID REFERENCES gdb_versions, layer_id INT,
+  objectid BIGINT, operation SMALLINT, geometry GEOMETRY, attributes JSONB,
+  base_geometry GEOMETRY NULL, base_attributes JSONB NULL, branch_gen BIGINT,
+  PRIMARY KEY (version_id, layer_id, objectid))` with a covering btree on
+  `(version_id, layer_id, objectid)`, a `GIST(geometry)`, and a partial index
+  `WHERE operation = <delete>`.
+- **Version read** (emitted only when `!VersionContext.IsDefault`):
+  `(DEFAULT base minus OIDs the branch shadows) UNION ALL (overlay non-deletes)`,
+  parameterized on `version_id` and bounded by `CommonAncestorGeneration`. When
+  `IsDefault`, the builder emits **nothing extra** — today's exact SQL — which is
+  the CITE firewall.
+- **Version write** routes the INSERT/UPDATE/DELETE to `version_edits` inside the
+  existing edit transaction, with `SET LOCAL honua.gdb_version = '<uuid>'` so the
+  trigger tags `feature_changes.version_id`. `DEFAULT` edits set no GUC and target
+  `features` — byte-identical.
+
+### Resolved sub-decisions (recommendations adopted)
+
+1. **Capture the ancestor row image on first branch-touch.** When a version first
+   shadows an `(layer_id, objectid)`, snapshot the then-current `DEFAULT` row into
+   `version_edits.base_geometry`/`base_attributes`. This populates #1287's
+   `BaseStateJson` and lets reconcile classify conflicts as
+   *base vs current-`DEFAULT` vs current-branch* rather than the weaker
+   *current-vs-current*. Cost is one extra read on first touch only.
+2. **Single global generation sequence for v1; posts serialize on generation
+   advance.** Accept this throughput model for the first release rather than
+   introducing per-layer generation streams. Per-layer streams are a future
+   optimization if/when post throughput becomes a bottleneck (a shared design
+   point with #371).
+3. **Ship v1 overlay-only; defer hybrid promotion (Approach 4).** No per-version
+   indexed-table promotion until the overlay anti-join cost is *measured* on large
+   layers. If promotion is later warranted, prefer `LIST`-partitioning
+   `version_edits` by `version_id` over per-version DDL tables.
+
+### Native PostgreSQL features
+
+**Use:** the transaction-scoped GUC + trigger (`048`); JSONB row images in the
+overlay (column-compatible with `features`); targeted indexes **on the overlay
+only**; the durable `sync_generation` sequence as the "moment."
+
+**Avoid (with reasons):**
+
+- **MVCC snapshots** (`pg_export_snapshot` / `SET TRANSACTION SNAPSHOT`) as
+  "moments" — session-scoped, short-lived, and pin vacuum; a branch lives for
+  weeks. The durable generation number is the moment.
+- **Base-table partitioning by `version_id`** — routes every `DEFAULT` query
+  through partition pruning, taxing the byte-identical guarantee. (Partitioning the
+  *overlay* is an optional later scaling lever only.)
+- **Row-Level Security** for version visibility — forces a policy predicate onto
+  every `DEFAULT` read and, with pooling + GUCs, a leaked GUC becomes a
+  wrong-visibility security incident. Keep version routing in explicit SQL.
+- **Rules / `INSTEAD OF` views** — rule-system footguns / dynamic DDL; use inline
+  SQL mirroring `FeatureQueryBuilder.Temporal.cs`.
+- **System-versioned temporal extensions** (`temporal_tables`, `periods`,
+  PG18 native temporal), **logical replication / publications, FDW, materialized
+  views** — wrong tools for this storage problem (and per-version DDL would *break*
+  publications).
+
+## Consequences
+
+- The `DEFAULT` read/edit path is provably unchanged, protecting CITE 952/952.
+- Version reads scale with *edits*, not table size, so long-lived/divergent
+  branches do not tax the primary `DEFAULT` workload.
+- Branch versioning is honestly **Postgres-only** and localized to one overlay
+  table plus one query/writer branch; DuckDB/SQL Server/MySQL register a
+  `NotSupported` `IVersionManager` (`SupportsVersioning = false`).
+- Reconcile/post reuse the existing collapse kernel, generation sequence,
+  `ReplicaConflictRecord` taxonomy (#1287), and `IFeatureWriter` — no parallel
+  conflict model or history store.
+- Rollback is non-destructive: drop `version_edits` and the deferred query/writer
+  branches; `feature_changes.version_id` may remain (NULL-only). No `DEFAULT` data
+  is ever touched.
+- Storing the ancestor image on first touch adds bounded write/storage cost per
+  branch-edited row; acceptable for correct reconcile.
+
+## Implementation surface (deferred wiring, tracked under #1272)
+
+- `PostgresVersionManager` implementing `IVersionManager` over `gdb_versions` +
+  `version_edits`; `CreateAsync` stamps `common_ancestor_gen = currval(sync_generation)`.
+- `FeatureQueryBuilder.Version.cs` (mirror `FeatureQueryBuilder.Temporal.cs`):
+  no-op when `IsDefault`, else the overlay `UNION` form. Thread a nullable
+  `VersionContext` onto `FeatureQuery`.
+- Writes (`FeatureDataAccess.Edits.cs` / `IFeatureWriter` / `FeatureEditBatch`):
+  set `SET LOCAL honua.gdb_version` and route to `version_edits`; capture ancestor
+  on first touch.
+- Reconcile/post via `Honua.Jobs` under a Redis-backed version lock; replace the
+  hard `gdbVersion is not supported` rejections
+  (`FeatureServerRequestHandlers.Edits.cs:431/542/741`) with
+  `IVersionManager.ResolveAsync`.
+- `VersionManagementServer` GeoServices protocol slice
+  (create/delete/alter/start*/stop*/reconcile/post/versions/versionInfo),
+  Enterprise-gated, advertised in FeatureServer metadata.
+- `049_CreateVersionEdits.sql` is the only additive schema change beyond `047/048`.
+
+## Cross-references
+
+- #1272 — Branch-versioned editing + production offline replica/change-tracking
+  (Track A merged; Track B foundation in PR #1500; this ADR decides Track B storage).
+- #1270 — Epic: editing-model parity.
+- #371 — Named versions, reconcile/post, multi-user concurrent editing (owns the
+  reconcile/post UX + auto-resolution policy this substrate serves).
+- #1285 — Temporal data history API (shares the `feature_changes` generation cursor;
+  post should write a temporal checkpoint).
+- #1287 — Durable disconnected-sync conflict records (reconcile reuses
+  `ReplicaConflictRecord`; `BaseStateJson` is fed by the first-touch ancestor image).
+- ADR-0046 — Progressive `IDatabaseSession` migration (transaction model used by edits).

--- a/docs/contributor/adr/README.md
+++ b/docs/contributor/adr/README.md
@@ -54,6 +54,7 @@ This folder contains Architecture Decision Records (ADRs) for the Honua greenfie
 | [0046](0046-audit-c3-database-session-progressive-migration.md) | Audit C3 — Progressive `IDatabaseSession` Migration With Coexistence | Accepted | 2026-05 |
 | [0047](0047-module-dependency-policy.md) | Module Dependency Policy | Accepted | 2026-05 |
 | [0049](0049-single-auth-identity-token-foundation.md) | Single Auth/Identity/Token Foundation Shared by OIDC SSO and ArcGIS OAuth2 | Accepted | 2026-06 |
+| [0051](0051-branch-versioning-storage-model.md) | Branch-Versioning Storage Model (Overlay/Moment Over the Live Base Table) | Accepted | 2026-06 |
 
 ## Template
 


### PR DESCRIPTION
## Issue Link
Related to #1272, #1270

## Summary
Records the architecture decision for how Esri-style **branch versioning** stores and reads versioned edits in the PostgreSQL provider, and which native PostgreSQL features to leverage vs avoid. This is the storage substrate the deferred Track B wiring (PR #1500) builds on. Grounded in the actual code: `DEFAULT` is the live base `features` table (never copied) and `feature_changes` is an OID-only log, so the decision centers on where branch row *values* live while keeping the `DEFAULT` path byte-identical (CITE 952/952).

## Changes Made
- Added `docs/contributor/adr/0051-branch-versioning-storage-model.md` (Accepted).
- **Decision:** adopt the overlay/moment model over the live base table, adding a shared, version-discriminated `honua.version_edits` overlay table (new migration `049`) for branch row values; reject per-version DDL tables and bitemporal base-table rows (the latter cannot keep `DEFAULT` byte-identical).
- Resolved the three open sub-decisions per the design recommendation: capture the ancestor row image on first branch-touch (feeds #1287 `BaseStateJson`); single global generation sequence with posts serializing for v1; ship v1 overlay-only and defer hybrid promotion.
- Recorded native-PostgreSQL guidance — use the GUC+trigger, JSONB row images, overlay-only indexes, and the durable generation sequence as the "moment"; avoid MVCC snapshots as moments, base-table partitioning, RLS, rules/`INSTEAD OF` views, and system-versioned temporal extensions.
- Indexed the ADR in `docs/contributor/adr/README.md`.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Docs-only; ADR cross-references and file paths verified against the tree.

## Gate Impact
- [x] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent — docs-only change, no build/test required; ADR file paths and cross-references verified against the tree
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
