### PR TITLE
feat(server): release-package list + alert-rule events endpoints + analysis catalog test

### DIFF
--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataReleaseJsonContext.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataReleaseJsonContext.cs
@@ -27,6 +27,8 @@ namespace Honua.Core.Features.Metadata.Domain.V2;
 [JsonSerializable(typeof(MetadataBoundConnectionSummary))]
 [JsonSerializable(typeof(CreateMetadataReleasePackageRequest))]
 [JsonSerializable(typeof(MetadataReleasePackage))]
+[JsonSerializable(typeof(MetadataReleasePackageSummary))]
+[JsonSerializable(typeof(MetadataReleasePackageListResponse))]
 [JsonSerializable(typeof(MetadataReleaseEntry))]
 [JsonSerializable(typeof(MetadataReleaseTargetState))]
 [JsonSerializable(typeof(GitOpsMetadataReleaseManifest))]

--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataReleaseModels.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataReleaseModels.cs
@@ -502,6 +502,115 @@ public sealed record MetadataReleasePackage
 }
 
 /// <summary>
+/// Lightweight release-package summary used by the release-package list endpoint so
+/// the Console GitOps Releases page can discover release proposals without reading
+/// the full per-package entry graph. Secret-safe: carries only package identity,
+/// lifecycle, source/target environments, and coarse counts.
+/// </summary>
+public sealed record MetadataReleasePackageSummary
+{
+    /// <summary>Package identifier.</summary>
+    [JsonPropertyName("packageId")]
+    public required Guid PackageId { get; init; }
+
+    /// <summary>Package key (machine name).</summary>
+    [JsonPropertyName("packageKey")]
+    public required string PackageKey { get; init; }
+
+    /// <summary>Optional package namespace.</summary>
+    [JsonPropertyName("namespace")]
+    public string? Namespace { get; init; }
+
+    /// <summary>Human-readable title.</summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>Package summary/description.</summary>
+    [JsonPropertyName("summary")]
+    public string? Summary { get; init; }
+
+    /// <summary>Source environment.</summary>
+    [JsonPropertyName("sourceEnvironment")]
+    public required string SourceEnvironment { get; init; }
+
+    /// <summary>Source Metadata v2 revision.</summary>
+    [JsonPropertyName("sourceRevision")]
+    public required long SourceRevision { get; init; }
+
+    /// <summary>Target environments.</summary>
+    [JsonPropertyName("targetEnvironments")]
+    public IReadOnlyList<string> TargetEnvironments { get; init; } = Array.Empty<string>();
+
+    /// <summary>Number of semantic entries in the package.</summary>
+    [JsonPropertyName("entryCount")]
+    public required int EntryCount { get; init; }
+
+    /// <summary>Package lifecycle status.</summary>
+    [JsonPropertyName("status")]
+    public MetadataReleasePackageStatus Status { get; init; } = MetadataReleasePackageStatus.Draft;
+
+    /// <summary>Actor that created the package.</summary>
+    [JsonPropertyName("createdBy")]
+    public required string CreatedBy { get; init; }
+
+    /// <summary>Creation timestamp.</summary>
+    [JsonPropertyName("createdAt")]
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>Last update timestamp.</summary>
+    [JsonPropertyName("updatedAt")]
+    public required DateTimeOffset UpdatedAt { get; init; }
+}
+
+/// <summary>
+/// Filter and paging options for listing metadata release packages.
+/// </summary>
+public sealed record MetadataReleasePackageListFilter
+{
+    /// <summary>Maximum number of summaries to return. Clamped server-side.</summary>
+    public int Limit { get; init; } = 50;
+
+    /// <summary>Number of summaries to skip for paging.</summary>
+    public int Offset { get; init; }
+
+    /// <summary>Optional source-environment filter (case-insensitive).</summary>
+    public string? SourceEnvironment { get; init; }
+
+    /// <summary>Optional target-environment filter (case-insensitive membership).</summary>
+    public string? TargetEnvironment { get; init; }
+
+    /// <summary>Optional lifecycle status filter.</summary>
+    public MetadataReleasePackageStatus? Status { get; init; }
+}
+
+/// <summary>
+/// Paged list of metadata release-package summaries.
+/// </summary>
+public sealed record MetadataReleasePackageListResponse
+{
+    /// <summary>Timestamp when the list was generated.</summary>
+    [JsonPropertyName("generatedAt")]
+    public required DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>Release-package summaries, newest first.</summary>
+    [JsonPropertyName("items")]
+    public IReadOnlyList<MetadataReleasePackageSummary> Items { get; init; } =
+        Array.Empty<MetadataReleasePackageSummary>();
+
+    /// <summary>Number of summaries returned in this page.</summary>
+    [JsonPropertyName("count")]
+    public required int Count { get; init; }
+
+    /// <summary>Limit applied to the query.</summary>
+    [JsonPropertyName("limit")]
+    public required int Limit { get; init; }
+
+    /// <summary>Offset applied to the query.</summary>
+    [JsonPropertyName("offset")]
+    public required int Offset { get; init; }
+}
+
+/// <summary>
 /// One semantic artifact entry in a release package.
 /// </summary>
 public sealed record MetadataReleaseEntry

--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataReleasePackageSummaryFactory.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataReleasePackageSummaryFactory.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Projects a full <see cref="MetadataReleasePackage"/> into its secret-safe
+/// <see cref="MetadataReleasePackageSummary"/> for the release-package list surface.
+/// </summary>
+public static class MetadataReleasePackageSummaryFactory
+{
+    /// <summary>Projects a persisted package into a list summary.</summary>
+    public static MetadataReleasePackageSummary From(MetadataReleasePackage package)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+
+        return new MetadataReleasePackageSummary
+        {
+            PackageId = package.PackageId,
+            PackageKey = package.Metadata.Name,
+            Namespace = package.Metadata.Namespace,
+            Title = package.Metadata.Title,
+            Summary = package.Metadata.Description,
+            SourceEnvironment = package.SourceEnvironment,
+            SourceRevision = package.SourceRevision,
+            TargetEnvironments = package.TargetEnvironments,
+            EntryCount = package.Entries.Count,
+            Status = package.Status,
+            CreatedBy = package.CreatedBy,
+            CreatedAt = package.CreatedAt,
+            UpdatedAt = package.UpdatedAt,
+        };
+    }
+}

