### PR TITLE
docs: add pilot onboarding runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ curl http://localhost:8080/healthz/ready
 
 PostGIS starts automatically. Migrations run on first boot. HTTP/1 REST and gRPC-Web are at
 `http://localhost:8080`; native h2c gRPC for SDK/mobile clients is at `http://localhost:8081`.
+For self-hosted pilots, run the [pilot onboarding runbook](docs/guides/deploy/pilot-onboarding-runbook.md)
+before exercising durable jobs/workflows or handing the deployment to another team.
 
 **Pre-built image** (bring your own PostGIS):
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ curl http://localhost:8080/healthz/ready
 | You are a… | Start here |
 |---|---|
 | **Developer** building apps and integrations | [Quickstart](get-started/quickstart.md) · [Make your first map](get-started/first-map.md) · [Protocols](concepts/protocols.md) |
-| **Admin / operator** running the server | [Deploy with Docker Compose](guides/deploy/docker-compose.md) · [Publish layers](guides/publish/publish-layers.md) · [Set up authentication](guides/secure/authentication.md) |
+| **Admin / operator** running the server | [Deploy with Docker Compose](guides/deploy/docker-compose.md) · [Pilot onboarding runbook](guides/deploy/pilot-onboarding-runbook.md) · [Set up authentication](guides/secure/authentication.md) |
 | **Analyst** consuming the data | [Connect Excel and Power BI](guides/connect/excel-power-bi.md) · [Query features](guides/query-analyze/query-features.md) · [Export data](guides/query-analyze/export-data.md) |
 
 ## What do you want to do?

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -53,6 +53,7 @@
   - [Compliance](guides/secure/compliance.md)
 - Deploy & operate
   - [Docker Compose](guides/deploy/docker-compose.md)
+  - [Pilot onboarding runbook](guides/deploy/pilot-onboarding-runbook.md)
   - [Kubernetes](guides/deploy/kubernetes.md)
   - [Cloud deployments](guides/deploy/cloud-deployments.md)
   - [Local development](guides/deploy/local-development.md)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -65,6 +65,7 @@ Task-oriented guides, grouped by what you want to do. New to Honua? Start with t
 | I want to… | Guide |
 |---|---|
 | Run locally with Docker Compose | [Docker Compose](deploy/docker-compose.md) |
+| Validate pilot prerequisites and first-hour failure modes | [Pilot onboarding runbook](deploy/pilot-onboarding-runbook.md) |
 | Run without containers for development | [Local development](deploy/local-development.md) |
 | Deploy on Kubernetes | [Kubernetes](deploy/kubernetes.md) |
 | Deploy on AWS, Azure, or GCP | [Cloud deployments](deploy/cloud-deployments.md) |

