### PR TITLE
feat: add durable ImportDataset GP job that owns the full import pipeline (#1630)

### DIFF
--- a/src/Honua.Core/Features/Import/Domain/ImportResult.cs
+++ b/src/Honua.Core/Features/Import/Domain/ImportResult.cs
@@ -26,6 +26,23 @@ public sealed record ImportResult
     public required string TableName { get; init; }
 
     /// <summary>
+    /// Physical staging table name actually created in the database (provider-prefixed,
+    /// e.g. <c>imported_&lt;table&gt;</c>). Distinct from <see cref="TableName"/>, which is
+    /// the caller-supplied logical name. Callers that need to introspect or publish the
+    /// imported table (for example the durable import GP job) must use this name rather than
+    /// reconstructing the provider naming convention. Falls back to <see cref="TableName"/>
+    /// when the provider does not stage into a separate physical table.
+    /// </summary>
+    public string? PhysicalTableName { get; init; }
+
+    /// <summary>
+    /// Schema that owns the physical staging table (provider operational-data schema,
+    /// e.g. <c>honua_data</c>). Pair with <see cref="PhysicalTableName"/> to locate the
+    /// imported table.
+    /// </summary>
+    public string? Schema { get; init; }
+
+    /// <summary>
     /// Stable source kind for admin import result views.
     /// </summary>
     public string SourceKind { get; init; } = "file";
@@ -89,11 +106,15 @@ public sealed record ImportResult
         int featureCount,
         int? detectedSrid = null,
         TimeSpan duration = default,
-        IReadOnlyList<string>? warnings = null) =>
+        IReadOnlyList<string>? warnings = null,
+        string? physicalTableName = null,
+        string? schema = null) =>
         new()
         {
             Success = true,
             TableName = tableName,
+            PhysicalTableName = physicalTableName ?? tableName,
+            Schema = schema,
             Format = format,
             FeatureCount = featureCount,
             DetectedSrid = detectedSrid,

--- a/src/Honua.Geometry/Features/FileImport/Services/StreamingGeoJsonReader.cs
+++ b/src/Honua.Geometry/Features/FileImport/Services/StreamingGeoJsonReader.cs
@@ -85,6 +85,7 @@ internal sealed class StreamingGeoJsonReader
 
             var featureCount = 0;
             var processingState = new JsonProcessingState();
+            var firstChunk = true;
 
             while (true)
             {
@@ -108,6 +109,19 @@ internal sealed class StreamingGeoJsonReader
                     leftoverBuffer!.AsSpan(0, leftoverLength).CopyTo(combinedBuffer);
                     buffer.AsSpan(0, bytesRead).CopyTo(combinedBuffer.AsSpan(leftoverLength, bytesRead));
                     data = combinedBuffer.AsMemory(0, leftoverLength + bytesRead);
+                }
+
+                // Skip a leading UTF-8 BOM (EF BB BF) on the first chunk — many real-world
+                // GeoJSON files (and anything written via Encoding.UTF8) start with one, and
+                // Utf8JsonReader treats it as an invalid start-of-value token otherwise.
+                if (firstChunk)
+                {
+                    firstChunk = false;
+                    var span = data.Span;
+                    if (span.Length >= 3 && span[0] == 0xEF && span[1] == 0xBB && span[2] == 0xBF)
+                    {
+                        data = data[3..];
+                    }
                 }
 
                 // Process chunk synchronously to avoid ref struct issues

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
@@ -712,6 +712,41 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
         },
 
         // -----------------------------------------------------------------------
+        // Data-import operations (1)
+        // First-class durable import pipeline (#1630). import.dataset owns the
+        // full fetch -> validate+chunk -> import -> flatten -> tile ->
+        // extent+MVT refresh -> provenance flow as ONE managed durable job,
+        // composing the existing import / publishing / raster services. This is
+        // the canonical execution layer the geospatial-mcp publish_data family
+        // submits into. Managed profile: the steps are orchestration + provider
+        // service calls, not native GDAL work, so the lean dispatcher runs it.
+        // -----------------------------------------------------------------------
+        new ProcessDefinition
+        {
+            ProcessId = "import.dataset",
+            Title = "Import Dataset",
+            Description = "Imports a staged geospatial dataset end-to-end as one durable job: stages the source, imports it (the streaming importer enforces the per-feature geometry size guard / chunking), flattens the generic imported table into a typed layer (rebuilding the MVT materialization), optionally tiles a raster layer with overviews, refreshes the layer and service extents, and records a provenance artifact. Resumes by re-running from the staged source under overwrite idempotency.",
+            Category = "import",
+            Parameters =
+            [
+                Param("connection", "Connection", "Registered secure connection id (GUID) or name identifying the target Honua catalog database.", ProcessParameterValueType.Text, required: true),
+                Param("sourcePath", "Source Path", "Absolute path to the staged source file on the worker-accessible filesystem.", ProcessParameterValueType.Text, required: true),
+                Param("fileName", "File Name", "Original file name, used for format detection (e.g. parcels.geojson).", ProcessParameterValueType.Text, required: true),
+                Param("tableName", "Table Name", "Target table name for the generic imported table (imported_<table>).", ProcessParameterValueType.Text, required: true),
+                Param("layerName", "Layer Name", "Display name for the published typed layer.", ProcessParameterValueType.Text, required: true),
+                Param("serviceName", "Service Name", "Service to publish the layer into. Defaults to 'default'.", ProcessParameterValueType.Text),
+                Param("description", "Description", "Optional layer description.", ProcessParameterValueType.Text),
+                Param("geometryColumn", "Geometry Column", "Optional geometry column name override for the typed layer.", ProcessParameterValueType.Text),
+                Param("targetSchema", "Target Schema", "Optional schema for the imported/typed data. Defaults to the configured operational-data schema (honua_data).", ProcessParameterValueType.Text),
+                Param("sourceUrl", "Source URL", "Optional originating URL when the source was fetched from a remote object, recorded in provenance.", ProcessParameterValueType.Text),
+                Param("sourceSrid", "Source SRID", "Optional source spatial reference identifier when the source lacks embedded CRS metadata.", ProcessParameterValueType.Srid),
+                Param("targetSrid", "Target SRID", "Target spatial reference identifier for the imported geometries. Defaults to 4326.", ProcessParameterValueType.Srid),
+                Param("rasterLayerId", "Raster Layer", "When the source is a raster, the layer identifier to tile into; triggers raster import, statistics, and tile/overview pre-generation.", ProcessParameterValueType.LayerId),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer]
+        },
+
+        // -----------------------------------------------------------------------
         // GeoETL transform operations (8)
         // Reconciled from feat/geoetl-baseline onto the #1185 add-a-capability
         // contract: each transform reads a FeatureCollection data URI on the

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
@@ -67,6 +67,7 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
         GeoJsonFileSinkExecutor geoJsonFileSink,
         QuarantineSinkExecutor quarantineSink,
         ExternalPostgisSinkExecutor externalPostgisSink,
