### PR TITLE
fix: move basic OIDC SSO to Pro

### DIFF
--- a/docs/concepts/editions-and-licensing.md
+++ b/docs/concepts/editions-and-licensing.md
@@ -5,8 +5,8 @@ Honua's source is available under the [Elastic License 2.0](https://github.com/h
 | Edition | How it activates | Scope |
 |---|---|---|
 | Community | Default — no license file configured | Baseline platform: all protocols, publishing, one-shot file import, portal token issuance |
-| Pro | Signed license file with Pro entitlements | Adds features such as feature editing, spatial analytics, real-time streams, Redis caching, geocoding |
-| Enterprise | Signed license file with Enterprise entitlements | Adds features such as OIDC authentication, branch versioning, service imports, the plugin SDK |
+| Pro | Signed license file with Pro entitlements | Adds features such as feature editing, spatial analytics, real-time streams, Redis caching, geocoding, single-provider OIDC SSO |
+| Enterprise | Signed license file with Enterprise entitlements | Adds features such as multi-provider OIDC governance, claim-to-role mapping, branch versioning, service imports, the plugin SDK |
 
 A server with no license — or with a missing, malformed, or expired one — runs in Community mode. Nothing breaks; paid features simply stay inactive.
 
@@ -25,7 +25,7 @@ A license is a small UTF-8 JSON envelope signed with Ed25519:
 
 The decoded payload declares `licenseId`, `licensedTo`, `edition`, `issuedAt`, an optional `expiresAt`, and an `entitlements` array of feature keys. Validation is fully offline — the server verifies the signature against locally configured trusted public keys; no license server or phone-home is involved.
 
-Feature activation is entitlement-based: Community-tier features are always active, and a paid feature is active only when its key (for example `editing.feature-edits` or `identity.oidc`) appears in the signed `entitlements` array. The `edition` label is operator-facing and does not by itself activate every feature in that edition. Inspect the full feature inventory at `GET /api/v1/admin/license/entitlements`.
+Feature activation is entitlement-based: Community-tier features are always active, and a paid feature is active only when its key (for example `editing.feature-edits` or `identity.oidc`) appears in the signed `entitlements` array. Basic single-provider OIDC is a Pro entitlement; multi-provider OIDC configuration and claim-to-role mapping remain Enterprise entitlements. The `edition` label is operator-facing and does not by itself activate every feature in that edition. Inspect the full feature inventory at `GET /api/v1/admin/license/entitlements`.
 
 ## Configuration
 

--- a/docs/internal/contributor/adr/0024-open-core-edition-model.md
+++ b/docs/internal/contributor/adr/0024-open-core-edition-model.md
@@ -85,6 +85,7 @@ Everything in Community, plus:
 | **Real-Time Streaming** | WebSocket/SSE feature subscriptions with spatial and attribute filters | Integrations |
 | **Spatial Analytics API** | Server-side clustering (DBSCAN), density heatmaps, spatial joins, buffer analytics — PostGIS power as clean endpoints | Product Assurance |
 | **AI Spatial Agent** | Natural language spatial query translation; anomaly detection (statistical outliers on geometry/attributes); auto-documentation (ISO 19115/FGDC metadata generation from layer schemas); schema suggestion (field type, index, and spatial reference recommendations for imported data) — all via enhanced MCP | Product Assurance |
+| **Basic SSO** | Single-provider OIDC authentication with Azure AD, Google, Okta, Auth0, or generic OIDC — no SSO tax for teams that only need one identity provider | Single Sign-On |
 | **Offline Sync** | GeoPackage-based delta sync for field collection workflows | Product Assurance |
 | **Style Engine** | Programmatic style generation, theme engine (dark, accessible, print), style versioning and diffing | Product Assurance |
 | **Priority Support** | Email support, 48hr response SLA | Support |
@@ -104,7 +105,7 @@ Everything in Pro, plus:
 
 | Area | Included | EnterpriseReady Pillar |
 |------|----------|----------------------|
-| **SSO / OIDC** | Okta, Entra ID, Ping, Auth0; SAML bridge; SCIM user/group provisioning | Single Sign-On |
+| **Identity Governance** | Multi-provider OIDC configuration, claim-to-role mapping, SAML bridge, SCIM user/group provisioning | Single Sign-On |
 | **RBAC** | Per-service, per-layer, per-operation role-based access; row-level security | Role-Based Access Control |
 | **Audit Logging** | Immutable audit trail (who queried/edited what, when, from where); SIEM export (Splunk, Datadog, Elastic) | Audit Logging |
 | **Change Management** | GitOps manifest API (apply, dryRun, prune); drift detection; approval workflows; rollback | Change Management |
@@ -181,7 +182,7 @@ License checks must be:
 
 | Pillar | Community | Pro | Enterprise |
 |--------|-----------|-----|-----------|
-| Single Sign-On | API keys | API keys | OIDC, SAML, SCIM |
+| Single Sign-On | API keys | Single-provider OIDC | Multi-provider OIDC, SAML, SCIM |
 | Audit Logging | Structured logs | Structured logs | Immutable trail + SIEM |
 | RBAC | Admin key (all-or-nothing) | Admin key | Per-resource roles + RLS |
 | Change Management | Manual config | Manual config | GitOps + drift detection + private operator copilot |

--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -98,6 +98,25 @@ public static class FeatureCatalog
     public const string PluginSdkKey = "plugin.sdk";
 
     /// <summary>
