### PR TITLE
fix: resolve nightly CI breaks (security scan + admin SDK compatibility)

### DIFF
--- a/.github/workflows/security-nightly.yml
+++ b/.github/workflows/security-nightly.yml
@@ -21,6 +21,9 @@ env:
   DOTNET_NOLOGO: true
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # Authenticate the Trivy installer's GitHub release lookup so it is not throttled by the
+  # unauthenticated API rate limit (the cause of intermittent "unable to find tag" install failures).
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 concurrency:
   group: security-nightly-${{ github.ref }}
@@ -333,13 +336,22 @@ jobs:
             postgis/postgis:16-3.4
 
           echo "Waiting for PostGIS to accept connections..."
+          ready=false
           for _ in $(seq 1 60); do
             if docker exec honua-runtime-db pg_isready -U honua -d honua >/dev/null 2>&1; then
+              ready=true
               break
             fi
             sleep 2
           done
-          docker exec honua-runtime-db pg_isready -U honua -d honua
+          # The readiness loop is authoritative. A bare `pg_isready` here under `set -e` previously
+          # aborted the whole step when PostGIS's first-boot initdb bounced the server between the
+          # loop's success and this check; the app container has its own connection retries + a sleep.
+          if [ "$ready" != true ]; then
+            echo "::error::PostGIS did not become ready in time"
+            docker logs honua-runtime-db || true
+            exit 1
+          fi
 
           docker run -d \
             --name honua-runtime-test \

--- a/src/Honua.Server/Features/Admin/AdminInfoEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AdminInfoEndpoints.cs
@@ -53,16 +53,29 @@ internal static class AdminInfoEndpoints
 
     private static IResult HandleGetCapabilities()
     {
+        var serverVersion = GetServerVersion();
         var response = new AdminCapabilitiesResponse
         {
             MetadataApiVersion = MetadataV2Constants.ApiVersion,
             MetadataSchemaVersion = MetadataV2Constants.SchemaVersion,
-            ServerVersion = GetServerVersion()
+            ServerVersion = serverVersion,
+            // The generated JS/Python/.NET admin SDKs parse this `compatibility` contract from the
+            // capabilities response (serverVersion is required by all three; the admin API major lets
+            // the .NET SDK's CheckCompatibilityAsync confirm the server speaks admin API v1).
+            Compatibility = new AdminCompatibility
+            {
+                ServerVersion = serverVersion,
+                AdminApiMajor = AdminApiMajor,
+                MetadataApiVersion = MetadataV2Constants.ApiVersion,
+                MetadataSchemaVersion = MetadataV2Constants.SchemaVersion
+            }
         };
         return Results.Json(
             ApiResponse<AdminCapabilitiesResponse>.CreateSuccess(response),
             AdminInfoJsonContext.Default.ApiResponseAdminCapabilitiesResponse);
     }
+
+    private const string AdminApiMajor = "v1";
 
     private static string GetServerVersion()
     {
@@ -97,6 +110,27 @@ public sealed record AdminCapabilitiesResponse
 
     [JsonPropertyName("serverVersion")]
     public string ServerVersion { get; init; } = string.Empty;
+
+    [JsonPropertyName("compatibility")]
+    public AdminCompatibility Compatibility { get; init; } = new();
+}
+
+/// <summary>
+/// Compatibility contract consumed by the generated admin SDKs to confirm they can talk to this server.
+/// </summary>
+public sealed record AdminCompatibility
+{
+    [JsonPropertyName("serverVersion")]
+    public string ServerVersion { get; init; } = string.Empty;
+
+    [JsonPropertyName("adminApiMajor")]
+    public string AdminApiMajor { get; init; } = string.Empty;
+
+    [JsonPropertyName("metadataApiVersion")]
+    public string MetadataApiVersion { get; init; } = string.Empty;
+
+    [JsonPropertyName("metadataSchemaVersion")]
+    public string MetadataSchemaVersion { get; init; } = string.Empty;
 }
 
 [JsonSerializable(typeof(ApiResponse<AdminVersionResponse>))]

--- a/src/Honua.Server/Features/Admin/AdminInfoEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AdminInfoEndpoints.cs
@@ -60,11 +60,32 @@ internal static class AdminInfoEndpoints
             MetadataSchemaVersion = MetadataV2Constants.SchemaVersion,
             ServerVersion = serverVersion,
             // The generated JS/Python/.NET admin SDKs parse this `compatibility` contract from the
