### PR TITLE
feat: Kubernetes closed-loop promotion via Argo Rollouts (#1554)

### DIFF
--- a/docs/contributor/adr/0052-kubernetes-closed-loop-promotion-via-argo-rollouts.md
+++ b/docs/contributor/adr/0052-kubernetes-closed-loop-promotion-via-argo-rollouts.md
@@ -1,0 +1,161 @@
+# ADR-0052: Kubernetes closed-loop promotion via Argo Rollouts
+
+## Status
+
+Accepted (`honua-io/honua-server#1554`, child of `#1537`).
+
+## Context
+
+The operator-promotion control plane (`src/Honua.Server/Features/ControlPlane/`)
+drives Console-initiated release packages through a durable, leased reconciler
+(`DeployWorkflowReconciler`) over the `IDeployBackend` abstraction and the
+`WorkflowOperationRecord` lifecycle. Every managed deploy target is already
+closed-loop — AWS Lambda alias, AWS ECS + ALB, Azure Container Apps revision,
+and Azure Functions slot all observe real provider state and drive automatic
+promotion or rollback, gated by `PrometheusDeployTelemetrySignalEvaluator`.
+
+Kubernetes was the one open target. `KubernetesGitOpsDeployBackend`
+(`GitOpsDeployBackends.cs`) is a hand-off stub: `ObserveAsync`/`RollbackAsync`
+return `ManualInterventionRequired` / "confirm out of band". The Console could
+stage and record a K8s promotion, but the weighted canary and auto-rollback were
+delegated entirely to whatever external controller the operator ran, with no
+status reflected back into the operation. If Kubernetes + Helm is a primary
+enterprise deploy substrate, this left the promotion UX non-uniform: some targets
+fully automated, K8s silently manual.
+
+`#1537` set the preferred direction: *a first-class integration with an external
+progressive-delivery controller whose status is reflected back into the operation
+lifecycle*, rather than a from-scratch in-process Kubernetes rollout engine. The
+decision in front of us is which controller, and how its status maps onto the
+`WorkflowOperationStatus` lifecycle the reconciler already understands.
+
+Constraints that dominate:
+
+1. **Do not rebuild a rollout engine.** Teams that run Kubernetes at the scale
+   where weighted canary matters already standardize on a progressive-delivery
+   controller. Reimplementing traffic-splitting, ReplicaSet management, analysis
+   runs, and metric-driven aborts in `honua-server` would duplicate a mature
+   ecosystem and own a large surface we do not need to own.
+2. **Stay behind `IDeployBackend` + `WorkflowOperationRecord`.** The Console
+   promotion flow, the leased reconciler, the telemetry gate, and the precomputed
+   rollback plans must be unchanged. The new backend is just another
+   `IDeployBackend` selected by `Backend` name under
+   `DeployTargetKind.Kubernetes`.
+3. **No new heavy dependency.** The existing `KubernetesJobBatchComputeBackend`
+   reaches the Kubernetes API through a narrow raw-HTTP client
+   (`KubernetesJobClient`) instead of the official `KubernetesClient` NuGet
+   package, to keep the trim/AOT surface small and reuse the in-cluster
+   service-account / out-of-cluster CA-trust auth chain. The rollout integration
+   should reuse that same path.
+4. **Model stays Console-driven (per `#1537` non-goals).** Honua does not become
+   an autonomous Flux/Argo pull-from-git reconciler. The GitOps manifest remains
+   the declarative artifact; Honua initiates and observes the rollout. The unused
+   `GitOpsWatchManifestPath` scaffolding stays out of scope.
+
+The two mainstream candidates are **Argo Rollouts** and **Flagger**:
+
+- **Argo Rollouts** introduces a first-class `Rollout` custom resource that
+  replaces the `Deployment`. Promotion and abort are explicit, imperative verbs
+  against the resource: set the pod-template image to start, clear the pause to
+  promote, set `status.abort=true` to roll back. The rollout's current canary
+  weight, phase, pause conditions, and stable/current ReplicaSet hashes are all
+  on `.status`, so an external orchestrator can both *drive* and *observe* the
+  rollout through a small, well-defined set of REST operations.
+- **Flagger** drives a canary by mutating a target `Deployment` and watching its
+  own `Canary` resource; it is more metrics-loop-centric and expects to own the
+  analysis cadence. Externally initiating a specific promotion or abort step,
+  and reading back a discrete "paused at weight N, ready for the gate" signal, is
+  a weaker fit for Honua's reconciler, which already runs the telemetry gate and
+  wants to issue an explicit promote/abort.
+
+## Decision
+
+Integrate with **Argo Rollouts** as a new closed-loop Kubernetes deploy backend,
+`honua-kubernetes-argo-rollouts` (`KubernetesArgoRolloutsDeployBackend`), and
+reflect the `Rollout` resource's controller-reported status back into the
+`WorkflowOperationRecord` lifecycle. The progressive stepped ramp itself
+(`5→25→50→100`, pauses, analysis) is owned by the cluster-side
+`spec.strategy.canary.steps` on the `Rollout`; Honua initiates the rollout,
+observes the step weight and phase, and gates promotion/rollback through the
+existing shared telemetry-gated reconciler.
+
+The backend coexists with the existing `honua-gitops-kubernetes` passthrough
+stub under `DeployTargetKind.Kubernetes`; targets choose by `Backend` name, so
+operators who genuinely want pure out-of-band GitOps hand-off keep that option.
+
+### Controller access
+
+A new narrow REST adapter, `ArgoRolloutsClient` (`IArgoRolloutsClient`), speaks
+the Argo Rollouts `argoproj.io/v1alpha1` `Rollout` API:
+
+- `GetRolloutAsync` — `GET .../rollouts/{name}`, parse `.status`.
+- `SetImageAsync` — strategic-merge `PATCH` of
+  `spec.template.spec.containers[name].image` (start the rollout; the container
+  name is the merge key so sibling containers and pod-template fields survive).
+- `PromoteAsync` — merge-`PATCH` the `status` subresource to null
+  `pauseConditions` and clear `abort`, then merge-`PATCH` `spec.paused=false`
+  (mirrors `kubectl-argo-rollouts promote`).
+- `AbortAsync` — merge-`PATCH` `status.abort=true` (mirrors
+  `kubectl-argo-rollouts abort`), which reverts traffic to the stable revision.
+
+To avoid duplicating the credential chain, the in-cluster service-account /
+out-of-cluster CA-trust auth and request shaping were extracted from
+`KubernetesJobClient` into a shared `KubernetesApiRequestFactory`, consumed by
+both the Job batch client and the new rollout client over the same
+`control-plane-kubernetes` HTTP client. No new NuGet dependency is added.
+
+### Status mapping
+
+The backend maps Argo `Rollout` status onto `WorkflowOperationStatus` so the
+reconciler's existing observe → telemetry-gate → promote/rollback loop drives
+real transitions:
+
+| Argo Rollout observation | Workflow status | Signal |
+|---|---|---|
+| `Progressing`, not paused | `Reconciling` | — |
+| `Paused` at the configured canary weight (`status.canary.weights.canary.weight`) | `Reconciling` | `PromotionRecommended=true` |
+| `Healthy` and `currentPodHash == stableRS` | `Succeeded` | terminal |
+| `Healthy` but `currentPodHash != stableRS` (mid-ramp) | `Reconciling` | — |
+| `Degraded`, or `status.abort=true` | `Reconciling` | `RollbackRecommended=true` |
+| During `RollbackRequested`: reverted to stable (`Healthy`, hashes equal) | `RolledBack` | terminal |
+| Rollout resource not found | `Failed` | configuration error |
+
+`PromoteAsync` issues the promote verb and stays `Reconciling` until a later
+`ObserveAsync` sees `Healthy` + stable; `RollbackAsync` issues the abort verb and
+returns `RollbackRequested`, which subsequent observations resolve to `RolledBack`
+once the controller has reverted. When the controller does not report both pod
+hashes (older Argo versions), `Healthy` is treated as converged so the operation
+still terminates. Canary-weight gating requires `telemetry.connection` at plan
+time, matching the AWS ECS + ALB contract, so the auto-rollback signal always has
+a metrics source.
+
+### Required target parameters
+
+`kubernetes.namespace` (or in-cluster auto-detected), `kubernetes.argo.rollout_name`
+(or `targetName`), `kubernetes.argo.container_name`, and `desiredRevision` (the
+image to roll out). Optional `deployment.canary_weight_percentage` /
+`kubernetes.argo.canary_weight_percentage` with a required `telemetry.connection`.
+
+## Consequences
+
+**Easier.** Kubernetes promotions become closed-loop and uniform with the other
+managed targets: weighted canary + automatic rollback driven by the same Console
+flow, the same leased reconciler, and the same telemetry gate, with rollout status
+visible on the operation record instead of `ManualInterventionRequired`. The auth
+chain is now shared between the Job and rollout clients, reducing duplication.
+Provider error text (resource names, namespaces, request detail) is sanitized off
+the durable operation record and only the structured log carries the raw
+Kubernetes error.
+
+**More constrained.** This backend requires the operator to run Argo Rollouts on
+the cluster and to model their workload as a `Rollout` resource (not a plain
+`Deployment`); a `honua-helm` change to optionally ship the `Rollout` CR is the
+expected follow-on when teams adopt it. The stepped canary ramp and analysis
+templates are authored cluster-side, not in Honua — Honua observes and gates, it
+does not define the steps. Teams who standardize on Flagger or a pure GitOps
+hand-off are not served by this specific backend; they keep the
+`honua-gitops-kubernetes` passthrough. Live verification against a real cluster +
+Argo controller is out of scope for unit CI; the backend is covered by mocked
+controller-status tests mirroring `AwsEcsAlbDeployBackendTests`, and a live test
+lane can follow the `AwsEcsAlbDeployBackendLiveTests` pattern when a cluster is
+available.

--- a/docs/contributor/adr/README.md
+++ b/docs/contributor/adr/README.md
@@ -55,6 +55,7 @@ This folder contains Architecture Decision Records (ADRs) for the Honua greenfie
 | [0047](0047-module-dependency-policy.md) | Module Dependency Policy | Accepted | 2026-05 |
 | [0049](0049-single-auth-identity-token-foundation.md) | Single Auth/Identity/Token Foundation Shared by OIDC SSO and ArcGIS OAuth2 | Accepted | 2026-06 |
 | [0051](0051-branch-versioning-storage-model.md) | Branch-Versioning Storage Model (Overlay/Moment Over the Live Base Table) | Accepted | 2026-06 |
+| [0052](0052-kubernetes-closed-loop-promotion-via-argo-rollouts.md) | Kubernetes Closed-Loop Promotion via Argo Rollouts | Accepted | 2026-06 |
 
 ## Template
 

--- a/docs/operator/CONTROL_PLANE_API.md
+++ b/docs/operator/CONTROL_PLANE_API.md
@@ -682,6 +682,31 @@ approval check and the write (mitigating a TOCTOU race where a recomputed plan
 would otherwise roll back under a stale approval). Callers should re-read the
 operation and re-approve against the current plan.
 
+#### Deploy backends and traffic-shifting targets
+
+A deploy operation resolves to an `IDeployBackend` by the target's `Backend`
+name and `TargetKind`. The following backends are closed-loop: Honua observes
+real provider state and drives weighted promotion and automatic rollback through
+the leased reconciler and the telemetry gate, so the operation lifecycle reflects
+actual rollout state rather than `ManualInterventionRequired`.
+
+| Backend | TargetKind | Mechanism |
+|---|---|---|
+| `honua-aws-lambda-alias` | `AwsLambda` | Alias-weighted version traffic shifting |
+| `honua-aws-ecs-alb` | `AwsEcs` | ALB listener-rule weights across stable/canary services |
+| `honua-azure-container-apps-revision` | `AzureContainerApps` | Revision traffic splitting |
+| `honua-azure-functions-slot` | `AzureFunctions` | Deployment-slot swap |
+| `honua-kubernetes-argo-rollouts` | `Kubernetes` | Weighted canary + auto-rollback via an external [Argo Rollouts](https://argo-rollouts.readthedocs.io/) controller; status reflected into the operation lifecycle (ADR-0052) |
+
+The `honua-gitops-*` backends (including `honua-gitops-kubernetes`) remain
+available as a pure out-of-band GitOps passthrough: they hand the rollout to an
+external controller and return `ManualInterventionRequired` for observation.
+Honua is not positioning Flux or Argo CD as its primary control plane; the
+Kubernetes integration is Console-driven promotion with the GitOps manifest as
+the declarative artifact, not an autonomous pull-from-git reconciler. See the
+[Upgrade and Rollback Runbook](runbooks/UPGRADE_AND_ROLLBACK.md) for per-backend
+configuration and required parameters.
+
 ### **Alert Management Endpoints**
 
 | Endpoint | Method | Purpose |

--- a/docs/operator/runbooks/UPGRADE_AND_ROLLBACK.md
+++ b/docs/operator/runbooks/UPGRADE_AND_ROLLBACK.md
@@ -496,6 +496,82 @@ Tests skip automatically when any required variable is missing. AWS credentials 
 
 ---
 
+## Kubernetes Argo Rollouts Canary
+
+Kubernetes deploys use an external [Argo Rollouts](https://argo-rollouts.readthedocs.io/) controller for weighted canary traffic shifting and automatic rollback, managed through the deploy controller backend `honua-kubernetes-argo-rollouts`. Honua initiates the rollout (sets the canary image), observes the controller-reported rollout status, and drives promotion or rollback through the shared telemetry-gated reconciler — the operation lifecycle reflects real rollout state instead of `ManualInterventionRequired`. The stepped canary ramp itself (`5→25→50→100`, pauses, analysis) is owned by the `Rollout` resource's `spec.strategy.canary.steps` on the cluster. This backend coexists with the GitOps passthrough backend `honua-gitops-kubernetes`; targets pick by `Backend` name. The decision is recorded in [ADR-0052](../../contributor/adr/0052-kubernetes-closed-loop-promotion-via-argo-rollouts.md).
+
+### Resource pre-conditions
+
+The operator (typically Helm/Terraform) must provision **before** submitting any deploy operation:
+
+- **Argo Rollouts controller** installed in the cluster.
+- A **`Rollout` custom resource** (`argoproj.io/v1alpha1`) for the workload — not a plain `Deployment` — with its `spec.strategy.canary.steps` defining the weighted ramp and any analysis templates. The container Honua shifts must be named in `kubernetes.argo.container_name`.
+- **Kubernetes API access** for the Honua server: in-cluster service-account RBAC (or an out-of-cluster `ControlPlane:Kubernetes:ApiServerUrl` + bearer token / CA bundle) granting `get` and `patch` on `rollouts` and `rollouts/status` in the target namespace. Honua reuses the same auth/CA path as the Kubernetes Job batch backend (`ControlPlane:Kubernetes:*`).
+
+Honua reads and writes only the named `Rollout`; the controller owns ReplicaSet management, traffic splitting, and analysis.
+
+### Lifecycle
+
+1. **Preflight**: `PlanAsync` validates that the namespace, rollout name, container name, and a non-empty `desiredRevision` (container image) are present. When a canary weight is set (`deployment.canary_weight_percentage` or `kubernetes.argo.canary_weight_percentage`), it requires `telemetry.connection` so the rollout can be promoted or rolled back automatically.
+2. **Start**: The controller backend reads the current pod-template image (captured for rollback baseline), then strategic-merge-patches `spec.template.spec.containers[name].image` to `desiredRevision`. Argo Rollouts begins the configured canary steps. The patch is keyed by container name so sibling containers and pod-template fields are preserved.
+3. **Observe**: Each reconciliation reads the `Rollout` `.status`. The observation maps controller state onto the operation lifecycle:
+    - **Paused at the configured canary weight** (`status.canary.weights.canary.weight` equals the target percentage): `Reconciling` with `PromotionRecommended=true`. The reconciler runs the telemetry gate and, on pass, promotes.
+    - **Healthy and fully promoted** (`status.currentPodHash == status.stableRS`): `Succeeded`.
+    - **Healthy but mid-ramp** (`currentPodHash != stableRS`): stays `Reconciling`.
+    - **Degraded or aborted** (`status.phase == Degraded` or `status.abort == true`): `Reconciling` with `RollbackRecommended=true`, which drives automatic rollback.
+    - **Rollout resource not found**: `Failed` (provision the `Rollout` before deploying).
+4. **Promote**: After the telemetry gate passes, the controller backend clears the rollout's pause conditions on the `status` subresource and unsets `spec.paused` (mirrors `kubectl-argo-rollouts promote`). Argo advances to the next step or to 100%. The operation stays `Reconciling` until a later observation reports `Healthy` + stable, then `Succeeded`.
+5. **Rollback**: The controller backend sets `status.abort=true` (mirrors `kubectl-argo-rollouts abort`) and reports `RollbackRequested`. Subsequent observations return `RolledBack` once the controller has reverted to the stable revision (`Healthy`, `currentPodHash == stableRS`).
+
+### Configuration (canary traffic shifting)
+
+```json
+{
+  "ControlPlane": {
+    "Kubernetes": {
+      "InClusterAutoDetect": true
+    },
+    "DeployTargets": [
+      {
+        "TargetId": "prod-k8s",
+        "TargetKind": "Kubernetes",
+        "Backend": "honua-kubernetes-argo-rollouts",
+        "Environment": "production",
+        "TargetName": "honua-server",
+        "Parameters": {
+          "kubernetes.namespace": "honua-prod",
+          "kubernetes.argo.rollout_name": "honua-server",
+          "kubernetes.argo.container_name": "honua",
+          "deployment.canary_weight_percentage": "25",
+          "telemetry.connection": "prod-prom"
+        }
+      }
+    ]
+  }
+}
+```
+
+`desiredRevision` on each deploy operation must be the container image reference to roll out (for example `ghcr.io/honua/honua-server:sha-42`). Omit `deployment.canary_weight_percentage` for a rollout that pauses once for manual/telemetry-gated promotion without a weighted ramp.
+
+### Limitations
+
+- The workload must be modeled as an Argo `Rollout` resource; a plain `Deployment` is not driven by this backend.
+- The stepped canary ramp and analysis templates are authored cluster-side on the `Rollout`. Honua observes the step weight and gates promotion/rollback; it does not define the steps.
+- `SupportsCancellation` is `false`; in-flight rollouts are settled by promotion or rollback (abort), not cancellation.
+- When the controller does not report both `currentPodHash` and `stableRS` (older Argo versions), a `Healthy` phase is treated as fully converged so the operation still terminates.
+
+### Manual intervention scenarios
+
+- **Rollout not found**: `StartAsync`/`ObserveAsync` return a `Failed` observation naming the missing rollout/namespace. Provision the `Rollout` resource (and the Argo Rollouts controller) before retrying.
+- **Kubernetes API errors**: submission, observation, promotion, and rollback paths sanitise Kubernetes/Argo API errors. Operators see a stable `Argo Rollouts state lookup failed…` message on the operation record; the underlying error (resource names, namespaces, request detail) is in the structured log.
+- **Controller stalled mid-ramp**: if Argo holds the rollout `Progressing` without pausing or completing (for example a stuck analysis run), the operation stays `Reconciling`. Inspect with `kubectl argo rollouts get rollout <name> -n <ns>` and correct the rollout or analysis out-of-band.
+
+### GitOps passthrough alternative
+
+Operators who manage Kubernetes through a pure out-of-band GitOps hand-off (Flux/Argo CD, or Flagger) can use the `honua-gitops-kubernetes` backend instead. That backend delegates all state observation to the external controller and returns `ManualInterventionRequired` for observation.
+
+---
+
 ## Rollback Procedure
 
 ### Application Rollback First

--- a/src/Honua.Server/Features/ControlPlane/ArgoRolloutsClient.cs
+++ b/src/Honua.Server/Features/ControlPlane/ArgoRolloutsClient.cs
@@ -1,0 +1,609 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Argo Rollouts lifecycle phase as reported by <c>.status.phase</c> on the Rollout
+/// custom resource. Mirrors the canonical Argo Rollouts phases so the deploy backend
+/// can map them onto the control-plane operation lifecycle without taking a dependency
+/// on the Argo client libraries.
+/// </summary>
+internal enum ArgoRolloutPhase
+{
+    /// <summary>
+    /// Phase could not be determined from the resource status (missing or unknown value).
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// The rollout is actively progressing toward the desired ReplicaSet.
+    /// </summary>
+    Progressing,
+
+    /// <summary>
+    /// The rollout is paused at a canary step (for example awaiting a manual or
+    /// telemetry-gated promotion).
+    /// </summary>
+    Paused,
+
+    /// <summary>
+    /// The rollout fully converged and is serving the desired revision at 100% weight.
+    /// </summary>
+    Healthy,
+
+    /// <summary>
+    /// The rollout failed analysis, progress deadline, or was aborted and is degraded.
+    /// </summary>
+    Degraded
+}
+
+/// <summary>
+/// Read-only snapshot of an Argo Rollouts <c>Rollout</c> custom resource. Only the
+/// fields the deploy backend needs to map rollout status into the control-plane
+/// operation lifecycle are modeled.
+/// </summary>
+internal sealed record ArgoRolloutState
+{
+    /// <summary>
+    /// Rollout name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Reported lifecycle phase from <c>.status.phase</c>.
+    /// </summary>
+    public ArgoRolloutPhase Phase { get; init; }
+
+    /// <summary>
+    /// Operator-facing message from <c>.status.message</c>, when present.
+    /// </summary>
+    public string? Message { get; init; }
+
+    /// <summary>
+    /// Canary traffic weight currently routed to the new revision
+    /// (<c>.status.canary.weights.canary.weight</c>). Null when the rollout is not
+    /// reporting a weighted canary (for example a blue-green strategy or a rollout that
+    /// has not started shifting traffic).
+    /// </summary>
+    public int? CanaryWeight { get; init; }
+
+    /// <summary>
+    /// Whether the rollout currently has at least one pause condition
+    /// (<c>.status.pauseConditions</c>) — typically an unweighted or weighted canary
+    /// step that is waiting for promotion.
+    /// </summary>
+    public bool IsPaused { get; init; }
+
+    /// <summary>
+    /// Whether the rollout is in an aborted state (<c>.status.abort</c>), which drives
+    /// it back to the stable revision.
+    /// </summary>
+    public bool IsAborted { get; init; }
+
+    /// <summary>
+    /// Pod-template-hash of the current desired revision (<c>.status.currentPodHash</c>).
+    /// </summary>
+    public string? CurrentPodHash { get; init; }
+
+    /// <summary>
+    /// Stable ReplicaSet pod-template-hash (<c>.status.stableRS</c>). When this matches
+    /// <see cref="CurrentPodHash"/> the desired revision has become the stable revision.
+    /// </summary>
+    public string? StableRevisionHash { get; init; }
+
+    /// <summary>
+    /// Container image currently set on the rollout pod template for the configured
+    /// container (<c>spec.template.spec.containers[name].image</c>). Used to confirm the
+    /// desired image was applied at submission time.
+    /// </summary>
+    public string? PodTemplateImage { get; init; }
+}
+
+/// <summary>
+/// Narrow REST adapter over the Argo Rollouts <c>argoproj.io/v1alpha1</c> Rollout API.
+/// Only the verbs the <see cref="KubernetesArgoRolloutsDeployBackend"/> needs are
+/// modeled — get status, set the canary image (start), promote (clear pause), and abort
+/// (rollback) — so the surface stays AOT-friendly and free of the Argo client libraries.
+/// </summary>
+internal interface IArgoRolloutsClient
+{
+    /// <summary>
+    /// Fetches the current Rollout status. Returns null when the Rollout does not exist
+    /// (404) so the backend can surface a configuration error rather than throwing.
+    /// </summary>
+    Task<ArgoRolloutState?> GetRolloutAsync(
+        string @namespace,
+        string name,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the container image on the Rollout pod template, which triggers Argo Rollouts
+    /// to begin the configured canary steps. Uses a strategic-merge patch keyed by the
+    /// container name so sibling containers and pod-template fields are preserved.
+    /// </summary>
+    Task<ArgoRolloutState> SetImageAsync(
+        string @namespace,
+        string name,
+        string containerName,
+        string image,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Promotes a paused Rollout by clearing its pause conditions on the status
+    /// subresource and unsetting <c>spec.paused</c>. Argo Rollouts then advances to the
+    /// next canary step (or to 100% when the final step is reached). Mirrors the
+    /// <c>kubectl-argo-rollouts promote</c> behavior.
+    /// </summary>
+    Task<ArgoRolloutState> PromoteAsync(
+        string @namespace,
+        string name,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Aborts a Rollout by setting <c>status.abort=true</c>, which drives traffic back to
+    /// the stable revision. Mirrors the <c>kubectl-argo-rollouts abort</c> behavior.
+    /// </summary>
+    Task<ArgoRolloutState> AbortAsync(
+        string @namespace,
+        string name,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Raw-HTTP implementation of <see cref="IArgoRolloutsClient"/>. Reuses the shared
+/// Kubernetes API request factory (in-cluster service-account or configured
+/// out-of-cluster auth) and the <c>control-plane-kubernetes</c> HTTP client so it shares
+/// one credential-resolution and TLS-trust path with <see cref="KubernetesJobClient"/>.
+/// </summary>
+internal sealed partial class ArgoRolloutsClient(
+    IHttpClientFactory httpClientFactory,
+    KubernetesApiRequestFactory requestFactory,
+    ILogger<ArgoRolloutsClient> logger) : IArgoRolloutsClient
+{
+    private const string StrategicMergePatchContentType = "application/strategic-merge-patch+json";
+    private const string MergePatchContentType = "application/merge-patch+json";
+
+    public async Task<ArgoRolloutState?> GetRolloutAsync(
+        string @namespace,
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(@namespace);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        using var request = await requestFactory.CreateRequestAsync(
+                HttpMethod.Get,
+                BuildRolloutPath(@namespace, name),
+                payload: null,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        using var client = httpClientFactory.CreateClient(KubernetesJobClient.HttpClientName);
+        using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            await ThrowApiErrorAsync(response, "get Rollout", cancellationToken).ConfigureAwait(false);
+        }
+
+        return await ParseRolloutAsync(response, name, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<ArgoRolloutState> SetImageAsync(
+        string @namespace,
+        string name,
+        string containerName,
+        string image,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(@namespace);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(image);
+
+        var patch = ArgoRolloutsPatchSerializer.SerializeSetImage(containerName, image);
+        return await PatchRolloutAsync(
+                @namespace,
+                name,
+                BuildRolloutPath(@namespace, name),
+                patch,
+                StrategicMergePatchContentType,
+                "set Rollout image",
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<ArgoRolloutState> PromoteAsync(
+        string @namespace,
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(@namespace);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        // Clear the pause on the status subresource so the controller advances to the
+        // next canary step, and unset spec.paused so a spec-level pause does not re-pause
+        // the rollout. Mirrors the kubectl-argo-rollouts promote contract.
+        await PatchRolloutAsync(
+                @namespace,
+                name,
+                BuildRolloutStatusPath(@namespace, name),
+                ArgoRolloutsPatchSerializer.SerializeClearPauseStatus(),
+                MergePatchContentType,
+                "promote Rollout (status)",
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return await PatchRolloutAsync(
+                @namespace,
+                name,
+                BuildRolloutPath(@namespace, name),
+                ArgoRolloutsPatchSerializer.SerializeUnpauseSpec(),
+                MergePatchContentType,
+                "promote Rollout (spec)",
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<ArgoRolloutState> AbortAsync(
+        string @namespace,
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(@namespace);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        // Setting status.abort=true reverts the rollout to the stable revision. Argo
+        // Rollouts owns the abort field on the status subresource.
+        return await PatchRolloutAsync(
+                @namespace,
+                name,
+                BuildRolloutStatusPath(@namespace, name),
+                ArgoRolloutsPatchSerializer.SerializeAbortStatus(),
+                MergePatchContentType,
+                "abort Rollout",
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<ArgoRolloutState> PatchRolloutAsync(
+        string @namespace,
+        string name,
+        string path,
+        byte[] patch,
+        string contentType,
+        string operation,
+        CancellationToken cancellationToken)
+    {
+        using var request = await requestFactory.CreateRequestAsync(
+                HttpMethod.Patch,
+                path,
+                patch,
+                cancellationToken,
+                contentType)
+            .ConfigureAwait(false);
+
+        using var client = httpClientFactory.CreateClient(KubernetesJobClient.HttpClientName);
+        using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            await ThrowApiErrorAsync(response, operation, cancellationToken).ConfigureAwait(false);
+        }
+
+        return await ParseRolloutAsync(response, name, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string BuildRolloutPath(string @namespace, string name)
+        => $"/apis/argoproj.io/v1alpha1/namespaces/{Uri.EscapeDataString(@namespace)}/rollouts/{Uri.EscapeDataString(name)}";
+
+    private static string BuildRolloutStatusPath(string @namespace, string name)
+        => BuildRolloutPath(@namespace, name) + "/status";
+
+    private static async Task<ArgoRolloutState> ParseRolloutAsync(
+        HttpResponseMessage response,
+        string name,
+        CancellationToken cancellationToken)
+    {
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return ArgoRolloutsPatchSerializer.ParseRollout(document.RootElement, name);
+    }
+
+    private async Task ThrowApiErrorAsync(
+        HttpResponseMessage response,
+        string operation,
+        CancellationToken cancellationToken)
+    {
+        string body;
+        try
+        {
+            body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception readEx)
+        {
+            body = $"<unreadable response body: {readEx.Message}>";
+        }
+
+        Log.ArgoRolloutsApiError(logger, operation, (int)response.StatusCode, body);
+        throw new HttpRequestException(
+            $"Argo Rollouts API request to {operation} failed with status {(int)response.StatusCode}: {body}",
+            inner: null,
+            response.StatusCode);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9100, LogLevel.Warning,
+            "Argo Rollouts API call to {Operation} failed with status {StatusCode}: {Body}")]
+        public static partial void ArgoRolloutsApiError(ILogger logger, string operation, int statusCode, string body);
+    }
+}
+
+/// <summary>
+/// Serializes the small set of Argo Rollouts patch bodies and parses Rollout status.
+/// Lifted out of <see cref="ArgoRolloutsClient"/> so the patch/parse contract can be
+/// unit-tested without an HTTP fake.
+/// </summary>
+internal static class ArgoRolloutsPatchSerializer
+{
+    private static readonly JsonWriterOptions WriterOptions = new() { Indented = false };
+
+    /// <summary>
+    /// Builds a strategic-merge patch that sets the image on a named container in the
+    /// Rollout pod template. The container name is the strategic-merge key so sibling
+    /// containers are preserved.
+    /// </summary>
+    public static byte[] SerializeSetImage(string containerName, string image)
+    {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer, WriterOptions))
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("spec");
+            writer.WriteStartObject();
+            writer.WritePropertyName("template");
+            writer.WriteStartObject();
+            writer.WritePropertyName("spec");
+            writer.WriteStartObject();
+            writer.WritePropertyName("containers");
+            writer.WriteStartArray();
+            writer.WriteStartObject();
+            writer.WriteString("name", containerName);
+            writer.WriteString("image", image);
+            writer.WriteEndObject();
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// Builds a merge patch for the status subresource that clears pause conditions and
+    /// unsets the abort flag, advancing a paused rollout.
+    /// </summary>
+    public static byte[] SerializeClearPauseStatus()
+    {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer, WriterOptions))
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("status");
+            writer.WriteStartObject();
+            writer.WriteNull("pauseConditions");
+            writer.WriteBoolean("abort", false);
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// Builds a merge patch that unsets <c>spec.paused</c> so a spec-level pause does not
+    /// re-pause the rollout after promotion.
+    /// </summary>
+    public static byte[] SerializeUnpauseSpec()
+    {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer, WriterOptions))
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("spec");
+            writer.WriteStartObject();
+            writer.WriteBoolean("paused", false);
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// Builds a merge patch for the status subresource that sets <c>abort=true</c>,
+    /// driving the rollout back to the stable revision.
+    /// </summary>
+    public static byte[] SerializeAbortStatus()
+    {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer, WriterOptions))
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("status");
+            writer.WriteStartObject();
+            writer.WriteBoolean("abort", true);
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// Parses an Argo Rollouts custom-resource JSON document into the narrow
+    /// <see cref="ArgoRolloutState"/> the deploy backend consumes.
+    /// </summary>
+    public static ArgoRolloutState ParseRollout(JsonElement root, string fallbackName)
+    {
+        var name = fallbackName;
+        if (root.TryGetProperty("metadata", out var metadata) &&
+            metadata.ValueKind == JsonValueKind.Object &&
+            metadata.TryGetProperty("name", out var nameElement) &&
+            nameElement.ValueKind == JsonValueKind.String)
+        {
+            name = nameElement.GetString() ?? fallbackName;
+        }
+
+        var phase = ArgoRolloutPhase.Unknown;
+        string? message = null;
+        int? canaryWeight = null;
+        var isPaused = false;
+        var isAborted = false;
+        string? currentPodHash = null;
+        string? stableRevisionHash = null;
+
+        if (root.TryGetProperty("status", out var status) && status.ValueKind == JsonValueKind.Object)
+        {
+            if (status.TryGetProperty("phase", out var phaseElement) &&
+                phaseElement.ValueKind == JsonValueKind.String)
+            {
+                phase = ParsePhase(phaseElement.GetString());
+            }
+
+            if (status.TryGetProperty("message", out var messageElement) &&
+                messageElement.ValueKind == JsonValueKind.String)
+            {
+                message = messageElement.GetString();
+            }
+
+            if (status.TryGetProperty("abort", out var abortElement) &&
+                (abortElement.ValueKind == JsonValueKind.True || abortElement.ValueKind == JsonValueKind.False))
+            {
+                isAborted = abortElement.GetBoolean();
+            }
+
+            if (status.TryGetProperty("pauseConditions", out var pauseElement) &&
+                pauseElement.ValueKind == JsonValueKind.Array)
+            {
+                isPaused = pauseElement.GetArrayLength() > 0;
+            }
+
+            if (status.TryGetProperty("currentPodHash", out var currentHashElement) &&
+                currentHashElement.ValueKind == JsonValueKind.String)
+            {
+                currentPodHash = currentHashElement.GetString();
+            }
+
+            if (status.TryGetProperty("stableRS", out var stableElement) &&
+                stableElement.ValueKind == JsonValueKind.String)
+            {
+                stableRevisionHash = stableElement.GetString();
+            }
+
+            canaryWeight = ParseCanaryWeight(status);
+        }
+
+        var podTemplateImage = ParsePodTemplateImage(root);
+
+        return new ArgoRolloutState
+        {
+            Name = name,
+            Phase = phase,
+            Message = message,
+            CanaryWeight = canaryWeight,
+            IsPaused = isPaused,
+            IsAborted = isAborted,
+            CurrentPodHash = currentPodHash,
+            StableRevisionHash = stableRevisionHash,
+            PodTemplateImage = podTemplateImage
+        };
+    }
+
+    private static ArgoRolloutPhase ParsePhase(string? phase)
+        => phase switch
+        {
+            "Progressing" => ArgoRolloutPhase.Progressing,
+            "Paused" => ArgoRolloutPhase.Paused,
+            "Healthy" => ArgoRolloutPhase.Healthy,
+            "Degraded" => ArgoRolloutPhase.Degraded,
+            _ => ArgoRolloutPhase.Unknown
+        };
+
+    private static int? ParseCanaryWeight(JsonElement status)
+    {
+        // .status.canary.weights.canary.weight is the authoritative current canary share.
+        if (!status.TryGetProperty("canary", out var canary) || canary.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (!canary.TryGetProperty("weights", out var weights) || weights.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (!weights.TryGetProperty("canary", out var canaryWeights) || canaryWeights.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (canaryWeights.TryGetProperty("weight", out var weightElement) &&
+            weightElement.ValueKind == JsonValueKind.Number &&
+            weightElement.TryGetInt32(out var weight))
+        {
+            return weight;
+        }
+
+        return null;
+    }
+
+    private static string? ParsePodTemplateImage(JsonElement root)
+    {
+        if (!root.TryGetProperty("spec", out var spec) || spec.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (!spec.TryGetProperty("template", out var template) || template.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (!template.TryGetProperty("spec", out var templateSpec) || templateSpec.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (!templateSpec.TryGetProperty("containers", out var containers) ||
+            containers.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        foreach (var container in containers.EnumerateArray())
+        {
+            if (container.ValueKind == JsonValueKind.Object &&
+                container.TryGetProperty("image", out var imageElement) &&
+                imageElement.ValueKind == JsonValueKind.String)
+            {
+                return imageElement.GetString();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Honua.Server/Features/ControlPlane/KubernetesApiRequestFactory.cs
+++ b/src/Honua.Server/Features/ControlPlane/KubernetesApiRequestFactory.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Shared builder for authenticated Kubernetes API server requests. Resolves the
+/// in-cluster service-account context (projected token + API server env vars) or the
+/// explicitly configured out-of-cluster endpoint, attaches the bearer token, and
+/// combines the API server base URL with a REST path. Extracted from
+/// <see cref="KubernetesJobClient"/> so the Job batch backend and the Argo Rollouts
+/// deploy backend share one credential-resolution and request-shaping path instead of
+/// each duplicating the auth chain. Keeps the trim/AOT surface small by avoiding the
+/// official <c>KubernetesClient</c> NuGet dependency.
+/// </summary>
+internal sealed class KubernetesApiRequestFactory(IOptionsMonitor<KubernetesExecutionOptions> options)
+{
+    private const string InClusterTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+    private const string InClusterHostEnv = "KUBERNETES_SERVICE_HOST";
+    private const string InClusterPortEnv = "KUBERNETES_SERVICE_PORT";
+
+    /// <summary>
+    /// Builds an authenticated <see cref="HttpRequestMessage"/> for the given Kubernetes
+    /// REST path. When <paramref name="contentType"/> is supplied the payload is sent with
+    /// that media type (used for JSON merge/strategic-merge PATCH bodies); otherwise it
+    /// defaults to <c>application/json</c>.
+    /// </summary>
+    public async Task<HttpRequestMessage> CreateRequestAsync(
+        HttpMethod method,
+        string relativeUrl,
+        byte[]? payload,
+        CancellationToken cancellationToken,
+        string contentType = "application/json")
+    {
+        var resolved = ResolveAuthentication();
+        var absoluteUri = CombineApiServerUri(resolved.ApiServer, relativeUrl);
+        var request = new HttpRequestMessage(method, absoluteUri);
+
+        var token = await ReadTokenAsync(resolved, cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(token))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+
+        if (payload != null)
+        {
+            request.Content = new ByteArrayContent(payload);
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType)
+            {
+                CharSet = Encoding.UTF8.WebName
+            };
+        }
+
+        return request;
+    }
+
+    /// <summary>
+    /// Joins the API server base URL with a Kubernetes REST path while preserving any
+    /// non-root path on the base (e.g. when the API server sits behind a path-based
+    /// gateway at <c>https://proxy.example/k8s</c>). <see cref="Uri(Uri, string)"/> drops
+    /// the base path whenever the relative URL starts with "/", so build the string
+    /// explicitly instead.
+    /// </summary>
+    internal static Uri CombineApiServerUri(Uri apiServer, string relativeUrl)
+    {
+        ArgumentNullException.ThrowIfNull(apiServer);
+        ArgumentException.ThrowIfNullOrEmpty(relativeUrl);
+
+        var basePart = apiServer.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        var suffix = relativeUrl.StartsWith('/') ? relativeUrl : "/" + relativeUrl;
+        return new Uri(basePart + suffix, UriKind.Absolute);
+    }
+
+    private KubernetesAuthContext ResolveAuthentication()
+    {
+        var current = options.CurrentValue;
+
+        if (current.InClusterAutoDetect && TryResolveInClusterContext(out var inCluster))
+        {
+            return inCluster;
+        }
+
+        if (string.IsNullOrWhiteSpace(current.ApiServerUrl))
+        {
+            throw new InvalidOperationException(
+                "Kubernetes control-plane backend is configured but no API server endpoint is available. " +
+                "Set ControlPlane:Kubernetes:ApiServerUrl or enable in-cluster auto-detection.");
+        }
+
+        return new KubernetesAuthContext(
+            new Uri(current.ApiServerUrl, UriKind.Absolute),
+            current.BearerTokenPath,
+            current.BearerToken);
+    }
+
+    private static bool TryResolveInClusterContext(out KubernetesAuthContext context)
+    {
+        var host = Environment.GetEnvironmentVariable(InClusterHostEnv);
+        var port = Environment.GetEnvironmentVariable(InClusterPortEnv);
+        if (string.IsNullOrWhiteSpace(host) || string.IsNullOrWhiteSpace(port) || !File.Exists(InClusterTokenPath))
+        {
+            context = default;
+            return false;
+        }
+
+        context = new KubernetesAuthContext(
+            new Uri($"https://{host}:{port}", UriKind.Absolute),
+            InClusterTokenPath,
+            BearerToken: null);
+        return true;
+    }
+
+    private static async Task<string?> ReadTokenAsync(
+        KubernetesAuthContext context,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrEmpty(context.BearerToken))
+        {
+            return context.BearerToken;
+        }
+
+        if (string.IsNullOrEmpty(context.BearerTokenPath) || !File.Exists(context.BearerTokenPath))
+        {
+            return null;
+        }
+
+        var token = await File.ReadAllTextAsync(context.BearerTokenPath, cancellationToken).ConfigureAwait(false);
+        return token.Trim();
+    }
+
+    private readonly record struct KubernetesAuthContext(
+        Uri ApiServer,
+        string? BearerTokenPath,
+        string? BearerToken);
+}

--- a/src/Honua.Server/Features/ControlPlane/KubernetesArgoRolloutsDeployBackend.cs
+++ b/src/Honua.Server/Features/ControlPlane/KubernetesArgoRolloutsDeployBackend.cs
@@ -1,0 +1,581 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.ServiceDefaults;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Closed-loop Kubernetes deploy backend that drives a weighted canary rollout and
+/// automatic rollback through an external <a href="https://argo-rollouts.readthedocs.io/">Argo
+/// Rollouts</a> controller. Honua mutates the Rollout custom resource (set the canary
+/// image to start, promote to advance a paused step, abort to roll back) and reflects the
+/// controller-reported rollout status back into the <see cref="WorkflowOperationRecord"/>
+/// lifecycle so <see cref="ObserveAsync"/>, <see cref="PromoteAsync"/>, and
+/// <see cref="RollbackAsync"/> drive real state transitions rather than
+/// <see cref="WorkflowOperationStatus.ManualInterventionRequired"/>.
+///
+/// The progressive canary stepping itself (5→25→50→100, pause/analysis) is owned by the
+/// Argo Rollouts <c>spec.strategy.canary.steps</c> on the cluster; Honua observes the
+/// step weight and gates promotion/rollback through the shared telemetry-gated
+/// reconciler. Coexists with the GitOps passthrough backend
+/// <c>honua-gitops-kubernetes</c> under <see cref="DeployTargetKind.Kubernetes"/>;
+/// targets pick by <see cref="DeployTargetDefinition.Backend"/> name.
+/// </summary>
+internal sealed partial class KubernetesArgoRolloutsDeployBackend(
+    IArgoRolloutsClient rolloutsClient,
+    ILogger<KubernetesArgoRolloutsDeployBackend> logger) : IDeployBackend
+{
+    internal const string AdapterBackendName = "honua-kubernetes-argo-rollouts";
+
+    /// <summary>Parameter key for the Rollout namespace.</summary>
+    internal const string NamespaceParameter = "kubernetes.namespace";
+
+    /// <summary>Parameter key for the Argo Rollout resource name.</summary>
+    internal const string RolloutNameParameter = "kubernetes.argo.rollout_name";
+
+    /// <summary>Parameter key for the container whose image the rollout shifts.</summary>
+    internal const string ContainerNameParameter = "kubernetes.argo.container_name";
+
+    public string BackendName => AdapterBackendName;
+
+    public DeployTargetKind TargetKind => DeployTargetKind.Kubernetes;
+
+    public Task<DeployBackendCapabilities> GetCapabilitiesAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new DeployBackendCapabilities
+        {
+            SupportsRollback = true,
+            SupportsCancellation = false,
+            SupportsTrafficShifting = true,
+            // Kubernetes schema migrations are managed by Honua's migration runner on
+            // boot, but image-level rollouts do not run them inside the deploy workflow.
+            RequiresOutOfBandMigrations = true,
+            SupportsProgressPolling = true,
+            SupportsRevisionPinning = true
+        });
+
+    public Task<DeployPlan> PlanAsync(DeployOperationSpec spec, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var blockingReasons = new List<string>();
+        var warnings = new List<string>();
+        var target = ResolveTarget(spec);
+
+        if (string.IsNullOrWhiteSpace(spec.TargetId))
+        {
+            blockingReasons.Add("A target ID is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(spec.DesiredRevision))
+        {
+            blockingReasons.Add("A desired image reference is required for Kubernetes Argo Rollouts deploy workflows.");
+        }
+
+        if (string.IsNullOrWhiteSpace(target.Namespace))
+        {
+            blockingReasons.Add("Kubernetes Argo Rollouts deploy workflows require kubernetes.namespace (or in-cluster namespace auto-detection).");
+        }
+
+        if (string.IsNullOrWhiteSpace(target.RolloutName))
+        {
+            blockingReasons.Add("Kubernetes Argo Rollouts deploy workflows require kubernetes.argo.rollout_name (or targetName).");
+        }
+
+        if (string.IsNullOrWhiteSpace(target.ContainerName))
+        {
+            blockingReasons.Add("Kubernetes Argo Rollouts deploy workflows require kubernetes.argo.container_name to identify the container image to shift.");
+        }
+
+        if (string.IsNullOrWhiteSpace(spec.ArtifactReference))
+        {
+            warnings.Add("No artifact reference is configured for this target.");
+        }
+
+        if (!TryResolveCanaryWeightPercentage(spec.Parameters, out var canaryWeight, out var canaryError))
+        {
+            blockingReasons.Add(canaryError ?? "Kubernetes Argo Rollouts canary weight is invalid.");
+        }
+        else if (canaryWeight.HasValue &&
+            (!spec.Parameters.TryGetValue("telemetry.connection", out var telemetryConnection) ||
+             string.IsNullOrWhiteSpace(telemetryConnection)))
+        {
+            blockingReasons.Add("Kubernetes Argo Rollouts canary traffic shifting requires telemetry.connection so the rollout can be promoted or rolled back automatically.");
+        }
+
+        return Task.FromResult(new DeployPlan
+        {
+            IsReadyToSubmit = blockingReasons.Count == 0 && !spec.RequiresApproval,
+            RequiresApproval = spec.RequiresApproval,
+            RequiresOutOfBandMigrations = spec.RequiresOutOfBandMigrations,
+            BlockingReasons = blockingReasons,
+            Warnings = warnings
+        });
+    }
+
+    public async Task<DeploySubmissionResult> StartAsync(
+        WorkflowOperationRecord operation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        var spec = operation.Deploy ?? throw new InvalidOperationException("Deploy workflow operation is missing deploy metadata.");
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var target = ResolveTarget(spec);
+        EnsureValidTarget(target);
+
+        using var activity = StartActivity(ControlPlaneTelemetry.Activities.BackendStart, operation, target);
+
+        try
+        {
+            // Capture the currently deployed image so rollback (abort) has a known
+            // baseline and the reconciler can persist CurrentRevision.
+            var existing = await rolloutsClient.GetRolloutAsync(target.Namespace!, target.RolloutName!, cancellationToken)
+                .ConfigureAwait(false);
+            if (existing == null)
+            {
+                Log.RolloutNotFound(logger, operation.OperationId, spec.TargetId, target.Namespace!, target.RolloutName!);
+                return new DeploySubmissionResult
+                {
+                    Status = WorkflowOperationStatus.Failed,
+                    Message = $"Argo Rollout '{target.RolloutName}' was not found in namespace '{target.Namespace}'. Provision the Rollout resource before submitting a deploy."
+                };
+            }
+
+            var observedImage = existing.PodTemplateImage;
+
+            // Setting the image triggers the Argo Rollouts controller to begin the
+            // configured canary steps. The controller owns the stepped ramp; Honua
+            // observes and gates.
+            await rolloutsClient.SetImageAsync(
+                    target.Namespace!,
+                    target.RolloutName!,
+                    target.ContainerName!,
+                    spec.DesiredRevision,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            Log.OperationSubmitted(logger, operation.OperationId, spec.TargetId, target.Namespace!, target.RolloutName!, spec.DesiredRevision);
+            return new DeploySubmissionResult
+            {
+                Status = WorkflowOperationStatus.Submitted,
+                ProviderOperationId = $"{target.Namespace}/{target.RolloutName}",
+                ObservedRevision = observedImage,
+                Message = $"Argo Rollout '{target.RolloutName}' is rolling out image '{spec.DesiredRevision}'."
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            Log.SubmissionFailed(logger, operation.OperationId, spec.TargetId, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error);
+            return new DeploySubmissionResult
+            {
+                Status = WorkflowOperationStatus.Failed,
+                Message = SanitizedFailureMessage
+            };
+        }
+    }
+
+    public async Task<DeployObservation> ObserveAsync(
+        WorkflowOperationRecord operation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        var spec = operation.Deploy ?? throw new InvalidOperationException("Deploy workflow operation is missing deploy metadata.");
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var target = ResolveTarget(spec);
+
+        using var activity = StartActivity(ControlPlaneTelemetry.Activities.BackendObserve, operation, target);
+
+        try
+        {
+            EnsureValidTarget(target);
+            _ = TryResolveCanaryWeightPercentage(spec.Parameters, out var desiredCanaryWeight, out _);
+
+            var rollout = await rolloutsClient.GetRolloutAsync(target.Namespace!, target.RolloutName!, cancellationToken)
+                .ConfigureAwait(false);
+            if (rollout == null)
+            {
+                return new DeployObservation
+                {
+                    Status = WorkflowOperationStatus.Failed,
+                    ProviderOperationId = operation.ProviderOperationId,
+                    ObservedRevision = operation.ObservedState,
+                    Message = $"Argo Rollout '{target.RolloutName}' was not found in namespace '{target.Namespace}'."
+                };
+            }
+
+            Log.StateObserved(logger, target.RolloutName!, rollout.Phase.ToString(), rollout.CanaryWeight ?? -1, rollout.IsPaused);
+            var observedImage = rollout.PodTemplateImage ?? operation.ObservedState;
+
+            if (operation.Status == WorkflowOperationStatus.RollbackRequested)
+            {
+                return ObserveRollback(operation, spec, target, rollout, observedImage);
+            }
+
+            // A degraded rollout (failed analysis, progress-deadline exceeded, or an
+            // operator/controller abort) is the auto-rollback trigger. Surface
+            // RollbackRecommended so the shared reconciler drives RollbackAsync rather
+            // than leaving the operation stalled.
+            if (rollout.Phase == ArgoRolloutPhase.Degraded || rollout.IsAborted)
+            {
+                return new DeployObservation
+                {
+                    Status = WorkflowOperationStatus.Reconciling,
+                    ProviderOperationId = operation.ProviderOperationId,
+                    ObservedRevision = observedImage,
+                    RollbackRecommended = true,
+                    Message = rollout.Message is { Length: > 0 } degradedMessage
+                        ? $"Argo Rollout '{target.RolloutName}' is degraded: {degradedMessage}."
+                        : $"Argo Rollout '{target.RolloutName}' is degraded and is a rollback candidate."
+                };
+            }
+
+            // The desired revision is fully promoted once the rollout is Healthy and the
+            // desired pod hash has become the stable revision. Argo sets currentPodHash
+            // == stableRS only after the final step completes.
+            if (rollout.Phase == ArgoRolloutPhase.Healthy && IsFullyPromoted(rollout))
+            {
+                return new DeployObservation
+                {
+                    Status = WorkflowOperationStatus.Succeeded,
+                    ProviderOperationId = operation.ProviderOperationId,
+                    ObservedRevision = observedImage,
+                    Message = $"Argo Rollout '{target.RolloutName}' is healthy and fully promoted to image '{spec.DesiredRevision}'."
+                };
+            }
+
+            // Paused at a canary step that has reached the configured target weight is the
+            // promotion-ready signal. The shared reconciler runs the telemetry gate and,
+            // on pass, calls PromoteAsync to advance the rollout.
+            if (rollout.Phase == ArgoRolloutPhase.Paused &&
+                rollout.IsPaused &&
+                IsAtExpectedCanaryWeight(rollout, desiredCanaryWeight))
+            {
+                return new DeployObservation
+                {
+                    Status = WorkflowOperationStatus.Reconciling,
+                    ProviderOperationId = operation.ProviderOperationId,
+                    ObservedRevision = observedImage,
+                    PromotionRecommended = true,
+                    Message = desiredCanaryWeight.HasValue
+                        ? $"Argo Rollout '{target.RolloutName}' is paused with {rollout.CanaryWeight ?? desiredCanaryWeight.Value}% canary weight and is ready for promotion."
+                        : $"Argo Rollout '{target.RolloutName}' is paused at a canary step and is ready for promotion."
+                };
+            }
+
+            return new DeployObservation
+            {
+                Status = WorkflowOperationStatus.Reconciling,
+                ProviderOperationId = operation.ProviderOperationId,
+                ObservedRevision = observedImage,
+                Message = $"Argo Rollout '{target.RolloutName}' is progressing (phase={rollout.Phase}, canaryWeight={rollout.CanaryWeight?.ToString(CultureInfo.InvariantCulture) ?? "n/a"}, paused={rollout.IsPaused})."
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            Log.StateLookupFailed(logger, operation.OperationId, spec.TargetId, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error);
+            return new DeployObservation
+            {
+                Status = WorkflowOperationStatus.Failed,
+                ProviderOperationId = operation.ProviderOperationId,
+                ObservedRevision = operation.ObservedState,
+                Message = SanitizedFailureMessage
+            };
+        }
+    }
+
+    public async Task<DeployObservation> PromoteAsync(
+        WorkflowOperationRecord operation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        var spec = operation.Deploy ?? throw new InvalidOperationException("Deploy workflow operation is missing deploy metadata.");
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var target = ResolveTarget(spec);
+        EnsureValidTarget(target);
+
+        using var activity = StartActivity(ControlPlaneTelemetry.Activities.BackendObserve, operation, target);
+
+        try
+        {
+            var rollout = await rolloutsClient.PromoteAsync(target.Namespace!, target.RolloutName!, cancellationToken)
+                .ConfigureAwait(false);
+
+            Log.PromotionRequested(logger, operation.OperationId, spec.TargetId, target.Namespace!, target.RolloutName!);
+
+            // Promotion advances the rollout to the next canary step (or 100% at the final
+            // step). The terminal Succeeded transition is recognised by a later ObserveAsync
+            // once the controller reports Healthy with the desired pod hash stable, so a
+            // promote that has not yet fully converged stays Reconciling.
+            if (rollout.Phase == ArgoRolloutPhase.Healthy && IsFullyPromoted(rollout))
+            {
+                return new DeployObservation
+                {
+                    Status = WorkflowOperationStatus.Succeeded,
+                    ProviderOperationId = operation.ProviderOperationId,
+                    ObservedRevision = rollout.PodTemplateImage ?? spec.DesiredRevision,
+                    Message = $"Argo Rollout '{target.RolloutName}' promoted and is healthy on image '{spec.DesiredRevision}'."
+                };
+            }
+
+            return new DeployObservation
+            {
+                Status = WorkflowOperationStatus.Reconciling,
+                ProviderOperationId = operation.ProviderOperationId,
+                ObservedRevision = rollout.PodTemplateImage ?? operation.ObservedState,
+                Message = $"Argo Rollout '{target.RolloutName}' promotion requested; controller is advancing to the next step."
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            Log.StateLookupFailed(logger, operation.OperationId, spec.TargetId, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error);
+            return new DeployObservation
+            {
+                Status = WorkflowOperationStatus.Failed,
+                ProviderOperationId = operation.ProviderOperationId,
+                ObservedRevision = operation.ObservedState,
+                Message = SanitizedFailureMessage
+            };
+        }
+    }
+
+    public async Task<DeployObservation> RollbackAsync(
+        WorkflowOperationRecord operation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        var spec = operation.Deploy ?? throw new InvalidOperationException("Deploy workflow operation is missing deploy metadata.");
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var target = ResolveTarget(spec);
+        EnsureValidTarget(target);
+
+        using var activity = StartActivity(ControlPlaneTelemetry.Activities.BackendRollback, operation, target);
+
+        try
+        {
+            await rolloutsClient.AbortAsync(target.Namespace!, target.RolloutName!, cancellationToken)
+                .ConfigureAwait(false);
+
+            Log.RollbackRequested(logger, operation.OperationId, spec.TargetId, target.Namespace!, target.RolloutName!);
+            return new DeployObservation
+            {
+                Status = WorkflowOperationStatus.RollbackRequested,
+                ProviderOperationId = operation.ProviderOperationId,
+                ObservedRevision = spec.CurrentRevision ?? operation.ObservedState,
+                Message = $"Argo Rollout '{target.RolloutName}' abort requested; the controller is reverting traffic to the stable revision."
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            Log.StateLookupFailed(logger, operation.OperationId, spec.TargetId, ex.Message);
+            activity?.SetStatus(ActivityStatusCode.Error);
+            return new DeployObservation
+            {
+                Status = WorkflowOperationStatus.Failed,
+                ProviderOperationId = operation.ProviderOperationId,
+                ObservedRevision = operation.ObservedState,
+                Message = SanitizedFailureMessage
+            };
+        }
+    }
+
+    private static DeployObservation ObserveRollback(
+        WorkflowOperationRecord operation,
+        DeployOperationSpec spec,
+        ArgoRolloutsDeployTarget target,
+        ArgoRolloutState rollout,
+        string? observedImage)
+    {
+        // An aborted rollout is terminal as RolledBack once Argo has reverted to the
+        // stable revision: the rollout is Healthy again and the current pod hash has
+        // settled back onto the stable ReplicaSet. While the controller is still draining
+        // the canary the operation stays RollbackRequested.
+        var revertedToStable = rollout.Phase == ArgoRolloutPhase.Healthy && IsFullyPromoted(rollout);
+        if (revertedToStable)
+        {
+            return new DeployObservation
+            {
+                Status = WorkflowOperationStatus.RolledBack,
+                ProviderOperationId = operation.ProviderOperationId,
+                ObservedRevision = spec.CurrentRevision ?? observedImage,
+                Message = $"Argo Rollout '{target.RolloutName}' rolled back to the stable revision."
+            };
+        }
+
+        return new DeployObservation
+        {
+            Status = WorkflowOperationStatus.RollbackRequested,
+            ProviderOperationId = operation.ProviderOperationId,
+            ObservedRevision = observedImage,
+            Message = $"Argo Rollout '{target.RolloutName}' rollback is still settling (phase={rollout.Phase}, aborted={rollout.IsAborted})."
+        };
+    }
+
+    // A rollout is fully promoted when the desired (current) pod hash has become the
+    // stable ReplicaSet. Argo only sets stableRS == currentPodHash after the final canary
+    // step completes, so this distinguishes a Healthy-but-mid-rollout state (current !=
+    // stable) from full convergence. When the controller does not report either hash,
+    // treat Healthy as converged so older Argo versions still terminate the operation.
+    private static bool IsFullyPromoted(ArgoRolloutState rollout)
+    {
+        if (string.IsNullOrWhiteSpace(rollout.CurrentPodHash) || string.IsNullOrWhiteSpace(rollout.StableRevisionHash))
+        {
+            return true;
+        }
+
+        return string.Equals(rollout.CurrentPodHash, rollout.StableRevisionHash, StringComparison.Ordinal);
+    }
+
+    // When a canary weight is configured the rollout must be holding exactly that share
+    // before promotion is recommended; otherwise any paused canary step is treated as
+    // promotion-ready (immediate-cutover rollouts with a single manual pause).
+    private static bool IsAtExpectedCanaryWeight(ArgoRolloutState rollout, int? desiredCanaryWeight)
+    {
+        if (!desiredCanaryWeight.HasValue)
+        {
+            return true;
+        }
+
+        return rollout.CanaryWeight == desiredCanaryWeight.Value;
+    }
+
+    private static ArgoRolloutsDeployTarget ResolveTarget(DeployOperationSpec spec)
+    {
+        var parameters = spec.Parameters;
+        return new ArgoRolloutsDeployTarget
+        {
+            Namespace = GetParameter(parameters, NamespaceParameter)
+                ?? KubernetesJobClient.TryReadInClusterNamespace(),
+            RolloutName = GetParameter(parameters, RolloutNameParameter) ?? spec.TargetName,
+            ContainerName = GetParameter(parameters, ContainerNameParameter)
+        };
+    }
+
+    private static void EnsureValidTarget(ArgoRolloutsDeployTarget target)
+    {
+        if (string.IsNullOrWhiteSpace(target.Namespace) ||
+            string.IsNullOrWhiteSpace(target.RolloutName) ||
+            string.IsNullOrWhiteSpace(target.ContainerName))
+        {
+            throw new InvalidOperationException("Kubernetes Argo Rollouts deploy target is missing namespace, rollout name, or container name metadata.");
+        }
+    }
+
+    private static string? GetParameter(IReadOnlyDictionary<string, string> parameters, string key)
+        => parameters.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value.Trim()
+            : null;
+
+    private static bool TryResolveCanaryWeightPercentage(
+        IReadOnlyDictionary<string, string> parameters,
+        out int? weight,
+        out string? error)
+    {
+        var rawValue = GetParameter(parameters, "kubernetes.argo.canary_weight_percentage")
+            ?? GetParameter(parameters, "deployment.canary_weight_percentage");
+        if (string.IsNullOrWhiteSpace(rawValue))
+        {
+            weight = null;
+            error = null;
+            return true;
+        }
+
+        if (!int.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedPercentage))
+        {
+            weight = null;
+            error = "Kubernetes Argo Rollouts canary weight must be an integer percentage between 1 and 99.";
+            return false;
+        }
+
+        if (parsedPercentage <= 0 || parsedPercentage >= 100)
+        {
+            weight = null;
+            error = "Kubernetes Argo Rollouts canary weight must be greater than 0 and less than 100 percent.";
+            return false;
+        }
+
+        weight = parsedPercentage;
+        error = null;
+        return true;
+    }
+
+    private static Activity? StartActivity(string activityName, WorkflowOperationRecord operation, ArgoRolloutsDeployTarget target)
+    {
+        var activity = HonuaTelemetry.ActivitySource.StartActivity(activityName, ActivityKind.Internal);
+        if (activity == null)
+        {
+            return null;
+        }
+
+        activity.SetTag(HonuaTelemetry.Tags.Operation, AdapterBackendName);
+        activity.SetTag(ControlPlaneTelemetry.Tags.Backend, AdapterBackendName);
+        activity.SetTag(ControlPlaneTelemetry.Tags.TargetKind, DeployTargetKind.Kubernetes.ToString());
+        activity.SetTag("honua.controlplane.operation_id", operation.OperationId);
+        if (operation.Deploy is { } deploy)
+        {
+            activity.SetTag("honua.controlplane.target_id", deploy.TargetId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(target.Namespace))
+        {
+            activity.SetTag("honua.controlplane.kubernetes.namespace", target.Namespace);
+        }
+
+        if (!string.IsNullOrWhiteSpace(target.RolloutName))
+        {
+            activity.SetTag("honua.controlplane.kubernetes.argo.rollout", target.RolloutName);
+        }
+
+        return activity;
+    }
+
+    // Provider error text from the Kubernetes/Argo API can carry resource names,
+    // namespaces, and request detail. The raw error already went to the structured log;
+    // the durable operation record gets a stable, generic message.
+    private const string SanitizedFailureMessage =
+        "Argo Rollouts state lookup failed for this rollout. Check the deploy controller logs for the underlying Kubernetes error.";
+
+    private sealed record ArgoRolloutsDeployTarget
+    {
+        public string? Namespace { get; init; }
+
+        public string? RolloutName { get; init; }
+
+        public string? ContainerName { get; init; }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9101, LogLevel.Information, "Submitted Argo Rollouts deploy workflow operation {OperationId} for target {TargetId} ({Namespace}/{RolloutName}) to image {DesiredImage}")]
+        public static partial void OperationSubmitted(ILogger logger, string operationId, string targetId, string @namespace, string rolloutName, string desiredImage);
+
+        [LoggerMessage(9102, LogLevel.Information, "Promotion requested for Argo Rollouts workflow operation {OperationId} targeting {TargetId} ({Namespace}/{RolloutName})")]
+        public static partial void PromotionRequested(ILogger logger, string operationId, string targetId, string @namespace, string rolloutName);
+
+        [LoggerMessage(9103, LogLevel.Warning, "Rollback (abort) requested for Argo Rollouts workflow operation {OperationId} targeting {TargetId} ({Namespace}/{RolloutName})")]
+        public static partial void RollbackRequested(ILogger logger, string operationId, string targetId, string @namespace, string rolloutName);
+
+        [LoggerMessage(9104, LogLevel.Warning, "Argo Rollouts state lookup failed for workflow operation {OperationId} targeting {TargetId}: {ErrorMessage}")]
+        public static partial void StateLookupFailed(ILogger logger, string operationId, string targetId, string errorMessage);
+
+        [LoggerMessage(9105, LogLevel.Debug, "Observed Argo Rollout {RolloutName}: phase={Phase} canaryWeight={CanaryWeight} paused={Paused}")]
+        public static partial void StateObserved(ILogger logger, string rolloutName, string phase, int canaryWeight, bool paused);
+
+        [LoggerMessage(9106, LogLevel.Warning, "Argo Rollouts submission failed for workflow operation {OperationId} targeting {TargetId}: {ErrorMessage}")]
+        public static partial void SubmissionFailed(ILogger logger, string operationId, string targetId, string errorMessage);
+
+        [LoggerMessage(9107, LogLevel.Warning, "Argo Rollout {RolloutName} not found in namespace {Namespace} for workflow operation {OperationId} targeting {TargetId}")]
+        public static partial void RolloutNotFound(ILogger logger, string operationId, string targetId, string @namespace, string rolloutName);
+    }
+}

--- a/src/Honua.Server/Features/ControlPlane/KubernetesJobClient.cs
+++ b/src/Honua.Server/Features/ControlPlane/KubernetesJobClient.cs
@@ -2,12 +2,9 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Text.Json;
-using Microsoft.Extensions.Options;
 
 namespace Honua.ControlPlane;
 
@@ -130,16 +127,13 @@ internal interface IKubernetesJobClient
 /// </summary>
 internal sealed partial class KubernetesJobClient(
     IHttpClientFactory httpClientFactory,
-    IOptionsMonitor<KubernetesExecutionOptions> options,
+    KubernetesApiRequestFactory requestFactory,
     ILogger<KubernetesJobClient> logger) : IKubernetesJobClient
 {
     internal const string HttpClientName = "control-plane-kubernetes";
 
-    private const string InClusterTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token";
     private const string InClusterCaCertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
     private const string InClusterNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
-    private const string InClusterHostEnv = "KUBERNETES_SERVICE_HOST";
-    private const string InClusterPortEnv = "KUBERNETES_SERVICE_PORT";
 
     public async Task<KubernetesJobCreateResult> CreateJobAsync(
         KubernetesJobManifest manifest,
@@ -283,107 +277,12 @@ internal sealed partial class KubernetesJobClient(
         return KubernetesJobManifestSerializer.ParsePodList(document.RootElement);
     }
 
-    private async Task<HttpRequestMessage> CreateRequestAsync(
+    private Task<HttpRequestMessage> CreateRequestAsync(
         HttpMethod method,
         string relativeUrl,
         byte[]? payload,
         CancellationToken cancellationToken)
-    {
-        var resolved = ResolveAuthentication();
-        var absoluteUri = CombineApiServerUri(resolved.ApiServer, relativeUrl);
-        var request = new HttpRequestMessage(method, absoluteUri);
-
-        var token = await ReadTokenAsync(resolved, cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(token))
-        {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        }
-
-        if (payload != null)
-        {
-            request.Content = new ByteArrayContent(payload);
-            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json")
-            {
-                CharSet = Encoding.UTF8.WebName
-            };
-        }
-
-        return request;
-    }
-
-    /// <summary>
-    /// Joins the API server base URL with a Kubernetes REST path while preserving any
-    /// non-root path on the base (e.g. when the API server sits behind a path-based
-    /// gateway at <c>https://proxy.example/k8s</c>). <see cref="Uri(Uri, string)"/> drops
-    /// the base path whenever the relative URL starts with "/", so build the string
-    /// explicitly instead.
-    /// </summary>
-    internal static Uri CombineApiServerUri(Uri apiServer, string relativeUrl)
-    {
-        ArgumentNullException.ThrowIfNull(apiServer);
-        ArgumentException.ThrowIfNullOrEmpty(relativeUrl);
-
-        var basePart = apiServer.GetLeftPart(UriPartial.Path).TrimEnd('/');
-        var suffix = relativeUrl.StartsWith('/') ? relativeUrl : "/" + relativeUrl;
-        return new Uri(basePart + suffix, UriKind.Absolute);
-    }
-
-    private KubernetesAuthContext ResolveAuthentication()
-    {
-        var current = options.CurrentValue;
-
-        if (current.InClusterAutoDetect && TryResolveInClusterContext(out var inCluster))
-        {
-            return inCluster;
-        }
-
-        if (string.IsNullOrWhiteSpace(current.ApiServerUrl))
-        {
-            throw new InvalidOperationException(
-                "Kubernetes execution backend is configured but no API server endpoint is available. " +
-                "Set ControlPlane:Kubernetes:ApiServerUrl or enable in-cluster auto-detection.");
-        }
-
-        return new KubernetesAuthContext(
-            new Uri(current.ApiServerUrl, UriKind.Absolute),
-            current.BearerTokenPath,
-            current.BearerToken);
-    }
-
-    private static bool TryResolveInClusterContext(out KubernetesAuthContext context)
-    {
-        var host = Environment.GetEnvironmentVariable(InClusterHostEnv);
-        var port = Environment.GetEnvironmentVariable(InClusterPortEnv);
-        if (string.IsNullOrWhiteSpace(host) || string.IsNullOrWhiteSpace(port) || !File.Exists(InClusterTokenPath))
-        {
-            context = default!;
-            return false;
-        }
-
-        context = new KubernetesAuthContext(
-            new Uri($"https://{host}:{port}", UriKind.Absolute),
-            InClusterTokenPath,
-            BearerToken: null);
-        return true;
-    }
-
-    private static async Task<string?> ReadTokenAsync(
-        KubernetesAuthContext context,
-        CancellationToken cancellationToken)
-    {
-        if (!string.IsNullOrEmpty(context.BearerToken))
-        {
-            return context.BearerToken;
-        }
-
-        if (string.IsNullOrEmpty(context.BearerTokenPath) || !File.Exists(context.BearerTokenPath))
-        {
-            return null;
-        }
-
-        var token = await File.ReadAllTextAsync(context.BearerTokenPath, cancellationToken).ConfigureAwait(false);
-        return token.Trim();
-    }
+        => requestFactory.CreateRequestAsync(method, relativeUrl, payload, cancellationToken);
 
     private static async Task<KubernetesJobStatusSnapshot?> ParseJobResponseAsync(
         HttpResponseMessage response,
@@ -439,7 +338,7 @@ internal sealed partial class KubernetesJobClient(
     /// Creates an <see cref="HttpMessageHandler"/> that trusts the Kubernetes API server CA.
     /// When <paramref name="inClusterAutoDetect"/> is true and the projected service-account
     /// CA is available, uses that bundle (matching the in-cluster path selected by
-    /// <see cref="ResolveAuthentication"/>). Otherwise, trusts a PEM bundle at
+    /// <see cref="KubernetesApiRequestFactory"/>). Otherwise, trusts a PEM bundle at
     /// <paramref name="caBundlePath"/> if provided (for clusters fronted by a private or
     /// self-signed CA); otherwise falls back to the OS trust store so operators whose API
     /// server chains to a public CA keep working. Wired at DI registration time.
@@ -471,7 +370,7 @@ internal sealed partial class KubernetesJobClient(
     }
 
     /// <summary>
-    /// Mirrors the auth-context decision made by <see cref="ResolveAuthentication"/>: the
+    /// Mirrors the auth-context decision made by <see cref="KubernetesApiRequestFactory"/>: the
     /// projected in-cluster CA only validates the local cluster's API server, so it is
     /// preferred only when in-cluster auto-detect is enabled. When operators disable
     /// auto-detect to target a different cluster via an explicit <c>ApiServerUrl</c>, the
@@ -587,11 +486,6 @@ internal sealed partial class KubernetesJobClient(
 
         return null;
     }
-
-    private readonly record struct KubernetesAuthContext(
-        Uri ApiServer,
-        string? BearerTokenPath,
-        string? BearerToken);
 
     private static partial class Log
     {

--- a/src/Honua.Server/Startup/BatchAndDeployBackendsRegistration.cs
+++ b/src/Honua.Server/Startup/BatchAndDeployBackendsRegistration.cs
@@ -36,9 +36,15 @@ internal static class BatchAndDeployBackendsRegistration
         services.AddSingleton<DeployWorkflowService>();
         services.AddSingleton<IDeployTelemetrySignalEvaluator, PrometheusDeployTelemetrySignalEvaluator>();
 
+        // Shared Kubernetes API request factory (in-cluster / out-of-cluster auth) consumed
+        // by both the Argo Rollouts deploy client and the Kubernetes Job batch client.
+        services.AddSingleton<KubernetesApiRequestFactory>();
+        services.AddSingleton<IArgoRolloutsClient, ArgoRolloutsClient>();
+
         // Deploy backend concrete singletons. Order matters for the IEnumerable<IDeployBackend>
         // resolution below — keep the existing K8s/AWS/Azure ordering.
         services.AddSingleton<KubernetesGitOpsDeployBackend>();
+        services.AddSingleton<KubernetesArgoRolloutsDeployBackend>();
 #if !HONUA_EXCLUDE_AWS
         services.AddSingleton<AwsEcsGitOpsDeployBackend>();
         services.AddSingleton<AwsEcsAlbDeployBackend>();
@@ -54,6 +60,7 @@ internal static class BatchAndDeployBackendsRegistration
         services.AddSingleton<AzureFunctionsGitOpsDeployBackend>();
 #endif
         services.AddSingleton<IDeployBackend>(sp => sp.GetRequiredService<KubernetesGitOpsDeployBackend>());
+        services.AddSingleton<IDeployBackend>(sp => sp.GetRequiredService<KubernetesArgoRolloutsDeployBackend>());
 #if !HONUA_EXCLUDE_AWS
         services.AddSingleton<IDeployBackend>(sp => sp.GetRequiredService<AwsEcsGitOpsDeployBackend>());
         services.AddSingleton<IDeployBackend>(sp => sp.GetRequiredService<AwsEcsAlbDeployBackend>());

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ArgoRolloutsPatchSerializerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ArgoRolloutsPatchSerializerTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.ControlPlane;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+public sealed class ArgoRolloutsPatchSerializerTests
+{
+    [Fact]
+    public void SerializeSetImage_KeysByContainerName()
+    {
+        var patch = ArgoRolloutsPatchSerializer.SerializeSetImage("honua", "ghcr.io/honua/server:sha-42");
+
+        using var document = JsonDocument.Parse(patch);
+        var container = document.RootElement
+            .GetProperty("spec")
+            .GetProperty("template")
+            .GetProperty("spec")
+            .GetProperty("containers")[0];
+
+        container.GetProperty("name").GetString().Should().Be("honua");
+        container.GetProperty("image").GetString().Should().Be("ghcr.io/honua/server:sha-42");
+    }
+
+    [Fact]
+    public void SerializeClearPauseStatus_NullsPauseConditionsAndClearsAbort()
+    {
+        var patch = ArgoRolloutsPatchSerializer.SerializeClearPauseStatus();
+
+        using var document = JsonDocument.Parse(patch);
+        var status = document.RootElement.GetProperty("status");
+
+        status.GetProperty("pauseConditions").ValueKind.Should().Be(JsonValueKind.Null);
+        status.GetProperty("abort").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void SerializeAbortStatus_SetsAbortTrue()
+    {
+        var patch = ArgoRolloutsPatchSerializer.SerializeAbortStatus();
+
+        using var document = JsonDocument.Parse(patch);
+        document.RootElement.GetProperty("status").GetProperty("abort").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void SerializeUnpauseSpec_SetsPausedFalse()
+    {
+        var patch = ArgoRolloutsPatchSerializer.SerializeUnpauseSpec();
+
+        using var document = JsonDocument.Parse(patch);
+        document.RootElement.GetProperty("spec").GetProperty("paused").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseRollout_ReadsPhaseWeightPauseAndHashes()
+    {
+        const string json = """
+        {
+          "metadata": { "name": "honua-server" },
+          "spec": {
+            "template": {
+              "spec": {
+                "containers": [ { "name": "honua", "image": "ghcr.io/honua/server:sha-42" } ]
+              }
+            }
+          },
+          "status": {
+            "phase": "Paused",
+            "message": "waiting for manual promotion",
+            "abort": false,
+            "pauseConditions": [ { "reason": "CanaryPauseStep" } ],
+            "currentPodHash": "abc123",
+            "stableRS": "stable999",
+            "canary": { "weights": { "canary": { "weight": 25 } } }
+          }
+        }
+        """;
+        using var document = JsonDocument.Parse(json);
+
+        var state = ArgoRolloutsPatchSerializer.ParseRollout(document.RootElement, "fallback");
+
+        state.Name.Should().Be("honua-server");
+        state.Phase.Should().Be(ArgoRolloutPhase.Paused);
+        state.Message.Should().Be("waiting for manual promotion");
+        state.IsPaused.Should().BeTrue();
+        state.IsAborted.Should().BeFalse();
+        state.CanaryWeight.Should().Be(25);
+        state.CurrentPodHash.Should().Be("abc123");
+        state.StableRevisionHash.Should().Be("stable999");
+        state.PodTemplateImage.Should().Be("ghcr.io/honua/server:sha-42");
+    }
+
+    [Fact]
+    public void ParseRollout_HealthyWithoutPauseOrCanary_ReportsHealthy()
+    {
+        const string json = """
+        {
+          "metadata": { "name": "honua-server" },
+          "status": {
+            "phase": "Healthy",
+            "currentPodHash": "abc123",
+            "stableRS": "abc123"
+          }
+        }
+        """;
+        using var document = JsonDocument.Parse(json);
+
+        var state = ArgoRolloutsPatchSerializer.ParseRollout(document.RootElement, "fallback");
+
+        state.Phase.Should().Be(ArgoRolloutPhase.Healthy);
+        state.IsPaused.Should().BeFalse();
+        state.CanaryWeight.Should().BeNull();
+        state.CurrentPodHash.Should().Be(state.StableRevisionHash);
+    }
+
+    [Fact]
+    public void ParseRollout_AbortedDegraded_ReportsAbortAndDegraded()
+    {
+        const string json = """
+        {
+          "status": {
+            "phase": "Degraded",
+            "abort": true,
+            "message": "analysis run failed"
+          }
+        }
+        """;
+        using var document = JsonDocument.Parse(json);
+
+        var state = ArgoRolloutsPatchSerializer.ParseRollout(document.RootElement, "honua-server");
+
+        state.Name.Should().Be("honua-server");
+        state.Phase.Should().Be(ArgoRolloutPhase.Degraded);
+        state.IsAborted.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseRollout_MissingStatus_UsesUnknownPhaseAndFallbackName()
+    {
+        using var document = JsonDocument.Parse("{}");
+
+        var state = ArgoRolloutsPatchSerializer.ParseRollout(document.RootElement, "honua-server");
+
+        state.Name.Should().Be("honua-server");
+        state.Phase.Should().Be(ArgoRolloutPhase.Unknown);
+        state.IsPaused.Should().BeFalse();
+        state.IsAborted.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PatchBodies_AreValidUtf8Json()
+    {
+        foreach (var patch in new[]
+        {
+            ArgoRolloutsPatchSerializer.SerializeSetImage("honua", "image:tag"),
+            ArgoRolloutsPatchSerializer.SerializeClearPauseStatus(),
+            ArgoRolloutsPatchSerializer.SerializeUnpauseSpec(),
+            ArgoRolloutsPatchSerializer.SerializeAbortStatus()
+        })
+        {
+            var act = () => JsonDocument.Parse(Encoding.UTF8.GetString(patch));
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/KubernetesArgoRolloutsDeployBackendTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/KubernetesArgoRolloutsDeployBackendTests.cs
@@ -1,0 +1,600 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.ControlPlane;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+public sealed class KubernetesArgoRolloutsDeployBackendTests
+{
+    private const string Namespace = "honua-prod";
+    private const string RolloutName = "honua-server";
+    private const string ContainerName = "honua";
+    private const string DesiredImage = "ghcr.io/honua/honua-server:sha-42";
+    private const string PreviousImage = "ghcr.io/honua/honua-server:sha-41";
+
+    [Fact]
+    public async Task PlanAsync_MissingRolloutName_HasBlockingReason()
+    {
+        var backend = CreateBackend();
+
+        var parameters = BaseParameters();
+        parameters.Remove(KubernetesArgoRolloutsDeployBackend.RolloutNameParameter);
+
+        var plan = await backend.PlanAsync(CreateSpec(parameters: parameters, targetName: ""));
+
+        plan.IsReadyToSubmit.Should().BeFalse();
+        plan.BlockingReasons.Should().Contain(reason => reason.Contains("rollout_name", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PlanAsync_MissingContainerName_HasBlockingReason()
+    {
+        var backend = CreateBackend();
+
+        var parameters = BaseParameters();
+        parameters.Remove(KubernetesArgoRolloutsDeployBackend.ContainerNameParameter);
+
+        var plan = await backend.PlanAsync(CreateSpec(parameters: parameters));
+
+        plan.IsReadyToSubmit.Should().BeFalse();
+        plan.BlockingReasons.Should().Contain(reason => reason.Contains("container_name", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PlanAsync_CanaryWeightWithoutTelemetryConnection_HasBlockingReason()
+    {
+        var backend = CreateBackend();
+
+        var parameters = BaseParameters();
+        parameters["deployment.canary_weight_percentage"] = "25";
+
+        var plan = await backend.PlanAsync(CreateSpec(parameters: parameters));
+
+        plan.IsReadyToSubmit.Should().BeFalse();
+        plan.BlockingReasons.Should().Contain(reason => reason.Contains("telemetry.connection", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PlanAsync_CanaryWeightOutOfRange_HasBlockingReason()
+    {
+        var backend = CreateBackend();
+
+        var parameters = BaseParameters();
+        parameters["deployment.canary_weight_percentage"] = "150";
+        parameters["telemetry.connection"] = "prod-prom";
+
+        var plan = await backend.PlanAsync(CreateSpec(parameters: parameters));
+
+        plan.IsReadyToSubmit.Should().BeFalse();
+        plan.BlockingReasons.Should().Contain(reason => reason.Contains("canary weight", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task PlanAsync_ValidImmediateParameters_IsReadyToSubmit()
+    {
+        var backend = CreateBackend();
+
+        var plan = await backend.PlanAsync(CreateSpec());
+
+        plan.IsReadyToSubmit.Should().BeTrue();
+        plan.BlockingReasons.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PlanAsync_ValidCanaryParameters_IsReadyToSubmit()
+    {
+        var backend = CreateBackend();
+
+        var plan = await backend.PlanAsync(CreateSpec(parameters: CanaryParameters()));
+
+        plan.IsReadyToSubmit.Should().BeTrue();
+        plan.BlockingReasons.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StartAsync_SetsImageAndCapturesPreviousImage()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            RolloutState = ProgressingRollout(PreviousImage)
+        };
+        var backend = CreateBackend(client);
+
+        var submission = await backend.StartAsync(CreateOperation(parameters: CanaryParameters()));
+
+        submission.Status.Should().Be(WorkflowOperationStatus.Submitted);
+        submission.ProviderOperationId.Should().Be($"{Namespace}/{RolloutName}");
+        submission.ObservedRevision.Should().Be(PreviousImage);
+        client.LastSetImage.Should().Be(DesiredImage);
+        client.LastSetImageContainer.Should().Be(ContainerName);
+    }
+
+    [Fact]
+    public async Task StartAsync_RolloutMissing_ReturnsFailed()
+    {
+        var client = new StubArgoRolloutsClient { RolloutState = null };
+        var backend = CreateBackend(client);
+
+        var submission = await backend.StartAsync(CreateOperation(parameters: CanaryParameters()));
+
+        submission.Status.Should().Be(WorkflowOperationStatus.Failed);
+        submission.Message.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task ObserveAsync_PausedAtExpectedCanaryWeight_RecommendsPromotion()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            RolloutState = new ArgoRolloutState
+            {
+                Name = RolloutName,
+                Phase = ArgoRolloutPhase.Paused,
+                IsPaused = true,
+                CanaryWeight = 25,
+                PodTemplateImage = DesiredImage,
+                CurrentPodHash = "abc123",
+                StableRevisionHash = "stable999"
+            }
+        };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.ObserveAsync(CreateOperation(
+            parameters: CanaryParameters(),
+            status: WorkflowOperationStatus.Reconciling));
+
+        observation.Status.Should().Be(WorkflowOperationStatus.Reconciling);
+        observation.PromotionRecommended.Should().BeTrue();
+        observation.RollbackRecommended.Should().BeFalse();
+        observation.ObservedRevision.Should().Be(DesiredImage);
+    }
+
+    [Fact]
+    public async Task ObserveAsync_PausedAtWrongCanaryWeight_DoesNotRecommendPromotion()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            RolloutState = new ArgoRolloutState
+            {
+                Name = RolloutName,
+                Phase = ArgoRolloutPhase.Paused,
+                IsPaused = true,
+                CanaryWeight = 5,
+                PodTemplateImage = DesiredImage
+            }
+        };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.ObserveAsync(CreateOperation(
+            parameters: CanaryParameters(),
+            status: WorkflowOperationStatus.Reconciling));
+
+        observation.Status.Should().Be(WorkflowOperationStatus.Reconciling);
+        observation.PromotionRecommended.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ObserveAsync_HealthyAndStable_ReturnsSucceeded()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            RolloutState = new ArgoRolloutState
+            {
+                Name = RolloutName,
+                Phase = ArgoRolloutPhase.Healthy,
+                PodTemplateImage = DesiredImage,
+                CurrentPodHash = "abc123",
+                StableRevisionHash = "abc123"
+            }
+        };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.ObserveAsync(CreateOperation(status: WorkflowOperationStatus.Reconciling));
+
+        observation.Status.Should().Be(WorkflowOperationStatus.Succeeded);
+        observation.ObservedRevision.Should().Be(DesiredImage);
+    }
+
+    [Fact]
+    public async Task ObserveAsync_HealthyButNotYetStable_StaysReconciling()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            RolloutState = new ArgoRolloutState
+            {
+                Name = RolloutName,
+                Phase = ArgoRolloutPhase.Healthy,
+                PodTemplateImage = DesiredImage,
+                CurrentPodHash = "abc123",
+                StableRevisionHash = "stable999"
+            }
+        };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.ObserveAsync(CreateOperation(status: WorkflowOperationStatus.Reconciling));
+
+        observation.Status.Should().Be(WorkflowOperationStatus.Reconciling);
+    }
+
+    [Fact]
+    public async Task ObserveAsync_DegradedRollout_RecommendsRollback()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            RolloutState = new ArgoRolloutState
+            {
+                Name = RolloutName,
+                Phase = ArgoRolloutPhase.Degraded,
+                Message = "canary analysis failed",
+                PodTemplateImage = DesiredImage
+            }
+        };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.ObserveAsync(CreateOperation(
+            parameters: CanaryParameters(),
+            status: WorkflowOperationStatus.Reconciling));
+
+        observation.Status.Should().Be(WorkflowOperationStatus.Reconciling);
+        observation.RollbackRecommended.Should().BeTrue();
+        observation.Message.Should().Contain("degraded");
+    }
+
+    [Fact]
+    public async Task ObserveAsync_AbortedRollout_RecommendsRollback()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            RolloutState = new ArgoRolloutState
+            {
+                Name = RolloutName,
+                Phase = ArgoRolloutPhase.Progressing,
+                IsAborted = true,
+                PodTemplateImage = DesiredImage
+            }
+        };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.ObserveAsync(CreateOperation(status: WorkflowOperationStatus.Reconciling));
+
+        observation.Status.Should().Be(WorkflowOperationStatus.Reconciling);
+        observation.RollbackRecommended.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ObserveAsync_RollbackRequested_RevertedToStable_ReturnsRolledBack()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            RolloutState = new ArgoRolloutState
+            {
+                Name = RolloutName,
+                Phase = ArgoRolloutPhase.Healthy,
+                PodTemplateImage = PreviousImage,
+                CurrentPodHash = "stable999",
+                StableRevisionHash = "stable999"
+            }
+        };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.ObserveAsync(CreateOperation(
+            currentRevision: PreviousImage,
+            status: WorkflowOperationStatus.RollbackRequested));
+
+        observation.Status.Should().Be(WorkflowOperationStatus.RolledBack);
+        observation.ObservedRevision.Should().Be(PreviousImage);
+    }
+
+    [Fact]
+    public async Task ObserveAsync_RollbackRequested_StillSettling_RemainsRollbackRequested()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            RolloutState = new ArgoRolloutState
+            {
+                Name = RolloutName,
+                Phase = ArgoRolloutPhase.Progressing,
+                IsAborted = true,
+                PodTemplateImage = DesiredImage,
+                CurrentPodHash = "abc123",
+                StableRevisionHash = "stable999"
+            }
+        };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.ObserveAsync(CreateOperation(status: WorkflowOperationStatus.RollbackRequested));
+
+        observation.Status.Should().Be(WorkflowOperationStatus.RollbackRequested);
+    }
+
+    [Fact]
+    public async Task ObserveAsync_RolloutMissing_ReturnsFailed()
+    {
+        var client = new StubArgoRolloutsClient { RolloutState = null };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.ObserveAsync(CreateOperation());
+
+        observation.Status.Should().Be(WorkflowOperationStatus.Failed);
+        observation.Message.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task PromoteAsync_AdvancesRollout_StaysReconcilingUntilHealthy()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            RolloutState = new ArgoRolloutState
+            {
+                Name = RolloutName,
+                Phase = ArgoRolloutPhase.Progressing,
+                PodTemplateImage = DesiredImage,
+                CurrentPodHash = "abc123",
+                StableRevisionHash = "stable999"
+            }
+        };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.PromoteAsync(CreateOperation(parameters: CanaryParameters()));
+
+        observation.Status.Should().Be(WorkflowOperationStatus.Reconciling);
+        client.PromoteCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task PromoteAsync_RolloutHealthyAndStable_ReturnsSucceeded()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            RolloutState = new ArgoRolloutState
+            {
+                Name = RolloutName,
+                Phase = ArgoRolloutPhase.Healthy,
+                PodTemplateImage = DesiredImage,
+                CurrentPodHash = "abc123",
+                StableRevisionHash = "abc123"
+            }
+        };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.PromoteAsync(CreateOperation(parameters: CanaryParameters()));
+
+        observation.Status.Should().Be(WorkflowOperationStatus.Succeeded);
+        client.PromoteCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RollbackAsync_AbortsRollout_ReturnsRollbackRequested()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            RolloutState = ProgressingRollout(DesiredImage)
+        };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.RollbackAsync(CreateOperation(
+            currentRevision: PreviousImage,
+            parameters: CanaryParameters()));
+
+        observation.Status.Should().Be(WorkflowOperationStatus.RollbackRequested);
+        observation.ObservedRevision.Should().Be(PreviousImage);
+        client.AbortCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task StartAsync_HttpError_ReturnsFailedWithoutLeakingProviderDetail()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            RolloutState = ProgressingRollout(PreviousImage),
+            SetImageException = new HttpRequestException("Forbidden: rollout token=secret-token-abc", null, HttpStatusCode.Forbidden)
+        };
+        var backend = CreateBackend(client);
+
+        var submission = await backend.StartAsync(CreateOperation(parameters: CanaryParameters()));
+
+        submission.Status.Should().Be(WorkflowOperationStatus.Failed);
+        submission.Message.Should().NotBeNullOrEmpty();
+        submission.Message.Should().NotContain("secret-token-abc");
+    }
+
+    [Fact]
+    public async Task ObserveAsync_HttpError_ReturnsFailedWithoutLeakingProviderDetail()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            GetException = new HttpRequestException("Unauthorized: bearer=secret-bearer-xyz", null, HttpStatusCode.Unauthorized)
+        };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.ObserveAsync(CreateOperation());
+
+        observation.Status.Should().Be(WorkflowOperationStatus.Failed);
+        observation.Message.Should().NotContain("secret-bearer-xyz");
+    }
+
+    [Fact]
+    public async Task RollbackAsync_HttpError_ReturnsFailedWithoutLeakingProviderDetail()
+    {
+        var client = new StubArgoRolloutsClient
+        {
+            AbortException = new HttpRequestException("Conflict: resourceVersion=secret-rv-999", null, HttpStatusCode.Conflict)
+        };
+        var backend = CreateBackend(client);
+
+        var observation = await backend.RollbackAsync(CreateOperation(parameters: CanaryParameters()));
+
+        observation.Status.Should().Be(WorkflowOperationStatus.Failed);
+        observation.Message.Should().NotContain("secret-rv-999");
+    }
+
+    [Fact]
+    public async Task GetCapabilitiesAsync_AdvertisesTrafficShiftingAndPromotion()
+    {
+        var backend = CreateBackend();
+
+        var capabilities = await backend.GetCapabilitiesAsync();
+
+        capabilities.SupportsRollback.Should().BeTrue();
+        capabilities.SupportsTrafficShifting.Should().BeTrue();
+        capabilities.SupportsProgressPolling.Should().BeTrue();
+        capabilities.SupportsRevisionPinning.Should().BeTrue();
+        capabilities.SupportsCancellation.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BackendName_AndTargetKind_AreStable()
+    {
+        var backend = CreateBackend();
+
+        backend.BackendName.Should().Be("honua-kubernetes-argo-rollouts");
+        backend.TargetKind.Should().Be(DeployTargetKind.Kubernetes);
+    }
+
+    private static KubernetesArgoRolloutsDeployBackend CreateBackend(StubArgoRolloutsClient? client = null)
+        => new(
+            client ?? new StubArgoRolloutsClient { RolloutState = ProgressingRollout(DesiredImage) },
+            NullLogger<KubernetesArgoRolloutsDeployBackend>.Instance);
+
+    private static ArgoRolloutState ProgressingRollout(string image)
+        => new()
+        {
+            Name = RolloutName,
+            Phase = ArgoRolloutPhase.Progressing,
+            PodTemplateImage = image,
+            CurrentPodHash = "abc123",
+            StableRevisionHash = "stable999"
+        };
+
+    private static DeployOperationSpec CreateSpec(
+        string desiredRevision = DesiredImage,
+        string targetName = RolloutName,
+        IReadOnlyDictionary<string, string>? parameters = null)
+        => new()
+        {
+            TargetId = "prod-k8s",
+            TargetKind = DeployTargetKind.Kubernetes,
+            Backend = "honua-kubernetes-argo-rollouts",
+            Environment = "production",
+            TargetName = targetName,
+            ArtifactReference = "ghcr.io/honua/honua-server",
+            DesiredRevision = desiredRevision,
+            RequiresOutOfBandMigrations = true,
+            Parameters = parameters ?? BaseParameters()
+        };
+
+    private static WorkflowOperationRecord CreateOperation(
+        string desiredRevision = DesiredImage,
+        string? currentRevision = null,
+        WorkflowOperationStatus status = WorkflowOperationStatus.Submitted,
+        IReadOnlyDictionary<string, string>? parameters = null)
+    {
+        var spec = CreateSpec(desiredRevision, parameters: parameters) with
+        {
+            CurrentRevision = currentRevision
+        };
+
+        return new WorkflowOperationRecord
+        {
+            OperationId = $"deploy-{Guid.NewGuid():N}",
+            Kind = WorkflowOperationKind.Deploy,
+            Status = status,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            UpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            CurrentPhase = "Testing",
+            Audit = new OperationAuditInfo(),
+            Concurrency = new OperationConcurrencyPolicy
+            {
+                PartitionKey = "production:prod-k8s",
+                RequiresExclusiveLease = true
+            },
+            Deploy = spec
+        };
+    }
+
+    private static Dictionary<string, string> BaseParameters()
+        => new(StringComparer.Ordinal)
+        {
+            [KubernetesArgoRolloutsDeployBackend.NamespaceParameter] = Namespace,
+            [KubernetesArgoRolloutsDeployBackend.RolloutNameParameter] = RolloutName,
+            [KubernetesArgoRolloutsDeployBackend.ContainerNameParameter] = ContainerName
+        };
+
+    private static Dictionary<string, string> CanaryParameters()
+    {
+        var parameters = BaseParameters();
+        parameters["deployment.canary_weight_percentage"] = "25";
+        parameters["telemetry.connection"] = "prod-prom";
+        return parameters;
+    }
+
+    private sealed class StubArgoRolloutsClient : IArgoRolloutsClient
+    {
+        public ArgoRolloutState? RolloutState { get; set; }
+
+        public string? LastSetImage { get; private set; }
+
+        public string? LastSetImageContainer { get; private set; }
+
+        public bool PromoteCalled { get; private set; }
+
+        public bool AbortCalled { get; private set; }
+
+        public Exception? GetException { get; set; }
+
+        public Exception? SetImageException { get; set; }
+
+        public Exception? PromoteException { get; set; }
+
+        public Exception? AbortException { get; set; }
+
+        public Task<ArgoRolloutState?> GetRolloutAsync(string @namespace, string name, CancellationToken cancellationToken = default)
+        {
+            if (GetException != null)
+            {
+                throw GetException;
+            }
+
+            return Task.FromResult(RolloutState);
+        }
+
+        public Task<ArgoRolloutState> SetImageAsync(string @namespace, string name, string containerName, string image, CancellationToken cancellationToken = default)
+        {
+            if (SetImageException != null)
+            {
+                throw SetImageException;
+            }
+
+            LastSetImage = image;
+            LastSetImageContainer = containerName;
+            return Task.FromResult(RolloutState ?? throw new InvalidOperationException("RolloutState not configured."));
+        }
+
+        public Task<ArgoRolloutState> PromoteAsync(string @namespace, string name, CancellationToken cancellationToken = default)
+        {
+            if (PromoteException != null)
+            {
+                throw PromoteException;
+            }
+
+            PromoteCalled = true;
+            return Task.FromResult(RolloutState ?? throw new InvalidOperationException("RolloutState not configured."));
+        }
+
+        public Task<ArgoRolloutState> AbortAsync(string @namespace, string name, CancellationToken cancellationToken = default)
+        {
+            if (AbortException != null)
+            {
+                throw AbortException;
+            }
+
+            AbortCalled = true;
+            return Task.FromResult(RolloutState ?? throw new InvalidOperationException("RolloutState not configured."));
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/KubernetesJobClientTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/KubernetesJobClientTests.cs
@@ -14,7 +14,7 @@ public sealed class KubernetesJobClientTests
     [Fact]
     public void CombineApiServerUri_WithRootBase_PrefixesRelativePath()
     {
-        var combined = KubernetesJobClient.CombineApiServerUri(
+        var combined = KubernetesApiRequestFactory.CombineApiServerUri(
             new Uri("https://cluster.example"),
             "/apis/batch/v1/namespaces/honua/jobs");
 
@@ -24,7 +24,7 @@ public sealed class KubernetesJobClientTests
     [Fact]
     public void CombineApiServerUri_WithTrailingSlashOnBase_ProducesSinglePathSeparator()
     {
-        var combined = KubernetesJobClient.CombineApiServerUri(
+        var combined = KubernetesApiRequestFactory.CombineApiServerUri(
             new Uri("https://cluster.example/"),
             "/apis/batch/v1/namespaces/honua/jobs");
 
@@ -34,7 +34,7 @@ public sealed class KubernetesJobClientTests
     [Fact]
     public void CombineApiServerUri_WithPathPrefix_PreservesBasePath()
     {
-        var combined = KubernetesJobClient.CombineApiServerUri(
+        var combined = KubernetesApiRequestFactory.CombineApiServerUri(
             new Uri("https://proxy.example/k8s"),
             "/apis/batch/v1/namespaces/honua/jobs");
 
@@ -44,7 +44,7 @@ public sealed class KubernetesJobClientTests
     [Fact]
     public void CombineApiServerUri_WithTrailingSlashOnPathPrefix_ProducesSingleSeparator()
     {
-        var combined = KubernetesJobClient.CombineApiServerUri(
+        var combined = KubernetesApiRequestFactory.CombineApiServerUri(
             new Uri("https://proxy.example/k8s/"),
             "/apis/batch/v1/namespaces/honua/jobs");
 
@@ -54,7 +54,7 @@ public sealed class KubernetesJobClientTests
     [Fact]
     public void CombineApiServerUri_DropsBaseQueryAndFragment()
     {
-        var combined = KubernetesJobClient.CombineApiServerUri(
+        var combined = KubernetesApiRequestFactory.CombineApiServerUri(
             new Uri("https://proxy.example/k8s?leak=yes#frag"),
             "/apis/batch/v1/namespaces/honua/jobs");
 


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1554 (child of #1537)

## Summary
Makes the Kubernetes deploy target **closed-loop** — in-product weighted canary rollout plus automatic rollback — via a first-class integration with an external **Argo Rollouts** controller. The controller's rollout status is observed and reflected back into the `WorkflowOperationRecord` operation lifecycle, so `ObserveAsync`/`PromoteAsync`/`RollbackAsync` drive real state transitions instead of the prior `ManualInterventionRequired` / "confirm out of band" stub. Kubernetes was the last deploy target where the promotion loop was open (the AWS Lambda alias, ECS+ALB, Azure Container Apps revision, and Azure Functions slot backends are already closed-loop).

The integration stays entirely behind the existing `IDeployBackend` abstraction and the `WorkflowOperationRecord` lifecycle, so the Console-driven promotion flow, the leased `DeployWorkflowReconciler`, and the telemetry gate are unchanged. The stepped canary ramp itself (5→25→50→100, pauses, analysis) is owned cluster-side by the `Rollout` resource's `spec.strategy.canary.steps`; Honua initiates the rollout, observes the step weight/phase, and gates promotion/rollback. The decision (Argo Rollouts vs Flagger vs native, and the status→lifecycle mapping) is recorded in **ADR-0052**.

This is a clean integration, not a reimplementation: no autonomous Flux/Argo pull-from-git reconciler, model stays Console-driven promotion with the GitOps manifest as the declarative artifact (`GitOpsWatchManifestPath` scaffolding remains out of scope).

## Changes Made
- **New `KubernetesArgoRolloutsDeployBackend`** (`honua-kubernetes-argo-rollouts`, `DeployTargetKind.Kubernetes`): maps Argo `Rollout` status onto the workflow lifecycle — paused-at-target-weight → `Reconciling`+`PromotionRecommended`; healthy+stable → `Succeeded`; degraded/aborted → `Reconciling`+`RollbackRecommended`; rollback reverted-to-stable → `RolledBack`. Coexists with the `honua-gitops-kubernetes` passthrough stub; targets pick by `Backend` name. Sanitizes Kubernetes/Argo API errors off the durable operation record (raw error to structured log only).
- **New `ArgoRolloutsClient` / `IArgoRolloutsClient`** + `ArgoRolloutsPatchSerializer`: narrow raw-HTTP adapter over the `argoproj.io/v1alpha1` Rollout API — get status, set image (start), promote (clear pause), abort (rollback). No new NuGet dependency.
- **New `KubernetesApiRequestFactory`**: extracted the in-cluster/out-of-cluster auth + request-shaping from `KubernetesJobClient` so the Job batch client and the rollout client share one credential/CA path (DRY); `KubernetesJobClient` refactored to consume it.
- **DI wiring** in `BatchAndDeployBackendsRegistration.cs` (factory, client, backend registered next to the K8s GitOps backend, preserving enumerable order).
- **ADR-0052** + adr/README index entry.
- **Docs**: `runbooks/UPGRADE_AND_ROLLBACK.md` (new Kubernetes Argo Rollouts canary section) and `CONTROL_PLANE_API.md` (deploy-backend/target table reflecting the real closed-loop capability).
- **Tests**: `KubernetesArgoRolloutsDeployBackendTests` (observe→promote/rollback through the K8s backend, mirroring `AwsEcsAlbDeployBackendTests`), `ArgoRolloutsPatchSerializerTests`, and repointed `KubernetesJobClientTests` static-method calls to the new factory.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Control-plane/deploy + new tests: **102 passed, 0 failed**. Architecture enforcement: **109 passed, 1 skipped, 0 failed**. `dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true` clean; `dotnet format --verify-no-changes` clean. Live verification against a real cluster + Argo controller is out of scope here (no cluster available); the backend is covered by mocked controller-status tests, with a live lane able to follow the `AwsEcsAlbDeployBackendLiveTests` pattern when one is provisioned.

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [x] Documentation updated

New deploy backend name (`honua-kubernetes-argo-rollouts`) and target parameters (`kubernetes.namespace`, `kubernetes.argo.rollout_name`, `kubernetes.argo.container_name`, optional `deployment.canary_weight_percentage` + `telemetry.connection`). No OpenAPI/proto changes — the change is behind `IDeployBackend`; the Console promotion flow and admin deploy endpoints are unchanged.

## Release/Deploy Impact
- [x] Requires infrastructure changes

Operators must run an Argo Rollouts controller and model the workload as a `Rollout` resource (not a plain `Deployment`) to use this backend; a `honua-helm` change to optionally ship the `Rollout` CR is the expected follow-on. Pure GitOps/Flagger users keep the `honua-gitops-kubernetes` passthrough. No database migration, no env/secret changes (reuses existing `ControlPlane:Kubernetes:*` auth config).

## Breaking Changes
None. The Argo Rollouts backend is additive and selected by `Backend` name; the existing `honua-gitops-kubernetes` passthrough is unchanged.

---

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
