### PR TITLE
fix: make admin OpenAPI document and capabilities handshake anonymously readable (#1635, #1633)

### DIFF
--- a/docs/developer/api-specs/admin-api.json
+++ b/docs/developer/api-specs/admin-api.json
@@ -722,8 +722,9 @@
           "Metadata"
         ],
         "summary": "Get Admin Capabilities",
-        "description": "Returns metadata capabilities and the canonical SDK compatibility contract for the control plane.",
+        "description": "Returns metadata capabilities and the canonical SDK compatibility contract for the control plane. Readable anonymously so SDK compatibility checks can run before credentials exist.",
         "operationId": "getAdminCapabilities",
+        "security": [],
         "responses": {
           "200": {
             "description": "Admin metadata capabilities and SDK compatibility metadata",
@@ -1871,8 +1872,9 @@
           "Configuration"
         ],
         "summary": "Get Admin OpenAPI Specification",
-        "description": "Returns the bundled OpenAPI contract snapshot for the admin/control-plane API.",
+        "description": "Returns the bundled OpenAPI contract snapshot for the admin/control-plane API. The document itself is readable anonymously; the operations it describes require admin authentication.",
         "operationId": "getAdminOpenApi",
+        "security": [],
         "parameters": [
           {
             "name": "f",

--- a/docs/reference/admin-api/overview.md
+++ b/docs/reference/admin-api/overview.md
@@ -41,7 +41,7 @@ Each capability record reports:
 
 The document also carries `transports` (REST, GeoServices, OGC, OData, STAC, tiles, gRPC, MCP, QGIS, mTLS), `limits` (query, analysis, upload, and job limits), and `policies` (license and entitlement state). The manifest is informational only — operation endpoints remain the source of truth for authorization and resource checks. Do not persist it as an authorization cache.
 
-Control-plane SDKs should instead call the admin-only `GET /api/v1/admin/capabilities` once per session and branch on its `data.compatibility` object (server version, control-plane major, feature flags).
+Control-plane SDKs should instead call `GET /api/v1/admin/capabilities` once per session and branch on its `data.compatibility` object (server version, control-plane major, feature flags). The capabilities handshake is readable anonymously so `checkCompatibility()` can run before credentials exist; every other admin endpoint requires authentication.
 
 ## OpenAPI specs
 

--- a/src/Honua.Server/Features/Admin/AdminEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AdminEndpoints.cs
@@ -50,10 +50,15 @@ internal static class AdminEndpoints
         _ = adminGroup.MapMethods("/config", _nonGetMethods, HandleGetOnlyMethodNotAllowed)
             .WithDisplayName("Get Configuration Documentation Method Not Allowed");
 
-        // Runtime OpenAPI endpoint for admin/control-plane contract.
+        // Runtime OpenAPI endpoint for admin/control-plane contract. The document is
+        // public API documentation (the same bundled admin-api.json snapshot committed
+        // to the repo), not a secret: it is served anonymously so the /docs explorer and
+        // evaluators can read it without credentials (#1635). Every actual admin
+        // operation stays behind the group's admin authorization.
         _ = adminGroup.MapMethods("/openapi.json", [HttpMethods.Get], HandleGetOpenApiSpec)
             .WithDisplayName("Get Admin OpenAPI Specification")
-            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .AllowAnonymous();
         _ = adminGroup.MapMethods("/openapi.json", _nonGetMethods, HandleGetOnlyMethodNotAllowed)
             .WithDisplayName("Get Admin OpenAPI Specification Method Not Allowed");
 

--- a/src/Honua.Server/Features/Admin/AdminInfoEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AdminInfoEndpoints.cs
@@ -30,11 +30,18 @@ internal static class AdminInfoEndpoints
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
             .Produces<ApiResponse<AdminVersionResponse>>();
 
+        // Anonymous by design (#1633): this is the SDK compatibility handshake
+        // (checkCompatibility/getCompatibility) that browser consumers run before they
+        // have credentials. The payload is constant, non-sensitive build metadata —
+        // server version, release channel, control-plane API major/base path, metadata
+        // schema versions, and compile-time feature switches. It contains no connection
+        // details, tenants, topology, or deployment-specific configuration.
         group.MapGet("/capabilities", HandleGetCapabilities)
             .WithName("GetAdminCapabilities")
             .WithSummary("Get admin API capabilities")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
-            .Produces<ApiResponse<AdminCapabilitiesResponse>>();
+            .Produces<ApiResponse<AdminCapabilitiesResponse>>()
+            .AllowAnonymous();
     }
 
     private static IResult HandleGetVersion()

--- a/tests/dotnet/Honua.Server.Tests/Comprehensive/ContractCoverageMatrixTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Comprehensive/ContractCoverageMatrixTests.cs
@@ -18,9 +18,9 @@ namespace Honua.Server.Tests.Comprehensive;
 /// <list type="table">
 /// <listheader><term>Endpoint</term><description>Scenarios</description></listheader>
 /// <item><term>GET  /api/v1/admin/config</term><description>happy, 401</description></item>
-/// <item><term>GET  /api/v1/admin/openapi.json</term><description>happy, 401</description></item>
+/// <item><term>GET  /api/v1/admin/openapi.json</term><description>happy, anonymous 200 (#1635)</description></item>
 /// <item><term>GET  /api/v1/admin/version</term><description>happy, 401</description></item>
-/// <item><term>GET  /api/v1/admin/capabilities</term><description>happy, 401</description></item>
+/// <item><term>GET  /api/v1/admin/capabilities</term><description>happy, anonymous 200 (#1633)</description></item>
 /// <item><term>GET  /api/v1/admin/services</term><description>happy, 401</description></item>
 /// <item><term>GET  /api/v1/admin/services/{name}/settings</term><description>happy, 401</description></item>
 /// <item><term>PUT  /api/v1/admin/services/{name}/protocols</term><description>happy, 401</description></item>

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminAuthorizationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminAuthorizationTests.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using FluentAssertions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
@@ -56,12 +57,19 @@ public sealed class AdminAuthorizationTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
+    // The admin OpenAPI document is public API documentation (the bundled
+    // admin-api.json snapshot), intentionally readable without credentials so the
+    // /docs explorer can load it (#1635). The operations it documents stay gated.
     [IntegrationTest]
     [Endpoint("GET /api/v1/admin/openapi.json")]
-    public async Task GetOpenApi_WithoutAuth_Returns401()
+    public async Task GetOpenApi_WithoutAuth_Returns200WithValidOpenApiDocument()
     {
         var response = await _unauthenticatedClient.GetAsync("/api/v1/admin/openapi.json");
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("openapi").GetString().Should().StartWith("3.0");
+        document.RootElement.TryGetProperty("paths", out _).Should().BeTrue();
     }
 
     [IntegrationTest]
@@ -72,12 +80,32 @@ public sealed class AdminAuthorizationTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
+    // The capabilities handshake is intentionally anonymous (#1633): browser SDK
+    // consumers run checkCompatibility() before they have credentials. The payload
+    // must stay limited to constant build metadata — assert the expected fields are
+    // present and that nothing deployment-specific leaks alongside them.
     [IntegrationTest]
     [Endpoint("GET /api/v1/admin/capabilities")]
-    public async Task GetCapabilities_WithoutAuth_Returns401()
+    public async Task GetCapabilities_WithoutAuth_Returns200WithCompatibilityContract()
     {
         var response = await _unauthenticatedClient.GetAsync("/api/v1/admin/capabilities");
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+
+        var data = document.RootElement.GetProperty("data");
+        var compatibility = data.GetProperty("compatibility");
+        compatibility.GetProperty("serverVersion").GetString().Should().NotBeNullOrWhiteSpace();
+        compatibility.GetProperty("releaseChannel").GetString().Should().NotBeNullOrWhiteSpace();
+        compatibility.GetProperty("controlPlaneApi").GetProperty("major").GetInt32().Should().Be(1);
+        compatibility.GetProperty("metadataSchemas").GetArrayLength().Should().BeGreaterThan(0);
+        compatibility.TryGetProperty("features", out _).Should().BeTrue();
+
+        // Guard against the anonymous surface growing sensitive content: the response
+        // must stay limited to the documented compatibility envelope.
+        data.EnumerateObject().Select(property => property.Name).Should().BeEquivalentTo(
+            ["metadataApiVersion", "metadataSchemaVersion", "serverVersion", "compatibility"]);
     }
 
     // --- ServiceSettingsEndpoints ---

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/SecurityComplianceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/SecurityComplianceTests.cs
@@ -100,13 +100,16 @@ public sealed class SecurityComplianceTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("GET /api/v1/admin/openapi.json")]
-    public async Task Authentication_AdminOpenApiWithoutApiKey_ShouldReturn401()
+    public async Task Authentication_AdminOpenApiWithoutApiKey_ShouldReturn200()
     {
+        // The admin OpenAPI document is public documentation (the bundled
+        // admin-api.json snapshot) and is intentionally anonymous (#1635);
+        // the admin operations it documents remain authenticated.
         var request = new HttpRequestMessage(HttpMethod.Get, "/api/v1/admin/openapi.json");
 
         var response = await _client.SendAsync(request);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]


### PR DESCRIPTION
## Issue Link
Fixes #1635
Fixes #1633

## Summary
Makes the two public-metadata surfaces of the admin control plane anonymously readable while keeping every actual admin operation behind admin authorization:

- `GET /api/v1/admin/openapi.json` now allows anonymous access, so the `/docs` Scalar explorer can load the Admin API document (it previously 401'd and Scalar showed "Document could not be loaded"). The endpoint serves the bundled `admin-api.json` snapshot — public API documentation already committed to the repo, not a secret.
- `GET /api/v1/admin/capabilities` now allows anonymous access so the JS SDK's browser `checkCompatibility()` handshake can run before credentials exist. The payload was reviewed and is constant, non-sensitive build metadata only: server version, release channel, control-plane API major/base path, metadata schema versions, and compile-time feature switches. No connection details, tenants, topology, or deployment-specific configuration.

## Changes Made
- Add `AllowAnonymous()` to `GET /api/v1/admin/openapi.json` in `AdminEndpoints.cs` with a rationale comment (#1635); all other admin endpoints keep the group's `RequireAdminAuthorization()`
- Add `AllowAnonymous()` to `GET /api/v1/admin/capabilities` in `AdminInfoEndpoints.cs` with a rationale comment (#1633); `GET /api/v1/admin/version` stays authenticated
- Mark both operations with `"security": []` in the bundled `docs/developer/api-specs/admin-api.json` spec snapshot and document the anonymous-read behavior in `docs/reference/admin-api/overview.md`
- Rewrite `AdminAuthorizationTests`: anonymous GET of the OpenAPI document asserts 200 + valid OpenAPI 3.0 JSON (`openapi`, `paths`); anonymous GET of capabilities asserts 200 with the documented compatibility envelope and a guard that the `data` payload contains exactly `metadataApiVersion`/`metadataSchemaVersion`/`serverVersion`/`compatibility` (so sensitive fields can never silently join the anonymous surface)
- Update `SecurityComplianceTests` (admin OpenAPI anonymous now 200) and the `ContractCoverageMatrixTests` scenario matrix doc
- All other admin 401 coverage (config, version, services, connections, deploy, alerts, ...) unchanged and still passing

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