-            // capabilities response (serverVersion is required by all three; the admin API major lets
-            // the .NET SDK's CheckCompatibilityAsync confirm the server speaks admin API v1).
+            // capabilities response per docs/developer/SDK_COMPATIBILITY_METADATA.md. The documented
+            // envelope (controlPlaneApi/releaseChannel/metadataSchemas/features) is the canonical
+            // handshake; the flat adminApiMajor/metadata* fields are retained as a backward-compatible
+            // superset (adding fields under `compatibility` is a v1-compatible change per the contract).
             Compatibility = new AdminCompatibility
             {
                 ServerVersion = serverVersion,
+                ReleaseChannel = DeriveReleaseChannel(serverVersion),
+                ControlPlaneApi = new AdminControlPlaneApi
+                {
+                    Major = AdminApiMajorNumber,
+                    BasePath = AdminApiBasePath,
+                    Deprecated = false
+                },
+                MetadataSchemas =
+                [
+                    new AdminMetadataSchema { Version = MetadataV2Constants.ApiVersion, Deprecated = false }
+                ],
+                Features = new AdminCompatibilityFeatures
+                {
+                    MetadataResources = true,
+                    ManifestExport = true,
+                    ManifestApply = true,
+                    ManifestDryRun = true,
+                    ManifestPrune = true
+                },
                 AdminApiMajor = AdminApiMajor,
                 MetadataApiVersion = MetadataV2Constants.ApiVersion,
                 MetadataSchemaVersion = MetadataV2Constants.SchemaVersion
@@ -76,6 +97,54 @@ internal static class AdminInfoEndpoints
     }
 
     private const string AdminApiMajor = "v1";
+    private const int AdminApiMajorNumber = 1;
+    private const string AdminApiBasePath = "/api/v1/admin";
+
+    /// <summary>
+    /// Derives the SDK <c>releaseChannel</c> from the server's build-version metadata, per
+    /// docs/developer/SDK_COMPATIBILITY_METADATA.md ("Release Channel Values"). A version with no
+    /// pre-release label is <c>stable</c>; recognized pre-release labels map to their channel; any
+    /// other pre-release falls back to <c>dev</c>. SemVer build metadata (after <c>+</c>) is ignored.
+    /// </summary>
+    private static string DeriveReleaseChannel(string version)
+    {
+        var buildMetadata = version.IndexOf('+', StringComparison.Ordinal);
+        var core = buildMetadata >= 0 ? version[..buildMetadata] : version;
+
+        var preReleaseStart = core.IndexOf('-', StringComparison.Ordinal);
+        if (preReleaseStart < 0)
+        {
+            return "stable";
+        }
+
+        var preRelease = core[(preReleaseStart + 1)..].ToLowerInvariant();
+        if (preRelease.Contains("nightly", StringComparison.Ordinal))
+        {
+            return "nightly";
+        }
+        if (preRelease.Contains("preview", StringComparison.Ordinal))
+        {
+            return "preview";
+        }
+        if (preRelease.Contains("alpha", StringComparison.Ordinal))
+        {
+            return "alpha";
+        }
+        if (preRelease.Contains("beta", StringComparison.Ordinal))
+        {
+            return "beta";
+        }
+        if (preRelease.Contains("lts", StringComparison.Ordinal))
+        {
+            return "lts";
+        }
+        if (preRelease.StartsWith("rc", StringComparison.Ordinal))
+        {
+            return "rc";
+        }
+
+        return "dev";
+    }
 
     private static string GetServerVersion()
     {
@@ -116,13 +185,31 @@ public sealed record AdminCapabilitiesResponse
 }
 
 /// <summary>
