### PR TITLE
feat: audit coverage matrix and middleware instrumentation (#507)

### DIFF
--- a/docs/operator/README.md
+++ b/docs/operator/README.md
@@ -15,6 +15,7 @@ Deploy, configure, monitor, and manage Honua Server.
 - [Security](security.md) — Authentication, authorization, CORS, CSP
 - [Client Certificate Authentication](client-certificate-authentication.md) — Native/admin mTLS modes, trust profiles, mappings, revocations, and response contracts
 - [Compliance Framework](compliance-framework.md) — SOC 2 / FedRAMP readiness evidence, data residency policy + dry-run, compliance key-version rotation, report export
+- [Audit Coverage Matrix](audit-coverage-matrix.md) — Which operations emit audit events (admin actions, destructive writes, authentication/authorization) and where emission lives
 - [HTTP Client Resilience](http-client-resilience.md) — Retry, circuit breaker, and timeout tuning for external services
 - [Feature Change Webhooks](feature-change-webhooks.md) — Event notification setup
 - [Feature Streaming](feature-streaming.md) — WebSocket/SSE feature-change subscriptions

--- a/docs/operator/audit-coverage-matrix.md
+++ b/docs/operator/audit-coverage-matrix.md
@@ -1,0 +1,104 @@
+# Audit Coverage Matrix
+
+This document is the authoritative definition of **which operations Honua Server
+records as audit events**, how each maps to the audit event model, and where the
+emission happens. It pairs with:
+
+- The audit event model and storage (`Honua.Core.Features.AuditLog`, the
+  `honua.audit_log` Postgres sink) — see [`compliance-framework.md`](compliance-framework.md).
+- The middleware-driven instrumentation that emits the events (#507).
+
+Audit emission is **middleware-driven and pipeline-driven**, never added by hand
+in individual endpoint handlers. Two shared components carry every row below:
+
+| Component | Location | Covers |
+|---|---|---|
+| `AuditLogMiddleware` + `IAuditActionResolver` | `Honua.Hosting/Features/Middleware` | HTTP-surface operations resolved from the matched **route + method + status**: admin mutations, authentication/login, authorization failures. |
+| `AuditingFeatureWriter` (shared `IFeatureWriter` decorator) | `Honua.Hosting/Features/Middleware` | Destructive feature writes (delete, bulk/transactional edit) at the shared edit-pipeline boundary, so **every** protocol adapter (GeoServices, OGC API Features, WFS-T, OData, gRPC) is covered once. |
+
+The route → action mapping lives in `DefaultAuditActionResolver`; it is the code
+form of this matrix. The destructive-write rows are emitted by the writer
+decorator rather than the resolver because protocols such as WFS-T and gRPC
+tunnel the operation through a single endpoint where the route alone cannot
+reveal whether a delete occurred.
+
+## Event model recap
+
+Each emitted `AuditEvent` carries:
+
+- `Timestamp` (UTC, set at emit time)
+- `EventType` — one of `Authentication`, `Authorization`, `AdminAction`,
+  `ConfigChange`, `DataExport`, `DataDelete`
+- `Actor` / `ActorType` — the authenticated principal (user id, hashed API-key
+  id, `anonymous`, or `system`); the raw API key is never recorded
+- `ResourceType` / `ResourceId` — the targeted resource family and identifier
+- `Action` — a stable dotted-lowercase verb (e.g. `admin.delete`, `feature.delete`)
+- `Outcome` — `Success`, `Failure`, or `Denied`
+- `CorrelationId`, `RemoteIp`, `UserAgent` (IP/UA may be `null` per privacy policy)
+- `Details` — a pre-sanitized JSON object; never contains SQL, connection
+  strings, secrets, stack traces, or raw payloads
+
+## Coverage matrix
+
+### Administrative actions
+
+| Operation | Route family | Method(s) | EventType | Action | Outcome source |
+|---|---|---|---|---|---|
+| Any admin control-plane mutation (service/connection/user/role create, update, delete; configuration changes; OIDC, client-cert, alert, import, license, deploy admin, etc.) | `/api/v{version}/admin/**` | `POST`, `PUT`, `PATCH`, `DELETE` | `AdminAction` | `admin.{method}` | 2xx → `Success`; 401 → `Failure`; 403 → `Denied`; other → `Failure` |
+
+The admin surface is covered by a **route-prefix rule** rather than per-endpoint
+wiring, so newly added admin mutation endpoints are audited automatically. Read
+(`GET`/`HEAD`) admin requests are not audited on success; an admin read that is
+rejected `401`/`403` is still captured by the authorization row below.
+
+### Authentication and authorization
+
+| Operation | Route | Method | EventType | Action | Outcome source |
+|---|---|---|---|---|---|
+| Admin OIDC backend-assisted login (code → token exchange) | `/api/v{version}/admin/auth/providers/{providerKey}/token` | `POST` | `Authentication` | `auth.login` | 2xx → `Success`; failure → `Failure`/`Denied` |
+| First-party OAuth token issuance | `/oauth/token`, `/sharing/rest/oauth2/token` | `POST` | `Authentication` | `auth.token.issue` | 2xx → `Success`; failure → `Failure`/`Denied` |
+| Failed authentication (any route) | `**` | any | `Authentication` | `auth.failure` | `401` → `Failure` |
+| Permission denied (any route) | `**` | any | `Authorization` | `auth.denied` | `403` → `Denied` |
+
+Login success and failed login therefore both produce an `auth.login`
+(success/failure) event on the login routes, while a bare `401`/`403` on any
+other route is captured as `auth.failure` / `auth.denied`. This satisfies
+"login, failed login, permission denied".
+
+### Destructive data writes
+
+Emitted by `AuditingFeatureWriter` at the shared `IFeatureWriter` boundary, so
+the protocol that initiated the edit does not matter.
+
+| Operation | Triggered by (examples) | EventType | Action | Outcome source |
+|---|---|---|---|---|
+| Single feature delete | FeatureServer `deleteFeatures`, OGC API Features `DELETE .../items/{id}`, OData entity `DELETE`, gRPC delete | `DataDelete` | `feature.delete` | deleted → `Success`; not found → `Failure`; exception → `Failure` |
+| Bulk / transactional edit containing deletes | FeatureServer `applyEdits` (with deletes), OGC API Features transaction, WFS-T `Transaction`, OData `$batch` change set, gRPC apply-edits | `DataDelete` | `feature.bulk-edit.delete` | `result.IsSuccess` → `Success`/`Failure` |
+| Bulk edit (multi-operation, no delete) | `applyEdits` / transaction with >1 create/update | `DataDelete` | `feature.bulk-edit` | `result.IsSuccess` → `Success`/`Failure` |
+
+`ResourceType` is `feature`; `ResourceId` is the storage layer id. `Details`
+carries operation counts (`created`/`updated`/`deleted`/`rolledBack`) — never the
+feature payloads. Single-feature creates and single-feature updates are **not**
+treated as destructive-write audit events; they remain covered by mutation
+metrics/logging.
+
+## Out of scope (this slice)
+
+Per #507 and its parent #350, the following are intentionally not part of this
+matrix:
+
+- Audit event schema and storage (delivered in #504).
+- Export, retention, and SIEM integration.
+- Secure-connection-specific connection auditing (#354).
+- Generic structured-logging improvements.
+
+## Edition gating
+
+Audit emission is **not** edition-gated. The `FeatureCatalog` has no audit or
+compliance entitlement, and the audit sink already degrades safely to
+`NullAuditLog` when no durable backend is configured (tests, non-database hosts).
+Gating destructive-write or admin-action auditing behind an edition would create
+forensic blind spots in lower editions, so emission runs unconditionally and the
+sink decides durability. If an audit entitlement is later introduced, gate it in
+the shared components above (resolver + writer decorator) so the gate stays
+consistent across every protocol.

--- a/src/Honua.Core/Features/AuditLog/Abstractions/AuditActionDescriptor.cs
+++ b/src/Honua.Core/Features/AuditLog/Abstractions/AuditActionDescriptor.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.AuditLog.Abstractions;
+
+/// <summary>
+/// Declarative description of an audited operation. Produced by an
+/// <see cref="IAuditActionResolver"/> from the matched route + HTTP method and
+/// consumed by the audit middleware to construct an <see cref="AuditEvent"/>
+/// without per-endpoint code.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The descriptor is the data-plane representation of a single row in the audit
+/// coverage matrix (see <c>docs/operator/audit-coverage-matrix.md</c>). It binds
+/// a recognized operation to its stable <see cref="AuditEventType"/>, dotted
+/// <see cref="Action"/> verb, and the resource family the operation targets.
+/// Outcome and actor are resolved per-request by the middleware (from the final
+/// response status code and the authenticated principal) rather than baked into
+/// the descriptor, so a single descriptor covers both success and failure.
+/// </para>
+/// </remarks>
+public sealed record AuditActionDescriptor
+{
+    /// <summary>Category of the audited event.</summary>
+    public required AuditEventType EventType { get; init; }
+
+    /// <summary>
+    /// Dotted-lowercase action verb recorded on the audit event
+    /// (e.g. <c>"admin.config.update"</c>, <c>"feature.delete"</c>,
+    /// <c>"auth.success"</c>). Stable across releases so downstream forensic
+    /// tooling can filter on it.
+    /// </summary>
+    public required string Action { get; init; }
+
+    /// <summary>
+    /// Resource family the operation targets (e.g. <c>"admin"</c>,
+    /// <c>"layer"</c>, <c>"feature"</c>, <c>"http"</c>). Maps to
+    /// <see cref="AuditEvent.ResourceType"/>.
+    /// </summary>
+    public required string ResourceType { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, the middleware emits an audit event even when
+    /// the operation succeeds with a 2xx response. When <see langword="false"/>,
+    /// the operation is only audited on a security-relevant failure
+    /// (401/403/5xx) — used for read paths that should not flood the audit sink
+    /// on every successful request.
+    /// </summary>
+    public bool AuditOnSuccess { get; init; } = true;
+}

--- a/src/Honua.Core/Features/AuditLog/Abstractions/IAuditActionResolver.cs
+++ b/src/Honua.Core/Features/AuditLog/Abstractions/IAuditActionResolver.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.AuditLog.Abstractions;
+
+/// <summary>
+/// Maps a matched HTTP route (method + route pattern) to an
+/// <see cref="AuditActionDescriptor"/> so the audit middleware can decide,
+/// centrally and declaratively, which operations are audited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the single source of truth that keeps audit emission
+/// <i>middleware-driven</i> rather than scattered across endpoint handlers. The
+/// route pattern passed in is the raw ASP.NET Core route template of the matched
+/// endpoint (e.g. <c>"/api/v{version:apiVersion}/admin/connections/{id}"</c>),
+/// which is stable regardless of the concrete request path, so the resolver does
+/// not have to canonicalize ids out of arbitrary URLs.
+/// </para>
+/// <para>
+/// Implementations must be deterministic, allocation-light, and side-effect free
+/// — they run on the hot path for every request.
+/// </para>
+/// </remarks>
+public interface IAuditActionResolver
+{
+    /// <summary>
+    /// Resolve the audit descriptor for a matched route, or <see langword="null"/>
+    /// when the operation is not in the audit coverage matrix.
+    /// </summary>
+    /// <param name="httpMethod">The request HTTP method (e.g. <c>GET</c>, <c>POST</c>, <c>DELETE</c>).</param>
+    /// <param name="routePattern">
+    /// The raw route template of the matched endpoint, or <see langword="null"/>
+    /// when no endpoint matched (e.g. a 404 before routing resolved a handler).
+    /// </param>
+    /// <returns>The descriptor to audit, or <see langword="null"/> to skip.</returns>
+    AuditActionDescriptor? Resolve(string httpMethod, string? routePattern);
+}

--- a/src/Honua.Hosting/Features/Middleware/AuditContextResolver.cs
+++ b/src/Honua.Hosting/Features/Middleware/AuditContextResolver.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.AuditLog.Abstractions;
+using Microsoft.AspNetCore.Http;
+
+namespace Honua.Infrastructure.Middleware;
+
+/// <summary>
+/// Shared helpers for deriving audit fields (actor, correlation id, remote ip,
+/// user agent) from an <see cref="HttpContext"/>. Centralizes the actor-resolution
+/// rules so every audit emit site — middleware and the shared edit-pipeline
+/// decorator — records identical, non-secret-leaking values.
+/// </summary>
+internal static class AuditContextResolver
+{
+    private const string CorrelationIdHeader = "X-Correlation-ID";
+
+    /// <summary>
+    /// Resolve the actor identity and classification from the request principal.
+    /// API-key callers are recorded by their stable hashed key id (never the raw
+    /// key); authenticated users by user id; everything else as anonymous.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <param name="actorType">The resolved actor classification.</param>
+    /// <returns>The actor identifier.</returns>
+    public static string ResolveActor(HttpContext context, out AuditActorType actorType)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var identity = context.User?.Identity;
+        if (identity is { IsAuthenticated: true } && !string.IsNullOrWhiteSpace(identity.Name))
+        {
+            // For API-key authenticated callers the handler attaches an
+            // "api_key_id" claim; prefer that as a stable actor identifier so
+            // we never log the raw key name.
+            var apiKeyId = context.User?.FindFirst("api_key_id")?.Value;
+            if (!string.IsNullOrWhiteSpace(apiKeyId))
+            {
+                actorType = AuditActorType.ApiKey;
+                return apiKeyId;
+            }
+
+            actorType = AuditActorType.UserId;
+            return identity.Name;
+        }
+
+        actorType = AuditActorType.Anonymous;
+        return AuditEvent.AnonymousActor;
+    }
+
+    /// <summary>
+    /// Resolve the correlation id, preferring the response correlation header,
+    /// falling back to the trace identifier or a fresh GUID.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <returns>A non-empty correlation id.</returns>
+    public static string ResolveCorrelationId(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.Response.Headers.TryGetValue(CorrelationIdHeader, out var headerValue) &&
+            !string.IsNullOrWhiteSpace(headerValue.ToString()))
+        {
+            return headerValue.ToString();
+        }
+
+        return string.IsNullOrWhiteSpace(context.TraceIdentifier)
+            ? Guid.NewGuid().ToString("D")
+            : context.TraceIdentifier;
+    }
+
+    /// <summary>Resolve the caller's remote IP, or <see langword="null"/>.</summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <returns>The remote IP string or <see langword="null"/>.</returns>
+    public static string? ResolveRemoteIp(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.Connection.RemoteIpAddress?.ToString();
+    }
+
+    /// <summary>Resolve the caller's user agent, or <see langword="null"/>.</summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <returns>The user agent string or <see langword="null"/>.</returns>
+    public static string? ResolveUserAgent(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.Request.Headers.UserAgent.ToString() is { Length: > 0 } ua ? ua : null;
+    }
+}

--- a/src/Honua.Hosting/Features/Middleware/AuditInstrumentationServiceCollectionExtensions.cs
+++ b/src/Honua.Hosting/Features/Middleware/AuditInstrumentationServiceCollectionExtensions.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.AuditLog;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Infrastructure.Middleware;
+
+/// <summary>
+/// DI registration for the middleware-driven audit instrumentation (#507):
+/// the route-to-action resolver consumed by the audit middleware and the shared
+/// edit-pipeline <see cref="IFeatureWriter"/> audit decorator.
+/// </summary>
+public static class AuditInstrumentationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register the <see cref="IAuditActionResolver"/> used by the audit
+    /// middleware to map matched routes to audit descriptors. Uses
+    /// <c>TryAdd</c> so a host can override the matrix.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaAuditActionResolver(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.AddHttpContextAccessor();
+        services.TryAddSingleton<IAuditActionResolver, DefaultAuditActionResolver>();
+        return services;
+    }
+
+    /// <summary>
+    /// Wrap the currently-registered <see cref="IFeatureWriter"/> with the
+    /// <see cref="AuditingFeatureWriter"/> so that destructive feature writes
+    /// (deletes and bulk/transactional edits) emit audit events at the shared
+    /// edit-pipeline boundary, covering every protocol adapter uniformly.
+    /// </summary>
+    /// <remarks>
+    /// Call this <i>after</i> the active data provider has registered its
+    /// <see cref="IFeatureWriter"/>. The previously-registered descriptor becomes
+    /// the decorated inner writer. If no writer is registered the call is a no-op.
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddAuditingFeatureWriter(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var innerDescriptor = services.LastOrDefault(static d => d.ServiceType == typeof(IFeatureWriter));
+        if (innerDescriptor is null)
+        {
+            // No provider writer registered yet; nothing to decorate.
+            return services;
+        }
+
+        services.AddHttpContextAccessor();
+        services.Remove(innerDescriptor);
+
+        services.Add(ServiceDescriptor.Describe(
+            typeof(IFeatureWriter),
+            sp =>
+            {
+                var inner = (IFeatureWriter)CreateInner(sp, innerDescriptor);
+                var auditLog = sp.GetService<IAuditLog>() ?? NullAuditLog.Instance;
+                var httpContextAccessor = sp.GetRequiredService<IHttpContextAccessor>();
+                return new AuditingFeatureWriter(inner, auditLog, httpContextAccessor);
+            },
+            innerDescriptor.Lifetime));
+
+        return services;
+    }
+
+    private static object CreateInner(IServiceProvider sp, ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationInstance is not null)
+        {
+            return descriptor.ImplementationInstance;
+        }
+
+        if (descriptor.ImplementationFactory is not null)
+        {
+            return descriptor.ImplementationFactory(sp);
+        }
+
+        if (descriptor.ImplementationType is not null)
+        {
+            return ActivatorUtilities.CreateInstance(sp, descriptor.ImplementationType);
+        }
+
+        throw new InvalidOperationException(
+            "The registered IFeatureWriter descriptor has no resolvable implementation to decorate.");
+    }
+}

--- a/src/Honua.Hosting/Features/Middleware/AuditLogMiddleware.cs
+++ b/src/Honua.Hosting/Features/Middleware/AuditLogMiddleware.cs
@@ -1,38 +1,52 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using Honua.Core.Features.AuditLog.Abstractions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Infrastructure.Middleware;
 
 /// <summary>
-/// Bridges the per-request HTTP context to the audit log feature (#1144).
+/// Centralized, route-metadata-driven audit emitter (#507). Bridges the
+/// per-request HTTP context to the audit log feature so that security-relevant
+/// operations are recorded without each endpoint making manual audit calls.
 /// </summary>
 /// <remarks>
 /// <para>
-/// This middleware is deliberately lightweight: it does NOT record an audit
-/// event for every request (that is the job of metrics / access logs). Its
-/// role is to (a) ensure <see cref="IAuditLog"/> is resolvable from the
-/// request scope, and (b) emit a single <c>auth.failure</c> audit event when
-/// the pipeline ultimately rejects a request with <c>401 Unauthorized</c> or
-/// <c>403 Forbidden</c>. Individual handlers that perform security-relevant
-/// actions (delete, export, config change, ...) call
-/// <see cref="IAuditLog.RecordAsync"/> directly.
+/// After the rest of the pipeline runs (so it observes the final status code and
+/// resolved principal), the middleware:
 /// </para>
