### PR TITLE
fix: CORS error-response headers + If-Match, AOT-safe OData ETag, raster-stats backfill budget (#1627, #1629, #1647, #1649)

### DIFF
--- a/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
@@ -31,6 +31,14 @@ internal sealed class PostgresRasterStore : IRasterStore
     private const int RasterStatisticsLockNamespace = 0x0484_5222;
     private const int LayerStatisticsLockNamespace = 0x0484_5223;
 
+    // A single statistics backfill runs ST_SummaryStats across every pixel of a raster (or
+    // every raster in a mosaic) and can exceed a minute on county-scale imagery. The compute
+    // is serialized behind a transaction-scoped advisory lock (single-flight), so it is given
+    // a dedicated, generous timeout — independent of the ~30s request-path command/statement
+    // timeout default — otherwise the first cold read on a large raster times out and the
+    // statistics never persist, retrying forever instead of self-healing (#1649).
+    private const int StatisticsComputeTimeoutSeconds = 300;
+
     private readonly IDatabaseConnectionProvider _connectionProvider;
     private readonly ILogger<PostgresRasterStore> _logger;
     private readonly string _rasterDataTable;
@@ -1000,11 +1008,16 @@ internal sealed class PostgresRasterStore : IRasterStore
 
         try
         {
+            // Grant this single-flight transaction the dedicated compute budget so a
+            // county-scale ST_SummaryStats can finish and persist instead of timing out (#1649).
+            await ApplyStatisticsComputeBudgetAsync(connection, transaction, cancellationToken).ConfigureAwait(false);
+
             // Compute and persist in a single statement (mirrors the import-time
             // ComputeAndStoreStatisticsAsync semantics, including nodata_pixel_count).
             await using (var command = connection.CreateCommand())
             {
                 command.Transaction = transaction;
+                command.CommandTimeout = StatisticsComputeTimeoutSeconds;
                 command.CommandText = $"""
                     INSERT INTO {_rasterStatisticsTable}
                         (raster_data_id, band_number, min_value, max_value, mean_value, std_dev, valid_pixel_count, nodata_pixel_count)
@@ -1063,6 +1076,10 @@ internal sealed class PostgresRasterStore : IRasterStore
 
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
         await AcquireBackfillLockAsync(connection, transaction, LayerStatisticsLockNamespace, layerId, cancellationToken).ConfigureAwait(false);
+
+        // Grant this single-flight transaction the dedicated compute budget so a large-mosaic
+        // ST_SummaryStats can finish and persist instead of timing out (#1649).
+        await ApplyStatisticsComputeBudgetAsync(connection, transaction, cancellationToken).ConfigureAwait(false);
 
         List<RasterStatistics> persisted;
         try
@@ -1205,6 +1222,7 @@ internal sealed class PostgresRasterStore : IRasterStore
         CancellationToken cancellationToken)
     {
         await using var command = connection.CreateCommand();
+        command.CommandTimeout = StatisticsComputeTimeoutSeconds;
         command.CommandText = $"""
             SELECT band,
                    (stats).min AS min_value,
@@ -1237,6 +1255,7 @@ internal sealed class PostgresRasterStore : IRasterStore
     {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
+        command.CommandTimeout = StatisticsComputeTimeoutSeconds;
         command.CommandText = $"""
             WITH requested AS (
                 SELECT unnest(@rasterIds) AS raster_id
@@ -1347,6 +1366,24 @@ internal sealed class PostgresRasterStore : IRasterStore
         command.CommandText = "SELECT pg_advisory_xact_lock(@namespace, @lockKey);";
         AddParameter(command, "@namespace", lockNamespace);
         AddParameter(command, "@lockKey", lockKey);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Raises the statement timeout for the statistics-backfill transaction to the dedicated
+    /// compute budget. <c>SET LOCAL</c> is transaction-scoped, so the elevated budget reverts on
+    /// commit/rollback and never leaks back to the pooled connection's request-path statements.
+    /// </summary>
+    private static async Task ApplyStatisticsComputeBudgetAsync(
+        DbConnection connection,
+        DbTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = FormattableString.Invariant(
+            $"SET LOCAL statement_timeout = {StatisticsComputeTimeoutSeconds * 1000}");
+        command.CommandTimeout = StatisticsComputeTimeoutSeconds;
         await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.Response.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.Response.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
-using System.Text.Json;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Geometry.Abstractions;
 using Honua.Core.Features.Shared.Models;
@@ -72,8 +71,7 @@ internal sealed partial class ODataBatchHandler
 
     private string ComputeFeatureEtag(Dictionary<string, object?> payload)
     {
-        var canonical = ODataUtilityService.NormalizeForEtag(payload);
-        var json = JsonSerializer.SerializeToUtf8Bytes(canonical);
+        var json = ODataUtilityService.SerializeForEtag(payload);
         return _etagService.ComputeETag(json);
     }
 }

--- a/src/Honua.Protocols.OData/Features/Services/ODataCrudService.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataCrudService.cs
@@ -570,8 +570,7 @@ internal sealed partial class ODataCrudService
         IReadOnlyDictionary<string, object?> attributes)
     {
         var payload = ODataUtilityService.BuildFeaturePayload(layerId, feature, geometry, attributes);
-        var canonical = ODataUtilityService.NormalizeForEtag(payload);
-        var json = JsonSerializer.SerializeToUtf8Bytes(canonical);
+        var json = ODataUtilityService.SerializeForEtag(payload);
         return _etagService.ComputeETag(json);
     }
 

--- a/src/Honua.Protocols.OData/Features/Services/ODataUtilityService.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataUtilityService.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Buffers;
 using System.Collections.Frozen;
 using System.Globalization;
+using System.Text.Json;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Shared.Models;
@@ -797,6 +799,106 @@ internal static class ODataUtilityService
         }
 
         return value;
+    }
+
+    /// <summary>
+    /// Produces deterministic UTF-8 JSON bytes for ETag computation by walking the
+    /// key-sorted <see cref="NormalizeForEtag(object?)"/> structure with a manual
+    /// <see cref="Utf8JsonWriter"/>. This replaces the reflection-based
+    /// <c>JsonSerializer.SerializeToUtf8Bytes(object)</c> overload, which throws
+    /// "Reflection-based serialization has been disabled" under <c>PublishAot=true</c>
+    /// and previously 500'd every OData write on AOT images (#1647).
+    /// </summary>
+    /// <param name="payload">The feature payload to canonicalize for ETag hashing.</param>
+    /// <returns>Canonical UTF-8 JSON bytes with object keys sorted for stability.</returns>
+    public static byte[] SerializeForEtag(IReadOnlyDictionary<string, object?> payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        var canonical = NormalizeForEtag(payload);
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            WriteEtagValue(writer, canonical);
+        }
+
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static void WriteEtagValue(Utf8JsonWriter writer, object? value)
+    {
+        switch (value)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case SortedDictionary<string, object?> dict:
+                writer.WriteStartObject();
+                foreach (var kvp in dict)
+                {
+                    writer.WritePropertyName(kvp.Key);
+                    WriteEtagValue(writer, kvp.Value);
+                }
+
+                writer.WriteEndObject();
+                break;
+            case object?[] array:
+                writer.WriteStartArray();
+                foreach (var item in array)
+                {
+                    WriteEtagValue(writer, item);
+                }
+
+                writer.WriteEndArray();
+                break;
+            case string s:
+                writer.WriteStringValue(s);
+                break;
+            case bool b:
+                writer.WriteBooleanValue(b);
+                break;
+            case byte bt:
+                writer.WriteNumberValue(bt);
+                break;
+            case short sh:
+                writer.WriteNumberValue(sh);
+                break;
+            case int i:
+                writer.WriteNumberValue(i);
+                break;
+            case long l:
+                writer.WriteNumberValue(l);
+                break;
+            case float f:
+                writer.WriteNumberValue(f);
+                break;
+            case double d:
+                writer.WriteNumberValue(d);
+                break;
+            case decimal dec:
+                writer.WriteNumberValue(dec);
+                break;
+            case DateTime dt:
+                writer.WriteStringValue(dt.ToString("O", CultureInfo.InvariantCulture));
+                break;
+            case DateTimeOffset dto:
+                writer.WriteStringValue(dto.ToString("O", CultureInfo.InvariantCulture));
+                break;
+            case Guid g:
+                writer.WriteStringValue(g);
+                break;
+            case ODataSpatialGeometry geometry:
+                // Geometry is a known, source-generated type — serialize it through its
+                // JsonTypeInfo so geometry changes still affect the ETag (AOT-safe).
+                JsonSerializer.Serialize(writer, geometry, ODataJsonContext.Default.ODataSpatialGeometry);
+                break;
+            default:
+                // Last-resort for unanticipated complex attribute values: the
+                // source-generated Object type info, matching the streaming writer's
+                // AOT-safe fallback. Avoids the reflection-based serializer overload.
+                JsonSerializer.Serialize(writer, value, ODataJsonContext.Default.Object);
+                break;
+        }
     }
 
     private static string NormalizeEtagHeader(string etag)

--- a/src/Honua.Server/Features/Infrastructure/Security/CorsConfiguration.cs
+++ b/src/Honua.Server/Features/Infrastructure/Security/CorsConfiguration.cs
@@ -18,6 +18,21 @@ public static class CorsConfiguration
         "http://localhost:8080"
     ];
 
+    /// <summary>
+    /// Request headers allowed on cross-origin requests by default. Includes the full
+    /// set of conditional headers (<c>If-Match</c>, <c>If-Unmodified-Since</c>, …) so
+    /// browser/Office clients can send ETag preconditions on PATCH/PUT/DELETE — without
+    /// these, optimistic concurrency is silently unavailable cross-origin (#1629).
+    /// Additional headers can be appended via <c>Cors:AllowedHeaders</c> configuration.
+    /// </summary>
+    private static readonly string[] DefaultAllowedHeaders =
+    [
+        "Content-Type", "Authorization", "X-API-Key", "X-Correlation-ID",
+        "X-Grpc-Web", "X-User-Agent", "Range", "If-Range",
+        "If-Match", "If-None-Match", "If-Modified-Since", "If-Unmodified-Since",
+        "Prefer"
+    ];
+
     public const string DevelopmentPolicy = "DevelopmentCors";
     public const string ProductionPolicy = "ProductionCors";
     public const string RestrictedPolicy = "RestrictedCors";
@@ -113,8 +128,7 @@ public static class CorsConfiguration
             }
 
             policy.WithMethods("GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
-                  .WithHeaders("Content-Type", "Authorization", "X-API-Key", "X-Correlation-ID",
-                      "X-Grpc-Web", "X-User-Agent", "Range", "If-Range", "If-None-Match", "If-Modified-Since")
+                  .WithHeaders(ResolveAllowedHeaders(configuration))
                   .WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding", "Grpc-Accept-Encoding",
                       "Accept-Ranges", "Content-Range", "Content-Length", "ETag", "Last-Modified")
                   .SetIsOriginAllowed(origin => IsOriginAllowed(origin, allowedOrigins))
@@ -135,6 +149,26 @@ public static class CorsConfiguration
                 CorsLog.NoCorsOriginsConfigured(logger);
             }
         }
+    }
+
+    /// <summary>
+    /// Resolves the cross-origin allowed-request-header list: the standard default set
+    /// (which includes conditional/ETag headers) unioned with any operator-supplied
+    /// <c>Cors:AllowedHeaders</c> entries. Configured headers extend the defaults rather
+    /// than replacing them, so adding a custom header never silently drops <c>If-Match</c>.
+    /// </summary>
+    private static string[] ResolveAllowedHeaders(IConfiguration configuration)
+    {
+        var configured = configuration.GetSection("Cors:AllowedHeaders").Get<string[]>();
+        if (configured is null || configured.Length == 0)
+        {
+            return DefaultAllowedHeaders;
+        }
+
+        return DefaultAllowedHeaders
+            .Concat(configured.Where(h => !string.IsNullOrWhiteSpace(h)).Select(h => h.Trim()))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     private static string[] ResolveAllowedOrigins(IConfiguration configuration)
@@ -372,6 +406,13 @@ public sealed class CorsOptions
     /// Used for sensitive operations requiring tighter security.
     /// </summary>
     public string[] RestrictedOrigins { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Additional cross-origin allowed request headers, appended to the standard default
+    /// set (which already includes conditional/ETag headers such as <c>If-Match</c>).
+    /// Configured values extend the defaults; they do not replace them.
+    /// </summary>
+    public string[] AllowedHeaders { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// Whether to allow credentials in CORS requests.

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -981,16 +981,6 @@ app.UseSerilogRequestLogging(options =>
             : Serilog.Events.LogEventLevel.Information;
 });
 
-// Add global exception handling middleware after request logging.
-app.UseGlobalExceptionHandling();
-
-// Emit the Esri/GeoServices error envelope for routing-level 404/405 (and
-// 406/415/501) terminations under /rest that would otherwise return a bodyless
-// status. Scoped to GeoServices paths so OGC/STAC/OData/admin contracts are
-// untouched. Runs after global exception handling so thrown exceptions keep their
-// existing protocol shaping and only status-only responses are re-shaped here.
-app.UseRestErrorEnvelope();
-
 // Capture the original gRPC-Web indicator before UseGrpcWeb rewrites Content-Type
 // from application/grpc-web* to application/grpc, so the client-certificate
 // enforcement middleware downstream can still distinguish gRPC-Web from native gRPC
@@ -1011,8 +1001,22 @@ app.Use(async (context, next) =>
 // Enable gRPC-Web for all gRPC services (before CORS and endpoint mapping)
 app.UseGrpcWeb(new GrpcWebOptions { DefaultEnabled = true });
 
-// Add CORS middleware before auth to handle preflight requests
+// Add CORS middleware before the exception handler so error responses (4xx/5xx) carry
+// Access-Control-Allow-Origin headers; otherwise browsers report every server error as
+// a CORS failure, masking the real status/body from web clients (#1627). It also stays
+// after UseGrpcWeb (preserving the gRPC-Web preflight ordering) and before auth so it can
+// answer preflight requests.
 app.UseHonuaCors(app.Environment);
+
+// Add global exception handling middleware after request logging.
+app.UseGlobalExceptionHandling();
+
+// Emit the Esri/GeoServices error envelope for routing-level 404/405 (and
+// 406/415/501) terminations under /rest that would otherwise return a bodyless
+// status. Scoped to GeoServices paths so OGC/STAC/OData/admin contracts are
+// untouched. Runs after global exception handling so thrown exceptions keep their
+// existing protocol shaping and only status-only responses are re-shaped here.
+app.UseRestErrorEnvelope();
 
 // Validate query, form, and selected header inputs before authentication and endpoint execution.
 app.UseInputValidation();

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataEtagSerializationTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataEtagSerializationTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Honua.Protocols.OData.Models;
+using Honua.Protocols.OData.Services;
+using Xunit;
+
+namespace Honua.Protocols.OData.Tests.Services;
+
+/// <summary>
+/// Unit tests for the AOT-safe ETag canonicalizer (#1647). The previous implementation
+/// used the reflection-based <c>JsonSerializer.SerializeToUtf8Bytes(object)</c> overload,
+/// which throws "Reflection-based serialization has been disabled" under PublishAot=true
+/// and 500'd every OData write on AOT Lambda images.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Component", "OData")]
+[Trait("Feature", "ETag")]
+public sealed class ODataEtagSerializationTests
+{
+    [Fact]
+    public void SerializeForEtag_DoesNotUseReflectionSerializer_AndProducesBytes()
+    {
+        // The mix of scalar types and a complex geometry object is exactly what tripped
+        // the reflection serializer on AOT. This must succeed without throwing.
+        var payload = SamplePayload();
+
+        var bytes = ODataUtilityService.SerializeForEtag(payload);
+
+        Assert.NotEmpty(bytes);
+        // Sanity: the output is valid JSON text.
+        var json = Encoding.UTF8.GetString(bytes);
+        Assert.StartsWith("{", json, StringComparison.Ordinal);
+        Assert.Contains("\"Wailuku\"", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SerializeForEtag_IsKeyOrderIndependent()
+    {
+        var first = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["ObjectId"] = 1L,
+            ["Name"] = "Wailuku",
+            ["Acres"] = 12.5,
+        };
+        var second = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Acres"] = 12.5,
+            ["Name"] = "Wailuku",
+            ["ObjectId"] = 1L,
+        };
+
+        // Canonicalization sorts keys, so insertion order must not change the ETag bytes.
+        Assert.Equal(
+            ODataUtilityService.SerializeForEtag(first),
+            ODataUtilityService.SerializeForEtag(second));
+    }
+
+    [Fact]
+    public void SerializeForEtag_GeometryChange_ChangesBytes()
+    {
+        var withPoint = SamplePayload();
+        var withMovedPoint = SamplePayload();
+        withMovedPoint["Geometry"] = new ODataSpatialGeometry
+        {
+            Type = "Point",
+            CoordinatesJson = "[1.0,2.0]",
+        };
+
+        // Geometry must remain part of the canonical ETag input — otherwise optimistic
+        // concurrency would not detect a geometry-only edit.
+        Assert.NotEqual(
+            ODataUtilityService.SerializeForEtag(withPoint),
+            ODataUtilityService.SerializeForEtag(withMovedPoint));
+    }
+
+    private static Dictionary<string, object?> SamplePayload() =>
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["ObjectId"] = 1L,
+            ["Name"] = "Wailuku",
+            ["Acres"] = 12.5,
+            ["Active"] = true,
+            ["Geometry"] = new ODataSpatialGeometry
+            {
+                Type = "Point",
+                CoordinatesJson = "[0.0,0.0]",
+            },
+        };
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Security/CorsConfigurationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Security/CorsConfigurationTests.cs
@@ -58,6 +58,44 @@ public sealed class CorsConfigurationTests
         Assert.Contains("Last-Modified", policy.ExposedHeaders);
     }
 
+    [Fact]
+    public async Task ProductionPolicy_AllowsConditionalHeadersByDefault()
+    {
+        // If-Match (and other conditional headers) must be allowed cross-origin so
+        // browser/Office clients can send ETag preconditions on PATCH/PUT/DELETE,
+        // enabling optimistic concurrency from the browser (#1629).
+        var policy = await ResolvePolicyAsync(
+            CorsConfiguration.ProductionPolicy,
+            isDevelopment: false,
+            new Dictionary<string, string?>
+            {
+                ["Cors:AllowedOrigins:0"] = "https://app.example.com"
+            });
+
+        Assert.Contains("If-Match", policy.Headers);
+        Assert.Contains("If-Unmodified-Since", policy.Headers);
+        Assert.Contains("If-None-Match", policy.Headers);
+    }
+
+    [Fact]
+    public async Task ProductionPolicy_AppendsConfiguredHeadersWithoutDroppingDefaults()
+    {
+        // Operator-supplied Cors:AllowedHeaders entries extend the default set; they
+        // must never silently replace the standard conditional headers.
+        var policy = await ResolvePolicyAsync(
+            CorsConfiguration.ProductionPolicy,
+            isDevelopment: false,
+            new Dictionary<string, string?>
+            {
+                ["Cors:AllowedOrigins:0"] = "https://app.example.com",
+                ["Cors:AllowedHeaders:0"] = "X-Custom-Header"
+            });
+
+        Assert.Contains("X-Custom-Header", policy.Headers);
+        Assert.Contains("If-Match", policy.Headers);
+        Assert.Contains("Content-Type", policy.Headers);
+    }
+
     private static async Task<CorsPolicy> ResolvePolicyAsync(
         string policyName,
         bool isDevelopment,


### PR DESCRIPTION
## Issue Link
Fixes #1627
Fixes #1629
Fixes #1647
Fixes #1649

## Summary
Bundles four independent, localized demo-seeding bug fixes (grouped to reduce CI overhead). Each is small and self-contained.

## Changes Made
- **#1627 — CORS on error responses:** registered the CORS middleware ahead of `UseGlobalExceptionHandling` and the REST error envelope so 4xx/5xx responses carry `Access-Control-Allow-Origin`. Browsers previously reported every server error as a CORS failure, masking the real status/body. gRPC-Web stays before CORS to preserve preflight ordering.
- **#1629 — If-Match cross-origin:** the production CORS policy now allows the full conditional-header set (`If-Match`, `If-Unmodified-Since`, `If-None-Match`, …) by default, and `Cors:AllowedHeaders` extends (never replaces) the defaults — restoring browser/Office ETag preconditions on PATCH.
- **#1647 — OData writes 500 on AOT:** replaced the reflection-based `JsonSerializer.SerializeToUtf8Bytes(object)` ETag serialization (throws "Reflection-based serialization has been disabled" under `PublishAot=true`) with an AOT-safe `Utf8JsonWriter` canonicalizer that preserves geometry. Fixes both `ODataCrudService` and the `$batch` response path.
- **#1649 — raster-stats backfill timeout:** the lazy raster-statistics backfill gets a dedicated 300s statement budget (`SET LOCAL statement_timeout` + `CommandTimeout`) scoped to its single-flight advisory-locked transaction, so county-scale `ST_SummaryStats` persists instead of timing out under the 30s request-path default.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- Added CORS conditional-header tests (4/4 pass) and AOT-safe ETag serializer unit tests (3/3 pass: determinism, key-order independence, geometry sensitivity).
- Full `Honua.sln` Release build (warnings-as-errors) clean; `dotnet format --verify-no-changes` clean.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality