### PR TITLE
feat: branch-version conflict resolution — policies, 3-way report, field merge (#371)

### DIFF
--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -1376,6 +1376,8 @@
         "VersionManagementServer::startEditing",
         "VersionManagementServer::stopEditing",
         "VersionManagementServer::reconcile",
+        "VersionManagementServer::inspectConflicts",
+        "VersionManagementServer::resolveConflicts",
         "VersionManagementServer::post"
       ],
       "proofs": [

--- a/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/VersionOperations.cs
+++ b/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/VersionOperations.cs
@@ -34,30 +34,135 @@ public readonly record struct AlterVersionRequest(
     string? Description = null);
 
 /// <summary>
+/// Auto-resolution policy applied by the version manager's <c>ReconcileAsync</c> when a
+/// reconcile detects overlapping edits between a branch version and DEFAULT since the merge base
+/// (#371). When a deterministic policy is supplied the manager resolves each conflict in place so the
+/// version can be posted; when <see cref="None"/> the manager preserves the manual-review behavior
+/// (conflicts are reported, persisted, and block <c>Post</c> until resolved).
+/// </summary>
+public enum VersionReconcilePolicy
+{
+    /// <summary>
+    /// No automatic resolution. Overlapping edits are reported as conflicts and block <c>Post</c>
+    /// until an operator resolves them through the manual conflict-resolution surface. This is the
+    /// default and matches the substrate's pre-#371 behavior.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Resolve each conflict in favor of the edit made most recently (by change generation). Maps to
+    /// Esri's last-write-wins style auto-merge.
+    /// </summary>
+    LastWriteWins = 1,
+
+    /// <summary>Resolve every conflict in favor of the branch (edit) version.</summary>
+    VersionWins = 2,
+
+    /// <summary>Resolve every conflict in favor of the target (DEFAULT) version.</summary>
+    DefaultWins = 3,
+}
+
+/// <summary>
+/// Operator choice for a single manually-resolved reconcile conflict (#371). Selects which side of a
+/// three-way conflict (base / DEFAULT / version) becomes the posted state for the feature. Field-level
+/// merges are produced automatically during reconcile for disjoint field edits, so the manual surface
+/// resolves only genuinely-overlapping conflicts at the feature grain.
+/// </summary>
+public enum VersionConflictResolutionChoice
+{
+    /// <summary>Take the branch (edit) version's image for the conflicting feature.</summary>
+    TakeVersion = 0,
+
+    /// <summary>Take the target (DEFAULT) image for the conflicting feature.</summary>
+    TakeDefault = 1,
+
+    /// <summary>Take the common-ancestor (base) image for the conflicting feature.</summary>
+    TakeBase = 2,
+}
+
+/// <summary>
+/// A single field-level difference observed for a conflicting feature: the attribute name and its
+/// base, DEFAULT, and version values rendered as opaque strings. Lets a client/UI present a precise
+/// per-field three-way diff without coupling to the physical attribute schema.
+/// </summary>
+/// <param name="Name">Attribute name.</param>
+/// <param name="Base">Common-ancestor value (string-rendered), or null when absent.</param>
+/// <param name="Default">DEFAULT (target) value (string-rendered), or null when absent.</param>
+/// <param name="Version">Branch (edit) value (string-rendered), or null when absent.</param>
+public readonly record struct VersionConflictFieldDiff(
+    string Name,
+    string? Base,
+    string? Default,
+    string? Version);
+
+/// <summary>
 /// Classification of an unresolved reconcile conflict between version edits and DEFAULT edits made
-/// since the version's merge base. Reuses the disconnected-sync conflict taxonomy (#1272 Track B).
+/// since the version's merge base, with the three-way feature images that let a client/UI render a
+/// before/after/base diff (#1272 Track B substrate; before/after/base + field diffs added by #371).
+/// The image fields are opaque pre-serialized JSON (attribute image) and WKT (geometry) so the
+/// conflict-review surface stays decoupled from the physical feature schema and never leaks SQL,
+/// connection details, or provider internals.
 /// </summary>
 /// <param name="LayerId">Storage-layer id of the conflicting feature.</param>
 /// <param name="ObjectId">Stable object id of the conflicting feature.</param>
 /// <param name="ConflictType">Conflict classification.</param>
+/// <param name="BaseAttributesJson">Common-ancestor attribute image (JSON), or null when unknown.</param>
+/// <param name="DefaultAttributesJson">DEFAULT (target) attribute image (JSON), or null when the row was deleted.</param>
+/// <param name="VersionAttributesJson">Branch (edit) attribute image (JSON), or null when the row was deleted.</param>
+/// <param name="BaseGeometryWkt">Common-ancestor geometry (WKT), or null when absent.</param>
+/// <param name="DefaultGeometryWkt">DEFAULT (target) geometry (WKT), or null when absent/deleted.</param>
+/// <param name="VersionGeometryWkt">Branch (edit) geometry (WKT), or null when absent/deleted.</param>
+/// <param name="FieldDiffs">Per-field three-way diffs for the overlapping fields that made this a conflict.</param>
 public readonly record struct VersionReconcileConflict(
     int LayerId,
     long ObjectId,
-    ReplicaConflictType ConflictType);
+    ReplicaConflictType ConflictType,
+    string? BaseAttributesJson = null,
+    string? DefaultAttributesJson = null,
+    string? VersionAttributesJson = null,
+    string? BaseGeometryWkt = null,
+    string? DefaultGeometryWkt = null,
+    string? VersionGeometryWkt = null,
+    ImmutableArray<VersionConflictFieldDiff> FieldDiffs = default);
 
 /// <summary>
 /// Result of a reconcile: the conflicts detected between the version and DEFAULT since the merge
 /// base, and whether the version is clear to post. A reconcile pulls DEFAULT changes since
-/// <see cref="GdbVersion.CommonAncestorGeneration"/> into the version, applies auto-resolution
-/// policies (owned by #371), and reports any remaining conflicts that block <c>Post</c>.
+/// <see cref="GdbVersion.CommonAncestorGeneration"/> into the version, auto-merges disjoint
+/// field-level edits, applies the supplied <see cref="VersionReconcilePolicy"/> auto-resolution
+/// policy (#371), and reports any remaining conflicts that block <c>Post</c>.
 /// </summary>
-/// <param name="Conflicts">Unresolved conflicts; non-empty blocks post.</param>
-/// <param name="CanPost">True when the version reconciled cleanly and may be posted.</param>
+/// <param name="Conflicts">Unresolved conflicts after auto-merge and policy application; non-empty blocks post.</param>
+/// <param name="CanPost">True when the version reconciled cleanly (or was auto-resolved) and may be posted.</param>
 /// <param name="NewCommonAncestorGeneration">The DEFAULT generation the version is now reconciled to.</param>
+/// <param name="AutoResolvedCount">Number of conflicts the supplied policy resolved automatically.</param>
 public readonly record struct VersionReconcileResult(
     ImmutableArray<VersionReconcileConflict> Conflicts,
     bool CanPost,
-    long NewCommonAncestorGeneration);
+    long NewCommonAncestorGeneration,
+    int AutoResolvedCount = 0);
+
+/// <summary>
+/// One operator-submitted resolution choice for a pending reconcile conflict (#371).
+/// </summary>
+/// <param name="LayerId">Storage-layer id of the conflicting feature.</param>
+/// <param name="ObjectId">Stable object id of the conflicting feature.</param>
+/// <param name="Choice">Which side of the three-way conflict to keep.</param>
+public readonly record struct VersionConflictResolution(
+    int LayerId,
+    long ObjectId,
+    VersionConflictResolutionChoice Choice);
+
+/// <summary>
+/// Outcome of applying a batch of manual conflict resolutions to a version (#371).
+/// </summary>
+/// <param name="Resolved">Number of conflicts transitioned to resolved by this call.</param>
+/// <param name="Remaining">Number of pending conflicts still blocking <c>Post</c> after this call.</param>
+/// <param name="CanPost">True when no pending conflicts remain and the version may be posted.</param>
+public readonly record struct VersionConflictResolutionResult(
+    int Resolved,
+    int Remaining,
+    bool CanPost);
 
 /// <summary>
 /// Result of a post: after a clean reconcile, the version's net changes are replayed onto DEFAULT in

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IVersionManager.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IVersionManager.cs
@@ -59,11 +59,49 @@ public interface IVersionManager
     /// <returns>The resolved context, or null when the named version does not exist.</returns>
     Task<VersionContext?> ResolveAsync(string? gdbVersion, CancellationToken cancellationToken = default);
 
-    /// <summary>Reconciles a version against DEFAULT, detecting conflicts since the merge base.</summary>
+    /// <summary>
+    /// Reconciles a version against DEFAULT, detecting conflicts since the merge base. Disjoint
+    /// field-level edits auto-merge; only genuinely-overlapping edits (overlapping fields,
+    /// geometry-vs-geometry, or update-vs-delete) become conflicts. When <paramref name="policy"/> is
+    /// a deterministic policy (#371) each conflict is auto-resolved so the version may be posted; when
+    /// <see cref="VersionReconcilePolicy.None"/> the unresolved conflicts are persisted for manual
+    /// review and block <c>Post</c>.
+    /// </summary>
     /// <param name="versionId">Version to reconcile.</param>
