### PR TITLE
fix: apply Postgres session settings via connection initializer for RDS Proxy compatibility

### DIFF
--- a/docs/reference/configuration/data-sources/postgis.md
+++ b/docs/reference/configuration/data-sources/postgis.md
@@ -62,6 +62,14 @@ The preflight result is available via `GET /api/v1/admin/deploy/preflight?includ
 3. Connection pooling: Flexible Server supports built-in PgBouncer; Honua works with both direct and pooled connections.
 4. High availability: configure zone-redundant HA. Honua connects to the primary endpoint; failover is transparent at the DNS level.
 
+## Connection poolers and proxies (RDS Proxy, PgBouncer)
+
+Honua applies its PostgreSQL session settings (`lock_timeout`, `statement_timeout`, `idle_in_transaction_session_timeout`, and the default `search_path`) with plain `SET` statements that run after each physical connection opens — not via the libpq `options` startup parameter, which AWS RDS Proxy rejects (`0A000: Feature not supported: RDS Proxy currently doesn't support command-line options`) and transaction-mode poolers such as PgBouncer break on.
+
+- **AWS RDS Proxy** is supported and is the recommended way to protect connection slots when running Honua on Lambda or other rapidly scaling serverless platforms. Note that the per-connection `SET` statements cause [session pinning](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-pinning.html) on the proxy: each Honua-held connection stays pinned to one database connection. This reduces the proxy's ability to multiplex but preserves the thing the proxy is deployed for — capping total database connections; size `Limits__Connections__MaxConnectionPoolSize` accordingly.
+- **PgBouncer (transaction mode)**: connections open without errors, but transaction-mode pooling does not guarantee that session-level `SET` values follow Honua's connection across transactions. Prefer session mode, or use direct connections with Honua's own pool limits.
+- **Npgsql multiplexing** (`Limits__Connections__Multiplexing=true`, default `false`) is mutually exclusive with RDS Proxy and transaction-mode poolers: in multiplexing mode Honua intentionally keeps the session settings on the `options` startup parameter, because startup parameters are the only delivery that survives interleaved logical sessions on shared physical connections. Leave multiplexing off (the default) when connecting through any pooler or proxy.
+
 ## Pooling and admission variables
 
 | Variable | Default | Purpose |
