### PR TITLE
fix: rebuild MVT feature snapshot on source re-import (#1628)

### DIFF
--- a/src/Honua.Core/Features/Admin/Abstractions/ILayerPublishingService.cs
+++ b/src/Honua.Core/Features/Admin/Abstractions/ILayerPublishingService.cs
@@ -96,4 +96,46 @@ public interface ILayerPublishingService
         string connectionString,
         string serviceName,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Rebuild a published layer's canonical feature snapshot (<c>honua.features</c>) from
+    /// its live source table.
+    /// </summary>
+    /// <remarks>
+    /// Publishing materializes a one-time snapshot of the source table into the canonical
+    /// <c>features</c> table that the server-side MVT/tile path reads, while the feature-query
+    /// paths read the live source table. Re-importing or otherwise updating the source leaves
+    /// that snapshot stale until it is rebuilt, so callers invoke this after a source mutation
+    /// to keep tiles consistent with the live data.
+    /// </remarks>
+    /// <param name="connectionString">PostgreSQL connection string.</param>
+    /// <param name="layerId">Identifier of the published layer to refresh.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The refresh result, or <see langword="null"/> when no such published layer exists.</returns>
+    Task<MaterializedFeatureRefreshResult?> RefreshMaterializedFeaturesAsync(
+        string connectionString,
+        int layerId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Rebuild the canonical feature snapshot for every published layer backed by the given
+    /// source table, from that live source table.
+    /// </summary>
+    /// <remarks>
+    /// Used by the import path, which knows the source <c>schema.table</c> it just (re)loaded
+    /// but not the layer ids. See <see cref="RefreshMaterializedFeaturesAsync(string,int,CancellationToken)"/>
+    /// for why the snapshot must be rebuilt after a source mutation.
+    /// </remarks>
+    /// <param name="connectionString">PostgreSQL connection string.</param>
+    /// <param name="schema">Source schema of the (re)loaded table. When <see langword="null"/>
+    /// or whitespace, every published layer backed by a table with the given name is refreshed
+    /// regardless of schema (the import path may not know the resolved target schema).</param>
+    /// <param name="table">Source table that was (re)loaded.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>One result per refreshed layer; empty when the table backs no published layer.</returns>
+    Task<IReadOnlyList<MaterializedFeatureRefreshResult>> RefreshMaterializedFeaturesForSourceTableAsync(
+        string connectionString,
+        string? schema,
+        string table,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Honua.Core/Features/Admin/Domain/LayerPublishingModels.cs
+++ b/src/Honua.Core/Features/Admin/Domain/LayerPublishingModels.cs
@@ -442,6 +442,44 @@ public sealed class LayerExtentRefreshLayerResult
 }
 
 /// <summary>
+/// Result of re-materializing a published layer's canonical feature snapshot
+/// (<c>honua.features</c>) from its live source table.
+/// </summary>
+/// <remarks>
+/// The canonical snapshot backs the publish-time materialization that the server-side
+/// MVT/tile path reads. Re-importing or updating a published source table leaves that
+/// snapshot stale until it is rebuilt, so callers refresh it after a source mutation to
+/// keep tiles consistent with the live source the feature-query paths read.
+/// </remarks>
+public sealed class MaterializedFeatureRefreshResult
+{
+    /// <summary>
+    /// Identifier of the layer whose canonical snapshot was rebuilt.
+    /// </summary>
+    public int LayerId { get; init; }
+
+    /// <summary>
+    /// Display name of the refreshed layer.
+    /// </summary>
+    public required string LayerName { get; init; }
+
+    /// <summary>
+    /// Source schema the snapshot was rebuilt from.
+    /// </summary>
+    public required string Schema { get; init; }
+
+    /// <summary>
+    /// Source table the snapshot was rebuilt from.
+    /// </summary>
+    public required string Table { get; init; }
+
+    /// <summary>
+    /// Number of features materialized into the canonical snapshot after the rebuild.
+    /// </summary>
+    public int MaterializedFeatureCount { get; init; }
+}
+
+/// <summary>
 /// Error categories for layer publishing operations.
 /// </summary>
 public enum LayerPublishingErrorKind

--- a/src/Honua.Import/Features/FileImport/ImportEndpoints.cs
+++ b/src/Honua.Import/Features/FileImport/ImportEndpoints.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using Honua.Core.Features.Admin.Abstractions;
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
@@ -634,6 +635,21 @@ internal static partial class ImportEndpoints
                 UploadId = importRequest.UploadId,
                 CloudFileId = importRequest.CloudFileId
             };
+
+            // Re-importing into a table that is already published leaves the canonical
+            // `honua.features` snapshot — and the MVT/tiles built from it — stale, while the
+            // feature-query paths read the live source. Rebuild the snapshot so tiles stay
+            // consistent with the freshly imported data (honua-server#1628). Best-effort:
+            // a refresh failure must not fail the import that already succeeded.
+            if (importResult.Success)
+            {
+                await TryRefreshPublishedSnapshotAsync(
+                    context,
+                    importRequest.TargetSchema,
+                    importRequest.TableName,
+                    cancellationToken);
+            }
+
             IResult syncResult = Results.Json(importResult, ImportJsonContext.Default.ImportResult);
             await syncResult.ExecuteAsync(context);
         }
@@ -677,6 +693,52 @@ internal static partial class ImportEndpoints
             {
                 MultipartParsingHelpers.TryDeleteFile(request.File.LocalFilePath);
             }
+        }
+    }
+
+    /// <summary>
+    /// Best-effort rebuild of the canonical <c>honua.features</c> snapshot for any published
+    /// layer backed by the just-imported source table, so MVT/tiles reflect the new data.
+    /// A failure here is logged and swallowed: the import itself already succeeded.
+    /// </summary>
+    private static async Task TryRefreshPublishedSnapshotAsync(
+        HttpContext context,
+        string? targetSchema,
+        string tableName,
+        CancellationToken cancellationToken)
+    {
+        var publishingService = context.RequestServices.GetService<ILayerPublishingService>();
+        var connectionProvider = context.RequestServices.GetService<IDatabaseConnectionProvider>();
+        if (publishingService == null || connectionProvider == null)
+        {
+            return;
+        }
+
+        try
+        {
+            var connectionString = connectionProvider.GetConnectionString();
+            var refreshed = await publishingService
+                .RefreshMaterializedFeaturesForSourceTableAsync(
+                    connectionString,
+                    targetSchema,
+                    tableName,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (refreshed.Count > 0)
+            {
+                var logger = context.RequestServices.GetRequiredService<ILogger<ImportEndpointsLog>>();
+                Log.SnapshotRefreshed(logger, tableName, refreshed.Count);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            var logger = context.RequestServices.GetRequiredService<ILogger<ImportEndpointsLog>>();
+            Log.SnapshotRefreshFailed(logger, tableName, ex);
         }
     }
 
@@ -1447,6 +1509,24 @@ internal static partial class ImportEndpoints
         /// <param name="failureReason">Provider-specific failure reason.</param>
         [LoggerMessage(EventId = 3304, Level = LogLevel.Warning, Message = "Cloud upload failed for import file {FileName}: {FailureReason}")]
         public static partial void CloudUploadFailed(ILogger logger, string fileName, string failureReason);
+
+        /// <summary>
+        /// Logs when the post-import canonical snapshot rebuild for published layers fails.
+        /// </summary>
+        /// <param name="logger">The logger instance.</param>
+        /// <param name="tableName">The imported source table name.</param>
+        /// <param name="exception">The exception that caused the failure.</param>
+        [LoggerMessage(EventId = 3305, Level = LogLevel.Warning, Message = "Failed to rebuild published feature snapshot after importing table {TableName}")]
+        public static partial void SnapshotRefreshFailed(ILogger logger, string tableName, Exception exception);
+
+        /// <summary>
+        /// Logs when the post-import canonical snapshot rebuild refreshes one or more layers.
+        /// </summary>
+        /// <param name="logger">The logger instance.</param>
+        /// <param name="tableName">The imported source table name.</param>
+        /// <param name="layerCount">Number of published layers whose snapshot was rebuilt.</param>
+        [LoggerMessage(EventId = 3306, Level = LogLevel.Information, Message = "Rebuilt published feature snapshot for {LayerCount} layer(s) after importing table {TableName}")]
+        public static partial void SnapshotRefreshed(ILogger logger, string tableName, int layerCount);
     }
 
 }

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.FeatureRefresh.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.FeatureRefresh.cs
@@ -1,0 +1,344 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+//
+// Partial: canonical feature snapshot refresh.
+//
+// Rebuilds a published layer's rows in the canonical `features` table from its live source
+// table. Publishing materializes a one-time snapshot (MaterializeLayerFeaturesAsync) that the
+// server-side MVT/tile path reads, while the feature-query paths read the live source table.
+// Re-importing or updating the source therefore leaves the snapshot — and the tiles built from
+// it — silently stale (honua-server#1628). These helpers delete the layer's stale snapshot rows
+// and re-insert them from the live source within a single transaction so tiles stay consistent
+// with the live data the query paths serve.
+
+using System.Globalization;
+using Honua.Core.Features.Admin.Domain;
+using Npgsql;
+
+namespace Honua.Postgres.Features.Admin;
+
+internal sealed partial class PostgreSqlLayerPublishingService
+{
+    /// <inheritdoc/>
+    public async Task<MaterializedFeatureRefreshResult?> RefreshMaterializedFeaturesAsync(
+        string connectionString,
+        int layerId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        var metadata = await ResolveMaterializeRefreshMetadataByIdAsync(
+                connectionString,
+                layerId,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (metadata == null)
+        {
+            return null;
+        }
+
+        return await RebuildLayerSnapshotAsync(connectionString, metadata, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<MaterializedFeatureRefreshResult>> RefreshMaterializedFeaturesForSourceTableAsync(
+        string connectionString,
+        string? schema,
+        string table,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        ArgumentException.ThrowIfNullOrWhiteSpace(table);
+
+        var layerMetadata = await ResolveMaterializeRefreshMetadataBySourceAsync(
+                connectionString,
+                schema,
+                table,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (layerMetadata.Count == 0)
+        {
+            return [];
+        }
+
+        var results = new List<MaterializedFeatureRefreshResult>(layerMetadata.Count);
+        foreach (var metadata in layerMetadata)
+        {
+            var result = await RebuildLayerSnapshotAsync(connectionString, metadata, cancellationToken)
+                .ConfigureAwait(false);
+            if (result != null)
+            {
+                results.Add(result);
+            }
+        }
+
+        return results;
+    }
+
+    private async Task<MaterializedFeatureRefreshResult?> RebuildLayerSnapshotAsync(
+        string connectionString,
+        MaterializeRefreshMetadata metadata,
+        CancellationToken cancellationToken)
+    {
+        // Re-introspect the live source table so the rebuilt snapshot picks up any source
+        // schema changes and so the projected attributes match what the layer published.
+        var tableInfo = await ResolveTableInfoAsync(
+                connectionString,
+                metadata.Schema,
+                metadata.Table,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (tableInfo == null)
+        {
+            // Source table is gone; leave the existing snapshot untouched rather than
+            // wiping the canonical rows the tile path still serves.
+            return null;
+        }
+
+        var attributeColumns = SelectMaterializedAttributeColumns(
+            tableInfo,
+            metadata.FieldNames,
+            metadata.GeometryColumn);
+
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        await DeleteLayerFeaturesAsync(connection, transaction, metadata.LayerId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var materializedCount = await MaterializeLayerFeaturesAsync(
+                connection,
+                transaction,
+                metadata.LayerId,
+                metadata.Schema,
+                metadata.Table,
+                metadata.GeometryColumn,
+                metadata.Srid,
+                attributeColumns,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+        Log.LayerSnapshotRefreshed(_logger, metadata.LayerId, materializedCount);
+
+        return new MaterializedFeatureRefreshResult
+        {
+            LayerId = metadata.LayerId,
+            LayerName = metadata.LayerName,
+            Schema = metadata.Schema,
+            Table = metadata.Table,
+            MaterializedFeatureCount = materializedCount
+        };
+    }
+
+    private static List<ColumnInfo> SelectMaterializedAttributeColumns(
+        TableInfo tableInfo,
+        IReadOnlyList<string> publishedFieldNames,
+        string geometryColumn)
+    {
+        // Mirror the publish-time projection: every published, non-geometry source column is
+        // folded into the canonical `attributes` JSONB (the primary key is included too, exactly
+        // as MaterializeLayerFeaturesAsync does at publish). Order by the layer's field order so
+        // the rebuilt JSONB matches the original snapshot shape.
+        var sourceColumns = tableInfo.Columns.ToDictionary(
+            column => column.Name,
+            StringComparer.OrdinalIgnoreCase);
+
+        var selected = new List<ColumnInfo>(publishedFieldNames.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var fieldName in publishedFieldNames)
+        {
+            if (string.Equals(fieldName, geometryColumn, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (sourceColumns.TryGetValue(fieldName, out var column) && seen.Add(column.Name))
+            {
+                selected.Add(column);
+            }
+        }
+
+        return selected;
+    }
+
+    private static async Task DeleteLayerFeaturesAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        int layerId,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            DELETE FROM features
+            WHERE layer_id = @layerId;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("@layerId", layerId);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<MaterializeRefreshMetadata?> ResolveMaterializeRefreshMetadataByIdAsync(
+        string connectionString,
+        int layerId,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        const string sql = """
+            SELECT
+                layer_id,
+                layer_name,
+                table_schema,
+                table_name,
+                geometry_column,
+                COALESCE(NULLIF(srid, 0), NULLIF(storage_srid, 0), @catalogSrid) AS layer_srid
+            FROM honua.layers
+            WHERE layer_id = @layerId;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@layerId", layerId);
+        command.Parameters.AddWithValue("@catalogSrid", CatalogExtentSrid);
+
+        MaterializeRefreshMetadata? metadata;
+        await using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        {
+            metadata = await ReadMaterializeRefreshMetadataAsync(reader, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (metadata == null)
+        {
+            return null;
+        }
+
+        var fieldNames = await ReadLayerFieldNamesAsync(connection, metadata.LayerId, cancellationToken)
+            .ConfigureAwait(false);
+        return metadata with { FieldNames = fieldNames };
+    }
+
+    private static async Task<IReadOnlyList<MaterializeRefreshMetadata>> ResolveMaterializeRefreshMetadataBySourceAsync(
+        string connectionString,
+        string? schema,
+        string table,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        // When the caller knows the resolved schema, constrain by it; otherwise match every
+        // published layer for the table name (the import path may not know which schema its
+        // table resolved to). @schema is NULL in the latter case.
+        const string sql = """
+            SELECT
+                layer_id,
+                layer_name,
+                table_schema,
+                table_name,
+                geometry_column,
+                COALESCE(NULLIF(srid, 0), NULLIF(storage_srid, 0), @catalogSrid) AS layer_srid
+            FROM honua.layers
+            WHERE table_name = @table
+              AND (@schema IS NULL OR table_schema = @schema)
+            ORDER BY layer_id;
+            """;
+
+        var bases = new List<MaterializeRefreshMetadata>();
+        await using (var command = new NpgsqlCommand(sql, connection))
+        {
+            command.Parameters.AddWithValue(
+                "@schema",
+                string.IsNullOrWhiteSpace(schema) ? DBNull.Value : schema);
+            command.Parameters.AddWithValue("@table", table);
+            command.Parameters.AddWithValue("@catalogSrid", CatalogExtentSrid);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (true)
+            {
+                var metadata = await ReadMaterializeRefreshMetadataAsync(reader, cancellationToken).ConfigureAwait(false);
+                if (metadata == null)
+                {
+                    break;
+                }
+
+                bases.Add(metadata);
+            }
+        }
+
+        if (bases.Count == 0)
+        {
+            return [];
+        }
+
+        var resolved = new List<MaterializeRefreshMetadata>(bases.Count);
+        foreach (var metadata in bases)
+        {
+            var fieldNames = await ReadLayerFieldNamesAsync(connection, metadata.LayerId, cancellationToken)
+                .ConfigureAwait(false);
+            resolved.Add(metadata with { FieldNames = fieldNames });
+        }
+
+        return resolved;
+    }
+
+    private static async Task<MaterializeRefreshMetadata?> ReadMaterializeRefreshMetadataAsync(
+        NpgsqlDataReader reader,
+        CancellationToken cancellationToken)
+    {
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        if (reader.IsDBNull(4))
+        {
+            // No geometry column recorded — not a materializable spatial layer.
+            return null;
+        }
+
+        return new MaterializeRefreshMetadata(
+            reader.GetInt32(0),
+            reader.GetString(1),
+            reader.GetString(2),
+            reader.GetString(3),
+            reader.GetString(4),
+            reader.GetInt32(5),
+            []);
+    }
+
+    private static async Task<IReadOnlyList<string>> ReadLayerFieldNamesAsync(
+        NpgsqlConnection connection,
+        int layerId,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT field_name
+            FROM honua.layer_fields
+            WHERE layer_id = @layerId
+            ORDER BY field_order, field_name;
+            """;
+
+        var fieldNames = new List<string>();
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@layerId", layerId);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            fieldNames.Add(reader.GetString(0));
+        }
+
+        return fieldNames;
+    }
+
+    private sealed record MaterializeRefreshMetadata(
+        int LayerId,
+        string LayerName,
+        string Schema,
+        string Table,
+        string GeometryColumn,
+        int Srid,
+        IReadOnlyList<string> FieldNames);
+}

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
@@ -648,6 +648,12 @@ internal sealed partial class PostgreSqlLayerPublishingService(
             Level = LogLevel.Information,
             Message = "Materialized {FeatureCount} features for published layer {LayerId}")]
         public static partial void LayerMaterialized(ILogger logger, int layerId, int featureCount);
+
+        [LoggerMessage(
+            EventId = 8203,
+            Level = LogLevel.Information,
+            Message = "Rebuilt canonical feature snapshot with {FeatureCount} features for published layer {LayerId}")]
+        public static partial void LayerSnapshotRefreshed(ILogger logger, int layerId, int featureCount);
     }
 
     private sealed record LayerFieldInsert(

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -92,6 +92,7 @@ public static class EndpointRegistry
         new("GET", "/api/v1/admin/connections/{id}/layers"),
         new("POST", "/api/v1/admin/connections/{id}/layers"),
         new("POST", "/api/v1/admin/connections/{id}/layers/extents/refresh"),
+        new("POST", "/api/v1/admin/connections/{id}/layers/{layerId}/features/refresh"),
         new("PUT", "/api/v1/admin/connections/{id}/layers/{layerId}/enabled"),
         new("PUT", "/api/v1/admin/connections/{id}/layers/enabled"),
         new("GET", "/api/v1/admin/version"),

--- a/src/Honua.Server/Features/Admin/LayerPublishingEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/LayerPublishingEndpoints.cs
@@ -69,6 +69,15 @@ internal static class LayerPublishingEndpoints
             .Produces<ApiResponse<object>>(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status500InternalServerError);
 
+        group.MapPost("/{layerId:int}/features/refresh", HandleRefreshLayerFeatures)
+            .WithDisplayName("Refresh Layer Feature Snapshot")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
+            .Produces<ApiResponse<MaterializedFeatureRefreshResult>>(StatusCodes.Status200OK)
+            .Produces<ApiResponse<object>>(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .Produces<ApiResponse<object>>(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
+
         var tableGroup = endpoints.MapGroup("/api/v{version:apiVersion}/admin/connections/{id}/tables")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
@@ -392,6 +401,86 @@ internal static class LayerPublishingEndpoints
             return TypedResults.Problem(
                 title: "Layer extent refresh failed",
                 detail: "An internal error occurred while refreshing layer extents.",
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return TypedResults.Forbid();
+        }
+    }
+
+    private static async Task<IResult>
+        HandleRefreshLayerFeatures(
+            string id,
+            int layerId,
+            [FromServices] ISecureConnectionResolver resolver,
+            [FromServices] ILayerPublishingService publishingService,
+            [FromServices] IDatabaseMigrationRunner migrationRunner,
+            HttpContext context,
+            [FromServices] ILogger<LayerPublishingEndpointsLog> logger)
+    {
+        var gate = context.RequestServices.GetRequiredService<OperatorApprovalGate>();
+        var approvalResult = gate.EvaluateApproval(
+            context, OperatorResourceType.Catalog, OperatorOperation.Publish);
+        if (approvalResult != null) return approvalResult;
+
+        try
+        {
+            var connectionString = await ResolveConnectionStringAsync(id, resolver, context.RequestAborted);
+            var migrationResult = await migrationRunner.RunMigrationsAsync(
+                connectionString,
+                typeof(Program).Assembly,
+                context.RequestAborted);
+
+            if (!migrationResult.Successful)
+            {
+                LayerPublishingLog.LayerFeatureRefreshMigrationFailed(
+                    logger,
+                    migrationResult.ErrorMessage,
+                    migrationResult.Error);
+                return TypedResults.BadRequest(ApiResponse<object>.Failure("Database migration failed."));
+            }
+
+            var result = await publishingService.RefreshMaterializedFeaturesAsync(
+                connectionString,
+                layerId,
+                context.RequestAborted);
+
+            if (result == null)
+            {
+                return TypedResults.NotFound(ApiResponse<object>.Failure("Published layer not found."));
+            }
+
+            return Results.Json(
+                ApiResponse<MaterializedFeatureRefreshResult>.CreateSuccess(result),
+                LayerPublishingJsonContext.Default.ApiResponseMaterializedFeatureRefreshResult);
+        }
+        catch (LayerPublishingException ex) when (ex.ErrorKind == LayerPublishingErrorKind.NotFound)
+        {
+            LayerPublishingLog.LayerFeatureRefreshNotFound(logger, ex);
+            return TypedResults.NotFound(ApiResponse<object>.Failure(GetSafeLayerPublishingMessage(ex)));
+        }
+        catch (LayerPublishingException ex)
+        {
+            LayerPublishingLog.LayerFeatureRefreshFailed(logger, ex);
+            return TypedResults.BadRequest(ApiResponse<object>.Failure(GetSafeLayerPublishingMessage(ex)));
+        }
+        catch (ArgumentException ex)
+        {
+            LayerPublishingLog.LayerFeatureRefreshInvalidRequest(logger, ex);
+            return TypedResults.BadRequest(ApiResponse<object>.Failure("Invalid request parameters."));
+        }
+        catch (ResourceNotFoundException ex)
+        {
+            LayerPublishingLog.LayerFeatureRefreshConnectionNotFound(logger, ex);
+            return TypedResults.NotFound(ApiResponse<object>.Failure("The requested resource was not found."));
+        }
+        catch (InvalidOperationException ex)
+        {
+            LayerPublishingLog.LayerFeatureRefreshInvalidOperation(logger, ex);
+            return TypedResults.Problem(
+                title: "Layer feature refresh failed",
+                detail: "An internal error occurred while refreshing layer features.",
                 statusCode: StatusCodes.Status500InternalServerError);
         }
         catch (UnauthorizedAccessException)

--- a/src/Honua.Server/Features/Admin/LayerPublishingLog.cs
+++ b/src/Honua.Server/Features/Admin/LayerPublishingLog.cs
@@ -93,4 +93,22 @@ internal static partial class LayerPublishingLog
 
     [LoggerMessage(EventId = 9649, Level = LogLevel.Error, Message = "Layer extent refresh failed due to invalid operation")]
     public static partial void LayerExtentRefreshInvalidOperation(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 9650, Level = LogLevel.Error, Message = "Layer feature refresh migration failed: {Message}")]
+    public static partial void LayerFeatureRefreshMigrationFailed(ILogger logger, string? message, Exception? exception);
+
+    [LoggerMessage(EventId = 9651, Level = LogLevel.Warning, Message = "Layer feature refresh not found")]
+    public static partial void LayerFeatureRefreshNotFound(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 9652, Level = LogLevel.Warning, Message = "Layer feature refresh failed")]
+    public static partial void LayerFeatureRefreshFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 9653, Level = LogLevel.Warning, Message = "Layer feature refresh invalid request")]
+    public static partial void LayerFeatureRefreshInvalidRequest(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 9654, Level = LogLevel.Warning, Message = "Layer feature refresh connection not found")]
+    public static partial void LayerFeatureRefreshConnectionNotFound(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 9655, Level = LogLevel.Error, Message = "Layer feature refresh failed due to invalid operation")]
+    public static partial void LayerFeatureRefreshInvalidOperation(ILogger logger, Exception exception);
 }

--- a/src/Honua.Server/Features/Admin/Models/LayerPublishingJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/LayerPublishingJsonContext.cs
@@ -18,6 +18,8 @@ namespace Honua.Server.Features.Admin.Models;
 [JsonSerializable(typeof(ApiResponse<PublishedLayerSummary>))]
 [JsonSerializable(typeof(ApiResponse<TablePublishValidationResult>))]
 [JsonSerializable(typeof(ApiResponse<LayerExtentRefreshResult>))]
+[JsonSerializable(typeof(ApiResponse<MaterializedFeatureRefreshResult>))]
+[JsonSerializable(typeof(MaterializedFeatureRefreshResult))]
 [JsonSerializable(typeof(ApiResponse<object>))]
 [JsonSerializable(typeof(PublishLayerRequest))]
 [JsonSerializable(typeof(ValidateTablePublishRequest))]

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceApplyPlanTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceApplyPlanTests.cs
@@ -588,6 +588,19 @@ public sealed class GeoServerImportServiceApplyPlanTests
             CancellationToken cancellationToken = default)
             => Task.FromResult<LayerExtentRefreshResult?>(null);
 
+        public Task<MaterializedFeatureRefreshResult?> RefreshMaterializedFeaturesAsync(
+            string connectionString,
+            int layerId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<MaterializedFeatureRefreshResult?>(null);
+
+        public Task<IReadOnlyList<MaterializedFeatureRefreshResult>> RefreshMaterializedFeaturesForSourceTableAsync(
+            string connectionString,
+            string? schema,
+            string table,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<MaterializedFeatureRefreshResult>>([]);
+
         private static PublishedLayerSummary CreateSummary(
             int layerId,
             string schema,

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceDataSourceApplyTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceDataSourceApplyTests.cs
@@ -627,6 +627,19 @@ public sealed class GeoServerImportServiceDataSourceApplyTests
             string serviceName,
             CancellationToken cancellationToken = default)
             => Task.FromResult<LayerExtentRefreshResult?>(null);
+
+        public Task<MaterializedFeatureRefreshResult?> RefreshMaterializedFeaturesAsync(
+            string connectionString,
+            int layerId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<MaterializedFeatureRefreshResult?>(null);
+
+        public Task<IReadOnlyList<MaterializedFeatureRefreshResult>> RefreshMaterializedFeaturesForSourceTableAsync(
+            string connectionString,
+            string? schema,
+            string table,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<MaterializedFeatureRefreshResult>>([]);
     }
 
     /// <summary>
@@ -708,6 +721,19 @@ public sealed class GeoServerImportServiceDataSourceApplyTests
             string serviceName,
             CancellationToken cancellationToken = default)
             => Task.FromResult<LayerExtentRefreshResult?>(null);
+
+        public Task<MaterializedFeatureRefreshResult?> RefreshMaterializedFeaturesAsync(
+            string connectionString,
+            int layerId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<MaterializedFeatureRefreshResult?>(null);
+
+        public Task<IReadOnlyList<MaterializedFeatureRefreshResult>> RefreshMaterializedFeaturesForSourceTableAsync(
+            string connectionString,
+            string? schema,
+            string table,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<MaterializedFeatureRefreshResult>>([]);
     }
 
     private sealed class RecordingMigrationCatalogWriter : IMigrationCatalogWriter

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportWorkspaceScopingTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportWorkspaceScopingTests.cs
@@ -530,6 +530,19 @@ public sealed class GeoServerImportWorkspaceScopingTests
             string serviceName,
             CancellationToken cancellationToken = default)
             => Task.FromResult<LayerExtentRefreshResult?>(null);
+
+        public Task<MaterializedFeatureRefreshResult?> RefreshMaterializedFeaturesAsync(
+            string connectionString,
+            int layerId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<MaterializedFeatureRefreshResult?>(null);
+
+        public Task<IReadOnlyList<MaterializedFeatureRefreshResult>> RefreshMaterializedFeaturesForSourceTableAsync(
+            string connectionString,
+            string? schema,
+            string table,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<MaterializedFeatureRefreshResult>>([]);
     }
 
     private sealed class RecordingMigrationCatalogWriter : IMigrationCatalogWriter

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportReconciliationGateTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportReconciliationGateTests.cs
@@ -201,6 +201,14 @@ public sealed class GeoservicesImportReconciliationGateTests(PostgresFixture fix
         public Task<LayerExtentRefreshResult?> RefreshLayerExtentsAsync(
             string connectionString, string serviceName, CancellationToken cancellationToken = default)
             => Task.FromResult<LayerExtentRefreshResult?>(null);
+
+        public Task<MaterializedFeatureRefreshResult?> RefreshMaterializedFeaturesAsync(
+            string connectionString, int layerId, CancellationToken cancellationToken = default)
+            => Task.FromResult<MaterializedFeatureRefreshResult?>(null);
+
+        public Task<IReadOnlyList<MaterializedFeatureRefreshResult>> RefreshMaterializedFeaturesForSourceTableAsync(
+            string connectionString, string? schema, string table, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<MaterializedFeatureRefreshResult>>([]);
     }
 
     private sealed class SimpleFeatureServerHandler : HttpMessageHandler

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportServiceAttachmentImportTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportServiceAttachmentImportTests.cs
@@ -332,6 +332,19 @@ public sealed class GeoservicesImportServiceAttachmentImportTests(PostgresFixtur
             string serviceName,
             CancellationToken cancellationToken = default)
             => Task.FromResult<LayerExtentRefreshResult?>(null);
+
+        public Task<MaterializedFeatureRefreshResult?> RefreshMaterializedFeaturesAsync(
+            string connectionString,
+            int layerId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<MaterializedFeatureRefreshResult?>(null);
+
+        public Task<IReadOnlyList<MaterializedFeatureRefreshResult>> RefreshMaterializedFeaturesForSourceTableAsync(
+            string connectionString,
+            string? schema,
+            string table,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<MaterializedFeatureRefreshResult>>([]);
     }
 
     private sealed class AttachmentFeatureServerHandler(long? failAttachmentId = null) : HttpMessageHandler

--- a/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
@@ -495,6 +495,95 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.Update)]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
+    [Endpoint("POST /api/v1/admin/connections/{id}/layers/{layerId}/features/refresh")]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    [Endpoint("GET /ogc/tiles/collections/{collectionId}/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}")]
+    public async Task RefreshMaterializedFeatures_AfterSourceUpdate_RebuildsSnapshotMvtReads()
+    {
+        // The published layer materializes a one-time snapshot of the source table into the
+        // canonical `honua.features` table that the server-side MVT/tile path reads, while the
+        // feature-query paths read the live source. After updating the source, the query path
+        // sees the new row but the MVT snapshot stays stale until rebuilt (honua-server#1628).
+        var publishedLayer = await PublishLayerAsync(new PublishLayerRequest
+        {
+            Schema = _schema,
+            Table = _tableName,
+            LayerName = $"Layer {_tableName}",
+            Description = "Layer publish materialized feature refresh integration test",
+            GeometryColumn = "geom",
+            GeometryType = "Point",
+            Srid = 4326,
+            PrimaryKey = "id",
+            Fields = _idNamePopulationFields,
+            ServiceName = _serviceName,
+            Enabled = true
+        });
+        _layerId = publishedLayer.LayerId;
+
+        // The publish-time snapshot has exactly one row (the seeded "Test Feature").
+        (await GetCanonicalSnapshotCountAsync(_layerId.Value)).Should().Be(1);
+
+        // The vector tile path serves data from that canonical snapshot. (200 with bytes when the
+        // tile holds features, 204 when empty; either confirms the MVT endpoint is reachable for
+        // the published collection — the load-bearing assertions below are the snapshot row count.)
+        var tilePath = $"/ogc/tiles/collections/{_layerId}/tiles/WebMercatorQuad/4/7/8";
+        var staleTileResponse = await _client.GetAsync(tilePath);
+        staleTileResponse.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NoContent);
+
+        // Update the live source table, as a re-import would.
+        await InsertPostGisFeatureAsync("Reimported Feature", 250, 1.001d, 1.001d);
+
+        // The feature-query path reads the live source and immediately sees the new row, but the
+        // canonical snapshot the MVT path reads is unchanged — the staleness this fix addresses.
+        var ogcItemsResponse = await _client.GetAsync(
+            $"/ogc/features/collections/{_layerId}/items?f=json&limit=10");
+        ogcItemsResponse.Be200Ok();
+        using (var ogcItemsDocument = JsonDocument.Parse(await ogcItemsResponse.Content.ReadAsStringAsync()))
+        {
+            ogcItemsDocument.RootElement.GetProperty("features").GetArrayLength().Should().Be(2);
+        }
+
+        (await GetCanonicalSnapshotCountAsync(_layerId.Value))
+            .Should().Be(1, "the snapshot the MVT path reads is stale until rebuilt");
+
+        // Rebuilding the snapshot from the live source brings the MVT path back in sync.
+        var refreshResponse = await _client.PostAsync(
+            $"/api/v1/admin/connections/{_connectionId}/layers/{_layerId}/features/refresh",
+            content: null);
+
+        var refreshPayload = await refreshResponse.Content.ReadAsStringAsync();
+        refreshResponse.StatusCode.Should().Be(HttpStatusCode.OK, $"response: {refreshPayload}");
+        var refreshApi = JsonSerializer.Deserialize<ApiResponse<MaterializedFeatureRefreshResult>>(
+            refreshPayload,
+            _jsonOptions);
+
+        refreshApi.Should().NotBeNull();
+        refreshApi!.Success.Should().BeTrue();
+        refreshApi.Data.Should().NotBeNull();
+        refreshApi.Data!.LayerId.Should().Be(_layerId.Value);
+        refreshApi.Data.MaterializedFeatureCount.Should().Be(2);
+
+        // The canonical snapshot the MVT path reads now reflects the updated source.
+        (await GetCanonicalSnapshotCountAsync(_layerId.Value)).Should().Be(2);
+
+        var rebuiltTileResponse = await _client.GetAsync(tilePath);
+        rebuiltTileResponse.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NoContent);
+    }
+
+    private async Task<int> GetCanonicalSnapshotCountAsync(int layerId)
+    {
+        await using var connection = await _fixture.Postgres.GetConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*)::int FROM features WHERE layer_id = @layerId;";
+        command.Parameters.AddWithValue("layerId", layerId);
+        var result = await command.ExecuteScalarAsync();
+        return Convert.ToInt32(result, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Update)]
     [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
     [Endpoint("POST /api/v1/admin/connections/{id}/layers/extents/refresh")]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]

--- a/tests/dotnet/Honua.TestKit/TestWebApplicationFactory.cs
+++ b/tests/dotnet/Honua.TestKit/TestWebApplicationFactory.cs
@@ -347,6 +347,23 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
         {
             return Task.FromResult<LayerExtentRefreshResult?>(null);
         }
+
+        public Task<MaterializedFeatureRefreshResult?> RefreshMaterializedFeaturesAsync(
+            string connectionString,
+            int layerId,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<MaterializedFeatureRefreshResult?>(null);
+        }
+
+        public Task<IReadOnlyList<MaterializedFeatureRefreshResult>> RefreshMaterializedFeaturesForSourceTableAsync(
+            string connectionString,
+            string? schema,
+            string table,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<MaterializedFeatureRefreshResult>>([]);
+        }
     }
 
     private sealed class NullDatabaseMigrationRunner : IDatabaseMigrationRunner


