### PR TITLE
fix(scripts): strip UTF-8 BOM from shell scripts (#1651)

### DIFF
--- a/docker/cite/shared/scripts/execute-wcs20-tests.sh
+++ b/docker/cite/shared/scripts/execute-wcs20-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/sh
+#!/bin/sh
 
 # Runs the official OGC WCS 2.0 ETS from the ogccite/ets-wcs20 image and
 # writes machine-readable results into /results for the outer harness.

--- a/docker/cite/shared/scripts/execute-wfs1-tests.sh
+++ b/docker/cite/shared/scripts/execute-wfs1-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/sh
+#!/bin/sh
 
 # OGC CITE Team Engine test execution script for WFS 1.0.0 and 1.1.0.
 

--- a/docker/cite/shared/scripts/execute-wfs20-tests.sh
+++ b/docker/cite/shared/scripts/execute-wfs20-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/sh
+#!/bin/sh
 
 # OGC CITE Team Engine test execution script
 # Runs actual WFS 2.0 conformance tests against Honua Server

--- a/docker/client-compat/arcgis-stub/run.sh
+++ b/docker/client-compat/arcgis-stub/run.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Runs the ArcGIS Pro REST stub against a running honua service.
 set -euo pipefail
 

--- a/docker/client-compat/cesium/run.sh
+++ b/docker/client-compat/cesium/run.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Runs the Cesium browser interop suite against a running honua service and
 # copies emitted .cert.json envelopes into /output.
 set -euo pipefail

--- a/docker/client-compat/gdal/run.sh
+++ b/docker/client-compat/gdal/run.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Runs the GDAL/OGR interop suite against the Compose honua service and writes
 # the JSON evidence envelope plus per-protocol .cert.json envelopes to /output
 # for the baseline-diff step.

--- a/docker/client-compat/openlayers/run.sh
+++ b/docker/client-compat/openlayers/run.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Runs the OpenLayers (and js-browser MapLibre + Esri Leaflet) interop suites
 # against a running honua service and copies emitted .cert.json envelopes
 # into /output.

--- a/docker/client-compat/pyqgis/run.sh
+++ b/docker/client-compat/pyqgis/run.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Runs the PyQGIS client compatibility suite against a running honua service
 # and copies the generated .cert.json envelopes into /output.
 set -euo pipefail

--- a/docker/client-compat/seed/run.sh
+++ b/docker/client-compat/seed/run.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Applies the canonical client-compat seed bundle to a freshly-started
 # postgres so honua + lane services see the expected services and layers:
 #   - tests/seed/client-compat-v1.sql → schema + `test_service` (layer 0)

--- a/docker/cloud/azure-functions/handler.sh
+++ b/docker/cloud/azure-functions/handler.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/sh
+#!/bin/sh
 
 set -eu
 

--- a/docker/cloud/lambda/bootstrap.sh
+++ b/docker/cloud/lambda/bootstrap.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/sh
+#!/bin/sh
 set -eu
 
 export ASPNETCORE_URLS="${ASPNETCORE_URLS:-http://0.0.0.0:${PORT:-8080}}"

--- a/docker/routing/import-osm.sh
+++ b/docker/routing/import-osm.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 #
 # import-osm.sh — import a real OpenStreetMap extract into the Honua pgRouting
 # development database using osm2pgrouting (issue #1266).

--- a/docker/scale-test/nginx/render-scale-test-conf.sh
+++ b/docker/scale-test/nginx/render-scale-test-conf.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/sh
+#!/bin/sh
 set -eu
 
 template_path="/etc/nginx/scale-test.conf.template"

--- a/scripts/ci/check-instructions-sync.sh
+++ b/scripts/ci/check-instructions-sync.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 if [[ ! -f "AGENTS.md" ]]; then

--- a/scripts/ci/check-parity-scorecard-baseline-sync.sh
+++ b/scripts/ci/check-parity-scorecard-baseline-sync.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 parity_test_file="${1:-tests/dotnet/Honua.Server.Tests/Import/GeoservicesParityIntegrationTests.cs}"

--- a/scripts/ci/check-parity-scorecard-regression.sh
+++ b/scripts/ci/check-parity-scorecard-regression.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 if [[ $# -lt 2 ]]; then

--- a/scripts/ci/compute-affected-projects.sh
+++ b/scripts/ci/compute-affected-projects.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Compute the closure of .csproj files affected by a diff so CI build steps
 # can scope `dotnet build` to changed projects + their reverse-dependencies
 # instead of rebuilding the whole solution every push.

--- a/scripts/ci/generate-cross-server-gap-report.sh
+++ b/scripts/ci/generate-cross-server-gap-report.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 if [[ $# -ne 2 ]]; then

--- a/scripts/ci/generate-sdk-compatibility-table.sh
+++ b/scripts/ci/generate-sdk-compatibility-table.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/ci/honua-server-targeted-tests.sh
+++ b/scripts/ci/honua-server-targeted-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Compute the server-tests shard subset to execute on a pull request based on
 # the changed files in the diff. Owned by ADR-0037. The shard map and watched
 # prefix lists are sourced from .github/ci-shards.json.

--- a/scripts/ci/pre-pr-check.sh
+++ b/scripts/ci/pre-pr-check.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Pre-PR validation with the SAME smart filters CI uses, so a local run only

--- a/scripts/ci/run-sdk-server-compatibility.sh
+++ b/scripts/ci/run-sdk-server-compatibility.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/ci/run-server-test-shard.sh
+++ b/scripts/ci/run-server-test-shard.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Run one Honua.Server.Tests shard with heartbeat, timeout, and timing output.
 
 set -euo pipefail

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Validate CI shard routing without starting runtime test runners.
 
 set -euo pipefail

--- a/scripts/ci/validate-openapi-contracts.sh
+++ b/scripts/ci/validate-openapi-contracts.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/client-compat/client-compat-server.sh
+++ b/scripts/client-compat/client-compat-server.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # Client compatibility server setup (WSL side).
 # Builds image, starts Docker Compose, seeds data, and keeps the server

--- a/scripts/client-compat/refresh-baselines.sh
+++ b/scripts/client-compat/refresh-baselines.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Re-runs the docker/client-compat matrix and overwrites tests/baselines/client-compat
 # with the resulting envelopes. Intended for scheduled baseline-refresh PRs;
 # do NOT run in regular CI.

--- a/scripts/client-compat/run-client-compat-smoke.sh
+++ b/scripts/client-compat/run-client-compat-smoke.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 usage() {

--- a/scripts/cloud/deploy-canary.sh
+++ b/scripts/cloud/deploy-canary.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -euo pipefail
 
 # Canary Deployment Script for Honua Server

--- a/scripts/cloud/deploy-rolling.sh
+++ b/scripts/cloud/deploy-rolling.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -euo pipefail
 
 # Rolling Deployment Script for Honua Server

--- a/scripts/cloud/post-deployment-verification.sh
+++ b/scripts/cloud/post-deployment-verification.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -euo pipefail
 
 # Post-Deployment Verification Script for Honua Server

--- a/scripts/cloud/rollback-deployment.sh
+++ b/scripts/cloud/rollback-deployment.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/cloud/run-cloud-post-apply-validation.sh
+++ b/scripts/cloud/run-cloud-post-apply-validation.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -euo pipefail
 
 TF_OUTPUT_JSON=""

--- a/scripts/cloud/setup-github-app-env.sh
+++ b/scripts/cloud/setup-github-app-env.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 APP_ID="2932471"

--- a/scripts/conformance/cite/build-cite-evidence.sh
+++ b/scripts/conformance/cite/build-cite-evidence.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # Builds a static, website-linkable evidence bundle from local CITE result
 # directories. The bundle includes a human-readable index, machine-readable

--- a/scripts/conformance/cite/run-cite-gml32-tests.sh
+++ b/scripts/conformance/cite/run-cite-gml32-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # GML 3.2 CITE conformance testing script for Honua Server.
 # Validates GML document output against the OGC GML 3.2 specification.

--- a/scripts/conformance/cite/run-cite-gpkg12-tests.sh
+++ b/scripts/conformance/cite/run-cite-gpkg12-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # GeoPackage 1.2 CITE conformance testing script for Honua Server.
 # Validates GeoPackage file output against the OGC GeoPackage 1.2 specification.

--- a/scripts/conformance/cite/run-cite-kml22-tests.sh
+++ b/scripts/conformance/cite/run-cite-kml22-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # KML 2.2 CITE conformance testing script for Honua Server.
 # Validates KML document output against the OGC KML 2.2 specification.

--- a/scripts/conformance/cite/run-cite-tests.sh
+++ b/scripts/conformance/cite/run-cite-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # OGC API Features CITE conformance testing script for Honua Server
 # Runs the official OGC Compliance and Interoperability Testing & Evaluation (CITE) suite

--- a/scripts/conformance/cite/run-cite-tiles-tests.sh
+++ b/scripts/conformance/cite/run-cite-tiles-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # OGC API Tiles CITE conformance testing script for Honua Server
 # Runs the official OGC Compliance and Interoperability Testing & Evaluation (CITE) suite

--- a/scripts/conformance/cite/run-cite-wcs20-tests.sh
+++ b/scripts/conformance/cite/run-cite-wcs20-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # WCS 2.0 CITE conformance testing script for Honua Server.
 

--- a/scripts/conformance/cite/run-cite-wfs10-tests.sh
+++ b/scripts/conformance/cite/run-cite-wfs10-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # OGC WFS 1.0 CITE conformance testing script for Honua Server.
 

--- a/scripts/conformance/cite/run-cite-wfs11-tests.sh
+++ b/scripts/conformance/cite/run-cite-wfs11-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # OGC WFS 1.1 CITE conformance testing script for Honua Server.
 

--- a/scripts/conformance/cite/run-cite-wfs20-tests.sh
+++ b/scripts/conformance/cite/run-cite-wfs20-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # OGC WFS 2.0 CITE conformance testing script for Honua Server
 # Runs the official OGC Compliance and Interoperability Testing & Evaluation (CITE) suite

--- a/scripts/conformance/cite/run-cite-wms-tests.sh
+++ b/scripts/conformance/cite/run-cite-wms-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # WMS 1.3 CITE conformance testing script for Honua Server.
 

--- a/scripts/conformance/cite/run-cite-wmts-tests.sh
+++ b/scripts/conformance/cite/run-cite-wmts-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # WMTS 1.0 CITE conformance testing script for Honua Server.
 

--- a/scripts/conformance/ogc/run-ogc-maps-conformance-tests.sh
+++ b/scripts/conformance/ogc/run-ogc-maps-conformance-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # OGC API - Maps conformance verification for Honua Server.
 # This runner uses the server integration conformance suite while

--- a/scripts/conformance/ogc/validate-ogc-conformance.sh
+++ b/scripts/conformance/ogc/validate-ogc-conformance.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # Validate that advertised OGC API Features conformance classes were actually tested.
 

--- a/scripts/conformance/run-production-audit.sh
+++ b/scripts/conformance/run-production-audit.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/demos/run-mobile-offline-demo.sh
+++ b/scripts/demos/run-mobile-offline-demo.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/scripts/demos/run-stac-ops-demo.sh
+++ b/scripts/demos/run-stac-ops-demo.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/scripts/dev/dev-setup.sh
+++ b/scripts/dev/dev-setup.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -euo pipefail
 
 # Development Environment Setup Script for Honua Server

--- a/scripts/dev/seed-admin-sample.sh
+++ b/scripts/dev/seed-admin-sample.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Reset the local test schema and seed the admin preview sample FeatureServer.
 #
 # Environment variables:

--- a/scripts/dev/setup-git-hooks.sh
+++ b/scripts/dev/setup-git-hooks.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Setup script to install git hooks for pre-PR validation enforcement
 
 set -e

--- a/scripts/dev/setup-playwright-wsl.sh
+++ b/scripts/dev/setup-playwright-wsl.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 if [[ ! -f /etc/os-release ]]; then

--- a/scripts/dev/with-test-docker-cleanup.sh
+++ b/scripts/dev/with-test-docker-cleanup.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 usage() {

--- a/scripts/host/reclaim-wsl-space.sh
+++ b/scripts/host/reclaim-wsl-space.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/migrations/migrate_constructor_validation.sh
+++ b/scripts/migrations/migrate_constructor_validation.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # Constructor Validation Migration Script (Bash)
 # Automatically refactors constructor null validation patterns to use the new validation framework

--- a/scripts/release/build-release-manifest.sh
+++ b/scripts/release/build-release-manifest.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # Build (or refresh) a Honua release-train manifest from release-bundle evidence.
 #

--- a/scripts/release/collect-evidence.sh
+++ b/scripts/release/collect-evidence.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # Merge per-suite evidence records (emitted by dispatch-and-wait.sh, one JSON
 # object per line) plus the static suite registry (release/bundle-suites.json)

--- a/scripts/release/dispatch-and-wait.sh
+++ b/scripts/release/dispatch-and-wait.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # Dispatch a GitHub Actions workflow (optionally in another repo), wait for the
 # run it created, and print a one-line evidence JSON describing the result:

--- a/scripts/release/smoke-build-release-manifest.sh
+++ b/scripts/release/smoke-build-release-manifest.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # Self-test for scripts/release/build-release-manifest.sh.
 #

--- a/scripts/release/smoke-release-bundle-pipeline.sh
+++ b/scripts/release/smoke-release-bundle-pipeline.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # End-to-end smoke for the release-bundle data pipeline:
 #   bundle-suites.json + per-suite results

--- a/scripts/scale/run-load-soak-tests.sh
+++ b/scripts/scale/run-load-soak-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # Load/soak testing script for Honua Server
 # Runs NBomber scenarios and captures system + API metrics.

--- a/scripts/scale/scale-test.sh
+++ b/scripts/scale/scale-test.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # Scale-out testing script for Honua Server
 # Tests distributed caching, load balancing, and multi-instance scenarios

--- a/scripts/scale/transaction-test.sh
+++ b/scripts/scale/transaction-test.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # Transaction semantics testing script for Honua Server
 # Tests actual behavior when instances fail mid-transaction

--- a/scripts/sdk/generate-control-plane-sdks.sh
+++ b/scripts/sdk/generate-control-plane-sdks.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/security/secret-management.sh
+++ b/scripts/security/secret-management.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -euo pipefail
 
 # Secret Management Script for Honua Server

--- a/scripts/security/verify-security-fixes.sh
+++ b/scripts/security/verify-security-fixes.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 #
 # Security Fixes Verification Script

--- a/tests/seed/apply-yaml-seed.sh
+++ b/tests/seed/apply-yaml-seed.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Extracts SQL statements from a version-1 seed YAML file and applies them
 # via psql. Requires: python3 (or python), pyyaml, psql.
 #


### PR DESCRIPTION
## Issue Link
Fixes #1651

## Summary
Commit `3427d23ee` (#1641) prepended a UTF-8 BOM (`EF BB BF`) to the committed blobs of 70 tracked `.sh` files. The BOM precedes the shebang, so the kernel falls back to `/bin/sh` (dash) — which rejects `set -o pipefail` — or aborts with `exec format error`. This broke three nightlies (GML 3.2 CITE, GeoPackage 1.2 CITE, Real-Client Interop Matrix) and silently degraded CI/container entrypoints including `scripts/ci/pre-pr-check.sh`.

## Changes Made
- Strip the leading UTF-8 BOM from all 70 affected `.sh` files (working-tree content only; no logic changes)
- Retain the `.gitattributes` `*.sh text eol=lf` enforcement from #1641
- Verified every previously-broken script now parses under `bash -n`

## Testing
- [x] Manual testing performed

## Gate Impact
- [x] Nightly gates (conformance, performance, security)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above