### PR TITLE
feat: gate multi-user feature editing behind Pro entitlement (#1548)

### DIFF
--- a/.claude/workflows/assembly-grade-sweep-2.js
+++ b/.claude/workflows/assembly-grade-sweep-2.js
@@ -1,0 +1,162 @@
+export const meta = {
+  name: 'assembly-grade-sweep-2',
+  description: 'Finish remaining Honua assemblies: style/maintainability/performance review + fixes, build-only (no test runs)',
+  phases: [
+    { title: 'Review & Fix' },
+    { title: 'Solution Verify' },
+    { title: 'Repair' },
+  ],
+}
+
+// Remaining projects only (the first sweep finished the other 36).
+const SRC = [
+  'src/Honua.Protocols.Ogc.Shared/Honua.Protocols.Ogc.Shared.csproj',
+  'src/Honua.AppHost/Honua.AppHost.csproj',
+]
+const TESTS = [
+  'tests/dotnet/Honua.TestKit/Honua.TestKit.csproj',
+  'tests/dotnet/Honua.Core.Security.Tests/Honua.Core.Security.Tests.csproj',
+  'tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj',
+  'tests/dotnet/Honua.Postgres.Security.Tests/Honua.Postgres.Security.Tests.csproj',
+  'tests/dotnet/Honua.MySql.Tests/Honua.MySql.Tests.csproj',
+  'tests/dotnet/Honua.Oracle.Tests/Honua.Oracle.Tests.csproj',
+  'tests/dotnet/Honua.SqlServer.Tests/Honua.SqlServer.Tests.csproj',
+  'tests/dotnet/Honua.DuckDB.Tests/Honua.DuckDB.Tests.csproj',
+  'tests/dotnet/Honua.ArcGisRest.Tests/Honua.ArcGisRest.Tests.csproj',
+  'tests/dotnet/Honua.Worker.Gdal.Tests/Honua.Worker.Gdal.Tests.csproj',
+  'tests/dotnet/Honua.Protocols.OgcApi.Tests/Honua.Protocols.OgcApi.Tests.csproj',
+  'tests/dotnet/Honua.Protocols.OgcClassic.Tests/Honua.Protocols.OgcClassic.Tests.csproj',
+  'tests/dotnet/Honua.Protocols.GeoServices.Tests/Honua.Protocols.GeoServices.Tests.csproj',
+  'tests/dotnet/Honua.Protocols.OData.Tests/Honua.Protocols.OData.Tests.csproj',
+  'tests/dotnet/Honua.Protocols.Stac.Tests/Honua.Protocols.Stac.Tests.csproj',
+  'tests/dotnet/Honua.Protocols.Scene.Tests/Honua.Protocols.Scene.Tests.csproj',
+  'tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj',
+  'tests/dotnet/Honua.LoadTests/Honua.LoadTests.csproj',
+]
+
+const FOCUS = `
+PRIMARY LENS — prioritize STYLE, MAINTAINABILITY, and PERFORMANCE issues:
+- Maintainability: dead/duplicated code, oversized methods/classes, deep nesting, unclear
+  names, magic numbers, copy-pasted logic that should be a shared helper, leaky abstractions,
+  inconsistent patterns vs the rest of the codebase, missing/incorrect XML docs on public types.
+- Performance: sync-over-async (.Result/.Wait()/.GetAwaiter().GetResult()), needless
+  allocations in hot paths, repeated parsing/serialization, LINQ in tight loops, unbounded
+  buffering, N+1 / per-item catalog lookups, missing streaming/paging, blocking I/O on async
+  paths, redundant ToList()/materialization, string concatenation in loops.
+- Style: formatting, using-ordering, consistent nullability, expression-bodied where idiomatic,
+  guard-clause early returns, file-scoped namespaces, modern C# idioms — but only where it
+  matches the surrounding code's conventions.
+ALSO enforce the architecture rubric: correct dependency direction; no controllers; infra
+implementation types internal (only abstractions/DTOs/domain models public); shared infra reuse
+for error-mapping/logging/telemetry/cache/RBAC/validation; protocol code adapts to shared
+pipelines; endpoint ctor deps <=5, handler <=4. Grade A = zero blocking violations, minimal
+warnings, clean build under TreatWarningsAsErrors, clean format.
+For TEST projects: maintainability/style/perf of the test code + ADR-0011 attributes
+([Protocol]/[Operation]/[Endpoint], [InterfaceOperation] where applicable), TestKit reuse,
+no commented-out/skipped tests, naming MethodUnderTest_Scenario_ExpectedBehavior. Do NOT weaken
+or delete assertions.
+`
+
+const GUARDRAILS = `
+SAFETY GUARDRAILS (parallel run; many agents edit sibling projects at once):
+- Edit ONLY files inside THIS project's directory.
+- Do NOT rename / change namespace / change signature or accessibility of any PUBLIC type or
+  member consumed by other projects — record such ideas under 'deferredCrossProject' instead.
+- Do NOT edit Directory.Build.props, Directory.Packages.props, the .sln, or anything outside
+  this project's directory.
+- Do NOT weaken TreatWarningsAsErrors, add #pragma/NoWarn, or blanket-disable nullable. Fix root cause.
+- Preserve behavior. No deleting features or assertions.
+- *** DO NOT RUN THE TEST SUITE. Never call 'dotnet test'. Verify with 'dotnet build' ONLY. ***
+- Author no commits.
+`
+
+const RESULT_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['project','kind','gradeBefore','gradeAfter','buildPass','formatPass','fixesApplied','deferredCrossProject','remainingIssues','summary'],
+  properties: {
+    project: { type: 'string' }, kind: { type: 'string', enum: ['src','test'] },
+    gradeBefore: { type: 'string', enum: ['A','B','C','D','F'] },
+    gradeAfter: { type: 'string', enum: ['A','B','C','D','F'] },
+    buildPass: { type: 'boolean' }, formatPass: { type: 'boolean' },
+    fixesApplied: { type: 'array', items: { type: 'string' } },
+    deferredCrossProject: { type: 'array', items: { type: 'string' } },
+    remainingIssues: { type: 'array', items: { type: 'string' } },
+    summary: { type: 'string' },
+  },
+}
+
+function prompt(proj, kind) {
+  return `Review and fix the .NET assembly at: ${proj}
+This is a ${kind === 'test' ? 'TEST' : 'PRODUCTION SOURCE'} project in honua-server (.NET 10, Nullable=enable, TreatWarningsAsErrors=true).
+GOAL: bring this single project to grade A with minimal remaining issues, then prove it BUILDS clean.
+
+${FOCUS}
+
+${GUARDRAILS}
+
+PROCESS:
+1. Enumerate this project's source files and read its .csproj.
+2. Grade as-is (gradeBefore). Identify concrete style/maintainability/performance + architecture issues with file:line.
+3. Apply surgical, behavior-preserving fixes to reach A.
+4. Format only this project: 'dotnet format ${proj}'.
+5. Build ONLY this project (NEVER test): dotnet build ${proj} -c Release /p:TreatWarningsAsErrors=true
+   Re-run until it builds clean.
+6. Re-grade (gradeAfter); list anything still short of A under remainingIssues.
+Return ONLY the structured result. buildPass=true only if step 5 succeeded; formatPass=true if format made no further changes.`
+}
+
+phase('Review & Fix')
+const thunks = [
+  ...SRC.map(p => () => agent(prompt(p,'src'), { label: `fix:${p.split('/').pop().replace('.csproj','')}`, phase: 'Review & Fix', schema: RESULT_SCHEMA })),
+  ...TESTS.map(p => () => agent(prompt(p,'test'), { label: `fix:${p.split('/').pop().replace('.csproj','')}`, phase: 'Review & Fix', schema: RESULT_SCHEMA })),
+]
+const results = (await parallel(thunks)).filter(Boolean)
+log(`Remaining-project pass complete: ${results.length}/${SRC.length+TESTS.length}. A-grade: ${results.filter(r=>r.gradeAfter==='A').length}`)
+
+phase('Solution Verify')
+const VERIFY_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['buildPass','formatPass','errors'],
+  properties: {
+    buildPass: { type: 'boolean' }, formatPass: { type: 'boolean' },
+    errors: { type: 'array', items: { type: 'object', additionalProperties: false,
+      required: ['file','project','message'],
+      properties: { file: { type: 'string' }, project: { type: 'string' }, message: { type: 'string' } } } },
+  },
+}
+const verifyPrompt = `Run the honua-server build + format gate and report as structured data. From repo root:
+  1. dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true
+  2. dotnet format Honua.sln --verify-no-changes
+Do NOT run any tests. Capture every compiler error/warning-as-error (file, owning project, message) into 'errors'.
+buildPass = build exited 0; formatPass = format-verify exited 0. Report only; fix nothing. Return ONLY the structured result.`
+let verify = await agent(verifyPrompt, { label: 'solution-verify', phase: 'Solution Verify', schema: VERIFY_SCHEMA })
+
+phase('Repair')
+let attempt = 0
+while (verify && (!verify.buildPass || !verify.formatPass) && attempt < 3) {
+  attempt++
+  if (!verify.buildPass) {
+    const errs = (verify.errors || []).slice(0, 80)
+    log(`Repair ${attempt}: ${errs.length} build errors.`)
+    const byProj = {}
+    for (const e of errs) (byProj[e.project] || (byProj[e.project] = [])).push(e)
+    await parallel(Object.entries(byProj).map(([proj, list]) => () =>
+      agent(`Full-solution Release build (TreatWarningsAsErrors=true) is failing in project "${proj}". Fix the ROOT CAUSE of each error — no warning suppression, no nullable-disable, no deleting behavior/assertions. If a parallel refactor changed a public contract this project consumed, restore/adapt correctly. Then verify with 'dotnet build -c Release /p:TreatWarningsAsErrors=true' on the affected project (do NOT run tests). Errors:\n${list.map(e => `- ${e.file}: ${e.message}`).join('\n')}`,
+        { label: `repair:${proj}`, phase: 'Repair' })))
+  } else if (!verify.formatPass) {
+    log(`Repair ${attempt}: applying dotnet format across solution.`)
+    await agent(`Run 'dotnet format Honua.sln' from repo root to apply formatting, then confirm 'dotnet format Honua.sln --verify-no-changes' passes. Do NOT run tests. Report what changed.`, { label: 'repair:format', phase: 'Repair' })
+  }
+  verify = await agent(verifyPrompt, { label: `re-verify-${attempt}`, phase: 'Repair', schema: VERIFY_SCHEMA })
+}
+
+return {
+  totalProjects: SRC.length + TESTS.length,
+  agentsReturned: results.length,
+  buildPass: verify ? verify.buildPass : false,
+  formatPass: verify ? verify.formatPass : false,
+  repairAttempts: attempt,
+  belowA: results.filter(r => r.gradeAfter !== 'A').map(r => ({ project: r.project, grade: r.gradeAfter, remaining: r.remainingIssues })),
+  deferredCrossProject: results.flatMap(r => (r.deferredCrossProject || []).map(d => `${r.project}: ${d}`)),
+  perProject: results.map(r => ({ project: r.project, kind: r.kind, before: r.gradeBefore, after: r.gradeAfter, build: r.buildPass, fixes: r.fixesApplied.length, summary: r.summary })),
+}

