### PR TITLE
fix: keep readiness healthy on single-node deployments without Redis

### DIFF
--- a/docs/guides/deploy/monitoring.md
+++ b/docs/guides/deploy/monitoring.md
@@ -74,7 +74,7 @@ Expected: `Healthy` followed by a JSON health snapshot with status fields.
 - **`/metrics` returns 404** — `HONUA_OBSERVABILITY` is not `true`, or the path was moved with `Observability__Prometheus__Path`.
 - **`/metrics` returns 401** — the scrape request is missing the `X-API-Key` header (or OIDC bearer token).
 - **No traces in your backend** — set `HONUA_OPENTELEMETRY=true` and an `OTEL_EXPORTER_OTLP_ENDPOINT`; confirm status via `GET /api/v1/admin/observability/telemetry`.
-- **`/healthz/ready` flaps** — usually database connectivity; check `GET /monitoring/health/comprehensive` for the failing dependency.
+- **`/healthz/ready` flaps** — usually database connectivity; check `GET /monitoring/health/comprehensive` for the failing dependency. If Redis is configured, an unreachable Redis also fails readiness (durable feature-change event storage); a deployment with no Redis configured runs events in single-node in-memory mode and stays `Ready`.
 
 ## Next steps
 

--- a/docs/guides/deploy/troubleshooting.md
+++ b/docs/guides/deploy/troubleshooting.md
@@ -14,6 +14,8 @@ docker logs --tail 200 honua-server
 
 Expected: `Healthy` and `Ready`. If either fails, start with the startup or database tables below. Admin-only diagnostics: `GET /monitoring/health/production`, `GET /monitoring/health/comprehensive`, `GET /api/v1/admin/observability/errors`.
 
+A single-node deployment with no Redis configured reports `Ready` — feature-change events run in node-local in-memory mode (a startup warning notes this). If `/healthz/ready` returns `503` while `/healthz/live` is healthy and Redis **is** configured, Redis is unreachable: check `ConnectionStrings__Redis` and the Redis server itself.
+
 ## Startup
 
 | Symptom | Diagnosis | Fix |

--- a/src/Honua.Hosting/Features/Events/IFeatureChangeEventStore.cs
+++ b/src/Honua.Hosting/Features/Events/IFeatureChangeEventStore.cs
@@ -28,6 +28,15 @@ internal interface IFeatureChangeEventStore
 internal interface IFeatureChangeEventStoreHealth
 {
     bool CanPersistEvents { get; }
+
+    /// <summary>
+    /// True when events are currently persisted to node-local in-memory storage instead of
+    /// durable Redis storage — either because no Redis is configured (explicit single-node
+    /// mode) or because Redis is temporarily unavailable and fallback is permitted.
+    /// Mirrors <c>ICacheHealthChecker.IsUsingFallback</c> (ADR-0017) so readiness can report
+    /// healthy-with-degraded-note instead of failing.
+    /// </summary>
+    bool IsUsingInMemoryFallback { get; }
 }
 
 /// <summary>

--- a/src/Honua.Hosting/Features/Events/InMemoryFeatureChangeEventStore.cs
+++ b/src/Honua.Hosting/Features/Events/InMemoryFeatureChangeEventStore.cs
@@ -79,6 +79,9 @@ internal sealed class InMemoryFeatureChangeEventStore(
         ? !_redisUnavailable || _allowInMemoryFallback
         : _allowInMemoryFallback;
 
+    public bool IsUsingInMemoryFallback => _allowInMemoryFallback
+        && (_redisDb is null || _redisUnavailable);
+
     public async Task<FeatureChangeEvent> AppendAsync(
         FeatureChangeEventRequest request,
         CancellationToken cancellationToken = default)

--- a/src/Honua.Server/Features/HealthCheck/ReadinessCheckService.cs
+++ b/src/Honua.Server/Features/HealthCheck/ReadinessCheckService.cs
@@ -108,6 +108,14 @@ internal sealed class ReadinessCheckService : IReadinessCheckService
                         featureChangeStoreStopwatch.Elapsed.TotalMilliseconds);
                     return ReadinessResult.NotReady("Feature-change event storage unavailable");
                 }
+
+                // In-memory single-node mode (no Redis configured) is healthy-but-degraded,
+                // mirroring the cache fallback check above; it must not fail readiness (#1618).
+                Log.HealthCheckExecuted(
+                    _logger,
+                    "FeatureChangeEventStore",
+                    _featureChangeEventStoreHealth.IsUsingInMemoryFallback ? "Healthy (fallback)" : "Healthy",
+                    featureChangeStoreStopwatch.Elapsed.TotalMilliseconds);
             }
 
             return ReadinessResult.Ready();

--- a/src/Honua.Server/Startup/FeatureEventsAndStreamingRegistration.cs
+++ b/src/Honua.Server/Startup/FeatureEventsAndStreamingRegistration.cs
@@ -17,10 +17,14 @@ namespace Honua.Server.Startup;
 /// <summary>
 /// Registers feature-change event plumbing (event store, retry queue, webhook dispatcher,
 /// transactional outbox, stream session manager, and the streaming publisher). The boolean
-/// flag forwards the host-level decision about whether in-memory event stores are tolerated
-/// (Development / Test) or strictly forbidden (Production / Staging).
+/// flag forwards the host-level decision about whether silent in-memory fallback is tolerated
+/// (Development / Test) or strictly forbidden (Production / Staging). The strict durability
+/// requirement only applies when Redis is actually configured: with no Redis at all the
+/// deployment is a supported single-node/serverless topology (#1618), so the event store runs
+/// in explicit in-memory single-node mode (with a startup warning) instead of reporting
+/// permanently unhealthy — unconfigured is not unhealthy; unreachable is.
 /// </summary>
-internal static class FeatureEventsAndStreamingRegistration
+internal static partial class FeatureEventsAndStreamingRegistration
 {
     public static IServiceCollection AddHonuaFeatureEventsAndStreaming(
         this IServiceCollection services,
@@ -35,10 +39,24 @@ internal static class FeatureEventsAndStreamingRegistration
             .ValidateOnStart();
         services.AddSingleton<IFeatureChangeEventStore>(sp =>
         {
+            var redis = sp.GetService<IConnectionMultiplexer>();
+
+            // Durability can only be enforced against a Redis that is actually configured.
+            // No Redis registered => single-node/serverless deployment: degrade to explicit
+            // node-local in-memory storage (ADR-0017 fallback pattern) instead of reporting
+            // the store permanently unhealthy (#1618). When Redis IS configured, the strict
+            // environments keep requiring it, so a real Redis outage still fails readiness.
+            var allowInMemoryFallback = !requiresDurableDistributedEvents || redis is null;
+            if (requiresDurableDistributedEvents && redis is null)
+            {
+                LogSingleNodeInMemoryEventStore(
+                    sp.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(FeatureEventsAndStreamingRegistration).FullName!));
+            }
+
             return new InMemoryFeatureChangeEventStore(
                 sp.GetRequiredService<IOptions<FeatureChangeEventOptions>>(),
-                sp.GetService<IConnectionMultiplexer>(),
-                allowInMemoryFallback: !requiresDurableDistributedEvents);
+                redis,
+                allowInMemoryFallback);
         });
         services.AddSingleton<IFeatureChangeEventStoreHealth>(sp =>
             (IFeatureChangeEventStoreHealth)sp.GetRequiredService<IFeatureChangeEventStore>());
@@ -109,4 +127,12 @@ internal static class FeatureEventsAndStreamingRegistration
 
         return services;
     }
+
+    [LoggerMessage(
+        EventId = 5110,
+        Level = LogLevel.Warning,
+        Message = "No Redis is configured; feature-change events use node-local in-memory storage (single-node mode). " +
+                  "Events do not survive restarts and are not shared across nodes. " +
+                  "Configure ConnectionStrings:redis for durable multi-node event storage.")]
+    private static partial void LogSingleNodeInMemoryEventStore(ILogger logger);
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Events/FeatureChangeWebhookDispatcherTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Events/FeatureChangeWebhookDispatcherTests.cs
@@ -708,6 +708,8 @@ public sealed class FeatureChangeWebhookDispatcherTests
 
         public bool CanPersistEvents => false;
 
