### PR TITLE
chore: finish quality sweep follow-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -662,6 +662,16 @@ jobs:
             --logger "console;verbosity=minimal" \
             --results-directory ./tests/TestResults
 
+      - name: Run .NET Tests (Core Security)
+        timeout-minutes: 3
+        run: |
+          dotnet test tests/dotnet/Honua.Core.Security.Tests/Honua.Core.Security.Tests.csproj \
+            --no-restore \
+            --configuration Release \
+            --logger "trx;LogFileName=core-security-tests.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults
+
       - name: Run .NET Tests (Server Fast Tier)
         # Per ADR-0037 the Fast tier runs across every test project on every
         # PR, including Honua.Server.Tests. Filtering by Tier=Fast keeps this

--- a/docs/gis/data/geoservices-rest-parity.json
+++ b/docs/gis/data/geoservices-rest-parity.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "lastReviewed": "2026-06-02",
+  "lastReviewed": "2026-06-10",
   "canonicalDocs": {
-    "landingPage": "docs/gis/geoservices-rest-parity.md",
+    "landingPage": "docs/reference/compatibility/geoservices-parity.md",
     "machineReadableExport": "docs/gis/data/geoservices-rest-parity.json"
   },
   "statusVocabulary": {
@@ -24,7 +24,7 @@
       "id": "feature-server",
       "displayName": "FeatureServer",
       "parity": "partial",
-      "drillDownDoc": "docs/gis/feature-server-matrix.md",
+      "drillDownDoc": "docs/reference/compatibility/geoservices-parity.md",
       "implementedSurface": [
         "query",
         "service and layer metadata",
@@ -48,7 +48,8 @@
         "queryClusters (Honua extension, Pro)",
         "spatialJoin (Honua extension, Pro)",
         "queryBufferAggregate (Honua extension, Pro)",
-        "queryDensity (Honua extension, Pro)"
+        "queryDensity (Honua extension, Pro)",
+        "generateRenderer"
       ],
       "knownGaps": [
         "cleanupChangeTracking",
@@ -475,19 +476,19 @@
             "honuaEndpoints": [
               "GET /rest/services/{serviceId}/FeatureServer/{layerId}/{featureId}/attachments/{attachmentId}"
             ]
-          }
-        ],
-        "partial": [
+          },
           {
             "name": "Generate Renderer",
             "esriPath": "/rest/services/{serviceId}/FeatureServer/{layerId}/generateRenderer",
             "methods": [
-              "GET"
+              "GET",
+              "POST"
             ],
             "honuaEndpoints": [
-              "GET /rest/services/{serviceId}/FeatureServer/{layerId}/generateRenderer"
+              "GET /rest/services/{serviceId}/FeatureServer/{layerId}/generateRenderer",
+              "POST /rest/services/{serviceId}/FeatureServer/{layerId}/generateRenderer"
             ],
-            "notes": "Returns a simple renderer. classificationDef is rejected."
+            "notes": "Supports simple renderer output plus classificationDef-driven class-break and unique-value renderers."
           },
           {
             "name": "Query Attachments",
@@ -500,9 +501,10 @@
               "GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryAttachments",
               "POST /rest/services/{serviceId}/FeatureServer/{layerId}/queryAttachments"
             ],
-            "notes": "Only objectId-driven lookup is supported."
+            "notes": "Supports objectIds plus attachmentTypes, keywords, size, definitionExpression, returnMetadata, and returnUrl facets; globalIds are rejected with a GeoServices 400 because Honua uses integer object IDs."
           }
         ],