-/// Compatibility contract consumed by the generated admin SDKs to confirm they can talk to this server.
+/// Compatibility contract consumed by the generated admin SDKs to confirm they can talk to this
+/// server. Mirrors <c>data.compatibility</c> in docs/developer/SDK_COMPATIBILITY_METADATA.md.
 /// </summary>
 public sealed record AdminCompatibility
 {
     [JsonPropertyName("serverVersion")]
     public string ServerVersion { get; init; } = string.Empty;
 
+    /// <summary>Rollout channel derived from build-version metadata (stable, lts, preview, alpha, ...).</summary>
+    [JsonPropertyName("releaseChannel")]
+    public string ReleaseChannel { get; init; } = string.Empty;
+
+    /// <summary>Control-plane (admin) API major/base-path/deprecation the SDK gates on first.</summary>
+    [JsonPropertyName("controlPlaneApi")]
+    public AdminControlPlaneApi ControlPlaneApi { get; init; } = new();
+
+    /// <summary>Supported metadata schema versions, newest non-deprecated first.</summary>
+    [JsonPropertyName("metadataSchemas")]
+    public IReadOnlyList<AdminMetadataSchema> MetadataSchemas { get; init; } = [];
+
+    /// <summary>Coarse feature switches so SDKs branch without probing endpoints.</summary>
+    [JsonPropertyName("features")]
+    public AdminCompatibilityFeatures Features { get; init; } = new();
+
+    // Retained flat fields (backward-compatible superset; not part of the canonical envelope).
     [JsonPropertyName("adminApiMajor")]
     public string AdminApiMajor { get; init; } = string.Empty;
 
@@ -131,6 +218,48 @@ public sealed record AdminCompatibility
 
     [JsonPropertyName("metadataSchemaVersion")]
     public string MetadataSchemaVersion { get; init; } = string.Empty;
+}
+
+/// <summary>Control-plane (admin) API identity the SDK gates on before constructing admin paths.</summary>
+public sealed record AdminControlPlaneApi
+{
+    [JsonPropertyName("major")]
+    public int Major { get; init; }
+
+    [JsonPropertyName("basePath")]
+    public string BasePath { get; init; } = string.Empty;
+
+    [JsonPropertyName("deprecated")]
+    public bool Deprecated { get; init; }
+}
+
+/// <summary>A supported metadata schema version and whether it is deprecated.</summary>
+public sealed record AdminMetadataSchema
+{
+    [JsonPropertyName("version")]
+    public string Version { get; init; } = string.Empty;
+
+    [JsonPropertyName("deprecated")]
+    public bool Deprecated { get; init; }
+}
+
+/// <summary>Coarse server-owned feature switches advertised in the compatibility handshake.</summary>
+public sealed record AdminCompatibilityFeatures
+{
+    [JsonPropertyName("metadataResources")]
+    public bool MetadataResources { get; init; }
+
+    [JsonPropertyName("manifestExport")]
+    public bool ManifestExport { get; init; }
+
+    [JsonPropertyName("manifestApply")]
+    public bool ManifestApply { get; init; }
+
+    [JsonPropertyName("manifestDryRun")]
+    public bool ManifestDryRun { get; init; }
+
+    [JsonPropertyName("manifestPrune")]
+    public bool ManifestPrune { get; init; }
 }
 
 [JsonSerializable(typeof(ApiResponse<AdminVersionResponse>))]

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminCapabilitiesEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminCapabilitiesEndpointTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+/// <summary>
+/// Verifies that <c>GET /api/v1/admin/capabilities</c> emits the canonical
+/// <c>data.compatibility</c> envelope the generated admin SDKs handshake on, per
+/// docs/developer/SDK_COMPATIBILITY_METADATA.md (controlPlaneApi / releaseChannel /
+/// metadataSchemas / features) — not just the flat fields.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+public sealed class AdminCapabilitiesEndpointTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/capabilities")]
+    public async Task GetCapabilities_EmitsDocumentedCompatibilityEnvelope()
+    {
+        var response = await _fixture.Client.GetAsync("/api/v1/admin/capabilities");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        var compatibility = document.RootElement.GetProperty("data").GetProperty("compatibility");
+
+        compatibility.GetProperty("serverVersion").GetString().Should().NotBeNullOrWhiteSpace();
+        compatibility.GetProperty("releaseChannel").GetString().Should().NotBeNullOrWhiteSpace();
+
+        // controlPlaneApi.major must be the numeric major the SDK gates on first.
+        var controlPlaneApi = compatibility.GetProperty("controlPlaneApi");
+        controlPlaneApi.GetProperty("major").GetInt32().Should().Be(1);
+        controlPlaneApi.GetProperty("basePath").GetString().Should().Be("/api/v1/admin");
+        controlPlaneApi.GetProperty("deprecated").GetBoolean().Should().BeFalse();
+
+        // metadataSchemas is an array of { version, deprecated }, newest non-deprecated usable.
+        var metadataSchemas = compatibility.GetProperty("metadataSchemas");
+        metadataSchemas.ValueKind.Should().Be(JsonValueKind.Array);
+        metadataSchemas.GetArrayLength().Should().BeGreaterThan(0);
+        metadataSchemas[0].GetProperty("version").GetString().Should().NotBeNullOrWhiteSpace();
+        metadataSchemas[0].TryGetProperty("deprecated", out _).Should().BeTrue();
+
+        // features advertises the manifest workflow switches.
+        var features = compatibility.GetProperty("features");
+        features.GetProperty("metadataResources").GetBoolean().Should().BeTrue();
+        features.GetProperty("manifestExport").GetBoolean().Should().BeTrue();
+        features.GetProperty("manifestApply").GetBoolean().Should().BeTrue();
+        features.GetProperty("manifestDryRun").GetBoolean().Should().BeTrue();
+        features.GetProperty("manifestPrune").GetBoolean().Should().BeTrue();
+    }
+}

