### PR TITLE
fix: serve ImageServer raster statistics from persisted snapshots

### DIFF
--- a/src/Honua.Core/Features/Raster/Abstractions/IRasterStore.cs
+++ b/src/Honua.Core/Features/Raster/Abstractions/IRasterStore.cs
@@ -128,7 +128,9 @@ public interface IRasterStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Calculates statistics for raster bands.
+    /// Gets statistics for raster bands. Implementations must serve persisted values
+    /// (written at import time, or computed once and persisted on first read) rather than
+    /// recomputing per request: full-pixel scans take tens of seconds on real datasets (#1639).
     /// </summary>
     /// <param name="layerId">Layer identifier containing the raster</param>
     /// <param name="rasterId">Raster identifier to analyze</param>
@@ -142,7 +144,9 @@ public interface IRasterStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Calculates statistics for a composited layer mosaic.
+    /// Gets statistics for a composited layer mosaic. Implementations must persist computed
+    /// values keyed by the layer's raster-id set and serve subsequent reads from the persisted
+    /// rows; the snapshot is invalidated when the layer's raster membership changes.
     /// </summary>
     Task<RasterStatistics[]> GetMosaicStatisticsAsync(
         int layerId,

--- a/src/Honua.Postgres/Features/Raster/PostgresRasterLog.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresRasterLog.cs
@@ -130,4 +130,28 @@ internal static partial class PostgresRasterLog
         Level = LogLevel.Debug,
         Message = "Raster storage table {TableName} is unavailable; returning an empty raster result.")]
     public static partial void RasterStorageUnavailable(ILogger logger, Exception ex, string tableName);
+
+    [LoggerMessage(
+        EventId = 7820,
+        Level = LogLevel.Information,
+        Message = "Backfilled persisted statistics for layer {LayerId}, raster {RasterId}: {BandCount} bands")]
+    public static partial void RasterStatisticsBackfilled(ILogger logger, int layerId, long rasterId, int bandCount);
+
+    [LoggerMessage(
+        EventId = 7821,
+        Level = LogLevel.Warning,
+        Message = "Failed to persist backfilled statistics for layer {LayerId}, raster {RasterId}; serving computed values without persistence")]
+    public static partial void RasterStatisticsPersistFailed(ILogger logger, Exception ex, int layerId, long rasterId);
+
+    [LoggerMessage(
+        EventId = 7822,
+        Level = LogLevel.Information,
+        Message = "Backfilled persisted mosaic statistics for layer {LayerId} ({RasterCount} rasters, {MergeStrategy}): {BandCount} bands")]
+    public static partial void LayerStatisticsBackfilled(ILogger logger, int layerId, int rasterCount, string mergeStrategy, int bandCount);
+
+    [LoggerMessage(
+        EventId = 7823,
+        Level = LogLevel.Warning,
+        Message = "Failed to persist mosaic statistics for layer {LayerId}; serving computed values without persistence")]
+    public static partial void LayerStatisticsPersistFailed(ILogger logger, Exception ex, int layerId);
 }

--- a/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
@@ -4,11 +4,14 @@
 using System.Collections.Frozen;
 using System.Data.Common;
 using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
 using Honua.Postgres.Features.Infrastructure;
 using Microsoft.Extensions.Logging;
+using Npgsql;
 
 namespace Honua.Postgres.Features.Raster;
 
@@ -22,10 +25,17 @@ internal sealed class PostgresRasterStore : IRasterStore
     private static readonly FrozenSet<string> _allowedResamplingAlgorithms = new[] { "NearestNeighbor", "Bilinear", "Cubic", "Lanczos" }.ToFrozenSet(StringComparer.Ordinal);
     private static readonly FrozenSet<string> _allowedZonalStatistics = new[] { "count", "sum", "mean", "min", "max", "stddev", "variance" }.ToFrozenSet(StringComparer.Ordinal);
 
+    // Advisory-lock namespaces for the compute-once-then-persist statistics backfill.
+    // Distinct from PostgresRasterImportService.RasterImportLayerLockNamespace (0x0484_5221)
+    // so a long-running import never serializes against a metadata read.
+    private const int RasterStatisticsLockNamespace = 0x0484_5222;
+    private const int LayerStatisticsLockNamespace = 0x0484_5223;
+
     private readonly IDatabaseConnectionProvider _connectionProvider;
     private readonly ILogger<PostgresRasterStore> _logger;
     private readonly string _rasterDataTable;
     private readonly string _rasterStatisticsTable;
+    private readonly string _rasterLayerStatisticsTable;
     private readonly string _rasterTilesTable;
     private readonly string _featuresTable;
 
@@ -39,6 +49,7 @@ internal sealed class PostgresRasterStore : IRasterStore
 
         _rasterDataTable = SchemaSearchPath.QualifyTable("raster_data", schemaName);
         _rasterStatisticsTable = SchemaSearchPath.QualifyTable("raster_statistics", schemaName);
+        _rasterLayerStatisticsTable = SchemaSearchPath.QualifyTable("raster_layer_statistics", schemaName);
         _rasterTilesTable = SchemaSearchPath.QualifyTable("raster_tiles", schemaName);
         _featuresTable = SchemaSearchPath.QualifyTable(DatabaseSchema.FeaturesTable, schemaName);
     }
@@ -904,77 +915,16 @@ internal sealed class PostgresRasterStore : IRasterStore
     {
         await using var connection = await _connectionProvider.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
 
-        // Try cached statistics first
-        await using var cachedCommand = connection.CreateCommand();
-        cachedCommand.CommandText = $"""
-            SELECT band_number, min_value, max_value, mean_value, std_dev,
-                   valid_pixel_count, nodata_pixel_count
-            FROM {_rasterStatisticsTable}
-            WHERE raster_data_id = @rasterId
-            ORDER BY band_number
-            """;
-        AddParameter(cachedCommand, "@rasterId", rasterId);
+        // Serve persisted statistics (written at import time, or backfilled below). Computing
+        // ST_SummaryStats per request scans every raster pixel and takes tens of seconds on
+        // real-world datasets (#1639), so the request path must never recompute.
+        var stats = await ReadPersistedRasterStatisticsAsync(connection, transaction: null, rasterId, cancellationToken).ConfigureAwait(false);
 
-        var stats = new List<RasterStatistics>();
-        await using var cachedReader = await cachedCommand.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        while (await cachedReader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        if (stats.Count == 0)
         {
-            stats.Add(new RasterStatistics
-            {
-                Band = cachedReader.GetInt32(0),
-                MinValue = cachedReader.IsDBNull(1) ? null : cachedReader.GetDouble(1),
-                MaxValue = cachedReader.IsDBNull(2) ? null : cachedReader.GetDouble(2),
-                MeanValue = cachedReader.IsDBNull(3) ? null : cachedReader.GetDouble(3),
-                StandardDeviation = cachedReader.IsDBNull(4) ? null : cachedReader.GetDouble(4),
-                ValidPixelCount = cachedReader.IsDBNull(5) ? 0 : cachedReader.GetInt64(5),
-                NoDataPixelCount = cachedReader.IsDBNull(6) ? 0 : cachedReader.GetInt64(6)
-            });
-        }
-
-        if (stats.Count > 0)
-        {
-            if (bands != null)
-            {
-                stats = stats.Where(s => bands.Contains(s.Band)).ToList();
-            }
-
-            PostgresRasterLog.StatisticsCalculated(_logger, layerId, rasterId, stats.Count);
-            return stats.ToArray();
-        }
-
-        // Compute statistics dynamically via PostGIS ST_SummaryStats
-        await using var computeCommand = connection.CreateCommand();
-        computeCommand.CommandText = $"""
-            SELECT band,
-                   (stats).min AS min_value,
-                   (stats).max AS max_value,
-                   (stats).mean AS mean_value,
-                   (stats).stddev AS std_dev,
-                   (stats).count AS valid_count
-            FROM (
-                SELECT generate_series(1, ST_NumBands(raster)) AS band,
-                       ST_SummaryStats(raster, generate_series(1, ST_NumBands(raster))) AS stats
-                FROM {_rasterDataTable}
-                WHERE layer_id = @layerId AND id = @rasterId
-            ) sub
-            ORDER BY band
-            """;
-        AddParameter(computeCommand, "@layerId", layerId);
-        AddParameter(computeCommand, "@rasterId", rasterId);
-
-        await using var computeReader = await computeCommand.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        while (await computeReader.ReadAsync(cancellationToken).ConfigureAwait(false))
-        {
-            stats.Add(new RasterStatistics
-            {
-                Band = computeReader.GetInt32(0),
-                MinValue = computeReader.IsDBNull(1) ? null : computeReader.GetDouble(1),
-                MaxValue = computeReader.IsDBNull(2) ? null : computeReader.GetDouble(2),
-                MeanValue = computeReader.IsDBNull(3) ? null : computeReader.GetDouble(3),
-                StandardDeviation = computeReader.IsDBNull(4) ? null : computeReader.GetDouble(4),
-                ValidPixelCount = computeReader.IsDBNull(5) ? 0 : computeReader.GetInt64(5),
-                NoDataPixelCount = 0
-            });
+            // Lazy backfill for rasters registered before statistics persistence existed:
+            // compute once, persist, then serve the persisted rows forever.
+            stats = await BackfillRasterStatisticsAsync(connection, layerId, rasterId, cancellationToken).ConfigureAwait(false);
         }
 
         if (bands != null)
@@ -1001,7 +951,292 @@ internal sealed class PostgresRasterStore : IRasterStore
 
         await using var connection = await _connectionProvider.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
 
+        // Mosaic statistics are keyed by (layer, merge strategy, raster-id set) so any change
+        // to the layer's raster membership invalidates the persisted rows automatically.
+        var signature = CreateMosaicSignature(rasterIds);
+        var strategyKey = mergeStrategy.ToString();
+
+        var stats = await ReadPersistedLayerStatisticsAsync(connection, transaction: null, layerId, strategyKey, signature, cancellationToken).ConfigureAwait(false);
+
+        if (stats.Count == 0)
+        {
+            stats = await BackfillLayerStatisticsAsync(connection, layerId, rasterIds, mergeStrategy, strategyKey, signature, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (bands != null)
+        {
+            stats = stats.Where(s => bands.Contains(s.Band)).ToList();
+        }
+
+        return stats.ToArray();
+    }
+
+    // =============================================================================
+    // Statistics persistence (compute-once-then-persist backfill, #1639)
+    // =============================================================================
+
+    /// <summary>
+    /// Backfills per-raster band statistics: serializes concurrent cold readers behind a
+    /// transaction-scoped advisory lock (thundering-herd guard), computes ST_SummaryStats once,
+    /// persists the rows into <c>raster_statistics</c>, and returns them. If persistence is not
+    /// possible (e.g. a read-only connection) the computed values are still served.
+    /// </summary>
+    private async Task<List<RasterStatistics>> BackfillRasterStatisticsAsync(
+        DbConnection connection,
+        int layerId,
+        long rasterId,
+        CancellationToken cancellationToken)
+    {
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        await AcquireBackfillLockAsync(connection, transaction, RasterStatisticsLockNamespace, HashLockKey(rasterId), cancellationToken).ConfigureAwait(false);
+
+        // Another request may have computed and committed while we waited on the lock.
+        var persisted = await ReadPersistedRasterStatisticsAsync(connection, transaction, rasterId, cancellationToken).ConfigureAwait(false);
+        if (persisted.Count > 0)
+        {
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return persisted;
+        }
+
+        try
+        {
+            // Compute and persist in a single statement (mirrors the import-time
+            // ComputeAndStoreStatisticsAsync semantics, including nodata_pixel_count).
+            await using (var command = connection.CreateCommand())
+            {
+                command.Transaction = transaction;
+                command.CommandText = $"""
+                    INSERT INTO {_rasterStatisticsTable}
+                        (raster_data_id, band_number, min_value, max_value, mean_value, std_dev, valid_pixel_count, nodata_pixel_count)
+                    SELECT @rasterId, sub.band,
+                           (sub.stats).min, (sub.stats).max, (sub.stats).mean, (sub.stats).stddev,
+                           (sub.stats).count,
+                           GREATEST(sub.total_pixels - (sub.stats).count, 0)
+                    FROM (
+                        SELECT generate_series(1, ST_NumBands(raster)) AS band,
+                               ST_SummaryStats(raster, generate_series(1, ST_NumBands(raster))) AS stats,
+                               (ST_Width(raster)::bigint * ST_Height(raster)::bigint) AS total_pixels
+                        FROM {_rasterDataTable}
+                        WHERE layer_id = @layerId AND id = @rasterId
+                    ) sub
+                    ON CONFLICT (raster_data_id, band_number) DO NOTHING
+                    """;
+                AddParameter(command, "@layerId", layerId);
+                AddParameter(command, "@rasterId", rasterId);
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            var stats = await ReadPersistedRasterStatisticsAsync(connection, transaction, rasterId, cancellationToken).ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            PostgresRasterLog.RasterStatisticsBackfilled(_logger, layerId, rasterId, stats.Count);
+            return stats;
+        }
+        catch (PostgresException ex)
+        {
+            // Persistence is best-effort: fall back to computing without persisting so
+            // read-only deployments keep working (at the old per-request cost).
+            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            PostgresRasterLog.RasterStatisticsPersistFailed(_logger, ex, layerId, rasterId);
+            return await ComputeRasterStatisticsAsync(connection, layerId, rasterId, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Backfills layer-level mosaic statistics into <c>raster_layer_statistics</c>, pruning rows
+    /// persisted for a previous raster-id set of the same merge strategy. Follows the same
+    /// advisory-lock + compute-once-then-persist pattern as <see cref="BackfillRasterStatisticsAsync"/>.
+    /// </summary>
+    private async Task<List<RasterStatistics>> BackfillLayerStatisticsAsync(
+        DbConnection connection,
+        int layerId,
+        long[] rasterIds,
+        RasterMergeStrategy mergeStrategy,
+        string strategyKey,
+        string signature,
+        CancellationToken cancellationToken)
+    {
+        // Self-provision the snapshot table so already-registered datasets backfill without a
+        // manual migration (same pattern as PostgresMetadataV2GraphStore.EnsureSchemaAsync —
+        // a no-op once 003_CreateRasterLayerStatistics.sql has been applied). Best-effort: a
+        // read-only connection simply keeps the legacy compute path below.
+        await TryEnsureLayerStatisticsTableAsync(connection, cancellationToken).ConfigureAwait(false);
+
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        await AcquireBackfillLockAsync(connection, transaction, LayerStatisticsLockNamespace, layerId, cancellationToken).ConfigureAwait(false);
+
+        List<RasterStatistics> persisted;
+        try
+        {
+            persisted = await ReadPersistedLayerStatisticsAsync(connection, transaction, layerId, strategyKey, signature, cancellationToken).ConfigureAwait(false);
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UndefinedTable)
+        {
+            // Table could not be provisioned (read-only deployment); compute without persisting.
+            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            PostgresRasterLog.LayerStatisticsPersistFailed(_logger, ex, layerId);
+            return await ComputeMosaicStatisticsAsync(connection, transaction: null, layerId, rasterIds, mergeStrategy, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (persisted.Count > 0)
+        {
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return persisted;
+        }
+
+        var computed = await ComputeMosaicStatisticsAsync(connection, transaction, layerId, rasterIds, mergeStrategy, cancellationToken).ConfigureAwait(false);
+        if (computed.Count == 0)
+        {
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return computed;
+        }
+
+        try
+        {
+            // Prune rows computed for a previous raster-id set of this strategy, then persist.
+            await using (var prune = connection.CreateCommand())
+            {
+                prune.Transaction = transaction;
+                prune.CommandText = $"""
+                    DELETE FROM {_rasterLayerStatisticsTable}
+                    WHERE layer_id = @layerId AND merge_strategy = @strategy AND raster_signature <> @signature
+                    """;
+                AddParameter(prune, "@layerId", layerId);
+                AddParameter(prune, "@strategy", strategyKey);
+                AddParameter(prune, "@signature", signature);
+                await prune.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            foreach (var band in computed)
+            {
+                await using var insert = connection.CreateCommand();
+                insert.Transaction = transaction;
+                insert.CommandText = $"""
+                    INSERT INTO {_rasterLayerStatisticsTable}
+                        (layer_id, merge_strategy, raster_signature, band_number, min_value, max_value, mean_value, std_dev, valid_pixel_count, nodata_pixel_count)
+                    VALUES (@layerId, @strategy, @signature, @band, @min, @max, @mean, @stddev, @validCount, @noDataCount)
+                    ON CONFLICT (layer_id, merge_strategy, raster_signature, band_number) DO NOTHING
+                    """;
+                AddParameter(insert, "@layerId", layerId);
+                AddParameter(insert, "@strategy", strategyKey);
+                AddParameter(insert, "@signature", signature);
+                AddParameter(insert, "@band", band.Band);
+                AddParameter(insert, "@min", (object?)band.MinValue ?? DBNull.Value);
+                AddParameter(insert, "@max", (object?)band.MaxValue ?? DBNull.Value);
+                AddParameter(insert, "@mean", (object?)band.MeanValue ?? DBNull.Value);
+                AddParameter(insert, "@stddev", (object?)band.StandardDeviation ?? DBNull.Value);
+                AddParameter(insert, "@validCount", band.ValidPixelCount);
+                AddParameter(insert, "@noDataCount", band.NoDataPixelCount);
+                await insert.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            PostgresRasterLog.LayerStatisticsBackfilled(_logger, layerId, rasterIds.Length, strategyKey, computed.Count);
+        }
+        catch (PostgresException ex)
+        {
+            // Persistence is best-effort; still serve the computed values.
+            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            PostgresRasterLog.LayerStatisticsPersistFailed(_logger, ex, layerId);
+        }
+
+        return computed;
+    }
+
+    private async Task<List<RasterStatistics>> ReadPersistedRasterStatisticsAsync(
+        DbConnection connection,
+        DbTransaction? transaction,
+        long rasterId,
+        CancellationToken cancellationToken)
+    {
         await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = $"""
+            SELECT band_number, min_value, max_value, mean_value, std_dev,
+                   valid_pixel_count, nodata_pixel_count
+            FROM {_rasterStatisticsTable}
+            WHERE raster_data_id = @rasterId
+            ORDER BY band_number
+            """;
+        AddParameter(command, "@rasterId", rasterId);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        return await ReadStatisticsRowsAsync(reader, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<List<RasterStatistics>> ReadPersistedLayerStatisticsAsync(
+        DbConnection connection,
+        DbTransaction? transaction,
+        int layerId,
+        string strategyKey,
+        string signature,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = $"""
+                SELECT band_number, min_value, max_value, mean_value, std_dev,
+                       valid_pixel_count, nodata_pixel_count
+                FROM {_rasterLayerStatisticsTable}
+                WHERE layer_id = @layerId AND merge_strategy = @strategy AND raster_signature = @signature
+                ORDER BY band_number
+                """;
+            AddParameter(command, "@layerId", layerId);
+            AddParameter(command, "@strategy", strategyKey);
+            AddParameter(command, "@signature", signature);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            return await ReadStatisticsRowsAsync(reader, cancellationToken).ConfigureAwait(false);
+        }
+        catch (PostgresException ex) when (transaction is null && ex.SqlState == PostgresErrorCodes.UndefinedTable)
+        {
+            // Snapshot table not provisioned yet; treat as a cache miss so the backfill
+            // path can create it. Inside a transaction the error must propagate because
+            // the transaction is already aborted.
+            return [];
+        }
+    }
+
+    private async Task<List<RasterStatistics>> ComputeRasterStatisticsAsync(
+        DbConnection connection,
+        int layerId,
+        long rasterId,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            SELECT band,
+                   (stats).min AS min_value,
+                   (stats).max AS max_value,
+                   (stats).mean AS mean_value,
+                   (stats).stddev AS std_dev,
+                   (stats).count AS valid_count
+            FROM (
+                SELECT generate_series(1, ST_NumBands(raster)) AS band,
+                       ST_SummaryStats(raster, generate_series(1, ST_NumBands(raster))) AS stats
+                FROM {_rasterDataTable}
+                WHERE layer_id = @layerId AND id = @rasterId
+            ) sub
+            ORDER BY band
+            """;
+        AddParameter(command, "@layerId", layerId);
+        AddParameter(command, "@rasterId", rasterId);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        return await ReadStatisticsRowsAsync(reader, cancellationToken, hasNoDataColumn: false).ConfigureAwait(false);
+    }
+
+    private async Task<List<RasterStatistics>> ComputeMosaicStatisticsAsync(
+        DbConnection connection,
+        DbTransaction? transaction,
+        int layerId,
+        long[] rasterIds,
+        RasterMergeStrategy mergeStrategy,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
         command.CommandText = $"""
             WITH requested AS (
                 SELECT unnest(@rasterIds) AS raster_id
@@ -1037,8 +1272,16 @@ internal sealed class PostgresRasterStore : IRasterStore
         AddParameter(command, "@layerId", layerId);
         AddParameter(command, "@rasterIds", rasterIds);
 
-        var stats = new List<RasterStatistics>();
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        return await ReadStatisticsRowsAsync(reader, cancellationToken, hasNoDataColumn: false).ConfigureAwait(false);
+    }
+
+    private static async Task<List<RasterStatistics>> ReadStatisticsRowsAsync(
+        DbDataReader reader,
+        CancellationToken cancellationToken,
+        bool hasNoDataColumn = true)
+    {
+        var stats = new List<RasterStatistics>();
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
             stats.Add(new RasterStatistics
@@ -1049,16 +1292,76 @@ internal sealed class PostgresRasterStore : IRasterStore
                 MeanValue = reader.IsDBNull(3) ? null : reader.GetDouble(3),
                 StandardDeviation = reader.IsDBNull(4) ? null : reader.GetDouble(4),
                 ValidPixelCount = reader.IsDBNull(5) ? 0 : reader.GetInt64(5),
-                NoDataPixelCount = 0
+                NoDataPixelCount = hasNoDataColumn && !reader.IsDBNull(6) ? reader.GetInt64(6) : 0
             });
         }
 
-        if (bands != null)
-        {
-            stats = stats.Where(s => bands.Contains(s.Band)).ToList();
-        }
+        return stats;
+    }
 
-        return stats.ToArray();
+    private async Task TryEnsureLayerStatisticsTableAsync(DbConnection connection, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            CREATE TABLE IF NOT EXISTS {_rasterLayerStatisticsTable} (
+                layer_id INTEGER NOT NULL,
+                merge_strategy VARCHAR(32) NOT NULL,
+                raster_signature TEXT NOT NULL,
+                band_number INTEGER NOT NULL,
+                min_value DOUBLE PRECISION,
+                max_value DOUBLE PRECISION,
+                mean_value DOUBLE PRECISION,
+                std_dev DOUBLE PRECISION,
+                valid_pixel_count BIGINT,
+                nodata_pixel_count BIGINT,
+                computed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                PRIMARY KEY (layer_id, merge_strategy, raster_signature, band_number)
+            )
+            """;
+
+        try
+        {
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (PostgresException ex) when (
+            ex.SqlState is PostgresErrorCodes.UniqueViolation
+                or PostgresErrorCodes.DuplicateTable
+                or PostgresErrorCodes.DuplicateObject
+                or PostgresErrorCodes.InsufficientPrivilege
+                or PostgresErrorCodes.ReadOnlySqlTransaction)
+        {
+            // Concurrent CREATE TABLE IF NOT EXISTS race, or a read-only deployment.
+            // Both are tolerated: the read path treats a missing table as a cache miss.
+        }
+    }
+
+    private static async Task AcquireBackfillLockAsync(
+        DbConnection connection,
+        DbTransaction transaction,
+        int lockNamespace,
+        int lockKey,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "SELECT pg_advisory_xact_lock(@namespace, @lockKey);";
+        AddParameter(command, "@namespace", lockNamespace);
+        AddParameter(command, "@lockKey", lockKey);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static int HashLockKey(long value) => unchecked((int)value ^ (int)(value >>> 32));
+
+    /// <summary>
+    /// Builds a deterministic identity for a layer's mosaic source set. Any raster added to or
+    /// removed from the layer changes the signature, which invalidates persisted mosaic rows.
+    /// </summary>
+    private static string CreateMosaicSignature(long[] rasterIds)
+    {
+        var ordered = rasterIds.Distinct().Order().ToArray();
+        var joined = string.Join(",", ordered);
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(joined));
+        return string.Create(CultureInfo.InvariantCulture, $"{ordered.Length}:{Convert.ToHexStringLower(hash)}");
     }
 
     /// <inheritdoc />

--- a/src/Honua.Postgres/Migrations/003_CreateRasterLayerStatistics.sql
+++ b/src/Honua.Postgres/Migrations/003_CreateRasterLayerStatistics.sql
@@ -1,0 +1,33 @@
+-- Migration: Create Raster Layer Statistics Table
+-- Description: Persists layer-level (mosaic) band statistics so GeoServices ImageServer
+--              service metadata is served from persisted values instead of recomputing
+--              ST_SummaryStats over every raster tile per request (#1639).
+-- Version: 1.0
+-- Date: 2026-06-12
+--
+-- Rows are keyed by (layer_id, merge_strategy, raster_signature, band_number) where
+-- raster_signature is a deterministic digest of the layer's raster-id set. Importing or
+-- deleting a raster changes the signature, so stale rows are ignored and pruned by the
+-- next compute-once-then-persist backfill.
+--
+-- NOTE: PostgresRasterStore also self-provisions this table at runtime
+-- (CREATE TABLE IF NOT EXISTS) so deployments registered before this migration backfill
+-- lazily. Keep this definition byte-compatible with
+-- PostgresRasterStore.TryEnsureLayerStatisticsTableAsync.
+
+CREATE TABLE IF NOT EXISTS honua.raster_layer_statistics (
+    layer_id INTEGER NOT NULL,
+    merge_strategy VARCHAR(32) NOT NULL,
+    raster_signature TEXT NOT NULL,
+    band_number INTEGER NOT NULL,
+    min_value DOUBLE PRECISION,
+    max_value DOUBLE PRECISION,
+    mean_value DOUBLE PRECISION,
+    std_dev DOUBLE PRECISION,
+    valid_pixel_count BIGINT,
+    nodata_pixel_count BIGINT,
+    computed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (layer_id, merge_strategy, raster_signature, band_number)
+);
+
+COMMENT ON TABLE honua.raster_layer_statistics IS 'Persisted layer-level (mosaic) band statistics served by ImageServer/WCS metadata endpoints; invalidated by raster_signature when the layer''s raster set changes';

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterStoreStatisticsTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterStoreStatisticsTests.cs
@@ -1,0 +1,317 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Postgres.Features.Raster;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+
+namespace Honua.Postgres.Tests.Features.Raster;
+
+/// <summary>
+/// Verifies the compute-once-then-persist statistics behavior behind ImageServer/WCS
+/// service metadata (#1639): statistics must be served from persisted rows and never
+/// recomputed per request once a backfill has run.
+/// </summary>
+[Collection("Database")]
+public sealed class PostgresRasterStoreStatisticsTests(PostgresFixture fixture)
+{
+    private const int LayerId = 1639;
+
+    [IntegrationTest]
+    public async Task GetStatisticsAsync_WithoutPersistedRows_BackfillsAndServesPersistedValues()
+    {
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreStatisticsTests));
+        try
+        {
+            await CreateRasterTablesAsync(schemaName);
+            var rasterId = await InsertConstantRasterAsync(schemaName, "single", value: 7, upperLeftX: 0);
+            var store = CreateStore(schemaName);
+
+            var first = await store.GetStatisticsAsync(LayerId, rasterId);
+
+            first.Should().ContainSingle();
+            first[0].Band.Should().Be(1);
+            first[0].MinValue.Should().Be(7);
+            first[0].MaxValue.Should().Be(7);
+            first[0].MeanValue.Should().Be(7);
+            first[0].ValidPixelCount.Should().Be(4);
+            first[0].NoDataPixelCount.Should().Be(0);
+
+            (await CountAsync(schemaName, "SELECT COUNT(*) FROM raster_statistics WHERE raster_data_id = " + rasterId))
+                .Should().Be(1, "the first read must persist the computed statistics");
+
+            // Tamper with the persisted row: a second read must serve the tampered value,
+            // proving it does not recompute from the raster pixels.
+            await ExecuteAsync(schemaName, $"UPDATE raster_statistics SET min_value = -123 WHERE raster_data_id = {rasterId}");
+
+            var second = await store.GetStatisticsAsync(LayerId, rasterId);
+
+            second.Should().ContainSingle();
+            second[0].MinValue.Should().Be(-123);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task GetStatisticsAsync_ConcurrentColdReads_PersistExactlyOneRowSetPerBand()
+    {
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreStatisticsTests));
+        try
+        {
+            await CreateRasterTablesAsync(schemaName);
+            var rasterId = await InsertTwoBandRasterAsync(schemaName);
+            var store = CreateStore(schemaName);
+
+            var results = await Task.WhenAll(
+                Enumerable.Range(0, 4).Select(_ => store.GetStatisticsAsync(LayerId, rasterId)));
+
+            foreach (var result in results)
+            {
+                result.Should().HaveCount(2);
+                result[0].MeanValue.Should().Be(10);
+                result[1].MeanValue.Should().Be(20);
+            }
+
+            (await CountAsync(schemaName, "SELECT COUNT(*) FROM raster_statistics WHERE raster_data_id = " + rasterId))
+                .Should().Be(2, "the advisory lock must guard against a thundering herd of writers");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task GetMosaicStatisticsAsync_WithoutPersistedRows_BackfillsLayerStatisticsAndServesPersistedValues()
+    {
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreStatisticsTests));
+        try
+        {
+            // raster_layer_statistics is intentionally not created here: the store must
+            // self-provision it (lazy backfill on deployments without the 003 migration).
+            await CreateRasterTablesAsync(schemaName);
+            var west = await InsertConstantRasterAsync(schemaName, "west", value: 10, upperLeftX: 0);
+            var east = await InsertConstantRasterAsync(schemaName, "east", value: 30, upperLeftX: 2);
+            var store = CreateStore(schemaName);
+
+            var first = await store.GetMosaicStatisticsAsync(LayerId, [west, east], RasterMergeStrategy.Newest);
+
+            first.Should().ContainSingle();
+            first[0].MinValue.Should().Be(10);
+            first[0].MaxValue.Should().Be(30);
+            first[0].MeanValue.Should().Be(20);
+
+            (await CountAsync(schemaName, $"SELECT COUNT(*) FROM raster_layer_statistics WHERE layer_id = {LayerId}"))
+                .Should().Be(1, "the first mosaic read must persist the layer-level statistics");
+
+            await ExecuteAsync(schemaName, $"UPDATE raster_layer_statistics SET max_value = 999 WHERE layer_id = {LayerId}");
+
+            var second = await store.GetMosaicStatisticsAsync(LayerId, [west, east], RasterMergeStrategy.Newest);
+
+            second.Should().ContainSingle();
+            second[0].MaxValue.Should().Be(999, "repeat reads must serve the persisted snapshot, not recompute the mosaic");
+
+            // The band filter must also be applied to persisted rows.
+            var filtered = await store.GetMosaicStatisticsAsync(LayerId, [west, east], RasterMergeStrategy.Newest, bands: [2]);
+            filtered.Should().BeEmpty();
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task GetMosaicStatisticsAsync_WhenRasterSetChanges_RecomputesAndPrunesStaleRows()
+    {
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreStatisticsTests));
+        try
+        {
+            await CreateRasterTablesAsync(schemaName);
+            var west = await InsertConstantRasterAsync(schemaName, "west", value: 10, upperLeftX: 0);
+            var east = await InsertConstantRasterAsync(schemaName, "east", value: 30, upperLeftX: 2);
+            var store = CreateStore(schemaName);
+
+            var initial = await store.GetMosaicStatisticsAsync(LayerId, [west, east], RasterMergeStrategy.Newest);
+            initial.Should().ContainSingle().Which.MaxValue.Should().Be(30);
+
+            // A new raster joins the layer: the signature changes, the persisted snapshot
+            // must be recomputed and stale rows for the old raster set pruned.
+            var north = await InsertConstantRasterAsync(schemaName, "north", value: 50, upperLeftX: 4);
+
+            var updated = await store.GetMosaicStatisticsAsync(LayerId, [west, east, north], RasterMergeStrategy.Newest);
+
+            updated.Should().ContainSingle();
+            updated[0].MaxValue.Should().Be(50);
+
+            (await CountAsync(schemaName, $"SELECT COUNT(DISTINCT raster_signature) FROM raster_layer_statistics WHERE layer_id = {LayerId}"))
+                .Should().Be(1, "stale signatures must be pruned when a new snapshot is persisted");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    private PostgresRasterStore CreateStore(string schemaName)
+        => new(
+            new FixtureConnectionProvider(fixture.DataSource),
+            NullLogger<PostgresRasterStore>.Instance,
+            schemaName);
+
+    private async Task CreateRasterTablesAsync(string schemaName)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TABLE IF NOT EXISTS raster_data (
+                id BIGSERIAL PRIMARY KEY,
+                layer_id INTEGER NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                raster raster NOT NULL,
+                acquisition_date TIMESTAMPTZ,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ,
+                width INTEGER GENERATED ALWAYS AS (ST_Width(raster)) STORED,
+                height INTEGER GENERATED ALWAYS AS (ST_Height(raster)) STORED,
+                band_count INTEGER GENERATED ALWAYS AS (ST_NumBands(raster)) STORED,
+                pixel_type VARCHAR(10) GENERATED ALWAYS AS (ST_BandPixelType(raster, 1)) STORED,
+                srid INTEGER GENERATED ALWAYS AS (ST_SRID(raster)) STORED
+            );
+
+            CREATE TABLE IF NOT EXISTS raster_statistics (
+                id BIGSERIAL PRIMARY KEY,
+                raster_data_id BIGINT NOT NULL REFERENCES raster_data(id) ON DELETE CASCADE,
+                band_number INTEGER NOT NULL,
+                min_value DOUBLE PRECISION,
+                max_value DOUBLE PRECISION,
+                mean_value DOUBLE PRECISION,
+                std_dev DOUBLE PRECISION,
+                valid_pixel_count BIGINT,
+                nodata_pixel_count BIGINT,
+                computed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT raster_statistics_unique_band UNIQUE (raster_data_id, band_number)
+            );
+            """;
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private async Task<long> InsertConstantRasterAsync(string schemaName, string name, double value, double upperLeftX)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO raster_data (layer_id, name, raster, acquisition_date, created_at)
+            SELECT @layerId,
+                   @name,
+                   ST_AddBand(
+                       ST_MakeEmptyRaster(2, 2, @upperLeftX, 2, 1, -1, 0, 0, 4326),
+                       '32BF'::text,
+                       @value,
+                       NULL
+                   ),
+                   NOW(),
+                   NOW()
+            RETURNING id;
+            """;
+        command.Parameters.AddWithValue("layerId", LayerId);
+        command.Parameters.AddWithValue("name", name);
+        command.Parameters.AddWithValue("upperLeftX", upperLeftX);
+        command.Parameters.AddWithValue("value", value);
+        return (long)(await command.ExecuteScalarAsync())!;
+    }
+
+    private async Task<long> InsertTwoBandRasterAsync(string schemaName)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO raster_data (layer_id, name, raster, acquisition_date, created_at)
+            SELECT @layerId,
+                   'two-band',
+                   ST_AddBand(
+                       ST_AddBand(
+                           ST_MakeEmptyRaster(2, 2, 0, 2, 1, -1, 0, 0, 4326),
+                           '32BF'::text,
+                           10,
+                           NULL
+                       ),
+                       '32BF'::text,
+                       20,
+                       NULL
+                   ),
+                   NOW(),
+                   NOW()
+            RETURNING id;
+            """;
+        command.Parameters.AddWithValue("layerId", LayerId);
+        return (long)(await command.ExecuteScalarAsync())!;
+    }
+
+    private async Task<long> CountAsync(string schemaName, string sql)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        return (long)(await command.ExecuteScalarAsync())!;
+    }
+
+    private async Task ExecuteAsync(string schemaName, string sql)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private sealed class FixtureConnectionProvider(NpgsqlDataSource dataSource) : IDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => dataSource.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+            => await dataSource.OpenConnectionAsync(cancellationToken);
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var connection = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var transaction = await connection.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (connection, transaction);
+            }
+            catch
+            {
+                await connection.DisposeAsync();
+                throw;
+            }
+        }
+
+        public async Task<T> ExecuteWithDeadlockRetryAsync<T>(
+            Func<Task<T>> operation,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await operation();
+        }
+
+        public async Task ExecuteWithDeadlockRetryAsync(
+            Func<Task> operation,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await operation();
+        }
+    }
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMosaicIntegrationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMosaicIntegrationTests.cs
@@ -203,6 +203,48 @@ public sealed class ImageServerMosaicIntegrationTests
     }
 
     [IntegrationTest]
+    [Endpoint("GET /rest/services/{id}/ImageServer")]
+    [Operation(Operations.GetServiceInfo)]
+    public async Task GetServiceInfo_ServesBandStatisticsFromPersistedMosaicSnapshot()
+    {
+        var fixture = await CreateFixtureAsync();
+        try
+        {
+            // The first request backfills the persisted layer-level statistics snapshot (#1639).
+            var first = await fixture.Client.GetAsync($"/rest/services/{WebAppFixture.TestLayerId}/ImageServer?f=json");
+            first.StatusCode.Should().Be(HttpStatusCode.OK);
+            using (var json = JsonDocument.Parse(await first.Content.ReadAsStringAsync()))
+            {
+                json.RootElement.GetProperty("minValues")[0].GetDouble().Should().Be(5);
+                json.RootElement.GetProperty("maxValues")[0].GetDouble().Should().Be(40);
+            }
+
+            // Tamper with the persisted snapshot. The next request must serve the tampered
+            // value verbatim, proving service metadata is read from persisted statistics and
+            // never recomputed from the raster pixels per request.
+            await using (var connection = await fixture.Postgres.GetConnectionAsync(fixture.CurrentSchema))
+            await using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "UPDATE honua.raster_layer_statistics SET max_value = 12345 WHERE layer_id = @layerId;";
+                command.Parameters.AddWithValue("layerId", WebAppFixture.TestLayerId);
+                var tampered = await command.ExecuteNonQueryAsync();
+                tampered.Should().BeGreaterThan(0, "the first request must have persisted the mosaic statistics");
+            }
+
+            var second = await fixture.Client.GetAsync($"/rest/services/{WebAppFixture.TestLayerId}/ImageServer?f=json");
+            second.StatusCode.Should().Be(HttpStatusCode.OK);
+            using (var json = JsonDocument.Parse(await second.Content.ReadAsStringAsync()))
+            {
+                json.RootElement.GetProperty("maxValues")[0].GetDouble().Should().Be(12345);
+            }
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
     [Endpoint("GET /rest/services/{id}/ImageServer/exportImage")]
     [Operation(Operations.Export)]
     public async Task ExportImage_AsInlineJpegMosaic_AppliesCompressionQuality()

--- a/tests/seed/base-schema.sql
+++ b/tests/seed/base-schema.sql
@@ -186,6 +186,24 @@ CREATE TABLE IF NOT EXISTS honua.raster_statistics (
     CONSTRAINT raster_statistics_unique_band UNIQUE (raster_data_id, band_number)
 );
 
+-- Layer-level (mosaic) band statistics persisted by PostgresRasterStore so ImageServer
+-- service metadata is served from persisted values instead of per-request ST_SummaryStats
+-- (#1639). Keep in sync with src/Honua.Postgres/Migrations/003_CreateRasterLayerStatistics.sql.
+CREATE TABLE IF NOT EXISTS honua.raster_layer_statistics (
+    layer_id INTEGER NOT NULL,
+    merge_strategy VARCHAR(32) NOT NULL,
+    raster_signature TEXT NOT NULL,
+    band_number INTEGER NOT NULL,
+    min_value DOUBLE PRECISION,
+    max_value DOUBLE PRECISION,
+    mean_value DOUBLE PRECISION,
+    std_dev DOUBLE PRECISION,
+    valid_pixel_count BIGINT,
+    nodata_pixel_count BIGINT,
+    computed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (layer_id, merge_strategy, raster_signature, band_number)
+);
+
 CREATE TABLE IF NOT EXISTS honua.raster_tiles (
     id BIGSERIAL PRIMARY KEY,
     raster_data_id BIGINT NOT NULL REFERENCES honua.raster_data(id) ON DELETE CASCADE,

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -220,6 +220,23 @@ sql:
           CONSTRAINT raster_statistics_unique_band UNIQUE (raster_data_id, band_number)
       );
   - "CREATE INDEX IF NOT EXISTS idx_raster_statistics_raster_data_id ON honua.raster_statistics(raster_data_id);"
+  # Layer-level (mosaic) band statistics persisted by PostgresRasterStore (#1639).
+  # Keep in sync with src/Honua.Postgres/Migrations/003_CreateRasterLayerStatistics.sql.
+  - |
+      CREATE TABLE IF NOT EXISTS honua.raster_layer_statistics (
+          layer_id INTEGER NOT NULL,
+          merge_strategy VARCHAR(32) NOT NULL,
+          raster_signature TEXT NOT NULL,
+          band_number INTEGER NOT NULL,
+          min_value DOUBLE PRECISION,
+          max_value DOUBLE PRECISION,
+          mean_value DOUBLE PRECISION,
+          std_dev DOUBLE PRECISION,
+          valid_pixel_count BIGINT,
+          nodata_pixel_count BIGINT,
+          computed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          PRIMARY KEY (layer_id, merge_strategy, raster_signature, band_number)
+      );
   - |
       CREATE TABLE IF NOT EXISTS honua.raster_tiles (
           id BIGSERIAL PRIMARY KEY,


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1639

## Summary
GeoServices ImageServer service metadata (`GET /rest/services/{id}/ImageServer?f=json`) took 30-40+ seconds on real PostGIS-raster datasets (the live demo's `maui-hillshade` answered in 30.4s, `maui-imagery` timed out at 40s) while FeatureServer metadata answered in 0.38s. Since `?f=json` is the first request every Esri client makes (esri-leaflet, ArcGIS JS API, ArcGIS Pro), every add-layer stalled for 30-40s.

Root cause (confirmed in code): `PostgresRasterStore` recomputed band statistics from the raster pixels on every request.
- `GetMosaicStatisticsAsync` always ran `ST_Union` + `ST_SummaryStats` over every raster in the layer, per call - the dominant cost for multi-raster mosaic layers like the demo's.
- `GetStatisticsAsync` fell back to a full `ST_SummaryStats` pixel scan whenever `raster_statistics` had no rows for the raster (datasets registered outside the import pipeline) and never persisted the result, so every request paid the scan again.

Statistics are now compute-once-then-persist and the request path never recomputes. Expected post-fix latency: the first `?f=json` per dataset after deploy pays one final compute (lazy backfill), every subsequent request is an indexed snapshot read - the same order of magnitude as FeatureServer metadata (~0.4s) instead of 30-40s. The metadata document is semantically unchanged for Esri clients (same values, now read from persisted rows).

## Changes Made
- `GetStatisticsAsync` serves persisted `raster_statistics` rows and lazily backfills missing ones in a single compute+insert statement with the same semantics as the import-time `ComputeAndStoreStatisticsAsync` (including `nodata_pixel_count`).
- `GetMosaicStatisticsAsync` persists layer-level mosaic statistics into a new `raster_layer_statistics` table keyed by `(layer_id, merge_strategy, raster_signature)`, where the signature is a digest of the layer's raster-id set: importing or deleting a raster changes the signature, invalidating the snapshot automatically; stale signatures are pruned on the next persist.
- Concurrent cold reads serialize behind `pg_advisory_xact_lock` namespaces distinct from the raster-import lock (thundering-herd guard); lock waiters re-read the persisted rows instead of recomputing. Persistence is best-effort: read-only deployments fall back to the legacy compute path.
- Added `src/Honua.Postgres/Migrations/003_CreateRasterLayerStatistics.sql`; the store also self-provisions the table via `CREATE TABLE IF NOT EXISTS` (same pattern as `PostgresMetadataV2GraphStore`), so already-deployed servers backfill without out-of-band migration coordination.
- Updated `tests/seed/base-schema.sql` and `tests/seed/server.yaml` with the new table, and documented the persisted-read contract on `IRasterStore`.
- Tests: new `PostgresRasterStoreStatisticsTests` (lazy backfill, tamper-proofed persisted reads, concurrent cold reads persisting exactly one row set per band, signature invalidation + pruning) and a new ImageServer integration test proving `?f=json` band statistics are served from the persisted mosaic snapshot and never recomputed.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Local validation: 4/4 new `PostgresRasterStoreStatisticsTests` (Testcontainers); 270/270 `Honua.Protocols.GeoServices.Tests` ImageServer test classes (full set, 15m24s); Release build with `TreatWarningsAsErrors=true` clean; `dotnet format --verify-no-changes` clean on all changed files; architecture tests 108 passed / 1 skipped (one unrelated SDK-workflow assertion fails only on CRLF Windows checkouts; passes on LF).

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

The 003 migration ships with the PR, but the store self-provisions the snapshot table at runtime, so no deployment coordination is required.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