+        ImportDatasetJobExecutor importDataset,
         ILogger<GeoprocessingDispatchJobExecutor> logger)
     {
         ArgumentNullException.ThrowIfNull(buffer);
@@ -100,6 +101,7 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
         ArgumentNullException.ThrowIfNull(geoJsonFileSink);
         ArgumentNullException.ThrowIfNull(quarantineSink);
         ArgumentNullException.ThrowIfNull(externalPostgisSink);
+        ArgumentNullException.ThrowIfNull(importDataset);
         ArgumentNullException.ThrowIfNull(logger);
 
         _handlers = new Dictionary<string, IJobExecutor>(StringComparer.Ordinal)
@@ -135,6 +137,7 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
             [GeoJsonFileSinkExecutor.HandledProcessId] = geoJsonFileSink,
             [QuarantineSinkExecutor.HandledProcessId] = quarantineSink,
             [ExternalPostgisSinkExecutor.HandledProcessId] = externalPostgisSink,
+            [ImportDatasetJobExecutor.HandledProcessId] = importDataset,
         }.ToFrozenDictionary(StringComparer.Ordinal);
 
         _logger = logger;

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ImportDatasetJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ImportDatasetJobExecutor.cs
@@ -1,0 +1,596 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.Admin.Abstractions;
+using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.FileImport.Abstractions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.ControlPlane;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// Production <see cref="IJobExecutor"/> for the <c>import.dataset</c> process (#1630).
+///
+/// Owns the full import pipeline as one durable, async GP job rather than the
+/// half-orchestrated remote-import endpoint that only wrote a generic
+/// <c>imported_&lt;table&gt;</c>. This executor ORCHESTRATES the existing
+/// per-step services — it does not re-implement any of them — in this order:
+///
+/// <list type="number">
+///   <item><description><b>fetch/stage</b> — resolves the catalog connection and validates the staged source path.</description></item>
+///   <item><description><b>validate + chunk</b> — delegated to <see cref="IFileImportService"/>, which runs the
+///     <c>ImportGeometrySizeGuard</c> vertex/ring guard per feature during streaming import (#1626).</description></item>
+///   <item><description><b>import</b> — <see cref="IFileImportService.ImportFileAsync(ImportRequest, IProgress{ImportProgress}?, CancellationToken)"/>
+///     streams the source into the generic <c>imported_&lt;table&gt;</c>.</description></item>
+///   <item><description><b>flatten</b> — <see cref="ILayerPublishingService.PublishLayerAsync"/> introspects the imported
+///     table and materializes the typed layer schema; the same call rebuilds the MVT materialization (#1628).</description></item>
+///   <item><description><b>tile</b> — when a raster layer is supplied,
+///     <see cref="IRasterImportService.ImportAsync"/> loads the raster, computes statistics, and pre-generates tiles/overviews (#1625).</description></item>
+///   <item><description><b>extent + MVT refresh</b> — <see cref="ILayerPublishingService.RefreshLayerExtentsAsync"/>
+///     recomputes the layer and service extents from the now-typed source.</description></item>
+///   <item><description><b>provenance</b> — a structured provenance record is appended to the execution log and
+///     published as a JSON data-URI artifact (source, table, layer, counts, timings).</description></item>
+/// </list>
+///
+/// Like <c>sink.external-postgis</c>, the executor resolves provider services
+/// (which live in the active data-provider assembly, not in Honua.Geoprocessing)
+/// at execution time through an <see cref="IServiceScopeFactory"/> scope. The job
+/// runs through the canonical durable substrate (ADR-0031), so progress polling,
+/// heartbeats, retry, cancellation, and the #1624 in-memory single-node fallback
+/// are inherited rather than reimplemented.
+///
+/// <para>
+/// Scope realism (#1630): this lands the durable job SKELETON that runs every
+/// step end-to-end in order with progress reporting and provenance. Full
+/// mid-step resume (re-entering a partially-completed import after a crash)
+/// re-runs from the staged source under <c>OverwriteExisting</c> idempotency
+/// rather than checkpointing each row; finer-grained resume is deferred.
+/// </para>
+/// </summary>
+internal sealed partial class ImportDatasetJobExecutor : IJobExecutor
+{
+    /// <summary>
+    /// The single process id this executor handles. Matches the catalog entry
+    /// in <see cref="BuiltInProcessCatalog"/>.
+    /// </summary>
+    internal const string HandledProcessId = "import.dataset";
+
+    private const string ProvenanceDataUriPrefix = "data:application/json;base64,";
+
+    // The fixed shape honua.create_import_table materializes for the generic
+    // imported_<table> (id SERIAL PRIMARY KEY, geometry GEOMETRY, properties JSONB).
+    private const string ImportTableGeometryColumn = "geometry";
+    private const string ImportTablePrimaryKey = "id";
+    private static readonly string[] ImportTableFields = ["id", "properties"];
+
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger<ImportDatasetJobExecutor> _logger;
+
+    public ImportDatasetJobExecutor(
+        IServiceScopeFactory serviceScopeFactory,
+        ILogger<ImportDatasetJobExecutor> logger)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+        _logger = logger;
+    }
+
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var resolvedProcessId = GeoprocessingDispatchHelper.ResolveProcessId(job.Spec.Parameters);
+        if (!string.Equals(resolvedProcessId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(_logger, job.OperationId, resolvedProcessId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{resolvedProcessId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        var inputs = new StepInputReader(job.Spec.Parameters);
+        if (!TryReadInputs(inputs, out var request, out var inputError))
+        {
+            Log.InvalidInputs(_logger, job.OperationId, inputError);
+            return JobExecutionResult.Failed($"Invalid {HandledProcessId} inputs: {inputError}");
+        }
+
+        var startedAt = DateTimeOffset.UtcNow;
+        var warnings = new List<string>();
+
+        // Step 1 — fetch/stage. Resolve the catalog connection and confirm the
+        // staged source file exists before doing any DB work.
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Staging source", cancellationToken).ConfigureAwait(false);
+
+        if (!File.Exists(request.SourcePath))
+        {
+            return JobExecutionResult.Failed(
+                $"Invalid {HandledProcessId} inputs: staged source file was not found.");
+        }
+
+        using var scope = _serviceScopeFactory.CreateScope();
+        var services = scope.ServiceProvider;
+
+        var connectionResolver = services.GetService<ISecureConnectionResolver>();
+        if (connectionResolver is null)
+        {
+            return JobExecutionResult.Failed($"{HandledProcessId} failed: secure connection resolver is not configured.");
+        }
+
+        string connectionString;
+        try
+        {
+            connectionString = Guid.TryParse(request.ConnectionRef, out var connectionId)
+                ? await connectionResolver.ResolveConnectionStringAsync(connectionId, cancellationToken).ConfigureAwait(false)
+                : await connectionResolver.ResolveConnectionStringAsync(request.ConnectionRef, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.ConnectionResolveFailed(_logger, job.OperationId, ex);
+            return JobExecutionResult.Failed($"{HandledProcessId} failed: the target connection could not be resolved.");
+        }
+
+        var importService = services.GetService<IFileImportService>();
+        var publishingService = services.GetService<ILayerPublishingService>();
+        if (importService is null || publishingService is null)
+        {
+            return JobExecutionResult.Failed(
+                $"{HandledProcessId} failed: import/publishing services are not configured for the active provider.");
+        }
+
+        // Step 2 + 3 — validate+chunk and import. The size guard (#1626) runs
+        // inside the streaming importer per feature; the executor does not
+        // duplicate that logic.
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(15, "Validating and importing source", cancellationToken).ConfigureAwait(false);
+
+        ImportResult importResult;
+        try
+        {
+            // Pass the staged file by path (not an open stream): this mirrors the
+            // admin upload path and keeps the import re-runnable from the staged
+            // source under overwrite idempotency, which is the resume contract.
+            var importRequest = new ImportRequest
+            {
+                LocalFilePath = request.SourcePath,
+                FileName = request.FileName,
+                TableName = request.TableName,
+                TargetSchema = request.TargetSchema,
+                SourceSrid = request.SourceSrid,
+                TargetSrid = request.TargetSrid,
+                OverwriteExisting = true,
+                SourceKind = request.SourceUrl is null ? "file" : "url",
+                SourceUrl = request.SourceUrl
+            };
+
+            importResult = await importService
+                .ImportFileAsync(importRequest, progress: null, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.ImportFailed(_logger, job.OperationId, ex);
+            return JobExecutionResult.Failed($"{HandledProcessId} failed during import: {ex.GetType().Name}.");
+        }
+
+        if (!importResult.Success)
+        {
+            return JobExecutionResult.Failed(
+                $"{HandledProcessId} import step failed: {importResult.ErrorMessage ?? importResult.ErrorCode ?? "unknown error"}.");
+        }
+
+        warnings.AddRange(importResult.Warnings);
+        await context.ReportProgressAsync(45, "Imported source rows", cancellationToken).ConfigureAwait(false);
+
+        // Step 4 — flatten to typed schema. PublishLayerAsync introspects the
+        // imported table and materializes the typed layer; the same call rebuilds
+        // the MVT materialization (#1628).
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(55, "Flattening to typed layer", cancellationToken).ConfigureAwait(false);
+
+        // The streaming importer is the single source of truth for the physical staging
+        // table it actually created (provider-prefixed, e.g. imported_<table>) and the
+        // operational-data schema that owns it (default honua_data). Publish exactly those
+        // rather than reconstructing the provider's naming/schema convention here, which
+        // would drift from the importer. Fall back to the logical name/resolved schema only
+        // when an older provider does not surface the physical identifiers.
+        var physicalTable = string.IsNullOrWhiteSpace(importResult.PhysicalTableName)
+            ? importResult.TableName
+            : importResult.PhysicalTableName!;
+        var resolvedSchema = importResult.Schema is { Length: > 0 } importedSchema
+            ? importedSchema
+            : string.IsNullOrWhiteSpace(request.TargetSchema)
+                ? ResolveOperationalSchema(services)
+                : request.TargetSchema!;
+        var detectedSrid = importResult.DetectedSrid ?? request.TargetSrid;
+
+        PublishedLayerSummary publishedLayer;
+        try
+        {
+            // The streaming importer materializes the generic imported_<table> with a
+            // fixed shape (id SERIAL PRIMARY KEY, geometry GEOMETRY(Geometry, srid),
+            // properties JSONB) via honua.create_import_table. Pass those known
+            // conventions through to publish so the flatten step does not depend on
+            // best-effort column auto-discovery; an explicit caller override still wins.
+            var publishRequest = new LayerPublishRequest
+            {
+                Schema = resolvedSchema,
+                Table = physicalTable,
+                LayerName = request.LayerName,
+                Description = request.Description,
+                GeometryColumn = string.IsNullOrWhiteSpace(request.GeometryColumn)
+                    ? ImportTableGeometryColumn
+                    : request.GeometryColumn,
+                PrimaryKey = ImportTablePrimaryKey,
+                Fields = ImportTableFields,
+                Srid = detectedSrid,
+                ServiceName = request.ServiceName,
+                ConnectionId = Guid.TryParse(request.ConnectionRef, out var pubConnectionId)
+                    ? pubConnectionId
+                    : null,
+                Enabled = true
+            };
+
+            publishedLayer = await publishingService
+                .PublishLayerAsync(connectionString, publishRequest, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (LayerPublishingException ex)
+        {
+            // LayerPublishingException carries a client-safe, sanitized message
+            // (no SQL/provider internals), so it is safe to surface to the caller.
+            Log.FlattenFailed(_logger, job.OperationId, ex);
+            return JobExecutionResult.Failed($"{HandledProcessId} failed during flatten: {ex.Message}");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Do not surface raw provider/SQL exception text to callers; the full
+            // exception is captured in the structured log for diagnosis.
+            Log.FlattenFailed(_logger, job.OperationId, ex);
+            return JobExecutionResult.Failed($"{HandledProcessId} failed during flatten: {ex.GetType().Name}.");
+        }
+
+        await context.ReportProgressAsync(70, "Published typed layer", cancellationToken).ConfigureAwait(false);
+
+        // Step 5 — raster tiling/overviews (optional). Only runs when the source
+        // is a raster and a raster import service is configured.
+        var tilesGenerated = 0;
+        if (request.RasterLayerId is { } rasterLayerId)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(78, "Tiling raster", cancellationToken).ConfigureAwait(false);
+
+            var rasterService = services.GetService<IRasterImportService>();
+            if (rasterService is null)
+            {
+                warnings.Add("raster tiling was requested but no raster import service is configured; skipped.");
+            }
+            else
+            {
+                var rasterFormat = rasterService.DetectFormat(request.FileName);
+                if (rasterFormat is null)
+                {
+                    warnings.Add($"raster tiling skipped: '{request.FileName}' is not a supported raster format.");
+                }
+                else
+                {
+                    try
+                    {
+                        var rasterResult = await rasterService.ImportAsync(
+                            new RasterImportRequest
+                            {
+                                LayerId = rasterLayerId,
+                                Name = request.LayerName,
+                                Description = request.Description,
+                                FilePath = request.SourcePath,
+                                FileName = request.FileName,
+                                Format = rasterFormat.Value,
+                                Srid = request.SourceSrid
+                            },
+                            progress: null,
+                            cancellationToken).ConfigureAwait(false);
+
+                        if (rasterResult.Success)
+                        {
+                            tilesGenerated = rasterResult.TilesGenerated;
+                            warnings.AddRange(rasterResult.Warnings);
+                        }
+                        else
+                        {
+                            return JobExecutionResult.Failed(
+                                $"{HandledProcessId} failed during raster tiling: {rasterResult.ErrorMessage ?? "unknown error"}.");
+                        }
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        Log.TileFailed(_logger, job.OperationId, ex);
+                        return JobExecutionResult.Failed($"{HandledProcessId} failed during raster tiling: {ex.GetType().Name}.");
+                    }
+                }
+            }
+        }
+
+        // Step 6 — extent + MVT materialization refresh. Recomputes the layer and
+        // service extents from the now-typed source.
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(88, "Refreshing extents", cancellationToken).ConfigureAwait(false);
+
+        var serviceName = string.IsNullOrWhiteSpace(request.ServiceName) ? "default" : request.ServiceName!;
+        try
+        {
+            await publishingService
+                .RefreshLayerExtentsAsync(connectionString, serviceName, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Extent refresh is a best-effort finishing step; a failure here does
+            // not invalidate the imported/typed data, so surface it as a warning
+            // rather than failing the whole job.
+            Log.ExtentRefreshFailed(_logger, job.OperationId, ex);
+            warnings.Add("extent refresh did not complete; layer extents may be stale until the next refresh.");
+        }
+
+        // Step 7 — provenance. Record the import lineage through the canonical
+        // log + artifact substrate (no bespoke provenance schema).
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(96, "Recording provenance", cancellationToken).ConfigureAwait(false);
+
+        var completedAt = DateTimeOffset.UtcNow;
+        var provenance = BuildProvenance(
+            job.OperationId,
+            request,
+            importResult,
+            physicalTable,
+            publishedLayer,
+            tilesGenerated,
+            startedAt,
+            completedAt,
+            warnings);
+
+        await context.AppendLogAsync(
+            new ExecutionLogEntry
+            {
+                Timestamp = completedAt,
+                Level = ExecutionLogLevel.Info,
+                Message = $"Imported '{request.FileName}' into layer {publishedLayer.LayerId} "
+                    + $"({importResult.FeatureCount} features, {tilesGenerated} raster tiles).",
+                Phase = "Provenance",
+                Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["sourceFile"] = request.FileName,
+                    ["table"] = physicalTable,
+                    ["layerId"] = publishedLayer.LayerId.ToString(CultureInfo.InvariantCulture),
+                    ["serviceName"] = serviceName,
+                    ["featureCount"] = importResult.FeatureCount.ToString(CultureInfo.InvariantCulture),
+                    ["tilesGenerated"] = tilesGenerated.ToString(CultureInfo.InvariantCulture)
+                }
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        await context.PublishArtifactAsync(provenance, cancellationToken).ConfigureAwait(false);
+        await context.ReportProgressAsync(100, "Import completed", cancellationToken).ConfigureAwait(false);
+
+        return JobExecutionResult.Succeeded(warnings.Count > 0 ? warnings : null);
+    }
+
+    private static bool TryReadInputs(StepInputReader inputs, out ImportDatasetInputs request, out string error)
+    {
+        request = default!;
+
+        if (!inputs.TryGetRequired("connection", out var connectionRef, out var connectionError))
+        {
+            error = connectionError;
+            return false;
+        }
+
+        if (!inputs.TryGetRequired("sourcePath", out var sourcePath, out var sourcePathError))
+        {
+            error = sourcePathError;
+            return false;
+        }
+
+        if (!inputs.TryGetRequired("fileName", out var fileName, out var fileNameError))
+        {
+            error = fileNameError;
+            return false;
+        }
+
+        if (!inputs.TryGetRequired("tableName", out var tableName, out var tableNameError))
+        {
+            error = tableNameError;
+            return false;
+        }
+
+        if (!inputs.TryGetRequired("layerName", out var layerName, out var layerNameError))
+        {
+            error = layerNameError;
+            return false;
+        }
+
+        int? sourceSrid = null;
+        if (inputs.TryGet("sourceSrid", out var sourceSridRaw)
+            && int.TryParse(sourceSridRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedSourceSrid))
+        {
+            sourceSrid = parsedSourceSrid;
+        }
+
+        var targetSrid = 4326;
+        if (inputs.TryGet("targetSrid", out var targetSridRaw)
+            && int.TryParse(targetSridRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedTargetSrid)
+            && parsedTargetSrid > 0)
+        {
+            targetSrid = parsedTargetSrid;
+        }
+
+        int? rasterLayerId = null;
+        if (inputs.TryGet("rasterLayerId", out var rasterLayerIdRaw)
+            && int.TryParse(rasterLayerIdRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedRasterLayerId)
+            && parsedRasterLayerId > 0)
+        {
+            rasterLayerId = parsedRasterLayerId;
+        }
+
+        request = new ImportDatasetInputs
+        {
+            ConnectionRef = connectionRef,
+            SourcePath = sourcePath,
+            FileName = fileName,
+            TableName = tableName,
+            LayerName = layerName,
+            Description = inputs.TryGet("description", out var description) ? description : null,
+            GeometryColumn = inputs.TryGet("geometryColumn", out var geometryColumn) ? geometryColumn : null,
+            ServiceName = inputs.TryGet("serviceName", out var serviceName) ? serviceName : null,
+            TargetSchema = inputs.TryGet("targetSchema", out var targetSchema) ? targetSchema : null,
+            SourceUrl = inputs.TryGet("sourceUrl", out var sourceUrl) ? sourceUrl : null,
+            SourceSrid = sourceSrid,
+            TargetSrid = targetSrid,
+            RasterLayerId = rasterLayerId
+        };
+
+        error = "";
+        return true;
+    }
+
+    private static string ResolveOperationalSchema(IServiceProvider services)
+    {
+        // Mirror PostgresSchemaConfiguration.FromConfiguration: imports default
+        // to the configured operational-data schema, falling back to honua_data.
+        const string defaultDataSchema = "honua_data";
+        var configuration = services.GetService<IConfiguration>();
+        var configured = configuration?["Database:DefaultOperationalSchema"];
+        return string.IsNullOrWhiteSpace(configured) ? defaultDataSchema : configured.Trim();
+    }
+
+    private static string BuildProvenance(
+        string operationId,
+        ImportDatasetInputs request,
+        ImportResult importResult,
+        string physicalTable,
+        PublishedLayerSummary publishedLayer,
+        int tilesGenerated,
+        DateTimeOffset startedAt,
+        DateTimeOffset completedAt,
+        IReadOnlyList<string> warnings)
+    {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "ImportProvenance");
+            writer.WriteString("processId", HandledProcessId);
+            writer.WriteString("operationId", operationId);
+            writer.WriteString("sourceFile", request.FileName);
+            if (request.SourceUrl is not null)
+            {
+                writer.WriteString("sourceUrl", request.SourceUrl);
+            }
+
+            writer.WriteString("importedTable", physicalTable);
+            writer.WriteString("format", importResult.Format.ToString());
+            writer.WriteNumber("featureCount", importResult.FeatureCount);
+            if (importResult.DetectedSrid is { } detectedSrid)
+            {
+                writer.WriteNumber("detectedSrid", detectedSrid);
+            }
+
+            writer.WriteNumber("layerId", publishedLayer.LayerId);
+            writer.WriteString("layerName", publishedLayer.LayerName);
+            writer.WriteString("serviceName", string.IsNullOrWhiteSpace(request.ServiceName) ? "default" : request.ServiceName!);
+            writer.WriteNumber("tilesGenerated", tilesGenerated);
+            writer.WriteString("startedAt", startedAt.ToString("O", CultureInfo.InvariantCulture));
+            writer.WriteString("completedAt", completedAt.ToString("O", CultureInfo.InvariantCulture));
+            writer.WriteNumber("durationSeconds", (completedAt - startedAt).TotalSeconds);
+
+            writer.WriteStartArray("warnings");
+            foreach (var warning in warnings)
+            {
+                writer.WriteStringValue(warning);
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        var sb = new StringBuilder(ProvenanceDataUriPrefix.Length + ((int)buffer.Length * 2));
+        sb.Append(ProvenanceDataUriPrefix);
+        sb.Append(Convert.ToBase64String(buffer.ToArray()));
+        return sb.ToString();
+    }
+
+    private sealed record ImportDatasetInputs
+    {
+        public required string ConnectionRef { get; init; }
+
+        public required string SourcePath { get; init; }
+
+        public required string FileName { get; init; }
+
+        public required string TableName { get; init; }
+
+        public required string LayerName { get; init; }
+
+        public string? Description { get; init; }
+
+        public string? GeometryColumn { get; init; }
+
+        public string? ServiceName { get; init; }
+
+        public string? TargetSchema { get; init; }
+
+        public string? SourceUrl { get; init; }
+
+        public int? SourceSrid { get; init; }
+
+        public int TargetSrid { get; init; }
+
+        public int? RasterLayerId { get; init; }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9200, LogLevel.Warning,
+            "Import dataset executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9201, LogLevel.Warning,
+            "Import dataset executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9202, LogLevel.Error,
+            "Import dataset executor failed job {OperationId}: connection resolution failed")]
+        public static partial void ConnectionResolveFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9203, LogLevel.Error,
+            "Import dataset executor failed job {OperationId} during import")]
+        public static partial void ImportFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9204, LogLevel.Error,
+            "Import dataset executor failed job {OperationId} during flatten/publish")]
+        public static partial void FlattenFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9205, LogLevel.Error,
+            "Import dataset executor failed job {OperationId} during raster tiling")]
+        public static partial void TileFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9206, LogLevel.Warning,
+            "Import dataset executor job {OperationId}: extent refresh did not complete")]
+        public static partial void ExtentRefreshFailed(ILogger logger, string operationId, Exception exception);
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -159,6 +159,16 @@ internal static class GeoprocessingServiceCollectionExtensions
         services.TryAddSingleton<GeoJsonFileSinkExecutor>();
         services.TryAddSingleton<QuarantineSinkExecutor>();
         services.TryAddSingleton<ExternalPostgisSinkExecutor>();
+
+        // Import-dataset orchestration executor (#1630). Owns the full durable
+        // import pipeline (fetch -> validate+chunk -> import -> flatten -> tile ->
+        // extent+MVT refresh -> provenance) by composing the existing provider
+        // services, which it resolves at execution time through an
+        // IServiceScopeFactory scope (the provider implementations live in the
+        // active data-provider assembly, out of reach for this module — the same
+        // pattern ExternalPostgisSinkExecutor uses).
+        services.TryAddSingleton<ImportDatasetJobExecutor>();
+
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IJobExecutor, GeoprocessingDispatchJobExecutor>());
 

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
@@ -541,7 +541,9 @@ internal sealed partial class StreamingFileImportService : IFileImportService
                 importedCount,
                 detectedSrid,
                 stopwatch.Elapsed,
-                warnings);
+                warnings,
+                physicalTableName: GetAllowedTableName(request.TableName),
+                schema: ResolveTargetSchema(request.TargetSchema));
             return result;
         }
         catch (OperationCanceledException)

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -6,6 +6,7 @@ using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Geoprocessing;
 using Honua.Geoprocessing.Execution;
 using Honua.TestKit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -87,6 +88,9 @@ public sealed class CatalogExecutableConformanceTests
         "sink.geojson-file",
         "sink.quarantine",
         "sink.external-postgis",