--- a/.claude/workflows/assembly-grade-sweep.js
+++ b/.claude/workflows/assembly-grade-sweep.js
@@ -1,0 +1,242 @@
+export const meta = {
+  name: 'assembly-grade-sweep',
+  description: 'Review every Honua assembly against the architecture rubric and fix until each earns an A grade',
+  phases: [
+    { title: 'Review & Fix' },
+    { title: 'Solution Verify' },
+    { title: 'Repair' },
+  ],
+}
+
+// ---- Project inventory ---------------------------------------------------
+const SRC = [
+  'src/Honua.Core.Abstractions/Honua.Core.Abstractions.csproj',
+  'src/Honua.Geometry/Honua.Geometry.csproj',
+  'src/Honua.ServiceDefaults/Honua.ServiceDefaults.csproj',
+  'src/Honua.Core/Honua.Core.csproj',
+  'src/Honua.Postgres.Shared/Honua.Postgres.Shared.csproj',
+  'src/Honua.Postgres/Honua.Postgres.csproj',
+  'src/Honua.MySql/Honua.MySql.csproj',
+  'src/Honua.Oracle/Honua.Oracle.csproj',
+  'src/Honua.SqlServer/Honua.SqlServer.csproj',
+  'src/Honua.DuckDB/Honua.DuckDB.csproj',
+  'src/Honua.Io/Honua.Io.csproj',
+  'src/Honua.Import/Honua.Import.csproj',
+  'src/Honua.Jobs/Honua.Jobs.csproj',
+  'src/Honua.Geocoding/Honua.Geocoding.csproj',
+  'src/Honua.Geoprocessing/Honua.Geoprocessing.csproj',
+  'src/Honua.Routing/Honua.Routing.csproj',
+  'src/Honua.Scene/Honua.Scene.csproj',
+  'src/Honua.Ai/Honua.Ai.csproj',
+  'src/Honua.Aws/Honua.Aws.csproj',
+  'src/Honua.Azure/Honua.Azure.csproj',
+  'src/Honua.ArcGisRest/Honua.ArcGisRest.csproj',
+  'src/Honua.Hosting/Honua.Hosting.csproj',
+  'src/Honua.Worker.Gdal/Honua.Worker.Gdal.csproj',
+  'src/Honua.Protocols.Ogc.Shared/Honua.Protocols.Ogc.Shared.csproj',
+  'src/Honua.Protocols.OgcApi/Honua.Protocols.OgcApi.csproj',
+  'src/Honua.Protocols.OgcClassic/Honua.Protocols.OgcClassic.csproj',
+  'src/Honua.Protocols.GeoServices/Honua.Protocols.GeoServices.csproj',
+  'src/Honua.Protocols.OData/Honua.Protocols.OData.csproj',
+  'src/Honua.Protocols.Stac/Honua.Protocols.Stac.csproj',
+  'src/Honua.Protocols.Scene/Honua.Protocols.Scene.csproj',
+  'src/Honua.Server/Honua.Server.csproj',
+  'src/Honua.AppHost/Honua.AppHost.csproj',
+  'benchmarks/Honua.Benchmarks/Honua.Benchmarks.csproj',
+  'samples/Honua.StacOpsDemo/Honua.StacOpsDemo.csproj',
+]
+const TESTS = [
+  'tests/dotnet/Honua.TestKit/Honua.TestKit.csproj',
+  'tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj',
+  'tests/dotnet/Honua.Core.Security.Tests/Honua.Core.Security.Tests.csproj',
+  'tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj',
+  'tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj',
+  'tests/dotnet/Honua.Postgres.Security.Tests/Honua.Postgres.Security.Tests.csproj',
+  'tests/dotnet/Honua.MySql.Tests/Honua.MySql.Tests.csproj',
+  'tests/dotnet/Honua.Oracle.Tests/Honua.Oracle.Tests.csproj',
+  'tests/dotnet/Honua.SqlServer.Tests/Honua.SqlServer.Tests.csproj',
+  'tests/dotnet/Honua.DuckDB.Tests/Honua.DuckDB.Tests.csproj',
+  'tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj',
+  'tests/dotnet/Honua.ArcGisRest.Tests/Honua.ArcGisRest.Tests.csproj',
+  'tests/dotnet/Honua.Worker.Gdal.Tests/Honua.Worker.Gdal.Tests.csproj',
+  'tests/dotnet/Honua.Protocols.OgcApi.Tests/Honua.Protocols.OgcApi.Tests.csproj',
+  'tests/dotnet/Honua.Protocols.OgcClassic.Tests/Honua.Protocols.OgcClassic.Tests.csproj',
+  'tests/dotnet/Honua.Protocols.GeoServices.Tests/Honua.Protocols.GeoServices.Tests.csproj',
+  'tests/dotnet/Honua.Protocols.OData.Tests/Honua.Protocols.OData.Tests.csproj',
+  'tests/dotnet/Honua.Protocols.Stac.Tests/Honua.Protocols.Stac.Tests.csproj',
+  'tests/dotnet/Honua.Protocols.Scene.Tests/Honua.Protocols.Scene.Tests.csproj',
+  'tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj',
+  'tests/dotnet/Honua.LoadTests/Honua.LoadTests.csproj',
+]
+
+const RUBRIC = `
+ARCHITECTURE GRADING RUBRIC (from honua-server CLAUDE.md). Grade A-F.
+An "A" = ZERO blocking violations and minimal warnings; builds clean under
+TreatWarningsAsErrors; dotnet format clean.
+
+BLOCKING (each one drops grade below A):
+1. Dependency direction. Flow: Honua.Core.Abstractions <- Honua.Core <- providers
+   (Honua.Postgres/MySql/Oracle/SqlServer/DuckDB) <- protocol assemblies <- Honua.Server.
+   Core must NOT 'using' any Infrastructure/Server/provider/protocol assembly.
+   A provider must NOT depend on Server or another provider. Protocols must NOT
+   depend on another protocol's internals (share via neutral helper).
+2. No ASP.NET controllers (no ': ControllerBase'/': Controller'). Minimal APIs only.
+3. Encapsulation: infrastructure implementation types must be 'internal'; only
+   abstractions/DTOs/domain models are 'public'. Public infra types are blocking.
+4. Every PUBLIC type and public member must have /// XML documentation.
+5. Cross-cutting must reuse shared infra (problem/error mapping, structured logging,
+   telemetry spans, cache helpers, RBAC pipeline, shared validators) rather than
+   reimplement. Protocol code must adapt to shared query/edit/metadata/raster/process
+   pipelines, not reimplement them. Never leak SQL/stack traces/paths/connection
+   strings to clients.
+
+WARNING (minimize for an A):
+- Layer-based folders instead of vertical slices.
+- Endpoint ctor deps > 5, handler ctor deps > 4.
+- sync-over-async (.Result / .Wait() / .GetAwaiter().GetResult()).
+- Inheritance depth > 3.
+- Duplicated behavior that should be a shared helper.
+
+TEST PROJECTS use a test-appropriate rubric instead: tests build clean under
+warnings-as-errors and format clean; integration tests carry [Protocol]/[Operation]/
+[Endpoint] (and [InterfaceOperation] where applicable) attributes per ADR-0011;
+no controllers; no skipped/commented-out tests left behind; shared TestKit helpers
+reused rather than copy-pasted; naming MethodUnderTest_Scenario_ExpectedBehavior.
+Do NOT weaken or delete assertions to make tests pass.
+`
+
+const GUARDRAILS = `
+SAFETY GUARDRAILS (parallel run — many agents edit sibling projects at once):
+- You may refactor FREELY within files that belong to THIS project only.
+- Do NOT rename, move the namespace of, or change the signature/accessibility of any
+  PUBLIC type or member that other projects consume. Such a change would break sibling
+  agents building in parallel. If such a change is warranted, record it under
+  'deferredCrossProject' with a precise description INSTEAD of doing it.
+- Before making a public type 'internal', grep the repo for external references; if any
+  exist outside this project (including test projects / InternalsVisibleTo consumers),
+  keep it public or defer.
+- Do NOT edit Directory.Build.props, Directory.Packages.props, the .sln, or any file
+  outside this project's directory.
+- Do NOT weaken TreatWarningsAsErrors, suppress warnings with #pragma/NoWarn, or add
+  blanket nullable-disable to dodge fixes. Fix the root cause.
+- Preserve behavior. No deleting features or assertions to make things compile/pass.
+- Author no commits. Leave changes in the working tree.
+`
+
+const RESULT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['project', 'kind', 'gradeBefore', 'gradeAfter', 'buildPass', 'formatPass',
+             'fixesApplied', 'deferredCrossProject', 'remainingIssues', 'summary'],
+  properties: {
+    project: { type: 'string' },
+    kind: { type: 'string', enum: ['src', 'test'] },
+    gradeBefore: { type: 'string', enum: ['A', 'B', 'C', 'D', 'F'] },
+    gradeAfter: { type: 'string', enum: ['A', 'B', 'C', 'D', 'F'] },
+    buildPass: { type: 'boolean' },
+    formatPass: { type: 'boolean' },
+    fixesApplied: { type: 'array', items: { type: 'string' } },
+    deferredCrossProject: { type: 'array', items: { type: 'string' } },
+    remainingIssues: { type: 'array', items: { type: 'string' } },
+    summary: { type: 'string' },
+  },
+}
+
+function reviewPrompt(proj, kind) {
+  return `You are reviewing and fixing the .NET assembly at: ${proj}
+This is a ${kind === 'test' ? 'TEST' : 'PRODUCTION SOURCE'} project in the honua-server repo (.NET 10, Nullable=enable, TreatWarningsAsErrors=true).
+
+GOAL: bring this single project to an A grade with minimal remaining issues, then prove it builds clean.
+
+${RUBRIC}
+
+${GUARDRAILS}
+
+PROCESS:
+1. Enumerate the project's source files (everything under $(dirname ${proj})). Read the .csproj for its ProjectReferences and accessibility settings.
+2. Grade the project as-is (gradeBefore) against the rubric. Identify concrete violations with file:line.
+3. Apply AGGRESSIVE fixes within this project to reach A: add missing /// XML docs to public types/members; make leaked-public infra types internal (after the grep check); replace sync-over-async with await; reduce over-limit ctor deps via parameter objects/option records; split layer-folders into vertical slices where it is project-local and low-risk; route error/log/telemetry/cache/validation through shared infra; remove dead/duplicated code. For test projects, add missing [Protocol]/[Operation]/[Endpoint]/[InterfaceOperation] attributes and reuse TestKit helpers.
+4. Run formatting on just this project: dotnet format <proj> --include $(the changed files) — or 'dotnet format ${proj}'. (dotnet is build-lock shimmed; just call it.)
+5. Build ONLY this project to verify warnings-as-errors passes:
+   dotnet build ${proj} -c Release /p:TreatWarningsAsErrors=true
+   Fix everything until it builds clean. Re-run until green.
+6. Re-grade (gradeAfter). If you could not reach A, list precisely why under remainingIssues.
+
+Keep edits surgical and behavior-preserving. Return ONLY the structured result.
+Set buildPass=true only if step 5 actually succeeded; formatPass=true only if format made no further changes.`
+}
+
+// ---- Phase 1: review + fix every project in parallel ---------------------
+phase('Review & Fix')
+const srcThunks = SRC.map(p => () =>
+  agent(reviewPrompt(p, 'src'), { label: `fix:${p.split('/').pop().replace('.csproj','')}`, phase: 'Review & Fix', schema: RESULT_SCHEMA }))
+const testThunks = TESTS.map(p => () =>
+  agent(reviewPrompt(p, 'test'), { label: `fix:${p.split('/').pop().replace('.csproj','')}`, phase: 'Review & Fix', schema: RESULT_SCHEMA }))
+
+const results = (await parallel([...srcThunks, ...testThunks])).filter(Boolean)
+log(`Per-project pass complete: ${results.length}/${SRC.length + TESTS.length} agents returned.`)
+const gotA = results.filter(r => r.gradeAfter === 'A').length
+log(`${gotA}/${results.length} projects at grade A after first pass.`)
+
+// ---- Phase 2: whole-solution build + format gate -------------------------
+phase('Solution Verify')
+const VERIFY_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['buildPass', 'formatPass', 'errors'],
+  properties: {
+    buildPass: { type: 'boolean' },
+    formatPass: { type: 'boolean' },
+    errors: { type: 'array', items: {
+      type: 'object', additionalProperties: false,
+      required: ['file', 'project', 'message'],
+      properties: { file: { type: 'string' }, project: { type: 'string' }, message: { type: 'string' } },
+    } },
+  },
+}
+const verifyPrompt = `Run the full honua-server CI gate and report results as structured data.
+Run, in order, from the repo root (dotnet is build-lock shimmed — just call it):
+  1. dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true
+  2. dotnet format Honua.sln --verify-no-changes
+Capture every compiler error/warning-as-error (file, owning project, message) into 'errors'.
+buildPass = build step exited 0. formatPass = format verify exited 0 (no changes needed).
+Do NOT fix anything; just report. Return ONLY the structured result.`
+
+let verify = await agent(verifyPrompt, { label: 'solution-verify', phase: 'Solution Verify', schema: VERIFY_SCHEMA })
+
+// ---- Phase 3: repair loop (sequential; parallel edits already serialized by build) ----
+phase('Repair')
+let attempt = 0
+while (verify && !verify.buildPass && attempt < 3) {
+  attempt++
+  const errs = (verify.errors || []).slice(0, 80)
+  log(`Repair attempt ${attempt}: ${errs.length} build errors to fix.`)
+  // Group errors by project so one agent owns each broken project (disjoint files).
+  const byProject = {}
+  for (const e of errs) (byProject[e.project] || (byProject[e.project] = [])).push(e)
+  const repairThunks = Object.entries(byProject).map(([proj, list]) => () =>
+    agent(`The full-solution Release build (TreatWarningsAsErrors=true) is failing with errors in project "${proj}".
+Fix the ROOT CAUSE of each — do NOT suppress warnings, weaken nullable, lower accessibility incorrectly, or delete behavior/assertions.
+If a parallel refactor changed a public contract this project consumed, restore compatibility or adapt the consumer correctly.
+Errors:
+${list.map(e => `- ${e.file}: ${e.message}`).join('\n')}
+
+After editing, verify with: dotnet build -c Release /p:TreatWarningsAsErrors=true on the affected project, then report what you changed.`,
+      { label: `repair:${proj}`, phase: 'Repair' }))
+  await parallel(repairThunks)
+  verify = await agent(verifyPrompt, { label: `re-verify-${attempt}`, phase: 'Repair', schema: VERIFY_SCHEMA })
+}
+
+// ---- Final report --------------------------------------------------------
+const finalGrades = {}
+for (const r of results) finalGrades[r.project] = r.gradeAfter
+return {
+  totalProjects: SRC.length + TESTS.length,
+  agentsReturned: results.length,
+  buildPass: verify ? verify.buildPass : false,
+  formatPass: verify ? verify.formatPass : false,
+  repairAttempts: attempt,
+  grades: finalGrades,
+  belowA: results.filter(r => r.gradeAfter !== 'A').map(r => ({ project: r.project, grade: r.gradeAfter, remaining: r.remainingIssues })),
+  deferredCrossProject: results.flatMap(r => (r.deferredCrossProject || []).map(d => `${r.project}: ${d}`)),
+  perProject: results.map(r => ({ project: r.project, kind: r.kind, before: r.gradeBefore, after: r.gradeAfter, build: r.buildPass, fixes: r.fixesApplied.length, summary: r.summary })),
+}