--- a/docs/guides/deploy/pilot-onboarding-runbook.md
+++ b/docs/guides/deploy/pilot-onboarding-runbook.md
@@ -1,0 +1,140 @@
+# Pilot onboarding runbook
+
+Use this runbook before handing a self-hosted pilot to an operator or customer team. It focuses on the first-hour failures that look like generic server errors but usually come from missing runtime prerequisites, Redis, or an inactive Metadata v2 snapshot.
+
+**Prerequisites:** shell access to the deployment, the admin password, access to the PostGIS database, and either `redis-cli` or the managed Redis provider's connectivity test.
+
+## Runtime prerequisites
+
+### Local or disposable pilot
+
+The repository Docker Compose stack supplies PostGIS and runs migrations. A local pilot still needs explicit runtime secrets and Redis when it exercises asynchronous work:
+
+```bash
+HONUA_ADMIN_PASSWORD=replace-with-admin-password
+Security__ConnectionEncryption__MasterKey=replace-with-32-plus-character-secret
+HONUA_REDIS_URL=redis:6379
+```
+
+Start Redis with the Compose profile when durable jobs, queued imports, OGC Processes, GPServer async jobs, tile-operation jobs, or workflow runs are in scope:
+
+```bash
+HONUA_REDIS_URL=redis:6379 docker compose --profile redis up -d
+```
+
+The stock Compose file maps host `HONUA_REDIS_URL` into the container's `ConnectionStrings__Redis`. If you use a `docker-compose.override.yml`, setting `ConnectionStrings__Redis: redis:6379` on the `honua` service is equivalent.
+
+For a disposable fresh-stack smoke test only, clear volumes first:
+
+```bash
+docker compose down -v
+HONUA_REDIS_URL=redis:6379 docker compose --profile redis up -d
+curl -fsS http://localhost:8080/healthz/ready
+```
+
+Do not use `docker compose down -v` against a pilot that contains customer data.
+
+### Production pilot
+
+Production pilots need these prerequisites before traffic is routed:
+
+| Prerequisite | Required value |
+|---|---|
+| PostGIS | PostgreSQL with PostGIS enabled, reachable from every Honua replica. |
+| `ConnectionStrings__DefaultConnection` | Primary PostGIS connection string. Migrations run at startup unless `HONUA_SKIP_MIGRATIONS=true`; do not skip them for a new pilot. |
+| `HONUA_ADMIN_PASSWORD` | Strong admin secret delivered through the platform secret store. Admin endpoints refuse to operate without it in production. |
+| `Security__ConnectionEncryption__MasterKey` | 32+ character secret when storing encrypted connection credentials. |
+| `Metadata__Environment` | Stable environment id for this deployment, for example `dev`, `staging`, or `prod`. Defaults to `default` if unset. |
+| `ConnectionStrings__Redis` | Required for durable jobs/workflows, queued imports, geoprocessing jobs, workflow definitions/runs, execution logs, and cross-replica job coordination. |
+
+Redis cache fallback only protects cache reads. It is not a durable job/workflow substitute. If a production pilot includes background imports, OGC Processes, GPServer async jobs, tile jobs, or workflow orchestration, run Redis with persistence enabled, for example managed Redis persistence or Redis AOF.
+
+## Verify dependencies
+
+Set these once for the commands below:
+
+```bash
+HONUA_URL=http://localhost:8080
+HONUA_ADMIN_PASSWORD=replace-with-admin-password
+METADATA_ENV=default
+```
+
+Use the environment id from `Metadata__Environment` for `METADATA_ENV`; if neither `Metadata__Environment` nor `Environment` is set, use `default`.
+
+| Dependency | Check | Healthy result |
+|---|---|---|
+| Process liveness | `curl -fsS "$HONUA_URL/healthz/live"` | `Healthy` |
+| Readiness, migrations, database, configured cache | `curl -fsS "$HONUA_URL/healthz/ready"` | `Ready` |
+| PostGIS | `psql "$ConnectionStrings__DefaultConnection" -c "select postgis_full_version();"` | PostGIS version text |
+| Compose PostGIS | `docker compose exec postgres pg_isready -U honua_user -d honua_dev` | `accepting connections` |
+| Redis from Compose | `docker compose exec redis redis-cli ping` | `PONG` |
+| Honua cache/Redis view | `curl -fsS -H "X-API-Key: $HONUA_ADMIN_PASSWORD" "$HONUA_URL/api/v1/admin/cache/status"` | `isHealthy: true`; `isUsingFallback: false` when Redis is required |
+| Runtime config | `curl -fsS -H "X-API-Key: $HONUA_ADMIN_PASSWORD" "$HONUA_URL/api/v1/admin/config"` | Effective env-derived config is visible |
+| Performance and license health | `curl -fsS -H "X-API-Key: $HONUA_ADMIN_PASSWORD" "$HONUA_URL/healthz/metrics"` | JSON status is `healthy` |
+
+If `/healthz/ready` returns `503` and the body is `Not Ready`, use `/api/v1/admin/cache/status`, database logs, and server logs to identify whether the failing check is migrations, PostGIS, or cache/Redis.
+
+## Activate Metadata v2
+
+Honua serves layer/service metadata from the active Metadata v2 graph for the configured environment. The active graph is the row in `honua.metadata_v2_current` that points at a revision in `honua.metadata_v2_snapshots`.
+
+Supported activation path:
+
+1. Set the deployment environment id with `Metadata__Environment` before the server starts. Keep it stable across restarts and replicas.
+2. Register or import a dataset.
+3. Publish at least one layer through the admin publish API, for example the quickstart's `POST /api/v1/admin/connections/{connectionId}/layers` flow.
+4. Any successful publish or later metadata authoring update saves a new Metadata v2 graph revision and makes it current for that environment.
+
+Do not hand-edit `metadata_v2_current` for normal onboarding. If you restore a database backup, restore `metadata_v2_snapshots`, `metadata_v2_current`, and the sidecar index tables with the catalog data. If you only restored older v1 catalog tables, run a publish or metadata update in the same `Metadata__Environment` to persist and activate the v2 graph.
+
+Detect the active snapshot through the admin API:
+
+```bash
+curl -i -H "X-API-Key: $HONUA_ADMIN_PASSWORD" \
+  "$HONUA_URL/api/v1/admin/metadata/environments/$METADATA_ENV/inventory"
+```
+
+Expected: `200 OK` with `environment`, `revision`, `eTag`, and `entries`. A `404` with `Metadata v2 environment '<env>' does not have an active revision.` means no snapshot is active for that environment.
+
+Detect it directly in PostGIS:
+
+```bash
+psql "$ConnectionStrings__DefaultConnection" \
+  -v env="$METADATA_ENV" \
+  -c "select c.environment, c.revision, c.activated_at, s.etag
+      from honua.metadata_v2_current c
+      join honua.metadata_v2_snapshots s
+        on s.environment = c.environment and s.revision = c.revision
+      where c.environment = :'env';"
+```
+
+No rows means no active snapshot for that environment. A row in another environment usually means `Metadata__Environment` is wrong for the running deployment.
+
+## Failure modes
+
+| Symptom | Likely cause | Confirm | Fix |
+|---|---|---|---|
+| Runtime metadata routes return `500`; logs contain `No Metadata v2 snapshot has been activated for environment '<env>'.` | The running `Metadata__Environment` has no active Metadata v2 snapshot and no compatible legacy catalog to synthesize from. | Inventory endpoint returns `404`; SQL query against `metadata_v2_current` returns no row. | Publish a layer or make a metadata authoring update in the same environment. If this is a restore, restore the metadata-v2 tables with the catalog. |
+| `GET /api/v1/admin/metadata/environments/<env>/inventory` returns `404` with `does not have an active revision` | No active snapshot for the requested environment, or the request used the wrong environment id. | Compare `Metadata__Environment` with rows in `honua.metadata_v2_current`. | Use the correct environment id or activate a snapshot by publishing/updating metadata. |
+| OGC Processes, GPServer async job routes, workflow routes, queued imports, or tile-operation jobs return `503` | Redis-backed durable queue/store is missing or unavailable. | `/api/v1/admin/cache/status` reports fallback or unhealthy; Redis `PING` fails; logs mention job queue/store or distributed import coordination. | Configure `ConnectionStrings__Redis`, restore Redis, restart affected replicas, then resubmit the job. |
+| `503 Distributed import coordination is unavailable` | Queued ArcGIS/GeoServer import coordination cannot reach Redis. | Redis `PING` fails or import logs contain Redis connection failures. | Restore Redis and retry the import; queued import requests are not safely durable without Redis. |
+| `/healthz/ready` returns `503` with body `Not Ready` | Migrations, PostGIS, configured cache, or feature-change storage failed readiness. | Check server logs, database health, and `/api/v1/admin/cache/status`. | Fix the named dependency and restart only if configuration changed. |
+| Admin calls return `401` in a fresh pilot | `HONUA_ADMIN_PASSWORD` was not set in the running container or the request omitted `X-API-Key`. | Check effective deployment env and request headers. | Set the admin password through the deployment secret store and send `X-API-Key: <password>`. |
+| Creating a saved connection fails with `Master key not configured` | `Security__ConnectionEncryption__MasterKey` is absent or shorter than 32 characters. | Check env configuration. | Set a 32+ character master key and restart before storing encrypted connection credentials. |
+
+## Before handoff
+
+- `curl -fsS "$HONUA_URL/healthz/ready"` returns `Ready`.
+- Redis `PING` returns `PONG` when jobs/workflows are in scope.
+- `/api/v1/admin/cache/status` is healthy and not using fallback when Redis is required.
+- The metadata inventory endpoint for `Metadata__Environment` returns `200 OK`.
+- At least one published layer can be fetched through the expected public protocol.
+- Server logs contain no startup validation errors, migration failures, Redis connection loops, or `No Metadata v2 snapshot has been activated` messages.
+
+## Related pages
+
+- [Quickstart](../../get-started/quickstart.md)
+- [Deploy with Docker Compose](docker-compose.md)
+- [Monitoring](monitoring.md)
+- [Troubleshooting](troubleshooting.md)
+- [Scale and tune performance](scaling-and-performance.md)


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1600