+    /// <param name="policy">Auto-resolution policy; <see cref="VersionReconcilePolicy.None"/> for manual review.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The reconcile result.</returns>
-    Task<VersionReconcileResult> ReconcileAsync(Guid versionId, CancellationToken cancellationToken = default);
+    Task<VersionReconcileResult> ReconcileAsync(
+        Guid versionId,
+        VersionReconcilePolicy policy = VersionReconcilePolicy.None,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the current set of pending (unresolved) conflicts persisted for a version, each with the
+    /// three-way base/DEFAULT/version images and per-field diffs for a manual-resolution UI (#371). An
+    /// empty result means there are no pending conflicts and the version may be posted.
+    /// </summary>
+    /// <param name="versionId">Version whose pending conflicts to inspect.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The pending conflicts.</returns>
+    Task<IReadOnlyList<VersionReconcileConflict>> GetPendingConflictsAsync(
+        Guid versionId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Applies operator-submitted resolution choices to a version's pending conflicts (#371). Each
+    /// choice rewrites the branch overlay row to the selected side (version/DEFAULT/base) and clears
+    /// the persisted pending conflict, after which <c>Post</c> may proceed once no pending conflicts
+    /// remain.
+    /// </summary>
+    /// <param name="versionId">Version whose conflicts to resolve.</param>
+    /// <param name="resolutions">Per-feature resolution choices.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resolution outcome (resolved/remaining counts and whether post may proceed).</returns>
+    Task<VersionConflictResolutionResult> ResolveConflictsAsync(
+        Guid versionId,
+        IReadOnlyList<VersionConflictResolution> resolutions,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Posts a reconciled version's net changes onto DEFAULT. Refused while unresolved conflicts

--- a/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpVersionManager.cs
+++ b/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpVersionManager.cs
@@ -48,7 +48,23 @@ public sealed class NoOpVersionManager : IVersionManager
     }
 
     /// <inheritdoc />
-    public Task<VersionReconcileResult> ReconcileAsync(Guid versionId, CancellationToken cancellationToken = default)
+    public Task<VersionReconcileResult> ReconcileAsync(
+        Guid versionId,
+        VersionReconcilePolicy policy = VersionReconcilePolicy.None,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Branch versioning is not supported by this data provider.");
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<VersionReconcileConflict>> GetPendingConflictsAsync(
+        Guid versionId,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Branch versioning is not supported by this data provider.");
+
+    /// <inheritdoc />
+    public Task<VersionConflictResolutionResult> ResolveConflictsAsync(
+        Guid versionId,
+        IReadOnlyList<VersionConflictResolution> resolutions,
+        CancellationToken cancellationToken = default)
         => throw new NotSupportedException("Branch versioning is not supported by this data provider.");
 
     /// <inheritdoc />

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresVersionManager.ReconcilePost.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresVersionManager.ReconcilePost.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using System.Data;
+using System.Text.Json;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Postgres.Features.Infrastructure;
 using Npgsql;
@@ -11,25 +12,36 @@ namespace Honua.Postgres.Features.FeatureStore.Services;
 
 internal sealed partial class PostgresVersionManager
 {
-    // Reconcile/post core (#1272 Track B Slice 2, ADR-0051). Reconcile diffs DEFAULT feature_changes since
-    // the version's merge base against the version's tagged overlay edits and classifies overlapping-OID
-    // conflicts using the #1287 conflict taxonomy. A clean reconcile advances common_ancestor_gen. Post
-    // (only when conflict-free) replays the version's net overlay rows onto the live DEFAULT features table
-    // in one transaction and advances the generation through the existing change-tracking trigger.
+    // Reconcile/post core (#1272 Track B Slice 2, ADR-0051; conflict-resolution layer #371). Reconcile
+    // diffs DEFAULT feature_changes since the version's merge base against the version's tagged overlay
+    // edits. For overlapping (layer_id, objectid) pairs it loads the three-way base/DEFAULT/version
+    // images and:
+    //   * auto-merges disjoint field-level edits (a feature edited in both the branch and DEFAULT but on
+    //     DISJOINT attribute sets is merged into the overlay, not flagged);
+    //   * classifies the rest as genuine conflicts (overlapping fields, geometry-vs-geometry,
+    //     update-vs-delete) and, per #371, either auto-resolves them per the supplied policy
+    //     (last-write-wins / version-wins / default-wins) or persists them as pending conflicts for
+    //     manual review and blocks post.
+    // A clean reconcile (no remaining conflicts) advances common_ancestor_gen. Post (only when
+    // conflict-free) replays the version's net overlay rows onto the live DEFAULT features table in one
+    // transaction and advances the generation through the existing change-tracking trigger.
     //
     // ADR-vs-reality note: ADR-0051 says post replays "via the shared IFeatureWriter". IFeatureWriter's
-    // Feature model cannot preserve a branch-created row's explicit objectid (CreateAsync auto-assigns) and
-    // round-trips attributes through a typed dictionary, so branch creates would lose their stable OID and
-    // JSONB fidelity. Post therefore replays the net overlay rows with direct parameterized SQL against the
-    // same base `features` table (and its change-tracking trigger), preserving objectid and the raw JSONB
-    // image, inside a single transaction. Read/edit still flow through the shared pipeline.
+    // Feature model cannot preserve a branch-created row's explicit objectid (CreateAsync auto-assigns)
+    // and round-trips attributes through a typed dictionary, so branch creates would lose their stable
+    // OID and JSONB fidelity. Post therefore replays the net overlay rows with direct parameterized SQL
+    // against the same base `features` table (and its change-tracking trigger), preserving objectid and
+    // the raw JSONB image, inside a single transaction. Read/edit still flow through the shared pipeline.
     //
     // Deferred (out of scope for this slice, see PR): the Redis-backed version lock + Honua.Jobs async
-    // execution wrapper, #371 auto-resolution policies, and durable #1287 ReplicaConflictRecord persistence.
-    // The reconcile/post engine here is synchronous; the job wrapper will later call it under a lock.
+    // execution wrapper (ADR-0051 / #1511). The reconcile/post engine here is synchronous; the job
+    // wrapper will later call it under a lock.
 
     /// <inheritdoc />
-    public async Task<VersionReconcileResult> ReconcileAsync(Guid versionId, CancellationToken cancellationToken = default)
+    public async Task<VersionReconcileResult> ReconcileAsync(
+        Guid versionId,
+        VersionReconcilePolicy policy = VersionReconcilePolicy.None,
+        CancellationToken cancellationToken = default)
     {
         var version = await LoadVersionAsync(versionId, cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Version {versionId} does not exist.");
@@ -38,16 +50,49 @@ internal sealed partial class PostgresVersionManager
         try
         {
             var currentGeneration = await GetCurrentGenerationAsync(cancellationToken).ConfigureAwait(false);
-            var conflicts = await DetectConflictsAsync(versionId, version.CommonAncestorGeneration, cancellationToken).ConfigureAwait(false);
+            var analysis = await AnalyzeOverlapsAsync(versionId, version.CommonAncestorGeneration, cancellationToken)
+                .ConfigureAwait(false);
 
-            if (conflicts.IsEmpty)
+            // Disjoint field-level edits auto-merge into the overlay so post carries both sides.
+            foreach (var merge in analysis.AutoMerges)
             {
-                // Clean reconcile: advance the merge base to the current DEFAULT generation.
-                await AdvanceCommonAncestorAsync(versionId, currentGeneration, cancellationToken).ConfigureAwait(false);
-                return new VersionReconcileResult(conflicts, CanPost: true, NewCommonAncestorGeneration: currentGeneration);
+                await ApplyFieldMergeAsync(versionId, merge, cancellationToken).ConfigureAwait(false);
             }
 
-            return new VersionReconcileResult(conflicts, CanPost: false, NewCommonAncestorGeneration: version.CommonAncestorGeneration);
+            var autoResolved = 0;
+            var unresolved = ImmutableArray.CreateBuilder<VersionReconcileConflict>();
+            foreach (var conflict in analysis.Conflicts)
+            {
+                if (policy != VersionReconcilePolicy.None &&
+                    await TryAutoResolveAsync(versionId, conflict, policy, cancellationToken).ConfigureAwait(false))
+                {
+                    autoResolved++;
+                    continue;
+                }
+
+                unresolved.Add(conflict.ToReport());
+            }
+
+            // Persist the unresolved set (manual review) and clear any stale pending rows that were
+            // auto-merged or auto-resolved this run, so inspect/post see the current pending set.
+            await PersistPendingConflictsAsync(versionId, unresolved, cancellationToken).ConfigureAwait(false);
+
+            if (unresolved.Count == 0)
+            {
+                // Clean (or fully auto-resolved) reconcile: advance the merge base to current DEFAULT.
+                await AdvanceCommonAncestorAsync(versionId, currentGeneration, cancellationToken).ConfigureAwait(false);
+                return new VersionReconcileResult(
+                    ImmutableArray<VersionReconcileConflict>.Empty,
+                    CanPost: true,
+                    NewCommonAncestorGeneration: currentGeneration,
+                    AutoResolvedCount: autoResolved);
+            }
+
+            return new VersionReconcileResult(
+                unresolved.ToImmutable(),
+                CanPost: false,
+                NewCommonAncestorGeneration: version.CommonAncestorGeneration,
+                AutoResolvedCount: autoResolved);
         }
         finally
         {
@@ -56,15 +101,73 @@ internal sealed partial class PostgresVersionManager
     }
 
     /// <inheritdoc />
+    public async Task<IReadOnlyList<VersionReconcileConflict>> GetPendingConflictsAsync(
+        Guid versionId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand("""
+            SELECT layer_id, objectid, conflict_type,
+                   base_attributes::text, default_attributes::text, version_attributes::text,
+                   base_geometry_wkt, default_geometry_wkt, version_geometry_wkt, field_diffs::text
+            FROM honua.version_conflicts
+            WHERE version_id = @version AND status = 0
+            ORDER BY layer_id, objectid
+            """, connection);
+        command.Parameters.AddWithValue("version", versionId);
+
+        var results = new List<VersionReconcileConflict>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var fieldDiffsJson = reader.IsDBNull(9) ? null : reader.GetString(9);
+            results.Add(new VersionReconcileConflict(
+                reader.GetInt32(0),
+                reader.GetInt64(1),
+                (ReplicaConflictType)reader.GetInt16(2),
+                BaseAttributesJson: reader.IsDBNull(3) ? null : reader.GetString(3),
+                DefaultAttributesJson: reader.IsDBNull(4) ? null : reader.GetString(4),
+                VersionAttributesJson: reader.IsDBNull(5) ? null : reader.GetString(5),
+                BaseGeometryWkt: reader.IsDBNull(6) ? null : reader.GetString(6),
+                DefaultGeometryWkt: reader.IsDBNull(7) ? null : reader.GetString(7),
+                VersionGeometryWkt: reader.IsDBNull(8) ? null : reader.GetString(8),
+                FieldDiffs: DeserializeFieldDiffs(fieldDiffsJson)));
+        }
+
+        return results;
+    }
+
+    /// <inheritdoc />
+    public async Task<VersionConflictResolutionResult> ResolveConflictsAsync(
+        Guid versionId,
+        IReadOnlyList<VersionConflictResolution> resolutions,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resolutions);
+
+        var resolved = 0;
+        foreach (var resolution in resolutions)
+        {
+            if (await ApplyManualResolutionAsync(versionId, resolution, cancellationToken).ConfigureAwait(false))
+            {
+                resolved++;
+            }
+        }
+
+        var remaining = await CountPendingConflictsAsync(versionId, cancellationToken).ConfigureAwait(false);
+        return new VersionConflictResolutionResult(resolved, remaining, CanPost: remaining == 0);
+    }
+
+    /// <inheritdoc />
     public async Task<VersionPostResult> PostAsync(Guid versionId, CancellationToken cancellationToken = default)
     {
         var version = await LoadVersionAsync(versionId, cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Version {versionId} does not exist.");
 
-        // Post is refused while unresolved conflicts remain since the merge base; the caller must
-        // reconcile clean first.
-        var conflicts = await DetectConflictsAsync(versionId, version.CommonAncestorGeneration, cancellationToken).ConfigureAwait(false);
-        if (!conflicts.IsEmpty)
+        // Post is refused while pending (unresolved) conflicts remain for the version; the caller must
+        // reconcile clean, auto-resolve via policy, or manually resolve first.
+        var pending = await CountPendingConflictsAsync(versionId, cancellationToken).ConfigureAwait(false);
+        if (pending > 0)
         {
             return new VersionPostResult(Posted: false, AppliedChanges: 0, ServerGeneration: 0, BlockedByConflicts: true);
         }
@@ -178,19 +281,23 @@ internal sealed partial class PostgresVersionManager
         return result is long gen ? gen : 0;
     }
 
-    private async Task<ImmutableArray<VersionReconcileConflict>> DetectConflictsAsync(
+    /// <summary>
+    /// Loads the three-way (base/DEFAULT/version) images for every overlay row that shadows an
+    /// (layer_id, objectid) DEFAULT also changed since the merge base, classifies each as a genuine
+    /// conflict or an auto-mergeable disjoint-field edit, and returns both sets.
+    /// </summary>
+    private async Task<OverlapAnalysis> AnalyzeOverlapsAsync(
         Guid versionId,
         long commonAncestorGen,
         CancellationToken cancellationToken)
     {
-        // Conflicts are (layer_id, objectid) pairs the branch shadows that DEFAULT also changed since the
-        // merge base. The classification pairs the branch overlay operation with the net DEFAULT operation:
-        //   DEFAULT delete + branch update  -> DeleteUpdate
-        //   branch delete  + DEFAULT update -> UpdateDelete
-        //   otherwise overlapping edit      -> Attribute (generic overlap; finer geometry/attribute
-        //                                      classification is owned by #371's policy layer).
+        var featuresTable = DatabaseSchema.GetFeaturesTableName(_schemaName);
         await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
-        await using var command = new NpgsqlCommand("""
+
+        // default_changes: the net DEFAULT operation per (layer_id, objectid) since the merge base.
+        // For each overlapping overlay row, join the live DEFAULT row (NULL when DEFAULT deleted it) and
+        // the branch's captured base image. Geometry is rendered to WKT for display only.
+        await using var command = new NpgsqlCommand($"""
             WITH default_changes AS (
                 SELECT layer_id, objectid,
                        (array_agg(operation ORDER BY generation DESC))[1] AS last_op
@@ -198,15 +305,24 @@ internal sealed partial class PostgresVersionManager
                 WHERE version_id IS NULL AND generation > @ancestor
                 GROUP BY layer_id, objectid
             )
-            SELECT ve.layer_id, ve.objectid, ve.operation AS branch_op, dc.last_op AS default_op
+            SELECT ve.layer_id, ve.objectid, ve.operation AS branch_op, dc.last_op AS default_op,
+                   ve.base_attributes::text   AS base_attrs,
+                   f.attributes::text         AS default_attrs,
+                   ve.attributes::text        AS version_attrs,
+                   ST_AsText(ve.base_geometry) AS base_geom,
+                   ST_AsText(f.geometry)       AS default_geom,
+                   ST_AsText(ve.geometry)      AS version_geom
             FROM honua.version_edits ve
             JOIN default_changes dc ON dc.layer_id = ve.layer_id AND dc.objectid = ve.objectid
+            LEFT JOIN {featuresTable} f ON f.layer_id = ve.layer_id AND f.objectid = ve.objectid
             WHERE ve.version_id = @version
             """, connection);
         command.Parameters.AddWithValue("ancestor", commonAncestorGen);
         command.Parameters.AddWithValue("version", versionId);
 
-        var conflicts = ImmutableArray.CreateBuilder<VersionReconcileConflict>();
+        var conflicts = new List<OverlapConflict>();
+        var merges = new List<FieldMerge>();
+
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -214,18 +330,314 @@ internal sealed partial class PostgresVersionManager
             var objectId = reader.GetInt64(1);
             var branchOp = reader.GetInt16(2);
             var defaultOp = reader.GetInt16(3);
+            var baseAttrs = reader.IsDBNull(4) ? null : reader.GetString(4);
+            var defaultAttrs = reader.IsDBNull(5) ? null : reader.GetString(5);
+            var versionAttrs = reader.IsDBNull(6) ? null : reader.GetString(6);
+            var baseGeom = reader.IsDBNull(7) ? null : reader.GetString(7);
+            var defaultGeom = reader.IsDBNull(8) ? null : reader.GetString(8);
+            var versionGeom = reader.IsDBNull(9) ? null : reader.GetString(9);
 
-            var type = (branchOp, defaultOp) switch
+            // Delete-vs-update pairs are always genuine conflicts.
+            if (branchOp == 2 && defaultOp == 3)
             {
-                (2, 3) => ReplicaConflictType.UpdateDelete,  // branch updated, DEFAULT deleted
-                (3, 2) => ReplicaConflictType.DeleteUpdate,  // branch deleted, DEFAULT updated
-                _ => ReplicaConflictType.Attribute,
-            };
+                conflicts.Add(new OverlapConflict(layerId, objectId, ReplicaConflictType.UpdateDelete,
+                    baseAttrs, defaultAttrs, versionAttrs, baseGeom, defaultGeom, versionGeom, ImmutableArray<VersionConflictFieldDiff>.Empty));
+                continue;
+            }
 
-            conflicts.Add(new VersionReconcileConflict(layerId, objectId, type));
+            if (branchOp == 3 && defaultOp == 2)
+            {
+                conflicts.Add(new OverlapConflict(layerId, objectId, ReplicaConflictType.DeleteUpdate,
+                    baseAttrs, defaultAttrs, versionAttrs, baseGeom, defaultGeom, versionGeom, ImmutableArray<VersionConflictFieldDiff>.Empty));
+                continue;
+            }
+
+            if (branchOp == 3 && defaultOp == 3)
+            {
+                // Both deleted the same row: a no-op convergence, not a conflict.
+                continue;
+            }
+
+            // Update-vs-update: compute the field-level diffs and decide overlap vs auto-merge.
+            var baseFields = ParseAttributes(baseAttrs);
+            var defaultFields = ParseAttributes(defaultAttrs);
+            var versionFields = ParseAttributes(versionAttrs);
+
+            var defaultChangedFields = ChangedFields(baseFields, defaultFields);
+            var versionChangedFields = ChangedFields(baseFields, versionFields);
+            var overlappingFields = defaultChangedFields.Intersect(versionChangedFields, StringComparer.Ordinal).ToArray();
+
+            var geometryChangedOnBoth = !string.Equals(baseGeom, defaultGeom, StringComparison.Ordinal)
+                && !string.Equals(baseGeom, versionGeom, StringComparison.Ordinal)
+                && !string.Equals(defaultGeom, versionGeom, StringComparison.Ordinal);
+
+            if (overlappingFields.Length == 0 && !geometryChangedOnBoth)
+            {
+                // Disjoint edits: auto-merge DEFAULT's field changes (and a DEFAULT-only geometry change)
+                // into the overlay so a post carries both sides without a conflict.
+                var defaultOnlyGeometryChanged =
+                    !string.Equals(baseGeom, defaultGeom, StringComparison.Ordinal)
+                    && string.Equals(baseGeom, versionGeom, StringComparison.Ordinal);
+                merges.Add(new FieldMerge(layerId, objectId, defaultChangedFields, defaultFields, defaultOnlyGeometryChanged));
+                continue;
+            }
+
+            var fieldDiffs = BuildFieldDiffs(overlappingFields, baseFields, defaultFields, versionFields);
+            var conflictType = overlappingFields.Length > 0
+                ? ReplicaConflictType.Attribute
+                : ReplicaConflictType.Geometry;
+            conflicts.Add(new OverlapConflict(layerId, objectId, conflictType,
+                baseAttrs, defaultAttrs, versionAttrs, baseGeom, defaultGeom, versionGeom, fieldDiffs));
         }
 
-        return conflicts.ToImmutable();
+        return new OverlapAnalysis(conflicts, merges);
+    }
+
+    /// <summary>
+    /// Auto-merges DEFAULT's disjoint field changes (and an optional DEFAULT-only geometry change) into
+    /// the branch overlay row so the subsequent post carries both sides of a non-conflicting edit.
+    /// </summary>
+    private async Task ApplyFieldMergeAsync(Guid versionId, FieldMerge merge, CancellationToken cancellationToken)
+    {
+        if (merge.DefaultChangedFields.Count == 0 && !merge.MergeDefaultGeometry)
+        {
+            return;
+        }
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        // Build the JSON patch of DEFAULT's changed fields and merge it onto the overlay attributes with
+        // the JSONB concat operator (||) — overlay keys win for any non-changed field, DEFAULT's changed
+        // fields are layered in. A field DEFAULT removed is rendered as a JSON null. A DEFAULT-only
+        // geometry change is copied from the live row.
+        var patchJson = BuildMergePatchJson(merge.DefaultChangedFields, merge.DefaultFields);
+        var geometryClause = merge.MergeDefaultGeometry
+            ? ", geometry = (SELECT f.geometry FROM " + DatabaseSchema.GetFeaturesTableName(_schemaName) +
+              " f WHERE f.layer_id = @layer AND f.objectid = @objectid)"
+            : string.Empty;
+
+        await using var command = new NpgsqlCommand(
+            "UPDATE honua.version_edits " +
+            "SET attributes = COALESCE(attributes, '{}'::jsonb) || @patch::jsonb, modified_at = now()" +
+            geometryClause + " " +
+            "WHERE version_id = @version AND layer_id = @layer AND objectid = @objectid",
+            connection);
+        command.Parameters.AddWithValue("patch", patchJson);
+        command.Parameters.AddWithValue("version", versionId);
+        command.Parameters.AddWithValue("layer", merge.LayerId);
+        command.Parameters.AddWithValue("objectid", merge.ObjectId);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deterministically resolves a single conflict per the supplied policy by rewriting the overlay row
+    /// to the winning side, so a subsequent post carries the resolved image. Returns false (leaving the
+    /// conflict for manual review) when a policy cannot be applied to the pairing.
+    /// </summary>
+    private async Task<bool> TryAutoResolveAsync(
+        Guid versionId,
+        OverlapConflict conflict,
+        VersionReconcilePolicy policy,
+        CancellationToken cancellationToken)
+    {
+        var side = policy switch
+        {
+            VersionReconcilePolicy.VersionWins => VersionConflictResolutionChoice.TakeVersion,
+            VersionReconcilePolicy.DefaultWins => VersionConflictResolutionChoice.TakeDefault,
+            VersionReconcilePolicy.LastWriteWins => await ResolveLastWriteWinsSideAsync(versionId, conflict, cancellationToken).ConfigureAwait(false),
+            _ => (VersionConflictResolutionChoice?)null,
+        };
+
+        if (side is null)
+        {
+            return false;
+        }
+
+        await ApplyResolutionToOverlayAsync(versionId, conflict.LayerId, conflict.ObjectId, side.Value, cancellationToken)
+            .ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves the last-write-wins side by comparing the latest change generation produced by the
+    /// branch overlay against the latest DEFAULT change generation for the feature since the merge base.
+    /// </summary>
+    private async Task<VersionConflictResolutionChoice> ResolveLastWriteWinsSideAsync(
+        Guid versionId,
+        OverlapConflict conflict,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand("""
+            SELECT
+                COALESCE((SELECT MAX(generation) FROM honua.feature_changes
+                          WHERE version_id = @version AND layer_id = @layer AND objectid = @objectid), 0) AS branch_gen,
+                COALESCE((SELECT MAX(generation) FROM honua.feature_changes
+                          WHERE version_id IS NULL AND layer_id = @layer AND objectid = @objectid), 0) AS default_gen
+            """, connection);
+        command.Parameters.AddWithValue("version", versionId);
+        command.Parameters.AddWithValue("layer", conflict.LayerId);
+        command.Parameters.AddWithValue("objectid", conflict.ObjectId);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+        var branchGen = reader.GetInt64(0);
+        var defaultGen = reader.GetInt64(1);
+
+        // The branch wins ties: an explicit branch edit is the more recent intentional change.
+        return branchGen >= defaultGen
+            ? VersionConflictResolutionChoice.TakeVersion
+            : VersionConflictResolutionChoice.TakeDefault;
+    }
+
+    /// <summary>
+    /// Applies one operator-submitted manual resolution: rewrites the overlay row to the chosen side and
+    /// marks the persisted pending conflict resolved. Returns false when there was no pending conflict.
+    /// </summary>
+    private async Task<bool> ApplyManualResolutionAsync(
+        Guid versionId,
+        VersionConflictResolution resolution,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var markCommand = new NpgsqlCommand("""
+            UPDATE honua.version_conflicts
+            SET status = 1, resolution_choice = @choice, resolved_at = now()
+            WHERE version_id = @version AND layer_id = @layer AND objectid = @objectid AND status = 0
+            """, connection);
+        markCommand.Parameters.AddWithValue("choice", (short)resolution.Choice);
+        markCommand.Parameters.AddWithValue("version", versionId);
+        markCommand.Parameters.AddWithValue("layer", resolution.LayerId);
+        markCommand.Parameters.AddWithValue("objectid", resolution.ObjectId);
+        var affected = await markCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        if (affected == 0)
+        {
+            return false;
+        }
+
+        await ApplyResolutionToOverlayAsync(versionId, resolution.LayerId, resolution.ObjectId, resolution.Choice, cancellationToken)
+            .ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>
+    /// Rewrites the branch overlay row for the resolved feature so the post replays the chosen side:
+    /// take-version keeps the overlay as-is; take-default rewrites the overlay to the live DEFAULT image
+    /// (or removes the overlay row when DEFAULT deleted it); take-base rewrites to the captured base
+    /// image. All keep the overlay-mediated post path so DEFAULT data is untouched until post.
+    /// </summary>
+    private async Task ApplyResolutionToOverlayAsync(
+        Guid versionId,
+        int layerId,
+        long objectId,
+        VersionConflictResolutionChoice choice,
+        CancellationToken cancellationToken)
+    {
+        if (choice == VersionConflictResolutionChoice.TakeVersion)
+        {
+            // The branch overlay already carries the version image; nothing to rewrite.
+            return;
+        }
+
+        var featuresTable = DatabaseSchema.GetFeaturesTableName(_schemaName);
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        if (choice == VersionConflictResolutionChoice.TakeDefault)
+        {
+            // Take DEFAULT: if DEFAULT still has the row, set the overlay to an UPDATE carrying DEFAULT's
+            // image (a no-op post against DEFAULT); if DEFAULT deleted it, drop the overlay row so the
+            // branch no longer shadows/posts the feature.
+            await using var command = new NpgsqlCommand($"""
+                WITH d AS (
+                    SELECT geometry, attributes FROM {featuresTable}
+                    WHERE layer_id = @layer AND objectid = @objectid
+                ),
+                upd AS (
+                    UPDATE honua.version_edits ve
+                    SET operation = 2, geometry = d.geometry, attributes = d.attributes, modified_at = now()
+                    FROM d
+                    WHERE ve.version_id = @version AND ve.layer_id = @layer AND ve.objectid = @objectid
+                    RETURNING 1
+                )
+                DELETE FROM honua.version_edits ve
+                WHERE ve.version_id = @version AND ve.layer_id = @layer AND ve.objectid = @objectid
+                  AND NOT EXISTS (SELECT 1 FROM d)
+                """, connection);
+            command.Parameters.AddWithValue("version", versionId);
+            command.Parameters.AddWithValue("layer", layerId);
+            command.Parameters.AddWithValue("objectid", objectId);
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        // TakeBase: rewrite the overlay to the captured base image (an UPDATE that restores the
+        // common-ancestor state on post).
+        await using var baseCommand = new NpgsqlCommand("""
+            UPDATE honua.version_edits
+            SET operation = 2, geometry = base_geometry, attributes = base_attributes, modified_at = now()
+            WHERE version_id = @version AND layer_id = @layer AND objectid = @objectid
+            """, connection);
+        baseCommand.Parameters.AddWithValue("version", versionId);
+        baseCommand.Parameters.AddWithValue("layer", layerId);
+        baseCommand.Parameters.AddWithValue("objectid", objectId);
+        await baseCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Replaces the version's persisted pending conflict set with the supplied unresolved conflicts:
+    /// clears stale pending rows (auto-merged / auto-resolved this run) and inserts the current set.
+    /// </summary>
+    private async Task PersistPendingConflictsAsync(
+        Guid versionId,
+        IReadOnlyCollection<VersionReconcileConflict> conflicts,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        await using (var clear = new NpgsqlCommand(
+            "DELETE FROM honua.version_conflicts WHERE version_id = @version AND status = 0", connection))
+        {
+            clear.Parameters.AddWithValue("version", versionId);
+            await clear.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        foreach (var conflict in conflicts)
+        {
+            await using var insert = new NpgsqlCommand("""
+                INSERT INTO honua.version_conflicts
+                    (version_id, layer_id, objectid, conflict_type, status,
+                     base_attributes, default_attributes, version_attributes,
+                     base_geometry_wkt, default_geometry_wkt, version_geometry_wkt, field_diffs)
+                VALUES (@version, @layer, @objectid, @type, 0,
+                        @base_attrs::jsonb, @default_attrs::jsonb, @version_attrs::jsonb,
+                        @base_geom, @default_geom, @version_geom, @field_diffs::jsonb)
+                """, connection);
+            insert.Parameters.AddWithValue("version", versionId);
+            insert.Parameters.AddWithValue("layer", conflict.LayerId);
+            insert.Parameters.AddWithValue("objectid", conflict.ObjectId);
+            insert.Parameters.AddWithValue("type", (short)conflict.ConflictType);
+            insert.Parameters.AddWithValue("base_attrs", (object?)conflict.BaseAttributesJson ?? DBNull.Value);
+            insert.Parameters.AddWithValue("default_attrs", (object?)conflict.DefaultAttributesJson ?? DBNull.Value);
+            insert.Parameters.AddWithValue("version_attrs", (object?)conflict.VersionAttributesJson ?? DBNull.Value);
+            insert.Parameters.AddWithValue("base_geom", (object?)conflict.BaseGeometryWkt ?? DBNull.Value);
+            insert.Parameters.AddWithValue("default_geom", (object?)conflict.DefaultGeometryWkt ?? DBNull.Value);
+            insert.Parameters.AddWithValue("version_geom", (object?)conflict.VersionGeometryWkt ?? DBNull.Value);
+            var fieldDiffsJson = conflict.FieldDiffs.IsDefaultOrEmpty
+                ? null
+                : JsonSerializer.Serialize(conflict.FieldDiffs.ToArray(), VersionConflictJson.FieldDiffArray);
+            insert.Parameters.AddWithValue("field_diffs", (object?)fieldDiffsJson ?? DBNull.Value);
+            await insert.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<int> CountPendingConflictsAsync(Guid versionId, CancellationToken cancellationToken)
+    {
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(
+            "SELECT COUNT(*) FROM honua.version_conflicts WHERE version_id = @version AND status = 0", connection);
+        command.Parameters.AddWithValue("version", versionId);
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return result is long count ? (int)count : 0;
     }
 
     private async Task AdvanceCommonAncestorAsync(Guid versionId, long generation, CancellationToken cancellationToken)
@@ -249,4 +661,169 @@ internal sealed partial class PostgresVersionManager
         await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    // ---- Field-level diff helpers --------------------------------------------------------------
+
+    private static ImmutableDictionary<string, JsonElement> ParseAttributes(string? attributesJson)
+    {
+        if (string.IsNullOrWhiteSpace(attributesJson))
+        {
+            return ImmutableDictionary<string, JsonElement>.Empty;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(attributesJson);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return ImmutableDictionary<string, JsonElement>.Empty;
+            }
+
+            var builder = ImmutableDictionary.CreateBuilder<string, JsonElement>(StringComparer.Ordinal);
+            foreach (var property in document.RootElement.EnumerateObject())
+            {
+                builder[property.Name] = property.Value.Clone();
+            }
+
+            return builder.ToImmutable();
+        }
+        catch (JsonException)
+        {
+            return ImmutableDictionary<string, JsonElement>.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Returns the set of attribute names whose value differs between the base image and a target image
+    /// (added, removed, or value-changed keys), compared by canonical JSON text.
+    /// </summary>
+    private static HashSet<string> ChangedFields(
+        ImmutableDictionary<string, JsonElement> baseFields,
+        ImmutableDictionary<string, JsonElement> targetFields)
+    {
+        var changed = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var key in baseFields.Keys.Union(targetFields.Keys, StringComparer.Ordinal))
+        {
+            var hasBase = baseFields.TryGetValue(key, out var baseValue);
+            var hasTarget = targetFields.TryGetValue(key, out var targetValue);
+            if (hasBase != hasTarget || (hasBase && hasTarget && !ElementsEqual(baseValue, targetValue)))
+            {
+                changed.Add(key);
+            }
+        }
+
+        return changed;
+    }
+
+    private static bool ElementsEqual(JsonElement left, JsonElement right)
+        => string.Equals(left.GetRawText(), right.GetRawText(), StringComparison.Ordinal);
+
+    private static ImmutableArray<VersionConflictFieldDiff> BuildFieldDiffs(
+        string[] fields,
+        ImmutableDictionary<string, JsonElement> baseFields,
+        ImmutableDictionary<string, JsonElement> defaultFields,
+        ImmutableDictionary<string, JsonElement> versionFields)
+    {
+        if (fields.Length == 0)
+        {
+            return ImmutableArray<VersionConflictFieldDiff>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<VersionConflictFieldDiff>(fields.Length);
+        foreach (var name in fields.OrderBy(n => n, StringComparer.Ordinal))
+        {
+            builder.Add(new VersionConflictFieldDiff(
+                name,
+                Render(baseFields, name),
+                Render(defaultFields, name),
+                Render(versionFields, name)));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static string? Render(ImmutableDictionary<string, JsonElement> fields, string name)
+        => fields.TryGetValue(name, out var value) ? value.GetRawText() : null;
+
+    /// <summary>
+    /// Builds a JSON object literal of DEFAULT's changed fields for the JSONB merge patch, rendering a
+    /// field DEFAULT removed as a JSON null. Values are emitted from their raw JSON text so the merged
+    /// value preserves DEFAULT's original JSON shape (numbers, strings, nested objects).
+    /// </summary>
+    private static string BuildMergePatchJson(
+        IReadOnlyCollection<string> changedFields,
+        ImmutableDictionary<string, JsonElement> defaultFields)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            foreach (var field in changedFields)
+            {
+                writer.WritePropertyName(field);
+                if (defaultFields.TryGetValue(field, out var value))
+                {
+                    value.WriteTo(writer);
+                }
+                else
+                {
+                    writer.WriteNullValue();
+                }
+            }
+
+            writer.WriteEndObject();
+        }
+
+        return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static ImmutableArray<VersionConflictFieldDiff> DeserializeFieldDiffs(string? fieldDiffsJson)
+    {
+        if (string.IsNullOrWhiteSpace(fieldDiffsJson))
+        {
+            return ImmutableArray<VersionConflictFieldDiff>.Empty;
+        }
+
+        var array = JsonSerializer.Deserialize(fieldDiffsJson, VersionConflictJson.FieldDiffArray);
+        return array is null or { Length: 0 }
+            ? ImmutableArray<VersionConflictFieldDiff>.Empty
+            : ImmutableArray.Create(array);
+    }
+
+    // ---- Internal analysis types ---------------------------------------------------------------
+
+    private sealed record OverlapAnalysis(
+        IReadOnlyList<OverlapConflict> Conflicts,
+        IReadOnlyList<FieldMerge> AutoMerges);
+
+    private sealed record OverlapConflict(
+        int LayerId,
+        long ObjectId,
+        ReplicaConflictType ConflictType,
+        string? BaseAttributesJson,
+        string? DefaultAttributesJson,
+        string? VersionAttributesJson,
+        string? BaseGeometryWkt,
+        string? DefaultGeometryWkt,
+        string? VersionGeometryWkt,
+        ImmutableArray<VersionConflictFieldDiff> FieldDiffs)
+    {
+        public VersionReconcileConflict ToReport() => new(
+            LayerId,
+            ObjectId,
+            ConflictType,
+            BaseAttributesJson,
+            DefaultAttributesJson,
+            VersionAttributesJson,
+            BaseGeometryWkt,
+            DefaultGeometryWkt,
+            VersionGeometryWkt,
+            FieldDiffs);
+    }
+
+    private sealed record FieldMerge(
+        int LayerId,
+        long ObjectId,
+        IReadOnlyCollection<string> DefaultChangedFields,
+        ImmutableDictionary<string, JsonElement> DefaultFields,
+        bool MergeDefaultGeometry);
 }

--- a/src/Honua.Postgres/Features/FeatureStore/Services/VersionConflictJson.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/VersionConflictJson.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Postgres.Features.FeatureStore.Services;
+
+/// <summary>
+/// Source-generated JSON contract used by the branch-version conflict-resolution layer (#371) to
+/// persist and read back the per-field three-way diff payload. AOT-safe and kept internal to the
+/// Postgres versioning slice.
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(VersionConflictFieldDiff[]))]
+internal sealed partial class VersionConflictJsonContext : JsonSerializerContext;
+
+/// <summary>
+/// Convenience accessor for the <see cref="VersionConflictJsonContext"/> type info.
+/// </summary>
+internal static class VersionConflictJson
+{
+    /// <summary>Type info for the persisted per-field three-way diff array.</summary>
+    public static JsonTypeInfo<VersionConflictFieldDiff[]> FieldDiffArray =>
+        VersionConflictJsonContext.Default.VersionConflictFieldDiffArray;
+}

--- a/src/Honua.Protocols.GeoServices/VersionManagementServer/Models/VersionManagementJsonContext.cs
+++ b/src/Honua.Protocols.GeoServices/VersionManagementServer/Models/VersionManagementJsonContext.cs
@@ -19,8 +19,12 @@ namespace Honua.Protocols.GeoServices.VersionManagementServer.Models;
 [JsonSerializable(typeof(VersionListResponse))]
 [JsonSerializable(typeof(CreateVersionResponse))]
 [JsonSerializable(typeof(VersionMomentResponse))]
+[JsonSerializable(typeof(VersionConflictFieldDiffInfo))]
+[JsonSerializable(typeof(VersionConflictFieldDiffInfo[]))]
 [JsonSerializable(typeof(VersionConflictInfo))]
 [JsonSerializable(typeof(VersionConflictInfo[]))]
 [JsonSerializable(typeof(ReconcileResponse))]
+[JsonSerializable(typeof(InspectConflictsResponse))]
+[JsonSerializable(typeof(ResolveConflictsResponse))]
 [JsonSerializable(typeof(PostResponse))]
 internal sealed partial class VersionManagementJsonContext : System.Text.Json.Serialization.JsonSerializerContext;

--- a/src/Honua.Protocols.GeoServices/VersionManagementServer/Models/VersionManagementModels.cs
+++ b/src/Honua.Protocols.GeoServices/VersionManagementServer/Models/VersionManagementModels.cs
@@ -90,8 +90,30 @@ public sealed class VersionMomentResponse
 }
 
 /// <summary>
-/// Esri-shaped conflict descriptor returned by <c>reconcile</c> when version edits collide with
-/// DEFAULT edits made since the merge base.
+/// A single field-level three-way diff for a conflicting feature, surfaced so a client/UI can show the
+/// base/DEFAULT/version values side by side for one attribute (#371).
+/// </summary>
+public sealed class VersionConflictFieldDiffInfo
+{
+    /// <summary>Attribute name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Common-ancestor (base) value rendered as JSON text, or null when absent.</summary>
+    public string? Base { get; init; }
+
+    /// <summary>DEFAULT (target) value rendered as JSON text, or null when absent.</summary>
+    public string? Default { get; init; }
+
+    /// <summary>Branch (version) value rendered as JSON text, or null when absent.</summary>
+    public string? Version { get; init; }
+}
+
+/// <summary>
+/// Esri-shaped conflict descriptor returned by <c>reconcile</c>/<c>inspectConflicts</c> when version
+/// edits collide with DEFAULT edits made since the merge base. Carries the three-way base/DEFAULT/
+/// version feature images plus per-field diffs so a conflict-resolution UI can render a before/after/
+/// base view (#371). Image fields are opaque JSON (attributes) and WKT (geometry) and never carry SQL,
+/// connection details, or provider internals.
 /// </summary>
 public sealed class VersionConflictInfo
 {
@@ -103,6 +125,27 @@ public sealed class VersionConflictInfo
 
     /// <summary>Conflict classification (attribute, geometry, deleteUpdate, updateDelete, ...).</summary>
     public required string ConflictType { get; init; }
+
+    /// <summary>Common-ancestor (base) attribute image as JSON text, or null when unknown.</summary>
+    public string? BaseAttributes { get; init; }
+
+    /// <summary>DEFAULT (target) attribute image as JSON text, or null when the row was deleted.</summary>
+    public string? DefaultAttributes { get; init; }
+
+    /// <summary>Branch (version) attribute image as JSON text, or null when the row was deleted.</summary>
+    public string? VersionAttributes { get; init; }
+
+    /// <summary>Common-ancestor (base) geometry as WKT, or null when absent.</summary>
+    public string? BaseGeometry { get; init; }
+
+    /// <summary>DEFAULT (target) geometry as WKT, or null when absent/deleted.</summary>
+    public string? DefaultGeometry { get; init; }
+
+    /// <summary>Branch (version) geometry as WKT, or null when absent/deleted.</summary>
+    public string? VersionGeometry { get; init; }
+
+    /// <summary>Per-field three-way diffs for the overlapping fields that made this a conflict.</summary>
+    public VersionConflictFieldDiffInfo[] FieldDiffs { get; init; } = [];
 }
 
 /// <summary>
@@ -116,11 +159,48 @@ public sealed class ReconcileResponse
     /// <summary>True when the reconcile detected unresolved conflicts that block <c>post</c>.</summary>
     public bool HasConflicts { get; init; }
 
-    /// <summary>True when the version reconciled cleanly and may be posted.</summary>
+    /// <summary>True when the version reconciled cleanly (or was auto-resolved) and may be posted.</summary>
     public bool CanPost { get; init; }
+
+    /// <summary>Number of conflicts the supplied auto-resolution policy resolved.</summary>
+    public int AutoResolvedCount { get; init; }
 
     /// <summary>Unresolved conflicts; non-empty blocks post.</summary>
     public VersionConflictInfo[] Conflicts { get; init; } = [];
+}
+
+/// <summary>
+/// Response for the <c>inspectConflicts</c> operation: the current pending conflict set for a version
+/// with the three-way images for a manual-resolution UI (#371).
+/// </summary>
+public sealed class InspectConflictsResponse
+{
+    /// <summary>Always true on success.</summary>
+    public bool Success { get; init; } = true;
+
+    /// <summary>True when there are pending conflicts blocking post.</summary>
+    public bool HasConflicts { get; init; }
+
+    /// <summary>The pending conflicts.</summary>
+    public VersionConflictInfo[] Conflicts { get; init; } = [];
+}
+
+/// <summary>
+/// Response for the <c>resolveConflicts</c> operation: the outcome of applying manual resolutions (#371).
+/// </summary>
+public sealed class ResolveConflictsResponse
+{
+    /// <summary>Always true on success.</summary>
+    public bool Success { get; init; } = true;
+
+    /// <summary>Number of conflicts transitioned to resolved by this call.</summary>
+    public int Resolved { get; init; }
+
+    /// <summary>Number of pending conflicts still blocking post after this call.</summary>
+    public int Remaining { get; init; }
+
+    /// <summary>True when no pending conflicts remain and the version may be posted.</summary>
+    public bool CanPost { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Protocols.GeoServices/VersionManagementServer/VersionManagementServerEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/VersionManagementServer/VersionManagementServerEndpoints.cs
@@ -111,6 +111,16 @@ public static class VersionManagementServerEndpoints
             .WithSummary("Reconcile a branch version against DEFAULT")
             .WithTags(Tag);
 
+        endpoints.MapGet($"{BasePath}/versions/{{versionGuid}}/inspectConflicts", HandleInspectConflicts)
+            .WithName("InspectVersionConflicts")
+            .WithSummary("Retrieve the pending conflict set for a branch version")
+            .WithTags(Tag);
+
+        endpoints.MapPost($"{BasePath}/versions/{{versionGuid}}/resolveConflicts", HandleResolveConflicts)
+            .WithName("ResolveVersionConflicts")
+            .WithSummary("Submit manual conflict resolutions for a branch version")
+            .WithTags(Tag);
+
         endpoints.MapPost($"{BasePath}/versions/{{versionGuid}}/post", HandlePost)
             .WithName("PostVersion")
             .WithSummary("Post a reconciled branch version's changes onto DEFAULT")
@@ -326,24 +336,112 @@ public static class VersionManagementServerEndpoints
         [FromServices] IVersionManager versionManager,
         CancellationToken cancellationToken)
     {
-        var (gate, _, versionId) = await AuthorizeReadAndResolveVersionAsync(
+        var (gate, values, versionId) = await AuthorizeReadAndResolveVersionAsync(
             serviceId, versionGuid, context, versionManager, cancellationToken).ConfigureAwait(false);
         if (gate is not null)
         {
             return gate;
         }
 
-        var result = await versionManager.ReconcileAsync(versionId, cancellationToken).ConfigureAwait(false);
+        var (policy, policyError) = ParseReconcilePolicy(context, values!);
+        if (policyError is not null)
+        {
+            return policyError;
+        }
+
+        var result = await versionManager.ReconcileAsync(versionId, policy, cancellationToken).ConfigureAwait(false);
         var response = new ReconcileResponse
         {
             HasConflicts = !result.Conflicts.IsDefaultOrEmpty && result.Conflicts.Length > 0,
             CanPost = result.CanPost,
+            AutoResolvedCount = result.AutoResolvedCount,
             Conflicts = result.Conflicts.IsDefaultOrEmpty
                 ? []
                 : result.Conflicts.Select(ToConflictInfo).ToArray(),
         };
 
         return Results.Json(response, VersionManagementJsonContext.Default.ReconcileResponse,
+            contentType: "application/json");
+    }
+
+    private static async Task<IResult> HandleInspectConflicts(
+        string serviceId,
+        string versionGuid,
+        HttpContext context,
+        [FromServices] IResourceValidator resourceValidator,
+        [FromServices] IVersionManager versionManager,
+        CancellationToken cancellationToken)
+    {
+        // Read-only review surface: gate on the entitlement + service validation, but no write auth and
+        // no request body (GET). Resolve the version directly.
+        var problem = await ValidateServiceAsync(serviceId, context, resourceValidator, cancellationToken)
+            .ConfigureAwait(false);
+        if (problem is not null)
+        {
+            return problem;
+        }
+
+        var entitlementGate = LicenseGate.RequireEntitlement(
+            context, FeatureCatalog.BranchVersioningKey, "Branch versioning");
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
+
+        if (!versionManager.SupportsVersioning)
+        {
+            return StandardErrorHelpers.CreateNotImplemented(
+                context,
+                "Branch versioning is not supported by the configured data provider.",
+                ["Branch versioning requires a PostgreSQL/PostGIS feature provider."]);
+        }
+
+        if (!Guid.TryParse(versionGuid, out var versionId))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "versionGuid is not a valid GUID.");
+        }
+
+        var conflicts = await versionManager.GetPendingConflictsAsync(versionId, cancellationToken).ConfigureAwait(false);
+        var response = new InspectConflictsResponse
+        {
+            HasConflicts = conflicts.Count > 0,
+            Conflicts = conflicts.Select(ToConflictInfo).ToArray(),
+        };
+
+        return Results.Json(response, VersionManagementJsonContext.Default.InspectConflictsResponse,
+            contentType: "application/json");
+    }
+
+    private static async Task<IResult> HandleResolveConflicts(
+        string serviceId,
+        string versionGuid,
+        HttpContext context,
+        [FromServices] IVersionManager versionManager,
+        CancellationToken cancellationToken)
+    {
+        var (gate, values, versionId) = await AuthorizeReadAndResolveVersionAsync(
+            serviceId, versionGuid, context, versionManager, cancellationToken).ConfigureAwait(false);
+        if (gate is not null)
+        {
+            return gate;
+        }
+
+        var (resolutions, parseError) = ParseResolutions(context, values!);
+        if (parseError is not null)
+        {
+            return parseError;
+        }
+
+        var result = await versionManager.ResolveConflictsAsync(versionId, resolutions!, cancellationToken)
+            .ConfigureAwait(false);
+        var response = new ResolveConflictsResponse
+        {
+            Resolved = result.Resolved,
+            Remaining = result.Remaining,
+            CanPost = result.CanPost,
+        };
+
+        return Results.Json(response, VersionManagementJsonContext.Default.ResolveConflictsResponse,
             contentType: "application/json");
     }
 
@@ -530,7 +628,141 @@ public static class VersionManagementServerEndpoints
         LayerId = conflict.LayerId,
         ObjectId = conflict.ObjectId,
         ConflictType = ConflictTypeToString(conflict.ConflictType),
+        BaseAttributes = conflict.BaseAttributesJson,
+        DefaultAttributes = conflict.DefaultAttributesJson,
+        VersionAttributes = conflict.VersionAttributesJson,
+        BaseGeometry = conflict.BaseGeometryWkt,
+        DefaultGeometry = conflict.DefaultGeometryWkt,
+        VersionGeometry = conflict.VersionGeometryWkt,
+        FieldDiffs = conflict.FieldDiffs.IsDefaultOrEmpty
+            ? []
+            : conflict.FieldDiffs.Select(d => new VersionConflictFieldDiffInfo
+            {
+                Name = d.Name,
+                Base = d.Base,
+                Default = d.Default,
+                Version = d.Version,
+            }).ToArray(),
     };
+
+    /// <summary>
+    /// Parses the reconcile auto-resolution policy from the request. Accepts Honua's named policies
+    /// (<c>none</c>/<c>lastWriteWins</c>/<c>versionWins</c>/<c>defaultWins</c>) on a <c>conflictResolution</c>
+    /// (or <c>resolutionPolicy</c>) parameter, and maps the Esri-style <c>abortIfConflicts</c> flag to
+    /// the manual (none) policy when set. Absent or empty resolves to <see cref="VersionReconcilePolicy.None"/>.
+    /// </summary>
+    private static (VersionReconcilePolicy Policy, IResult? Error) ParseReconcilePolicy(
+        HttpContext context,
+        IReadOnlyDictionary<string, StringValues> values)
+    {
+        var raw = GeoServicesRequestValueHelpers.GetValueString(values, "conflictResolution")
+            ?? GeoServicesRequestValueHelpers.GetValueString(values, "resolutionPolicy");
+
+        // abortIfConflicts=true is Esri's "do not auto-resolve" intent; force manual review.
+        var abortRaw = GeoServicesRequestValueHelpers.GetValueString(values, "abortIfConflicts");
+        if (string.Equals(abortRaw?.Trim(), "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return (VersionReconcilePolicy.None, null);
+        }
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return (VersionReconcilePolicy.None, null);
+        }
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "none" or "manual" => (VersionReconcilePolicy.None, null),
+            "lastwritewins" or "last-write-wins" => (VersionReconcilePolicy.LastWriteWins, null),
+            "versionwins" or "version-wins" or "favoreditversion" => (VersionReconcilePolicy.VersionWins, null),
+            "defaultwins" or "default-wins" or "favortargetversion" => (VersionReconcilePolicy.DefaultWins, null),
+            _ => (VersionReconcilePolicy.None, StandardErrorHelpers.CreateBadRequest(
+                context,
+                "Unsupported conflictResolution policy.",
+                ["Supported policies: none, lastWriteWins, versionWins, defaultWins."])),
+        };
+    }
+
+    /// <summary>
+    /// Parses the per-feature resolution choices from the <c>conflicts</c> JSON-array parameter. Each
+    /// element is <c>{ "layerId": int, "objectId": long, "choice": "version|default|base" }</c>.
+    /// </summary>
+    private static (IReadOnlyList<VersionConflictResolution>? Resolutions, IResult? Error) ParseResolutions(
+        HttpContext context,
+        IReadOnlyDictionary<string, StringValues> values)
+    {
+        var raw = GeoServicesRequestValueHelpers.GetValueString(values, "conflicts")
+            ?? GeoServicesRequestValueHelpers.GetValueString(values, "resolutions");
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return (null, StandardErrorHelpers.CreateBadRequest(
+                context, "conflicts parameter is required.",
+                ["Provide a JSON array of { layerId, objectId, choice } resolution objects."]));
+        }
+
+        try
+        {
+            using var document = System.Text.Json.JsonDocument.Parse(raw);
+            if (document.RootElement.ValueKind != System.Text.Json.JsonValueKind.Array)
+            {
+                return (null, StandardErrorHelpers.CreateBadRequest(context, "conflicts must be a JSON array."));
+            }
+
+            var resolutions = new List<VersionConflictResolution>();
+            foreach (var element in document.RootElement.EnumerateArray())
+            {
+                if (!element.TryGetProperty("layerId", out var layerProp) ||
+                    !element.TryGetProperty("objectId", out var objectProp) ||
+                    !element.TryGetProperty("choice", out var choiceProp))
+                {
+                    return (null, StandardErrorHelpers.CreateBadRequest(
+                        context, "Each conflict resolution requires layerId, objectId, and choice."));
+                }
+
+                if (!TryParseChoice(choiceProp.GetString(), out var choice))
+                {
+                    return (null, StandardErrorHelpers.CreateBadRequest(
+                        context, "Unsupported resolution choice.",
+                        ["Supported choices: version, default, base."]));
+                }
+
+                resolutions.Add(new VersionConflictResolution(
+                    layerProp.GetInt32(), objectProp.GetInt64(), choice));
+            }
+
+            return (resolutions, null);
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return (null, StandardErrorHelpers.CreateBadRequest(context, "conflicts is not valid JSON."));
+        }
+        catch (FormatException)
+        {
+            return (null, StandardErrorHelpers.CreateBadRequest(context, "conflicts contains an invalid layerId/objectId."));
+        }
+    }
+
+    private static bool TryParseChoice(string? raw, out VersionConflictResolutionChoice choice)
+    {
+        switch (raw?.Trim().ToLowerInvariant())
+        {
+            case "version":
+            case "takeversion":
+                choice = VersionConflictResolutionChoice.TakeVersion;
+                return true;
+            case "default":
+            case "takedefault":
+                choice = VersionConflictResolutionChoice.TakeDefault;
+                return true;
+            case "base":
+            case "takebase":
+                choice = VersionConflictResolutionChoice.TakeBase;
+                return true;
+            default:
+                choice = VersionConflictResolutionChoice.TakeVersion;
+                return false;
+        }
+    }
 
     private static string ConflictTypeToString(ReplicaConflictType type) => type switch
     {

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -663,6 +663,8 @@ public static class EndpointRegistry
         new("POST", "/rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/startEditing"),
         new("POST", "/rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/stopEditing"),
         new("POST", "/rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/reconcile"),
+        new("GET", "/rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/inspectConflicts"),
+        new("POST", "/rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/resolveConflicts"),
         new("POST", "/rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/post"),
         new("POST", "/rest/services/{serviceId}/FeatureServer/append"),
         new("POST", "/rest/services/{serviceId}/FeatureServer/{layerId}/append"),

--- a/src/Honua.Server/Migrations/054_CreateVersionConflicts.sql
+++ b/src/Honua.Server/Migrations/054_CreateVersionConflicts.sql
@@ -1,0 +1,71 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration: 054_CreateVersionConflicts.sql
+-- Description: Durable persistence for branch-version reconcile conflicts and their manual
+--              resolution state (#371). When a reconcile detects genuinely-overlapping edits between
+--              a branch version and DEFAULT since the merge base, it persists one pending row per
+--              conflicting (version_id, layer_id, objectid) here, carrying the three-way
+--              base/DEFAULT/version images (JSON attributes + WKT geometry) so a manual-resolution UI
+--              can render a before/after/base diff after the synchronous reconcile call returns. An
+--              operator resolution (take version / take default / take base) clears the pending row;
+--              post is blocked while any pending row remains for the version. This migration is
+--              additive and completely inert for DEFAULT (no DEFAULT read/write path touches this
+--              table), so existing replication/change-tracking and CITE paths stay byte-identical.
+-- Dependencies: Requires honua.gdb_versions (047).
+
+-- One pending conflict per (version_id, layer_id, objectid). The three-way images are opaque
+-- pre-serialized JSON/WKT so the review surface stays decoupled from the physical feature schema and
+-- the payload never carries SQL, connection details, or provider internals. conflict_type mirrors the
+-- ReplicaConflictType ordinal taxonomy (0=Attribute,1=Geometry,2=DeleteUpdate,3=UpdateDelete,...).
+CREATE TABLE IF NOT EXISTS honua.version_conflicts (
+    conflict_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    version_id UUID NOT NULL REFERENCES honua.gdb_versions(version_id) ON DELETE CASCADE,
+    layer_id INT NOT NULL,
+    objectid BIGINT NOT NULL,
+    -- Conflict classification (ReplicaConflictType ordinal).
+    conflict_type SMALLINT NOT NULL,
+    -- Lifecycle status: 0=pending, 1=resolved (mirrors ReplicaConflictStatus pending/resolved).
+    status SMALLINT NOT NULL DEFAULT 0,
+    -- Three-way images captured at reconcile time. attributes are JSONB; geometry is rendered to WKT
+    -- text (display/diff only — post replays from the live overlay, not from these images).
+    base_attributes JSONB,
+    default_attributes JSONB,
+    version_attributes JSONB,
+    base_geometry_wkt TEXT,
+    default_geometry_wkt TEXT,
+    version_geometry_wkt TEXT,
+    -- Per-field three-way diffs for the overlapping fields (JSON array of {name,base,default,version}).
+    field_diffs JSONB,
+    -- Resolution choice once resolved: 0=take version, 1=take default, 2=take base (NULL while pending).
+    resolution_choice SMALLINT,
+    resolved_by TEXT,
+    detected_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    resolved_at TIMESTAMPTZ,
+    CONSTRAINT version_conflicts_valid_status CHECK(status IN (0, 1)),
+    CONSTRAINT version_conflicts_valid_resolution CHECK(resolution_choice IS NULL OR resolution_choice IN (0, 1, 2))
+);
+
+-- At most one pending conflict per (version_id, layer_id, objectid): a re-reconcile refreshes the
+-- existing pending row rather than accumulating duplicates. Resolved rows are retained as audit
+-- evidence and are excluded from this partial unique index.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_version_conflicts_pending_feature
+    ON honua.version_conflicts(version_id, layer_id, objectid)
+    WHERE status = 0;
+
+-- Pending-conflict lookups for inspect/resolve and the post block check.
+CREATE INDEX IF NOT EXISTS idx_version_conflicts_version_status
+    ON honua.version_conflicts(version_id, status);
+
+COMMENT ON TABLE honua.version_conflicts IS
+    'Durable branch-version reconcile conflicts + manual resolution state; inert for DEFAULT (#371)';
+COMMENT ON COLUMN honua.version_conflicts.version_id IS 'Owning branch version (honua.gdb_versions)';
+COMMENT ON COLUMN honua.version_conflicts.layer_id IS 'Storage layer of the conflicting feature';
+COMMENT ON COLUMN honua.version_conflicts.objectid IS 'Object id of the conflicting feature';
+COMMENT ON COLUMN honua.version_conflicts.conflict_type IS 'Conflict classification (ReplicaConflictType ordinal)';
+COMMENT ON COLUMN honua.version_conflicts.status IS 'Lifecycle status: 0=pending, 1=resolved';
+COMMENT ON COLUMN honua.version_conflicts.base_attributes IS 'Common-ancestor attribute image (display/diff)';
+COMMENT ON COLUMN honua.version_conflicts.default_attributes IS 'DEFAULT (target) attribute image (display/diff)';
+COMMENT ON COLUMN honua.version_conflicts.version_attributes IS 'Branch (edit) attribute image (display/diff)';
+COMMENT ON COLUMN honua.version_conflicts.field_diffs IS 'Per-field three-way diffs (JSON array)';
+COMMENT ON COLUMN honua.version_conflicts.resolution_choice IS 'Resolution side once resolved: 0=version,1=default,2=base';

--- a/src/Honua.Server/OperationRegistry.cs
+++ b/src/Honua.Server/OperationRegistry.cs
@@ -139,6 +139,8 @@ public static class OperationRegistry
         new(VersionManagementServer, "startEditing"),
         new(VersionManagementServer, "stopEditing"),
         new(VersionManagementServer, "reconcile"),
+        new(VersionManagementServer, "inspectConflicts"),
+        new(VersionManagementServer, "resolveConflicts"),
         new(VersionManagementServer, "post"),
     ];
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/FeatureServerGdbVersionFlowTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/FeatureServerGdbVersionFlowTests.cs
@@ -103,6 +103,68 @@ public sealed class FeatureServerGdbVersionFlowTests : IAsyncLifetime
             .Should().Be($"/rest/services/{ServiceId}/VersionManagementServer");
     }
 
+    [IntegrationTest]
+    [Operation(Operations.VersionManagement)]
+    [Endpoint("POST /rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/resolveConflicts")]
+    [InterfaceOperation(TestProtocols.VersionManagementServer, "resolveConflicts")]
+    public async Task ConflictFlow_InspectThenResolveTakeVersion_PostsVersionValue()
+    {
+        var marker = "vconf_" + Guid.NewGuid().ToString("N")[..8];
+
+        // Seed a DEFAULT feature, then branch.
+        var seed = await PostFormAsync($"{LayerBase}/applyEdits", ("adds", BuildAddsJson(marker)), ("f", "json"));
+        seed.StatusCode.Should().Be(HttpStatusCode.OK, "seed add; body: {0}", await seed.Content.ReadAsStringAsync());
+        var objectId = await FirstAddObjectIdAsync(seed);
+
+        var versionGuid = await CreateVersionAsync("admin." + marker);
+
+        // Branch edits the feature's name; DEFAULT edits the SAME feature's name => overlapping conflict.
+        var branchEdit = await PostFormAsync($"{LayerBase}/applyEdits",
+            ("updates", BuildUpdateJson(objectId, marker + "_branch")), ("gdbVersion", versionGuid), ("f", "json"));
+        branchEdit.StatusCode.Should().Be(HttpStatusCode.OK, "branch edit; body: {0}", await branchEdit.Content.ReadAsStringAsync());
+
+        var defaultEdit = await PostFormAsync($"{LayerBase}/applyEdits",
+            ("updates", BuildUpdateJson(objectId, marker + "_default")), ("f", "json"));
+        defaultEdit.StatusCode.Should().Be(HttpStatusCode.OK, "default edit; body: {0}", await defaultEdit.Content.ReadAsStringAsync());
+
+        // Reconcile detects the conflict and blocks post.
+        var reconcile = await PostFormAsync($"{VmsBase}/versions/{versionGuid}/reconcile", ("f", "json"));
+        using (var reconcileDoc = JsonDocument.Parse(await reconcile.Content.ReadAsStringAsync()))
+        {
+            reconcileDoc.RootElement.GetProperty("hasConflicts").GetBoolean().Should().BeTrue();
+            reconcileDoc.RootElement.GetProperty("canPost").GetBoolean().Should().BeFalse();
+        }
+
+        // inspectConflicts returns the persisted 3-way conflict report.
+        var inspect = await _fixture.Client.GetAsync($"{VmsBase}/versions/{versionGuid}/inspectConflicts?f=json");
+        inspect.StatusCode.Should().Be(HttpStatusCode.OK, "inspect; body: {0}", await inspect.Content.ReadAsStringAsync());
+        using (var inspectDoc = JsonDocument.Parse(await inspect.Content.ReadAsStringAsync()))
+        {
+            inspectDoc.RootElement.GetProperty("hasConflicts").GetBoolean().Should().BeTrue();
+            var conflict = inspectDoc.RootElement.GetProperty("conflicts").EnumerateArray().Single();
+            conflict.GetProperty("objectId").GetInt64().Should().Be(objectId);
+            conflict.GetProperty("versionAttributes").GetString().Should().Contain(marker + "_branch");
+            conflict.GetProperty("defaultAttributes").GetString().Should().Contain(marker + "_default");
+        }
+
+        // Resolve taking the version side; post then succeeds and DEFAULT carries the branch value.
+        var conflicts = $"[{{\"layerId\":0,\"objectId\":{objectId},\"choice\":\"version\"}}]";
+        var resolve = await PostFormAsync($"{VmsBase}/versions/{versionGuid}/resolveConflicts",
+            ("conflicts", conflicts), ("f", "json"));
+        resolve.StatusCode.Should().Be(HttpStatusCode.OK, "resolve; body: {0}", await resolve.Content.ReadAsStringAsync());
+        using (var resolveDoc = JsonDocument.Parse(await resolve.Content.ReadAsStringAsync()))
+        {
+            resolveDoc.RootElement.GetProperty("resolved").GetInt32().Should().Be(1);
+            resolveDoc.RootElement.GetProperty("canPost").GetBoolean().Should().BeTrue();
+        }
+
+        var post = await PostFormAsync($"{VmsBase}/versions/{versionGuid}/post", ("f", "json"));
+        post.StatusCode.Should().Be(HttpStatusCode.OK, "post; body: {0}", await post.Content.ReadAsStringAsync());
+
+        (await QueryCountAsync(marker + "_branch", gdbVersion: null)).Should().Be(1,
+            "DEFAULT reflects the version value chosen by the manual resolution");
+    }
+
     // ---- helpers --------------------------------------------------------------------------------
 
     private async Task<string> CreateVersionAsync(string versionName)
@@ -148,6 +210,22 @@ public sealed class FeatureServerGdbVersionFlowTests : IAsyncLifetime
             new { attributes = new Dictionary<string, object?> { ["name"] = marker } }
         };
         return JsonSerializer.Serialize(adds);
+    }
+
+    private static string BuildUpdateJson(long objectId, string name)
+    {
+        var updates = new[]
+        {
+            new { attributes = new Dictionary<string, object?> { ["objectid"] = objectId, ["name"] = name } }
+        };
+        return JsonSerializer.Serialize(updates);
+    }
+
+    private static async Task<long> FirstAddObjectIdAsync(HttpResponseMessage applyEditsResponse)
+    {
+        using var doc = JsonDocument.Parse(await applyEditsResponse.Content.ReadAsStringAsync());
+        var add = doc.RootElement.GetProperty("addResults").EnumerateArray().First();
+        return add.GetProperty("objectId").GetInt64();
     }
 
     private Task<HttpResponseMessage> PostFormAsync(string url, params (string Key, string Value)[] fields)

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
@@ -208,6 +208,69 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.VersionManagement)]
+    [Endpoint("POST /rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/reconcile")]
+    [InterfaceOperation(TestProtocols.VersionManagementServer, "reconcile")]
+    public async Task Reconcile_WithPolicy_ReportsAutoResolvedCount()
+    {
+        // A clean version with a policy still returns the auto-resolved count field (zero here) and can
+        // post; this exercises the conflictResolution parameter parsing on the reconcile endpoint.
+        var created = await CreateVersionAsync("admin.reconcile_policy");
+        var guid = created.GetProperty("versionGuid").GetString();
+
+        var response = await PostFormAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/reconcile",
+            ("conflictResolution", "lastWriteWins"), ("f", "json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "reconcile with a policy should succeed; body: {0}", await response.Content.ReadAsStringAsync());
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("canPost").GetBoolean().Should().BeTrue();
+        doc.RootElement.GetProperty("autoResolvedCount").GetInt32().Should().Be(0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.VersionManagement)]
+    [Endpoint("GET /rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/inspectConflicts")]
+    [InterfaceOperation(TestProtocols.VersionManagementServer, "inspectConflicts")]
+    public async Task InspectConflicts_CleanVersion_ReturnsNoConflicts()
+    {
+        var created = await CreateVersionAsync("admin.inspect_clean");
+        var guid = created.GetProperty("versionGuid").GetString();
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/inspectConflicts?f=json");
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "inspectConflicts should succeed; body: {0}", await response.Content.ReadAsStringAsync());
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("hasConflicts").GetBoolean().Should().BeFalse();
+        doc.RootElement.GetProperty("conflicts").GetArrayLength().Should().Be(0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.VersionManagement)]
+    [Endpoint("POST /rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/resolveConflicts")]
+    [InterfaceOperation(TestProtocols.VersionManagementServer, "resolveConflicts")]
+    public async Task ResolveConflicts_NoPendingConflicts_ReturnsCanPost()
+    {
+        // With no pending conflicts, submitting an (empty-effect) resolution leaves the version postable.
+        var created = await CreateVersionAsync("admin.resolve_clean");
+        var guid = created.GetProperty("versionGuid").GetString();
+
+        var conflicts = "[{\"layerId\":0,\"objectId\":1,\"choice\":\"version\"}]";
+        var response = await PostFormAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/resolveConflicts",
+            ("conflicts", conflicts), ("f", "json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "resolveConflicts should succeed; body: {0}", await response.Content.ReadAsStringAsync());
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("canPost").GetBoolean().Should().BeTrue();
+        doc.RootElement.GetProperty("remaining").GetInt32().Should().Be(0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.VersionManagement)]
     [Endpoint("POST /rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/post")]
     [InterfaceOperation(TestProtocols.VersionManagementServer, "post")]
     public async Task Post_AfterReconcile_Succeeds()

--- a/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningIntegrationTests.cs
@@ -232,7 +232,7 @@ public sealed class BranchVersioningIntegrationTests : IAsyncLifetime
                 versionContext: VersionContext.ForVersion(version)),
             CancellationToken.None);
 
-        var result = await versionManager.ReconcileAsync(version.VersionId, CancellationToken.None);
+        var result = await versionManager.ReconcileAsync(version.VersionId, cancellationToken: CancellationToken.None);
 
         result.CanPost.Should().BeTrue();
         result.Conflicts.Should().BeEmpty();
@@ -257,7 +257,7 @@ public sealed class BranchVersioningIntegrationTests : IAsyncLifetime
             CancellationToken.None);
         await store.UpdateAsync(PointsLayerId, BuildFeature("Conflict-Default", 7.9, 7.9, feature.Id), CancellationToken.None);
 
-        var reconcile = await versionManager.ReconcileAsync(version.VersionId, CancellationToken.None);
+        var reconcile = await versionManager.ReconcileAsync(version.VersionId, cancellationToken: CancellationToken.None);
         reconcile.CanPost.Should().BeFalse();
         reconcile.Conflicts.Should().ContainSingle(c => c.ObjectId == feature.Id);
 
@@ -287,7 +287,7 @@ public sealed class BranchVersioningIntegrationTests : IAsyncLifetime
                 versionContext: VersionContext.ForVersion(version)),
             CancellationToken.None);
 
-        var reconcile = await versionManager.ReconcileAsync(version.VersionId, CancellationToken.None);
+        var reconcile = await versionManager.ReconcileAsync(version.VersionId, cancellationToken: CancellationToken.None);
         reconcile.CanPost.Should().BeTrue();
 
         var post = await versionManager.PostAsync(version.VersionId, CancellationToken.None);
@@ -303,14 +303,189 @@ public sealed class BranchVersioningIntegrationTests : IAsyncLifetime
         names.Should().NotContain("Keep");
     }
 
+    [Fact]
+    public async Task Reconcile_DisjointFieldEdits_AutoMergesWithoutConflict()
+    {
+        var store = CreateFeatureStore();
+        var versionManager = CreateVersionManager();
+
+        // Base feature with two attribute fields.
+        var feature = await store.CreateAsync(
+            PointsLayerId, BuildFeatureWithFields(9.0, 9.0, ("name", "Disjoint"), ("status", "open")), CancellationToken.None);
+        var version = await versionManager.CreateAsync(
+            new CreateVersionRequest("Disjoint", "sde", VersionAccess.Public), CancellationToken.None);
+
+        // Branch edits only "name"; DEFAULT edits only "status" => disjoint, auto-mergeable.
+        await store.ApplyEditsAsync(
+            PointsLayerId,
+            FeatureEditBatch.Create(
+                updates: ImmutableArray.Create(BuildFeatureWithFields(9.0, 9.0, feature.Id, ("name", "Branch"), ("status", "open"))),
+                versionContext: VersionContext.ForVersion(version)),
+            CancellationToken.None);
+        await store.UpdateAsync(
+            PointsLayerId, BuildFeatureWithFields(9.0, 9.0, feature.Id, ("name", "Disjoint"), ("status", "closed")), CancellationToken.None);
+
+        var reconcile = await versionManager.ReconcileAsync(version.VersionId, cancellationToken: CancellationToken.None);
+        reconcile.Conflicts.Should().BeEmpty("disjoint field edits auto-merge");
+        reconcile.CanPost.Should().BeTrue();
+
+        var post = await versionManager.PostAsync(version.VersionId, CancellationToken.None);
+        post.Posted.Should().BeTrue();
+
+        // DEFAULT carries BOTH the branch's name and DEFAULT's status.
+        var rows = await store.QueryAsync(PointsLayerId, new FeatureQuery(), CancellationToken.None);
+        var merged = rows.Items.Single(f => f.Id == feature.Id);
+        FieldValue(merged, "name").Should().Be("Branch");
+        FieldValue(merged, "status").Should().Be("closed");
+    }
+
+    [Fact]
+    public async Task Reconcile_OverlappingFieldEdits_ReportsThreeWayConflict()
+    {
+        var store = CreateFeatureStore();
+        var versionManager = CreateVersionManager();
+
+        var feature = await store.CreateAsync(
+            PointsLayerId, BuildFeatureWithFields(10.0, 10.0, ("name", "Base"), ("status", "open")), CancellationToken.None);
+        var version = await versionManager.CreateAsync(
+            new CreateVersionRequest("Overlap", "sde", VersionAccess.Public), CancellationToken.None);
+
+        // Both edit "status" => overlapping field => genuine conflict with a 3-way report.
+        await store.ApplyEditsAsync(
+            PointsLayerId,
+            FeatureEditBatch.Create(
+                updates: ImmutableArray.Create(BuildFeatureWithFields(10.0, 10.0, feature.Id, ("name", "Base"), ("status", "branch"))),
+                versionContext: VersionContext.ForVersion(version)),
+            CancellationToken.None);
+        await store.UpdateAsync(
+            PointsLayerId, BuildFeatureWithFields(10.0, 10.0, feature.Id, ("name", "Base"), ("status", "default")), CancellationToken.None);
+
+        var reconcile = await versionManager.ReconcileAsync(version.VersionId, cancellationToken: CancellationToken.None);
+        reconcile.CanPost.Should().BeFalse();
+        var conflict = reconcile.Conflicts.Should().ContainSingle(c => c.ObjectId == feature.Id).Subject;
+        conflict.ConflictType.Should().Be(ReplicaConflictType.Attribute);
+        conflict.BaseAttributesJson.Should().Contain("open");
+        conflict.DefaultAttributesJson.Should().Contain("default");
+        conflict.VersionAttributesJson.Should().Contain("branch");
+
+        var statusDiff = conflict.FieldDiffs.Should().ContainSingle(d => d.Name == "status").Subject;
+        statusDiff.Base.Should().Contain("open");
+        statusDiff.Default.Should().Contain("default");
+        statusDiff.Version.Should().Contain("branch");
+
+        // The pending conflict is persisted and retrievable for a manual-resolution UI.
+        var pending = await versionManager.GetPendingConflictsAsync(version.VersionId, CancellationToken.None);
+        pending.Should().ContainSingle(c => c.ObjectId == feature.Id);
+    }
+
+    [Theory]
+    [InlineData(VersionReconcilePolicy.VersionWins, "branch")]
+    [InlineData(VersionReconcilePolicy.DefaultWins, "default")]
+    [InlineData(VersionReconcilePolicy.LastWriteWins, "default")]
+    public async Task Reconcile_WithPolicy_AutoResolvesAndPosts(VersionReconcilePolicy policy, string expectedStatus)
+    {
+        var store = CreateFeatureStore();
+        var versionManager = CreateVersionManager();
+
+        var feature = await store.CreateAsync(
+            PointsLayerId, BuildFeatureWithFields(11.0, 11.0, ("name", "Base"), ("status", "open")), CancellationToken.None);
+        var version = await versionManager.CreateAsync(
+            new CreateVersionRequest($"Policy_{policy}", "sde", VersionAccess.Public), CancellationToken.None);
+
+        // Branch edits status first, then DEFAULT edits status later (DEFAULT is the last write).
+        await store.ApplyEditsAsync(
+            PointsLayerId,
+            FeatureEditBatch.Create(
+                updates: ImmutableArray.Create(BuildFeatureWithFields(11.0, 11.0, feature.Id, ("name", "Base"), ("status", "branch"))),
+                versionContext: VersionContext.ForVersion(version)),
+            CancellationToken.None);
+        await store.UpdateAsync(
+            PointsLayerId, BuildFeatureWithFields(11.0, 11.0, feature.Id, ("name", "Base"), ("status", "default")), CancellationToken.None);
+
+        var reconcile = await versionManager.ReconcileAsync(version.VersionId, policy, CancellationToken.None);
+        reconcile.CanPost.Should().BeTrue("policy auto-resolves the conflict");
+        reconcile.AutoResolvedCount.Should().Be(1);
+        reconcile.Conflicts.Should().BeEmpty();
+
+        var post = await versionManager.PostAsync(version.VersionId, CancellationToken.None);
+        post.Posted.Should().BeTrue();
+
+        var rows = await store.QueryAsync(PointsLayerId, new FeatureQuery(), CancellationToken.None);
+        var resolved = rows.Items.Single(f => f.Id == feature.Id);
+        FieldValue(resolved, "status").Should().Be(expectedStatus);
+    }
+
+    [Fact]
+    public async Task ResolveConflicts_TakeVersion_ClearsConflictAndPostsVersionImage()
+    {
+        var store = CreateFeatureStore();
+        var versionManager = CreateVersionManager();
+
+        var feature = await store.CreateAsync(
+            PointsLayerId, BuildFeatureWithFields(12.0, 12.0, ("name", "Base"), ("status", "open")), CancellationToken.None);
+        var version = await versionManager.CreateAsync(
+            new CreateVersionRequest("ManualResolve", "sde", VersionAccess.Public), CancellationToken.None);
+
+        await store.ApplyEditsAsync(
+            PointsLayerId,
+            FeatureEditBatch.Create(
+                updates: ImmutableArray.Create(BuildFeatureWithFields(12.0, 12.0, feature.Id, ("name", "Base"), ("status", "branch"))),
+                versionContext: VersionContext.ForVersion(version)),
+            CancellationToken.None);
+        await store.UpdateAsync(
+            PointsLayerId, BuildFeatureWithFields(12.0, 12.0, feature.Id, ("name", "Base"), ("status", "default")), CancellationToken.None);
+
+        var reconcile = await versionManager.ReconcileAsync(version.VersionId, cancellationToken: CancellationToken.None);
+        reconcile.CanPost.Should().BeFalse();
+
+        // Manual resolution: take the version side. Post is blocked until resolved.
+        var blocked = await versionManager.PostAsync(version.VersionId, CancellationToken.None);
+        blocked.BlockedByConflicts.Should().BeTrue();
+
+        var resolution = new VersionConflictResolution(PointsLayerId, feature.Id, VersionConflictResolutionChoice.TakeVersion);
+        var outcome = await versionManager.ResolveConflictsAsync(
+            version.VersionId, new[] { resolution }, CancellationToken.None);
+        outcome.Resolved.Should().Be(1);
+        outcome.Remaining.Should().Be(0);
+        outcome.CanPost.Should().BeTrue();
+
+        (await versionManager.GetPendingConflictsAsync(version.VersionId, CancellationToken.None))
+            .Should().BeEmpty();
+
+        var post = await versionManager.PostAsync(version.VersionId, CancellationToken.None);
+        post.Posted.Should().BeTrue();
+
+        var rows = await store.QueryAsync(PointsLayerId, new FeatureQuery(), CancellationToken.None);
+        FieldValue(rows.Items.Single(f => f.Id == feature.Id), "status").Should().Be("branch");
+    }
+
     private static string NameOf(Feature feature)
         => feature.Attributes.TryGetValue("name", out var value) ? value?.ToString() ?? string.Empty : string.Empty;
+
+    private static string? FieldValue(Feature feature, string field)
+        => feature.Attributes.TryGetValue(field, out var value) ? value?.ToString() : null;
 
     private static Feature BuildFeature(string name, double x, double y, long id = 0)
     {
         var point = _geometryFactory.CreatePoint(new Coordinate(x, y));
         point.SRID = 4326;
         var attributes = ImmutableDictionary<string, object?>.Empty.Add("name", name);
+        return new Feature { Id = id, Geometry = _wkbWriter.Write(point), Attributes = attributes };
+    }
+
+    private static Feature BuildFeatureWithFields(double x, double y, params (string Key, object? Value)[] fields)
+        => BuildFeatureWithFields(x, y, 0, fields);
+
+    private static Feature BuildFeatureWithFields(double x, double y, long id, params (string Key, object? Value)[] fields)
+    {
+        var point = _geometryFactory.CreatePoint(new Coordinate(x, y));
+        point.SRID = 4326;
+        var attributes = ImmutableDictionary<string, object?>.Empty;
+        foreach (var (key, value) in fields)
+        {
+            attributes = attributes.SetItem(key, value);
+        }
+
         return new Feature { Id = id, Geometry = _wkbWriter.Write(point), Attributes = attributes };
     }
 

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -1008,6 +1008,30 @@ sql:
   - "DROP TRIGGER IF EXISTS trigger_track_version_edits ON honua.version_edits;"
   - "CREATE TRIGGER trigger_track_version_edits BEFORE INSERT OR UPDATE ON honua.version_edits FOR EACH ROW EXECUTE FUNCTION honua.track_version_edits();"
   - |
+      CREATE TABLE IF NOT EXISTS honua.version_conflicts (
+          conflict_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          version_id UUID NOT NULL REFERENCES honua.gdb_versions(version_id) ON DELETE CASCADE,
+          layer_id INT NOT NULL,
+          objectid BIGINT NOT NULL,
+          conflict_type SMALLINT NOT NULL,
+          status SMALLINT NOT NULL DEFAULT 0,
+          base_attributes JSONB,
+          default_attributes JSONB,
+          version_attributes JSONB,
+          base_geometry_wkt TEXT,
+          default_geometry_wkt TEXT,
+          version_geometry_wkt TEXT,
+          field_diffs JSONB,
+          resolution_choice SMALLINT,
+          resolved_by TEXT,
+          detected_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          resolved_at TIMESTAMPTZ,
+          CONSTRAINT version_conflicts_valid_status CHECK(status IN (0, 1)),
+          CONSTRAINT version_conflicts_valid_resolution CHECK(resolution_choice IS NULL OR resolution_choice IN (0, 1, 2))
+      );
+  - "CREATE UNIQUE INDEX IF NOT EXISTS idx_version_conflicts_pending_feature ON honua.version_conflicts(version_id, layer_id, objectid) WHERE status = 0;"
+  - "CREATE INDEX IF NOT EXISTS idx_version_conflicts_version_status ON honua.version_conflicts(version_id, status);"
+  - |
       CREATE TABLE IF NOT EXISTS honua.fieldcollection_features (
           feature_id  TEXT        NOT NULL,
           layer_id    INT         NOT NULL,


### PR DESCRIPTION
## Issue Link
Related to #371

Addresses the **server-side remainder** of #371 (the reconcile/post conflict-resolution layer). The conflict-resolution **UI** lives in `honua-console`, so this PR intentionally does not auto-close #371.

## Summary
Implements the remaining #371 scope on top of the already-merged #1272 branch-versioning substrate (ADR-0051). Adds auto-resolution policies, a three-way (base/DEFAULT/version) conflict report with per-field diffs, automatic field-level merge of disjoint edits, and a durable manual conflict-resolution surface. The DEFAULT (`null`/`SDE.DEFAULT`) read/edit/change-tracking path stays byte-identical; all new behavior is branch-version-only, Postgres-only, and Enterprise-gated (`editing.branch-versioning`).

## Changes Made
- **Auto-resolution policies** (`VersionReconcilePolicy`: `None`/`LastWriteWins`/`VersionWins`/`DefaultWins`) threaded through `IVersionManager.ReconcileAsync(versionId, policy, ct)` and the VersionManagementServer `reconcile` endpoint via `conflictResolution`/`resolutionPolicy` (`abortIfConflicts=true` maps to manual review). A supplied policy rewrites the overlay row to the winning side so a subsequent `post` proceeds; `None` keeps today's manual-review behavior (persist conflicts, block post).
- **Three-way conflict report**: `VersionReconcileConflict` now carries base/DEFAULT/version attribute (JSON) and geometry (WKT) images plus per-field `VersionConflictFieldDiff[]`, computed from the captured base image, the live DEFAULT row, and the overlay row. Payloads are opaque JSON/WKT — no SQL, connection details, or provider internals.
- **Field-level merge**: disjoint attribute edits (a feature edited in both the branch and DEFAULT on non-overlapping fields, optionally with a DEFAULT-only geometry change) auto-merge into the overlay via a JSONB patch; only overlapping fields, geometry-vs-geometry, or update-vs-delete become true conflicts.
- **Manual conflict-resolution surface**: new `GET .../inspectConflicts` and `POST .../resolveConflicts` VersionManagementServer operations. Resolutions (`take version`/`default`/`base`, per feature) rewrite the overlay and clear the pending conflict; `post` is blocked until no pending conflicts remain. Backed by a durable `honua.version_conflicts` table (migration `054`).
- Registered the new routes/operations in `EndpointRegistry`/`OperationRegistry` and the public-interface proof ledger; extended the `version_conflicts` DDL into the test seed.
- **Deferred (explicit, unchanged):** the Redis-lock + Honua.Jobs async wrapper for reconcile/post (ADR-0051 / #1511) remains deferred. The synchronous reconcile/post engine is not regressed.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Local results (Docker/Testcontainers available):
- Architecture tests: **109 passed, 1 skipped**.
- Postgres FeatureQueryBuilder exact-SQL unit tests (CITE firewall): **58 passed**.
- Postgres `FeatureQueryBuilderVersionTests`: **8 passed**.
- Branch-versioning integration tests: **14 passed** (incl. new disjoint-field auto-merge, overlapping-field 3-way report, policy auto-resolve [3 cases], manual take-version resolution).
- VersionManagementServer endpoint tests: **15 passed** (incl. new `reconcile` policy param, `inspectConflicts`, `resolveConflicts`).
- `FeatureServerGdbVersionFlowTests`: **4 passed** (incl. new end-to-end inspect→resolve→post conflict flow).
- Core unit tests: **2512 passed**.
- `dotnet build Honua.sln --configuration Release /p:TreatWarningsAsErrors=true`: **0 warnings, 0 errors**.
- `dotnet format Honua.sln --verify-no-changes`: clean.

Not run locally: OGC CITE conformance suites (nightly gate; unaffected — DEFAULT path byte-identical) and the multi-node scale stack.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact
<!-- New GeoServices VersionManagementServer operations are additive; no OpenAPI/proto/control-plane SDK surface changed. -->

## Release/Deploy Impact
- [x] Requires database migration
<!-- Additive migration 054_CreateVersionConflicts.sql (CREATE TABLE IF NOT EXISTS + indexes); inert for DEFAULT, no backfill, idempotent. -->

## Edition Impact
Enterprise-only (`editing.branch-versioning` entitlement). Community/Pro are unaffected (single-version editing).

## Breaking Changes
None. `IVersionManager.ReconcileAsync` gained an optional `policy` parameter (default `None`) and two new interface methods; existing callers compile unchanged.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalents (Release build with TreatWarningsAsErrors, `dotnet format --verify-no-changes`, architecture + targeted unit/integration suites) and all passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract (additive VMS ops + proof ledger)
- [ ] If breaking admin/control-plane API changes: updated migration guide (n/a — no breaking changes)
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review (n/a)