--- a/tests/js/shared/constants.ts
+++ b/tests/js/shared/constants.ts
@@ -89,6 +89,8 @@ export const VALID_ESRI_GEOMETRY_TYPES = [
   'esriGeometryPolyline',
   'esriGeometryPolygon',
   'esriGeometryEnvelope',
+  // Honua reports Mixed / None / GeometryCollection layers' geometryType as esriGeometryNull.
+  'esriGeometryNull',
 ] as const;
 
 // =============================================================================

--- a/tests/seed/base-schema.sql
+++ b/tests/seed/base-schema.sql
@@ -951,8 +951,11 @@ INSERT INTO honua.layers (
     geometry_type, srid, extent, default_visibility
 )
 VALUES (
+    -- 'Mixed' so the heterogeneous JS geometry round-trip suite (point + line + polygon on one
+    -- layer) is accepted by the edit-time geometry-type enforcement. A 'Point' layer rejects
+    -- polyline/polygon adds. Mirrors the same fix applied to the local seed in tests/python/shared/postgis.py.
     0, 'Test Layer', 'Default layer for integration tests',
-    'features', 'Point', 4326,
+    'features', 'Mixed', 4326,
     ST_MakeEnvelope(-122.5, 37.7, -122.35, 37.84, 4326), true
 )
 ON CONFLICT (layer_id) DO UPDATE SET


### PR DESCRIPTION
## Issue Link
Fixes #1544

## Summary
Resolves the failing/cancelled nightly workflows on trunk (2026-06-08 cycle). Two were real code/CI bugs, two were external/transient flakes. Investigated each failing job's logs and root-caused them before fixing.

## Changes Made
- **Security Nightly** (`security-nightly.yml`): made the PostGIS readiness loop authoritative (an unguarded `pg_isready` under `set -e` aborted the Container Security Scan during PostGIS first-boot `initdb`); added `GITHUB_TOKEN` to the env so the Trivy installer's GitHub release lookup isn't throttled by the unauthenticated API rate limit. (Trivy found 0 HIGH/CRITICAL vulns.)
- **SDK Server Compatibility** (`AdminInfoEndpoints.cs`): restored the `compatibility` object on `GET /api/v1/admin/capabilities` that the generated JS/Python/.NET admin SDKs parse — it was dropped when `6b21f82` rewrote the admin endpoints, failing every matrix cell.
- **JS Integration Tests** (`tests/seed/base-schema.sql`, `tests/js/shared/constants.ts`): seed the CI integration layer as `Mixed` instead of `Point` so the heterogeneous geometry round-trip suite's polyline/polygon `applyEdits` are accepted by the edit-time geometry-type enforcement added in `b500c43`. `c1a8252` had fixed only the local `postgis.py` seed; CI provisions via `setup-honua-server` → `base-schema.sql`, which still declared `Point`. Also accept `esriGeometryNull` (reported by Mixed/None layers) in the JS metadata test's valid-type list.
- **GeoServices Parity Nightly**: external flake (live ArcGIS service count drift vs the imported snapshot); no code change — documented in #1544.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] Nightly gates (conformance, performance, security)
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — the admin capabilities `compatibility` field is additive; seed/test changes are CI-only.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)