## Summary
Adds a focused pilot onboarding runbook for runtime prerequisites, Metadata v2 snapshot activation, Redis-backed durable job/workflow requirements, and first-hour failure triage.

## Changes Made
- Added `docs/guides/deploy/pilot-onboarding-runbook.md` covering local/dev and production prerequisites, dependency checks, Metadata v2 activation, and symptom-to-cause fixes.
- Linked the runbook from the README quick-start/setup flow and docs guide indexes.
- Documented Redis fallback limits so cache fallback is not confused with durable job/workflow availability.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Manual validation performed:
- `rg -n "pilot onboarding runbook|Metadata__Environment|No Metadata v2 snapshot|ConnectionStrings__Redis|HONUA_REDIS_URL|durable jobs/workflows|metadata_v2_current|metadata_v2_snapshots|/api/v1/admin/cache/status|healthz/ready" README.md docs/README.md docs/SUMMARY.md docs/guides/README.md docs/guides/deploy/pilot-onboarding-runbook.md`
- `rg -n "Redis cache fallback only protects cache reads|not a durable job/workflow substitute|does not have an active revision|Distributed import coordination is unavailable|HONUA_REDIS_URL=redis:6379 docker compose --profile redis up -d" docs/guides/deploy/pilot-onboarding-runbook.md`
- `rg -n "Redis is optional|optional Redis|Redis is useful" docs/guides/deploy/pilot-onboarding-runbook.md README.md docs/guides/README.md docs/SUMMARY.md docs/README.md`
- `git diff --check`
- `git diff --cached --check`

Not run: `scripts/ci/pre-pr-check.sh` or broad dotnet tests, per docs-only scope and task instruction to run lightweight validation only.

## Gate Impact
- [ ] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [x] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review