### PR TITLE
fix(ci): full base fetch + fail-safe so required build jobs don't skip on a missing merge-base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,12 +252,18 @@ jobs:
       - name: Determine diff range
         id: diff
         run: |
+          # Fetch the base branch with FULL history (NOT --depth=1). The filter below
+          # uses a three-dot range (base...head) that needs a merge-base; a shallow
+          # base fetch makes `git diff` fail with "fatal: no merge base", which the
+          # downstream `|| true` silently turned into an empty changed-file list →
+          # build_changes=false → the required build jobs SKIP and the PR is stuck
+          # BLOCKED. checkout already used fetch-depth: 0, so this is a cheap ref update.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin ${{ github.base_ref }} --depth=1
-            echo "range=origin/${{ github.base_ref }}...${{ github.sha }}" >> $GITHUB_OUTPUT
+            git fetch --no-tags origin "${{ github.base_ref }}"
+            echo "range=origin/${{ github.base_ref }}...${{ github.sha }}" >> "$GITHUB_OUTPUT"
           else
-            git fetch origin trunk --depth=1
-            echo "range=origin/trunk...${{ github.sha }}" >> $GITHUB_OUTPUT
+            git fetch --no-tags origin trunk
+            echo "range=origin/trunk...${{ github.sha }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check for non-test changes
@@ -266,9 +272,25 @@ jobs:
           PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
           set -euo pipefail
-          CHANGED_FILES=$(git diff --name-only "${{ steps.diff.outputs.range }}" || true)
           POSTGRES_BASELINE='[{"pg_image":"postgis/postgis:16-3.4","pg_suffix":"16","collect_coverage":true}]'
           POSTGRES_FULL='[{"pg_image":"postgis/postgis:16-3.4","pg_suffix":"16","collect_coverage":true},{"pg_image":"postgis/postgis:17-3.5","pg_suffix":"17","collect_coverage":false},{"pg_image":"postgis/postgis:18-3.6","pg_suffix":"18","collect_coverage":false}]'
+
+          # Fail safe: if the diff range cannot be computed (e.g. no merge-base after a
+          # full base fetch), run the full build/integration lane rather than silently
+          # skipping the required build jobs. A diff failure must NEVER fall through to
+          # build_changes=false (that left PRs stuck BLOCKED with build jobs "skipping").
+          if ! CHANGED_FILES=$(git diff --name-only "${{ steps.diff.outputs.range }}" 2>/dev/null); then
+            echo "::warning::Diff range '${{ steps.diff.outputs.range }}' unavailable (no merge-base); running the full build lane."
+            {
+              echo "build_changes=true"
+              echo "non_test_changes=true"
+              echo "integration_changes=true"
+              echo "integration_reason=diff_range_unavailable"
+              echo "full_ci=false"
+              echo "postgres_matrix=${POSTGRES_BASELINE}"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "build_changes=true" >> "$GITHUB_OUTPUT"
@@ -377,7 +399,8 @@ jobs:
           set -euo pipefail
           all_shards_json=$(jq -c '[.shards[].name]' .github/ci-shards.json)
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ needs.changes.outputs.full_ci }}" != "true" ]; then
-            git fetch origin "${{ github.base_ref }}" --depth=1
+            # Full base history (not --depth=1) so the targeted-tests diff has a merge-base.
+            git fetch --no-tags origin "${{ github.base_ref }}"
             descriptor=$(scripts/ci/honua-server-targeted-tests.sh --base "origin/${{ github.base_ref }}")
           else
             reason="scheduled_or_manual_full_ci"


### PR DESCRIPTION
## Issue Link
Related to #1488

## Summary
Fixes a CI change-detection bug that left PRs stuck `BLOCKED` with the required build jobs perpetually "skipping". The `Detect Non-Test Changes` job fetched the base branch with `--depth=1` and then diffed a three-dot range (`origin/<base>...<sha>`). A shallow base branch has no reachable common ancestor, so `git diff` failed with `fatal: no merge base`; the trailing `|| true` swallowed the error into an **empty** changed-file list, which fell through to `build_changes=false`. The required `AOT Build Verification` and `Build & Format Check` jobs then skipped, and the PR could never go green (observed on #1488).

## Changes Made
- **Full base fetch:** drop `--depth=1` when fetching the base branch in `Determine diff range` (and in the `targeted-shards` diff). `actions/checkout` already uses `fetch-depth: 0`, so this is a cheap remote-ref update that makes the merge-base computable.
- **Fail safe:** if the diff range still cannot be computed (no merge-base), run the full build/integration lane (`build_changes=true`) instead of silently skipping. A diff failure must never resolve to "no build".

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

This PR's own CI is the test: the modified `Detect Non-Test Changes` runs on this PR, and the required build jobs running (not skipping) demonstrates the fix. YAML validated; the diff-range logic traced for both the merge-base and no-merge-base paths.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
