### PR TITLE
feat(import): route file-import reprojection through Esri-default datum catalog (#1501)

### DIFF
--- a/docs/gis/datum-transformation-parity.md
+++ b/docs/gis/datum-transformation-parity.md
@@ -71,14 +71,35 @@ This PR does **not** modify the Docker image. Provisioning the PROJ grid data
 the PostGIS image is a documented follow-up. Until then, grid-backed selections that hit
 a missing grid surface a PostGIS error mapped to the shared problem helper.
 
-## Import / reprojection path (follow-up)
+## Import / reprojection path
 
-The query/output path selects and applies the Esri-default transformation. The file/
-migration **import** reprojection path (`StreamingFileImportService`) currently relies on
-PostGIS' default pipeline when the source datum differs from the storage datum.
-Recording and applying the catalog-selected transformation on import (so stored geometry
-matches Esri-default reprojection) is a documented follow-up; it does not route through
-the shared `DatumTransformSql` chokepoint yet.
+The file/migration **import** reprojection path (`StreamingFileImportService`) now honors
+the same auditable Esri-default selection as the query path (#1501). When a feature is
+reprojected on import (`sourceSrid → targetSrid`), the service resolves the catalog's
+Esri-default pipeline via `IDatumTransformationCatalog.TryGetDefault` and applies it
+through the explicit 3-argument `ST_Transform(geom, '<pipeline>', toSrid)` form of
+`honua.insert_import_feature` — the same shape `DatumTransformSql.BuildTransformExpression`
+emits for the query path.
+
+Details and guarantees:
+
+- The reprojection executes server-side inside `honua.insert_import_feature`. Migration
+  `053_AddImportDatumTransformation.sql` adds an additive 7-argument overload that takes
+  the resolved PROJ pipeline; the legacy 6-argument overload is unchanged, and the import
+  service calls the 7-argument form **only** when a pipeline is actually resolved. Imports
+  with no curated default for the pair therefore keep PROJ's default (2-argument) behavior
+  byte-for-byte.
+- The pipeline is resolved for the request-level `(sourceSrid → targetSrid)` pair and is
+  applied per row **only** when the row's source SRID matches that pair. Rows carrying a
+  different per-feature SRID (e.g. mixed-CRS FileGDB layers) fall back to PROJ's default
+  pipeline; per-feature pipeline selection for heterogeneous-CRS imports is a follow-up.
+- Grid-gated selections (NADCON/NTv2/GEOID) follow the same explicit-failure contract as
+  the query path: a missing grid surfaces as a PostGIS error (mapped to the shared problem
+  helper) rather than a silent Helmert approximation. Provisioning the grid data in the
+  PostGIS image remains the separate follow-up above.
+- The legacy bulk helpers in `BulkImportExtensions` (`bulk_insert_import_features`, COPY)
+  are not on the live import path (no production callers) and are not yet routed; if they
+  are ever re-wired they must adopt the same overload.
 
 ## Vertical datum (Phase 4 — minimal)
 

--- a/docs/gis/datum-transformation-parity.md
+++ b/docs/gis/datum-transformation-parity.md
@@ -93,6 +93,11 @@ Details and guarantees:
   applied per row **only** when the row's source SRID matches that pair. Rows carrying a
   different per-feature SRID (e.g. mixed-CRS FileGDB layers) fall back to PROJ's default
   pipeline; per-feature pipeline selection for heterogeneous-CRS imports is a follow-up.
+- Only **forward** selections are applied. The catalog synthesizes reverse directions with
+  `TransformForward = false` but keeps the forward pipeline; applying that forward pipeline to
+  reverse-direction input (e.g. a NAD27→NAD83 NADCON shift on NAD83 coordinates) would corrupt
+  the result, so reverse-direction imports fall back to PROJ's default path until inverse
+  pipelines are emitted.
 - Grid-gated selections (NADCON/NTv2/GEOID) follow the same explicit-failure contract as
   the query path: a missing grid surfaces as a PostGIS error (mapped to the shared problem
   helper) rather than a silent Helmert approximation. Provisioning the grid data in the

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Batch.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Batch.cs
@@ -122,16 +122,34 @@ internal sealed partial class StreamingFileImportService
             properties[i] = BuildPropertiesJson(feature);
         }
 
-        const string sql = """
-            SELECT honua.insert_import_feature(
-                @schema_name,
-                @table_name,
-                payload.wkb,
-                payload.source_srid,
-                @target_srid,
-                payload.properties)
-            FROM unnest(@wkbs, @source_srids, @properties) AS payload(wkb, source_srid, properties)
-            """;
+        // Honor the auditable Esri-default datum pipeline for the request-level
+        // (sourceSrid -> targetSrid) pair (#1501). The pipeline is applied only to rows
+        // whose source SRID matches the resolved pair; rows carrying a different per-feature
+        // SRID (e.g. mixed-CRS FileGDB layers) keep PROJ's default pipeline via a NULL.
+        var datumPipeline = ResolveImportDatumPipeline(sourceSrid, targetSrid);
+
+        var sql = datumPipeline is null
+            ? """
+                SELECT honua.insert_import_feature(
+                    @schema_name,
+                    @table_name,
+                    payload.wkb,
+                    payload.source_srid,
+                    @target_srid,
+                    payload.properties)
+                FROM unnest(@wkbs, @source_srids, @properties) AS payload(wkb, source_srid, properties)
+                """
+            : """
+                SELECT honua.insert_import_feature(
+                    @schema_name,
+                    @table_name,
+                    payload.wkb,
+                    payload.source_srid,
+                    @target_srid,
+                    payload.properties,
+                    CASE WHEN payload.source_srid = @datum_source_srid THEN @datum_pipeline ELSE NULL END)
+                FROM unnest(@wkbs, @source_srids, @properties) AS payload(wkb, source_srid, properties)
+                """;
 
         await using var command = new NpgsqlCommand(sql, connection)
         {
@@ -143,6 +161,11 @@ internal sealed partial class StreamingFileImportService
         command.Parameters.Add("wkbs", NpgsqlDbType.Array | NpgsqlDbType.Bytea).Value = wkbs;
         command.Parameters.Add("source_srids", NpgsqlDbType.Array | NpgsqlDbType.Integer).Value = sourceSrids;
         command.Parameters.Add("properties", NpgsqlDbType.Array | NpgsqlDbType.Jsonb).Value = properties;
+        if (datumPipeline is not null)
+        {
+            command.Parameters.Add("datum_source_srid", NpgsqlDbType.Integer).Value = sourceSrid;
+            command.Parameters.Add("datum_pipeline", NpgsqlDbType.Text).Value = datumPipeline;
+        }
 
         var imported = 0;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -168,7 +191,14 @@ internal sealed partial class StreamingFileImportService
         var imported = 0;
         var failed = 0;
 
-        await using var command = new NpgsqlCommand(InsertImportFeatureSql, connection)
+        // Honor the auditable Esri-default datum pipeline for the request-level
+        // (sourceSrid -> targetSrid) pair (#1501), applied per feature only when the
+        // feature's source SRID matches the resolved pair.
+        var datumPipeline = ResolveImportDatumPipeline(sourceSrid, targetSrid);
+
+        await using var command = new NpgsqlCommand(
+            datumPipeline is null ? InsertImportFeatureSql : InsertImportFeatureWithDatumSql,
+            connection)
         {
             Transaction = transaction
         };
@@ -179,6 +209,9 @@ internal sealed partial class StreamingFileImportService
         sourceSridParameter.Value = sourceSrid;
         command.Parameters.Add("target_srid", NpgsqlDbType.Integer).Value = targetSrid;
         var propertiesParameter = command.Parameters.Add("properties", NpgsqlDbType.Jsonb);
+        var datumPipelineParameter = datumPipeline is null
+            ? null
+            : command.Parameters.Add("datum_pipeline", NpgsqlDbType.Text);
 
         foreach (var feature in features)
         {
@@ -188,7 +221,14 @@ internal sealed partial class StreamingFileImportService
             {
                 wkbParameter.Value = CreateWkb(feature, wkbWriter) ?? (object)DBNull.Value;
                 var featureSrid = feature.Geometry?.SRID;
-                sourceSridParameter.Value = featureSrid is > 0 ? featureSrid.Value : sourceSrid;
+                var effectiveSourceSrid = featureSrid is > 0 ? featureSrid.Value : sourceSrid;
+                sourceSridParameter.Value = effectiveSourceSrid;
+                if (datumPipelineParameter is not null)
+                {
+                    datumPipelineParameter.Value = effectiveSourceSrid == sourceSrid
+                        ? datumPipeline!
+                        : (object)DBNull.Value;
+                }
                 propertiesParameter.Value = BuildPropertiesJson(feature);
                 await command.ExecuteNonQueryAsync(cancellationToken);
                 imported++;

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Crs;
 using Honua.Core.Features.Infrastructure.Monitoring;
 using Honua.Core.Features.Shared.Models;
 using Honua.Postgres.Features.Infrastructure;
@@ -40,9 +41,11 @@ internal sealed partial class StreamingFileImportService : IFileImportService
     private readonly ILogger<StreamingFileImportService> _logger;
     private readonly Honua.Core.Features.Infrastructure.Abstractions.ICloudFileStorage? _cloudStorage;
     private readonly PostgresSchemaConfiguration _schemaConfiguration;
+    private readonly IDatumTransformationCatalog? _datumTransformationCatalog;
 
     private const string CreateImportTableSql = "SELECT honua.create_import_table(@schema_name, @table_name, @target_srid)";
     private const string InsertImportFeatureSql = "SELECT honua.insert_import_feature(@schema_name, @table_name, @wkb, @source_srid, @target_srid, @properties)";
+    private const string InsertImportFeatureWithDatumSql = "SELECT honua.insert_import_feature(@schema_name, @table_name, @wkb, @source_srid, @target_srid, @properties, @datum_pipeline)";
     private const int CrsDetectionHeaderSize = 8192;
     private const long DefaultMaxArchiveEntryBytes = 500L * 1024 * 1024;
     private const long DefaultMaxArchiveExtractedBytes = 1024L * 1024 * 1024;
@@ -77,7 +80,8 @@ internal sealed partial class StreamingFileImportService : IFileImportService
         ILogger<StreamingFileImportService> logger,
         ImportLimits? limits = null,
         Honua.Core.Features.Infrastructure.Abstractions.ICloudFileStorage? cloudStorage = null,
-        PostgresSchemaConfiguration? schemaConfiguration = null)
+        PostgresSchemaConfiguration? schemaConfiguration = null,
+        IDatumTransformationCatalog? datumTransformationCatalog = null)
     {
         _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
         _crsDetectionService = crsDetectionService ?? throw new ArgumentNullException(nameof(crsDetectionService));
@@ -91,6 +95,31 @@ internal sealed partial class StreamingFileImportService : IFileImportService
             PostgresSchemaConfiguration.DefaultMetadataSchema,
             PostgresSchemaConfiguration.DefaultDataSchema,
             [PostgresSchemaConfiguration.DefaultDataSchema, "public"]);
+        _datumTransformationCatalog = datumTransformationCatalog;
+    }
+
+    /// <summary>
+    /// Resolves the Esri-default datum-transformation PROJ pipeline for the
+    /// <paramref name="sourceSrid"/> -&gt; <paramref name="targetSrid"/> import reprojection,
+    /// so the import path honors the same auditable geotransformation the query path uses
+    /// (#1501). Returns <see langword="null"/> when no transform is needed (equal SRIDs),
+    /// no catalog is wired, or the catalog has no curated default for the pair — in every
+    /// such case the import keeps PROJ's default (2-argument <c>ST_Transform</c>) behavior.
+    /// </summary>
+    private string? ResolveImportDatumPipeline(int sourceSrid, int targetSrid)
+    {
+        if (sourceSrid == targetSrid || _datumTransformationCatalog is null)
+        {
+            return null;
+        }
+
+        if (_datumTransformationCatalog.TryGetDefault(sourceSrid, targetSrid, out var selection)
+            && selection.ProjPipeline is { Length: > 0 } pipeline)
+        {
+            return pipeline;
+        }
+
+        return null;
     }
 
     /// <inheritdoc/>

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
@@ -106,6 +106,14 @@ internal sealed partial class StreamingFileImportService : IFileImportService
     /// no catalog is wired, or the catalog has no curated default for the pair — in every
     /// such case the import keeps PROJ's default (2-argument <c>ST_Transform</c>) behavior.
     /// </summary>
+    /// <remarks>
+    /// Only forward selections are applied. The catalog synthesizes reverse directions with
+    /// <see cref="DatumTransformationSelection.TransformForward"/> set to <see langword="false"/> but
+    /// keeps the forward <see cref="DatumTransformationSelection.ProjPipeline"/>; applying that forward
+    /// pipeline to reverse-direction input (e.g. a NAD27→NAD83 NADCON shift on NAD83 coordinates) would
+    /// corrupt the result. Until inverse pipelines are emitted, reverse-direction imports fall back to
+    /// PROJ's default path rather than the (wrong-way) explicit pipeline.
+    /// </remarks>
     private string? ResolveImportDatumPipeline(int sourceSrid, int targetSrid)
     {
         if (sourceSrid == targetSrid || _datumTransformationCatalog is null)
@@ -114,6 +122,7 @@ internal sealed partial class StreamingFileImportService : IFileImportService
         }
 
         if (_datumTransformationCatalog.TryGetDefault(sourceSrid, targetSrid, out var selection)
+            && selection.TransformForward
             && selection.ProjPipeline is { Length: > 0 } pipeline)
         {
             return pipeline;

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -364,6 +364,13 @@ internal static class ServiceCollectionExtensions
             return limits;
         });
 
