### PR TITLE
test: stop running the migration-batch background poller in the test host (#1359 follow-up)

### DIFF
--- a/tests/dotnet/Honua.TestKit/Mixins/WebAppFixturePostgresWiringMixin.cs
+++ b/tests/dotnet/Honua.TestKit/Mixins/WebAppFixturePostgresWiringMixin.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Npgsql;
 
 namespace Honua.TestKit.Mixins;
@@ -119,6 +120,49 @@ internal static class WebAppFixturePostgresWiringMixin
     }
 
     /// <summary>
+    /// Timer-based background DB pollers/reconcilers that should not run in the test host.
+    /// Matched by implementation-type name to avoid the TestKit referencing internal host types.
+    /// </summary>
+    /// <remarks>
+    /// Limited to <c>MigrationBatchBackgroundService</c>: its logic is exercised directly by
+    /// <c>MigrationBatchEndpointTests</c> via a recording orchestrator, so nothing depends on the
+    /// timer loop, and it was the confirmed source of the cross-schema
+    /// <c>honua.migration_batch_runs</c> "relation does not exist" noise. The Deploy/ExecutionJob/
+    /// FeatureChange reconcilers are intentionally NOT disabled — ControlPlane integration tests
+    /// submit work and wait for those background loops to advance it, so removing them hangs the
+    /// "Infra and Security" shard. Gating additional pollers requires per-poller verification.
+    /// </remarks>
+    private static readonly HashSet<string> _disabledTestHostPollers = new(StringComparer.Ordinal)
+    {
+        "MigrationBatchBackgroundService",
+    };
+
+    /// <summary>
+    /// Removes the timer-based background DB pollers/reconcilers from the test host. Under the
+    /// parallelized schema-isolated test shards (#1359/#1532) these poll the database every few
+    /// seconds from outside any request scope — so they cannot pick up the per-test schema —
+    /// producing cross-schema "relation does not exist" log noise and background DB contention
+    /// multiplied across every parallel test server. Their reconciliation logic is exercised
+    /// directly by dedicated tests (e.g. <c>MigrationBatchEndpointTests</c> via a recording
+    /// orchestrator, and the ControlPlane/Events reconciler unit tests), so the timer wrapper
+    /// serves no purpose in the WebAppFixture host.
+    /// </summary>
+    internal static void RemoveBackgroundPollers(IServiceCollection services)
+    {
+        var pollers = services
+            .Where(descriptor =>
+                descriptor.ServiceType == typeof(IHostedService) &&
+                descriptor.ImplementationType is { } implementation &&
+                _disabledTestHostPollers.Contains(implementation.Name))
+            .ToList();
+
+        foreach (var descriptor in pollers)
+        {
+            services.Remove(descriptor);
+        }
+    }
+
+    /// <summary>
     /// Builds the minimal in-memory <see cref="IConfiguration"/> that
     /// <c>Honua.Postgres.ServiceCollectionExtensions.AddPostgreSqlServices</c> reads to
     /// re-register the PostgreSQL-backed services. The optional
@@ -204,6 +248,7 @@ internal static class WebAppFixturePostgresWiringMixin
         IEnumerable<Action<IServiceCollection>> userConfigurations)
     {
         RemovePostgresBackedServices(services);
+        RemoveBackgroundPollers(services);
 
         var testConfiguration = BuildPostgresTestConfiguration(connectionString);
         Honua.Postgres.ServiceCollectionExtensions.AddPostgreSqlServices(services, testConfiguration);
@@ -235,6 +280,7 @@ internal static class WebAppFixturePostgresWiringMixin
         IDictionary<string, string?>? extraConfiguration = null)
     {
         RemovePostgresBackedServices(services);
+        RemoveBackgroundPollers(services);
 
         var testConfiguration = BuildPostgresTestConfiguration(connectionString, extraConfiguration);
         Honua.Postgres.ServiceCollectionExtensions.AddPostgreSqlServices(services, testConfiguration);


### PR DESCRIPTION
## Issue Link
Related to #1359

## Summary
Follow-up to the parallelized schema-isolated test shards (#1359/#1532). The `WebAppFixture` test host ran `MigrationBatchBackgroundService`, which polls `honua.migration_batch_runs` every few seconds from **outside any request scope**, producing the cross-schema `relation "honua.migration_batch_runs" does not exist` log noise and background DB contention multiplied across every parallel test server. This removes that one poller from the test host.

**Scope (narrowed after CI):** only the migration-batch poller is disabled. The Deploy/ExecutionJob/FeatureChange reconcilers are intentionally **kept** — ControlPlane/Infra integration tests rely on those background loops, and disabling them hangs the "Infra and Security" shard. Gating additional pollers needs per-poller verification.

**Honesty note:** this is a PR-flake **hygiene** improvement (less background DB contention + log noise under parallel shards). It is **not** a proven fix for any specific failure, and it does **not** address the current nightly breaks (JS integration, SDK compatibility, GeoServices parity, security-nightly — separate suites).

## Changes Made
- Add `WebAppFixturePostgresWiringMixin.RemoveBackgroundPollers`, which strips the `MigrationBatchBackgroundService` `IHostedService` registration from the test host (matched by implementation-type name so TestKit doesn't reference internal host types).
- Call it from both the isolated and shared test-host wiring paths.
- Test-host only — **no production code change**.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

- `Honua.TestKit` builds clean under `TreatWarningsAsErrors`.
- The migration-batch + reconciler test classes pass (56 tests), including the `WebAppFixture`-based `MigrationBatchEndpointTests` (recording orchestrator) — confirming the host still boots with the migration-batch poller removed and that nothing depends on its timer loop.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — test infrastructure only; production hosted-service registration is unchanged.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality