### PR TITLE
fix(docker): build STAC ops demo into lambda.aot from repo (#1650)

### DIFF
--- a/docker/Dockerfile.lambda.aot
+++ b/docker/Dockerfile.lambda.aot
@@ -65,6 +65,10 @@ COPY src/Honua.Plugins.Abstractions/*.csproj src/Honua.Plugins.Abstractions/
 COPY samples/Honua.StacOpsDemo/*.csproj samples/Honua.StacOpsDemo/
 
 ARG TARGETARCH
+# Slim by default: set HONUA_INCLUDE_STAC_OPS_DEMO=true to keep the hosted STAC ops
+# demo assets (samples/stac-ops) so the live demo image builds from this repo instead
+# of an out-of-repo patch (#1650). Mirrors the root Dockerfile.
+ARG HONUA_INCLUDE_STAC_OPS_DEMO=false
 
 RUN --mount=type=cache,target=/root/.nuget/packages \
     --mount=type=secret,id=github_actor \
@@ -76,13 +80,18 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
     esac && \
     sh scripts/docker/restore-dotnet-with-github-packages.sh src/Honua.Server/Honua.Server.csproj \
       --runtime "$RUNTIME_ID" \
-      -p:RuntimeIdentifier="$RUNTIME_ID"
+      -p:RuntimeIdentifier="$RUNTIME_ID" && \
+    if [ "$HONUA_INCLUDE_STAC_OPS_DEMO" = "true" ]; then \
+      sh scripts/docker/restore-dotnet-with-github-packages.sh samples/Honua.StacOpsDemo/Honua.StacOpsDemo.csproj; \
+    fi
 
 FROM restore AS build
 
 COPY . .
 
 ARG CONFIGURATION=Release
+# Re-declared so the build stage sees the build-arg for the conditional STAC ops publish.
+ARG HONUA_INCLUDE_STAC_OPS_DEMO=false
 RUN --mount=type=cache,target=/root/.nuget/packages \
     case "${TARGETARCH:-amd64}" in \
       amd64) RUNTIME_ID="linux-x64" ; ILC_SINGLE_THREADED="false" ;; \
@@ -104,7 +113,14 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
       -p:IlcOptimizationPreference=Speed \
       -p:IlcSingleThreaded="$ILC_SINGLE_THREADED" \
       -p:HonuaSkipOracleForAotVerification=true && \
-    rm -rf /app/BlazorDebugProxy /app/wwwroot && \
+    if [ "$HONUA_INCLUDE_STAC_OPS_DEMO" = "true" ]; then \
+      dotnet publish samples/Honua.StacOpsDemo/Honua.StacOpsDemo.csproj \
+        --configuration "$CONFIGURATION" --no-restore --output /tmp/stac-ops-demo && \
+      mkdir -p /app/wwwroot/samples && \
+      cp -a /tmp/stac-ops-demo/wwwroot/samples/stac-ops /app/wwwroot/samples/; \
+    fi && \
+    rm -rf /tmp/stac-ops-demo /app/BlazorDebugProxy && \
+    if [ "$HONUA_INCLUDE_STAC_OPS_DEMO" != "true" ]; then rm -rf /app/wwwroot; else rm -rf /app/wwwroot/admin; fi && \
     find /app -type f \( -name '*.pdb' -o -name '*.dbg' \) -delete
 
 FROM ${DOTNET_RUNTIME_DEPS_IMAGE} AS runtime


### PR DESCRIPTION
## Issue Link
Fixes #1650

## Summary
Ports the root Dockerfile's `HONUA_INCLUDE_STAC_OPS_DEMO` build-arg into `docker/Dockerfile.lambda.aot` so the STAC ops demo can be built into the Lambda AOT image directly from the repo, closing the out-of-repo-patch gap used for the hosted demo image.

## Changes Made
- Declare the `HONUA_INCLUDE_STAC_OPS_DEMO` build-arg in both build stages of `docker/Dockerfile.lambda.aot`.
- Conditionally restore + publish the StacOps demo assets when the arg is `true`; preserve `wwwroot/samples/stac-ops`.
- Keep the slim default (arg unset) unchanged so the standard image is unaffected.

## Testing
- [x] Manual testing performed
- Validated via the buildx CI lane (AOT cannot build locally); the slim default path is unchanged.

## Gate Impact
- [x] Release gates (packaging, publishing)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires infrastructure changes
- Deploy passes `--build-arg HONUA_INCLUDE_STAC_OPS_DEMO=true` for the demo image tag only.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format
- [x] PR title matches main commit message
- [x] Issue number linked above