+/// <list type="bullet">
+/// <item><description>
+/// Looks up the matched endpoint's route template via
+/// <see cref="IAuditActionResolver"/>. When the route is in the audit coverage
+/// matrix (admin mutations, login, token issuance, ...) it emits the matching
+/// event with the outcome derived from the response status code. This is how
+/// "all admin API operations" and authentication events are audited centrally.
+/// </description></item>
+/// <item><description>
+/// Independently emits an <c>auth.failure</c> / permission-denied event whenever
+/// the pipeline rejects a request with <c>401</c> or <c>403</c> — even for routes
+/// that are not otherwise in the matrix — so authorization failures are always
+/// captured.
+/// </description></item>
+/// </list>
 /// <para>
-/// The 401/403 audit emit runs <i>after</i> the rest of the pipeline so it
-/// observes the final status code, including codes set by downstream
-/// authentication / authorization handlers.
+/// Destructive feature writes (delete / bulk edit) are emitted by the shared
+/// edit-pipeline decorator rather than here, because protocols like WFS-T and
+/// gRPC tunnel the operation through a single endpoint where the route does not
+/// reveal it. Keeping that one concern in shared infrastructure ensures every
+/// protocol adapter is covered consistently.
 /// </para>
 /// </remarks>
-internal sealed class AuditLogMiddleware(RequestDelegate next)
+internal sealed class AuditLogMiddleware(RequestDelegate next, IAuditActionResolver actionResolver)
 {
-    private const string CorrelationIdHeader = "X-Correlation-ID";
-
     private readonly RequestDelegate _next = next ?? throw new ArgumentNullException(nameof(next));
+    private readonly IAuditActionResolver _actionResolver = actionResolver ?? throw new ArgumentNullException(nameof(actionResolver));
 
     public async Task InvokeAsync(HttpContext context)
     {
@@ -40,43 +54,27 @@ internal sealed class AuditLogMiddleware(RequestDelegate next)
 
         await _next(context).ConfigureAwait(false);
 
-        // Only emit the auth-failure audit event when the response is a 401 or 403.
-        // Other failure paths (404, 500, ...) are not security-relevant in the
-        // forensic sense and are covered by metrics / logs.
-        var status = context.Response.StatusCode;
-        if (status != StatusCodes.Status401Unauthorized && status != StatusCodes.Status403Forbidden)
-        {
-            return;
-        }
-
         var auditLog = context.RequestServices.GetService<IAuditLog>();
         if (auditLog is null)
         {
             return;
         }
 
-        // Resolve the actor in best-effort fashion. If the request authenticated
-        // (and was then 403'd) we still want the actor identity; otherwise it
-        // is recorded as anonymous.
-        var actor = ResolveActor(context, out var actorType);
+        var status = context.Response.StatusCode;
+        var isAuthFailure = status is StatusCodes.Status401Unauthorized or StatusCodes.Status403Forbidden;
 
-        var auditEvent = new AuditEvent
+        var descriptor = ResolveDescriptor(context);
+
+        // Nothing to audit: route is not in the matrix and the request did not
+        // fail authentication/authorization.
+        if (descriptor is null && !isAuthFailure)
         {
-            Timestamp = DateTimeOffset.UtcNow,
-            EventType = AuditEventType.Authentication,
-            Actor = actor,
-            ActorType = actorType,
-            ResourceType = "http",
-            ResourceId = context.Request.Path.HasValue ? context.Request.Path.Value : null,
-            Action = "auth.failure",
-            Outcome = status == StatusCodes.Status403Forbidden
-                ? AuditOutcome.Denied
-                : AuditOutcome.Failure,
-            CorrelationId = ResolveCorrelationId(context),
-            RemoteIp = context.Connection.RemoteIpAddress?.ToString(),
-            UserAgent = context.Request.Headers.UserAgent.ToString() is { Length: > 0 } ua ? ua : null,
-            Details = $"{{\"status\":{status},\"method\":\"{context.Request.Method}\"}}",
-        };
+            return;
+        }
+
+        var auditEvent = descriptor is not null
+            ? BuildMatrixEvent(context, descriptor, status, isAuthFailure)
+            : BuildAuthFailureEvent(context, status);
 
         try
         {
@@ -90,40 +88,93 @@ internal sealed class AuditLogMiddleware(RequestDelegate next)
         }
     }
 
-    private static string ResolveActor(HttpContext context, out AuditActorType actorType)
+    private AuditActionDescriptor? ResolveDescriptor(HttpContext context)
     {
-        var identity = context.User?.Identity;
-        if (identity is { IsAuthenticated: true } && !string.IsNullOrWhiteSpace(identity.Name))
+        var routePattern = ResolveRoutePattern(context);
+        if (routePattern is null)
         {
-            // For API-key authenticated callers the handler attaches an
-            // "api_key_id" claim; prefer that as a stable actor identifier so
-            // we never log the raw key name.
-            var apiKeyId = context.User?.FindFirst("api_key_id")?.Value;
-            if (!string.IsNullOrWhiteSpace(apiKeyId))
-            {
-                actorType = AuditActorType.ApiKey;
-                return apiKeyId;
-            }
-
-            actorType = AuditActorType.UserId;
-            return identity.Name;
+            return null;
         }
 
-        actorType = AuditActorType.Anonymous;
-        return AuditEvent.AnonymousActor;
+        var descriptor = _actionResolver.Resolve(context.Request.Method, routePattern);
+        if (descriptor is null)
+        {
+            return null;
+        }
+
+        // Honour the descriptor's success policy: read-style descriptors only
+        // emit on failure to avoid flooding the sink on every successful request.
+        if (!descriptor.AuditOnSuccess && IsSuccessStatus(context.Response.StatusCode))
+        {
+            return null;
+        }
+
+        return descriptor;
     }
 
-    private static string ResolveCorrelationId(HttpContext context)
+    private static AuditEvent BuildMatrixEvent(
+        HttpContext context,
+        AuditActionDescriptor descriptor,
+        int status,
+        bool isAuthFailure)
     {
-        if (context.Response.Headers.TryGetValue(CorrelationIdHeader, out var headerValue) &&
-            !string.IsNullOrWhiteSpace(headerValue.ToString()))
+        var outcome = isAuthFailure
+            ? (status == StatusCodes.Status403Forbidden ? AuditOutcome.Denied : AuditOutcome.Failure)
+            : (IsSuccessStatus(status) ? AuditOutcome.Success : AuditOutcome.Failure);
+
+        return new AuditEvent
         {
-            return headerValue.ToString();
+            Timestamp = DateTimeOffset.UtcNow,
+            EventType = descriptor.EventType,
+            Actor = AuditContextResolver.ResolveActor(context, out var actorType),
+            ActorType = actorType,
+            ResourceType = descriptor.ResourceType,
+            ResourceId = context.Request.Path.HasValue ? context.Request.Path.Value : null,
+            Action = descriptor.Action,
+            Outcome = outcome,
+            CorrelationId = AuditContextResolver.ResolveCorrelationId(context),
+            RemoteIp = AuditContextResolver.ResolveRemoteIp(context),
+            UserAgent = AuditContextResolver.ResolveUserAgent(context),
+            Details = BuildDetails(context, status),
+        };
+    }
+
+    private static AuditEvent BuildAuthFailureEvent(HttpContext context, int status)
+        => new()
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            EventType = status == StatusCodes.Status403Forbidden
+                ? AuditEventType.Authorization
+                : AuditEventType.Authentication,
+            Actor = AuditContextResolver.ResolveActor(context, out var actorType),
+            ActorType = actorType,
+            ResourceType = "http",
+            ResourceId = context.Request.Path.HasValue ? context.Request.Path.Value : null,
+            Action = status == StatusCodes.Status403Forbidden ? "auth.denied" : "auth.failure",
+            Outcome = status == StatusCodes.Status403Forbidden
+                ? AuditOutcome.Denied
+                : AuditOutcome.Failure,
+            CorrelationId = AuditContextResolver.ResolveCorrelationId(context),
+            RemoteIp = AuditContextResolver.ResolveRemoteIp(context),
+            UserAgent = AuditContextResolver.ResolveUserAgent(context),
+            Details = BuildDetails(context, status),
+        };
+
+    private static string BuildDetails(HttpContext context, int status)
+        => string.Create(
+            CultureInfo.InvariantCulture,
+            $"{{\"status\":{status},\"method\":\"{context.Request.Method}\"}}");
+
+    private static bool IsSuccessStatus(int status) => status is >= 200 and < 300;
+
+    private static string? ResolveRoutePattern(HttpContext context)
+    {
+        if (context.GetEndpoint() is RouteEndpoint routeEndpoint)
+        {
+            return routeEndpoint.RoutePattern.RawText;
         }
 
-        return string.IsNullOrWhiteSpace(context.TraceIdentifier)
-            ? Guid.NewGuid().ToString("D")
-            : context.TraceIdentifier;
+        return null;
     }
 }
 
@@ -134,10 +185,13 @@ public static class AuditLogMiddlewareExtensions
 {
     /// <summary>
     /// Register the audit-log middleware. Should be added after correlation-id
-    /// middleware (so the audit event can stamp the request's correlation id)
-    /// and after authentication so it can observe the resolved
-    /// <see cref="HttpContext.User"/>.
+    /// middleware (so the audit event can stamp the request's correlation id),
+    /// after routing (so the matched endpoint's route template is available), and
+    /// after authentication / authorization so it can observe the resolved
+    /// <see cref="HttpContext.User"/> and the final status code.
     /// </summary>
+    /// <param name="app">The application builder.</param>
+    /// <returns>The application builder for chaining.</returns>
     public static IApplicationBuilder UseHonuaAuditLog(this IApplicationBuilder app)
     {
         ArgumentNullException.ThrowIfNull(app);

--- a/src/Honua.Hosting/Features/Middleware/AuditingFeatureWriter.cs
+++ b/src/Honua.Hosting/Features/Middleware/AuditingFeatureWriter.cs
@@ -1,0 +1,206 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Microsoft.AspNetCore.Http;
+
+namespace Honua.Infrastructure.Middleware;
+
+/// <summary>
+/// Decorates the provider <see cref="IFeatureWriter"/> to emit audit events for
+/// destructive feature writes (single deletes and bulk / transactional edits) at
+/// the shared edit-pipeline boundary (#507).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every protocol adapter that mutates features — GeoServices FeatureServer
+/// <c>applyEdits</c>/<c>deleteFeatures</c>, OGC API Features delete/transaction,
+/// WFS-T, OData CRUD, and gRPC edits — funnels through <see cref="IFeatureWriter"/>.
+/// Auditing here (rather than in each protocol handler) guarantees uniform
+/// coverage and honours the protocol-adapter rule that cross-cutting behaviour is
+/// implemented once in shared infrastructure. Creates and pure updates are not
+/// audited as destructive operations; only deletes and batches that contain a
+/// delete (or are otherwise bulk mutations) are recorded.
+/// </para>
+/// <para>
+/// Audit emission never alters the write result and never throws back into the
+/// edit path: <see cref="IAuditLog"/> implementations are expected to swallow
+/// transient failures, and a defensive try/catch guards the rest.
+/// </para>
+/// </remarks>
+internal sealed class AuditingFeatureWriter(
+    IFeatureWriter inner,
+    IAuditLog auditLog,
+    IHttpContextAccessor httpContextAccessor) : IFeatureWriter
+{
+    private readonly IFeatureWriter _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    private readonly IAuditLog _auditLog = auditLog ?? throw new ArgumentNullException(nameof(auditLog));
+    private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor
+        ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+
+    public Task<Feature> CreateAsync(int layerId, Feature feature, CancellationToken cancellationToken = default)
+        => _inner.CreateAsync(layerId, feature, cancellationToken);
+
+    public Task<Feature> UpdateAsync(int layerId, Feature feature, CancellationToken cancellationToken = default)
+        => _inner.UpdateAsync(layerId, feature, cancellationToken);
+
+    public async Task<bool> DeleteAsync(int layerId, long featureId, CancellationToken cancellationToken = default)
+    {
+        var deleted = false;
+        try
+        {
+            deleted = await _inner.DeleteAsync(layerId, featureId, cancellationToken).ConfigureAwait(false);
+            await EmitDeleteAsync(layerId, featureId, deleted, cancellationToken).ConfigureAwait(false);
+            return deleted;
+        }
+        catch
+        {
+            await EmitDeleteFailureAsync(layerId, featureId, cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public async Task<FeatureEditResult> ApplyEditsAsync(
+        int layerId,
+        FeatureEditBatch editBatch,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var result = await _inner.ApplyEditsAsync(layerId, editBatch, cancellationToken).ConfigureAwait(false);
+            await EmitBulkEditAsync(layerId, editBatch, result, cancellationToken).ConfigureAwait(false);
+            return result;
+        }
+        catch
+        {
+            await EmitBulkEditFailureAsync(layerId, editBatch, cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private Task EmitDeleteAsync(int layerId, long featureId, bool deleted, CancellationToken cancellationToken)
+        => RecordAsync(
+            action: "feature.delete",
+            layerId: layerId,
+            outcome: deleted ? AuditOutcome.Success : AuditOutcome.Failure,
+            details: string.Create(
+                CultureInfo.InvariantCulture,
+                $"{{\"objectId\":{featureId},\"deleted\":{(deleted ? "true" : "false")}}}"),
+            cancellationToken);
+
+    private Task EmitDeleteFailureAsync(int layerId, long featureId, CancellationToken cancellationToken)
+        => RecordAsync(
+            action: "feature.delete",
+            layerId: layerId,
+            outcome: AuditOutcome.Failure,
+            details: string.Create(CultureInfo.InvariantCulture, $"{{\"objectId\":{featureId},\"deleted\":false}}"),
+            cancellationToken);
+
+    private Task EmitBulkEditAsync(
+        int layerId,
+        FeatureEditBatch editBatch,
+        FeatureEditResult result,
+        CancellationToken cancellationToken)
+    {
+        var deleteCount = CountDeletes(editBatch);
+
+        // Only audit when the batch is destructive (contains deletes) or is a bulk
+        // mutation (more than one operation). Single create/update writes are not
+        // forensic events of interest for the destructive-write matrix row.
+        if (deleteCount == 0 && editBatch.TotalOperations <= 1)
+        {
+            return Task.CompletedTask;
+        }
+
+        var action = deleteCount > 0 ? "feature.bulk-edit.delete" : "feature.bulk-edit";
+        var details = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{{\"created\":{result.CreatedCount},\"updated\":{result.UpdatedCount},\"deleted\":{result.DeletedCount},\"rolledBack\":{(result.WasRolledBack ? "true" : "false")}}}");
+
+        return RecordAsync(
+            action,
+            layerId,
+            result.IsSuccess ? AuditOutcome.Success : AuditOutcome.Failure,
+            details,
+            cancellationToken);
+    }
+
+    private Task EmitBulkEditFailureAsync(int layerId, FeatureEditBatch editBatch, CancellationToken cancellationToken)
+    {
+        var deleteCount = CountDeletes(editBatch);
+        if (deleteCount == 0 && editBatch.TotalOperations <= 1)
+        {
+            return Task.CompletedTask;
+        }
+
+        var action = deleteCount > 0 ? "feature.bulk-edit.delete" : "feature.bulk-edit";
+        return RecordAsync(
+            action,
+            layerId,
+            AuditOutcome.Failure,
+            details: "{\"error\":true}",
+            cancellationToken);
+    }
+
+    private static int CountDeletes(FeatureEditBatch editBatch)
+    {
+        var direct = editBatch.Deletes.IsDefault ? 0 : editBatch.Deletes.Length;
+        var inOps = editBatch.Operations.IsDefault
+            ? 0
+            : editBatch.Operations.Count(static op => op.Kind == FeatureEditOperationKind.Delete);
+        return direct + inOps;
+    }
+
+    private async Task RecordAsync(
+        string action,
+        int layerId,
+        AuditOutcome outcome,
+        string details,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var context = _httpContextAccessor.HttpContext;
+            string actor;
+            AuditActorType actorType;
+            if (context is not null)
+            {
+                actor = AuditContextResolver.ResolveActor(context, out actorType);
+            }
+            else
+            {
+                // No request scope (e.g. background sync / replica apply). Record
+                // the write as a system action rather than dropping the event.
+                actor = AuditEvent.AnonymousActor;
+                actorType = AuditActorType.System;
+            }
+
+            var auditEvent = new AuditEvent
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                EventType = AuditEventType.DataDelete,
+                Actor = actor,
+                ActorType = actorType,
+                ResourceType = "feature",
+                ResourceId = layerId.ToString(CultureInfo.InvariantCulture),
+                Action = action,
+                Outcome = outcome,
+                CorrelationId = context is not null
+                    ? AuditContextResolver.ResolveCorrelationId(context)
+                    : Guid.NewGuid().ToString("D"),
+                RemoteIp = context is not null ? AuditContextResolver.ResolveRemoteIp(context) : null,
+                UserAgent = context is not null ? AuditContextResolver.ResolveUserAgent(context) : null,
+                Details = details,
+            };
+
+            await _auditLog.RecordAsync(auditEvent, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Auditing must never break the edit path. Sinks log their own errors.
+        }
+    }
+}

--- a/src/Honua.Hosting/Features/Middleware/DefaultAuditActionResolver.cs
+++ b/src/Honua.Hosting/Features/Middleware/DefaultAuditActionResolver.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using Honua.Core.Features.AuditLog.Abstractions;
+
+namespace Honua.Infrastructure.Middleware;
+
+/// <summary>
+/// Default, data-driven implementation of <see cref="IAuditActionResolver"/>.
+/// Encodes the audit coverage matrix
+/// (<c>docs/operator/audit-coverage-matrix.md</c>) so that audit emission stays
+/// middleware-driven instead of being scattered across endpoint handlers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Resolution proceeds in two stages so the matrix stays terse:
+/// </para>
+/// <list type="number">
+/// <item>
+/// <description>
+/// Exact, named routes for security-sensitive authentication operations
+/// (login, token refresh) are matched against an explicit table keyed by
+/// <c>"METHOD routePattern"</c>.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// Any remaining mutating request (<c>POST</c>/<c>PUT</c>/<c>PATCH</c>/<c>DELETE</c>)
+/// whose route falls under the admin control-plane prefix
+/// (<c>/api/v{version}/admin</c>) is classified as an administrative action,
+/// so the entire admin surface is covered without enumerating every endpoint.
+/// </description>
+/// </item>
+/// </list>
+/// <para>
+/// Destructive feature writes (single deletes and bulk/transactional edits) are
+/// deliberately <i>not</i> resolved here. Because protocols such as WFS-T and
+/// gRPC dispatch through a single endpoint where the route cannot reveal the
+/// operation, those events are emitted once at the shared edit-pipeline boundary
+/// (the <c>IFeatureWriter</c> audit decorator) so every protocol adapter is
+/// covered uniformly.
+/// </para>
+/// </remarks>
+internal sealed class DefaultAuditActionResolver : IAuditActionResolver
+{
+    private const string AdminRoutePrefix = "/api/v{version:apiversion}/admin";
+
+    // Mutating HTTP methods. GET/HEAD/OPTIONS/TRACE never imply a state change and
+    // are only audited via the failure path (401/403) handled by the middleware.
+    private static readonly FrozenSet<string> MutatingMethods =
+        new[] { "POST", "PUT", "PATCH", "DELETE" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    // Explicit, named routes that need a more specific classification than the
+    // admin-prefix fallback — security-sensitive authentication routes.
+    private static readonly FrozenDictionary<string, AuditActionDescriptor> NamedRoutes = BuildNamedRoutes();
+
+    public AuditActionDescriptor? Resolve(string httpMethod, string? routePattern)
+    {
+        if (string.IsNullOrWhiteSpace(httpMethod) || string.IsNullOrWhiteSpace(routePattern))
+        {
+            return null;
+        }
+
+        var normalizedPattern = Normalize(routePattern);
+        var key = $"{httpMethod.ToUpperInvariant()} {normalizedPattern}";
+
+        if (NamedRoutes.TryGetValue(key, out var descriptor))
+        {
+            return descriptor;
+        }
+
+        // Admin control-plane fallback: every mutating request under the admin
+        // prefix is an administrative action. This keeps "all admin API
+        // operations emit audit events" true without per-endpoint wiring.
+        if (MutatingMethods.Contains(httpMethod) &&
+            normalizedPattern.StartsWith(AdminRoutePrefix, StringComparison.Ordinal))
+        {
+            return new AuditActionDescriptor
+            {
+                EventType = AuditEventType.AdminAction,
+                Action = $"admin.{httpMethod.ToLowerInvariant()}",
+                ResourceType = "admin",
+            };
+        }
+
+        return null;
+    }
+
+    // Route templates can carry route constraints/casing that vary by registration
+    // site (e.g. "{version:apiVersion}"). Lower-case + trim trailing slash so the
+    // matrix table can use a single canonical form.
+    private static string Normalize(string routePattern)
+    {
+        var trimmed = routePattern.Trim();
+        if (trimmed.Length > 1 && trimmed.EndsWith('/'))
+        {
+            trimmed = trimmed[..^1];
+        }
+
+        if (!trimmed.StartsWith('/'))
+        {
+            trimmed = "/" + trimmed;
+        }
+
+        return trimmed.ToLowerInvariant();
+    }
+
+    private static FrozenDictionary<string, AuditActionDescriptor> BuildNamedRoutes()
+    {
+        var authLogin = new AuditActionDescriptor
+        {
+            EventType = AuditEventType.Authentication,
+            Action = "auth.login",
+            ResourceType = "session",
+        };
+
+        // Token issuance via the OAuth client-credentials / password endpoints is
+        // also a login for forensic purposes.
+        var authToken = new AuditActionDescriptor
+        {
+            EventType = AuditEventType.Authentication,
+            Action = "auth.token.issue",
+            ResourceType = "session",
+        };
+
+        var pairs = new Dictionary<string, AuditActionDescriptor>(StringComparer.Ordinal);
+
+        void Add(string method, string pattern, AuditActionDescriptor descriptor)
+            => pairs[$"{method} {Normalize(pattern)}"] = descriptor;
+
+        // -- Security-sensitive authentication operations --
+        // Admin OIDC backend-assisted login (authorization-code -> token exchange).
+        Add("POST", "/api/v{version:apiVersion}/admin/auth/providers/{providerKey}/token", authLogin);
+
+        // First-party OAuth token endpoints (api-key / client-credentials issuance).
+        Add("POST", "/oauth/token", authToken);
+        Add("POST", "/sharing/rest/oauth2/token", authToken);
+
+        return pairs.ToFrozenDictionary(StringComparer.Ordinal);
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/AuditLog/ServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/AuditLog/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using Honua.Core.Features.AuditLog;
 using Honua.Core.Features.AuditLog.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Infrastructure.Middleware;
 using Honua.Postgres.Features.AuditLog;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -38,6 +39,10 @@ internal static class AuditLogServiceCollectionExtensions
     public static IServiceCollection AddHonuaAuditLog(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
+
+        // Route-to-action resolver used by the audit middleware to decide which
+        // operations are audited declaratively, from route metadata (#507).
+        services.AddHonuaAuditActionResolver();
 
         services.TryAddScoped<IAuditLog>(static sp =>
         {

--- a/src/Honua.Server/Startup/InfrastructureCompositionRoot.cs
+++ b/src/Honua.Server/Startup/InfrastructureCompositionRoot.cs
@@ -15,6 +15,7 @@ using Honua.Core.Features.Styling.Abstractions;
 using Honua.Core.Features.Geometry.Abstractions;
 using Honua.Infrastructure.Caching;
 using Honua.Infrastructure.Configuration;
+using Honua.Infrastructure.Middleware;
 using Honua.Infrastructure.Monitoring;
 using Honua.Infrastructure.Services;
 using Microsoft.Extensions.Caching.Distributed;
@@ -55,6 +56,12 @@ internal static class InfrastructureCompositionRoot
             default:
                 throw new InvalidOperationException($"Unsupported data source provider '{configuredProvider}'.");
         }
+
+        // Wrap the provider's IFeatureWriter with the shared audit decorator (#507)
+        // so destructive feature writes (deletes, bulk/transactional edits) emit
+        // audit events once, at the shared edit-pipeline boundary, for every
+        // protocol adapter (FeatureServer, OGC API Features, WFS-T, OData, gRPC).
+        services.AddAuditingFeatureWriter();
 
         // Register the SQL Server spatial provider as an additional read-only feature backend (#850).
         // Metadata v2 publications whose connection resolves to provider 'sqlserver'/'mssql' are routed here

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Middleware/AuditLogMiddlewareTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Middleware/AuditLogMiddlewareTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Tests.Infrastructure.Middleware;
+
+/// <summary>
+/// End-to-end integration tests proving the audit middleware emits events for
+/// admin mutations, authentication, and authorization outcomes purely from route
+/// metadata, without per-endpoint audit calls (#507).
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Configuration)]
+public sealed class AuditLogMiddlewareTests : IAsyncLifetime
+{
+    private readonly CapturingAuditLog _audit = new();
+    private readonly WebAppFixture _fixture;
+
+    public AuditLogMiddlewareTests()
+    {
+        _fixture = new WebAppFixture().ConfigureServices(services =>
+        {
+            services.RemoveAll<IAuditLog>();
+            services.AddSingleton<IAuditLog>(_audit);
+        });
+    }
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/cache/invalidate")]
+    public async Task AdminMutation_Authenticated_EmitsAdminActionEvent()
+    {
+        var client = _fixture.CreateAdminClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/api/v1/admin/cache/invalidate",
+            new { scope = "all" });
+
+        // The middleware audits regardless of the handler's success/failure body.
+        var evt = await WaitForEventAsync(e => e.EventType == AuditEventType.AdminAction);
+        evt.Should().NotBeNull();
+        evt!.Action.Should().Be("admin.post");
+        evt.ResourceType.Should().Be("admin");
+        evt.ResourceId.Should().Be("/api/v1/admin/cache/invalidate");
+        evt.CorrelationId.Should().NotBeNullOrWhiteSpace();
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task<AuditEvent?> WaitForEventAsync(Func<AuditEvent, bool> predicate)
+    {
+        // The middleware records after the response is written; the audit write is
+        // awaited within the request, so a short poll covers test-host scheduling.
+        for (var attempt = 0; attempt < 50; attempt++)
+        {
+            var match = _audit.Events.FirstOrDefault(predicate);
+            if (match is not null)
+            {
+                return match;
+            }
+
+            await Task.Delay(20);
+        }
+
+        return _audit.Events.FirstOrDefault(predicate);
+    }
+
+    private sealed class CapturingAuditLog : IAuditLog
+    {
+        private readonly ConcurrentQueue<AuditEvent> _events = new();
+
+        public IReadOnlyCollection<AuditEvent> Events => _events.ToArray();
+
+        public Task RecordAsync(AuditEvent auditEvent, CancellationToken cancellationToken = default)
+        {
+            _events.Enqueue(auditEvent);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Middleware/AuditLogMiddlewareUnitTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Middleware/AuditLogMiddlewareUnitTests.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Infrastructure.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Infrastructure.Middleware;
+
+/// <summary>
+/// Unit tests that drive <see cref="AuditLogMiddleware"/> directly to prove the
+/// authentication / authorization and login emission branches without standing up
+/// the full host (which bypasses auth in the integration harness) (#507).
+/// </summary>
+public sealed class AuditLogMiddlewareUnitTests
+{
+    private readonly CapturingAuditLog _audit = new();
+
+    [Fact]
+    public async Task FailedLogin_OnAnyRoute_EmitsAuthFailure()
+    {
+        var context = BuildContext(
+            method: "GET",
+            routePattern: "/api/v1/admin/config",
+            authenticated: false);
+
+        await InvokeAsync(context, finalStatus: StatusCodes.Status401Unauthorized);
+
+        var evt = _audit.Events.Should().ContainSingle().Subject;
+        evt.EventType.Should().Be(AuditEventType.Authentication);
+        evt.Action.Should().Be("auth.failure");
+        evt.Outcome.Should().Be(AuditOutcome.Failure);
+        evt.ActorType.Should().Be(AuditActorType.Anonymous);
+    }
+
+    [Fact]
+    public async Task PermissionDenied_OnAnyRoute_EmitsAuthorizationDenied()
+    {
+        var context = BuildContext(
+            method: "DELETE",
+            routePattern: "/api/v1/admin/roles/{id}",
+            authenticated: true);
+
+        await InvokeAsync(context, finalStatus: StatusCodes.Status403Forbidden);
+
+        // The admin-action descriptor matches the route, but the 403 outcome wins.
+        var evt = _audit.Events.Should().ContainSingle().Subject;
+        evt.Outcome.Should().Be(AuditOutcome.Denied);
+        evt.ActorType.Should().Be(AuditActorType.UserId);
+    }
+
+    [Fact]
+    public async Task SuccessfulLogin_OnTokenRoute_EmitsAuthLoginSuccess()
+    {
+        var context = BuildContext(
+            method: "POST",
+            routePattern: "/api/v{version:apiVersion}/admin/auth/providers/{providerKey}/token",
+            authenticated: true);
+
+        await InvokeAsync(context, finalStatus: StatusCodes.Status200OK);
+
+        var evt = _audit.Events.Should().ContainSingle().Subject;
+        evt.EventType.Should().Be(AuditEventType.Authentication);
+        evt.Action.Should().Be("auth.login");
+        evt.Outcome.Should().Be(AuditOutcome.Success);
+    }
+
+    [Fact]
+    public async Task FailedLogin_OnTokenRoute_EmitsAuthLoginFailure()
+    {
+        var context = BuildContext(
+            method: "POST",
+            routePattern: "/api/v{version:apiVersion}/admin/auth/providers/{providerKey}/token",
+            authenticated: false);
+
+        await InvokeAsync(context, finalStatus: StatusCodes.Status401Unauthorized);
+
+        var evt = _audit.Events.Should().ContainSingle().Subject;
+        evt.Action.Should().Be("auth.login");
+        evt.Outcome.Should().Be(AuditOutcome.Failure);
+    }
+
+    [Fact]
+    public async Task NonAuditedRoute_Success_EmitsNothing()
+    {
+        var context = BuildContext(
+            method: "GET",
+            routePattern: "/healthz/live",
+            authenticated: false);
+
+        await InvokeAsync(context, finalStatus: StatusCodes.Status200OK);
+
+        _audit.Events.Should().BeEmpty();
+    }
+
+    private async Task InvokeAsync(HttpContext context, int finalStatus)
+    {
+        var middleware = new AuditLogMiddleware(
+            next: ctx =>
+            {
+                ctx.Response.StatusCode = finalStatus;
+                return Task.CompletedTask;
+            },
+            actionResolver: new DefaultAuditActionResolver());
+
+        await middleware.InvokeAsync(context);
+    }
+
+    private DefaultHttpContext BuildContext(string method, string routePattern, bool authenticated)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IAuditLog>(_audit);
+
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+        };
+        context.Request.Method = method;
+        context.Request.Path = "/" + routePattern.TrimStart('/').Replace("{", string.Empty, StringComparison.Ordinal).Replace("}", string.Empty, StringComparison.Ordinal);
+        context.Connection.RemoteIpAddress = System.Net.IPAddress.Loopback;
+
+        if (authenticated)
+        {
+            context.User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.Name, "operator@example.com") },
+                authenticationType: "Test"));
+        }
+
+        var endpoint = new RouteEndpoint(
+            requestDelegate: _ => Task.CompletedTask,
+            routePattern: RoutePatternFactory.Parse(routePattern),
+            order: 0,
+            metadata: new EndpointMetadataCollection(),
+            displayName: routePattern);
+        context.SetEndpoint(endpoint);
+
+        return context;
+    }
+
+    private sealed class CapturingAuditLog : IAuditLog
+    {
+        public List<AuditEvent> Events { get; } = new();
+
+        public Task RecordAsync(AuditEvent auditEvent, CancellationToken cancellationToken = default)
+        {
+            Events.Add(auditEvent);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Middleware/AuditingFeatureWriterTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Middleware/AuditingFeatureWriterTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Infrastructure.Middleware;
+using Microsoft.AspNetCore.Http;
+
+namespace Honua.Server.Tests.Infrastructure.Middleware;
+
+/// <summary>
+/// Unit tests for <see cref="AuditingFeatureWriter"/> — the shared edit-pipeline
+/// decorator that emits destructive-write audit events for every protocol
+/// adapter (#507).
+/// </summary>
+public sealed class AuditingFeatureWriterTests
+{
+    private readonly CapturingAuditLog _auditLog = new();
+    private readonly StubFeatureWriter _inner = new();
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly AuditingFeatureWriter _writer;
+
+    public AuditingFeatureWriterTests()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            new[] { new Claim(ClaimTypes.Name, "operator@example.com") },
+            authenticationType: "Test"));
+        httpContext.Connection.RemoteIpAddress = System.Net.IPAddress.Loopback;
+        _httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
+        _writer = new AuditingFeatureWriter(_inner, _auditLog, _httpContextAccessor);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenDeleted_EmitsFeatureDeleteSuccess()
+    {
+        _inner.DeleteResult = true;
+
+        var result = await _writer.DeleteAsync(layerId: 7, featureId: 42);
+
+        result.Should().BeTrue();
+        var evt = _auditLog.Events.Should().ContainSingle().Subject;
+        evt.EventType.Should().Be(AuditEventType.DataDelete);
+        evt.Action.Should().Be("feature.delete");
+        evt.Outcome.Should().Be(AuditOutcome.Success);
+        evt.ResourceType.Should().Be("feature");
+        evt.ResourceId.Should().Be("7");
+        evt.Actor.Should().Be("operator@example.com");
+        evt.ActorType.Should().Be(AuditActorType.UserId);
+        evt.Details.Should().Contain("\"objectId\":42");
+        evt.Details.Should().NotContain("connection");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenNotFound_EmitsFailureOutcome()
+    {
+        _inner.DeleteResult = false;
+
+        await _writer.DeleteAsync(layerId: 3, featureId: 99);
+
+        var evt = _auditLog.Events.Should().ContainSingle().Subject;
+        evt.Action.Should().Be("feature.delete");
+        evt.Outcome.Should().Be(AuditOutcome.Failure);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenInnerThrows_EmitsFailureAndRethrows()
+    {
+        _inner.ThrowOnDelete = true;
+
+        var act = async () => await _writer.DeleteAsync(layerId: 1, featureId: 5);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        var evt = _auditLog.Events.Should().ContainSingle().Subject;
+        evt.Outcome.Should().Be(AuditOutcome.Failure);
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_WithDeletes_EmitsBulkDeleteEvent()
+    {
+        _inner.EditResult = FeatureEditResult.Success(createdCount: 0, updatedCount: 0, deletedCount: 2);
+        var batch = FeatureEditBatch.Create(deletes: ImmutableArray.Create(1L, 2L));
+
+        await _writer.ApplyEditsAsync(layerId: 11, batch);
+
+        var evt = _auditLog.Events.Should().ContainSingle().Subject;
+        evt.EventType.Should().Be(AuditEventType.DataDelete);
+        evt.Action.Should().Be("feature.bulk-edit.delete");
+        evt.Outcome.Should().Be(AuditOutcome.Success);
+        evt.Details.Should().Contain("\"deleted\":2");
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_WithMultipleCreatesNoDelete_EmitsBulkEdit()
+    {
+        _inner.EditResult = FeatureEditResult.Success(createdCount: 3, updatedCount: 0, deletedCount: 0);
+        var creates = ImmutableArray.Create(NewFeature(), NewFeature(), NewFeature());
+        var batch = FeatureEditBatch.Create(creates: creates);
+
+        await _writer.ApplyEditsAsync(layerId: 4, batch);
+
+        var evt = _auditLog.Events.Should().ContainSingle().Subject;
+        evt.Action.Should().Be("feature.bulk-edit");
+        evt.Outcome.Should().Be(AuditOutcome.Success);
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_SingleCreate_DoesNotEmit()
+    {
+        _inner.EditResult = FeatureEditResult.Success(createdCount: 1, updatedCount: 0, deletedCount: 0);
+        var batch = FeatureEditBatch.Create(creates: ImmutableArray.Create(NewFeature()));
+
+        await _writer.ApplyEditsAsync(layerId: 4, batch);
+
+        _auditLog.Events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateAsync_And_UpdateAsync_AreNotAudited()
+    {
+        await _writer.CreateAsync(2, NewFeature());
+        await _writer.UpdateAsync(2, NewFeature());
+
+        _auditLog.Events.Should().BeEmpty();
+    }
+
+    private static Feature NewFeature() => new()
+    {
+        Id = 0,
+        Geometry = null,
+        Attributes = ImmutableDictionary<string, object?>.Empty,
+    };
+
+    private sealed class StubFeatureWriter : IFeatureWriter
+    {
+        public bool DeleteResult { get; set; } = true;
+
+        public bool ThrowOnDelete { get; set; }
+
+        public FeatureEditResult EditResult { get; set; } =
+            FeatureEditResult.Success(0, 0, 0);
+
+        public Task<Feature> CreateAsync(int layerId, Feature feature, CancellationToken cancellationToken = default)
+            => Task.FromResult(feature);
+
+        public Task<Feature> UpdateAsync(int layerId, Feature feature, CancellationToken cancellationToken = default)
+            => Task.FromResult(feature);
+
+        public Task<bool> DeleteAsync(int layerId, long featureId, CancellationToken cancellationToken = default)
+        {
+            if (ThrowOnDelete)
+            {
+                throw new InvalidOperationException("delete failed");
+            }
+
+            return Task.FromResult(DeleteResult);
+        }
+
+        public Task<FeatureEditResult> ApplyEditsAsync(
+            int layerId,
+            FeatureEditBatch editBatch,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(EditResult);
+    }
+
+    private sealed class CapturingAuditLog : IAuditLog
+    {
+        public List<AuditEvent> Events { get; } = new();
+
+        public Task RecordAsync(AuditEvent auditEvent, CancellationToken cancellationToken = default)
+        {
+            Events.Add(auditEvent);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Middleware/DefaultAuditActionResolverTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Middleware/DefaultAuditActionResolverTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Infrastructure.Middleware;
+
+namespace Honua.Server.Tests.Infrastructure.Middleware;
+
+/// <summary>
+/// Unit tests for <see cref="DefaultAuditActionResolver"/> — the data-driven
+/// audit coverage matrix that keeps audit emission middleware-driven (#507).
+/// </summary>
+public sealed class DefaultAuditActionResolverTests
+{
+    private readonly DefaultAuditActionResolver _resolver = new();
+
+    [Theory]
+    [InlineData("POST", "/api/v{version:apiVersion}/admin/connections")]
+    [InlineData("PUT", "/api/v{version:apiVersion}/admin/connections/{id}")]
+    [InlineData("PATCH", "/api/v{version:apiVersion}/admin/users/{id}")]
+    [InlineData("DELETE", "/api/v{version:apiVersion}/admin/roles/{id}")]
+    public void Resolve_AdminMutation_ReturnsAdminActionDescriptor(string method, string route)
+    {
+        var descriptor = _resolver.Resolve(method, route);
+
+        descriptor.Should().NotBeNull();
+        descriptor!.EventType.Should().Be(AuditEventType.AdminAction);
+        descriptor.ResourceType.Should().Be("admin");
+        descriptor.Action.Should().Be($"admin.{method.ToLowerInvariant()}");
+    }
+
+    [Theory]
+    [InlineData("GET", "/api/v{version:apiVersion}/admin/connections/{id}")]
+    [InlineData("HEAD", "/api/v{version:apiVersion}/admin/config")]
+    [InlineData("OPTIONS", "/api/v{version:apiVersion}/admin/config")]
+    public void Resolve_AdminRead_ReturnsNull(string method, string route)
+    {
+        _resolver.Resolve(method, route).Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_AdminLoginTokenExchange_ReturnsAuthenticationDescriptor()
+    {
+        var descriptor = _resolver.Resolve(
+            "POST",
+            "/api/v{version:apiVersion}/admin/auth/providers/{providerKey}/token");
+
+        descriptor.Should().NotBeNull();
+        descriptor!.EventType.Should().Be(AuditEventType.Authentication);
+        descriptor.Action.Should().Be("auth.login");
+        descriptor.ResourceType.Should().Be("session");
+    }
+
+    [Theory]
+    [InlineData("/oauth/token")]
+    [InlineData("/sharing/rest/oauth2/token")]
+    public void Resolve_OAuthTokenIssuance_ReturnsAuthenticationDescriptor(string route)
+    {
+        var descriptor = _resolver.Resolve("POST", route);
+
+        descriptor.Should().NotBeNull();
+        descriptor!.EventType.Should().Be(AuditEventType.Authentication);
+        descriptor.Action.Should().Be("auth.token.issue");
+    }
+
+    [Theory]
+    [InlineData("GET", "/rest/services/{serviceId}/FeatureServer/{layerId:int}/query")]
+    [InlineData("POST", "/ogc/features/collections/{collectionId}/items")]
+    [InlineData("GET", "/healthz/live")]
+    [InlineData("GET", "/odata/Layers")]
+    public void Resolve_NonAuditedRoute_ReturnsNull(string method, string route)
+    {
+        _resolver.Resolve(method, route).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("POST", "/rest/services/{serviceId}/FeatureServer/{layerId:int}/deleteFeatures")]
+    [InlineData("POST", "/rest/services/{serviceId}/FeatureServer/{layerId:int}/applyEdits")]
+    [InlineData("DELETE", "/ogc/features/collections/{collectionId}/items/{featureId}")]
+    public void Resolve_DestructiveFeatureWrite_ReturnsNull_EmittedByWriterDecorator(string method, string route)
+    {
+        // Destructive feature writes are intentionally NOT resolved by the route
+        // resolver; they are emitted at the shared IFeatureWriter boundary so that
+        // single-endpoint protocols (WFS-T, gRPC) are covered uniformly.
+        _resolver.Resolve(method, route).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("", "/api/v1/admin/config")]
+    [InlineData("POST", null)]
+    [InlineData("POST", "")]
+    public void Resolve_MissingInputs_ReturnsNull(string? method, string? route)
+    {
+        _resolver.Resolve(method!, route).Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_AdminRoute_IsCaseInsensitiveOnRouteConstraints()
+    {
+        // apiVersion constraint casing must not affect prefix matching.
+        var descriptor = _resolver.Resolve("DELETE", "/api/v{version:APIVERSION}/admin/scenes/{id}");
+
+        descriptor.Should().NotBeNull();
+        descriptor!.EventType.Should().Be(AuditEventType.AdminAction);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #507

## Summary
Implements the audit coverage matrix and **middleware-driven** audit instrumentation for #507 (parent #350; depends on #504, done). Defines exactly which operations emit audit events and emits them from shared infrastructure — admin mutations and authentication/authorization via `AuditLogMiddleware` keyed on the matched route + method + status, and destructive feature writes via a shared `IFeatureWriter` decorator at the canonical edit-pipeline boundary. No per-endpoint manual audit calls are added; existing manual audit emitters are left untouched so coverage is additive and non-regressive.

## Changes Made
- **Matrix doc**: `docs/operator/audit-coverage-matrix.md` — authoritative definition of audited operations (admin actions, destructive writes, authentication/authorization) mapped to `AuditEventType`, action, and outcome; linked from `docs/operator/README.md`.
- **Core abstractions**: `AuditActionDescriptor` + `IAuditActionResolver` (`Honua.Core/Features/AuditLog/Abstractions`).
- **Resolver (the matrix in code)**: `DefaultAuditActionResolver` (`Honua.Hosting`) — every mutating request under the admin control-plane prefix is an `AdminAction`; admin OIDC login (`/admin/auth/providers/{providerKey}/token`) and OAuth token routes (`/oauth/token`, `/sharing/rest/oauth2/token`) are `Authentication` events.
- **Middleware**: `AuditLogMiddleware` now resolves the matched route via `IAuditActionResolver` and emits the descriptor's event with outcome derived from the final status code (success login, admin mutations), in addition to the existing 401/403 `auth.failure` / `auth.denied` path. Shared actor/correlation/IP/UA derivation extracted to `AuditContextResolver`.
- **Shared edit-pipeline decorator**: `AuditingFeatureWriter` decorates the provider `IFeatureWriter` so single deletes and bulk/transactional edits emit `DataDelete` events once, covering FeatureServer, OGC API Features, WFS-T, OData, and gRPC uniformly. Wired in `InfrastructureCompositionRoot` right after the provider registers its writer; resolver registered via `AddHonuaAuditLog`.
- **Edition gating**: not gated. No audit/compliance entitlement exists in `FeatureCatalog`, and the sink already degrades to `NullAuditLog` when no durable backend is configured. Gating would create forensic blind spots in lower editions; rationale is documented in the matrix doc.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Local results (all green):
- `dotnet build Honua.sln --configuration Release /p:TreatWarningsAsErrors=true` — succeeded, 0 warnings / 0 errors.
- `dotnet format Honua.sln --verify-no-changes` — clean (exit 0).
- New audit tests: 34 passed / 0 failed (`DefaultAuditActionResolverTests`, `AuditingFeatureWriterTests`, `AuditLogMiddlewareUnitTests`, and the Docker-backed `AuditLogMiddlewareTests` integration test for admin-mutation emission).
- Architecture tests (`Honua.Architecture.Tests`): 109 passed, 1 skipped.

Coverage of required scenarios: admin mutation (success + 401), feature single delete (success/not-found/exception), bulk edit (with deletes / multi-op / single-op no-emit), successful login, failed login, permission denied. The failed-login and permission-denied middleware branches are proven by direct middleware unit tests because the integration harness runs with dev-auth bypass enabled (so 401/403 are unreachable through the in-process admin client); the one DB-backed integration test confirms real end-to-end admin-mutation emission.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed

No public HTTP routes or wire contracts change; this is internal middleware + an `IFeatureWriter` decorator plus operator documentation.

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

No new migrations (the `honua.audit_log` schema landed in #504). No new env vars or infra. Audit emission runs unconditionally; durability still depends on whether a Postgres-backed `IAuditLog` sink is configured (else `NullAuditLog`).

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed — Release build (warnings-as-errors), `dotnet format --verify-no-changes`, and tests all green. One unrelated test (`DbUpMigrations.MobileOfflineDemoSeed_AppliesToCanonicalSchema`) hit a transient Postgres `40P01` deadlock under concurrent Testcontainers load on a shared CI host; it passes 1/1 in isolation and is not touched by this change.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract (N/A — no client-visible behavior change)
- [ ] If breaking admin/control-plane API changes: updated migration guide (N/A — no breaking changes)
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review (N/A)

