### PR TITLE
feat: licensing capacity meter (#1588) and Pro gates for offline-sync/agentic-AI (#1592)

### DIFF
--- a/src/Honua.Ai/Features/AnalysisContent/AnalysisContentEndpoints.cs
+++ b/src/Honua.Ai/Features/AnalysisContent/AnalysisContentEndpoints.cs
@@ -6,9 +6,11 @@ using Honua.Ai.AnalysisGeneration;
 using Honua.Ai.QueryGeneration;
 using Honua.Core.Features.AnalysisContent.Abstractions;
 using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Validation.Contracts;
 using Honua.Geoprocessing;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Microsoft.AspNetCore.Mvc;
 
@@ -129,6 +131,15 @@ internal static partial class AnalysisContentEndpoints
             return Results.Json(bad, AnalysisGenerationApiJsonContext.Default.AnalysisGenerationResult, statusCode: StatusCodes.Status400BadRequest);
         }
 
+        var entitlementGate = LicenseGate.RequireEntitlement(
+            context,
+            FeatureCatalog.AiWorkflowGenerationKey,
+            "AI analysis generation");
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
+
         var result = await generation.GenerateAsync(
             new AnalysisGenerationRequest
             {
@@ -166,6 +177,15 @@ internal static partial class AnalysisContentEndpoints
         {
             var bad = new QueryGenerationResult { Status = "error", Rationale = "A non-empty 'prompt' is required." };
             return Results.Json(bad, QueryGenerationApiJsonContext.Default.QueryGenerationResult, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var entitlementGate = LicenseGate.RequireEntitlement(
+            context,
+            FeatureCatalog.AiWorkflowGenerationKey,
+            "AI saved-query generation");
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
         }
 
         var result = await generation.GenerateAsync(

--- a/src/Honua.Ai/Features/Grounding/Spec/SpecGroundingEndpointExtensions.cs
+++ b/src/Honua.Ai/Features/Grounding/Spec/SpecGroundingEndpointExtensions.cs
@@ -4,9 +4,11 @@
 using System.Collections.Immutable;
 using System.Text.Json;
 using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Spec.Canonical;
 using Honua.Core.Features.Spec.Domain;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Licensing;
 
 namespace Honua.Ai.Grounding.Spec;
 
@@ -63,6 +65,15 @@ internal static class SpecGroundingEndpointExtensions
         if (!TryMapClarificationAnswer(request.ClarificationAnswer, out var clarificationAnswer, out var clarificationError))
         {
             return InvalidRequest(clarificationError);
+        }
+
+        var entitlementGate = LicenseGate.RequireEntitlement(
+            httpContext,
+            FeatureCatalog.AiGroundingKey,
+            "Spec grounding mutations");
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
         }
 
         var result = await groundingService.MutateAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ExecutePlanTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ExecutePlanTool.cs
@@ -3,7 +3,9 @@
 
 using System.Text.Json;
 using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Geoprocessing;
+using Honua.Infrastructure.Licensing;
 using Honua.Ai.Protocols.Mcp.Models;
 
 namespace Honua.Ai.Protocols.Mcp.Tools;
@@ -52,6 +54,14 @@ internal sealed class ExecutePlanTool : IMcpTool
         await _jobService
             .EnsureCallerAuthorizedAsync(principal, OperatorResourceType.Process, OperatorOperation.Execute, cancellationToken)
             .ConfigureAwait(false);
+
+        var entitlement = LicenseGate.CheckEntitlement(
+            httpContext.RequestServices,
+            FeatureCatalog.AiSpecApplyKey);
+        if (!entitlement.IsActive)
+        {
+            throw new GeoprocessingPreconditionFailedException(entitlement.UpgradeMessage);
+        }
 
         var argument = McpToolHelpers.ParseArguments(arguments, McpJsonContext.Default.McpExecutePlanArgument);
         var plan = McpToolHelpers.ToDomainPlan(argument.Plan);

--- a/src/Honua.Core/Features/Licensing/Abstractions/ILicenseCapacityMeter.cs
+++ b/src/Honua.Core/Features/Licensing/Abstractions/ILicenseCapacityMeter.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Licensing.Domain;
+
+namespace Honua.Core.Features.Licensing.Abstractions;
+
+/// <summary>
+/// Provides topology-neutral capacity metering and registration admission for license bands.
+/// </summary>
+public interface ILicenseCapacityMeter
+{
+    /// <summary>
+    /// Registers or refreshes a serving instance in the capacity meter.
+    /// </summary>
+    /// <param name="request">Registration request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Registration admission decision.</returns>
+    Task<LicenseCapacityRegistrationDecision> RegisterInstanceAsync(
+        LicenseCapacityRegistrationRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the current capacity state used by admission and admin dashboards.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Capacity state.</returns>
+    Task<LicenseCapacityState> GetCapacityStateAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Activates or deactivates declared surge mode.
+    /// </summary>
+    /// <param name="enabled">Whether surge mode should be active.</param>
+    /// <param name="reason">Optional operator-facing reason.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Updated capacity state.</returns>
+    Task<LicenseCapacityState> SetSurgeModeAsync(
+        bool enabled,
+        string? reason,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -70,6 +70,12 @@ public static class FeatureCatalog
         /// <summary>Editing features — branch versioning, reconcile/post, multi-user editing.</summary>
         public const string Editing = "Editing";
 
+        /// <summary>Offline field operations and disconnected sync features.</summary>
+        public const string FieldOps = "FieldOps";
+
+        /// <summary>Agentic AI generation, grounding, and execution features.</summary>
+        public const string Ai = "AI";
+
         /// <summary>Server extensibility features — plugin/extension SDK.</summary>
         public const string Extensibility = "Extensibility";
     }
@@ -89,6 +95,32 @@ public static class FeatureCatalog
     /// and Enterprise branch versioning (<c>editing.branch-versioning</c>) are separate entitlements.
     /// </summary>
     public const string FeatureEditsKey = "editing.feature-edits";
+
+    /// <summary>
+    /// Entitlement key for disconnected field operations — form offline policy discovery,
+    /// FieldCollection cursor/change sync, and GeoServices replica/GeoPackage delta sync.
+    /// Online form package reads and submissions remain Community surfaces.
+    /// </summary>
+    public const string FieldOpsOfflineSyncKey = "fieldops.offline-sync";
+
+    /// <summary>
+    /// Entitlement key for applying executable spec plans and MCP execution tools that submit
+    /// server-side agentic work. Spec validation, planning, discovery, and read/query paths stay
+    /// Community.
+    /// </summary>
+    public const string AiSpecApplyKey = "ai.spec-apply";
+
+    /// <summary>
+    /// Entitlement key for natural-language spec mutation grounding. Deterministic summaries and
+    /// discovery paths remain Community.
+    /// </summary>
+    public const string AiGroundingKey = "ai.grounding";
+
+    /// <summary>
+    /// Entitlement key for natural-language generation of workflows, maps, apps, forms, reports,
+    /// dashboards, saved queries, and analysis packages.
+    /// </summary>
+    public const string AiWorkflowGenerationKey = "ai.workflow-generation";
 
     /// <summary>
     /// Entitlement key for the server plugin/extension SDK (custom feature validators and edit
@@ -172,6 +204,10 @@ public static class FeatureCatalog
         new("streaming.feature-subscriptions", "Real-Time Feature Streams", Categories.Streaming,
             HonuaEdition.Pro, "Subscribe to WebSocket and SSE feature-change streams with filters and replay cursors."),
 
+        // Field operations — Pro (disconnected/offline sync; online collection remains Community)
+        new(FieldOpsOfflineSyncKey, "Offline/Field Sync", Categories.FieldOps,
+            HonuaEdition.Pro, "Use disconnected field sync, form offline policy discovery, GeoServices replica/GeoPackage delta sync, and FieldCollection cursor/change exchange."),
+
         // Import — Enterprise
         new("import.geoservices", "GeoServices Import", Categories.Import,
             HonuaEdition.Enterprise, "Import layers from ArcGIS REST services."),
@@ -245,6 +281,14 @@ public static class FeatureCatalog
         // Editing — Enterprise (Esri-style branch versioning; Postgres-only)
         new(BranchVersioningKey, "Branch Versioning", Categories.Editing,
             HonuaEdition.Enterprise, "Named gdb versions with isolated edits, reconcile/post back to DEFAULT, and gdbVersion-scoped editing/querying over the GeoServices VersionManagementServer."),
+
+        // AI operations — Pro (read/discovery/query surfaces remain Community)
+        new(AiSpecApplyKey, "Spec Apply Execution", Categories.Ai,
+            HonuaEdition.Pro, "Apply executable specs and submit MCP plan execution jobs from agentic tooling."),
+        new(AiGroundingKey, "Spec Grounding Mutations", Categories.Ai,
+            HonuaEdition.Pro, "Ground natural-language turns into validated spec mutation plans."),
+        new(AiWorkflowGenerationKey, "AI Workflow and Content Generation", Categories.Ai,
+            HonuaEdition.Pro, "Generate or refine workflows, maps, apps, forms, reports, dashboards, saved queries, and analysis packages from natural-language prompts."),
 
         // Extensibility — Enterprise (plugin/extension SDK)
         new(PluginSdkKey, "Plugin/Extension SDK", Categories.Extensibility,

--- a/src/Honua.Core/Features/Licensing/Domain/LicenseCapacityCalculator.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/LicenseCapacityCalculator.cs
@@ -1,0 +1,201 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Licensing.Domain;
+
+/// <summary>
+/// Shared capacity-band policy calculations for licensing.
+/// </summary>
+public static class LicenseCapacityCalculator
+{
+    /// <summary>
+    /// One serving unit covers up to this many virtual CPUs.
+    /// </summary>
+    public const decimal VcpuPerServingUnit = 8m;
+
+    /// <summary>
+    /// One serving unit covers up to this many GiB of memory.
+    /// </summary>
+    public const decimal MemoryGiBPerServingUnit = 32m;
+
+    /// <summary>
+    /// Free burst headroom above the sustained capacity band.
+    /// </summary>
+    public const decimal BurstMultiplier = 1.25m;
+
+    /// <summary>
+    /// Sustained-growth grace period after p95 exceeds the licensed band.
+    /// </summary>
+    public const int GracePeriodDays = 30;
+
+    /// <summary>
+    /// Computes serving units from explicit units or topology resources.
+    /// </summary>
+    /// <param name="explicitServingUnits">Operator-supplied serving-unit weight.</param>
+    /// <param name="vCpu">Virtual CPU count for the serving instance.</param>
+    /// <param name="memoryGiB">Memory in GiB for the serving instance.</param>
+    /// <param name="serverlessConcurrentExecutions">Serverless concurrent execution weight.</param>
+    /// <returns>Serving units, minimum one.</returns>
+    public static decimal ComputeServingUnits(
+        decimal? explicitServingUnits = null,
+        double? vCpu = null,
+        double? memoryGiB = null,
+        int? serverlessConcurrentExecutions = null)
+    {
+        if (explicitServingUnits is > 0m)
+        {
+            return explicitServingUnits.Value;
+        }
+
+        var cpuUnits = vCpu is > 0d
+            ? Math.Ceiling((decimal)vCpu.Value / VcpuPerServingUnit)
+            : 0m;
+        var memoryUnits = memoryGiB is > 0d
+            ? Math.Ceiling((decimal)memoryGiB.Value / MemoryGiBPerServingUnit)
+            : 0m;
+        var executionUnits = serverlessConcurrentExecutions is > 0
+            ? Math.Ceiling(serverlessConcurrentExecutions.Value / VcpuPerServingUnit)
+            : 0m;
+
+        return Math.Max(1m, Math.Max(cpuUnits, Math.Max(memoryUnits, executionUnits)));
+    }
+
+    /// <summary>
+    /// Computes nearest-rank p95 from samples, excluding declared surge windows.
+    /// </summary>
+    /// <param name="samples">Capacity samples.</param>
+    /// <returns>P95 serving units, or zero when no non-surge samples exist.</returns>
+    public static decimal ComputeP95(IEnumerable<LicenseCapacitySample> samples)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+
+        var ordered = samples
+            .Where(sample => !sample.IsSurge)
+            .Select(sample => sample.ServingUnits)
+            .Order()
+            .ToArray();
+
+        if (ordered.Length == 0)
+        {
+            return 0m;
+        }
+
+        var rank = (int)Math.Ceiling(ordered.Length * 0.95d) - 1;
+        return ordered[Math.Clamp(rank, 0, ordered.Length - 1)];
+    }
+
+    /// <summary>
+    /// Gets the 125 percent burst ceiling for a capacity band.
+    /// </summary>
+    /// <param name="terms">Capacity terms.</param>
+    /// <returns>Burst ceiling in serving units.</returns>
+    public static decimal GetBurstCeiling(LicenseCapacityTerms terms)
+    {
+        ArgumentNullException.ThrowIfNull(terms);
+        return terms.MaxSustainedServingUnits * BurstMultiplier;
+    }
+
+    /// <summary>
+    /// Gets whether a deployment role is excluded from production band fit.
+    /// </summary>
+    /// <param name="role">Deployment role.</param>
+    /// <returns>True when the role is not production.</returns>
+    public static bool IsExcludedRole(LicenseDeploymentRole role) => role != LicenseDeploymentRole.Production;
+
+    /// <summary>
+    /// Determines the capacity band state from live and p95 usage.
+    /// </summary>
+    /// <param name="terms">Capacity terms, when configured.</param>
+    /// <param name="currentServingUnits">Current live production serving units.</param>
+    /// <param name="p95ServingUnits">Rolling p95 production serving units.</param>
+    /// <param name="graceStartedAt">Current grace-clock start, when active.</param>
+    /// <param name="surgeActive">Whether declared surge mode is active.</param>
+    /// <param name="meteringGap">Whether coordinated metering is unavailable.</param>
+    /// <param name="excluded">Whether the local role is excluded from band accounting.</param>
+    /// <param name="now">Current timestamp.</param>
+    /// <returns>Capacity band state.</returns>
+    public static LicenseCapacityBandState DetermineBandState(
+        LicenseCapacityTerms? terms,
+        decimal currentServingUnits,
+        decimal p95ServingUnits,
+        DateTimeOffset? graceStartedAt,
+        bool surgeActive,
+        bool meteringGap,
+        bool excluded,
+        DateTimeOffset now)
+    {
+        if (meteringGap)
+        {
+            return LicenseCapacityBandState.MeteringGap;
+        }
+
+        if (terms is null)
+        {
+            return LicenseCapacityBandState.NotConfigured;
+        }
+
+        if (excluded)
+        {
+            return LicenseCapacityBandState.Excluded;
+        }
+
+        if (surgeActive)
+        {
+            return LicenseCapacityBandState.Surge;
+        }
+
+        var baseCeiling = terms.MaxSustainedServingUnits;
+        if (p95ServingUnits > baseCeiling)
+        {
+            if (graceStartedAt.HasValue &&
+                now - graceStartedAt.Value >= TimeSpan.FromDays(GracePeriodDays))
+            {
+                return LicenseCapacityBandState.GraceExpired;
+            }
+
+            return LicenseCapacityBandState.Grace;
+        }
+
+        if (currentServingUnits > baseCeiling)
+        {
+            return LicenseCapacityBandState.Burst;
+        }
+
+        return p95ServingUnits >= baseCeiling * 0.8m
+            ? LicenseCapacityBandState.ApproachingBand
+            : LicenseCapacityBandState.Normal;
+    }
+
+    /// <summary>
+    /// Determines whether a new production registration should be refused.
+    /// </summary>
+    /// <param name="terms">Capacity terms, when configured.</param>
+    /// <param name="currentServingUnits">Current live production serving units, excluding the joining instance.</param>
+    /// <param name="joiningServingUnits">Serving units for the joining instance.</param>
+    /// <param name="state">Current capacity band state.</param>
+    /// <param name="excluded">Whether the joining instance is excluded from band accounting.</param>
+    /// <returns>True when the joining registration is above the active ceiling.</returns>
+    public static bool ShouldRefuseRegistration(
+        LicenseCapacityTerms? terms,
+        decimal currentServingUnits,
+        decimal joiningServingUnits,
+        LicenseCapacityBandState state,
+        bool excluded)
+    {
+        if (terms is null ||
+            excluded ||
+            state is LicenseCapacityBandState.NotConfigured or
+                LicenseCapacityBandState.Excluded or
+                LicenseCapacityBandState.Surge or
+                LicenseCapacityBandState.MeteringGap)
+        {
+            return false;
+        }
+
+        var ceiling = state == LicenseCapacityBandState.GraceExpired
+            ? terms.MaxSustainedServingUnits
+            : GetBurstCeiling(terms);
+
+        return currentServingUnits + joiningServingUnits > ceiling;
+    }
+}

--- a/src/Honua.Core/Features/Licensing/Domain/LicenseCapacityModels.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/LicenseCapacityModels.cs
@@ -1,0 +1,425 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Licensing.Domain;
+
+/// <summary>
+/// Deployment roles used by the licensing capacity meter.
+/// </summary>
+public enum LicenseDeploymentRole
+{
+    /// <summary>
+    /// Production serving capacity that counts toward the licensed band.
+    /// </summary>
+    Production = 0,
+
+    /// <summary>
+    /// Developer or local capacity excluded from the licensed band.
+    /// </summary>
+    Development = 1,
+
+    /// <summary>
+    /// Automated test capacity excluded from the licensed band.
+    /// </summary>
+    Test = 2,
+
+    /// <summary>
+    /// Staging or pre-production capacity excluded from the licensed band.
+    /// </summary>
+    Staging = 3,
+
+    /// <summary>
+    /// Cold disaster-recovery capacity excluded from the licensed band.
+    /// </summary>
+    ColdDr = 4,
+}
+
+/// <summary>
+/// Runtime topology marker reported by a serving instance.
+/// </summary>
+public enum LicenseServingTopology
+{
+    /// <summary>
+    /// A single serving node without distributed coordination.
+    /// </summary>
+    SingleNode = 0,
+
+    /// <summary>
+    /// A virtual machine or bare-metal host.
+    /// </summary>
+    VirtualMachine = 1,
+
+    /// <summary>
+    /// A Kubernetes, ECS, or similar replica-managed topology.
+    /// </summary>
+    ReplicaSet = 2,
+
+    /// <summary>
+    /// A serverless warm execution environment.
+    /// </summary>
+    Serverless = 3,
+}
+
+/// <summary>
+/// Capacity-band state reported by the license meter.
+/// </summary>
+public enum LicenseCapacityBandState
+{
+    /// <summary>
+    /// No capacity band is encoded in the active license.
+    /// </summary>
+    NotConfigured = 0,
+
+    /// <summary>
+    /// The current deployment role is excluded from capacity accounting.
+    /// </summary>
+    Excluded = 1,
+
+    /// <summary>
+    /// Capacity is inside the licensed band.
+    /// </summary>
+    Normal = 2,
+
+    /// <summary>
+    /// P95 capacity is at or above the 80 percent warning threshold.
+    /// </summary>
+    ApproachingBand = 3,
+
+    /// <summary>
+    /// Live capacity is above the base band but inside the 125 percent burst ceiling.
+    /// </summary>
+    Burst = 4,
+
+    /// <summary>
+    /// P95 capacity is above the base band and the sustained-growth grace clock is active.
+    /// </summary>
+    Grace = 5,
+
+    /// <summary>
+    /// The sustained-growth grace period has expired.
+    /// </summary>
+    GraceExpired = 6,
+
+    /// <summary>
+    /// Operator-declared surge mode is active and p95 samples are masked.
+    /// </summary>
+    Surge = 7,
+
+    /// <summary>
+    /// Capacity enforcement is suspended because the coordinated meter is unavailable.
+    /// </summary>
+    MeteringGap = 8,
+}
+
+/// <summary>
+/// Constants for license surge allowance names.
+/// </summary>
+public static class LicenseCapacitySurgeAllowances
+{
+    /// <summary>
+    /// Standard allowance for ordinary paid licenses.
+    /// </summary>
+    public const string Standard = "standard";
+
+    /// <summary>
+    /// High allowance for licenses with a purchased surge pack.
+    /// </summary>
+    public const string High = "high";
+
+    /// <summary>
+    /// Unlimited allowance for licenses with uncapped surge rights.
+    /// </summary>
+    public const string Unlimited = "unlimited";
+}
+
+/// <summary>
+/// Capacity-band terms encoded in a signed license.
+/// </summary>
+public sealed class LicenseCapacityTerms
+{
+    /// <summary>
+    /// Maximum sustained p95 serving units included in the license.
+    /// </summary>
+    public required decimal MaxSustainedServingUnits { get; init; }
+
+    /// <summary>
+    /// Number of declared surge days available per calendar year. Null means unlimited.
+    /// </summary>
+    public int? AnnualSurgeDays { get; init; } = 14;
+
+    /// <summary>
+    /// Human-readable surge allowance tier.
+    /// </summary>
+    public string SurgeAllowance { get; init; } = LicenseCapacitySurgeAllowances.Standard;
+}
+
+/// <summary>
+/// One live serving instance as seen by the capacity meter.
+/// </summary>
+public sealed class LicenseCapacityInstance
+{
+    /// <summary>
+    /// Stable instance identifier.
+    /// </summary>
+    public required string InstanceId { get; init; }
+
+    /// <summary>
+    /// Serving-unit weight for this instance.
+    /// </summary>
+    public required decimal ServingUnits { get; init; }
+
+    /// <summary>
+    /// Deployment role reported by this instance.
+    /// </summary>
+    public required LicenseDeploymentRole DeploymentRole { get; init; }
+
+    /// <summary>
+    /// Runtime topology reported by this instance.
+    /// </summary>
+    public required LicenseServingTopology Topology { get; init; }
+
+    /// <summary>
+    /// Last heartbeat timestamp known to the meter.
+    /// </summary>
+    public required DateTimeOffset LastHeartbeatAt { get; init; }
+
+    /// <summary>
+    /// Whether this instance contributes to the production band calculation.
+    /// </summary>
+    public required bool CountsTowardBand { get; init; }
+}
+
+/// <summary>
+/// One sampled capacity value for p95 computation.
+/// </summary>
+public sealed class LicenseCapacitySample
+{
+    /// <summary>
+    /// Sample timestamp.
+    /// </summary>
+    public required DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>
+    /// Concurrent serving units observed at this sample.
+    /// </summary>
+    public required decimal ServingUnits { get; init; }
+
+    /// <summary>
+    /// Whether this sample occurred during declared surge mode and is excluded from p95.
+    /// </summary>
+    public required bool IsSurge { get; init; }
+}
+
+/// <summary>
+/// Declared surge-mode state and annual allowance accounting.
+/// </summary>
+public sealed class LicenseSurgeModeState
+{
+    /// <summary>
+    /// Whether surge mode is active.
+    /// </summary>
+    public required bool IsActive { get; init; }
+
+    /// <summary>
+    /// When the active surge window started.
+    /// </summary>
+    public DateTimeOffset? ActivatedAt { get; init; }
+
+    /// <summary>
+    /// Operator-supplied activation reason.
+    /// </summary>
+    public string? Reason { get; init; }
+
+    /// <summary>
+    /// Annual surge-day allowance. Null means unlimited.
+    /// </summary>
+    public int? AnnualAllowanceDays { get; init; }
+
+    /// <summary>
+    /// Surge days used in the current calendar year, including the active window.
+    /// </summary>
+    public decimal UsedDaysThisYear { get; init; }
+
+    /// <summary>
+    /// Remaining surge days in the current calendar year. Null means unlimited.
+    /// </summary>
+    public decimal? RemainingDaysThisYear { get; init; }
+}
+
+/// <summary>
+/// Current capacity meter state shown in the admin dashboard and used by admission checks.
+/// </summary>
+public sealed class LicenseCapacityState
+{
+    /// <summary>
+    /// Capacity-band state.
+    /// </summary>
+    public required LicenseCapacityBandState State { get; init; }
+
+    /// <summary>
+    /// Capacity terms encoded in the active license, when present.
+    /// </summary>
+    public LicenseCapacityTerms? Terms { get; init; }
+
+    /// <summary>
+    /// Current live production serving units.
+    /// </summary>
+    public required decimal CurrentServingUnits { get; init; }
+
+    /// <summary>
+    /// Rolling p95 production serving units, excluding surge samples.
+    /// </summary>
+    public required decimal P95ServingUnits { get; init; }
+
+    /// <summary>
+    /// The 125 percent burst ceiling derived from the base band.
+    /// </summary>
+    public decimal? BurstCeilingServingUnits { get; init; }
+
+    /// <summary>
+    /// Burst multiplier applied to the base band.
+    /// </summary>
+    public required decimal BurstMultiplier { get; init; }
+
+    /// <summary>
+    /// Sustained-growth grace period in days.
+    /// </summary>
+    public required int GracePeriodDays { get; init; }
+
+    /// <summary>
+    /// When the current sustained-growth grace clock started.
+    /// </summary>
+    public DateTimeOffset? GraceStartedAt { get; init; }
+
+    /// <summary>
+    /// When the current sustained-growth grace period expires.
+    /// </summary>
+    public DateTimeOffset? GraceExpiresAt { get; init; }
+
+    /// <summary>
+    /// Whether new production registrations above the active ceiling are refused.
+    /// </summary>
+    public required bool RegistrationEnforced { get; init; }
+
+    /// <summary>
+    /// Whether Redis coordination is configured.
+    /// </summary>
+    public required bool RedisConfigured { get; init; }
+
+    /// <summary>
+    /// Whether Redis coordination is being used for this state.
+    /// </summary>
+    public required bool RedisCoordinated { get; init; }
+
+    /// <summary>
+    /// Whether enforcement is suspended due to an unavailable coordinated meter.
+    /// </summary>
+    public required bool MeteringGap { get; init; }
+
+    /// <summary>
+    /// Role reported by the local serving instance.
+    /// </summary>
+    public required LicenseDeploymentRole LocalDeploymentRole { get; init; }
+
+    /// <summary>
+    /// Topology reported by the local serving instance.
+    /// </summary>
+    public required LicenseServingTopology LocalTopology { get; init; }
+
+    /// <summary>
+    /// Serving-unit weight for the local instance.
+    /// </summary>
+    public required decimal LocalServingUnits { get; init; }
+
+    /// <summary>
+    /// Whether the local instance is excluded from production band accounting.
+    /// </summary>
+    public required bool LocalRoleExcluded { get; init; }
+
+    /// <summary>
+    /// Number of live heartbeat records known to the meter.
+    /// </summary>
+    public required int LiveInstanceCount { get; init; }
+
+    /// <summary>
+    /// Number of live production instances counted toward the band.
+    /// </summary>
+    public required int ProductionInstanceCount { get; init; }
+
+    /// <summary>
+    /// Number of live non-production instances excluded from the band.
+    /// </summary>
+    public required int ExcludedInstanceCount { get; init; }
+
+    /// <summary>
+    /// Surge mode and allowance state.
+    /// </summary>
+    public required LicenseSurgeModeState Surge { get; init; }
+
+    /// <summary>
+    /// Whether p95 usage has reached the 80 percent warning threshold.
+    /// </summary>
+    public required bool Warning80Percent { get; init; }
+
+    /// <summary>
+    /// Whether p95 usage is above the licensed base band.
+    /// </summary>
+    public required bool Warning100Percent { get; init; }
+
+    /// <summary>
+    /// Safe operator-facing state messages.
+    /// </summary>
+    public IReadOnlyList<string> Messages { get; init; } = [];
+}
+
+/// <summary>
+/// Request to register or refresh a serving instance in the capacity meter.
+/// </summary>
+public sealed class LicenseCapacityRegistrationRequest
+{
+    /// <summary>
+    /// Stable serving instance identifier.
+    /// </summary>
+    public required string InstanceId { get; init; }
+
+    /// <summary>
+    /// Serving-unit weight for the instance.
+    /// </summary>
+    public required decimal ServingUnits { get; init; }
+
+    /// <summary>
+    /// Deployment role for the instance.
+    /// </summary>
+    public required LicenseDeploymentRole DeploymentRole { get; init; }
+
+    /// <summary>
+    /// Runtime topology for the instance.
+    /// </summary>
+    public required LicenseServingTopology Topology { get; init; }
+
+    /// <summary>
+    /// Whether this call is a heartbeat refresh for an already admitted instance.
+    /// </summary>
+    public bool IsRefresh { get; init; }
+}
+
+/// <summary>
+/// Result of capacity registration.
+/// </summary>
+public sealed class LicenseCapacityRegistrationDecision
+{
+    /// <summary>
+    /// Whether the serving instance was admitted.
+    /// </summary>
+    public required bool IsAccepted { get; init; }
+
+    /// <summary>
+    /// Safe operator-facing reason for the decision.
+    /// </summary>
+    public required string Reason { get; init; }
+
+    /// <summary>
+    /// Capacity state used for the decision.
+    /// </summary>
+    public required LicenseCapacityState State { get; init; }
+}

--- a/src/Honua.Core/Features/Licensing/Domain/LicenseInfo.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/LicenseInfo.cs
@@ -47,6 +47,11 @@ public sealed class LicenseInfo
     /// Entitlements granted by this license.
     /// </summary>
     public IReadOnlyList<Entitlement> Entitlements { get; init; } = [];
+
+    /// <summary>
+    /// Capacity-band terms granted by this license.
+    /// </summary>
+    public LicenseCapacityTerms? CapacityTerms { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Licensing/Domain/LicenseModels.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/LicenseModels.cs
@@ -76,6 +76,7 @@ public enum LicenseValidationState
 /// <param name="LicenseId">Stable license identifier when a license is loaded</param>
 /// <param name="IssuedAt">License issue timestamp when a license is loaded</param>
 /// <param name="Entitlements">Known feature entitlements and their active state</param>
+/// <param name="CapacityTerms">Capacity-band terms encoded in the active license</param>
 public sealed record LicenseStatus(
     HonuaEdition Edition,
     bool IsValid,
@@ -84,7 +85,8 @@ public sealed record LicenseStatus(
     LicenseValidationState ValidationState = LicenseValidationState.Valid,
     string? LicenseId = null,
     DateTimeOffset? IssuedAt = null,
-    IReadOnlyList<Entitlement>? Entitlements = null)
+    IReadOnlyList<Entitlement>? Entitlements = null,
+    LicenseCapacityTerms? CapacityTerms = null)
 {
     /// <summary>
     /// Days until license expiry, null if no expiry.
@@ -108,6 +110,7 @@ public sealed record LicenseStatus(
 /// <param name="ActiveEntitlementKeys">Active entitlement keys for O(1) gate checks.</param>
 /// <param name="SnapshotVersion">Monotonic in-process snapshot version.</param>
 /// <param name="KeyId">Trusted signing key identifier when a license is loaded.</param>
+/// <param name="CapacityTerms">Capacity-band terms encoded in the active license.</param>
 public sealed record LicenseSnapshot(
     HonuaEdition Edition,
     bool IsValid,
@@ -119,7 +122,8 @@ public sealed record LicenseSnapshot(
     IReadOnlyList<Entitlement> Entitlements,
     IReadOnlySet<string> ActiveEntitlementKeys,
     long SnapshotVersion,
-    string? KeyId)
+    string? KeyId,
+    LicenseCapacityTerms? CapacityTerms = null)
 {
     /// <summary>
     /// Gets whether the supplied entitlement key is active in this snapshot.

--- a/src/Honua.Hosting/Features/Licensing/FileBackedLicenseService.cs
+++ b/src/Honua.Hosting/Features/Licensing/FileBackedLicenseService.cs
@@ -105,7 +105,8 @@ internal sealed class FileBackedLicenseService :
             snapshot.ValidationState,
             snapshot.LicenseId,
             snapshot.IssuedAt,
-            snapshot.Entitlements);
+            snapshot.Entitlements,
+            snapshot.CapacityTerms);
     }
 
     public async Task<LicenseUploadResult> UploadLicenseAsync(
@@ -149,7 +150,8 @@ internal sealed class FileBackedLicenseService :
             snapshot.ValidationState,
             snapshot.LicenseId,
             snapshot.IssuedAt,
-            snapshot.Entitlements);
+            snapshot.Entitlements,
+            snapshot.CapacityTerms);
 
         var activeEntitlements = snapshot.Entitlements
             .Where(entitlement => entitlement.IsActive)
@@ -399,6 +401,37 @@ internal sealed class FileBackedLicenseService :
             return false;
         }
 
+        if (payload.Capacity is not null &&
+            !TryValidateCapacityTerms(payload.Capacity, out reason))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryValidateCapacityTerms(LicenseCapacityTerms capacity, out string reason)
+    {
+        reason = string.Empty;
+
+        if (capacity.MaxSustainedServingUnits <= 0m)
+        {
+            reason = "invalid-capacity-band";
+            return false;
+        }
+
+        if (capacity.AnnualSurgeDays is < 0)
+        {
+            reason = "invalid-surge-days";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(capacity.SurgeAllowance))
+        {
+            reason = "invalid-surge-allowance";
+            return false;
+        }
+
         return true;
     }
 
@@ -482,6 +515,8 @@ internal sealed class FileBackedLicenseService :
             })
             .ToArray();
 
+        var capacityTerms = isValid ? payload?.Capacity : null;
+
         return new LicenseSnapshot(
             edition,
             isValid,
@@ -493,7 +528,8 @@ internal sealed class FileBackedLicenseService :
             entitlements,
             activeKeys,
             snapshotVersion,
-            keyId);
+            keyId,
+            capacityTerms);
     }
 
     private void PublishCommunity(
@@ -558,7 +594,8 @@ internal sealed class FileBackedLicenseService :
             LicensedTo = snapshot.LicensedTo,
             LicenseId = snapshot.LicenseId,
             IssuedAt = snapshot.IssuedAt,
-            Entitlements = snapshot.Entitlements
+            Entitlements = snapshot.Entitlements,
+            CapacityTerms = snapshot.CapacityTerms
         };
     }
 

--- a/src/Honua.Hosting/Features/Licensing/LicenseCapacityMeter.cs
+++ b/src/Honua.Hosting/Features/Licensing/LicenseCapacityMeter.cs
@@ -1,0 +1,971 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using System.Text;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace Honua.Infrastructure.Licensing;
+
+internal sealed partial class LicenseCapacityMeter : BackgroundService, ILicenseCapacityMeter
+{
+    private const string RegistrationScript = """
+        local members = redis.call('SMEMBERS', KEYS[1])
+        local current = 0
+        for _, key in ipairs(members) do
+            if key ~= KEYS[2] then
+                local payload = redis.call('GET', key)
+                if payload then
+                    local first_sep = string.find(payload, '|')
+                    local role_start = first_sep + 1
+                    local second_sep = string.find(payload, '|', role_start)
+                    local units = tonumber(string.sub(payload, 1, first_sep - 1)) or 0
+                    local role = string.sub(payload, role_start, second_sep - 1)
+                    if role == 'Production' then
+                        current = current + units
+                    end
+                else
+                    redis.call('SREM', KEYS[1], key)
+                end
+            end
+        end
+
+        local joining = tonumber(ARGV[1]) or 0
+        local enforce = ARGV[2] == '1'
+        local ceiling = tonumber(ARGV[3]) or 0
+        if enforce and current + joining > ceiling then
+            return { 0, current }
+        end
+
+        redis.call('SET', KEYS[2], ARGV[4], 'PX', ARGV[5])
+        redis.call('SADD', KEYS[1], KEYS[2])
+        return { 1, current + joining }
+        """;
+
+    private static readonly Counter<long> SurgeModeChanges = HonuaTelemetry.Meter.CreateCounter<long>(
+        "honua.license.capacity.surge_mode_changes",
+        unit: "{change}",
+        description: "Declared licensing surge-mode changes.");
+
+    private static readonly Counter<long> RegistrationRefusals = HonuaTelemetry.Meter.CreateCounter<long>(
+        "honua.license.capacity.registration_refusals",
+        unit: "{registration}",
+        description: "Serving instance registrations refused by capacity-band enforcement.");
+
+    private readonly ILicenseEntitlementService _licenseEntitlements;
+    private readonly IOptions<LicenseCapacityOptions> _options;
+    private readonly IConnectionMultiplexer? _redis;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<LicenseCapacityMeter> _logger;
+    private readonly object _sync = new();
+    private readonly Dictionary<string, LicenseCapacityInstance> _localInstances = new(StringComparer.Ordinal);
+    private readonly List<LicenseCapacitySample> _localSamples = [];
+    private DateTimeOffset? _localGraceStartedAt;
+    private LocalSurgeState? _localSurge;
+    private decimal _localSurgeUsedDays;
+    private volatile bool _registeredSelf;
+    private volatile bool _meteringGap;
+
+    public LicenseCapacityMeter(
+        ILicenseEntitlementService licenseEntitlements,
+        IOptions<LicenseCapacityOptions> options,
+        TimeProvider timeProvider,
+        ILogger<LicenseCapacityMeter> logger,
+        IConnectionMultiplexer? redis = null)
+    {
+        _licenseEntitlements = licenseEntitlements;
+        _options = options;
+        _redis = redis;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public async Task<LicenseCapacityRegistrationDecision> RegisterInstanceAsync(
+        LicenseCapacityRegistrationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.InstanceId);
+
+        var normalized = NormalizeRequest(request);
+        var snapshot = _licenseEntitlements.GetSnapshot();
+        var terms = snapshot.CapacityTerms;
+        var preRegistrationState = await BuildStateAsync(
+            terms,
+            excludeInstanceId: normalized.InstanceId,
+            updateGrace: true,
+            cancellationToken).ConfigureAwait(false);
+
+        var excluded = LicenseCapacityCalculator.IsExcludedRole(normalized.DeploymentRole);
+        var joiningUnits = excluded ? 0m : normalized.ServingUnits;
+        var shouldRefuse = !normalized.IsRefresh &&
+            LicenseCapacityCalculator.ShouldRefuseRegistration(
+                terms,
+                preRegistrationState.CurrentServingUnits,
+                joiningUnits,
+                preRegistrationState.State,
+                excluded);
+
+        if (shouldRefuse)
+        {
+            RegistrationRefusals.Add(
+                1,
+                new KeyValuePair<string, object?>("honua.license.capacity.state", preRegistrationState.State.ToString()));
+            LicenseCapacityMeterLog.RegistrationRefused(
+                _logger,
+                normalized.InstanceId,
+                preRegistrationState.CurrentServingUnits,
+                joiningUnits,
+                terms?.MaxSustainedServingUnits ?? 0m,
+                preRegistrationState.State);
+
+            return new LicenseCapacityRegistrationDecision
+            {
+                IsAccepted = false,
+                Reason = "Registration refused: serving capacity is above the active license band ceiling.",
+                State = preRegistrationState
+            };
+        }
+
+        var accepted = await UpsertHeartbeatAsync(
+            normalized,
+            preRegistrationState,
+            enforce: !normalized.IsRefresh &&
+                terms is not null &&
+                !excluded &&
+                preRegistrationState.State is not LicenseCapacityBandState.NotConfigured and
+                    not LicenseCapacityBandState.Excluded and
+                    not LicenseCapacityBandState.Surge and
+                    not LicenseCapacityBandState.MeteringGap,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!accepted)
+        {
+            var current = await BuildStateAsync(
+                terms,
+                excludeInstanceId: normalized.InstanceId,
+                updateGrace: false,
+                cancellationToken).ConfigureAwait(false);
+            RegistrationRefusals.Add(
+                1,
+                new KeyValuePair<string, object?>("honua.license.capacity.state", current.State.ToString()));
+            LicenseCapacityMeterLog.RegistrationRefused(
+                _logger,
+                normalized.InstanceId,
+                current.CurrentServingUnits,
+                joiningUnits,
+                terms?.MaxSustainedServingUnits ?? 0m,
+                current.State);
+
+            return new LicenseCapacityRegistrationDecision
+            {
+                IsAccepted = false,
+                Reason = "Registration refused: concurrent scale-up exceeded the active license band ceiling.",
+                State = current
+            };
+        }
+
+        var state = await GetCapacityStateAsync(cancellationToken).ConfigureAwait(false);
+        return new LicenseCapacityRegistrationDecision
+        {
+            IsAccepted = true,
+            Reason = state.MeteringGap
+                ? "Registration accepted with capacity enforcement suspended because the coordinated meter is unavailable."
+                : "Registration accepted.",
+            State = state
+        };
+    }
+
+    public async Task<LicenseCapacityState> GetCapacityStateAsync(CancellationToken cancellationToken = default)
+    {
+        var terms = _licenseEntitlements.GetSnapshot().CapacityTerms;
+        return await BuildStateAsync(
+            terms,
+            excludeInstanceId: null,
+            updateGrace: true,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<LicenseCapacityState> SetSurgeModeAsync(
+        bool enabled,
+        string? reason,
+        CancellationToken cancellationToken = default)
+    {
+        var now = _timeProvider.GetUtcNow();
+        if (UseRedis)
+        {
+            try
+            {
+                var database = _redis!.GetDatabase();
+                if (enabled)
+                {
+                    await database.StringSetAsync(
+                        SurgeKey,
+                        FormatSurgePayload(now, reason),
+                        flags: CommandFlags.DemandMaster).ConfigureAwait(false);
+                }
+                else
+                {
+                    var active = await ReadRedisSurgeAsync(database, now).ConfigureAwait(false);
+                    if (active?.IsActive == true && active.ActivatedAt.HasValue)
+                    {
+                        var usedDays = Math.Max(0m, (decimal)(now - active.ActivatedAt.Value).TotalDays);
+                        await database.StringIncrementAsync(
+                            SurgeUsageKey(now),
+                            (double)usedDays,
+                            CommandFlags.DemandMaster).ConfigureAwait(false);
+                    }
+
+                    await database.KeyDeleteAsync(SurgeKey, CommandFlags.DemandMaster).ConfigureAwait(false);
+                }
+
+                _meteringGap = false;
+            }
+            catch (Exception ex) when (IsRedisException(ex))
+            {
+                MarkMeteringGap(ex);
+                SetLocalSurge(enabled, reason, now);
+            }
+        }
+        else
+        {
+            SetLocalSurge(enabled, reason, now);
+        }
+
+        SurgeModeChanges.Add(
+            1,
+            new KeyValuePair<string, object?>("honua.license.surge.enabled", enabled));
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity(
+            "honua.license.capacity.surge",
+            ActivityKind.Internal);
+        activity?.SetTag("honua.license.surge.enabled", enabled);
+        activity?.SetTag("honua.license.surge.reason_present", !string.IsNullOrWhiteSpace(reason));
+        LicenseCapacityMeterLog.SurgeModeChanged(_logger, enabled, reason);
+
+        return await GetCapacityStateAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public override async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_options.Value.RegistrationEnabled)
+        {
+            await base.StartAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var registration = await RegisterInstanceAsync(BuildLocalRequest(isRefresh: false), cancellationToken)
+            .ConfigureAwait(false);
+        if (!registration.IsAccepted)
+        {
+            throw new InvalidOperationException(registration.Reason);
+        }
+
+        _registeredSelf = true;
+        await RecordSampleAsync(registration.State, cancellationToken).ConfigureAwait(false);
+        await base.StartAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.Value.RegistrationEnabled)
+        {
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var delay = NormalizePositive(_options.Value.HeartbeatInterval, TimeSpan.FromSeconds(15));
+            await Task.Delay(delay, stoppingToken).ConfigureAwait(false);
+
+            var refresh = await RegisterInstanceAsync(BuildLocalRequest(isRefresh: true), stoppingToken)
+                .ConfigureAwait(false);
+            if (!refresh.IsAccepted)
+            {
+                LicenseCapacityMeterLog.RefreshRefused(_logger, refresh.Reason);
+            }
+
+            await RecordSampleAsync(refresh.State, stoppingToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<bool> UpsertHeartbeatAsync(
+        LicenseCapacityRegistrationRequest request,
+        LicenseCapacityState state,
+        bool enforce,
+        CancellationToken cancellationToken)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var instance = ToInstance(request, now);
+
+        if (!UseRedis)
+        {
+            UpsertLocalInstance(instance);
+            return true;
+        }
+
+        try
+        {
+            var database = _redis!.GetDatabase();
+            var joiningMilliUnits = ToMilliUnits(instance.CountsTowardBand ? instance.ServingUnits : 0m);
+            var ceiling = state.State == LicenseCapacityBandState.GraceExpired
+                ? state.Terms?.MaxSustainedServingUnits ?? 0m
+                : state.BurstCeilingServingUnits ?? 0m;
+            var ceilingMilliUnits = ToMilliUnits(ceiling);
+
+            var result = (RedisResult[]?)await database.ScriptEvaluateAsync(
+                RegistrationScript,
+                new RedisKey[] { InstanceSetKey, InstanceKey(instance.InstanceId) },
+                new RedisValue[]
+                {
+                    joiningMilliUnits.ToString(CultureInfo.InvariantCulture),
+                    enforce ? "1" : "0",
+                    ceilingMilliUnits.ToString(CultureInfo.InvariantCulture),
+                    FormatInstancePayload(instance),
+                    HeartbeatTtlMilliseconds.ToString(CultureInfo.InvariantCulture)
+                },
+                CommandFlags.DemandMaster).ConfigureAwait(false);
+
+            _meteringGap = false;
+            if (result is null || result.Length == 0)
+            {
+                return false;
+            }
+
+            return (int)result[0] == 1;
+        }
+        catch (Exception ex) when (IsRedisException(ex))
+        {
+            MarkMeteringGap(ex);
+            UpsertLocalInstance(instance);
+            return true;
+        }
+    }
+
+    private async Task<LicenseCapacityState> BuildStateAsync(
+        LicenseCapacityTerms? terms,
+        string? excludeInstanceId,
+        bool updateGrace,
+        CancellationToken cancellationToken)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var localRequest = BuildLocalRequest(isRefresh: _registeredSelf);
+        var localExcluded = LicenseCapacityCalculator.IsExcludedRole(localRequest.DeploymentRole);
+        MeterRead read;
+
+        if (UseRedis)
+        {
+            try
+            {
+                read = await ReadRedisMeterAsync(now, excludeInstanceId).ConfigureAwait(false);
+                _meteringGap = false;
+            }
+            catch (Exception ex) when (IsRedisException(ex))
+            {
+                MarkMeteringGap(ex);
+                read = ReadLocalMeter(now, excludeInstanceId) with { MeteringGap = true };
+            }
+        }
+        else
+        {
+            read = ReadLocalMeter(now, excludeInstanceId);
+        }
+
+        var surge = read.Surge ?? new LocalSurgeState(false, null, null, 0m);
+        var p95 = LicenseCapacityCalculator.ComputeP95(read.Samples);
+        if (p95 == 0m && !surge.IsActive && read.CurrentServingUnits > 0m)
+        {
+            p95 = read.CurrentServingUnits;
+        }
+
+        var graceStartedAt = updateGrace
+            ? await UpdateGraceAsync(terms, p95, surge.IsActive, read.MeteringGap, now).ConfigureAwait(false)
+            : read.GraceStartedAt;
+
+        var state = LicenseCapacityCalculator.DetermineBandState(
+            terms,
+            read.CurrentServingUnits,
+            p95,
+            graceStartedAt,
+            surge.IsActive,
+            read.MeteringGap,
+            localExcluded,
+            now);
+
+        decimal? burstCeiling = terms is null
+            ? null
+            : LicenseCapacityCalculator.GetBurstCeiling(terms);
+        var graceExpiresAt = graceStartedAt?.AddDays(LicenseCapacityCalculator.GracePeriodDays);
+        var warning80 = terms is not null && p95 >= terms.MaxSustainedServingUnits * 0.8m;
+        var warning100 = terms is not null && p95 > terms.MaxSustainedServingUnits;
+        var productionCount = read.Instances.Count(instance => instance.CountsTowardBand);
+        var excludedCount = read.Instances.Count - productionCount;
+
+        return new LicenseCapacityState
+        {
+            State = state,
+            Terms = terms,
+            CurrentServingUnits = read.CurrentServingUnits,
+            P95ServingUnits = p95,
+            BurstCeilingServingUnits = burstCeiling,
+            BurstMultiplier = LicenseCapacityCalculator.BurstMultiplier,
+            GracePeriodDays = LicenseCapacityCalculator.GracePeriodDays,
+            GraceStartedAt = graceStartedAt,
+            GraceExpiresAt = graceExpiresAt,
+            RegistrationEnforced = terms is not null && state != LicenseCapacityBandState.MeteringGap,
+            RedisConfigured = _redis is not null,
+            RedisCoordinated = UseRedis && !read.MeteringGap,
+            MeteringGap = read.MeteringGap,
+            LocalDeploymentRole = localRequest.DeploymentRole,
+            LocalTopology = localRequest.Topology,
+            LocalServingUnits = localRequest.ServingUnits,
+            LocalRoleExcluded = localExcluded,
+            LiveInstanceCount = read.Instances.Count,
+            ProductionInstanceCount = productionCount,
+            ExcludedInstanceCount = excludedCount,
+            Surge = BuildSurgeState(surge, terms, now),
+            Warning80Percent = warning80,
+            Warning100Percent = warning100,
+            Messages = BuildMessages(state, read.MeteringGap)
+        };
+    }
+
+    private async Task<DateTimeOffset?> UpdateGraceAsync(
+        LicenseCapacityTerms? terms,
+        decimal p95ServingUnits,
+        bool surgeActive,
+        bool meteringGap,
+        DateTimeOffset now)
+    {
+        if (terms is null || surgeActive || meteringGap)
+        {
+            return UseRedis
+                ? await ReadRedisGraceAsync().ConfigureAwait(false)
+                : _localGraceStartedAt;
+        }
+
+        if (p95ServingUnits > terms.MaxSustainedServingUnits)
+        {
+            var existing = UseRedis
+                ? await ReadRedisGraceAsync().ConfigureAwait(false)
+                : _localGraceStartedAt;
+            if (existing.HasValue)
+            {
+                return existing;
+            }
+
+            if (UseRedis)
+            {
+                try
+                {
+                    await _redis!.GetDatabase().StringSetAsync(
+                        GraceKey,
+                        now.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture),
+                        flags: CommandFlags.DemandMaster).ConfigureAwait(false);
+                    _meteringGap = false;
+                }
+                catch (Exception ex) when (IsRedisException(ex))
+                {
+                    MarkMeteringGap(ex);
+                    _localGraceStartedAt = now;
+                }
+            }
+            else
+            {
+                _localGraceStartedAt = now;
+            }
+
+            return now;
+        }
+
+        if (UseRedis)
+        {
+            try
+            {
+                await _redis!.GetDatabase().KeyDeleteAsync(GraceKey, CommandFlags.DemandMaster).ConfigureAwait(false);
+                _meteringGap = false;
+            }
+            catch (Exception ex) when (IsRedisException(ex))
+            {
+                MarkMeteringGap(ex);
+                _localGraceStartedAt = null;
+            }
+        }
+        else
+        {
+            _localGraceStartedAt = null;
+        }
+
+        return null;
+    }
+
+    private async Task RecordSampleAsync(LicenseCapacityState state, CancellationToken cancellationToken)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var sample = new LicenseCapacitySample
+        {
+            Timestamp = now,
+            ServingUnits = state.CurrentServingUnits,
+            IsSurge = state.Surge.IsActive
+        };
+
+        if (!UseRedis)
+        {
+            AddLocalSample(sample);
+            return;
+        }
+
+        try
+        {
+            var database = _redis!.GetDatabase();
+            var lockAcquired = await database.StringSetAsync(
+                SampleLockKey,
+                LocalInstanceId,
+                expiry: NormalizePositive(_options.Value.SampleInterval, TimeSpan.FromMinutes(5)),
+                when: When.NotExists,
+                flags: CommandFlags.DemandMaster).ConfigureAwait(false);
+            if (!lockAcquired)
+            {
+                return;
+            }
+
+            await database.ListRightPushAsync(
+                SampleKey,
+                FormatSamplePayload(sample),
+                flags: CommandFlags.DemandMaster).ConfigureAwait(false);
+            await database.ListTrimAsync(SampleKey, -10_000, -1, CommandFlags.DemandMaster).ConfigureAwait(false);
+            _meteringGap = false;
+        }
+        catch (Exception ex) when (IsRedisException(ex))
+        {
+            MarkMeteringGap(ex);
+            AddLocalSample(sample);
+        }
+
+        _ = cancellationToken;
+    }
+
+    private async Task<MeterRead> ReadRedisMeterAsync(DateTimeOffset now, string? excludeInstanceId)
+    {
+        var database = _redis!.GetDatabase();
+        var members = await database.SetMembersAsync(InstanceSetKey).ConfigureAwait(false);
+        var instances = new List<LicenseCapacityInstance>(members.Length);
+
+        foreach (var member in members)
+        {
+            var key = (RedisKey)member.ToString();
+            var payload = await database.StringGetAsync(key).ConfigureAwait(false);
+            if (!payload.HasValue)
+            {
+                await database.SetRemoveAsync(InstanceSetKey, member, CommandFlags.DemandMaster).ConfigureAwait(false);
+                continue;
+            }
+
+            if (TryParseInstancePayload(key, payload.ToString(), out var instance) &&
+                !string.Equals(instance.InstanceId, excludeInstanceId, StringComparison.Ordinal))
+            {
+                instances.Add(instance);
+            }
+        }
+
+        var samples = await ReadRedisSamplesAsync(database, now).ConfigureAwait(false);
+        var surge = await ReadRedisSurgeAsync(database, now).ConfigureAwait(false);
+        var grace = await ReadRedisGraceAsync().ConfigureAwait(false);
+        var currentUnits = instances
+            .Where(instance => instance.CountsTowardBand)
+            .Sum(instance => instance.ServingUnits);
+
+        return new MeterRead(instances, samples, surge, grace, currentUnits, MeteringGap: false);
+    }
+
+    private MeterRead ReadLocalMeter(DateTimeOffset now, string? excludeInstanceId)
+    {
+        lock (_sync)
+        {
+            var windowStart = now - NormalizePositive(_options.Value.SampleWindow, TimeSpan.FromDays(30));
+            _localSamples.RemoveAll(sample => sample.Timestamp < windowStart);
+            var instances = _localInstances.Values
+                .Where(instance => !string.Equals(instance.InstanceId, excludeInstanceId, StringComparison.Ordinal))
+                .ToList();
+            var samples = _localSamples.ToList();
+            var currentUnits = instances
+                .Where(instance => instance.CountsTowardBand)
+                .Sum(instance => instance.ServingUnits);
+            return new MeterRead(instances, samples, _localSurge, _localGraceStartedAt, currentUnits, _meteringGap);
+        }
+    }
+
+    private async Task<IReadOnlyList<LicenseCapacitySample>> ReadRedisSamplesAsync(IDatabase database, DateTimeOffset now)
+    {
+        var windowStart = now - NormalizePositive(_options.Value.SampleWindow, TimeSpan.FromDays(30));
+        var values = await database.ListRangeAsync(SampleKey).ConfigureAwait(false);
+        var samples = new List<LicenseCapacitySample>(values.Length);
+        foreach (var value in values)
+        {
+            if (TryParseSamplePayload(value.ToString(), out var sample) && sample.Timestamp >= windowStart)
+            {
+                samples.Add(sample);
+            }
+        }
+
+        return samples;
+    }
+
+    private async Task<LocalSurgeState?> ReadRedisSurgeAsync(IDatabase database, DateTimeOffset now)
+    {
+        var payload = await database.StringGetAsync(SurgeKey).ConfigureAwait(false);
+        var usedDays = await ReadRedisSurgeUsedDaysAsync(database, now).ConfigureAwait(false);
+        if (!payload.HasValue || !TryParseSurgePayload(payload.ToString(), out var activatedAt, out var reason))
+        {
+            return usedDays == 0m
+                ? null
+                : new LocalSurgeState(false, null, null, usedDays);
+        }
+
+        return new LocalSurgeState(true, activatedAt, reason, usedDays);
+    }
+
+    private async Task<decimal> ReadRedisSurgeUsedDaysAsync(IDatabase database, DateTimeOffset now)
+    {
+        var value = await database.StringGetAsync(SurgeUsageKey(now)).ConfigureAwait(false);
+        return value.HasValue &&
+            decimal.TryParse(value.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var used)
+            ? used
+            : 0m;
+    }
+
+    private async Task<DateTimeOffset?> ReadRedisGraceAsync()
+    {
+        if (!UseRedis)
+        {
+            return _localGraceStartedAt;
+        }
+
+        try
+        {
+            var value = await _redis!.GetDatabase().StringGetAsync(GraceKey).ConfigureAwait(false);
+            return value.HasValue &&
+                long.TryParse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var unixMs)
+                ? DateTimeOffset.FromUnixTimeMilliseconds(unixMs)
+                : null;
+        }
+        catch (Exception ex) when (IsRedisException(ex))
+        {
+            MarkMeteringGap(ex);
+            return _localGraceStartedAt;
+        }
+    }
+
+    private static LicenseSurgeModeState BuildSurgeState(
+        LocalSurgeState? local,
+        LicenseCapacityTerms? terms,
+        DateTimeOffset now)
+    {
+        var allowance = terms?.AnnualSurgeDays;
+        var activeDays = local?.IsActive == true && local.ActivatedAt.HasValue
+            ? Math.Max(0m, (decimal)(now - local.ActivatedAt.Value).TotalDays)
+            : 0m;
+        var used = (local?.UsedDaysThisYear ?? 0m) + activeDays;
+        var remaining = allowance.HasValue
+            ? Math.Max(0m, allowance.Value - used)
+            : (decimal?)null;
+
+        return new LicenseSurgeModeState
+        {
+            IsActive = local?.IsActive == true,
+            ActivatedAt = local?.ActivatedAt,
+            Reason = local?.Reason,
+            AnnualAllowanceDays = allowance,
+            UsedDaysThisYear = decimal.Round(used, 4),
+            RemainingDaysThisYear = remaining.HasValue ? decimal.Round(remaining.Value, 4) : null
+        };
+    }
+
+    private void SetLocalSurge(bool enabled, string? reason, DateTimeOffset now)
+    {
+        lock (_sync)
+        {
+            if (enabled)
+            {
+                _localSurge = new LocalSurgeState(true, now, reason, _localSurgeUsedDays);
+                return;
+            }
+
+            if (_localSurge?.IsActive == true && _localSurge.ActivatedAt.HasValue)
+            {
+                _localSurgeUsedDays += Math.Max(0m, (decimal)(now - _localSurge.ActivatedAt.Value).TotalDays);
+            }
+
+            _localSurge = _localSurgeUsedDays == 0m
+                ? null
+                : new LocalSurgeState(false, null, null, _localSurgeUsedDays);
+        }
+    }
+
+    private LicenseCapacityRegistrationRequest BuildLocalRequest(bool isRefresh)
+        => new()
+        {
+            InstanceId = LocalInstanceId,
+            ServingUnits = LicenseCapacityCalculator.ComputeServingUnits(
+                _options.Value.ServingUnits,
+                _options.Value.Vcpu,
+                _options.Value.MemoryGiB,
+                _options.Value.ServerlessConcurrentExecutions),
+            DeploymentRole = ParseEnum(_options.Value.DeploymentRole, LicenseDeploymentRole.Production),
+            Topology = ParseEnum(_options.Value.Topology, LicenseServingTopology.SingleNode),
+            IsRefresh = isRefresh
+        };
+
+    private string LocalInstanceId
+        => string.IsNullOrWhiteSpace(_options.Value.InstanceId)
+            ? $"{Environment.MachineName}-{Environment.ProcessId.ToString(CultureInfo.InvariantCulture)}"
+            : _options.Value.InstanceId;
+
+    private static LicenseCapacityRegistrationRequest NormalizeRequest(LicenseCapacityRegistrationRequest request)
+        => new()
+        {
+            InstanceId = request.InstanceId.Trim(),
+            ServingUnits = request.ServingUnits > 0m ? request.ServingUnits : 1m,
+            DeploymentRole = request.DeploymentRole,
+            Topology = request.Topology,
+            IsRefresh = request.IsRefresh
+        };
+
+    private static LicenseCapacityInstance ToInstance(LicenseCapacityRegistrationRequest request, DateTimeOffset now)
+        => new()
+        {
+            InstanceId = request.InstanceId,
+            ServingUnits = request.ServingUnits,
+            DeploymentRole = request.DeploymentRole,
+            Topology = request.Topology,
+            LastHeartbeatAt = now,
+            CountsTowardBand = !LicenseCapacityCalculator.IsExcludedRole(request.DeploymentRole)
+        };
+
+    private void UpsertLocalInstance(LicenseCapacityInstance instance)
+    {
+        lock (_sync)
+        {
+            _localInstances[instance.InstanceId] = instance;
+        }
+    }
+
+    private void AddLocalSample(LicenseCapacitySample sample)
+    {
+        lock (_sync)
+        {
+            var windowStart = sample.Timestamp - NormalizePositive(_options.Value.SampleWindow, TimeSpan.FromDays(30));
+            _localSamples.RemoveAll(existing => existing.Timestamp < windowStart);
+            _localSamples.Add(sample);
+        }
+    }
+
+    private static IReadOnlyList<string> BuildMessages(LicenseCapacityBandState state, bool meteringGap)
+    {
+        if (meteringGap)
+        {
+            return ["Capacity enforcement is suspended because Redis coordination is unavailable; serving remains fail-open."];
+        }
+
+        return state switch
+        {
+            LicenseCapacityBandState.NotConfigured => ["No capacity band is encoded in the active license."],
+            LicenseCapacityBandState.Excluded => ["This deployment role is excluded from production capacity accounting."],
+            LicenseCapacityBandState.ApproachingBand => ["P95 serving capacity is at or above 80 percent of the licensed band."],
+            LicenseCapacityBandState.Burst => ["Live serving capacity is using free burst headroom."],
+            LicenseCapacityBandState.Grace => ["P95 serving capacity is above the licensed band; the sustained-growth grace clock is active."],
+            LicenseCapacityBandState.GraceExpired => ["The sustained-growth grace period has expired; new production registrations above the base band are refused."],
+            LicenseCapacityBandState.Surge => ["Declared surge mode is active; registrations are allowed and p95 samples are excluded."],
+            _ => []
+        };
+    }
+
+    private bool UseRedis => _redis?.IsConnected == true;
+
+    private string KeyPrefix => _options.Value.RedisKeyPrefix.TrimEnd(':');
+
+    private RedisKey InstanceSetKey => $"{KeyPrefix}:instances";
+
+    private RedisKey InstanceKey(string instanceId)
+        => $"{KeyPrefix}:instance:{Convert.ToHexString(Encoding.UTF8.GetBytes(instanceId))}";
+
+    private RedisKey SampleKey => $"{KeyPrefix}:samples";
+
+    private RedisKey SampleLockKey => $"{KeyPrefix}:sample-lock";
+
+    private RedisKey SurgeKey => $"{KeyPrefix}:surge";
+
+    private RedisKey GraceKey => $"{KeyPrefix}:grace-started";
+
+    private RedisKey SurgeUsageKey(DateTimeOffset now) => $"{KeyPrefix}:surge-used-days:{now.Year.ToString(CultureInfo.InvariantCulture)}";
+
+    private long HeartbeatTtlMilliseconds
+        => (long)NormalizePositive(_options.Value.HeartbeatTtl, TimeSpan.FromSeconds(60)).TotalMilliseconds;
+
+    private static long ToMilliUnits(decimal servingUnits)
+        => (long)Math.Ceiling(servingUnits * 1000m);
+
+    private static decimal FromMilliUnits(long milliUnits)
+        => milliUnits / 1000m;
+
+    private static string FormatInstancePayload(LicenseCapacityInstance instance)
+        => string.Join(
+            '|',
+            ToMilliUnits(instance.ServingUnits).ToString(CultureInfo.InvariantCulture),
+            instance.DeploymentRole.ToString(),
+            instance.Topology.ToString(),
+            instance.LastHeartbeatAt.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture),
+            Convert.ToHexString(Encoding.UTF8.GetBytes(instance.InstanceId)));
+
+    private static bool TryParseInstancePayload(
+        RedisKey key,
+        string payload,
+        out LicenseCapacityInstance instance)
+    {
+        instance = null!;
+        var parts = payload.Split('|');
+        if (parts.Length < 5 ||
+            !long.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var milliUnits) ||
+            !Enum.TryParse(parts[1], ignoreCase: true, out LicenseDeploymentRole role) ||
+            !Enum.TryParse(parts[2], ignoreCase: true, out LicenseServingTopology topology) ||
+            !long.TryParse(parts[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out var unixMs))
+        {
+            return false;
+        }
+
+        var instanceId = TryDecodeHexString(parts[4], out var decoded)
+            ? decoded
+            : key.ToString();
+        instance = new LicenseCapacityInstance
+        {
+            InstanceId = instanceId,
+            ServingUnits = FromMilliUnits(milliUnits),
+            DeploymentRole = role,
+            Topology = topology,
+            LastHeartbeatAt = DateTimeOffset.FromUnixTimeMilliseconds(unixMs),
+            CountsTowardBand = !LicenseCapacityCalculator.IsExcludedRole(role)
+        };
+        return true;
+    }
+
+    private static string FormatSamplePayload(LicenseCapacitySample sample)
+        => string.Join(
+            '|',
+            sample.Timestamp.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture),
+            ToMilliUnits(sample.ServingUnits).ToString(CultureInfo.InvariantCulture),
+            sample.IsSurge ? "1" : "0");
+
+    private static bool TryParseSamplePayload(string payload, out LicenseCapacitySample sample)
+    {
+        sample = null!;
+        var parts = payload.Split('|');
+        if (parts.Length < 3 ||
+            !long.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var unixMs) ||
+            !long.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var milliUnits))
+        {
+            return false;
+        }
+
+        sample = new LicenseCapacitySample
+        {
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(unixMs),
+            ServingUnits = FromMilliUnits(milliUnits),
+            IsSurge = parts[2] == "1"
+        };
+        return true;
+    }
+
+    private static string FormatSurgePayload(DateTimeOffset activatedAt, string? reason)
+        => string.Join(
+            '|',
+            activatedAt.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture),
+            Convert.ToHexString(Encoding.UTF8.GetBytes(reason ?? string.Empty)));
+
+    private static bool TryParseSurgePayload(
+        string payload,
+        out DateTimeOffset activatedAt,
+        out string? reason)
+    {
+        activatedAt = default;
+        reason = null;
+        var parts = payload.Split('|', count: 2);
+        if (parts.Length == 0 ||
+            !long.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var unixMs))
+        {
+            return false;
+        }
+
+        activatedAt = DateTimeOffset.FromUnixTimeMilliseconds(unixMs);
+        if (parts.Length > 1 && TryDecodeHexString(parts[1], out var decoded))
+        {
+            reason = decoded;
+        }
+
+        return true;
+    }
+
+    private static bool TryDecodeHexString(string value, out string decoded)
+    {
+        try
+        {
+            decoded = Encoding.UTF8.GetString(Convert.FromHexString(value));
+            return true;
+        }
+        catch (FormatException)
+        {
+            decoded = string.Empty;
+            return false;
+        }
+    }
+
+    private static TEnum ParseEnum<TEnum>(string? value, TEnum fallback)
+        where TEnum : struct
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        var normalized = value.Replace("-", string.Empty, StringComparison.Ordinal)
+            .Replace("_", string.Empty, StringComparison.Ordinal)
+            .Replace(" ", string.Empty, StringComparison.Ordinal);
+        return Enum.TryParse<TEnum>(normalized, ignoreCase: true, out var parsed)
+            ? parsed
+            : fallback;
+    }
+
+    private static TimeSpan NormalizePositive(TimeSpan value, TimeSpan fallback)
+        => value > TimeSpan.Zero ? value : fallback;
+
+    private static bool IsRedisException(Exception ex)
+        => ex is RedisException or RedisConnectionException or RedisTimeoutException or RedisServerException;
+
+    private void MarkMeteringGap(Exception exception)
+    {
+        if (!_meteringGap)
+        {
+            LicenseCapacityMeterLog.RedisMeteringGap(_logger, exception.GetType().Name);
+        }
+
+        _meteringGap = true;
+    }
+
+    private sealed record MeterRead(
+        IReadOnlyList<LicenseCapacityInstance> Instances,
+        IReadOnlyList<LicenseCapacitySample> Samples,
+        LocalSurgeState? Surge,
+        DateTimeOffset? GraceStartedAt,
+        decimal CurrentServingUnits,
+        bool MeteringGap);
+
+    private sealed record LocalSurgeState(
+        bool IsActive,
+        DateTimeOffset? ActivatedAt,
+        string? Reason,
+        decimal UsedDaysThisYear);
+}

--- a/src/Honua.Hosting/Features/Licensing/LicenseCapacityMeterLog.cs
+++ b/src/Honua.Hosting/Features/Licensing/LicenseCapacityMeterLog.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Licensing.Domain;
+
+namespace Honua.Infrastructure.Licensing;
+
+internal static partial class LicenseCapacityMeterLog
+{
+    [LoggerMessage(
+        EventId = 10020,
+        Level = LogLevel.Warning,
+        Message = "Serving instance registration refused by license capacity band. instanceId={InstanceId} currentUnits={CurrentUnits} joiningUnits={JoiningUnits} maxSustainedUnits={MaxSustainedUnits} state={State}")]
+    public static partial void RegistrationRefused(
+        ILogger logger,
+        string instanceId,
+        decimal currentUnits,
+        decimal joiningUnits,
+        decimal maxSustainedUnits,
+        LicenseCapacityBandState state);
+
+    [LoggerMessage(
+        EventId = 10021,
+        Level = LogLevel.Warning,
+        Message = "Serving instance heartbeat refresh was not accepted. reason={Reason}")]
+    public static partial void RefreshRefused(ILogger logger, string reason);
+
+    [LoggerMessage(
+        EventId = 10022,
+        Level = LogLevel.Warning,
+        Message = "License capacity meter entered fail-open metering gap after Redis error. errorType={ErrorType}")]
+    public static partial void RedisMeteringGap(ILogger logger, string errorType);
+
+    [LoggerMessage(
+        EventId = 10023,
+        Level = LogLevel.Information,
+        Message = "License capacity surge mode changed. enabled={Enabled} reason={Reason}")]
+    public static partial void SurgeModeChanged(ILogger logger, bool enabled, string? reason);
+}