+        "partial": [],
         "notImplemented": [
           {
             "name": "Cleanup Change Tracking",
@@ -741,7 +743,7 @@
       "id": "map-server",
       "displayName": "MapServer",
       "parity": "partial",
-      "drillDownDoc": "docs/gis/map-server-matrix.md",
+      "drillDownDoc": "docs/reference/compatibility/geoservices-parity.md",
       "implementedSurface": [
         "service metadata",
         "layer metadata",
@@ -756,15 +758,15 @@
         "tiles",
         "generateKml",
         "WMS",
-        "WMTS"
+        "WMTS",
+        "generateRenderer",
+        "queryAttachments",
+        "queryRelatedRecords"
       ],
       "knownGaps": [
         "exportTiles",
         "estimateExportTilesSize",
-        "generateRenderer",
-        "queryAttachments",
         "queryLegends",
-        "queryRelatedRecords",
         "additional Esri child resources"
       ],
       "evidence": {
@@ -940,6 +942,45 @@
             "honuaEndpoints": [
               "GET /rest/services/{serviceId}/MapServer/{layerId}/{featureId}"
             ]
+          },
+          {
+            "name": "Generate Renderer",
+            "esriPath": "/rest/services/{serviceId}/MapServer/{layerId}/generateRenderer",
+            "methods": [
+              "GET",
+              "POST"
+            ],
+            "honuaEndpoints": [
+              "GET /rest/services/{serviceId}/MapServer/{layerId}/generateRenderer",
+              "POST /rest/services/{serviceId}/MapServer/{layerId}/generateRenderer"
+            ],
+            "notes": "Layer-scoped adapter that delegates to the FeatureServer generateRenderer handler."
+          },
+          {
+            "name": "Query Attachments",
+            "esriPath": "/rest/services/{serviceId}/MapServer/{layerId}/queryAttachments",
+            "methods": [
+              "GET",
+              "POST"
+            ],
+            "honuaEndpoints": [
+              "GET /rest/services/{serviceId}/MapServer/{layerId}/queryAttachments",
+              "POST /rest/services/{serviceId}/MapServer/{layerId}/queryAttachments"
+            ],
+            "notes": "Layer-scoped adapter that delegates to the FeatureServer queryAttachments handler."
+          },
+          {
+            "name": "Query Related Records",
+            "esriPath": "/rest/services/{serviceId}/MapServer/{layerId}/queryRelatedRecords",
+            "methods": [
+              "GET",
+              "POST"
+            ],
+            "honuaEndpoints": [
+              "GET /rest/services/{serviceId}/MapServer/{layerId}/queryRelatedRecords",
+              "POST /rest/services/{serviceId}/MapServer/{layerId}/queryRelatedRecords"
+            ],
+            "notes": "Layer-scoped adapter that delegates to the FeatureServer queryRelatedRecords handler."
           }
         ],
         "partial": [
@@ -974,32 +1015,8 @@
             ]
           },
           {
-            "name": "Generate Renderer",
-            "esriPath": "/rest/services/{serviceId}/MapServer/generateRenderer",
-            "methods": [
-              "GET",
-              "POST"
-            ]
-          },
-          {
-            "name": "Query Attachments",
-            "esriPath": "/rest/services/{serviceId}/MapServer/{layerId}/queryAttachments",
-            "methods": [
-              "GET",
-              "POST"
-            ]
-          },
-          {
             "name": "Query Legends",
             "esriPath": "/rest/services/{serviceId}/MapServer/queryLegends",
-            "methods": [
-              "GET",
-              "POST"
-            ]
-          },
-          {
-            "name": "Query Related Records",
-            "esriPath": "/rest/services/{serviceId}/MapServer/{layerId}/queryRelatedRecords",
             "methods": [
               "GET",
               "POST"
@@ -1099,7 +1116,7 @@
       "id": "image-server",
       "displayName": "ImageServer",
       "parity": "partial",
-      "drillDownDoc": "docs/gis/image-server-matrix.md",
+      "drillDownDoc": "docs/reference/compatibility/geoservices-parity.md",
       "implementedSurface": [
         "service metadata (with timeInfo when temporal)",
         "exportImage",
@@ -1109,7 +1126,15 @@
         "computeStatisticsHistograms",
         "legend",
         "computeClass (raster function chain validation)",
-        "WCS 2.0.1 KVP"
+        "WCS 2.0.1 KVP",
+        "getSamples",
+        "computeHistograms",
+        "keyProperties",
+        "multidimensionalInfo",
+        "statistics",
+        "histograms",
+        "rasterFunctionInfos",
+        "rasterAttributeTable"
       ],
       "knownGaps": [
         "queryBoundary",
@@ -1183,6 +1208,98 @@
               "GET /rest/services/{id}/ImageServer/tile/{level}/{row}/{col}"
             ],
             "notes": "Supports png, jpeg, and tiff tile output. When multiple rasters overlap the requested tile, Honua renders a mosaic using the resolved merge strategy."
+          },
+          {
+            "name": "Compute Histograms",
+            "esriPath": "/rest/services/{id}/ImageServer/computeHistograms",
+            "methods": [
+              "GET",
+              "POST"
+            ],
+            "honuaEndpoints": [
+              "GET /rest/services/{id}/ImageServer/computeHistograms",
+              "POST /rest/services/{id}/ImageServer/computeHistograms"
+            ],
+            "notes": "Alias-compatible histogram endpoint over the same raster histogram pipeline used by computeStatisticsHistograms."
+          },
+          {
+            "name": "Get Samples",
+            "esriPath": "/rest/services/{id}/ImageServer/getSamples",
+            "methods": [
+              "GET",
+              "POST"
+            ],
+            "honuaEndpoints": [
+              "GET /rest/services/{id}/ImageServer/getSamples",
+              "POST /rest/services/{id}/ImageServer/getSamples"
+            ],
+            "notes": "Samples pixel values at request points and caps sample count at 1000."
+          },
+          {
+            "name": "Key Properties",
+            "esriPath": "/rest/services/{id}/ImageServer/keyProperties",
+            "methods": [
+              "GET"
+            ],
+            "honuaEndpoints": [
+              "GET /rest/services/{id}/ImageServer/keyProperties"
+            ],
+            "notes": "Returns spec-shaped raster key-property documents from the shared raster store; non-applicable cases return empty documents."
+          },
+          {
+            "name": "Multidimensional Info",
+            "esriPath": "/rest/services/{id}/ImageServer/multidimensionalInfo",
+            "methods": [
+              "GET"
+            ],
+            "honuaEndpoints": [
+              "GET /rest/services/{id}/ImageServer/multidimensionalInfo"
+            ],
+            "notes": "Returns spec-shaped multidimensional metadata; non-applicable layers return {\"variables\": []}."
+          },
+          {
+            "name": "Statistics",
+            "esriPath": "/rest/services/{id}/ImageServer/statistics",
+            "methods": [
+              "GET"
+            ],
+            "honuaEndpoints": [
+              "GET /rest/services/{id}/ImageServer/statistics"
+            ],
+            "notes": "Returns per-band raster statistics documents when available."
+          },
+          {
+            "name": "Histograms",
+            "esriPath": "/rest/services/{id}/ImageServer/histograms",
+            "methods": [
+              "GET"
+            ],
+            "honuaEndpoints": [
+              "GET /rest/services/{id}/ImageServer/histograms"
+            ],
+            "notes": "Returns per-band raster histogram documents when available."
+          },
+          {
+            "name": "Raster Function Infos",
+            "esriPath": "/rest/services/{id}/ImageServer/rasterFunctionInfos",
+            "methods": [
+              "GET"
+            ],
+            "honuaEndpoints": [
+              "GET /rest/services/{id}/ImageServer/rasterFunctionInfos"
+            ],
+            "notes": "Returns the raster function info document for the resolved layer."
+          },
+          {
+            "name": "Raster Attribute Table",
+            "esriPath": "/rest/services/{id}/ImageServer/rasterAttributeTable",
+            "methods": [
+              "GET"
+            ],
+            "honuaEndpoints": [
+              "GET /rest/services/{id}/ImageServer/rasterAttributeTable"
+            ],
+            "notes": "Returns a spec-shaped raster attribute table document; non-applicable layers return an empty table."
           }
         ],
         "partial": [
@@ -1268,14 +1385,6 @@
             ]
           },
           {
-            "name": "Compute Histograms",
-            "esriPath": "/rest/services/{id}/ImageServer/computeHistograms",
-            "methods": [
-              "GET",
-              "POST"
-            ]
-          },
-          {
             "name": "Delete Rasters",
             "esriPath": "/rest/services/{id}/ImageServer/deleteRasters",
             "methods": [
@@ -1300,14 +1409,6 @@
           {
             "name": "Find",
             "esriPath": "/rest/services/{id}/ImageServer/find",
-            "methods": [
-              "GET",
-              "POST"
-            ]
-          },
-          {
-            "name": "Get Samples",
-            "esriPath": "/rest/services/{id}/ImageServer/getSamples",
             "methods": [
               "GET",
               "POST"
@@ -1371,18 +1472,12 @@
         ],
         "notImplemented": [
           "colormap",
-          "histograms",
           "info/*",
           "imageSupportData",
-          "keyProperties",
           "kml",
-          "multiDimensionalInfo",
-          "rasterAttributeTable",
           "{rasterId}/*",
           "rasterFile",
-          "rasterFunctionInfos",
           "slices",
-          "statistics",
           "WMTS"
         ]
       },
@@ -1603,7 +1698,7 @@
       "id": "geometry-service",
       "displayName": "Geometry Service",
       "parity": "complete",
-      "drillDownDoc": "docs/gis/geometry-service-matrix.md",
+      "drillDownDoc": "docs/reference/compatibility/geoservices-parity.md",
       "implementedSurface": [
         "Geometry Service metadata",
         "Buffer",
@@ -2013,7 +2108,7 @@
       "id": "gp-server",
       "displayName": "GPServer",
       "parity": "partial",
-      "drillDownDoc": "docs/gis/geoprocess-framework-analysis.md",
+      "drillDownDoc": "docs/guides/query-analyze/run-geoprocessing.md",
       "implementedSurface": [
         "PrintingTools Export Web Map Task (service info, sync execute, async submitJob, job status, job result)",
         "PrintingTools Get Layout Templates Info Task (sync execute)",
@@ -2027,8 +2122,8 @@
       ],
       "evidence": {
         "canonicalModel": [
-          "docs/gis/geoprocess-framework-analysis.md",
-          "docs/contributor/adr/0029-geoprocess-canonical-model-mappings.md"
+          "docs/guides/query-analyze/run-geoprocessing.md",
+          "docs/internal/contributor/adr/0029-geoprocess-canonical-model-mappings.md"
         ],
         "code": [
           "src/Honua.Server/Features/PrintingTools/PrintingToolsEndpoints.cs",
@@ -2168,7 +2263,7 @@
       "id": "portal-sharing",
       "displayName": "Portal Sharing",
       "parity": "partial",
-      "drillDownDoc": "docs/operator/security.md",
+      "drillDownDoc": "docs/guides/secure/authentication.md",
       "implementedSurface": [
         "POST /sharing/rest/generateToken (form-encoded)",
         "GET /sharing/rest/generateToken (query-string)",
@@ -2226,7 +2321,7 @@
       "id": "geocode-server",
       "displayName": "GeocodeServer",
       "parity": "partial",
-      "drillDownDoc": "docs/gis/geocode-server-matrix.md",
+      "drillDownDoc": "docs/internal/spikes/geocode-server-matrix.md",
       "implementedSurface": [
         "service metadata",
         "findAddressCandidates",
@@ -2423,6 +2518,92 @@
         "Only f=json and f=pjson responses are supported.",
         "outFields projection, magicKey round-tripping, category filtering, and forStorage/matchOutOfRange are not implemented.",
         "A parameter is only forwarded when at least one backing provider acts on it (Nominatim honors searchExtent for forward and langCode for reverse; Azure Maps and Amazon Location additionally honor suggestion bounds/bias)."
+      ]
+    },
+    {
+      "id": "na-server",
+      "displayName": "NAServer",
+      "parity": "partial",
+      "drillDownDoc": "docs/reference/compatibility/geoservices-parity.md",
+      "implementedSurface": [
+        "Route solve",
+        "ServiceArea solveServiceArea",
+        "ClosestFacility solveClosestFacility compatibility envelope"
+      ],
+      "knownGaps": [
+        "GET solve routes",
+        "ClosestFacility canonical solver",
+        "OD cost matrix",
+        "location-allocation",
+        "barriers",
+        "multiple travel modes",
+        "network-dataset editing"
+      ],
+      "evidence": {
+        "code": [
+          "src/Honua.Protocols.GeoServices/NAServer/NAServerEndpoints.cs",
+          "src/Honua.Protocols.GeoServices/NAServer/NAServerParameterTranslation.cs",
+          "src/Honua.Protocols.GeoServices/NAServer/NAServerResultMapping.cs",
+          "src/Honua.Routing/Features/Routing/Abstractions/IRoutingProvider.cs"
+        ],
+        "tests": [
+          "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/NAServer/NAServerEndpointTests.cs",
+          "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/NAServer/NAServerTranslationUnitTests.cs"
+        ]
+      },
+      "operations": {
+        "implemented": [
+          {
+            "name": "Route solve",
+            "esriPath": "/rest/services/{serviceId}/NAServer/Route/solve",
+            "methods": [
+              "POST"
+            ],
+            "honuaEndpoints": [
+              "POST /rest/services/{serviceId}/NAServer/Route/solve"
+            ],
+            "notes": "Parses stops, inSR/outSR, returnRoutes, and returnDirections, delegates to the configured IRoutingProvider, and returns Esri route and directions feature sets."
+          },
+          {
+            "name": "ServiceArea solveServiceArea",
+            "esriPath": "/rest/services/{serviceId}/NAServer/ServiceArea/solveServiceArea",
+            "methods": [
+              "POST"
+            ],
+            "honuaEndpoints": [
+              "POST /rest/services/{serviceId}/NAServer/ServiceArea/solveServiceArea"
+            ],
+            "notes": "Parses facilities, defaultBreaks, inSR/outSR, and travelDirection, validates provider-advertised travel-direction support, and returns Esri saPolygons."
+          }
+        ],
+        "partial": [
+          {
+            "name": "ClosestFacility solveClosestFacility",
+            "esriPath": "/rest/services/{serviceId}/NAServer/ClosestFacility/solveClosestFacility",
+            "methods": [
+              "POST"
+            ],
+            "honuaEndpoints": [
+              "POST /rest/services/{serviceId}/NAServer/ClosestFacility/solveClosestFacility"
+            ],
+            "notes": "Compatibility probe route that returns a deterministic closest-facility route/directions envelope; not yet backed by a canonical closest-facility solver."
+          }
+        ],
+        "notImplemented": [
+          {
+            "name": "OD cost matrix, location-allocation, barriers, multiple travel modes, network-dataset editing",
+            "esriPath": "/rest/services/{serviceId}/NAServer/*",
+            "methods": [
+              "GET",
+              "POST"
+            ]
+          }
+        ]
+      },
+      "knownLimitations": [
+        "NAServer route and service-area solves are POST-only.",
+        "ClosestFacility is a deterministic compatibility envelope until a canonical closest-facility contract lands.",
+        "Unsupported provider capabilities return GeoServices 400 error envelopes."
       ]
     }
   ]

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -32,12 +32,12 @@
         },
         {
           "proofClass": "contract-governance",
-          "proofMechanism": "Source-generated CapabilityManifestJsonContext keeps the wire shape AOT-safe; docs/developer/capability-manifest.md documents the raw manifest, scope validation, availability gates, limit sections, reason codes, cache policy, and SDK projection rules.",
+          "proofMechanism": "Source-generated CapabilityManifestJsonContext keeps the wire shape AOT-safe; docs/reference/admin-api/overview.md documents the raw manifest, scope validation, availability gates, limit sections, reason codes, cache policy, and SDK projection rules.",
           "executionLane": "ci:test-all",
           "evidenceLocations": [
             "src/Honua.Server/Features/Capabilities/Models/CapabilityManifestJsonContext.cs",
             "src/Honua.Server/Features/Capabilities/Models/CapabilityManifestModels.cs",
-            "docs/developer/capability-manifest.md"
+            "docs/reference/admin-api/overview.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -208,7 +208,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-js/issues/39"
           ],
           "ownerRepo": "honua-sdk-js",
@@ -223,7 +223,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-python/issues/21"
           ],
           "ownerRepo": "honua-sdk-python",
@@ -238,7 +238,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-dotnet/issues/31"
           ],
           "ownerRepo": "honua-sdk-dotnet",
@@ -281,7 +281,7 @@
           "proofMechanism": "Form package contract and offline policy semantics are documented for Console, mobile, and SDK clients.",
           "executionLane": "docs+review",
           "evidenceLocations": [
-            "docs/developer/form-package-api.md",
+            "docs/reference/admin-api/forms.md",
             "src/Honua.Core/Features/Forms/Packages/FormPackageContracts.cs"
           ],
           "ownerRepo": "honua-server",
@@ -322,14 +322,14 @@
         },
         {
           "proofClass": "contract-governance",
-          "proofMechanism": "Source-generated ConsoleJsonContext keeps the wire shapes AOT-safe and SDK-consumable; the docs/admin-api/console-content-and-rbac.md contract describes the canonical item, action, provenance, Share, public-link, and embed shapes.",
+          "proofMechanism": "Source-generated ConsoleJsonContext keeps the wire shapes AOT-safe and SDK-consumable; the docs/internal/admin-api/console-content-and-rbac.md contract describes the canonical item, action, provenance, Share, public-link, and embed shapes.",
           "executionLane": "ci:test-all",
           "evidenceLocations": [
             "src/Honua.Server/Features/Console/Models/ConsoleJsonContext.cs",
             "src/Honua.Core.Abstractions/Features/Console/Domain/ConsoleContentItem.cs",
             "src/Honua.Core.Abstractions/Features/Console/Domain/ConsoleShareProjection.cs",
             "src/Honua.Core.Abstractions/Features/Console/Domain/ConsoleShareTokens.cs",
-            "docs/admin-api/console-content-and-rbac.md"
+            "docs/internal/admin-api/console-content-and-rbac.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -373,7 +373,7 @@
           "evidenceLocations": [
             "src/Honua.Server/Features/WorkflowPackages/WorkflowPackagesJsonContext.cs",
             "src/Honua.Core/Features/WorkflowPackages/Domain/WorkflowPackageModels.cs",
-            "docs/admin-api/console-workflow-packages.md"
+            "docs/internal/admin-api/console-workflow-packages.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -418,7 +418,7 @@
           "evidenceLocations": [
             "src/Honua.Server/Features/Admin/Jobs/ConsoleJobJsonContext.cs",
             "src/Honua.Server/Features/Admin/Jobs/ConsoleJobModels.cs",
-            "docs/admin-api/console-job-observability.md"
+            "docs/internal/admin-api/console-job-observability.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -581,7 +581,7 @@
           "evidenceLocations": [
             "src/Honua.Server/Features/Studio/Models/StudioApiJsonContext.cs",
             "src/Honua.Core/Features/Studio/Domain/StudioJsonContext.cs",
-            "docs/admin-api/studio-package-lifecycle.md"
+            "docs/internal/admin-api/studio-package-lifecycle.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -625,7 +625,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-js/issues/105"
           ],
           "ownerRepo": "honua-sdk-js",
@@ -640,7 +640,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-python/issues/49"
           ],
           "ownerRepo": "honua-sdk-python",
@@ -655,7 +655,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-dotnet/issues/134"
           ],
           "ownerRepo": "honua-sdk-dotnet",
@@ -700,7 +700,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-js/issues/105"
           ],
           "ownerRepo": "honua-sdk-js",
@@ -715,7 +715,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-python/issues/49"
           ],
           "ownerRepo": "honua-sdk-python",
@@ -730,7 +730,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-dotnet/issues/134"
           ],
           "ownerRepo": "honua-sdk-dotnet",