+        // Durable import pipeline (#1630): managed orchestration job that composes
+        // the import / publishing / raster services through an IServiceScopeFactory.
+        "import.dataset",
     };
 
     // Processes that execute ONLY through the synchronous PostGIS SpatialAnalytics
@@ -336,6 +340,9 @@ public sealed class CatalogExecutableConformanceTests
             new GeoJsonFileSinkExecutor(monitor),
             new QuarantineSinkExecutor(monitor),
             new ExternalPostgisSinkExecutor(monitor),
+            new ImportDatasetJobExecutor(
+                Substitute.For<IServiceScopeFactory>(),
+                NullLogger<ImportDatasetJobExecutor>.Instance),
             NullLogger<GeoprocessingDispatchJobExecutor>.Instance);
 
         return dispatcher.SupportedProcessIds;

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
@@ -8,6 +8,7 @@ using Honua.Geoprocessing;
 using Honua.Geoprocessing.Execution;
 using Honua.ControlPlane;
 using Honua.TestKit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -108,6 +109,7 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         "sink.geojson-file",
         "sink.quarantine",
         "sink.external-postgis",
+        "import.dataset",
     };
 
     [UnitTest]
@@ -166,6 +168,9 @@ public sealed class GeoprocessingDispatchJobExecutorTests
             new GeoJsonFileSinkExecutor(monitor),
             new QuarantineSinkExecutor(monitor),
             new ExternalPostgisSinkExecutor(monitor),