+        public bool IsUsingInMemoryFallback => false;
+
         public Task<FeatureChangeEvent> AppendAsync(FeatureChangeEventRequest request, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Events/InMemoryFeatureChangeEventStoreTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Events/InMemoryFeatureChangeEventStoreTests.cs
@@ -48,6 +48,63 @@ public sealed class InMemoryFeatureChangeEventStoreTests
 
         await act.Should().ThrowAsync<InvalidOperationException>();
         ((IFeatureChangeEventStoreHealth)store).CanPersistEvents.Should().BeFalse();
+        ((IFeatureChangeEventStoreHealth)store).IsUsingInMemoryFallback.Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task AppendAsync_WithoutRedisInSingleNodeMode_PersistsInMemoryAndReportsHealthyFallback()
+    {
+        // Single-node/serverless topology (#1618): no Redis configured, in-memory mode allowed.
+        var store = new InMemoryFeatureChangeEventStore(
+            Options.Create(new FeatureChangeEventOptions { MaxRetainedEvents = 100 }),
+            redis: null,
+            allowInMemoryFallback: true);
+
+        store.CanPersistEvents.Should().BeTrue();
+        store.IsUsingInMemoryFallback.Should().BeTrue();
+
+        var created = await store.AppendAsync(new FeatureChangeEventRequest
+        {
+            ServiceId = "svc-1",
+            LayerId = 0,
+            ObjectId = 1,
+            Operation = "update",
+            Protocol = "rest",
+            RequestId = "req-1"
+        });
+
+        created.Cursor.Should().Be(1);
+        var events = await store.QueryAsync(cursor: null, from: null, to: null, limit: 10);
+        events.Should().ContainSingle(e => e.EventId == created.EventId);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task AppendAsync_WithoutRedisAndDurabilityRequired_ReportsUnavailableAndThrows()
+    {
+        // Strict store contract retained: durability required + no Redis = cannot persist.
+        // (The host registration never produces this combination anymore — when Redis is
+        // unconfigured it explicitly allows the in-memory single-node mode, see
+        // FeatureEventsAndStreamingRegistration.)
+        var store = new InMemoryFeatureChangeEventStore(
+            Options.Create(new FeatureChangeEventOptions { MaxRetainedEvents = 100 }),
+            redis: null,
+            allowInMemoryFallback: false);
+
+        ((IFeatureChangeEventStoreHealth)store).CanPersistEvents.Should().BeFalse();
+
+        var act = () => store.AppendAsync(new FeatureChangeEventRequest
+        {
+            ServiceId = "svc-1",
+            LayerId = 0,
+            ObjectId = 1,
+            Operation = "update",
+            Protocol = "rest",
+            RequestId = "req-1"
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
     [UnitTest]

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/ReadinessCheckServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/ReadinessCheckServiceTests.cs
@@ -143,6 +143,54 @@ public sealed class ReadinessCheckServiceTests
 
     [UnitTest]
     [Operation(Operations.HealthCheck)]
+    public async Task CheckReadinessAsync_WithFeatureChangeStoreInFallbackMode_StillReturnsReady()
+    {
+        // Single-node deployment without Redis (#1618): the event store runs in
+        // explicit in-memory mode and must report healthy-with-degraded-note.
+        var logger = new MockLogger<ReadinessCheckService>();
+        var migrationState = new MigrationState();
+        migrationState.MarkSucceeded();
+        var service = new ReadinessCheckService(
+            new MockHealthyDatabaseChecker(),
+            migrationState,
+            logger,
+            featureChangeEventStoreHealth: new MockFeatureChangeEventStoreHealth(
+                canPersistEvents: true,
+                isUsingInMemoryFallback: true));
+
+        var result = await service.CheckReadinessAsync();
+
+        result.IsReady.Should().BeTrue();
+        result.StatusCode.Should().Be(200);
+        result.Message.Should().Be("Ready");
+        logger.LogCalls.Should().ContainSingle(call =>
+            call.Message.Contains("FeatureChangeEventStore", StringComparison.Ordinal)
+            && call.Message.Contains("Healthy (fallback)", StringComparison.Ordinal));
+    }
+
+    [UnitTest]
+    [Operation(Operations.HealthCheck)]
+    public async Task CheckReadinessAsync_WithDurableFeatureChangeStore_LogsHealthyWithoutFallbackNote()
+    {
+        var logger = new MockLogger<ReadinessCheckService>();
+        var migrationState = new MigrationState();
+        migrationState.MarkSucceeded();
+        var service = new ReadinessCheckService(
+            new MockHealthyDatabaseChecker(),
+            migrationState,
+            logger,
+            featureChangeEventStoreHealth: new MockFeatureChangeEventStoreHealth(canPersistEvents: true));
+
+        var result = await service.CheckReadinessAsync();
+
+        result.IsReady.Should().BeTrue();
+        logger.LogCalls.Should().ContainSingle(call =>
+            call.Message.Contains("FeatureChangeEventStore", StringComparison.Ordinal)
+            && !call.Message.Contains("fallback", StringComparison.Ordinal));
+    }
+
+    [UnitTest]
+    [Operation(Operations.HealthCheck)]
     public async Task CheckReadinessAsync_WithUnhealthyCache_ReturnsNotReady()
     {
         // Arrange
@@ -368,9 +416,11 @@ internal sealed class MockCancellationDatabaseChecker : IDatabaseHealthChecker
     }
 }
 
-internal sealed class MockFeatureChangeEventStoreHealth(bool canPersistEvents) : IFeatureChangeEventStoreHealth
+internal sealed class MockFeatureChangeEventStoreHealth(bool canPersistEvents, bool isUsingInMemoryFallback = false) : IFeatureChangeEventStoreHealth
 {
     public bool CanPersistEvents { get; } = canPersistEvents;
+
+    public bool IsUsingInMemoryFallback { get; } = isUsingInMemoryFallback;
 }
 
 internal sealed class ThrowingCacheHealthChecker : ICacheHealthChecker
@@ -391,6 +441,8 @@ internal sealed class DelayedFeatureChangeEventStoreHealth(bool canPersistEvents
             return canPersistEvents;
         }
     }
+
+    public bool IsUsingInMemoryFallback => false;
 }
 
 /// <summary>

--- a/tests/dotnet/Honua.Server.Tests/Startup/FeatureEventsAndStreamingRegistrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Startup/FeatureEventsAndStreamingRegistrationTests.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Infrastructure.Events;
+using Honua.Infrastructure.Monitoring;
+using Honua.Server.Features.HealthCheck;
+using Honua.Server.Startup;
+using Honua.Server.Tests.Infrastructure;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using StackExchange.Redis;
+
+namespace Honua.Server.Tests.Startup;
+
+/// <summary>
+/// Regression tests for #1618: readiness on single-node deployments without Redis.
+/// The host-level registration must only enforce durable Redis-backed feature-change
+/// event storage when Redis is actually configured — unconfigured is not unhealthy,
+/// unreachable is.
+/// </summary>
+[Protocol(TestProtocols.Health)]
+public sealed class FeatureEventsAndStreamingRegistrationTests
+{
+    [UnitTest]
+    [Operation(Operations.HealthCheck)]
+    public async Task CheckReadinessAsync_DurableEnvironmentWithoutRedisConfigured_ReturnsReady()
+    {
+        // Production-equivalent host (requiresDurableDistributedEvents = true) with no
+        // Redis configured: supported single-node/serverless topology must report Ready.
+        await using var provider = BuildServices(requiresDurableDistributedEvents: true, redis: null);
+        var health = provider.GetRequiredService<IFeatureChangeEventStoreHealth>();
+
+        health.CanPersistEvents.Should().BeTrue();
+        health.IsUsingInMemoryFallback.Should().BeTrue();
+
+        var result = await CreateReadinessService(health).CheckReadinessAsync();
+
+        result.IsReady.Should().BeTrue();
+        result.StatusCode.Should().Be(200);
+    }
+
+    [UnitTest]
+    [Operation(Operations.HealthCheck)]
+    public async Task CheckReadinessAsync_DurableEnvironmentWithRedisUnreachable_ReturnsNotReady()
+    {
+        // Redis IS configured but the durable write path fails: that is a real fault and
+        // must still fail readiness — the single-node fix must not mask Redis outages.
+        await using var provider = BuildServices(
+            requiresDurableDistributedEvents: true,
+            redis: CreateRedis(CreateFailingDatabase()));
+        var store = provider.GetRequiredService<IFeatureChangeEventStore>();
+        var health = provider.GetRequiredService<IFeatureChangeEventStoreHealth>();
+
+        var act = () => store.AppendAsync(CreateRequest());
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        health.CanPersistEvents.Should().BeFalse();
+
+        var result = await CreateReadinessService(health).CheckReadinessAsync();
+
+        result.IsReady.Should().BeFalse();
+        result.StatusCode.Should().Be(503);
+        result.Message.Should().Be("Not Ready - Feature-change event storage unavailable");
+    }
+
+    [UnitTest]
+    [Operation(Operations.HealthCheck)]
+    public async Task CheckReadinessAsync_DurableEnvironmentWithHealthyRedis_ReturnsReady()
+    {
+        // Existing durable behavior is intact: configured and reachable Redis stays Ready
+        // and is not reported as fallback.
+        await using var provider = BuildServices(
+            requiresDurableDistributedEvents: true,
+            redis: CreateRedis(CreateHealthyDatabase()));
+        var store = provider.GetRequiredService<IFeatureChangeEventStore>();
+        var health = provider.GetRequiredService<IFeatureChangeEventStoreHealth>();
+
+        var created = await store.AppendAsync(CreateRequest());
+        created.Should().NotBeNull();
+
+        health.CanPersistEvents.Should().BeTrue();
+        health.IsUsingInMemoryFallback.Should().BeFalse();
+
+        var result = await CreateReadinessService(health).CheckReadinessAsync();
+
+        result.IsReady.Should().BeTrue();
+        result.StatusCode.Should().Be(200);
+    }
+
+    [UnitTest]
+    [Operation(Operations.HealthCheck)]
+    public async Task CheckReadinessAsync_RelaxedEnvironmentWithoutRedis_ReturnsReady()
+    {
+        // Development/Test hosts keep their existing in-memory behavior.
+        await using var provider = BuildServices(requiresDurableDistributedEvents: false, redis: null);
+        var health = provider.GetRequiredService<IFeatureChangeEventStoreHealth>();
+
+        health.CanPersistEvents.Should().BeTrue();
+
+        var result = await CreateReadinessService(health).CheckReadinessAsync();
+
+        result.IsReady.Should().BeTrue();
+        result.StatusCode.Should().Be(200);
+    }
+
+    private static ServiceProvider BuildServices(bool requiresDurableDistributedEvents, IConnectionMultiplexer? redis)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        if (redis is not null)
+        {
+            services.AddSingleton(redis);
+        }
+
+        var configuration = new ConfigurationBuilder().Build();
+        services.AddHonuaFeatureEventsAndStreaming(configuration, requiresDurableDistributedEvents);
+        return services.BuildServiceProvider();
+    }
+
+    private static ReadinessCheckService CreateReadinessService(IFeatureChangeEventStoreHealth health)
+    {
+        var migrationState = new MigrationState();
+        migrationState.MarkSucceeded();
+        return new ReadinessCheckService(
+            new MockHealthyDatabaseChecker(),
+            migrationState,
+            new MockLogger<ReadinessCheckService>(),
+            cacheHealthChecker: null,
+            featureChangeEventStoreHealth: health);
+    }
+
+    private static IConnectionMultiplexer CreateRedis(IDatabase database)
+    {
+        var redis = Substitute.For<IConnectionMultiplexer>();
+        redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
+        return redis;
+    }
+
+    private static IDatabase CreateFailingDatabase()
+    {
+        var database = Substitute.For<IDatabase>();
+        database.ScriptEvaluateAsync(
+                Arg.Any<string>(),
+                Arg.Any<RedisKey[]>(),
+                Arg.Any<RedisValue[]>(),
+                Arg.Any<CommandFlags>())
+            .Returns<Task<RedisResult>>(_ =>
+                Task.FromException<RedisResult>(new RedisConnectionException(ConnectionFailureType.SocketFailure, "simulated outage")));
+        return database;
+    }
+
+    private static IDatabase CreateHealthyDatabase()
+    {
+        var database = Substitute.For<IDatabase>();
+        database.ScriptEvaluateAsync(
+                Arg.Any<string>(),
+                Arg.Any<RedisKey[]>(),
+                Arg.Any<RedisValue[]>(),
+                Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(RedisResult.Create(new[] { RedisResult.Create((RedisValue)"1"), RedisResult.Create((RedisValue)"1") })));
+        database.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(RedisValue.Null);
+        database.SortedSetLengthAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<double>(),
+                Arg.Any<double>(),
+                Arg.Any<Exclude>(),
+                Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(0L));
+        return database;
+    }
+
+    private static FeatureChangeEventRequest CreateRequest() => new()
+    {
+        ServiceId = "svc-1",
+        LayerId = 0,
+        ObjectId = 1,
+        Operation = "update",
+        Protocol = "rest",
+        RequestId = "req-1"
+    };
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1618

## Summary
On single-node/serverless deployments with no Redis configured (e.g. the hosted demo Lambda with `redis_enabled = false`), `/healthz/ready` returned `503` permanently because Production hard-requires Redis for the feature-change event store. Single-node is a supported topology, so unconfigured Redis must not fail readiness.

**Design choice:** the strict durability requirement now only applies when Redis is actually configured — *unconfigured is not unhealthy; unreachable is.* When no `IConnectionMultiplexer` is registered, the host registration explicitly enables the node-local in-memory event store (ADR-0017 fallback pattern) and logs a startup warning that events are not durable or shared across nodes. Readiness reports `Healthy (fallback)` for the event store and returns `200`. When Redis **is** configured, nothing changes: a configured-but-unreachable Redis still fails the durable write path, `CanPersistEvents` goes false, and readiness returns `503` — the fix does not mask real Redis outages (startup also still hard-fails in durable environments if the configured Redis cannot establish a connection).

Once this ships, the honua-iac `examples/aws-demo` README workaround ("don't wire `/healthz/ready` into monitors") can be removed — readiness is meaningful for uptime checks on single-node deployments again.

## Changes Made
- `FeatureEventsAndStreamingRegistration`: only enforce durable Redis-backed event storage when Redis is actually configured; with no Redis registered, run the event store in explicit in-memory single-node mode and emit a startup warning (`LoggerMessage` 5110) pointing at `ConnectionStrings:redis`
- `IFeatureChangeEventStoreHealth`/`InMemoryFeatureChangeEventStore`: new `IsUsingInMemoryFallback` health signal mirroring `ICacheHealthChecker.IsUsingFallback` (ADR-0017)
- `ReadinessCheckService`: log the event-store check as `Healthy (fallback)` vs `Healthy` instead of failing; the `CanPersistEvents == false` 503 path is unchanged
- Tests: new `FeatureEventsAndStreamingRegistrationTests` covering ready-without-Redis (durable env), NOT-ready with Redis configured but unreachable, ready with healthy Redis (no fallback flag), and relaxed-env behavior; extended `ReadinessCheckServiceTests` (fallback-mode ready + durable-mode log) and `InMemoryFeatureChangeEventStoreTests` (single-node persistence, strict-contract throw)
- Docs: `docs/guides/deploy/monitoring.md` and `docs/guides/deploy/troubleshooting.md` explain ready-without-Redis vs 503-with-unreachable-Redis semantics

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review