### PR TITLE
docs: cloud-native format coverage + private terraform links (#1583)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,4 +42,4 @@ curl http://localhost:8080/healthz/ready
 
 ## Ecosystem
 
-[honua-sdk-js](https://github.com/honua-io/honua-sdk-js) · [honua-sdk-dotnet](https://github.com/honua-io/honua-sdk-dotnet) · Honua Console (coming soon) · [honua-helm](https://github.com/honua-io/honua-helm) / [honua-terraform](https://github.com/honua-io/honua-terraform) — see the [ecosystem overview](concepts/ecosystem.md).
+[honua-sdk-js](https://github.com/honua-io/honua-sdk-js) · [honua-sdk-dotnet](https://github.com/honua-io/honua-sdk-dotnet) · Honua Console (coming soon) · [honua-helm](https://github.com/honua-io/honua-helm) / Terraform modules (private) — see the [ecosystem overview](concepts/ecosystem.md).

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -77,6 +77,7 @@
   - [OData](reference/protocols/odata.md)
   - [STAC](reference/protocols/stac.md)
   - [Vector tiles](reference/protocols/vector-tiles.md)
+  - [Cloud-native formats](reference/protocols/cloud-native-formats.md)
   - [Terrain & elevation](reference/protocols/terrain-and-elevation.md)
   - [3D Tiles & scenes](reference/protocols/3d-tiles-and-scenes.md)
   - [gRPC](reference/protocols/grpc.md)

--- a/docs/concepts/ecosystem.md
+++ b/docs/concepts/ecosystem.md
@@ -13,7 +13,7 @@ Honua is developed as a family of repositories around this server. This page map
 | [honua-sdk-python](https://github.com/honua-io/honua-sdk-python) | Python SDK for the control plane and data APIs |
 | [honua-mobile](https://github.com/honua-io/honua-mobile) | .NET MAUI-first mobile SDK with GeoPackage/offline field-collection foundation |
 | [honua-helm](https://github.com/honua-io/honua-helm) | Helm chart for Kubernetes deployment |
-| [honua-terraform](https://github.com/honua-io/honua-terraform) | Terraform modules, environments, and validation CI |
+| honua-iac (private) | Terraform modules, environments, and validation CI — available to customers through support |
 | [geospatial-grpc](https://github.com/honua-io/geospatial-grpc) | Open gRPC protocol definitions (`geospatial.v1`) for feature services, spatial types, and forms — the canonical `.proto` source the server consumes |
 | [geospatial-mcp](https://github.com/honua-io/geospatial-mcp) | Open geospatial MCP standard for analyst, map, and app-builder agent workflows |
 
@@ -32,4 +32,4 @@ Current SDK package lines are pre-release (alpha); pin exact versions and valida
 
 ## Deployment tooling
 
-[honua-helm](https://github.com/honua-io/honua-helm) and [honua-terraform](https://github.com/honua-io/honua-terraform) package the server for Kubernetes and for AWS/Azure infrastructure respectively. They are infrastructure surfaces around the same container image documented in [Architecture](architecture.md); start with the [deployment guides](../guides/deploy/docker-compose.md).
+[honua-helm](https://github.com/honua-io/honua-helm) and the private Terraform modules (honua-iac, available to customers) package the server for Kubernetes and for AWS/Azure infrastructure respectively. They are infrastructure surfaces around the same container image documented in [Architecture](architecture.md); start with the [deployment guides](../guides/deploy/docker-compose.md).

--- a/docs/concepts/protocols.md
+++ b/docs/concepts/protocols.md
@@ -28,8 +28,21 @@ Honua serves every published layer through multiple protocols at once — the sa
 | 3D Tiles scenes | `/scenes/{sceneId}/tileset.json` | CesiumJS, 3D Tiles clients | Serving hosted or generated OGC 3D Tiles tilesets |
 | gRPC (`geospatial.v1`) | port `8081` (h2c), gRPC-Web on `8080` | Honua SDKs, mobile, services | High-throughput programmatic access from SDK clients |
 | MCP | `/mcp` | AI agents | Agents validate, plan, and run geoprocessing via JSON-RPC |
+| PMTiles | `/api/v1/tiles/pmtiles/{artifactId}` | MapLibre, serverless tile hosting | Single-file tile archives served with HTTP range requests |
+| Cloud rasters (COG) | registered via admin API, served via ImageServer / WCS / OGC Coverages | Raster pipelines | Cloud-optimized GeoTIFFs in S3/Azure served without copying |
 
 Protocols are enabled per service; a layer is reachable through every protocol its service lists. Read-only providers expose the same surfaces minus write operations. See [Data model](data-model.md).
+
+## Cloud-native formats
+
+Beyond the protocol endpoints, Honua works directly with the cloud-native geospatial format family — see the [cloud-native formats reference](../reference/protocols/cloud-native-formats.md) for endpoints and current status per format:
+
+- **COG (Cloud-Optimized GeoTIFF)** — file import, plus in-place registration of rasters living in S3/Azure; served through ImageServer, WCS 2.0.1, and OGC API Coverages.
+- **PMTiles** — tile archives produced by tile-operations jobs and served with HTTP range requests for serverless/CDN hosting.
+- **GeoParquet / GeoArrow / FlatGeobuf** — import formats and FeatureServer query output formats (`f=parquet|arrow|fgb`) for analytics and notebook workflows.
+- **Zarr** — store registration and catalog metadata (`/api/v1/admin/zarr-stores`); protocol serving is not yet exposed.
+- **Cloud-optimized HDF5 / NetCDF4** — multidimensional coverage registration and catalog metadata (`/api/v1/admin/multidim-coverages`); the reader is build-optional and protocol serving is not yet exposed.
+- **STAC** — the catalog surface (`/stac`) for discovering these assets.
 
 ## GeoServices REST (Esri-compatible)
 

--- a/docs/guides/deploy/cloud-deployments.md
+++ b/docs/guides/deploy/cloud-deployments.md
@@ -4,7 +4,7 @@ You'll pick a managed-cloud deployment pattern for Honua — ECS/Fargate, Lambda
 
 **Prerequisites:** A PostGIS database (RDS or Azure Database for PostgreSQL Flexible Server), the required env vars from [Configure Honua Server](configuration.md) (`ConnectionStrings__DefaultConnection`, `HONUA_ADMIN_PASSWORD`, `Security__ConnectionEncryption__MasterKey`, `Cors__AllowedOrigins__0`), and TLS terminated at the edge (ALB, API Gateway, Front Door) — Honua does not terminate TLS.
 
-Infrastructure-as-code for all of these patterns lives in the separate [honua-terraform](https://github.com/honua-io/honua-terraform) repository.
+Infrastructure-as-code for all of these patterns ships as private Terraform modules (honua-iac), available to customers through support.
 
 ## Pick a pattern
 

--- a/docs/guides/deploy/upgrade-and-rollback.md
+++ b/docs/guides/deploy/upgrade-and-rollback.md
@@ -54,7 +54,7 @@ For canary/gated rollouts, Honua's control plane drives the deployment through a
 | `POST /api/v1/admin/deploy/operations/{operationId}/submit` | Start the rollout |
 | `POST /api/v1/admin/deploy/operations/{operationId}/rollback` | Roll the operation back |
 
-Deploy targets are configured under `ControlPlane__DeployTargets__*` with a backend per platform: `honua-kubernetes-argo-rollouts` (Argo Rollouts canary), `honua-aws-ecs-alb` (ALB weighted target groups), `honua-gitops-aws-lambda` (alias weights), `honua-azure-container-apps-revision` (revision traffic split), `honua-gitops-azure-functions` (slot swap), plus GitOps passthrough variants. When a target sets `telemetry.connection` (a `ControlPlane__TelemetryConnections` entry, Prometheus or CloudWatch), the reconciler gates promotion on error rate and p95 latency and triggers automatic rollback on breach. Keep environment-specific target metadata in [honua-terraform](https://github.com/honua-io/honua-terraform).
+Deploy targets are configured under `ControlPlane__DeployTargets__*` with a backend per platform: `honua-kubernetes-argo-rollouts` (Argo Rollouts canary), `honua-aws-ecs-alb` (ALB weighted target groups), `honua-gitops-aws-lambda` (alias weights), `honua-azure-container-apps-revision` (revision traffic split), `honua-gitops-azure-functions` (slot swap), plus GitOps passthrough variants. When a target sets `telemetry.connection` (a `ControlPlane__TelemetryConnections` entry, Prometheus or CloudWatch), the reconciler gates promotion on error rate and p95 latency and triggers automatic rollback on breach. Keep environment-specific target metadata in your infrastructure-as-code repository (Honua's Terraform modules are available to customers through support).
 
 ## Rollback
 

--- a/docs/internal/contributor/development/k3d-helm.md
+++ b/docs/internal/contributor/development/k3d-helm.md
@@ -24,5 +24,5 @@ helpers.
 
 - [`honua-helm`](https://github.com/honua-io/honua-helm) for Helm charts and
   local Kubernetes workflows
-- [`honua-terraform`](https://github.com/honua-io/honua-terraform) for
+- `honua-iac` (private) for
   Terraform infrastructure provisioning

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -6,7 +6,7 @@ Lookup material for Honua's public surfaces: protocols, the admin API, configura
 
 | Section | Contents |
 | --- | --- |
-| [Protocols](protocols/ogc-apis.md) | Per-protocol references: OGC APIs, classic OGC (WMS/WFS/WCS/WMTS), GeoServices REST, OData, STAC, vector tiles, terrain, 3D Tiles/scenes, gRPC. |
+| [Protocols](protocols/ogc-apis.md) | Per-protocol references: OGC APIs, classic OGC (WMS/WFS/WCS/WMTS), GeoServices REST, OData, STAC, vector tiles, [cloud-native formats (COG, PMTiles, Zarr, HDF5/NetCDF)](protocols/cloud-native-formats.md), terrain, 3D Tiles/scenes, gRPC. MCP for AI agents is covered in the [MCP guide](../guides/connect/ai-agents-mcp.md) and [protocol overview](../concepts/protocols.md#mcp). |
 | [Admin API](admin-api/overview.md) | Control-plane usage: connections and layers, imports and jobs, styles, forms, users/roles/licensing. |
 | [Configuration](configuration/environment-variables.md) | The canonical [environment variable reference](configuration/environment-variables.md) and [data source providers](configuration/data-sources/README.md). |
 | [Compatibility](compatibility/ogc-conformance.md) | [OGC conformance](compatibility/ogc-conformance.md), [GeoServices parity](compatibility/geoservices-parity.md), [client compatibility](compatibility/clients.md). |

--- a/docs/reference/protocols/cloud-native-formats.md
+++ b/docs/reference/protocols/cloud-native-formats.md
@@ -1,0 +1,46 @@
+# Cloud-native formats
+
+Honua's support for the cloud-native geospatial format family: what each format is used for, the endpoints involved, and an honest status per format. Formats fall into three roles — **registered sources** (data stays in object storage, Honua serves it), **produced artifacts** (Honua generates them), and **wire formats** (query output negotiation).
+
+## Status summary
+
+| Format | Role | Register / produce | Serve / consume | Status |
+|---|---|---|---|---|
+| COG / GeoTIFF | Registered source + import | `POST /api/v1/admin/cloud-rasters` (S3/Azure, in place) or file import `POST /api/v1/admin/import/raster` | ImageServer (`exportImage`, `identify`, tiles), WCS 2.0.1, OGC API Coverages | Serving live |
+| PMTiles | Produced artifact | Tile-operations jobs (`archive`, `publish`) — see [Publish tiles](../../guides/publish/publish-tiles.md) | `GET`/`HEAD /api/v1/tiles/pmtiles/{artifactId}` (HTTP range requests) | Serving live |
+| GeoParquet | Import + wire format | File import (`.parquet`, `.geoparquet`) | FeatureServer `f=parquet` (GeoParquet 1.1.0, PostGIS-backed layers) | Live |
+| GeoArrow | Wire format | — | FeatureServer `f=arrow` (Arrow IPC stream, PostGIS-backed layers) | Live |
+| FlatGeobuf | Import + wire format | File import (`.fgb`) | FeatureServer `f=fgb` (PostGIS-backed layers) | Live |
+| Zarr | Registered source | `POST /api/v1/admin/zarr-stores` (CRUD + `/refresh`) | Catalog/metadata only | Registration live; protocol serving not yet exposed |
+| Cloud-optimized HDF5 / NetCDF4 | Registered source | `POST /api/v1/admin/multidim-coverages` (CRUD; URL-registered, not file-imported) | Catalog/metadata only; reader is build-optional | Registration live; protocol serving not yet exposed |
+
+## COG and cloud rasters
+
+Register a raster that already lives in object storage — no copy, no conversion:
+
+```bash
+HONUA_URL=http://localhost:8080
+curl -s -H "X-API-Key: $ADMIN_KEY" -H "Content-Type: application/json" \
+  -d '{"layerId":"imagery","name":"Imagery 2026","provider":"AwsS3","bucket":"my-rasters","objectKey":"imagery/2026.tif"}' \
+  $HONUA_URL/api/v1/admin/cloud-rasters
+```
+
+The registered raster serves through the same pipeline as imported rasters: GeoServices ImageServer, WCS 2.0.1, and OGC API Coverages. Workflow detail: [Publish rasters](../../guides/publish/publish-rasters.md).
+
+## PMTiles
+
+Tile-operations jobs can `archive` a layer's tiles into a single PMTiles file and `publish` it; the artifact is served with HTTP range support at `/api/v1/tiles/pmtiles/{artifactId}`, which makes it suitable for CDN fronting or serverless map hosting. Workflow detail and URL strategies: [Publish tiles](../../guides/publish/publish-tiles.md#pmtiles).
+
+## Analytics wire formats
+
+PostGIS-backed layers negotiate columnar/binary outputs on FeatureServer query (`f=parquet`, `f=arrow`, `f=fgb`, `f=geobuf`) for notebook and pipeline consumption — see [Export data](../../guides/query-analyze/export-data.md) and the [data formats matrix](../data-formats.md) for which surfaces serve which formats.
+
+## Zarr and multidimensional coverages (HDF5/NetCDF)
+
+Both are **registration and catalog surfaces today**: Honua stores the source descriptor and metadata and exposes them through the admin API, but does not yet serve them through a query/coverage protocol. The HDF5/NetCDF reader is optional per build (`MultidimensionalCoverage` reader), and `/api/v1/admin/multidim-coverages/{id}/refresh` returns `501` until it is enabled. Treat protocol exposure for both as roadmap, not shipped.
+
+## Related
+
+- [Data formats matrix](../data-formats.md) — full import/export format support
+- [STAC](stac.md) — catalog discovery for these assets
+- [OGC APIs](ogc-apis.md) — the Coverages surface COG serving rides on


### PR DESCRIPTION
﻿## Issue Link
Related to #1583

## Summary
Two docs gap-fixes found in review of the rewritten docs:

1. **Cloud-native format coverage was missing.** The canonical protocol matrix and reference section did not surface COG, PMTiles, Zarr, cloud-optimized HDF5/NetCDF, or the analytics wire formats, even though the site advertises them. Added with verified, honest status per format.
2. **honua-terraform links 404** (repo renamed honua-iac and made private) — six public docs links replaced.

## Changes Made
- New `docs/reference/protocols/cloud-native-formats.md`: status table + endpoints per format, verified against EndpointRegistry.cs — COG serving live (ImageServer/WCS/Coverages via cloud-rasters registration), PMTiles serving live (range-request artifact route), GeoParquet/GeoArrow/FlatGeobuf live as FeatureServer wire formats, **Zarr and HDF5/NetCDF marked registration/catalog-only** (no public serving routes exist; multidim reader is build-optional and refresh returns 501) — claims-discipline accurate, not aspirational
- `docs/concepts/protocols.md`: PMTiles and cloud-raster rows added to the canonical matrix + a "Cloud-native formats" section linking the new reference page
- `docs/reference/README.md`: protocols row now enumerates cloud-native formats and points MCP readers at the MCP guide + protocol overview
- `docs/SUMMARY.md`: new page added to nav
- Terraform link sweep: docs/README.md, concepts/ecosystem.md, guides/deploy/cloud-deployments.md, guides/deploy/upgrade-and-rollback.md, internal k3d note — honua-helm stays the public pointer; Terraform modules described as private (honua-iac), available to customers through support

## Testing
- [x] Manual testing performed

Relative-link check on all touched pages (0 broken); format/endpoint claims verified against src (EndpointRegistry.cs, Honua.Core Multidimensional abstractions, zarr-stores/cloud-rasters admin endpoints). Docs-only.

## Gate Impact
- [x] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
