### PR TITLE
feat: test/dev-gated observability seed endpoint for Console live smoke (#1229)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,15 @@ HONUA_ADMIN_PASSWORD=
 # HONUA_DEV_AUTH=true
 # HONUA_DEV_AUTH_ACK=i-understand-this-bypasses-auth
 
+# Operate observability seed for Console Testcontainers (DO NOT USE IN PRODUCTION)
+# Enables the admin-only, dev/test-gated seed endpoint that creates deterministic
+# alert + durable job records for honua-console live smoke tests (server #1229).
+#   POST /api/v1/admin/dev/fixtures/operate-observability/console-testcontainers-v1
+# Only honoured when ASPNETCORE_ENVIRONMENT is Development or Test and the data
+# provider is PostgreSQL; setting it in Production fails startup. Requires X-API-Key
+# admin auth. See docs/admin-api/operate-observability-fixtures.md.
+# HONUA_ENABLE_OBSERVABILITY_TEST_SEED=true
+
 # =============================================================================
 # COMPLIANCE FRAMEWORK (SOC 2 / FedRAMP readiness)
 # =============================================================================

--- a/docs/admin-api/operate-observability-fixtures.md
+++ b/docs/admin-api/operate-observability-fixtures.md
@@ -4,6 +4,17 @@ Honua Server exposes an explicit Development/Test seed facility for Console
 Testcontainers that need live Operate observability data from a real
 honua-server plus PostgreSQL runtime.
 
+This is the supported, non-production seed path that satisfies
+[honua-server#1229](https://github.com/honua-io/honua-server/issues/1229): it lets
+a downstream Console Testcontainers fixture create deterministic **active alert**
+and **durable job** records (plus related telemetry/log/event/investigation rows
+for cross-surface links) against a real honua-server image without reaching into
+PostgreSQL tables. The seeded records are visible only through the same
+public/admin observability read APIs Console consumes, and the path is disabled
+or fails fast in normal production configuration. This unblocks
+[honua-console#24](https://github.com/honua-io/honua-console/issues/24)'s final
+live alert/job evidence.
+
 The fixture is disabled by default. When enabled it is rejected outside
 `Development` and `Test` environments and requires the PostgreSQL provider; both
 checks fail fast at startup (`OptionsValidationException`) rather than serving
@@ -20,6 +31,21 @@ OperateObservabilityFixture__Enabled=true
 OperateObservabilityFixture__Profile=console-testcontainers-v1
 OperateObservabilityFixture__SeedOnStartup=false
 ```
+
+CI and Testcontainers can instead use the single flat alias
+`HONUA_ENABLE_OBSERVABILITY_TEST_SEED` (mirroring `HONUA_DEV_AUTH`). It is
+equivalent to the nested `OperateObservabilityFixture__Enabled=true` key and is
+the recommended switch for Console's Testcontainers fixture:
+
+```bash
+ASPNETCORE_ENVIRONMENT=Test
+HONUA_ENABLE_OBSERVABILITY_TEST_SEED=true
+```
+
+The flat alias can only enable the feature; it never disables an explicit
+`OperateObservabilityFixture__Enabled=true`. Like the nested key, it is rejected
+outside `Development`/`Test` (startup fails with `OptionsValidationException`), so
+setting it in production does not expose the seed path.
 
 The container must use PostgreSQL. The fixture does not support DuckDB, MySQL,
 or MariaDB providers.
@@ -160,6 +186,23 @@ Fixed identifiers:
 The alert zone polygon is a small Honolulu Harbor footprint declared in
 WGS84/EPSG:4326 and validated through the same geometry path as the production
 alert-zone admin API.
+
+## #1229 acceptance criteria
+
+| Criterion | How this path satisfies it |
+| --- | --- |
+| Start a real container with documented test/dev config and seed deterministic alert + job data | `ASPNETCORE_ENVIRONMENT=Test` + `HONUA_ENABLE_OBSERVABILITY_TEST_SEED=true` (or `OperateObservabilityFixture__Enabled=true`), then `POST /api/v1/admin/dev/fixtures/operate-observability/console-testcontainers-v1` with `X-API-Key`. |
+| Seeded records visible through public/admin observability APIs, not private tables | Alerts via `GET /api/v1/admin/observability/alerts?serviceId=operate-fixture-console`; jobs via `GET /api/v1/admin/jobs?correlationId=corr-operate-fixture-001`. The seeder writes through `IAlertEventStore`/`IExecutionJobStore`, the same stores the read APIs use. |
+| Seed path disabled/inaccessible in normal production | Disabled by default (endpoint returns `404`); enabling it under a non-Development/Test environment fails startup with `OptionsValidationException`. |
+| Documentation names env vars, auth, and expected record IDs/names | This document — see **Enable**, **Seed**, and the **Fixed identifiers** table. |
+| Console#24 can replace skipped/partial live alert + job evidence | The `alerts`/`jobs` keys in the response `links` map return the exact filtered read URLs to assert against. |
+
+The deterministic identifiers Console asserts by (auth: `X-API-Key` admin key):
+
+- Active (open) alert: lifecycle `open`, severity `Warning`, `serviceId=operate-fixture-console`, dedupe key `console-testcontainers-v1:alert-open`.
+- Resolved alert: lifecycle `resolved`, severity `Critical`, dedupe key `console-testcontainers-v1:alert-resolved`.
+- Durable jobs: `operate-fixture-job-succeeded` (Succeeded) and `operate-fixture-job-failed` (Failed).
+- Investigation: `inv-operate-fixture-console`.
 
 ## Notes
 

--- a/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureConstants.cs
+++ b/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureConstants.cs
@@ -18,4 +18,13 @@ internal static class OperateObservabilityFixtureConstants
     public const string InvestigationId = "inv-operate-fixture-console";
     public const string FixtureProfileParameter = "honua.fixture.profile";
     public const string FixtureSourceHydratedParameter = "honua.fixture.source_hydrated";
+
+    /// <summary>
+    /// Flat environment-variable alias for <c>OperateObservabilityFixture:Enabled</c>. CI and
+    /// Testcontainers fixtures prefer a single documented <c>HONUA_*</c> switch (mirroring
+    /// <c>HONUA_DEV_AUTH</c>/<c>HONUA_ENABLE_BASIC_AUTH_COMPAT</c>) over a nested config key.
+    /// Setting this to a truthy value (#1229) enables the Console observability seed endpoint
+    /// in Development/Test, just like the nested key.
+    /// </summary>
+    public const string EnableEnvironmentVariable = "HONUA_ENABLE_OBSERVABILITY_TEST_SEED";
 }

--- a/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureOptions.cs
+++ b/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureOptions.cs
@@ -14,6 +14,24 @@ internal sealed class OperateObservabilityFixtureOptions
     public string Profile { get; set; } = OperateObservabilityFixtureConstants.Profile;
 
     public bool SeedOnStartup { get; set; }
+
+    /// <summary>
+    /// Resolves the effective enabled state by honouring either the nested
+    /// <c>OperateObservabilityFixture:Enabled</c> config key or the flat
+    /// <see cref="OperateObservabilityFixtureConstants.EnableEnvironmentVariable"/> alias.
+    /// </summary>
+    /// <remarks>
+    /// The flat alias makes the seed path a single documented switch for CI and Console
+    /// Testcontainers (#1229). It can only turn the feature on; it never disables an explicit
+    /// <c>OperateObservabilityFixture:Enabled=true</c>.
+    /// </remarks>
+    public static bool ResolveEnabled(IConfiguration configuration, bool boundEnabled)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return boundEnabled ||
+               configuration.GetValue(OperateObservabilityFixtureConstants.EnableEnvironmentVariable, false);
+    }
 }
 
 internal sealed class OperateObservabilityFixtureOptionsValidator(

--- a/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureServiceCollectionExtensions.cs
@@ -21,6 +21,10 @@ internal static class OperateObservabilityFixtureServiceCollectionExtensions
         services
             .AddOptions<OperateObservabilityFixtureOptions>()
             .Bind(configuration.GetSection(OperateObservabilityFixtureOptions.SectionName))
+            // Honour the flat HONUA_ENABLE_OBSERVABILITY_TEST_SEED alias everywhere the bound
+            // options are consumed (endpoint mapping, validator, startup seed service) (#1229).
+            .PostConfigure(opts => opts.Enabled =
+                OperateObservabilityFixtureOptions.ResolveEnabled(configuration, opts.Enabled))
             .ValidateOnStart();
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IValidateOptions<OperateObservabilityFixtureOptions>,
@@ -28,6 +32,7 @@ internal static class OperateObservabilityFixtureServiceCollectionExtensions
 
         var options = new OperateObservabilityFixtureOptions();
         configuration.GetSection(OperateObservabilityFixtureOptions.SectionName).Bind(options);
+        options.Enabled = OperateObservabilityFixtureOptions.ResolveEnabled(configuration, options.Enabled);
         var validation = new OperateObservabilityFixtureOptionsValidator(environment, configuration).Validate(null, options);
         if (validation.Failed)
         {

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/OperateObservabilityFixtureEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/OperateObservabilityFixtureEndpointsTests.cs
@@ -300,6 +300,41 @@ public sealed class OperateObservabilityFixtureOptionsTests
         result.Failures.Should().Contain(failure => failure.Contains("Development or Test", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void ResolveEnabled_WhenFlatEnvAliasIsTrue_EnablesFixture()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["HONUA_ENABLE_OBSERVABILITY_TEST_SEED"] = "true"
+            })
+            .Build();
+
+        OperateObservabilityFixtureOptions.ResolveEnabled(configuration, boundEnabled: false)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void ResolveEnabled_WithNoFlagSet_StaysDisabled()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        OperateObservabilityFixtureOptions.ResolveEnabled(configuration, boundEnabled: false)
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void ResolveEnabled_WhenNestedKeyIsTrue_StaysEnabledRegardlessOfAlias()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        OperateObservabilityFixtureOptions.ResolveEnabled(configuration, boundEnabled: true)
+            .Should()
+            .BeTrue();
+    }
+
     private sealed class FakeHostEnvironment(string environmentName) : IHostEnvironment
     {
         public string EnvironmentName { get; set; } = environmentName;
@@ -339,5 +374,70 @@ public sealed class OperateObservabilityFixtureDisabledEndpointTests : IAsyncLif
         var response = await _client.PostAsync(SeedRoute, content: null);
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}
+
+/// <summary>
+/// Verifies the flat <c>HONUA_ENABLE_OBSERVABILITY_TEST_SEED</c> env-var alias enables the seed
+/// endpoint and produces the same deterministic alert + job records Console asserts (#1229).
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Configuration)]
+public sealed class OperateObservabilityFixtureEnvAliasEndpointTests : IAsyncLifetime
+{
+    private const string SeedRoute = "/api/v1/admin/dev/fixtures/operate-observability/console-testcontainers-v1";
+    private const string SucceededJobId = "operate-fixture-job-succeeded";
+    private const string FailedJobId = "operate-fixture-job-failed";
+
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public OperateObservabilityFixtureEnvAliasEndpointTests()
+    {
+        // Enable only via the flat HONUA_ENABLE_OBSERVABILITY_TEST_SEED alias; the nested
+        // OperateObservabilityFixture:Enabled key is intentionally left unset.
+        _fixture = new WebAppFixture()
+            .ConfigureWebHost(builder => builder.UseSetting("HONUA_ENABLE_OBSERVABILITY_TEST_SEED", "true"));
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateAdminClient();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/dev/fixtures/operate-observability/{profile}")]
+    public async Task SeedOperateObservabilityFixture_EnabledViaFlatEnvAlias_SeedsAlertsAndJobs()
+    {
+        var seedResponse = await _client.PostAsync(SeedRoute, content: null);
+
+        var seedBody = await seedResponse.Content.ReadAsStringAsync();
+        seedResponse.StatusCode.Should().Be(HttpStatusCode.OK, seedBody);
+        using var seed = JsonDocument.Parse(seedBody);
+        var openAlertId = seed.RootElement.GetProperty("alerts").GetProperty("openAlertEventId").GetInt64();
+
+        var alerts = await _client.GetAsync("/api/v1/admin/observability/alerts?serviceId=operate-fixture-console&pageSize=20");
+        alerts.StatusCode.Should().Be(HttpStatusCode.OK);
+        using (var doc = JsonDocument.Parse(await alerts.Content.ReadAsStringAsync()))
+        {
+            doc.RootElement.GetProperty("items").EnumerateArray()
+                .Should()
+                .Contain(alert =>
+                    alert.GetProperty("eventId").GetInt64() == openAlertId &&
+                    alert.GetProperty("lifecycleStatus").GetString() == "open");
+        }
+
+        var jobs = await _client.GetAsync("/api/v1/admin/jobs?correlationId=corr-operate-fixture-001&limit=10");
+        jobs.StatusCode.Should().Be(HttpStatusCode.OK);
+        using (var doc = JsonDocument.Parse(await jobs.Content.ReadAsStringAsync()))
+        {
+            var items = doc.RootElement.GetProperty("items").EnumerateArray().ToArray();
+            items.Should().Contain(job => job.GetProperty("jobId").GetString() == SucceededJobId);
+            items.Should().Contain(job => job.GetProperty("jobId").GetString() == FailedJobId);
+        }
     }
 }


### PR DESCRIPTION
## Issue Link
Fixes #1229

## Summary
honua-console#24 binds the Operate observability workspace to real honua-server admin APIs, but Console's live Testcontainers tests could not deterministically create live ALERT and durable JOB records to assert the event-viewer/alerts/jobs/logs surfaces. honua-server already ships a supported, admin-only, dev/test-gated seed endpoint (`POST /api/v1/admin/dev/fixtures/operate-observability/console-testcontainers-v1`) that creates deterministic, idempotent active+resolved alert events and succeeded/failed durable jobs (plus telemetry/log/audit/investigation rows) through the same `IAlertEventStore`/`IExecutionJobStore` the read APIs use. This PR makes that path trivially consumable from CI/Testcontainers by adding a single documented flat env switch and documenting the path against #1229's acceptance criteria.

## Changes Made
- Add `HONUA_ENABLE_OBSERVABILITY_TEST_SEED` as a flat env-var alias for `OperateObservabilityFixture:Enabled` (mirrors `HONUA_DEV_AUTH`/`HONUA_ENABLE_BASIC_AUTH_COMPAT`). Resolved via `OperateObservabilityFixtureOptions.ResolveEnabled` and applied through `PostConfigure` so the endpoint mapping, options validator, and startup seed service all honour it. The alias can only enable the feature; it never disables an explicit nested key.
- Preserve production gating: the alias flows through the existing `IValidateOptions` so enabling it outside Development/Test (or on DuckDB/MySQL/MariaDB) still fails fast at startup with `OptionsValidationException`; when off the endpoint stays unmapped (404).
- Document the endpoint, the env var(s), `X-API-Key` admin auth, container setup, deterministic seed IDs, and an explicit #1229 acceptance-criteria mapping in `docs/admin-api/operate-observability-fixtures.md`; add the switch to `.env.example`.
- Add tests: an integration test that enables the seed only via the flat alias and asserts the open alert + both jobs are visible through `/api/v1/admin/observability/alerts` and `/api/v1/admin/jobs`; plus unit tests for `ResolveEnabled` (alias on, default off, nested key precedence).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

`dotnet build src/Honua.Server/Honua.Server.csproj -c Debug` → 0 warnings / 0 errors. `dotnet test Honua.Server.Tests --filter OperateObservabilityFixture` → 7 passed / 0 failed (Docker + PostgreSQL Testcontainers), covering: seed creates alerts+jobs visible through the public admin read APIs, idempotent re-seed, gated-off-by-default (404), production-environment validation failure, and the new flat-env-alias path.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] None — no docs or contract impact

The dev/test-only seed endpoint remains intentionally excluded from the curated `docs/developer/api-specs/admin-api.json` SDK snapshot.

## Release/Deploy Impact
- [x] Requires environment variable or secret changes
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] None — standard merge-and-release flow

New opt-in `HONUA_ENABLE_OBSERVABILITY_TEST_SEED` env var (dev/test only; ignored/fails fast in production). No production default changes.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

> Note: `scripts/ci/pre-pr-check.sh` was run locally; its only finding was the pre-existing Windows-worktree quirk where the tracked `CLAUDE.md` symlink (git mode `120000` to `AGENTS.md`) materializes as a plain text file on Windows checkout. This is unchanged by this PR and is correct on trunk/Linux CI. Build (0/0) and the touched observability tests (7/7) pass.
