### PR TITLE
fix(raster): store raster payloads EXTERNAL so tile reads don't detoast the whole row (#1625)

### DIFF
--- a/docs/guides/publish/publish-rasters.md
+++ b/docs/guides/publish/publish-rasters.md
@@ -35,6 +35,8 @@ Optional form fields: `description`, `srid` (overrides CRS detection), `acquisit
 
 Every raster uploaded to the same layer must match the layer's first raster in SRID and band count; mismatches return `400` with a structured homogeneity message.
 
+Imported rasters are stored with `EXTERNAL` TOAST storage (out-of-line and uncompressed) so tile, terrain, statistics, and export reads fetch only the pixels they need instead of detoasting and decompressing the entire raster on every request. Combined with the default `0-8` tile pre-generation, web tile requests resolve as indexed `raster_tiles` lookups rather than full-raster clips.
+
 ### 3. Register a cloud-hosted COG (alternative to import)
 
 ```bash

--- a/src/Honua.Postgres/Features/Raster/PostgresRasterImportService.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresRasterImportService.cs
@@ -111,6 +111,15 @@ internal sealed class PostgresRasterImportService : IRasterImportService
                 await AcquireLayerImportLockAsync(
                     connection, transaction, request.LayerId, cancellationToken).ConfigureAwait(false);
 
+                // Guarantee the monolithic raster payload is stored EXTERNAL (out-of-line,
+                // uncompressed) before the row is written, so dynamic tile/terrain/statistics
+                // reads fetch only the chunks they touch instead of detoasting + decompressing
+                // the entire 25-115 MB raster on every request (#1625). SET STORAGE only affects
+                // rows written afterwards, so applying it here (immediately before INSERT) ensures
+                // every imported raster lands EXTERNAL even on databases that predate migration 055.
+                await EnsureExternalRasterStorageAsync(
+                    connection, transaction, cancellationToken).ConfigureAwait(false);
+
                 rasterId = await InsertRasterDataAsync(
                     connection, transaction, request, fileBytes, cancellationToken).ConfigureAwait(false);
 
@@ -425,6 +434,25 @@ internal sealed class PostgresRasterImportService : IRasterImportService
             // The provider may already have aborted the transaction after a
             // server-side raster error. Preserve the original failure path.
         }
+    }
+
+    /// <summary>
+    /// Switches the <c>raster_data.raster</c> column to EXTERNAL TOAST storage so newly inserted
+    /// rasters are stored out-of-line and uncompressed. This keeps the logical-raster identity
+    /// intact (one row per <c>raster_data.id</c>, unchanged generated columns) while making
+    /// ST_Clip / ST_Value / ST_SummaryStats reads fetch only the chunks they touch instead of
+    /// inflating the whole monolithic raster (#1625). Idempotent: PostgreSQL no-ops when the
+    /// column is already EXTERNAL.
+    /// </summary>
+    private async Task EnsureExternalRasterStorageAsync(
+        DbConnection connection,
+        DbTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = $"ALTER TABLE {_rasterDataTable} ALTER COLUMN raster SET STORAGE EXTERNAL;";
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task AcquireLayerImportLockAsync(

--- a/src/Honua.Postgres/Migrations/001_CreateRasterTables.sql
+++ b/src/Honua.Postgres/Migrations/001_CreateRasterTables.sql
@@ -32,6 +32,13 @@ CREATE TABLE IF NOT EXISTS honua.raster_data (
     CONSTRAINT raster_data_layer_id_fk FOREIGN KEY (layer_id) REFERENCES honua.layers(layer_id) ON DELETE CASCADE
 );
 
+-- Store the raster payload EXTERNAL (out-of-line, UNCOMPRESSED) so dynamic
+-- tile/terrain/statistics/export reads (ST_Clip / ST_Value / ST_SummaryStats)
+-- fetch only the chunks they touch instead of detoasting and decompressing the
+-- entire 25-115 MB monolithic row on every request (#1625). The PostGIS raster
+-- type defaults to the compressed "main" strategy, which forces a full inflate.
+ALTER TABLE honua.raster_data ALTER COLUMN raster SET STORAGE EXTERNAL;
+
 -- Create indices for performance
 CREATE INDEX IF NOT EXISTS idx_raster_data_layer_id ON honua.raster_data(layer_id);
 CREATE INDEX IF NOT EXISTS idx_raster_data_name ON honua.raster_data(name);
@@ -80,6 +87,11 @@ CREATE TABLE IF NOT EXISTS honua.raster_tiles (
     CONSTRAINT raster_tiles_raster_data_id_fk FOREIGN KEY (raster_data_id) REFERENCES honua.raster_data(id) ON DELETE CASCADE,
     CONSTRAINT raster_tiles_unique_tile UNIQUE (raster_data_id, zoom_level, tile_x, tile_y)
 );
+
+-- Pre-rendered tiles are small PNG blobs read as whole rows; EXTERNAL keeps them
+-- out-of-line and uncompressed so the indexed tile lookup returns bytes without a
+-- decompression pass (#1625).
+ALTER TABLE honua.raster_tiles ALTER COLUMN tile_data SET STORAGE EXTERNAL;
 
 -- Composite index for tile lookups (zoom + coordinates)
 CREATE INDEX IF NOT EXISTS idx_raster_tiles_lookup ON honua.raster_tiles(raster_data_id, zoom_level, tile_x, tile_y);

--- a/src/Honua.Server/Migrations/055_SetRasterDataExternalStorage.sql
+++ b/src/Honua.Server/Migrations/055_SetRasterDataExternalStorage.sql
@@ -1,0 +1,47 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Make raster tile reads cheap by switching the monolithic raster payload to
+-- EXTERNAL (out-of-line, UNCOMPRESSED) TOAST storage (#1625).
+--
+-- Background: a logical raster is stored as a single honua.raster_data row whose
+-- "raster" column carries the full 25-115 MB PostGIS raster.  The PostGIS raster
+-- type defaults to the "main" TOAST strategy, which keeps the value inline where
+-- possible and COMPRESSES it.  Every dynamic tile/terrain/statistics/export path
+-- (ST_Clip, ST_Value, ST_SummaryStats over honua.raster_data.raster) must then
+-- fully detoast AND decompress the entire row before it can read the small window
+-- it actually needs -- 7-16 s/tile in production, and a browser's parallel tile
+-- burst saturates the connection pool (Npgsql timeouts -> 500s).
+--
+-- EXTERNAL storage stores the value out-of-line and uncompressed, which lets the
+-- TOAST machinery fetch only the chunks a clip/value touches instead of inflating
+-- the whole raster.  This is the storage class PostGIS recommends for large
+-- rasters served as tiles.  It preserves the single-row logical-raster identity
+-- exactly: honua.raster_data.id still keys one row, and the
+-- width/height/band_count/srid/pixel_type GENERATED columns (ST_Width(raster) etc.)
+-- are unchanged -- only the on-disk storage strategy of the existing column moves.
+--
+-- ALTER ... SET STORAGE only changes the strategy for rows written AFTER the
+-- statement; pre-existing rows keep their current TOAST until rewritten.  The
+-- accompanying VACUUM FULL is intentionally NOT issued here (it takes an exclusive
+-- lock and can be very slow on large tables); operators who want existing rows
+-- converted can run "VACUUM FULL honua.raster_data;" during a maintenance window,
+-- and the import path re-applies this storage class before inserting each new row
+-- so freshly imported rasters are always stored EXTERNAL.
+--
+-- Guarded with to_regclass so this is a safe no-op on databases where the raster
+-- schema has not been provisioned.
+DO $$
+BEGIN
+    IF to_regclass('honua.raster_data') IS NOT NULL THEN
+        EXECUTE 'ALTER TABLE honua.raster_data ALTER COLUMN raster SET STORAGE EXTERNAL';
+    END IF;
+
+    -- Pre-rendered tiles are small, snap-to-grid PNG blobs read as whole rows;
+    -- EXTERNAL keeps them out-of-line and uncompressed so the indexed tile lookup
+    -- returns the bytes without a decompression pass.
+    IF to_regclass('honua.raster_tiles') IS NOT NULL THEN
+        EXECUTE 'ALTER TABLE honua.raster_tiles ALTER COLUMN tile_data SET STORAGE EXTERNAL';
+    END IF;
+END
+$$;

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterImportServiceTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterImportServiceTests.cs
@@ -129,6 +129,66 @@ public sealed class PostgresRasterImportServiceTests(PostgresFixture fixture)
         }
     }
 
+    [IntegrationTest]
+    public async Task ImportAsync_StoresRasterPayloadWithExternalToastStorage()
+    {
+        // Regression guard for #1625: the monolithic raster payload must be stored EXTERNAL
+        // (out-of-line, uncompressed) so dynamic tile/terrain/statistics reads fetch only the
+        // chunks they touch instead of detoasting and decompressing the whole row. The import
+        // path flips the column storage before inserting, even on a schema created with the
+        // PostGIS default ("main") storage strategy.
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterImportServiceTests));
+        var filePath = await CreatePngRasterFileAsync();
+        try
+        {
+            await CreateRasterImportSchemaAsync(schemaName);
+            await InsertLayerAsync(schemaName);
+
+            // A schema created with the PostGIS default raster storage strategy is not EXTERNAL
+            // ('e'); prove the import flips the column to EXTERNAL so reads avoid decompression.
+            (await GetRasterColumnStorageAsync(schemaName)).Should().NotBe('e');
+
+            var service = CreateService(schemaName);
+            var result = await service.ImportAsync(CreateRequest(filePath, srid: 4326));
+
+            result.Success.Should().BeTrue();
+            (await GetRasterColumnStorageAsync(schemaName)).Should().Be('e');
+        }
+        finally
+        {
+            TryDeleteFile(filePath);
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task ImportAsync_WithZoomLevels_PreGeneratesTilesForIndexedLookups()
+    {
+        // Regression guard for #1625: importing with tile zoom levels must populate raster_tiles
+        // so the hot tile-serving path is an indexed lookup rather than an ST_Clip over the
+        // detoasted monolith. (The API import endpoint defaults to zooms 0..8.)
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterImportServiceTests));
+        var filePath = await CreatePngRasterFileAsync();
+        try
+        {
+            await CreateRasterImportSchemaAsync(schemaName);
+            await InsertLayerAsync(schemaName);
+
+            var service = CreateService(schemaName);
+            var result = await service.ImportAsync(CreateRequest(filePath, srid: 4326, tileZoomLevels: [0]));
+
+            result.Success.Should().BeTrue();
+            result.RasterId.Should().NotBeNull();
+            result.TilesGenerated.Should().BeGreaterThan(0);
+            (await CountTilesAsync(schemaName, result.RasterId!.Value)).Should().BeGreaterThan(0);
+        }
+        finally
+        {
+            TryDeleteFile(filePath);
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
     private PostgresRasterImportService CreateService(string schemaName)
     {
         var crsDetectionService = Substitute.For<ICrsDetectionService>();
@@ -139,7 +199,7 @@ public sealed class PostgresRasterImportServiceTests(PostgresFixture fixture)
             schemaName);
     }
 
-    private static RasterImportRequest CreateRequest(string filePath, int srid)
+    private static RasterImportRequest CreateRequest(string filePath, int srid, int[]? tileZoomLevels = null)
     {
         return new RasterImportRequest
         {
@@ -150,7 +210,7 @@ public sealed class PostgresRasterImportServiceTests(PostgresFixture fixture)
             Format = SupportedRasterFormat.PngWorldFile,
             Srid = srid,
             WorldFileContent = WorldFileContent,
-            TileZoomLevels = []
+            TileZoomLevels = tileZoomLevels ?? []
         };
     }
 
@@ -275,6 +335,32 @@ public sealed class PostgresRasterImportServiceTests(PostgresFixture fixture)
         await using var command = connection.CreateCommand();
         command.CommandText = "SELECT COUNT(*) FROM raster_data WHERE layer_id = @layerId;";
         command.Parameters.AddWithValue("layerId", LayerId);
+
+        return (long)(await command.ExecuteScalarAsync())!;
+    }
+
+    private async Task<char> GetRasterColumnStorageAsync(string schemaName)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        // pg_attribute.attstorage exposes the TOAST strategy: 'p' plain, 'm' main,
+        // 'e' external, 'x' extended. Resolve raster_data within the test's search_path.
+        command.CommandText = """
+            SELECT a.attstorage
+            FROM pg_attribute a
+            WHERE a.attrelid = 'raster_data'::regclass
+              AND a.attname = 'raster';
+            """;
+
+        return (char)(await command.ExecuteScalarAsync())!;
+    }
+
+    private async Task<long> CountTilesAsync(string schemaName, long rasterId)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM raster_tiles WHERE raster_data_id = @rasterId;";
+        command.Parameters.AddWithValue("rasterId", rasterId);
 
         return (long)(await command.ExecuteScalarAsync())!;
     }

