### PR TITLE
fix(docker): rescue Lambda AOT Dockerfile fixes + nightly CI publish

### DIFF
--- a/.github/workflows/nightly-container-build.yml
+++ b/.github/workflows/nightly-container-build.yml
@@ -88,6 +88,126 @@ jobs:
           provenance: true
           sbom: true
 
+  build-lambda-aot:
+    name: Build & Push Lambda AOT (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY_GHCR }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME_GHCR }}
+            docker.io/${{ env.IMAGE_NAME_DOCKERHUB }}
+          tags: |
+            type=raw,value=nightly-lambda-aot
+            type=raw,value=nightly-lambda-aot-{{date 'YYYYMMDD'}}
+            type=sha,prefix=nightly-lambda-aot-
+          flavor: |
+            suffix=-${{ matrix.arch }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.lambda.aot
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            github_actor=${{ github.actor }}
+            github_token=${{ github.token }}
+          cache-from: type=gha,scope=nightly-lambda-aot-${{ matrix.arch }}
+          # ignore-error: a failed/interrupted GHA cache export (common on the
+          # hosted arm64 runner fleet, which can be preempted mid-export) must
+          # not fail an otherwise-successful build+push. The cache is a build
+          # accelerator, not a release artifact.
+          cache-to: type=gha,mode=max,scope=nightly-lambda-aot-${{ matrix.arch }},ignore-error=true
+          provenance: false
+          sbom: false
+
+  manifest-lambda-aot:
+    name: Publish Lambda AOT Manifests
+    runs-on: ubuntu-24.04
+    needs: build-lambda-aot
+    if: ${{ needs.build-lambda-aot.result == 'success' }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY_GHCR }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME_GHCR }}
+            docker.io/${{ env.IMAGE_NAME_DOCKERHUB }}
+          tags: |
+            type=raw,value=nightly-lambda-aot
+            type=raw,value=nightly-lambda-aot-{{date 'YYYYMMDD'}}
+            type=sha,prefix=nightly-lambda-aot-
+
+      - name: Create and push multi-arch manifests
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          for tag in $TAGS; do
+            docker buildx imagetools create -t "$tag" \
+              "${tag}-amd64" \
+              "${tag}-arm64"
+          done
+
   build-jit:
     name: Build & Push JIT (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}

--- a/docker/Dockerfile.lambda.aot
+++ b/docker/Dockerfile.lambda.aot
@@ -7,7 +7,7 @@
 ARG DOTNET_SDK_IMAGE=mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc
 ARG DOTNET_RUNTIME_DEPS_IMAGE=mcr.microsoft.com/dotnet/runtime-deps:10.0@sha256:962ef681468320cc5ef25fa18259cf3200247cec2ee96c2574174d4824272151
 
-FROM ${DOTNET_SDK_IMAGE} AS build
+FROM ${DOTNET_SDK_IMAGE} AS restore
 WORKDIR /src
 
 RUN apt-get update && \
@@ -16,10 +16,45 @@ RUN apt-get update && \
 
 COPY Honua.sln Directory.Build.props Directory.Packages.props NuGet.config .editorconfig ./
 COPY scripts/docker/restore-dotnet-with-github-packages.sh scripts/docker/
