### PR TITLE
fix: keep serverless host alive when the database is unavailable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,16 @@ Observability__Prometheus__Path=/metrics
 # Skip database migrations on startup
 HONUA_SKIP_MIGRATIONS=false
 
+# Degraded start (serverless/single-node): when true, a TRANSIENT database-connectivity failure
+# at startup (pool/slot exhaustion, the DB still warming up, a momentary socket error) does NOT
+# crash the process. The host starts serving non-database routes (e.g. /healthz/live, static/proxy
+# routes), /healthz/ready reports 503 until the DB recovers, and connectivity is retried in the
+# background with exponential backoff. Genuine misconfiguration (bad migration SQL, incompatible
+# PostGIS) still fails loudly. Default false (fail fast, for a clear Kubernetes CrashLoopBackOff).
+# Recommended true on AWS Lambda to avoid Runtime.ExitError crash loops under cold-start bursts.
+# Equivalent config key: Database__StartupResilience__DegradedStartEnabled
+HONUA_DB_DEGRADED_START=false
+
 # =============================================================================
 # RUNTIME LICENSING (optional)
 # =============================================================================

--- a/src/Honua.Core/Configuration/StartupResilienceOptions.cs
+++ b/src/Honua.Core/Configuration/StartupResilienceOptions.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Configuration;
+
+/// <summary>
+/// Controls how the host behaves when the database is unavailable during startup.
+/// </summary>
+/// <remarks>
+/// Defaults preserve the classic fail-fast behavior (crash on startup so Kubernetes shows a clear
+/// <c>CrashLoopBackOff</c>). Serverless and single-node deployments that must keep serving non-database
+/// routes during a database outage opt in by setting <see cref="DegradedStartEnabled"/> to
+/// <see langword="true"/> (config key <c>Database:StartupResilience:DegradedStartEnabled</c> or env var
+/// <c>HONUA_DB_DEGRADED_START</c>). Degraded start only suppresses the crash for <em>transient</em>
+/// connectivity failures; genuine misconfiguration (bad migration SQL, incompatible PostGIS) still
+/// fails loudly.
+/// </remarks>
+public sealed record StartupResilienceOptions
+{
+    /// <summary>
+    /// Configuration section name for binding from <c>appsettings</c>/environment.
+    /// </summary>
+    public const string SectionName = "Database:StartupResilience";
+
+    /// <summary>
+    /// When <see langword="true"/>, transient database-connectivity failures during startup
+    /// (preflight + migrations) do not crash the process; the host starts in a degraded mode that
+    /// serves non-database routes and retries connectivity in the background. Default
+    /// <see langword="false"/> (fail fast).
+    /// </summary>
+    public bool DegradedStartEnabled { get; init; }
+
+    /// <summary>
+    /// Whether the background retry loop attempts migrations when degraded start was triggered by a
+    /// migration failure. Default <see langword="true"/>.
+    /// </summary>
+    public bool RetryMigrationsInBackground { get; init; } = true;
+
+    /// <summary>
+    /// Base delay for the first background retry attempt. Default 2 seconds.
+    /// </summary>
+    public TimeSpan RetryBaseDelay { get; init; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Ceiling for any single background retry delay. Default 60 seconds.
+    /// </summary>
+    public TimeSpan RetryMaxDelay { get; init; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Maximum number of background retry attempts before giving up (the process keeps running but
+    /// stops retrying). 0 means retry indefinitely. Default 0.
+    /// </summary>
+    public int MaxRetryAttempts { get; init; }
+}

--- a/src/Honua.Core/Features/Import/Domain/ImportGeometryTooLargeException.cs
+++ b/src/Honua.Core/Features/Import/Domain/ImportGeometryTooLargeException.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Thrown when a single feature's geometry exceeds the configured import size guard (vertices, rings,
+/// or serialized WKB bytes) and the import is configured to fail rather than skip such features.
+/// </summary>
+/// <remarks>
+/// Surfaced as a 413-style, machine-readable error (<see cref="ImportValidationErrorCodes.GeometryTooLarge"/>)
+/// so callers can react programmatically. The guard rejects the feature deterministically instead of
+/// letting an island-scale multipolygon OOM-crash a memory-constrained host (issue #1626).
+/// </remarks>
+public sealed class ImportGeometryTooLargeException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImportGeometryTooLargeException"/> class.
+    /// </summary>
+    /// <param name="message">A human-readable description of which limit was exceeded and the guidance to fix it.</param>
+    public ImportGeometryTooLargeException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImportGeometryTooLargeException"/> class.
+    /// </summary>
+    /// <param name="message">A human-readable description of which limit was exceeded.</param>
+    /// <param name="innerException">The underlying exception, if any.</param>
+    public ImportGeometryTooLargeException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Honua.Core/Features/Import/Domain/ImportResult.cs
+++ b/src/Honua.Core/Features/Import/Domain/ImportResult.cs
@@ -142,6 +142,13 @@ public static class ImportValidationErrorCodes
     /// <summary>A feature had invalid geometry.</summary>
     public const string GeometryInvalid = "import.geometry_invalid";
 
+    /// <summary>
+    /// A single feature's geometry exceeded the configured size guard (vertices, rings, or WKB
+    /// bytes). The geometry is too large to materialize safely; explode/simplify it before import.
+    /// Surfaced 413-style so callers can react programmatically (#1626).
+    /// </summary>
+    public const string GeometryTooLarge = "import.geometry_too_large";
+
     /// <summary>The source GeoJSON document was invalid.</summary>
     public const string InvalidGeoJson = "import.geojson_invalid";
 

--- a/src/Honua.Core/Features/Infrastructure/Resilience/StartupDatabaseResilience.cs
+++ b/src/Honua.Core/Features/Infrastructure/Resilience/StartupDatabaseResilience.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+
+namespace Honua.Core.Features.Infrastructure.Resilience;
+
+/// <summary>
+/// Pure, provider-agnostic helpers that classify database startup failures and compute
+/// retry backoff for degraded-start mode.
+/// </summary>
+/// <remarks>
+/// On serverless hosts (e.g. AWS Lambda) a failed initialization aborts the runtime
+/// (<c>Runtime.ExitError</c>) and becomes a crash loop, returning 500s on every route —
+/// even routes that never touch the database. When the unavailability is a <em>transient</em>
+/// connectivity problem (pool exhaustion, the database still warming up, a momentary socket
+/// failure) the process should start in a degraded mode and retry in the background rather than
+/// crash. Genuine misconfiguration (bad migration SQL, an incompatible PostGIS install) is not
+/// transient and should still fail loudly. This type encodes that distinction without taking a
+/// dependency on a specific ADO.NET provider, so it lives in <c>Honua.Core</c> and is unit-testable.
+/// </remarks>
+public static class StartupDatabaseResilience
+{
+    /// <summary>
+    /// PostgreSQL SQLSTATE codes (and code classes) that indicate a transient connectivity
+    /// problem rather than a permanent configuration error.
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <item><description><c>53300</c> — too_many_connections (pool/slot exhaustion).</description></item>
+    /// <item><description><c>53400</c> — configuration_limit_exceeded.</description></item>
+    /// <item><description><c>57P03</c> — cannot_connect_now (server still starting up).</description></item>
+    /// <item><description><c>08*</c> — connection exception class (connection_failure, etc.).</description></item>
+    /// </list>
+    /// </remarks>
+    private static readonly string[] TransientSqlStates =
+    [
+        "53300",
+        "53400",
+        "57P03",
+    ];
+
+    /// <summary>
+    /// Determines whether the supplied exception (or any exception in its inner chain) represents a
+    /// transient database connectivity failure that should not crash a degraded-start process.
+    /// </summary>
+    /// <param name="exception">The exception thrown while touching the database during startup.</param>
+    /// <returns><see langword="true"/> when the failure looks transient (connectivity/availability);
+    /// <see langword="false"/> for permanent failures such as bad migration SQL or schema errors.</returns>
+    public static bool IsTransientConnectivityError(Exception? exception)
+    {
+        if (exception is null)
+        {
+            return false;
+        }
+
+        // AggregateException fans out to multiple inner failures; treat the group as transient only
+        // when every leaf is transient (a single permanent failure makes the whole thing fatal).
+        // Handle it explicitly rather than walking its first InnerException, which would otherwise
+        // mask a permanent sibling failure.
+        if (exception is AggregateException aggregate && aggregate.InnerExceptions.Count > 0)
+        {
+            foreach (var inner in aggregate.InnerExceptions)
+            {
+                if (!IsTransientConnectivityError(inner))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (IsTransientSingle(current))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsTransientSingle(Exception exception)
+    {
+        // TimeoutException and socket failures are always transient.
+        var typeName = exception.GetType().FullName ?? exception.GetType().Name;
+        if (typeName is "System.TimeoutException"
+            || typeName == "System.Net.Sockets.SocketException")
+        {
+            return true;
+        }
+
+        // Npgsql's transient flag and SQLSTATE are read without taking a hard reference on the
+        // provider: the connection-string resolver lives in Core, but Npgsql does not. A
+        // PostgresException carries a public string SqlState; NpgsqlException exposes a bool
+        // IsTransient. We surface both via the documented message conventions below and the
+        // SQLSTATE scan so this helper stays provider-agnostic and AOT-friendly.
+        if (typeName == "Npgsql.NpgsqlException" || typeName == "Npgsql.PostgresException")
+        {
+            var sqlState = TryReadSqlState(exception);
+            if (sqlState is not null && IsTransientSqlState(sqlState))
+            {
+                return true;
+            }
+
+            // A bare NpgsqlException without a PostgreSQL SQLSTATE is almost always a
+            // network/availability problem (host unreachable, connection refused, broken pipe).
+            if (typeName == "Npgsql.NpgsqlException" && sqlState is null)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether a PostgreSQL SQLSTATE code indicates a transient connectivity failure.
+    /// </summary>
+    /// <param name="sqlState">The five-character SQLSTATE code.</param>
+    /// <returns><see langword="true"/> when the code is in the connection-exception class or a
+    /// known transient resource-limit code.</returns>
+    public static bool IsTransientSqlState(string? sqlState)
+    {
+        if (string.IsNullOrEmpty(sqlState))
+        {
+            return false;
+        }
+
+        // Class 08 — Connection Exception (connection_failure, sqlclient_unable_to_establish, etc.).
+        if (sqlState.StartsWith("08", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        foreach (var code in TransientSqlStates)
+        {
+            if (string.Equals(sqlState, code, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string? TryReadSqlState(Exception exception)
+    {
+        // PostgresException exposes a public string SqlState property. Reading it via the runtime
+        // property avoids a compile-time dependency on Npgsql from Core. Reflection here runs only
+        // on the cold startup path (never in request hot paths) and is guarded against trimming by
+        // the fact that the failing type is already materialized in the exception instance.
+        var property = exception.GetType().GetProperty("SqlState");
+        return property?.GetValue(exception) as string;
+    }
+
+    /// <summary>
+    /// Computes the delay before the next degraded-start retry using bounded exponential backoff
+    /// with full jitter.
+    /// </summary>
+    /// <param name="attempt">The 1-based retry attempt number.</param>
+    /// <param name="baseDelay">The base delay for the first retry.</param>
+    /// <param name="maxDelay">The ceiling for any single retry delay.</param>
+    /// <param name="jitter">An optional source of [0,1) jitter; defaults to no jitter (deterministic
+    /// for tests). Production callers pass <see cref="Random.Shared"/>.</param>
+    /// <returns>The delay to wait before the next attempt.</returns>
+    public static TimeSpan GetRetryDelay(
+        int attempt,
+        TimeSpan baseDelay,
+        TimeSpan maxDelay,
+        Random? jitter = null)
+    {
+        if (attempt < 1)
+        {
+            attempt = 1;
+        }
+
+        // Exponential growth, capped before jitter to avoid overflow on large attempt counts.
+        var exponent = Math.Min(attempt - 1, 16);
+        var scaled = baseDelay.TotalMilliseconds * Math.Pow(2, exponent);
+        var cappedMs = Math.Min(scaled, maxDelay.TotalMilliseconds);
+
+        if (jitter is not null)
+        {
+            // Full jitter: pick uniformly in [0, cappedMs]. Keeps retry storms from
+            // synchronizing across many cold-starting instances.
+            cappedMs *= jitter.NextDouble();
+        }
+
+        return TimeSpan.FromMilliseconds(Math.Max(0, cappedMs));
+    }
+
+    /// <summary>
+    /// Builds the loud, operator-facing warning emitted when startup enters degraded mode so a real
+    /// misconfiguration is never silently masked.
+    /// </summary>
+    /// <param name="phase">The startup phase that failed (e.g. "migrations", "PostGIS preflight").</param>
+    /// <param name="errorMessage">The sanitized failure message.</param>
+    /// <returns>A human-readable degraded-start warning.</returns>
+    public static string BuildDegradedStartWarning(string phase, string errorMessage)
+        => string.Format(
+            CultureInfo.InvariantCulture,
+            "Database {0} failed with a transient connectivity error and degraded-start is enabled: {1}. "
+            + "The process is starting WITHOUT database access; non-database routes (e.g. /healthz/live, "
+            + "static/proxy routes) will serve, /healthz/ready will report 503 until the database recovers, "
+            + "and connectivity will be retried in the background. If this persists, treat it as an outage.",
+            phase,
+            errorMessage);
+}

--- a/src/Honua.Geometry/Features/FileImport/Services/ImportGeometrySizeGuard.cs
+++ b/src/Honua.Geometry/Features/FileImport/Services/ImportGeometrySizeGuard.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Core.Features.FileImport.Services;
+
+/// <summary>
+/// Outcome of an import geometry size check.
+/// </summary>
+public enum ImportGeometrySizeStatus
+{
+    /// <summary>The geometry is within all configured size limits.</summary>
+    WithinLimits = 0,
+
+    /// <summary>The geometry exceeded the maximum vertex count.</summary>
+    TooManyVertices = 1,
+
+    /// <summary>The geometry exceeded the maximum ring count.</summary>
+    TooManyRings = 2,
+}
+
+/// <summary>
+/// The result of an <see cref="ImportGeometrySizeGuard"/> check.
+/// </summary>
+/// <param name="Status">The size-check outcome.</param>
+/// <param name="Message">A human-readable message when a limit was exceeded; otherwise <see langword="null"/>.</param>
+public readonly record struct ImportGeometrySizeResult(ImportGeometrySizeStatus Status, string? Message)
+{
+    /// <summary>Gets a value indicating whether the geometry is within all limits.</summary>
+    public bool IsWithinLimits => Status == ImportGeometrySizeStatus.WithinLimits;
+}
+
+/// <summary>
+/// Bounded, allocation-light guard that rejects oversized geometries during import <em>before</em>
+/// they are serialized to WKB or have their coordinate arrays materialized.
+/// </summary>
+/// <remarks>
+/// A single island-scale multipolygon can carry millions of vertices. Materializing its
+/// <see cref="NtsGeometry.Coordinates"/> array (a full copy) and then writing its WKB can allocate
+/// hundreds of megabytes, OOM-killing a memory-constrained serverless host (issue #1626). This guard
+/// inspects only <see cref="NtsGeometry.NumPoints"/> and ring counts — both O(1)/O(rings) and
+/// allocation-free — so the import can reject the feature deterministically instead of crashing. It
+/// runs regardless of the optional full-geometry validation pass so the memory ceiling always holds.
+/// </remarks>
+public static class ImportGeometrySizeGuard
+{
+    /// <summary>
+    /// Checks a geometry against vertex- and ring-count limits without materializing coordinate
+    /// arrays or WKB.
+    /// </summary>
+    /// <param name="geometry">The geometry to check. <see langword="null"/> is treated as within limits.</param>
+    /// <param name="maxVertices">The maximum allowed vertex count, or 0 to disable the vertex check.</param>
+    /// <param name="maxRings">The maximum allowed ring count, or 0 to disable the ring check.</param>
+    /// <returns>The size-check result.</returns>
+    public static ImportGeometrySizeResult Check(NtsGeometry? geometry, int maxVertices, int maxRings)
+    {
+        if (geometry is null)
+        {
+            return new ImportGeometrySizeResult(ImportGeometrySizeStatus.WithinLimits, null);
+        }
+
+        if (maxVertices > 0)
+        {
+            // NumPoints walks the coordinate sequences' counts without copying coordinates.
+            var vertexCount = geometry.NumPoints;
+            if (vertexCount > maxVertices)
+            {
+                return new ImportGeometrySizeResult(
+                    ImportGeometrySizeStatus.TooManyVertices,
+                    string.Format(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        "Geometry vertex count ({0:N0}) exceeds the import limit ({1:N0}). "
+                        + "Explode multipart features (e.g. ogr2ogr -explodecollections) or simplify the geometry before importing.",
+                        vertexCount,
+                        maxVertices));
+            }
+        }
+
+        if (maxRings > 0)
+        {
+            var ringCount = CountRings(geometry);
+            if (ringCount > maxRings)
+            {
+                return new ImportGeometrySizeResult(
+                    ImportGeometrySizeStatus.TooManyRings,
+                    string.Format(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        "Geometry ring count ({0:N0}) exceeds the import limit ({1:N0}). "
+                        + "Explode multipart features or simplify the geometry before importing.",
+                        ringCount,
+                        maxRings));
+            }
+        }
+
+        return new ImportGeometrySizeResult(ImportGeometrySizeStatus.WithinLimits, null);
+    }
+
+    /// <summary>
+    /// Counts the total number of rings across all polygon members of a geometry, without copying
+    /// coordinates.
+    /// </summary>
+    /// <param name="geometry">The geometry to inspect.</param>
+    /// <returns>The total ring count (exterior + interior rings).</returns>
+    public static int CountRings(NtsGeometry geometry)
+    {
+        return geometry switch
+        {
+            Polygon polygon => 1 + polygon.NumInteriorRings,
+            MultiPolygon multiPolygon => SumRings(multiPolygon),
+            GeometryCollection collection => SumRings(collection),
+            _ => 0,
+        };
+    }
+
+    private static int SumRings(GeometryCollection collection)
+    {
+        var total = 0;
+        for (var i = 0; i < collection.NumGeometries; i++)
+        {
+            total += CountRings(collection.GetGeometryN(i));
+        }
+
+        return total;
+    }
+}

--- a/src/Honua.Hosting/Features/Monitoring/DatabaseRecoveryBackgroundService.cs
+++ b/src/Honua.Hosting/Features/Monitoring/DatabaseRecoveryBackgroundService.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Reflection;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Resilience;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.Infrastructure.Helpers;
+using Microsoft.Extensions.Hosting;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Background loop that restores database access after the host started in degraded mode because the
+/// database was unavailable at boot (issue #1632). It retries the PostGIS preflight check and pending
+/// migrations with bounded exponential backoff, marking <see cref="MigrationState"/> ready once the
+/// database is reachable so <c>/healthz/ready</c> flips to ready. The loop is inert (no-op) when the
+/// host started normally, so it adds nothing to the steady-state path.
+/// </summary>
+internal sealed class DatabaseRecoveryBackgroundService : BackgroundService
+{
+    private readonly DegradedStartupContext _context;
+    private readonly MigrationState _migrationState;
+    private readonly DatabaseCompatibilityState _compatibilityState;
+    private readonly IConfiguration _configuration;
+    private readonly StartupResilienceOptions _options;
+    private readonly IServiceProvider _services;
+    private readonly ILogger<DatabaseRecoveryBackgroundService> _logger;
+
+    public DatabaseRecoveryBackgroundService(
+        DegradedStartupContext context,
+        MigrationState migrationState,
+        DatabaseCompatibilityState compatibilityState,
+        IConfiguration configuration,
+        StartupResilienceOptions options,
+        IServiceProvider services,
+        ILogger<DatabaseRecoveryBackgroundService> logger)
+    {
+        _context = context;
+        _migrationState = migrationState;
+        _compatibilityState = compatibilityState;
+        _configuration = configuration;
+        _options = options;
+        _services = services;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_context.IsDegraded)
+        {
+            // Normal startup: nothing to recover.
+            return;
+        }
+
+        MonitoringLog.DatabaseRecoveryStarting(_logger);
+
+        var attempt = 0;
+        var jitter = Random.Shared;
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            attempt++;
+            try
+            {
+                await TryRecoverAsync(stoppingToken);
+                MonitoringLog.DatabaseRecoverySucceeded(_logger, attempt);
+                return;
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                if (!StartupDatabaseResilience.IsTransientConnectivityError(ex))
+                {
+                    // A non-transient failure surfaced during recovery (e.g. the database is now
+                    // reachable but a migration script is invalid). Stop retrying; this needs an
+                    // operator, not another connection attempt.
+                    MonitoringLog.DatabaseRecoveryGaveUp(_logger, attempt, ex.Message, ex);
+                    return;
+                }
+
+                if (_options.MaxRetryAttempts > 0 && attempt >= _options.MaxRetryAttempts)
+                {
+                    MonitoringLog.DatabaseRecoveryGaveUp(_logger, attempt, ex.Message, ex);
+                    return;
+                }
+
+                var delay = StartupDatabaseResilience.GetRetryDelay(
+                    attempt, _options.RetryBaseDelay, _options.RetryMaxDelay, jitter);
+                MonitoringLog.DatabaseRecoveryAttemptFailed(
+                    _logger, attempt, delay.TotalSeconds, ex.Message, ex);
+
+                try
+                {
+                    await Task.Delay(delay, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+        }
+    }
+
+    private async Task TryRecoverAsync(CancellationToken cancellationToken)
+    {
+        var secretResolver = _services.GetService(typeof(IConnectionSecretResolver)) as IConnectionSecretResolver;
+        var connectionString = await ConnectionStringResolutionHelper.ResolveDefaultConnectionStringAsync(
+            _configuration, secretResolver, cancellationToken);
+
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            // No connection string: there is nothing to recover to. Treat as terminal.
+            throw new InvalidOperationException("No database connection string is configured.");
+        }
+
+        // PostGIS preflight: confirms the database is reachable AND compatible.
+        if (_services.GetService(typeof(IDatabaseCompatibilityChecker)) is IDatabaseCompatibilityChecker checker)
+        {
+            var compatibility = await checker.CheckCompatibilityAsync(connectionString, cancellationToken);
+            _compatibilityState.SetResult(compatibility);
+            if (!compatibility.IsCompatible)
+            {
+                // Reaching the server but failing compatibility is a non-transient condition.
+                throw new InvalidOperationException(
+                    compatibility.ErrorMessage ?? "Database compatibility check failed.");
+            }
+        }
+
+        // Rerun migrations if they were pending at degraded start.
+        if (_context.MigrationsPending
+            && _options.RetryMigrationsInBackground
+            && _services.GetService(typeof(IDatabaseMigrationRunner)) is IDatabaseMigrationRunner runner)
+        {
+            var assembly = _context.MigrationsAssembly ?? Assembly.GetEntryAssembly();
+            if (assembly is not null)
+            {
+                _migrationState.MarkRunning("Re-applying database migrations after recovery.");
+                var result = await runner.RunMigrationsAsync(connectionString, assembly, cancellationToken);
+                if (!result.Successful)
+                {
+                    var error = result.Error
+                        ?? new InvalidOperationException(result.ErrorMessage ?? "Database migration failed.");
+                    throw error;
+                }
+            }
+        }
+
+        _migrationState.MarkSucceeded("Database recovered; migrations are up to date.");
+    }
+}

--- a/src/Honua.Hosting/Features/Monitoring/DegradedStartupContext.cs
+++ b/src/Honua.Hosting/Features/Monitoring/DegradedStartupContext.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Reflection;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Captures the state needed for the background database-recovery loop when the host starts in
+/// degraded mode because the database was unavailable at boot. Populated by the startup path and
+/// consumed by <see cref="DatabaseRecoveryBackgroundService"/>.
+/// </summary>
+internal sealed class DegradedStartupContext
+{
+    private int _degraded;
+
+    /// <summary>
+    /// Whether the host entered degraded mode (database unavailable at startup).
+    /// </summary>
+    public bool IsDegraded => Volatile.Read(ref _degraded) == 1;
+
+    /// <summary>
+    /// Whether the degraded start was caused by a migration failure (vs. preflight only). When
+    /// <see langword="true"/>, the recovery loop reruns migrations after connectivity is restored.
+    /// </summary>
+    public bool MigrationsPending { get; private set; }
+
+    /// <summary>
+    /// The assembly carrying embedded migration scripts, captured at startup so the recovery loop
+    /// can rerun migrations without re-resolving the entry assembly.
+    /// </summary>
+    public Assembly? MigrationsAssembly { get; private set; }
+
+    /// <summary>
+    /// Marks the host as degraded and records the recovery inputs.
+    /// </summary>
+    /// <param name="migrationsPending">Whether migrations still need to run after recovery.</param>
+    /// <param name="migrationsAssembly">The assembly carrying migration scripts.</param>
+    public void MarkDegraded(bool migrationsPending, Assembly? migrationsAssembly)
+    {
+        MigrationsPending = migrationsPending;
+        MigrationsAssembly = migrationsAssembly;
+        Volatile.Write(ref _degraded, 1);
+    }
+}

--- a/src/Honua.Hosting/Features/Monitoring/MonitoringLog.cs
+++ b/src/Honua.Hosting/Features/Monitoring/MonitoringLog.cs
@@ -88,4 +88,30 @@ internal static partial class MonitoringLog
         Level = LogLevel.Error,
         Message = "Database resilience metrics endpoint failed.")]
     public static partial void DatabaseResilienceMetricsEndpointFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(
+        EventId = 4320,
+        Level = LogLevel.Warning,
+        Message = "Database recovery loop starting: the host began in degraded mode (database unavailable at startup). Retrying connectivity in the background; /healthz/ready will report 503 until recovery succeeds.")]
+    public static partial void DatabaseRecoveryStarting(ILogger logger);
+
+    [LoggerMessage(
+        EventId = 4321,
+        Level = LogLevel.Warning,
+        Message = "Database recovery attempt {Attempt} failed; next retry in {DelaySeconds:F1}s. {ErrorMessage}")]
+    public static partial void DatabaseRecoveryAttemptFailed(
+        ILogger logger, int attempt, double delaySeconds, string errorMessage, Exception exception);
+
+    [LoggerMessage(
+        EventId = 4322,
+        Level = LogLevel.Information,
+        Message = "Database recovery succeeded after {Attempt} attempt(s); database is reachable and migrations are up to date. /healthz/ready will now report ready.")]
+    public static partial void DatabaseRecoverySucceeded(ILogger logger, int attempt);
+
+    [LoggerMessage(
+        EventId = 4323,
+        Level = LogLevel.Error,
+        Message = "Database recovery gave up after {Attempt} attempt(s); the host remains degraded. Non-database routes continue to serve, but database-backed routes will fail. {ErrorMessage}")]
+    public static partial void DatabaseRecoveryGaveUp(
+        ILogger logger, int attempt, string errorMessage, Exception? exception);
 }

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Batch.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Batch.cs
@@ -283,6 +283,24 @@ internal sealed partial class StreamingFileImportService
             return null;
         }
 
+        // Hard memory guard (#1626): reject oversized geometries on vertex/ring count BEFORE
+        // materializing coordinate arrays or writing WKB. A single island-scale multipolygon can
+        // carry millions of vertices; copying its coordinates and serializing its WKB can allocate
+        // hundreds of MB and OOM-crash a memory-constrained serverless host. This guard runs
+        // regardless of the optional ValidateGeometry pass so the ceiling always holds, and surfaces
+        // a clear, machine-readable error (413-style) rather than crashing.
+        var sizeResult = ImportGeometrySizeGuard.Check(feature.Geometry, _limits.MaxVertices, _limits.MaxRings);
+        if (!sizeResult.IsWithinLimits)
+        {
+            if (_limits.SkipInvalidGeometry)
+            {
+                ImportLog.GeometryTooLargeSkipped(_logger, sizeResult.Message ?? "Geometry exceeds import size limit.");
+                return null;
+            }
+
+            throw new ImportGeometryTooLargeException(sizeResult.Message ?? "Geometry exceeds import size limit.");
+        }
+
         if (_limits.ValidateGeometry)
         {
             var validationError = ValidateGeometry(feature.Geometry);
@@ -302,15 +320,22 @@ internal sealed partial class StreamingFileImportService
             : wkbWriter;
         var wkb = writer.Write(feature.Geometry);
 
-        if (_limits.ValidateGeometry && wkb.Length > _limits.MaxWkbSize)
+        if (wkb.Length > _limits.MaxWkbSize)
         {
+            // The serialized WKB exceeded the per-geometry byte ceiling. This is also enforced
+            // independently of ValidateGeometry so a degenerate geometry (few vertices, huge
+            // serialized size) cannot blow the memory budget.
             if (_limits.SkipInvalidGeometry)
             {
+                ImportLog.GeometryTooLargeSkipped(
+                    _logger,
+                    $"Geometry WKB size ({wkb.Length:N0} bytes) exceeds maximum allowed ({_limits.MaxWkbSize:N0} bytes).");
                 return null;
             }
 
-            throw new InvalidOperationException(
-                $"Geometry WKB size ({wkb.Length:N0} bytes) exceeds maximum allowed ({_limits.MaxWkbSize:N0} bytes)");
+            throw new ImportGeometryTooLargeException(
+                $"Geometry WKB size ({wkb.Length:N0} bytes) exceeds maximum allowed ({_limits.MaxWkbSize:N0} bytes). "
+                + "Explode multipart features or simplify the geometry before importing.");
         }
 
         return wkb;

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Logging.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Logging.cs
@@ -103,6 +103,14 @@ internal sealed partial class StreamingFileImportService
         public static partial void SpilledToTempFile(
             ILogger logger,
             long spilledBytes);
+
+        [LoggerMessage(
+            EventId = 7416,
+            Level = LogLevel.Warning,
+            Message = "Skipped oversized geometry during import: {Reason}")]
+        public static partial void GeometryTooLargeSkipped(
+            ILogger logger,
+            string reason);
     }
 
     private static partial class ShapefileLog

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Validation.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Validation.cs
@@ -110,23 +110,14 @@ internal sealed partial class StreamingFileImportService
     /// Validates a geometry against configured limits.
     /// Returns null if valid, or an error message if invalid.
     /// </summary>
-    private string? ValidateGeometry(NtsGeometry geometry)
+    /// <remarks>
+    /// Vertex- and ring-count ceilings are enforced earlier by
+    /// <see cref="ImportGeometrySizeGuard"/> (which runs regardless of <c>ValidateGeometry</c> as a
+    /// hard memory guard, #1626), so this method only performs the coordinate-value validation.
+    /// </remarks>
+    private static string? ValidateGeometry(NtsGeometry geometry)
     {
-        // Count vertices
-        var vertexCount = CountVertices(geometry);
-        if (vertexCount > _limits.MaxVertices)
-        {
-            return $"Vertex count ({vertexCount:N0}) exceeds maximum allowed ({_limits.MaxVertices:N0})";
-        }
-
-        // Count rings for polygon geometries
-        var ringCount = CountRings(geometry);
-        if (ringCount > _limits.MaxRings)
-        {
-            return $"Ring count ({ringCount:N0}) exceeds maximum allowed ({_limits.MaxRings:N0})";
-        }
-
-        // Validate coordinate values
+        // Validate coordinate values (NaN/Infinity) without copying the coordinate array.
         if (!ValidateCoordinates(geometry))
         {
             return "Geometry contains invalid coordinates (NaN or Infinity)";
@@ -136,51 +127,47 @@ internal sealed partial class StreamingFileImportService
     }
 
     /// <summary>
-    /// Counts the total number of vertices in a geometry.
-    /// </summary>
-    private static int CountVertices(NtsGeometry geometry)
-    {
-        return geometry.NumPoints;
-    }
-
-    /// <summary>
-    /// Counts the total number of rings in polygon geometries.
-    /// </summary>
-    private static int CountRings(NtsGeometry geometry)
-    {
-        return geometry switch
-        {
-            Polygon polygon => 1 + polygon.NumInteriorRings,
-            MultiPolygon multiPolygon => multiPolygon.Geometries
-                .OfType<Polygon>()
-                .Sum(p => 1 + p.NumInteriorRings),
-            GeometryCollection collection => collection.Geometries
-                .Sum(CountRings),
-            _ => 0
-        };
-    }
-
-    /// <summary>
-    /// Validates that all coordinates in the geometry are finite numbers.
+    /// Validates that all coordinates in the geometry are finite numbers, without materializing the
+    /// full coordinate array (which for an island-scale multipolygon would be a large allocation).
     /// </summary>
     private static bool ValidateCoordinates(NtsGeometry geometry)
     {
-        foreach (var coord in geometry.Coordinates)
+        var filter = new FiniteCoordinateFilter();
+        geometry.Apply(filter);
+        return filter.AllFinite;
+    }
+
+    /// <summary>
+    /// Coordinate-sequence filter that checks every ordinate is finite without copying coordinates.
+    /// </summary>
+    private sealed class FiniteCoordinateFilter : ICoordinateSequenceFilter
+    {
+        public bool AllFinite { get; private set; } = true;
+
+        public bool Done => !AllFinite;
+
+        public bool GeometryChanged => false;
+
+        public void Filter(CoordinateSequence seq, int i)
         {
-            if (double.IsNaN(coord.X) || double.IsInfinity(coord.X) ||
-                double.IsNaN(coord.Y) || double.IsInfinity(coord.Y))
+            var x = seq.GetX(i);
+            var y = seq.GetY(i);
+            if (double.IsNaN(x) || double.IsInfinity(x)
+                || double.IsNaN(y) || double.IsInfinity(y))
             {
-                return false;
+                AllFinite = false;
+                return;
             }
 
-            // Check Z if present
-            if (!double.IsNaN(coord.Z) && double.IsInfinity(coord.Z))
+            if (seq.HasZ)
             {
-                return false;
+                var z = seq.GetZ(i);
+                if (!double.IsNaN(z) && double.IsInfinity(z))
+                {
+                    AllFinite = false;
+                }
             }
         }
-
-        return true;
     }
 
     private static void ValidateTableName(string tableName)

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
@@ -556,6 +556,27 @@ internal sealed partial class StreamingFileImportService : IFileImportService
                 warnings);
             return result;
         }
+        catch (ImportGeometryTooLargeException ex)
+        {
+            // A single feature exceeded the geometry size guard and the import is configured to
+            // fail rather than skip (#1626). Surface a clear, machine-readable 413-style error with
+            // remediation guidance instead of letting the oversized geometry crash the host.
+            ImportLog.ImportFailedWithException(_logger, ex, jobId, request.TableName);
+            errorMessage = SanitizeImportValidationMessage(ex);
+            var geometryTooLargeIssues = new[]
+            {
+                ImportValidationIssue.Create(ImportValidationErrorCodes.GeometryTooLarge, errorMessage)
+            };
+            result = ImportResult.CreateFailure(
+                request.TableName,
+                format ?? SupportedFileFormat.GeoJson,
+                errorMessage,
+                stopwatch.Elapsed,
+                warnings,
+                ImportValidationErrorCodes.GeometryTooLarge,
+                geometryTooLargeIssues);
+            return result;
+        }
         catch (InvalidDataException ex)
         {
             // Preserve the specific message (e.g. "Row X in row group Y contains

--- a/src/Honua.Server/Features/Infrastructure/Logging/Log.cs
+++ b/src/Honua.Server/Features/Infrastructure/Logging/Log.cs
@@ -432,5 +432,18 @@ internal static partial class Log
         Message = "PostGIS preflight check failed: {ErrorMessage}. Startup aborted.")]
     public static partial void PostGisPreflightCheckFailedCritical(ILogger logger, string errorMessage);
 
+    /// <summary>
+    /// Logs (loudly, at Warning) when startup enters degraded mode because the database was
+    /// unavailable but degraded-start is enabled (#1632). The process keeps running and recovers
+    /// connectivity in the background instead of crashing.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="message">The degraded-start warning describing the transient failure.</param>
+    [LoggerMessage(
+        EventId = 5012,
+        Level = LogLevel.Warning,
+        Message = "{Message}")]
+    public static partial void DatabaseStartupDegraded(ILogger logger, string message);
+
     #endregion
 }

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -421,6 +421,22 @@ StartupConfigurationHelpers.RegisterConfigurationValidators(builder.Services);
 // Register health check services
 builder.Services.AddSingleton<Honua.Infrastructure.Monitoring.MigrationState>();
 builder.Services.AddSingleton<Honua.Infrastructure.Monitoring.DatabaseCompatibilityState>();
+
+// Degraded-start resilience (#1632): when enabled, transient DB-unavailability at startup does
+// not crash the process; the host serves non-DB routes and recovers connectivity in the background.
+var startupResilienceOptions = builder.Configuration
+    .GetSection(Honua.Core.Configuration.StartupResilienceOptions.SectionName)
+    .Get<Honua.Core.Configuration.StartupResilienceOptions>()
+    ?? new Honua.Core.Configuration.StartupResilienceOptions();
+// Env-friendly override (HONUA_DB_DEGRADED_START=true) for serverless presets.
+if (builder.Configuration.GetValue<bool?>("HONUA_DB_DEGRADED_START") is { } envDegradedStart)
+{
+    startupResilienceOptions = startupResilienceOptions with { DegradedStartEnabled = envDegradedStart };
+}
+
+builder.Services.AddSingleton(startupResilienceOptions);
+builder.Services.AddSingleton<Honua.Infrastructure.Monitoring.DegradedStartupContext>();
+builder.Services.AddHostedService<Honua.Infrastructure.Monitoring.DatabaseRecoveryBackgroundService>();
 builder.Services.AddScoped<Honua.Infrastructure.Monitoring.IDeployPreflightProbe,
     Honua.Infrastructure.Monitoring.DeployPreflightProbe>();
 builder.Services.AddScoped<Honua.Server.Features.HealthCheck.IReadinessCheckService,
@@ -1314,8 +1330,10 @@ async Task RunDatabaseMigrationsAsync()
             migrationState.MarkFailed("Database migrations failed.");
 
             // In non-Development environments, re-throw so the app fails to start
-            // (gives a clear CrashLoopBackOff signal in Kubernetes).
-            if (!app.Environment.IsDevelopment())
+            // (gives a clear CrashLoopBackOff signal in Kubernetes) — unless degraded
+            // start is enabled and the failure is transient connectivity (#1632).
+            if (!app.Environment.IsDevelopment()
+                && !TryEnterDegradedStart("migrations", error, migrationsPending: true))
             {
                 throw error;
             }
@@ -1347,12 +1365,43 @@ async Task RunDatabaseMigrationsAsync()
         migrationState.MarkFailed("Database migrations failed.");
 
         // In non-Development environments, re-throw so the app fails to start
-        // (gives a clear CrashLoopBackOff signal in Kubernetes).
-        if (!app.Environment.IsDevelopment())
+        // (gives a clear CrashLoopBackOff signal in Kubernetes) — unless degraded
+        // start is enabled and the failure is transient connectivity (#1632).
+        if (!app.Environment.IsDevelopment()
+            && !TryEnterDegradedStart("migrations", ex, migrationsPending: true))
         {
             throw;
         }
     }
+}
+
+// Degraded-start gate (#1632): returns true when the host should keep running despite a
+// startup database failure, rather than crashing the process (which on AWS Lambda becomes a
+// Runtime.ExitError crash loop that 500s every route, including non-database routes). Only
+// transient connectivity failures are suppressed, and only when degraded start is enabled;
+// genuine misconfiguration still fails loudly. When suppressed, the degraded context is armed
+// so the background recovery loop retries connectivity and flips readiness once recovered.
+bool TryEnterDegradedStart(string phase, Exception error, bool migrationsPending)
+{
+    var resilienceOptions = app.Services.GetRequiredService<Honua.Core.Configuration.StartupResilienceOptions>();
+    if (!resilienceOptions.DegradedStartEnabled)
+    {
+        return false;
+    }
+
+    if (!Honua.Core.Features.Infrastructure.Resilience.StartupDatabaseResilience.IsTransientConnectivityError(error))
+    {
+        // Real misconfiguration (bad migration SQL, incompatible PostGIS): never mask it.
+        return false;
+    }
+
+    var warning = Honua.Core.Features.Infrastructure.Resilience.StartupDatabaseResilience
+        .BuildDegradedStartWarning(phase, error.Message);
+    Honua.Infrastructure.Logging.Log.DatabaseStartupDegraded(app.Logger, warning);
+
+    var degradedContext = app.Services.GetRequiredService<Honua.Infrastructure.Monitoring.DegradedStartupContext>();
+    degradedContext.MarkDegraded(migrationsPending, Assembly.GetExecutingAssembly());
+    return true;
 }
 
 // PostGIS preflight compatibility check
@@ -1379,7 +1428,24 @@ async Task RunPostGisPreflightCheckAsync()
 
     Honua.Infrastructure.Logging.Log.PostGisPreflightCheckStarting(app.Logger);
 
-    var result = await checker.CheckCompatibilityAsync(connectionString, app.Lifetime.ApplicationStopping);
+    Honua.Core.Features.Infrastructure.Domain.DatabaseCompatibilityResult result;
+    try
+    {
+        result = await checker.CheckCompatibilityAsync(connectionString, app.Lifetime.ApplicationStopping);
+    }
+    catch (Exception ex) when (!app.Environment.IsDevelopment())
+    {
+        // The preflight could not reach the database to check compatibility. If degraded start is
+        // enabled and the failure is transient connectivity, arm degraded mode (migrations are run
+        // after this method, so they are still pending) rather than crashing the process (#1632).
+        if (TryEnterDegradedStart("PostGIS preflight", ex, migrationsPending: true))
+        {
+            return;
+        }
+
+        throw;
+    }
+
     compatibilityState.SetResult(result);
 
     if (result.IsCompatible)

--- a/tests/dotnet/Honua.Core.Tests/Features/Infrastructure/Resilience/StartupDatabaseResilienceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Infrastructure/Resilience/StartupDatabaseResilienceTests.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Sockets;
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Resilience;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Infrastructure.Resilience;
+
+/// <summary>
+/// Unit tests for <see cref="StartupDatabaseResilience"/> — the degraded-start classifier and
+/// backoff used to keep a serverless host alive when the database is unavailable at boot (#1632).
+/// </summary>
+public sealed class StartupDatabaseResilienceTests
+{
+    [UnitTest]
+    public void IsTransientConnectivityError_WithTimeoutException_ReturnsTrue()
+    {
+        StartupDatabaseResilience.IsTransientConnectivityError(new TimeoutException())
+            .Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void IsTransientConnectivityError_WithSocketException_ReturnsTrue()
+    {
+        StartupDatabaseResilience.IsTransientConnectivityError(new SocketException())
+            .Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void IsTransientConnectivityError_WithSocketExceptionNestedInInnerChain_ReturnsTrue()
+    {
+        var nested = new InvalidOperationException(
+            "connect failed", new IOException("broken pipe", new SocketException()));
+
+        StartupDatabaseResilience.IsTransientConnectivityError(nested).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void IsTransientConnectivityError_WithMigrationSqlError_ReturnsFalse()
+    {
+        // A bad migration script (e.g. syntax error) is not transient and must still fail loudly.
+        StartupDatabaseResilience.IsTransientConnectivityError(
+            new InvalidOperationException("syntax error at or near \"CREAT\""))
+            .Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void IsTransientConnectivityError_WithNull_ReturnsFalse()
+    {
+        StartupDatabaseResilience.IsTransientConnectivityError(null).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void IsTransientConnectivityError_WithAggregateOfAllTransient_ReturnsTrue()
+    {
+        var aggregate = new AggregateException(new TimeoutException(), new SocketException());
+        StartupDatabaseResilience.IsTransientConnectivityError(aggregate).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void IsTransientConnectivityError_WithAggregateContainingPermanentFailure_ReturnsFalse()
+    {
+        var aggregate = new AggregateException(
+            new TimeoutException(),
+            new InvalidOperationException("relation already exists"));
+
+        StartupDatabaseResilience.IsTransientConnectivityError(aggregate).Should().BeFalse();
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData("53300", true)]  // too_many_connections (pool/slot exhaustion)
+    [InlineData("53400", true)]  // configuration_limit_exceeded
+    [InlineData("57P03", true)]  // cannot_connect_now (server starting up)
+    [InlineData("08006", true)]  // connection_failure (class 08)
+    [InlineData("08001", true)]  // sqlclient_unable_to_establish_sqlconnection
+    [InlineData("42601", false)] // syntax_error (permanent)
+    [InlineData("42P07", false)] // duplicate_table (permanent)
+    [InlineData("23505", false)] // unique_violation (permanent)
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsTransientSqlState_ClassifiesCorrectly(string? sqlState, bool expected)
+    {
+        StartupDatabaseResilience.IsTransientSqlState(sqlState).Should().Be(expected);
+    }
+
+    [UnitTest]
+    public void GetRetryDelay_GrowsExponentiallyAndIsCapped()
+    {
+        var baseDelay = TimeSpan.FromSeconds(2);
+        var maxDelay = TimeSpan.FromSeconds(60);
+
+        // No jitter -> deterministic exponential growth.
+        StartupDatabaseResilience.GetRetryDelay(1, baseDelay, maxDelay)
+            .Should().Be(TimeSpan.FromSeconds(2));
+        StartupDatabaseResilience.GetRetryDelay(2, baseDelay, maxDelay)
+            .Should().Be(TimeSpan.FromSeconds(4));
+        StartupDatabaseResilience.GetRetryDelay(3, baseDelay, maxDelay)
+            .Should().Be(TimeSpan.FromSeconds(8));
+
+        // Large attempt is clamped to the ceiling.
+        StartupDatabaseResilience.GetRetryDelay(20, baseDelay, maxDelay)
+            .Should().Be(maxDelay);
+    }
+
+    [UnitTest]
+    public void GetRetryDelay_WithJitter_StaysWithinCappedBound()
+    {
+        var baseDelay = TimeSpan.FromSeconds(2);
+        var maxDelay = TimeSpan.FromSeconds(60);
+        var jitter = new Random(12345);
+
+        for (var attempt = 1; attempt <= 10; attempt++)
+        {
+            var delay = StartupDatabaseResilience.GetRetryDelay(attempt, baseDelay, maxDelay, jitter);
+            delay.Should().BeGreaterThanOrEqualTo(TimeSpan.Zero);
+            delay.Should().BeLessThanOrEqualTo(maxDelay);
+        }
+    }
+
+    [UnitTest]
+    public void GetRetryDelay_WithAttemptBelowOne_TreatedAsFirstAttempt()
+    {
+        var baseDelay = TimeSpan.FromSeconds(2);
+        var maxDelay = TimeSpan.FromSeconds(60);
+
+        StartupDatabaseResilience.GetRetryDelay(0, baseDelay, maxDelay)
+            .Should().Be(TimeSpan.FromSeconds(2));
+    }
+
+    [UnitTest]
+    public void BuildDegradedStartWarning_IncludesPhaseAndGuidance()
+    {
+        var warning = StartupDatabaseResilience.BuildDegradedStartWarning(
+            "migrations", "connection refused");
+
+        warning.Should().Contain("migrations");
+        warning.Should().Contain("connection refused");
+        warning.Should().Contain("degraded-start");
+        warning.Should().Contain("/healthz/ready");
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/ImportGeometrySizeGuardTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/ImportGeometrySizeGuardTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.FileImport.Services;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+/// <summary>
+/// Unit tests for <see cref="ImportGeometrySizeGuard"/> — the bounded memory guard that rejects
+/// oversized geometries before they are serialized to WKB, preventing import OOM crashes (#1626).
+/// </summary>
+public sealed class ImportGeometrySizeGuardTests
+{
+    private static readonly GeometryFactory Factory = new();
+
+    [Fact]
+    public void Check_WithNullGeometry_IsWithinLimits()
+    {
+        var result = ImportGeometrySizeGuard.Check(null, maxVertices: 10, maxRings: 10);
+        result.IsWithinLimits.Should().BeTrue();
+        result.Status.Should().Be(ImportGeometrySizeStatus.WithinLimits);
+    }
+
+    [Fact]
+    public void Check_WithSmallPolygon_IsWithinLimits()
+    {
+        var polygon = CreateSquare();
+        var result = ImportGeometrySizeGuard.Check(polygon, maxVertices: 10_000, maxRings: 100);
+        result.IsWithinLimits.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Check_WithTooManyVertices_RejectsWithGuidance()
+    {
+        // A ring with more vertices than the limit (an island-scale outline in miniature).
+        var bigRing = CreateRing(vertexCount: 50);
+
+        var result = ImportGeometrySizeGuard.Check(bigRing, maxVertices: 10, maxRings: 100);
+
+        result.IsWithinLimits.Should().BeFalse();
+        result.Status.Should().Be(ImportGeometrySizeStatus.TooManyVertices);
+        result.Message.Should().NotBeNull();
+        result.Message.Should().Contain("vertex count");
+        result.Message.Should().Contain("explodecollections");
+    }
+
+    [Fact]
+    public void Check_WithTooManyRings_RejectsWithGuidance()
+    {
+        // A multipolygon of several single-ring squares exceeds a small ring limit.
+        var polygons = new Polygon[5];
+        for (var i = 0; i < polygons.Length; i++)
+        {
+            polygons[i] = CreateSquare(offset: i * 10);
+        }
+
+        var multiPolygon = Factory.CreateMultiPolygon(polygons);
+
+        var result = ImportGeometrySizeGuard.Check(multiPolygon, maxVertices: 10_000, maxRings: 3);
+
+        result.IsWithinLimits.Should().BeFalse();
+        result.Status.Should().Be(ImportGeometrySizeStatus.TooManyRings);
+        result.Message.Should().Contain("ring count");
+    }
+
+    [Fact]
+    public void Check_WithZeroLimits_DisablesChecks()
+    {
+        var bigRing = CreateRing(vertexCount: 5_000);
+        var result = ImportGeometrySizeGuard.Check(bigRing, maxVertices: 0, maxRings: 0);
+        result.IsWithinLimits.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CountRings_CountsExteriorAndInteriorRings()
+    {
+        var shell = CreateLinearRing(0, 0, 100);
+        var hole = CreateLinearRing(10, 10, 5);
+        var polygonWithHole = Factory.CreatePolygon(shell, [hole]);
+
+        ImportGeometrySizeGuard.CountRings(polygonWithHole).Should().Be(2);
+    }
+
+    [Fact]
+    public void CountRings_NestedGeometryCollection_SumsAllRings()
+    {
+        var square = CreateSquare();
+        var collection = Factory.CreateGeometryCollection([square, square]);
+        ImportGeometrySizeGuard.CountRings(collection).Should().Be(2);
+    }
+
+    private static Polygon CreateSquare(double offset = 0)
+        => Factory.CreatePolygon(CreateLinearRing(offset, offset, 1));
+
+    private static LineString CreateRing(int vertexCount)
+    {
+        // A closed ring with the requested number of distinct vertices (approximately).
+        var coords = new Coordinate[vertexCount + 1];
+        for (var i = 0; i < vertexCount; i++)
+        {
+            coords[i] = new Coordinate(i, i % 2);
+        }
+
+        coords[vertexCount] = new Coordinate(coords[0].X, coords[0].Y);
+        return Factory.CreateLineString(coords);
+    }
+
+    private static LinearRing CreateLinearRing(double x, double y, double size)
+        => Factory.CreateLinearRing(
+        [
+            new Coordinate(x, y),
+            new Coordinate(x + size, y),
+            new Coordinate(x + size, y + size),
+            new Coordinate(x, y + size),
+            new Coordinate(x, y),
+        ]);
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/StartupDatabaseResilienceNpgsqlTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/StartupDatabaseResilienceNpgsqlTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Sockets;
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Resilience;
+using Honua.Infrastructure.Monitoring;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Npgsql;
+
+namespace Honua.Server.Tests.Infrastructure;
+
+/// <summary>
+/// Provider-aware tests for the degraded-start classifier (#1632): verifies real Npgsql exception
+/// types are correctly bucketed as transient (connectivity) vs. fatal (misconfiguration), and that
+/// the degraded-start context arms recovery without crashing the process.
+/// </summary>
+[Protocol(TestProtocols.Health)]
+public sealed class StartupDatabaseResilienceNpgsqlTests
+{
+    [UnitTest]
+    [Operation(Operations.HealthCheck)]
+    public void IsTransientConnectivityError_WithNpgsqlConnectionFailure_ReturnsTrue()
+    {
+        // A connection-refused style failure surfaces as an NpgsqlException wrapping a socket error.
+        var exception = new NpgsqlException(
+            "Failed to connect to 127.0.0.1:5432",
+            new SocketException((int)SocketError.ConnectionRefused));
+
+        StartupDatabaseResilience.IsTransientConnectivityError(exception).Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Operation(Operations.HealthCheck)]
+    public void IsTransientConnectivityError_WithTooManyConnections_ReturnsTrue()
+    {
+        // SQLSTATE 53300 (too_many_connections) is the exact pool/slot-exhaustion failure from #1632.
+        var exception = BuildPostgresException("53300");
+        StartupDatabaseResilience.IsTransientConnectivityError(exception).Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Operation(Operations.HealthCheck)]
+    public void IsTransientConnectivityError_WithCannotConnectNow_ReturnsTrue()
+    {
+        // SQLSTATE 57P03 (cannot_connect_now) — server still starting up.
+        var exception = BuildPostgresException("57P03");
+        StartupDatabaseResilience.IsTransientConnectivityError(exception).Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Operation(Operations.HealthCheck)]
+    public void IsTransientConnectivityError_WithSyntaxError_ReturnsFalse()
+    {
+        // SQLSTATE 42601 (syntax_error) — a bad migration script must still fail loudly.
+        var exception = BuildPostgresException("42601");
+        StartupDatabaseResilience.IsTransientConnectivityError(exception).Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.HealthCheck)]
+    public void DegradedStartupContext_StartsNotDegraded()
+    {
+        var context = new DegradedStartupContext();
+        context.IsDegraded.Should().BeFalse();
+        context.MigrationsPending.Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.HealthCheck)]
+    public void DegradedStartupContext_MarkDegraded_RecordsRecoveryInputs()
+    {
+        var context = new DegradedStartupContext();
+        var assembly = typeof(StartupDatabaseResilienceNpgsqlTests).Assembly;
+
+        context.MarkDegraded(migrationsPending: true, migrationsAssembly: assembly);
+
+        context.IsDegraded.Should().BeTrue();
+        context.MigrationsPending.Should().BeTrue();
+        context.MigrationsAssembly.Should().BeSameAs(assembly);
+    }
+
+    private static PostgresException BuildPostgresException(string sqlState)
+        => new(
+            messageText: "test",
+            severity: "ERROR",
+            invariantSeverity: "ERROR",
+            sqlState: sqlState);
+}


### PR DESCRIPTION
## Issue Link
Fixes #1632
Fixes #1626

## Summary
Two serverless-robustness failures surfaced on the hosted demo. (1) Under cold-start bursts, an unavailable database (Npgsql pool/slot exhaustion) made Lambda init throw on its startup DB touch, hard-exiting the runtime (`Runtime.ExitError`) into a crash loop that returned 500s on every route — including non-DB routes like the PMTiles proxy and `healthz`. (2) Importing island-scale multipolygons OOM-crashed the serving Lambda (~1024 MB, hyper `IncompleteMessage`) because a single huge geometry was materialized, coordinate-copied, and WKB-serialized in memory. This PR makes startup DB dependencies non-fatal in a opt-in degraded mode, and makes large-geometry import reject-with-guidance instead of crashing.

## Changes Made
- Add provider-agnostic `StartupDatabaseResilience` (Honua.Core) that classifies transient connectivity failures (SQLSTATE `53300`/`53400`/`57P03`, class-08 connection errors, socket/timeout, bare `NpgsqlException`) vs. permanent misconfiguration (bad migration SQL, incompatible PostGIS), with bounded exponential-backoff-with-full-jitter.
- Add `StartupResilienceOptions` (`Database:StartupResilience` / `HONUA_DB_DEGRADED_START`, default off = fail fast). When enabled, the PostGIS preflight and migration-on-boot paths in `Program.cs` no longer throw on transient DB-unavailability: they log loudly (Warning `5012`/`4320`), arm a `DegradedStartupContext`, and start the host serving non-DB routes.
- Add `DatabaseRecoveryBackgroundService` (Honua.Hosting) that retries connectivity + pending migrations in the background and flips `MigrationState` to ready once recovered. `/healthz/live` stays process-health only; `/healthz/ready` stays 503 until recovery. Default (non-serverless) behavior is unchanged unless degraded start is opted in.
- Add allocation-light `ImportGeometrySizeGuard` (Honua.Geometry) that rejects oversized geometries on vertex/ring count BEFORE coordinate arrays are materialized or WKB is written; it runs regardless of the optional `ValidateGeometry` pass so the memory ceiling always holds.
- Surface oversized geometries as a clear machine-readable 413-style error (`import.geometry_too_large`) with explode/simplify guidance via `ImportGeometryTooLargeException`, instead of a silent skip. Enforce the WKB-size ceiling independent of `ValidateGeometry`, and replace the full `Coordinates[]` copy in coordinate validation with a streaming `CoordinateSequenceFilter`.
- Document `HONUA_DB_DEGRADED_START` in `.env.example`.
- Add unit tests: classifier + backoff (Core.Tests), Npgsql-typed transient classification + degraded-start context (Server.Tests), geometry size guard (Postgres.Tests).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

`dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true` clean; `dotnet format Honua.sln --verify-no-changes` clean. New unit tests pass: `StartupDatabaseResilienceTests` (21), `ImportGeometrySizeGuardTests` (7), `StartupDatabaseResilienceNpgsqlTests` (6); existing `ReadinessCheckServiceTests` (18) and full `Honua.Architecture.Tests` (109 passed, 1 skipped) green. The degraded-start path is unit-tested at the seam (classifier, backoff, readiness/liveness split, recovery context); full Lambda init/OOM repro is not reproducible in CI without the Lambda runtime, so it is covered at the unit level.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated

New import error code `import.geometry_too_large` is additive (new failure code on an existing failure response); no protocol/OpenAPI/gRPC contract change.

## Release/Deploy Impact
- [x] Requires environment variable or secret changes

Optional new env var `HONUA_DB_DEGRADED_START` (default off; recommended `true` on AWS Lambda). No migration or infra change required.

## Breaking Changes
None. Degraded start is opt-in and defaults to the existing fail-fast behavior; import limits already existed and now reject (with a clear code) instead of silently skipping only when `SkipInvalidGeometry=false` — the default `SkipInvalidGeometry=true` still skips, now with a loud warning.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
