### PR TITLE
test(admin): add missing [Operation] to AdminCapabilitiesEndpointTests

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminCapabilitiesEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminCapabilitiesEndpointTests.cs
@@ -18,6 +18,7 @@ namespace Honua.Server.Tests.Features.Admin;
 /// </summary>
 [Collection("Database")]
 [Protocol(TestProtocols.Admin)]
+[Operation(Operations.Metadata)]
 public sealed class AdminCapabilitiesEndpointTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();


### PR DESCRIPTION
## Issue Link
Related to #1544

## Summary
Unbreaks the **trunk** architecture gate. #1543 (`fix: resolve nightly CI breaks`) merged the new `AdminCapabilitiesEndpointTests` with an `[Endpoint]` attribute but no `[Operation]`. The architecture guard `AllIntegrationTestMethods_MustHaveOperationAndEndpointAttributes` requires every integration test method to carry an `[Operation]` (method- or class-level) plus `[Endpoint]`, so it now **fails on trunk** — and on every PR that runs the Architecture shard. The `[Operation]` fix was pushed to the PR branch *after* #1543 had already merged, so it never reached trunk.

## Changes Made
- Add class-level `[Operation(Operations.Metadata)]` to `AdminCapabilitiesEndpointTests` (the capabilities endpoint advertises compatibility/metadata).

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

- `Honua.Architecture.Tests` `AllIntegrationTestMethods_MustHaveOperationAndEndpointAttributes` passes (was failing on trunk).

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — test attribute only.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality