### PR TITLE
feat: branch-versioning readable/editable version core (#1272)

### DIFF
--- a/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/FeatureEdit.cs
+++ b/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/FeatureEdit.cs
@@ -43,6 +43,16 @@ public readonly record struct FeatureEditBatch
     public bool UseGlobalIds { get; init; } = false;
 
     /// <summary>
+    /// Branch version the edit targets (#1272 Track B, ADR-0051). A null value or
+    /// <see cref="VersionContext.IsDefault"/> means the DEFAULT version: writers must use the
+    /// byte-identical non-versioned base write path (target <c>features</c>, no version GUC). A
+    /// non-DEFAULT context routes the edit to the version overlay, sets the transaction-scoped version
+    /// GUC so the change-tracking trigger tags produced changes, and captures the DEFAULT base image on
+    /// the version's first touch of an <c>(layer_id, objectid)</c>.
+    /// </summary>
+    public VersionContext? VersionContext { get; init; }
+
+    /// <summary>
     /// Initializes a new FeatureEditBatch with default values
     /// </summary>
     public FeatureEditBatch()
@@ -62,6 +72,7 @@ public readonly record struct FeatureEditBatch
     /// <param name="rollbackOnFailure">Whether to rollback all changes on failure</param>
     /// <param name="useGlobalIds">Whether to use global IDs</param>
     /// <param name="operations">Ordered operations to apply when request sequencing must be preserved</param>
+    /// <param name="versionContext">Branch version the edit targets; null/DEFAULT uses the byte-identical base write path</param>
     /// <returns>Edit batch instance</returns>
     public static FeatureEditBatch Create(
         ImmutableArray<Feature> creates = default,
@@ -69,7 +80,8 @@ public readonly record struct FeatureEditBatch
         ImmutableArray<long> deletes = default,
         bool rollbackOnFailure = false,
         bool useGlobalIds = false,
-        ImmutableArray<FeatureEditOperation> operations = default)
+        ImmutableArray<FeatureEditOperation> operations = default,
+        VersionContext? versionContext = null)
         => new()
         {
             Operations = operations.IsDefault ? ImmutableArray<FeatureEditOperation>.Empty : operations,
@@ -77,7 +89,8 @@ public readonly record struct FeatureEditBatch
             Updates = updates.IsDefault ? ImmutableArray<Feature>.Empty : updates,
             Deletes = deletes.IsDefault ? ImmutableArray<long>.Empty : deletes,
             RollbackOnFailure = rollbackOnFailure,
-            UseGlobalIds = useGlobalIds
+            UseGlobalIds = useGlobalIds,
+            VersionContext = versionContext
         };
 
     /// <summary>

--- a/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/FeatureQuery.cs
+++ b/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/FeatureQuery.cs
@@ -163,6 +163,15 @@ public readonly record struct FeatureQuery
     public TopFilter? TopFilter { get; init; }
 
     /// <summary>
+    /// Branch version the read targets (#1272 Track B, ADR-0051). A null value or
+    /// <see cref="VersionContext.IsDefault"/> means the DEFAULT version: the provider must emit the
+    /// byte-identical non-versioned base query. A non-DEFAULT context overlays the version's deltas onto
+    /// the DEFAULT base. Threaded through the shared query pipeline so every protocol adapter can request
+    /// a versioned read without reimplementing data access.
+    /// </summary>
+    public VersionContext? VersionContext { get; init; }
+
+    /// <summary>
     /// Creates a simple WHERE clause query
     /// </summary>
     /// <param name="where">WHERE clause expression</param>