--- a/src/Honua.Hosting/Features/Licensing/LicenseCapacityOptions.cs
+++ b/src/Honua.Hosting/Features/Licensing/LicenseCapacityOptions.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Licensing;
+
+internal sealed class LicenseCapacityOptions
+{
+    public const string SectionName = "Licensing:Capacity";
+
+    public bool RegistrationEnabled { get; set; } = true;
+
+    public string? InstanceId { get; set; }
+
+    public string DeploymentRole { get; set; } = "Production";
+
+    public string Topology { get; set; } = "SingleNode";
+
+    public decimal? ServingUnits { get; set; }
+
+    public double? Vcpu { get; set; }
+
+    public double? MemoryGiB { get; set; }
+
+    public int? ServerlessConcurrentExecutions { get; set; }
+
+    public TimeSpan HeartbeatInterval { get; set; } = TimeSpan.FromSeconds(15);
+
+    public TimeSpan HeartbeatTtl { get; set; } = TimeSpan.FromSeconds(60);
+
+    public TimeSpan SampleInterval { get; set; } = TimeSpan.FromMinutes(5);
+
+    public TimeSpan SampleWindow { get; set; } = TimeSpan.FromDays(30);
+
+    public string RedisKeyPrefix { get; set; } = "honua:license:capacity";
+}

--- a/src/Honua.Hosting/Features/Licensing/LicenseFileModels.cs
+++ b/src/Honua.Hosting/Features/Licensing/LicenseFileModels.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Text.Json.Serialization;
+using Honua.Core.Features.Licensing.Domain;
 
 namespace Honua.Infrastructure.Licensing;
 
@@ -32,6 +33,8 @@ internal sealed class SignedLicensePayload
 
     public string[]? Entitlements { get; init; }
 
+    public LicenseCapacityTerms? Capacity { get; init; }
+
     public Dictionary<string, string>? Metadata { get; init; }
 }
 
@@ -60,6 +63,7 @@ internal sealed class LicenseHealthSummary
     WriteIndented = false)]
 [JsonSerializable(typeof(SignedLicenseEnvelope))]
 [JsonSerializable(typeof(SignedLicensePayload))]
+[JsonSerializable(typeof(LicenseCapacityTerms))]
 [JsonSerializable(typeof(Dictionary<string, string>))]
 [JsonSerializable(typeof(string[]))]
 [JsonSerializable(typeof(LicenseHealthSummary))]

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -3,6 +3,7 @@
 
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
@@ -10,6 +11,7 @@ using Honua.Core.Features.Shared.Models;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Core.Configuration;
 using System.Collections.Immutable;
+using Honua.Infrastructure.Licensing;
 using Honua.Protocols.GeoServices;
 using Honua.Protocols.GeoServices.FeatureServer.Models;
 using Honua.Protocols.GeoServices.FeatureServer.Services;