### PR DESCRIPTION
## Issue Link
Fixes #1628

## Summary
Published source-backed layers materialize a one-time snapshot of their source table into the canonical `honua.features` table that the server-side MVT/tile path reads, while the feature-query paths (FeatureServer, OGC API Features) read the **live** source table via the storage binding. After a re-import or update to the source, the query paths show the new data but the MVT snapshot keeps serving the old data — silently — until an explicit re-publish. This is the data-consistency bug reported when seeding the hosted demo.

A full structural fix (routing MVT through the same binding-resolved reader as FeatureServer) is large and risky: the OGC Tiles endpoint injects a singleton `ITileProvider` and never resolves the per-layer storage binding, the shared query router has no MVT operation, and the source-backed reader has no server-side `ST_AsMVT` path. The issue explicitly accepts the alternative — "re-import must invalidate/rebuild the materialization automatically" — so this PR rebuilds the canonical snapshot from the live source whenever the source is re-imported, plus an explicit admin rebuild endpoint. The snapshot the MVT path reads is then kept in sync with the live data the query paths serve.

## Changes Made
- Added `MaterializedFeatureRefreshResult` and two `ILayerPublishingService` methods: `RefreshMaterializedFeaturesAsync` (by layer id) and `RefreshMaterializedFeaturesForSourceTableAsync` (by source schema/table; schema optional for the import path).
- Implemented them in a new `PostgreSqlLayerPublishingService.FeatureRefresh.cs` partial: resolve the layer's source schema/table/geometry/SRID and published fields from `honua.layers`/`honua.layer_fields`, re-introspect the live source, then `DELETE` the layer's stale rows in `features` and re-materialize from the live source in one transaction (reusing the existing publish-time `MaterializeLayerFeaturesAsync`).
- Wired automatic refresh into the file-import success path (`ImportEndpoints`): after a successful import, any published layer backed by the imported source table has its snapshot rebuilt. Best-effort — a refresh failure is logged and never fails the import that already succeeded.
- Added `POST /api/v1/admin/connections/{id}/layers/{layerId}/features/refresh` for explicit rebuilds (background/migration imports, manual ops), mirroring the existing extents-refresh endpoint, and registered it in `EndpointRegistry`.
- Added an integration test (Testcontainers + PostGIS): publish a source-backed layer, confirm the canonical snapshot has 1 row and the MVT tile endpoint is reachable; insert a new source row; confirm OGC API Features sees 2 rows while the snapshot stays at 1 (the staleness); call the refresh endpoint and confirm the snapshot rebuilds to 2 and the MVT tile stays reachable.
- Updated the six `ILayerPublishingService` test doubles to implement the new members.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [ ] OpenAPI spec changed
- [ ] None — no docs or contract impact

Adds one admin endpoint (`POST .../layers/{layerId}/features/refresh`) and two `ILayerPublishingService` methods. No OGC protocol spec changes.

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. The new `ILayerPublishingService` members are additive; the import path change is best-effort and transparent on existing flows.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

### Verification
- `dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true` — clean (0 warnings, 0 errors).
- `dotnet format Honua.sln --verify-no-changes` — clean.
- New test `RefreshMaterializedFeatures_AfterSourceUpdate_RebuildsSnapshotMvtReads` — passed.
- Full `LayerPublishingIntegrationTests` (25) — passed.
- Architecture EndpointRegistry / ApiSurfaceCoverage / OpenApiDrift (6) — passed.
- Import apply-plan/workspace-scoping doubles (16) — passed.

### Deferred
The complete structural unification — routing the OGC Tiles MVT/raster read through the same `FeatureProviderQueryRouter` binding the feature-query paths use, so source-backed layers need no canonical snapshot at all (TODO honua-server#974) — remains out of scope. It requires adding an MVT operation to the router, an `ST_AsMVT` path in the storage-mapped reader over arbitrary source schemas/connections, and threading binding resolution into the tiles endpoint.
