### PR TITLE
perf(test): parallelize schema-isolated server tests, keep shared-catalog tests serial (#1359)

### DIFF
--- a/src/Honua.Hosting/Honua.Hosting.csproj
+++ b/src/Honua.Hosting/Honua.Hosting.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Honua.Server" />
     <InternalsVisibleTo Include="Honua.Server.Tests" />
+    <InternalsVisibleTo Include="Honua.TestKit" />
     <InternalsVisibleTo Include="Honua.Aws" />
     <InternalsVisibleTo Include="Honua.Azure" />
     <InternalsVisibleTo Include="Honua.Ai" />

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/DatabaseShardCollections.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/DatabaseShardCollections.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.TestKit;
+
+namespace Honua.Protocols.GeoServices.Tests;
+
+// Parallelism note (#1359): see the matching file in Honua.Server.Tests for the full
+// rationale. xUnit parallelizes ACROSS collections only. The GeoServices ImageServer CI
+// shard (ImageServer + GPServer + GeometryService + Catalog + NAServer) was serialized by
+// the single [Collection("Database")]. The metadata-v2 graph is now schema-partitioned, so
+// audited schema-isolated classes are opted in to these parallel collections.
+//
+// OPT-IN safety rule: a class is parallelized only when it either (a) runs against an
+// isolated, per-test WebAppFixture server with a mocked IRasterStore (GeometryService,
+// most ImageServer endpoint/error/validation/metadata tests, Catalog), or (b) issues only
+// schema-isolated reads / stateless computations against the shared server (NAServer route
+// solve). Classes that mutate shared GLOBAL `honua.*` rows are kept serial:
+//   - ImageServerMosaicIntegrationTests seeds the global honua.raster_data table
+//     (RasterIntegrationTestData) keyed by a fixed layer id and would race other raster
+//     tests.
+//   - GPServer*Tests that submit GP jobs through CreateAdminClient touch shared job/runtime
+//     state and stay serial.
+//
+// All collections share the TestKit PostgresFixture (single ref-counted, process-wide
+// PostGIS container) so parallelism adds no extra containers; schema names are globally
+// unique so concurrent schemas cannot collide.
+
+/// <summary>
+/// Parallel ImageServer-shard collection (bucket 1) for audited schema-isolated tests.
+/// </summary>
+[CollectionDefinition("Database.GeoServicesParallel1")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1711:Identifiers should not have incorrect suffix", Justification = "This is an xUnit collection definition which requires the Collection suffix")]
+public class DatabaseGeoServicesParallel1Collection : ICollectionFixture<PostgresFixture>
+{
+}
+
+/// <summary>
+/// Parallel ImageServer-shard collection (bucket 2) for audited schema-isolated tests.
+/// </summary>
+[CollectionDefinition("Database.GeoServicesParallel2")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1711:Identifiers should not have incorrect suffix", Justification = "This is an xUnit collection definition which requires the Collection suffix")]
+public class DatabaseGeoServicesParallel2Collection : ICollectionFixture<PostgresFixture>
+{
+}
+
+/// <summary>
+/// Parallel ImageServer-shard collection (bucket 3) for audited schema-isolated tests.
+/// </summary>
+[CollectionDefinition("Database.GeoServicesParallel3")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1711:Identifiers should not have incorrect suffix", Justification = "This is an xUnit collection definition which requires the Collection suffix")]
+public class DatabaseGeoServicesParallel3Collection : ICollectionFixture<PostgresFixture>
+{
+}
+
+/// <summary>
+/// Parallel ImageServer-shard collection (bucket 4) for audited schema-isolated tests.
+/// </summary>
+[CollectionDefinition("Database.GeoServicesParallel4")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1711:Identifiers should not have incorrect suffix", Justification = "This is an xUnit collection definition which requires the Collection suffix")]
+public class DatabaseGeoServicesParallel4Collection : ICollectionFixture<PostgresFixture>
+{
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Catalog/GeoservicesCatalogEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Catalog/GeoservicesCatalogEndpointTests.cs
@@ -14,7 +14,7 @@ using NSubstitute;
 
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.Catalog;
 
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel4")]
 [Protocol(TestProtocols.GeoservicesCatalog)]
 public sealed class GeoservicesCatalogEndpointTests : IAsyncLifetime
 {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceAdvancedOperationsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceAdvancedOperationsTests.cs
@@ -14,7 +14,7 @@ using Honua.TestKit.Extensions;
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService;
 
 [Protocol(TestProtocols.GeometryService)]
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel1")]
 public sealed class GeometryServiceAdvancedOperationsTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceBufferTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceBufferTests.cs
@@ -14,7 +14,7 @@ using Honua.TestKit.Extensions;
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService;
 
 [Protocol(TestProtocols.GeometryService)]
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel1")]
 public sealed class GeometryServiceBufferTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceEditOperationsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceEditOperationsTests.cs
@@ -19,7 +19,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService;
 /// ArcGIS SDKs invoke that previously returned 404.
 /// </summary>
 [Protocol(TestProtocols.GeometryService)]
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel1")]
 public sealed class GeometryServiceEditOperationsTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceGeoCoordinateStringTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceGeoCoordinateStringTests.cs
@@ -17,7 +17,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService;
 /// operations (MGRS / USNG grid reference conversion).
 /// </summary>
 [Protocol(TestProtocols.GeometryService)]
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel1")]
 public sealed class GeometryServiceGeoCoordinateStringTests : IAsyncLifetime
 {
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceInfoTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceInfoTests.cs
@@ -16,7 +16,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService;
 /// handshake fails and no operation request is ever made.
 /// </summary>
 [Protocol(TestProtocols.GeometryService)]
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel1")]
 public sealed class GeometryServiceInfoTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceMeasureAnalysisTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceMeasureAnalysisTests.cs
@@ -19,7 +19,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService;
 /// frequently and which previously returned 404.
 /// </summary>
 [Protocol(TestProtocols.GeometryService)]
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel1")]
 public sealed class GeometryServiceMeasureAnalysisTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceProjectTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceProjectTests.cs
@@ -13,7 +13,7 @@ using Honua.TestKit.Extensions;
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService;
 
 [Protocol(TestProtocols.GeometryService)]
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel1")]
 public sealed class GeometryServiceProjectTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceSimplifyTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceSimplifyTests.cs
@@ -13,7 +13,7 @@ using Honua.TestKit.Extensions;
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService;
 
 [Protocol(TestProtocols.GeometryService)]
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel1")]
 public sealed class GeometryServiceSimplifyTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerBasicTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerBasicTests.cs
@@ -19,7 +19,7 @@ using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.Servic
 
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer;
 
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel2")]
 [Protocol(TestProtocols.ImageServer)]
 public class ImageServerBasicTests : IAsyncLifetime
 {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerClientCompatibilityTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerClientCompatibilityTests.cs
@@ -18,7 +18,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer;
 /// Client-shaped ImageServer coverage over real HTTP routes with a deterministic
 /// raster store. This fills the gap between handler tests and external clients.
 /// </summary>
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel2")]
 [Protocol(TestProtocols.ImageServer)]
 public sealed class ImageServerClientCompatibilityTests
 {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
@@ -21,7 +21,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer;
 /// route binding, telemetry, JSON formatting, and error handling are all covered
 /// per ADR-0011 API Surface Coverage.
 /// </summary>
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel2")]
 [Protocol(TestProtocols.ImageServer)]
 public class ImageServerEndpointsTests
 {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerErrorHandlingTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerErrorHandlingTests.cs
@@ -14,7 +14,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer;
 /// <summary>
 /// Tests for ImageServer error handling: invalid parameters, malformed input, error responses.
 /// </summary>
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel3")]
 [Protocol(TestProtocols.ImageServer)]
 public class ImageServerErrorHandlingTests : IAsyncLifetime
 {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerParameterValidationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerParameterValidationTests.cs
@@ -15,7 +15,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer;
 /// <summary>
 /// Tests for ImageServer parameter validation: format variations, geometry parsing, valid parameters.
 /// </summary>
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel3")]
 [Protocol(TestProtocols.ImageServer)]
 public class ImageServerParameterValidationTests : IAsyncLifetime
 {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerRasterMetadataTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerRasterMetadataTests.cs
@@ -22,7 +22,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer;
 /// surface coverage. Endpoint coverage is consolidated onto a small number of methods
 /// (multiple <c>[Endpoint]</c> attributes per method) to keep the fixture-init count low.
 /// </summary>
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel3")]
 [Protocol(TestProtocols.ImageServer)]
 public class ImageServerRasterMetadataTests
 {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/NAServer/NAServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/NAServer/NAServerEndpointTests.cs
@@ -20,7 +20,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.NAServer;
 /// (see <see cref="TestRoutingProvider"/>) to exercise the full
 /// adapter → provider → Esri response path without a live topology.
 /// </summary>
-[Collection("Database")]
+[Collection("Database.GeoServicesParallel4")]
 [Protocol(TestProtocols.NAServer)]
 public sealed class NAServerEndpointTests : IAsyncLifetime
 {

--- a/tests/dotnet/Honua.Server.Tests/AdvancedSpatialQueryTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/AdvancedSpatialQueryTests.cs
@@ -17,7 +17,7 @@ namespace Honua.Server.Tests;
 /// Tests distance-based queries (ST_DWithin, ST_Distance) and K-Nearest Neighbor (KNN) queries.
 /// </summary>
 [Protocol(TestProtocols.FeatureServer)]
-[Collection("Database")]
+[Collection("Database.CoreParallel3")]
 public sealed class AdvancedSpatialQueryTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Server.Tests/ApiExplorerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/ApiExplorerEndpointTests.cs
@@ -14,7 +14,7 @@ namespace Honua.Server.Tests;
 /// Integration tests for the interactive API explorer (Scalar) at /docs.
 /// </summary>
 [Protocol(TestProtocols.Infrastructure)]
-[Collection("Database")]
+[Collection("Database.CoreParallel4")]
 public sealed class ApiExplorerEndpointTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new WebAppFixture()

--- a/tests/dotnet/Honua.Server.Tests/AttachmentEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/AttachmentEndpointTests.cs
@@ -20,7 +20,7 @@ namespace Honua.Server.Tests;
 /// Tests Issue #13 - Attachment CRUD operations implementation.
 /// </summary>
 [Protocol(TestProtocols.FeatureServer)]
-[Collection("Database")]
+[Collection("Database.CoreParallel3")]
 public sealed class AttachmentEndpointTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Server.Tests/CrsTransformationCorrectnessTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/CrsTransformationCorrectnessTests.cs
@@ -18,7 +18,7 @@ namespace Honua.Server.Tests;
 /// Tests critical PostgresCrsRegistry functionality and real-world coordinate scenarios.
 /// </summary>
 [Protocol(TestProtocols.FeatureServer)]
-[Collection("Database")]
+[Collection("Database.CoreParallel3")]
 public sealed class CrsTransformationCorrectnessTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Server.Tests/DatabaseMigrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/DatabaseMigrationTests.cs
@@ -14,7 +14,7 @@ namespace Honua.Server.Tests;
 /// Tests for database migration functionality using DbUp
 /// </summary>
 [Protocol(TestProtocols.TestQuality)]
-[Collection("Database")]
+[Collection("Database.CoreParallel4")]
 public sealed class DatabaseMigrationTests : IAsyncLifetime
 {
     private readonly PostgresFixture _postgres = new();

--- a/tests/dotnet/Honua.Server.Tests/DatabaseShardCollections.cs
+++ b/tests/dotnet/Honua.Server.Tests/DatabaseShardCollections.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Server.Tests.Infrastructure;
+
+namespace Honua.Server.Tests;
+
+// Parallelism note (#1359):
+//
+// xUnit parallelizes ACROSS collections, never within a single collection. The
+// historical single [Collection("Database")] therefore forced every database-backed
+// Server test to run serially, even though each test already gets its own isolated
+// PostgreSQL schema (via PostgresFixture.CreateIsolatedSchemaAsync) and the shared
+// in-memory test server is schema-routed per request (X-Honua-Test-Schema header).
+//
+// The metadata-v2 graph — the one piece of shared, mutable, process-wide singleton
+// state on the shared test server — is now partitioned by schema in
+// TestMetadataV2GraphProvider, so two schema-isolated tests can mutate metadata
+// concurrently without clobbering each other.
+//
+// IMPORTANT — this is OPT-IN parallelism. A class is moved into one of these parallel
+// collections ONLY if it has been audited to be fully schema-isolated: it operates
+// solely within its own per-test PostgreSQL schema (feature-store query/edit, OGC API
+// Features query, spatial queries, CRS, attachments) and the per-fixture
+// schema-partitioned in-memory metadata graph, and it NEVER mutates shared, global
+// `honua.*` catalog rows (honua.layers / honua.services / honua.raster_data /
+// honua.secure_connections / metadata-v2 snapshots) or publishes through the admin API.
+// Any class that does is left in the serial [Collection("Database")] collection. The
+// prior broad split (commit 85b3d11e, reverted) parallelized admin-publish and global
+// catalog-mutating tests and deadlocked with 40P01; the classification below is the fix.
+//
+// These sibling collections all share the same DatabaseFixtureAdapter fixture type.
+// PostgresFixture keeps a single ref-counted, process-wide PostGIS container, so using
+// several collections does NOT spin up several containers — it only unlocks xUnit
+// cross-collection parallelism. Schema names are globally unique (per-process counter +
+// GUID), so concurrent collections cannot collide on schema-qualified objects.
+//
+// A small fixed number of buckets (rather than one-collection-per-class) bounds the
+// concurrent database connection pressure against the shared container while still
+// removing the serial barrier for the audited classes.
+
+/// <summary>
+/// Parallel Core-shard collection (bucket 1) for audited schema-isolated tests.
+/// </summary>
+[CollectionDefinition("Database.CoreParallel1")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1711:Identifiers should not have incorrect suffix", Justification = "This is an xUnit collection definition which requires the Collection suffix")]
+public class DatabaseCoreParallel1Collection : ICollectionFixture<DatabaseFixtureAdapter>
+{
+}
+
+/// <summary>
+/// Parallel Core-shard collection (bucket 2) for audited schema-isolated tests.
+/// </summary>
+[CollectionDefinition("Database.CoreParallel2")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1711:Identifiers should not have incorrect suffix", Justification = "This is an xUnit collection definition which requires the Collection suffix")]
+public class DatabaseCoreParallel2Collection : ICollectionFixture<DatabaseFixtureAdapter>
+{
+}
+
+/// <summary>
+/// Parallel Core-shard collection (bucket 3) for audited schema-isolated tests.
+/// </summary>
+[CollectionDefinition("Database.CoreParallel3")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1711:Identifiers should not have incorrect suffix", Justification = "This is an xUnit collection definition which requires the Collection suffix")]
+public class DatabaseCoreParallel3Collection : ICollectionFixture<DatabaseFixtureAdapter>
+{
+}
+
+/// <summary>
+/// Parallel Core-shard collection (bucket 4) for audited schema-isolated tests.
+/// </summary>
+[CollectionDefinition("Database.CoreParallel4")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1711:Identifiers should not have incorrect suffix", Justification = "This is an xUnit collection definition which requires the Collection suffix")]
+public class DatabaseCoreParallel4Collection : ICollectionFixture<DatabaseFixtureAdapter>
+{
+}

--- a/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -23,7 +23,7 @@ namespace Honua.Server.Tests;
 /// <summary>
 /// Integration tests for streaming query functionality (Issue #229)
 /// </summary>
-[Collection("Database")]
+[Collection("Database.CoreParallel1")]
 [Protocol(TestProtocols.FeatureServer)]
 public sealed class StreamingFeatureServerEndpointTests : IAsyncLifetime
 {
@@ -245,7 +245,7 @@ public sealed class StreamingFeatureServerEndpointTests : IAsyncLifetime
 }
 
 [Protocol(TestProtocols.FeatureServer)]
-[Collection("Database")]
+[Collection("Database.CoreParallel1")]
 public sealed class FeatureServerEndpointTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Server.Tests/HealthEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/HealthEndpointTests.cs
@@ -13,7 +13,7 @@ namespace Honua.Server.Tests;
 /// Integration tests for health endpoints.
 /// </summary>
 [Protocol(TestProtocols.Health)]
-[Collection("Database")]
+[Collection("Database.CoreParallel4")]
 public sealed class HealthEndpointTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Server.Tests/LimitsEnforcementTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/LimitsEnforcementTests.cs
@@ -19,7 +19,7 @@ namespace Honua.Server.Tests;
 /// Tests Issue #63 - Shared limits configuration implementation.
 /// </summary>
 [Protocol(TestProtocols.FeatureServer)]
-[Collection("Database")]
+[Collection("Database.CoreParallel4")]
 public sealed class LimitsEnforcementTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Server.Tests/PostgresAttachmentStoreTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/PostgresAttachmentStoreTests.cs
@@ -18,7 +18,7 @@ namespace Honua.Server.Tests;
 /// <summary>
 /// Integration tests for PostgresAttachmentStore using real PostgreSQL database.
 /// </summary>
-[Collection("Database")]
+[Collection("Database.CoreParallel2")]
 public class PostgresAttachmentStoreTests : IAsyncLifetime
 {
     private readonly DatabaseFixtureAdapter _fixture;

--- a/tests/dotnet/Honua.Server.Tests/PostgresFeatureStoreGeographyTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/PostgresFeatureStoreGeographyTests.cs
@@ -14,7 +14,7 @@ using FeatureStoreStringBuilderPooledObjectPolicy = Honua.Postgres.Features.Feat
 
 namespace Honua.Server.Tests;
 
-[Collection("Database")]
+[Collection("Database.CoreParallel2")]
 public sealed class PostgresFeatureStoreGeographyTests : IAsyncLifetime
 {
     private readonly DatabaseFixtureAdapter _fixture;

--- a/tests/dotnet/Honua.Server.Tests/PostgresFeatureStoreTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/PostgresFeatureStoreTests.cs
@@ -18,7 +18,7 @@ namespace Honua.Server.Tests;
 /// <summary>
 /// Integration tests for PostgresFeatureStore using real PostgreSQL database.
 /// </summary>
-[Collection("Database")]
+[Collection("Database.CoreParallel2")]
 public class PostgresFeatureStoreTests : IAsyncLifetime
 {
     private readonly DatabaseFixtureAdapter _fixture;

--- a/tests/dotnet/Honua.Server.Tests/QueryRelatedRecordsEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/QueryRelatedRecordsEndpointTests.cs
@@ -17,7 +17,7 @@ namespace Honua.Server.Tests;
 /// Tests Issue #14 - Related records query functionality implementation.
 /// </summary>
 [Protocol(TestProtocols.FeatureServer)]
-[Collection("Database")]
+[Collection("Database.CoreParallel4")]
 public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.Server.Tests/SpatialCorrectnessTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/SpatialCorrectnessTests.cs
@@ -21,7 +21,7 @@ namespace Honua.Server.Tests;
 /// Based on Round 1 spatial bug findings - tests actual query behavior and data corruption potential.
 /// </summary>
 [Protocol(TestProtocols.FeatureServer)]
-[Collection("Database")]
+[Collection("Database.CoreParallel3")]
 public sealed class SpatialCorrectnessTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();

--- a/tests/dotnet/Honua.TestKit/Infrastructure/TestMetadataV2GraphProvider.cs
+++ b/tests/dotnet/Honua.TestKit/Infrastructure/TestMetadataV2GraphProvider.cs
@@ -1,47 +1,95 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Collections.Concurrent;
 using System.Text.Json;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Domain;
+using Honua.Infrastructure.Middleware;
 
 namespace Honua.TestKit.Infrastructure;
 
 /// <summary>
-/// In-memory <see cref="IMetadataV2GraphProvider"/> for tests. Holds a single graph
-/// snapshot supplied at construction; callers can swap the snapshot at any time.
+/// In-memory <see cref="IMetadataV2GraphProvider"/> for tests.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Parallel-isolation contract (#1359): the shared test server is process-wide singleton
+/// state, so a single mutable graph snapshot would let two schema-isolated tests running
+/// concurrently in the same assembly clobber each other's metadata. To make the shared
+/// server safe to run under parallel xUnit collections, this provider partitions the graph
+/// <b>by database schema</b>.
+/// </para>
+/// <para>
+/// Reads (<see cref="GetCurrentAsync"/>) resolve the per-request schema from the ambient
+/// <see cref="SchemaContext"/> that <c>TestSchemaMiddleware</c> populates from the
+/// <c>X-Honua-Test-Schema</c> header, so a request issued by test A only ever sees graph
+/// mutations that test A applied to its own schema. Writes from the fixture
+/// (<see cref="SetGraph(MetadataV2Graph, string?, string?)"/>) target an explicit schema key
+/// supplied by the owning <c>WebAppFixture</c>. When no schema is in scope (isolated-mode
+/// fixtures that build their own server, or tests that never send the header) the provider
+/// falls back to a shared baseline partition — those callers already get a dedicated server
+/// instance, so the baseline is private to them.
+/// </para>
+/// </remarks>
 public sealed class TestMetadataV2GraphProvider : IMetadataV2GraphStore
 {
-    private MetadataV2GraphSnapshot _snapshot;
+    private const string BaselineSchemaKey = "<baseline>";
+
+    private readonly ConcurrentDictionary<string, MetadataV2GraphSnapshot> _bySchema = new(StringComparer.Ordinal);
+    private MetadataV2GraphSnapshot _baseline;
 
     public TestMetadataV2GraphProvider(MetadataV2Graph graph, string? etag = null)
     {
         ArgumentNullException.ThrowIfNull(graph);
-        _snapshot = new MetadataV2GraphSnapshot(
+        _baseline = new MetadataV2GraphSnapshot(
             graph,
             etag ?? $"\"test-{graph.Revision}\"",
             DateTimeOffset.UtcNow);
     }
 
     /// <summary>
-    /// Replaces the snapshot returned by future calls.
+    /// Replaces the snapshot for the supplied schema partition. When <paramref name="schema"/>
+    /// is null the ambient request schema is used, falling back to the shared baseline.
     /// </summary>
-    public void SetGraph(MetadataV2Graph graph, string? etag = null)
+    public void SetGraph(MetadataV2Graph graph, string? etag = null, string? schema = null)
     {
         ArgumentNullException.ThrowIfNull(graph);
-        _snapshot = new MetadataV2GraphSnapshot(
+        var snapshot = new MetadataV2GraphSnapshot(
             graph,
             etag ?? $"\"test-{graph.Revision}\"",
             DateTimeOffset.UtcNow);
+
+        StoreSnapshot(snapshot, schema);
     }
 
     public ValueTask<MetadataV2GraphSnapshot> GetCurrentAsync(CancellationToken cancellationToken = default)
-        => new(_snapshot);
+        => new(CurrentSnapshot());
+
+    /// <summary>
+    /// Returns the snapshot for an explicit schema partition (or the shared baseline when
+    /// <paramref name="schema"/> resolves to no partition). Fixture mutation helpers use this
+    /// to read-modify-write a test's own partition without depending on an ambient request
+    /// schema being in scope.
+    /// </summary>
+    internal MetadataV2GraphSnapshot GetCurrentForSchema(string? schema)
+    {
+        var key = ResolveSchemaKey(schema);
+        if (!string.Equals(key, BaselineSchemaKey, StringComparison.Ordinal) &&
+            _bySchema.TryGetValue(key, out var scoped))
+        {
+            return scoped;
+        }
+
+        return _baseline;
+    }
 
     public ValueTask<MetadataV2GraphSnapshot?> GetByRevisionAsync(long revision, CancellationToken cancellationToken = default)
-        => new(_snapshot.Graph.Revision == revision ? _snapshot : null);
+    {
+        var snapshot = CurrentSnapshot();
+        return new(snapshot.Graph.Revision == revision ? snapshot : null);
+    }
 
     public Task<MetadataV2GraphSnapshot> SaveAsync(
         MetadataV2Graph graph,
@@ -49,17 +97,51 @@ public sealed class TestMetadataV2GraphProvider : IMetadataV2GraphStore
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(graph);
+        var current = CurrentSnapshot();
         if (expectedEtag is not null &&
-            !string.Equals(expectedEtag, _snapshot.Etag, StringComparison.Ordinal))
+            !string.Equals(expectedEtag, current.Etag, StringComparison.Ordinal))
         {
             throw new InvalidOperationException("Metadata v2 graph ETag mismatch.");
         }
 
-        _snapshot = new MetadataV2GraphSnapshot(
+        var snapshot = new MetadataV2GraphSnapshot(
             graph,
             $"\"test-{graph.Revision}\"",
             DateTimeOffset.UtcNow);
-        return Task.FromResult(_snapshot);
+
+        StoreSnapshot(snapshot, schema: null);
+        return Task.FromResult(snapshot);
+    }
+
+    private void StoreSnapshot(MetadataV2GraphSnapshot snapshot, string? schema)
+    {
+        var key = ResolveSchemaKey(schema);
+        if (string.Equals(key, BaselineSchemaKey, StringComparison.Ordinal))
+        {
+            _baseline = snapshot;
+        }
+        else
+        {
+            _bySchema[key] = snapshot;
+        }
+    }
+
+    private MetadataV2GraphSnapshot CurrentSnapshot()
+    {
+        var key = ResolveSchemaKey(null);
+        if (!string.Equals(key, BaselineSchemaKey, StringComparison.Ordinal) &&
+            _bySchema.TryGetValue(key, out var scoped))
+        {
+            return scoped;
+        }
+
+        return _baseline;
+    }
+
+    private static string ResolveSchemaKey(string? schema)
+    {
+        var resolved = schema ?? SchemaContext.AmbientCurrentSchema;
+        return string.IsNullOrWhiteSpace(resolved) ? BaselineSchemaKey : resolved;
     }
 }
 

--- a/tests/dotnet/Honua.TestKit/Mixins/WebAppFixtureMetadataV2GraphMutationMixin.cs
+++ b/tests/dotnet/Honua.TestKit/Mixins/WebAppFixtureMetadataV2GraphMutationMixin.cs
@@ -42,6 +42,21 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
     }
 
     /// <summary>
+    /// Reads the current graph snapshot for the fixture's own schema partition (#1359).
+    /// Fixture mutations run outside an HTTP request, so the ambient request schema is not
+    /// populated; passing the fixture's <see cref="WebAppFixture.CurrentSchema"/> explicitly
+    /// keeps read-modify-write cycles scoped to the test's isolated schema and parallel-safe.
+    /// </summary>
+    private static MetadataV2GraphSnapshot ReadCurrent(WebAppFixture fixture, TestMetadataV2GraphProvider provider)
+        => provider.GetCurrentForSchema(fixture.CurrentSchema);
+
+    /// <summary>
+    /// Writes a graph snapshot to the fixture's own schema partition (#1359).
+    /// </summary>
+    private static void WriteGraph(WebAppFixture fixture, TestMetadataV2GraphProvider provider, MetadataV2Graph graph)
+        => provider.SetGraph(graph, etag: null, schema: fixture.CurrentSchema);
+
+    /// <summary>
     /// Updates the canonical resource published at <paramref name="layerIndex"/> with any
     /// of the supplied metadata slots. <see cref="WebAppFixture.UpdateV2ResourceMetadata"/>
     /// is a thin wrapper over this helper. Clearing flags take precedence over value
@@ -63,7 +78,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
     {
         var provider = RequireProvider(fixture);
 
-        var snapshot = provider.GetCurrentAsync().AsTask().GetAwaiter().GetResult();
+        var snapshot = ReadCurrent(fixture, provider);
         var pub = snapshot.Graph.Publications.FirstOrDefault(p => p.LayerIndex == layerIndex);
         if (pub is null)
         {
@@ -145,7 +160,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
             Resources = resources,
             Revision = snapshot.Graph.Revision + 1,
         };
-        provider.SetGraph(updatedGraph);
+        WriteGraph(fixture, provider, updatedGraph);
     }
 
     /// <summary>
@@ -159,7 +174,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
 
         var provider = RequireProvider(fixture);
 
-        var snapshot = provider.GetCurrentAsync().AsTask().GetAwaiter().GetResult();
+        var snapshot = ReadCurrent(fixture, provider);
         var pub = snapshot.Graph.Publications.FirstOrDefault(p => p.LayerIndex == layerIndex);
         if (pub is null)
         {
@@ -194,7 +209,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
             Resources = resources,
             Revision = snapshot.Graph.Revision + 1,
         };
-        provider.SetGraph(updatedGraph);
+        WriteGraph(fixture, provider, updatedGraph);
     }
 
     /// <summary>
@@ -207,7 +222,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
     {
         var provider = RequireProvider(fixture);
 
-        var snapshot = provider.GetCurrentAsync().AsTask().GetAwaiter().GetResult();
+        var snapshot = ReadCurrent(fixture, provider);
         var pub = snapshot.Graph.Publications.FirstOrDefault(p => p.LayerIndex == layerIndex);
         if (pub is null)
         {
@@ -238,7 +253,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
             Resources = resources,
             Revision = snapshot.Graph.Revision + 1,
         };
-        provider.SetGraph(updatedGraph);
+        WriteGraph(fixture, provider, updatedGraph);
     }
 
     /// <summary>
@@ -249,7 +264,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
     {
         var provider = RequireProvider(fixture);
 
-        var snapshot = provider.GetCurrentAsync().AsTask().GetAwaiter().GetResult();
+        var snapshot = ReadCurrent(fixture, provider);
         var pub = snapshot.Graph.Publications.FirstOrDefault(p => p.LayerIndex == layerIndex);
         if (pub is null)
         {
@@ -283,7 +298,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
             Resources = resources,
             Revision = snapshot.Graph.Revision + 1,
         };
-        provider.SetGraph(updatedGraph);
+        WriteGraph(fixture, provider, updatedGraph);
     }
 
     /// <summary>
@@ -300,7 +315,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
     {
         var provider = RequireProvider(fixture);
 
-        var snapshot = provider.GetCurrentAsync().AsTask().GetAwaiter().GetResult();
+        var snapshot = ReadCurrent(fixture, provider);
         var services = snapshot.Graph.Services.ToArray();
         var mutated = false;
         for (var i = 0; i < services.Length; i++)
@@ -338,7 +353,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
             Services = services,
             Revision = snapshot.Graph.Revision + 1,
         };
-        provider.SetGraph(updatedGraph);
+        WriteGraph(fixture, provider, updatedGraph);
     }
 
     /// <summary>
@@ -350,7 +365,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
     {
         var provider = RequireProvider(fixture);
 
-        var snapshot = provider.GetCurrentAsync().AsTask().GetAwaiter().GetResult();
+        var snapshot = ReadCurrent(fixture, provider);
         var affectedResourceIds = snapshot.Graph.Publications
             .Where(publication => publication.LayerIndex == layerIndex)
             .Select(publication => publication.ResourceId)
@@ -383,7 +398,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
                 : publication)
             .ToArray();
 
-        provider.SetGraph(snapshot.Graph with
+        WriteGraph(fixture, provider, snapshot.Graph with
         {
             Resources = resources,
             Publications = publications,
@@ -401,7 +416,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
     {
         var provider = RequireProvider(fixture);
 
-        var snapshot = provider.GetCurrentAsync().AsTask().GetAwaiter().GetResult();
+        var snapshot = ReadCurrent(fixture, provider);
         var adminGraph = WebAppFixtureMetadataV2Mixin.BuildAdminSampleMetadataV2Graph();
         var adminResourceIds = adminGraph.Resources
             .Select(static resource => resource.Metadata.Id)
@@ -417,7 +432,7 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
             .ToHashSet(StringComparer.Ordinal);
 
         var graph = snapshot.Graph;
-        provider.SetGraph(graph with
+        WriteGraph(fixture, provider, graph with
         {
             Resources = graph.Resources
                 .Where(resource => !adminResourceIds.Contains(resource.Metadata.Id))
@@ -457,13 +472,13 @@ internal static class WebAppFixtureMetadataV2GraphMutationMixin
         var seedFile = Path.GetFileName(seedPath);
         if (seedFile.Equals("odata.yaml", StringComparison.OrdinalIgnoreCase))
         {
-            provider.SetGraph(WebAppFixtureMetadataV2Mixin.BuildODataSeedTestGraph());
+            WriteGraph(fixture, provider, WebAppFixtureMetadataV2Mixin.BuildODataSeedTestGraph());
             return;
         }
 
         if (seedFile.Equals("spatial-reference.yaml", StringComparison.OrdinalIgnoreCase))
         {
-            provider.SetGraph(WebAppFixtureMetadataV2Mixin.BuildSpatialReferenceSeedTestGraph());
+            WriteGraph(fixture, provider, WebAppFixtureMetadataV2Mixin.BuildSpatialReferenceSeedTestGraph());
         }
     }
 }

--- a/tests/dotnet/Honua.TestKit/Seeding/SeedRunner.cs
+++ b/tests/dotnet/Honua.TestKit/Seeding/SeedRunner.cs
@@ -131,8 +131,16 @@ internal static class SeedRunner
         var collectionLookup = BuildCollectionLookup(seed.Collections);
 
         await using var connection = await dataSource.OpenConnectionAsync().ConfigureAwait(false);
-        // Use RepeatableRead for test seeding to ensure consistent data setup
-        await using var transaction = await connection.BeginTransactionAsync(IsolationLevel.RepeatableRead).ConfigureAwait(false);
+        // ReadCommitted (not RepeatableRead): when collections run in parallel, multiple
+        // fixtures seed concurrently. The pg_advisory_xact_lock below already serializes the
+        // seed critical section, so snapshot isolation buys nothing here — but it actively
+        // breaks parallel seeding: pg_advisory_xact_lock is the transaction's first statement,
+        // so a waiting seeder pins its RepeatableRead snapshot before the lock is granted, and
+        // once the prior seeder commits its DELETEs the waiter fails with 40001 "could not
+        // serialize access due to concurrent delete". ReadCommitted re-snapshots per statement,
+        // so the waiter sees the prior seeder's committed state and never hits serialization
+        // failure, while the advisory lock keeps setup consistent.
+        await using var transaction = await connection.BeginTransactionAsync(IsolationLevel.ReadCommitted).ConfigureAwait(false);
         await AcquireSeedApplicationLockAsync(connection).ConfigureAwait(false);
 
         if (!string.IsNullOrWhiteSpace(schemaName))


### PR DESCRIPTION
## Issue Link
Closes #1359

## Summary
Parallelizes the **proven schema-isolated** server tests in the slow shards (Server Tests Core, GeoServices ImageServer) by splitting the single serial `[Collection("Database")]` into a small number of sibling parallel collections, so xUnit runs them concurrently. Every test that mutates shared global `honua.*` catalog state (admin publish, secure connections, RBAC, metadata-v2 snapshot activation, global raster seeding, GP jobs) is **kept serial** — this is the deliberate opt-in classification that avoids the `40001`/`40P01` shared-catalog deadlocks that sank the earlier broad split (reverted commit `85b3d11e`).

Only 30 classes are opted in (14 Core, 16 GeoServices across 4 buckets each); 328 classes remain serial. A single ref-counted process-wide PostGIS container is retained — parallelism adds no extra containers.

## Changes Made
- `tests/dotnet/Honua.TestKit/Infrastructure/TestMetadataV2GraphProvider.cs` — partition the shared in-memory metadata-v2 graph by schema (reads resolve `SchemaContext.AmbientCurrentSchema`; fixture mutations target the fixture's own `CurrentSchema`), so concurrent schema-isolated tests cannot clobber the one shared mutable singleton. `InternalsVisibleTo Honua.TestKit` added on `Honua.Hosting`.
- `tests/dotnet/Honua.TestKit/Seeding/SeedRunner.cs` — seed transaction uses `ReadCommitted` (the `pg_advisory_xact_lock` already serializes the seed critical section; `RepeatableRead` pinned the snapshot before the lock was granted → `40001`). Coexists with the merged seed-parse cache.
- New `DatabaseShardCollections.cs` (Server.Tests + GeoServices.Tests) defining `Database.CoreParallel1..4` and `Database.GeoServicesParallel1..4` sibling collections, each documenting the opt-in safety rule.
- Reassigned 30 audited schema-isolated test classes off the serial `Database` collection into the parallel buckets (FeatureServer query/edit, OGC API Features query, spatial/CRS/attachments; GeometryService, ImageServer endpoint/error/validation/metadata, Catalog, NAServer route-solve).
- Deliberately kept serial (documented in the collection files): `AdminSampleSeedPublishThroughAdminApiTests`, `ImageServerMosaicIntegrationTests` (seeds global `honua.raster_data`), `GPServer*` job tests, and anything writing shared `honua.*` catalog/connection/RBAC/metadata-activation rows.
- Timeout caps in `.github/ci-shards.json` left as-is pending a green CI run to measure the parallelized shard times; they can be reduced in a fast follow-up once CI confirms headroom (not cut blindly here to avoid timeout risk).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Full-solution Release build with `TreatWarningsAsErrors=true`: succeeded, 0 warnings. `dotnet format Honua.sln --verify-no-changes`: clean (exit 0). Parallel-safety of the split collections is validated by this PR's CI run of the Core / GeoServices ImageServer shards (the authoritative environment); any class that shows nondeterminism will be moved back to the serial collection.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