+# Copy ALL project files referenced (directly or transitively) by Honua.Server so
+# that `dotnet restore` can generate obj/project.assets.json for every project before
+# `COPY . .` and the --no-restore publish step.  Omitting any referenced .csproj here
+# causes NuGet to skip it during restore; the subsequent publish then fails with
+# NETSDK1004 ("Assets file not found") for those projects.
 COPY src/Honua.Core/*.csproj src/Honua.Core/
 COPY src/Honua.Postgres/*.csproj src/Honua.Postgres/
+COPY src/Honua.Postgres.Shared/*.csproj src/Honua.Postgres.Shared/
 COPY src/Honua.ServiceDefaults/*.csproj src/Honua.ServiceDefaults/
 COPY src/Honua.Server/*.csproj src/Honua.Server/
+COPY src/Honua.DuckDB/*.csproj src/Honua.DuckDB/
+COPY src/Honua.SqlServer/*.csproj src/Honua.SqlServer/
+COPY src/Honua.MySql/*.csproj src/Honua.MySql/
+COPY src/Honua.ArcGisRest/*.csproj src/Honua.ArcGisRest/
+COPY src/Honua.Oracle/*.csproj src/Honua.Oracle/
+COPY src/Honua.Hosting/*.csproj src/Honua.Hosting/
+COPY src/Honua.Jobs/*.csproj src/Honua.Jobs/
+COPY src/Honua.Protocols.OData/*.csproj src/Honua.Protocols.OData/
+COPY src/Honua.Geocoding/*.csproj src/Honua.Geocoding/
+COPY src/Honua.Aws/*.csproj src/Honua.Aws/
+COPY src/Honua.Azure/*.csproj src/Honua.Azure/
+COPY src/Honua.Ai/*.csproj src/Honua.Ai/
+COPY src/Honua.Geometry/*.csproj src/Honua.Geometry/
+COPY src/Honua.Geoprocessing/*.csproj src/Honua.Geoprocessing/
+COPY src/Honua.Io/*.csproj src/Honua.Io/
+COPY src/Honua.Import/*.csproj src/Honua.Import/
+COPY src/Honua.Protocols.Scene/*.csproj src/Honua.Protocols.Scene/
+COPY src/Honua.Protocols.Ogc.Shared/*.csproj src/Honua.Protocols.Ogc.Shared/
+COPY src/Honua.Protocols.OgcApi/*.csproj src/Honua.Protocols.OgcApi/
+COPY src/Honua.Protocols.OgcClassic/*.csproj src/Honua.Protocols.OgcClassic/
+COPY src/Honua.Protocols.Stac/*.csproj src/Honua.Protocols.Stac/
+COPY src/Honua.Protocols.GeoServices/*.csproj src/Honua.Protocols.GeoServices/
+COPY src/Honua.Scene/*.csproj src/Honua.Scene/
+COPY src/Honua.Core.Abstractions/*.csproj src/Honua.Core.Abstractions/
+COPY src/Honua.Routing/*.csproj src/Honua.Routing/
+# StacOpsDemo is in samples/ and is conditional on HonuaIncludeStacOpsDemo != false;
+# when PublishAot=true and RuntimeIdentifier is set it is excluded, but its .csproj
+# must be present for the solution-wide restore to succeed without NETSDK1004.
+COPY samples/Honua.StacOpsDemo/*.csproj samples/Honua.StacOpsDemo/
 
 ARG TARGETARCH
 
@@ -34,6 +69,8 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
     sh scripts/docker/restore-dotnet-with-github-packages.sh src/Honua.Server/Honua.Server.csproj \
       --runtime "$RUNTIME_ID" \
       -p:RuntimeIdentifier="$RUNTIME_ID"
+
+FROM restore AS build
 
 COPY . .
 
@@ -57,7 +94,8 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
       -p:StripSymbols=true \
       -p:OptimizationPreference=Speed \
       -p:IlcOptimizationPreference=Speed \
-      -p:IlcSingleThreaded="$ILC_SINGLE_THREADED" && \
+      -p:IlcSingleThreaded="$ILC_SINGLE_THREADED" \
+      -p:HonuaSkipOracleForAotVerification=true && \
     rm -rf /app/BlazorDebugProxy /app/wwwroot && \
     find /app -type f \( -name '*.pdb' -o -name '*.dbg' \) -delete
 


### PR DESCRIPTION
Fixes #1617

## What is here

Two commits cherry-ported from PR #1611 (which could not merge cleanly because it was cut from fix/bughunt-3) plus the nightly CI job that #1617 requested.

### Commit 1: fix(docker): restore all transitive .csproj files and exclude Oracle from Lambda AOT publish

docker/Dockerfile.lambda.aot only copied 4 .csproj files before the dotnet restore step, so NuGet silently skipped the remaining ~25 referenced projects. The --no-restore publish step then failed with NETSDK1004 for every omitted project.

Changes:
- Adds COPY lines for every direct/transitive ProjectReference of Honua.Server before the restore RUN step.
- Splits the first build stage into a named restore stage so CI can target --target restore without running the 50-min AOT compile.
- Passes -p:HonuaSkipOracleForAotVerification=true to dotnet publish to suppress the IL3000 error from Oracle.ManagedDataAccess.Core (Assembly.Location is not AOT-safe). The #if !HONUA_SKIP_ORACLE guard in Program.cs is already on trunk.

### Commit 2: ci: add nightly Lambda AOT build/publish job (closes #1617)

Adds build-lambda-aot and manifest-lambda-aot jobs to .github/workflows/nightly-container-build.yml, mirroring the existing build-aot structure:
- amd64: ubuntu-24.04 (native runner)
- arm64: ubuntu-24.04-arm (native runner; QEMU cross-build is known-broken with MSB4223, not added)
- Tags: nightly-lambda-aot, nightly-lambda-aot-YYYYMMDD, nightly-lambda-aot-sha (all with -amd64/-arm64 suffix on per-arch images, merged into fat manifests)
- provenance: false / sbom: false matching the existing release Lambda AOT entry in deploy-platform-images.yml (AWS Lambda rejects unknown OCI manifest entries)
- GHA cache scoped per arch

## What was already on trunk vs cherry-picked

| Fix | Status |
|---|---|
| #if !HONUA_SKIP_ORACLE guard in Program.cs (f1e33a0) | Already on trunk (e9dc23a) |
| COPY all transitive .csproj before restore (050e2dc) | Cherry-picked / adapted |
| -p:HonuaSkipOracleForAotVerification=true in publish (f798250) | Cherry-picked |

## Supersedes PR #1611

PR #1611 (fix/lambda-aot-restore-rid) was cut from fix/bughunt-3 and carries ~60 unrelated commits. The three AOT-fix commits from it are rescued here onto a clean trunk base.