### PR TITLE
docs: fix broken Container Security README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/honua-io/honua-server/actions/workflows/ci.yml/badge.svg)](https://github.com/honua-io/honua-server/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/honua-io/honua-server/actions/workflows/codeql.yml/badge.svg)](https://github.com/honua-io/honua-server/actions/workflows/codeql.yml)
-[![Container Security](https://github.com/honua-io/honua-server/actions/workflows/container-security.yml/badge.svg)](https://github.com/honua-io/honua-server/actions/workflows/container-security.yml)
+[![Security Nightly](https://github.com/honua-io/honua-server/actions/workflows/security-nightly.yml/badge.svg)](https://github.com/honua-io/honua-server/actions/workflows/security-nightly.yml)
 [![License](https://img.shields.io/badge/License-Elastic_License_2.0-blue.svg)](https://github.com/honua-io/honua-server/blob/trunk/LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-10.0-blue.svg)](https://dotnet.microsoft.com/download/dotnet/10.0)
 [![PostGIS](https://img.shields.io/badge/PostGIS-3.5-brightgreen.svg)](https://postgis.net/)


### PR DESCRIPTION
## Summary
The README's **Container Security** badge pointed at `.github/workflows/container-security.yml`, which doesn't exist on `trunk` — so it rendered as a broken/invalid badge.

Container/image scanning now lives in **`security-nightly.yml`** ("Security Nightly") — the single nightly security lane covering dependency, filesystem, and **container image (Trivy) scans** (it has a `container-security-scan` job that builds the image and scans it). Repointed the badge there and relabeled it "Security Nightly" so the badge reflects the actual workflow it links to.

## Changes Made
- README badge: `container-security.yml` → `security-nightly.yml`, label "Container Security" → "Security Nightly".

## Breaking Changes
None — docs only.