### PR TITLE
feat: multi-provider deploy telemetry gate — CloudWatch (#1556)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Aspire.Npgsql" Version="13.2.2" />
     <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.2.2" />
     <PackageVersion Include="AWSSDK.Batch" Version="4.0.8.8" />
+    <PackageVersion Include="AWSSDK.CloudWatch" Version="4.0.11.2" />
     <PackageVersion Include="AWSSDK.ECS" Version="4.0.9" />
     <PackageVersion Include="AWSSDK.ElasticLoadBalancingV2" Version="4.0.5" />
     <PackageVersion Include="AWSSDK.Lambda" Version="4.0.14.1" />

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -329,9 +329,28 @@ The recommended alerting path uses managed cloud services rather than self-hoste
 
 For self-hosted multi-node environments, Prometheus can also scrape `GET /metrics` directly with admin credentials and act as both the collector and the query backend for deploy rollback gates.
 
-### Deploy Telemetry Presets
+### Deploy Telemetry Providers and Presets
 
-Deploy targets can point at a Prometheus-compatible query backend by setting `telemetry.connection` in the control-plane target parameters.
+Deploy targets point at a telemetry query backend by setting `telemetry.connection` in the
+control-plane target parameters. Each `ControlPlane:TelemetryConnections` entry declares a
+`Provider` that selects the metrics backend:
+
+- `prometheus` (default): PromQL backend. The presets below synthesize PromQL automatically.
+- `cloudwatch`: Amazon CloudWatch backend. Requires explicit `telemetry.*.query` CloudWatch
+  metric-math expressions (the presets only emit PromQL). Available unless the server is built
+  with `HONUA_EXCLUDE_AWS`. Credentials come from the AWS SDK default credential chain; scope IAM
+  to `cloudwatch:GetMetricData`. Set the connection's optional `Region`, or let it be inferred from
+  a regional `BaseUrl` (`https://monitoring.<region>.amazonaws.com`).
+
+An unconfigured/unknown `Provider` does not stall silently: the gate returns a
+`WaitForMoreTelemetry` decision with an explicit message and logs a warning naming the connection,
+the unsupported provider, and the supported providers; auto-rollback stays disabled for that
+operation until a supported provider is configured.
+
+The thresholds, warmup, minimum-sample gate, and promote/rollback/wait decision are identical
+across providers — only the query dialect differs.
+
+The PromQL presets:
 
 - Default Kubernetes preset: when a Kubernetes deploy target sets `telemetry.connection`, Honua uses the built-in `kubernetes-honua-http` policy unless you override it.
 - AWS ALB canary preset: set `telemetry.policy=aws-alb-canary` and expose a distinct Prometheus scrape lane for the canary tasks, typically via a separate scrape job such as `honua-canary`.
@@ -352,7 +371,8 @@ Useful target parameters:
 - `containerapp.canary_weight_percentage`: optional Azure Container Apps canary traffic percentage (1–99) for the `honua-azure-container-apps-revision` backend; requires `telemetry.connection`
 - `aws.ecs.canary_weight_percentage`: optional AWS ECS canary traffic percentage (1–99) for the `honua-aws-ecs-alb` backend; requires `telemetry.connection`. Equivalent to the generic `deployment.canary_weight_percentage` key
 
-Explicit query overrides still win:
+Explicit query overrides still win (and are required for `cloudwatch` connections, expressed as
+CloudWatch metric-math; for `prometheus` connections they are PromQL):
 
 - `telemetry.error_rate.query`
 - `telemetry.latency_p95.query`
@@ -366,8 +386,14 @@ Keep environment-specific `ControlPlane` target metadata in the infrastructure r
     "TelemetryConnections": [
       {
         "ConnectionId": "prometheus-default",
-        "ConnectionType": "Prometheus",
+        "Provider": "prometheus",
         "BaseUrl": "https://prometheus.example.com"
+      },
+      {
+        "ConnectionId": "cloudwatch-prod",
+        "Provider": "cloudwatch",
+        "BaseUrl": "https://monitoring.us-east-1.amazonaws.com",
+        "Region": "us-east-1"
       }
     ],
     "DeployTargets": [

--- a/docs/operator/runbooks/UPGRADE_AND_ROLLBACK.md
+++ b/docs/operator/runbooks/UPGRADE_AND_ROLLBACK.md
@@ -117,9 +117,73 @@ That rehearsal:
 - routes a weighted subset of traffic through Nginx
 - supports a forced canary header (`X-Honua-Canary: always`) for targeted verification
 - triggers rollback automatically when the canary lane degrades
-- can use a configured Prometheus-compatible telemetry connection as the real rollback signal source in non-local environments
+- can use a configured telemetry connection (Prometheus or CloudWatch; see "Deploy Telemetry Gate Providers" below) as the real rollback signal source in non-local environments
 
 `./scripts/cloud/deploy-canary.sh` remains a cluster-specific helper for environments that already have an external traffic-splitting substrate, but the scale-test path above is the canary flow validated in-repo for `#388`.
+
+---
+
+## Deploy Telemetry Gate Providers
+
+The deploy telemetry gate that drives automatic promote/rollback reads its signals from a named
+telemetry connection configured under `ControlPlane.TelemetryConnections`. A deploy operation
+selects the connection with the `telemetry.connection` parameter; the connection's `Provider`
+selects which metrics backend executes the error-rate / latency / sample-count queries.
+
+| Provider | `Provider` value | Query dialect | Notes |
+|---|---|---|---|
+| Prometheus (default) | `prometheus` | PromQL | Reference provider. The `honua-http`, `aws-alb-canary`, `aws-lambda-canary`, and `azure-aca-canary` presets synthesize PromQL automatically. |
+| Amazon CloudWatch | `cloudwatch` | CloudWatch metric-math | Requires explicit `telemetry.error_rate.query` / `telemetry.latency_p95.query` / `telemetry.sample_count.query` metric-math expressions — the built-in presets only emit PromQL. Available when the server is built with the AWS surface (not `HONUA_EXCLUDE_AWS`). |
+
+Thresholds, warmup, the minimum-sample gate, and the promote/rollback/wait decision are shared
+across providers, so only the query dialect differs.
+
+**Unsupported / unconfigured providers.** If a connection's `Provider` does not match a registered
+evaluator (for example `datadog`, or a typo), the gate does **not** stall silently. It emits a
+`WaitForMoreTelemetry` decision with an explicit message and logs a warning identifying the
+connection, the unsupported provider, and the providers that are supported. Auto-rollback stays
+disabled for that operation until a supported provider is configured.
+
+### CloudWatch telemetry connection
+
+```json
+{
+  "ControlPlane": {
+    "TelemetryConnections": [
+      {
+        "ConnectionId": "prod-cw",
+        "Provider": "cloudwatch",
+        "BaseUrl": "https://monitoring.us-east-1.amazonaws.com",
+        "Region": "us-east-1",
+        "TimeoutSeconds": 10
+      }
+    ]
+  }
+}
+```
+
+- `Region` is optional; when omitted the region is inferred from a regional `BaseUrl`
+  (`https://monitoring.<region>.amazonaws.com`), and failing that the AWS SDK's default region
+  resolution applies.
+- Credentials are resolved by the AWS SDK's standard credential chain (environment, shared config,
+  instance/task role). No secrets are stored on the connection — keep IAM scoped to
+  `cloudwatch:GetMetricData`.
+- Supply CloudWatch metric-math expressions per signal, for example:
+
+```json
+{
+  "telemetry.connection": "prod-cw",
+  "telemetry.sample_count.query": "SELECT COUNT(request_count) FROM SCHEMA(\"Honua/Http\", canary)",
+  "telemetry.sample_count.minimum": "10",
+  "telemetry.error_rate.query": "errors / requests",
+  "telemetry.error_rate.threshold": "0.05",
+  "telemetry.latency_p95.query": "p95_latency_ms",
+  "telemetry.latency_p95.threshold_ms": "2000"
+}
+```
+
+`BaseUrl` is required and must be HTTPS for every connection (validated at startup); for CloudWatch
+it doubles as the region hint.
 
 ---
 

--- a/src/Honua.Aws/Features/ControlPlane/CloudWatchDeployTelemetryProviderEvaluator.cs
+++ b/src/Honua.Aws/Features/ControlPlane/CloudWatchDeployTelemetryProviderEvaluator.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Amazon;
+using Amazon.CloudWatch;
+using Amazon.CloudWatch.Model;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Thin seam over the AWS CloudWatch <c>GetMetricData</c> API so the deploy telemetry gate can be
+/// unit-tested without a live AWS account. The production implementation is
+/// <see cref="AwsSdkCloudWatchMetricClient"/>; tests substitute a fake.
+/// </summary>
+internal interface ICloudWatchMetricClient
+{
+    /// <summary>
+    /// Evaluates a single CloudWatch metric-math expression over the supplied window and returns
+    /// the most recent datapoint, or <c>null</c> when CloudWatch returned no datapoints.
+    /// </summary>
+    Task<double?> GetExpressionValueAsync(
+        string? region,
+        string expression,
+        DateTime startUtc,
+        DateTime endUtc,
+        int periodSeconds,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class AwsSdkCloudWatchMetricClient : ICloudWatchMetricClient
+{
+    public async Task<double?> GetExpressionValueAsync(
+        string? region,
+        string expression,
+        DateTime startUtc,
+        DateTime endUtc,
+        int periodSeconds,
+        CancellationToken cancellationToken)
+    {
+        using var client = CreateClient(region);
+        var response = await client.GetMetricDataAsync(
+            new GetMetricDataRequest
+            {
+                StartTime = startUtc,
+                EndTime = endUtc,
+                ScanBy = ScanBy.TimestampDescending,
+                MetricDataQueries =
+                [
+                    new MetricDataQuery
+                    {
+                        Id = "honua_deploy_signal",
+                        Expression = expression,
+                        Period = periodSeconds,
+                        ReturnData = true
+                    }
+                ]
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        var result = response.MetricDataResults?.FirstOrDefault();
+        if (result?.Values is { Count: > 0 } values)
+        {
+            // ScanBy.TimestampDescending orders datapoints newest-first.
+            return values[0];
+        }
+
+        return null;
+    }
+
+    private static AmazonCloudWatchClient CreateClient(string? region)
+        => string.IsNullOrWhiteSpace(region)
+            ? new AmazonCloudWatchClient()
+            : new AmazonCloudWatchClient(RegionEndpoint.GetBySystemName(region));
+}
+
+/// <summary>
+/// CloudWatch-backed deploy telemetry provider. Selected when a telemetry connection's
+/// <c>Provider</c> is <c>cloudwatch</c>. The policy's error-rate / latency / sample-count query
+/// strings are interpreted as CloudWatch metric-math expressions (for example
+/// <c>SELECT AVG(...)</c> Metrics Insights or arithmetic over metric ids). Thresholds and the
+/// promote/rollback/wait decision are shared with every other provider via
+/// <c>DeployTelemetryProviderEvaluation</c>, so only the query dialect differs from Prometheus.
+/// </summary>
+internal sealed class CloudWatchDeployTelemetryProviderEvaluator(
+    ICloudWatchMetricClient metricClient) : IDeployTelemetryProviderEvaluator
+{
+    // CloudWatch metric-math evaluates over a window; mirror the Prometheus presets' 5m rate
+    // window and 300s sample horizon so thresholds keep the same meaning across providers.
+    private const int WindowSeconds = 300;
+
+    public string Provider => "cloudwatch";
+
+    public async Task<DeployTelemetryReadings> ReadAsync(
+        DeployTelemetryPolicyDescriptor policy,
+        DeployTelemetryConnectionDescriptor connection,
+        CancellationToken cancellationToken)
+    {
+        // CloudWatch has no preset query dialect; the Honua HTTP presets emit PromQL. Require the
+        // operator to supply explicit CloudWatch metric-math expressions so we never silently ship
+        // PromQL to CloudWatch and stall.
+        if (!policy.HasExplicitQueryOverride)
+        {
+            throw new InvalidOperationException(
+                $"Telemetry connection '{connection.ConnectionId}' uses the cloudwatch provider, which requires explicit " +
+                "telemetry.error_rate.query / telemetry.latency_p95.query / telemetry.sample_count.query CloudWatch metric-math expressions.");
+        }
+
+        var region = ResolveRegion(connection);
+        var endUtc = DateTime.UtcNow;
+        var startUtc = endUtc.AddSeconds(-WindowSeconds);
+
+        var sampleCount = string.IsNullOrWhiteSpace(policy.MinimumSampleQuery)
+            ? (double?)null
+            : await metricClient.GetExpressionValueAsync(region, policy.MinimumSampleQuery, startUtc, endUtc, WindowSeconds, cancellationToken).ConfigureAwait(false);
+
+        if (policy.MinimumSampleCount.HasValue && (!sampleCount.HasValue || sampleCount.Value < policy.MinimumSampleCount.Value))
+        {
+            return new DeployTelemetryReadings { SampleCount = sampleCount };
+        }
+
+        double? errorRate = null;
+        if (!string.IsNullOrWhiteSpace(policy.ErrorRateQuery) && policy.ErrorRateThreshold.HasValue)
+        {
+            errorRate = await metricClient.GetExpressionValueAsync(region, policy.ErrorRateQuery, startUtc, endUtc, WindowSeconds, cancellationToken).ConfigureAwait(false);
+        }
+
+        double? latencyP95 = null;
+        if (!string.IsNullOrWhiteSpace(policy.LatencyP95Query) && policy.LatencyP95ThresholdMs.HasValue)
+        {
+            latencyP95 = await metricClient.GetExpressionValueAsync(region, policy.LatencyP95Query, startUtc, endUtc, WindowSeconds, cancellationToken).ConfigureAwait(false);
+        }
+
+        return new DeployTelemetryReadings
+        {
+            SampleCount = sampleCount,
+            ErrorRate = errorRate,
+            LatencyP95 = latencyP95
+        };
+    }
+
+    private static string? ResolveRegion(DeployTelemetryConnectionDescriptor connection)
+    {
+        if (!string.IsNullOrWhiteSpace(connection.Region))
+        {
+            return connection.Region.Trim();
+        }
+
+        // Fall back to inferring the region from a regional CloudWatch BaseUrl such as
+        // https://monitoring.us-east-1.amazonaws.com. When neither is set the SDK's default
+        // credential/region resolution chain applies.
+        if (Uri.TryCreate(connection.BaseUrl, UriKind.Absolute, out var uri))
+        {
+            var labels = uri.Host.Split('.', StringSplitOptions.RemoveEmptyEntries);
+            if (labels.Length >= 4 &&
+                string.Equals(labels[0], "monitoring", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(labels[^2], "amazonaws", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(labels[^1], "com", StringComparison.OrdinalIgnoreCase))
+            {
+                return labels[1];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Honua.Aws/Honua.Aws.csproj
+++ b/src/Honua.Aws/Honua.Aws.csproj
@@ -32,6 +32,7 @@
          is intentionally excluded — it lives in Honua.Geocoding. -->
     <PackageReference Include="AWSSDK.S3" />
     <PackageReference Include="AWSSDK.Batch" />
+    <PackageReference Include="AWSSDK.CloudWatch" />
     <PackageReference Include="AWSSDK.ECS" />
     <PackageReference Include="AWSSDK.ElasticLoadBalancingV2" />
     <PackageReference Include="AWSSDK.Lambda" />

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/DeployTelemetryProvider.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/DeployTelemetryProvider.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Provider-neutral view of a configured telemetry connection passed to an
+/// <see cref="IDeployTelemetryProviderEvaluator"/>. The server maps its internal connection
+/// options onto this descriptor so cloud provider evaluators (which live in cloud-specific
+/// assemblies) do not depend on the server's configuration types.
+/// </summary>
+public sealed record DeployTelemetryConnectionDescriptor
+{
+    /// <summary>Stable identifier of the telemetry connection.</summary>
+    public required string ConnectionId { get; init; }
+
+    /// <summary>Metrics backend selector (for example <c>prometheus</c> or <c>cloudwatch</c>).</summary>
+    public required string Provider { get; init; }
+
+    /// <summary>
+    /// For HTTP providers, the query API base URL. For cloud providers, the regional endpoint used
+    /// only to infer a region when <see cref="Region"/> is unset.
+    /// </summary>
+    public string BaseUrl { get; init; } = string.Empty;
+
+    /// <summary>Relative query path for HTTP providers (for example <c>/api/v1/query</c>).</summary>
+    public string QueryPath { get; init; } = "/api/v1/query";
+
+    /// <summary>Optional outbound auth header name for HTTP providers.</summary>
+    public string? AuthHeaderName { get; init; }
+
+    /// <summary>Optional outbound auth header value for HTTP providers.</summary>
+    public string? AuthHeaderValue { get; init; }
+
+    /// <summary>Optional cloud region (for example <c>us-east-1</c>) for cloud providers.</summary>
+    public string? Region { get; init; }
+
+    /// <summary>Per-request timeout in seconds.</summary>
+    public int TimeoutSeconds { get; init; } = 10;
+}
+
+/// <summary>
+/// Provider-neutral deploy telemetry policy: the error-rate / latency / sample-count thresholds and
+/// the per-signal query strings to evaluate, independent of which metrics backend runs them.
+/// </summary>
+public sealed record DeployTelemetryPolicyDescriptor
+{
+    /// <summary>Identifier of the telemetry connection to query.</summary>
+    public required string ConnectionId { get; init; }
+
+    /// <summary>Backend-dialect query that yields the error rate, or <c>null</c> when unused.</summary>
+    public string? ErrorRateQuery { get; init; }
+
+    /// <summary>Maximum acceptable error rate before rollback is recommended.</summary>
+    public double? ErrorRateThreshold { get; init; }
+
+    /// <summary>Backend-dialect query that yields p95 latency in milliseconds, or <c>null</c> when unused.</summary>
+    public string? LatencyP95Query { get; init; }
+
+    /// <summary>Maximum acceptable p95 latency in milliseconds before rollback is recommended.</summary>
+    public double? LatencyP95ThresholdMs { get; init; }
+
+    /// <summary>Backend-dialect query that yields the observed sample count, or <c>null</c> when unused.</summary>
+    public string? MinimumSampleQuery { get; init; }
+
+    /// <summary>Minimum sample count required before the gate settles instead of waiting.</summary>
+    public double? MinimumSampleCount { get; init; }
+
+    /// <summary>
+    /// Indicates the operator supplied explicit query overrides (rather than relying on a built-in
+    /// preset). Cloud providers without a preset query dialect require this.
+    /// </summary>
+    public bool HasExplicitQueryOverride { get; init; }
+}
+
+/// <summary>
+/// Raw metric readings for the configured deploy telemetry signals. A <c>null</c> reading means the
+/// signal was not configured or no datapoint was available yet.
+/// </summary>
+public sealed record DeployTelemetryReadings
+{
+    /// <summary>Observed sample count, or <c>null</c> when unavailable.</summary>
+    public double? SampleCount { get; init; }
+
+    /// <summary>Observed error rate, or <c>null</c> when unavailable.</summary>
+    public double? ErrorRate { get; init; }
+
+    /// <summary>Observed p95 latency in milliseconds, or <c>null</c> when unavailable.</summary>
+    public double? LatencyP95 { get; init; }
+}
+
+/// <summary>
+/// Reads the configured deploy telemetry signals for a single metrics backend
+/// (Prometheus, CloudWatch, …). Provider selection happens in the server's dispatcher by matching
+/// <see cref="Provider"/> against the connection's provider value; implementations only translate
+/// the policy's query strings into their native dialect and return raw readings.
+/// </summary>
+public interface IDeployTelemetryProviderEvaluator
+{
+    /// <summary>
+    /// The connection provider value (case-insensitive) this evaluator handles,
+    /// for example <c>prometheus</c> or <c>cloudwatch</c>.
+    /// </summary>
+    string Provider { get; }
+
+    /// <summary>
+    /// Reads the configured signals for the supplied policy/connection pair.
+    /// </summary>
+    Task<DeployTelemetryReadings> ReadAsync(
+        DeployTelemetryPolicyDescriptor policy,
+        DeployTelemetryConnectionDescriptor connection,
+        CancellationToken cancellationToken);
+}

--- a/src/Honua.Server/Features/ControlPlane/ControlPlaneOptions.cs
+++ b/src/Honua.Server/Features/ControlPlane/ControlPlaneOptions.cs
@@ -190,8 +190,19 @@ internal sealed class DeployTelemetryConnectionOptions
 {
     public string ConnectionId { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Metrics backend that executes this connection's deploy-gate queries. Supported values:
+    /// <c>prometheus</c> (default) and <c>cloudwatch</c>. An unsupported value disables
+    /// auto-rollback signals for the connection and is logged at startup-evaluation time.
+    /// </summary>
     public string Provider { get; set; } = "prometheus";
 
+    /// <summary>
+    /// For <c>prometheus</c>, the HTTPS base URL of the query API. For cloud providers such as
+    /// <c>cloudwatch</c>, the regional endpoint (for example
+    /// <c>https://monitoring.us-east-1.amazonaws.com</c>) used only to infer the region when
+    /// <see cref="Region"/> is not set.
+    /// </summary>
     public string BaseUrl { get; set; } = string.Empty;
 
     public string QueryPath { get; set; } = "/api/v1/query";
@@ -199,6 +210,13 @@ internal sealed class DeployTelemetryConnectionOptions
     public string? AuthHeaderName { get; set; }
 
     public string? AuthHeaderValue { get; set; }
+
+    /// <summary>
+    /// Optional AWS region (for example <c>us-east-1</c>) for the <c>cloudwatch</c> provider.
+    /// When unset the region is inferred from <see cref="BaseUrl"/>; failing that the AWS SDK's
+    /// default region resolution applies. Ignored by the <c>prometheus</c> provider.
+    /// </summary>
+    public string? Region { get; set; }
 
     public int TimeoutSeconds { get; set; } = 10;
 }

--- a/src/Honua.Server/Features/ControlPlane/DeployTelemetryPolicy.cs
+++ b/src/Honua.Server/Features/ControlPlane/DeployTelemetryPolicy.cs
@@ -1,0 +1,314 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Provider-neutral deploy telemetry policy parsed from a deploy operation's parameters.
+/// </summary>
+/// <remarks>
+/// The policy describes <em>what</em> to evaluate (error-rate / latency / sample-count
+/// thresholds plus the per-signal query strings) independently of <em>which</em> metrics
+/// backend executes the queries. Prometheus connections interpret the query strings as
+/// PromQL; CloudWatch connections interpret the error-rate/latency/sample-count query
+/// strings as CloudWatch metric-math expressions. Presets only synthesize PromQL, so a
+/// non-Prometheus provider requires explicit query overrides.
+/// </remarks>
+internal sealed record DeployTelemetryPolicy
+{
+    private const string DefaultPrometheusJob = "honua";
+    private const string DefaultCanaryPrometheusJob = "honua-canary";
+
+    public required string ConnectionId { get; init; }
+
+    public string? ErrorRateQuery { get; init; }
+
+    public double? ErrorRateThreshold { get; init; }
+
+    public string? LatencyP95Query { get; init; }
+
+    public double? LatencyP95ThresholdMs { get; init; }
+
+    public string? MinimumSampleQuery { get; init; }
+
+    public double? MinimumSampleCount { get; init; }
+
+    public TimeSpan WarmupDuration { get; init; } = TimeSpan.FromMinutes(2);
+
+    public string? ValidationError { get; init; }
+
+    public bool IsValid => string.IsNullOrWhiteSpace(ValidationError);
+
+    /// <summary>
+    /// Indicates the operator supplied at least one explicit query override rather than relying
+    /// on a Prometheus preset. Non-Prometheus providers require this because presets emit PromQL.
+    /// </summary>
+    public bool HasExplicitQueryOverride { get; init; }
+
+    /// <summary>
+    /// Projects this internal policy onto the provider-neutral descriptor passed to
+    /// <see cref="IDeployTelemetryProviderEvaluator"/> implementations.
+    /// </summary>
+    public DeployTelemetryPolicyDescriptor ToDescriptor()
+        => new()
+        {
+            ConnectionId = ConnectionId,
+            ErrorRateQuery = ErrorRateQuery,
+            ErrorRateThreshold = ErrorRateThreshold,
+            LatencyP95Query = LatencyP95Query,
+            LatencyP95ThresholdMs = LatencyP95ThresholdMs,
+            MinimumSampleQuery = MinimumSampleQuery,
+            MinimumSampleCount = MinimumSampleCount,
+            HasExplicitQueryOverride = HasExplicitQueryOverride
+        };
+
+    public static DeployTelemetryPolicy? Parse(DeployOperationSpec spec)
+    {
+        var parameters = spec.Parameters;
+        if (!parameters.TryGetValue("telemetry.connection", out var connectionId) ||
+            string.IsNullOrWhiteSpace(connectionId))
+        {
+            return null;
+        }
+
+        var preset = ResolvePreset(spec);
+        var explicitErrorQuery = Get(parameters, "telemetry.error_rate.query");
+        var explicitLatencyQuery = Get(parameters, "telemetry.latency_p95.query");
+        var explicitSampleQuery = Get(parameters, "telemetry.sample_count.query");
+        var errorRateQuery = explicitErrorQuery ?? preset?.ErrorRateQuery;
+        var latencyQuery = explicitLatencyQuery ?? preset?.LatencyP95Query;
+        var sampleQuery = explicitSampleQuery ?? preset?.MinimumSampleQuery;
+
+        if (string.IsNullOrWhiteSpace(errorRateQuery) &&
+            string.IsNullOrWhiteSpace(latencyQuery) &&
+            string.IsNullOrWhiteSpace(sampleQuery))
+        {
+            return null;
+        }
+
+        var errorThreshold = ParseOptionalDouble(parameters, "telemetry.error_rate.threshold") ?? preset?.ErrorRateThreshold;
+        var latencyThreshold = ParseOptionalDouble(parameters, "telemetry.latency_p95.threshold_ms") ?? preset?.LatencyP95ThresholdMs;
+        var sampleMinimum = ParseOptionalDouble(parameters, "telemetry.sample_count.minimum") ?? preset?.MinimumSampleCount;
+        var warmupSeconds = ParseOptionalDouble(parameters, "telemetry.warmup_seconds");
+
+        // When the operator supplied explicit query overrides, the preset's input
+        // requirement (e.g. canary selector / job) no longer applies — the per-query
+        // threshold checks below validate the override-only policy.
+        var hasExplicitQueryOverride =
+            !string.IsNullOrWhiteSpace(explicitErrorQuery) ||
+            !string.IsNullOrWhiteSpace(explicitLatencyQuery) ||
+            !string.IsNullOrWhiteSpace(explicitSampleQuery);
+        var validationError = hasExplicitQueryOverride ? null : preset?.ValidationError;
+        if (!string.IsNullOrWhiteSpace(errorRateQuery) && !errorThreshold.HasValue)
+        {
+            validationError = "Deploy telemetry policy is invalid because telemetry.error_rate.threshold is missing.";
+        }
+        else if (!string.IsNullOrWhiteSpace(latencyQuery) && !latencyThreshold.HasValue)
+        {
+            validationError = "Deploy telemetry policy is invalid because telemetry.latency_p95.threshold_ms is missing.";
+        }
+        else if (!string.IsNullOrWhiteSpace(sampleQuery) && !sampleMinimum.HasValue)
+        {
+            validationError = "Deploy telemetry policy is invalid because telemetry.sample_count.minimum is missing.";
+        }
+
+        return new DeployTelemetryPolicy
+        {
+            ConnectionId = connectionId.Trim(),
+            ErrorRateQuery = errorRateQuery,
+            ErrorRateThreshold = errorThreshold,
+            LatencyP95Query = latencyQuery,
+            LatencyP95ThresholdMs = latencyThreshold,
+            MinimumSampleQuery = sampleQuery,
+            MinimumSampleCount = sampleMinimum,
+            WarmupDuration = warmupSeconds.HasValue && warmupSeconds.Value > 0
+                ? TimeSpan.FromSeconds(warmupSeconds.Value)
+                : preset?.WarmupDuration ?? TimeSpan.FromMinutes(2),
+            ValidationError = validationError,
+            HasExplicitQueryOverride = hasExplicitQueryOverride
+        };
+    }
+
+    private static DeployTelemetryPolicy? ResolvePreset(DeployOperationSpec spec)
+    {
+        var parameters = spec.Parameters;
+        var policyName = Get(parameters, "telemetry.policy") ?? GetDefaultPolicyName(spec);
+        if (string.IsNullOrWhiteSpace(policyName))
+        {
+            return null;
+        }
+
+        return policyName.ToLowerInvariant() switch
+        {
+            "honua-http" or "kubernetes-honua-http" => CreateHonuaHttpPreset(parameters),
+            "aws-alb-canary" => CreateAwsAlbCanaryPreset(parameters),
+            "aws-lambda-canary" => CreateAwsLambdaCanaryPreset(parameters),
+            "azure-aca-canary" => CreateAzureAcaCanaryPreset(parameters),
+            _ => new DeployTelemetryPolicy
+            {
+                ConnectionId = string.Empty,
+                ValidationError = $"Deploy telemetry policy '{policyName}' is not supported."
+            }
+        };
+    }
+
+    private static string? GetDefaultPolicyName(DeployOperationSpec spec)
+        => spec.TargetKind switch
+        {
+            DeployTargetKind.Kubernetes => "kubernetes-honua-http",
+            // ECS canary deploys are configured by setting a canary weight via
+            // aws.ecs.canary_weight_percentage or the generic
+            // deployment.canary_weight_percentage; either key implies the rollout
+            // is gated on canary-only telemetry. Without that signal the runbook
+            // and PlanAsync would advertise a canary policy while the evaluator
+            // silently fell back to aggregate Honua HTTP metrics.
+            DeployTargetKind.AwsEcs => HasCanarySignalConfiguration(spec.Parameters) || HasCanaryWeight(spec.Parameters)
+                ? "aws-alb-canary"
+                : "honua-http",
+            DeployTargetKind.AwsLambda => HasCanarySignalConfiguration(spec.Parameters) ? "aws-lambda-canary" : "honua-http",
+            DeployTargetKind.AzureContainerApps => HasCanarySignalConfiguration(spec.Parameters) ? "azure-aca-canary" : "honua-http",
+            DeployTargetKind.AzureFunctions => "honua-http",
+            _ => null
+        };
+
+    private static bool HasCanarySignalConfiguration(IReadOnlyDictionary<string, string> parameters)
+        => parameters.ContainsKey("telemetry.prometheus.canary_selector")
+           || parameters.ContainsKey("telemetry.prometheus.canary_job");
+
+    private static bool HasCanaryWeight(IReadOnlyDictionary<string, string> parameters)
+        => HasNonEmpty(parameters, "aws.ecs.canary_weight_percentage")
+           || HasNonEmpty(parameters, "deployment.canary_weight_percentage");
+
+    private static bool HasNonEmpty(IReadOnlyDictionary<string, string> parameters, string key)
+        => parameters.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value);
+
+    private static DeployTelemetryPolicy CreateHonuaHttpPreset(IReadOnlyDictionary<string, string> parameters)
+    {
+        var selector = BuildPrometheusSelector(
+            parameters,
+            selectorKey: "telemetry.prometheus.selector",
+            jobKey: "telemetry.prometheus.job",
+            defaultJob: DefaultPrometheusJob);
+
+        return string.IsNullOrWhiteSpace(selector)
+            ? InvalidPreset("Deploy telemetry policy 'kubernetes-honua-http' requires a Prometheus selector or job.")
+            : CreateHonuaHttpPolicy(selector, warmupDuration: TimeSpan.FromMinutes(2));
+    }
+
+    private static DeployTelemetryPolicy CreateAwsAlbCanaryPreset(IReadOnlyDictionary<string, string> parameters)
+        => CreateCanaryPreset(parameters, "aws-alb-canary");
+
+    private static DeployTelemetryPolicy CreateAwsLambdaCanaryPreset(IReadOnlyDictionary<string, string> parameters)
+        => CreateCanaryPreset(parameters, "aws-lambda-canary");
+
+    private static DeployTelemetryPolicy CreateAzureAcaCanaryPreset(IReadOnlyDictionary<string, string> parameters)
+        => CreateCanaryPreset(parameters, "azure-aca-canary");
+
+    private static DeployTelemetryPolicy CreateCanaryPreset(IReadOnlyDictionary<string, string> parameters, string presetName)
+    {
+        var selector = BuildPrometheusSelector(
+            parameters,
+            selectorKey: "telemetry.prometheus.canary_selector",
+            jobKey: "telemetry.prometheus.canary_job",
+            defaultJob: DefaultCanaryPrometheusJob,
+            fallbackSelectorKey: "telemetry.prometheus.selector",
+            fallbackJobKey: "telemetry.prometheus.job");
+
+        return string.IsNullOrWhiteSpace(selector)
+            ? InvalidPreset($"Deploy telemetry policy '{presetName}' requires a canary Prometheus selector or canary job.")
+            : CreateHonuaHttpPolicy(selector, warmupDuration: TimeSpan.FromMinutes(3), minimumSampleCount: 10);
+    }
+
+    private static DeployTelemetryPolicy CreateHonuaHttpPolicy(
+        string selector,
+        TimeSpan warmupDuration,
+        double minimumSampleCount = 20)
+    {
+        var metricSelector = WrapSelector(selector);
+        var errorSelector = AppendLabelMatcher(selector, "status_code=~\"5..\"");
+
+        return new DeployTelemetryPolicy
+        {
+            ConnectionId = string.Empty,
+            ErrorRateQuery =
+                $"sum(rate(honua_http_request_total{WrapSelector(errorSelector)}[5m])) / clamp_min(sum(rate(honua_http_request_total{metricSelector}[5m])), 0.001)",
+            ErrorRateThreshold = 0.05,
+            LatencyP95Query =
+                $"histogram_quantile(0.95, sum(rate(honua_http_request_duration_ms_bucket{metricSelector}[5m])) by (le))",
+            LatencyP95ThresholdMs = 2000,
+            MinimumSampleQuery =
+                $"sum(rate(honua_http_request_total{metricSelector}[5m])) * 300",
+            MinimumSampleCount = minimumSampleCount,
+            WarmupDuration = warmupDuration
+        };
+    }
+
+    private static DeployTelemetryPolicy InvalidPreset(string message)
+        => new()
+        {
+            ConnectionId = string.Empty,
+            ValidationError = message
+        };
+
+    private static string BuildPrometheusSelector(
+        IReadOnlyDictionary<string, string> parameters,
+        string selectorKey,
+        string jobKey,
+        string? defaultJob,
+        string? fallbackSelectorKey = null,
+        string? fallbackJobKey = null)
+    {
+        var rawSelector = Get(parameters, selectorKey)
+            ?? (fallbackSelectorKey != null ? Get(parameters, fallbackSelectorKey) : null);
+        var extraSelector = Get(parameters, "telemetry.prometheus.extra_selector");
+        var job = Get(parameters, jobKey)
+            ?? (fallbackJobKey != null ? Get(parameters, fallbackJobKey) : null)
+            ?? defaultJob;
+
+        var matchers = new List<string>();
+        if (!string.IsNullOrWhiteSpace(rawSelector))
+        {
+            matchers.Add(rawSelector);
+        }
+        else if (!string.IsNullOrWhiteSpace(job))
+        {
+            matchers.Add($"job={QuotePrometheusValue(job)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(extraSelector))
+        {
+            matchers.Add(extraSelector);
+        }
+
+        return string.Join(",", matchers.Where(static matcher => !string.IsNullOrWhiteSpace(matcher)));
+    }
+
+    private static string QuotePrometheusValue(string value)
+        => $"\"{value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal)}\"";
+
+    private static string WrapSelector(string selector)
+        => string.IsNullOrWhiteSpace(selector) ? string.Empty : $"{{{selector}}}";
+
+    private static string AppendLabelMatcher(string selector, string labelMatcher)
+        => string.IsNullOrWhiteSpace(selector) ? labelMatcher : $"{selector},{labelMatcher}";
+
+    private static string? Get(IReadOnlyDictionary<string, string> parameters, string key)
+        => parameters.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value.Trim()
+            : null;
+
+    private static double? ParseOptionalDouble(IReadOnlyDictionary<string, string> parameters, string key)
+    {
+        if (!parameters.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        return double.TryParse(raw, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+}

--- a/src/Honua.Server/Features/ControlPlane/DeployTelemetrySignalEvaluator.cs
+++ b/src/Honua.Server/Features/ControlPlane/DeployTelemetrySignalEvaluator.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using System.Text.Json;
-using Honua.Core.Configuration;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Infrastructure.Validation;
 using Microsoft.Extensions.Options;
@@ -30,13 +29,21 @@ internal sealed record DeployTelemetryDecision
 }
 
 /// <summary>
-/// Prometheus-compatible telemetry evaluator used to gate deploy success and trigger rollback.
+/// Multi-provider deploy telemetry gate. Parses the provider-neutral
+/// <see cref="DeployTelemetryPolicy"/>, applies warmup, resolves the named telemetry connection,
+/// then dispatches the metric reads to the <see cref="IDeployTelemetryProviderEvaluator"/> whose
+/// <see cref="IDeployTelemetryProviderEvaluator.Provider"/> matches the connection's
+/// <c>Provider</c>. An unknown/unconfigured provider surfaces an explicit, logged
+/// "unsupported provider" wait rather than stalling silently forever.
 /// </summary>
-internal sealed class PrometheusDeployTelemetrySignalEvaluator(
+internal sealed class DeployTelemetrySignalEvaluator(
     IOptionsMonitor<ControlPlaneOptions> optionsMonitor,
-    IHttpClientFactory httpClientFactory,
-    ILogger<PrometheusDeployTelemetrySignalEvaluator> logger) : IDeployTelemetrySignalEvaluator
+    IEnumerable<IDeployTelemetryProviderEvaluator> providerEvaluators,
+    ILogger<DeployTelemetrySignalEvaluator> logger) : IDeployTelemetrySignalEvaluator
 {
+    private readonly Dictionary<string, IDeployTelemetryProviderEvaluator> _providers =
+        BuildProviderMap(providerEvaluators);
+
     public async Task<DeployTelemetryDecision?> EvaluateAsync(
         WorkflowOperationRecord operation,
         CancellationToken cancellationToken = default)
@@ -83,79 +90,32 @@ internal sealed class PrometheusDeployTelemetrySignalEvaluator(
             };
         }
 
-        if (!string.Equals(connection.Provider, "prometheus", StringComparison.OrdinalIgnoreCase))
+        var providerKey = connection.Provider?.Trim() ?? string.Empty;
+        if (!_providers.TryGetValue(providerKey, out var providerEvaluator))
         {
+            // Surface an explicit, logged signal rather than stalling silently forever. The
+            // reconciler keeps the operation in Reconciling on WaitForMoreTelemetry, so the
+            // log is the operator's breadcrumb that the connection's provider is unsupported.
+            DeployTelemetrySignalEvaluatorLog.UnsupportedProvider(
+                logger,
+                operation.OperationId,
+                connection.ConnectionId,
+                string.IsNullOrWhiteSpace(providerKey) ? "(empty)" : providerKey,
+                string.Join(", ", _providers.Keys.OrderBy(static key => key, StringComparer.Ordinal)));
+
             return new DeployTelemetryDecision
             {
                 WaitForMoreTelemetry = true,
-                Message = $"Waiting for telemetry confirmation because provider '{connection.Provider}' is not supported for deploy rollback signals."
+                Message = $"Waiting for telemetry confirmation because provider '{connection.Provider}' on connection '{connection.ConnectionId}' is not supported for deploy rollback signals."
             };
         }
 
         try
         {
-            var validatedConnection = await ValidateConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
-            var sampleCount = string.IsNullOrWhiteSpace(policy.MinimumSampleQuery)
-                ? null
-                : await ExecutePrometheusQueryAsync(validatedConnection, policy.MinimumSampleQuery, cancellationToken).ConfigureAwait(false);
-
-            if (policy.MinimumSampleCount.HasValue && (!sampleCount.HasValue || sampleCount.Value < policy.MinimumSampleCount.Value))
-            {
-                return new DeployTelemetryDecision
-                {
-                    WaitForMoreTelemetry = true,
-                    Message = sampleCount.HasValue
-                        ? $"Waiting for telemetry confirmation because sample count {sampleCount.Value.ToString("0.###", CultureInfo.InvariantCulture)} is below the required minimum {policy.MinimumSampleCount.Value.ToString("0.###", CultureInfo.InvariantCulture)}."
-                        : "Waiting for telemetry confirmation because no sample-count signal is available yet."
-                };
-            }
-
-            var breachMessages = new List<string>();
-            var healthySignals = new List<string>();
-
-            if (!string.IsNullOrWhiteSpace(policy.ErrorRateQuery) && policy.ErrorRateThreshold.HasValue)
-            {
-                var errorRate = await ExecutePrometheusQueryAsync(validatedConnection, policy.ErrorRateQuery, cancellationToken).ConfigureAwait(false);
-                if (errorRate.HasValue && errorRate.Value > policy.ErrorRateThreshold.Value)
-                {
-                    breachMessages.Add(
-                        $"error rate {errorRate.Value.ToString("0.###", CultureInfo.InvariantCulture)} exceeded threshold {policy.ErrorRateThreshold.Value.ToString("0.###", CultureInfo.InvariantCulture)}");
-                }
-                else
-                {
-                    healthySignals.Add("error-rate signal is within threshold");
-                }
-            }
-
-            if (!string.IsNullOrWhiteSpace(policy.LatencyP95Query) && policy.LatencyP95ThresholdMs.HasValue)
-            {
-                var latencyP95 = await ExecutePrometheusQueryAsync(validatedConnection, policy.LatencyP95Query, cancellationToken).ConfigureAwait(false);
-                if (latencyP95.HasValue && latencyP95.Value > policy.LatencyP95ThresholdMs.Value)
-                {
-                    breachMessages.Add(
-                        $"p95 latency {latencyP95.Value.ToString("0.###", CultureInfo.InvariantCulture)}ms exceeded threshold {policy.LatencyP95ThresholdMs.Value.ToString("0.###", CultureInfo.InvariantCulture)}ms");
-                }
-                else
-                {
-                    healthySignals.Add("latency signal is within threshold");
-                }
-            }
-
-            if (breachMessages.Count > 0)
-            {
-                return new DeployTelemetryDecision
-                {
-                    RollbackRecommended = true,
-                    Message = $"Automatic rollback requested because telemetry detected canary degradation: {string.Join("; ", breachMessages)}."
-                };
-            }
-
-            return new DeployTelemetryDecision
-            {
-                Message = healthySignals.Count > 0
-                    ? $"Telemetry gate passed: {string.Join("; ", healthySignals)}."
-                    : "Telemetry gate passed."
-            };
+            var readings = await providerEvaluator
+                .ReadAsync(policy.ToDescriptor(), ToDescriptor(connection), cancellationToken)
+                .ConfigureAwait(false);
+            return Evaluate(policy, readings);
         }
         catch (Exception ex)
         {
@@ -168,8 +128,149 @@ internal sealed class PrometheusDeployTelemetrySignalEvaluator(
         }
     }
 
+    /// <summary>
+    /// Provider-neutral evaluation of telemetry readings against the policy thresholds. Keeps
+    /// promote/rollback/wait semantics identical regardless of which metrics backend produced them.
+    /// </summary>
+    internal static DeployTelemetryDecision Evaluate(DeployTelemetryPolicy policy, DeployTelemetryReadings readings)
+    {
+        if (policy.MinimumSampleCount.HasValue &&
+            (!readings.SampleCount.HasValue || readings.SampleCount.Value < policy.MinimumSampleCount.Value))
+        {
+            return new DeployTelemetryDecision
+            {
+                WaitForMoreTelemetry = true,
+                Message = readings.SampleCount.HasValue
+                    ? $"Waiting for telemetry confirmation because sample count {Format(readings.SampleCount.Value)} is below the required minimum {Format(policy.MinimumSampleCount.Value)}."
+                    : "Waiting for telemetry confirmation because no sample-count signal is available yet."
+            };
+        }
+
+        var breachMessages = new List<string>();
+        var healthySignals = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(policy.ErrorRateQuery) && policy.ErrorRateThreshold.HasValue)
+        {
+            if (readings.ErrorRate.HasValue && readings.ErrorRate.Value > policy.ErrorRateThreshold.Value)
+            {
+                breachMessages.Add(
+                    $"error rate {Format(readings.ErrorRate.Value)} exceeded threshold {Format(policy.ErrorRateThreshold.Value)}");
+            }
+            else
+            {
+                healthySignals.Add("error-rate signal is within threshold");
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(policy.LatencyP95Query) && policy.LatencyP95ThresholdMs.HasValue)
+        {
+            if (readings.LatencyP95.HasValue && readings.LatencyP95.Value > policy.LatencyP95ThresholdMs.Value)
+            {
+                breachMessages.Add(
+                    $"p95 latency {Format(readings.LatencyP95.Value)}ms exceeded threshold {Format(policy.LatencyP95ThresholdMs.Value)}ms");
+            }
+            else
+            {
+                healthySignals.Add("latency signal is within threshold");
+            }
+        }
+
+        if (breachMessages.Count > 0)
+        {
+            return new DeployTelemetryDecision
+            {
+                RollbackRecommended = true,
+                Message = $"Automatic rollback requested because telemetry detected canary degradation: {string.Join("; ", breachMessages)}."
+            };
+        }
+
+        return new DeployTelemetryDecision
+        {
+            Message = healthySignals.Count > 0
+                ? $"Telemetry gate passed: {string.Join("; ", healthySignals)}."
+                : "Telemetry gate passed."
+        };
+    }
+
+    private static DeployTelemetryConnectionDescriptor ToDescriptor(DeployTelemetryConnectionOptions connection)
+        => new()
+        {
+            ConnectionId = connection.ConnectionId,
+            Provider = connection.Provider,
+            BaseUrl = connection.BaseUrl,
+            QueryPath = connection.QueryPath,
+            AuthHeaderName = connection.AuthHeaderName,
+            AuthHeaderValue = connection.AuthHeaderValue,
+            Region = connection.Region,
+            TimeoutSeconds = connection.TimeoutSeconds
+        };
+
+    private static string Format(double value)
+        => value.ToString("0.###", CultureInfo.InvariantCulture);
+
+    private static Dictionary<string, IDeployTelemetryProviderEvaluator> BuildProviderMap(
+        IEnumerable<IDeployTelemetryProviderEvaluator> providerEvaluators)
+    {
+        var map = new Dictionary<string, IDeployTelemetryProviderEvaluator>(StringComparer.OrdinalIgnoreCase);
+        foreach (var evaluator in providerEvaluators)
+        {
+            // First registration wins so a host can override a built-in provider deliberately.
+            map.TryAdd(evaluator.Provider, evaluator);
+        }
+
+        return map;
+    }
+}
+
+/// <summary>
+/// Prometheus-compatible telemetry provider used to gate deploy success and trigger rollback.
+/// Reference implementation for the multi-provider gate.
+/// </summary>
+internal sealed class PrometheusDeployTelemetryProviderEvaluator(
+    IHttpClientFactory httpClientFactory) : IDeployTelemetryProviderEvaluator
+{
+    public string Provider => "prometheus";
+
+    public async Task<DeployTelemetryReadings> ReadAsync(
+        DeployTelemetryPolicyDescriptor policy,
+        DeployTelemetryConnectionDescriptor connection,
+        CancellationToken cancellationToken)
+    {
+        var validatedConnection = await ValidateConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+
+        var sampleCount = string.IsNullOrWhiteSpace(policy.MinimumSampleQuery)
+            ? (double?)null
+            : await ExecutePrometheusQueryAsync(validatedConnection, policy.MinimumSampleQuery, cancellationToken).ConfigureAwait(false);
+
+        // Short-circuit when the sample-count gate already fails; mirrors the original
+        // evaluator that did not query error-rate/latency until the minimum sample was met.
+        if (policy.MinimumSampleCount.HasValue && (!sampleCount.HasValue || sampleCount.Value < policy.MinimumSampleCount.Value))
+        {
+            return new DeployTelemetryReadings { SampleCount = sampleCount };
+        }
+
+        double? errorRate = null;
+        if (!string.IsNullOrWhiteSpace(policy.ErrorRateQuery) && policy.ErrorRateThreshold.HasValue)
+        {
+            errorRate = await ExecutePrometheusQueryAsync(validatedConnection, policy.ErrorRateQuery, cancellationToken).ConfigureAwait(false);
+        }
+
+        double? latencyP95 = null;
+        if (!string.IsNullOrWhiteSpace(policy.LatencyP95Query) && policy.LatencyP95ThresholdMs.HasValue)
+        {
+            latencyP95 = await ExecutePrometheusQueryAsync(validatedConnection, policy.LatencyP95Query, cancellationToken).ConfigureAwait(false);
+        }
+
+        return new DeployTelemetryReadings
+        {
+            SampleCount = sampleCount,
+            ErrorRate = errorRate,
+            LatencyP95 = latencyP95
+        };
+    }
+
     private static async Task<ValidatedTelemetryConnection> ValidateConnectionAsync(
-        DeployTelemetryConnectionOptions connection,
+        DeployTelemetryConnectionDescriptor connection,
         CancellationToken cancellationToken)
     {
         var baseUrlValidation = await OutboundHttpUrlValidator
@@ -279,278 +380,6 @@ internal sealed class PrometheusDeployTelemetrySignalEvaluator(
         return double.TryParse(raw, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsed)
             ? parsed
             : null;
-    }
-
-    private sealed record DeployTelemetryPolicy
-    {
-        private const string DefaultPrometheusJob = "honua";
-        private const string DefaultCanaryPrometheusJob = "honua-canary";
-
-        public required string ConnectionId { get; init; }
-
-        public string? ErrorRateQuery { get; init; }
-
-        public double? ErrorRateThreshold { get; init; }
-
-        public string? LatencyP95Query { get; init; }
-
-        public double? LatencyP95ThresholdMs { get; init; }
-
-        public string? MinimumSampleQuery { get; init; }
-
-        public double? MinimumSampleCount { get; init; }
-
-        public TimeSpan WarmupDuration { get; init; } = TimeSpan.FromMinutes(2);
-
-        public string? ValidationError { get; init; }
-
-        public bool IsValid => string.IsNullOrWhiteSpace(ValidationError);
-
-        public static DeployTelemetryPolicy? Parse(DeployOperationSpec spec)
-        {
-            var parameters = spec.Parameters;
-            if (!parameters.TryGetValue("telemetry.connection", out var connectionId) ||
-                string.IsNullOrWhiteSpace(connectionId))
-            {
-                return null;
-            }
-
-            var preset = ResolvePreset(spec);
-            var explicitErrorQuery = Get(parameters, "telemetry.error_rate.query");
-            var explicitLatencyQuery = Get(parameters, "telemetry.latency_p95.query");
-            var explicitSampleQuery = Get(parameters, "telemetry.sample_count.query");
-            var errorRateQuery = explicitErrorQuery ?? preset?.ErrorRateQuery;
-            var latencyQuery = explicitLatencyQuery ?? preset?.LatencyP95Query;
-            var sampleQuery = explicitSampleQuery ?? preset?.MinimumSampleQuery;
-
-            if (string.IsNullOrWhiteSpace(errorRateQuery) &&
-                string.IsNullOrWhiteSpace(latencyQuery) &&
-                string.IsNullOrWhiteSpace(sampleQuery))
-            {
-                return null;
-            }
-
-            var errorThreshold = ParseOptionalDouble(parameters, "telemetry.error_rate.threshold") ?? preset?.ErrorRateThreshold;
-            var latencyThreshold = ParseOptionalDouble(parameters, "telemetry.latency_p95.threshold_ms") ?? preset?.LatencyP95ThresholdMs;
-            var sampleMinimum = ParseOptionalDouble(parameters, "telemetry.sample_count.minimum") ?? preset?.MinimumSampleCount;
-            var warmupSeconds = ParseOptionalDouble(parameters, "telemetry.warmup_seconds");
-
-            // When the operator supplied explicit query overrides, the preset's input
-            // requirement (e.g. canary selector / job) no longer applies — the per-query
-            // threshold checks below validate the override-only policy.
-            var hasExplicitQueryOverride =
-                !string.IsNullOrWhiteSpace(explicitErrorQuery) ||
-                !string.IsNullOrWhiteSpace(explicitLatencyQuery) ||
-                !string.IsNullOrWhiteSpace(explicitSampleQuery);
-            var validationError = hasExplicitQueryOverride ? null : preset?.ValidationError;
-            if (!string.IsNullOrWhiteSpace(errorRateQuery) && !errorThreshold.HasValue)
-            {
-                validationError = "Deploy telemetry policy is invalid because telemetry.error_rate.threshold is missing.";
-            }
-            else if (!string.IsNullOrWhiteSpace(latencyQuery) && !latencyThreshold.HasValue)
-            {
-                validationError = "Deploy telemetry policy is invalid because telemetry.latency_p95.threshold_ms is missing.";
-            }
-            else if (!string.IsNullOrWhiteSpace(sampleQuery) && !sampleMinimum.HasValue)
-            {
-                validationError = "Deploy telemetry policy is invalid because telemetry.sample_count.minimum is missing.";
-            }
-
-            return new DeployTelemetryPolicy
-            {
-                ConnectionId = connectionId.Trim(),
-                ErrorRateQuery = errorRateQuery,
-                ErrorRateThreshold = errorThreshold,
-                LatencyP95Query = latencyQuery,
-                LatencyP95ThresholdMs = latencyThreshold,
-                MinimumSampleQuery = sampleQuery,
-                MinimumSampleCount = sampleMinimum,
-                WarmupDuration = warmupSeconds.HasValue && warmupSeconds.Value > 0
-                    ? TimeSpan.FromSeconds(warmupSeconds.Value)
-                    : preset?.WarmupDuration ?? TimeSpan.FromMinutes(2),
-                ValidationError = validationError
-            };
-        }
-
-        private static DeployTelemetryPolicy? ResolvePreset(DeployOperationSpec spec)
-        {
-            var parameters = spec.Parameters;
-            var policyName = Get(parameters, "telemetry.policy") ?? GetDefaultPolicyName(spec);
-            if (string.IsNullOrWhiteSpace(policyName))
-            {
-                return null;
-            }
-
-            return policyName.ToLowerInvariant() switch
-            {
-                "honua-http" or "kubernetes-honua-http" => CreateHonuaHttpPreset(parameters),
-                "aws-alb-canary" => CreateAwsAlbCanaryPreset(parameters),
-                "aws-lambda-canary" => CreateAwsLambdaCanaryPreset(parameters),
-                "azure-aca-canary" => CreateAzureAcaCanaryPreset(parameters),
-                _ => new DeployTelemetryPolicy
-                {
-                    ConnectionId = string.Empty,
-                    ValidationError = $"Deploy telemetry policy '{policyName}' is not supported."
-                }
-            };
-        }
-
-        private static string? GetDefaultPolicyName(DeployOperationSpec spec)
-            => spec.TargetKind switch
-            {
-                DeployTargetKind.Kubernetes => "kubernetes-honua-http",
-                // ECS canary deploys are configured by setting a canary weight via
-                // aws.ecs.canary_weight_percentage or the generic
-                // deployment.canary_weight_percentage; either key implies the rollout
-                // is gated on canary-only telemetry. Without that signal the runbook
-                // and PlanAsync would advertise a canary policy while the evaluator
-                // silently fell back to aggregate Honua HTTP metrics.
-                DeployTargetKind.AwsEcs => HasCanarySignalConfiguration(spec.Parameters) || HasCanaryWeight(spec.Parameters)
-                    ? "aws-alb-canary"
-                    : "honua-http",
-                DeployTargetKind.AwsLambda => HasCanarySignalConfiguration(spec.Parameters) ? "aws-lambda-canary" : "honua-http",
-                DeployTargetKind.AzureContainerApps => HasCanarySignalConfiguration(spec.Parameters) ? "azure-aca-canary" : "honua-http",
-                DeployTargetKind.AzureFunctions => "honua-http",
-                _ => null
-            };
-
-        private static bool HasCanarySignalConfiguration(IReadOnlyDictionary<string, string> parameters)
-            => parameters.ContainsKey("telemetry.prometheus.canary_selector")
-               || parameters.ContainsKey("telemetry.prometheus.canary_job");
-
-        private static bool HasCanaryWeight(IReadOnlyDictionary<string, string> parameters)
-            => HasNonEmpty(parameters, "aws.ecs.canary_weight_percentage")
-               || HasNonEmpty(parameters, "deployment.canary_weight_percentage");
-
-        private static bool HasNonEmpty(IReadOnlyDictionary<string, string> parameters, string key)
-            => parameters.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value);
-
-        private static DeployTelemetryPolicy CreateHonuaHttpPreset(IReadOnlyDictionary<string, string> parameters)
-        {
-            var selector = BuildPrometheusSelector(
-                parameters,
-                selectorKey: "telemetry.prometheus.selector",
-                jobKey: "telemetry.prometheus.job",
-                defaultJob: DefaultPrometheusJob);
-
-            return string.IsNullOrWhiteSpace(selector)
-                ? InvalidPreset("Deploy telemetry policy 'kubernetes-honua-http' requires a Prometheus selector or job.")
-                : CreateHonuaHttpPolicy(selector, warmupDuration: TimeSpan.FromMinutes(2));
-        }
-
-        private static DeployTelemetryPolicy CreateAwsAlbCanaryPreset(IReadOnlyDictionary<string, string> parameters)
-            => CreateCanaryPreset(parameters, "aws-alb-canary");
-
-        private static DeployTelemetryPolicy CreateAwsLambdaCanaryPreset(IReadOnlyDictionary<string, string> parameters)
-            => CreateCanaryPreset(parameters, "aws-lambda-canary");
-
-        private static DeployTelemetryPolicy CreateAzureAcaCanaryPreset(IReadOnlyDictionary<string, string> parameters)
-            => CreateCanaryPreset(parameters, "azure-aca-canary");
-
-        private static DeployTelemetryPolicy CreateCanaryPreset(IReadOnlyDictionary<string, string> parameters, string presetName)
-        {
-            var selector = BuildPrometheusSelector(
-                parameters,
-                selectorKey: "telemetry.prometheus.canary_selector",
-                jobKey: "telemetry.prometheus.canary_job",
-                defaultJob: DefaultCanaryPrometheusJob,
-                fallbackSelectorKey: "telemetry.prometheus.selector",
-                fallbackJobKey: "telemetry.prometheus.job");
-
-            return string.IsNullOrWhiteSpace(selector)
-                ? InvalidPreset($"Deploy telemetry policy '{presetName}' requires a canary Prometheus selector or canary job.")
-                : CreateHonuaHttpPolicy(selector, warmupDuration: TimeSpan.FromMinutes(3), minimumSampleCount: 10);
-        }
-
-        private static DeployTelemetryPolicy CreateHonuaHttpPolicy(
-            string selector,
-            TimeSpan warmupDuration,
-            double minimumSampleCount = 20)
-        {
-            var metricSelector = WrapSelector(selector);
-            var errorSelector = AppendLabelMatcher(selector, "status_code=~\"5..\"");
-
-            return new DeployTelemetryPolicy
-            {
-                ConnectionId = string.Empty,
-                ErrorRateQuery =
-                    $"sum(rate(honua_http_request_total{WrapSelector(errorSelector)}[5m])) / clamp_min(sum(rate(honua_http_request_total{metricSelector}[5m])), 0.001)",
-                ErrorRateThreshold = 0.05,
-                LatencyP95Query =
-                    $"histogram_quantile(0.95, sum(rate(honua_http_request_duration_ms_bucket{metricSelector}[5m])) by (le))",
-                LatencyP95ThresholdMs = 2000,
-                MinimumSampleQuery =
-                    $"sum(rate(honua_http_request_total{metricSelector}[5m])) * 300",
-                MinimumSampleCount = minimumSampleCount,
-                WarmupDuration = warmupDuration
-            };
-        }
-
-        private static DeployTelemetryPolicy InvalidPreset(string message)
-            => new()
-            {
-                ConnectionId = string.Empty,
-                ValidationError = message
-            };
-
-        private static string BuildPrometheusSelector(
-            IReadOnlyDictionary<string, string> parameters,
-            string selectorKey,
-            string jobKey,
-            string? defaultJob,
-            string? fallbackSelectorKey = null,
-            string? fallbackJobKey = null)
-        {
-            var rawSelector = Get(parameters, selectorKey)
-                ?? (fallbackSelectorKey != null ? Get(parameters, fallbackSelectorKey) : null);
-            var extraSelector = Get(parameters, "telemetry.prometheus.extra_selector");
-            var job = Get(parameters, jobKey)
-                ?? (fallbackJobKey != null ? Get(parameters, fallbackJobKey) : null)
-                ?? defaultJob;
-
-            var matchers = new List<string>();
-            if (!string.IsNullOrWhiteSpace(rawSelector))
-            {
-                matchers.Add(rawSelector);
-            }
-            else if (!string.IsNullOrWhiteSpace(job))
-            {
-                matchers.Add($"job={QuotePrometheusValue(job)}");
-            }
-
-            if (!string.IsNullOrWhiteSpace(extraSelector))
-            {
-                matchers.Add(extraSelector);
-            }
-
-            return string.Join(",", matchers.Where(static matcher => !string.IsNullOrWhiteSpace(matcher)));
-        }
-
-        private static string QuotePrometheusValue(string value)
-            => $"\"{value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal)}\"";
-
-        private static string WrapSelector(string selector)
-            => string.IsNullOrWhiteSpace(selector) ? string.Empty : $"{{{selector}}}";
-
-        private static string AppendLabelMatcher(string selector, string labelMatcher)
-            => string.IsNullOrWhiteSpace(selector) ? labelMatcher : $"{selector},{labelMatcher}";
-
-        private static string? Get(IReadOnlyDictionary<string, string> parameters, string key)
-            => parameters.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)
-                ? value.Trim()
-                : null;
-
-        private static double? ParseOptionalDouble(IReadOnlyDictionary<string, string> parameters, string key)
-        {
-            if (!parameters.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw))
-            {
-                return null;
-            }
-
-            return double.TryParse(raw, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsed)
-                ? parsed
-                : null;
-        }
     }
 
     private sealed record ValidatedTelemetryConnection(

--- a/src/Honua.Server/Features/ControlPlane/DeployTelemetrySignalEvaluatorLog.cs
+++ b/src/Honua.Server/Features/ControlPlane/DeployTelemetrySignalEvaluatorLog.cs
@@ -7,4 +7,7 @@ internal static partial class DeployTelemetrySignalEvaluatorLog
 {
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to evaluate deploy telemetry signals for operation {OperationId}")]
     public static partial void EvaluationFailed(ILogger logger, string operationId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Deploy telemetry connection '{ConnectionId}' uses unsupported provider '{Provider}' for operation {OperationId}; auto-rollback signals are disabled until a supported provider is configured (supported: {SupportedProviders}).")]
+    public static partial void UnsupportedProvider(ILogger logger, string operationId, string connectionId, string provider, string supportedProviders);
 }

--- a/src/Honua.Server/Startup/BatchAndDeployBackendsRegistration.cs
+++ b/src/Honua.Server/Startup/BatchAndDeployBackendsRegistration.cs
@@ -34,7 +34,16 @@ internal static class BatchAndDeployBackendsRegistration
         services.AddSingleton<IDeployTargetRegistry, ConfigurationDeployTargetRegistry>();
         services.AddSingleton<IExecutionJobDefinitionRegistry, ConfigurationExecutionJobDefinitionRegistry>();
         services.AddSingleton<DeployWorkflowService>();
-        services.AddSingleton<IDeployTelemetrySignalEvaluator, PrometheusDeployTelemetrySignalEvaluator>();
+
+        // Multi-provider deploy telemetry gate. The dispatcher selects a provider evaluator by the
+        // telemetry connection's Provider; Prometheus is always available, CloudWatch is added with
+        // the rest of the AWS surface.
+        services.AddSingleton<IDeployTelemetryProviderEvaluator, PrometheusDeployTelemetryProviderEvaluator>();
+#if !HONUA_EXCLUDE_AWS
+        services.AddSingleton<ICloudWatchMetricClient, AwsSdkCloudWatchMetricClient>();
+        services.AddSingleton<IDeployTelemetryProviderEvaluator, CloudWatchDeployTelemetryProviderEvaluator>();
+#endif
+        services.AddSingleton<IDeployTelemetrySignalEvaluator, DeployTelemetrySignalEvaluator>();
 
         // Deploy backend concrete singletons. Order matters for the IEnumerable<IDeployBackend>
         // resolution below — keep the existing K8s/AWS/Azure ordering.

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/CloudWatchDeployTelemetryProviderEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/CloudWatchDeployTelemetryProviderEvaluatorTests.cs
@@ -1,0 +1,251 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.ControlPlane;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Verifies the CloudWatch deploy telemetry provider end-to-end through the multi-provider
+/// dispatcher with a faked CloudWatch metric client (no live AWS account required).
+/// </summary>
+public sealed class CloudWatchDeployTelemetryProviderEvaluatorTests
+{
+    private const string ErrorRateExpression = "errors / requests";
+    private const string LatencyExpression = "p95_latency";
+    private const string SampleExpression = "request_count";
+
+    [Fact]
+    public async Task EvaluateAsync_HealthyCloudWatchMetrics_ReturnsPromoteSignal()
+    {
+        var client = new FakeCloudWatchMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleExpression] = 50,
+            [ErrorRateExpression] = 0.01,
+            [LatencyExpression] = 120
+        });
+
+        var decision = await Evaluate(client);
+
+        decision.Should().NotBeNull();
+        decision!.WaitForMoreTelemetry.Should().BeFalse();
+        decision.RollbackRecommended.Should().BeFalse();
+        client.RequestedExpressions.Should().Contain([SampleExpression, ErrorRateExpression, LatencyExpression]);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_BreachingErrorRate_ReturnsRollbackSignal()
+    {
+        var client = new FakeCloudWatchMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleExpression] = 50,
+            [ErrorRateExpression] = 0.4,
+            [LatencyExpression] = 120
+        });
+
+        var decision = await Evaluate(client);
+
+        decision.Should().NotBeNull();
+        decision!.RollbackRecommended.Should().BeTrue();
+        decision.WaitForMoreTelemetry.Should().BeFalse();
+        decision.Message.Should().Contain("error rate");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_BreachingLatency_ReturnsRollbackSignal()
+    {
+        var client = new FakeCloudWatchMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleExpression] = 50,
+            [ErrorRateExpression] = 0.01,
+            [LatencyExpression] = 9000
+        });
+
+        var decision = await Evaluate(client);
+
+        decision.Should().NotBeNull();
+        decision!.RollbackRecommended.Should().BeTrue();
+        decision.Message.Should().Contain("latency");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_BelowMinimumSampleCount_WaitsForMoreTelemetry()
+    {
+        var client = new FakeCloudWatchMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleExpression] = 3,
+            [ErrorRateExpression] = 0.4,
+            [LatencyExpression] = 9000
+        });
+
+        var decision = await Evaluate(client);
+
+        decision.Should().NotBeNull();
+        decision!.WaitForMoreTelemetry.Should().BeTrue();
+        decision.RollbackRecommended.Should().BeFalse();
+        // Error-rate / latency must not be read until the minimum sample gate clears.
+        client.RequestedExpressions.Should().ContainSingle().Which.Should().Be(SampleExpression);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithoutExplicitQueries_FailsClosedToWait()
+    {
+        // CloudWatch has no preset query dialect (presets emit PromQL); a connection that relies on
+        // a preset must fall back to a wait rather than shipping PromQL to CloudWatch.
+        var client = new FakeCloudWatchMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal));
+
+        var evaluator = CreateDispatcher(client);
+        var decision = await evaluator.EvaluateAsync(CreateOperation(new Dictionary<string, string>
+        {
+            ["telemetry.connection"] = "prod-cw",
+            ["telemetry.policy"] = "aws-lambda-canary",
+            ["telemetry.prometheus.canary_job"] = "honua-canary"
+        }));
+
+        decision.Should().NotBeNull();
+        decision!.WaitForMoreTelemetry.Should().BeTrue();
+        client.RequestedExpressions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_ResolvesRegion_FromConnectionRegion()
+    {
+        var client = new FakeCloudWatchMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleExpression] = 50,
+            [ErrorRateExpression] = 0.01,
+            [LatencyExpression] = 120
+        });
+
+        await Evaluate(client, region: "eu-west-1");
+
+        client.LastRegion.Should().Be("eu-west-1");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_InfersRegion_FromRegionalBaseUrl()
+    {
+        var client = new FakeCloudWatchMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleExpression] = 50,
+            [ErrorRateExpression] = 0.01,
+            [LatencyExpression] = 120
+        });
+
+        await Evaluate(client, baseUrl: "https://monitoring.us-east-2.amazonaws.com");
+
+        client.LastRegion.Should().Be("us-east-2");
+    }
+
+    private static async Task<DeployTelemetryDecision?> Evaluate(
+        FakeCloudWatchMetricClient client,
+        string? region = null,
+        string baseUrl = "https://monitoring.us-east-1.amazonaws.com")
+    {
+        var evaluator = CreateDispatcher(client, region, baseUrl);
+        return await evaluator.EvaluateAsync(CreateOperation(new Dictionary<string, string>
+        {
+            ["telemetry.connection"] = "prod-cw",
+            ["telemetry.error_rate.query"] = ErrorRateExpression,
+            ["telemetry.error_rate.threshold"] = "0.05",
+            ["telemetry.latency_p95.query"] = LatencyExpression,
+            ["telemetry.latency_p95.threshold_ms"] = "2000",
+            ["telemetry.sample_count.query"] = SampleExpression,
+            ["telemetry.sample_count.minimum"] = "10"
+        }));
+    }
+
+    private static DeployTelemetrySignalEvaluator CreateDispatcher(
+        FakeCloudWatchMetricClient client,
+        string? region = null,
+        string baseUrl = "https://monitoring.us-east-1.amazonaws.com")
+    {
+        var cloudWatchProvider = new CloudWatchDeployTelemetryProviderEvaluator(client);
+        var options = new ControlPlaneOptions
+        {
+            TelemetryConnections =
+            [
+                new DeployTelemetryConnectionOptions
+                {
+                    ConnectionId = "prod-cw",
+                    Provider = "cloudwatch",
+                    BaseUrl = baseUrl,
+                    Region = region,
+                    TimeoutSeconds = 2
+                }
+            ]
+        };
+
+        return new DeployTelemetrySignalEvaluator(
+            new TestControlPlaneOptionsMonitor(options),
+            [cloudWatchProvider],
+            NullLogger<DeployTelemetrySignalEvaluator>.Instance);
+    }
+
+    private static WorkflowOperationRecord CreateOperation(IReadOnlyDictionary<string, string> parameters)
+    {
+        var now = DateTimeOffset.UtcNow.AddMinutes(-5);
+        return new WorkflowOperationRecord
+        {
+            OperationId = $"deploy-{Guid.NewGuid():N}",
+            Kind = WorkflowOperationKind.Deploy,
+            Status = WorkflowOperationStatus.Reconciling,
+            CreatedAt = now,
+            UpdatedAt = now,
+            CurrentPhase = "Reconciling rollout",
+            Audit = new OperationAuditInfo(),
+            Concurrency = new OperationConcurrencyPolicy
+            {
+                PartitionKey = "production:prod-api",
+                RequiresExclusiveLease = true
+            },
+            Deploy = new DeployOperationSpec
+            {
+                TargetId = "prod-api",
+                TargetKind = DeployTargetKind.AwsEcs,
+                Backend = "honua-aws-ecs-alb",
+                Environment = "production",
+                TargetName = "honua-server",
+                ArtifactReference = "ghcr.io/honua/server",
+                RuntimeProfile = "dotnet-api",
+                CurrentRevision = "sha256:old",
+                DesiredRevision = "sha256:new",
+                Parameters = new Dictionary<string, string>(parameters, StringComparer.Ordinal)
+            }
+        };
+    }
+
+    private sealed class TestControlPlaneOptionsMonitor(ControlPlaneOptions currentValue) : IOptionsMonitor<ControlPlaneOptions>
+    {
+        public ControlPlaneOptions CurrentValue => currentValue;
+
+        public ControlPlaneOptions Get(string? name) => currentValue;
+
+        public IDisposable? OnChange(Action<ControlPlaneOptions, string?> listener) => null;
+    }
+
+    private sealed class FakeCloudWatchMetricClient(IReadOnlyDictionary<string, double?> values) : ICloudWatchMetricClient
+    {
+        public ConcurrentQueue<string> RequestedExpressions { get; } = new();
+
+        public string? LastRegion { get; private set; }
+
+        public Task<double?> GetExpressionValueAsync(
+            string? region,
+            string expression,
+            DateTime startUtc,
+            DateTime endUtc,
+            int periodSeconds,
+            CancellationToken cancellationToken)
+        {
+            LastRegion = region;
+            RequestedExpressions.Enqueue(expression);
+            return Task.FromResult(values.TryGetValue(expression, out var value) ? value : null);
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployTelemetrySignalEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployTelemetrySignalEvaluatorTests.cs
@@ -303,7 +303,135 @@ public sealed class DeployTelemetrySignalEvaluatorTests
         capturedQueries.Should().BeEmpty();
     }
 
-    private static PrometheusDeployTelemetrySignalEvaluator CreateEvaluator(
+    [Fact]
+    public async Task EvaluateAsync_WithUnsupportedProvider_WaitsWithExplicitMessage_AndDoesNotQuery()
+    {
+        var capturedQueries = new ConcurrentQueue<string>();
+        var evaluator = CreateEvaluator(
+            capturedQueries,
+            connection: new DeployTelemetryConnectionOptions
+            {
+                ConnectionId = "prod-prom",
+                Provider = "datadog",
+                BaseUrl = "https://api.datadoghq.com",
+                TimeoutSeconds = 2
+            });
+
+        var decision = await evaluator.EvaluateAsync(CreateOperation(
+            DeployTargetKind.Kubernetes,
+            new Dictionary<string, string>
+            {
+                ["telemetry.connection"] = "prod-prom",
+                ["telemetry.prometheus.job"] = "honua-prod"
+            }));
+
+        decision.Should().NotBeNull();
+        decision!.WaitForMoreTelemetry.Should().BeTrue();
+        decision.RollbackRecommended.Should().BeFalse();
+        decision.Message.Should().Contain("datadog");
+        decision.Message.Should().Contain("not supported");
+        capturedQueries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_SelectsProviderByConnectionProvider()
+    {
+        // Two providers registered; the connection's Provider ("fake-metrics") selects the fake
+        // one rather than Prometheus, proving dispatch is driven by the connection.
+        var fakeProvider = new FakeProviderEvaluator("fake-metrics", new DeployTelemetryReadings
+        {
+            SampleCount = 50,
+            ErrorRate = 0.01,
+            LatencyP95 = 120
+        });
+        var prometheusProvider = new PrometheusDeployTelemetryProviderEvaluator(
+            new StubHttpClientFactory(new HttpClient(new DelegateHttpMessageHandler(_ =>
+                throw new InvalidOperationException("Prometheus provider must not be invoked.")))));
+
+        var evaluator = new DeployTelemetrySignalEvaluator(
+            new TestControlPlaneOptionsMonitor(new ControlPlaneOptions
+            {
+                TelemetryConnections =
+                [
+                    new DeployTelemetryConnectionOptions
+                    {
+                        ConnectionId = "prod-metrics",
+                        Provider = "fake-metrics",
+                        BaseUrl = "https://example.com",
+                        TimeoutSeconds = 2
+                    }
+                ]
+            }),
+            [prometheusProvider, fakeProvider],
+            NullLogger<DeployTelemetrySignalEvaluator>.Instance);
+
+        var decision = await evaluator.EvaluateAsync(CreateOperation(
+            DeployTargetKind.AwsEcs,
+            new Dictionary<string, string>
+            {
+                ["telemetry.connection"] = "prod-metrics",
+                ["telemetry.policy"] = "aws-lambda-canary",
+                ["telemetry.error_rate.query"] = "errors / requests",
+                ["telemetry.error_rate.threshold"] = "0.05",
+                ["telemetry.latency_p95.query"] = "p95",
+                ["telemetry.latency_p95.threshold_ms"] = "2000",
+                ["telemetry.sample_count.query"] = "requests",
+                ["telemetry.sample_count.minimum"] = "10"
+            },
+            createdAt: DateTimeOffset.UtcNow.AddMinutes(-5)));
+
+        decision.Should().NotBeNull();
+        decision!.WaitForMoreTelemetry.Should().BeFalse();
+        decision.RollbackRecommended.Should().BeFalse();
+        fakeProvider.WasInvoked.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_ProviderReadingBreachesThreshold_RecommendsRollback()
+    {
+        var fakeProvider = new FakeProviderEvaluator("fake-metrics", new DeployTelemetryReadings
+        {
+            SampleCount = 50,
+            ErrorRate = 0.5,
+            LatencyP95 = 120
+        });
+
+        var evaluator = new DeployTelemetrySignalEvaluator(
+            new TestControlPlaneOptionsMonitor(new ControlPlaneOptions
+            {
+                TelemetryConnections =
+                [
+                    new DeployTelemetryConnectionOptions
+                    {
+                        ConnectionId = "prod-metrics",
+                        Provider = "fake-metrics",
+                        BaseUrl = "https://example.com",
+                        TimeoutSeconds = 2
+                    }
+                ]
+            }),
+            [fakeProvider],
+            NullLogger<DeployTelemetrySignalEvaluator>.Instance);
+
+        var decision = await evaluator.EvaluateAsync(CreateOperation(
+            DeployTargetKind.AwsEcs,
+            new Dictionary<string, string>
+            {
+                ["telemetry.connection"] = "prod-metrics",
+                ["telemetry.error_rate.query"] = "errors / requests",
+                ["telemetry.error_rate.threshold"] = "0.05",
+                ["telemetry.sample_count.query"] = "requests",
+                ["telemetry.sample_count.minimum"] = "10"
+            },
+            createdAt: DateTimeOffset.UtcNow.AddMinutes(-5)));
+
+        decision.Should().NotBeNull();
+        decision!.RollbackRecommended.Should().BeTrue();
+        decision.WaitForMoreTelemetry.Should().BeFalse();
+        decision.Message.Should().Contain("error rate");
+    }
+
+    private static DeployTelemetrySignalEvaluator CreateEvaluator(
         ConcurrentQueue<string> capturedQueries,
         DeployTelemetryConnectionOptions? connection = null,
         params string[] responses)
@@ -326,7 +454,10 @@ public sealed class DeployTelemetrySignalEvaluatorTests
             };
         });
 
-        return new PrometheusDeployTelemetrySignalEvaluator(
+        var prometheusProvider = new PrometheusDeployTelemetryProviderEvaluator(
+            new StubHttpClientFactory(new HttpClient(handler)));
+
+        return new DeployTelemetrySignalEvaluator(
             new TestControlPlaneOptionsMonitor(new ControlPlaneOptions
             {
                 TelemetryConnections =
@@ -340,8 +471,8 @@ public sealed class DeployTelemetrySignalEvaluatorTests
                     }
                 ]
             }),
-            new StubHttpClientFactory(new HttpClient(handler)),
-            NullLogger<PrometheusDeployTelemetrySignalEvaluator>.Instance);
+            [prometheusProvider],
+            NullLogger<DeployTelemetrySignalEvaluator>.Instance);
     }
 
     private static string[] CreateSuccessfulResponses(string sampleCount, string errorRate, string latencyP95)
@@ -409,5 +540,21 @@ public sealed class DeployTelemetrySignalEvaluatorTests
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             => Task.FromResult(handler(request));
+    }
+
+    private sealed class FakeProviderEvaluator(string provider, DeployTelemetryReadings readings) : IDeployTelemetryProviderEvaluator
+    {
+        public string Provider => provider;
+
+        public bool WasInvoked { get; private set; }
+
+        public Task<DeployTelemetryReadings> ReadAsync(
+            DeployTelemetryPolicyDescriptor policy,
+            DeployTelemetryConnectionDescriptor connection,
+            CancellationToken cancellationToken)
+        {
+            WasInvoked = true;
+            return Task.FromResult(readings);
+        }
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowServiceTests.cs
@@ -561,7 +561,7 @@ public sealed class DeployWorkflowServiceTests
         };
     }
 