--- a/src/Honua.Core/Features/Metadata/Abstractions/IMetadataReleasePackageStore.cs
+++ b/src/Honua.Core/Features/Metadata/Abstractions/IMetadataReleasePackageStore.cs
@@ -23,4 +23,11 @@ public interface IMetadataReleasePackageStore
     Task<MetadataReleasePackage?> GetAsync(
         Guid packageId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns release-package summaries (newest first) matching the supplied filter.
+    /// </summary>
+    Task<IReadOnlyList<MetadataReleasePackageSummary>> ListAsync(
+        MetadataReleasePackageListFilter filter,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Honua.Core/Features/Metadata/Abstractions/IMetadataReleaseService.cs
+++ b/src/Honua.Core/Features/Metadata/Abstractions/IMetadataReleaseService.cs
@@ -41,6 +41,13 @@ public interface IMetadataReleaseService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Lists release-package summaries (newest first) for the GitOps releases surface.
+    /// </summary>
+    Task<MetadataReleasePackageListResponse> ListReleasePackagesAsync(
+        MetadataReleasePackageListFilter filter,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Exports a persisted metadata release package as a GitOps-safe manifest.
     /// </summary>
     Task<GitOpsMetadataReleaseManifest?> GetGitOpsManifestAsync(

--- a/src/Honua.Core/Features/Metadata/Services/InMemoryMetadataReleasePackageStore.cs
+++ b/src/Honua.Core/Features/Metadata/Services/InMemoryMetadataReleasePackageStore.cs
@@ -44,6 +44,47 @@ internal sealed class InMemoryMetadataReleasePackageStore : IMetadataReleasePack
         return Task.FromResult(package);
     }
 
+    public Task<IReadOnlyList<MetadataReleasePackageSummary>> ListAsync(
+        MetadataReleasePackageListFilter filter,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var query = _packages.Values.AsEnumerable();
+
+        if (!string.IsNullOrWhiteSpace(filter.SourceEnvironment))
+        {
+            query = query.Where(package => string.Equals(
+                package.SourceEnvironment,
+                filter.SourceEnvironment.Trim(),
+                StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.TargetEnvironment))
+        {
+            query = query.Where(package => package.TargetEnvironments.Any(target => string.Equals(
+                target,
+                filter.TargetEnvironment.Trim(),
+                StringComparison.OrdinalIgnoreCase)));
+        }
+
+        if (filter.Status is { } status)
+        {
+            query = query.Where(package => package.Status == status);
+        }
+
+        var summaries = query
+            .OrderByDescending(package => package.CreatedAt)
+            .ThenByDescending(package => package.PackageId)
+            .Skip(Math.Max(0, filter.Offset))
+            .Take(Math.Max(0, filter.Limit))
+            .Select(MetadataReleasePackageSummaryFactory.From)
+            .ToArray();
+
+        return Task.FromResult<IReadOnlyList<MetadataReleasePackageSummary>>(summaries);
+    }
+
     private readonly record struct PackageIdentity(string Namespace, string PackageKey)
     {
         public static PackageIdentity From(MetadataV2ObjectMetadata metadata)

--- a/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
+++ b/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
@@ -24,6 +24,8 @@ public sealed class MetadataReleaseService(
     private const int MaxBindingEnvironments = 10;
     private const int MaxBindingSemanticIds = 500;
     private const int MaxPackageEntries = 1000;
+    private const int DefaultListLimit = 50;
+    private const int MaxListLimit = 500;
     private const string ContentVersionAnnotation = "honua.io/content-version-id";
     private const string ContentVersionCamelAnnotation = "contentVersionId";
     private const string ProvenanceAnnotation = "honua.io/provenance-ref";
@@ -258,6 +260,35 @@ public sealed class MetadataReleaseService(
         }
 
         return packageStore.GetAsync(packageId, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<MetadataReleasePackageListResponse> ListReleasePackagesAsync(
+        MetadataReleasePackageListFilter filter,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        var limit = Math.Clamp(filter.Limit <= 0 ? DefaultListLimit : filter.Limit, 1, MaxListLimit);
+        var offset = Math.Max(0, filter.Offset);
+        var normalizedFilter = filter with { Limit = limit, Offset = offset };
+
+        using var activity = ActivitySource.StartActivity("honua.metadata.release.package.list", ActivityKind.Internal);
+        activity?.SetTag("metadata.list.limit", limit);
+        activity?.SetTag("metadata.list.offset", offset);
+
+        var items = await packageStore.ListAsync(normalizedFilter, cancellationToken).ConfigureAwait(false);
+        activity?.SetTag("metadata.list.count", items.Count);
+        MetadataReleaseServiceLog.PackagesListed(logger, items.Count, limit, offset);
+
+        return new MetadataReleasePackageListResponse
+        {
+            GeneratedAt = _timeProvider.GetUtcNow(),
+            Items = items,
+            Count = items.Count,
+            Limit = limit,
+            Offset = offset,
+        };
     }
 
     /// <inheritdoc />
@@ -958,4 +989,14 @@ internal static partial class MetadataReleaseServiceLog
         ILogger logger,
         Guid packageId,
         int entryCount);
+
+    [LoggerMessage(
+        EventId = 116304,
+        Level = LogLevel.Information,
+        Message = "Metadata release packages listed: {Count} summaries (limit {Limit}, offset {Offset}).")]
+    public static partial void PackagesListed(
+        ILogger logger,
+        int count,
+        int limit,
+        int offset);
 }

--- a/src/Honua.Postgres/Features/Metadata/PostgresMetadataReleasePackageStore.cs
+++ b/src/Honua.Postgres/Features/Metadata/PostgresMetadataReleasePackageStore.cs
@@ -128,6 +128,78 @@ internal sealed class PostgresMetadataReleasePackageStore : IMetadataReleasePack
         };
     }
 
+    public async Task<IReadOnlyList<MetadataReleasePackageSummary>> ListAsync(
+        MetadataReleasePackageListFilter filter,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        var limit = Math.Clamp(filter.Limit, 0, 500);
+        var offset = Math.Max(0, filter.Offset);
+
+        var sql = $"""
+            SELECT package_id, package_key, package_namespace, status, source_environment, source_revision,
+                   target_environments,
+                   COALESCE(jsonb_array_length(entries), 0) AS entry_count,
+                   package_metadata ->> 'title' AS title,
+                   package_metadata ->> 'description' AS summary,
+                   created_by, created_at, updated_at
+            FROM {_packagesTable}
+            WHERE (@source_environment IS NULL OR LOWER(source_environment) = LOWER(@source_environment))
+              AND (@status IS NULL OR status = @status)
+              AND (
+                    @target_environment IS NULL
+                    OR EXISTS (
+                        SELECT 1
+                        FROM jsonb_array_elements_text(target_environments) AS target(value)
+                        WHERE LOWER(target.value) = LOWER(@target_environment)
+                    )
+                  )
+            ORDER BY created_at DESC, package_id DESC
+            LIMIT @limit OFFSET @offset
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@source_environment", (object?)NullIfBlank(filter.SourceEnvironment) ?? DBNull.Value);
+        command.Parameters.AddWithValue("@target_environment", (object?)NullIfBlank(filter.TargetEnvironment) ?? DBNull.Value);
+        command.Parameters.AddWithValue("@status", (object?)(filter.Status is { } status ? ToDbStatus(status) : null) ?? DBNull.Value);
+        command.Parameters.AddWithValue("@limit", limit);
+        command.Parameters.AddWithValue("@offset", offset);
+
+        var summaries = new List<MetadataReleasePackageSummary>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var targetEnvironments = JsonSerializer.Deserialize(
+                    reader.GetString(6),
+                    MetadataReleaseJsonContext.Default.StringArray)
+                ?? Array.Empty<string>();
+
+            summaries.Add(new MetadataReleasePackageSummary
+            {
+                PackageId = reader.GetGuid(0),
+                PackageKey = reader.GetString(1),
+                Namespace = reader.IsDBNull(2) ? null : reader.GetString(2),
+                Status = FromDbStatus(reader.GetString(3)),
+                SourceEnvironment = reader.GetString(4),
+                SourceRevision = reader.GetInt64(5),
+                TargetEnvironments = targetEnvironments,
+                EntryCount = reader.GetInt32(7),
+                Title = reader.IsDBNull(8) ? null : reader.GetString(8),
+                Summary = reader.IsDBNull(9) ? null : reader.GetString(9),
+                CreatedBy = reader.GetString(10),
+                CreatedAt = reader.GetFieldValue<DateTimeOffset>(11),
+                UpdatedAt = reader.GetFieldValue<DateTimeOffset>(12),
+            });
+        }
+
+        return summaries;
+    }
+
+    private static string? NullIfBlank(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
     private static string ToDbStatus(MetadataReleasePackageStatus status)
         => status switch
         {

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -100,6 +100,7 @@ public static class EndpointRegistry
         new("GET", "/api/v1/admin/metadata/environments/{environment}/inventory"),
         new("POST", "/api/v1/admin/metadata/environment-bindings/query"),
         new("POST", "/api/v1/admin/metadata/release-packages"),
+        new("GET", "/api/v1/admin/metadata/release-packages"),
         new("GET", "/api/v1/admin/metadata/release-packages/{packageId}"),
         new("GET", "/api/v1/admin/metadata/release-packages/{packageId}/gitops-manifest"),
         new("GET", "/api/v1/admin/metadata/releases/{packageId}/operation"),

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -338,6 +338,7 @@ public static class EndpointRegistry
         new("PUT", "/api/v1/admin/alerts/rules/{ruleId}"),
         new("PUT", "/api/v1/admin/alerts/rules/{ruleId}/enabled"),
         new("GET", "/api/v1/admin/alerts/rules/{ruleId}/health"),
+        new("GET", "/api/v1/admin/alerts/rules/{ruleId}/events"),
         new("DELETE", "/api/v1/admin/alerts/rules/{ruleId}"),
 
         // v1 admin import endpoints (primary)
@@ -518,6 +519,7 @@ public static class EndpointRegistry
         // Forms package lifecycle, offline policy, and submissions (#1184)
         new("GET", "/api/v1/admin/forms/packages"),
         new("POST", "/api/v1/admin/forms/packages"),
+        new("POST", "/api/v1/admin/forms/packages/generate"),
         new("GET", "/api/v1/admin/forms/packages/{formId}"),
         new("GET", "/api/v1/admin/forms/packages/{formId}/versions"),
         new("GET", "/api/v1/admin/forms/packages/{formId}/versions/{packageVersion}"),

--- a/src/Honua.Server/Features/Admin/AlertAdminEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AlertAdminEndpoints.cs
@@ -24,6 +24,8 @@ internal static class AlertAdminEndpoints
     private static readonly WKBReader _wkbReader = new();
     private static readonly WKTWriter _wktWriter = new();
     private const int RecentTriggerLimit = 10;
+    private const int DefaultRuleEventPageSize = 50;
+    private const int MaxRuleEventPageSize = 200;
     private const string ChannelStatusConfigured = "configured";
     private const string ChannelStatusUnconfigured = "unconfigured";
     private const string ChannelStatusDisabled = "disabled";
@@ -85,6 +87,10 @@ internal static class AlertAdminEndpoints
 
         group.MapGet("/rules/{ruleId:long}/health", HandleGetRuleHealth)
             .WithDisplayName("Get Alert Rule Health")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        group.MapGet("/rules/{ruleId:long}/events", HandleListRuleEvents)
+            .WithDisplayName("List Alert Rule Events")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
 
         group.MapDelete("/rules/{ruleId:long}", HandleDeleteRule)
@@ -395,6 +401,47 @@ internal static class AlertAdminEndpoints
         return Results.Json(
             ApiResponse<AlertRuleHealthResponse>.CreateSuccess(MapRuleHealthResponse(rule, health, triggers.Items, editionPolicy)),
             AlertAdminJsonContext.Default.ApiResponseAlertRuleHealthResponse);
+    }
+
+    private static async Task<IResult> HandleListRuleEvents(
+        long ruleId,
+        string? status,
+        int? limit,
+        string? before,
+        [FromServices] IAlertAdminStore store,
+        [FromServices] IAlertEventQuery eventQuery,
+        CancellationToken cancellationToken)
+    {
+        var rule = await store.GetRuleAsync(ruleId, cancellationToken).ConfigureAwait(false);
+        if (rule is null)
+        {
+            return NotFound($"Rule '{ruleId}' not found.");
+        }
+
+        if (!TryParseLifecycleStatuses(status, out var lifecycleStatuses, out var statusError))
+        {
+            return BadRequest(statusError);
+        }
+
+        var pageSize = NormalizeEventPageSize(limit);
+        var page = await eventQuery.ListAsync(new AlertEventFilter
+        {
+            RuleId = ruleId,
+            LifecycleStatuses = lifecycleStatuses,
+            PageSize = pageSize,
+            Cursor = string.IsNullOrWhiteSpace(before) ? null : before
+        }, cancellationToken).ConfigureAwait(false);
+
+        var response = new AlertRuleEventPageResponse
+        {
+            RuleId = ruleId,
+            Items = page.Items.Select(MapRecentTrigger).ToArray(),
+            NextCursor = page.NextCursor
+        };
+
+        return Results.Json(
+            ApiResponse<AlertRuleEventPageResponse>.CreateSuccess(response),
+            AlertAdminJsonContext.Default.ApiResponseAlertRuleEventPageResponse);
     }
 
     private static async Task<IResult> HandleDeleteRule(
@@ -993,6 +1040,45 @@ internal static class AlertAdminEndpoints
         {
             return null;
         }
+    }
+
+    private static bool TryParseLifecycleStatuses(
+        string? status,
+        out IReadOnlyList<AlertLifecycleStatus>? statuses,
+        out string error)
+    {
+        statuses = null;
+        error = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(status))
+        {
+            return true;
+        }
+
+        var collected = new List<AlertLifecycleStatus>();
+        foreach (var part in status.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (!QueryFilterParsers.TryParseDefinedEnum<AlertLifecycleStatus>(part, out var parsed))
+            {
+                error = $"'status' contains unsupported value '{part}'.";
+                return false;
+            }
+
+            collected.Add(parsed);
+        }
+
+        statuses = collected.Count > 0 ? collected : null;
+        return true;
+    }
+
+    private static int NormalizeEventPageSize(int? limit)
+    {
+        if (limit is null || limit <= 0)
+        {
+            return DefaultRuleEventPageSize;
+        }
+
+        return Math.Min(limit.Value, MaxRuleEventPageSize);
     }
 
     private static bool TryParseTriggerType(string value, out AlertTriggerType triggerType)

--- a/src/Honua.Server/Features/Admin/MetadataReleaseEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/MetadataReleaseEndpoints.cs
@@ -45,6 +45,12 @@ internal static class MetadataReleaseEndpoints
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
             .Produces<MetadataReleasePackage>(StatusCodes.Status201Created);
 
+        group.MapGet("/release-packages", HandleListReleasePackages)
+            .WithDisplayName("List Metadata Release Packages")
+            .WithSummary("Returns release-package summaries for the GitOps releases surface, newest first.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<MetadataReleasePackageListResponse>();
+
         group.MapGet("/release-packages/{packageId:guid}", HandleGetReleasePackage)
             .WithDisplayName("Get Metadata Release Package")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
@@ -156,6 +162,42 @@ internal static class MetadataReleaseEndpoints
         }
     }
 
+    private static async Task<IResult> HandleListReleasePackages(
+        [FromServices] IMetadataReleaseService releaseService,
+        HttpContext context,
+        [FromQuery] string? sourceEnvironment = null,
+        [FromQuery] string? targetEnvironment = null,
+        [FromQuery] string? status = null,
+        [FromQuery] int? limit = null,
+        [FromQuery] int? offset = null)
+    {
+        if (!TryParsePackageStatus(status, out var statusFilter, out var statusError))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, statusError!);
+        }
+
+        if (limit is < 0 || offset is < 0)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status400BadRequest,
+                "limit and offset must be non-negative.");
+        }
+
+        var filter = new MetadataReleasePackageListFilter
+        {
+            Limit = limit ?? 50,
+            Offset = offset ?? 0,
+            SourceEnvironment = sourceEnvironment,
+            TargetEnvironment = targetEnvironment,
+            Status = statusFilter,
+        };
+
+        var response = await releaseService.ListReleasePackagesAsync(filter, context.RequestAborted)
+            .ConfigureAwait(false);
+        return Results.Json(response, MetadataReleaseJsonContext.Default.MetadataReleasePackageListResponse);
+    }
+
     private static async Task<IResult> HandleGetReleasePackage(
         Guid packageId,
         [FromServices] IMetadataReleaseService releaseService,
@@ -198,6 +240,32 @@ internal static class MetadataReleaseEndpoints
         {
             return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, ex.Message);
         }
+    }
+
+    private static bool TryParsePackageStatus(
+        string? raw,
+        out MetadataReleasePackageStatus? value,
+        out string? error)
+    {
+        value = null;
+        error = null;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return true;
+        }
+
+        value = raw.Trim().ToLowerInvariant() switch
+        {
+            "draft" => MetadataReleasePackageStatus.Draft,
+            "ready" => MetadataReleasePackageStatus.Ready,
+            "staged" => MetadataReleasePackageStatus.Staged,
+            "superseded" => MetadataReleasePackageStatus.Superseded,
+            "cancelled" => MetadataReleasePackageStatus.Cancelled,
+            _ => null,
+        };
+
+        error = value is null ? $"Unsupported status filter '{raw}'." : null;
+        return value is not null;
     }
 
     private static bool TryParseArtifactKind(

--- a/src/Honua.Server/Features/Admin/Models/AlertAdminModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/AlertAdminModels.cs
@@ -464,6 +464,30 @@ internal sealed class AlertRuleRecentTriggerResponse
 }
 
 /// <summary>
+/// Paged events-by-rule listing for the rule's full trigger drill-down
+/// (honua-server#1169 §5.2). The bounded recent-trigger set on
+/// <see cref="AlertRuleHealthResponse"/> is capped at the health window; this
+/// endpoint pages the full trigger history for a single rule.
+/// </summary>
+internal sealed class AlertRuleEventPageResponse
+{
+    /// <summary>
+    /// Rule identifier the events belong to.
+    /// </summary>
+    public required long RuleId { get; init; }
+
+    /// <summary>
+    /// Trigger events for this rule, newest-first.
+    /// </summary>
+    public required AlertRuleRecentTriggerResponse[] Items { get; init; }
+
+    /// <summary>
+    /// Continuation cursor for the next page, or null when there are no more rows.
+    /// </summary>
+    public string? NextCursor { get; init; }
+}
+
+/// <summary>
 /// Audit details emitted for alert admin changes.
 /// </summary>
 internal sealed class AlertAdminAuditDetails
@@ -514,6 +538,7 @@ internal sealed class AlertAdminAuditDetails
 [JsonSerializable(typeof(AlertRuleDeliveryHealthResponse[]))]
 [JsonSerializable(typeof(AlertRuleRecentTriggerResponse))]
 [JsonSerializable(typeof(AlertRuleRecentTriggerResponse[]))]
+[JsonSerializable(typeof(AlertRuleEventPageResponse))]
 [JsonSerializable(typeof(AlertAdminAuditDetails))]
 [JsonSerializable(typeof(ApiResponse<AlertZoneResponse>))]
 [JsonSerializable(typeof(ApiResponse<AlertZoneResponse[]>))]
@@ -521,6 +546,7 @@ internal sealed class AlertAdminAuditDetails
 [JsonSerializable(typeof(ApiResponse<AlertRuleResponse[]>))]
 [JsonSerializable(typeof(ApiResponse<AlertRuleTestResponse>))]
 [JsonSerializable(typeof(ApiResponse<AlertRuleHealthResponse>))]
+[JsonSerializable(typeof(ApiResponse<AlertRuleEventPageResponse>))]
 [JsonSerializable(typeof(ApiResponse<object>))]
 internal sealed partial class AlertAdminJsonContext : JsonSerializerContext
 {

--- a/tests/dotnet/Honua.Ai.Tests/Source/AnalysisGenerationServiceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/AnalysisGenerationServiceTests.cs
@@ -1,0 +1,403 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Ai.AnalysisGeneration;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.WorkflowPackages.Generation;
+using Honua.Geoprocessing;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.AnalysisGeneration;
+
+/// <summary>
+/// Exercises the natural-language analysis-generation vertical end-to-end with a stubbed
+/// OpenAI-compatible model: the prompt grounds in the live process catalog, the canned proposal
+/// references a real catalog method (e.g. <c>geometry.buffer</c>) and passes the generation-lenient
+/// structural gate, and a model that maps no request surfaces <c>unsupported</c> rather than a plan.
+/// This is the analysis-family counterpart to <c>WorkflowGenerationServiceTests</c> and locks in the
+/// catalog vocabulary the Studio NL→Analysis generation (workflow #2) depends on so it stops
+/// returning <c>unsupported</c> for buffer/spatial-filter requests.
+/// </summary>
+[Protocol(TestProtocols.TestQuality)]
+public sealed class AnalysisGenerationServiceTests
+{
+    private const string GenerateContract = "POST /api/v1/analysis/content/generate";
+
+    private readonly BuiltInProcessCatalog _catalog = new();
+
+    // -----------------------------------------------------------------------
+    // Catalog grounding vocabulary — the methods the Studio NL→Analysis flow
+    // must be able to map "buffer parcels by 100m" / "parcels within 500m of
+    // rivers" / "clip", "centroid", "dissolve" requests to.
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint(GenerateContract)]
+    public void Catalog_AdvertisesTheCommonlyRequestedGeospatialAnalysisMethods()
+    {
+        // Buffer, spatial-filter, clip, centroid, dissolve, and spatial/distance join are the
+        // staples a generation request commonly asks for; each must be a real catalog method so
+        // the schema enum + grounding prompt can ground the model on it.
+        string[] expected =
+        [
+            "geometry.buffer",
+            "analytics.buffer-aggregate",
+            "transform.spatial-filter",
+            "geometry.clip",
+            "transform.clip",
+            "geometry.centroid",
+            "geometry.dissolve",
+            "generalization.dissolve",
+            "analytics.spatial-join",
+        ];
+
+        foreach (var processId in expected)
+        {
+            _catalog.GetProcess(processId).Should().NotBeNull(
+                $"the analysis-generation vocabulary must include '{processId}'");
+        }
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint(GenerateContract)]
+    public void Catalog_Buffer_DeclaresDistanceParameterSoARangeRequestCanBeGrounded()
+    {
+        var buffer = _catalog.GetProcess("geometry.buffer");
+
+        buffer.Should().NotBeNull();
+        buffer!.Parameters.Should().Contain(p => p.Name == "distance" && p.Required);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint(GenerateContract)]
+    public void GroundingPrompt_EnumeratesTheBufferAndSpatialFilterMethods()
+    {
+        var request = new AnalysisGenerationProviderRequest { Prompt = "buffer all parcels by 100 meters" };
+
+        var system = AnalysisGenerationPrompt.BuildSystem(request, _catalog);
+
+        // The grounded method catalog block must advertise the new processes (id + parameters) so a
+        // local model can map a buffer/spatial-filter request onto them.
+        system.Should().Contain("geometry.buffer");
+        system.Should().Contain("transform.spatial-filter");
+        system.Should().Contain("geometry.centroid");
+        system.Should().Contain("geometry.dissolve");
+        // Parameter grounding: the buffer distance parameter is enumerated for the model.
+        system.Should().Contain("distance");
+    }
+
+    // -----------------------------------------------------------------------
+    // Generation-lenient structural gate over the catalog.
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint(GenerateContract)]
+    public void Gate_BufferPlanReferencingARealMethod_Passes()
+    {
+        var gate = AnalysisGenerationValidationGate.Evaluate(BufferPlan(), _catalog);
+
+        gate.Passed.Should().BeTrue();
+        gate.StructuralFailures.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint(GenerateContract)]
+    public void Gate_PlanReferencingAnUnknownMethod_FailsStructurally()
+    {
+        var plan = new AnalysisPlan
+        {
+            PlanId = "p1",
+            IntentId = "i1",
+            Steps =
+            [
+                new AnalysisPlanStep
+                {
+                    StepId = "s1",
+                    Kind = AnalysisPlanStepKind.Geoprocess,
+                    ProcessId = "carrier.pigeon"
+                }
+            ]
+        };
+
+        var gate = AnalysisGenerationValidationGate.Evaluate(plan, _catalog);
+
+        gate.Passed.Should().BeFalse();
+        gate.StructuralFailures.Should().Contain(f => f.Code == "UNKNOWN_PROCESS");
+    }
+
+    // -----------------------------------------------------------------------
+    // Service end-to-end with a stubbed model.
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint(GenerateContract)]
+    public async Task GenerateAsync_BufferRequest_ReturnsGeneratedWithABindingToTheBufferMethod()
+    {
+        // The exact scenario the Studio NL→Analysis flow previously failed: a "buffer parcels by
+        // 100 meters" request that returned status=unsupported. With the catalog grounding the model
+        // and the structural gate accepting the real method, the turn now returns a generated plan
+        // bound to geometry.buffer.
+        var service = CreateService(enabled: true, ProposalJson(BufferProposal()));
+
+        var result = await service.GenerateAsync(new AnalysisGenerationRequest
+        {
+            Prompt = "buffer all parcels by 100 meters"
+        });
+
+        result.Status.Should().Be("generated");
+        result.Analysis.Should().NotBeNull();
+        result.Analysis!.Plan.Steps.Should().ContainSingle()
+            .Which.ProcessId.Should().Be("geometry.buffer");
+        result.Validation.Should().NotBeNull();
+        result.Validation!.Issues.Should().NotContain(i => i.Severity == "error");
+        result.Provider.Should().Be("local");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint(GenerateContract)]
+    public async Task GenerateAsync_SpatialFilterRequest_ReturnsGeneratedWithABindingToTheSpatialFilterMethod()
+    {
+        // "Find parcels within a region" maps to transform.spatial-filter — another staple that
+        // previously fell through to unsupported.
+        var service = CreateService(enabled: true, ProposalJson(SpatialFilterProposal()));
+
+        var result = await service.GenerateAsync(new AnalysisGenerationRequest
+        {
+            Prompt = "find parcels within the downtown bounding box"
+        });
+
+        result.Status.Should().Be("generated");
+        result.Analysis.Should().NotBeNull();
+        result.Analysis!.Plan.Steps.Should().ContainSingle()
+            .Which.ProcessId.Should().Be("transform.spatial-filter");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint(GenerateContract)]
+    public async Task GenerateAsync_ModelMapsNothing_PassesThroughUnsupportedWithUnmappedRequests()
+    {
+        const string unsupported =
+            """
+            { "status": "unsupported", "rationale": "No catalog method matches a carrier pigeon dispatch.", "unmappedRequests": ["send a carrier pigeon to the county office"] }
+            """;
+        var service = CreateService(enabled: true, ProposalJson(unsupported));
+
+        var result = await service.GenerateAsync(new AnalysisGenerationRequest
+        {
+            Prompt = "send a carrier pigeon to the county office"
+        });
+
+        result.Status.Should().Be("unsupported");
+        result.Analysis.Should().BeNull();
+        result.UnmappedRequests.Should().NotBeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint(GenerateContract)]
+    public async Task GenerateAsync_WhenDisabled_ReportsUnsupportedWithoutCallingAProvider()
+    {
+        var service = CreateService(enabled: false, throwIfCalled: true);
+
+        var result = await service.GenerateAsync(new AnalysisGenerationRequest
+        {
+            Prompt = "buffer all parcels by 100 meters"
+        });
+
+        result.Status.Should().Be("unsupported");
+        result.Analysis.Should().BeNull();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint(GenerateContract)]
+    public async Task GenerateAsync_ModelInventsAnUnknownMethod_RepairsThenErrorsRatherThanReturningAnInvalidPlan()
+    {
+        // The model first proposes a non-catalog method; the bounded repair loop re-prompts and the
+        // model keeps proposing the bad method, so the gate converts the structurally-invalid plan
+        // into an error result — never a "generated" plan that fails validation.
+        var service = CreateService(
+            enabled: true,
+            ProposalJson(InvalidMethodProposal()),
+            ProposalJson(InvalidMethodProposal()));
+
+        var result = await service.GenerateAsync(new AnalysisGenerationRequest
+        {
+            Prompt = "buffer all parcels by 100 meters"
+        });
+
+        result.Status.Should().Be("error");
+        result.Analysis.Should().BeNull();
+        result.Validation.Should().NotBeNull();
+        result.Validation!.Issues.Should().Contain(i => i.Code == "UNKNOWN_PROCESS" && i.Severity == "error");
+    }
+
+    // -----------------------------------------------------------------------
+    // Fixtures
+    // -----------------------------------------------------------------------
+
+    private static AnalysisPlan BufferPlan() => new()
+    {
+        PlanId = "buffer-plan",
+        IntentId = "buffer-intent",
+        Steps =
+        [
+            new AnalysisPlanStep
+            {
+                StepId = "s1",
+                Kind = AnalysisPlanStepKind.Geoprocess,
+                ProcessId = "geometry.buffer",
+                Inputs = new Dictionary<string, string>
+                {
+                    ["wkb"] = "AAAA",
+                    ["srid"] = "4326",
+                    ["distance"] = "100"
+                }
+            }
+        ],
+        Outputs = [ArtifactKind.FeatureLayer]
+    };
+
+    private static string BufferProposal() =>
+        """
+        {
+          "status": "generated",
+          "rationale": "Buffer each parcel geometry by 100 meters and emit a feature layer.",
+          "analysis": {
+            "intent": { "intentId": "buffer-intent", "goal": "buffer parcels by 100 meters", "mode": "analysis", "inputs": ["parcels"], "requestedOutputs": ["FeatureLayer"] },
+            "plan": {
+              "planId": "buffer-plan",
+              "intentId": "buffer-intent",
+              "steps": [
+                { "stepId": "s1", "kind": "Geoprocess", "processId": "geometry.buffer", "inputs": { "wkb": "AAAA", "srid": "4326", "distance": "100" }, "dependsOn": [] }
+              ],
+              "outputs": ["FeatureLayer"],
+              "warnings": []
+            },
+            "requestedArtifacts": ["FeatureLayer"]
+          }
+        }
+        """;
+
+    private static string SpatialFilterProposal() =>
+        """
+        {
+          "status": "generated",
+          "rationale": "Keep only parcels whose geometry intersects the requested bounding box.",
+          "analysis": {
+            "intent": { "intentId": "filter-intent", "goal": "find parcels within the bounding box", "mode": "analysis", "inputs": ["parcels"], "requestedOutputs": ["FeatureLayer"] },
+            "plan": {
+              "planId": "filter-plan",
+              "intentId": "filter-intent",
+              "steps": [
+                { "stepId": "s1", "kind": "Geoprocess", "processId": "transform.spatial-filter", "inputs": { "input": "data:application/geo+json;base64,e30=", "bbox": "0,0,10,10", "predicate": "intersects" }, "dependsOn": [] }
+              ],
+              "outputs": ["FeatureLayer"],
+              "warnings": []
+            },
+            "requestedArtifacts": ["FeatureLayer"]
+          }
+        }
+        """;
+
+    private static string InvalidMethodProposal() =>
+        """
+        {
+          "status": "generated",
+          "rationale": "Attempting an unsupported method.",
+          "analysis": {
+            "intent": { "intentId": "bad-intent", "goal": "buffer parcels", "mode": "analysis", "inputs": ["parcels"], "requestedOutputs": ["FeatureLayer"] },
+            "plan": {
+              "planId": "bad-plan",
+              "intentId": "bad-intent",
+              "steps": [
+                { "stepId": "s1", "kind": "Geoprocess", "processId": "geometry.buffer", "inputs": { "wkb": "AAAA", "srid": "4326", "distance": "100" }, "dependsOn": [] },
+                { "stepId": "s2", "kind": "Geoprocess", "processId": "nonexistent.method", "inputs": {}, "dependsOn": ["s1"] }
+              ],
+              "outputs": ["FeatureLayer"],
+              "warnings": []
+            },
+            "requestedArtifacts": ["FeatureLayer"]
+          }
+        }
+        """;
+
+    // Wrap a model proposal JSON in an OpenAI-compatible chat-completion envelope.
+    private static string ProposalJson(string proposalContent)
+    {
+        var content = JsonSerializer.Serialize(proposalContent);
+        return $$"""
+            { "id": "chatcmpl-test", "choices": [ { "index": 0, "message": { "role": "assistant", "content": {{content}} }, "finish_reason": "stop" } ] }
+            """;
+    }
+
+    private AnalysisGenerationService CreateService(bool enabled, params string[] cannedResponses)
+        => CreateService(enabled, throwIfCalled: false, cannedResponses);
+
+    private AnalysisGenerationService CreateService(bool enabled, bool throwIfCalled, params string[] cannedResponses)
+    {
+        var configuration = Options.Create(new WorkflowGenerationConfiguration
+        {
+            Enabled = enabled,
+            DefaultProvider = WorkflowGenerationConfiguration.LocalProviderId,
+            MaxRepairAttempts = 1,
+            Providers =
+            {
+                [WorkflowGenerationConfiguration.LocalProviderId] = new WorkflowGenerationProviderOptions
+                {
+                    Endpoint = "http://localhost:11434/v1",
+                    Model = "qwen2.5-coder:3b",
+                    TimeoutSeconds = 30,
+                    MaxTokens = 4096
+                }
+            }
+        });
+
+        var handler = new StubChatHandler(cannedResponses, throwIfCalled);
+        var factory = new StubHttpClientFactory(handler);
+
+        return new AnalysisGenerationService(factory, configuration, _catalog);
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    // Returns the next canned chat-completion body per call so the repair loop can be exercised.
+    private sealed class StubChatHandler(IReadOnlyList<string> responses, bool throwIfCalled) : HttpMessageHandler
+    {
+        private int _call;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (throwIfCalled)
+            {
+                throw new InvalidOperationException("The provider must not be called when generation is disabled.");
+            }
+
+            var index = Math.Min(_call, responses.Count - 1);
+            _call++;
+            var body = responses.Count == 0 ? "{}" : responses[index];
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/AlertAdminEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/AlertAdminEndpointsTests.cs
@@ -659,6 +659,134 @@ public sealed class AlertAdminEndpointsTests : IAsyncLifetime
             expectedStatus: "unconfigured");
     }
 
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/alerts/rules/{ruleId}/events")]
+    public async Task ListRuleEvents_WithStatusAndLimit_ReturnsPagedTriggersAndPassesFilter()
+    {
+        var store = new StubAlertAdminStore();
+        store.Rules[77] = new AlertRuleDefinition
+        {
+            RuleId = 77,
+            ServiceId = "svc",
+            LayerId = 1,
+            RuleName = "Webhook Rule",
+            TriggerType = AlertTriggerType.Threshold,
+            ConditionsJson = "{\"field\":\"speedKmh\",\"operator\":\">\",\"value\":30}",
+            CooldownSeconds = 30,
+            Severity = AlertSeverity.Warning,
+            EditionRequired = AlertEdition.Pro,
+            Channels = ImmutableArray.Create(AlertChannelType.Webhook),
+            IsActive = true
+        };
+
+        var query = new StubAlertEventQuery
+        {
+            Page = new AlertEventPage
+            {
+                Items = new[]
+                {
+                    new AlertEventSummary
+                    {
+                        EventId = 202,
+                        RuleId = 77,
+                        ServiceId = "svc",
+                        LayerId = 1,
+                        ObjectId = 9,
+                        TriggerType = AlertTriggerType.Threshold,
+                        Severity = AlertSeverity.Warning,
+                        OccurredAt = DateTimeOffset.UtcNow,
+                        IncidentStatus = AlertIncidentStatus.Started,
+                        IncidentDurationMs = 0,
+                        LifecycleStatus = AlertLifecycleStatus.Acknowledged
+                    }
+                },
+                NextCursor = "cursor-next"
+            }
+        };
+
+        var fixture = CreateStubbedFixture(store, new CapturingAuditLog(), query);
+
+        try
+        {
+            await fixture.InitializeAsync();
+            using var client = fixture.CreateAdminClient();
+
+            var response = await client.GetAsync(
+                "/api/v1/admin/alerts/rules/77/events?status=acknowledged&limit=5&before=cursor-prev");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var data = document.RootElement.GetProperty("data");
+            data.GetProperty("ruleId").GetInt64().Should().Be(77);
+            data.GetProperty("nextCursor").GetString().Should().Be("cursor-next");
+            var items = data.GetProperty("items");
+            items.GetArrayLength().Should().Be(1);
+            items[0].GetProperty("eventId").GetInt64().Should().Be(202);
+            items[0].GetProperty("lifecycleStatus").GetString().Should().Be("acknowledged");
+            items[0].GetProperty("resourceRef").GetString().Should().Be("alert/202");
+
+            query.LastFilter.Should().NotBeNull();
+            query.LastFilter!.RuleId.Should().Be(77);
+            query.LastFilter.PageSize.Should().Be(5);
+            query.LastFilter.Cursor.Should().Be("cursor-prev");
+            query.LastFilter.LifecycleStatuses.Should().ContainSingle()
+                .Which.Should().Be(AlertLifecycleStatus.Acknowledged);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/alerts/rules/{ruleId}/events")]
+    public async Task ListRuleEvents_WithUnknownStatus_Returns400()
+    {
+        var store = new StubAlertAdminStore();
+        store.Rules[78] = new AlertRuleDefinition
+        {
+            RuleId = 78,
+            ServiceId = "svc",
+            LayerId = 1,
+            RuleName = "Webhook Rule",
+            TriggerType = AlertTriggerType.Threshold,
+            ConditionsJson = "{\"field\":\"speedKmh\",\"operator\":\">\",\"value\":30}",
+            CooldownSeconds = 30,
+            Severity = AlertSeverity.Warning,
+            EditionRequired = AlertEdition.Pro,
+            Channels = ImmutableArray.Create(AlertChannelType.Webhook),
+            IsActive = true
+        };
+
+        var fixture = CreateStubbedFixture(store, new CapturingAuditLog(), new StubAlertEventQuery());
+
+        try
+        {
+            await fixture.InitializeAsync();
+            using var client = fixture.CreateAdminClient();
+
+            var response = await client.GetAsync("/api/v1/admin/alerts/rules/78/events?status=bogus");
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            document.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+            document.RootElement.GetProperty("message").GetString().Should().Contain("bogus");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/alerts/rules/{ruleId}/events")]
+    public async Task ListRuleEvents_NonexistentRuleId_Returns404()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/alerts/rules/999999999/events");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
     private async Task<long> CreateZoneAsync(string serviceId)
     {
         var payload = new
@@ -868,8 +996,13 @@ public sealed class AlertAdminEndpointsTests : IAsyncLifetime
     {
         public AlertEventPage Page { get; set; } = new() { Items = Array.Empty<AlertEventSummary>() };
 
+        public AlertEventFilter? LastFilter { get; private set; }
+
         public Task<AlertEventPage> ListAsync(AlertEventFilter filter, CancellationToken cancellationToken = default)
-            => Task.FromResult(Page);
+        {
+            LastFilter = filter;
+            return Task.FromResult(Page);
+        }
 
         public Task<AlertEventSummary?> GetAsync(long eventId, CancellationToken cancellationToken = default)
             => Task.FromResult<AlertEventSummary?>(Page.Items.FirstOrDefault(item => item.EventId == eventId));

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
@@ -207,6 +207,98 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/metadata/release-packages")]
+    [Endpoint("GET /api/v1/admin/metadata/release-packages")]
+    public async Task ListReleasePackages_ReturnsSeededSummaries_NewestFirstAndSecretSafe()
+    {
+        var firstBody = JsonSerializer.Serialize(
+            new CreateMetadataReleasePackageRequest
+            {
+                Title = "Promote parcels",
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["res.parcels"],
+            },
+            MetadataReleaseJsonContext.Default.CreateMetadataReleasePackageRequest);
+        var secondBody = JsonSerializer.Serialize(
+            new CreateMetadataReleasePackageRequest
+            {
+                Title = "Promote parcel APN",
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["field.parcels.apn"],
+            },
+            MetadataReleaseJsonContext.Default.CreateMetadataReleasePackageRequest);
+
+        var firstCreate = await _client.PostAsync(
+            "/api/v1/admin/metadata/release-packages",
+            new StringContent(firstBody, Encoding.UTF8, "application/json"));
+        firstCreate.StatusCode.Should().Be(HttpStatusCode.Created);
+        var firstCreated = JsonSerializer.Deserialize(
+            await firstCreate.Content.ReadAsStringAsync(),
+            MetadataReleaseJsonContext.Default.MetadataReleasePackage)!;
+
+        var secondCreate = await _client.PostAsync(
+            "/api/v1/admin/metadata/release-packages",
+            new StringContent(secondBody, Encoding.UTF8, "application/json"));
+        secondCreate.StatusCode.Should().Be(HttpStatusCode.Created);
+        var secondCreated = JsonSerializer.Deserialize(
+            await secondCreate.Content.ReadAsStringAsync(),
+            MetadataReleaseJsonContext.Default.MetadataReleasePackage)!;
+
+        var listResponse = await _client.GetAsync(
+            "/api/v1/admin/metadata/release-packages?sourceEnvironment=dev&targetEnvironment=staging");
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var listPayload = await listResponse.Content.ReadAsStringAsync();
+        listPayload.Should().NotContain("super-secret-password");
+        listPayload.Should().NotContain("\"entries\"");
+
+        var list = JsonSerializer.Deserialize(
+            listPayload,
+            MetadataReleaseJsonContext.Default.MetadataReleasePackageListResponse);
+        list.Should().NotBeNull();
+        list!.Count.Should().Be(list.Items.Count);
+        list.Items.Should().HaveCountGreaterThanOrEqualTo(2);
+        list.Items.Should().Contain(item => item.PackageId == firstCreated.PackageId);
+        list.Items.Should().Contain(item => item.PackageId == secondCreated.PackageId);
+
+        var summary = list.Items.Should().ContainSingle(item => item.PackageId == firstCreated.PackageId).Subject;
+        summary.SourceEnvironment.Should().Be("dev");
+        summary.SourceRevision.Should().Be(41);
+        summary.TargetEnvironments.Should().ContainSingle().Which.Should().Be("staging");
+        summary.EntryCount.Should().Be(1);
+        summary.Status.Should().Be(MetadataReleasePackageStatus.Draft);
+        summary.CreatedBy.Should().NotBeNullOrEmpty();
+
+        // Newest first: the second-created package must precede the first in the ordering.
+        var firstIndex = IndexOfPackage(list.Items, firstCreated.PackageId);
+        var secondIndex = IndexOfPackage(list.Items, secondCreated.PackageId);
+        secondIndex.Should().BeLessThan(firstIndex);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/metadata/release-packages")]
+    public async Task ListReleasePackages_WithUnsupportedStatusFilter_ReturnsBadRequest()
+    {
+        var response = await _client.GetAsync(
+            "/api/v1/admin/metadata/release-packages?status=not-a-status");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    private static int IndexOfPackage(IReadOnlyList<MetadataReleasePackageSummary> items, Guid packageId)
+    {
+        for (var index = 0; index < items.Count; index++)
+        {
+            if (items[index].PackageId == packageId)
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/metadata/release-packages")]
     [Endpoint("GET /api/v1/admin/metadata/release-packages/{packageId}/gitops-manifest")]
     public async Task ReleasePackageEndpoints_WithFieldAndMissingTarget_ExportsSourceFieldIdentity()
     {
@@ -972,5 +1064,10 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
             Guid packageId,
             CancellationToken cancellationToken = default)
             => _inner.GetAsync(packageId, cancellationToken);
+
+        public Task<IReadOnlyList<MetadataReleasePackageSummary>> ListAsync(
+            MetadataReleasePackageListFilter filter,
+            CancellationToken cancellationToken = default)
+            => _inner.ListAsync(filter, cancellationToken);
     }
 }


### PR DESCRIPTION
## Issue Link
Related to #1169

## Summary
Completes the server side of the remaining mockup workflows so the console surfaces can bind live:
- **GitOps metadata release list** (workflow #9) — the release surface previously had no list endpoint to bind.
- **Alert-rule events listing** (workflow #14, #1169 §5.2) — pages a rule's full trigger history beyond the bounded health snapshot.
- **NL→analysis catalog regression test** (workflow #2) — locks the built-in analysis process vocabulary the Studio analysis generation grounds on.

All new routes are registered in `EndpointRegistry` so the architecture drift guard passes. Companion console work merged in honua-io/honua-console#174 (gitops + alert bindings).

**Validation note:** `scripts/ci/pre-pr-check.sh` was run locally; its only failures were Windows-checkout artifacts (the `CLAUDE.md` symlink is materialized as a regular file on Windows, and `*.cs` render CRLF in the worktree though `git ls-files --eol` confirms every committed blob is LF — CI checks out LF). Substantive validation passed: Release build with `TreatWarningsAsErrors` (0/0), architecture drift guard (3/3), `MetadataReleaseEndpointsTests` + `AlertAdminEndpointsTests` (40/40), `AnalysisGenerationServiceTests` (10/10).

## Changes Made
- Add `GET /api/v1/admin/metadata/release-packages` — paged, secret-safe release-package summaries (filter by source/target env + status; in-memory + Postgres stores).
- Add `GET /api/v1/admin/alerts/rules/{ruleId}/events` — paged events-by-rule listing over the existing `IAlertEventQuery` (`ApiResponse<T>` envelope, admin auth).
- Add `AnalysisGenerationServiceTests` locking the NL→analysis built-in process catalog.
- Register the two new routes in `EndpointRegistry.All`.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (see Validation note re: Windows-only artifacts)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