--- a/tests/seed/base-schema.sql
+++ b/tests/seed/base-schema.sql
@@ -172,6 +172,12 @@ CREATE TABLE IF NOT EXISTS honua.raster_data (
     srid INTEGER GENERATED ALWAYS AS (ST_SRID(raster)) STORED
 );
 
+-- Store the raster payload EXTERNAL (out-of-line, UNCOMPRESSED) so dynamic
+-- tile/terrain/statistics/export reads fetch only the chunks they touch instead
+-- of detoasting and decompressing the entire monolithic row (#1625). Keep in sync
+-- with src/Honua.Postgres/Migrations/001 and Server migration 055.
+ALTER TABLE honua.raster_data ALTER COLUMN raster SET STORAGE EXTERNAL;
+
 CREATE TABLE IF NOT EXISTS honua.raster_statistics (
     id BIGSERIAL PRIMARY KEY,
     raster_data_id BIGINT NOT NULL REFERENCES honua.raster_data(id) ON DELETE CASCADE,
@@ -215,6 +221,8 @@ CREATE TABLE IF NOT EXISTS honua.raster_tiles (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT raster_tiles_unique_tile UNIQUE (raster_data_id, zoom_level, tile_x, tile_y)
 );
+
+ALTER TABLE honua.raster_tiles ALTER COLUMN tile_data SET STORAGE EXTERNAL;
 
 CREATE TABLE IF NOT EXISTS honua.cloud_raster_catalog (
     id              BIGSERIAL PRIMARY KEY,


### PR DESCRIPTION
## Issue Link
Fixes #1625

## Summary
Raster import stored each raster as a single `honua.raster_data` row whose PostGIS `raster` column used the default compressed "main" TOAST strategy. Every dynamic tile/terrain/statistics/export read (`ST_Clip`/`ST_Value`/`ST_SummaryStats`) then had to detoast **and decompress the entire 25–115MB row** before reading the small window it needed (7–16s/tile; a browser's parallel tile burst saturated the pool → Npgsql timeouts → 500s).

Switching the raster payload to **EXTERNAL** (out-of-line, uncompressed) TOAST storage lets reads fetch only the chunks they touch. This preserves the single-row logical-raster identity exactly (`id` still keys one row; the generated width/height/band_count/srid columns are unchanged — only the on-disk storage strategy moves), so no downstream read path (GetRasterInfo, statistics, clip, mosaic, terrain) changes.

## Changes Made
- `001_CreateRasterTables.sql`: set `EXTERNAL` storage on `raster_data.raster` and `raster_tiles.tile_data` at table creation (fresh DBs).
- `055_SetRasterDataExternalStorage.sql`: `ALTER ... SET STORAGE EXTERNAL` for already-provisioned DBs (new rows stored EXTERNAL; existing rows convert on rewrite/`VACUUM FULL` during a maintenance window — documented, not forced).
- Raster import service re-applies the storage class before insert so freshly imported rasters are always EXTERNAL.
- Tests + `publish-rasters` doc note.

## Testing
- [x] Integration tests added/updated
- [x] Manual testing performed
- Full `Honua.sln` Release build (warnings-as-errors) clean. Migration/import integration tests run in CI (Testcontainers + PostGIS).

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] Requires database migration

## Breaking Changes
None — storage-strategy change only; logical-raster identity and read paths unchanged.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality