### PR TITLE
docs: strengthen ADR-0051 — weigh synthetic-layer_id alternative + record as-built divergences (#1272)

### DIFF
--- a/docs/contributor/adr/0051-branch-versioning-storage-model.md
+++ b/docs/contributor/adr/0051-branch-versioning-storage-model.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-Accepted
+Accepted — implemented and merged via #1504 (foundation), #1508 (overlay storage +
+reads/writes), #1509 (reconcile/post), and #1510 (`VersionManagementServer` +
+`gdbVersion` routing); #1272 closed. As-built divergences and deferred refinements are
+noted inline and tracked in #1511.
 
 ## Context
 
@@ -56,6 +59,13 @@ so the 952/952 OGC CITE baseline cannot regress when `gdbVersion` is absent.
    rows in `features`; a branch is a named view over row history.
 4. **Hybrid.** Overlay by default; promote a hot/long-lived version to its own
    indexed delta table.
+5. **Synthetic `layer_id` discriminator.** A version is a synthetic
+   `branch_layer_id` (allocated from a high range); branch rows live in the shared
+   `features` table under that id. DEFAULT queries (filtered by the base layer_id)
+   never see them, and the existing change-tracking trigger covers branch rows with
+   no new plumbing. (This is the approach an independent parallel implementation
+   chose — weighed here because its reuse of the layer_id discriminator is genuinely
+   elegant.)
 
 | Axis | 1 Overlay | 2 Per-version tables | 3 Bitemporal base |
 |---|---|---|---|
@@ -71,6 +81,34 @@ Per-version DDL tables are strictly dominated by the overlay (same benefits, DDL
 churn cost). Bitemporal is the "purest" history model and natively solves the
 OID-only gap, but it moves version state into the `DEFAULT` hot path and **cannot
 guarantee the byte-identical `DEFAULT` query** — disqualifying for #1272.
+
+The **synthetic `layer_id` discriminator (Approach 5)** deserves a direct rebuttal
+because it is simpler than the overlay and reuses more existing infrastructure — it
+needs no `version_edits` table and no new trigger. It is rejected for one decisive
+structural reason plus two semantic ones:
+
+- **ObjectID identity (decisive).** `features.objectid` is the *global* primary key,
+  so the same `objectid` cannot exist under both the base layer_id and a branch
+  layer_id. A branch therefore cannot preserve a DEFAULT feature's OID — but Esri
+  branch versioning, ArcGIS clients, and reconcile-by-OID all require OID stability
+  across versions. No amount of layer_id machinery fixes this: it is a consequence
+  of the global-PK schema. The overlay table keys on `(version_id, layer_id,
+  objectid)`, so the *same* OID lives in DEFAULT and in the branch overlay — identity
+  preserved. This is the single deciding factor.
+- **No fork / empty branch.** With a registry-only create (no copy) and a read that
+  swaps to `branch_layer_id` (no UNION with base), a freshly created branch is
+  *empty* — you cannot edit an existing DEFAULT feature in isolation, only add rows
+  to a scratch layer. The overlay read (`base ⊎ branch edits`) gives true fork
+  semantics with copy-on-first-touch.
+- **Reconcile/post.** Merging branch edits back to DEFAULT under a separate layer_id
+  means re-keying OIDs on post (because of the PK collision above), which the model
+  has no clean answer for; the overlay's shared-OID rows replay onto `features`
+  directly.
+
+The layer_id-discriminator insight (versions ride the existing change-tracking trigger
+for free) is real, and the overlay model captures the same benefit by tagging
+`feature_changes.version_id` from the same trigger — without inheriting the OID
+collision.
 
 ## Decision
 
@@ -154,7 +192,7 @@ only**; the durable `sync_generation` sequence as the "moment."
 - Storing the ancestor image on first touch adds bounded write/storage cost per
   branch-edited row; acceptable for correct reconcile.
 
-## Implementation surface (deferred wiring, tracked under #1272)
+## Implementation surface (as built)
 
 - `PostgresVersionManager` implementing `IVersionManager` over `gdb_versions` +
   `version_edits`; `CreateAsync` stamps `common_ancestor_gen = currval(sync_generation)`.