-    private static PrometheusDeployTelemetrySignalEvaluator CreateTelemetryEvaluator(params string[] responses)
+    private static DeployTelemetrySignalEvaluator CreateTelemetryEvaluator(params string[] responses)
     {
         var responseQueue = new ConcurrentQueue<string>(responses);
         var optionsMonitor = new TestControlPlaneOptionsMonitor(new ControlPlaneOptions
@@ -578,8 +578,7 @@ public sealed class DeployWorkflowServiceTests
             ]
         });
 
-        return new PrometheusDeployTelemetrySignalEvaluator(
-            optionsMonitor,
+        var prometheusProvider = new PrometheusDeployTelemetryProviderEvaluator(
             new StubHttpClientFactory(new HttpClient(new DelegateHttpMessageHandler(_ =>
                 new HttpResponseMessage(HttpStatusCode.OK)
                 {
@@ -589,8 +588,12 @@ public sealed class DeployWorkflowServiceTests
                             : """{"status":"success","data":{"resultType":"vector","result":[]}}""",
                         Encoding.UTF8,
                         "application/json")
-                }))),
-            NullLogger<PrometheusDeployTelemetrySignalEvaluator>.Instance);
+                }))));
+
+        return new DeployTelemetrySignalEvaluator(
+            optionsMonitor,
+            [prometheusProvider],
+            NullLogger<DeployTelemetrySignalEvaluator>.Instance);
     }
 
     private sealed class TestDeployTargetRegistry : IDeployTargetRegistry


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1556
Parent: #1537 (operator-promotion gaps — multi-provider telemetry gate)