+        // The datum-transformation catalog is the auditable source of truth for which PROJ
+        // pipeline a (sourceSrid -> targetSrid) reprojection uses. It is also registered by
+        // the GeoServices query slice; TryAdd keeps this idempotent so the import path can
+        // resolve it even when GeoServices is not composed (#1501).
+        services.TryAddSingleton<Honua.Core.Features.Infrastructure.Crs.IDatumTransformationCatalog>(
+            static _ => Honua.Core.Features.Infrastructure.Crs.EsriDatumTransformationCatalog.Create());
+
         // Register streaming file import service with memory-efficient batch processing
         services.AddScoped<IFileImportService>(serviceProvider =>
         {
@@ -380,7 +387,8 @@ internal static class ServiceCollectionExtensions
                 logger,
                 limits,
                 cloudStorage,
-                serviceProvider.GetRequiredService<PostgresSchemaConfiguration>());
+                serviceProvider.GetRequiredService<PostgresSchemaConfiguration>(),
+                serviceProvider.GetService<Honua.Core.Features.Infrastructure.Crs.IDatumTransformationCatalog>());
         });
 
         // Register universal import job service using unified progress store

--- a/src/Honua.Server/Migrations/053_AddImportDatumTransformation.sql
+++ b/src/Honua.Server/Migrations/053_AddImportDatumTransformation.sql
@@ -1,0 +1,47 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration: 053_AddImportDatumTransformation.sql
+-- Route the file-import reprojection path through the same explicit datum-pipeline
+-- selection used by the query path (#1501, follow-up to #1274). The original
+-- honua.insert_import_feature reprojects with the bare 2-argument ST_Transform, so
+-- PROJ silently picks its own "best available" pipeline rather than the auditable
+-- Esri-default geotransformation resolved by IDatumTransformationCatalog. This adds
+-- an additive overload that accepts an optional PROJ pipeline string and emits the
+-- explicit 3-argument ST_Transform(geom, '<pipeline>', toSrid) form — the same shape
+-- the query builders emit through DatumTransformSql.BuildTransformExpression.
+--
+-- The existing 6-argument overload is left untouched for backward compatibility; the
+-- import service calls this 7-argument overload only when a pipeline has actually been
+-- resolved for the (sourceSrid -> targetSrid) pair, so imports with no curated default
+-- keep their current behavior byte-for-byte.
+
+CREATE SCHEMA IF NOT EXISTS honua;
+
+CREATE OR REPLACE FUNCTION honua.insert_import_feature(
+    schema_name text,
+    table_name text,
+    wkb bytea,
+    source_srid integer,
+    target_srid integer,
+    properties jsonb,
+    datum_transformation_pipeline text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- A null/empty pipeline keeps PROJ's default (2-argument) behavior; a non-empty
+    -- pipeline forces the explicit Esri-parity pipeline via the 3-argument overload.
+    IF datum_transformation_pipeline IS NULL OR length(datum_transformation_pipeline) = 0 THEN
+        EXECUTE format(
+            'INSERT INTO %I.%I (geometry, properties) VALUES (ST_Transform(ST_GeomFromWKB($1, $2), $3), $4)',
+            schema_name, table_name)
+        USING wkb, source_srid, target_srid, properties;
+    ELSE
+        EXECUTE format(
+            'INSERT INTO %I.%I (geometry, properties) VALUES (ST_Transform(ST_GeomFromWKB($1, $2), $4, $3), $5)',
+            schema_name, table_name)
+        USING wkb, source_srid, target_srid, datum_transformation_pipeline, properties;
+    END IF;
+END;
+$$;

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/ImportDatumTransformationTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/ImportDatumTransformationTests.cs
@@ -1,0 +1,320 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Crs;
+using Honua.Postgres.Features.FileImport;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+/// <summary>
+/// Verifies the file-import reprojection path routes through the auditable
+/// Esri-default datum-transformation catalog (#1501). Imports that resolve a curated
+/// PROJ pipeline for the <c>(sourceSrid -&gt; targetSrid)</c> pair must apply it through
+/// the explicit 3-argument <c>ST_Transform</c> overload of <c>honua.insert_import_feature</c>;
+/// imports with no curated default keep PROJ's default (2-argument) behavior.
+/// </summary>
+[Collection("Database")]
+public sealed class ImportDatumTransformationTests(PostgresFixture fixture)
+{
+    // honua.insert_import_feature now ships both the legacy 6-argument overload and the
+    // 7-argument datum-pipeline overload (migration 053). The fixture does not run
+    // migrations, so the functions are created inline here, mirroring the migration.
+    private const string CreateImportFunctionsSql = """
+        CREATE OR REPLACE FUNCTION honua.create_import_table(schema_name text, table_name text, target_srid integer DEFAULT 4326)
+        RETURNS void
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            EXECUTE format('CREATE SCHEMA IF NOT EXISTS %I', schema_name);
+            EXECUTE format('DROP TABLE IF EXISTS %I.%I', schema_name, table_name);
+            EXECUTE format(
+                'CREATE TABLE %I.%I (id SERIAL PRIMARY KEY, geometry GEOMETRY(Geometry, %s), properties JSONB, created_at TIMESTAMPTZ DEFAULT NOW())',
+                schema_name, table_name, target_srid);
+            EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.%I USING GIST (geometry)', 'idx_' || table_name || '_geometry', schema_name, table_name);
+        END;
+        $$;
+
+        CREATE OR REPLACE FUNCTION honua.insert_import_feature(
+            schema_name text,
+            table_name text,
+            wkb bytea,
+            source_srid integer,
+            target_srid integer,
+            properties jsonb)
+        RETURNS void
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            EXECUTE format(
+                'INSERT INTO %I.%I (geometry, properties) VALUES (ST_Transform(ST_GeomFromWKB($1, $2), $3), $4)',
+                schema_name, table_name)
+            USING wkb, source_srid, target_srid, properties;
+        END;
+        $$;
+
+        CREATE OR REPLACE FUNCTION honua.insert_import_feature(
+            schema_name text,
+            table_name text,
+            wkb bytea,
+            source_srid integer,
+            target_srid integer,
+            properties jsonb,
+            datum_transformation_pipeline text)
+        RETURNS void
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            IF datum_transformation_pipeline IS NULL OR length(datum_transformation_pipeline) = 0 THEN
+                EXECUTE format(
+                    'INSERT INTO %I.%I (geometry, properties) VALUES (ST_Transform(ST_GeomFromWKB($1, $2), $3), $4)',
+                    schema_name, table_name)
+                USING wkb, source_srid, target_srid, properties;
+            ELSE
+                EXECUTE format(
+                    'INSERT INTO %I.%I (geometry, properties) VALUES (ST_Transform(ST_GeomFromWKB($1, $2), $4, $3), $5)',
+                    schema_name, table_name)
+                USING wkb, source_srid, target_srid, datum_transformation_pipeline, properties;
+            END IF;
+        END;
+        $$;
+        """;
+
+    // A single NAD83 (EPSG:4269) point near Denver. NAD83 and WGS84 coincide to ~1 m,
+    // so the Esri-default null transformation lands essentially on the input coordinate.
+    private const double Nad83Lon = -104.9903;
+    private const double Nad83Lat = 39.7392;
+    private static readonly string PointGeoJson = $$"""
+        {
+          "type": "FeatureCollection",
+          "features": [
+            { "type": "Feature", "geometry": { "type": "Point", "coordinates": [{{Nad83Lon}}, {{Nad83Lat}}] }, "properties": { "name": "denver" } }
+          ]
+        }
+        """;
+
+    [IntegrationTest]
+    public async Task ImportFileAsync_Nad83ToWgs84_WithCatalog_AppliesEsriDefaultPipelineAndSucceeds()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(ImportDatumTransformationTests));
+        try
+        {
+            await EnsureImportFunctionsAsync();
+
+            // The real catalog resolves NAD83->WGS84 to the Esri-default null transformation
+            // (+proj=noop), so the import must succeed and land on the input coordinate.
+            var service = CreateService(schema, EsriDatumTransformationCatalog.Create());
+            var result = await ImportPointAsync(service, schema, "datum_real", sourceSrid: 4269, targetSrid: 4326);
+
+            result.Success.Should().BeTrue(result.ErrorMessage);
+            result.FeatureCount.Should().Be(1);
+
+            var (x, y, srid) = await ReadSinglePointAsync(schema, "imported_datum_real");
+            srid.Should().Be(4326);
+            x.Should().BeApproximately(Nad83Lon, 1e-5);
+            y.Should().BeApproximately(Nad83Lat, 1e-5);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task ImportFileAsync_RoutesCatalogPipelineIntoStTransform()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(ImportDatumTransformationTests));
+        try
+        {
+            await EnsureImportFunctionsAsync();
+
+            // A catalog that returns a syntactically invalid PROJ pipeline for the pair.
+            // The import can only fail if that pipeline string actually reaches PostGIS'
+            // 3-argument ST_Transform — proving the import path honors the catalog selection
+            // rather than silently using the 2-argument default.
+            var service = CreateService(schema, new InvalidPipelineCatalog());
+            var result = await ImportPointAsync(service, schema, "datum_routed", sourceSrid: 4269, targetSrid: 4326);
+
+            result.Success.Should().BeFalse(
+                "the catalog's pipeline must be routed into ST_Transform, and an invalid pipeline must surface as a failure");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task ImportFileAsync_WithoutCatalog_KeepsDefaultPipelineBehavior()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(ImportDatumTransformationTests));
+        try
+        {
+            await EnsureImportFunctionsAsync();
+
+            // No catalog wired: even the same invalid-pipeline pair would not be consulted,
+            // so the import uses the unchanged 2-argument default path and succeeds.
+            var service = CreateService(schema, datumTransformationCatalog: null);
+            var result = await ImportPointAsync(service, schema, "datum_none", sourceSrid: 4269, targetSrid: 4326);
+
+            result.Success.Should().BeTrue(result.ErrorMessage);
+            result.FeatureCount.Should().Be(1);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task ImportFileAsync_EqualSourceAndTarget_DoesNotConsultCatalog()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(ImportDatumTransformationTests));
+        try
+        {
+            await EnsureImportFunctionsAsync();
+
+            // Equal SRIDs need no reprojection; the invalid-pipeline catalog must never be
+            // consulted, so the import succeeds.
+            var service = CreateService(schema, new InvalidPipelineCatalog());
+            var result = await ImportPointAsync(service, schema, "datum_equal", sourceSrid: 4326, targetSrid: 4326);
+
+            result.Success.Should().BeTrue(result.ErrorMessage);
+            result.FeatureCount.Should().Be(1);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    private StreamingFileImportService CreateService(string schema, IDatumTransformationCatalog? datumTransformationCatalog)
+    {
+        var provider = new TestConnectionProvider(fixture.DataSource, schema);
+        return new StreamingFileImportService(
+            provider,
+            new CrsDetectionService(provider, NullLogger<CrsDetectionService>.Instance),
+            new TestFileFormatDetectionService(),
+            new NoopPerformanceMonitor(),
+            NullLogger<StreamingFileImportService>.Instance,
+            limits: null,
+            cloudStorage: null,
+            schemaConfiguration: null,
+            datumTransformationCatalog: datumTransformationCatalog);
+    }
+
+    private static async Task<ImportResult> ImportPointAsync(
+        StreamingFileImportService service,
+        string schema,
+        string tableName,
+        int sourceSrid,
+        int targetSrid)
+    {
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(PointGeoJson));
+        return await service.ImportFileAsync(new ImportRequest
+        {
+            FileStream = stream,
+            FileName = "points.geojson",
+            TableName = tableName,
+            TargetSchema = schema,
+            SourceSrid = sourceSrid,
+            TargetSrid = targetSrid,
+        });
+    }
+
+    private async Task<(double X, double Y, int Srid)> ReadSinglePointAsync(string schema, string table)
+    {
+        await using var connection = await fixture.DataSource.OpenConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            $"SELECT ST_X(geometry), ST_Y(geometry), ST_SRID(geometry) FROM \"{schema}\".\"{table}\" LIMIT 1;";
+        await using var reader = await command.ExecuteReaderAsync();
+        (await reader.ReadAsync()).Should().BeTrue("the import must have written exactly one row");
+        return (reader.GetDouble(0), reader.GetDouble(1), reader.GetInt32(2));
+    }
+
+    private async Task EnsureImportFunctionsAsync()
+    {
+        await using var conn = await fixture.DataSource.OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "CREATE SCHEMA IF NOT EXISTS honua;\n" + CreateImportFunctionsSql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// A catalog that always offers a syntactically invalid PROJ pipeline for any pair,
+    /// used to prove the import path routes the catalog selection into ST_Transform.
+    /// </summary>
+    private sealed class InvalidPipelineCatalog : IDatumTransformationCatalog
+    {
+        public bool TryGetDefault(int fromSrid, int toSrid, [NotNullWhen(true)] out DatumTransformationSelection? selection)
+        {
+            selection = new DatumTransformationSelection
+            {
+                Name = "Honua_Test_Invalid_Pipeline",
+                FromSrid = fromSrid,
+                ToSrid = toSrid,
+                ProjPipeline = "+proj=pipeline +step +proj=honua_not_a_real_operation",
+            };
+            return true;
+        }
+
+        public bool TryGetByWkid(int wkid, int fromSrid, int toSrid, [NotNullWhen(true)] out DatumTransformationSelection? selection)
+        {
+            selection = null;
+            return false;
+        }
+    }
+
+    private sealed class TestConnectionProvider(NpgsqlDataSource dataSource, string schemaName) : IDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => dataSource.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            var conn = await dataSource.OpenConnectionAsync(cancellationToken);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SET search_path TO \"{schemaName}\", honua, public;";
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+            return conn;
+        }
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var conn = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var tx = await conn.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (conn, tx);
+            }
+            catch
+            {
+                await conn.DisposeAsync();
+                throw;
+            }
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(
+            Func<Task<T>> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(
+            Func<Task> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/ImportDatumTransformationTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/ImportDatumTransformationTests.cs
@@ -199,6 +199,30 @@ public sealed class ImportDatumTransformationTests(PostgresFixture fixture)
         }
     }
 
+    [IntegrationTest]
+    public async Task ImportFileAsync_ReverseDirectionSelection_FallsBackToDefaultPath()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(ImportDatumTransformationTests));
+        try
+        {
+            await EnsureImportFunctionsAsync();
+
+            // A reverse-direction selection (TransformForward = false) carries the forward pipeline,
+            // which must NOT be applied in reverse (it would corrupt coordinates). The import must skip
+            // the explicit pipeline and use PROJ's default 2-argument path — so even though the catalog
+            // hands back a syntactically invalid pipeline, the import succeeds because it is never used.
+            var service = CreateService(schema, new ReverseDirectionPipelineCatalog());
+            var result = await ImportPointAsync(service, schema, "datum_reverse", sourceSrid: 4269, targetSrid: 4326);
+
+            result.Success.Should().BeTrue(result.ErrorMessage);
+            result.FeatureCount.Should().Be(1);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
     private StreamingFileImportService CreateService(string schema, IDatumTransformationCatalog? datumTransformationCatalog)
     {
         var provider = new TestConnectionProvider(fixture.DataSource, schema);
@@ -266,6 +290,33 @@ public sealed class ImportDatumTransformationTests(PostgresFixture fixture)
                 FromSrid = fromSrid,
                 ToSrid = toSrid,
                 ProjPipeline = "+proj=pipeline +step +proj=honua_not_a_real_operation",
+            };
+            return true;
+        }
+
+        public bool TryGetByWkid(int wkid, int fromSrid, int toSrid, [NotNullWhen(true)] out DatumTransformationSelection? selection)
+        {
+            selection = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// A catalog that returns a reverse-direction selection (<c>TransformForward = false</c>) carrying a
+    /// forward (and here deliberately invalid) pipeline, used to prove the import path does NOT apply the
+    /// forward pipeline in reverse but falls back to PROJ's default path.
+    /// </summary>
+    private sealed class ReverseDirectionPipelineCatalog : IDatumTransformationCatalog
+    {
+        public bool TryGetDefault(int fromSrid, int toSrid, [NotNullWhen(true)] out DatumTransformationSelection? selection)
+        {
+            selection = new DatumTransformationSelection
+            {
+                Name = "Honua_Test_Reverse_Pipeline",
+                FromSrid = fromSrid,
+                ToSrid = toSrid,
+                ProjPipeline = "+proj=pipeline +step +proj=honua_not_a_real_operation",
+                TransformForward = false,
             };
             return true;
         }


### PR DESCRIPTION
## Issue Link
Related to #1501

## Summary
Routes the file-import reprojection path through the same auditable Esri-default datum-transformation catalog the query path already uses (#1274/#1497). Previously `honua.insert_import_feature` reprojected with the bare 2-argument `ST_Transform(geom, toSrid)`, so PROJ silently chose its own pipeline instead of the curated Esri default — stored geometry could diverge from Esri-default reprojection. This closes the **import/reprojection-path** acceptance criterion of #1501; the remaining #1501 criteria (Helmert pair seeding, PROJ grid provisioning, tolerance tightening) stay open.

## Changes Made
- Migration `053_AddImportDatumTransformation.sql`: additive 7-argument `honua.insert_import_feature` overload that emits the explicit `ST_Transform(geom, '<pipeline>', toSrid)` form when a pipeline is supplied; the legacy 6-argument overload is untouched.
- `StreamingFileImportService` resolves the Esri-default pipeline for the request-level `(sourceSrid → targetSrid)` pair via `IDatumTransformationCatalog.TryGetDefault` and applies it in both the fast (unnest, per-row SRID-guarded `CASE`) and individual insert paths; the 7-arg form is used only when a pipeline is actually resolved, so imports with no curated default keep their current behavior byte-for-byte.
- Registered `IDatumTransformationCatalog` in `Honua.Postgres` (`TryAddSingleton`, idempotent with the GeoServices registration) and threaded it into the import factory.
- Updated `docs/gis/datum-transformation-parity.md` to mark the import path as honoring the catalog, with the per-feature-SRID and grid-gated caveats.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

New `ImportDatumTransformationTests` (Testcontainers + PostGIS), 4 passing: real-catalog NAD83→WGS84 success, routing proof via an invalid-pipeline catalog, and no-catalog / equal-SRID fallback. `dotnet build` clean under `TreatWarningsAsErrors=true`.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires database migration
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