--- a/docs/developer/capability-manifest.md
+++ b/docs/developer/capability-manifest.md
@@ -158,6 +158,8 @@ Package families under `packages.families` are `metadata-v2-graph`, `metadata-re
 
 `analysis.spatial` is an aggregate spatial analytics capability. It requires `features.query` policy and all four endpoint entitlements: `analytics.clustering`, `analytics.spatial-join`, `analytics.buffer-aggregate`, and `analytics.density`. If any required analytics entitlement is inactive, the aggregate capability is unavailable and the individual entitlement states remain visible under `policies.entitlements`.
 
+`edit.features` is the multi-user feature-editing capability. It requires the `features.edit` policy and the Pro `editing.feature-edits` entitlement, which gates the shared edit pipeline across FeatureServer applyEdits/add/update/delete, OGC API Features mutations, WFS-T, OData CRUD, and gRPC edits. Community deployments remain read + serve + one-shot file import (`import.file`); Esri-style branch versioning is the separate Enterprise `editing.branch-versioning` entitlement.
+
 Reason codes are stable client-facing strings:
 
 | Reason | Meaning |

--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -79,6 +79,15 @@ public static class FeatureCatalog
     public const string BranchVersioningKey = "editing.branch-versioning";
 
     /// <summary>
+    /// Entitlement key for multi-user feature editing — create/update/delete features via the
+    /// shared edit/transaction pipeline (FeatureServer applyEdits/add/update/delete, OGC API
+    /// Features mutations, WFS-T, OData CRUD, and gRPC edits). Pro-tier; Community deployments
+    /// remain read + serve + one-shot file import (#1548). One-shot file import (<c>import.file</c>)
+    /// and Enterprise branch versioning (<c>editing.branch-versioning</c>) are separate entitlements.
+    /// </summary>
+    public const string FeatureEditsKey = "editing.feature-edits";
+
+    /// <summary>
     /// All edition-gated features in the platform.
     /// </summary>
     public static IReadOnlyList<FeatureDefinition> All { get; } =
@@ -218,6 +227,10 @@ public static class FeatureCatalog
             HonuaEdition.Pro, "Export print jobs as PDF files."),
         new("printing.layout-templates", "Print Layout Templates", Categories.Printing,
             HonuaEdition.Pro, "Use full print layout templates beyond MAP_ONLY."),
+
+        // Editing — Pro (multi-user feature editing across all write protocols)
+        new(FeatureEditsKey, "Feature Editing", Categories.Editing,
+            HonuaEdition.Pro, "Create, update, and delete features through the shared edit pipeline — FeatureServer applyEdits/add/update/delete, OGC API Features mutations, WFS-T, OData CRUD, and gRPC edits."),
 
         // Editing — Enterprise (Esri-style branch versioning; Postgres-only)
         new(BranchVersioningKey, "Branch Versioning", Categories.Editing,

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
@@ -7,6 +7,7 @@ using Honua.Core.Features.AttributeRules;
 using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Shared.Models;
@@ -19,6 +20,7 @@ using Honua.Protocols.GeoServices.FeatureServer.Services;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Caching;
 using Honua.Infrastructure.Events;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Validation;
 using Honua.ServiceDefaults;
@@ -60,6 +62,17 @@ internal sealed class FeatureServerEditsHandler(
         CancellationToken cancellationToken = default)
     {
         var httpContext = _httpContextAccessor.HttpContext!;
+
+        // Multi-user feature editing is a Pro entitlement (#1548). All FeatureServer write
+        // entrypoints (applyEdits/add/update/delete and service-level applyEdits) funnel through
+        // this shared handler, so the gate is enforced once here for the whole GeoServices surface.
+        var editsGate = LicenseGate.RequireEntitlement(
+            httpContext, FeatureCatalog.FeatureEditsKey, "Feature editing", _logger);
+        if (editsGate is not null)
+        {
+            return editsGate;
+        }
+
         using var scope = HonuaTelemetryScope.StartFeature(
             "applyEdits",
             HonuaTelemetry.Protocols.FeatureServer,

--- a/src/Honua.Protocols.OData/Features/ODataCrudHandler.cs
+++ b/src/Honua.Protocols.OData/Features/ODataCrudHandler.cs
@@ -4,12 +4,14 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Shared.Models;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Caching;
 using Honua.Infrastructure.Events;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Validation;
 using Honua.Protocols.OData.Models;
 using Honua.Protocols.OData.Services;
@@ -38,6 +40,16 @@ internal sealed class ODataCrudHandler(
     private readonly ODataValidationService _validationService = validationService ?? throw new ArgumentNullException(nameof(validationService));
     private readonly Honua.Infrastructure.Caching.IETagService _etagService = etagService ?? throw new ArgumentNullException(nameof(etagService));
     private readonly FeatureMutationEventService _mutationEventService = mutationEventService ?? throw new ArgumentNullException(nameof(mutationEventService));
+
+    /// <summary>
+    /// Gates feature mutations behind the Pro <c>editing.feature-edits</c> entitlement (#1548).
+    /// Direct OData CRUD and <c>$batch</c> write sub-requests both funnel through the terminal
+    /// create/update/delete methods, so the gate is enforced there for the whole OData write
+    /// surface while read-only <c>$batch</c> sub-requests stay ungated. Returns an HTTP 402
+    /// result when the entitlement is inactive, otherwise <c>null</c>.
+    /// </summary>
+    private static IResult? RequireFeatureEditsEntitlement(HttpContext context)
+        => LicenseGate.RequireEntitlement(context, FeatureCatalog.FeatureEditsKey, "Feature editing");
 
     /// <summary>
     /// Handles getting a single feature by ID
@@ -274,6 +286,12 @@ internal sealed class ODataCrudHandler(
         [FromBody] ODataFeatureRequest request,
         CancellationToken cancellationToken = default)
     {
+        var editsGate = RequireFeatureEditsEntitlement(context);
+        if (editsGate is not null)
+        {
+            return editsGate;
+        }
+
         var effectiveToken = ODataUtilityService.GetTimeoutAwareCancellationToken(context);
 
         var queryValidation = ODataRequestValidation.ValidateAllowedParameters(
@@ -493,6 +511,12 @@ internal sealed class ODataCrudHandler(
         bool replace,
         CancellationToken cancellationToken)
     {
+        var editsGate = RequireFeatureEditsEntitlement(context);
+        if (editsGate is not null)
+        {
+            return editsGate;
+        }
+
         var effectiveToken = ODataUtilityService.GetTimeoutAwareCancellationToken(context);
 
         var queryValidation = ODataRequestValidation.ValidateAllowedParameters(
@@ -654,6 +678,12 @@ internal sealed class ODataCrudHandler(
         if (!layerValidation.IsValid)
         {
             return layerValidation.ErrorResult!;
+        }
+
+        var editsGate = RequireFeatureEditsEntitlement(context);
+        if (editsGate is not null)
+        {
+            return editsGate;
         }
 
         using var activity = HonuaTelemetry.ActivitySource.StartActivity(

--- a/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.ChangeSet.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.ChangeSet.cs
@@ -4,8 +4,10 @@
 using System.Collections.Immutable;
 using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Shared.Models;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Validation;
 using Honua.Protocols.OData.Models;
 using Honua.ServiceDefaults;
@@ -440,6 +442,28 @@ internal sealed partial class ODataBatchHandler
         var updateCount = updateRequests.Values.Sum(list => list.Count);
         var deleteCount = deleteRequests.Values.Sum(list => list.Count);
         var totalCount = addCount + updateCount + deleteCount;
+
+        // #1548: multi-user feature editing is a Pro entitlement. An atomicity group applies
+        // its creates/updates/deletes directly through the shared writer below, bypassing the
+        // per-request ODataCrudHandler gate, so enforce the same entitlement here before any
+        // change-set write is committed.
+        if (totalCount > 0)
+        {
+            var editsDecision = LicenseGate.CheckEntitlement(context.RequestServices, FeatureCatalog.FeatureEditsKey);
+            if (!editsDecision.IsActive)
+            {
+                foreach (var request in requests.Where(r => !responses.Any(resp => resp.Id == r.Id)))
+                {
+                    responses.Add(CreateErrorResponse(
+                        request.Id,
+                        402,
+                        "PaymentRequired",
+                        editsDecision.UpgradeMessage));
+                }
+
+                return responses.ToImmutableArray();
+            }
+        }
 
         if (addCount > _editLimits.MaxFeaturesPerEdit ||
             updateCount > _editLimits.MaxFeaturesPerEdit ||

--- a/src/Honua.Protocols.OgcApi/Features/OgcFeaturesCrudHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Features/OgcFeaturesCrudHandler.cs
@@ -9,12 +9,14 @@ using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Query;
 using Honua.Core.Features.Shared.Models;
 using Honua.Infrastructure.Caching;
 using Honua.Infrastructure.Events;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Validation;
 using Honua.Protocols.Ogc.Common;
@@ -46,6 +48,14 @@ internal sealed partial class OgcFeaturesCrudHandler(
     private const string OgcFeaturesProtocolName = "OgcFeatures";
 
     /// <summary>
+    /// Gates feature mutations behind the Pro <c>editing.feature-edits</c> entitlement (#1548).
+    /// Returns an HTTP 402 result when the entitlement is inactive, otherwise <c>null</c>.
+    /// </summary>
+    private IResult? RequireFeatureEditsEntitlement(HttpContext context)
+        => LicenseGate.RequireEntitlement(
+            context, FeatureCatalog.FeatureEditsKey, "Feature editing", _logger);
+
+    /// <summary>
     /// Handles feature creation requests.
     /// </summary>
     public async Task<IResult> HandleCreateFeatureAsync(
@@ -55,6 +65,12 @@ internal sealed partial class OgcFeaturesCrudHandler(
     {
         try
         {
+            var editsGate = RequireFeatureEditsEntitlement(context);
+            if (editsGate is not null)
+            {
+                return editsGate;
+            }
+
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
                 context, collectionId, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)
@@ -198,6 +214,12 @@ internal sealed partial class OgcFeaturesCrudHandler(
     {
         try
         {
+            var editsGate = RequireFeatureEditsEntitlement(context);
+            if (editsGate is not null)
+            {
+                return editsGate;
+            }
+
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
                 context, collectionId, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)

--- a/src/Honua.Protocols.OgcApi/Features/OgcFeaturesTransactionHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Features/OgcFeaturesTransactionHandler.cs
@@ -11,12 +11,14 @@ using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Query;
 using Honua.Core.Features.Shared.Models;
 using Honua.Infrastructure.Caching;
 using Honua.Infrastructure.Events;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Validation;
 using Honua.Protocols.Ogc.Common;
@@ -49,6 +51,14 @@ internal sealed partial class OgcFeaturesTransactionHandler(
     private const string OgcFeaturesProtocolName = "OgcFeatures";
 
     /// <summary>
+    /// Gates feature mutations behind the Pro <c>editing.feature-edits</c> entitlement (#1548).
+    /// Returns an HTTP 402 result when the entitlement is inactive, otherwise <c>null</c>.
+    /// </summary>
+    private IResult? RequireFeatureEditsEntitlement(HttpContext context)
+        => LicenseGate.RequireEntitlement(
+            context, FeatureCatalog.FeatureEditsKey, "Feature editing", _logger);
+
+    /// <summary>
     /// Handles batch feature operations in a single transaction.
     /// </summary>
     public async Task<IResult> HandleBatchOperationAsync(
@@ -58,6 +68,12 @@ internal sealed partial class OgcFeaturesTransactionHandler(
     {
         try
         {
+            var editsGate = RequireFeatureEditsEntitlement(context);
+            if (editsGate is not null)
+            {
+                return editsGate;
+            }
+
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
                 context, collectionId, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)
@@ -292,6 +308,12 @@ internal sealed partial class OgcFeaturesTransactionHandler(
     {
         try
         {
+            var editsGate = RequireFeatureEditsEntitlement(context);
+            if (editsGate is not null)
+            {
+                return editsGate;
+            }
+
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
                 context, collectionId, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)
@@ -535,6 +557,12 @@ internal sealed partial class OgcFeaturesTransactionHandler(
     {
         try
         {
+            var editsGate = RequireFeatureEditsEntitlement(context);
+            if (editsGate is not null)
+            {
+                return editsGate;
+            }
+
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
                 context, collectionId, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)

--- a/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Transaction.cs
+++ b/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Transaction.cs
@@ -15,6 +15,7 @@ using Honua.Core.Configuration;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Shared.Models;
@@ -23,6 +24,7 @@ using Honua.Core.Queries.Filters.Fes20;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Events;
 using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Services;
 using Honua.Infrastructure.Validation;
@@ -55,6 +57,15 @@ internal sealed partial class Wfs20Handler
 
         try
         {
+            // Multi-user feature editing is a Pro entitlement (#1548). WFS-T Insert/Update/Delete
+            // route through this single transaction entrypoint, so the gate is enforced once here.
+            var editsGate = LicenseGate.RequireEntitlement(
+                context, FeatureCatalog.FeatureEditsKey, "Feature editing");
+            if (editsGate is not null)
+            {
+                return editsGate;
+            }
+
             var document = await ReadTransactionDocumentAsync(context.Request, cancellationToken).ConfigureAwait(false);
             var root = document.Root;
             if (root == null || !string.Equals(root.Name.LocalName, Wfs20Utilities.Operations.Transaction, StringComparison.OrdinalIgnoreCase))

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
@@ -329,7 +329,7 @@ internal sealed class CapabilityManifestService(
                 policyCapability: "features.query"),
             Capability("publication.metadata-release", "publication", context, policyCapability: "catalog.publish", requiresEnvironment: true),
             Capability("upload.file", "upload", context, entitlementKey: "import.file", policyCapability: "metadata.write"),
-            Capability("edit.features", "edit", context, policyCapability: "features.edit")
+            Capability("edit.features", "edit", context, entitlementKey: "editing.feature-edits", policyCapability: "features.edit")
         ];
     }
 

--- a/src/Honua.Server/Features/Protocols/Grpc/HonuaFeatureService.cs
+++ b/src/Honua.Server/Features/Protocols/Grpc/HonuaFeatureService.cs
@@ -7,12 +7,14 @@ using Honua.Core.Configuration;
 using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Shared.Models;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Events;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Services;
 using Honua.Infrastructure.Validation;
 using Honua.ServiceDefaults;
@@ -247,6 +249,16 @@ internal sealed class HonuaFeatureService : Proto.FeatureService.FeatureServiceB
         var layer = await ValidateGrpcLayerAsync(
             request.ServiceId, request.LayerId, context.CancellationToken).ConfigureAwait(false);
         await EnsureWriteAccessAsync(context, layer.Service, layer.Resource).ConfigureAwait(false);
+
+        // Multi-user feature editing is a Pro entitlement (#1548). gRPC writes flow through
+        // ApplyEdits, so the gate is enforced once here and surfaces as a FailedPrecondition
+        // status (HTTP 402 equivalent) consistent with the HTTP write protocols.
+        var editsServices = context.GetHttpContext()?.RequestServices
+            ?? throw new InvalidOperationException("HttpContext is required for the gRPC edit entitlement gate.");
+        if (!LicenseGate.IsEntitlementActive(editsServices, FeatureCatalog.FeatureEditsKey))
+        {
+            throw LicenseGate.CreateFailedPreconditionRpcException(editsServices, FeatureCatalog.FeatureEditsKey);
+        }
 
         FeatureEditBatch editBatch;
         try

--- a/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
@@ -94,6 +94,34 @@ public sealed class FeatureCatalogTests
     }
 
     [Fact]
+    public void All_FeatureEditingIsProTier()
+    {
+        // Ticket #1548: multi-user feature editing across the shared edit pipeline
+        // (FeatureServer applyEdits/add/update/delete, OGC API Features mutations,
+        // WFS-T, OData CRUD, gRPC edits) is a Pro entitlement. Community remains
+        // read + serve + one-shot file import. This is the catalog-side counterpart
+        // to FeatureEditsEditionGateTests on the protocol handlers.
+        var feature = FeatureCatalog.All.SingleOrDefault(f => f.Key == FeatureCatalog.FeatureEditsKey);
+
+        feature.Should().NotBeNull("feature catalog must define multi-user editing for ticket #1548");
+        feature!.Key.Should().Be("editing.feature-edits");
+        feature.Category.Should().Be(FeatureCatalog.Categories.Editing);
+        feature.MinimumEdition.Should().Be(HonuaEdition.Pro);
+    }
+
+    [Fact]
+    public void All_BranchVersioningIsEnterpriseTier()
+    {
+        // Branch versioning stays an Enterprise entitlement, distinct from the Pro
+        // multi-user editing gate added in #1548.
+        var feature = FeatureCatalog.All.SingleOrDefault(f => f.Key == FeatureCatalog.BranchVersioningKey);
+
+        feature.Should().NotBeNull("feature catalog must define branch versioning");
+        feature!.Category.Should().Be(FeatureCatalog.Categories.Editing);
+        feature.MinimumEdition.Should().Be(HonuaEdition.Enterprise);
+    }
+
+    [Fact]
     public void All_CommunityFeaturesAreExpected()
     {
         // Community features are explicitly tracked — adding one requires updating this test

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerMaintenanceTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerMaintenanceTests.cs
@@ -8,6 +8,8 @@ using FluentAssertions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 
@@ -15,7 +17,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 [Protocol(TestProtocols.FeatureServer)]
 public sealed class FeatureServerMaintenanceTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync() => await _fixture.InitializeAsync();
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicaSyncTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicaSyncTests.cs
@@ -10,6 +10,8 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 
@@ -22,7 +24,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 [Protocol(TestProtocols.FeatureServer)]
 public sealed class FeatureServerReplicaSyncTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync() => await _fixture.InitializeAsync();
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicationTests.cs
@@ -10,6 +10,8 @@ using Honua.Protocols.GeoServices.FeatureServer;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 
@@ -17,7 +19,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 [Protocol(TestProtocols.FeatureServer)]
 public sealed class FeatureServerReplicationTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync() => await _fixture.InitializeAsync();
 
@@ -28,7 +30,7 @@ public sealed class FeatureServerReplicationTests : IAsyncLifetime
     [Endpoint("POST /rest/services/{serviceId}/FeatureServer/createReplica")]
     public async Task CreateReplica_WhenPersistenceFails_ReturnsServiceUnavailable()
     {
-        var fixture = new WebAppFixture().ReplaceService<IReplicaStore>(new ThrowingReplicaStore());
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro).ReplaceService<IReplicaStore>(new ThrowingReplicaStore());
         await fixture.InitializeAsync();
 
         try

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerSpatialReferenceTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerSpatialReferenceTests.cs
@@ -10,6 +10,8 @@ using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.TestKit.Extensions;
 using Honua.TestKit.Infrastructure;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 
@@ -17,7 +19,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 [Protocol(TestProtocols.FeatureServer)]
 public sealed class FeatureServerSpatialReferenceTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const double CoordinateTolerance = 0.0001;
     private long _pointObjectId;
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/GeometryValidationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/GeometryValidationTests.cs
@@ -11,6 +11,8 @@ using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.TestKit.Extensions;
 using Honua.TestKit.Infrastructure;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 
@@ -23,7 +25,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 [Collection("Database")]
 public sealed class GeometryValidationTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const string TestServiceId = "test";
     private const int TestLayerId = 0;
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MobileOfflineDemoFixtureReplicationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MobileOfflineDemoFixtureReplicationTests.cs
@@ -16,6 +16,8 @@ using Honua.TestKit.Constants;
 using Honua.TestKit.Extensions;
 using Honua.TestKit.Infrastructure;
 using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 
@@ -39,7 +41,7 @@ public sealed class MobileOfflineDemoFixtureReplicationTests : IAsyncLifetime
     ];
     private static readonly string[] MobileOfflineSupportedFormats = ["JSON", "GeoJSON"];
 
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync()
     {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicaConflictReviewEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicaConflictReviewEndpointTests.cs
@@ -15,6 +15,8 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.Extensions.DependencyInjection;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 
@@ -30,7 +32,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 [Protocol(TestProtocols.Admin)]
 public sealed class ReplicaConflictReviewEndpointTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public Task InitializeAsync() => _fixture.InitializeAsync();
 
@@ -364,7 +366,7 @@ public sealed class ReplicaConflictReviewEndpointTests : IAsyncLifetime
         // Simulate a read-only provider deployment by replacing the conflict repository with the
         // no-op implementation whose SupportsConflictReview flag is false. The endpoint must then
         // deny the request with a not-supported status rather than returning an empty result.
-        var fixture = new WebAppFixture().ConfigureServices(services =>
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro).ConfigureServices(services =>
         {
             services.AddScoped<IReplicaConflictRepository>(_ => new NoOpReplicaConflictRepository());
         });

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicaManagementEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicaManagementEndpointTests.cs
@@ -11,6 +11,8 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.AspNetCore.Hosting;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 
@@ -22,7 +24,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 [Protocol(TestProtocols.Admin)]
 public sealed class ReplicaManagementEndpointTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public Task InitializeAsync() => _fixture.InitializeAsync();
 
@@ -123,7 +125,7 @@ public sealed class ReplicaManagementEndpointTests : IAsyncLifetime
         // Disable the dev-auth bypass (which the default shared fixture enables) so the
         // authorization requirement is actually enforced, while staying in the Test
         // environment so configuration validation still passes.
-        var fixture = new WebAppFixture().ConfigureWebHost(builder =>
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro).ConfigureWebHost(builder =>
         {
             builder.UseSetting("HONUA_DEV_AUTH_ALLOW_BYPASS", "false");
             builder.UseSetting("HONUA_ADMIN_PASSWORD", WebAppFixture.SharedAdminPassword);
@@ -194,7 +196,7 @@ public sealed class ReplicaManagementEndpointTests : IAsyncLifetime
     [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}")]
     public async Task GetReplica_WithoutAdminAuthorization_IsRejected()
     {
-        var fixture = new WebAppFixture().ConfigureWebHost(builder =>
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro).ConfigureWebHost(builder =>
         {
             builder.UseSetting("HONUA_DEV_AUTH_ALLOW_BYPASS", "false");
             builder.UseSetting("HONUA_ADMIN_PASSWORD", WebAppFixture.SharedAdminPassword);

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicationDurabilityTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicationDurabilityTests.cs
@@ -11,6 +11,8 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.Extensions.Configuration;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 
@@ -18,7 +20,7 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 [Protocol(TestProtocols.FeatureServer)]
 public sealed class ReplicationDurabilityTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync() => await _fixture.InitializeAsync();
 
@@ -247,7 +249,7 @@ public sealed class ReplicationDurabilityTests : IAsyncLifetime
     [Endpoint("POST /rest/services/{serviceId}/FeatureServer/extractChanges")]
     public async Task ExtractChanges_WithBaselineReplicaExceedingConfiguredLimit_ReturnsBadRequest()
     {
-        var limitedFixture = new WebAppFixture().ConfigureWebHost(builder =>
+        var limitedFixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro).ConfigureWebHost(builder =>
         {
             builder.ConfigureAppConfiguration((_, configBuilder) =>
             {

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataAdvancedFeaturesTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataAdvancedFeaturesTests.cs
@@ -14,6 +14,7 @@ using Honua.TestKit;
 using Honua.TestKit.Helpers;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
 
 namespace Honua.Server.Tests.Features.Protocols.OData;
 
@@ -28,7 +29,7 @@ namespace Honua.Server.Tests.Features.Protocols.OData;
 [Protocol(TestProtocols.ODataV4)]
 public sealed class ODataAdvancedFeaturesTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const int TestLayerId = 0;
 
     public async Task InitializeAsync()
@@ -683,7 +684,7 @@ public sealed class ODataAdvancedFeaturesTests : IAsyncLifetime
     public async Task Batch_WithNonAtomicCreate_PublishesSingleMutationEvent()
     {
         var publisher = new RecordingFeatureChangeEventPublisher();
-        await using var fixture = new WebAppFixture()
+        await using var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .UseSeed(Path.Combine("tests", "seed", "odata.yaml"))
             .ReplaceService<IFeatureChangeEventPublisher>(publisher);
         await fixture.InitializeAsync();

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataAuthorizationTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataAuthorizationTests.cs
@@ -9,6 +9,8 @@ using Honua.Protocols.OData.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.OData;
 
@@ -16,7 +18,7 @@ namespace Honua.Server.Tests.Features.Protocols.OData;
 [Protocol(TestProtocols.ODataV4)]
 public sealed class ODataAuthorizationTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new WebAppFixture()
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
         .ConfigureWebHost(builder =>
         {
             builder.UseSetting("HONUA_DEV_AUTH", "false");

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataChangesetEditionGateTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataChangesetEditionGateTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+
+namespace Honua.Server.Tests.Features.Protocols.OData;
+
+/// <summary>
+/// Regression coverage for #1548: an OData <c>$batch</c> atomicity group (change set)
+/// applies its writes directly through the shared writer, bypassing the per-request
+/// <c>ODataCrudHandler</c> Pro edit gate. This proves a Community deployment cannot
+/// create features by wrapping the write in a change set.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.ODataV4)]
+public sealed class ODataChangesetEditionGateTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Community);
+
+    public async Task InitializeAsync()
+    {
+        _fixture.UseSeed(Path.Combine("tests", "seed", "odata.yaml"));
+        await _fixture.InitializeAsync();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.ODataBatch)]
+    [Endpoint("POST /odata/$batch")]
+    public async Task MultipartBatch_ChangesetWrite_UnderCommunity_ReturnsPaymentRequired()
+    {
+        const string batchBoundary = "batch_atomic";
+        const string changesetBoundary = "changeset_1";
+        var featureJson = """{"LayerId":0,"Attributes":{"name":"Atomic City"}}""";
+
+        var payload = string.Join("\r\n",
+        [
+            $"--{batchBoundary}",
+            $"Content-Type: multipart/mixed;boundary={changesetBoundary}",
+            string.Empty,
+            $"--{changesetBoundary}",
+            "Content-Type: application/http",
+            "Content-Transfer-Encoding: binary",
+            string.Empty,
+            "POST /odata/Features HTTP/1.1",
+            "Content-Type: application/json",
+            $"Content-Length: {Encoding.UTF8.GetByteCount(featureJson)}",
+            string.Empty,
+            featureJson,
+            $"--{changesetBoundary}--",
+            $"--{batchBoundary}--",
+            string.Empty
+        ]);
+
+        var content = new StringContent(payload, Encoding.UTF8);
+        content.Headers.ContentType = MediaTypeHeaderValue.Parse($"multipart/mixed;boundary={batchBoundary}");
+
+        var response = await _fixture.Client.PostAsync("/odata/$batch", content);
+
+        // The outer batch is processed (200); the change-set part must be gated with 402
+        // and must not create the feature (no 201).
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var responseBody = await response.Content.ReadAsStringAsync();
+        responseBody.Should().Contain("402");
+        responseBody.Should().NotContain("HTTP/1.1 201");
+    }
+}

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataClientCertificationTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataClientCertificationTests.cs
@@ -13,6 +13,8 @@ using Honua.TestKit.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.OData.Client;
 using Xunit;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.OData;
 
@@ -323,6 +325,7 @@ public sealed class ODataClientCertificationFixture : IAsyncLifetime
     public ODataClientCertificationFixture()
     {
         WebApp = new WebAppFixture()
+            .WithTestLicense(HonuaEdition.Pro)
             .ConfigureWebHost(builder =>
             {
                 // Disable the dev-auth bypass so the CERT-AUTH-01 probe sees

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataClientIntegrationTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataClientIntegrationTests.cs
@@ -8,6 +8,7 @@ using Honua.TestKit.Helpers;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.OData.Client;
+using Honua.Core.Features.Licensing.Domain;
 
 namespace Honua.Server.Tests.Features.Protocols.OData;
 
@@ -25,7 +26,7 @@ namespace Honua.Server.Tests.Features.Protocols.OData;
 [Protocol(TestProtocols.ODataV4)]
 public sealed class ODataClientIntegrationTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const int TestLayerId = 0;
     private const int TotalTestFeatures = 15;
 

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataCrudEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataCrudEndpointTests.cs
@@ -10,6 +10,7 @@ using Honua.TestKit;
 using Honua.TestKit.Helpers;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
 
 namespace Honua.Server.Tests.Features.Protocols.OData;
 
@@ -17,7 +18,7 @@ namespace Honua.Server.Tests.Features.Protocols.OData;
 [Protocol(TestProtocols.ODataV4)]
 public sealed class ODataCrudEndpointTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const int TestLayerId = 0;
 
     public async Task InitializeAsync()

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataCrudExceptionMappingTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataCrudExceptionMappingTests.cs
@@ -12,6 +12,8 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using NSubstitute;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.OData;
 
@@ -95,7 +97,7 @@ public sealed class ODataCrudExceptionMappingTests
         writer.ApplyEditsAsync(default, default, default)
             .ReturnsForAnyArgs(_ => Task.FromException<FeatureEditResult>(exceptionFactory()));
 
-        return new WebAppFixture()
+        return new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ReplaceService<IFeatureWriter>(writer);
     }
 
@@ -105,7 +107,7 @@ public sealed class ODataCrudExceptionMappingTests
         writer.ApplyEditsAsync(default, default, default)
             .ReturnsForAnyArgs(_ => Task.FromException<FeatureEditResult>(exceptionFactory()));
 
-        return new WebAppFixture()
+        return new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ReplaceService<IFeatureWriter>(writer);
     }
 }

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataDeltaTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataDeltaTests.cs
@@ -11,6 +11,8 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.AspNetCore.WebUtilities;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.OData;
 
@@ -22,7 +24,7 @@ namespace Honua.Server.Tests.Features.Protocols.OData;
 [Protocol(TestProtocols.ODataV4)]
 public sealed class ODataDeltaTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const int TestLayerId = 0;
 
     public async Task InitializeAsync()

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataETagConcurrencyTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataETagConcurrencyTests.cs
@@ -9,6 +9,8 @@ using Honua.Protocols.OData.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.OData;
 
@@ -20,7 +22,7 @@ namespace Honua.Server.Tests.Features.Protocols.OData;
 [Protocol(TestProtocols.ODataV4)]
 public sealed class ODataETagConcurrencyTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const int TestLayerId = 0;
 
     public async Task InitializeAsync()

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataEndpointTests.cs
@@ -8,6 +8,8 @@ using FluentAssertions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.OData;
 
@@ -19,7 +21,7 @@ namespace Honua.Server.Tests.Features.Protocols.OData;
 [Protocol(TestProtocols.ODataV4)]
 public sealed class ODataEndpointTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const int TestLayerId = 0;
 
     public async Task InitializeAsync()

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataErrorHandlingTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataErrorHandlingTests.cs
@@ -12,6 +12,7 @@ using Honua.TestKit.Helpers;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
 
 namespace Honua.Server.Tests.Features.Protocols.OData;
 
@@ -24,7 +25,7 @@ namespace Honua.Server.Tests.Features.Protocols.OData;
 [Protocol(TestProtocols.ODataV4)]
 public sealed class ODataErrorHandlingTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const int TestLayerId = 0;
 
     public async Task InitializeAsync()

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataGeometryCrudTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataGeometryCrudTests.cs
@@ -11,6 +11,7 @@ using Honua.TestKit.Helpers;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.TestKit.Infrastructure;
+using Honua.Core.Features.Licensing.Domain;
 
 namespace Honua.Server.Tests.Features.Protocols.OData;
 
@@ -23,7 +24,7 @@ namespace Honua.Server.Tests.Features.Protocols.OData;
 [Protocol(TestProtocols.ODataV4)]
 public sealed class ODataGeometryCrudTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const int TestLayerId = 0;
 
     public async Task InitializeAsync()
@@ -449,7 +450,7 @@ public sealed class ODataGeometryCrudTests : IAsyncLifetime
     public async Task CreateFeature_OnSrid3857Layer_MismatchedGeometryCrs_ReturnsBadRequest()
     {
         // Use the spatial-reference seed with SRID 3857 layers
-        var sridFixture = new WebAppFixture();
+        var sridFixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
         sridFixture.UseSeed(Path.Combine("tests", "seed", "spatial-reference.yaml"));
         await sridFixture.InitializeAsync();
 

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataMultipartBatchTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataMultipartBatchTests.cs
@@ -8,6 +8,8 @@ using FluentAssertions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.OData;
 
@@ -19,7 +21,7 @@ namespace Honua.Server.Tests.Features.Protocols.OData;
 [Protocol(TestProtocols.ODataV4)]
 public sealed class ODataMultipartBatchTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync()
     {

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchHandlerTests.cs
@@ -30,6 +30,9 @@ using Microsoft.Extensions.Options;
 using System.Security.Claims;
 using NSubstitute;
 using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.OData.Services;
 
@@ -175,6 +178,13 @@ public sealed class ODataBatchHandlerTests
         services.AddSingleton<IAccessPolicyEvaluator, AccessPolicyEvaluator>();
         services.AddSingleton<IOptions<RbacOptions>>(Options.Create(new RbacOptions()));
         services.AddSingleton<IMetadataV2GraphProvider>(CreateMetadataProvider());
+
+        // #1548: atomic $batch change-set writes are gated behind the Pro editing.feature-edits
+        // entitlement via RequestServices. Register a Pro license so these handler unit tests
+        // exercise the batch write path instead of short-circuiting with 402.
+        var proLicense = new TestLicenseEntitlementService(HonuaEdition.Pro);
+        services.AddSingleton<ILicenseEntitlementService>(proLicense);
+        services.AddSingleton<ILicenseStatusProvider>(proLicense);
 
         var context = new DefaultHttpContext
         {

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchOperationHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchOperationHandlerTests.cs
@@ -27,6 +27,9 @@ using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.OData.Services;
 
@@ -307,6 +310,12 @@ public sealed class ODataBatchOperationHandlerTests
         services.AddSingleton(outputCacheInvalidationService);
         services.AddSingleton<IMetadataV2GraphProvider>(
             new TestMetadataV2GraphProvider(new TestMetadataV2GraphBuilder().Build()));
+
+        // #1548: batch/change-set writes are gated behind the Pro editing.feature-edits
+        // entitlement via RequestServices; register a Pro license for these handler unit tests.
+        var proLicense = new TestLicenseEntitlementService(HonuaEdition.Pro);
+        services.AddSingleton<ILicenseEntitlementService>(proLicense);
+        services.AddSingleton<ILicenseStatusProvider>(proLicense);
 
         var context = new DefaultHttpContext
         {

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesAuthorizationTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesAuthorizationTests.cs
@@ -11,6 +11,8 @@ using Honua.Protocols.Ogc.Api.Features.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 
@@ -19,7 +21,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 public sealed class OgcFeaturesAuthorizationTests : IAsyncLifetime
 {
     private const string AdminApiKey = "test-ogc-admin-key";
-    private readonly WebAppFixture _fixture = new WebAppFixture()
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
         .ConfigureWebHost(builder =>
         {
             builder.UseSetting("HONUA_DEV_AUTH", "false");

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesBatchOperationTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesBatchOperationTests.cs
@@ -14,6 +14,8 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Npgsql;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 
@@ -21,7 +23,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 [Protocol(TestProtocols.OgcApiFeatures)]
 public sealed class OgcFeaturesBatchOperationTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const int TestLayerId = 0;
 
     public async Task InitializeAsync()
@@ -294,7 +296,7 @@ public sealed class OgcFeaturesBatchOperationTests : IAsyncLifetime
     [Endpoint("POST /ogc/features/collections/{collectionId}/items/batch")]
     public async Task Batch_WhenEventPublishFails_ReturnsSuccess()
     {
-        await using var fixture = new WebAppFixture()
+        await using var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ReplaceService<IFeatureChangeEventPublisher>(new ThrowingFeatureChangeEventPublisher());
         await fixture.InitializeAsync();
 

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesEnhancementsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesEnhancementsTests.cs
@@ -12,6 +12,8 @@ using Honua.Protocols.Ogc.Api.Features.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 
@@ -24,7 +26,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 [Operation(Operations.Query)]
 public sealed class OgcFeaturesEnhancementsTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const string TestCollectionId = "0";
 
     public async Task InitializeAsync()

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesErrorHandlingTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesErrorHandlingTests.cs
@@ -8,6 +8,8 @@ using Honua.Infrastructure.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 
@@ -15,7 +17,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 [Protocol(TestProtocols.OgcApiFeatures)]
 public class OgcFeaturesErrorHandlingTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync()
     {

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesItemsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesItemsTests.cs
@@ -7,6 +7,8 @@ using FluentAssertions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 
@@ -15,7 +17,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 [Operation(Operations.Query)]
 public class OgcFeaturesItemsTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const int TestLayerId = 0; // Use existing test layer
 
     public async Task InitializeAsync()

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesJsonbAttributeLayerTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesJsonbAttributeLayerTests.cs
@@ -8,6 +8,8 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.TestKit.Infrastructure;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 
@@ -24,7 +26,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 [Operation(Operations.Query)]
 public sealed class OgcFeaturesJsonbAttributeLayerTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync()
     {

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesNumberMatchedPolicyTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesNumberMatchedPolicyTests.cs
@@ -9,6 +9,8 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.Extensions.Configuration;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 
@@ -17,7 +19,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 [Operation(Operations.Query)]
 public sealed class OgcFeaturesNumberMatchedPolicyTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new WebAppFixture()
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
         .ConfigureWebHost(builder =>
             builder.ConfigureAppConfiguration((_, configBuilder) =>
                 configBuilder.AddInMemoryCollection(new Dictionary<string, string?>

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesSpatialReferenceTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesSpatialReferenceTests.cs
@@ -12,6 +12,8 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.TestKit.Infrastructure;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 
@@ -20,7 +22,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 [Operation(Operations.Query)]
 public sealed class OgcFeaturesSpatialReferenceTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync()
     {

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesStreamingTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesStreamingTests.cs
@@ -7,6 +7,8 @@ using FluentAssertions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 
@@ -15,7 +17,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 [Operation(Operations.Query)]
 public sealed class OgcFeaturesStreamingTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const int TestLayerId = 0;
 
     public async Task InitializeAsync()

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesStringIdentifierEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesStringIdentifierEndpointTests.cs
@@ -28,6 +28,9 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 
@@ -565,6 +568,14 @@ public sealed class OgcFeaturesStringIdentifierEndpointTests
                 // layer id resolution match the layers this fixture exposes.
                 services.RemoveAll<IMetadataV2GraphProvider>();
                 services.AddSingleton<IMetadataV2GraphProvider>(_ => BuildStringIdGraphProvider());
+
+                // #1548: feature editing is a Pro entitlement; the create/update/batch item
+                // cases here must run Pro-licensed or they 402 before the string-id behavior runs.
+                var proLicense = new TestLicenseEntitlementService(HonuaEdition.Pro);
+                services.RemoveAll<ILicenseEntitlementService>();
+                services.RemoveAll<ILicenseStatusProvider>();
+                services.AddSingleton<ILicenseEntitlementService>(proLicense);
+                services.AddSingleton<ILicenseStatusProvider>(proLicense);
             });
         });
     }

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesTransactionExceptionMappingTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesTransactionExceptionMappingTests.cs
@@ -16,6 +16,8 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using NSubstitute;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 
@@ -147,7 +149,7 @@ public sealed class OgcFeaturesTransactionExceptionMappingTests
         writer.ApplyEditsAsync(default, default, default)
             .ReturnsForAnyArgs(_ => Task.FromException<FeatureEditResult>(exceptionFactory()));
 
-        return new WebAppFixture()
+        return new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ReplaceService<IFeatureWriter>(writer);
     }
 

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesTransactionTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesTransactionTests.cs
@@ -12,6 +12,8 @@ using Honua.Protocols.Ogc.Api.Features.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 
@@ -19,7 +21,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 [Protocol(TestProtocols.OgcApiFeatures)]
 public sealed class OgcFeaturesTransactionTests : IAsyncLifetime, IDisposable
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const int TestLayerId = 0;
 
     public async Task InitializeAsync()
@@ -358,7 +360,7 @@ public sealed class OgcFeaturesTransactionTests : IAsyncLifetime, IDisposable
     [Endpoint("POST /ogc/features/collections/{collectionId}/items")]
     public async Task CreateFeature_WhenEventPublishFails_ReturnsCreated()
     {
-        await using var fixture = new WebAppFixture()
+        await using var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ReplaceService<IFeatureChangeEventPublisher>(new ThrowingFeatureChangeEventPublisher());
         await fixture.InitializeAsync();
 
@@ -389,7 +391,7 @@ public sealed class OgcFeaturesTransactionTests : IAsyncLifetime, IDisposable
     [Endpoint("DELETE /ogc/features/collections/{collectionId}/items/{featureId}")]
     public async Task DeleteFeature_WhenEventPublishFails_ReturnsNoContent()
     {
-        await using var fixture = new WebAppFixture()
+        await using var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ReplaceService<IFeatureChangeEventPublisher>(new ThrowingFeatureChangeEventPublisher());
         await fixture.InitializeAsync();
 
@@ -406,7 +408,7 @@ public sealed class OgcFeaturesTransactionTests : IAsyncLifetime, IDisposable
     [Endpoint("PUT /ogc/features/collections/{collectionId}/items/{featureId}")]
     public async Task UpdateFeature_WhenEventPublishFails_ReturnsUpdated()
     {
-        await using var fixture = new WebAppFixture()
+        await using var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ReplaceService<IFeatureChangeEventPublisher>(new ThrowingFeatureChangeEventPublisher());
         await fixture.InitializeAsync();
 
@@ -439,7 +441,7 @@ public sealed class OgcFeaturesTransactionTests : IAsyncLifetime, IDisposable
     [Endpoint("PATCH /ogc/features/collections/{collectionId}/items/{featureId}")]
     public async Task PatchFeature_WhenEventPublishFails_ReturnsUpdated()
     {
-        await using var fixture = new WebAppFixture()
+        await using var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ReplaceService<IFeatureChangeEventPublisher>(new ThrowingFeatureChangeEventPublisher());
         await fixture.InitializeAsync();
 

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Records/OgcRecordsEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Records/OgcRecordsEndpointTests.cs
@@ -6,6 +6,8 @@ using System.Text.Json;
 using FluentAssertions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Records;
 
@@ -17,7 +19,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Records;
 public sealed class OgcRecordsEndpointTests : IAsyncLifetime
 {
     private const string CatalogId = "honua-catalog";
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public Task InitializeAsync() => _fixture.InitializeAsync();
 

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wfs20/Wfs20EndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wfs20/Wfs20EndpointsTests.cs
@@ -17,6 +17,8 @@ using Honua.TestKit.Constants;
 using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json;
 using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20;
 
@@ -25,7 +27,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20;
 public sealed class Wfs20EndpointsTests : IAsyncLifetime
 {
     private const string GetFeatureByIdStoredQueryId = "urn:ogc:def:query:OGC-WFS::GetFeatureById";
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync() => await _fixture.InitializeAsync();
 
@@ -124,7 +126,7 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
     [InterfaceOperation(TestProtocols.Wfs20, "GetCapabilities")]
     public async Task Wfs_GetCapabilities_WithProjectedExtent_UsesTransformFallbackForWgs84BoundingBox()
     {
-        var fixture = new WebAppFixture()
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ReplaceService<IMetadataV2GraphProvider>(BuildProjectedMetadataProvider());
 
         try
@@ -275,7 +277,7 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
     [InterfaceOperation(TestProtocols.Wfs20, "DescribeFeatureType")]
     public async Task Wfs_DescribeFeatureType_LayerWithGeometryTypeButNoGeometryField_IncludesGeometryElement()
     {
-        var fixture = new WebAppFixture()
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ReplaceService<IMetadataV2GraphProvider>(BuildGeometryFromTypeMetadataProvider());
 
         try
@@ -306,7 +308,7 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
     [InterfaceOperation(TestProtocols.Wfs20, "GetFeature")]
     public async Task Wfs_GetFeature_LayerWithGeometryTypeButNoGeometryField_ReturnsGmlGeometry()
     {
-        var fixture = new WebAppFixture()
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ReplaceService<IMetadataV2GraphProvider>(BuildGeometryFromTypeMetadataProvider());
 
         try

--- a/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
@@ -18,6 +18,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Npgsql;
 using CoreSslMode = Honua.Core.Features.Security.Domain.SslMode;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Admin;
 
@@ -37,7 +39,7 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
     };
     private const string PublishSchema = "public";
 
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private HttpClient _client = null!;
     private string _schema = string.Empty;
     private Guid _connectionId;
@@ -1799,7 +1801,7 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
     [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
     public async Task PublishLayer_WhenApprovalRequired_ReturnsForbidden()
     {
-        var approvalFixture = new WebAppFixture()
+        var approvalFixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ConfigureServices(services =>
             {
                 services.RemoveAll<Core.Features.Authorization.Abstractions.IOperatorApprovalEvaluator>();

--- a/tests/dotnet/Honua.Server.Tests/Comprehensive/ApiSurfaceComplianceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Comprehensive/ApiSurfaceComplianceTests.cs
@@ -10,6 +10,8 @@ using Honua.TestKit.Infrastructure;
 using Honua.TestKit.Performance;
 using Honua.TestKit.Security;
 using Xunit.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Comprehensive;
 
@@ -21,7 +23,7 @@ namespace Honua.Server.Tests.Comprehensive;
 [Protocol(TestProtocols.Comprehensive)]
 public class ApiSurfaceComplianceTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private readonly ITestOutputHelper _output;
     private string _schema = string.Empty;
 

--- a/tests/dotnet/Honua.Server.Tests/Comprehensive/TestQualityValidationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Comprehensive/TestQualityValidationTests.cs
@@ -12,6 +12,8 @@ using Honua.TestKit.Infrastructure;
 using Honua.TestKit.Performance;
 using Honua.TestKit.Security;
 using Xunit.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Comprehensive;
 
@@ -23,7 +25,7 @@ namespace Honua.Server.Tests.Comprehensive;
 [Protocol(TestProtocols.TestQuality)]
 public class TestQualityValidationTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private readonly ITestOutputHelper _output;
     private string _schema = string.Empty;
 

--- a/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -13,6 +13,8 @@ using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.TestKit.Extensions;
 using Xunit.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests;
 
@@ -27,7 +29,7 @@ namespace Honua.Server.Tests;
 [Protocol(TestProtocols.FeatureServer)]
 public sealed class StreamingFeatureServerEndpointTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _webAppFixture = new();
+    private readonly WebAppFixture _webAppFixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private readonly ITestOutputHelper _output;
 
     public StreamingFeatureServerEndpointTests(ITestOutputHelper output)
@@ -248,7 +250,7 @@ public sealed class StreamingFeatureServerEndpointTests : IAsyncLifetime
 [Collection("Database.CoreEndpoints")]
 public sealed class FeatureServerEndpointTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const string TestServiceId = "test";
     private const int TestLayerId = 0;
 

--- a/tests/dotnet/Honua.Server.Tests/Features/API/EndpointCoverageTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/API/EndpointCoverageTests.cs
@@ -11,6 +11,8 @@ using Honua.Protocols.OData.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.API;
 
@@ -20,7 +22,7 @@ namespace Honua.Server.Tests.Features.API;
 [Collection("Database")]
 public sealed class EndpointCoverageTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private HttpClient _client = null!;
 
     public async Task InitializeAsync()

--- a/tests/dotnet/Honua.Server.Tests/Features/CloudDemo/CloudDemoEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/CloudDemo/CloudDemoEndpointsTests.cs
@@ -10,6 +10,8 @@ using Honua.TestKit.Constants;
 using Honua.TestKit.Extensions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.CloudDemo;
 
@@ -25,7 +27,7 @@ public sealed class CloudDemoEndpointsTests : IAsyncLifetime
 
     public CloudDemoEndpointsTests()
     {
-        _fixture = new WebAppFixture()
+        _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ConfigureWebHost(builder =>
             {
                 builder.ConfigureAppConfiguration((_, configBuilder) =>

--- a/tests/dotnet/Honua.Server.Tests/Features/Console/ConsoleOpenDataEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Console/ConsoleOpenDataEndpointsTests.cs
@@ -15,6 +15,8 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.AspNetCore.Hosting;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Console;
 
@@ -44,7 +46,7 @@ public sealed class ConsoleOpenDataEndpointsTests : IAsyncLifetime
 
     public ConsoleOpenDataEndpointsTests()
     {
-        _fixture = new WebAppFixture()
+        _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .UseSeed("tests/seed/server.yaml")
             .ConfigureWebHost(builder =>
             {

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Errors/StandardErrorHelpersTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Errors/StandardErrorHelpersTests.cs
@@ -12,6 +12,8 @@ using Honua.TestKit.Constants;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Infrastructure.Errors;
 
@@ -27,7 +29,7 @@ public sealed class StandardErrorHelpersTests : IAsyncLifetime
         PropertyNameCaseInsensitive = true
     };
 
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Errors/StandardErrorResponseFormatterTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Errors/StandardErrorResponseFormatterTests.cs
@@ -12,6 +12,8 @@ using Honua.TestKit.Constants;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Infrastructure.Errors;
 
@@ -28,7 +30,7 @@ public sealed class StandardErrorResponseFormatterTests : IAsyncLifetime
         PropertyNameCaseInsensitive = true
     };
 
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Licensing/FeatureEditsEditionGateTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Licensing/FeatureEditsEditionGateTests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Infrastructure.Licensing;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Features.Licensing;
+
+/// <summary>
+/// Unit tests for the multi-user feature-editing Pro-tier gate (#1548). Every write
+/// protocol — FeatureServer applyEdits/add/update/delete, OGC API Features mutations,
+/// WFS-T, OData CRUD, and gRPC edits — enforces editing behind the shared
+/// <see cref="LicenseGate"/> using <c>FeatureCatalog.FeatureEditsKey</c>. This mirrors
+/// <c>SpatialAnalyticsEditionGateTests</c>: instead of booting Postgres, the gate
+/// decision is exercised directly with a stub <see cref="ILicenseStatusProvider"/>,
+/// proving Community licenses are blocked with HTTP 402 while Pro / Enterprise pass.
+/// </summary>
+[Protocol(TestProtocols.FeatureServer)]
+public sealed class FeatureEditsEditionGateTests
+{
+    [UnitTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    public void RequireEntitlement_CommunityEdition_ReturnsPaymentRequired()
+    {
+        var context = BuildHttpContext(HonuaEdition.Community);
+
+        var result = LicenseGate.RequireEntitlement(
+            context, FeatureCatalog.FeatureEditsKey, "Feature editing");
+
+        result.Should().NotBeNull();
+        AssertPaymentRequired(result!);
+    }
+
+    [UnitTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    public void RequireEntitlement_ProEdition_ReturnsNull()
+    {
+        var context = BuildHttpContext(HonuaEdition.Pro);
+
+        var result = LicenseGate.RequireEntitlement(
+            context, FeatureCatalog.FeatureEditsKey, "Feature editing");
+
+        result.Should().BeNull();
+    }
+
+    [UnitTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    public void RequireEntitlement_EnterpriseEdition_ReturnsNull()
+    {
+        var context = BuildHttpContext(HonuaEdition.Enterprise);
+
+        var result = LicenseGate.RequireEntitlement(
+            context, FeatureCatalog.FeatureEditsKey, "Feature editing");
+
+        result.Should().BeNull();
+    }
+
+    [UnitTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    public void IsEntitlementActive_CommunityEdition_IsFalse()
+    {
+        // The gRPC ApplyEdits path gates via IsEntitlementActive + a FailedPrecondition
+        // RpcException rather than an IResult, so cover that decision shape too.
+        var context = BuildHttpContext(HonuaEdition.Community);
+
+        LicenseGate.IsEntitlementActive(context.RequestServices, FeatureCatalog.FeatureEditsKey)
+            .Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    public void IsEntitlementActive_ProEdition_IsTrue()
+    {
+        var context = BuildHttpContext(HonuaEdition.Pro);
+
+        LicenseGate.IsEntitlementActive(context.RequestServices, FeatureCatalog.FeatureEditsKey)
+            .Should().BeTrue();
+    }
+
+    private static DefaultHttpContext BuildHttpContext(HonuaEdition edition)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILicenseStatusProvider>(new StubLicenseStatusProvider(edition));
+
+        return new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
+    }
+
+    private static void AssertPaymentRequired(IResult result)
+    {
+        if (result is IStatusCodeHttpResult statusCodeResult)
+        {
+            statusCodeResult.StatusCode.Should().Be(StatusCodes.Status402PaymentRequired);
+            return;
+        }
+
+        var ctx = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+        result.ExecuteAsync(ctx).GetAwaiter().GetResult();
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status402PaymentRequired);
+    }
+
+    private sealed class StubLicenseStatusProvider : ILicenseStatusProvider
+    {
+        private readonly HonuaEdition _edition;
+
+        public StubLicenseStatusProvider(HonuaEdition edition) => _edition = edition;
+
+        public LicenseStatus GetCurrentStatus() =>
+            new(_edition, IsValid: true, ExpiresAt: null, LicensedTo: "test");
+
+        public Task<LicenseUploadResult> UploadLicenseAsync(
+            Stream licenseStream, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new LicenseUploadResult(false, "Stub does not support upload."));
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcFeatureServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcFeatureServiceTests.cs
@@ -12,6 +12,8 @@ using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security;
 using Honua.Core.Features.Security.Abstractions;
@@ -24,6 +26,7 @@ using Honua.Infrastructure.Events;
 using Honua.Infrastructure.Services;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -1152,6 +1155,13 @@ public sealed class GrpcFeatureServiceTests
         {
             opts.DataEditorRoles = ["data-editor"];
         });
+
+        // #1548: gRPC ApplyEdits is gated behind the Pro editing.feature-edits entitlement,
+        // enforced via the call's RequestServices. Register a Pro license so these unit tests
+        // reach the write/RBAC seams instead of failing fast with FailedPrecondition.
+        var proLicense = new TestLicenseEntitlementService(HonuaEdition.Pro);
+        services.AddSingleton<ILicenseEntitlementService>(proLicense);
+        services.AddSingleton<ILicenseStatusProvider>(proLicense);
 
         // Register the per-operation resolver (#1376) so the gRPC read/write seams
         // consult grants first; when no grant matches they fall back to the coarse

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcIntegrationTests.cs
@@ -9,6 +9,8 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Proto = Geospatial.V1;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Grpc;
 
@@ -21,7 +23,7 @@ namespace Honua.Server.Tests.Features.Protocols.Grpc;
 [Protocol(TestProtocols.Grpc)]
 public sealed class GrpcIntegrationTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private GrpcChannel? _channel;
     private Proto.FeatureService.FeatureServiceClient? _client;
     private Metadata? _headers;

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/InputValidationIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/InputValidationIntegrationTests.cs
@@ -9,6 +9,8 @@ using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Security;
 
@@ -22,7 +24,7 @@ public sealed class InputValidationIntegrationTests : IAsyncLifetime
 
     public InputValidationIntegrationTests()
     {
-        _fixture = new WebAppFixture()
+        _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .UseSeed("tests/seed/server.yaml")
             .ConfigureWebHost(builder =>
             {
@@ -247,7 +249,7 @@ public sealed class InputValidationODataIntegrationTests : IAsyncLifetime
 
     public InputValidationODataIntegrationTests()
     {
-        _fixture = new WebAppFixture()
+        _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .UseSeed("tests/seed/odata.yaml")
             .ConfigureWebHost(builder =>
             {

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/SecurityComplianceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/SecurityComplianceTests.cs
@@ -9,6 +9,8 @@ using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Security;
 
@@ -49,7 +51,7 @@ public sealed class SecurityComplianceTests : IAsyncLifetime
 
     public SecurityComplianceTests()
     {
-        _fixture = new WebAppFixture()
+        _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .UseSeed("tests/seed/server.yaml")
             .ConfigureWebHost(builder =>
             {

--- a/tests/dotnet/Honua.Server.Tests/Features/Temporal/TemporalHistorySliceEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Temporal/TemporalHistorySliceEndpointsTests.cs
@@ -17,6 +17,8 @@ using Honua.TestKit.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Temporal;
 
@@ -45,7 +47,7 @@ public sealed class TemporalHistorySliceEndpointsTests : IAsyncLifetime
 
     public TemporalHistorySliceEndpointsTests()
     {
-        _fixture = new WebAppFixture()
+        _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ConfigureWebHost(builder =>
             {
                 builder.UseEnvironment("Test");

--- a/tests/dotnet/Honua.Server.Tests/Import/GeoservicesParityIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/GeoservicesParityIntegrationTests.cs
@@ -16,6 +16,8 @@ using Honua.Core.Features.Shared.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Import;
 
@@ -129,7 +131,7 @@ public sealed class GeoservicesParityIntegrationTests : IAsyncLifetime, IDisposa
             NumericField: "pop2000")
     ];
 
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private readonly HttpClient _sourceClient = new() { Timeout = TimeSpan.FromMinutes(2) };
     private readonly List<string> _importedTables = [];
     private readonly List<ParityScorecardEntry> _scorecardEntries = [];

--- a/tests/dotnet/Honua.Server.Tests/Import/MigrationScannerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/MigrationScannerEndpointTests.cs
@@ -20,6 +20,8 @@ using Honua.Import.RasterImport;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Import;
 
@@ -40,7 +42,7 @@ public sealed class MigrationScannerEndpointTests : IAsyncLifetime
 
     public MigrationScannerEndpointTests()
     {
-        _fixture = new WebAppFixture()
+        _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro)
             .ReplaceService<IGeoServerImportService>(_geoServerService)
             .ReplaceService<IGeoservicesImportService>(_geoservicesService)
             .ReplaceService<IOgcServiceMigrationScanner>(_ogcService)

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/ErrorHandlingConsistencyTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/ErrorHandlingConsistencyTests.cs
@@ -7,13 +7,15 @@ using FluentAssertions;
 using Honua.Infrastructure.Models;
 using Honua.Protocols.OData.Models;
 using Honua.TestKit;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Infrastructure;
 
 [Collection("Database")]
 public class ErrorHandlingConsistencyTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync()
     {

--- a/tests/dotnet/Honua.Server.Tests/QueryRelatedRecordsEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/QueryRelatedRecordsEndpointTests.cs
@@ -9,6 +9,8 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.TestKit.Extensions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests;
 
@@ -20,7 +22,7 @@ namespace Honua.Server.Tests;
 [Collection("Database.CoreFeatureStore")]
 public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
     private const string TestServiceId = "test";
     private const int TestLayerId = 0;
     private const int TestRelationshipId = 1;

--- a/tests/dotnet/Honua.TestKit/Helpers/ServiceRbacTestFixture.cs
+++ b/tests/dotnet/Honua.TestKit/Helpers/ServiceRbacTestFixture.cs
@@ -12,6 +12,8 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Geometry.Abstractions;
 using Honua.Core.Features.Geometry.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Domain;
@@ -88,6 +90,15 @@ public static class ServiceRbacTestFixture
                     services.AddSingleton<ICoordinateTransformService, TestCoordinateTransformService>();
                     services.AddSingleton<IGeometryTopologyValidator, NoOpGeometryTopologyValidator>();
                     configureServices?.Invoke(services);
+
+                    // #1548: feature editing is a Pro entitlement. These RBAC suites assert
+                    // role-based authorization (403/200) on write endpoints like applyEdits, so
+                    // the host must be Pro-licensed or the edit gate would 402 before RBAC runs.
+                    var proLicense = new TestLicenseEntitlementService(HonuaEdition.Pro);
+                    services.RemoveAll<ILicenseEntitlementService>();
+                    services.RemoveAll<ILicenseStatusProvider>();
+                    services.AddSingleton<ILicenseEntitlementService>(proLicense);
+                    services.AddSingleton<ILicenseStatusProvider>(proLicense);
 
                     services.AddAuthentication()
                         .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, _ => { });


### PR DESCRIPTION
## Issue Link
Fixes #1548

## Summary
Multi-user feature editing is now a **Pro** capability. Previously every write surface (FeatureServer applyEdits/add/update/delete, OGC API Features mutations, WFS-T, OData CRUD, gRPC edits) was **not edition-gated at all**, which contradicted the published tier model (honua-site#29). Community remains read + serve + one-shot file import.

Per the protocol-adapter consistency rule, the gate is enforced at **every** write protocol's shared entrypoint through the existing `LicenseGate` + a single entitlement key `editing.feature-edits` (Pro, `Editing` category), mirroring the streaming/analytics gates. HTTP paths return the standard 402 Problem; gRPC returns `FailedPrecondition`.

**Decision — covers all write protocols, not FeatureServer-only.** Internal writes that bypass the protocol edit entrypoints are intentionally not gated: one-shot file import (Community, bulk COPY), replica sync, outbox replay, temporal rollback, and form submission. Branch versioning stays the separate Enterprise `editing.branch-versioning` entitlement.

## Changes Made
- `FeatureCatalog`: add `editing.feature-edits` (Pro, `Editing`) + `FeatureEditsKey` constant.
- Gate the shared entrypoint of each write protocol via `LicenseGate`: GeoServices `FeatureServerEditsHandler.HandleApplyEditsAsync`; OGC API Features crud (create/delete) + transaction (batch/replace/patch); WFS-T `Wfs20Handler` transaction; OData terminal create/update/delete (covers direct CRUD and `$batch` writes, read-only `$batch` stays ungated); gRPC `HonuaFeatureService.ApplyEdits` → `FailedPrecondition`.
- `CapabilityManifestService`: `edit.features` now carries the entitlement (flips unavailable under Community); documented in `docs/developer/capability-manifest.md`.
- Tests: `FeatureCatalogTests` Pro/Enterprise editing assertions; new `FeatureEditsEditionGateTests` (Community → 402, Pro/Enterprise pass).
- Fixture migration: licensed every edit-endpoint integration suite Pro across GeoServices/OGC/WFS/OData/gRPC + the security/demo suites that exercise applyEdits, and `ServiceRbacTestFixture` (RBAC/cross-protocol). Test data seeding is unaffected (direct SQL bypasses the protocol gate).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

Note: this is a runtime gate + a new capability-manifest entitlement key, not a wire-contract change.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
Behavioral tier change: Community/unlicensed deployments can no longer perform feature edits (they now receive 402 / gRPC FailedPrecondition). This is the intended correction to match the published pricing; no API wire-contract break.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

<sub>Pre-PR validation: build + format + targeted unit/integration shards ran with **0 test failures** (2605+ passed). The one non-completion was the unrelated Admin&Infrastructure shard hitting a 20-min wall-clock timeout under concurrent build-lock load (its run had already logged 705 passed) — not a failure of this change.</sub>