@@ -75,6 +83,7 @@ The preflight result is available via `GET /api/v1/admin/deploy/preflight?includ
 | `Limits__Connections__StatementTimeout` / `LockTimeout` | `00:00:30` | Server-side statement and lock timeouts. |
 | `Limits__Connections__IdleInTransactionTimeout` | `00:01:00` | Idle-in-transaction timeout. |
 | `Limits__Connections__AdaptiveConcurrencyEnabled` | `false` | Adaptive query admission below the concurrency ceiling. |
+| `Limits__Connections__Multiplexing` | `false` | Npgsql multiplexing (`false`, `true`, or `auto`). Incompatible with RDS Proxy and transaction-mode poolers — see [Connection poolers and proxies](#connection-poolers-and-proxies-rds-proxy-pgbouncer). |
 
 The full admission set (adaptive bounds, target lease duration, update interval) is in the [environment variable reference](../environment-variables.md#admission-and-pooling). Pool and admission behavior can be observed at `GET /monitoring/metrics/connection-pool`.
 

--- a/docs/reference/configuration/environment-variables.md
+++ b/docs/reference/configuration/environment-variables.md
@@ -186,6 +186,9 @@ Database connection pool and query admission:
 | `Limits__Connections__AdaptiveConcurrencyMaxQueries` | `0` (= `MaxConcurrentQueries`) | Adaptive upper bound. |
 | `Limits__Connections__AdaptiveConcurrencyTargetDurationMs` | `100` | Target database lease duration. |
 | `Limits__Connections__AdaptiveConcurrencyUpdateIntervalMs` | `1000` | Min interval between adaptive adjustments. |
+| `Limits__Connections__Multiplexing` | `false` | Npgsql multiplexing (`false`, `true`, or `auto`). Incompatible with AWS RDS Proxy and transaction-mode poolers — see [PostGIS connection poolers and proxies](data-sources/postgis.md#connection-poolers-and-proxies-rds-proxy-pgbouncer). |
+
+Session settings (`StatementTimeout`, `LockTimeout`, `IdleInTransactionTimeout`, default `search_path`) are applied with `SET` statements after each physical connection opens, so Honua works behind AWS RDS Proxy and PgBouncer (session mode); see the [PostGIS pooler notes](data-sources/postgis.md#connection-poolers-and-proxies-rds-proxy-pgbouncer).
 
 Geoprocessing job admission and executor guardrails:
 

--- a/src/Honua.Postgres.Shared/Features/Infrastructure/PostgresDataSourceFactory.cs
+++ b/src/Honua.Postgres.Shared/Features/Infrastructure/PostgresDataSourceFactory.cs
@@ -80,10 +80,11 @@ internal static class PostgresDataSourceFactory
         var useMultiplexing = ResolveMultiplexing(limits.Multiplexing, schemaHeadersEnabled);
         connectionStringBuilder.Multiplexing = useMultiplexing;
         // Keep NoResetOnClose=true when schema headers are off so that RESET ALL
-        // is NOT sent on pool return — otherwise Npgsql clears the search_path set
-        // via the Options parameter, breaking schema-qualified queries on reused
-        // connections.  When schema headers are enabled (test isolation), we need
-        // the reset so per-test SET search_path overrides are cleared.
+        // is NOT sent on pool return — otherwise Npgsql clears the session settings
+        // (timeouts + search_path) applied by the physical-connection initializer
+        // below, breaking schema-qualified queries on reused connections.  When
+        // schema headers are enabled (test isolation), we need the reset so
+        // per-test SET search_path overrides are cleared.
         connectionStringBuilder.NoResetOnClose = !schemaHeadersEnabled;
 
         if (useMultiplexing)
@@ -100,26 +101,136 @@ internal static class PostgresDataSourceFactory
             connectionStringBuilder.TcpKeepAliveInterval = 2;
         }
 
-        // SECURITY: Configure lock timeouts to prevent indefinite blocking
-        var lockTimeout = (int)limits.LockTimeout.TotalSeconds;
-        var statementTimeout = (int)limits.StatementTimeout.TotalSeconds;
-        var idleTimeout = (int)limits.IdleInTransactionTimeout.TotalSeconds;
-        var options =
-            $"-c lock_timeout={lockTimeout}s -c statement_timeout={statementTimeout}s -c idle_in_transaction_session_timeout={idleTimeout}s";
+        // SECURITY: server-side timeouts (lock/statement/idle-in-transaction) prevent
+        // indefinite blocking, and an optional default search_path avoids a
+        // per-request SET round-trip. How these session settings reach the server
+        // matters (issue #1638):
+        //
+        // - Default path (no multiplexing, no schema headers): apply them via a
+        //   physical-connection initializer that runs plain SET statements right
+        //   after each physical connection opens. Combined with NoResetOnClose=true
+        //   (no RESET ALL on pool return, see above) the settings last for the
+        //   lifetime of the physical connection — identical semantics to the
+        //   previous startup-options approach. Crucially this avoids the libpq
+        //   `options` STARTUP parameter, which AWS RDS Proxy rejects outright
+        //   ("0A000: Feature not supported: RDS Proxy currently doesn't support
+        //   command-line options") and which transaction-mode poolers (pgbouncer)
+        //   break on. Behind RDS Proxy the per-connection SET causes session
+        //   pinning — acceptable: connection-slot protection is the reason a proxy
+        //   is deployed in the first place.
+        //
+        // - Multiplexing: keep the `options` startup parameter. Startup parameters
+        //   become per-session defaults that survive RESET ALL, which is the only
+        //   reliable way to guarantee these settings when commands from many logical
+        //   sessions interleave over shared physical connections. Consequence:
+        //   Limits:Connections:Multiplexing=true is mutually exclusive with
+        //   RDS Proxy / transaction-mode poolers (documented in
+        //   docs/reference/configuration/data-sources/postgis.md). Multiplexing
+        //   already defaults off (see ResolveMultiplexing).
+        //
+        // - Schema headers (test isolation): keep the `options` startup parameter.
+        //   NoResetOnClose=false in this mode, so Npgsql resets session state on
+        //   every pool return; initializer-applied SETs would be wiped by the first
+        //   reset, while startup options survive RESET ALL as session defaults. This
+        //   mode is test-only and never runs behind a connection proxy.
+        var searchPathSchema = ResolveSearchPathSchema(schemaHeadersEnabled, defaultSchema);
 
-        // When a default schema is known and schema headers are NOT active, embed
-        // search_path in the connection string. This avoids a per-connection SET
-        // round-trip and is safe with multiplexing (Options apply per-session, not
-        // per-physical-connection).
+        if (useMultiplexing || schemaHeadersEnabled)
+        {
+            connectionStringBuilder.Options = BuildSessionSettingsStartupOptions(limits, searchPathSchema);
+        }
+        else
+        {
+            var initializerSql = BuildSessionSettingsSql(limits, searchPathSchema);
+            builder.UsePhysicalConnectionInitializer(
+                connection =>
+                {
+                    using var command = connection.CreateCommand();
+                    command.CommandText = initializerSql;
+                    command.ExecuteNonQuery();
+                },
+                async connection =>
+                {
+                    await using var command = connection.CreateCommand();
+                    command.CommandText = initializerSql;
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+                });
+        }
+    }
+
+    /// <summary>
+    /// Resolves the schema embedded in the default search_path, or <see langword="null"/>
+    /// when none applies. Schema-header mode owns search_path per request, and only
+    /// values that pass the <see cref="SchemaSearchPath.IsValidIdentifier"/> allow-list
+    /// are accepted (SQL-injection guard — the value is later interpolated as a quoted
+    /// identifier).
+    /// </summary>
+    internal static string? ResolveSearchPathSchema(bool schemaHeadersEnabled, string? defaultSchema)
+    {
         if (!schemaHeadersEnabled &&
             !string.IsNullOrWhiteSpace(defaultSchema) &&
             SchemaSearchPath.IsValidIdentifier(defaultSchema))
         {
-            options += $" -c search_path=\"{defaultSchema.Trim()}\",public";
+            return defaultSchema.Trim();
         }
 
-        connectionStringBuilder.Options = options;
+        return null;
     }
+
+    /// <summary>
+    /// Builds the libpq <c>options</c> startup parameter carrying the session settings.
+    /// Used only for multiplexing and schema-header modes — RDS Proxy and
+    /// transaction-mode poolers reject this startup parameter, so the default path uses
+    /// <see cref="BuildSessionSettingsSql"/> instead.
+    /// </summary>
+    internal static string BuildSessionSettingsStartupOptions(ConnectionLimits limits, string? searchPathSchema)
+    {
+        ArgumentNullException.ThrowIfNull(limits);
+
+        var (lockTimeout, statementTimeout, idleTimeout) = GetTimeoutSeconds(limits);
+        var options =
+            $"-c lock_timeout={lockTimeout}s -c statement_timeout={statementTimeout}s -c idle_in_transaction_session_timeout={idleTimeout}s";
+
+        if (searchPathSchema is not null)
+        {
+            options += $" -c search_path=\"{searchPathSchema}\",public";
+        }
+
+        return options;
+    }
+
+    /// <summary>
+    /// Builds the <c>SET</c> batch executed by the physical-connection initializer on
+    /// the default (non-multiplexing) path. Plain SET statements after connect are
+    /// compatible with AWS RDS Proxy and pgbouncer, unlike the <c>options</c> startup
+    /// parameter (issue #1638).
+    /// </summary>
+    internal static string BuildSessionSettingsSql(ConnectionLimits limits, string? searchPathSchema)
+    {
+        ArgumentNullException.ThrowIfNull(limits);
+
+        var (lockTimeout, statementTimeout, idleTimeout) = GetTimeoutSeconds(limits);
+        // codeql[cs/sql-injection]: timeout values are integers derived from configuration
+        // TimeSpans, and searchPathSchema is validated against the ^[A-Za-z_][A-Za-z0-9_]*$
+        // allow-list in ResolveSearchPathSchema; PostgreSQL SET does not accept parameter
+        // binding for these settings.
+        var sql =
+            $"SET lock_timeout = '{lockTimeout}s'; " +
+            $"SET statement_timeout = '{statementTimeout}s'; " +
+            $"SET idle_in_transaction_session_timeout = '{idleTimeout}s';";
+
+        if (searchPathSchema is not null)
+        {
+            sql += $" SET search_path = \"{searchPathSchema}\", public;";
+        }
+
+        return sql;
+    }
+
+    private static (int LockTimeout, int StatementTimeout, int IdleTimeout) GetTimeoutSeconds(ConnectionLimits limits)
+        => ((int)limits.LockTimeout.TotalSeconds,
+            (int)limits.StatementTimeout.TotalSeconds,
+            (int)limits.IdleInTransactionTimeout.TotalSeconds);
 
     /// <summary>
     /// Resolves the effective multiplexing setting.

--- a/src/Honua.Postgres.Shared/Features/Infrastructure/SchemaSearchPath.cs
+++ b/src/Honua.Postgres.Shared/Features/Infrastructure/SchemaSearchPath.cs
@@ -27,8 +27,10 @@ internal static partial class SchemaSearchPath
             throw new InvalidOperationException($"Invalid schema name '{schemaName}'.");
         }
 
-        // Skip the SET round-trip when the connection string already embeds
-        // this schema via the Options parameter (Tier 3 optimization).
+        // Skip the SET round-trip when the data source already pins this schema as
+        // the default search_path — applied by PostgresDataSourceFactory via the
+        // physical-connection initializer (or the Options startup parameter when
+        // multiplexing is enabled). Tier 3 optimization.
         if (!string.IsNullOrWhiteSpace(connectionStringDefaultSchema) &&
             string.Equals(sanitized, connectionStringDefaultSchema.Trim(), StringComparison.Ordinal))
         {

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/PostgresDataSourceFactorySessionSettingsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/PostgresDataSourceFactorySessionSettingsTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Configuration;
+using Honua.Postgres.Features.Infrastructure;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Npgsql;
+
+namespace Honua.Server.Tests.Infrastructure;
+
+/// <summary>
+/// Integration tests proving that <see cref="PostgresDataSourceFactory"/> applies the
+/// session settings (lock/statement/idle-in-transaction timeouts and default
+/// search_path) via the physical-connection initializer — i.e. with plain SET
+/// statements after connect instead of the libpq <c>options</c> startup parameter,
+/// which AWS RDS Proxy rejects with 0A000 and transaction-mode poolers break on
+/// (issue #1638) — and that the settings survive pool return.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.TestQuality)]
+public sealed class PostgresDataSourceFactorySessionSettingsTests : IAsyncLifetime
+{
+    private readonly DatabaseFixtureAdapter _fixture;
+    private string _schemaName = null!;
+
+    public PostgresDataSourceFactorySessionSettingsTests(DatabaseFixtureAdapter fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Short label: the fixture appends "_<counter>_<32-char guid>" and the full
+        // schema name must stay within PostgreSQL's 63-byte identifier limit, or the
+        // server truncates it and the search_path assertions below fail.
+        _schemaName = await _fixture.CreateIsolatedSchemaAsync("SessionSettings");
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DropSchemaAsync(_schemaName);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Create_NonMultiplexing_AppliesSessionSettingsWithoutOptionsStartupParameter()
+    {
+        var limits = new ConnectionLimits
+        {
+            LockTimeout = TimeSpan.FromSeconds(17),
+            StatementTimeout = TimeSpan.FromSeconds(43),
+            IdleInTransactionTimeout = TimeSpan.FromSeconds(59),
+            MinConnectionPoolSize = 0,
+            MaxConnectionPoolSize = 2,
+        };
+
+        await using var dataSource = PostgresDataSourceFactory.Create(
+            _fixture.ConnectionString, schemaHeadersEnabled: false, limits, defaultSchema: _schemaName);
+
+        // The startup parameter that RDS Proxy rejects must not be present.
+        dataSource.ConnectionString.Should().NotContainEquivalentOf("options");
+
+        await using (var connection = await dataSource.OpenConnectionAsync())
+        {
+            (await ShowAsync(connection, "lock_timeout")).Should().Be("17s");
+            (await ShowAsync(connection, "statement_timeout")).Should().Be("43s");
+            (await ShowAsync(connection, "idle_in_transaction_session_timeout")).Should().Be("59s");
+            (await ShowAsync(connection, "search_path")).Should().Contain(_schemaName).And.Contain("public");
+        }
+
+        // Reopen from the pool: NoResetOnClose=true must preserve the
+        // initializer-applied settings across pool return, exactly as the old
+        // startup-options approach did.
+        await using (var connection = await dataSource.OpenConnectionAsync())
+        {
+            (await ShowAsync(connection, "lock_timeout")).Should().Be("17s");
+            (await ShowAsync(connection, "statement_timeout")).Should().Be("43s");
+            (await ShowAsync(connection, "idle_in_transaction_session_timeout")).Should().Be("59s");
+            (await ShowAsync(connection, "search_path")).Should().Contain(_schemaName).And.Contain("public");
+        }
+    }
+
+    private static async Task<string?> ShowAsync(NpgsqlConnection connection, string setting)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"SHOW {setting}";
+        return (string?)await command.ExecuteScalarAsync();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/PostgresDataSourceFactoryTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/PostgresDataSourceFactoryTests.cs
@@ -6,16 +6,21 @@ using Honua.Core.Configuration;
 using Honua.Postgres.Features.Infrastructure;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Npgsql;
 
 namespace Honua.Server.Tests.Infrastructure;
 
 /// <summary>
-/// Tests for <see cref="PostgresDataSourceFactory"/> multiplexing resolution
-/// and connection pool default tuning.
+/// Tests for <see cref="PostgresDataSourceFactory"/> multiplexing resolution,
+/// connection pool default tuning, and session-settings delivery (physical-connection
+/// initializer vs. the libpq <c>options</c> startup parameter, which AWS RDS Proxy and
+/// transaction-mode poolers reject — issue #1638).
 /// </summary>
 [Protocol(TestProtocols.TestQuality)]
 public sealed class PostgresDataSourceFactoryTests
 {
+    private const string TestConnectionString = "Host=localhost;Database=honua;Username=honua";
+
     [Theory]
     [InlineData("false", false, false)]
     [InlineData("true", false, true)]
@@ -54,5 +59,117 @@ public sealed class PostgresDataSourceFactoryTests
         limits.BufferSizeBytes.Should().Be(32768);
         limits.Multiplexing.Should().Be("false");
         limits.ConnectionAcquisitionTimeoutSeconds.Should().Be(5);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void Configure_DefaultNonMultiplexingPath_DoesNotUseOptionsStartupParameter()
+    {
+        var builder = new NpgsqlDataSourceBuilder(TestConnectionString);
+
+        PostgresDataSourceFactory.Configure(builder, schemaHeadersEnabled: false, new ConnectionLimits(), defaultSchema: "tenant");
+
+        builder.ConnectionStringBuilder.Options.Should().BeNullOrEmpty(
+            "RDS Proxy rejects the libpq options startup parameter with 0A000, so the default path must not use it");
+        builder.ConnectionStringBuilder.Multiplexing.Should().BeFalse();
+        builder.ConnectionStringBuilder.NoResetOnClose.Should().BeTrue(
+            "initializer-applied session settings must survive pool return");
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void Create_DefaultNonMultiplexingPath_ConnectionStringContainsNoOptions()
+    {
+        using var dataSource = PostgresDataSourceFactory.Create(
+            TestConnectionString, schemaHeadersEnabled: false, new ConnectionLimits(), defaultSchema: "tenant");
+
+        dataSource.ConnectionString.Should().NotContainEquivalentOf("options",
+            "RDS Proxy and transaction-mode poolers reject the options startup parameter");
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void Configure_MultiplexingEnabled_KeepsOptionsStartupParameter()
+    {
+        // Deliberate: with multiplexing, startup options are the only per-session-default
+        // delivery that survives interleaved logical sessions; multiplexing is therefore
+        // documented as mutually exclusive with RDS Proxy / transaction-mode poolers.
+        var builder = new NpgsqlDataSourceBuilder(TestConnectionString);
+        var limits = new ConnectionLimits { Multiplexing = "true" };
+
+        PostgresDataSourceFactory.Configure(builder, schemaHeadersEnabled: false, limits, defaultSchema: "tenant");
+
+        builder.ConnectionStringBuilder.Multiplexing.Should().BeTrue();
+        builder.ConnectionStringBuilder.Options.Should().Be(
+            "-c lock_timeout=30s -c statement_timeout=30s -c idle_in_transaction_session_timeout=60s -c search_path=\"tenant\",public");
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void Configure_SchemaHeadersEnabled_KeepsOptionsStartupParameterWithoutSearchPath()
+    {
+        // Schema-header (test isolation) mode resets session state on pool return
+        // (NoResetOnClose=false), which would wipe initializer-applied SETs — so the
+        // timeouts stay on the startup parameter, and search_path is owned per request.
+        var builder = new NpgsqlDataSourceBuilder(TestConnectionString);
+
+        PostgresDataSourceFactory.Configure(builder, schemaHeadersEnabled: true, new ConnectionLimits(), defaultSchema: "tenant");
+
+        builder.ConnectionStringBuilder.NoResetOnClose.Should().BeFalse();
+        builder.ConnectionStringBuilder.Options.Should().Be(
+            "-c lock_timeout=30s -c statement_timeout=30s -c idle_in_transaction_session_timeout=60s");
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void BuildSessionSettingsSql_IncludesTimeoutsAndQuotedSearchPath()
+    {
+        var limits = new ConnectionLimits
+        {
+            LockTimeout = TimeSpan.FromSeconds(11),
+            StatementTimeout = TimeSpan.FromSeconds(22),
+            IdleInTransactionTimeout = TimeSpan.FromSeconds(33),
+        };
+
+        var sql = PostgresDataSourceFactory.BuildSessionSettingsSql(limits, "tenant");
+
+        sql.Should().Contain("SET lock_timeout = '11s';");
+        sql.Should().Contain("SET statement_timeout = '22s';");
+        sql.Should().Contain("SET idle_in_transaction_session_timeout = '33s';");
+        sql.Should().Contain("SET search_path = \"tenant\", public;");
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void BuildSessionSettingsSql_WithoutSchema_OmitsSearchPath()
+    {
+        var sql = PostgresDataSourceFactory.BuildSessionSettingsSql(new ConnectionLimits(), searchPathSchema: null);
+
+        sql.Should().Contain("SET lock_timeout = '30s';");
+        sql.Should().Contain("SET statement_timeout = '30s';");
+        sql.Should().Contain("SET idle_in_transaction_session_timeout = '60s';");
+        sql.Should().NotContain("search_path");
+    }
+
+    [Theory]
+    // Valid identifiers pass through trimmed.
+    [InlineData(false, "tenant", "tenant")]
+    [InlineData(false, "Tenant_01", "Tenant_01")]
+    // Schema-header mode owns search_path per request — never embed a default.
+    [InlineData(true, "tenant", null)]
+    // Null/blank values are ignored.
+    [InlineData(false, null, null)]
+    [InlineData(false, "", null)]
+    [InlineData(false, "   ", null)]
+    // Values failing the identifier allow-list are rejected (SQL-injection guard).
+    [InlineData(false, "bad-schema", null)]
+    [InlineData(false, "tenant\";DROP TABLE x;--", null)]
+    [InlineData(false, "tenant,public", null)]
+    [Operation(Operations.TestInfrastructure)]
+    public void ResolveSearchPathSchema_AppliesIdentifierAllowList(bool schemaHeaders, string? schema, string? expected)
+    {
+        var result = PostgresDataSourceFactory.ResolveSearchPathSchema(schemaHeaders, schema);
+
+        result.Should().Be(expected);
     }
 }


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1638

## Summary
Honua Server could not run behind AWS RDS Proxy: `PostgresDataSourceFactory` delivered its session settings (`lock_timeout`, `statement_timeout`, `idle_in_transaction_session_timeout`, and the optional default `search_path`) via the libpq `options` **startup parameter**, which RDS Proxy rejects outright (`0A000: Feature not supported: RDS Proxy currently doesn't support command-line options`). This hit live on the demo stack (demo.honua.io) on 2026-06-12 — the proxy provisioned for Lambda connection-slot protection (honua-io/honua-iac#46) went healthy, but every DB-backed route then 500'd and the proxy had to be rolled back. Transaction-mode poolers (PgBouncer) break on the startup parameter too.

