### PR TITLE
license: move file import (import.file) from Pro to Community

### DIFF
--- a/docs/developer/capability-manifest.md
+++ b/docs/developer/capability-manifest.md
@@ -101,7 +101,7 @@ Example response excerpt, with required sections such as `packages` and `limits`
       {
         "key": "import.file",
         "active": true,
-        "minimumEdition": "Pro"
+        "minimumEdition": "Community"
       }
     ],
     "authorizationNotice": "Manifest availability is informational only; operation endpoints remain the source of truth for authorization, tenant, environment, license, and resource checks."

--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -145,9 +145,9 @@ public static class FeatureCatalog
         new("caching.redis", "Redis Distributed Cache", Categories.Caching,
             HonuaEdition.Pro, "Redis-backed distributed cache for multi-node deployments."),
 
-        // Import — Pro
+        // Import — Community (one-shot file import ships in Community; see docs/features/README.md)
         new("import.file", "File Import", Categories.Import,
-            HonuaEdition.Pro, "Import geospatial data from file uploads (GeoJSON, Shapefile, GeoPackage)."),
+            HonuaEdition.Community, "Import geospatial data from file uploads (GeoJSON, Shapefile, GeoPackage)."),
 
         // Streaming — Pro
         new("streaming.feature-subscriptions", "Real-Time Feature Streams", Categories.Streaming,

--- a/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
@@ -108,7 +108,8 @@ public sealed class FeatureCatalogTests
             "temporal.filtering",
             "temporal.extent-discovery",
             "identity.portal-token",
-            "identity.portal-sharing"
+            "identity.portal-sharing",
+            "import.file"
         ]);
     }
 


### PR DESCRIPTION
## Summary

One-shot **file import** (GeoJSON / Shapefile / GeoPackage) is a **Community** capability. The `FeatureCatalog` entry gated `import.file` at **Pro**, which contradicted both the published tier model and [`docs/features/README.md`](../blob/trunk/docs/features/README.md) — *"Community continues to ship one-shot file import unchanged."* This flips the gate to Community to match.

## Changes

- `FeatureCatalog`: `import.file` `MinimumEdition` Pro → **Community**.
- `FeatureCatalogTests.All_CommunityFeaturesAreExpected`: add `import.file` to the tracked Community set.
- `docs/developer/capability-manifest.md`: example entitlement `minimumEdition` Pro → Community.

## Validation

`FeatureCatalogTests`: **23/23 pass** (`dotnet test --filter FeatureCatalogTests`).

This loosens a gate (no caller loses access). Related: honua-site#29 reflects file import under Community; the converse decision (FeatureServer editing → Pro) is tracked separately in #1548.