@@ -775,7 +775,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-js/issues/105"
           ],
           "ownerRepo": "honua-sdk-js",
@@ -790,7 +790,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-python/issues/49"
           ],
           "ownerRepo": "honua-sdk-python",
@@ -805,7 +805,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-dotnet/issues/134"
           ],
           "ownerRepo": "honua-sdk-dotnet",
@@ -851,7 +851,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-js/issues/105"
           ],
           "ownerRepo": "honua-sdk-js",
@@ -866,7 +866,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-python/issues/49"
           ],
           "ownerRepo": "honua-sdk-python",
@@ -881,7 +881,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-dotnet/issues/134"
           ],
           "ownerRepo": "honua-sdk-dotnet",
@@ -1117,7 +1117,7 @@
           "evidenceLocations": [
             ".github/workflows/geoservices-parity-nightly.yml",
             ".github/workflows/parity-scorecard-governance.yml",
-            "docs/gis/geoservices-rest-parity.md",
+            "docs/reference/compatibility/geoservices-parity.md",
             "docs/gis/data/geoservices-rest-parity.json"
           ],
           "ownerRepo": "honua-server",
@@ -1178,7 +1178,7 @@
           "evidenceLocations": [
             ".github/workflows/geoservices-parity-nightly.yml",
             ".github/workflows/parity-scorecard-governance.yml",
-            "docs/gis/geoservices-rest-parity.md",
+            "docs/reference/compatibility/geoservices-parity.md",
             "docs/gis/data/geoservices-rest-parity.json"
           ],
           "ownerRepo": "honua-server",
