### PR TITLE
feat: tenant-scoped metadata resolution for OGC and STAC (#1580)

### DIFF
--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2Common.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2Common.cs
@@ -59,6 +59,18 @@ public sealed record MetadataV2ObjectMetadata
     public string? Namespace { get; init; }
 
     /// <summary>
+    /// Owning tenant identifier for tenant-scoped deployments (#1580). When set, the
+    /// entity is only visible to requests whose resolved tenant context (issue #1144)
+    /// carries the same tenant id; the shared metadata lookup helpers treat a mismatch
+    /// as "not found" so a tenant cannot discover another tenant's collections, items,
+    /// or tiles. When <see langword="null"/> or empty the entity is unscoped and
+    /// visible to every tenant (single-tenant backwards compatibility). Visibility
+    /// rules live in <see cref="MetadataV2TenantVisibility"/>.
+    /// </summary>
+    [JsonPropertyName("tenant")]
+    public string? Tenant { get; init; }
+
+    /// <summary>
     /// Human-readable display title.
     /// </summary>
     [JsonPropertyName("title")]

--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2TenantVisibility.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2TenantVisibility.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Tenant-scope visibility rules for Metadata v2 graph entities (#1580).
+/// </summary>
+/// <remarks>
+/// <para>
+/// An entity declares its owning tenant through
+/// <see cref="MetadataV2ObjectMetadata.Tenant"/>. The rules are intentionally simple
+/// and fail closed:
+/// </para>
+/// <list type="bullet">
+///   <item><description>An entity with no tenant (<see langword="null"/> or
+///   whitespace) is <b>unscoped</b> and visible to every request, including requests
+///   that resolved no tenant context. This preserves single-tenant behavior for
+///   existing graphs.</description></item>
+///   <item><description>A tenant-scoped entity is visible only when the request
+///   resolved a tenant id that matches exactly (ordinal, case-sensitive). A request
+///   without a tenant context never sees scoped entities.</description></item>
+///   <item><description>A publication is visible only when the publication itself,
+///   its canonical resource, and the publishing service are all visible — scoping any
+///   one node in the chain hides the published surface.</description></item>
+/// </list>
+/// <para>
+/// Shared lookup helpers (layer/collection validation, STAC publication resolution)
+/// apply these rules <em>before</em> access-policy evaluation and storage-layer
+/// resolution, so cross-tenant requests observe "not found" rather than "forbidden"
+/// and cannot probe for another tenant's identifiers.
+/// </para>
+/// </remarks>
+public static class MetadataV2TenantVisibility
+{
+    /// <summary>
+    /// Core rule: is an entity owned by <paramref name="entityTenant"/> visible to a
+    /// request resolved to <paramref name="requestTenant"/>?
+    /// </summary>
+    /// <param name="entityTenant">The entity's owning tenant; null/whitespace means unscoped.</param>
+    /// <param name="requestTenant">The request's resolved tenant id; null/whitespace means
+    /// no tenant context was resolved.</param>
+    /// <returns><see langword="true"/> when the entity is visible to the request.</returns>
+    public static bool IsVisibleToTenant(string? entityTenant, string? requestTenant)
+    {
+        if (string.IsNullOrWhiteSpace(entityTenant))
+        {
+            // Unscoped entity: visible to everyone (single-tenant back-compat).
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(requestTenant))
+        {
+            // Scoped entity but no tenant resolved for the request: fail closed.
+            return false;
+        }
+
+        return string.Equals(entityTenant, requestTenant, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Whether a resource is visible to the request tenant. A null resource is treated
+    /// as visible so callers can keep their existing null-handling (missing resources
+    /// already resolve to "not found").
+    /// </summary>
+    /// <param name="resource">The canonical resource, when resolved.</param>
+    /// <param name="requestTenant">The request's resolved tenant id.</param>
+    /// <returns><see langword="true"/> when visible.</returns>
+    public static bool IsVisibleToTenant(MetadataV2Resource? resource, string? requestTenant)
+        => resource is null || IsVisibleToTenant(resource.Metadata.Tenant, requestTenant);
+
+    /// <summary>
+    /// Whether a service is visible to the request tenant. A null service is treated
+    /// as visible (publications without a resolvable service are filtered elsewhere).
+    /// </summary>
+    /// <param name="service">The publishing service, when resolved.</param>
+    /// <param name="requestTenant">The request's resolved tenant id.</param>
+    /// <returns><see langword="true"/> when visible.</returns>
+    public static bool IsVisibleToTenant(MetadataV2Service? service, string? requestTenant)
+        => service is null || IsVisibleToTenant(service.Metadata.Tenant, requestTenant);
+
+    /// <summary>
+    /// Combined rule for a published surface: the publication, its canonical resource,
+    /// and the publishing service must all be visible to the request tenant.
+    /// </summary>
+    /// <param name="publication">The publication being resolved.</param>
+    /// <param name="resource">The canonical resource backing the publication, when resolved.</param>
+    /// <param name="service">The service the publication is exposed through, when resolved.</param>
+    /// <param name="requestTenant">The request's resolved tenant id.</param>
+    /// <returns><see langword="true"/> when the published surface is visible.</returns>
+    public static bool IsVisibleToTenant(
+        MetadataV2Publication publication,
+        MetadataV2Resource? resource,
+        MetadataV2Service? service,
+        string? requestTenant)
+    {
+        ArgumentNullException.ThrowIfNull(publication);
+        return IsVisibleToTenant(publication.Metadata.Tenant, requestTenant)
+            && IsVisibleToTenant(resource, requestTenant)
+            && IsVisibleToTenant(service, requestTenant);
+    }
+}

--- a/src/Honua.Hosting/Features/Authentication/AccessPolicyHelpers.cs
+++ b/src/Honua.Hosting/Features/Authentication/AccessPolicyHelpers.cs
@@ -22,6 +22,15 @@ internal static class AccessPolicyHelpers
 {
     internal const string AuthRequiredMessage = "Authentication is required to access this resource.";
     internal const string AccessForbiddenMessage = "Access to this resource is forbidden.";
+
+    /// <summary>
+    /// Internal denial reason recorded when a metadata entity is hidden from the
+    /// request's tenant (#1580). Never surfaced to clients —
+    /// <see cref="CreateAccessDeniedResult"/> maps every forbidden decision to the
+    /// generic <see cref="AccessForbiddenMessage"/> so tenant ownership does not leak.
+    /// </summary>
+    internal const string TenantScopeDeniedReason = "Resource is outside the request tenant scope.";
+
     private static readonly ClaimsPrincipal AnonymousPrincipal = new(new ClaimsIdentity());
 
     /// <summary>
@@ -72,6 +81,11 @@ internal static class AccessPolicyHelpers
         AccessScope scope = AccessScope.Read)
     {
         ArgumentNullException.ThrowIfNull(resource);
+        if (!TenantScopeHelpers.IsTenantVisible(context, resource, service))
+        {
+            return StandardErrorHelpers.CreateForbidden(context, AccessForbiddenMessage);
+        }
+
         return RequireAccess(context, resource.AccessPolicy, service?.AccessPolicy, scope);
     }
 
@@ -126,6 +140,13 @@ internal static class AccessPolicyHelpers
     {
         ArgumentNullException.ThrowIfNull(resource);
 
+        // Tenant scope gates before grant evaluation (#1580): a per-operation grant
+        // must never authorize access to another tenant's resource.
+        if (!TenantScopeHelpers.IsTenantVisible(context, resource, service))
+        {
+            return StandardErrorHelpers.CreateForbidden(context, AccessForbiddenMessage);
+        }
+
         var serviceName = service?.Metadata.Name;
         if (!string.IsNullOrWhiteSpace(serviceName))
         {
@@ -167,6 +188,11 @@ internal static class AccessPolicyHelpers
     {
         ArgumentNullException.ThrowIfNull(service);
 
+        if (!TenantScopeHelpers.IsTenantVisible(context, resource: null, service))
+        {
+            return StandardErrorHelpers.CreateForbidden(context, AccessForbiddenMessage);
+        }
+
         var serviceName = service.Metadata.Name;
         if (!string.IsNullOrWhiteSpace(serviceName))
         {
@@ -207,6 +233,12 @@ internal static class AccessPolicyHelpers
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(resource);
+
+        // Tenant scope gates before grant evaluation (#1580).
+        if (!TenantScopeHelpers.IsTenantVisible(context, resource, service))
+        {
+            return AccessDecision.Forbidden(TenantScopeDeniedReason);
+        }
 
         var serviceName = service?.Metadata.Name;
         if (!string.IsNullOrWhiteSpace(serviceName))
@@ -339,6 +371,11 @@ internal static class AccessPolicyHelpers
         AccessScope scope = AccessScope.Read)
     {
         ArgumentNullException.ThrowIfNull(service);
+        if (!TenantScopeHelpers.IsTenantVisible(context, resource: null, service))
+        {
+            return StandardErrorHelpers.CreateForbidden(context, AccessForbiddenMessage);
+        }
+
         return RequireAccess(context, null, service.AccessPolicy, scope);
     }
 
@@ -347,9 +384,35 @@ internal static class AccessPolicyHelpers
         MetadataV2Resource resource,
         MetadataV2Service? service = null,
         AccessScope scope = AccessScope.Read)
+        => EvaluateResourceAccess(context, resource, service, scope).IsAllowed;
+
+    /// <summary>
+    /// Tenant-aware sibling of <see cref="EvaluateAccess"/> for callers that hold the
+    /// resolved <see cref="MetadataV2Resource"/>/<see cref="MetadataV2Service"/> pair
+    /// (#1580). Resources scoped to another tenant evaluate to a forbidden decision
+    /// before the coarse <see cref="AccessPolicy"/> seam runs, so enumeration surfaces
+    /// (collection lists, capability documents) hide foreign-tenant entries the same
+    /// way the per-item validators do. Prefer this over raw
+    /// <see cref="EvaluateAccess"/> whenever the metadata entities are available.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <param name="resource">The resource (layer) being accessed.</param>
+    /// <param name="service">The owning service, when known.</param>
+    /// <param name="scope">The requested access scope.</param>
+    /// <returns>The access decision.</returns>
+    public static AccessDecision EvaluateResourceAccess(
+        HttpContext context,
+        MetadataV2Resource resource,
+        MetadataV2Service? service = null,
+        AccessScope scope = AccessScope.Read)
     {
         ArgumentNullException.ThrowIfNull(resource);
-        return EvaluateAccess(context, resource.AccessPolicy, service?.AccessPolicy, scope).IsAllowed;
+        if (!TenantScopeHelpers.IsTenantVisible(context, resource, service))
+        {
+            return AccessDecision.Forbidden(TenantScopeDeniedReason);
+        }
+
+        return EvaluateAccess(context, resource.AccessPolicy, service?.AccessPolicy, scope);
     }
 
     /// <summary>
@@ -385,6 +448,11 @@ internal static class AccessPolicyHelpers
         AccessScope scope = AccessScope.Read)
     {
         ArgumentNullException.ThrowIfNull(resource);
+        if (!TenantScopeHelpers.IsTenantVisible(context, resource, service))
+        {
+            return false;
+        }
+
         var evaluator = context.RequestServices.GetRequiredService<IAccessPolicyEvaluator>();
         return evaluator.Evaluate(AnonymousPrincipal, resource.AccessPolicy, service?.AccessPolicy, scope).IsAllowed;
     }
@@ -395,6 +463,11 @@ internal static class AccessPolicyHelpers
         AccessScope scope = AccessScope.Read)
     {
         ArgumentNullException.ThrowIfNull(service);
+        if (!TenantScopeHelpers.IsTenantVisible(context, resource: null, service))
+        {
+            return false;
+        }
+
         var evaluator = context.RequestServices.GetRequiredService<IAccessPolicyEvaluator>();
         return evaluator.Evaluate(AnonymousPrincipal, null, service.AccessPolicy, scope).IsAllowed;
     }
@@ -411,7 +484,7 @@ internal static class AccessPolicyHelpers
 
         foreach (var resource in resources)
         {
-            var decision = EvaluateAccess(context, resource.AccessPolicy, service?.AccessPolicy, scope);
+            var decision = EvaluateResourceAccess(context, resource, service, scope);
             if (decision.IsAllowed)
             {
                 return null;

--- a/src/Honua.Hosting/Features/Authentication/TenantScopeHelpers.cs
+++ b/src/Honua.Hosting/Features/Authentication/TenantScopeHelpers.cs
@@ -24,7 +24,7 @@ internal static class TenantScopeHelpers
     /// <param name="context">The request context.</param>
     /// <returns>The resolved tenant id, or null.</returns>
     internal static string? ResolveRequestTenantId(HttpContext context)
-        => context.RequestServices.GetService<ITenantContext>()?.TenantId;
+        => context.RequestServices?.GetService<ITenantContext>()?.TenantId;
 
     /// <summary>
     /// Whether the (resource, service) pair is visible to the current request's tenant.

--- a/src/Honua.Hosting/Features/Authentication/TenantScopeHelpers.cs
+++ b/src/Honua.Hosting/Features/Authentication/TenantScopeHelpers.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.MultiTenancy.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Infrastructure.Authentication;
+
+/// <summary>
+/// HTTP-side bridge between the per-request <see cref="ITenantContext"/> rail
+/// (issue #1144) and the pure <see cref="MetadataV2TenantVisibility"/> rules
+/// (issue #1580). Shared metadata lookup and access-policy helpers consult these
+/// methods so tenant isolation is enforced in one place rather than per protocol.
+/// </summary>
+internal static class TenantScopeHelpers
+{
+    /// <summary>
+    /// Resolves the tenant id of the current request, or <see langword="null"/> when
+    /// no tenant context is registered or no tenant was resolved. A null result means
+    /// tenant-scoped metadata entities are not visible (fail closed); unscoped
+    /// entities remain visible.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <returns>The resolved tenant id, or null.</returns>
+    internal static string? ResolveRequestTenantId(HttpContext context)
+        => context.RequestServices.GetService<ITenantContext>()?.TenantId;
+
+    /// <summary>
+    /// Whether the (resource, service) pair is visible to the current request's tenant.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <param name="resource">The canonical resource, when resolved.</param>
+    /// <param name="service">The publishing service, when resolved.</param>
+    /// <returns><see langword="true"/> when visible.</returns>
+    internal static bool IsTenantVisible(
+        HttpContext context,
+        MetadataV2Resource? resource,
+        MetadataV2Service? service)
+    {
+        var tenantId = ResolveRequestTenantId(context);
+        return MetadataV2TenantVisibility.IsVisibleToTenant(resource, tenantId)
+            && MetadataV2TenantVisibility.IsVisibleToTenant(service, tenantId);
+    }
+
+    /// <summary>
+    /// Whether the published (publication, resource, service) triple is visible to the
+    /// current request's tenant.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <param name="publication">The publication being resolved.</param>
+    /// <param name="resource">The canonical resource, when resolved.</param>
+    /// <param name="service">The publishing service, when resolved.</param>
+    /// <returns><see langword="true"/> when visible.</returns>
+    internal static bool IsTenantVisible(
+        HttpContext context,
+        MetadataV2Publication publication,
+        MetadataV2Resource? resource,
+        MetadataV2Service? service)
+        => MetadataV2TenantVisibility.IsVisibleToTenant(
+            publication, resource, service, ResolveRequestTenantId(context));
+
+    /// <summary>
+    /// Whether a resolved publication/resource/service triple is visible to the current
+    /// request tenant.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <param name="publication">The publication being resolved.</param>
+    /// <param name="resource">The canonical resource backing the publication, when resolved.</param>
+    /// <param name="service">The service the publication is exposed through, when resolved.</param>
+    /// <returns><see langword="true"/> when visible.</returns>
+    internal static bool IsPublicationVisible(
+        HttpContext context,
+        MetadataV2Publication publication,
+        MetadataV2Resource? resource,
+        MetadataV2Service? service)
+        => IsTenantVisible(context, publication, resource, service);
+}

--- a/src/Honua.Hosting/Features/Caching/ResponseCacheUtilities.cs
+++ b/src/Honua.Hosting/Features/Caching/ResponseCacheUtilities.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Honua.Core.Features.Caching;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Queries.Filters;
+using Honua.Infrastructure.Authentication;
 using Microsoft.AspNetCore.Http;
 
 namespace Honua.Infrastructure.Caching;
@@ -138,6 +139,7 @@ internal static class ResponseCacheUtilities
         var canonicalQuery = BuildCanonicalQueryString(request.Query);
         var accept = request.Headers.Accept.ToString();
         var prefer = request.Headers["Prefer"].ToString();
+        var tenant = TenantScopeHelpers.ResolveRequestTenantId(request.HttpContext) ?? "<none>";
         var keyMaterial = string.Concat(
             request.Method, '|',
             request.Scheme, '|',
@@ -146,7 +148,8 @@ internal static class ResponseCacheUtilities
             request.Path.Value ?? string.Empty, '|',
             canonicalQuery, '|',
             accept, '|',
-            prefer);
+            prefer, '|',
+            tenant);
 
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(keyMaterial)))
             .ToLowerInvariant();

--- a/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
+++ b/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
@@ -122,7 +122,7 @@ internal static class LayerValidationHelpers
             : cancellationToken;
 
         var snapshot = await GetV2SnapshotAsync(context, effectiveToken).ConfigureAwait(false);
-        var (publication, resource, service) = ResolveV2Triple(snapshot, layerId, requiredProtocol);
+        var (publication, resource, service) = ResolveV2Triple(context, snapshot, layerId, requiredProtocol);
 
         if (publication is null || resource is null || IsRetired(publication) || IsRetired(resource))
         {
@@ -176,7 +176,7 @@ internal static class LayerValidationHelpers
         CancellationToken cancellationToken = default)
     {
         var snapshot = await GetV2SnapshotAsync(context, cancellationToken).ConfigureAwait(false);
-        var (publication, resource, service) = ResolveV2Triple(snapshot, layerId, requiredProtocol);
+        var (publication, resource, service) = ResolveV2Triple(context, snapshot, layerId, requiredProtocol);
 
         if (publication is null || resource is null || IsRetired(publication) || IsRetired(resource))
         {
@@ -258,10 +258,18 @@ internal static class LayerValidationHelpers
         // service enables every protocol, so without the publication-type preference the
         // first publication in document order wins — which routes feature reads to the
         // raster image binding and 500s.
+        bool IsTenantVisible(MetadataV2Publication p)
+        {
+            var matchedResource = snapshot.ResolveResource(p);
+            var matchedService = snapshot.Index.ServicesById.TryGetValue(p.ServiceId, out var s) ? s : null;
+            return TenantScopeHelpers.IsPublicationVisible(context, p, matchedResource, matchedService);
+        }
+
         if (!string.IsNullOrWhiteSpace(requiredProtocol))
         {
             var protocolMatches = snapshot.Graph.Publications.Where(p =>
                 MatchesCollectionId(p) &&
+                IsTenantVisible(p) &&
                 snapshot.Index.ServicesById.TryGetValue(p.ServiceId, out var s) &&
                 MetadataV2ServiceProtocols.IsProtocolEnabled(s, requiredProtocol));
             publication = protocolMatches
@@ -269,7 +277,7 @@ internal static class LayerValidationHelpers
                 .ThenByDescending(p => p.IsPrimary)
                 .FirstOrDefault();
         }
-        publication ??= snapshot.Graph.Publications.FirstOrDefault(MatchesCollectionId);
+        publication ??= snapshot.Graph.Publications.FirstOrDefault(p => MatchesCollectionId(p) && IsTenantVisible(p));
 
         if (publication is null || IsRetired(publication))
         {
@@ -285,6 +293,16 @@ internal static class LayerValidationHelpers
         var service = snapshot.Index.ServicesById.TryGetValue(publication.ServiceId, out var resolvedService)
             ? resolvedService
             : null;
+
+        if (!TenantScopeHelpers.IsPublicationVisible(context, publication, resource, service))
+        {
+            return new MetadataV2ValidationResult(
+                false,
+                null,
+                null,
+                null,
+                StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found."));
+        }
 
         if (resource is null || IsRetired(resource))
         {
@@ -355,7 +373,7 @@ internal static class LayerValidationHelpers
         CancellationToken cancellationToken = default)
     {
         var snapshot = await GetV2SnapshotAsync(context, cancellationToken).ConfigureAwait(false);
-        var (publication, resource, service) = ResolveV2Triple(snapshot, layerId, requiredProtocol);
+        var (publication, resource, service) = ResolveV2Triple(context, snapshot, layerId, requiredProtocol);
 
         if (publication is null || resource is null || IsRetired(publication) || IsRetired(resource))
         {
@@ -451,7 +469,7 @@ internal static class LayerValidationHelpers
         CancellationToken cancellationToken = default)
     {
         var snapshot = await GetV2SnapshotAsync(context, cancellationToken).ConfigureAwait(false);
-        var (_, _, service) = ResolveV2Triple(snapshot, layerId, requiredProtocol);
+        var (_, _, service) = ResolveV2Triple(context, snapshot, layerId, requiredProtocol);
         return service;
     }
 
@@ -489,6 +507,8 @@ internal static class LayerValidationHelpers
         {
             if (pub.LayerIndex != layerId) continue;
             if (!snapshot.Index.ServicesById.TryGetValue(pub.ServiceId, out var service)) continue;
+            var resource = snapshot.ResolveResource(pub);
+            if (!TenantScopeHelpers.IsPublicationVisible(context, pub, resource, service)) continue;
 
             if (!string.IsNullOrWhiteSpace(requiredProtocol) &&
                 !MetadataV2ServiceProtocols.IsProtocolEnabled(service, requiredProtocol))
@@ -550,6 +570,7 @@ internal static class LayerValidationHelpers
 
     private static (MetadataV2Publication? Publication, MetadataV2Resource? Resource, MetadataV2Service? Service)
         ResolveV2Triple(
+            HttpContext context,
             MetadataV2GraphSnapshot snapshot,
             int layerId,
             string? requiredProtocol)
@@ -561,6 +582,14 @@ internal static class LayerValidationHelpers
         //   4. lexicographically earliest by service name
         var candidatePublications = snapshot.Graph.Publications
             .Where(p => p.LayerIndex == layerId)
+            .Where(p =>
+            {
+                var resource = snapshot.ResolveResource(p);
+                var service = snapshot.Index.ServicesById.TryGetValue(p.ServiceId, out var resolvedService)
+                    ? resolvedService
+                    : null;
+                return TenantScopeHelpers.IsPublicationVisible(context, p, resource, service);
+            })
             .ToList();
 
         if (!string.IsNullOrWhiteSpace(requiredProtocol))
@@ -575,7 +604,9 @@ internal static class LayerValidationHelpers
             if (preferred is not null)
             {
                 var preferredResource = snapshot.ResolveResource(preferred);
-                var preferredService = snapshot.Index.ServicesById[preferred.ServiceId];
+                var preferredService = snapshot.Index.ServicesById.TryGetValue(preferred.ServiceId, out var resolvedPreferredService)
+                    ? resolvedPreferredService
+                    : null;
                 return (preferred, preferredResource, preferredService);
             }
         }
@@ -696,6 +727,13 @@ internal static class LayerValidationHelpers
             if (pubResource is null) continue;
             if (string.Equals(pubResource.Metadata.Id, validation.Resource.Metadata.Id, StringComparison.OrdinalIgnoreCase))
             {
+                var pubService = snapshot.Index.ServicesById.TryGetValue(pub.ServiceId, out var resolvedPubService)
+                    ? resolvedPubService
+                    : null;
+                if (!TenantScopeHelpers.IsPublicationVisible(context, pub, pubResource, pubService))
+                {
+                    continue;
+                }
                 canonical = pub;
                 break;
             }
@@ -814,7 +852,7 @@ internal static class LayerValidationHelpers
         }
         service ??= snapshot.Index.ServicesByName.TryGetValue(serviceName, out var s) ? s : null;
 
-        if (service is null)
+        if (service is null || !TenantScopeHelpers.IsTenantVisible(context, resource: null, service))
         {
             return new MetadataV2ServiceValidationResult(
                 false, null, [], [],
@@ -838,6 +876,7 @@ internal static class LayerValidationHelpers
         }
 
         var publications = snapshot.PublicationsForService(service.Metadata.Id);
+        var visiblePublications = new List<MetadataV2Publication>(publications.Count);
         var resources = new List<MetadataV2Resource>(publications.Count);
         foreach (var pub in publications)
         {
@@ -846,15 +885,20 @@ internal static class LayerValidationHelpers
             {
                 continue;
             }
+            if (!TenantScopeHelpers.IsPublicationVisible(context, pub, resource, service))
+            {
+                continue;
+            }
             // Drop resources the caller can't read; capability documents normally hide them.
             if (!AccessPolicyHelpers.IsResourceAccessible(context, resource, service, scope))
             {
                 continue;
             }
+            visiblePublications.Add(pub);
             resources.Add(resource);
         }
 
-        return new MetadataV2ServiceValidationResult(true, service, publications, resources, null);
+        return new MetadataV2ServiceValidationResult(true, service, visiblePublications, resources, null);
     }
 }
 

--- a/src/Honua.Protocols.OgcApi/Features/CollectionsEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Features/CollectionsEndpoints.cs
@@ -148,6 +148,10 @@ internal static class CollectionsEndpoints
                 {
                     continue;
                 }
+                if (!TenantScopeHelpers.IsPublicationVisible(context, publication, resource, service))
+                {
+                    continue;
+                }
                 canonicalByResource[resource.Metadata.Id] = (publication, service);
             }
 
@@ -164,6 +168,10 @@ internal static class CollectionsEndpoints
                 }
                 var resource = snapshot.ResolveResource(publication);
                 if (resource is null)
+                {
+                    continue;
+                }
+                if (!TenantScopeHelpers.IsPublicationVisible(context, publication, resource, service))
                 {
                     continue;
                 }

--- a/src/Honua.Protocols.OgcApi/Tiles/CollectionsEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Tiles/CollectionsEndpoints.cs
@@ -97,11 +97,12 @@ internal static class CollectionsEndpoints
                 {
                     continue;
                 }
+                if (!TenantScopeHelpers.IsPublicationVisible(context, publication, resource, service))
+                {
+                    continue;
+                }
 
-                var decision = AccessPolicyHelpers.EvaluateAccess(
-                    context,
-                    resource.AccessPolicy,
-                    service.AccessPolicy);
+                var decision = AccessPolicyHelpers.EvaluateResourceAccess(context, resource, service);
 
                 if (decision.IsAllowed)
                 {

--- a/src/Honua.Protocols.OgcApi/Tiles/TilesEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Tiles/TilesEndpoints.cs
@@ -1090,6 +1090,10 @@ internal static partial class TilesEndpoints
                 {
                     continue;
                 }
+                if (!TenantScopeHelpers.IsPublicationVisible(context, publication, resource, service))
+                {
+                    continue;
+                }
 
                 var decision = AccessPolicyHelpers.EvaluateAccess(
                     context,
@@ -1207,10 +1211,10 @@ internal static partial class TilesEndpoints
         bool missingCollectionIsBadRequest,
         CancellationToken cancellationToken)
     {
-        var publication = FindCollectionPublication(snapshot, collectionId, requireProtocol: true, out var service);
+        var publication = FindCollectionPublication(context, snapshot, collectionId, requireProtocol: true, out var service);
         if (publication is null || service is null)
         {
-            var existsWithoutProtocol = FindCollectionPublication(snapshot, collectionId, requireProtocol: false, out _) is not null;
+            var existsWithoutProtocol = FindCollectionPublication(context, snapshot, collectionId, requireProtocol: false, out _) is not null;
             var error = existsWithoutProtocol || !missingCollectionIsBadRequest
                 ? StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.")
                 : StandardErrorHelpers.CreateBadRequest(context, $"Collection '{collectionId}' not found.");
@@ -1249,6 +1253,7 @@ internal static partial class TilesEndpoints
     }
 
     private static MetadataV2Publication? FindCollectionPublication(
+        HttpContext context,
         MetadataV2GraphSnapshot snapshot,
         string collectionId,
         bool requireProtocol,
@@ -1269,6 +1274,12 @@ internal static partial class TilesEndpoints
 
             if (requireProtocol &&
                 !MetadataV2ServiceProtocols.IsProtocolEnabled(candidateService, OgcApiTilesProtocol))
+            {
+                continue;
+            }
+
+            var resource = snapshot.ResolveResource(publication);
+            if (!TenantScopeHelpers.IsPublicationVisible(context, publication, resource, candidateService))
             {
                 continue;
             }

--- a/src/Honua.Protocols.Stac/Services/StacV2Lookups.cs
+++ b/src/Honua.Protocols.Stac/Services/StacV2Lookups.cs
@@ -84,6 +84,11 @@ internal static class StacV2Lookups
                 continue;
             }
 
+            if (!TenantScopeHelpers.IsPublicationVisible(context, pub, resource, service))
+            {
+                continue;
+            }
+
             if (!AccessPolicyHelpers.IsResourceAccessible(context, resource, service))
             {
                 continue;
@@ -152,6 +157,11 @@ internal static class StacV2Lookups
 
             var resource = snapshot.ResolveResource(pub);
             if (resource is null)
+            {
+                continue;
+            }
+
+            if (!TenantScopeHelpers.IsPublicationVisible(context, pub, resource, service))
             {
                 continue;
             }

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using System.IO.Compression;
 using Honua.Core.Features.Infrastructure.Monitoring;
 using Honua.Core.Features.Observability.Abstractions;
+using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Caching;
 using Honua.Infrastructure.Compression;
 using Honua.Infrastructure.Models;
@@ -77,6 +78,7 @@ internal static class ObservabilityServiceCollectionExtensions
             {
                 policy.AddPolicy<RouteTagOutputCachePolicy>();
                 policy.AddPolicy<AnonymousOnlyOutputCachePolicy>();
+                policy.VaryByValue(static context => ResolveTenantOutputCacheKey(context));
             });
 
             // Service metadata caching policy
@@ -554,6 +556,9 @@ internal static class ObservabilityServiceCollectionExtensions
             });
         }
     }
+
+    private static KeyValuePair<string, string> ResolveTenantOutputCacheKey(HttpContext context)
+        => new("tenant", TenantScopeHelpers.ResolveRequestTenantId(context) ?? "<none>");
 
     // Configure response compression for GeoJSON and JSON responses
     private static void ConfigureResponseCompression(IServiceCollection services)


### PR DESCRIPTION
Closes #1580

## Summary

Adds tenant-scoped metadata resolution so OGC API (Features/Tiles) and STAC surfaces honor per-tenant visibility when resolving collections and layers. Tenant scope is evaluated through shared access-policy helpers rather than per-protocol logic.

## Changes Made

- Add `MetadataV2TenantVisibility` domain model and `TenantScopeHelpers` for shared tenant-scope evaluation
- Extend `AccessPolicyHelpers` and `LayerValidationHelpers` to apply tenant visibility filtering
- Wire tenant-scoped resolution into OGC API Features/Tiles `CollectionsEndpoints`, `TilesEndpoints`, and STAC `StacV2Lookups`
- Vary response cache keys by tenant scope in `ResponseCacheUtilities`
- Add tenant identifiers to observability enrichment

## Breaking Changes

None.

## Gate Impact

- [x] No gate-tier changes (additive metadata resolution; shared pipeline reused)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