@@ -27,12 +29,24 @@ namespace Honua.Protocols.GeoServices.FeatureServer;
 
 internal static partial class FeatureServerEndpoints
 {
+    private static IResult? RequireOfflineSyncEntitlement(HttpContext context)
+        => LicenseGate.RequireEntitlement(
+            context,
+            FeatureCatalog.FieldOpsOfflineSyncKey,
+            "GeoServices offline sync");
+
     private static async Task<IResult> HandleReplicas(
         string serviceId,
         HttpContext context)
     {
         using var activity = HonuaTelemetry.ActivitySource.StartActivity("featureserver.replicas");
         activity?.SetTag(HonuaTelemetry.Tags.ServiceId, serviceId);
+
+        var entitlementGate = RequireOfflineSyncEntitlement(context);
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
 
         var cancellationToken = GetTimeoutAwareCancellationToken(context);
         var serviceValidationResult = await ValidateReplicationServiceV2Async(serviceId, context, cancellationToken);
@@ -96,6 +110,12 @@ internal static partial class FeatureServerEndpoints
         using var activity = HonuaTelemetry.ActivitySource.StartActivity("featureserver.replicaInfo");
         activity?.SetTag(HonuaTelemetry.Tags.ServiceId, serviceId);
         activity?.SetTag("honua.replicaId", replicaId);
+
+        var entitlementGate = RequireOfflineSyncEntitlement(context);
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
 
         var cancellationToken = GetTimeoutAwareCancellationToken(context);
         var serviceValidationResult = await ValidateReplicationServiceV2Async(serviceId, context, cancellationToken);
@@ -171,6 +191,12 @@ internal static partial class FeatureServerEndpoints
     {
         using var activity = HonuaTelemetry.ActivitySource.StartActivity("featureserver.createReplica");
         activity?.SetTag(HonuaTelemetry.Tags.ServiceId, serviceId);
+
+        var entitlementGate = RequireOfflineSyncEntitlement(context);
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
 
         var cancellationToken = GetTimeoutAwareCancellationToken(context);
         var serviceValidationResult = await ValidateReplicationServiceV2Async(serviceId, context, cancellationToken);
@@ -285,6 +311,12 @@ internal static partial class FeatureServerEndpoints
     {
         using var activity = HonuaTelemetry.ActivitySource.StartActivity("featureserver.extractChanges");
         activity?.SetTag(HonuaTelemetry.Tags.ServiceId, serviceId);
+
+        var entitlementGate = RequireOfflineSyncEntitlement(context);
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
 
         var cancellationToken = GetTimeoutAwareCancellationToken(context);
         var serviceValidationResult = await ValidateReplicationServiceV2Async(serviceId, context, cancellationToken);
@@ -730,6 +762,12 @@ internal static partial class FeatureServerEndpoints
     {
         using var activity = HonuaTelemetry.ActivitySource.StartActivity("featureserver.synchronizeReplica");
         activity?.SetTag(HonuaTelemetry.Tags.ServiceId, serviceId);
+
+        var entitlementGate = RequireOfflineSyncEntitlement(context);
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
 
         var cancellationToken = GetTimeoutAwareCancellationToken(context);
         var serviceValidationResult = await ValidateReplicationServiceV2Async(serviceId, context, cancellationToken);
@@ -1218,6 +1256,12 @@ internal static partial class FeatureServerEndpoints
     {
         using var activity = HonuaTelemetry.ActivitySource.StartActivity("featureserver.unRegisterReplica");
         activity?.SetTag(HonuaTelemetry.Tags.ServiceId, serviceId);
+
+        var entitlementGate = RequireOfflineSyncEntitlement(context);
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
 
         var cancellationToken = GetTimeoutAwareCancellationToken(context);
         var serviceValidationResult = await ValidateReplicationServiceV2Async(serviceId, context, cancellationToken);

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -159,6 +159,8 @@ public static class EndpointRegistry
         new("GET", "/api/v1/admin/license"),
         new("POST", "/api/v1/admin/license"),
         new("GET", "/api/v1/admin/license/entitlements"),
+        new("GET", "/api/v1/admin/license/capacity"),
+        new("POST", "/api/v1/admin/license/capacity/surge"),
 
         // v1 platform admin endpoints (#513)
         new("GET", "/api/v1/admin/license/status"),

--- a/src/Honua.Server/Features/Admin/LicenseAdminEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/LicenseAdminEndpoints.cs
@@ -32,6 +32,17 @@ internal static class LicenseAdminEndpoints
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
             .Produces<ApiResponse<LicenseStatusResponse>>();
 
+        group.MapGet("/capacity", HandleGetCapacityState)
+            .WithDisplayName("Get License Capacity State")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<ApiResponse<LicenseCapacityState>>();
+
+        group.MapPost("/capacity/surge", HandleSetSurgeMode)
+            .WithDisplayName("Set License Surge Mode")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
+            .Produces<ApiResponse<LicenseCapacityState>>()
+            .Produces<ApiResponse<object>>(StatusCodes.Status400BadRequest);
+
         group.MapGet("/features", HandleGetEntitlements)
             .WithDisplayName("Get License Feature Entitlements")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
@@ -44,10 +55,12 @@ internal static class LicenseAdminEndpoints
             .Produces<ApiResponse<LicenseUploadResponse>>(StatusCodes.Status400BadRequest);
     }
 
-    private static IResult HandleGetLicenseStatus(
+    private static async Task<IResult> HandleGetLicenseStatus(
         [FromServices] ILicenseEntitlementService entitlementService,
+        [FromServices] ILicenseCapacityMeter capacityMeter,
         [FromServices] IOptions<LicenseOptions> licenseOptions,
-        [FromServices] ILogger<LicenseAdminEndpointsLog> logger)
+        [FromServices] ILogger<LicenseAdminEndpointsLog> logger,
+        CancellationToken cancellationToken)
     {
         AdminLog.LicenseStatusQueried(logger);
 
@@ -60,13 +73,52 @@ internal static class LicenseAdminEndpoints
             snapshot.ValidationState,
             snapshot.LicenseId,
             snapshot.IssuedAt,
-            snapshot.Entitlements);
+            snapshot.Entitlements,
+            snapshot.CapacityTerms);
 
-        var response = LicenseStatusResponseMapper.FromStatus(status, licenseOptions.Value.ExpiryWarningDays);
+        var capacity = await capacityMeter.GetCapacityStateAsync(cancellationToken).ConfigureAwait(false);
+        var response = LicenseStatusResponseMapper.FromStatus(
+            status,
+            licenseOptions.Value.ExpiryWarningDays,
+            capacity);
 
         return Results.Json(
             ApiResponse<LicenseStatusResponse>.CreateSuccess(response),
             LicenseAdminJsonContext.Default.ApiResponseLicenseStatusResponse);
+    }
+
+    private static async Task<IResult> HandleGetCapacityState(
+        [FromServices] ILicenseCapacityMeter capacityMeter,
+        CancellationToken cancellationToken)
+    {
+        var capacity = await capacityMeter.GetCapacityStateAsync(cancellationToken).ConfigureAwait(false);
+        return Results.Json(
+            ApiResponse<LicenseCapacityState>.CreateSuccess(capacity),
+            LicenseAdminJsonContext.Default.ApiResponseLicenseCapacityState);
+    }
+
+    private static async Task<IResult> HandleSetSurgeMode(
+        [FromServices] ILicenseCapacityMeter capacityMeter,
+        HttpContext context,
+        CancellationToken cancellationToken)
+    {
+        var request = await context.Request.ReadFromJsonAsync(
+            LicenseAdminJsonContext.Default.LicenseSurgeModeRequest,
+            cancellationToken).ConfigureAwait(false);
+        if (request is null)
+        {
+            return Results.Json(
+                ApiResponse<object>.Failure("Surge mode request body is required."),
+                LicenseAdminJsonContext.Default.ApiResponseObject,
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var capacity = await capacityMeter
+            .SetSurgeModeAsync(request.Enabled, request.Reason, cancellationToken)
+            .ConfigureAwait(false);
+        return Results.Json(
+            ApiResponse<LicenseCapacityState>.CreateSuccess(capacity),
+            LicenseAdminJsonContext.Default.ApiResponseLicenseCapacityState);
     }
 
     private static IResult HandleGetEntitlements(

--- a/src/Honua.Server/Features/Admin/LicenseEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/LicenseEndpoints.cs
@@ -72,6 +72,7 @@ internal static partial class LicenseEndpoints
     private static async Task<Results<Ok<ApiResponse<LicenseStatusResponse>>, ProblemHttpResult>>
         HandleGetLicenseStatus(
             [FromServices] ILicenseManager licenseManager,
+            [FromServices] ILicenseCapacityMeter capacityMeter,
             [FromServices] IOptions<LicenseOptions> licenseOptions,
             [FromServices] ILogger<LicenseEndpointsLog> logger,
             HttpContext context)
@@ -79,8 +80,12 @@ internal static partial class LicenseEndpoints
         try
         {
             var info = await licenseManager.GetLicenseInfoAsync(context.RequestAborted);
+            var capacity = await capacityMeter.GetCapacityStateAsync(context.RequestAborted);
 
-            var response = LicenseStatusResponseMapper.FromInfo(info, licenseOptions.Value.ExpiryWarningDays);
+            var response = LicenseStatusResponseMapper.FromInfo(
+                info,
+                licenseOptions.Value.ExpiryWarningDays,
+                capacity);
 
             LicenseLog.LicenseStatusQueried(logger, info.Edition, info.IsValid);
             return TypedResults.Ok(ApiResponse<LicenseStatusResponse>.CreateSuccess(response));
@@ -98,6 +103,7 @@ internal static partial class LicenseEndpoints
     private static async Task<Results<Ok<ApiResponse<LicenseStatusResponse>>, BadRequest<ApiResponse<object>>, ProblemHttpResult>>
         HandleUploadLicense(
             [FromServices] ILicenseStatusProvider licenseProvider,
+            [FromServices] ILicenseCapacityMeter capacityMeter,
             [FromServices] IOptions<LicenseOptions> licenseOptions,
             [FromServices] ILogger<LicenseEndpointsLog> logger,
             HttpContext context)
@@ -112,7 +118,11 @@ internal static partial class LicenseEndpoints
             }
 
             var status = licenseProvider.GetCurrentStatus();
-            var response = LicenseStatusResponseMapper.FromStatus(status, licenseOptions.Value.ExpiryWarningDays);
+            var capacity = await capacityMeter.GetCapacityStateAsync(context.RequestAborted);
+            var response = LicenseStatusResponseMapper.FromStatus(
+                status,
+                licenseOptions.Value.ExpiryWarningDays,
+                capacity);
 
             LicenseLog.LicenseUploaded(logger, response.Edition);
             return TypedResults.Ok(ApiResponse<LicenseStatusResponse>.CreateSuccess(response));

--- a/src/Honua.Server/Features/Admin/LicenseStatusResponseMapper.cs
+++ b/src/Honua.Server/Features/Admin/LicenseStatusResponseMapper.cs
@@ -8,7 +8,10 @@ namespace Honua.Server.Features.Admin;
 
 internal static class LicenseStatusResponseMapper
 {
-    internal static LicenseStatusResponse FromInfo(LicenseInfo info, int expiryWarningDays)
+    internal static LicenseStatusResponse FromInfo(
+        LicenseInfo info,
+        int expiryWarningDays,
+        LicenseCapacityState? capacity = null)
     {
         ArgumentNullException.ThrowIfNull(info);
 
@@ -26,10 +29,14 @@ internal static class LicenseStatusResponseMapper
             DaysUntilExpiry = daysUntilExpiry,
             ExpiryWarning = IsExpiryWarning(daysUntilExpiry, expiryWarningDays),
             Entitlements = info.Entitlements.Select(ToEntitlementResponse).ToList(),
+            Capacity = capacity,
         };
     }
 
-    internal static LicenseStatusResponse FromStatus(LicenseStatus status, int expiryWarningDays)
+    internal static LicenseStatusResponse FromStatus(
+        LicenseStatus status,
+        int expiryWarningDays,
+        LicenseCapacityState? capacity = null)
     {
         ArgumentNullException.ThrowIfNull(status);
 
@@ -47,6 +54,7 @@ internal static class LicenseStatusResponseMapper
             DaysUntilExpiry = daysUntilExpiry,
             ExpiryWarning = IsExpiryWarning(daysUntilExpiry, expiryWarningDays),
             Entitlements = (status.Entitlements ?? []).Select(ToEntitlementResponse).ToList(),
+            Capacity = capacity,
         };
     }
 

--- a/src/Honua.Server/Features/Admin/Models/LicenseAdminJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/LicenseAdminJsonContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Text.Json.Serialization;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Infrastructure.Models;
 
 namespace Honua.Server.Features.Admin.Models;
@@ -16,10 +17,15 @@ namespace Honua.Server.Features.Admin.Models;
 [JsonSerializable(typeof(ApiResponse<LicenseStatusResponse>))]
 [JsonSerializable(typeof(ApiResponse<LicenseEntitlementsResponse>))]
 [JsonSerializable(typeof(ApiResponse<LicenseUploadResponse>))]
+[JsonSerializable(typeof(ApiResponse<LicenseCapacityState>))]
 [JsonSerializable(typeof(ApiResponse<object>))]
 [JsonSerializable(typeof(LicenseStatusResponse))]
 [JsonSerializable(typeof(LicenseEntitlementsResponse))]
 [JsonSerializable(typeof(LicenseUploadResponse))]
+[JsonSerializable(typeof(LicenseSurgeModeRequest))]
+[JsonSerializable(typeof(LicenseCapacityState))]
+[JsonSerializable(typeof(LicenseCapacityTerms))]
+[JsonSerializable(typeof(LicenseSurgeModeState))]
 [JsonSerializable(typeof(FeatureEntitlementItem))]
 [JsonSerializable(typeof(FeatureEntitlementItem[]))]
 internal sealed partial class LicenseAdminJsonContext : JsonSerializerContext

--- a/src/Honua.Server/Features/Admin/Models/LicenseAdminModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/LicenseAdminModels.cs
@@ -70,3 +70,19 @@ public sealed class LicenseUploadResponse
     /// </summary>
     public required string Message { get; init; }
 }
+
+/// <summary>
+/// Request body for changing declared license surge mode.
+/// </summary>
+public sealed class LicenseSurgeModeRequest
+{
+    /// <summary>
+    /// Whether surge mode should be active.
+    /// </summary>
+    public required bool Enabled { get; init; }
+
+    /// <summary>
+    /// Optional operator-facing reason for the surge declaration.
+    /// </summary>
+    public string? Reason { get; init; }
+}

--- a/src/Honua.Server/Features/Admin/Models/LicenseJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/LicenseJsonContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Text.Json.Serialization;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Infrastructure.Models;
 
 namespace Honua.Server.Features.Admin.Models;
@@ -17,6 +18,9 @@ namespace Honua.Server.Features.Admin.Models;
 [JsonSerializable(typeof(ApiResponse<IReadOnlyList<EntitlementResponse>>))]
 [JsonSerializable(typeof(ApiResponse<object>))]
 [JsonSerializable(typeof(LicenseStatusResponse))]
+[JsonSerializable(typeof(LicenseCapacityState))]
+[JsonSerializable(typeof(LicenseCapacityTerms))]
+[JsonSerializable(typeof(LicenseSurgeModeState))]
 [JsonSerializable(typeof(EntitlementResponse))]
 internal sealed partial class LicenseJsonContext : JsonSerializerContext
 {

--- a/src/Honua.Server/Features/Admin/Models/LicenseModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/LicenseModels.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Licensing.Domain;
+
 namespace Honua.Server.Features.Admin.Models;
 
 /// <summary>
@@ -57,6 +59,11 @@ public sealed class LicenseStatusResponse
     /// Entitlements granted by this license.
     /// </summary>
     public IReadOnlyList<EntitlementResponse> Entitlements { get; init; } = [];
+
+    /// <summary>
+    /// Capacity-band terms and current meter state used by license admission.
+    /// </summary>
+    public LicenseCapacityState? Capacity { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
@@ -306,10 +306,13 @@ internal sealed class CapabilityManifestService(
             Capability("temporal.histogram", "temporal", context, entitlementKey: "temporal.histogram"),
             Capability("temporal.time-series-tiles", "temporal", context, entitlementKey: "temporal.time-series-tiles"),
 
-            Capability("sync.offline", "sync", context, supported: syncSupported, policyCapability: "features.edit", requiresWorkspace: true),
+            Capability("sync.offline", "sync", context, supported: syncSupported, entitlementKey: FeatureCatalog.FieldOpsOfflineSyncKey, policyCapability: "features.edit", requiresWorkspace: true),
             Capability("realtime.feature-streams", "realtime", context, entitlementKey: "streaming.feature-subscriptions"),
             Capability("alerts.geofence", "alerts", context, entitlementKey: "alerts.enter-exit", configured: alertOptionsValue.Enabled),
             Capability("jobs.runner", "jobs", context, supported: workloadCount > 0 || batchBackends.Any(), requiresAuthentication: true),
+            Capability("ai.spec-apply", "ai", context, entitlementKey: FeatureCatalog.AiSpecApplyKey),
+            Capability("ai.grounding", "ai", context, entitlementKey: FeatureCatalog.AiGroundingKey),
+            Capability("ai.workflow-generation", "ai", context, entitlementKey: FeatureCatalog.AiWorkflowGenerationKey),
             Capability("gitops.release-manifest", "gitops", context, configured: deployTargetCount > 0, policyCapability: "catalog.publish", requiresEnvironment: true),
 
             Capability("transport.grpc", "transports", context),

--- a/src/Honua.Server/Features/Console/Publications/ContentPublicationEndpoints.cs
+++ b/src/Honua.Server/Features/Console/Publications/ContentPublicationEndpoints.cs
@@ -5,11 +5,13 @@ using System.Text.Json;
 using Honua.Ai.DashboardGeneration;
 using Honua.Ai.ReportGeneration;
 using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Publishing.Content;
 using Honua.Core.Features.Publishing.Content.Abstractions;
 using Honua.Core.Features.Publishing.Content.Domain;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Caching;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Honua.ServiceDefaults;
 using Microsoft.AspNetCore.Mvc;
@@ -151,6 +153,15 @@ internal static class ContentPublicationEndpoints
             return Results.Json(bad, ReportGenerationApiJsonContext.Default.ReportGenerationResult, statusCode: StatusCodes.Status400BadRequest);
         }
 
+        var entitlementGate = LicenseGate.RequireEntitlement(
+            context,
+            FeatureCatalog.AiWorkflowGenerationKey,
+            "AI report generation");
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
+
         var result = await generation.GenerateAsync(
             new ReportGenerationRequest
             {
@@ -188,6 +199,15 @@ internal static class ContentPublicationEndpoints
         {
             var bad = new DashboardGenerationResult { Status = "error", Rationale = "A non-empty 'prompt' is required." };
             return Results.Json(bad, DashboardGenerationApiJsonContext.Default.DashboardGenerationResult, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var entitlementGate = LicenseGate.RequireEntitlement(
+            context,
+            FeatureCatalog.AiWorkflowGenerationKey,
+            "AI dashboard generation");
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
         }
 
         var result = await generation.GenerateAsync(

--- a/src/Honua.Server/Features/Forms/FormOfflinePolicyService.cs
+++ b/src/Honua.Server/Features/Forms/FormOfflinePolicyService.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Forms.Packages;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Honua.ServiceDefaults;
 
@@ -25,6 +27,15 @@ internal sealed class FormOfflinePolicyService
         activity?.SetTag("honua.protocol", "forms");
         activity?.SetTag("honua.operation", "offline-policy");
         activity?.SetTag("honua.forms.form_id", formId);
+
+        var entitlementGate = LicenseGate.RequireEntitlement(
+            context,
+            FeatureCatalog.FieldOpsOfflineSyncKey,
+            "Form offline policy");
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
 
         var packageVersion = await _store.GetCurrentVersionAsync(formId, FormPackageStatus.Published, context.RequestAborted)
             .ConfigureAwait(false);

--- a/src/Honua.Server/Features/Forms/FormPackageEndpoints.cs
+++ b/src/Honua.Server/Features/Forms/FormPackageEndpoints.cs
@@ -4,7 +4,9 @@
 using System.Text.Json;
 using Honua.Ai.FormGeneration;
 using Honua.Core.Features.Forms.Packages;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Licensing;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Honua.Server.Features.Forms;
@@ -154,6 +156,15 @@ internal static class FormPackageEndpoints
             return Results.Json(bad, FormGenerationApiJsonContext.Default.FormGenerationResult, statusCode: StatusCodes.Status400BadRequest);
         }
 
+        var entitlementGate = LicenseGate.RequireEntitlement(
+            context,
+            FeatureCatalog.AiWorkflowGenerationKey,
+            "AI form generation");
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
+
         var result = await generation.GenerateAsync(
             new FormGenerationRequest
             {
@@ -245,7 +256,15 @@ internal static class FormPackageEndpoints
         [FromServices] FormPackageLifecycleService service,
         string formId,
         [FromQuery] int? clientVersion)
-        => service.GetCompatibilityAsync(context, formId, clientVersion);
+    {
+        var entitlementGate = LicenseGate.RequireEntitlement(
+            context,
+            FeatureCatalog.FieldOpsOfflineSyncKey,
+            "Form offline compatibility");
+        return entitlementGate is not null
+            ? Task.FromResult(entitlementGate)
+            : service.GetCompatibilityAsync(context, formId, clientVersion);
+    }
 
     private static Task<IResult> HandleGetOfflinePolicy(
         HttpContext context,

--- a/src/Honua.Server/Features/Mobile/FieldCollection/FieldCollectionSyncEndpoints.cs
+++ b/src/Honua.Server/Features/Mobile/FieldCollection/FieldCollectionSyncEndpoints.cs
@@ -3,9 +3,11 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Mobile.FieldCollection.Abstractions;
 using Honua.Core.Features.Mobile.FieldCollection.Domain;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Honua.ServiceDefaults;
 using Microsoft.AspNetCore.Mvc;
@@ -90,6 +92,12 @@ internal static class FieldCollectionSyncEndpoints
         activity?.SetTag("honua.operation", "generation");
         var logger = loggerFactory.CreateLogger(typeof(FieldCollectionSyncEndpoints));
 
+        var entitlementGate = RequireOfflineSyncEntitlement(context);
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
+
         var serverGeneration = await store.GetCurrentGenerationAsync(context.RequestAborted).ConfigureAwait(false);
         activity?.SetTag("honua.fieldcollection.server_generation", serverGeneration);
         FieldCollectionSyncLog.GenerationServed(logger, serverGeneration);
@@ -109,6 +117,12 @@ internal static class FieldCollectionSyncEndpoints
         activity?.SetTag("honua.protocol", ProtocolTag);
         activity?.SetTag("honua.operation", "sync-cursor");
         var logger = loggerFactory.CreateLogger(typeof(FieldCollectionSyncEndpoints));
+
+        var entitlementGate = RequireOfflineSyncEntitlement(context);
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
 
         var clientId = ResolveClientId(context);
         activity?.SetTag("honua.fieldcollection.client_id", clientId);
@@ -136,6 +150,12 @@ internal static class FieldCollectionSyncEndpoints
         activity?.SetTag("honua.protocol", ProtocolTag);
         activity?.SetTag("honua.operation", "sync-cursor-ack");
         var logger = loggerFactory.CreateLogger(typeof(FieldCollectionSyncEndpoints));
+
+        var entitlementGate = RequireOfflineSyncEntitlement(context);
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
 
         if (body?.LastSyncGeneration is not long lastSyncGeneration)
         {
@@ -196,6 +216,12 @@ internal static class FieldCollectionSyncEndpoints
         activity?.SetTag("honua.protocol", ProtocolTag);
         activity?.SetTag("honua.operation", "pull");
         var logger = loggerFactory.CreateLogger(typeof(FieldCollectionSyncEndpoints));
+
+        var entitlementGate = RequireOfflineSyncEntitlement(context);
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
 
         var since = sinceGeneration ?? 0L;
         if (since < 0)
@@ -273,6 +299,12 @@ internal static class FieldCollectionSyncEndpoints
         activity?.SetTag("honua.protocol", ProtocolTag);
         activity?.SetTag("honua.operation", "push");
         var logger = loggerFactory.CreateLogger(typeof(FieldCollectionSyncEndpoints));
+
+        var entitlementGate = RequireOfflineSyncEntitlement(context);
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
 
         if (body is null)
         {
@@ -487,4 +519,10 @@ internal static class FieldCollectionSyncEndpoints
         // must not cache stale data on intermediate proxies.
         response.Headers.CacheControl = "no-store";
     }
+
+    private static IResult? RequireOfflineSyncEntitlement(HttpContext context)
+        => LicenseGate.RequireEntitlement(
+            context,
+            FeatureCatalog.FieldOpsOfflineSyncKey,
+            "Offline field sync");
 }

--- a/src/Honua.Server/Features/Spec/HonuaSpecService.cs
+++ b/src/Honua.Server/Features/Spec/HonuaSpecService.cs
@@ -3,8 +3,10 @@
 
 using System.Globalization;
 using Grpc.Core;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Spec.Abstractions;
 using Honua.Core.Features.Spec.Domain;
+using Honua.Infrastructure.Licensing;
 using Proto = Geospatial.V1;
 
 namespace Honua.Server.Features.Spec;
@@ -18,13 +20,16 @@ internal sealed class HonuaSpecService : Proto.SpecService.SpecServiceBase
 {
     private readonly ISpecPlanner _planner;
     private readonly ISpecApplyEngine _applyEngine;
+    private readonly IServiceProvider _services;
 
-    public HonuaSpecService(ISpecPlanner planner, ISpecApplyEngine applyEngine)
+    public HonuaSpecService(ISpecPlanner planner, ISpecApplyEngine applyEngine, IServiceProvider services)
     {
         ArgumentNullException.ThrowIfNull(planner);
         ArgumentNullException.ThrowIfNull(applyEngine);
+        ArgumentNullException.ThrowIfNull(services);
         _planner = planner;
         _applyEngine = applyEngine;
+        _services = services;
     }
 
     public override async Task<Proto.PlanSpecResponse> PlanSpec(
@@ -109,6 +114,23 @@ internal sealed class HonuaSpecService : Proto.SpecService.SpecServiceBase
             throw new RpcException(new Status(
                 StatusCode.InvalidArgument,
                 $"{SpecDiagnosticCodes.UnknownCacheMode}: cache_mode '{((int)request.CacheMode).ToString(CultureInfo.InvariantCulture)}' is not a defined SpecCacheMode value."));
+        }
+
+        var plan = await _planner.PlanAsync(document, context.CancellationToken).ConfigureAwait(false);
+        foreach (var warning in plan.Warnings)
+        {
+            if (warning.Severity == SpecDiagnosticSeverity.Error)
+            {
+                throw new RpcException(new Status(
+                    StatusCode.InvalidArgument,
+                    $"{warning.Code}: {warning.Message}"));
+            }
+        }
+
+        var requestServices = context.GetHttpContext()?.RequestServices ?? _services;
+        if (!LicenseGate.IsEntitlementActive(requestServices, FeatureCatalog.AiSpecApplyKey))
+        {
+            throw LicenseGate.CreateFailedPreconditionRpcException(requestServices, FeatureCatalog.AiSpecApplyKey);
         }
 
         var options = new SpecApplyOptions

--- a/src/Honua.Server/Features/Spec/SpecEndpoints.cs
+++ b/src/Honua.Server/Features/Spec/SpecEndpoints.cs
@@ -2,8 +2,10 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Text.Json;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Spec.Abstractions;
 using Honua.Core.Features.Spec.Domain;
+using Honua.Infrastructure.Licensing;
 using Honua.Server.Features.Spec.Models;
 using Honua.ServiceDefaults;
 using Microsoft.AspNetCore.Http;
@@ -220,6 +222,7 @@ internal static class SpecEndpoints
 
     private static async Task<IResult> HandleApplyAsync(
         HttpContext context,
+        ISpecPlanner planner,
         ISpecApplyEngine engine,
         CancellationToken cancellationToken)
     {
@@ -260,6 +263,24 @@ internal static class SpecEndpoints
             return BuildProblem(StatusCodes.Status400BadRequest,
                 SpecDiagnosticCodes.UnknownCacheMode,
                 "Request 'cacheMode' must be one of: ReadWrite, ReadOnly, Bypass.");
+        }
+
+        var plan = await planner.PlanAsync(document, cancellationToken).ConfigureAwait(false);
+        var fatalPlanDiagnostics = plan.Warnings
+            .Where(static warning => warning.Severity == SpecDiagnosticSeverity.Error)
+            .ToList();
+        if (fatalPlanDiagnostics.Count > 0)
+        {
+            return ProblemFromInvalid(new SpecDocumentInvalidException(fatalPlanDiagnostics));
+        }
+
+        var entitlementGate = LicenseGate.RequireEntitlement(
+            context,
+            FeatureCatalog.AiSpecApplyKey,
+            "Spec apply");
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
         }
 
         var options = new SpecApplyOptions

--- a/src/Honua.Server/Features/Studio/StudioPackageEndpoints.cs
+++ b/src/Honua.Server/Features/Studio/StudioPackageEndpoints.cs
@@ -5,11 +5,13 @@ using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 using Honua.Ai.AppGeneration;
 using Honua.Ai.MapGeneration;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Studio.Abstractions;
 using Honua.Core.Features.Studio.Domain;
 using Honua.Core.Features.Studio.Services;
 using Honua.Server.Features.Console;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Honua.Server.Features.Studio.Models;
 using Microsoft.AspNetCore.Mvc;
@@ -131,6 +133,15 @@ internal static class StudioPackageEndpoints
             return Results.Json(bad, AppGenerationApiJsonContext.Default.AppGenerationResult, statusCode: StatusCodes.Status400BadRequest);
         }
 
+        var entitlementGate = LicenseGate.RequireEntitlement(
+            context,
+            FeatureCatalog.AiWorkflowGenerationKey,
+            "AI app generation");
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
+        }
+
         var result = await generation.GenerateAsync(
             new AppGenerationRequest
             {
@@ -168,6 +179,15 @@ internal static class StudioPackageEndpoints
         {
             var bad = new MapGenerationResult { Status = "error", Rationale = "A non-empty 'prompt' is required." };
             return Results.Json(bad, MapGenerationApiJsonContext.Default.MapGenerationResult, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var entitlementGate = LicenseGate.RequireEntitlement(
+            context,
+            FeatureCatalog.AiWorkflowGenerationKey,
+            "AI map generation");
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
         }
 
         var result = await generation.GenerateAsync(

--- a/src/Honua.Server/Features/WorkflowPackages/WorkflowPackageEndpoints.cs
+++ b/src/Honua.Server/Features/WorkflowPackages/WorkflowPackageEndpoints.cs
@@ -5,8 +5,10 @@ using Honua.Core.Features.WorkflowPackages.Abstractions;
 using Honua.Core.Features.WorkflowPackages.Domain;
 using Honua.Core.Features.WorkflowPackages.Generation.Abstractions;
 using Honua.Core.Features.WorkflowPackages.Generation.Domain;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Geoprocessing;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 
 namespace Honua.Server.Features.WorkflowPackages;
@@ -155,6 +157,15 @@ internal static class WorkflowPackageEndpoints
         {
             return TypedResults.BadRequest(
                 ApiResponse<WorkflowGenerationResult>.Failure("A non-empty 'prompt' is required."));
+        }
+
+        var entitlementGate = LicenseGate.RequireEntitlement(
+            context,
+            FeatureCatalog.AiWorkflowGenerationKey,
+            "AI workflow generation");
+        if (entitlementGate is not null)
+        {
+            return entitlementGate;
         }
 
         var result = await generation.GenerateAsync(

--- a/src/Honua.Server/Startup/LicensingRegistration.cs
+++ b/src/Honua.Server/Startup/LicensingRegistration.cs
@@ -8,6 +8,7 @@ using Honua.Infrastructure.Extensions;
 using Honua.Infrastructure.Licensing;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
 
 namespace Honua.Server.Startup;
 
@@ -26,6 +27,8 @@ internal static class LicensingRegistration
     {
         services.Configure<LicenseOptions>(
             configuration.GetSection(LicenseOptions.SectionName));
+        services.Configure<LicenseCapacityOptions>(
+            configuration.GetSection(LicenseCapacityOptions.SectionName));
         services.AddSingleton<IEd25519Verifier, BouncyCastleEd25519Verifier>();
         services.AddSingleton<FileBackedLicenseService>();
         services.AddSingleton<ILicenseEntitlementService>(sp =>
@@ -36,6 +39,18 @@ internal static class LicensingRegistration
             sp.GetRequiredService<FileBackedLicenseService>());
         services.AddHostedService(sp =>
             sp.GetRequiredService<FileBackedLicenseService>());
+
+        services.AddSingleton<LicenseCapacityMeter>(sp =>
+            new LicenseCapacityMeter(
+                sp.GetRequiredService<ILicenseEntitlementService>(),
+                sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<LicenseCapacityOptions>>(),
+                sp.GetService<TimeProvider>() ?? TimeProvider.System,
+                sp.GetRequiredService<ILogger<LicenseCapacityMeter>>(),
+                sp.GetService<IConnectionMultiplexer>()));
+        services.AddSingleton<ILicenseCapacityMeter>(sp =>
+            sp.GetRequiredService<LicenseCapacityMeter>());
+        services.AddHostedService(sp =>
+            sp.GetRequiredService<LicenseCapacityMeter>());
 
         // Test/dev only: an explicit Licensing:DevGrantEdition grants every entitlement up to that
         // edition without a signed license, so an out-of-process test/CI server can exercise

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpTestFactory.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpTestFactory.cs
@@ -3,9 +3,13 @@
 
 using System.Security.Claims;
 using System.Text.Json;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Ai.Protocols.Mcp.Models;
+using Honua.TestKit.Helpers;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Server.Tests.Features.Protocols.Mcp;
 
@@ -15,13 +19,20 @@ namespace Honua.Server.Tests.Features.Protocols.Mcp;
 /// </summary>
 internal static class McpTestFactory
 {
-    public static DefaultHttpContext AuthenticatedHttpContext(string user = "test-user") => new()
+    public static DefaultHttpContext AuthenticatedHttpContext(
+        string user = "test-user",
+        HonuaEdition edition = HonuaEdition.Pro) => new()
     {
+        RequestServices = CreateRequestServices(edition),
         User = new ClaimsPrincipal(new ClaimsIdentity(
             [new Claim(ClaimTypes.Name, user)], "Test"))
     };
 
-    public static DefaultHttpContext AnonymousHttpContext() => new();
+    public static DefaultHttpContext AnonymousHttpContext(
+        HonuaEdition edition = HonuaEdition.Pro) => new()
+    {
+        RequestServices = CreateRequestServices(edition)
+    };
 
     public static McpPlanInput CreateValidPlanInput() => new()
     {
@@ -50,5 +61,14 @@ internal static class McpTestFactory
     {
         using var document = JsonDocument.Parse(json);
         return document.RootElement.Clone();
+    }
+
+    private static IServiceProvider CreateRequestServices(HonuaEdition edition)
+    {
+        var license = new TestLicenseEntitlementService(edition);
+        return new ServiceCollection()
+            .AddSingleton<ILicenseEntitlementService>(license)
+            .AddSingleton<ILicenseStatusProvider>(license)
+            .BuildServiceProvider();
     }
 }

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpTestFactory.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpTestFactory.cs
@@ -22,17 +22,17 @@ internal static class McpTestFactory
     public static DefaultHttpContext AuthenticatedHttpContext(
         string user = "test-user",
         HonuaEdition edition = HonuaEdition.Pro) => new()
-    {
-        RequestServices = CreateRequestServices(edition),
-        User = new ClaimsPrincipal(new ClaimsIdentity(
+        {
+            RequestServices = CreateRequestServices(edition),
+            User = new ClaimsPrincipal(new ClaimsIdentity(
             [new Claim(ClaimTypes.Name, user)], "Test"))
-    };
+        };
 
     public static DefaultHttpContext AnonymousHttpContext(
         HonuaEdition edition = HonuaEdition.Pro) => new()
-    {
-        RequestServices = CreateRequestServices(edition)
-    };
+        {
+            RequestServices = CreateRequestServices(edition)
+        };
 
     public static McpPlanInput CreateValidPlanInput() => new()
     {

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpToolDelegationTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpToolDelegationTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Geoprocessing;
 using Honua.Ai.Protocols.Mcp;
 using Honua.Ai.Protocols.Mcp.Models;
@@ -201,6 +202,38 @@ public sealed class McpToolDelegationTests
             Arg.Any<ClaimsPrincipal>(),
             Arg.Any<IReadOnlyDictionary<string, string>>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /mcp tools/call honua_execute_plan")]
+    public async Task ExecutePlan_WithCommunityLicense_ThrowsPreconditionBeforeSubmitting()
+    {
+        var tool = new ExecutePlanTool(_jobService, NullLogger<ExecutePlanTool>.Instance);
+        var arguments = McpTestFactory.ToArguments(
+            new McpExecutePlanArgument
+            {
+                Plan = McpTestFactory.CreateValidPlanInput(),
+                IdempotencyKey = "idem-key-1"
+            },
+            McpJsonContext.Default.McpExecutePlanArgument);
+        var context = McpTestFactory.AuthenticatedHttpContext(edition: HonuaEdition.Community);
+
+        var act = async () => await tool.InvokeAsync(context, arguments, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<GeoprocessingPreconditionFailedException>();
+        ex.Which.Message.Should().Contain(FeatureCatalog.AiSpecApplyKey);
+        await _jobService.Received(1).EnsureCallerAuthorizedAsync(
+            Arg.Any<ClaimsPrincipal>(),
+            OperatorResourceType.Process,
+            OperatorOperation.Execute,
+            Arg.Any<CancellationToken>());
+        await _jobService.DidNotReceiveWithAnyArgs().SubmitJobAsync(
+            default!,
+            default,
+            default!,
+            default!,
+            default);
     }
 
     [UnitTest]

--- a/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
@@ -53,6 +53,8 @@ public sealed class FeatureCatalogTests
         categories.Should().Contain(FeatureCatalog.Categories.Analytics);
         categories.Should().Contain(FeatureCatalog.Categories.Streaming);
         categories.Should().Contain(FeatureCatalog.Categories.Temporal);
+        categories.Should().Contain(FeatureCatalog.Categories.FieldOps);
+        categories.Should().Contain(FeatureCatalog.Categories.Ai);
     }
 
     [Theory]
@@ -106,6 +108,36 @@ public sealed class FeatureCatalogTests
         feature.Should().NotBeNull("feature catalog must define multi-user editing for ticket #1548");
         feature!.Key.Should().Be("editing.feature-edits");
         feature.Category.Should().Be(FeatureCatalog.Categories.Editing);
+        feature.MinimumEdition.Should().Be(HonuaEdition.Pro);
+    }
+
+    [Fact]
+    public void All_OfflineFieldSyncIsProTier()
+    {
+        // Ticket #1592: disconnected sync and field offline policy discovery
+        // are Pro entitlements; online form reads/submissions remain Community.
+        var feature = FeatureCatalog.All.SingleOrDefault(f => f.Key == FeatureCatalog.FieldOpsOfflineSyncKey);
+
+        feature.Should().NotBeNull("feature catalog must define offline field sync for ticket #1592");
+        feature!.Key.Should().Be("fieldops.offline-sync");
+        feature.Category.Should().Be(FeatureCatalog.Categories.FieldOps);
+        feature.MinimumEdition.Should().Be(HonuaEdition.Pro);
+    }
+
+    [Theory]
+    [InlineData(FeatureCatalog.AiSpecApplyKey, "ai.spec-apply")]
+    [InlineData(FeatureCatalog.AiGroundingKey, "ai.grounding")]
+    [InlineData(FeatureCatalog.AiWorkflowGenerationKey, "ai.workflow-generation")]
+    public void All_AgenticAiOperationsAreProTier(string key, string expectedKey)
+    {
+        // Ticket #1592: AI operations that mutate, generate, or submit
+        // execution work are Pro entitlements. Discovery/query/read surfaces
+        // stay Community and are not represented by these keys.
+        var feature = FeatureCatalog.All.SingleOrDefault(f => f.Key == key);
+
+        feature.Should().NotBeNull($"feature catalog must define '{expectedKey}' for ticket #1592");
+        feature!.Key.Should().Be(expectedKey);
+        feature.Category.Should().Be(FeatureCatalog.Categories.Ai);
         feature.MinimumEdition.Should().Be(HonuaEdition.Pro);
     }
 

--- a/tests/dotnet/Honua.Core.Tests/Features/Licensing/LicenseCapacityCalculatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Licensing/LicenseCapacityCalculatorTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Core.Tests.Features.Licensing;
+
+[Protocol(ProtocolNames.Admin)]
+[Operation(Operations.LicenseManagement)]
+public sealed class LicenseCapacityCalculatorTests
+{
+    [UnitTest]
+    public void ComputeServingUnits_WithLargerNode_UsesMaxResourceMultiple()
+    {
+        var units = LicenseCapacityCalculator.ComputeServingUnits(vCpu: 20, memoryGiB: 96);
+
+        Assert.Equal(3m, units);
+    }
+
+    [UnitTest]
+    public void ComputeServingUnits_WithServerlessConcurrency_NormalizesToUnits()
+    {
+        var units = LicenseCapacityCalculator.ComputeServingUnits(serverlessConcurrentExecutions: 17);
+
+        Assert.Equal(3m, units);
+    }
+
+    [UnitTest]
+    public void ComputeP95_ExcludesSurgeSamples()
+    {
+        var samples = Enumerable.Range(1, 19)
+            .Select(value => new LicenseCapacitySample
+            {
+                Timestamp = DateTimeOffset.UtcNow.AddMinutes(value),
+                ServingUnits = value,
+                IsSurge = false
+            })
+            .Append(new LicenseCapacitySample
+            {
+                Timestamp = DateTimeOffset.UtcNow.AddHours(1),
+                ServingUnits = 100,
+                IsSurge = true
+            });
+
+        var p95 = LicenseCapacityCalculator.ComputeP95(samples);
+
+        Assert.Equal(19m, p95);
+    }
+
+    [UnitTest]
+    public void DetermineBandState_WithCurrentAboveBandAndP95InsideBand_ReturnsBurst()
+    {
+        var terms = new LicenseCapacityTerms { MaxSustainedServingUnits = 4m };
+
+        var state = LicenseCapacityCalculator.DetermineBandState(
+            terms,
+            currentServingUnits: 5m,
+            p95ServingUnits: 4m,
+            graceStartedAt: null,
+            surgeActive: false,
+            meteringGap: false,
+            excluded: false,
+            now: DateTimeOffset.UtcNow);
+
+        Assert.Equal(LicenseCapacityBandState.Burst, state);
+    }
+
+    [UnitTest]
+    public void ShouldRefuseRegistration_BeforeGraceExpiry_Allows125PercentBurst()
+    {
+        var terms = new LicenseCapacityTerms { MaxSustainedServingUnits = 4m };
+
+        var allowed = LicenseCapacityCalculator.ShouldRefuseRegistration(
+            terms,
+            currentServingUnits: 4m,
+            joiningServingUnits: 1m,
+            LicenseCapacityBandState.Burst,
+            excluded: false);
+        var refused = LicenseCapacityCalculator.ShouldRefuseRegistration(
+            terms,
+            currentServingUnits: 4m,
+            joiningServingUnits: 1.1m,
+            LicenseCapacityBandState.Burst,
+            excluded: false);
+
+        Assert.False(allowed);
+        Assert.True(refused);
+    }
+
+    [UnitTest]
+    public void ShouldRefuseRegistration_AfterGraceExpiry_UsesBaseBand()
+    {
+        var terms = new LicenseCapacityTerms { MaxSustainedServingUnits = 4m };
+
+        var refused = LicenseCapacityCalculator.ShouldRefuseRegistration(
+            terms,
+            currentServingUnits: 4m,
+            joiningServingUnits: 0.1m,
+            LicenseCapacityBandState.GraceExpired,
+            excluded: false);
+
+        Assert.True(refused);
+    }
+
+    [UnitTest]
+    public void ShouldRefuseRegistration_ForExcludedRole_IsAlwaysAllowed()
+    {
+        var terms = new LicenseCapacityTerms { MaxSustainedServingUnits = 1m };
+
+        var refused = LicenseCapacityCalculator.ShouldRefuseRegistration(
+            terms,
+            currentServingUnits: 100m,
+            joiningServingUnits: 100m,
+            LicenseCapacityBandState.GraceExpired,
+            excluded: true);
+
+        Assert.False(refused);
+        Assert.True(LicenseCapacityCalculator.IsExcludedRole(LicenseDeploymentRole.Staging));
+    }
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicationTests.cs
@@ -98,6 +98,38 @@ public sealed class FeatureServerReplicationTests : IAsyncLifetime
         creationDate.GetInt64().Should().BeGreaterThan(0);
     }
 
+    [IntegrationTest]
+    [Operation(Operations.CreateReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/createReplica")]
+    public async Task CreateReplica_WithCommunityLicense_ReturnsPaymentRequired()
+    {
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Community);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var payload = JsonSerializer.Serialize(new
+            {
+                replicaName = "CommunityReplica",
+                layers = "0",
+                syncModel = "perReplica",
+                f = "json"
+            });
+
+            var response = await fixture.Client.PostAsync(
+                $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/createReplica",
+                new StringContent(payload, Encoding.UTF8, "application/json"));
+
+            response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+            var body = await response.Content.ReadAsStringAsync();
+            body.Should().Contain(FeatureCatalog.FieldOpsOfflineSyncKey);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
     // The ArcGIS API for Python (FeatureLayerCollection.create_replica /
     // extract_changes) sends the `layers` parameter as the Esri JSON-array form
     // (layers=[0] / layers=[0,1]) rather than the comma-separated form. Both forms

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/LicenseEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/LicenseEndpointsTests.cs
@@ -80,7 +80,13 @@ public class LicenseEndpointsTests : IAsyncLifetime
         var license = LicenseTestSupport.CreateSignedLicense(
             HonuaEdition.Pro,
             expiresAt: DateTimeOffset.UtcNow.AddDays(30),
-            entitlements: ["analytics.clustering", "staticmap.high-dpi"]);
+            entitlements: ["analytics.clustering", "staticmap.high-dpi"],
+            capacity: new LicenseCapacityTerms
+            {
+                MaxSustainedServingUnits = 4m,
+                AnnualSurgeDays = 14,
+                SurgeAllowance = LicenseCapacitySurgeAllowances.Standard
+            });
         await File.WriteAllBytesAsync(licensePath, license.LicenseData);
 
         var fixture = new WebAppFixture()
@@ -121,6 +127,10 @@ public class LicenseEndpointsTests : IAsyncLifetime
                 entitlement.Key == "analytics.clustering" && entitlement.IsActive);
             Assert.Contains(result.Data.Entitlements, entitlement =>
                 entitlement.Key == "analytics.spatial-join" && !entitlement.IsActive);
+            Assert.NotNull(result.Data.Capacity);
+            Assert.Equal(4m, result.Data.Capacity.Terms?.MaxSustainedServingUnits);
+            Assert.Equal(1m, result.Data.Capacity.CurrentServingUnits);
+            Assert.Equal(LicenseCapacityBandState.Normal, result.Data.Capacity.State);
         }
         finally
         {
@@ -233,5 +243,44 @@ public class LicenseEndpointsTests : IAsyncLifetime
         Assert.True(result.Success);
         Assert.NotNull(result.Data);
         Assert.NotEmpty(result.Data);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/license/capacity")]
+    public async Task GetCapacity_WithAdminAuth_ReturnsMeterState()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/license/capacity");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<ApiResponse<LicenseCapacityState>>(json, _jsonOptions);
+
+        Assert.NotNull(result);
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Equal(LicenseCapacityBandState.NotConfigured, result.Data.State);
+        Assert.Equal(1m, result.Data.CurrentServingUnits);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/license/capacity/surge")]
+    public async Task SetSurgeMode_WithAdminAuth_ActivatesSurgeAccounting()
+    {
+        using var body = new StringContent(
+            """{"enabled":true,"reason":"incident response"}""",
+            Encoding.UTF8,
+            "application/json");
+
+        var response = await _client.PostAsync("/api/v1/admin/license/capacity/surge", body);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<ApiResponse<LicenseCapacityState>>(json, _jsonOptions);
+
+        Assert.NotNull(result);
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.True(result.Data.Surge.IsActive);
+        Assert.Equal("incident response", result.Data.Surge.Reason);
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Capabilities/CapabilityManifestEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Capabilities/CapabilityManifestEndpointTests.cs
@@ -45,9 +45,11 @@ public sealed class CapabilityManifestEndpointTests : IAsyncLifetime
         _fixture = CreateManifestFixture();
     }
 
-    private static WebAppFixture CreateManifestFixture(string[]? entitlements = null)
+    private static WebAppFixture CreateManifestFixture(
+        string[]? entitlements = null,
+        HonuaEdition edition = HonuaEdition.Pro)
         => new WebAppFixture()
-            .WithTestLicense(HonuaEdition.Pro, entitlements: entitlements)
+            .WithTestLicense(edition, entitlements: entitlements)
             .ConfigureServices(services =>
             {
                 services.RemoveAll<IMetadataV2EnvironmentSnapshotReader>();
@@ -173,7 +175,18 @@ public sealed class CapabilityManifestEndpointTests : IAsyncLifetime
             .Select(item => item.GetString())
             .Should().Contain("admin.rbac.write");
 
-        GetCapability(root, "sync.offline").GetProperty("category").GetString().Should().Be("sync");
+        var offlineSync = GetCapability(root, "sync.offline");
+        offlineSync.GetProperty("category").GetString().Should().Be("sync");
+        offlineSync.GetProperty("entitlementKey").GetString().Should().Be(FeatureCatalog.FieldOpsOfflineSyncKey);
+        offlineSync.GetProperty("minimumEdition").GetString().Should().Be("Pro");
+
+        var specApply = GetCapability(root, "ai.spec-apply");
+        specApply.GetProperty("available").GetBoolean().Should().BeTrue();
+        specApply.GetProperty("entitlementKey").GetString().Should().Be(FeatureCatalog.AiSpecApplyKey);
+        GetCapability(root, "ai.grounding").GetProperty("entitlementKey").GetString()
+            .Should().Be(FeatureCatalog.AiGroundingKey);
+        GetCapability(root, "ai.workflow-generation").GetProperty("entitlementKey").GetString()
+            .Should().Be(FeatureCatalog.AiWorkflowGenerationKey);
         GetCapability(root, "publication.metadata-release").GetProperty("available").GetBoolean().Should().BeTrue();
         root.GetProperty("limits").GetProperty("upload").GetProperty("maxUploadSizeBytes").GetInt64()
             .Should().Be(123456);
@@ -227,6 +240,43 @@ public sealed class CapabilityManifestEndpointTests : IAsyncLifetime
             appPackage.GetProperty("available").GetBoolean().Should().BeTrue();
             appPackage.TryGetProperty("reasonCode", out _).Should().BeFalse();
             appPackage.TryGetProperty("entitlementKey", out _).Should().BeFalse();
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/capabilities/manifest")]
+    public async Task GetManifest_WithCommunityLicense_MarksOfflineSyncAndAiOperationsUnavailable()
+    {
+        var fixture = CreateManifestFixture(edition: HonuaEdition.Community);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            using var client = fixture.CreateAdminClient();
+            using var response = await client.GetAsync(
+                "/api/v1/capabilities/manifest?workspaceId=field-team");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            using var document = await ReadDocumentAsync(response);
+            var root = document.RootElement;
+
+            var offlineSync = GetCapability(root, "sync.offline");
+            offlineSync.GetProperty("available").GetBoolean().Should().BeFalse();
+            offlineSync.GetProperty("reasonCode").GetString().Should().Be("license-required");
+            offlineSync.GetProperty("entitlementKey").GetString().Should().Be(FeatureCatalog.FieldOpsOfflineSyncKey);
+
+            foreach (var capabilityId in new[] { "ai.spec-apply", "ai.grounding", "ai.workflow-generation" })
+            {
+                var capability = GetCapability(root, capabilityId);
+                capability.GetProperty("available").GetBoolean().Should().BeFalse();
+                capability.GetProperty("reasonCode").GetString().Should().Be("license-required");
+                capability.GetProperty("minimumEdition").GetString().Should().Be("Pro");
+            }
         }
         finally
         {

--- a/tests/dotnet/Honua.Server.Tests/Features/Forms/FormPackageEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Forms/FormPackageEndpointsTests.cs
@@ -7,8 +7,10 @@ using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using Honua.Core.Features.Forms.Packages;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
+using Honua.TestKit.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 
@@ -18,7 +20,8 @@ namespace Honua.Server.Tests.Features.Forms;
 [Protocol(TestProtocols.Admin)]
 public sealed class FormPackageEndpointsTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture()
+        .WithTestLicense(HonuaEdition.Pro);
 
     public async Task InitializeAsync()
     {
@@ -446,6 +449,62 @@ public sealed class FormPackageEndpointsTests : IAsyncLifetime
             JsonContent("{}"));
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Configuration)]
+    [Endpoint("GET /api/v1/forms/packages/{formId}/offline-policy")]
+    [Endpoint("GET /api/v1/forms/packages/{formId}/compatibility")]
+    public async Task OfflineFormRuntime_WithCommunityLicense_ReturnsPaymentRequired()
+    {
+        var fixture = new WebAppFixture()
+            .WithTestLicense(HonuaEdition.Community);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            foreach (var path in new[]
+            {
+                "/api/v1/forms/packages/community-form/offline-policy",
+                "/api/v1/forms/packages/community-form/compatibility"
+            })
+            {
+                var response = await fixture.Client.GetAsync(path);
+
+                response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+                var body = await response.Content.ReadAsStringAsync();
+                body.Should().Contain(FeatureCatalog.FieldOpsOfflineSyncKey);
+            }
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Configuration)]
+    [Endpoint("POST /api/v1/admin/forms/packages/generate")]
+    public async Task GenerateFormPackage_WithCommunityLicense_ReturnsPaymentRequired()
+    {
+        var fixture = new WebAppFixture()
+            .WithTestLicense(HonuaEdition.Community);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var response = await fixture.Client.PostAsync(
+                "/api/v1/admin/forms/packages/generate",
+                JsonContent("""{"prompt":"Build a simple inspection form"}"""));
+
+            response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+            var body = await response.Content.ReadAsStringAsync();
+            body.Should().Contain(FeatureCatalog.AiWorkflowGenerationKey);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
     }
 
     private async Task<T> GetJsonAsync<T>(string path, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> jsonTypeInfo)

--- a/tests/dotnet/Honua.Server.Tests/Features/Grounding/Spec/SpecGroundingEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Grounding/Spec/SpecGroundingEndpointTests.cs
@@ -6,10 +6,12 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Grounding.Spec;
 
@@ -29,6 +31,7 @@ public sealed class SpecGroundingEndpointTests : IAsyncLifetime
             SpecGroundingTestSupport.CreateLayer(4, "Zones"));
 
         _fixture = new WebAppFixture()
+            .WithTestLicense(HonuaEdition.Pro)
             .ReplaceService<IMetadataV2GraphProvider>(graphProvider);
     }
 
@@ -262,6 +265,33 @@ public sealed class SpecGroundingEndpointTests : IAsyncLifetime
         clarification.GetProperty("candidates").EnumerateArray()
             .Select(candidate => candidate.GetProperty("unit").GetString())
             .Should().Equal("km", "m", "mi", "ft", "nm");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GroundingMutate)]
+    [Endpoint("POST /v1/grounding/spec/mutate")]
+    public async Task Mutate_WithCommunityLicense_ReturnsPaymentRequired()
+    {
+        var fixture = new WebAppFixture()
+            .WithTestLicense(HonuaEdition.Community);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var response = await fixture.Client.PostAsJsonAsync("/v1/grounding/spec/mutate", new
+            {
+                spec = SpecGroundingTestSupport.ParseJsonElement("{}"),
+                turn = "use rivers as rivers"
+            });
+
+            response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+            var body = await response.Content.ReadAsStringAsync();
+            body.Should().Contain(FeatureCatalog.AiGroundingKey);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Licensing/LicenseCapacityMeterTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Licensing/LicenseCapacityMeterTests.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Infrastructure.Licensing;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Licensing;
+
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.LicenseManagement)]
+public sealed class LicenseCapacityMeterTests
+{
+    [UnitTest]
+    public async Task RegisterInstance_WhenJoiningWouldExceedBurstCeiling_RefusesNewRegistrationOnly()
+    {
+        var meter = CreateMeter(maxSustainedUnits: 4m);
+
+        var first = await meter.RegisterInstanceAsync(new LicenseCapacityRegistrationRequest
+        {
+            InstanceId = "prod-a",
+            ServingUnits = 5m,
+            DeploymentRole = LicenseDeploymentRole.Production,
+            Topology = LicenseServingTopology.ReplicaSet
+        });
+        var second = await meter.RegisterInstanceAsync(new LicenseCapacityRegistrationRequest
+        {
+            InstanceId = "prod-b",
+            ServingUnits = 0.1m,
+            DeploymentRole = LicenseDeploymentRole.Production,
+            Topology = LicenseServingTopology.ReplicaSet
+        });
+        var state = await meter.GetCapacityStateAsync();
+
+        Assert.True(first.IsAccepted);
+        Assert.False(second.IsAccepted);
+        Assert.Equal(5m, state.CurrentServingUnits);
+        Assert.Equal(1, state.LiveInstanceCount);
+    }
+
+    [UnitTest]
+    public async Task RegisterInstance_WithNonProductionRole_DoesNotCountTowardBand()
+    {
+        var meter = CreateMeter(maxSustainedUnits: 1m);
+
+        var decision = await meter.RegisterInstanceAsync(new LicenseCapacityRegistrationRequest
+        {
+            InstanceId = "staging-a",
+            ServingUnits = 50m,
+            DeploymentRole = LicenseDeploymentRole.Staging,
+            Topology = LicenseServingTopology.ReplicaSet
+        });
+        var state = await meter.GetCapacityStateAsync();
+
+        Assert.True(decision.IsAccepted);
+        Assert.Equal(0m, state.CurrentServingUnits);
+        Assert.Equal(1, state.ExcludedInstanceCount);
+    }
+
+    [UnitTest]
+    public async Task RegisterInstance_WithSurgeMode_AllowsRegistrationAboveBurstCeiling()
+    {
+        var meter = CreateMeter(maxSustainedUnits: 1m);
+
+        var surge = await meter.SetSurgeModeAsync(enabled: true, reason: "incident response");
+        var decision = await meter.RegisterInstanceAsync(new LicenseCapacityRegistrationRequest
+        {
+            InstanceId = "prod-surge",
+            ServingUnits = 10m,
+            DeploymentRole = LicenseDeploymentRole.Production,
+            Topology = LicenseServingTopology.Serverless
+        });
+
+        Assert.True(surge.Surge.IsActive);
+        Assert.Equal(LicenseCapacityBandState.Surge, surge.State);
+        Assert.True(decision.IsAccepted);
+        Assert.Equal(10m, decision.State.CurrentServingUnits);
+    }
+
+    [UnitTest]
+    public async Task GetCapacityState_WithActiveSurge_IncludesActiveWindowInAllowanceAccounting()
+    {
+        var clock = new MutableTimeProvider(new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero));
+        var meter = CreateMeter(maxSustainedUnits: 1m, clock);
+
+        await meter.SetSurgeModeAsync(enabled: true, reason: "planned load test");
+        clock.Advance(TimeSpan.FromHours(12));
+        var state = await meter.GetCapacityStateAsync();
+
+        Assert.True(state.Surge.IsActive);
+        Assert.Equal(0.5m, state.Surge.UsedDaysThisYear);
+        Assert.Equal(13.5m, state.Surge.RemainingDaysThisYear);
+    }
+
+    private static LicenseCapacityMeter CreateMeter(decimal maxSustainedUnits, TimeProvider? timeProvider = null)
+    {
+        var license = new TestLicenseEntitlementService(
+            HonuaEdition.Enterprise,
+            capacityTerms: new LicenseCapacityTerms
+            {
+                MaxSustainedServingUnits = maxSustainedUnits,
+                AnnualSurgeDays = 14,
+                SurgeAllowance = LicenseCapacitySurgeAllowances.Standard
+            });
+        return new LicenseCapacityMeter(
+            license,
+            Options.Create(new LicenseCapacityOptions
+            {
+                RegistrationEnabled = false,
+                InstanceId = "local-test",
+                ServingUnits = 1m
+            }),
+            timeProvider ?? TimeProvider.System,
+            NullLogger<LicenseCapacityMeter>.Instance);
+    }
+
+    private sealed class MutableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan timeSpan) => _utcNow += timeSpan;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Mobile/FieldCollection/FieldCollectionSyncEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Mobile/FieldCollection/FieldCollectionSyncEndpointsTests.cs
@@ -6,9 +6,11 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
@@ -30,7 +32,8 @@ public sealed class FieldCollectionSyncEndpointsTests : IAsyncLifetime
     private const string SyncCursorPath = "/api/v1/fieldcollection/sync-cursor";
     private const string ChangesPath = "/api/v1/fieldcollection/changes";
 
-    private readonly WebAppFixture _fixture = new();
+    private readonly WebAppFixture _fixture = new WebAppFixture()
+        .WithTestLicense(HonuaEdition.Pro);
     private HttpClient _client = null!;
 
     public async Task InitializeAsync()
@@ -831,6 +834,68 @@ public sealed class FieldCollectionSyncEndpointsTests : IAsyncLifetime
             collectedAt = DateTimeOffset.UtcNow,
         },
     };
+}
+
+/// <summary>
+/// Verifies FieldCollection disconnected sync is licensed separately from
+/// basic online form collection (#1592).
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Features)]
+public sealed class FieldCollectionSyncLicenseGateTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new WebAppFixture()
+        .WithTestLicense(HonuaEdition.Community);
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/fieldcollection/generation")]
+    [Endpoint("GET /api/v1/fieldcollection/sync-cursor")]
+    [Endpoint("POST /api/v1/fieldcollection/sync-cursor")]
+    [Endpoint("GET /api/v1/fieldcollection/changes")]
+    [Endpoint("POST /api/v1/fieldcollection/changes")]
+    public async Task FieldCollectionSync_WithCommunityLicense_ReturnsPaymentRequired()
+    {
+        var requests = new Func<HttpRequestMessage>[]
+        {
+            static () => new HttpRequestMessage(HttpMethod.Get, "/api/v1/fieldcollection/generation"),
+            static () => new HttpRequestMessage(HttpMethod.Get, "/api/v1/fieldcollection/sync-cursor"),
+            static () => new HttpRequestMessage(HttpMethod.Post, "/api/v1/fieldcollection/sync-cursor")
+            {
+                Content = JsonContent.Create(new { lastSyncGeneration = 0L }),
+            },
+            static () => new HttpRequestMessage(HttpMethod.Get, "/api/v1/fieldcollection/changes"),
+            static () => new HttpRequestMessage(HttpMethod.Post, "/api/v1/fieldcollection/changes")
+            {
+                Content = JsonContent.Create(new
+                {
+                    changeId = Guid.NewGuid().ToString("N"),
+                    featureId = $"feat-{Guid.NewGuid():N}",
+                    layerId = 1,
+                    operation = "insert",
+                }),
+            },
+        };
+
+        foreach (var createRequest in requests)
+        {
+            using var request = createRequest();
+            using var response = await _client.SendAsync(request);
+
+            response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+            var body = await response.Content.ReadAsStringAsync();
+            body.Should().Contain(FeatureCatalog.FieldOpsOfflineSyncKey);
+        }
+    }
 }
 
 /// <summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/Spec/GrpcSpecServiceIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Spec/GrpcSpecServiceIntegrationTests.cs
@@ -5,9 +5,16 @@ using FluentAssertions;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Grpc.Net.Client.Web;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Proto = Geospatial.V1;
 
 namespace Honua.Server.Tests.Features.Spec;
@@ -21,19 +28,14 @@ namespace Honua.Server.Tests.Features.Spec;
 [Protocol(TestProtocols.Grpc)]
 public sealed class GrpcSpecServiceIntegrationTests : IDisposable
 {
-    private readonly TestWebApplicationFactory _factory;
+    private readonly WebApplicationFactory<Program> _factory;
     private readonly GrpcChannel _channel;
     private readonly Proto.SpecService.SpecServiceClient _client;
 
     public GrpcSpecServiceIntegrationTests()
     {
-        _factory = new TestWebApplicationFactory();
-        var testServerHandler = _factory.Server.CreateHandler();
-        var grpcWebHandler = new GrpcWebHandler(GrpcWebMode.GrpcWeb, testServerHandler);
-        _channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
-        {
-            HttpHandler = grpcWebHandler
-        });
+        _factory = CreateLicensedFactory(HonuaEdition.Pro);
+        _channel = CreateChannel(_factory);
         _client = new Proto.SpecService.SpecServiceClient(_channel);
     }
 
@@ -505,6 +507,34 @@ public sealed class GrpcSpecServiceIntegrationTests : IDisposable
     }
 
     [IntegrationTest]
+    [Operation(Operations.ProcessExecution)]
+    [Endpoint("POST /geospatial.v1.SpecService/ApplySpec")]
+    public async Task ApplySpec_WithCommunityLicense_RaisesFailedPreconditionBeforeStream()
+    {
+        using var factory = CreateLicensedFactory(HonuaEdition.Community);
+        using var channel = CreateChannel(factory);
+        var client = new Proto.SpecService.SpecServiceClient(channel);
+        var request = new Proto.ApplySpecRequest
+        {
+            Document = BuildDocument("node-a"),
+            CacheMode = Proto.SpecCacheMode.ReadWrite,
+            MaxConcurrency = 1
+        };
+
+        var act = async () =>
+        {
+            using var call = client.ApplySpec(request);
+            await foreach (var _ in call.ResponseStream.ReadAllAsync())
+            {
+            }
+        };
+
+        var ex = await act.Should().ThrowAsync<RpcException>();
+        ex.Which.StatusCode.Should().Be(StatusCode.FailedPrecondition);
+        ex.Which.Status.Detail.Should().Contain(FeatureCatalog.AiSpecApplyKey);
+    }
+
+    [IntegrationTest]
     [Operation(Operations.JobDismiss)]
     [Endpoint("POST /geospatial.v1.SpecService/CancelApply")]
     [InterfaceOperation(TestProtocols.Grpc, "geospatial.v1.SpecService/CancelApply")]
@@ -544,5 +574,29 @@ public sealed class GrpcSpecServiceIntegrationTests : IDisposable
             Op = "compute.noop"
         });
         return document;
+    }
+
+    private static WebApplicationFactory<Program> CreateLicensedFactory(HonuaEdition edition)
+    {
+        var license = new TestLicenseEntitlementService(edition);
+        return new TestWebApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    services.Replace(ServiceDescriptor.Singleton<ILicenseEntitlementService>(license));
+                    services.Replace(ServiceDescriptor.Singleton<ILicenseStatusProvider>(license));
+                });
+            });
+    }
+
+    private static GrpcChannel CreateChannel(WebApplicationFactory<Program> factory)
+    {
+        var testServerHandler = factory.Server.CreateHandler();
+        var grpcWebHandler = new GrpcWebHandler(GrpcWebMode.GrpcWeb, testServerHandler);
+        return GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+        {
+            HttpHandler = grpcWebHandler
+        });
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Spec/SpecEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Spec/SpecEndpointsTests.cs
@@ -5,9 +5,16 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Honua.Server.Tests.Features.Spec;
 
