### PR TITLE
feat: add custom Docker build profiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,22 +21,23 @@ WORKDIR /src
 RUN groupadd --gid 1001 --system builduser && \
     useradd --uid 1001 --gid 1001 --system --no-create-home --shell /usr/sbin/nologin builduser
 
-# Copy solution and project files first for better layer caching
+# Copy solution and source project graph first for restore. The modularized
+# assembly graph changes often enough that a hand-maintained csproj list is
+# more brittle than copying src/ into the restore layer.
 COPY Honua.sln Directory.Build.props Directory.Packages.props NuGet.config .editorconfig ./
+COPY eng/Honua.BuildProfiles.props eng/
 COPY scripts/docker/restore-dotnet-with-github-packages.sh scripts/docker/
-COPY src/Honua.Core/*.csproj src/Honua.Core/
-COPY src/Honua.DuckDB/*.csproj src/Honua.DuckDB/
-COPY src/Honua.MySql/*.csproj src/Honua.MySql/
-COPY src/Honua.Postgres/*.csproj src/Honua.Postgres/
-COPY src/Honua.SqlServer/*.csproj src/Honua.SqlServer/
-COPY src/Honua.ServiceDefaults/*.csproj src/Honua.ServiceDefaults/
-COPY src/Honua.Server/*.csproj src/Honua.Server/
+COPY src/ src/
 COPY docs/developer/api-specs/admin-api.json docs/developer/api-specs/
 COPY samples/Honua.StacOpsDemo/*.csproj samples/Honua.StacOpsDemo/
 
 ARG TARGETARCH
 # Slim by default: set HONUA_INCLUDE_STAC_OPS_DEMO=true to keep the hosted STAC ops demo assets.
 ARG HONUA_INCLUDE_STAC_OPS_DEMO=false
+ARG HONUA_BUILD_PROFILE=full
+ARG HONUA_INCLUDE_AWS=
+ARG HONUA_INCLUDE_AZURE=
+ARG HONUA_INCLUDE_ORACLE=
 
 # Restore dependencies.
 # SC2086 suppression rationale: EXTRA_MSBUILD_ARGS holds multiple MSBuild flags that must
@@ -49,7 +50,11 @@ RUN --mount=type=secret,id=github_actor \
         arm64) RUNTIME_ID="linux-musl-arm64" ;; \
         *) echo "Unsupported TARGETARCH=${TARGETARCH}" && exit 1 ;; \
     esac && \
-    EXTRA_MSBUILD_ARGS="-p:RuntimeIdentifier=$RUNTIME_ID -p:HonuaIncludeStacOpsDemo=false" && \
+    MODULE_MSBUILD_ARGS="-p:HonuaBuildProfile=${HONUA_BUILD_PROFILE:-full}" && \
+    if [ -n "${HONUA_INCLUDE_AWS:-}" ]; then MODULE_MSBUILD_ARGS="$MODULE_MSBUILD_ARGS -p:HonuaIncludeAws=$HONUA_INCLUDE_AWS"; fi && \
+    if [ -n "${HONUA_INCLUDE_AZURE:-}" ]; then MODULE_MSBUILD_ARGS="$MODULE_MSBUILD_ARGS -p:HonuaIncludeAzure=$HONUA_INCLUDE_AZURE"; fi && \
+    if [ -n "${HONUA_INCLUDE_ORACLE:-}" ]; then MODULE_MSBUILD_ARGS="$MODULE_MSBUILD_ARGS -p:HonuaIncludeOracle=$HONUA_INCLUDE_ORACLE"; fi && \
+    EXTRA_MSBUILD_ARGS="-p:RuntimeIdentifier=$RUNTIME_ID -p:HonuaIncludeStacOpsDemo=false $MODULE_MSBUILD_ARGS" && \
     sh scripts/docker/restore-dotnet-with-github-packages.sh src/Honua.Server/Honua.Server.csproj \
       --runtime "$RUNTIME_ID" \
       $EXTRA_MSBUILD_ARGS && \
@@ -73,7 +78,11 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
         arm64) RUNTIME_ID="linux-musl-arm64" ;; \
         *) echo "Unsupported TARGETARCH=${TARGETARCH}" && exit 1 ;; \
     esac && \
-    EXTRA_MSBUILD_ARGS="-p:RuntimeIdentifier=$RUNTIME_ID -p:HonuaIncludeStacOpsDemo=false" && \
+    MODULE_MSBUILD_ARGS="-p:HonuaBuildProfile=${HONUA_BUILD_PROFILE:-full}" && \
+    if [ -n "${HONUA_INCLUDE_AWS:-}" ]; then MODULE_MSBUILD_ARGS="$MODULE_MSBUILD_ARGS -p:HonuaIncludeAws=$HONUA_INCLUDE_AWS"; fi && \
+    if [ -n "${HONUA_INCLUDE_AZURE:-}" ]; then MODULE_MSBUILD_ARGS="$MODULE_MSBUILD_ARGS -p:HonuaIncludeAzure=$HONUA_INCLUDE_AZURE"; fi && \
+    if [ -n "${HONUA_INCLUDE_ORACLE:-}" ]; then MODULE_MSBUILD_ARGS="$MODULE_MSBUILD_ARGS -p:HonuaIncludeOracle=$HONUA_INCLUDE_ORACLE"; fi && \
+    EXTRA_MSBUILD_ARGS="-p:RuntimeIdentifier=$RUNTIME_ID -p:HonuaIncludeStacOpsDemo=false $MODULE_MSBUILD_ARGS" && \
     sh scripts/docker/restore-dotnet-with-github-packages.sh src/Honua.Server/Honua.Server.csproj \
       --runtime "$RUNTIME_ID" \
       $EXTRA_MSBUILD_ARGS && \

--- a/docker/Dockerfile.aot
+++ b/docker/Dockerfile.aot
@@ -29,10 +29,15 @@ RUN apk add --no-cache \
 # hand-maintained csproj copy-list that rots whenever projects are added/split
 # (e.g. the #1236 modularization). The dedicated restore layer keeps caching.
 COPY Honua.sln Directory.Build.props Directory.Packages.props NuGet.config .editorconfig ./
+COPY eng/Honua.BuildProfiles.props eng/
 COPY scripts/docker/restore-dotnet-with-github-packages.sh scripts/docker/
 COPY src/ src/
 
 ARG TARGETARCH
+ARG HONUA_BUILD_PROFILE=full
+ARG HONUA_INCLUDE_AWS=
+ARG HONUA_INCLUDE_AZURE=
+ARG HONUA_INCLUDE_ORACLE=
 
 # Restore dependencies for the target runtime so the AOT self-contained publish
 # (which runs --no-restore) finds obj/project.assets.json for every project in
@@ -45,9 +50,14 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
         arm64) RUNTIME_ID="linux-musl-arm64" ;; \
         *) echo "Unsupported TARGETARCH=${TARGETARCH}" && exit 1 ;; \
     esac && \
+    MODULE_MSBUILD_ARGS="-p:HonuaBuildProfile=${HONUA_BUILD_PROFILE:-full}" && \
+    if [ -n "${HONUA_INCLUDE_AWS:-}" ]; then MODULE_MSBUILD_ARGS="$MODULE_MSBUILD_ARGS -p:HonuaIncludeAws=$HONUA_INCLUDE_AWS"; fi && \
+    if [ -n "${HONUA_INCLUDE_AZURE:-}" ]; then MODULE_MSBUILD_ARGS="$MODULE_MSBUILD_ARGS -p:HonuaIncludeAzure=$HONUA_INCLUDE_AZURE"; fi && \
+    if [ -n "${HONUA_INCLUDE_ORACLE:-}" ]; then MODULE_MSBUILD_ARGS="$MODULE_MSBUILD_ARGS -p:HonuaIncludeOracle=$HONUA_INCLUDE_ORACLE"; fi && \
     sh scripts/docker/restore-dotnet-with-github-packages.sh src/Honua.Server/Honua.Server.csproj \
       --runtime "$RUNTIME_ID" \
-      -p:RuntimeIdentifier="$RUNTIME_ID"
+      -p:RuntimeIdentifier="$RUNTIME_ID" \
+      $MODULE_MSBUILD_ARGS
 
 # Copy source code
 COPY . .
@@ -78,12 +88,17 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
         arm64) RUNTIME_ID="linux-musl-arm64" ;; \
         *) echo "Unsupported TARGETARCH=${TARGETARCH}" && exit 1 ;; \
     esac && \
+    MODULE_MSBUILD_ARGS="-p:HonuaBuildProfile=${HONUA_BUILD_PROFILE:-full}" && \
+    if [ -n "${HONUA_INCLUDE_AWS:-}" ]; then MODULE_MSBUILD_ARGS="$MODULE_MSBUILD_ARGS -p:HonuaIncludeAws=$HONUA_INCLUDE_AWS"; fi && \
+    if [ -n "${HONUA_INCLUDE_AZURE:-}" ]; then MODULE_MSBUILD_ARGS="$MODULE_MSBUILD_ARGS -p:HonuaIncludeAzure=$HONUA_INCLUDE_AZURE"; fi && \
+    if [ -n "${HONUA_INCLUDE_ORACLE:-}" ]; then MODULE_MSBUILD_ARGS="$MODULE_MSBUILD_ARGS -p:HonuaIncludeOracle=$HONUA_INCLUDE_ORACLE"; fi && \
     attempt=1 && \
     max_attempts="${AOT_PUBLISH_MAX_ATTEMPTS:-3}" && \
     until \
         sh scripts/docker/restore-dotnet-with-github-packages.sh src/Honua.Server/Honua.Server.csproj \
           --runtime "$RUNTIME_ID" \
-          -p:RuntimeIdentifier="$RUNTIME_ID" && \
+          -p:RuntimeIdentifier="$RUNTIME_ID" \
+          $MODULE_MSBUILD_ARGS && \
         dotnet publish src/Honua.Server/Honua.Server.csproj \
           --configuration "$CONFIGURATION" \
           --runtime "$RUNTIME_ID" \
@@ -97,7 +112,8 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
           -p:StripSymbols=true \
           -p:OptimizationPreference=Speed \
           -p:IlcOptimizationPreference=Speed \
-          -p:IlcSingleThreaded=true ; \
+          -p:IlcSingleThreaded=true \
+          $MODULE_MSBUILD_ARGS ; \
     do \
         status=$? ; \
         if [ "$attempt" -ge "$max_attempts" ]; then \

--- a/eng/Honua.BuildProfiles.props
+++ b/eng/Honua.BuildProfiles.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <HonuaBuildProfile Condition="'$(HonuaBuildProfile)' == ''">full</HonuaBuildProfile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(HonuaBuildProfile)' == 'no-cloud'">
+    <HonuaIncludeAws Condition="'$(HonuaIncludeAws)' == ''">false</HonuaIncludeAws>
+    <HonuaIncludeAzure Condition="'$(HonuaIncludeAzure)' == ''">false</HonuaIncludeAzure>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(HonuaBuildProfile)' == 'slim'">
+    <HonuaIncludeAws Condition="'$(HonuaIncludeAws)' == ''">false</HonuaIncludeAws>
+    <HonuaIncludeAzure Condition="'$(HonuaIncludeAzure)' == ''">false</HonuaIncludeAzure>
+    <HonuaIncludeOracle Condition="'$(HonuaIncludeOracle)' == ''">false</HonuaIncludeOracle>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <HonuaIncludeAws Condition="'$(HonuaIncludeAws)' == ''">true</HonuaIncludeAws>
+    <HonuaIncludeAzure Condition="'$(HonuaIncludeAzure)' == ''">true</HonuaIncludeAzure>
+    <HonuaIncludeOracle Condition="'$(HonuaSkipOracleForAotVerification)' == 'true'">false</HonuaIncludeOracle>
+    <HonuaIncludeOracle Condition="'$(HonuaIncludeOracle)' == ''">true</HonuaIncludeOracle>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DefineConstants Condition="'$(HonuaIncludeAws)' != 'true'">$(DefineConstants);HONUA_EXCLUDE_AWS</DefineConstants>
+    <DefineConstants Condition="'$(HonuaIncludeAzure)' != 'true'">$(DefineConstants);HONUA_EXCLUDE_AZURE</DefineConstants>
+    <DefineConstants Condition="'$(HonuaIncludeOracle)' != 'true'">$(DefineConstants);HONUA_SKIP_ORACLE;HONUA_EXCLUDE_ORACLE</DefineConstants>
+  </PropertyGroup>
+
+  <Target Name="ValidateHonuaBuildProfile" BeforeTargets="PrepareForBuild;Restore">
+    <Error
+      Condition="'$(HonuaBuildProfile)' != 'full' and '$(HonuaBuildProfile)' != 'no-cloud' and '$(HonuaBuildProfile)' != 'slim'"
+      Text="Unsupported HonuaBuildProfile '$(HonuaBuildProfile)'. Supported profiles: full, no-cloud, slim." />
+  </Target>
+</Project>

--- a/src/Honua.Server/Features/Alerts/AlertDeliveryServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Alerts/AlertDeliveryServiceCollectionExtensions.cs
@@ -48,12 +48,32 @@ internal static class AlertDeliveryServiceCollectionExtensions
         services.AddSingleton<IAlertDeliverySink>(_ => new UnsupportedAlertDeliverySink(Core.Features.Alerts.Domain.AlertChannelType.Digest));
         services.AddHostedService<DigestFlushBackgroundService>();
 
+#if HONUA_EXCLUDE_AWS
+        RegisterUnsupportedAwsChannels(services);
+#else
         services.AddAwsAlertDeliveryChannels(configuration);
+#endif
+#if HONUA_EXCLUDE_AZURE
+        RegisterUnsupportedAzureChannels(services);
+#else
         services.AddAzureAlertDeliveryChannels(configuration);
+#endif
         RegisterSlack(services, configuration);
         RegisterTeams(services, configuration);
 
         return services;
+    }
+
+    private static void RegisterUnsupportedAwsChannels(IServiceCollection services)
+    {
+        services.AddSingleton<IAlertDeliverySink>(_ => new UnsupportedAlertDeliverySink(Core.Features.Alerts.Domain.AlertChannelType.AwsSns));
+        services.AddSingleton<IAlertDeliverySink>(_ => new UnsupportedAlertDeliverySink(Core.Features.Alerts.Domain.AlertChannelType.AwsSqs));
+    }
+
+    private static void RegisterUnsupportedAzureChannels(IServiceCollection services)
+    {
+        services.AddSingleton<IAlertDeliverySink>(_ => new UnsupportedAlertDeliverySink(Core.Features.Alerts.Domain.AlertChannelType.AzureEventGrid));
+        services.AddSingleton<IAlertDeliverySink>(_ => new UnsupportedAlertDeliverySink(Core.Features.Alerts.Domain.AlertChannelType.AzureEventHub));
     }
 
     private static void RegisterSlack(IServiceCollection services, IConfiguration configuration)

--- a/src/Honua.Server/Features/Alerts/AlertEditionPolicy.cs
+++ b/src/Honua.Server/Features/Alerts/AlertEditionPolicy.cs
@@ -64,13 +64,29 @@ internal sealed class AlertEditionPolicy : IAlertEditionPolicy
             AlertChannelType.Email => _deliveryOptions.Dispatch.Email is { SmtpHost.Length: > 0, FromAddress.Length: > 0, DefaultRecipient.Length: > 0 },
             AlertChannelType.Digest => !string.IsNullOrWhiteSpace(_options.Dispatch.Digest.WebhookUrl)
                 && !string.IsNullOrWhiteSpace(_options.Dispatch.Digest.WebhookSecret),
-            AlertChannelType.AwsSns => !string.IsNullOrWhiteSpace(_deliveryOptions.Dispatch.AwsSns?.TopicArn),
-            AlertChannelType.AzureEventGrid => !string.IsNullOrWhiteSpace(_deliveryOptions.Dispatch.AzureEventGrid?.TopicEndpoint),
             AlertChannelType.Slack => !string.IsNullOrWhiteSpace(_deliveryOptions.Dispatch.Slack?.WebhookUrl),
             AlertChannelType.MicrosoftTeams => !string.IsNullOrWhiteSpace(_deliveryOptions.Dispatch.Teams?.WebhookUrl),
+
+            // AWS / Azure channels are only deliverable when the build includes their cloud SDK. In
+            // no-cloud / slim builds they are backed solely by UnsupportedAlertDeliverySink, so they
+            // must report as unconfigured regardless of any leftover AlertDelivery:Dispatch:* settings —
+            // otherwise AlertPipeline would route to (and AlertAdminEndpoints would advertise) a channel
+            // whose every delivery fails immediately with the unsupported sink.
+#if HONUA_EXCLUDE_AWS
+            AlertChannelType.AwsSns => false,
+            AlertChannelType.AwsSqs => false,
+#else
+            AlertChannelType.AwsSns => !string.IsNullOrWhiteSpace(_deliveryOptions.Dispatch.AwsSns?.TopicArn),
             AlertChannelType.AwsSqs => !string.IsNullOrWhiteSpace(_deliveryOptions.Dispatch.AwsSqs?.QueueUrl),
+#endif
+#if HONUA_EXCLUDE_AZURE
+            AlertChannelType.AzureEventGrid => false,
+            AlertChannelType.AzureEventHub => false,
+#else
+            AlertChannelType.AzureEventGrid => !string.IsNullOrWhiteSpace(_deliveryOptions.Dispatch.AzureEventGrid?.TopicEndpoint),
             AlertChannelType.AzureEventHub => !string.IsNullOrWhiteSpace(_deliveryOptions.Dispatch.AzureEventHub?.ConnectionString)
                 && !string.IsNullOrWhiteSpace(_deliveryOptions.Dispatch.AzureEventHub?.EventHubName),
+#endif
             _ => false
         };
     }

--- a/src/Honua.Server/Features/ControlPlane/AzureBatchComputeBackend.cs
+++ b/src/Honua.Server/Features/ControlPlane/AzureBatchComputeBackend.cs
@@ -6,6 +6,7 @@ using System.Net;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 
+#if !HONUA_EXCLUDE_AZURE
 namespace Honua.ControlPlane;
 
 /// <summary>
@@ -547,3 +548,4 @@ internal sealed partial class AzureBatchComputeBackend(
         public static partial void JobAlreadyExists(ILogger logger, string operationId, string jobId, string poolId);
     }
 }
+#endif

--- a/src/Honua.Server/Features/ControlPlane/GitOpsDeployBackends.cs
+++ b/src/Honua.Server/Features/ControlPlane/GitOpsDeployBackends.cs
@@ -39,6 +39,7 @@ internal sealed class AzureContainerAppsGitOpsDeployBackend(ILogger<AzureContain
     public override DeployTargetKind TargetKind => DeployTargetKind.AzureContainerApps;
 }
 
+#if !HONUA_EXCLUDE_AZURE
 /// <summary>
 /// Direct Azure Container Apps revision traffic backend that manages revision traffic splitting
 /// through the ARM REST API without requiring an external GitOps controller.
@@ -459,7 +460,9 @@ internal sealed partial class AzureContainerAppsRevisionDeployBackend(
         public static partial void StateLookupFailed(ILogger logger, string operationId, string targetId, string errorMessage);
     }
 }
+#endif
 
+#if !HONUA_EXCLUDE_AZURE
 /// <summary>
 /// Built-in GitOps deploy backend for Azure Functions targets managed by Honua.
 /// </summary>
@@ -870,6 +873,7 @@ internal sealed partial class AzureFunctionsGitOpsDeployBackend(
         public static partial void StateLookupFailed(ILogger logger, string operationId, string targetId, string errorMessage);
     }
 }
+#endif
 
 /// <summary>
 /// Shared Azure resource ID parser for ARM-based deploy backends.

--- a/src/Honua.Server/Features/FileStorage/FileStorageServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/FileStorage/FileStorageServiceCollectionExtensions.cs
@@ -75,12 +75,20 @@ public static class FileStorageServiceCollectionExtensions
                 break;
 
             case CloudStorageProvider.AwsS3:
+#if HONUA_EXCLUDE_AWS
+                throw CreateUnavailableProviderException("AWS S3", "HonuaIncludeAws");
+#else
                 services.AddSingleton<ICloudFileStorage, AwsS3FileStorage>();
                 break;
+#endif
 
             case CloudStorageProvider.AzureBlob:
+#if HONUA_EXCLUDE_AZURE
+                throw CreateUnavailableProviderException("Azure Blob", "HonuaIncludeAzure");
+#else
                 services.AddSingleton<ICloudFileStorage, AzureBlobFileStorage>();
                 break;
+#endif
 
             default:
                 throw new InvalidOperationException($"Unknown storage provider: {providerName}");
@@ -135,12 +143,20 @@ public static class FileStorageServiceCollectionExtensions
                 break;
 
             case CloudStorageProvider.AwsS3:
+#if HONUA_EXCLUDE_AWS
+                throw CreateUnavailableProviderException("AWS S3", "HonuaIncludeAws");
+#else
                 services.AddSingleton<ICloudFileStorage, AwsS3FileStorage>();
                 break;
+#endif
 
             case CloudStorageProvider.AzureBlob:
+#if HONUA_EXCLUDE_AZURE
+                throw CreateUnavailableProviderException("Azure Blob", "HonuaIncludeAzure");
+#else
                 services.AddSingleton<ICloudFileStorage, AzureBlobFileStorage>();
                 break;
+#endif
 
             default:
                 throw new InvalidOperationException($"Unknown storage provider: {options.Provider}");
@@ -211,4 +227,11 @@ public static class FileStorageServiceCollectionExtensions
             return new InMemoryUploadProgressStore();
         });
     }
+
+    private static InvalidOperationException CreateUnavailableProviderException(
+        string providerName,
+        string includeProperty)
+        => new(
+            $"{providerName} file storage is not available in this Honua build. " +
+            $"Rebuild with -p:{includeProperty}=true or use HonuaBuildProfile=full.");
 }

--- a/src/Honua.Server/Features/Protocols/Cog/CogServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Protocols/Cog/CogServiceCollectionExtensions.cs
@@ -26,9 +26,13 @@ internal static class CogServiceCollectionExtensions
         // Register the tile resolver
         services.AddScoped<ICogTileResolver, CogTileResolver>();
 
-        // Register range readers based on available provider configurations
+        // Register range readers based on available provider configurations.
+#if !HONUA_EXCLUDE_AWS
         services.AddAwsCloudRangeReader(configuration);
+#endif
+#if !HONUA_EXCLUDE_AZURE
         services.AddAzureCloudRangeReader(configuration);
+#endif
 
         return services;
     }

--- a/src/Honua.Server/Honua.Server.csproj
+++ b/src/Honua.Server/Honua.Server.csproj
@@ -24,29 +24,8 @@
     <NoWarn>$(NoWarn);CS1591;IL2104;IL2026;IL3002;IL3050;CA1041;CA1000;CA1862;IDE0051;IDE0052;IDE0005;CA1844;IL2075</NoWarn>
   </PropertyGroup>
 
-  <!--
-    Native AOT publish cannot include the Oracle.ManagedDataAccess.Core driver:
-    it calls System.Reflection.Assembly.Location, which ILC reports as IL3000
-    (always empty under single-file / Native AOT) and treats as a hard error.
-    Oracle is an OPTIONAL read-only feature provider, so the AOT-verification
-    publish drops the Honua.Oracle ProjectReference entirely and compiles out
-    its registration via the HONUA_SKIP_ORACLE constant. This excludes the
-    non-single-file-safe driver from the AOT image WITHOUT weakening IL3000
-    diagnostics for first-party code. The default (non-AOT) build is unchanged
-    and continues to ship Oracle. Mirrors HonuaSkipAdminClientForAotVerification
-    / HonuaIncludeStacOpsDemo. ILC IL3000 docs: third-party Assembly.Location use.
-  -->
-  <PropertyGroup>
-    <!--
-      Opt-in ONLY: set explicitly by the AOT-verification publish command in
-      .github/workflows/ci.yml (alongside HonuaSkipAdminClientForAotVerification).
-      It is deliberately NOT auto-inferred from PublishAot/RuntimeIdentifier:
-      the multi-stage Docker publish restores without -p:PublishAot=false and
-      then builds with it, so an inferred condition would evaluate differently
-      between restore and build and drop Honua.Oracle's assets file (NETSDK1004).
-    -->
-    <DefineConstants Condition="'$(HonuaSkipOracleForAotVerification)' == 'true'">$(DefineConstants);HONUA_SKIP_ORACLE</DefineConstants>
-  </PropertyGroup>
+  <!-- Build-profile defaults and compile constants for custom Docker images. -->
+  <Import Project="..\..\eng\Honua.BuildProfiles.props" />
 
   <ItemGroup>
     <InternalsVisibleTo Include="Honua.Server.Tests" />
@@ -81,15 +60,15 @@
     <ProjectReference Include="..\Honua.SqlServer\Honua.SqlServer.csproj" />
     <ProjectReference Include="..\Honua.MySql\Honua.MySql.csproj" />
     <ProjectReference Include="..\Honua.ArcGisRest\Honua.ArcGisRest.csproj" />
-    <ProjectReference Include="..\Honua.Oracle\Honua.Oracle.csproj" Condition="'$(HonuaSkipOracleForAotVerification)' != 'true'" />
+    <ProjectReference Include="..\Honua.Oracle\Honua.Oracle.csproj" Condition="'$(HonuaIncludeOracle)' == 'true'" />
     <ProjectReference Include="..\Honua.ServiceDefaults\Honua.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Honua.Hosting\Honua.Hosting.csproj" />
     <ProjectReference Include="..\Honua.Jobs\Honua.Jobs.csproj" />
     <ProjectReference Include="..\Honua.Protocols.OData\Honua.Protocols.OData.csproj" />
     <ProjectReference Include="..\Honua.Geocoding\Honua.Geocoding.csproj" />
 
-    <ProjectReference Include="..\Honua.Aws\Honua.Aws.csproj" />
-    <ProjectReference Include="..\Honua.Azure\Honua.Azure.csproj" />
+    <ProjectReference Include="..\Honua.Aws\Honua.Aws.csproj" Condition="'$(HonuaIncludeAws)' == 'true'" />
+    <ProjectReference Include="..\Honua.Azure\Honua.Azure.csproj" Condition="'$(HonuaIncludeAzure)' == 'true'" />
 
     <ProjectReference Include="..\Honua.Ai\Honua.Ai.csproj" />
 

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -292,7 +292,9 @@ if (!isTestEnvironment || registerInfrastructureInTestEnvironment)
 Honua.Postgres.Features.Security.PostgresConnectionDriverServiceCollectionExtensions.AddPostgresConnectionDriver(builder.Services);
 Honua.MySql.Features.Security.MySqlConnectionDriverServiceCollectionExtensions.AddMySqlConnectionDriver(builder.Services);
 Honua.SqlServer.Features.Security.SqlServerConnectionDriverServiceCollectionExtensions.AddSqlServerConnectionDriver(builder.Services);
+#if !HONUA_SKIP_ORACLE
 Honua.Oracle.Features.Security.OracleConnectionDriverServiceCollectionExtensions.AddOracleConnectionDriver(builder.Services);
+#endif
 builder.Services.AddSingleton<Honua.Core.Features.Security.Abstractions.IConnectionDriverRegistry, Honua.Core.Features.Security.Abstractions.ConnectionDriverRegistry>();
 
 // IGeometryService is a pure NTS-backed compute service (its only dependency is
@@ -378,10 +380,12 @@ builder.Services.AddResilientHttpClient(
     configureHandler: () => KubernetesJobClient.CreatePrimaryHandler(
         kubernetesInClusterAutoDetect,
         kubernetesCaBundlePath));
+#if !HONUA_EXCLUDE_AZURE
 builder.Services.AddResilientHttpClient(
     AzureBatchDataPlaneClient.HttpClientName,
     "control-plane-azure-batch",
     HttpResiliencePolicies.FastApiDefaults);
+#endif
 // ---- Extracted: control-plane deploy + batch-compute backends (Startup/BatchAndDeployBackendsRegistration.cs)
 builder.Services.AddHonuaBatchAndDeployBackends();
 // ---- End extracted block

--- a/src/Honua.Server/Startup/BatchAndDeployBackendsRegistration.cs
+++ b/src/Honua.Server/Startup/BatchAndDeployBackendsRegistration.cs
@@ -18,14 +18,18 @@ internal static class BatchAndDeployBackendsRegistration
     public static IServiceCollection AddHonuaBatchAndDeployBackends(this IServiceCollection services)
     {
         // Cloud SDK adapter clients used by deploy + batch backends below.
+#if !HONUA_EXCLUDE_AWS
         services.AddSingleton<IAwsLambdaAliasClient, AwsSdkLambdaAliasClient>();
         services.AddSingleton<IAwsAlbClient, AwsSdkAlbClient>();
         services.AddSingleton<IAwsEcsClient, AwsSdkEcsClient>();
+#endif
+#if !HONUA_EXCLUDE_AZURE
         services.AddSingleton<IAzureFunctionsSlotClient, AzureManagementFunctionsSlotClient>();
         services.AddSingleton<IAzureContainerAppsRevisionClient, AzureManagementContainerAppsRevisionClient>();
         services.AddSingleton<IAzureBatchClient, AzureBatchDataPlaneClient>();
         services.AddSingleton<AzureBatchComputeBackend>();
         services.AddSingleton<IBatchComputeBackend>(sp => sp.GetRequiredService<AzureBatchComputeBackend>());
+#endif
 
         services.AddSingleton<IDeployTargetRegistry, ConfigurationDeployTargetRegistry>();
         services.AddSingleton<IExecutionJobDefinitionRegistry, ConfigurationExecutionJobDefinitionRegistry>();
@@ -35,19 +39,35 @@ internal static class BatchAndDeployBackendsRegistration
         // Deploy backend concrete singletons. Order matters for the IEnumerable<IDeployBackend>
         // resolution below — keep the existing K8s/AWS/Azure ordering.
         services.AddSingleton<KubernetesGitOpsDeployBackend>();
+#if !HONUA_EXCLUDE_AWS
         services.AddSingleton<AwsEcsGitOpsDeployBackend>();
         services.AddSingleton<AwsEcsAlbDeployBackend>();
+#endif
+#if !HONUA_EXCLUDE_AZURE
         services.AddSingleton<AzureContainerAppsGitOpsDeployBackend>();
         services.AddSingleton<AzureContainerAppsRevisionDeployBackend>();
+#endif
+#if !HONUA_EXCLUDE_AWS
         services.AddSingleton<AwsLambdaGitOpsDeployBackend>();
+#endif
+#if !HONUA_EXCLUDE_AZURE
         services.AddSingleton<AzureFunctionsGitOpsDeployBackend>();
+#endif
         services.AddSingleton<IDeployBackend>(sp => sp.GetRequiredService<KubernetesGitOpsDeployBackend>());
+#if !HONUA_EXCLUDE_AWS
         services.AddSingleton<IDeployBackend>(sp => sp.GetRequiredService<AwsEcsGitOpsDeployBackend>());
         services.AddSingleton<IDeployBackend>(sp => sp.GetRequiredService<AwsEcsAlbDeployBackend>());
+#endif
+#if !HONUA_EXCLUDE_AZURE
         services.AddSingleton<IDeployBackend>(sp => sp.GetRequiredService<AzureContainerAppsGitOpsDeployBackend>());
         services.AddSingleton<IDeployBackend>(sp => sp.GetRequiredService<AzureContainerAppsRevisionDeployBackend>());
+#endif
+#if !HONUA_EXCLUDE_AWS
         services.AddSingleton<IDeployBackend>(sp => sp.GetRequiredService<AwsLambdaGitOpsDeployBackend>());
+#endif
+#if !HONUA_EXCLUDE_AZURE
         services.AddSingleton<IDeployBackend>(sp => sp.GetRequiredService<AzureFunctionsGitOpsDeployBackend>());
+#endif
 
         // Batch backends. Local fallback is registered first so it sits earlier in the enumerable.
         services.AddSingleton<LocalBatchComputeBackend>();
@@ -59,9 +79,11 @@ internal static class BatchAndDeployBackendsRegistration
         // overrides) are carried on each ExecutionJobSpec.Parameters entry via ControlPlane:ExecutionWorkloads,
         // so the adapter has no global options section it depends on. Registering unconditionally keeps
         // the backend visible to the reconciler whenever an operator targets Backend=honua-aws-batch.
+#if !HONUA_EXCLUDE_AWS
         services.AddSingleton<IAwsBatchJobClient, AwsSdkBatchJobClient>();
         services.AddSingleton<AwsBatchComputeBackend>();
         services.AddSingleton<IBatchComputeBackend>(sp => sp.GetRequiredService<AwsBatchComputeBackend>());
+#endif
 
         services.AddSingleton<IKubernetesJobClient, KubernetesJobClient>();
         services.AddSingleton<KubernetesJobBatchComputeBackend>();

--- a/tests/dotnet/Honua.Architecture.Tests/CustomBuildProfileTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/CustomBuildProfileTests.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Text.Json;
+using System.Xml.Linq;
+using FluentAssertions;
+
+namespace Honua.Architecture.Tests;
+
+/// <summary>
+/// Guards the custom Docker/MSBuild build-profile contract for optional modules.
+/// </summary>
+public sealed class CustomBuildProfileTests
+{
+    [ArchitectureTest]
+    public void HonuaServer_ShouldImportBuildProfilesAndConditionCloudReferences()
+    {
+        var repositoryRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+        var serverProjectPath = Path.Combine(repositoryRoot, "src", "Honua.Server", "Honua.Server.csproj");
+        var document = XDocument.Load(serverProjectPath);
+
+        document.Descendants("Import")
+            .Select(element => element.Attribute("Project")?.Value)
+            .Should()
+            .Contain(@"..\..\eng\Honua.BuildProfiles.props");
+
+        var projectReferences = document.Descendants("ProjectReference")
+            .Select(element => new
+            {
+                Include = element.Attribute("Include")?.Value,
+                Condition = element.Attribute("Condition")?.Value
+            })
+            .ToList();
+
+        projectReferences.Should().Contain(reference =>
+            reference.Include == @"..\Honua.Aws\Honua.Aws.csproj" &&
+            reference.Condition == "'$(HonuaIncludeAws)' == 'true'");
+        projectReferences.Should().Contain(reference =>
+            reference.Include == @"..\Honua.Azure\Honua.Azure.csproj" &&
+            reference.Condition == "'$(HonuaIncludeAzure)' == 'true'");
+        projectReferences.Should().Contain(reference =>
+            reference.Include == @"..\Honua.Oracle\Honua.Oracle.csproj" &&
+            reference.Condition == "'$(HonuaIncludeOracle)' == 'true'");
+    }
+
+    [ArchitectureTest]
+    public void NoCloudProfile_ShouldDisableAwsAndAzureWhileAllowingExplicitOverrides()
+    {
+        var noCloudProperties = GetMsBuildProperties(
+            "HonuaIncludeAws,HonuaIncludeAzure,HonuaIncludeOracle",
+            "-p:HonuaBuildProfile=no-cloud");
+
+        noCloudProperties["HonuaIncludeAws"].Should().Be("false");
+        noCloudProperties["HonuaIncludeAzure"].Should().Be("false");
+        noCloudProperties["HonuaIncludeOracle"].Should().Be("true");
+
+        var overriddenProperties = GetMsBuildProperties(
+            "HonuaIncludeAws,HonuaIncludeAzure",
+            "-p:HonuaBuildProfile=no-cloud",
+            "-p:HonuaIncludeAws=true");
+
+        overriddenProperties["HonuaIncludeAws"].Should().Be("true");
+        overriddenProperties["HonuaIncludeAzure"].Should().Be("false");
+
+        var slimProperties = GetMsBuildProperties(
+            "HonuaIncludeAws,HonuaIncludeAzure,HonuaIncludeOracle",
+            "-p:HonuaBuildProfile=slim");
+
+        slimProperties["HonuaIncludeAws"].Should().Be("false");
+        slimProperties["HonuaIncludeAzure"].Should().Be("false");
+        slimProperties["HonuaIncludeOracle"].Should().Be("false");
+    }
+
+    [ArchitectureTest]
+    public void NoCloudProfile_ShouldExcludeCloudProjectReferencesAndEmitCompileConstants()
+    {
+        var projectReferenceNames = GetProjectReferenceNames("-p:HonuaBuildProfile=no-cloud");
+
+        projectReferenceNames.Should().NotContain("Honua.Aws");
+        projectReferenceNames.Should().NotContain("Honua.Azure");
+        projectReferenceNames.Should().Contain("Honua.Oracle");
+
+        var constants = GetMsBuildProperty("DefineConstants", "-p:HonuaBuildProfile=no-cloud")
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        constants.Should().Contain("HONUA_EXCLUDE_AWS");
+        constants.Should().Contain("HONUA_EXCLUDE_AZURE");
+        constants.Should().NotContain("HONUA_SKIP_ORACLE");
+    }
+
+    [ArchitectureTest]
+    public void Dockerfiles_ShouldExposeAndForwardCustomBuildProfileArguments()
+    {
+        var repositoryRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+        var dockerfiles = new[]
+        {
+            Path.Combine(repositoryRoot, "Dockerfile"),
+            Path.Combine(repositoryRoot, "docker", "Dockerfile.aot")
+        };
+
+        foreach (var dockerfile in dockerfiles)
+        {
+            var contents = File.ReadAllText(dockerfile);
+
+            contents.Should().Contain("ARG HONUA_BUILD_PROFILE=full", dockerfile);
+            contents.Should().Contain("ARG HONUA_INCLUDE_AWS=", dockerfile);
+            contents.Should().Contain("ARG HONUA_INCLUDE_AZURE=", dockerfile);
+            contents.Should().Contain("ARG HONUA_INCLUDE_ORACLE=", dockerfile);
+            contents.Should().Contain("COPY eng/Honua.BuildProfiles.props eng/", dockerfile);
+            contents.Should().Contain("-p:HonuaBuildProfile=${HONUA_BUILD_PROFILE:-full}", dockerfile);
+            contents.Should().Contain("-p:HonuaIncludeAws=$HONUA_INCLUDE_AWS", dockerfile);
+            contents.Should().Contain("-p:HonuaIncludeAzure=$HONUA_INCLUDE_AZURE", dockerfile);
+            contents.Should().Contain("-p:HonuaIncludeOracle=$HONUA_INCLUDE_ORACLE", dockerfile);
+        }
+    }
+
+    private static Dictionary<string, string> GetMsBuildProperties(
+        string propertyNames,
+        params string[] msbuildArguments)
+    {
+        using var document = JsonDocument.Parse(RunMsBuild($"-getProperty:{propertyNames}", msbuildArguments));
+        return document.RootElement
+            .GetProperty("Properties")
+            .EnumerateObject()
+            .ToDictionary(property => property.Name, property => property.Value.GetString() ?? string.Empty);
+    }
+
+    private static string GetMsBuildProperty(string propertyName, params string[] msbuildArguments)
+        => RunMsBuild($"-getProperty:{propertyName}", msbuildArguments).Trim();
+
+    private static List<string> GetProjectReferenceNames(params string[] msbuildArguments)
+    {
+        using var document = JsonDocument.Parse(RunMsBuild("-getItem:ProjectReference", msbuildArguments));
+        return document.RootElement
+            .GetProperty("Items")
+            .GetProperty("ProjectReference")
+            .EnumerateArray()
+            .Select(element => element.GetProperty("Filename").GetString())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!)
+            .ToList();
+    }
+
+    private static string RunMsBuild(string queryArgument, params string[] msbuildArguments)
+    {
+        var repositoryRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            WorkingDirectory = repositoryRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        startInfo.ArgumentList.Add("msbuild");
+        startInfo.ArgumentList.Add(Path.Combine("src", "Honua.Server", "Honua.Server.csproj"));
+        startInfo.ArgumentList.Add("-nologo");
+        startInfo.ArgumentList.Add("-v:q");
+        startInfo.ArgumentList.Add(queryArgument);
+
+        foreach (var argument in msbuildArguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Unable to start dotnet msbuild.");
+
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+
+        if (!process.WaitForExit(milliseconds: 30_000))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("dotnet msbuild property evaluation timed out.");
+        }
+
+        process.ExitCode.Should().Be(
+            0,
+            "dotnet msbuild must evaluate custom build profiles successfully. stderr: {0}",
+            error);
+
+        return output;
+    }
+}

--- a/tests/dotnet/Honua.Architecture.Tests/CustomBuildProfileTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/CustomBuildProfileTests.cs
@@ -115,6 +115,22 @@ public sealed class CustomBuildProfileTests
         }
     }
 
+    [ArchitectureTest]
+    public void AlertEditionPolicy_ShouldGateCloudChannelConfigurationBehindBuildProfileConstants()
+    {
+        var repositoryRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            repositoryRoot, "src", "Honua.Server", "Features", "Alerts", "AlertEditionPolicy.cs"));
+
+        // In no-cloud / slim builds the AWS / Azure channels are backed only by
+        // UnsupportedAlertDeliverySink, so IsChannelConfigured must report them unconfigured even when
+        // legacy AlertDelivery:Dispatch:* settings are present — otherwise the pipeline would dispatch to
+        // (and the admin API would advertise) a channel whose every delivery fails immediately. Guard the
+        // compile-time exclusion so the gate is not accidentally removed.
+        source.Should().Contain("#if HONUA_EXCLUDE_AWS");
+        source.Should().Contain("#if HONUA_EXCLUDE_AZURE");
+    }
+
     private static Dictionary<string, string> GetMsBuildProperties(
         string propertyNames,
         params string[] msbuildArguments)


### PR DESCRIPTION
## Issue Link
Closes #1529

## Summary
Adds named, build-time profiles so deployments can produce smaller, policy-constrained server images that exclude optional cloud/provider modules, instead of always restoring and compiling the full assembly graph. The default profile (`full`) keeps current behavior unchanged; `no-cloud` and `slim` exclude optional modules via MSBuild properties, with the composition root and Docker restore/publish kept consistent so Native AOT still sees a closed assembly graph.

## Changes Made
- Add centralized MSBuild build profiles for `full`, `no-cloud`, and `slim` custom server builds.
- Condition AWS, Azure, and Oracle server project references and emit compile constants for excluded modules.
- Guard cloud file storage, alert delivery, COG range readers, Azure Batch, and cloud deploy/batch backend registration when modules are excluded.
- Pass build profile and module override args through the default and AOT Dockerfiles during both restore and publish.
- Add architecture tests for profile evaluation, cloud project-reference exclusion, compile constants, and Docker argument plumbing.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Validation:
- `dotnet build src/Honua.Server/Honua.Server.csproj --configuration Release -p:HonuaBuildProfile=no-cloud -p:TreatWarningsAsErrors=true`
- `dotnet build src/Honua.Server/Honua.Server.csproj --no-restore --configuration Release -p:HonuaBuildProfile=slim -p:TreatWarningsAsErrors=true`
- `dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj --filter FullyQualifiedName~CustomBuildProfileTests`
- `dotnet format Honua.sln --verify-no-changes`

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Release gates (packaging, publishing)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires infrastructure changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None — the default `full` profile preserves the existing build/composition graph; excluded-module behavior is opt-in via build properties.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
