### PR TITLE
fix(docker): add eng/ and Plugins csproj COPY lines; enforce LF for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Force LF line endings for files that execute inside Linux containers.
+# Without this, Windows checkouts (core.autocrlf=true) inject CR bytes that
+# cause /bin/sh to fail with "set: Illegal option -" on the very first line
+# of restore-dotnet-with-github-packages.sh (and any other *.sh entrypoints).
+*.sh text eol=lf
+
+# Container entrypoints that are not *.sh but must stay LF inside the image.
+docker/cloud/lambda/bootstrap.sh text eol=lf
+docker/cloud/azure-functions/handler.sh text eol=lf

--- a/.github/workflows/nightly-container-build.yml
+++ b/.github/workflows/nightly-container-build.yml
@@ -88,6 +88,126 @@ jobs:
           provenance: true
           sbom: true
 
+  build-lambda-aot:
+    name: Build & Push Lambda AOT (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY_GHCR }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME_GHCR }}
+            docker.io/${{ env.IMAGE_NAME_DOCKERHUB }}
+          tags: |
+            type=raw,value=nightly-lambda-aot
+            type=raw,value=nightly-lambda-aot-{{date 'YYYYMMDD'}}
+            type=sha,prefix=nightly-lambda-aot-
+          flavor: |
+            suffix=-${{ matrix.arch }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.lambda.aot
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            github_actor=${{ github.actor }}
+            github_token=${{ github.token }}
+          cache-from: type=gha,scope=nightly-lambda-aot-${{ matrix.arch }}
+          # ignore-error: a failed/interrupted GHA cache export (common on the
+          # hosted arm64 runner fleet, which can be preempted mid-export) must
+          # not fail an otherwise-successful build+push. The cache is a build
+          # accelerator, not a release artifact.
+          cache-to: type=gha,mode=max,scope=nightly-lambda-aot-${{ matrix.arch }},ignore-error=true
+          provenance: false
+          sbom: false
+
+  manifest-lambda-aot:
+    name: Publish Lambda AOT Manifests
+    runs-on: ubuntu-24.04
+    needs: build-lambda-aot
+    if: ${{ needs.build-lambda-aot.result == 'success' }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY_GHCR }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME_GHCR }}
+            docker.io/${{ env.IMAGE_NAME_DOCKERHUB }}
+          tags: |
+            type=raw,value=nightly-lambda-aot
+            type=raw,value=nightly-lambda-aot-{{date 'YYYYMMDD'}}
+            type=sha,prefix=nightly-lambda-aot-
+
+      - name: Create and push multi-arch manifests
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          for tag in $TAGS; do
+            docker buildx imagetools create -t "$tag" \
+              "${tag}-amd64" \
+              "${tag}-arm64"
+          done
+
   build-jit:
     name: Build & Push JIT (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}

--- a/docker/Dockerfile.functions
+++ b/docker/Dockerfile.functions
@@ -21,11 +21,49 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY Honua.sln Directory.Build.props Directory.Packages.props NuGet.config .editorconfig ./
+# eng/ carries Honua.BuildProfiles.props (HonuaIncludeAws/Azure defaults).
+# Directory.Build.props imports it with an Exists() guard, so omitting it
+# makes restore and publish evaluate DIFFERENT project graphs: restore sees
+# the cloud providers off, publish (after COPY . .) sees them on, and the
+# publish fails with NETSDK1004 for every project restore skipped.
+COPY eng/ eng/
 COPY scripts/docker/restore-dotnet-with-github-packages.sh scripts/docker/
+# Copy ALL project files referenced (directly or transitively) by Honua.Server so
+# that `dotnet restore` can generate obj/project.assets.json for every project
+# before `COPY . .` and the --no-restore publish step.
 COPY src/Honua.Core/*.csproj src/Honua.Core/
+COPY src/Honua.Core.Abstractions/*.csproj src/Honua.Core.Abstractions/
 COPY src/Honua.Postgres/*.csproj src/Honua.Postgres/
+COPY src/Honua.Postgres.Shared/*.csproj src/Honua.Postgres.Shared/
 COPY src/Honua.ServiceDefaults/*.csproj src/Honua.ServiceDefaults/
 COPY src/Honua.Server/*.csproj src/Honua.Server/
+COPY src/Honua.DuckDB/*.csproj src/Honua.DuckDB/
+COPY src/Honua.SqlServer/*.csproj src/Honua.SqlServer/
+COPY src/Honua.MySql/*.csproj src/Honua.MySql/
+COPY src/Honua.ArcGisRest/*.csproj src/Honua.ArcGisRest/
+COPY src/Honua.Oracle/*.csproj src/Honua.Oracle/
+COPY src/Honua.Hosting/*.csproj src/Honua.Hosting/
+COPY src/Honua.Jobs/*.csproj src/Honua.Jobs/
+COPY src/Honua.Protocols.OData/*.csproj src/Honua.Protocols.OData/
+COPY src/Honua.Geocoding/*.csproj src/Honua.Geocoding/
+COPY src/Honua.Aws/*.csproj src/Honua.Aws/
+COPY src/Honua.Azure/*.csproj src/Honua.Azure/
+COPY src/Honua.Ai/*.csproj src/Honua.Ai/
+COPY src/Honua.Geometry/*.csproj src/Honua.Geometry/
+COPY src/Honua.Geoprocessing/*.csproj src/Honua.Geoprocessing/
+COPY src/Honua.Io/*.csproj src/Honua.Io/
+COPY src/Honua.Import/*.csproj src/Honua.Import/
+COPY src/Honua.Protocols.Scene/*.csproj src/Honua.Protocols.Scene/
+COPY src/Honua.Protocols.Ogc.Shared/*.csproj src/Honua.Protocols.Ogc.Shared/
+COPY src/Honua.Protocols.OgcApi/*.csproj src/Honua.Protocols.OgcApi/
+COPY src/Honua.Protocols.OgcClassic/*.csproj src/Honua.Protocols.OgcClassic/
+COPY src/Honua.Protocols.Stac/*.csproj src/Honua.Protocols.Stac/
+COPY src/Honua.Protocols.GeoServices/*.csproj src/Honua.Protocols.GeoServices/
+COPY src/Honua.Scene/*.csproj src/Honua.Scene/
+COPY src/Honua.Routing/*.csproj src/Honua.Routing/
+COPY src/Honua.Plugins/*.csproj src/Honua.Plugins/
+COPY src/Honua.Plugins.Abstractions/*.csproj src/Honua.Plugins.Abstractions/
+COPY samples/Honua.StacOpsDemo/*.csproj samples/Honua.StacOpsDemo/
 
 ARG TARGETARCH
 

--- a/docker/Dockerfile.functions.aot
+++ b/docker/Dockerfile.functions.aot
@@ -21,11 +21,49 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY Honua.sln Directory.Build.props Directory.Packages.props NuGet.config .editorconfig ./
+# eng/ carries Honua.BuildProfiles.props (HonuaIncludeAws/Azure defaults).
+# Directory.Build.props imports it with an Exists() guard, so omitting it
+# makes restore and publish evaluate DIFFERENT project graphs: restore sees
+# the cloud providers off, publish (after COPY . .) sees them on, and the
+# publish fails with NETSDK1004 for every project restore skipped.
+COPY eng/ eng/
 COPY scripts/docker/restore-dotnet-with-github-packages.sh scripts/docker/
+# Copy ALL project files referenced (directly or transitively) by Honua.Server so
+# that `dotnet restore` can generate obj/project.assets.json for every project
+# before `COPY . .` and the --no-restore publish step.
 COPY src/Honua.Core/*.csproj src/Honua.Core/
+COPY src/Honua.Core.Abstractions/*.csproj src/Honua.Core.Abstractions/
 COPY src/Honua.Postgres/*.csproj src/Honua.Postgres/
+COPY src/Honua.Postgres.Shared/*.csproj src/Honua.Postgres.Shared/
 COPY src/Honua.ServiceDefaults/*.csproj src/Honua.ServiceDefaults/
 COPY src/Honua.Server/*.csproj src/Honua.Server/
+COPY src/Honua.DuckDB/*.csproj src/Honua.DuckDB/
+COPY src/Honua.SqlServer/*.csproj src/Honua.SqlServer/
+COPY src/Honua.MySql/*.csproj src/Honua.MySql/
+COPY src/Honua.ArcGisRest/*.csproj src/Honua.ArcGisRest/
+COPY src/Honua.Oracle/*.csproj src/Honua.Oracle/
+COPY src/Honua.Hosting/*.csproj src/Honua.Hosting/
+COPY src/Honua.Jobs/*.csproj src/Honua.Jobs/
+COPY src/Honua.Protocols.OData/*.csproj src/Honua.Protocols.OData/
+COPY src/Honua.Geocoding/*.csproj src/Honua.Geocoding/
+COPY src/Honua.Aws/*.csproj src/Honua.Aws/
+COPY src/Honua.Azure/*.csproj src/Honua.Azure/
+COPY src/Honua.Ai/*.csproj src/Honua.Ai/
+COPY src/Honua.Geometry/*.csproj src/Honua.Geometry/
+COPY src/Honua.Geoprocessing/*.csproj src/Honua.Geoprocessing/
+COPY src/Honua.Io/*.csproj src/Honua.Io/
+COPY src/Honua.Import/*.csproj src/Honua.Import/
+COPY src/Honua.Protocols.Scene/*.csproj src/Honua.Protocols.Scene/
+COPY src/Honua.Protocols.Ogc.Shared/*.csproj src/Honua.Protocols.Ogc.Shared/
+COPY src/Honua.Protocols.OgcApi/*.csproj src/Honua.Protocols.OgcApi/
+COPY src/Honua.Protocols.OgcClassic/*.csproj src/Honua.Protocols.OgcClassic/
+COPY src/Honua.Protocols.Stac/*.csproj src/Honua.Protocols.Stac/
+COPY src/Honua.Protocols.GeoServices/*.csproj src/Honua.Protocols.GeoServices/
+COPY src/Honua.Scene/*.csproj src/Honua.Scene/
+COPY src/Honua.Routing/*.csproj src/Honua.Routing/
+COPY src/Honua.Plugins/*.csproj src/Honua.Plugins/
+COPY src/Honua.Plugins.Abstractions/*.csproj src/Honua.Plugins.Abstractions/
+COPY samples/Honua.StacOpsDemo/*.csproj samples/Honua.StacOpsDemo/
 
 ARG TARGETARCH
 

--- a/docker/Dockerfile.lambda
+++ b/docker/Dockerfile.lambda
@@ -11,11 +11,49 @@ FROM ${DOTNET_SDK_IMAGE} AS build
 WORKDIR /src
 
 COPY Honua.sln Directory.Build.props Directory.Packages.props NuGet.config .editorconfig ./
+# eng/ carries Honua.BuildProfiles.props (HonuaIncludeAws/Azure defaults).
+# Directory.Build.props imports it with an Exists() guard, so omitting it
+# makes restore and publish evaluate DIFFERENT project graphs: restore sees
+# the cloud providers off, publish (after COPY . .) sees them on, and the
+# publish fails with NETSDK1004 for every project restore skipped.
+COPY eng/ eng/
 COPY scripts/docker/restore-dotnet-with-github-packages.sh scripts/docker/
+# Copy ALL project files referenced (directly or transitively) by Honua.Server so
+# that `dotnet restore` can generate obj/project.assets.json for every project
+# before `COPY . .` and the --no-restore publish step.
 COPY src/Honua.Core/*.csproj src/Honua.Core/
+COPY src/Honua.Core.Abstractions/*.csproj src/Honua.Core.Abstractions/
 COPY src/Honua.Postgres/*.csproj src/Honua.Postgres/
+COPY src/Honua.Postgres.Shared/*.csproj src/Honua.Postgres.Shared/
 COPY src/Honua.ServiceDefaults/*.csproj src/Honua.ServiceDefaults/
 COPY src/Honua.Server/*.csproj src/Honua.Server/
+COPY src/Honua.DuckDB/*.csproj src/Honua.DuckDB/
+COPY src/Honua.SqlServer/*.csproj src/Honua.SqlServer/
+COPY src/Honua.MySql/*.csproj src/Honua.MySql/
+COPY src/Honua.ArcGisRest/*.csproj src/Honua.ArcGisRest/
+COPY src/Honua.Oracle/*.csproj src/Honua.Oracle/
+COPY src/Honua.Hosting/*.csproj src/Honua.Hosting/
+COPY src/Honua.Jobs/*.csproj src/Honua.Jobs/
+COPY src/Honua.Protocols.OData/*.csproj src/Honua.Protocols.OData/
+COPY src/Honua.Geocoding/*.csproj src/Honua.Geocoding/
+COPY src/Honua.Aws/*.csproj src/Honua.Aws/
+COPY src/Honua.Azure/*.csproj src/Honua.Azure/
+COPY src/Honua.Ai/*.csproj src/Honua.Ai/
+COPY src/Honua.Geometry/*.csproj src/Honua.Geometry/
+COPY src/Honua.Geoprocessing/*.csproj src/Honua.Geoprocessing/
+COPY src/Honua.Io/*.csproj src/Honua.Io/
+COPY src/Honua.Import/*.csproj src/Honua.Import/
+COPY src/Honua.Protocols.Scene/*.csproj src/Honua.Protocols.Scene/
+COPY src/Honua.Protocols.Ogc.Shared/*.csproj src/Honua.Protocols.Ogc.Shared/
+COPY src/Honua.Protocols.OgcApi/*.csproj src/Honua.Protocols.OgcApi/
+COPY src/Honua.Protocols.OgcClassic/*.csproj src/Honua.Protocols.OgcClassic/
+COPY src/Honua.Protocols.Stac/*.csproj src/Honua.Protocols.Stac/
+COPY src/Honua.Protocols.GeoServices/*.csproj src/Honua.Protocols.GeoServices/
+COPY src/Honua.Scene/*.csproj src/Honua.Scene/
+COPY src/Honua.Routing/*.csproj src/Honua.Routing/
+COPY src/Honua.Plugins/*.csproj src/Honua.Plugins/
+COPY src/Honua.Plugins.Abstractions/*.csproj src/Honua.Plugins.Abstractions/
+COPY samples/Honua.StacOpsDemo/*.csproj samples/Honua.StacOpsDemo/
 
 ARG TARGETARCH
 

--- a/docker/Dockerfile.lambda.aot
+++ b/docker/Dockerfile.lambda.aot
@@ -15,6 +15,12 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY Honua.sln Directory.Build.props Directory.Packages.props NuGet.config .editorconfig ./
+# eng/ carries Honua.BuildProfiles.props (HonuaIncludeAws/Azure defaults).
+# Directory.Build.props imports it with an Exists() guard, so omitting it
+# makes restore and publish evaluate DIFFERENT project graphs: restore sees
+# the cloud providers off, publish (after COPY . .) sees them on, and the
+# publish fails with NETSDK1004 for every project restore skipped.
+COPY eng/ eng/
 COPY scripts/docker/restore-dotnet-with-github-packages.sh scripts/docker/
 # Copy ALL project files referenced (directly or transitively) by Honua.Server so
 # that `dotnet restore` can generate obj/project.assets.json for every project before
@@ -51,6 +57,8 @@ COPY src/Honua.Protocols.GeoServices/*.csproj src/Honua.Protocols.GeoServices/
 COPY src/Honua.Scene/*.csproj src/Honua.Scene/
 COPY src/Honua.Core.Abstractions/*.csproj src/Honua.Core.Abstractions/
 COPY src/Honua.Routing/*.csproj src/Honua.Routing/
+COPY src/Honua.Plugins/*.csproj src/Honua.Plugins/
+COPY src/Honua.Plugins.Abstractions/*.csproj src/Honua.Plugins.Abstractions/
 # StacOpsDemo is in samples/ and is conditional on HonuaIncludeStacOpsDemo != false;
 # when PublishAot=true and RuntimeIdentifier is set it is excluded, but its .csproj
 # must be present for the solution-wide restore to succeed without NETSDK1004.

--- a/docker/Dockerfile.lambda.aot
+++ b/docker/Dockerfile.lambda.aot
@@ -7,7 +7,7 @@
 ARG DOTNET_SDK_IMAGE=mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc
 ARG DOTNET_RUNTIME_DEPS_IMAGE=mcr.microsoft.com/dotnet/runtime-deps:10.0@sha256:962ef681468320cc5ef25fa18259cf3200247cec2ee96c2574174d4824272151
 
-FROM ${DOTNET_SDK_IMAGE} AS build
+FROM ${DOTNET_SDK_IMAGE} AS restore
 WORKDIR /src
 
 RUN apt-get update && \
@@ -16,10 +16,45 @@ RUN apt-get update && \
 
 COPY Honua.sln Directory.Build.props Directory.Packages.props NuGet.config .editorconfig ./
 COPY scripts/docker/restore-dotnet-with-github-packages.sh scripts/docker/
+# Copy ALL project files referenced (directly or transitively) by Honua.Server so
+# that `dotnet restore` can generate obj/project.assets.json for every project before
+# `COPY . .` and the --no-restore publish step.  Omitting any referenced .csproj here
+# causes NuGet to skip it during restore; the subsequent publish then fails with
+# NETSDK1004 ("Assets file not found") for those projects.
 COPY src/Honua.Core/*.csproj src/Honua.Core/
 COPY src/Honua.Postgres/*.csproj src/Honua.Postgres/
+COPY src/Honua.Postgres.Shared/*.csproj src/Honua.Postgres.Shared/
 COPY src/Honua.ServiceDefaults/*.csproj src/Honua.ServiceDefaults/
 COPY src/Honua.Server/*.csproj src/Honua.Server/
+COPY src/Honua.DuckDB/*.csproj src/Honua.DuckDB/
+COPY src/Honua.SqlServer/*.csproj src/Honua.SqlServer/
+COPY src/Honua.MySql/*.csproj src/Honua.MySql/
+COPY src/Honua.ArcGisRest/*.csproj src/Honua.ArcGisRest/
+COPY src/Honua.Oracle/*.csproj src/Honua.Oracle/
+COPY src/Honua.Hosting/*.csproj src/Honua.Hosting/
+COPY src/Honua.Jobs/*.csproj src/Honua.Jobs/
+COPY src/Honua.Protocols.OData/*.csproj src/Honua.Protocols.OData/
+COPY src/Honua.Geocoding/*.csproj src/Honua.Geocoding/
+COPY src/Honua.Aws/*.csproj src/Honua.Aws/
+COPY src/Honua.Azure/*.csproj src/Honua.Azure/
+COPY src/Honua.Ai/*.csproj src/Honua.Ai/
+COPY src/Honua.Geometry/*.csproj src/Honua.Geometry/
+COPY src/Honua.Geoprocessing/*.csproj src/Honua.Geoprocessing/
+COPY src/Honua.Io/*.csproj src/Honua.Io/
+COPY src/Honua.Import/*.csproj src/Honua.Import/
+COPY src/Honua.Protocols.Scene/*.csproj src/Honua.Protocols.Scene/
+COPY src/Honua.Protocols.Ogc.Shared/*.csproj src/Honua.Protocols.Ogc.Shared/
+COPY src/Honua.Protocols.OgcApi/*.csproj src/Honua.Protocols.OgcApi/
+COPY src/Honua.Protocols.OgcClassic/*.csproj src/Honua.Protocols.OgcClassic/
+COPY src/Honua.Protocols.Stac/*.csproj src/Honua.Protocols.Stac/
+COPY src/Honua.Protocols.GeoServices/*.csproj src/Honua.Protocols.GeoServices/
+COPY src/Honua.Scene/*.csproj src/Honua.Scene/
+COPY src/Honua.Core.Abstractions/*.csproj src/Honua.Core.Abstractions/
+COPY src/Honua.Routing/*.csproj src/Honua.Routing/
+# StacOpsDemo is in samples/ and is conditional on HonuaIncludeStacOpsDemo != false;
+# when PublishAot=true and RuntimeIdentifier is set it is excluded, but its .csproj
+# must be present for the solution-wide restore to succeed without NETSDK1004.
+COPY samples/Honua.StacOpsDemo/*.csproj samples/Honua.StacOpsDemo/
 
 ARG TARGETARCH
 
@@ -34,6 +69,8 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
     sh scripts/docker/restore-dotnet-with-github-packages.sh src/Honua.Server/Honua.Server.csproj \
       --runtime "$RUNTIME_ID" \
       -p:RuntimeIdentifier="$RUNTIME_ID"
+
+FROM restore AS build
 
 COPY . .
 
@@ -57,7 +94,8 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
       -p:StripSymbols=true \
       -p:OptimizationPreference=Speed \
       -p:IlcOptimizationPreference=Speed \
-      -p:IlcSingleThreaded="$ILC_SINGLE_THREADED" && \
+      -p:IlcSingleThreaded="$ILC_SINGLE_THREADED" \
+      -p:HonuaSkipOracleForAotVerification=true && \
     rm -rf /app/BlazorDebugProxy /app/wwwroot && \
     find /app -type f \( -name '*.pdb' -o -name '*.dbg' \) -delete
 

--- a/docker/Dockerfile.lambda.aot.simple
+++ b/docker/Dockerfile.lambda.aot.simple
@@ -14,11 +14,49 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY Honua.sln Directory.Build.props Directory.Packages.props NuGet.config .editorconfig ./
+# eng/ carries Honua.BuildProfiles.props (HonuaIncludeAws/Azure defaults).
+# Directory.Build.props imports it with an Exists() guard, so omitting it
+# makes restore and publish evaluate DIFFERENT project graphs: restore sees
+# the cloud providers off, publish (after COPY . .) sees them on, and the
+# publish fails with NETSDK1004 for every project restore skipped.
+COPY eng/ eng/
 COPY scripts/docker/restore-dotnet-with-github-packages.sh scripts/docker/
+# Copy ALL project files referenced (directly or transitively) by Honua.Server so
+# that `dotnet restore` can generate obj/project.assets.json for every project
+# before `COPY . .` and the --no-restore publish step.
 COPY src/Honua.Core/*.csproj src/Honua.Core/
+COPY src/Honua.Core.Abstractions/*.csproj src/Honua.Core.Abstractions/
 COPY src/Honua.Postgres/*.csproj src/Honua.Postgres/
+COPY src/Honua.Postgres.Shared/*.csproj src/Honua.Postgres.Shared/
 COPY src/Honua.ServiceDefaults/*.csproj src/Honua.ServiceDefaults/
 COPY src/Honua.Server/*.csproj src/Honua.Server/
+COPY src/Honua.DuckDB/*.csproj src/Honua.DuckDB/
+COPY src/Honua.SqlServer/*.csproj src/Honua.SqlServer/
+COPY src/Honua.MySql/*.csproj src/Honua.MySql/
+COPY src/Honua.ArcGisRest/*.csproj src/Honua.ArcGisRest/
+COPY src/Honua.Oracle/*.csproj src/Honua.Oracle/
+COPY src/Honua.Hosting/*.csproj src/Honua.Hosting/
+COPY src/Honua.Jobs/*.csproj src/Honua.Jobs/
+COPY src/Honua.Protocols.OData/*.csproj src/Honua.Protocols.OData/
+COPY src/Honua.Geocoding/*.csproj src/Honua.Geocoding/
+COPY src/Honua.Aws/*.csproj src/Honua.Aws/
+COPY src/Honua.Azure/*.csproj src/Honua.Azure/
+COPY src/Honua.Ai/*.csproj src/Honua.Ai/
+COPY src/Honua.Geometry/*.csproj src/Honua.Geometry/
+COPY src/Honua.Geoprocessing/*.csproj src/Honua.Geoprocessing/
+COPY src/Honua.Io/*.csproj src/Honua.Io/
+COPY src/Honua.Import/*.csproj src/Honua.Import/
+COPY src/Honua.Protocols.Scene/*.csproj src/Honua.Protocols.Scene/
+COPY src/Honua.Protocols.Ogc.Shared/*.csproj src/Honua.Protocols.Ogc.Shared/
+COPY src/Honua.Protocols.OgcApi/*.csproj src/Honua.Protocols.OgcApi/
+COPY src/Honua.Protocols.OgcClassic/*.csproj src/Honua.Protocols.OgcClassic/
+COPY src/Honua.Protocols.Stac/*.csproj src/Honua.Protocols.Stac/
+COPY src/Honua.Protocols.GeoServices/*.csproj src/Honua.Protocols.GeoServices/
+COPY src/Honua.Scene/*.csproj src/Honua.Scene/
+COPY src/Honua.Routing/*.csproj src/Honua.Routing/
+COPY src/Honua.Plugins/*.csproj src/Honua.Plugins/
+COPY src/Honua.Plugins.Abstractions/*.csproj src/Honua.Plugins.Abstractions/
+COPY samples/Honua.StacOpsDemo/*.csproj samples/Honua.StacOpsDemo/
 
 ARG TARGETARCH
 

--- a/docker/cite/shared/scripts/execute-wcs20-tests.sh
+++ b/docker/cite/shared/scripts/execute-wcs20-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+﻿#!/bin/sh
 
 # Runs the official OGC WCS 2.0 ETS from the ogccite/ets-wcs20 image and
 # writes machine-readable results into /results for the outer harness.

--- a/docker/cite/shared/scripts/execute-wfs1-tests.sh
+++ b/docker/cite/shared/scripts/execute-wfs1-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+﻿#!/bin/sh
 
 # OGC CITE Team Engine test execution script for WFS 1.0.0 and 1.1.0.
 

--- a/docker/cite/shared/scripts/execute-wfs20-tests.sh
+++ b/docker/cite/shared/scripts/execute-wfs20-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+﻿#!/bin/sh
 
 # OGC CITE Team Engine test execution script
 # Runs actual WFS 2.0 conformance tests against Honua Server

--- a/docker/client-compat/arcgis-stub/run.sh
+++ b/docker/client-compat/arcgis-stub/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Runs the ArcGIS Pro REST stub against a running honua service.
 set -euo pipefail
 

--- a/docker/client-compat/cesium/run.sh
+++ b/docker/client-compat/cesium/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Runs the Cesium browser interop suite against a running honua service and
 # copies emitted .cert.json envelopes into /output.
 set -euo pipefail

--- a/docker/client-compat/gdal/run.sh
+++ b/docker/client-compat/gdal/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Runs the GDAL/OGR interop suite against the Compose honua service and writes
 # the JSON evidence envelope plus per-protocol .cert.json envelopes to /output
 # for the baseline-diff step.

--- a/docker/client-compat/openlayers/run.sh
+++ b/docker/client-compat/openlayers/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Runs the OpenLayers (and js-browser MapLibre + Esri Leaflet) interop suites
 # against a running honua service and copies emitted .cert.json envelopes
 # into /output.

--- a/docker/client-compat/pyqgis/run.sh
+++ b/docker/client-compat/pyqgis/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Runs the PyQGIS client compatibility suite against a running honua service
 # and copies the generated .cert.json envelopes into /output.
 set -euo pipefail

--- a/docker/client-compat/seed/run.sh
+++ b/docker/client-compat/seed/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Applies the canonical client-compat seed bundle to a freshly-started
 # postgres so honua + lane services see the expected services and layers:
 #   - tests/seed/client-compat-v1.sql → schema + `test_service` (layer 0)

--- a/docker/cloud/azure-functions/handler.sh
+++ b/docker/cloud/azure-functions/handler.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+﻿#!/bin/sh
 
 set -eu
 

--- a/docker/cloud/lambda/bootstrap.sh
+++ b/docker/cloud/lambda/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+﻿#!/bin/sh
 set -eu
 
 export ASPNETCORE_URLS="${ASPNETCORE_URLS:-http://0.0.0.0:${PORT:-8080}}"

--- a/docker/routing/import-osm.sh
+++ b/docker/routing/import-osm.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 #
 # import-osm.sh — import a real OpenStreetMap extract into the Honua pgRouting
 # development database using osm2pgrouting (issue #1266).

--- a/docker/scale-test/nginx/render-scale-test-conf.sh
+++ b/docker/scale-test/nginx/render-scale-test-conf.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+﻿#!/bin/sh
 set -eu
 
 template_path="/etc/nginx/scale-test.conf.template"

--- a/scripts/ci/check-instructions-sync.sh
+++ b/scripts/ci/check-instructions-sync.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
 
 if [[ ! -f "AGENTS.md" ]]; then

--- a/scripts/ci/check-parity-scorecard-baseline-sync.sh
+++ b/scripts/ci/check-parity-scorecard-baseline-sync.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
 
 parity_test_file="${1:-tests/dotnet/Honua.Server.Tests/Import/GeoservicesParityIntegrationTests.cs}"

--- a/scripts/ci/check-parity-scorecard-regression.sh
+++ b/scripts/ci/check-parity-scorecard-regression.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
 
 if [[ $# -lt 2 ]]; then

--- a/scripts/ci/compute-affected-projects.sh
+++ b/scripts/ci/compute-affected-projects.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Compute the closure of .csproj files affected by a diff so CI build steps
 # can scope `dotnet build` to changed projects + their reverse-dependencies
 # instead of rebuilding the whole solution every push.

--- a/scripts/ci/generate-cross-server-gap-report.sh
+++ b/scripts/ci/generate-cross-server-gap-report.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
 
 if [[ $# -ne 2 ]]; then

--- a/scripts/ci/generate-sdk-compatibility-table.sh
+++ b/scripts/ci/generate-sdk-compatibility-table.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/ci/honua-server-targeted-tests.sh
+++ b/scripts/ci/honua-server-targeted-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Compute the server-tests shard subset to execute on a pull request based on
 # the changed files in the diff. Owned by ADR-0037. The shard map and watched
 # prefix lists are sourced from .github/ci-shards.json.

--- a/scripts/ci/pre-pr-check.sh
+++ b/scripts/ci/pre-pr-check.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
 
 # Pre-PR validation with the SAME smart filters CI uses, so a local run only

--- a/scripts/ci/run-sdk-server-compatibility.sh
+++ b/scripts/ci/run-sdk-server-compatibility.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/ci/run-server-test-shard.sh
+++ b/scripts/ci/run-server-test-shard.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Run one Honua.Server.Tests shard with heartbeat, timeout, and timing output.
 
 set -euo pipefail

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Validate CI shard routing without starting runtime test runners.
 
 set -euo pipefail

--- a/scripts/ci/validate-openapi-contracts.sh
+++ b/scripts/ci/validate-openapi-contracts.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/client-compat/client-compat-server.sh
+++ b/scripts/client-compat/client-compat-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # Client compatibility server setup (WSL side).
 # Builds image, starts Docker Compose, seeds data, and keeps the server

--- a/scripts/client-compat/refresh-baselines.sh
+++ b/scripts/client-compat/refresh-baselines.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Re-runs the docker/client-compat matrix and overwrites tests/baselines/client-compat
 # with the resulting envelopes. Intended for scheduled baseline-refresh PRs;
 # do NOT run in regular CI.

--- a/scripts/client-compat/run-client-compat-smoke.sh
+++ b/scripts/client-compat/run-client-compat-smoke.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
 
 usage() {

--- a/scripts/cloud/deploy-canary.sh
+++ b/scripts/cloud/deploy-canary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 set -euo pipefail
 
 # Canary Deployment Script for Honua Server

--- a/scripts/cloud/deploy-rolling.sh
+++ b/scripts/cloud/deploy-rolling.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 set -euo pipefail
 
 # Rolling Deployment Script for Honua Server

--- a/scripts/cloud/post-deployment-verification.sh
+++ b/scripts/cloud/post-deployment-verification.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 set -euo pipefail
 
 # Post-Deployment Verification Script for Honua Server

--- a/scripts/cloud/rollback-deployment.sh
+++ b/scripts/cloud/rollback-deployment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/cloud/run-cloud-post-apply-validation.sh
+++ b/scripts/cloud/run-cloud-post-apply-validation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 set -euo pipefail
 
 TF_OUTPUT_JSON=""

--- a/scripts/cloud/setup-github-app-env.sh
+++ b/scripts/cloud/setup-github-app-env.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
 
 APP_ID="2932471"

--- a/scripts/conformance/cite/build-cite-evidence.sh
+++ b/scripts/conformance/cite/build-cite-evidence.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 # Builds a static, website-linkable evidence bundle from local CITE result
 # directories. The bundle includes a human-readable index, machine-readable

--- a/scripts/conformance/cite/run-cite-gml32-tests.sh
+++ b/scripts/conformance/cite/run-cite-gml32-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # GML 3.2 CITE conformance testing script for Honua Server.
 # Validates GML document output against the OGC GML 3.2 specification.

--- a/scripts/conformance/cite/run-cite-gpkg12-tests.sh
+++ b/scripts/conformance/cite/run-cite-gpkg12-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # GeoPackage 1.2 CITE conformance testing script for Honua Server.
 # Validates GeoPackage file output against the OGC GeoPackage 1.2 specification.

--- a/scripts/conformance/cite/run-cite-kml22-tests.sh
+++ b/scripts/conformance/cite/run-cite-kml22-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # KML 2.2 CITE conformance testing script for Honua Server.
 # Validates KML document output against the OGC KML 2.2 specification.

--- a/scripts/conformance/cite/run-cite-tests.sh
+++ b/scripts/conformance/cite/run-cite-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # OGC API Features CITE conformance testing script for Honua Server
 # Runs the official OGC Compliance and Interoperability Testing & Evaluation (CITE) suite

--- a/scripts/conformance/cite/run-cite-tiles-tests.sh
+++ b/scripts/conformance/cite/run-cite-tiles-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # OGC API Tiles CITE conformance testing script for Honua Server
 # Runs the official OGC Compliance and Interoperability Testing & Evaluation (CITE) suite

--- a/scripts/conformance/cite/run-cite-wcs20-tests.sh
+++ b/scripts/conformance/cite/run-cite-wcs20-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # WCS 2.0 CITE conformance testing script for Honua Server.
 

--- a/scripts/conformance/cite/run-cite-wfs10-tests.sh
+++ b/scripts/conformance/cite/run-cite-wfs10-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # OGC WFS 1.0 CITE conformance testing script for Honua Server.
 

--- a/scripts/conformance/cite/run-cite-wfs11-tests.sh
+++ b/scripts/conformance/cite/run-cite-wfs11-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # OGC WFS 1.1 CITE conformance testing script for Honua Server.
 

--- a/scripts/conformance/cite/run-cite-wfs20-tests.sh
+++ b/scripts/conformance/cite/run-cite-wfs20-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # OGC WFS 2.0 CITE conformance testing script for Honua Server
 # Runs the official OGC Compliance and Interoperability Testing & Evaluation (CITE) suite

--- a/scripts/conformance/cite/run-cite-wms-tests.sh
+++ b/scripts/conformance/cite/run-cite-wms-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # WMS 1.3 CITE conformance testing script for Honua Server.
 

--- a/scripts/conformance/cite/run-cite-wmts-tests.sh
+++ b/scripts/conformance/cite/run-cite-wmts-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # WMTS 1.0 CITE conformance testing script for Honua Server.
 

--- a/scripts/conformance/ogc/run-ogc-maps-conformance-tests.sh
+++ b/scripts/conformance/ogc/run-ogc-maps-conformance-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 # OGC API - Maps conformance verification for Honua Server.
 # This runner uses the server integration conformance suite while

--- a/scripts/conformance/ogc/validate-ogc-conformance.sh
+++ b/scripts/conformance/ogc/validate-ogc-conformance.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # Validate that advertised OGC API Features conformance classes were actually tested.
 

--- a/scripts/conformance/run-production-audit.sh
+++ b/scripts/conformance/run-production-audit.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/demos/run-mobile-offline-demo.sh
+++ b/scripts/demos/run-mobile-offline-demo.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/scripts/demos/run-stac-ops-demo.sh
+++ b/scripts/demos/run-stac-ops-demo.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/scripts/dev/dev-setup.sh
+++ b/scripts/dev/dev-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 set -euo pipefail
 
 # Development Environment Setup Script for Honua Server

--- a/scripts/dev/seed-admin-sample.sh
+++ b/scripts/dev/seed-admin-sample.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Reset the local test schema and seed the admin preview sample FeatureServer.
 #
 # Environment variables:

--- a/scripts/dev/setup-git-hooks.sh
+++ b/scripts/dev/setup-git-hooks.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Setup script to install git hooks for pre-PR validation enforcement
 
 set -e

--- a/scripts/dev/setup-playwright-wsl.sh
+++ b/scripts/dev/setup-playwright-wsl.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
 
 if [[ ! -f /etc/os-release ]]; then

--- a/scripts/dev/with-test-docker-cleanup.sh
+++ b/scripts/dev/with-test-docker-cleanup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
 
 usage() {

--- a/scripts/docker/build-with-github-packages.sh
+++ b/scripts/docker/build-with-github-packages.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
 
 docker_args=()

--- a/scripts/docker/restore-dotnet-with-github-packages.sh
+++ b/scripts/docker/restore-dotnet-with-github-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+﻿#!/bin/sh
 set -eu
 
 if [ "$#" -lt 1 ]; then

--- a/scripts/host/reclaim-wsl-space.sh
+++ b/scripts/host/reclaim-wsl-space.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/migrations/migrate_constructor_validation.sh
+++ b/scripts/migrations/migrate_constructor_validation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # Constructor Validation Migration Script (Bash)
 # Automatically refactors constructor null validation patterns to use the new validation framework

--- a/scripts/release/build-release-manifest.sh
+++ b/scripts/release/build-release-manifest.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 # Build (or refresh) a Honua release-train manifest from release-bundle evidence.
 #

--- a/scripts/release/collect-evidence.sh
+++ b/scripts/release/collect-evidence.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 # Merge per-suite evidence records (emitted by dispatch-and-wait.sh, one JSON
 # object per line) plus the static suite registry (release/bundle-suites.json)

--- a/scripts/release/dispatch-and-wait.sh
+++ b/scripts/release/dispatch-and-wait.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 # Dispatch a GitHub Actions workflow (optionally in another repo), wait for the
 # run it created, and print a one-line evidence JSON describing the result:

--- a/scripts/release/smoke-build-release-manifest.sh
+++ b/scripts/release/smoke-build-release-manifest.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 # Self-test for scripts/release/build-release-manifest.sh.
 #

--- a/scripts/release/smoke-release-bundle-pipeline.sh
+++ b/scripts/release/smoke-release-bundle-pipeline.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 # End-to-end smoke for the release-bundle data pipeline:
 #   bundle-suites.json + per-suite results

--- a/scripts/scale/run-load-soak-tests.sh
+++ b/scripts/scale/run-load-soak-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # Load/soak testing script for Honua Server
 # Runs NBomber scenarios and captures system + API metrics.

--- a/scripts/scale/scale-test.sh
+++ b/scripts/scale/scale-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # Scale-out testing script for Honua Server
 # Tests distributed caching, load balancing, and multi-instance scenarios

--- a/scripts/scale/transaction-test.sh
+++ b/scripts/scale/transaction-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 # Transaction semantics testing script for Honua Server
 # Tests actual behavior when instances fail mid-transaction

--- a/scripts/sdk/generate-control-plane-sdks.sh
+++ b/scripts/sdk/generate-control-plane-sdks.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/security/secret-management.sh
+++ b/scripts/security/secret-management.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 set -euo pipefail
 
 # Secret Management Script for Honua Server

--- a/scripts/security/verify-security-fixes.sh
+++ b/scripts/security/verify-security-fixes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+﻿#!/bin/bash
 
 #
 # Security Fixes Verification Script

--- a/tests/seed/apply-yaml-seed.sh
+++ b/tests/seed/apply-yaml-seed.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Extracts SQL statements from a version-1 seed YAML file and applies them
 # via psql. Requires: python3 (or python), pyyaml, psql.
 #


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1640

## Summary
docker/Dockerfile.lambda.aot's restore stage evaluated a different project graph than publish: the selective COPY list omitted eng/ (build-profile props) and the Honua.Plugins* csprojs, producing NETSDK1004 at publish; additionally, shell scripts copied from Windows checkouts arrived CRLF-mangled and failed under /bin/sh. This PR unifies both generations of Dockerfile fixes: trunk's #1623 set (31-project csproj pre-copy closure, HonuaSkipOracleForAotVerification, pinned digests) plus this branch's additions (eng/ + Plugins COPYs, .gitattributes eol enforcement for scripts).

## Changes Made
- Restore stage COPYs eng/ and Honua.Plugins* so restore and publish evaluate the same graph
- .gitattributes enforces LF for shell scripts (CRLF-proof on Windows checkouts/git archive)
- Conflict resolution preserves every #1623-era fix (pre-copy closure, Oracle skip prop, pinned digests)

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed — restore stage built from a clean git archive context; full graph restores cleanly

## Gate Impact
- [x] Nightly gates (conformance, performance, security) — the nightly-lambda-aot publish job consumes this Dockerfile
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None beyond fixing the Lambda image build