### PR TITLE
fix: catalog drifted /generate endpoints + close registry-drift scan gap (#1525)

### DIFF
--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -274,6 +274,8 @@ public static class EndpointRegistry
         new("POST", "/api/v1/studio/content-items/{itemId}/versions/{versionId}/publish-requests"),
         new("POST", "/api/v1/studio/content-items/{itemId}/versions/{versionId}/reopen"),
         new("POST", "/api/v1/studio/content-items/{itemId}/rollback-requests"),
+        // NL-assisted map package generation (#1180).
+        new("POST", "/api/v1/studio/map-packages/generate"),
 
         // v1 Studio map collaboration: comment threads + activity feed (#1278, slice 1)
         new("GET", "/api/v1/console/maps/{mapId}/collab/comments"),
@@ -289,6 +291,8 @@ public static class EndpointRegistry
         new("POST", "/api/v1/console/publications/{publicationId}/republish"),
         new("POST", "/api/v1/console/publications/{publicationId}/rollback"),
         new("PATCH", "/api/v1/console/publications/{publicationId}/policy"),
+        // NL-assisted report/dashboard content generation (#1183).
+        new("POST", "/api/v1/console/publications/generate"),
 
         // Temporal data history (slice 1 of #1166): capability discovery + as-of read.
         new("GET", "/api/v1/temporal/services/{serviceId}/layers/{layerId}/capabilities"),
@@ -514,6 +518,8 @@ public static class EndpointRegistry
         new("POST", "/api/v1/admin/forms/packages/{formId}/versions/{packageVersion}/validate"),
         new("POST", "/api/v1/admin/forms/packages/{formId}/versions/{packageVersion}/publish"),
         new("POST", "/api/v1/admin/forms/packages/{formId}/versions/{packageVersion}/reopen"),
+        // NL-assisted form package generation (#1184).
+        new("POST", "/api/v1/admin/forms/packages/generate"),
         new("GET", "/api/v1/forms/packages/{formId}"),
         new("GET", "/api/v1/forms/packages/{formId}/versions/{packageVersion}"),
         new("GET", "/api/v1/forms/packages/{formId}/offline-policy"),
@@ -1105,6 +1111,9 @@ public static class EndpointRegistry
         new("GET", "/v1/spec/artifact/{hash}"),
 
         // Analysis content HTTP surface (#1182, #1237).
+        // NL-assisted analysis-package and saved-query generation.
+        new("POST", "/api/v1/analysis/content/generate"),
+        new("POST", "/api/v1/analysis/content/queries/generate"),
         new("POST", "/api/v1/analysis/content/items"),
         new("GET", "/api/v1/analysis/content/items"),
         new("GET", "/api/v1/analysis/content/items/{itemId}"),

--- a/tests/dotnet/Honua.Architecture.Tests/EndpointRegistryDriftTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/EndpointRegistryDriftTests.cs
@@ -122,7 +122,7 @@ public sealed class EndpointRegistryDriftTests
         Directory.Exists(featuresRoot)
             .Should().BeTrue($"the audited features directory should exist at {featuresRoot}");
 
-        var discovered = ScanFeatureEndpoints(featuresRoot, repoRoot);
+        var discovered = ScanAllModuleEndpoints(repoRoot);
         var registered = BuildRegistrySet();
 
         var enforceable = discovered
@@ -194,9 +194,8 @@ public sealed class EndpointRegistryDriftTests
         // Guards against a regression where the regex or directory layout
         // changes and the scan silently passes because it discovered nothing.
         var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
-        var featuresRoot = Path.Combine(repoRoot, FeaturesRelativePath);
 
-        var discovered = ScanFeatureEndpoints(featuresRoot, repoRoot);
+        var discovered = ScanAllModuleEndpoints(repoRoot);
 
         discovered.Count.Should().BeGreaterThan(200,
             "the scanner should detect well over two hundred Map{Get,Post,...} calls; "
@@ -389,6 +388,32 @@ public sealed class EndpointRegistryDriftTests
         HashSet<string> FullRoutes,
         HashSet<string> GroupPrefixes,
         string CombinedSource);
+
+    /// <summary>
+    /// Forward-scan every <c>Map{Get,Post,Put,Delete,Patch}</c> route across the
+    /// <c>Honua.Server</c> features tree AND every extracted <c>src/Honua.*</c>
+    /// module (Honua.Ai, Honua.Geoprocessing, Honua.Protocols.*, …). As features
+    /// were carved out of <c>Honua.Server</c> their endpoint <c>Map*</c> calls
+    /// moved with them — e.g. the AnalysisContent <c>/generate</c> routes now live
+    /// in <c>Honua.Ai</c> — but every such route still has a registry obligation,
+    /// so the forward drift gate must scan those modules too. Host-wiring
+    /// resolution still anchors against the <c>Honua.Server</c> tree because the
+    /// extension methods are invoked from the server host.
+    /// </summary>
+    private static List<DiscoveredEndpoint> ScanAllModuleEndpoints(string repoRoot)
+    {
+        var featuresRoot = Path.Combine(repoRoot, FeaturesRelativePath);
+        var roots = new List<string> { featuresRoot };
+        roots.AddRange(ExtractedModuleRoots(repoRoot));
+
+        var discovered = new List<DiscoveredEndpoint>();
+        foreach (var root in roots.Where(Directory.Exists).Distinct(System.StringComparer.Ordinal))
+        {
+            discovered.AddRange(ScanFeatureEndpoints(root, repoRoot));
+        }
+
+        return discovered;
+    }
 
     private static List<DiscoveredEndpoint> ScanFeatureEndpoints(string featuresRoot, string repoRoot)
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
+using System.Text;
 using System.Text.Json;
 using Honua.Core.Features.AnalysisContent;
 using Honua.Core.Features.AnalysisContent.Domain;
@@ -527,6 +528,32 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
         var first = document.RootElement.GetProperty("errors").EnumerateArray().First();
         Assert.Equal("analysis.content.savedQuery.layerId.range", first.GetProperty("code").GetString());
         Assert.Equal("/savedQuery/layerId", first.GetProperty("path").GetString());
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /api/v1/analysis/content/generate")]
+    public async Task GenerateAnalysis_MissingPrompt_ReachesHandlerAndReturnsBadRequest()
+    {
+        // The generate route validates the prompt before invoking any AI provider, so an empty body
+        // exercises the wired endpoint (non-404) without calling a real LLM.
+        var response = await _client.PostAsync(
+            "/api/v1/analysis/content/generate",
+            new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /api/v1/analysis/content/queries/generate")]
+    public async Task GenerateSavedQuery_MissingPrompt_ReachesHandlerAndReturnsBadRequest()
+    {
+        var response = await _client.PostAsync(
+            "/api/v1/analysis/content/queries/generate",
+            new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     private static async Task<T?> ReadJsonAsync<T>(HttpResponseMessage response, HttpStatusCode expectedStatus)

--- a/tests/dotnet/Honua.Server.Tests/Features/Console/Publications/ContentPublicationEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Console/Publications/ContentPublicationEndpointsTests.cs
@@ -445,6 +445,17 @@ public sealed class ContentPublicationEndpointsTests : IAsyncLifetime
         codes.Should().Contain("publication.panels.invalid");
     }
 
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/console/publications/generate")]
+    public async Task GenerateContent_MissingPrompt_ReachesHandlerAndReturnsBadRequest()
+    {
+        // The generate route validates the prompt before invoking any AI provider, so an empty body
+        // exercises the wired endpoint (non-404) without calling a real LLM.
+        var response = await _client.PostAsync("/api/v1/console/publications/generate", JsonContent("{}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
     private async Task<ContentPublicationDetail> PublishAsync(string slug, ContentPublicationKind kind, string? payload = null)
     {
         var body = SerializePublish(new PublishContentRequest { Kind = kind, RouteSlug = slug, Title = slug, ContentPayload = payload });

--- a/tests/dotnet/Honua.Server.Tests/Features/Forms/FormPackageEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Forms/FormPackageEndpointsTests.cs
@@ -434,6 +434,20 @@ public sealed class FormPackageEndpointsTests : IAsyncLifetime
         return (long)(await command.ExecuteScalarAsync() ?? 0L);
     }
 
+    [IntegrationTest]
+    [Operation(Operations.Configuration)]
+    [Endpoint("POST /api/v1/admin/forms/packages/generate")]
+    public async Task GenerateFormPackage_MissingPrompt_ReachesHandlerAndReturnsBadRequest()
+    {
+        // The generate route validates the prompt before invoking any AI provider, so an empty body
+        // exercises the wired endpoint (non-404) without calling a real LLM.
+        var response = await _fixture.Client.PostAsync(
+            "/api/v1/admin/forms/packages/generate",
+            JsonContent("{}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
     private async Task<T> GetJsonAsync<T>(string path, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> jsonTypeInfo)
     {
         var response = await _fixture.Client.GetAsync(path);

--- a/tests/dotnet/Honua.Server.Tests/Features/Studio/StudioPackageEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Studio/StudioPackageEndpointsTests.cs
@@ -315,6 +315,17 @@ public sealed class StudioPackageEndpointsTests : IAsyncLifetime
         problem.GetProperty("detail").GetString().Should().Contain("route must start with '/'");
     }
 
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/studio/map-packages/generate")]
+    public async Task GenerateMapPackage_MissingPrompt_ReachesHandlerAndReturnsBadRequest()
+    {
+        // The generate route validates the prompt before invoking any AI provider, so an empty body
+        // exercises the wired endpoint (non-404) without calling a real LLM.
+        var response = await _client.PostAsync("/api/v1/studio/map-packages/generate", EmptyJson());
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
     private async Task<HttpResponseMessage> PostAsync<T>(string path, T body, JsonTypeInfo<T> typeInfo)
         => await _client.PostAsync(path, JsonContent(body, typeInfo));
 


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1525

## Summary
Five deployed `POST /generate` endpoints were never added to `EndpointRegistry.cs`. This is pre-existing trunk drift: because the registry-drift governance shards only run when `src/Honua.Server` is touched, the drift silently blocked every PR that touched that project. This PR catalogs the five routes, backs each with an integration HTTP request, and closes the source-scan coverage gap that let the AI-owned `analysis/content` routes drift in the first place.

## Changes Made
- Registered the five drifted routes in `src/Honua.Server/EndpointRegistry.cs` (each placed next to its existing feature block):
  - `POST /api/v1/admin/forms/packages/generate`
  - `POST /api/v1/console/publications/generate`
  - `POST /api/v1/studio/map-packages/generate`
  - `POST /api/v1/analysis/content/generate`
  - `POST /api/v1/analysis/content/queries/generate`
- Added one endpoint-level integration test per route (Forms, Console Publications, Studio, and two in AnalysisContent) so `AllEndpointRegistryEntries_AreBackedByHttpRequests` passes. Each posts an empty `{}` body and asserts `400 BadRequest`: every `/generate` handler validates the prompt before invoking any AI provider, so the request reaches the wired handler (non-404) without calling a real LLM.
- Extended the `Honua.Architecture.Tests` forward source scan (`EveryDiscoveredEndpoint_IsRegisteredInEndpointRegistry` + `FeatureScan_FindsASubstantialNumberOfEndpoints`) to scan every extracted `src/Honua.*` module (Honua.Ai, Honua.Geoprocessing, Honua.Protocols.*, …) in addition to `src/Honua.Server/Features`, reusing the existing `ExtractedModuleRoots` glob. This closes the gap that let the AI-owned analysis-content endpoints drift undetected. The extended scan surfaced no additional untracked routes beyond the five above.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (equivalent gates verified green: Release build, dotnet format, Architecture.Tests 104/0, Server.Tests Features.API 34/0)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review