## Summary
The deploy telemetry gate was Prometheus-only: `PrometheusDeployTelemetrySignalEvaluator` hard-checked `provider == "prometheus"` and returned `WaitForMoreTelemetry` indefinitely for any other provider, so auto-rollback never fired for environments whose metrics live in CloudWatch / Datadog / Azure Monitor.

This PR makes the gate multi-provider behind the existing `IDeployTelemetrySignalEvaluator` abstraction, selectable per telemetry connection by its `Provider`, and adds a fully implemented **Amazon CloudWatch** provider (the highest-value first provider, aligning with the already-supported AWS managed backends). Prometheus remains the reference implementation. Unknown/unconfigured providers now fail **sanely and visibly** instead of stalling silently.

## Changes Made
- **Provider dispatcher**: `DeployTelemetrySignalEvaluator` (registered as `IDeployTelemetrySignalEvaluator`) parses the provider-neutral policy, applies warmup, resolves the named connection, then dispatches metric reads to the `IDeployTelemetryProviderEvaluator` whose `Provider` matches the connection's `Provider`. Threshold/warmup/sample-gate and the promote/rollback/wait decision are shared, so semantics are identical across providers — only the query dialect differs.
- **New Core abstraction** (`Honua.Core`): `IDeployTelemetryProviderEvaluator` + provider-neutral `DeployTelemetryConnectionDescriptor` / `DeployTelemetryPolicyDescriptor` / `DeployTelemetryReadings`, so cloud-specific assemblies implement providers without depending on the server's internal config types.
- **Prometheus provider** refactored into `PrometheusDeployTelemetryProviderEvaluator` (PromQL), behavior-preserving (existing presets and queries unchanged).
- **CloudWatch provider** (`Honua.Aws`): `CloudWatchDeployTelemetryProviderEvaluator` over a thin `ICloudWatchMetricClient` seam (`AwsSdkCloudWatchMetricClient` uses `GetMetricData` metric-math). Operator supplies CloudWatch metric-math expressions via the existing `telemetry.error_rate.query` / `telemetry.latency_p95.query` / `telemetry.sample_count.query` overrides (presets only emit PromQL, so CloudWatch fails closed to a wait if no explicit queries are set). Region comes from a new optional `Region` connection field, inferred from a regional `BaseUrl`, or the AWS SDK default chain. Credentials use the standard AWS credential chain — no secrets on the connection.
- **Unknown/unsupported provider**: returns an explicit `WaitForMoreTelemetry` decision with a clear message **and** logs a warning naming the connection, the unsupported provider, and the supported providers. No indefinite silent stall.
- **DI**: Prometheus provider always registered; CloudWatch provider + `ICloudWatchMetricClient` registered under `!HONUA_EXCLUDE_AWS`; dispatcher composes `IEnumerable<IDeployTelemetryProviderEvaluator>`.
- **Config**: added `AWSSDK.CloudWatch` package; `DeployTelemetryConnectionOptions.Region` (optional); documented `Provider`/`BaseUrl` semantics.
- **Docs**: `docs/operator/runbooks/UPGRADE_AND_ROLLBACK.md` gains a "Deploy Telemetry Gate Providers" section (provider table, CloudWatch connection example, unsupported-provider behavior); `docs/operator/monitoring.md` updated to document multi-provider selection and fix the connection example to use `Provider` (was `ConnectionType`).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

