### PR TITLE
fix: serve empty catalogs when no metadata snapshot is activated (#1619)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,6 +42,8 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageVersion Include="Grpc.Net.Client.Web" Version="2.76.0" />
     <PackageVersion Include="Mapsui" Version="5.0.2" />
+    <!-- Transitive of NBomber.Contracts; pinned directly to clear GHSA-hv8m-jj95-wg3x (NU1903). -->
+    <PackageVersion Include="MessagePack" Version="2.5.301" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.6" />

--- a/src/Honua.AppHost/Honua.AppHost.csproj
+++ b/src/Honua.AppHost/Honua.AppHost.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.PostgreSQL" />
     <PackageReference Include="Aspire.Hosting.Redis" />
+    <!-- Direct pin of Aspire/StreamJsonRpc's transitive MessagePack to a patched version (GHSA-hv8m-jj95-wg3x). -->
+    <PackageReference Include="MessagePack" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honua.Postgres/Features/Metadata/PostgresMetadataV2GraphStore.cs
+++ b/src/Honua.Postgres/Features/Metadata/PostgresMetadataV2GraphStore.cs
@@ -70,14 +70,20 @@ internal sealed class PostgresMetadataV2GraphStore : IMetadataV2GraphStore, IMet
             // (and the collection-detail/items paths) to HTTP 500 alongside every other
             // protocol that resolves through this same shared metadata seam. Restore parity
             // by synthesizing the equivalent snapshot from the V1 catalog at read time.
-            // When the V1 catalog is also empty there is genuinely nothing to serve, so we
-            // keep the original throw. (honua-server#1412.)
+            // (honua-server#1412.)
             current = await TryBuildCompatSnapshotFromV1CatalogAsync(cancellationToken).ConfigureAwait(false);
-            if (current is null)
-            {
-                throw new InvalidOperationException(
-                    $"No Metadata v2 snapshot has been activated for environment '{_environment}'.");
-            }
+
+            // When both the V2 snapshot table and the V1 catalog are absent or empty the
+            // server is freshly deployed with zero published datasets. Every catalog-style
+            // endpoint (STAC /stac, GeoServices /rest/services, OGC API /collections, OData
+            // service document, WFS GetCapabilities, …) already handles an empty list
+            // gracefully and returns a valid empty response. Returning an empty-but-valid
+            // snapshot here makes ALL of those surfaces return 200 with zero
+            // items — the correct behaviour for a healthy but unpopulated server — instead
+            // of surfacing a 500. A snapshot that EXISTS in the database but fails to load
+            // (network/parse error) still 500s correctly because TryLoadCurrentAsync
+            // propagates that exception rather than returning null. (honua-server#1619.)
+            current ??= BuildEmptySnapshot();
         }
 
         if (_cachedCurrent is not null && _cachedCurrent.Etag == current.Etag)
@@ -566,6 +572,25 @@ internal sealed class PostgresMetadataV2GraphStore : IMetadataV2GraphStore, IMet
             cmd.Parameters.AddWithValue("@provider", (object?)conn.Provider ?? DBNull.Value);
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Builds an empty-but-valid in-memory snapshot for a freshly deployed server with no
+    /// published datasets. All catalog-style read surfaces (STAC, GeoServices, OGC API
+    /// Features, OData, WFS, …) enumerate the collections/services list and return a valid
+    /// empty response when the list is zero-length, so this snapshot produces 200s with no
+    /// items rather than 500s. It is never persisted to the database. (honua-server#1619.)
+    /// </summary>
+    private MetadataV2GraphSnapshot BuildEmptySnapshot()
+    {
+        var graph = new MetadataV2Graph
+        {
+            Environment = _environment,
+            Revision = 0,
+            GeneratedAt = DateTimeOffset.UtcNow,
+        };
+
+        return new MetadataV2GraphSnapshot(graph, "\"empty\"", DateTimeOffset.UtcNow);
     }
 
     private static MetadataV2GraphSnapshot MaterializeSnapshot(string json, string etag)

--- a/tests/dotnet/Honua.LoadTests/Honua.LoadTests.csproj
+++ b/tests/dotnet/Honua.LoadTests/Honua.LoadTests.csproj
@@ -11,6 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <!-- Direct pin of NBomber's transitive MessagePack to a patched version (GHSA-hv8m-jj95-wg3x). -->
+    <PackageReference Include="MessagePack" />
     <PackageReference Include="NBomber" />
     <PackageReference Include="NBomber.Http" />
     <PackageReference Include="xunit" />

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataV2GraphStoreCompatFallbackTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataV2GraphStoreCompatFallbackTests.cs
@@ -162,21 +162,93 @@ public sealed class PostgresMetadataV2GraphStoreCompatFallbackTests(PostgresFixt
     }
 
     [IntegrationTest]
-    public async Task GetCurrentAsync_NoV2SnapshotAndEmptyV1Catalog_StillThrows()
+    public async Task GetCurrentAsync_NoV2SnapshotAndEmptyV1Catalog_ReturnsEmptySnapshot()
     {
+        // Before honua-server#1619 this threw InvalidOperationException and caused every
+        // catalog-style endpoint (STAC, /rest/services, /ogc/features/collections, …) to
+        // return HTTP 500 on a freshly deployed server with zero published datasets.
+        // The correct behaviour is an empty-but-valid snapshot so those endpoints return
+        // 200 with zero items instead.
         var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresMetadataV2GraphStoreCompatFallbackTests));
         try
         {
-            // V1 catalog tables exist but contain no published service layers — there is genuinely
-            // nothing to serve, so the store keeps the original not-found contract.
+            // V1 catalog tables exist but contain no published service layers.
             await CreateV1CatalogTablesAsync(fixture.DataSource, schema);
 
             var provider = new TestConnectionProvider(fixture.DataSource, schema);
             var store = new PostgresMetadataV2GraphStore(provider, environment: "Test", schemaName: schema);
 
-            var act = () => store.GetCurrentAsync().AsTask();
+            var snapshot = await store.GetCurrentAsync();
 
-            await act.Should().ThrowAsync<InvalidOperationException>();
+            snapshot.Should().NotBeNull();
+            snapshot.Graph.Services.Should().BeEmpty("an empty server should have no services");
+            snapshot.Graph.Resources.Should().BeEmpty("an empty server should have no resources");
+            snapshot.Graph.Publications.Should().BeEmpty("an empty server should have no publications");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task GetCurrentAsync_NoV2SnapshotAndNoV1Tables_ReturnsEmptySnapshot()
+    {
+        // When the V1 catalog tables are absent (v2-only fresh database or pre-migration
+        // container), the store should still return an empty snapshot rather than 500ing.
+        // (honua-server#1619.)
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresMetadataV2GraphStoreCompatFallbackTests));
+        try
+        {
+            // Do NOT create V1 catalog tables — simulate a v2-only fresh database.
+            var provider = new TestConnectionProvider(fixture.DataSource, schema);
+            var store = new PostgresMetadataV2GraphStore(provider, environment: "Test", schemaName: schema);
+
+            var snapshot = await store.GetCurrentAsync();
+
+            snapshot.Should().NotBeNull();
+            snapshot.Graph.Services.Should().BeEmpty("a fresh v2-only database should have no services");
+            snapshot.Graph.Resources.Should().BeEmpty("a fresh v2-only database should have no resources");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task GetCurrentAsync_ActivatedSnapshotFailsToMaterialize_StillThrows()
+    {
+        // The empty-snapshot fallback (honua-server#1619) must apply ONLY when no snapshot
+        // exists. A snapshot that IS activated in the database but cannot be materialized
+        // (corrupt/empty document) is a genuine failure and must keep erroring — silently
+        // serving an empty catalog would mask data loss.
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresMetadataV2GraphStoreCompatFallbackTests));
+        try
+        {
+            var provider = new TestConnectionProvider(fixture.DataSource, schema);
+            var store = new PostgresMetadataV2GraphStore(provider, environment: "Test", schemaName: schema);
+
+            // Activate a real snapshot (SaveAsync self-heals the v2 schema), then corrupt
+            // the stored document so materialization fails on the next read.
+            var graph = new MetadataV2Graph
+            {
+                Environment = "Test",
+                Revision = 1,
+                GeneratedAt = DateTimeOffset.UtcNow,
+            };
+            await store.SaveAsync(graph, expectedEtag: null);
+            await ExecuteAsync(fixture.DataSource, schema, $"""
+                UPDATE "{schema}".metadata_v2_snapshots SET document = 'null'::jsonb
+                WHERE environment = 'Test' AND revision = 1;
+                """);
+
+            // A fresh store instance avoids the in-process cache so the read hits Postgres.
+            var readStore = new PostgresMetadataV2GraphStore(provider, environment: "Test", schemaName: schema);
+            var act = () => readStore.GetCurrentAsync().AsTask();
+
+            await act.Should().ThrowAsync<InvalidDataException>(
+                "an activated-but-unloadable snapshot must surface an error, not an empty catalog");
         }
         finally
         {

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/EmptyServerCatalogEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/EmptyServerCatalogEndpointTests.cs
@@ -1,0 +1,250 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Tests.Features.Infrastructure;
+
+/// <summary>
+/// Regression tests for honua-server#1619 — on a freshly deployed server with zero
+/// published datasets, catalog discovery endpoints (<c>GET /stac</c>,
+/// <c>GET /rest/services</c>, <c>GET /ogc/features</c>,
+/// <c>GET /ogc/features/collections</c>, and <c>GET /odata</c>) previously returned
+/// HTTP 500 with "No Metadata v2 snapshot has been activated for environment
+/// 'Production'". The correct behaviour is HTTP 200 with a valid empty response so
+/// evaluators who deploy before importing and uptime probes both see a healthy server.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Infrastructure)]
+public sealed class EmptyServerCatalogEndpointTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture;
+
+    public EmptyServerCatalogEndpointTests()
+    {
+        // Provide an in-memory graph with zero services/resources/publications to
+        // simulate a freshly deployed server that has never had a dataset published.
+        var emptyGraph = new TestMetadataV2GraphBuilder().Build();
+
+        _fixture = new WebAppFixture()
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IMetadataV2GraphProvider>();
+                services.RemoveAll<IMetadataV2GraphStore>();
+                var provider = new TestMetadataV2GraphProvider(emptyGraph);
+                services.AddSingleton(provider);
+                services.AddSingleton<IMetadataV2GraphProvider>(provider);
+                services.AddSingleton<IMetadataV2GraphStore>(provider);
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    // --- STAC ---
+
+    [IntegrationTest]
+    [Operation(Operations.StacCatalog)]
+    [Endpoint("GET /stac")]
+    public async Task GetStacCatalog_FreshServer_Returns200WithEmptyChildLinks()
+    {
+        // Arrange
+        var client = _fixture.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/stac");
+
+        // Assert — must be 200, not 500 (honua-server#1619)
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "a fresh server with no datasets must return a valid empty STAC catalog, not 500");
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(content);
+        var root = doc.RootElement;
+
+        // Valid STAC catalog structure
+        root.GetProperty("type").GetString().Should().Be("Catalog");
+        root.GetProperty("id").GetString().Should().NotBeNullOrEmpty();
+        root.GetProperty("description").GetString().Should().NotBeNullOrEmpty();
+
+        // Links array must exist and contain the mandatory self/root/conformance links
+        root.GetProperty("links").GetArrayLength().Should().BeGreaterThan(0,
+            "even an empty STAC catalog must have self, root, conformance, and search links");
+
+        // No child collection links — zero datasets
+        var links = root.GetProperty("links").EnumerateArray().ToArray();
+        var childLinks = links.Where(l =>
+        {
+            if (!l.TryGetProperty("rel", out var rel))
+            {
+                return false;
+            }
+
+            return rel.GetString() == "child";
+        }).ToArray();
+        childLinks.Should().BeEmpty("an empty server should not advertise any child collection links");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.StacCatalog)]
+    [Endpoint("GET /stac")]
+    public async Task GetStacCatalog_FreshServer_ReturnsValidContentType()
+    {
+        // Arrange
+        var client = _fixture.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/stac");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json",
+            "STAC catalog must be returned as JSON");
+    }
+
+    // --- GeoServices /rest/services ---
+
+    [IntegrationTest]
+    [Operation(Operations.GetServiceInfo)]
+    [Endpoint("GET /rest/services")]
+    public async Task GetRestServices_FreshServer_Returns200WithEmptyServicesList()
+    {
+        // Arrange
+        var client = _fixture.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/rest/services");
+
+        // Assert — must be 200, not 500 (honua-server#1619)
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "a fresh server with no datasets must return a valid empty services directory, not 500");
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(content);
+        var root = doc.RootElement;
+
+        // Valid GeoServices directory structure
+        root.GetProperty("currentVersion").GetDouble().Should().BeGreaterThan(0);
+        root.GetProperty("services").GetArrayLength().Should().Be(0,
+            "an empty server should advertise zero services");
+        root.GetProperty("folders").GetArrayLength().Should().Be(0,
+            "an empty server should advertise zero folders");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetServiceInfo)]
+    [Endpoint("GET /rest/services")]
+    public async Task GetRestServices_FreshServer_ReturnsValidJson()
+    {
+        // Arrange
+        var client = _fixture.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/rest/services");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json",
+            "GeoServices directory must be returned as JSON");
+
+        var content = await response.Content.ReadAsStringAsync();
+        var act = () => JsonDocument.Parse(content);
+        act.Should().NotThrow("response body must be valid JSON");
+    }
+
+    // --- OGC API Features landing page ---
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /ogc/features")]
+    public async Task GetOgcFeaturesLandingPage_FreshServer_Returns200WithValidLinks()
+    {
+        // Arrange
+        var client = _fixture.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/ogc/features");
+
+        // Assert — must be 200, not 500 (honua-server#1619)
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "a fresh server with no datasets must return a valid OGC API landing page, not 500");
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(content);
+        var root = doc.RootElement;
+
+        // OGC API - Features Core requires title/description/links on the landing page.
+        root.GetProperty("links").GetArrayLength().Should().BeGreaterThan(0,
+            "the landing page must always carry self/conformance/collections links");
+    }
+
+    // --- OGC API Features collections ---
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /ogc/features/collections")]
+    public async Task GetOgcFeaturesCollections_FreshServer_Returns200WithEmptyCollections()
+    {
+        // Arrange
+        var client = _fixture.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/ogc/features/collections");
+
+        // Assert — must be 200, not 500 (honua-server#1619)
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "a fresh server with no datasets must return a valid empty collections document, not 500");
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(content);
+        var root = doc.RootElement;
+
+        root.GetProperty("collections").GetArrayLength().Should().Be(0,
+            "an empty server should advertise zero collections");
+        root.GetProperty("links").GetArrayLength().Should().BeGreaterThan(0,
+            "even an empty collections document must carry a self link");
+    }
+
+    // --- OData service document ---
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /odata")]
+    public async Task GetODataServiceDocument_FreshServer_Returns404NotFiveHundred()
+    {
+        // The OData service document's documented empty-state contract is a 404 OData
+        // error ("OData is not enabled for any available service") — see
+        // ODataMetadataHandler.HandleGetServiceDocument and the endpoint's Produces(404).
+        // Before honua-server#1619 a fresh server never reached that contract: resolving
+        // publications threw and the endpoint returned 500. Pin the deliberate 404 here.
+
+        // Arrange
+        var client = _fixture.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/odata");
+
+        // Assert — must be the documented 404 OData error, never 500 (honua-server#1619)
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "a fresh server with no datasets must surface OData's documented not-enabled error, not 500");
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(content);
+        doc.RootElement.GetProperty("error").GetProperty("code").GetString()
+            .Should().Be("ResourceNotFound", "the body must be a valid OData v4 error document");
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Honua.TestKit.csproj
+++ b/tests/dotnet/Honua.TestKit/Honua.TestKit.csproj
@@ -19,6 +19,8 @@
     <PackageReference Include="Grpc.Net.Client" />
     <PackageReference Include="Grpc.Net.Client.Web" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <!-- Direct pin of NBomber's transitive MessagePack to a patched version (GHSA-hv8m-jj95-wg3x). -->
+    <PackageReference Include="MessagePack" />
     <PackageReference Include="NBomber" />
     <PackageReference Include="Parquet.Net" />
     <PackageReference Include="Snappier" />


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1619

## Summary
On a freshly deployed server with zero published datasets, every read surface that resolves metadata through `PostgresMetadataV2GraphStore.GetCurrentAsync` returned HTTP 500 ("No Metadata v2 snapshot has been activated for environment 'Production'") — including `GET /stac` and `GET /rest/services` seen during the demo.honua.io bring-up. This PR makes the store synthesize an empty-but-valid in-memory snapshot when no V2 snapshot has been activated AND the V1 compat catalog is empty/absent, so all catalog-style endpoints return their documented empty-state responses (200 with zero items; OData's documented 404 error document). A snapshot that exists but fails to load (corrupt/unreadable document) still errors — the fallback applies only to the genuine "nothing has ever been published" state.

Also pins transitive `MessagePack` to 2.5.301: advisory GHSA-hv8m-jj95-wg3x (published 2026-06-11) turns into NU1903, which fails every restore under `TreatWarningsAsErrors` and is currently breaking CI repo-wide. Without it this PR (and trunk) cannot go green.

## Changes Made
- `PostgresMetadataV2GraphStore.GetCurrentAsync`: when no V2 snapshot is activated and the V1 compat catalog yields nothing, return a synthesized empty snapshot (never persisted) instead of throwing `InvalidOperationException`
- New `BuildEmptySnapshot()` helper with rationale documented; load failures of an activated snapshot still propagate (`InvalidDataException` from `MaterializeSnapshot`)
- Updated `PostgresMetadataV2GraphStoreCompatFallbackTests`: empty-V1-catalog and no-V1-tables cases now assert an empty snapshot; new test pins that an activated-but-corrupt snapshot still throws rather than masking data loss with an empty catalog
- New `EmptyServerCatalogEndpointTests` covering the empty-server contract end to end: `GET /stac` (200, valid empty catalog, no child links), `GET /rest/services` (200, empty services/folders), `GET /ogc/features` (200 landing page), `GET /ogc/features/collections` (200, zero collections), `GET /odata` (documented 404 OData error document, not 500)
- Pin `MessagePack` 2.5.301 in `Directory.Packages.props` with direct references in `Honua.TestKit`, `Honua.LoadTests` (via NBomber), and `Honua.AppHost` (via Aspire/StreamJsonRpc) to clear GHSA-hv8m-jj95-wg3x (NU1903 breaks all CI restores)

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