@@ -1266,8 +1266,7 @@
           "evidenceLocations": [
             ".github/workflows/geoservices-parity-nightly.yml",
             ".github/workflows/parity-scorecard-governance.yml",
-            "docs/gis/geoservices-rest-parity.md",
-            "docs/gis/feature-server-matrix.md",
+            "docs/reference/compatibility/geoservices-parity.md",
             "docs/gis/data/geoservices-rest-parity.json"
           ],
           "ownerRepo": "honua-server",
@@ -1312,7 +1311,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-js/issues/39"
           ],
           "ownerRepo": "honua-sdk-js",
@@ -1327,7 +1326,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-python/issues/21"
           ],
           "ownerRepo": "honua-sdk-python",
@@ -1342,7 +1341,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-dotnet/issues/31"
           ],
           "ownerRepo": "honua-sdk-dotnet",
@@ -1447,8 +1446,7 @@
           "evidenceLocations": [
             ".github/workflows/geoservices-parity-nightly.yml",
             ".github/workflows/parity-scorecard-governance.yml",
-            "docs/gis/geoservices-rest-parity.md",
-            "docs/gis/map-server-matrix.md",
+            "docs/reference/compatibility/geoservices-parity.md",
             "docs/gis/data/geoservices-rest-parity.json"
           ],
           "ownerRepo": "honua-server",