+    /// Entitlement key for basic single-provider OpenID Connect authentication. Pro-tier:
+    /// one configured Azure AD, Google, Okta, Auth0, or generic OIDC provider.
+    /// </summary>
+    public const string OidcAuthenticationKey = "identity.oidc";
+
+    /// <summary>
+    /// Entitlement key for configuring multiple OIDC identity providers in one deployment.
+    /// Enterprise-only identity governance; basic single-provider OIDC is separately gated
+    /// by <see cref="OidcAuthenticationKey"/>.
+    /// </summary>
+    public const string OidcMultiProviderKey = "identity.oidc-multi-provider";
+
+    /// <summary>
+    /// Entitlement key for custom OIDC claim-to-role mapping. Enterprise-only identity
+    /// governance; default role assignment for basic single-provider OIDC remains Pro.
+    /// </summary>
+    public const string OidcClaimsMappingKey = "identity.claims-mapping";
+
+    /// <summary>
     /// All edition-gated features in the platform.
     /// </summary>
     public static IReadOnlyList<FeatureDefinition> All { get; } =
@@ -150,11 +169,15 @@ public static class FeatureCatalog
         new("identity.portal-sharing", "ArcGIS Portal Sharing Read Surface", Categories.Identity,
             HonuaEdition.Community, "Expose the read-only /sharing/rest Portal facade (info, portals/self, search, content/items) so Esri clients can discover Honua content as portal items."),
 
-        // Identity — Enterprise
-        new("identity.oidc", "OIDC Authentication", Categories.Identity,
-            HonuaEdition.Enterprise, "OpenID Connect multi-provider authentication with Azure AD, Google, and generic OIDC."),
-        new("identity.claims-mapping", "Claims Mapping", Categories.Identity,
-            HonuaEdition.Enterprise, "Custom claim-to-role mapping for OIDC providers."),
+        // Identity — Pro (no SSO tax for one provider)
+        new(OidcAuthenticationKey, "OIDC Authentication", Categories.Identity,
+            HonuaEdition.Pro, "Single-provider OpenID Connect authentication with Azure AD, Google, Okta, Auth0, or generic OIDC."),
+
+        // Identity — Enterprise (multi-provider governance)
+        new(OidcMultiProviderKey, "OIDC Multi-Provider SSO", Categories.Identity,
+            HonuaEdition.Enterprise, "Configure multiple OIDC identity providers in one deployment."),
+        new(OidcClaimsMappingKey, "Claims Mapping", Categories.Identity,
+            HonuaEdition.Enterprise, "Custom claim-to-role mapping and identity governance for OIDC providers."),
 
         // Caching — Pro
         new("caching.output-cache", "Output Caching", Categories.Caching,

--- a/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
@@ -122,6 +122,30 @@ public sealed class FeatureCatalogTests
     }
 
     [Fact]
+    public void All_OidcSingleProviderIsProAndGovernanceIsEnterprise()
+    {
+        // Ticket #1612: basic single-provider OIDC has no SSO tax and validates
+        // under Pro. Multi-provider configuration and claim-to-role mapping stay
+        // Enterprise identity-governance entitlements.
+        var oidc = FeatureCatalog.All.SingleOrDefault(f => f.Key == FeatureCatalog.OidcAuthenticationKey);
+        var multiProvider = FeatureCatalog.All.SingleOrDefault(f => f.Key == FeatureCatalog.OidcMultiProviderKey);
+        var claimsMapping = FeatureCatalog.All.SingleOrDefault(f => f.Key == FeatureCatalog.OidcClaimsMappingKey);
+
+        oidc.Should().NotBeNull("feature catalog must define basic OIDC authentication for ticket #1612");
+        oidc!.Category.Should().Be(FeatureCatalog.Categories.Identity);
+        oidc.MinimumEdition.Should().Be(HonuaEdition.Pro);
+        oidc.Description.Should().Contain("Single-provider");
+
+        multiProvider.Should().NotBeNull("feature catalog must keep multi-provider SSO Enterprise-gated");
+        multiProvider!.Category.Should().Be(FeatureCatalog.Categories.Identity);
+        multiProvider.MinimumEdition.Should().Be(HonuaEdition.Enterprise);
+
+        claimsMapping.Should().NotBeNull("feature catalog must keep OIDC claims mapping Enterprise-gated");
+        claimsMapping!.Category.Should().Be(FeatureCatalog.Categories.Identity);
+        claimsMapping.MinimumEdition.Should().Be(HonuaEdition.Enterprise);
+    }
+
+    [Fact]
     public void All_CommunityFeaturesAreExpected()
     {
         // Community features are explicitly tracked — adding one requires updating this test


### PR DESCRIPTION
## Issue Link
Fixes #1612

## Summary
Move basic single-provider OIDC SSO from Enterprise to Pro while keeping multi-provider identity governance Enterprise-gated.

## Changes Made
- Changed `identity.oidc` to a Pro entitlement for single-provider OIDC SSO.
- Added an Enterprise `identity.oidc-multi-provider` catalog key so multi-provider OIDC configuration remains separately gated.
- Kept OIDC claim-to-role mapping under an Enterprise entitlement and added a focused catalog test for the boundary.
- Updated ADR-0024 and the licensing concept doc to match the Pro/Enterprise identity split.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --filter FullyQualifiedName~FeatureCatalogTests` (26 passed)
- `dotnet format Honua.sln`
- `git diff --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review