@@ -659,7 +666,7 @@ public sealed class SpecEndpointsTests
         // Production DI registers a placeholder ReservedSpecResourceStateStore
         // for Dataset/Service/App. Apply must still reject the node kind-based
         // so the DI placeholder cannot mask the S1 gap.
-        using var factory = new TestWebApplicationFactory();
+        using var factory = CreateLicensedFactory(HonuaEdition.Pro);
         using var client = factory.CreateClient();
 
         var datasetNode = new Dictionary<string, object?>(StringComparer.Ordinal)
@@ -676,6 +683,26 @@ public sealed class SpecEndpointsTests
         Assert.Equal(
             "spec-kind-not-in-s1",
             failed.Payload.GetProperty("diagnostic").GetProperty("code").GetString());
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ProcessExecution)]
+    [Endpoint("POST /v1/spec/apply")]
+    public async Task Apply_WithCommunityLicense_ReturnsPaymentRequired()
+    {
+        using var factory = CreateLicensedFactory(HonuaEdition.Community);
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/spec/apply")
+        {
+            Content = JsonContent(BuildDocument(ComputeNode("a")))
+        };
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.PaymentRequired, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains(FeatureCatalog.AiSpecApplyKey, body, StringComparison.Ordinal);
     }
 
     [IntegrationTest]