@@ -1528,7 +1526,7 @@
           "executionLane": "nightly:cite-wms-conformance",
           "evidenceLocations": [
             ".github/workflows/cite-wms-conformance.yml",
-            "docs/gis/map-server-matrix.md"
+            "docs/reference/compatibility/geoservices-parity.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -1542,7 +1540,7 @@
           "evidenceLocations": [
             "tests/js/openlayers/wms/wms-discovery.test.ts",
             "docs/gis/CROSS_CLIENT_CERTIFICATION_MATRIX.md",
-            "docs/contributor/public-interface-quality-model.md"
+            "docs/internal/contributor/public-interface-quality-model.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -1638,7 +1636,7 @@
           "executionLane": "nightly:cite-wmts-conformance",
           "evidenceLocations": [
             ".github/workflows/cite-wmts-conformance.yml",
-            "docs/gis/map-server-matrix.md"
+            "docs/reference/compatibility/geoservices-parity.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -1652,7 +1650,7 @@
           "evidenceLocations": [
             "tests/js/openlayers/wmts/wmts-discovery.test.ts",
             "docs/gis/CROSS_CLIENT_CERTIFICATION_MATRIX.md",
-            "docs/contributor/public-interface-quality-model.md"
+            "docs/internal/contributor/public-interface-quality-model.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -1696,8 +1694,7 @@
           "evidenceLocations": [
             ".github/workflows/geoservices-parity-nightly.yml",
             ".github/workflows/parity-scorecard-governance.yml",
-            "docs/gis/geoservices-rest-parity.md",
-            "docs/gis/image-server-matrix.md",
+            "docs/reference/compatibility/geoservices-parity.md",
             "docs/gis/data/geoservices-rest-parity.json"
           ],
           "ownerRepo": "honua-server",
@@ -1759,8 +1756,8 @@
           "proofMechanism": "WCS coverage docs and ImageServer parity matrix describe the supported KVP operations, formats, CRS handling and CRS-advertisement caveats, cache posture, error behavior, and deferred extensions.",
           "executionLane": "release:docs-review",
           "evidenceLocations": [
-            "docs/gis/specifications/wcs-2.0.1-coverage.md",
-            "docs/gis/image-server-matrix.md",
+            "docs/archive/specifications/wcs-2.0.1-coverage.md",
+            "docs/reference/compatibility/geoservices-parity.md",
             "docs/gis/data/geoservices-rest-parity.json"
           ],
           "ownerRepo": "honua-server",
@@ -1906,7 +1903,7 @@
           "executionLane": "nightly:cite-conformance",
           "evidenceLocations": [
             ".github/workflows/cite-conformance.yml",
-            "docs/gis/specifications/ogc-api-features-coverage.md"
+            "docs/archive/specifications/ogc-api-features-coverage.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -1952,7 +1949,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-js/issues/39"
           ],
           "ownerRepo": "honua-sdk-js",
@@ -1967,7 +1964,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-python/issues/21"
           ],
           "ownerRepo": "honua-sdk-python",
@@ -1982,7 +1979,7 @@
           "evidenceLocations": [
             ".github/workflows/sdk-server-compatibility.yml",
             "scripts/ci/run-sdk-server-compatibility.sh",
-            "docs/developer/SDK_COMPATIBILITY_MATRIX.md",
+            "docs/concepts/ecosystem.md",
             "https://github.com/honua-io/honua-sdk-dotnet/issues/31"
           ],
           "ownerRepo": "honua-sdk-dotnet",
@@ -2026,7 +2023,7 @@
           "proofMechanism": "Supported OGC API Records subset is documented and validated by targeted endpoint coverage",
           "executionLane": "ci:test-all",
           "evidenceLocations": [
-            "docs/gis/specifications/ogc-api-records-coverage.md",
+            "docs/archive/specifications/ogc-api-records-coverage.md",
             "tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Records/OgcRecordsEndpointTests.cs"
           ],
           "ownerRepo": "honua-server",
@@ -2126,7 +2123,7 @@
           "executionLane": "nightly:cite-tiles-conformance",
           "evidenceLocations": [
             ".github/workflows/cite-tiles-conformance.yml",
-            "docs/gis/specifications/ogc-api-tiles-coverage.md"
+            "docs/archive/specifications/ogc-api-tiles-coverage.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -2187,8 +2184,7 @@
           "evidenceLocations": [
             ".github/workflows/geoservices-parity-nightly.yml",
             ".github/workflows/parity-scorecard-governance.yml",
-            "docs/gis/geoservices-rest-parity.md",
-            "docs/gis/geometry-service-matrix.md",
+            "docs/reference/compatibility/geoservices-parity.md",
             "docs/gis/data/geoservices-rest-parity.json"
           ],
           "ownerRepo": "honua-server",
@@ -2245,7 +2241,7 @@
           "proofMechanism": "OGC API Coverages route contract and implemented support matrix are documented with targeted endpoint coverage",
           "executionLane": "ci:test-all+architecture",
           "evidenceLocations": [
-            "docs/gis/specifications/ogc-api-coverages-coverage.md",
+            "docs/archive/specifications/ogc-api-coverages-coverage.md",
             "tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Coverages/OgcCoveragesEndpointsTests.cs"
           ],
           "ownerRepo": "honua-server",
@@ -2288,7 +2284,7 @@
           "proofMechanism": "OGC API Styles Phase 1 conformance classes (core, mapbox-styles, sld-10, sld-11, style-validation, partial manage-styles) are declared at /ogc/styles/conformance and documented, with targeted endpoint coverage",
           "executionLane": "ci:test-all+architecture",
           "evidenceLocations": [
-            "docs/gis/style-engine-protocol-consumption.md",
+            "docs/guides/style/style-maps.md",
             "tests/dotnet/Honua.Server.Tests/Features/Styling/OgcStylesEndpointTests.cs"
           ],
           "ownerRepo": "honua-server",
@@ -2733,7 +2729,7 @@
           "evidenceLocations": [
             "tests/dotnet/Honua.Server.Tests/Features/Protocols/Terrain/TerrainEndpointTests.cs",
             "tests/dotnet/Honua.Core.Tests/Features/Raster/TerrainRgbEncodingTests.cs",
-            "docs/gis/terrain-tiles.md"
+            "docs/reference/protocols/terrain-and-elevation.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -2781,7 +2777,7 @@
             "tests/dotnet/Honua.Protocols.Scene.Tests/Source/SceneAuthorizationTests.cs",
             "tests/dotnet/Honua.Protocols.Scene.Tests/Source/SceneAssetResolverTests.cs",
             "tests/fixtures/scenes/fixture-tileset/tileset.json",
-            "docs/gis/scenes-3dtiles.md"
+            "docs/reference/protocols/3d-tiles-and-scenes.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -2796,7 +2792,7 @@
             "tests/dotnet/Honua.Protocols.Scene.Tests/Source/SceneAccessEnvelopeEndpointTests.cs",
             "tests/dotnet/Honua.Protocols.Scene.Tests/Source/SceneAccessEnvelopeServiceTests.cs",
             "tests/dotnet/Honua.Protocols.Scene.Tests/Source/SceneAccessEnvelopeMisconfiguredEndpointTests.cs",
-            "docs/gis/scenes-3dtiles.md"
+            "docs/reference/protocols/3d-tiles-and-scenes.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -2900,7 +2896,7 @@
             "tests/dotnet/Honua.Server.Tests/Features/Admin/SceneDatasetEndpointsTests.cs",
             "tests/dotnet/Honua.Core.Tests/Features/Scene/SceneDatasetValidatorTests.cs",
             "tests/dotnet/Honua.Core.Tests/Features/Scene/SceneSnippetGeneratorTests.cs",
-            "docs/admin-api/scene-dataset-registry.md"
+            "docs/internal/admin-api/scene-dataset-registry.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -2948,7 +2944,7 @@
             "tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/GeometryTileBuilderTests.cs",
             "tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/TilesetDocumentWriterTests.cs",
             "tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/SceneTilesPublishExecutorTests.cs",
-            "docs/gis/scene-generation.md"
+            "docs/guides/publish/publish-3d-scenes.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -2991,7 +2987,7 @@
           "executionLane": "ci:test-all",
           "evidenceLocations": [
             "tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/ElevationEndpointTests.cs",
-            "docs/gis/elevation-api.md"
+            "docs/reference/protocols/terrain-and-elevation.md"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -3251,8 +3247,8 @@
           "executionLane": "ci:mcp-certification",
           "evidenceLocations": [
             ".github/workflows/ci.yml",
-            "docs/contributor/mcp-certification.md",
-            "docs/developer/MCP_SERVER.md"
+            "docs/internal/contributor/mcp-certification.md",
+            "docs/guides/connect/ai-agents-mcp.md"
           ],
           "ownerRepo": "honua-sdk-js",
           "status": "bounded-child-ticket",
@@ -3265,7 +3261,7 @@
           "executionLane": "ci:mcp-llm-smoke",
           "evidenceLocations": [
             ".github/workflows/ci.yml",
-            "docs/contributor/mcp-certification.md"
+            "docs/internal/contributor/mcp-certification.md"
           ],
           "ownerRepo": "honua-sdk-js",
           "status": "bounded-child-ticket",

--- a/docs/reference/compatibility/geoservices-parity.md
+++ b/docs/reference/compatibility/geoservices-parity.md
@@ -23,6 +23,7 @@ Status vocabulary:
 | [Geometry Service](#geometry-service) | Complete | Root metadata plus all 23 ArcGIS geometry operations | None at operation level; parameter-level caveats only |
 | GeocodeServer | Partial | Service metadata, findAddressCandidates, reverseGeocode, suggest, geocodeAddresses | `outFields`, `magicKey` round-trip, `category` filtering, non-default `outSR` — see [GeocodeServer matrix](../../internal/spikes/geocode-server-matrix.md) |
 | GPServer | Partial | PrintingTools; generic adapter with catalog-backed task metadata, async submitJob, job status/cancel/results over 34 seeded processes | Async-only, no generic `execute` route; `env:*` rejected — see [run geoprocessing](../../guides/query-analyze/run-geoprocessing.md) |
+| [NAServer](#naserver) | Partial | Route solve and service-area solve over the shared routing provider; minimal ClosestFacility probe envelope for mobile clients | POST-only; ClosestFacility is a deterministic stub; no OD cost matrix, location-allocation, barriers, or multiple travel modes |
 | Portal Sharing | Partial (token slice) | `generateToken` issuing opaque tokens consumable on `/rest/services/*` | OAuth2 named-user flow, item/group/community surface — see [authentication](../../guides/secure/authentication.md) |
 
 ## FeatureServer
@@ -137,6 +138,19 @@ Parameter-level caveats (the complete list):
   applies the correct datum transform directly.
 - `toGeoCoordinateString`/`fromGeoCoordinateString` support `MGRS` and `USNG`;
   `UTM`, `GARS`, `GEOREF`, `DD`, `DDM`, and `DMS` return a clear 400.
+
+## NAServer
+
+Esri spec: [Network Analyst Service](https://developers.arcgis.com/rest/services-reference/enterprise/network-analyst-service/).
+Routes are POST-only under `/rest/services/{serviceId}/NAServer` and adapt to
+the shared `IRoutingProvider` routing pipeline.
+
+| Operation(s) | Status | Notes |
+| --- | --- | --- |
+| Route/solve | Implemented | Parses `stops`, `inSR`/`outSR`, `returnRoutes`, and `returnDirections`; delegates to the configured routing provider and returns Esri route/directions feature sets. |
+| ServiceArea/solveServiceArea | Implemented | Parses `facilities`, `defaultBreaks`, `inSR`/`outSR`, and `travelDirection`; honours provider-advertised FromFacility/ToFacility support and returns Esri `saPolygons`. |
+| ClosestFacility/solveClosestFacility | Stub | Registered for mobile client probes and returns a deterministic route/directions envelope; it is not yet backed by a canonical closest-facility solver. |
+| Service metadata, OD cost matrix, location-allocation, network-dataset editing, multiple travel modes, point/line/polygon barriers | Not implemented | Route and service-area solves are the MVP routing scope. Unsupported provider capabilities return GeoServices 400 error envelopes rather than fabricated solves. |
 
 ## Sources and upkeep
 

--- a/docs/reference/configuration/data-sources/mysql-mariadb.md
+++ b/docs/reference/configuration/data-sources/mysql-mariadb.md
@@ -344,12 +344,9 @@ HONUA_TEST_MYSQL=1 dotnet test tests/dotnet/Honua.MySql.Tests/Honua.MySql.Tests.
     --filter "Category=MySql"
 ```
 
-If `HONUA_TEST_MYSQL` is unset (or not exactly `1`) the fixture short-circuits
-in `InitializeAsync` and every test in the class returns without exercising
-the container — a passing run with this gate disabled does **not** mean the
-integration suite ran. The same shape applies if Docker is unavailable: the
-fixture catches the container start failure and skips. They are not part of
-the default PR test suite.
+If `HONUA_TEST_MYSQL` is unset (or not exactly `1`) each infrastructure-gated
+test is reported as skipped before `InitializeAsync` starts Docker. They are
+not part of the default PR test suite.
 
 ### MariaDB compatibility
 

--- a/scripts/ci/pre-pr-check.sh
+++ b/scripts/ci/pre-pr-check.sh
@@ -193,6 +193,8 @@ elif [[ "${AFFECTED}" == "ALL" ]] || affected_contains "Honua.Server.csproj"; th
             --self-contained \
             -p:PublishAot=true \
             -p:HonuaSkipAdminClientForAotVerification=true \
+            -p:HonuaSkipOracleForAotVerification=true \
+            -p:HonuaIncludeStacOpsDemo=false \
             -p:StripSymbols=true \
             -o ./publish
     )

--- a/scripts/ci/pre-pr-check.sh
+++ b/scripts/ci/pre-pr-check.sh
@@ -135,6 +135,7 @@ run_unit_project() {
 }
 
 run_unit_project tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj
+run_unit_project tests/dotnet/Honua.Core.Security.Tests/Honua.Core.Security.Tests.csproj
 run_unit_project tests/dotnet/Honua.LoadTests/Honua.LoadTests.csproj
 run_unit_project tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj
 

--- a/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Capabilities.cs
+++ b/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Capabilities.cs
@@ -562,7 +562,7 @@ internal sealed partial class Wfs20Handler
     }
 
 
-    private static FilterCapabilities BuildFilterCapabilities()
+    internal static FilterCapabilities BuildFilterCapabilities()
     {
         return new FilterCapabilities
         {

--- a/tests/dotnet/Honua.Architecture.Tests/CoreAbstractionsIsolationTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/CoreAbstractionsIsolationTests.cs
@@ -15,7 +15,7 @@ namespace Honua.Architecture.Tests;
 /// or geospatial libraries, so protocol assemblies stay light-weight.
 /// </summary>
 /// <remarks>
-/// See <c>docs/contributor/adr/0041-core-abstractions-extraction.md</c> for the rationale
+/// See <c>docs/internal/contributor/adr/0041-core-abstractions-extraction.md</c> for the rationale
 /// and the multi-PR sequencing plan that moves the rest of the abstractions surface
 /// into this assembly.
 /// </remarks>

--- a/tests/dotnet/Honua.Architecture.Tests/HonuaAiIsolationTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/HonuaAiIsolationTests.cs
@@ -23,7 +23,7 @@ namespace Honua.Architecture.Tests;
 /// (re-introducing the cycle ADR-0047 forbids).
 /// </para>
 /// <para>
-/// See <c>docs/contributor/adr/0047-module-dependency-policy.md</c> for
+/// See <c>docs/internal/contributor/adr/0047-module-dependency-policy.md</c> for
 /// the module-dependency policy this guard sits inside.
 /// </para>
 /// </remarks>

--- a/tests/dotnet/Honua.Architecture.Tests/ModuleDependencyPolicyTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/ModuleDependencyPolicyTests.cs
@@ -8,7 +8,7 @@ namespace Honua.Architecture.Tests;
 
 /// <summary>
 /// Enforces the canonical Module Dependency Policy
-/// (<c>docs/contributor/adr/0047-module-dependency-policy.md</c>): every
+/// (<c>docs/internal/contributor/adr/0047-module-dependency-policy.md</c>): every
 /// <c>&lt;ProjectReference&gt;</c> declared by a runtime csproj must point at a
 /// provider that the consumer's matrix row permits.
 /// </summary>
@@ -408,7 +408,7 @@ public sealed class ModuleDependencyPolicyTests
                     $"({Path.GetFileNameWithoutExtension(csprojPath)}, {relativePath}) " +
                     $"references '{providerRole}' ({providerName}), which is forbidden by " +
                     "the ADR-0047 dependency-direction matrix. See " +
-                    "docs/contributor/adr/0047-module-dependency-policy.md " +
+                    "docs/internal/contributor/adr/0047-module-dependency-policy.md " +
                     $"§ 'Dependency direction matrix' — the ({consumerRole}, {providerRole}) " +
                     "cell is empty. Either route the dependency through a permitted layer, " +
                     "or (only if intentional) update both the ADR matrix and the test's " +
@@ -421,7 +421,7 @@ public sealed class ModuleDependencyPolicyTests
             .Should()
             .BeEmpty(
                 "every runtime ProjectReference must match the ADR-0047 dependency-direction " +
-                "matrix. See docs/contributor/adr/0047-module-dependency-policy.md for the " +
+                "matrix. See docs/internal/contributor/adr/0047-module-dependency-policy.md for the " +
                 "policy and the decision tree.");
 
         // ----- Ratchet enforcement -----
@@ -471,6 +471,7 @@ public sealed class ModuleDependencyPolicyTests
         var adrPath = Path.Combine(
             repositoryRoot,
             "docs",
+            "internal",
             "contributor",
             "adr",
             "0047-module-dependency-policy.md");

--- a/tests/dotnet/Honua.Core.Security.Tests/AssemblyInfo.cs
+++ b/tests/dotnet/Honua.Core.Security.Tests/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+[assembly: Xunit.AssemblyTrait("Category", "Unit")]
+[assembly: Xunit.AssemblyTrait("Tier", "Fast")]

--- a/tests/dotnet/Honua.Core.Security.Tests/DataConnectionTests.cs
+++ b/tests/dotnet/Honua.Core.Security.Tests/DataConnectionTests.cs
@@ -91,8 +91,10 @@ public sealed class DataConnectionTests
         };
 
         var json = JsonSerializer.Serialize(connection);
+        using var document = JsonDocument.Parse(json);
 
-        Assert.DoesNotContain("ConnectionString", json, StringComparison.OrdinalIgnoreCase);
+        Assert.False(document.RootElement.TryGetProperty(nameof(DataConnection.ConnectionString), out _));
+        Assert.True(document.RootElement.TryGetProperty(nameof(DataConnection.EncryptedConnectionString), out _));
         Assert.DoesNotContain("Password=secret", json, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("secret-token", json, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("SecretRef", json, StringComparison.OrdinalIgnoreCase);

--- a/tests/dotnet/Honua.MySql.Tests/Honua.MySql.Tests.csproj
+++ b/tests/dotnet/Honua.MySql.Tests/Honua.MySql.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Honua.MySql\Honua.MySql.csproj" />
     <ProjectReference Include="..\..\..\src\Honua.Core\Honua.Core.csproj" />
+    <ProjectReference Include="..\Honua.TestKit\Honua.TestKit.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/Honua.MySql.Tests/MySqlFeatureStoreIntegrationTests.cs
+++ b/tests/dotnet/Honua.MySql.Tests/MySqlFeatureStoreIntegrationTests.cs
@@ -23,7 +23,7 @@ namespace Honua.MySql.Tests;
 /// <c>HONUA_TEST_MYSQL=1 dotnet test --filter Category=MySql</c>.
 /// </summary>
 [Trait("Category", "MySql")]
-public class MySqlFeatureStoreIntegrationTests : IAsyncLifetime
+public sealed class MySqlFeatureStoreIntegrationTests : IAsyncLifetime
 {
     private const int LayerId = 1;
     private MySqlContainer _container = null!;

--- a/tests/dotnet/Honua.MySql.Tests/MySqlFeatureStoreIntegrationTests.cs
+++ b/tests/dotnet/Honua.MySql.Tests/MySqlFeatureStoreIntegrationTests.cs
@@ -6,6 +6,7 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.MySql.Features.FeatureStore;
 using Honua.MySql.Features.FeatureStore.Services;
 using Honua.MySql.Features.Infrastructure;
+using Honua.TestKit.Attributes;
 using Microsoft.Extensions.Logging.Abstractions;
 using MySqlConnector;
 using Testcontainers.MySql;
@@ -29,6 +30,8 @@ public class MySqlFeatureStoreIntegrationTests : IAsyncLifetime
     private MySqlDataSource _dataSource = null!;
     private MySqlFeatureStore _store = null!;
     private MySqlLayerMappingRegistry _registry = null!;
+
+    private const string TestMySqlEnvVar = "HONUA_TEST_MYSQL";
 
     public async Task InitializeAsync()
     {
@@ -110,7 +113,7 @@ public class MySqlFeatureStoreIntegrationTests : IAsyncLifetime
         }
     }
 
-    [MySqlIntegrationFact]
+    [RequiredEnvironmentFact(TestMySqlEnvVar, "1", skipReason: "Set HONUA_TEST_MYSQL=1 to run MySQL Testcontainers integration tests.")]
     public async Task Query_Count_Extent_RoundTripAgainstMysql8()
     {
         var query = new FeatureQuery();
@@ -130,7 +133,7 @@ public class MySqlFeatureStoreIntegrationTests : IAsyncLifetime
         Assert.True(extent.Value.MinY < extent.Value.MaxY);
     }
 
-    [MySqlIntegrationFact]
+    [RequiredEnvironmentFact(TestMySqlEnvVar, "1", skipReason: "Set HONUA_TEST_MYSQL=1 to run MySQL Testcontainers integration tests.")]
     public async Task Query_WithBboxIntersectsFilter_ReturnsSubset()
     {
         // Bounding-box polygon WKB covering the first ~5 parcels (lon -121.99..-121.95, lat 37.01..37.05).
@@ -160,7 +163,7 @@ public class MySqlFeatureStoreIntegrationTests : IAsyncLifetime
         Assert.True(count is > 0 and < 10);
     }
 
-    [MySqlIntegrationFact]
+    [RequiredEnvironmentFact(TestMySqlEnvVar, "1", skipReason: "Set HONUA_TEST_MYSQL=1 to run MySQL Testcontainers integration tests.")]
     public async Task GetAsync_KnownId_ReturnsFeature()
     {
         var feature = await _store.GetAsync(LayerId, featureId: 1);
@@ -169,7 +172,7 @@ public class MySqlFeatureStoreIntegrationTests : IAsyncLifetime
         Assert.Equal(1, feature!.Value.Id);
     }
 
-    [MySqlIntegrationFact]
+    [RequiredEnvironmentFact(TestMySqlEnvVar, "1", skipReason: "Set HONUA_TEST_MYSQL=1 to run MySQL Testcontainers integration tests.")]
     public async Task StreamFeaturesAsync_PagesThroughAllRows()
     {
         var seen = new List<long>();
@@ -185,7 +188,7 @@ public class MySqlFeatureStoreIntegrationTests : IAsyncLifetime
         Assert.Equal(Enumerable.Range(1, 10).Select(i => (long)i), seen);
     }
 
-    [MySqlIntegrationFact]
+    [RequiredEnvironmentFact(TestMySqlEnvVar, "1", skipReason: "Set HONUA_TEST_MYSQL=1 to run MySQL Testcontainers integration tests.")]
     public async Task StreamFeatureBatchesAsync_HonoursBatchSize()
     {
         var batches = new List<IReadOnlyList<Feature>>();
@@ -202,22 +205,11 @@ public class MySqlFeatureStoreIntegrationTests : IAsyncLifetime
         Assert.Single(batches[3]);
     }
 
-    [MySqlIntegrationFact]
+    [RequiredEnvironmentFact(TestMySqlEnvVar, "1", skipReason: "Set HONUA_TEST_MYSQL=1 to run MySQL Testcontainers integration tests.")]
     public async Task StreamGmlFeaturesAsync_ThrowsNotSupported()
     {
         Assert.Throws<NotSupportedException>(() =>
             _store.StreamGmlFeaturesAsync(LayerId, new FeatureQuery()));
         await Task.CompletedTask;
-    }
-}
-
-internal sealed class MySqlIntegrationFactAttribute : FactAttribute
-{
-    public MySqlIntegrationFactAttribute()
-    {
-        if (!string.Equals(Environment.GetEnvironmentVariable("HONUA_TEST_MYSQL"), "1", StringComparison.Ordinal))
-        {
-            Skip = "Set HONUA_TEST_MYSQL=1 to run MySQL Testcontainers integration tests.";
-        }
     }
 }

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wfs20/Wfs20FilterCapabilitiesFactory.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wfs20/Wfs20FilterCapabilitiesFactory.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
-using System.Reflection;
-using FluentAssertions;
 using Honua.Protocols.Ogc.Classic.Wfs20.Models;
 using Honua.Protocols.Ogc.Classic.Wfs20.Services;
 
@@ -10,22 +8,15 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20;
 
 /// <summary>
 /// Test helper that materializes the WFS 2.0 <see cref="FilterCapabilities"/> produced by
-/// the runtime. The production builder is a private static member of <see cref="Wfs20Handler"/>,
-/// so it is invoked via reflection here to keep the assertion suites pinned to the exact
-/// capabilities the server advertises.
+/// the runtime.
 /// </summary>
 internal static class Wfs20FilterCapabilitiesFactory
 {
     /// <summary>
-    /// Invokes the runtime's private <c>BuildFilterCapabilities</c> factory and returns its result.
+    /// Invokes the runtime's filter capabilities factory and returns its result.
     /// </summary>
     public static FilterCapabilities Build()
     {
-        var method = typeof(Wfs20Handler).GetMethod(
-            "BuildFilterCapabilities",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        method.Should().NotBeNull("Wfs20Handler.BuildFilterCapabilities should exist");
-
-        return (FilterCapabilities)method!.Invoke(null, null)!;
+        return Wfs20Handler.BuildFilterCapabilities();
     }
 }

--- a/tests/dotnet/Honua.SqlServer.Tests/Honua.SqlServer.Tests.csproj
+++ b/tests/dotnet/Honua.SqlServer.Tests/Honua.SqlServer.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Honua.SqlServer\Honua.SqlServer.csproj" />
     <ProjectReference Include="..\..\..\src\Honua.Core\Honua.Core.csproj" />
+    <ProjectReference Include="..\Honua.TestKit\Honua.TestKit.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/Honua.SqlServer.Tests/SqlServerFeatureStoreIntegrationTests.cs
+++ b/tests/dotnet/Honua.SqlServer.Tests/SqlServerFeatureStoreIntegrationTests.cs
@@ -30,7 +30,7 @@ namespace Honua.SqlServer.Tests;
 /// </code>
 /// </remarks>
 [Trait("Category", "SqlServerIntegration")]
-public class SqlServerFeatureStoreIntegrationTests : IAsyncLifetime
+public sealed class SqlServerFeatureStoreIntegrationTests : IAsyncLifetime
 {
     internal const string ConnectionEnvVar = "HONUA_SQLSERVER_TEST_CONNECTION";
     private const int LayerId = 1;

--- a/tests/dotnet/Honua.SqlServer.Tests/SqlServerFeatureStoreIntegrationTests.cs
+++ b/tests/dotnet/Honua.SqlServer.Tests/SqlServerFeatureStoreIntegrationTests.cs
@@ -8,6 +8,7 @@ using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.SqlServer;
 using Honua.SqlServer.Features.FeatureStore;
 using Honua.SqlServer.Features.FeatureStore.Services;
+using Honua.TestKit.Attributes;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -38,14 +39,12 @@ public class SqlServerFeatureStoreIntegrationTests : IAsyncLifetime
     private string _tableName = null!;
     private IFeatureReader _store = null!;
 
-    public static bool ShouldRun => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ConnectionEnvVar));
-
     public async Task InitializeAsync()
     {
         _connectionString = Environment.GetEnvironmentVariable(ConnectionEnvVar);
         if (string.IsNullOrWhiteSpace(_connectionString))
         {
-            return;
+            throw new InvalidOperationException($"Set {ConnectionEnvVar} to run SQL Server integration tests.");
         }
 
         _tableName = $"honua_sqlserver_test_{Guid.NewGuid():N}";
@@ -82,24 +81,22 @@ public class SqlServerFeatureStoreIntegrationTests : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        if (string.IsNullOrWhiteSpace(_connectionString) || string.IsNullOrWhiteSpace(_tableName))
+        if (!string.IsNullOrWhiteSpace(_connectionString) && !string.IsNullOrWhiteSpace(_tableName))
         {
-            return;
-        }
-
-        try
-        {
-            await using var connection = new SqlConnection(_connectionString);
-            await connection.OpenAsync();
-            await Execute(connection, $"DROP TABLE IF EXISTS [dbo].[{_tableName}]");
-        }
-        catch
-        {
-            // Best-effort cleanup; the test database may already have been dropped.
+            try
+            {
+                await using var connection = new SqlConnection(_connectionString);
+                await connection.OpenAsync();
+                await Execute(connection, $"DROP TABLE IF EXISTS [dbo].[{_tableName}]");
+            }
+            catch
+            {
+                // Best-effort cleanup; the test database may already have been dropped.
+            }
         }
     }
 
-    [SkippableFact]
+    [RequiredEnvironmentFact(ConnectionEnvVar, skipReason: "Set HONUA_SQLSERVER_TEST_CONNECTION to run SQL Server integration tests.")]
     public async Task QueryAsync_NoFilter_ReturnsAllFeatures()
     {
         var result = await _store.QueryAsync(LayerId, new FeatureQuery());
@@ -108,7 +105,7 @@ public class SqlServerFeatureStoreIntegrationTests : IAsyncLifetime
         Assert.All(result.Items, f => Assert.NotNull(f.Geometry));
     }
 
-    [SkippableFact]
+    [RequiredEnvironmentFact(ConnectionEnvVar, skipReason: "Set HONUA_SQLSERVER_TEST_CONNECTION to run SQL Server integration tests.")]
     public async Task CountAsync_NoFilter_ReturnsTotalRowCount()
     {
         var count = await _store.CountAsync(LayerId, new FeatureQuery());
@@ -116,7 +113,7 @@ public class SqlServerFeatureStoreIntegrationTests : IAsyncLifetime
         Assert.Equal(3, count);
     }
 
-    [SkippableFact]
+    [RequiredEnvironmentFact(ConnectionEnvVar, skipReason: "Set HONUA_SQLSERVER_TEST_CONNECTION to run SQL Server integration tests.")]
     public async Task GetExtentAsync_ReturnsLayerEnvelope()
     {
         var extent = await _store.GetExtentAsync(LayerId);
@@ -128,7 +125,7 @@ public class SqlServerFeatureStoreIntegrationTests : IAsyncLifetime
         Assert.Equal(20, extent.Value.MaxY);
     }
 
-    [SkippableFact]
+    [RequiredEnvironmentFact(ConnectionEnvVar, skipReason: "Set HONUA_SQLSERVER_TEST_CONNECTION to run SQL Server integration tests.")]
     public async Task QueryAsync_AttributeFilter_ReturnsMatching()
     {
         var result = await _store.QueryAsync(LayerId, new FeatureQuery { Where = "name = 'Alpha'" });
@@ -137,7 +134,7 @@ public class SqlServerFeatureStoreIntegrationTests : IAsyncLifetime
         Assert.Equal(1, result.Items[0].Id);
     }
 
-    [SkippableFact]
+    [RequiredEnvironmentFact(ConnectionEnvVar, skipReason: "Set HONUA_SQLSERVER_TEST_CONNECTION to run SQL Server integration tests.")]
     public async Task QueryAsync_LimitMatchingTotalRows_ReportsNoMoreResults()
     {
         // Three rows are seeded; a limit equal to the row count must not falsely advertise more.
@@ -147,7 +144,7 @@ public class SqlServerFeatureStoreIntegrationTests : IAsyncLifetime
         Assert.False(result.HasMoreResults);
     }
 
-    [SkippableFact]
+    [RequiredEnvironmentFact(ConnectionEnvVar, skipReason: "Set HONUA_SQLSERVER_TEST_CONNECTION to run SQL Server integration tests.")]
     public async Task QueryAsync_LimitBelowTotalRows_ReportsMoreResults()
     {
         var result = await _store.QueryAsync(LayerId, new FeatureQuery { Limit = 2 });
@@ -226,21 +223,5 @@ public class SqlServerFeatureStoreIntegrationTests : IAsyncLifetime
             LayerId,
             provider,
             Connection: null);
-    }
-}
-
-/// <summary>
-/// A <see cref="FactAttribute"/> that marks the test as skipped (rather than executed) when the
-/// <c>HONUA_SQLSERVER_TEST_CONNECTION</c> environment variable is not set, so the SQL Server
-/// integration suite is opt-in without silently passing.
-/// </summary>
-internal sealed class SkippableFactAttribute : FactAttribute
-{
-    public SkippableFactAttribute()
-    {
-        if (!SqlServerFeatureStoreIntegrationTests.ShouldRun)
-        {
-            Skip = $"Set {SqlServerFeatureStoreIntegrationTests.ConnectionEnvVar} to run SQL Server integration tests.";
-        }
     }
 }

--- a/tests/dotnet/Honua.TestKit/Attributes/RequiredEnvironmentFactAttribute.cs
+++ b/tests/dotnet/Honua.TestKit/Attributes/RequiredEnvironmentFactAttribute.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Xunit;
+
+namespace Honua.TestKit.Attributes;
+
+/// <summary>
+/// Marks a fact that requires an opt-in environment variable and reports it as skipped
+/// when the required infrastructure is not configured.
+/// </summary>
+public sealed class RequiredEnvironmentFactAttribute : FactAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequiredEnvironmentFactAttribute"/> class.
+    /// </summary>
+    /// <param name="environmentVariable">The environment variable that gates the test.</param>
+    /// <param name="requiredValue">
+    /// Optional exact value required for the test to run. When omitted, any non-empty value is accepted.
+    /// </param>
+    /// <param name="skipReason">Optional skip message used when the environment requirement is not met.</param>
+    public RequiredEnvironmentFactAttribute(
+        string environmentVariable,
+        string? requiredValue = null,
+        string? skipReason = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(environmentVariable);
+
+        var actualValue = Environment.GetEnvironmentVariable(environmentVariable);
+        var shouldRun = requiredValue is null
+            ? !string.IsNullOrWhiteSpace(actualValue)
+            : string.Equals(actualValue, requiredValue, StringComparison.Ordinal);
+
+        if (!shouldRun)
+        {
+            Skip = skipReason ?? CreateSkipReason(environmentVariable, requiredValue);
+        }
+    }
+
+    private static string CreateSkipReason(string environmentVariable, string? requiredValue)
+        => requiredValue is null
+            ? $"Set {environmentVariable} to run this infrastructure-gated test."
+            : $"Set {environmentVariable}={requiredValue} to run this infrastructure-gated test.";
+}


### PR DESCRIPTION
## Issue Link
Closes #1564.
Closes #1565.
Closes #1566.
Closes #1594.

## Summary
Finishes four quality-sweep follow-ups covering CI coverage, provider test skipping, WFS 2.0 test seams, and GeoServices parity documentation.

## Changes Made
- Added Core Security tests to the PR foundation gate and tagged the test assembly as Fast/Unit.
- Added a shared required-environment xUnit fact attribute and migrated MySQL/SQL Server provider tests to report infrastructure-gated cases as skipped.
- Exposed WFS 2.0 filter-capabilities construction through an internal testable API instead of private reflection.
- Resynced GeoServices parity docs/data for NAServer plus stale FeatureServer, MapServer, and ImageServer operation statuses.
- Updated architecture proof-ledger documentation paths after the docs reorganization.
- Aligned local pre-PR AOT verification with CI by excluding the Oracle provider and STAC ops demo from the AOT publish check.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Validation
- `scripts/ci/pre-pr-check.sh` (build, format, server shards, architecture, and AOT passed; final local architecture review failure was fixed and rerun cleanly)
- `python3 scripts/ci/local-architecture-review.py`
- `dotnet test tests/dotnet/Honua.Core.Security.Tests/Honua.Core.Security.Tests.csproj --no-restore --configuration Release --logger "console;verbosity=minimal"`
- `dotnet test tests/dotnet/Honua.MySql.Tests/Honua.MySql.Tests.csproj --configuration Release --logger "console;verbosity=minimal"` (167 passed, 6 skipped)
- `dotnet test tests/dotnet/Honua.SqlServer.Tests/Honua.SqlServer.Tests.csproj --configuration Release --logger "console;verbosity=minimal"` (30 passed, 6 skipped)
- `dotnet test tests/dotnet/Honua.Protocols.OgcClassic.Tests/Honua.Protocols.OgcClassic.Tests.csproj --configuration Release --filter "FullyQualifiedName~Wfs20EnhancedFilterCapabilitiesTests" --logger "console;verbosity=minimal"`
- `dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj --no-build --configuration Release --logger "console;verbosity=minimal"`
- `dotnet format Honua.sln`
- `jq empty docs/gis/data/geoservices-rest-parity.json docs/gis/data/public-interface-proof.json`
- Proof-ledger missing-path check
- Parity JSON semantic check for resynced operations and NAServer entries