@@ -173,10 +211,36 @@ only**; the durable `sync_generation` sequence as the "moment."
   Enterprise-gated, advertised in FeatureServer metadata.
 - `049_CreateVersionEdits.sql` is the only additive schema change beyond `047/048`.
 
+### As-built divergences and open risks (tracked in #1511)
+
+- **Post does not use `IFeatureWriter` literally.** This ADR specified post replays
+  via the shared `IFeatureWriter`; as built, `PostAsync` uses direct parameterized
+  SQL on `features` (in one transaction, through the same change-tracking trigger)
+  because `IFeatureWriter`'s `Feature` model auto-assigns objectids and round-trips
+  attributes through a typed dictionary — which would drop branch-created OIDs and
+  JSONB fidelity. A future transaction-scoped / explicit-OID `IFeatureWriter` overload
+  would let post use the shared writer as intended.
+- **Overlay read at scale is unvalidated.** The version read
+  (`base WHERE objectid NOT IN (overlay OIDs) UNION ALL overlay`) under spatial
+  predicates has not been measured on a large, highly-divergent version; the GIST
+  plan across the UNION/anti-join is the risk. Mitigation is hybrid promotion
+  (Approach 4) or LIST-partitioning `version_edits` by `version_id`, deferred until
+  measured. The DEFAULT path is unaffected.
+- **Single global generation sequence serializes posts.** Accepted for v1; per-layer
+  generation streams are a future option if concurrent multi-version post throughput
+  becomes a bottleneck.
+- **Esri `startReading`/`stopReading`/`startEditing`/`stopEditing`** are stateless
+  acknowledgements (the overlay/moment model carries the version per-request via
+  `gdbVersion`, so there is no server-held session); session-token semantics can be
+  added if a target client requires them.
+
 ## Cross-references
 
 - #1272 — Branch-versioned editing + production offline replica/change-tracking
-  (Track A merged; Track B foundation in PR #1500; this ADR decides Track B storage).
+  (closed; this ADR decided the branch-versioning storage model, implemented across
+  #1504/#1508/#1509/#1510).
+- #1511 — Branch-versioning follow-ups (post via `IFeatureWriter`, overlay-read-at-scale
+  validation, session-stateful edit, per-layer generation streams).
 - #1270 — Epic: editing-model parity.
 - #371 — Named versions, reconcile/post, multi-user concurrent editing (owns the
   reconcile/post UX + auto-resolution policy this substrate serves).


### PR DESCRIPTION
## Issue Link
Related to #1272, #1270, #1511

## Summary
Strengthens ADR-0051 (branch-versioning storage model) to address gaps surfaced after it was accepted: it never weighed the synthetic-`layer_id` discriminator approach that a parallel implementation independently chose, hand-waved overlay-read-at-scale, and stated a post-writer mechanism that diverged from the as-built code. The decision (overlay/moment model) is unchanged; this makes the record stand on its own merits.

## Changes Made
- Added the **synthetic-`layer_id` discriminator** as Approach 5 in "Approaches weighed", with a direct rebuttal: the decisive reason is **ObjectID identity** (`features.objectid` is the global PK, so a branch can't preserve DEFAULT OIDs — which Esri reconcile-by-OID requires), plus no-fork/empty-branch and reconcile re-keying. Credits the layer_id-reuse insight and notes the overlay captures the same change-tracking benefit without the OID collision.
- Recorded **as-built divergences and open risks** (new subsection, tracked in #1511): post uses direct parameterized SQL rather than `IFeatureWriter` (which auto-assigns OIDs / round-trips attributes); overlay-read-at-scale is unvalidated (hybrid promotion / `version_edits` partitioning as mitigation); single global generation sequence serializes posts; stateless start/stop-edit acknowledgements.
- Updated **Status** to "Accepted — implemented" with the merged PR set (#1504/#1508/#1509/#1510) and renamed the implementation section to "(as built)".
- Refreshed cross-references (#1272 closed; added #1511).

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Docs-only; file references verified against trunk.

## Gate Impact
- [x] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent — docs-only change; cross-references and file paths verified against trunk
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