+            new ImportDatasetJobExecutor(
+                Substitute.For<IServiceScopeFactory>(),
+                NullLogger<ImportDatasetJobExecutor>.Instance),
             NullLogger<GeoprocessingDispatchJobExecutor>.Instance);
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/ImportDatasetJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/ImportDatasetJobExecutorTests.cs
@@ -1,0 +1,297 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.Core.Features.Security.Domain;
+using Honua.Geoprocessing.Execution;
+using Honua.ControlPlane;
+using Honua.Infrastructure.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using CoreSslMode = Honua.Core.Features.Security.Domain.SslMode;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Integration coverage for the <c>import.dataset</c> durable GP job (#1630).
+/// Drives <see cref="ImportDatasetJobExecutor"/> against a real PostGIS
+/// container so the composed steps (stage -> import -> flatten/publish ->
+/// extent+MVT refresh -> provenance) execute end-to-end and the job reaches the
+/// typed/refreshed end-state. The executor adapts into the canonical job runtime
+/// (it is the <see cref="IJobExecutor"/> the dispatcher routes for the
+/// <c>import.dataset</c> process id); this test exercises that executor directly
+/// with a recording <see cref="IJobExecutionContext"/> double so progress,
+/// provenance, and the resulting layer can be asserted without standing up the
+/// Redis-backed worker loop.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.OgcApiProcesses)]
+public sealed class ImportDatasetJobExecutorTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+    private Guid _connectionId;
+    private string _stagedFilePath = string.Empty;
+    private string _tableName = string.Empty;
+    private string _serviceName = string.Empty;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _tableName = $"import_{Guid.NewGuid():N}";
+        _serviceName = $"svc_{Guid.NewGuid():N}";
+
+        await CreateSecureConnectionAsync(_fixture.Postgres.ConnectionString);
+        _stagedFilePath = StageGeoJsonSource();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (!string.IsNullOrWhiteSpace(_stagedFilePath) && File.Exists(_stagedFilePath))
+        {
+            File.Delete(_stagedFilePath);
+        }
+
+        await _fixture.DisposeAsync();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /ogc/processes/{processId}/execution")]
+    public async Task ExecuteAsync_StagedGeoJson_ImportsFlattensRefreshesAndRecordsProvenance()
+    {
+        // Arrange — resolve the executor exactly as the worker host would.
+        var executor = _fixture.Services.GetRequiredService<ImportDatasetJobExecutor>();
+        var context = new RecordingJobExecutionContext("op-import-dataset");
+        var job = BuildJobRecord();
+
+        // Act — run the full durable pipeline end-to-end.
+        var result = await executor.ExecuteAsync(job, context, CancellationToken.None);
+
+        // Assert — terminal success and ordered progress to 100%.
+        result.Status.Should().Be(
+            ExecutionJobStatus.Succeeded,
+            $"executor reported: {result.ErrorMessage}");
+        context.Progress.Should().NotBeEmpty();
+        context.Progress[^1].Percent.Should().Be(100);
+
+        // The flatten step published a typed layer; the imported table and the
+        // catalog layer row both exist and the features are queryable.
+        await AssertImportedTableHasRowsAsync();
+        var layerId = await ReadPublishedLayerIdAsync();
+        layerId.Should().BePositive("the flatten step must publish a typed catalog layer");
+
+        // The extent-refresh step populated a non-null layer extent.
+        var hasExtent = await LayerHasExtentAsync(layerId);
+        hasExtent.Should().BeTrue("the extent refresh step must compute the layer extent");
+
+        // The provenance step emitted exactly one provenance artifact describing
+        // the import lineage.
+        context.Artifacts.Should().ContainSingle();
+        var provenanceUri = context.Artifacts[0];
+        provenanceUri.Should().StartWith("data:application/json;base64,");
+
+        var base64 = provenanceUri["data:application/json;base64,".Length..];
+        using var doc = JsonDocument.Parse(Convert.FromBase64String(base64));
+        doc.RootElement.GetProperty("type").GetString().Should().Be("ImportProvenance");
+        doc.RootElement.GetProperty("processId").GetString().Should().Be("import.dataset");
+        doc.RootElement.GetProperty("featureCount").GetInt32().Should().Be(3);
+        doc.RootElement.GetProperty("layerId").GetInt32().Should().Be(layerId);
+
+        // A structured provenance log entry was recorded through the substrate.
+        context.Logs.Should().Contain(entry => entry.Phase == "Provenance");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /ogc/processes/{processId}/execution")]
+    public async Task ExecuteAsync_MissingRequiredInput_FailsWithoutPublishing()
+    {
+        var executor = _fixture.Services.GetRequiredService<ImportDatasetJobExecutor>();
+        var context = new RecordingJobExecutionContext("op-import-missing");
+
+        // Omit the required 'layerName' input.
+        var parameters = BuildBaseParameters();
+        parameters.Remove($"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.layerName");
+        var job = BuildJobRecord(parameters);
+
+        var result = await executor.ExecuteAsync(job, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("layerName");
+        context.Artifacts.Should().BeEmpty();
+    }
+
+    private ExecutionJobRecord BuildJobRecord(Dictionary<string, string>? parameters = null) =>
+        new()
+        {
+            OperationId = "op-import-dataset",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:import.dataset",
+                Parameters = parameters ?? BuildBaseParameters()
+            }
+        };
+
+    private Dictionary<string, string> BuildBaseParameters()
+    {
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = ImportDatasetJobExecutor.HandledProcessId,
+            ["protocolProcessId"] = ImportDatasetJobExecutor.HandledProcessId,
+            [prefix + "connection"] = _connectionId.ToString(),
+            [prefix + "sourcePath"] = _stagedFilePath,
+            [prefix + "fileName"] = "import_dataset.geojson",
+            [prefix + "tableName"] = _tableName,
+            [prefix + "layerName"] = $"Layer {_tableName}",
+            [prefix + "serviceName"] = _serviceName,
+            [prefix + "targetSrid"] = "4326"
+        };
+    }
+
+    private static string StageGeoJsonSource()
+    {
+        var geoJson = JsonSerializer.Serialize(new
+        {
+            type = "FeatureCollection",
+            features = new object[]
+            {
+                Feature(1, "Alpha", -122.4194, 37.7749),
+                Feature(2, "Bravo", -122.2711, 37.8044),
+                Feature(3, "Charlie", -122.0838, 37.3861)
+            }
+        });
+
+        var path = Path.Combine(Path.GetTempPath(), $"import_dataset_{Guid.NewGuid():N}.geojson");
+        File.WriteAllText(path, geoJson, Encoding.UTF8);
+        return path;
+
+        static object Feature(int id, string name, double x, double y) => new
+        {
+            type = "Feature",
+            geometry = new { type = "Point", coordinates = new[] { x, y } },
+            properties = new { id, name }
+        };
+    }
+
+    private async Task AssertImportedTableHasRowsAsync()
+    {
+        await using var connection = new NpgsqlConnection(_fixture.Postgres.ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            $"SELECT count(*) FROM information_schema.tables WHERE table_name = 'imported_{_tableName}';";
+        var tableExists = Convert.ToInt64(await command.ExecuteScalarAsync(), CultureInfo.InvariantCulture) > 0;
+        tableExists.Should().BeTrue("the import step must create the generic imported_<table>");
+    }
+
+    private async Task<int> ReadPublishedLayerIdAsync()
+    {
+        await using var connection = new NpgsqlConnection(_fixture.Postgres.ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT layer_id FROM honua.layers WHERE table_name = @table ORDER BY layer_id DESC LIMIT 1;";
+        command.Parameters.AddWithValue("table", $"imported_{_tableName}");
+        var scalar = await command.ExecuteScalarAsync();
+        return scalar is null or DBNull ? 0 : Convert.ToInt32(scalar, CultureInfo.InvariantCulture);
+    }
+
+    private async Task<bool> LayerHasExtentAsync(int layerId)
+    {
+        await using var connection = new NpgsqlConnection(_fixture.Postgres.ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT extent IS NOT NULL FROM honua.layers WHERE layer_id = @id;";
+        command.Parameters.AddWithValue("id", layerId);
+        var scalar = await command.ExecuteScalarAsync();
+        return scalar is bool flag && flag;
+    }
+
+    private async Task CreateSecureConnectionAsync(string connectionString)
+    {
+        using var scope = _fixture.Services.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<ISecureConnectionRegistry>();
+        var encryptionService = scope.ServiceProvider.GetRequiredService<IConnectionEncryptionService>();
+
+        var builder = new NpgsqlConnectionStringBuilder(connectionString);
+
+        // The executor resolves this connection string verbatim and opens raw
+        // connections that do NOT carry the per-test schema header the HTTP pipeline
+        // applies. In production the operational NpgsqlDataSource bakes the data schema
+        // into the connection search_path; mirror that here so the publish step's
+        // materialization into the shared `features` table (seeded into the isolated
+        // per-test schema) resolves, while keeping the literal `honua` catalog schema and
+        // `public` (PostGIS functions) on the path.
+        if (!string.IsNullOrWhiteSpace(_fixture.CurrentSchema))
+        {
+            builder.SearchPath = $"{_fixture.CurrentSchema},honua,public";
+        }
+
+        connectionString = builder.ConnectionString;
+        var encrypted = await encryptionService.EncryptConnectionStringAsync(connectionString);
+        var keyVersion = await encryptionService.GetCurrentKeyVersionAsync();
+        var sslRequired = builder.SslMode is Npgsql.SslMode.Require or Npgsql.SslMode.VerifyCA or Npgsql.SslMode.VerifyFull;
+        var sslMode = Enum.Parse<CoreSslMode>(builder.SslMode.ToString(), true);
+
+        var connection = DataConnection.CreateWithEncryptedCredentials(
+            name: $"import-dataset-{Guid.NewGuid():N}",
+            host: builder.Host!,
+            port: builder.Port,
+            databaseName: builder.Database!,
+            username: builder.Username!,
+            encryptedConnectionString: encrypted,
+            encryptionKeyVersion: keyVersion,
+            createdBy: nameof(ImportDatasetJobExecutorTests),
+            description: "Import dataset job integration test connection",
+            sslRequired: sslRequired,
+            sslMode: sslMode);
+
+        var created = await registry.CreateConnectionAsync(connection);
+        _connectionId = created.ConnectionId;
+    }
+
+    private sealed class RecordingJobExecutionContext(string operationId) : IJobExecutionContext
+    {
+        public string OperationId { get; } = operationId;
+
+        public List<(double? Percent, string? Phase)> Progress { get; } = [];
+
+        public List<ExecutionLogEntry> Logs { get; } = [];
+
+        public List<string> Artifacts { get; } = [];
+
+        public Task ReportProgressAsync(double? percentComplete, string? phase, CancellationToken cancellationToken = default)
+        {
+            Progress.Add((percentComplete, phase));
+            return Task.CompletedTask;
+        }
+
+        public Task AppendLogAsync(ExecutionLogEntry entry, CancellationToken cancellationToken = default)
+        {
+            Logs.Add(entry);
+            return Task.CompletedTask;
+        }
+
+        public Task PublishArtifactAsync(string artifactReference, CancellationToken cancellationToken = default)
+        {
+            Artifacts.Add(artifactReference);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
@@ -45,8 +45,9 @@ public sealed class ProcessCatalogTests
         // + 3 managed analytics counterparts (analytics.cluster-managed,
         // analytics.buffer-aggregate-managed, analytics.density-managed) added by
         // #1260 + 2 native-profile GDAL worker processes (gdal.gdalwarp,
-        // gdal.ogr2ogr) reconciled from feat/gdal-heavy-worker.
-        all.Should().HaveCount(57);
+        // gdal.ogr2ogr) reconciled from feat/gdal-heavy-worker + 1 durable
+        // import pipeline (import.dataset) added by #1630.
+        all.Should().HaveCount(58);
         all.Select(p => p.ProcessId).Should().OnlyHaveUniqueItems();
     }
 


### PR DESCRIPTION
## Issue Link
Fixes #1630

## Summary
Makes data import a first-class **durable geoprocessing job** (`import.dataset`) that owns the full pipeline — fetch/stage → validate + chunk → import → flatten to typed schema → raster tiling/overviews → extent + MVT materialization refresh → provenance — as one async, durable job per ADR-0031, instead of the half-orchestrated remote-import endpoint that only wrote a generic `imported_<table>` and left flatten/tile/extent/MVT-refresh unowned (the demo ran them as side-channel SQL).

The job **composes the existing per-step services** rather than reimplementing any of them, and **adapts into the canonical process/job runtime** — it is the `IJobExecutor` the geoprocessing dispatcher routes for the `import.dataset` process id (per the CLAUDE.md "Process/job execution" rule; no protocol-local job lifecycle). It is therefore submittable through the existing process surface (OGC API Processes `/ogc/processes/{processId}/execution`, GeoServices GPServer) and inherits progress polling, heartbeats, retry, cancellation, and the #1624 in-memory single-node fallback from the substrate. This is the execution layer the geospatial-mcp `publish_data` family will submit into.

### Steps and the existing service each reuses
| Step | Service reused |
|---|---|
| fetch/stage | resolves the catalog connection via `ISecureConnectionResolver`; validates the staged source path |
| validate + chunk | `IFileImportService.ImportFileAsync` — the streaming importer enforces the `ImportGeometrySizeGuard` vertex/ring guard per feature (#1626) |
| import | `IFileImportService.ImportFileAsync` (writes the generic `imported_<table>`) |
| flatten to typed schema | `ILayerPublishingService.PublishLayerAsync` — introspects the imported table, materializes the typed layer, and rebuilds the MVT materialization (#1628) |
| raster tiling/overviews | `IRasterImportService.ImportAsync` (#1625), when a raster layer is supplied |
| extent + MVT refresh | `ILayerPublishingService.RefreshLayerExtentsAsync` |
| provenance | structured execution-log entry + JSON provenance artifact through the canonical substrate (no bespoke schema) |

Provider services live in the active data-provider assembly, so the executor resolves them at execution time through an `IServiceScopeFactory` scope — the same pattern `sink.external-postgis` uses.

## Changes Made
- Add `ImportDatasetJobExecutor` (managed profile) that orchestrates the ordered steps by composing the existing import / publishing / raster / extent services
- Register `import.dataset` in the built-in process catalog and the geoprocessing dispatcher handler map (submit + progress-poll via the existing process surface)
- Surface the physical staging table name and operational schema on `ImportResult` so the flatten step targets the real imported table rather than the logical name
- Skip a leading UTF-8 BOM in the streaming GeoJSON reader so BOM-prefixed sources import cleanly
- Add a Testcontainers + PostGIS integration test that runs the job end-to-end and asserts it imports, flattens to a typed catalog layer, refreshes the extent, and records a provenance artifact, plus a missing-input negative test
- Update catalog/dispatcher conformance + count unit tests for the new process

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Import.dataset integration tests: 2/2 pass. Affected Server.Tests shard (import + conformance + dispatch + catalog): 124/124 pass. Architecture tests: 109/110 (1 pre-existing skip). Release build (warnings-as-errors) clean; `dotnet format --verify-no-changes` clean.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

(`import.dataset` is advertised through the existing OGC API Processes / GPServer process surface; no new HTTP route or proto change.)

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

### Deferred
Full mid-step resume re-runs from the staged source under overwrite idempotency (the importer's `OverwriteExisting` path) rather than per-row checkpointing; finer-grained resume is a follow-on.