### PR TITLE
fix(odata): cap $top at a server page size to prevent large spatial-query hangs (#1644)

### DIFF
--- a/docs/reference/protocols/odata.md
+++ b/docs/reference/protocols/odata.md
@@ -27,7 +27,7 @@ PATCH, PUT, and DELETE are also available on the layer-scoped key form `/odata/L
 | `$filter` | Partial | Operators and functions limited to the implemented subset below. |
 | `$select` | Implemented | Field projection; `*` returns all fields. |
 | `$orderby` | Partial | Simple field names with `asc`/`desc`; no expressions. |
-| `$top` / `$skip` | Implemented | Normalized by server limits. |
+| `$top` / `$skip` | Implemented | Normalized by server limits; `$top` is capped to the server page size (`OData:MaxPageSize`, see below). |
 | `$skiptoken` | Implemented | Opaque cursor paging; mutually exclusive with `$skip`. |
 | `$count` | Implemented | `@odata.count` in payload; `/$count` routes return text. |
 | `$expand` | Implemented | Relationship names; nested expand paths not supported. |
@@ -36,6 +36,23 @@ PATCH, PUT, and DELETE are also available on the layer-scoped key form `/odata/L
 | `$apply` | Implemented | `aggregate`, `groupby`, `filter`, `compute` transformations. |
 | `$deltatoken` | Implemented | Timestamp-based change tracking via `@odata.deltaLink`. |
 | `$format` | Partial | `json` / `application/json` only. |
+
+## Server-driven paging
+
+The server applies a page-size cap so a single request never tries to materialize an
+unbounded result set. The effective page size is `min($top, OData:MaxPageSize)`
+(default `1000`, configurable via the `OData:MaxPageSize` setting or the
+`OData__MaxPageSize` environment variable). When a client requests a `$top` larger than
+the cap, the server returns the first page (up to the cap) and an `@odata.nextLink` that
+carries the clamped `$top` and the next `$skip`; clients follow `@odata.nextLink` to page
+through the remaining rows. This is standard OData server-driven paging and keeps ad hoc
+spatial queries (for example `geo.intersects` combined with `$select`) from forcing a
+pathological database plan on a very large `LIMIT`.
+
+> **Behind a proxy/CDN:** `@odata.nextLink` (and all emitted links) use the configured
+> public origin, not the inbound `Host` header. Set `PUBLIC_BASE_URL` (or `Public:BaseUrl`)
+> so paging links resolve to the external URL. Clients that resolve `@odata.nextLink`
+> relative to the request URL are unaffected.
 
 ## $filter support
 

--- a/src/Honua.Protocols.OData/Features/ODataOptions.cs
+++ b/src/Honua.Protocols.OData/Features/ODataOptions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Honua.Protocols.OData;
+
+/// <summary>
+/// Configuration options for the OData v4 protocol adapter.
+/// </summary>
+public sealed class ODataOptions
+{
+    /// <summary>
+    /// The configuration section name that binds to these options.
+    /// </summary>
+    public const string SectionName = "OData";
+
+    /// <summary>
+    /// Server-driven paging cap. The effective page size is clamped to
+    /// <c>min($top, MaxPageSize)</c> so a single OData request never tries to
+    /// materialize an unbounded result page. When a client requests a larger
+    /// <c>$top</c>, the server returns the first page (up to this size) and
+    /// emits an <c>@odata.nextLink</c> so the client can page through the
+    /// remaining rows. A very large <c>$top</c> on an ad hoc spatial query
+    /// (for example <c>geo.intersects</c> with <c>$select</c>) otherwise
+    /// forces a pathological database plan that can exceed the request budget.
+    /// </summary>
+    [Range(1, 10000)]
+    public int MaxPageSize { get; set; } = 1000;
+}

--- a/src/Honua.Protocols.OData/Features/ODataServiceCollectionExtensions.cs
+++ b/src/Honua.Protocols.OData/Features/ODataServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using Honua.Infrastructure.Events;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Validation;
 using Honua.Protocols.OData.Services;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -20,9 +21,18 @@ namespace Honua.Protocols.OData;
 
 internal static class ODataServiceCollectionExtensions
 {
-    public static IServiceCollection AddOData(this IServiceCollection services)
+    public static IServiceCollection AddOData(this IServiceCollection services, IConfiguration? configuration = null)
     {
         ArgumentNullException.ThrowIfNull(services);
+
+        // Bind OData adapter options (e.g. OData:MaxPageSize, the server-driven
+        // paging cap). Binding is idempotent so module- and direct-registration
+        // paths can both call AddOData() safely.
+        var odataOptions = services.AddOptions<ODataOptions>();
+        if (configuration != null)
+        {
+            odataOptions.Bind(configuration.GetSection(ODataOptions.SectionName));
+        }
 
         // Audit-A1: install the OData error formatter delegate so
         // StandardErrorResponseFormatter (in Honua.Infrastructure.Models) can

--- a/src/Honua.Protocols.OData/Features/ODataStreamingQueryHandler.cs
+++ b/src/Honua.Protocols.OData/Features/ODataStreamingQueryHandler.cs
@@ -402,8 +402,12 @@ internal sealed partial class ODataStreamingQueryHandler(
                 return ODataUtilityService.CreateODataError(context, "InvalidQuery", queryError);
             }
 
-            // Determine if we should use streaming
-            bool useStreaming = pagination.Limit > StreamingThreshold && string.IsNullOrWhiteSpace(expand);
+            // Determine if we should use streaming. Base the decision on the originally
+            // requested $top, not the server page-size-clamped pagination.Limit (#1644):
+            // a request for a large page still streams the clamped page and emits an
+            // @odata.nextLink, rather than falling back to the buffered handler.
+            var requestedTop = topValue ?? pagination.Limit;
+            bool useStreaming = requestedTop > StreamingThreshold && string.IsNullOrWhiteSpace(expand);
 
             if (!useStreaming)
             {

--- a/src/Honua.Protocols.OData/Features/Services/ODataQueryParameterAdapter.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataQueryParameterAdapter.cs
@@ -8,6 +8,7 @@ using Honua.Core.Features.Query;
 using Honua.Core.Features.Shared.Models;
 using Honua.Core.Queries.Filters;
 using Honua.Infrastructure.Validation;
+using Microsoft.Extensions.Options;
 
 namespace Honua.Protocols.OData.Services;
 
@@ -40,10 +41,12 @@ internal readonly record struct ODataQueryParameters
 /// </summary>
 internal sealed class ODataQueryParameterAdapter(
     IFilterExpressionService filterExpressionService,
+    IOptions<ODataOptions> odataOptions,
     ILogger<ODataQueryParameterAdapter> logger) : IQueryParameterAdapter<ODataQueryParameters>
 {
     private readonly IFilterExpressionService _filterExpressionService = filterExpressionService
         ?? throw new ArgumentNullException(nameof(filterExpressionService));
+    private readonly int _maxPageSize = (odataOptions ?? throw new ArgumentNullException(nameof(odataOptions))).Value.MaxPageSize;
     private readonly ILogger<ODataQueryParameterAdapter> _logger = logger
         ?? throw new ArgumentNullException(nameof(logger));
 
@@ -120,12 +123,23 @@ internal sealed class ODataQueryParameterAdapter(
                 metadata["compute"] = parameters.Compute;
             }
 
+            // Clamp the effective page size to the configured server-driven paging cap
+            // (OData:MaxPageSize). A very large $top on an ad hoc spatial query
+            // (geo.intersects + $select) otherwise forces Postgres into a pathological
+            // plan for the huge LIMIT and the request hangs past the budget (#1644).
+            // The streaming handler emits an @odata.nextLink carrying this clamped page
+            // size so clients page through the remaining rows. A null $top keeps null
+            // (the downstream paging layer applies its own default and clamp).
+            var effectiveLimit = parameters.Top.HasValue
+                ? Math.Min(parameters.Top.Value, _maxPageSize)
+                : (int?)null;
+
             var unifiedQuery = new UnifiedQuery
             {
                 Filter = filter,
                 OutFields = outFields,
                 Offset = parameters.Skip,
-                Limit = parameters.Top,
+                Limit = effectiveLimit,
                 OrderBy = orderBy,
                 Hints = QueryHints.Create(
                     preferStreaming: (parameters.Top ?? DefaultLimits.DefaultResultCount) > DefaultLimits.DefaultResultCount,

--- a/src/Honua.Protocols.OData/Features/Services/ODataValidationService.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataValidationService.cs
@@ -4,6 +4,7 @@
 using Honua.Core.Configuration;
 using Honua.Core.Features.Validation;
 using Honua.Core.Features.Validation.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace Honua.Protocols.OData.Services;
 
@@ -14,15 +15,20 @@ namespace Honua.Protocols.OData.Services;
 internal sealed class ODataValidationService
 {
     private readonly ICommonQueryValidator _commonQueryValidator;
+    private readonly int _maxPageSize;
     private static readonly PaginationValidationOptions _odataPagination =
         new(MinOffset: 0, MinLimit: 1, OffsetParameterName: "$skip", LimitParameterName: "$top");
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ODataValidationService"/> class.
     /// </summary>
-    public ODataValidationService(ICommonQueryValidator commonQueryValidator)
+    public ODataValidationService(
+        ICommonQueryValidator commonQueryValidator,
+        IOptions<ODataOptions> odataOptions)
     {
         _commonQueryValidator = commonQueryValidator;
+        ArgumentNullException.ThrowIfNull(odataOptions);
+        _maxPageSize = odataOptions.Value.MaxPageSize;
     }
 
     /// <summary>
@@ -74,11 +80,38 @@ internal sealed class ODataValidationService
     }
 
     /// <summary>
+    /// The server-driven paging cap applied to OData <c>$top</c>. The effective
+    /// page size never exceeds this value; larger requests page via
+    /// <c>@odata.nextLink</c>.
+    /// </summary>
+    public int MaxPageSize => _maxPageSize;
+
+    /// <summary>
+    /// Clamps a requested page size to the configured server-driven paging cap.
+    /// A non-positive limit yields the cap so callers always materialize a
+    /// bounded page.
+    /// </summary>
+    public int ClampPageSize(int limit) => limit <= 0 ? _maxPageSize : Math.Min(limit, _maxPageSize);
+
+    /// <summary>
     /// Validates and normalizes pagination parameters, returning effective values with defaults.
+    /// The effective limit is clamped to <see cref="MaxPageSize"/> so a single OData request
+    /// never materializes an unbounded page; the streaming handler emits an <c>@odata.nextLink</c>
+    /// carrying the clamped <c>$top</c> so clients page through the remaining rows.
     /// </summary>
     public ValidationResult<PaginationValues> ValidateAndNormalizePagination(int? offset, int? limit)
     {
-        return _commonQueryValidator.ValidateAndNormalizePagination(offset, limit, _odataPagination);
+        var result = _commonQueryValidator.ValidateAndNormalizePagination(offset, limit, _odataPagination);
+        if (!result.IsValid || result.Value is null)
+        {
+            return result;
+        }
+
+        var normalized = result.Value;
+        var clampedLimit = ClampPageSize(normalized.Limit);
+        return clampedLimit == normalized.Limit
+            ? result
+            : ValidationResult<PaginationValues>.Success(normalized with { Limit = clampedLimit });
     }
 
     /// <summary>

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -104,7 +104,7 @@ internal static class FeatureRegistrationExtensions
         services.AddOgcProcesses(configuration);
         services.AddWfs20(configuration);
         services.AddWcs20();
-        services.AddOData();
+        services.AddOData(configuration);
         services.AddGeometryService();
         services.AddHonuaGrpc(configuration);
         services.AddObservability(configuration);

--- a/src/Honua.Server/Features/Infrastructure/Hosting/Modules/ODataProtocolModule.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/Modules/ODataProtocolModule.cs
@@ -26,7 +26,7 @@ public sealed class ODataProtocolModule : IHonuaProtocolModule
     public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(services);
-        services.AddOData();
+        services.AddOData(configuration);
     }
 
     /// <inheritdoc />

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataServerPagingEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataServerPagingEndpointTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+
+namespace Honua.Server.Tests.Features.Protocols.OData;
+
+/// <summary>
+/// Verifies OData server-driven paging (OData:MaxPageSize, #1644): a large $top must
+/// return promptly with a bounded first page and an @odata.nextLink, rather than
+/// materializing an unbounded LIMIT that hangs past the request budget on ad hoc
+/// spatial queries (geo.intersects + $select). The fixture pins a small MaxPageSize
+/// so the 15-feature seed exercises the multi-page path.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.ODataV4)]
+public sealed class ODataServerPagingEndpointTests : IAsyncLifetime
+{
+    private const int TestLayerId = 0;
+    private const int MaxPageSize = 5;
+
+    private readonly WebAppFixture _fixture = new WebAppFixture()
+        .WithTestLicense(HonuaEdition.Pro)
+        .ConfigureWebHost(builder => builder.UseSetting(
+            "OData:MaxPageSize",
+            MaxPageSize.ToString(CultureInfo.InvariantCulture)));
+
+    public async Task InitializeAsync()
+    {
+        _fixture.UseSeed(Path.Combine("tests", "seed", "odata.yaml"));
+        await _fixture.InitializeAsync();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /odata/Features({layerId})?$top=5000")]
+    public async Task Features_WithLargeTop_ReturnsBoundedPageWithNextLink()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var response = await _fixture.Client.GetAsync(
+            $"/odata/Features({TestLayerId})?$top=5000&$select=ObjectId,name",
+            cts.Token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync(cts.Token);
+        using var document = JsonDocument.Parse(content);
+        var root = document.RootElement;
+
+        var items = root.GetProperty("value").EnumerateArray().ToList();
+        items.Count.Should().Be(MaxPageSize, "the effective page size is clamped to OData:MaxPageSize");
+
+        root.TryGetProperty("@odata.nextLink", out var nextLink).Should().BeTrue(
+            "more rows than the page size exist, so the server must emit a nextLink for server-driven paging");
+        nextLink.GetString().Should().Contain($"$top={MaxPageSize}",
+            "the nextLink carries the clamped page size so clients page at a safe size");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /odata/Features({layerId})?$top=5000")]
+    public async Task Features_WithLargeTop_PagesThroughAllRowsViaNextLink()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(45));
+
+        var seen = new HashSet<int>();
+        var relativePath = $"/odata/Features({TestLayerId})?$top=5000&$select=ObjectId,name";
+        var pages = 0;
+
+        while (relativePath != null && pages < 20)
+        {
+            var response = await _fixture.Client.GetAsync(relativePath, cts.Token);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var content = await response.Content.ReadAsStringAsync(cts.Token);
+            using var document = JsonDocument.Parse(content);
+            var root = document.RootElement;
+
+            foreach (var item in root.GetProperty("value").EnumerateArray())
+            {
+                seen.Add(item.GetProperty("ObjectId").GetInt32());
+            }
+
+            relativePath = root.TryGetProperty("@odata.nextLink", out var nextLink)
+                ? ToRelative(nextLink.GetString()!)
+                : null;
+            pages++;
+        }
+
+        // The seed has 15 features on layer 0; all must be reachable across pages.
+        seen.Count.Should().Be(15);
+        pages.Should().BeGreaterThan(1, "a 15-row layer with a page size of 5 requires multiple pages");
+    }
+
+    private static string ToRelative(string url)
+    {
+        var uri = new Uri(url, UriKind.RelativeOrAbsolute);
+        return uri.IsAbsoluteUri ? uri.PathAndQuery : url;
+    }
+}

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchHandlerTests.cs
@@ -20,6 +20,7 @@ using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Caching;
 using Honua.Infrastructure.Events;
 using Honua.Infrastructure.Validation;
+using Honua.Protocols.OData;
 using Honua.Protocols.OData.Models;
 using Honua.Protocols.OData.Services;
 using Honua.TestKit.Infrastructure;
@@ -158,7 +159,7 @@ public sealed class ODataBatchHandlerTests
             new FeatureMutationValidator(Substitute.For<IGeometryValidator>()),
             Substitute.For<ICrsRegistry>(),
             new EditLimits(),
-            new ODataValidationService(Substitute.For<ICommonQueryValidator>()),
+            new ODataValidationService(Substitute.For<ICommonQueryValidator>(), Options.Create(new ODataOptions())),
             new ETagService(),
             new ODataEditParameterAdapter(Substitute.For<ILogger<ODataEditParameterAdapter>>()),
             new EditProcessor(Substitute.For<ILogger<EditProcessor>>()),

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchOperationHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchOperationHandlerTests.cs
@@ -26,6 +26,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Honua.TestKit.Helpers;
 
@@ -321,7 +322,7 @@ public sealed class ODataBatchOperationHandlerTests
             new FeatureMutationValidator(Substitute.For<IGeometryValidator>()),
             Substitute.For<ICrsRegistry>(),
             new EditLimits(),
-            new ODataValidationService(Substitute.For<ICommonQueryValidator>()),
+            new ODataValidationService(Substitute.For<ICommonQueryValidator>(), Options.Create(new ODataOptions())),
             new ETagService(),
             new ODataEditParameterAdapter(NullLogger<ODataEditParameterAdapter>.Instance),
             new EditProcessor(NullLogger<EditProcessor>.Instance),

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataPageSizeClampTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataPageSizeClampTests.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Validation;
+using Honua.Protocols.OData;
+using Honua.Protocols.OData.Services;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Protocols.OData;
+
+/// <summary>
+/// Unit tests for the OData server-driven paging cap (OData:MaxPageSize, #1644).
+/// A very large $top on an ad hoc spatial query (geo.intersects + $select) must be
+/// clamped so the server never materializes an unbounded page; the streaming handler
+/// then emits an @odata.nextLink carrying the clamped $top so clients page through.
+/// </summary>
+public sealed class ODataPageSizeClampTests
+{
+    private static ODataValidationService CreateService(int maxPageSize = 1000, int maxRecordCount = 10000)
+    {
+        var limits = new LimitsOptions
+        {
+            Query = new QueryLimits { MaxRecordCount = maxRecordCount }
+        };
+        var validator = new CommonQueryValidator(Options.Create(limits));
+        var options = Options.Create(new ODataOptions { MaxPageSize = maxPageSize });
+        return new ODataValidationService(validator, options);
+    }
+
+    [UnitTest]
+    public void ValidateAndNormalizePagination_TopAboveMaxPageSize_ClampsToMaxPageSize()
+    {
+        var service = CreateService(maxPageSize: 1000);
+
+        var result = service.ValidateAndNormalizePagination(offset: 0, limit: 4000);
+
+        result.IsValid.Should().BeTrue();
+        result.Value!.Limit.Should().Be(1000);
+        result.Value.Offset.Should().Be(0);
+    }
+
+    [UnitTest]
+    public void ValidateAndNormalizePagination_TopBelowMaxPageSize_PassesThrough()
+    {
+        var service = CreateService(maxPageSize: 1000);
+
+        var result = service.ValidateAndNormalizePagination(offset: 0, limit: 50);
+
+        result.IsValid.Should().BeTrue();
+        result.Value!.Limit.Should().Be(50);
+    }
+
+    [UnitTest]
+    public void ValidateAndNormalizePagination_TopEqualsMaxPageSize_PassesThrough()
+    {
+        var service = CreateService(maxPageSize: 1000);
+
+        var result = service.ValidateAndNormalizePagination(offset: 0, limit: 1000);
+
+        result.IsValid.Should().BeTrue();
+        result.Value!.Limit.Should().Be(1000);
+    }
+
+    [UnitTest]
+    public void ValidateAndNormalizePagination_TopOmitted_DefaultIsClampedToMaxPageSize()
+    {
+        // QueryLimits.DefaultRecordCount defaults to 1000; a smaller MaxPageSize must
+        // still bound the effective default page size.
+        var service = CreateService(maxPageSize: 500);
+
+        var result = service.ValidateAndNormalizePagination(offset: 0, limit: null);
+
+        result.IsValid.Should().BeTrue();
+        result.Value!.Limit.Should().Be(500);
+    }
+
+    [UnitTest]
+    public void ValidateAndNormalizePagination_PreservesOffsetWhenClamping()
+    {
+        var service = CreateService(maxPageSize: 1000);
+
+        var result = service.ValidateAndNormalizePagination(offset: 2000, limit: 8000);
+
+        result.IsValid.Should().BeTrue();
+        result.Value!.Offset.Should().Be(2000);
+        result.Value.Limit.Should().Be(1000);
+    }
+
+    [UnitTest]
+    public void ClampPageSize_LargeValue_ReturnsMaxPageSize()
+    {
+        var service = CreateService(maxPageSize: 1000);
+
+        service.ClampPageSize(10000).Should().Be(1000);
+        service.MaxPageSize.Should().Be(1000);
+    }
+
+    [UnitTest]
+    public void ClampPageSize_NonPositiveValue_ReturnsMaxPageSize()
+    {
+        var service = CreateService(maxPageSize: 1000);
+
+        service.ClampPageSize(0).Should().Be(1000);
+        service.ClampPageSize(-5).Should().Be(1000);
+    }
+
+    [UnitTest]
+    public void ClampPageSize_SmallValue_ReturnsRequestedSize()
+    {
+        var service = CreateService(maxPageSize: 1000);
+
+        service.ClampPageSize(250).Should().Be(250);
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #1644

## Summary
A very large OData `$top` (for example `$top=5000` combined with an ad hoc spatial filter such as `geo.intersects` plus `$select`) translated directly into an unbounded `LIMIT`, which forced Postgres into a pathological plan and let the request hang past the request budget. This PR caps the effective OData page size at a configurable server-driven paging limit (`OData:MaxPageSize`, default `1000`). When a client asks for more than the cap, the server returns a bounded first page and an `@odata.nextLink` carrying the clamped `$top` and next `$skip`, so clients page through the remaining rows safely. This is standard OData server-driven paging applied in the canonical query path.

## Changes Made
- Added `ODataOptions` (`OData:MaxPageSize`, default `1000`, range `1..10000`) bound from configuration via `AddOData(IConfiguration)`; wired through `FeatureRegistrationExtensions` and `ODataProtocolModule`.
- Clamped the effective canonical query `Limit` to `min($top, MaxPageSize)` in `ODataQueryParameterAdapter`, and added `MaxPageSize`/`ClampPageSize` plus clamping in `ODataValidationService.ValidateAndNormalizePagination`.
- Based the streaming-vs-buffered decision on the originally requested `$top` (not the clamped limit) in `ODataStreamingQueryHandler`, so a large request still streams the clamped page and emits an `@odata.nextLink`.
- Added unit tests (`ODataPageSizeClampTests`) and an integration test (`ODataServerPagingEndpointTests`) verifying clamping, bounded first page, nextLink emission, and full multi-page traversal; updated existing batch-handler tests for the new `ODataValidationService` constructor.
- Documented server-driven paging and the `OData:MaxPageSize`/`OData__MaxPageSize` setting in `docs/reference/protocols/odata.md`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [ ] None — standard merge-and-release flow
- [x] Requires environment variable or secret changes

## Breaking Changes
None. `OData:MaxPageSize` defaults to `1000`; clients that requested a larger `$top` now receive server-driven paging via `@odata.nextLink` instead of a single oversized page. The default page size is unchanged for typical requests.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