This PR moves the session settings off the startup parameter on the default path and onto a **physical-connection initializer** that issues plain `SET` statements right after each physical connection opens. Combined with the existing `NoResetOnClose=true` (no `RESET ALL` on pool return), the settings last for the lifetime of the physical connection — identical semantics to the previous startup-options approach, but proxy/pooler compatible. honua-io/honua-iac#46 (`db_proxy_enabled`) is unblocked by this fix.

**Multiplexing decision:** when `Limits__Connections__Multiplexing=true` (and in schema-headers test-isolation mode), the settings deliberately stay on the `options` startup parameter — startup parameters become per-session defaults that survive `RESET ALL`, the only reliable delivery when commands from many logical sessions interleave over shared physical connections (and schema-header mode runs with `NoResetOnClose=false`, which would wipe initializer-applied SETs on every pool return). Multiplexing is therefore documented as mutually exclusive with RDS Proxy / transaction-mode poolers; it already defaults off.

Behind RDS Proxy, the per-connection `SET` causes session pinning on the proxy — acceptable and documented: it preserves the thing the proxy is deployed for (capping total database connections).

## Changes Made
- `PostgresDataSourceFactory.Configure`: default (non-multiplexing, non-schema-headers) path now applies session settings via `UsePhysicalConnectionInitializer` issuing `SET` statements instead of `NpgsqlConnectionStringBuilder.Options`; multiplexing and schema-headers modes keep the startup parameter (documented inline with the rationale per mode).
- Extracted `ResolveSearchPathSchema` (preserves the `SchemaSearchPath.IsValidIdentifier` allow-list as the SQL-injection guard before the value is interpolated as a quoted identifier), `BuildSessionSettingsStartupOptions`, and `BuildSessionSettingsSql` as internal, unit-testable helpers.
- `SchemaSearchPath`: updated the Tier-3 skip comment to reflect the new delivery mechanism.
- Docs: new "Connection poolers and proxies (RDS Proxy, PgBouncer)" section in `docs/reference/configuration/data-sources/postgis.md` (session pinning note, PgBouncer guidance, multiplexing exclusivity) and `Limits__Connections__Multiplexing` rows/notes in the environment-variable reference.
- Tests: unit tests assert no `Options` on the default path, exact startup-options content for multiplexing/schema-headers modes, initializer SQL content (three timeouts + quoted search_path), and the identifier allow-list; new Testcontainers integration test proves the settings are applied via `SET` (no `options` in the connection string) and survive pool return.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [x] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

Infrastructure note: no change is required to deploy this, but it unblocks enabling `db_proxy_enabled` in the honua-iac aws-serverless module (honua-io/honua-iac#46).

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