`DeployTelemetrySignalEvaluatorTests` (Prometheus, unchanged scenarios) plus new cases: unknown-provider wait + no queries issued, provider selection by connection `Provider`, and a breaching-reading rollback. New `CloudWatchDeployTelemetryProviderEvaluatorTests` (faked CloudWatch client, no live AWS): healthy → promote, breaching error-rate/latency → rollback, below-minimum-sample → wait (and short-circuits before error/latency reads), no-explicit-queries → wait, region from `Region`, region inferred from regional `BaseUrl`. `DeployWorkflowServiceTests` updated to construct the dispatcher.

Results: telemetry-evaluator + workflow targeted suite 36 passed / 0 failed; full ControlPlane suite 480 passed / 0 failed / 3 skipped; Architecture tests 109 passed / 0 failed / 1 skipped; `dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true` clean; `dotnet format --verify-no-changes` clean.

> Note on `scripts/ci/pre-pr-check.sh`: its build, format, and Docker-prep steps passed. The full `.NET tests` step could not complete on the shared multi-agent build box — one run was SIGTERM'd (exit 143) and a retry hit the 40-minute server-test-shard cap (exit 124, "Server test shard 'Core' timed out") under heavy build-lock contention. Neither was a test failure: no assertion failures and not the known `DbUpMigrations.MobileOfflineDemoSeed_AppliesToCanonicalSchema` `40P01` deadlock flake. The affected suites above were run in isolation and are green. Opened as draft pending a clean full pre-pr-check run; CI will run the complete suite.

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [x] Documentation updated

New public abstractions in `Honua.Core.Features.ControlPlane.Abstractions` (`IDeployTelemetryProviderEvaluator` and descriptor records). No protocol/proto/OpenAPI changes.

## Release/Deploy Impact
- [x] Requires infrastructure changes
- [x] Requires environment variable or secret changes

Per-provider telemetry connections: a CloudWatch connection needs `Provider: "cloudwatch"`, a region (or regional `BaseUrl`), CloudWatch metric-math query overrides, and IAM scoped to `cloudwatch:GetMetricData`. Existing Prometheus connections are unchanged.

## Breaking Changes
None. Existing Prometheus connections and presets behave identically. The previous "stall on non-Prometheus" behavior is replaced by an explicit, logged wait; CloudWatch is additive.

---

## Pre-PR Checklist
- [ ] Ran scripts/ci/pre-pr-check.sh and all checks passed — see note below
- [x] Build, format-verify, and the affected test suites pass (details in Testing)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Follow-ups (separate issues/PRs)
- Datadog and Azure Monitor providers (issue #1556 explicitly scopes one provider fully; these are additive evaluators behind the same abstraction).
