### PR TITLE
fix(geoservices): opt-in ImageServer tileInfo for tiled Esri clients (#1648)

### DIFF
--- a/docs/reference/compatibility/geoservices-parity.md
+++ b/docs/reference/compatibility/geoservices-parity.md
@@ -91,7 +91,7 @@ raster layer identifier.
 
 | Operation(s) | Status | Notes |
 | --- | --- | --- |
-| Service metadata | Implemented | Aggregate mosaic extent/statistics, `timeInfo` when acquisition dates exist, `tileInfo`, output-cached. `objectIdField`/`fields`/`rasterFunctionInfos` root properties not yet populated. |
+| Service metadata | Implemented | Aggregate mosaic extent/statistics, `timeInfo` when acquisition dates exist, output-cached. Dynamic (`singleFusedMapCache: false`) by default; opt in to a WebMercatorQuad `tileInfo` for tiled Esri clients via `GeoServices:ImageServer:TileMetadata:Enabled`. `objectIdField`/`fields`/`rasterFunctionInfos` root properties not yet populated. |
 | tile, computeHistograms, getSamples | Implemented | PNG/JPEG/TIFF tiles, zoom 0–28, multi-raster mosaic; getSamples caps at 1000 samples. |
 | exportImage | Partial | JSON envelope with temporary `href` by default; `f=image` streams bytes. `bandIds`, `noData`, mosaic + single-instant `time` supported; `pixelType` validated but not applied; non-empty `renderingRule` returns 501; `bmp`/`gif` rejected with 400. |
 | identify | Partial | Point/envelope/polygon (area geometries identify at the envelope centroid); `returnCatalogItems`; `pixelSize` echoed but pyramid selection deferred; `renderingRule` not applied. |

--- a/docs/reference/protocols/geoservices-rest.md
+++ b/docs/reference/protocols/geoservices-rest.md
@@ -88,6 +88,19 @@ Base: `/rest/services/{serviceId}/ImageServer` (raster-backed services).
 curl -o dem.tif "https://server.example.com/rest/services/dem/ImageServer/exportImage?bbox=-122.5,37.7,-122.3,37.9&size=512,512&format=tiff&f=image"
 ```
 
+### Tiled-consumption metadata (`tileInfo`)
+
+By default an ImageServer advertises a **dynamic** service (`singleFusedMapCache: false`, no `tileInfo`). This keeps the descriptor — which the ArcGIS Maps SDK for .NET native runtime reads verbatim from `/conf.json` — compatible with the dynamic `exportImage` load path; advertising a cache makes that native runtime treat the service as cached and reject the configuration.
+
+The `/tile/{level}/{row}/{col}` route is always served. To let tiled Esri clients (for example `L.esri.tiledMapLayer`, which keys off `metadata.tileInfo.lods`) consume it directly, opt in to the static WebMercatorQuad cache descriptor:
+
+| Setting | Default | Effect |
+| --- | --- | --- |
+| `GeoServices:ImageServer:TileMetadata:Enabled` | `false` | When `true`, ImageServer metadata reports `singleFusedMapCache: true` plus a WebMercatorQuad `tileInfo` block (256×256 tiles, origin `(-20037508.34, 20037508.34)`, spatial reference 102100/3857, and the standard level-of-detail array). |
+| `GeoServices:ImageServer:TileMetadata:MaxLevel` | `23` | Highest zoom level emitted in `tileInfo.lods` (the tile route accepts up to 28). |
+
+Enable it only for deployments that primarily serve tiled Esri clients; the native ArcGIS Maps SDK for .NET dynamic `exportImage` path expects the default (dynamic) contract.
+
 See [GeoServices parity — ImageServer](../compatibility/geoservices-parity.md#imageserver).
 
 ## Geometry service

--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerMetadataHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerMetadataHandler.cs
@@ -11,7 +11,9 @@ using Honua.Protocols.GeoServices.ImageServer.Services;
 using Honua.Infrastructure.Models;
 using Honua.ServiceDefaults;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Honua.Protocols.GeoServices.ImageServer.Handlers;
 
@@ -119,6 +121,21 @@ internal sealed class ImageServerMetadataHandler
                 return StandardErrorHelpers.CreateInternalServerError(context, "Unable to determine raster extent.");
             }
 
+            // Tiled-consumption advertising is opt-in and defaults OFF. The same
+            // service descriptor is returned from the conf.json route the ArcGIS
+            // Maps SDK for .NET native runtime reads while loading an
+            // ImageServiceRaster; advertising a cache (singleFusedMapCache:true /
+            // tileInfo) makes that native parser treat the dynamic service as cached
+            // and reject the exportImage config (#1456). Enabling the flag emits the
+            // static WebMercatorQuad tileInfo that L.esri.tiledMapLayer requires while
+            // leaving the default (#1456-safe) dynamic contract untouched (#1648).
+            var tileMetadataOptions = context.RequestServices
+                .GetRequiredService<IOptions<ImageServerTileMetadataOptions>>().Value;
+            var advertiseTileCache = tileMetadataOptions.Enabled;
+            var tileInfo = advertiseTileCache
+                ? ImageServerTileInfoBuilder.Build(tileMetadataOptions.MaxLevel)
+                : null;
+
             // Build service info response
             var serviceInfo = new ImageServerServiceInfo
             {
@@ -165,9 +182,9 @@ internal sealed class ImageServerMetadataHandler
                 MaxImageHeight = MaxImageHeight,
                 MaxImageWidth = MaxImageWidth,
                 MaxRecordCount = MaxRecordCount,
-                SingleFusedMapCache = false,
+                SingleFusedMapCache = advertiseTileCache,
                 CacheType = null,
-                TileInfo = null,
+                TileInfo = tileInfo,
                 HasHistograms = true,
                 TimeInfo = BuildTimeInfo(ImageServerV2Lookups.ReadTimeFieldHints(resolved.Resource), rasters),
                 HasMultidimensions = multidimensionalInfo is { Variables.Length: > 0 },

--- a/src/Honua.Protocols.GeoServices/ImageServer/ImageServerServiceCollectionExtensions.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/ImageServerServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using Honua.Protocols.GeoServices.ImageServer.Handlers;
 using Honua.Protocols.GeoServices.ImageServer.Services;
+using Microsoft.Extensions.Configuration;
 
 namespace Honua.Protocols.GeoServices.ImageServer;
 
@@ -14,9 +15,22 @@ internal static class ImageServerServiceCollectionExtensions
     /// <summary>
     /// Registers Image Server services with dependency injection.
     /// </summary>
-    public static IServiceCollection AddImageServer(this IServiceCollection services)
+    /// <param name="services">The service collection to register into.</param>
+    /// <param name="configuration">
+    /// Application configuration used to bind <see cref="ImageServerTileMetadataOptions"/>
+    /// (the opt-in tiled-consumption metadata flag, #1648).
+    /// </param>
+    public static IServiceCollection AddImageServer(this IServiceCollection services, IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        // Opt-in WebMercatorQuad tileInfo advertising. Defaults OFF to keep the
+        // dynamic (#1456-safe) ImageServer contract the ArcGIS Maps SDK for .NET
+        // native runtime requires; deployments serving tiled Esri clients enable it
+        // via GeoServices:ImageServer:TileMetadata:Enabled (#1648).
+        services.Configure<ImageServerTileMetadataOptions>(
+            configuration.GetSection(ImageServerTileMetadataOptions.SectionName));
 
         // Register handlers
         services.AddScoped<ImageServerMetadataHandler>();

--- a/src/Honua.Protocols.GeoServices/ImageServer/ImageServerTileMetadataOptions.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/ImageServerTileMetadataOptions.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Honua.Protocols.GeoServices.ImageServer;
+
+/// <summary>
+/// Configuration options that control whether GeoServices ImageServer service
+/// metadata advertises a WebMercatorQuad tile cache (<c>singleFusedMapCache</c> +
+/// <c>tileInfo</c>) to match the live <c>/tile/{z}/{y}/{x}</c> route.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <c>/tile</c> route is always served, but advertising it in service metadata
+/// is opt-in and disabled by default. This is deliberate: the ImageServer service
+/// descriptor is also returned verbatim from the <c>conf.json</c> route that the
+/// ArcGIS Maps SDK for .NET native runtime reads while loading an
+/// <c>ImageServiceRaster</c>. That native parser treats a service advertising a
+/// cache (a <c>singleFusedMapCache:true</c> / tile-cache signal) as CACHED and then
+/// rejects honua's dynamic <c>exportImage</c> configuration with "Failed to read
+/// configuration data" (#1456).
+/// </para>
+/// <para>
+/// Enabling <see cref="Enabled"/> lets a deployment that primarily serves tiled
+/// Esri clients such as <c>L.esri.tiledMapLayer</c> opt in to the tiled contract
+/// (#1648); the default keeps the #1456-safe dynamic contract so the native .NET
+/// SDK dynamic <c>exportImage</c> path is never regressed.
+/// </para>
+/// </remarks>
+public sealed class ImageServerTileMetadataOptions
+{
+    /// <summary>
+    /// The configuration section name that binds to these options.
+    /// </summary>
+    public const string SectionName = "GeoServices:ImageServer:TileMetadata";
+
+    /// <summary>
+    /// When <see langword="true"/>, ImageServer service metadata advertises
+    /// <c>singleFusedMapCache:true</c> and a WebMercatorQuad <c>tileInfo</c> block
+    /// covering levels <c>0..</c><see cref="MaxLevel"/>. Defaults to
+    /// <see langword="false"/>, which preserves the dynamic (#1456-safe) contract
+    /// that the ArcGIS Maps SDK for .NET native runtime requires.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Highest WebMercatorQuad zoom level included in the advertised
+    /// <c>tileInfo.lods</c> array when <see cref="Enabled"/> is set. Esri clients
+    /// derive the maximum usable zoom from the largest level present. Defaults to
+    /// 23 (the standard Esri WebMercator basemap depth); the live tile route accepts
+    /// up to level 28.
+    /// </summary>
+    [Range(0, 28)]
+    public int MaxLevel { get; set; } = 23;
+}

--- a/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerTileInfoBuilder.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerTileInfoBuilder.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Protocols.GeoServices.ImageServer.Models;
+using SpatialConstants = Honua.Core.Features.Shared.Models.SpatialConstants;
+
+namespace Honua.Protocols.GeoServices.ImageServer.Services;
+
+/// <summary>
+/// Builds the static WebMercatorQuad (Esri "GoogleMapsCompatible") <c>tileInfo</c>
+/// descriptor advertised by ImageServer service metadata when tiled consumption is
+/// enabled. The level-of-detail table is fixed for the Web Mercator (EPSG:3857)
+/// 256-pixel tiling scheme that the live <c>/tile/{level}/{row}/{col}</c> route
+/// serves, so this is pure metadata assembly — not a new serving capability (#1648).
+/// </summary>
+internal static class ImageServerTileInfoBuilder
+{
+    /// <summary>Standard tile dimension, in pixels, for the WebMercatorQuad scheme.</summary>
+    private const int TileSize = 256;
+
+    /// <summary>Esri advertises a logical 96 DPI for WebMercator basemap caches.</summary>
+    private const int Dpi = 96;
+
+    /// <summary>
+    /// Ground resolution (meters per pixel) at zoom level 0 for a 256-pixel
+    /// WebMercatorQuad tile: <c>(2 * WebMercatorExtent) / 256</c>.
+    /// </summary>
+    private const double Resolution0 = (2.0 * SpatialConstants.WebMercatorExtent) / TileSize;
+
+    /// <summary>
+    /// Scale denominator at zoom level 0 for the WebMercatorQuad /
+    /// GoogleMapsCompatible tile matrix set. This is the OGC-standardized value that
+    /// Esri clients and the WMTS capabilities document (<c>WmtsRequestHandlers</c>)
+    /// both use; each subsequent level halves it.
+    /// </summary>
+    private const double ScaleDenominator0 = 559082264.0287178;
+
+    /// <summary>WebMercator spatial reference well-known id used by Esri tile caches.</summary>
+    private const int WebMercatorWkid = 102100;
+
+    /// <summary>The EPSG-aligned latest well-known id for WebMercator (3857).</summary>
+    private const int WebMercatorLatestWkid = 3857;
+
+    /// <summary>
+    /// Builds the fixed WebMercatorQuad <see cref="TileInfo"/> descriptor covering
+    /// levels <c>0..maxLevel</c> inclusive.
+    /// </summary>
+    /// <param name="maxLevel">
+    /// Highest zoom level to include in the LOD array (clamped to the Web Mercator
+    /// range 0–28 that the tile route accepts).
+    /// </param>
+    /// <returns>A populated <see cref="TileInfo"/> descriptor.</returns>
+    public static TileInfo Build(int maxLevel)
+    {
+        var clampedMax = Math.Clamp(maxLevel, 0, 28);
+        var lods = new LevelOfDetail[clampedMax + 1];
+        for (var level = 0; level <= clampedMax; level++)
+        {
+            var factor = (double)(1L << level);
+            lods[level] = new LevelOfDetail
+            {
+                Level = level,
+                Resolution = Resolution0 / factor,
+                Scale = ScaleDenominator0 / factor
+            };
+        }
+
+        return new TileInfo
+        {
+            Rows = TileSize,
+            Cols = TileSize,
+            Dpi = Dpi,
+            Format = "PNG",
+            CompressionQuality = null,
+            // WebMercatorQuad tiles originate at the top-left of the world extent.
+            Origin = new Point
+            {
+                X = -SpatialConstants.WebMercatorExtent,
+                Y = SpatialConstants.WebMercatorExtent
+            },
+            SpatialReference = new SpatialReference
+            {
+                Wkid = WebMercatorWkid,
+                LatestWkid = WebMercatorLatestWkid
+            },
+            Lods = lods
+        };
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -95,7 +95,7 @@ internal static class FeatureRegistrationExtensions
         services.AddCogServices(configuration);
         services.AddMultidimensionalCoverageServices();
         services.AddZarrServices();
-        services.AddImageServer();
+        services.AddImageServer(configuration);
         services.AddMapServer();
         services.AddOgcCoverages();
         services.AddOgcFeatures(configuration);

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMetadataHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMetadataHandlerTests.cs
@@ -7,6 +7,7 @@ using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.TestKit.Infrastructure;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
+using Honua.Protocols.GeoServices.ImageServer;
 using Honua.Protocols.GeoServices.ImageServer.Handlers;
 using Honua.Protocols.GeoServices.ImageServer.Models;
 using Honua.Protocols.GeoServices.ImageServer.Services;
@@ -370,10 +371,95 @@ public class ImageServerMetadataHandlerTests
         jsonResult!.Value!.SpatialReference.Wkid.Should().Be(4326);
     }
 
-    private static DefaultHttpContext CreateImageServerContext()
+    [UnitTest]
+    [Operation(Operations.GetServiceInfo)]
+    public async Task GetServiceInfoAsync_TileMetadataDisabled_OmitsTileInfoAndCache()
+    {
+        // Default (#1456-safe) contract: the ArcGIS Maps SDK for .NET native runtime
+        // reads this same descriptor from conf.json and rejects a service that
+        // advertises a cache. Tiled advertising must stay off unless opted in (#1648).
+        SetupSuccessfulMetadata();
+
+        var context = CreateImageServerContext();
+        var result = await _handler.GetServiceInfoAsync(context, 1);
+
+        var jsonResult = result as JsonHttpResult<ImageServerServiceInfo>;
+        jsonResult.Should().NotBeNull();
+        jsonResult!.Value!.SingleFusedMapCache.Should().BeFalse();
+        jsonResult.Value.TileInfo.Should().BeNull();
+    }
+
+    [UnitTest]
+    [Operation(Operations.GetServiceInfo)]
+    public async Task GetServiceInfoAsync_TileMetadataEnabled_EmitsWebMercatorTileInfo()
+    {
+        SetupSuccessfulMetadata();
+
+        var context = CreateImageServerContext(new ImageServerTileMetadataOptions { Enabled = true });
+        var result = await _handler.GetServiceInfoAsync(context, 1);
+
+        var jsonResult = result as JsonHttpResult<ImageServerServiceInfo>;
+        jsonResult.Should().NotBeNull();
+        var serviceInfo = jsonResult!.Value!;
+
+        serviceInfo.SingleFusedMapCache.Should().BeTrue();
+        serviceInfo.TileInfo.Should().NotBeNull();
+
+        var tileInfo = serviceInfo.TileInfo!;
+        tileInfo.Rows.Should().Be(256);
+        tileInfo.Cols.Should().Be(256);
+
+        // WebMercator (Esri 102100 / EPSG 3857) spatial reference.
+        tileInfo.SpatialReference.Wkid.Should().Be(102100);
+        tileInfo.SpatialReference.LatestWkid.Should().Be(3857);
+
+        // WebMercatorQuad tiles originate at the top-left of the world extent.
+        tileInfo.Origin.X.Should().BeApproximately(-20037508.342789244, 1e-6);
+        tileInfo.Origin.Y.Should().BeApproximately(20037508.342789244, 1e-6);
+
+        // Default depth is levels 0..23 inclusive.
+        tileInfo.Lods.Should().HaveCount(24);
+        tileInfo.Lods[0].Level.Should().Be(0);
+        tileInfo.Lods[0].Scale.Should().BeApproximately(559082264.0287178, 1e-3);
+        tileInfo.Lods[0].Resolution.Should().BeApproximately(156543.03392804097, 1e-6);
+
+        // Each successive level halves the scale denominator and resolution.
+        tileInfo.Lods[1].Scale.Should().BeApproximately(559082264.0287178 / 2.0, 1e-3);
+        tileInfo.Lods[23].Level.Should().Be(23);
+        tileInfo.Lods[23].Resolution.Should()
+            .BeApproximately(156543.03392804097 / (1L << 23), 1e-9);
+    }
+
+    [UnitTest]
+    [Operation(Operations.GetServiceInfo)]
+    public async Task GetServiceInfoAsync_TileMetadataEnabled_HonorsMaxLevel()
+    {
+        SetupSuccessfulMetadata();
+
+        var context = CreateImageServerContext(
+            new ImageServerTileMetadataOptions { Enabled = true, MaxLevel = 18 });
+        var result = await _handler.GetServiceInfoAsync(context, 1);
+
+        var jsonResult = result as JsonHttpResult<ImageServerServiceInfo>;
+        jsonResult.Should().NotBeNull();
+        var tileInfo = jsonResult!.Value!.TileInfo;
+        tileInfo.Should().NotBeNull();
+        tileInfo!.Lods.Should().HaveCount(19);
+        tileInfo.Lods[^1].Level.Should().Be(18);
+    }
+
+    private static DefaultHttpContext CreateImageServerContext(
+        ImageServerTileMetadataOptions? tileMetadataOptions = null)
     {
         var services = new ServiceCollection();
         services.AddSingleton<Microsoft.Extensions.Logging.ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddOptions();
+        services.Configure<ImageServerTileMetadataOptions>(options =>
+        {
+            var source = tileMetadataOptions ?? new ImageServerTileMetadataOptions();
+            options.Enabled = source.Enabled;
+            options.MaxLevel = source.MaxLevel;
+        });
 
         var context = new DefaultHttpContext();
         context.RequestServices = services.BuildServiceProvider();


### PR DESCRIPTION
## Issue Link
Fixes #1648

## Summary
GeoServices ImageServer service metadata hardcoded `singleFusedMapCache: false` and `tileInfo: null` even though the `/tile/{level}/{row}/{col}` route is always served. `L.esri.tiledMapLayer` keys off `metadata.tileInfo.lods` and throws without it, so tiled Esri consumption was impossible (the honua.io Esri Leaflet demo had to fall back to plain `L.tileLayer`).

The descriptor cannot simply be flipped on by default: the **same** document is returned verbatim from the `/conf.json` route that the ArcGIS Maps SDK for .NET native runtime reads while loading an `ImageServiceRaster`. That native parser treats a service advertising a cache (`singleFusedMapCache: true` / `tileInfo`) as **cached** and rejects honua's dynamic `exportImage` configuration with "Failed to read configuration data" — exactly the regression #1456 fixed. So this gates the tiled contract behind config: **default off keeps the #1456-safe dynamic contract; opt-in enables tileInfo for tiled Esri clients.**

When enabled, the metadata emits the static WebMercatorQuad LOD table (256×256 tiles, top-left origin, spatialReference 102100/3857, scale `559082264.0287178` halved per level, resolution `156543.03392804097` halved per level, levels `0..MaxLevel` default 23) — pure metadata assembly matching what the tile route already serves, no new serving capability.

## Changes Made
- Add `ImageServerTileMetadataOptions` (`Enabled`, `MaxLevel`) bound from `GeoServices:ImageServer:TileMetadata` in `AddImageServer`.
- Add `ImageServerTileInfoBuilder` that assembles the fixed WebMercatorQuad `tileInfo` from `SpatialConstants.WebMercatorExtent` and the canonical GoogleMapsCompatible scale denominator (the same value the WMTS handler uses).
- `ImageServerMetadataHandler` now emits `singleFusedMapCache` + `tileInfo` only when the flag is on; resolves the options via `RequestServices` to keep the handler at its 4-dependency limit.
- Document the opt-in flag in `docs/reference/protocols/geoservices-rest.md` and correct the ImageServer parity matrix (`tileInfo` was advertised as present but was actually null).

## Testing
- [x] Unit tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. Default behavior is byte-for-byte the current (#1456-safe) dynamic descriptor; the tiled contract is strictly opt-in.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
