### PR TITLE
test: align fresh-DB metadata test with the #1619 empty-snapshot contract

### DIFF
--- a/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataV2GraphStoreFreshDbTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataV2GraphStoreFreshDbTests.cs
@@ -19,12 +19,18 @@ namespace Honua.Postgres.Tests.Features.Metadata;
 /// with relation "honua.metadata_v2_current" does not exist (42P01). The store now
 /// tolerates the missing relation on read and self-heals the schema on write, so the
 /// publish path bootstraps an empty graph and succeeds instead of failing.
+///
+/// CONTRACT UPDATE (#1619/#1634): a fresh DB no longer surfaces "no snapshot" as an
+/// InvalidOperationException — GetCurrentAsync now returns an empty-but-valid
+/// snapshot so every catalog surface answers 200 with zero items on a healthy,
+/// unpopulated server. The #1341 spirit (never leak a raw 42P01) is asserted
+/// against that new contract below.
 /// </summary>
 [Collection("Database")]
 public sealed class PostgresMetadataV2GraphStoreFreshDbTests(PostgresFixture fixture)
 {
     [IntegrationTest]
-    public async Task GetCurrentAsync_WhenMetadataV2TablesMissing_ThrowsInvalidOperationInsteadOfRawPostgresError()
+    public async Task GetCurrentAsync_WhenMetadataV2TablesMissing_ReturnsEmptySnapshotInsteadOfRawPostgresError()
     {
         // Isolated schema that deliberately does NOT create the metadata_v2 tables —
         // exactly the fresh-DB shape that surfaced the 500.
@@ -34,11 +40,14 @@ public sealed class PostgresMetadataV2GraphStoreFreshDbTests(PostgresFixture fix
             var provider = new TestConnectionProvider(fixture.DataSource, schema);
             var store = new PostgresMetadataV2GraphStore(provider, environment: "Test", schemaName: schema);
 
-            var act = () => store.GetCurrentAsync().AsTask();
+            // #1341: a raw PostgresException (42P01) must never bubble out as a 500.
+            // #1619: "no snapshot" is no longer an error at all — a fresh DB yields an
+            // empty-but-valid snapshot so catalog surfaces answer 200 with zero items.
+            var snapshot = await store.GetCurrentAsync();
 
-            // The publish path catches InvalidOperationException to bootstrap an empty
-            // graph. A raw PostgresException (42P01) would bubble out as a 500.
-            await act.Should().ThrowAsync<InvalidOperationException>();
+            snapshot.Should().NotBeNull();
+            snapshot.Graph.Revision.Should().Be(0, "a fresh DB has no activated snapshot");
+            snapshot.Graph.Resources.Should().BeEmpty();
         }
         finally
         {


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes # (trunk CI breakage — no standalone issue; introduced by the #1619 fix in #1634)

## Summary
Trunk's Postgres Compatibility gate has been red for three runs: PostgresMetadataV2GraphStoreFreshDbTests pinned the pre-#1619 contract (fresh DB → InvalidOperationException), which #1634 deliberately replaced with the empty-snapshot behavior (fresh DB → Revision-0 snapshot → catalogs answer 200-with-zero-items). This realigns the regression test with the new contract while preserving the original #1341 intent: a raw 42P01 must never escape.

## Changes Made
- Updated PostgresMetadataV2GraphStoreFreshDbTests to assert a Revision-0, zero-resource snapshot on fresh DBs
- Preserved the negative assertion that no raw PostgresException (42P01) escapes
- No production code changes

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated (3/3 via Testcontainers locally)
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance) — un-reds the Postgres Compatibility gate for all queued PRs

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None