### PR TITLE
test: serialize DbUp migration setup under the seed advisory lock (#1568)

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/DatabaseMigrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/DatabaseMigrationTests.cs
@@ -52,7 +52,12 @@ public sealed class DatabaseMigrationTests : IAsyncLifetime
             .Build();
 
         // Act
-        var result = upgrader.PerformUpgrade();
+        DbUp.Engine.DatabaseUpgradeResult result = null!;
+        await _postgres.RunUnderSchemaMutationLockAsync(() =>
+        {
+            result = upgrader.PerformUpgrade();
+            return Task.CompletedTask;
+        });
 
         // Assert
         if (!result.Successful)
@@ -140,8 +145,14 @@ public sealed class DatabaseMigrationTests : IAsyncLifetime
             .Build();
 
         // Act - Run migrations twice
-        var firstResult = upgrader.PerformUpgrade();
-        var secondResult = upgrader.PerformUpgrade();
+        DbUp.Engine.DatabaseUpgradeResult firstResult = null!;
+        DbUp.Engine.DatabaseUpgradeResult secondResult = null!;
+        await _postgres.RunUnderSchemaMutationLockAsync(() =>
+        {
+            firstResult = upgrader.PerformUpgrade();
+            secondResult = upgrader.PerformUpgrade();
+            return Task.CompletedTask;
+        });
 
         // Assert
         firstResult.Successful.Should().BeTrue($"first migration should succeed. Error: {firstResult.Error}");
@@ -167,7 +178,12 @@ public sealed class DatabaseMigrationTests : IAsyncLifetime
             .WithTransaction()
             .Build();
 
-        var migrationResult = upgrader.PerformUpgrade();
+        DbUp.Engine.DatabaseUpgradeResult migrationResult = null!;
+        await _postgres.RunUnderSchemaMutationLockAsync(() =>
+        {
+            migrationResult = upgrader.PerformUpgrade();
+            return Task.CompletedTask;
+        });
         migrationResult.Successful.Should().BeTrue($"migrations should complete successfully. Error: {migrationResult.Error}");
 
         var baselineSeedPath = RepositoryPaths.Resolve("tests", "seed", "mobile-offline-demo-v1.sql");

--- a/tests/dotnet/Honua.TestKit/PostgresFixture.cs
+++ b/tests/dotnet/Honua.TestKit/PostgresFixture.cs
@@ -216,6 +216,56 @@ public sealed class PostgresFixture : IAsyncLifetime
     }
 
     /// <summary>
+    /// Runs a schema-mutating action (e.g. a raw DbUp upgrade) while holding the session-level
+    /// Postgres advisory lock shared with <see cref="Seeding.SeedRunner"/>, retrying on a
+    /// transient <c>40P01</c> deadlock / <c>40001</c> serialization failure.
+    /// </summary>
+    /// <remarks>
+    /// DbUp DDL (the <c>schema_versions</c> journal, <c>CREATE TABLE/INDEX</c>, extensions) takes
+    /// locks on the global <c>pg_catalog</c>, which per-test schema isolation does not protect.
+    /// Serializing every schema-mutating setup path on one advisory lock removes the catalog-level
+    /// lock-ordering deadlocks that flake parallel integration runs (honua-server#1568).
+    /// </remarks>
+    /// <param name="action">The schema-mutating work to run while the lock is held.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task RunUnderSchemaMutationLockAsync(Func<Task> action, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        const int maxAttempts = 4;
+        for (var attempt = 1; ; attempt++)
+        {
+            await using var lockConnection = await GetConnectionAsync().ConfigureAwait(false);
+            await ExecuteAdvisoryLockCommandAsync(lockConnection, "SELECT pg_advisory_lock(@key);", cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await action().ConfigureAwait(false);
+                return;
+            }
+            catch (PostgresException ex) when (attempt < maxAttempts && IsTransientLockFailure(ex))
+            {
+                // Deadlock / serialization victim: its transaction is fully rolled back, so retry
+                // is safe. The lock is released in the finally block before the next attempt.
+            }
+            finally
+            {
+                await ExecuteAdvisoryLockCommandAsync(lockConnection, "SELECT pg_advisory_unlock(@key);", cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async Task ExecuteAdvisoryLockCommandAsync(NpgsqlConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        _ = cmd.Parameters.AddWithValue("key", Seeding.SeedRunner.SeedApplicationLockKey);
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool IsTransientLockFailure(PostgresException ex)
+        => ex.SqlState is PostgresErrorCodes.DeadlockDetected or PostgresErrorCodes.SerializationFailure;
+
+    /// <summary>
     /// Clean up test data in the public schema (legacy method).
     /// Prefer schema-based isolation for parallel execution.
     /// </summary>

--- a/tests/dotnet/Honua.TestKit/Seeding/SeedRunner.cs
+++ b/tests/dotnet/Honua.TestKit/Seeding/SeedRunner.cs
@@ -57,7 +57,14 @@ internal static class SeedRunner
     private static readonly Regex _identifierRegex = new("^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.CultureInvariant);
     private static readonly Regex _typeRegex = new("^[A-Za-z0-9_(),\\s\\[\\]]+$", RegexOptions.CultureInvariant);
     private const int MaxConcurrencyRetryAttempts = 3;
-    private const long SeedApplicationLockKey = 7_893_641_160_553_452_791;
+
+    /// <summary>
+    /// Advisory-lock key serializing all schema-mutating test setup. Shared with
+    /// <see cref="PostgresFixture.RunUnderSchemaMutationLockAsync"/> so seeds and raw DbUp
+    /// migrations serialize on one lock rather than deadlocking on the global
+    /// <c>pg_catalog</c> under parallel test execution (honua-server#1568).
+    /// </summary>
+    internal const long SeedApplicationLockKey = 7_893_641_160_553_452_791;
 
     // honua-server#1359: the serially-seeded Database collections pay a per-test seed
     // cost. Re-reading and re-parsing the seed YAML from disk on every isolated-schema


### PR DESCRIPTION
## Issue Link
Closes #1568

## Summary
Eliminates the recurring `40P01: deadlock detected` integration-test flake (most often `DbUpMigrations.MobileOfflineDemoSeed_AppliesToCanonicalSchema`; it flaked unrelated PRs #1551/#1557/#1560 and forced CI re-runs). Root cause: `DatabaseMigrationTests` ran raw DbUp (`DeployChanges.To…PerformUpgrade`) with no advisory lock or retry, while `SeedRunner` serializes seeding on advisory key `7_893_641_160_553_452_791`. DbUp DDL locks the global `pg_catalog` — which per-test schema isolation does not protect — so concurrent collections deadlocked.

## Changes Made
- `SeedRunner.SeedApplicationLockKey`: `private` → `internal` so the one key is shared.
- `PostgresFixture.RunUnderSchemaMutationLockAsync(...)`: holds a session-level `pg_advisory_lock` on the shared key around the action and retries on transient `40P01`/`40001`.
- Wrapped the three `PerformUpgrade()` sites in `DatabaseMigrationTests` under it.
- Test-harness only — no runtime/product code change.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed — ran the equivalent for this test-harness-only change: Release build with `TreatWarningsAsErrors=true` (0 warnings / 0 errors), `dotnet format --verify-no-changes` (clean), and `DatabaseMigrationTests` (4/4 pass, including the previously-deadlocking `MobileOfflineDemoSeed`). The full suite runs in CI; under shared-host load the literal full run hits the very unrelated `40P01` shard flakes this PR fixes.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract (N/A)
- [ ] If breaking admin/control-plane API changes: updated migration guide (N/A)
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review (N/A)