--- a/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpVersionManager.cs
+++ b/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpVersionManager.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.FeatureStore.ReadOnlyProviders;
+
+/// <summary>
+/// Version manager for providers that do not support branch versioning (DuckDB, MySQL/MariaDB, and any
+/// non-Postgres feature slice). Reports <see cref="SupportsVersioning"/> = false, resolves the DEFAULT
+/// version (so non-versioned read/edit paths stay byte-identical) and rejects every other operation.
+/// Mirrors the no-op change-tracker stub so DI activation succeeds for protocol handlers that depend on
+/// <see cref="IVersionManager"/> while the underlying slice is read/query-only or non-Postgres (#1272).
+/// </summary>
+public sealed class NoOpVersionManager : IVersionManager
+{
+    /// <inheritdoc />
+    public bool SupportsVersioning => false;
+
+    /// <inheritdoc />
+    public Task<GdbVersion> CreateAsync(CreateVersionRequest request, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Branch versioning is not supported by this data provider.");
+
+    /// <inheritdoc />
+    public Task<bool> DeleteAsync(Guid versionId, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Branch versioning is not supported by this data provider.");
+
+    /// <inheritdoc />
+    public Task<GdbVersion?> AlterAsync(AlterVersionRequest request, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Branch versioning is not supported by this data provider.");
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<GdbVersion>> ListAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<GdbVersion>>(Array.Empty<GdbVersion>());
+
+    /// <inheritdoc />
+    public Task<VersionContext?> ResolveAsync(string? gdbVersion, CancellationToken cancellationToken = default)
+    {
+        // Absent/empty or the DEFAULT sentinel resolves to DEFAULT; any named version is unknown here.
+        if (string.IsNullOrWhiteSpace(gdbVersion) ||
+            gdbVersion.Trim().Equals("sde.default", StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.FromResult<VersionContext?>(VersionContext.Default);
+        }
+
+        return Task.FromResult<VersionContext?>(null);
+    }
+
+    /// <inheritdoc />
+    public Task<VersionReconcileResult> ReconcileAsync(Guid versionId, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Branch versioning is not supported by this data provider.");
+
+    /// <inheritdoc />
+    public Task<VersionPostResult> PostAsync(Guid versionId, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Branch versioning is not supported by this data provider.");
+}

--- a/src/Honua.DuckDB/ServiceCollectionExtensions.cs
+++ b/src/Honua.DuckDB/ServiceCollectionExtensions.cs
@@ -119,6 +119,7 @@ internal static class ServiceCollectionExtensions
         services.AddScoped<IReplicaRepository>(_ => new NoOpReplicaRepository());
         services.AddScoped<IReplicaConflictRepository>(_ => new NoOpReplicaConflictRepository());
         services.AddScoped<IChangeTracker>(_ => new NoOpChangeTracker());
+        services.AddScoped<IVersionManager>(_ => new NoOpVersionManager());
         services.AddScoped<IGeoJsonFeatureStore>(sp => sp.GetRequiredService<DuckDBFeatureStore>());
         services.AddScoped<IStreamingFeatureStore>(sp => sp.GetRequiredService<DuckDBFeatureStore>());
         services.AddScoped<ITileProvider>(_ => new ReadOnlyTileProvider("DuckDB"));

--- a/src/Honua.MySql/ServiceCollectionExtensions.cs
+++ b/src/Honua.MySql/ServiceCollectionExtensions.cs
@@ -107,6 +107,7 @@ internal static class ServiceCollectionExtensions
         services.AddScoped<IReplicaRepository>(_ => new NoOpReplicaRepository());
         services.AddScoped<IReplicaConflictRepository>(_ => new NoOpReplicaConflictRepository());
         services.AddScoped<IChangeTracker>(_ => new NoOpChangeTracker());
+        services.AddScoped<IVersionManager>(_ => new NoOpVersionManager());
         services.AddScoped<ITileProvider>(_ => new ReadOnlyTileProvider("MySQL/MariaDB"));
         services.AddScoped<IGmlFeatureStore>(_ => new ReadOnlyGmlFeatureStore("MySQL/MariaDB"));
 

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Edits.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Edits.cs
@@ -176,6 +176,13 @@ internal sealed partial class FeatureDataAccess
             return FeatureEditResult.Success(0, 0, 0);
         }
 
+        // Branch-versioned edits route to the overlay write path (#1272 Track B, ADR-0051). DEFAULT
+        // (null/IsDefault) falls through to the byte-identical base write path below, untouched.
+        if (editBatch.VersionContext is { IsDefault: false } version)
+        {
+            return await ApplyVersionedEditsAsync(layerId, editBatch, version, cancellationToken).ConfigureAwait(false);
+        }
+
         DbConnection dbConnection;
         NpgsqlTransaction? transaction;
 

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.VersionEdits.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.VersionEdits.cs
@@ -1,0 +1,386 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Data;
+using System.Globalization;
+using Honua.Core.Exceptions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.FeatureStore.Services;
+
+internal sealed partial class FeatureDataAccess
+{
+    // Branch-versioning overlay writes (#1272 Track B, ADR-0051). A non-DEFAULT edit batch routes the
+    // INSERT/UPDATE/DELETE to honua.version_edits inside one transaction, sets the transaction-scoped
+    // honua.gdb_version GUC, and captures the DEFAULT base image on the version's first touch of an
+    // (layer_id, objectid). DEFAULT data (`features`) is never touched by this path; the DEFAULT write
+    // path is left completely unchanged (byte-identical) and never reaches this file.
+    //
+    // The overlay's BEFORE trigger (049_CreateVersionEdits.sql) records each mutation into
+    // honua.feature_changes tagged with the producing version so reconcile/post (Slice 2) have a tagged
+    // version delta even though DEFAULT was never written.
+
+    private const string VersionEditsTableName = "honua.version_edits";
+
+    /// <summary>
+    /// Applies an edit batch against a branch version overlay. Always transactional so the GUC
+    /// (<c>SET LOCAL honua.gdb_version</c>) and the overlay upserts commit atomically. DEFAULT batches do
+    /// not reach here (see <see cref="ApplyEditsAsync"/>).
+    /// </summary>
+    private async Task<FeatureEditResult> ApplyVersionedEditsAsync(
+        int layerId,
+        FeatureEditBatch editBatch,
+        VersionContext version,
+        CancellationToken cancellationToken)
+    {
+        var versionId = version.VersionId
+            ?? throw new InvalidOperationException("Versioned edit batch is missing a version id.");
+
+        var (txConnection, dbTransaction) = await _connectionProvider
+            .OpenTransactionAsync(IsolationLevel.RepeatableRead, cancellationToken).ConfigureAwait(false);
+        await using var _ = txConnection;
+        var connection = txConnection.RequireNpgsqlConnection();
+        var transaction = (NpgsqlTransaction)dbTransaction;
+        await using var __ = transaction;
+
+        try
+        {
+            await SetVersionGucAsync(connection, transaction, versionId, cancellationToken).ConfigureAwait(false);
+
+            var createdIds = ImmutableArray.CreateBuilder<long>();
+            var createResults = ImmutableArray.CreateBuilder<EditOperationResult>();
+            var updateResults = ImmutableArray.CreateBuilder<EditOperationResult>();
+            var deleteResults = ImmutableArray.CreateBuilder<EditOperationResult>();
+
+            var failed = false;
+
+            if (!editBatch.Operations.IsDefaultOrEmpty)
+            {
+                foreach (var operation in editBatch.Operations)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var ok = await ApplyVersionedOperationAsync(
+                        layerId, versionId, operation, connection, transaction,
+                        createdIds, createResults, updateResults, deleteResults, cancellationToken).ConfigureAwait(false);
+                    if (!ok)
+                    {
+                        failed = true;
+                        if (editBatch.RollbackOnFailure)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                foreach (var feature in editBatch.Creates)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (!await TryVersionedCreateAsync(layerId, versionId, feature, connection, transaction, createdIds, createResults, cancellationToken).ConfigureAwait(false))
+                    {
+                        failed = true;
+                        if (editBatch.RollbackOnFailure) break;
+                    }
+                }
+
+                if (!(failed && editBatch.RollbackOnFailure))
+                {
+                    foreach (var feature in editBatch.Updates)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        if (!await TryVersionedUpdateAsync(layerId, versionId, feature, connection, transaction, updateResults, cancellationToken).ConfigureAwait(false))
+                        {
+                            failed = true;
+                            if (editBatch.RollbackOnFailure) break;
+                        }
+                    }
+                }
+
+                if (!(failed && editBatch.RollbackOnFailure))
+                {
+                    foreach (var objectId in editBatch.Deletes)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        if (!await TryVersionedDeleteAsync(layerId, versionId, objectId, connection, transaction, deleteResults, cancellationToken).ConfigureAwait(false))
+                        {
+                            failed = true;
+                            if (editBatch.RollbackOnFailure) break;
+                        }
+                    }
+                }
+            }
+
+            if (failed && editBatch.RollbackOnFailure)
+            {
+                await RollbackIfNeededAsync(transaction).ConfigureAwait(false);
+                return FeatureEditResult.Rollback(
+                    createResults.ToImmutable(), updateResults.ToImmutable(), deleteResults.ToImmutable());
+            }
+
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+            var immutableCreateResults = createResults.ToImmutable();
+            var immutableUpdateResults = updateResults.ToImmutable();
+            var immutableDeleteResults = deleteResults.ToImmutable();
+
+            return FeatureEditResult.Success(
+                immutableCreateResults.Count(static r => r.IsSuccess),
+                immutableUpdateResults.Count(static r => r.IsSuccess),
+                immutableDeleteResults.Count(static r => r.IsSuccess),
+                createdIds.ToImmutable(),
+                immutableCreateResults,
+                immutableUpdateResults,
+                immutableDeleteResults,
+                wasRolledBack: false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Log.ApplyEditsFailed(_logger, layerId, editBatch.TotalOperations, ex);
+            await RollbackIfNeededAsync(transaction).ConfigureAwait(false);
+            var (c, u, d) = CreateFailedOperationResults(editBatch, "Versioned edit batch failed.");
+            return FeatureEditResult.Rollback(c, u, d);
+        }
+    }
+
+    private async Task<bool> ApplyVersionedOperationAsync(
+        int layerId,
+        Guid versionId,
+        FeatureEditOperation operation,
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        ImmutableArray<long>.Builder createdIds,
+        ImmutableArray<EditOperationResult>.Builder createResults,
+        ImmutableArray<EditOperationResult>.Builder updateResults,
+        ImmutableArray<EditOperationResult>.Builder deleteResults,
+        CancellationToken cancellationToken)
+        => operation.Kind switch
+        {
+            FeatureEditOperationKind.Create => await TryVersionedCreateAsync(
+                layerId, versionId,
+                operation.Feature ?? throw new InvalidOperationException("Ordered create is missing the feature payload."),
+                connection, transaction, createdIds, createResults, cancellationToken).ConfigureAwait(false),
+            FeatureEditOperationKind.Update => await TryVersionedUpdateAsync(
+                layerId, versionId,
+                operation.Feature ?? throw new InvalidOperationException("Ordered update is missing the feature payload."),
+                connection, transaction, updateResults, cancellationToken).ConfigureAwait(false),
+            FeatureEditOperationKind.Delete => await TryVersionedDeleteAsync(
+                layerId, versionId,
+                operation.ObjectId ?? throw new InvalidOperationException("Ordered delete is missing the target object id."),
+                connection, transaction, deleteResults, cancellationToken).ConfigureAwait(false),
+            _ => throw new InvalidOperationException($"Unsupported ordered edit operation kind '{operation.Kind}'.")
+        };
+
+    private static async Task SetVersionGucAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        Guid versionId,
+        CancellationToken cancellationToken)
+    {
+        // set_config(..., is_local => true) is the parameterized equivalent of SET LOCAL and keeps the
+        // version id off the SQL text. The GUC is read by the change-tracking trigger family.
+        await using var command = new NpgsqlCommand(
+            "SELECT set_config('honua.gdb_version', $1, true)", connection)
+        {
+            Transaction = transaction
+        };
+        command.Parameters.AddWithValue(versionId.ToString());
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<bool> TryVersionedCreateAsync(
+        int layerId,
+        Guid versionId,
+        Feature feature,
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        ImmutableArray<long>.Builder createdIds,
+        ImmutableArray<EditOperationResult>.Builder createResults,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var geometryStorageType = await _cacheManager.GetGeometryStorageTypeAsync(cancellationToken).ConfigureAwait(false);
+            var layerSrid = await _cacheManager.GetLayerSridAsync(layerId, cancellationToken).ConfigureAwait(false);
+            ValidateGeometrySrid(feature.Geometry, layerSrid);
+            var geometryValueExpression = _geometryProcessor.GetGeometryWriteExpression(geometryStorageType, "$3", layerSrid);
+            var attributesJson = SerializeToJsonString(feature.Attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+
+            // Allocate a fresh objectid from the base features sequence so a later post can insert the
+            // branch-created row into DEFAULT without colliding with concurrently created DEFAULT rows.
+            var sql = string.Create(CultureInfo.InvariantCulture, $@"
+                INSERT INTO {VersionEditsTableName}
+                    (version_id, layer_id, objectid, operation, geometry, attributes, base_geometry, base_attributes)
+                VALUES (
+                    $1, $2,
+                    nextval(pg_get_serial_sequence('{_tableName}', 'objectid')),
+                    1, {geometryValueExpression}, $4, NULL, NULL)
+                RETURNING objectid");
+
+            await using var command = new NpgsqlCommand(sql, connection) { Transaction = transaction };
+            ApplyCommandTimeout(command, _queryTimeoutSeconds);
+            command.Parameters.AddWithValue(versionId);
+            command.Parameters.AddWithValue(layerId);
+            command.Parameters.Add(new NpgsqlParameter { Value = feature.Geometry ?? (object)DBNull.Value, NpgsqlDbType = NpgsqlDbType.Bytea });
+            command.Parameters.Add(new NpgsqlParameter { Value = attributesJson, NpgsqlDbType = NpgsqlDbType.Jsonb });
+
+            var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            var newId = Convert.ToInt64(result, CultureInfo.InvariantCulture);
+            createdIds.Add(newId);
+            createResults.Add(EditOperationResult.Success(newId, feature.Attributes.GetValueOrDefault("globalId")?.ToString()));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            createResults.Add(EditOperationResult.Failure(GetSafeEditOperationError(ex, "Create")));
+            return false;
+        }
+    }
+
+    private async Task<bool> TryVersionedUpdateAsync(
+        int layerId,
+        Guid versionId,
+        Feature feature,
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        ImmutableArray<EditOperationResult>.Builder updateResults,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var geometryStorageType = await _cacheManager.GetGeometryStorageTypeAsync(cancellationToken).ConfigureAwait(false);
+            var layerSrid = await _cacheManager.GetLayerSridAsync(layerId, cancellationToken).ConfigureAwait(false);
+            ValidateGeometrySrid(feature.Geometry, layerSrid);
+
+            var rowsAffected = await UpsertOverlayRowAsync(
+                layerId, versionId, feature.Id, operation: 2, feature.Geometry, feature.Attributes,
+                geometryStorageType, layerSrid, isDelete: false, connection, transaction, cancellationToken).ConfigureAwait(false);
+
+            if (rowsAffected == 0)
+            {
+                updateResults.Add(EditOperationResult.Failure($"Feature {feature.Id} not found", objectId: feature.Id));
+                return false;
+            }
+
+            updateResults.Add(EditOperationResult.Success(feature.Id, feature.Attributes.GetValueOrDefault("globalId")?.ToString()));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            updateResults.Add(EditOperationResult.Failure(GetSafeEditOperationError(ex, "Update"), objectId: feature.Id));
+            return false;
+        }
+    }
+
+    private async Task<bool> TryVersionedDeleteAsync(
+        int layerId,
+        Guid versionId,
+        long objectId,
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        ImmutableArray<EditOperationResult>.Builder deleteResults,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var geometryStorageType = await _cacheManager.GetGeometryStorageTypeAsync(cancellationToken).ConfigureAwait(false);
+            var layerSrid = await _cacheManager.GetLayerSridAsync(layerId, cancellationToken).ConfigureAwait(false);
+
+            var rowsAffected = await UpsertOverlayRowAsync(
+                layerId, versionId, objectId, operation: 3, geometry: null, attributes: null,
+                geometryStorageType, layerSrid, isDelete: true, connection, transaction, cancellationToken).ConfigureAwait(false);
+
+            if (rowsAffected == 0)
+            {
+                deleteResults.Add(EditOperationResult.Failure($"Feature {objectId} not found", objectId: objectId));
+                return false;
+            }
+
+            deleteResults.Add(EditOperationResult.Success(objectId));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            deleteResults.Add(EditOperationResult.Failure(GetSafeEditOperationError(ex, "Delete"), objectId: objectId));
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Upserts a branch overlay row for an existing (layer_id, objectid). On the version's FIRST touch the
+    /// then-current DEFAULT base image is snapshotted into base_geometry/base_attributes; subsequent
+    /// touches keep the captured base. Returns the number of affected overlay rows; 0 when neither a
+    /// DEFAULT row nor a prior overlay row exists (the target feature does not exist for the version).
+    /// </summary>
+    private async Task<int> UpsertOverlayRowAsync(
+        int layerId,
+        Guid versionId,
+        long objectId,
+        short operation,
+        byte[]? geometry,
+        ImmutableDictionary<string, object?>? attributes,
+        Honua.Core.Features.FeatureStore.Abstractions.GeometryStorageType geometryStorageType,
+        int? layerSrid,
+        bool isDelete,
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        var geometryValueExpression = isDelete
+            ? "NULL"
+            : _geometryProcessor.GetGeometryWriteExpression(geometryStorageType, "$4", layerSrid);
+        var attributesJson = isDelete
+            ? null
+            : SerializeToJsonString((attributes ?? ImmutableDictionary<string, object?>.Empty).ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+
+        // The CTE resolves whether the version already shadows the row (overlay) and the current DEFAULT
+        // base image, then INSERT ... ON CONFLICT upserts the overlay. base_* is captured from DEFAULT only
+        // when no prior overlay row exists (first touch); the ON CONFLICT branch preserves the existing
+        // base. The mutation is a no-op (0 rows) when neither an overlay row nor a DEFAULT row exists.
+        var sql = string.Create(CultureInfo.InvariantCulture, $@"
+            WITH base AS (
+                SELECT b.geometry AS base_geom, b.attributes AS base_attrs
+                FROM {_tableName} b
+                WHERE b.layer_id = $2 AND b.objectid = $3
+            ),
+            existing AS (
+                SELECT 1 FROM {VersionEditsTableName}
+                WHERE version_id = $1 AND layer_id = $2 AND objectid = $3
+            )
+            INSERT INTO {VersionEditsTableName}
+                (version_id, layer_id, objectid, operation, geometry, attributes, base_geometry, base_attributes)
+            SELECT $1, $2, $3, $5::smallint, {geometryValueExpression}, $6::jsonb,
+                   (SELECT base_geom FROM base), (SELECT base_attrs FROM base)
+            WHERE EXISTS (SELECT 1 FROM base) OR EXISTS (SELECT 1 FROM existing)
+            ON CONFLICT (version_id, layer_id, objectid) DO UPDATE
+                SET operation = EXCLUDED.operation,
+                    geometry = EXCLUDED.geometry,
+                    attributes = EXCLUDED.attributes,
+                    modified_at = now()");
+
+        await using var command = new NpgsqlCommand(sql, connection) { Transaction = transaction };
+        ApplyCommandTimeout(command, _queryTimeoutSeconds);
+        command.Parameters.AddWithValue(versionId);
+        command.Parameters.AddWithValue(layerId);
+        command.Parameters.AddWithValue(objectId);
+        command.Parameters.Add(new NpgsqlParameter { Value = geometry ?? (object)DBNull.Value, NpgsqlDbType = NpgsqlDbType.Bytea });
+        command.Parameters.AddWithValue((short)operation);
+        command.Parameters.Add(new NpgsqlParameter { Value = (object?)attributesJson ?? DBNull.Value, NpgsqlDbType = NpgsqlDbType.Jsonb });
+
+        try
+        {
+            return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
+        {
+            throw new ResourceConflictException("Versioned edit conflicted with existing overlay data.", ex);
+        }
+    }
+}

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Analytics.Joins.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Analytics.Joins.cs
@@ -59,6 +59,7 @@ internal sealed partial class FeatureQueryBuilder
         SpatialJoinQuery joinQuery,
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
     {
+        GuardVersionedReadSupported(targetQuery, "spatial-join");
         var sql = _stringBuilderPool.Get();
         try
         {

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Analytics.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Analytics.cs
@@ -48,6 +48,7 @@ internal sealed partial class FeatureQueryBuilder
         ClusterQuery clusterQuery,
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
     {
+        GuardVersionedReadSupported(query, "cluster");
         var sql = _stringBuilderPool.Get();
         try
         {
@@ -179,6 +180,7 @@ internal sealed partial class FeatureQueryBuilder
         BufferAggregateQuery bufferQuery,
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
     {
+        GuardVersionedReadSupported(query, "buffer-aggregate");
         var sql = _stringBuilderPool.Get();
         try
         {
@@ -286,6 +288,7 @@ internal sealed partial class FeatureQueryBuilder
         DensityQuery densityQuery,
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
     {
+        GuardVersionedReadSupported(query, "density");
         var sql = _stringBuilderPool.Get();
         try
         {

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Bins.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Bins.cs
@@ -18,6 +18,7 @@ internal sealed partial class FeatureQueryBuilder
         BinDefinition binDefinition,
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
     {
+        GuardVersionedReadSupported(query, "bins");
         if (!IsValidFieldName(binDefinition.Field))
         {
             throw new ArgumentException($"Invalid bin field name: {binDefinition.Field}", nameof(binDefinition));

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
@@ -53,6 +53,7 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
         FeatureQuery query,
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
     {
+        GuardVersionedReadSupported(query, "projected-point");
         var sql = _stringBuilderPool.Get();
         try
         {
@@ -175,8 +176,9 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
             var pointX = BuildPointCoordinateExpression(pointGeometry, "X");
             var pointY = BuildPointCoordinateExpression(pointGeometry, "Y");
             var (publicIdSelect, attributesSelect) = BuildRawAttributeSelectExpressions(query, ref paramIndex, parameters);
+            var featureSource = BuildVersionedFeatureSource(query, "features", ref paramIndex, parameters);
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {publicIdSelect} AS public_id, {attributesSelect} AS {DatabaseSchema.AttributesColumn}, {pointX} AS x, {pointY} AS y FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {publicIdSelect} AS public_id, {attributesSelect} AS {DatabaseSchema.AttributesColumn}, {pointX} AS x, {pointY} AS y FROM {featureSource} WHERE {DatabaseSchema.LayerIdColumn} = $1");
             AppendWhereClause(sql, query, ref paramIndex, parameters);
             AppendTemporalFilter(sql, query, ref paramIndex, parameters);
             AppendSpatialFilter(sql, query, geometryStorageType, ref paramIndex, parameters);
@@ -258,9 +260,11 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
         var sql = _stringBuilderPool.Get();
         try
         {
-            sql.Append(CultureInfo.InvariantCulture, $"SELECT COUNT(*) FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
             var paramIndex = 2;
             var parameters = new List<object>();
+            var featureSource = BuildVersionedFeatureSource(query, "features", ref paramIndex, parameters);
+
+            sql.Append(CultureInfo.InvariantCulture, $"SELECT COUNT(*) FROM {featureSource} WHERE {DatabaseSchema.LayerIdColumn} = $1");
 
             AppendWhereClause(sql, query, ref paramIndex, parameters);
             AppendTemporalFilter(sql, query, ref paramIndex, parameters);
@@ -286,9 +290,11 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
         var sql = _stringBuilderPool.Get();
         try
         {
-            sql.Append(CultureInfo.InvariantCulture, $"SELECT {DatabaseSchema.ObjectIdColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
             var paramIndex = 2;
             var parameters = new List<object>();
+            var featureSource = BuildVersionedFeatureSource(query, "features", ref paramIndex, parameters);
+
+            sql.Append(CultureInfo.InvariantCulture, $"SELECT {DatabaseSchema.ObjectIdColumn} FROM {featureSource} WHERE {DatabaseSchema.LayerIdColumn} = $1");
 
             AppendWhereClause(sql, query, ref paramIndex, parameters);
             AppendTemporalFilter(sql, query, ref paramIndex, parameters);
@@ -364,6 +370,7 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
         FeatureQuery? query,
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
     {
+        GuardVersionedReadSupported(query, "extent");
         var effectiveQuery = query ?? new FeatureQuery();
         var extentExpression = _geometryProcessor.GetGeometryOperand(geometryStorageType, null, effectiveQuery.SpatialReferenceSrid);
 
@@ -448,6 +455,7 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
         TileLimits tileLimits,
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
     {
+        GuardVersionedReadSupported(query, "mvt-tile");
         var sql = _stringBuilderPool.Get();
         try
         {

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.DateBins.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.DateBins.cs
@@ -17,6 +17,7 @@ internal sealed partial class FeatureQueryBuilder
         DateBinDefinition dateBin,
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
     {
+        GuardVersionedReadSupported(query, "date-bins");
         if (!IsValidFieldName(dateBin.BinField))
         {
             throw new ArgumentException($"Invalid bin field name: {dateBin.BinField}", nameof(dateBin));

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.EncodedFormats.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.EncodedFormats.cs
@@ -20,6 +20,7 @@ internal sealed partial class FeatureQueryBuilder
         FeatureQuery query,
         CoreGeometryStorageType geometryStorageType)
     {
+        GuardVersionedReadSupported(query, "encoded-binary");
         var spatialFilter = query.SpatialFilter;
         var isKnnQuery = spatialFilter.HasValue &&
                          spatialFilter.Value.SpatialRelationship == SpatialRelationship.NearestNeighbor;
@@ -184,10 +185,11 @@ internal sealed partial class FeatureQueryBuilder
                 ? $"{geometrySelect} AS {FeatureQueryEncoding.GeometryColumn}"
                 : geometrySelect;
             var attributesSelect = BuildAttributesSelectExpression(query, ref paramIndex, parameters);
+            var featureSource = BuildVersionedFeatureSource(query, "features", ref paramIndex, parameters);
 
             sql.Append(CultureInfo.InvariantCulture, $@"
                 SELECT {DatabaseSchema.ObjectIdColumn}, {geometryProjection}, {attributesSelect} AS {DatabaseSchema.AttributesColumn}, COUNT(*) OVER() as {FeatureQueryEncoding.InternalTotalCountColumn}
-                FROM {_tableName}
+                FROM {featureSource}
                 WHERE {DatabaseSchema.LayerIdColumn} = $1");
 
             AppendWhereClause(sql, query, ref paramIndex, parameters);

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.H3.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.H3.cs
@@ -28,6 +28,7 @@ internal sealed partial class FeatureQueryBuilder
         H3AggregationQuery h3Query,
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
     {
+        GuardVersionedReadSupported(query, "h3-aggregation");
         var sql = _stringBuilderPool.Get();
         try
         {
@@ -188,6 +189,7 @@ internal sealed partial class FeatureQueryBuilder
         Core.Configuration.TileLimits tileLimits,
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
     {
+        GuardVersionedReadSupported(query, "h3-tile");
         var sql = _stringBuilderPool.Get();
         try
         {

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.SelectClauses.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.SelectClauses.cs
@@ -65,6 +65,9 @@ internal sealed partial class FeatureQueryBuilder
 
         if (ShouldComputeDistance(spatialFilter))
         {
+            // The runtime distance column requires KNN/spatial parameter ordering the overlay does not yet
+            // thread; versioned distance reads are unsupported in v1. DEFAULT is unaffected.
+            GuardVersionedReadSupported(query, "select-with-distance");
             var geographyOperand = _geometryProcessor.GetGeographyOperand(geometryStorageType, query.SpatialReferenceSrid);
             var distanceParamExpression = BuildDistanceSelectOperand(spatialFilter!.Value, query, isKnnQuery, ref paramIndex, parameters);
             sql.Append(CultureInfo.InvariantCulture,
@@ -72,8 +75,9 @@ internal sealed partial class FeatureQueryBuilder
         }
         else
         {
+            var featureSource = BuildVersionedFeatureSource(query, "features", ref paramIndex, parameters);
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect}, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect}, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {featureSource} WHERE {DatabaseSchema.LayerIdColumn} = $1");
         }
     }
 
@@ -91,6 +95,7 @@ internal sealed partial class FeatureQueryBuilder
 
         if (ShouldComputeDistance(spatialFilter))
         {
+            GuardVersionedReadSupported(query, "select-gml-with-distance");
             var geographyOperand = _geometryProcessor.GetGeographyOperand(geometryStorageType, query.SpatialReferenceSrid);
             var distanceParamExpression = BuildDistanceSelectOperand(spatialFilter!.Value, query, isKnnQuery, ref paramIndex, parameters);
             sql.Append(CultureInfo.InvariantCulture,
@@ -98,8 +103,9 @@ internal sealed partial class FeatureQueryBuilder
         }
         else
         {
+            var featureSource = BuildVersionedFeatureSource(query, "features", ref paramIndex, parameters);
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {featureSource} WHERE {DatabaseSchema.LayerIdColumn} = $1");
         }
     }
 
@@ -117,6 +123,7 @@ internal sealed partial class FeatureQueryBuilder
 
         if (ShouldComputeDistance(spatialFilter))
         {
+            GuardVersionedReadSupported(query, "select-geojson-with-distance");
             var geographyOperand = _geometryProcessor.GetGeographyOperand(geometryStorageType, query.SpatialReferenceSrid);
             var distanceParamExpression = BuildDistanceSelectOperand(spatialFilter!.Value, query, isKnnQuery, ref paramIndex, parameters);
             sql.Append(CultureInfo.InvariantCulture,
@@ -124,8 +131,9 @@ internal sealed partial class FeatureQueryBuilder
         }
         else
         {
+            var featureSource = BuildVersionedFeatureSource(query, "features", ref paramIndex, parameters);
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {featureSource} WHERE {DatabaseSchema.LayerIdColumn} = $1");
         }
     }
 
@@ -143,6 +151,7 @@ internal sealed partial class FeatureQueryBuilder
 
         if (ShouldComputeDistance(spatialFilter))
         {
+            GuardVersionedReadSupported(query, "select-raw-geojson-with-distance");
             var geographyOperand = _geometryProcessor.GetGeographyOperand(geometryStorageType, query.SpatialReferenceSrid);
             var distanceParamExpression = BuildDistanceSelectOperand(spatialFilter!.Value, query, isKnnQuery, ref paramIndex, parameters);
             sql.Append(CultureInfo.InvariantCulture,
@@ -150,8 +159,9 @@ internal sealed partial class FeatureQueryBuilder
         }
         else
         {
+            var featureSource = BuildVersionedFeatureSource(query, "features", ref paramIndex, parameters);
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {publicIdSelect} AS public_id, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {publicIdSelect} AS public_id, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {featureSource} WHERE {DatabaseSchema.LayerIdColumn} = $1");
         }
     }
 
@@ -169,6 +179,7 @@ internal sealed partial class FeatureQueryBuilder
 
         if (ShouldComputeDistance(spatialFilter))
         {
+            GuardVersionedReadSupported(query, "select-kml-with-distance");
             var geographyOperand = _geometryProcessor.GetGeographyOperand(geometryStorageType, query.SpatialReferenceSrid);
             var distanceParamExpression = BuildDistanceSelectOperand(spatialFilter!.Value, query, isKnnQuery, ref paramIndex, parameters);
             sql.Append(CultureInfo.InvariantCulture,
@@ -176,8 +187,9 @@ internal sealed partial class FeatureQueryBuilder
         }
         else
         {
+            var featureSource = BuildVersionedFeatureSource(query, "features", ref paramIndex, parameters);
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {featureSource} WHERE {DatabaseSchema.LayerIdColumn} = $1");
         }
     }
 

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Statistics.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Statistics.cs
@@ -19,6 +19,7 @@ internal sealed partial class FeatureQueryBuilder
         FeatureQuery query,
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
     {
+        GuardVersionedReadSupported(query, "statistics");
         if (!query.OutStatistics.HasValue || query.OutStatistics.Value.IsDefaultOrEmpty)
         {
             throw new ArgumentException("OutStatistics must be specified for a statistics query.", nameof(query));

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.TopFeatures.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.TopFeatures.cs
@@ -18,6 +18,7 @@ internal sealed partial class FeatureQueryBuilder
         FeatureQuery query,
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
     {
+        GuardVersionedReadSupported(query, "top-features");
         if (!query.TopFilter.HasValue)
         {
             throw new ArgumentException("TopFilter must be specified for a top features query.", nameof(query));

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Version.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Version.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Postgres.Features.Infrastructure;
+
+namespace Honua.Postgres.Features.FeatureStore.Services;
+
+internal sealed partial class FeatureQueryBuilder
+{
+    // Branch-versioning overlay read (#1272 Track B, ADR-0051). The DEFAULT version emits NOTHING extra
+    // (today's exact SQL FROM the base features table) — this is the CITE firewall. A non-DEFAULT version
+    // replaces the base table reference with an overlay subquery that produces the identical column shape
+    // (objectid, layer_id, geometry, attributes) as the base table so the surrounding SELECT/WHERE is
+    // unchanged: (DEFAULT base minus the OIDs the branch shadows) UNION ALL (overlay non-delete rows).
+    //
+    // The overlay is only wired for the primary non-spatial-parameter read shapes (select/count/objectIds
+    // and the GeoServices point/raw paths) whose feature source is `FROM {_tableName} WHERE layer_id = $1`
+    // and whose query parameters are bound positionally from the builder's `parameters` list. KNN /
+    // distance / analytics / H3 / bins / MVT / encoded-binary versioned reads are intentionally not
+    // overlaid in v1 (see VersionedReadsNotSupported); they throw a clear NotSupported so no half-wired
+    // versioned shape silently returns DEFAULT data.
+
+    private const string VersionEditsTable = "honua.version_edits";
+
+    /// <summary>
+    /// Returns the feature-source SQL to substitute for the base table reference. For the DEFAULT version
+    /// this is the bare base table name, so the emitted SQL is byte-identical to the non-versioned path.
+    /// For a branch version it is a parenthesized overlay subquery aliased to <paramref name="alias"/>
+    /// that yields the same columns as the base table. The overlay's version parameter is appended to
+    /// <paramref name="parameters"/> in positional order at the point the source is emitted.
+    /// </summary>
+    private string BuildVersionedFeatureSource(
+        FeatureQuery query,
+        string alias,
+        ref int paramIndex,
+        List<object> parameters)
+    {
+        var version = query.VersionContext;
+        if (version is null || version.Value.IsDefault)
+        {
+            return _tableName;
+        }
+
+        // KNN / returnDistance reads bind the distance geometry ahead of the WHERE parameters
+        // (FeatureDataAccess.AddQueryParameters), an ordering the overlay's prepended version parameter
+        // would collide with. These spatial-parameter shapes are not overlaid in v1; throw rather than
+        // emit a versioned query whose parameters would bind out of order.
+        if (query.SpatialFilter is { } spatial &&
+            (spatial.SpatialRelationship == SpatialRelationship.NearestNeighbor || spatial.ReturnDistance))
+        {
+            throw new NotSupportedException(
+                "Branch-versioned KNN/returnDistance reads are not supported in this release. " +
+                "Use the DEFAULT version for nearest-neighbor or distance-returning queries.");
+        }
+
+        var versionId = version.Value.VersionId
+            ?? throw new InvalidOperationException("Non-default version context is missing a version id.");
+
+        var versionParamIndex = paramIndex++;
+        parameters.Add(versionId);
+        var versionParam = $"${versionParamIndex}";
+
+        var objectId = DatabaseSchema.ObjectIdColumn;
+        var layerId = DatabaseSchema.LayerIdColumn;
+        var geometry = DatabaseSchema.GeometryColumn;
+        var attributes = DatabaseSchema.AttributesColumn;
+
+        return string.Create(CultureInfo.InvariantCulture,
+            $"(SELECT b.{objectId}, b.{layerId}, b.{geometry}, b.{attributes} " +
+            $"FROM {_tableName} b " +
+            $"WHERE NOT EXISTS (SELECT 1 FROM {VersionEditsTable} ve " +
+            $"WHERE ve.version_id = {versionParam} AND ve.{layerId} = b.{layerId} AND ve.{objectId} = b.{objectId}) " +
+            $"UNION ALL " +
+            $"SELECT o.{objectId}, o.{layerId}, o.{geometry}, o.{attributes} " +
+            $"FROM {VersionEditsTable} o " +
+            $"WHERE o.version_id = {versionParam} AND o.operation <> 3) AS {alias}");
+    }
+
+    /// <summary>
+    /// Whether the query targets a non-DEFAULT branch version. DEFAULT (null/IsDefault) always returns
+    /// false so the byte-identical base path is taken.
+    /// </summary>
+    private static bool IsVersionedQuery(FeatureQuery query)
+        => query.VersionContext is { IsDefault: false };
+
+    /// <summary>
+    /// Guards a query shape that does not support the v1 branch-versioning overlay. Throws for a
+    /// non-DEFAULT version; no-op for DEFAULT so the base path is unaffected.
+    /// </summary>
+    private static void GuardVersionedReadSupported(FeatureQuery query, string shape)
+    {
+        if (IsVersionedQuery(query))
+        {
+            throw new NotSupportedException(
+                $"Branch-versioned reads are not supported for the '{shape}' query shape in this release. " +
+                "Use the DEFAULT version for this operation.");
+        }
+    }
+
+    /// <summary>
+    /// Nullable overload of <see cref="GuardVersionedReadSupported(FeatureQuery, string)"/> for builder
+    /// entry points that accept an optional query. A null query is DEFAULT (no guard).
+    /// </summary>
+    private static void GuardVersionedReadSupported(FeatureQuery? query, string shape)
+    {
+        if (query.HasValue)
+        {
+            GuardVersionedReadSupported(query.Value, shape);
+        }
+    }
+}

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresVersionManager.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresVersionManager.cs
@@ -1,0 +1,240 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Infrastructure;
+using Npgsql;
+
+namespace Honua.Postgres.Features.FeatureStore.Services;
+
+/// <summary>
+/// Postgres branch-versioning manager (#1272 Track B, ADR-0051). Owns gdb-version lifecycle over
+/// <c>honua.gdb_versions</c> + the overlay <c>honua.version_edits</c>. Reconcile/post are wired in a later
+/// slice; this manager provides create/delete/alter/list/resolve so versioned read/edit can be exercised
+/// end to end. A null or DEFAULT resolution always maps to the byte-identical base path.
+/// </summary>
+internal sealed class PostgresVersionManager : IVersionManager
+{
+    private const string DefaultVersionSentinel = "sde.default";
+
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+
+    /// <summary>Initializes the manager with the database connection provider.</summary>
+    /// <param name="connectionProvider">Database connection provider.</param>
+    public PostgresVersionManager(IDatabaseConnectionProvider connectionProvider)
+    {
+        _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+    }
+
+    /// <inheritdoc />
+    public bool SupportsVersioning => true;
+
+    /// <inheritdoc />
+    public async Task<GdbVersion> CreateAsync(CreateVersionRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.VersionName))
+        {
+            throw new ArgumentException("Version name is required.", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Owner))
+        {
+            throw new ArgumentException("Version owner is required.", nameof(request));
+        }
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        // The merge base is the current DEFAULT generation; reconcile pulls DEFAULT changes since this
+        // cursor into the branch. last_value mirrors PostgresChangeTracker.GetCurrentGenerationAsync.
+        const string sql = """
+            INSERT INTO honua.gdb_versions (version_name, owner, parent_version, access, state, common_ancestor_gen, branch_gen, description)
+            VALUES (@name, @owner, @parent, @access, 0, (SELECT last_value FROM honua.sync_generation), (SELECT last_value FROM honua.sync_generation), @description)
+            RETURNING version_id, version_name, owner, parent_version, access, state, common_ancestor_gen, branch_gen, description, created_at, modified_at
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("name", request.VersionName);
+        command.Parameters.AddWithValue("owner", request.Owner);
+        command.Parameters.AddWithValue("parent", (object?)request.ParentVersion ?? DBNull.Value);
+        command.Parameters.AddWithValue("access", (short)request.Access);
+        command.Parameters.AddWithValue("description", (object?)request.Description ?? DBNull.Value);
+
+        try
+        {
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw new InvalidOperationException("Failed to create branch version.");
+            }
+
+            return ReadVersion(reader);
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
+        {
+            throw new InvalidOperationException(
+                $"A version named '{request.VersionName}' already exists for owner '{request.Owner}'.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteAsync(Guid versionId, CancellationToken cancellationToken = default)
+    {
+        // ON DELETE CASCADE on honua.version_edits removes the overlay rows with the registry row.
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(
+            "DELETE FROM honua.gdb_versions WHERE version_id = @id", connection);
+        command.Parameters.AddWithValue("id", versionId);
+        var affected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return affected > 0;
+    }
+
+    /// <inheritdoc />
+    public async Task<GdbVersion?> AlterAsync(AlterVersionRequest request, CancellationToken cancellationToken = default)
+    {
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        const string sql = """
+            UPDATE honua.gdb_versions
+            SET version_name = COALESCE(@name, version_name),
+                access = COALESCE(@access, access),
+                description = CASE WHEN @description_set THEN @description ELSE description END,
+                modified_at = now()
+            WHERE version_id = @id
+            RETURNING version_id, version_name, owner, parent_version, access, state, common_ancestor_gen, branch_gen, description, created_at, modified_at
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("id", request.VersionId);
+        command.Parameters.AddWithValue("name", (object?)request.VersionName ?? DBNull.Value);
+        command.Parameters.AddWithValue("access", request.Access.HasValue ? (short)request.Access.Value : (object)DBNull.Value);
+        command.Parameters.AddWithValue("description_set", request.Description is not null);
+        command.Parameters.AddWithValue("description", (object?)request.Description ?? DBNull.Value);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return ReadVersion(reader);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<GdbVersion>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        const string sql = """
+            SELECT version_id, version_name, owner, parent_version, access, state, common_ancestor_gen, branch_gen, description, created_at, modified_at
+            FROM honua.gdb_versions
+            WHERE state <> 3
+            ORDER BY created_at
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        var results = ImmutableArray.CreateBuilder<GdbVersion>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            results.Add(ReadVersion(reader));
+        }
+
+        return results.ToImmutable();
+    }
+
+    /// <inheritdoc />
+    public async Task<VersionContext?> ResolveAsync(string? gdbVersion, CancellationToken cancellationToken = default)
+    {
+        // Absent/empty or the DEFAULT sentinel resolves to DEFAULT (byte-identical base path).
+        if (string.IsNullOrWhiteSpace(gdbVersion) ||
+            gdbVersion.Trim().Equals(DefaultVersionSentinel, StringComparison.OrdinalIgnoreCase))
+        {
+            return VersionContext.Default;
+        }
+
+        var version = await FindByIdentityAsync(gdbVersion.Trim(), cancellationToken).ConfigureAwait(false);
+        return version is null ? null : VersionContext.ForVersion(version.Value);
+    }
+
+    /// <inheritdoc />
+    public Task<VersionReconcileResult> ReconcileAsync(Guid versionId, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Branch-version reconcile is wired in a later slice (#1272).");
+
+    /// <inheritdoc />
+    public Task<VersionPostResult> PostAsync(Guid versionId, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Branch-version post is wired in a later slice (#1272).");
+
+    private async Task<GdbVersion?> FindByIdentityAsync(string gdbVersion, CancellationToken cancellationToken)
+    {
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        // Accept an explicit version-id GUID, or the Esri-style owner.name identity (case-insensitive).
+        string sql;
+        if (Guid.TryParse(gdbVersion, out var versionId))
+        {
+            sql = """
+                SELECT version_id, version_name, owner, parent_version, access, state, common_ancestor_gen, branch_gen, description, created_at, modified_at
+                FROM honua.gdb_versions
+                WHERE version_id = @id AND state <> 3
+                """;
+            await using var byId = new NpgsqlCommand(sql, connection);
+            byId.Parameters.AddWithValue("id", versionId);
+            return await ReadSingleAsync(byId, cancellationToken).ConfigureAwait(false);
+        }
+
+        var (owner, name) = SplitOwnerName(gdbVersion);
+        sql = """
+            SELECT version_id, version_name, owner, parent_version, access, state, common_ancestor_gen, branch_gen, description, created_at, modified_at
+            FROM honua.gdb_versions
+            WHERE state <> 3
+              AND LOWER(version_name) = LOWER(@name)
+              AND (@owner IS NULL OR LOWER(owner) = LOWER(@owner))
+            ORDER BY created_at
+            LIMIT 1
+            """;
+        await using var byName = new NpgsqlCommand(sql, connection);
+        byName.Parameters.AddWithValue("name", name);
+        byName.Parameters.AddWithValue("owner", (object?)owner ?? DBNull.Value);
+        return await ReadSingleAsync(byName, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<GdbVersion?> ReadSingleAsync(NpgsqlCommand command, CancellationToken cancellationToken)
+    {
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return ReadVersion(reader);
+    }
+
+    private static (string? Owner, string Name) SplitOwnerName(string gdbVersion)
+    {
+        // Esri identities are "owner.name"; match on the full name first, but a dotted value also lets us
+        // disambiguate by owner. Treat the substring after the last dot as the name and the prefix as owner.
+        var lastDot = gdbVersion.LastIndexOf('.');
+        if (lastDot <= 0 || lastDot == gdbVersion.Length - 1)
+        {
+            return (null, gdbVersion);
+        }
+
+        return (gdbVersion[..lastDot], gdbVersion[(lastDot + 1)..]);
+    }
+
+    private static GdbVersion ReadVersion(NpgsqlDataReader reader) => new()
+    {
+        VersionId = reader.GetGuid(0),
+        VersionName = reader.GetString(1),
+        Owner = reader.GetString(2),
+        ParentVersion = reader.IsDBNull(3) ? null : reader.GetGuid(3),
+        Access = (VersionAccess)reader.GetInt16(4),
+        State = (VersionState)reader.GetInt16(5),
+        CommonAncestorGeneration = reader.GetInt64(6),
+        BranchGeneration = reader.GetInt64(7),
+        Description = reader.IsDBNull(8) ? null : reader.GetString(8),
+        CreatedAt = reader.GetFieldValue<DateTimeOffset>(9),
+        ModifiedAt = reader.GetFieldValue<DateTimeOffset>(10),
+    };
+}

--- a/src/Honua.Server/Migrations/049_CreateVersionEdits.sql
+++ b/src/Honua.Server/Migrations/049_CreateVersionEdits.sql
@@ -1,0 +1,100 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration: 049_CreateVersionEdits.sql
+-- Description: Adds the branch-versioning overlay table that stores branch row *values* (#1272 Track B,
+--              ADR-0051). DEFAULT data stays the live base `features` table and is never copied; a
+--              version read overlays this table onto DEFAULT at a generation "moment" and a version
+--              write routes the row image here instead of `features`. This migration is additive and
+--              completely inert for DEFAULT (no DEFAULT read/write path touches `honua.version_edits`),
+--              so existing replication/change-tracking and CITE paths stay byte-identical.
+-- Dependencies: Requires honua.gdb_versions (047) and the current-schema `features` table (001).
+
+-- Branch overlay: one row per (version_id, layer_id, objectid) the version shadows. The row carries the
+-- branch's current image (operation/geometry/attributes) and, captured on the version's FIRST touch of
+-- the (layer_id, objectid), the then-current DEFAULT base image (base_geometry/base_attributes). The
+-- base image feeds reconcile conflict classification (base vs current-DEFAULT vs current-branch) and
+-- #1287's BaseStateJson. operation mirrors honua.feature_changes (1=insert, 2=update, 3=delete).
+CREATE TABLE IF NOT EXISTS honua.version_edits (
+    version_id UUID NOT NULL REFERENCES honua.gdb_versions(version_id) ON DELETE CASCADE,
+    layer_id INT NOT NULL,
+    objectid BIGINT NOT NULL,
+    -- Branch operation against DEFAULT: 1=insert, 2=update, 3=delete (matches honua.feature_changes).
+    operation SMALLINT NOT NULL,
+    -- Branch row image. NULL geometry/attributes are valid (geometryless features, delete rows).
+    geometry GEOMETRY,
+    attributes JSONB,
+    -- DEFAULT base image captured on first branch-touch of this (layer_id, objectid). NULL when the
+    -- branch row is a pure insert (no pre-existing DEFAULT row) or before first-touch capture runs.
+    base_geometry GEOMETRY,
+    base_attributes JSONB,
+    -- Branch generation at which this overlay row was last written (from honua.sync_generation).
+    branch_gen BIGINT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    modified_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (version_id, layer_id, objectid),
+    CONSTRAINT version_edits_valid_operation CHECK(operation IN (1, 2, 3))
+);
+
+-- Covering btree for the overlay read anti-join / shadowed-OID lookup and per-version delta scans.
+CREATE INDEX IF NOT EXISTS idx_version_edits_version_layer_objectid
+    ON honua.version_edits(version_id, layer_id, objectid);
+
+-- Spatial index over the overlay geometry so versioned spatial reads can use a GIST scan like DEFAULT.
+CREATE INDEX IF NOT EXISTS idx_version_edits_geometry
+    ON honua.version_edits USING GIST(geometry);
+
+-- Partial index over delete rows: the overlay read subtracts shadowed OIDs and never emits delete rows,
+-- and reconcile/post enumerate net deletes; both benefit from a delete-only partial index.
+CREATE INDEX IF NOT EXISTS idx_version_edits_deletes
+    ON honua.version_edits(version_id, layer_id, objectid)
+    WHERE operation = 3;
+
+COMMENT ON TABLE honua.version_edits IS
+    'Branch-versioning overlay: branch row values overlaid onto DEFAULT; inert for DEFAULT (#1272, ADR-0051)';
+COMMENT ON COLUMN honua.version_edits.version_id IS 'Owning branch version (honua.gdb_versions)';
+COMMENT ON COLUMN honua.version_edits.layer_id IS 'Storage layer of the shadowed feature';
+COMMENT ON COLUMN honua.version_edits.objectid IS 'Object id of the shadowed feature';
+COMMENT ON COLUMN honua.version_edits.operation IS 'Branch operation against DEFAULT: 1=insert, 2=update, 3=delete';
+COMMENT ON COLUMN honua.version_edits.geometry IS 'Branch geometry image; NULL for geometryless or delete rows';
+COMMENT ON COLUMN honua.version_edits.attributes IS 'Branch attribute image (JSONB); NULL for delete rows';
+COMMENT ON COLUMN honua.version_edits.base_geometry IS 'DEFAULT geometry captured on first branch-touch (feeds reconcile/BaseStateJson)';
+COMMENT ON COLUMN honua.version_edits.base_attributes IS 'DEFAULT attributes captured on first branch-touch (feeds reconcile/BaseStateJson)';
+COMMENT ON COLUMN honua.version_edits.branch_gen IS 'sync_generation at which this overlay row was last written';
+
+-- Version-aware change tracking for the overlay. The DEFAULT change-tracking trigger (012/048) is on
+-- `features` and never fires for overlay writes, so a sibling trigger records each overlay mutation into
+-- honua.feature_changes tagged with the producing version. The version_id is taken from the overlay row
+-- itself (authoritative), independent of the transaction GUC, so a tagged version delta exists for
+-- reconcile/post even though DEFAULT data was never touched. operation maps INSERT/UPDATE of the overlay
+-- row to the row's branch operation; a hard DELETE of an overlay row (e.g. on version drop via cascade)
+-- is not change-tracked. This is inert for DEFAULT: nothing writes honua.version_edits on the DEFAULT path.
+CREATE OR REPLACE FUNCTION honua.track_version_edits()
+RETURNS TRIGGER AS $$
+DECLARE
+    gen BIGINT;
+BEGIN
+    -- Overlay-row removals (version drop cascade) are not feature changes; skip them.
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+
+    gen := nextval('honua.sync_generation');
+
+    INSERT INTO honua.feature_changes (generation, layer_id, objectid, operation, version_id)
+    VALUES (gen, NEW.layer_id, NEW.objectid, NEW.operation, NEW.version_id);
+
+    -- Track the branch generation produced by this edit on the overlay row.
+    NEW.branch_gen := gen;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_track_version_edits ON honua.version_edits;
+CREATE TRIGGER trigger_track_version_edits
+    BEFORE INSERT OR UPDATE ON honua.version_edits
+    FOR EACH ROW
+    EXECUTE FUNCTION honua.track_version_edits();
+
+COMMENT ON FUNCTION honua.track_version_edits() IS
+    'Records branch overlay mutations into honua.feature_changes tagged with the producing version (#1272, ADR-0051)';

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -537,6 +537,11 @@ if (replicaProvider != DataProviderNames.DuckDb &&
     builder.Services.AddScoped<Honua.Core.Features.FeatureStore.Abstractions.IChangeTracker>(sp =>
         new Honua.Postgres.Features.FeatureStore.Services.PostgresChangeTracker(
             sp.GetRequiredService<Honua.Core.Features.Infrastructure.Abstractions.IDatabaseConnectionProvider>()));
+    // Branch-versioning manager (#1272 Track B, ADR-0051) — Postgres-only; read-only/non-Postgres
+    // providers register the NoOp stub (SupportsVersioning=false) in their ServiceCollectionExtensions.
+    builder.Services.AddScoped<Honua.Core.Features.FeatureStore.Abstractions.IVersionManager>(sp =>
+        new Honua.Postgres.Features.FeatureStore.Services.PostgresVersionManager(
+            sp.GetRequiredService<Honua.Core.Features.Infrastructure.Abstractions.IDatabaseConnectionProvider>()));
 }
 builder.Services.AddScoped<Honua.Protocols.GeoServices.FeatureServer.IReplicaStore>(sp =>
     new Honua.Protocols.GeoServices.FeatureServer.Services.CachingReplicaStore(

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderVersionTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderVersionTests.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Postgres.Features.FeatureStore.Services;
+using Microsoft.Extensions.ObjectPool;
+using FeatureStoreStringBuilderPooledObjectPolicy = Honua.Postgres.Features.FeatureStore.Services.StringBuilderPooledObjectPolicy;
+
+namespace Honua.Postgres.Tests.Features.FeatureStore;
+
+/// <summary>
+/// Branch-versioning overlay read tests (#1272 Track B, ADR-0051). The central guarantee proved here is
+/// the CITE firewall: for the DEFAULT version (null or <see cref="VersionContext.Default"/>) the builder
+/// must emit byte-identical SQL to the non-versioned base path. A non-DEFAULT version overlays the
+/// version_edits table onto DEFAULT.
+/// </summary>
+public sealed class FeatureQueryBuilderVersionTests
+{
+    private static readonly Guid SampleVersionId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    [Fact]
+    public void BuildSelectQuery_DefaultVersionNull_IsByteIdenticalToNonVersioned()
+    {
+        var builder = CreateQueryBuilder();
+        var baseline = builder.BuildSelectQuery(layerId: 1, new FeatureQuery());
+
+        var withNullVersion = builder.BuildSelectQuery(layerId: 1, new FeatureQuery { VersionContext = null });
+
+        // Byte-identical SQL is the CITE firewall: the DEFAULT (null) version must emit the exact same
+        // SQL as the non-versioned base query, with no overlay subquery.
+        withNullVersion.Sql.Should().Be(baseline.Sql);
+        withNullVersion.Sql.Should().Contain("WHERE layer_id = $1");
+        withNullVersion.Sql.Should().NotContain("version_edits");
+        withNullVersion.Sql.Should().NotContain("UNION ALL");
+        withNullVersion.WhereParameters.Should().Equal(baseline.WhereParameters);
+    }
+
+    [Fact]
+    public void BuildSelectQuery_ExplicitDefaultVersion_IsByteIdenticalToNonVersioned()
+    {
+        var builder = CreateQueryBuilder();
+        var baseline = builder.BuildSelectQuery(layerId: 1, new FeatureQuery());
+
+        var withDefault = builder.BuildSelectQuery(layerId: 1, new FeatureQuery { VersionContext = VersionContext.Default });
+
+        withDefault.Sql.Should().Be(baseline.Sql);
+        withDefault.Sql.Should().NotContain("version_edits");
+    }
+
+    [Fact]
+    public void BuildSelectQuery_BranchVersion_EmitsOverlayUnionAndBindsVersionId()
+    {
+        var builder = CreateQueryBuilder();
+        var query = new FeatureQuery
+        {
+            VersionContext = VersionContext.ForVersion(SampleVersion())
+        };
+
+        var result = builder.BuildSelectQuery(layerId: 1, query);
+
+        // Overlay shape: base-minus-shadowed UNION ALL overlay-non-deletes, parameterized on version_id.
+        result.Sql.Should().Contain("honua.version_edits");
+        result.Sql.Should().Contain("NOT EXISTS");
+        result.Sql.Should().Contain("UNION ALL");
+        result.Sql.Should().Contain("operation <> 3");
+        result.Sql.Should().Contain("AS features WHERE layer_id = $1");
+        result.WhereParameters.Should().Contain(SampleVersionId);
+    }
+
+    [Fact]
+    public void BuildCountQuery_DefaultVersion_IsByteIdentical()
+    {
+        var builder = CreateQueryBuilder();
+        var baseline = builder.BuildCountQuery(layerId: 7, new FeatureQuery());
+
+        var withDefault = builder.BuildCountQuery(layerId: 7, new FeatureQuery { VersionContext = VersionContext.Default });
+
+        withDefault.Sql.Should().Be(baseline.Sql);
+        withDefault.Sql.Should().NotContain("version_edits");
+    }
+
+    [Fact]
+    public void BuildCountQuery_BranchVersion_OverlaysVersionEdits()
+    {
+        var builder = CreateQueryBuilder();
+        var query = new FeatureQuery { VersionContext = VersionContext.ForVersion(SampleVersion()) };
+
+        var result = builder.BuildCountQuery(layerId: 7, query);
+
+        result.Sql.Should().Contain("honua.version_edits");
+        result.WhereParameters.Should().Contain(SampleVersionId);
+    }
+
+    [Fact]
+    public void BuildObjectIdsQuery_BranchVersion_OverlaysVersionEdits()
+    {
+        var builder = CreateQueryBuilder();
+        var query = new FeatureQuery { VersionContext = VersionContext.ForVersion(SampleVersion()) };
+
+        var result = builder.BuildObjectIdsQuery(layerId: 2, query);
+
+        result.Sql.Should().Contain("honua.version_edits");
+        result.WhereParameters.Should().Contain(SampleVersionId);
+    }
+
+    [Fact]
+    public void BuildStatisticsQuery_BranchVersion_IsNotSupported()
+    {
+        var builder = CreateQueryBuilder();
+        var query = new FeatureQuery
+        {
+            VersionContext = VersionContext.ForVersion(SampleVersion()),
+            OutStatistics = ImmutableArray.Create(new StatisticDefinition
+            {
+                StatisticType = StatisticType.Count,
+                OnStatisticField = "objectid",
+                OutStatisticFieldName = "cnt"
+            })
+        };
+
+        var act = () => builder.BuildStatisticsQuery(layerId: 1, query);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    [Fact]
+    public void BuildSelectQuery_BranchVersionNearestNeighbor_IsNotSupported()
+    {
+        var builder = CreateQueryBuilder();
+        var query = new FeatureQuery
+        {
+            VersionContext = VersionContext.ForVersion(SampleVersion()),
+            SpatialFilter = SpatialFilter.CreateKnnFilter(new byte[] { 1, 2, 3 }, count: 5)
+        };
+
+        var act = () => builder.BuildSelectGeoJsonQuery(layerId: 1, query);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    private static GdbVersion SampleVersion() => new()
+    {
+        VersionId = SampleVersionId,
+        VersionName = "sde.QA",
+        Owner = "sde",
+        Access = VersionAccess.Public,
+        State = VersionState.Active,
+        CommonAncestorGeneration = 5,
+        BranchGeneration = 9,
+        CreatedAt = DateTimeOffset.UtcNow,
+        ModifiedAt = DateTimeOffset.UtcNow,
+    };
+
+    private static FeatureQueryBuilder CreateQueryBuilder()
+    {
+        var poolProvider = new DefaultObjectPoolProvider();
+        var stringBuilderPool = poolProvider.Create(new FeatureStoreStringBuilderPooledObjectPolicy());
+        var geometryProcessor = new GeometryProcessor();
+        return new FeatureQueryBuilder(stringBuilderPool, geometryProcessor);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningIntegrationTests.cs
@@ -1,0 +1,277 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Reflection;
+using DbUp;
+using FluentAssertions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Postgres.Features.FeatureStore;
+using Honua.Postgres.Features.FeatureStore.Services;
+using Honua.Server.Tests.Infrastructure;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.ObjectPool;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using Npgsql;
+
+namespace Honua.Server.Tests.Features.FeatureStore;
+
+/// <summary>
+/// Branch-versioning Slice 1 integration tests (#1272 Track B, ADR-0051). Proves the readable/editable
+/// version core against a real PostGIS schema: a version's edits are isolated from DEFAULT, a versioned
+/// read overlays them, the DEFAULT read is unaffected, the ancestor base image is captured on first
+/// touch, and the DEFAULT (null version) read/edit path is byte-identical.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.TestQuality)]
+public sealed class BranchVersioningIntegrationTests : IAsyncLifetime
+{
+    private const int PointsLayerId = 91001;
+    private static readonly GeometryFactory _geometryFactory = new(new PrecisionModel(), 4326);
+    private static readonly WKBWriter _wkbWriter = new();
+    private static readonly string[] _expectedDefaultNames = ["Original-1", "Original-2"];
+    private static readonly string[] _expectedVersionedNames = ["Branch-New", "Branch-Updated"];
+
+    private readonly DatabaseFixtureAdapter _fixture;
+    private readonly string _schema;
+
+    public BranchVersioningIntegrationTests(DatabaseFixtureAdapter fixture)
+    {
+        _fixture = fixture;
+        _schema = $"test_bv_{Guid.NewGuid():N}";
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.ExecuteAsync($"CREATE SCHEMA {_schema}");
+
+        // Apply the full embedded migration set into the isolated schema so features + the honua.*
+        // versioning tables (gdb_versions, version_edits, feature_changes, sync_generation) and their
+        // triggers all exist exactly as production runs them.
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
+        {
+            SearchPath = $"{_schema},public"
+        };
+        var upgrader = DeployChanges.To
+            .PostgresqlDatabase(connectionStringBuilder.ToString(), _schema)
+            .JournalToPostgresqlTable(_schema, "schema_versions")
+            .WithScriptsEmbeddedInAssembly(Assembly.GetAssembly(typeof(Program))!)
+            .WithTransaction()
+            .Build();
+        var result = upgrader.PerformUpgrade();
+        result.Successful.Should().BeTrue(result.Error?.ToString());
+
+        // Register the test layer so the feature store resolves its SRID (4326) and stamps written
+        // geometries; without it the geography GIST index expression (ST_Transform(...,4326)) rejects
+        // the SRID-0 WKB the test produces.
+        await _fixture.ExecuteAsync($"""
+            INSERT INTO honua.layers (layer_id, layer_name, table_schema, table_name, geometry_type, srid)
+            VALUES ({PointsLayerId}, 'BV Points', '{_schema}', 'features', 'Point', 4326)
+            ON CONFLICT (layer_id) DO UPDATE SET srid = EXCLUDED.srid;
+            """);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.ExecuteAsync($"DROP SCHEMA {_schema} CASCADE");
+    }
+
+    [Fact]
+    public async Task VersionedEdit_IsIsolatedFromDefault_AndVersionedReadOverlaysIt()
+    {
+        var store = CreateFeatureStore();
+        var versionManager = CreateVersionManager();
+
+        // DEFAULT baseline: two features.
+        var feature1 = await store.CreateAsync(PointsLayerId, BuildFeature("Original-1", 1.0, 1.0), CancellationToken.None);
+        var feature2 = await store.CreateAsync(PointsLayerId, BuildFeature("Original-2", 2.0, 2.0), CancellationToken.None);
+
+        var version = await versionManager.CreateAsync(
+            new CreateVersionRequest("QA", "sde", VersionAccess.Public), CancellationToken.None);
+        var versionContext = VersionContext.ForVersion(version);
+
+        // Edit inside the version: update feature1, delete feature2, create a new branch-only feature.
+        var batch = FeatureEditBatch.Create(
+            creates: ImmutableArray.Create(BuildFeature("Branch-New", 3.0, 3.0)),
+            updates: ImmutableArray.Create(BuildFeature("Branch-Updated", 1.5, 1.5, feature1.Id)),
+            deletes: ImmutableArray.Create(feature2.Id),
+            rollbackOnFailure: true,
+            versionContext: versionContext);
+
+        var editResult = await store.ApplyEditsAsync(PointsLayerId, batch, CancellationToken.None);
+        editResult.WasRolledBack.Should().BeFalse();
+        editResult.CreatedCount.Should().Be(1);
+        editResult.UpdatedCount.Should().Be(1);
+        editResult.DeletedCount.Should().Be(1);
+
+        // DEFAULT read is unaffected: still the two originals.
+        var defaultRows = await store.QueryAsync(PointsLayerId, new FeatureQuery(), CancellationToken.None);
+        var defaultNames = defaultRows.Items.Select(NameOf).OrderBy(n => n).ToArray();
+        defaultNames.Should().BeEquivalentTo(_expectedDefaultNames);
+
+        // Versioned read overlays the branch edits: updated f1, branch-new, f2 deleted.
+        var versionedRows = await store.QueryAsync(
+            PointsLayerId,
+            new FeatureQuery { VersionContext = versionContext },
+            CancellationToken.None);
+        var versionedNames = versionedRows.Items.Select(NameOf).OrderBy(n => n).ToArray();
+        versionedNames.Should().BeEquivalentTo(_expectedVersionedNames);
+    }
+
+    [Fact]
+    public async Task VersionedFirstTouch_CapturesDefaultBaseImage()
+    {
+        var store = CreateFeatureStore();
+        var versionManager = CreateVersionManager();
+
+        var feature = await store.CreateAsync(PointsLayerId, BuildFeature("Base-Capture", 4.0, 4.0), CancellationToken.None);
+
+        var version = await versionManager.CreateAsync(
+            new CreateVersionRequest("Capture", "sde", VersionAccess.Public), CancellationToken.None);
+
+        var batch = FeatureEditBatch.Create(
+            updates: ImmutableArray.Create(BuildFeature("Mutated", 4.5, 4.5, feature.Id)),
+            versionContext: VersionContext.ForVersion(version));
+        await store.ApplyEditsAsync(PointsLayerId, batch, CancellationToken.None);
+
+        // The first branch touch must snapshot the then-current DEFAULT row into base_*.
+        await using var connection = await OpenSchemaConnectionAsync();
+        await using var command = new NpgsqlCommand(
+            "SELECT base_attributes IS NOT NULL, base_geometry IS NOT NULL FROM honua.version_edits WHERE version_id = @v AND layer_id = @l AND objectid = @o",
+            connection);
+        command.Parameters.AddWithValue("v", version.VersionId);
+        command.Parameters.AddWithValue("l", PointsLayerId);
+        command.Parameters.AddWithValue("o", feature.Id);
+        await using var reader = await command.ExecuteReaderAsync();
+        (await reader.ReadAsync()).Should().BeTrue();
+        reader.GetBoolean(0).Should().BeTrue("base attributes are captured on first branch touch");
+        reader.GetBoolean(1).Should().BeTrue("base geometry is captured on first branch touch");
+    }
+
+    [Fact]
+    public async Task VersionedChange_IsTaggedInChangeLog_DefaultChangeIsNot()
+    {
+        var store = CreateFeatureStore();
+        var versionManager = CreateVersionManager();
+
+        // A DEFAULT edit records a NULL-version change (byte-identical change-tracking).
+        var defaultFeature = await store.CreateAsync(PointsLayerId, BuildFeature("Default-Edit", 5.0, 5.0), CancellationToken.None);
+
+        var version = await versionManager.CreateAsync(
+            new CreateVersionRequest("Tagged", "sde", VersionAccess.Public), CancellationToken.None);
+
+        await store.ApplyEditsAsync(
+            PointsLayerId,
+            FeatureEditBatch.Create(
+                updates: ImmutableArray.Create(BuildFeature("Tagged-Edit", 5.5, 5.5, defaultFeature.Id)),
+                versionContext: VersionContext.ForVersion(version)),
+            CancellationToken.None);
+
+        await using var connection = await OpenSchemaConnectionAsync();
+        await using var versioned = new NpgsqlCommand(
+            "SELECT COUNT(*) FROM honua.feature_changes WHERE version_id = @v AND layer_id = @l", connection);
+        versioned.Parameters.AddWithValue("v", version.VersionId);
+        versioned.Parameters.AddWithValue("l", PointsLayerId);
+        var versionedCount = Convert.ToInt64(await versioned.ExecuteScalarAsync(), System.Globalization.CultureInfo.InvariantCulture);
+        versionedCount.Should().BeGreaterThan(0, "the overlay trigger tags version edits in the change log");
+
+        await using var defaultTagged = new NpgsqlCommand(
+            "SELECT COUNT(*) FROM honua.feature_changes WHERE version_id IS NULL AND layer_id = @l", connection);
+        defaultTagged.Parameters.AddWithValue("l", PointsLayerId);
+        var defaultNullVersionCount = Convert.ToInt64(await defaultTagged.ExecuteScalarAsync(), System.Globalization.CultureInfo.InvariantCulture);
+        defaultNullVersionCount.Should().BeGreaterThan(0, "DEFAULT edits stay NULL-version (byte-identical change tracking)");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DefaultSentinelAndAbsent_ResolveToDefault()
+    {
+        var versionManager = CreateVersionManager();
+
+        (await versionManager.ResolveAsync(null, CancellationToken.None))!.Value.IsDefault.Should().BeTrue();
+        (await versionManager.ResolveAsync("", CancellationToken.None))!.Value.IsDefault.Should().BeTrue();
+        (await versionManager.ResolveAsync("SDE.DEFAULT", CancellationToken.None))!.Value.IsDefault.Should().BeTrue();
+        (await versionManager.ResolveAsync("does.not.exist", CancellationToken.None)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateResolveDelete_VersionLifecycle_RoundTrips()
+    {
+        var versionManager = CreateVersionManager();
+
+        var created = await versionManager.CreateAsync(
+            new CreateVersionRequest("Lifecycle", "sde", VersionAccess.Protected, Description: "round trip"),
+            CancellationToken.None);
+        created.CommonAncestorGeneration.Should().BeGreaterThanOrEqualTo(0);
+
+        var resolved = await versionManager.ResolveAsync("sde.Lifecycle", CancellationToken.None);
+        resolved.Should().NotBeNull();
+        resolved!.Value.VersionId.Should().Be(created.VersionId);
+        resolved.Value.IsDefault.Should().BeFalse();
+
+        (await versionManager.DeleteAsync(created.VersionId, CancellationToken.None)).Should().BeTrue();
+        (await versionManager.ResolveAsync("sde.Lifecycle", CancellationToken.None)).Should().BeNull();
+    }
+
+    private static string NameOf(Feature feature)
+        => feature.Attributes.TryGetValue("name", out var value) ? value?.ToString() ?? string.Empty : string.Empty;
+
+    private static Feature BuildFeature(string name, double x, double y, long id = 0)
+    {
+        var point = _geometryFactory.CreatePoint(new Coordinate(x, y));
+        point.SRID = 4326;
+        var attributes = ImmutableDictionary<string, object?>.Empty.Add("name", name);
+        return new Feature { Id = id, Geometry = _wkbWriter.Write(point), Attributes = attributes };
+    }
+
+    private PostgresFeatureStoreRefactored CreateFeatureStore()
+    {
+        var connectionProvider = new TestDatabaseConnectionProvider(_fixture.DataSource, () => _schema);
+        var poolProvider = new DefaultObjectPoolProvider();
+        var stringBuilderPool = poolProvider.Create(new Microsoft.Extensions.ObjectPool.StringBuilderPooledObjectPolicy());
+        var dictionaryPool = poolProvider.Create(new DictionaryPooledObjectPolicy());
+        var geometryProcessor = new GeometryProcessor();
+        var cacheManager = new FeatureCacheManager(connectionProvider, NullLogger<FeatureCacheManager>.Instance, _schema);
+        var queryBuilder = new FeatureQueryBuilder(stringBuilderPool, geometryProcessor, _schema);
+        var dataAccess = new FeatureDataAccess(new FeatureDataAccessDependencies(
+            connectionProvider,
+            geometryProcessor,
+            cacheManager,
+            dictionaryPool,
+            StatementCache: null,
+            Logger: NullLogger<FeatureDataAccess>.Instance,
+            PerformanceOptions: null,
+            LimitsOptions: null,
+            PerformanceMonitor: null,
+            SchemaName: _schema));
+
+        return new PostgresFeatureStoreRefactored(
+            queryBuilder,
+            dataAccess,
+            cacheManager,
+            connectionProvider,
+            dictionaryPool,
+            connectionEncryptionService: null,
+            filterExpressionService: null);
+    }
+
+    private PostgresVersionManager CreateVersionManager()
+    {
+        var connectionProvider = new TestDatabaseConnectionProvider(_fixture.DataSource, () => _schema);
+        return new PostgresVersionManager(connectionProvider);
+    }
+
+    private async Task<NpgsqlConnection> OpenSchemaConnectionAsync()
+    {
+        var connection = await _fixture.DataSource.OpenConnectionAsync();
+        await using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = $"SET search_path TO {_schema}, public;";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        return connection;
+    }
+}


### PR DESCRIPTION
## Issue Link
Refs #1272, #1270
Related to #371, #1287, #1285

## Summary
Slice 1 of the branch-versioning wiring (#1272 Track B), implementing the accepted ADR-0051 overlay/moment storage model. This delivers the readable/editable version core: a shared overlay table for branch row values, a Postgres `IVersionManager`, version-aware overlay reads, and GUC-routed overlay writes — all gated so the DEFAULT (`null`/`SDE.DEFAULT`) read/edit path stays byte-identical and the OGC CITE 952/952 baseline cannot regress. Reconcile/post (Slice 2) and the GeoServices VersionManagementServer surface (Slice 3) are intentionally deferred.

## Changes Made
- Add migration `049_CreateVersionEdits.sql`: additive `honua.version_edits` overlay table (`version_id, layer_id, objectid, operation, geometry, attributes, base_geometry, base_attributes, branch_gen`, PK `(version_id, layer_id, objectid)`), covering btree + `GIST(geometry)` + delete-only partial index, plus a version-aware trigger that tags `honua.feature_changes` with the producing version. Completely inert for DEFAULT.
- Add `PostgresVersionManager : IVersionManager` over `gdb_versions` + `version_edits` (create stamps `common_ancestor_gen` from `sync_generation`; resolve maps owner.name / version-id and absent/`SDE.DEFAULT` to Default; delete cascades the overlay; reconcile/post throw NotSupported pending Slice 2).
- Add `NoOpVersionManager` (`SupportsVersioning=false`) and register it for DuckDB/MySQL; register `PostgresVersionManager` on the Postgres path.
- Add `FeatureQueryBuilder.Version.cs` overlay reads: DEFAULT emits today's exact SQL (CITE firewall); a branch version substitutes a `(base-minus-shadowed UNION ALL overlay-non-deletes)` subquery on the select/count/objectIds/optimized/point read shapes. KNN/distance/analytics/H3/bins/MVT/encoded versioned reads throw NotSupported rather than silently leak DEFAULT.
- Add `FeatureDataAccess.VersionEdits.cs`: versioned overlay writes in one transaction — `SET LOCAL honua.gdb_version`, route INSERT/UPDATE/DELETE to `version_edits`, capture the DEFAULT base image on first touch. DEFAULT writes are untouched.
- Thread a nullable `VersionContext` onto `FeatureQuery` and `FeatureEditBatch`.
- Add `FeatureQueryBuilderVersionTests` (byte-identical DEFAULT SQL + overlay shape + NotSupported guards) and `BranchVersioningIntegrationTests` (isolated versioned edit, overlay read, DEFAULT unaffected, first-touch base capture, change-log version tagging, version lifecycle).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires database migration

## Breaking Changes
None. The DEFAULT (`null`/`SDE.DEFAULT`) read/edit/change-tracking path is byte-identical: the 58 exact-SQL `FeatureQueryBuilder` unit tests, 42 DEFAULT feature-store integration tests, the change-tracking/replication/temporal regressions, and the full migration chain all pass unchanged.

---

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh ... (equivalent — Release warnings-as-errors build, format, affected tests green)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