@@ -700,7 +727,7 @@ public sealed class SpecEndpointsTests
     [FlakyTest("SSE response headers occasionally null mid-stream under combined Testcontainers/fixture load — tracked in #812")]
     public async Task Apply_LinearChain_StreamsSseEvents_AndSucceeds()
     {
-        using var factory = new TestWebApplicationFactory();
+        using var factory = CreateLicensedFactory(HonuaEdition.Pro);
         using var client = factory.CreateClient();
 
         var document = BuildDocument(
@@ -727,7 +754,7 @@ public sealed class SpecEndpointsTests
     [Endpoint("POST /v1/spec/apply")]
     public async Task Apply_RerunSameDocument_YieldsCachedEventsForEveryNode()
     {
-        using var factory = new TestWebApplicationFactory();
+        using var factory = CreateLicensedFactory(HonuaEdition.Pro);
         using var client = factory.CreateClient();
 
         var document = BuildDocument(
@@ -805,7 +832,7 @@ public sealed class SpecEndpointsTests
     [Endpoint("GET /v1/spec/artifact/{hash}")]
     public async Task Artifact_AfterApply_ReturnsStoredBytes()
     {
-        using var factory = new TestWebApplicationFactory();
+        using var factory = CreateLicensedFactory(HonuaEdition.Pro);
         using var client = factory.CreateClient();
 
         var document = BuildDocument(ComputeNode("a"));
@@ -855,6 +882,20 @@ public sealed class SpecEndpointsTests
             ["processFamilyVersion"] = "family/1.0",
             ["nodes"] = nodes
         };
+
+    private static WebApplicationFactory<Program> CreateLicensedFactory(HonuaEdition edition)
+    {
+        var license = new TestLicenseEntitlementService(edition);
+        return new TestWebApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    services.Replace(ServiceDescriptor.Singleton<ILicenseEntitlementService>(license));
+                    services.Replace(ServiceDescriptor.Singleton<ILicenseStatusProvider>(license));
+                });
+            });
+    }
 
     private static async Task<IReadOnlyList<SseFrame>> CollectSseEventsAsync(
         HttpClient client,

--- a/tests/dotnet/Honua.Server.Tests/Features/WorkflowPackages/WorkflowPackageEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/WorkflowPackages/WorkflowPackageEndpointsTests.cs
@@ -10,9 +10,11 @@ using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -41,6 +43,7 @@ public sealed class WorkflowPackageEndpointsTests : IAsyncLifetime
     public WorkflowPackageEndpointsTests()
     {
         _fixture = new WebAppFixture()
+            .WithTestLicense(HonuaEdition.Pro)
             .ConfigureServices(services =>
             {
                 services.RemoveAll<IExecutionJobStore>();
@@ -170,6 +173,32 @@ public sealed class WorkflowPackageEndpointsTests : IAsyncLifetime
             JsonOptions);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/console/workflow-packages/generate")]
+    public async Task GenerateWorkflow_WithCommunityLicense_ReturnsPaymentRequired()
+    {
+        var fixture = new WebAppFixture()
+            .WithTestLicense(HonuaEdition.Community);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            using var client = fixture.CreateAdminClient();
+            var response = await client.PostAsJsonAsync(
+                "/api/v1/console/workflow-packages/generate",
+                new { prompt = "Generate a parcel review workflow." },
+                JsonOptions);
+
+            response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+            var body = await response.Content.ReadAsStringAsync();
+            body.Should().Contain(FeatureCatalog.AiWorkflowGenerationKey);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.TestKit/Helpers/LicenseTestSupport.cs
+++ b/tests/dotnet/Honua.TestKit/Helpers/LicenseTestSupport.cs
@@ -12,6 +12,11 @@ namespace Honua.TestKit.Helpers;
 
 public static class LicenseTestSupport
 {
+    private static readonly JsonSerializerOptions PayloadJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
     private static readonly byte[] SigningSeed =
     [
         0x10, 0x42, 0x9A, 0xC1, 0x7E, 0x6D, 0x55, 0x3A,
@@ -27,20 +32,24 @@ public static class LicenseTestSupport
         DateTimeOffset? expiresAt = null,
         string[]? entitlements = null,
         string? keyId = null,
-        bool tamperSignature = false)
+        bool tamperSignature = false,
+        LicenseCapacityTerms? capacity = null)
     {
         var privateKey = new Ed25519PrivateKeyParameters(SigningSeed, 0);
         var publicKey = privateKey.GeneratePublicKey().GetEncoded();
-        var payload = JsonSerializer.Serialize(new
-        {
-            schema = "honua.license/v1",
-            licenseId = "lic-test-338",
-            licensedTo = "Honua Test Operator",
-            edition = edition.ToString(),
-            issuedAt = DateTimeOffset.UtcNow.AddDays(-1),
-            expiresAt,
-            entitlements = entitlements ?? ActiveEntitlementsFor(edition)
-        });
+        var payload = JsonSerializer.Serialize(
+            new
+            {
+                schema = "honua.license/v1",
+                licenseId = "lic-test-338",
+                licensedTo = "Honua Test Operator",
+                edition = edition.ToString(),
+                issuedAt = DateTimeOffset.UtcNow.AddDays(-1),
+                expiresAt,
+                entitlements = entitlements ?? ActiveEntitlementsFor(edition),
+                capacity
+            },
+            PayloadJsonOptions);
         var payloadBytes = Encoding.UTF8.GetBytes(payload);
 
         var signer = new Ed25519Signer();
@@ -74,7 +83,8 @@ public static class LicenseTestSupport
     public static LicenseSnapshot CreateSnapshot(
         HonuaEdition edition,
         LicenseValidationState validationState = LicenseValidationState.Valid,
-        string[]? entitlements = null)
+        string[]? entitlements = null,
+        LicenseCapacityTerms? capacityTerms = null)
     {
         var activeKeys = (entitlements ?? ActiveEntitlementsFor(edition))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -98,7 +108,8 @@ public static class LicenseTestSupport
             catalogEntitlements,
             activeKeys,
             SnapshotVersion: 1,
-            KeyId: KeyId);
+            KeyId: KeyId,
+            CapacityTerms: capacityTerms);
     }
 
     public static string Base64Url(byte[] bytes)
@@ -129,9 +140,10 @@ public sealed class TestLicenseEntitlementService : ILicenseEntitlementService, 
     public TestLicenseEntitlementService(
         HonuaEdition edition,
         LicenseValidationState validationState = LicenseValidationState.Valid,
-        string[]? entitlements = null)
+        string[]? entitlements = null,
+        LicenseCapacityTerms? capacityTerms = null)
     {
-        _snapshot = LicenseTestSupport.CreateSnapshot(edition, validationState, entitlements);
+        _snapshot = LicenseTestSupport.CreateSnapshot(edition, validationState, entitlements, capacityTerms);
     }
 
     public LicenseSnapshot GetSnapshot() => _snapshot;
@@ -145,7 +157,8 @@ public sealed class TestLicenseEntitlementService : ILicenseEntitlementService, 
             _snapshot.ValidationState,
             _snapshot.LicenseId,
             _snapshot.IssuedAt,
-            _snapshot.Entitlements);
+            _snapshot.Entitlements,
+            _snapshot.CapacityTerms);
 
     public Task<LicenseUploadResult> UploadLicenseAsync(
         Stream licenseStream,


### PR DESCRIPTION
## Related Issues

Closes #1588
Closes #1592

## Summary

Single integration branch combining the two licensing features that touch the
shared license-entitlement pipeline:

- **#1588** — topology-neutral capacity meter and elastic band enforcement
  (p95 units, burst, surge).
- **#1592** — Pro edition gates for offline/field sync and agentic AI operations
  (previously ungated).

They are bundled into one PR because both extend the same `FeatureCatalog` /
license-entitlement surfaces and share capability-manifest wiring.

## Changes Made

- Add topology-neutral capacity meter with elastic band enforcement (p95 units, burst, surge) (#1588)
- Gate offline/field-collection sync, form offline packages, workflow/studio packages, content publication, MCP agentic execution, and replication-extract surfaces behind Pro entitlements via the shared license entitlement pipeline (#1592)
- Wire capability-manifest and feature-catalog entries for the new gated surfaces
- Add endpoint/integration test coverage for the gated paths and capacity meter

## Breaking Changes

None. Additive entitlement gates; Community behavior unchanged where not Pro-scoped.

## Gate Impact

- [x] No gate-tier changes (additive features; no new required checks)

## Testing

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] `dotnet build Honua.sln --configuration Release /p:TreatWarningsAsErrors=true` → 0 warnings, 0 errors
- [x] `dotnet format Honua.sln --verify-no-changes` → clean
- [x] Honua.Core licensing unit tests → 39/39 passed
