### PR TITLE
fix: harden residual Phase 1 security threat-model risks (#1576)

### DIFF
--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -457,6 +457,8 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             throw new GeoprocessingNotFoundException($"Job '{jobId}' not found.");
         }
 
+        EnsureJobOwnership(job, principal);
+
         GeoprocessingServiceLog.JobRetrieved(_logger, jobId, job.Status.ToString());
         return job;
     }
@@ -484,6 +486,8 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             GeoprocessingServiceLog.JobNotFound(_logger, jobId);
             throw new GeoprocessingNotFoundException($"Job '{jobId}' not found.");
         }
+
+        EnsureJobOwnership(job, principal);
 
         if (!IsTerminal(job.Status))
         {
@@ -558,6 +562,8 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             GeoprocessingServiceLog.JobNotFound(_logger, jobId);
             throw new GeoprocessingNotFoundException($"Job '{jobId}' not found.");
         }
+
+        EnsureJobOwnership(job, principal);
 
         if (job.Status == ExecutionJobStatus.Cancelled)
         {
@@ -781,6 +787,40 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
 
         GeoprocessingServiceLog.AuthorizationDenied(_logger, resourceType.ToString(), operation.ToString());
         throw new GeoprocessingAuthorizationException(decision.RequiresAuthentication);
+    }
+
+    /// <summary>
+    /// Enforces that job state, results, and cancellation are scoped to the
+    /// principal that submitted the job (threat-model residual #1576). A coarse
+    /// <c>Job</c>-level grant authorizes the operation class; this check pins the
+    /// specific record to its submitter so one authenticated user cannot read or
+    /// cancel another user's jobs. Jobs without a recorded submitter (deployments
+    /// running with authentication disabled record no identity) keep the previous
+    /// behavior, and the conventional <c>admin</c> role retains full visibility
+    /// for operations. Denials surface as not-found so cross-principal probing
+    /// cannot confirm that a job identifier exists.
+    /// </summary>
+    private void EnsureJobOwnership(ExecutionJobRecord job, ClaimsPrincipal principal)
+    {
+        var owner = job.Audit.RequestedBy;
+        if (string.IsNullOrWhiteSpace(owner))
+        {
+            return;
+        }
+
+        var caller = principal.Identity?.Name;
+        if (string.Equals(owner, caller, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (principal.IsInRole("admin"))
+        {
+            return;
+        }
+
+        GeoprocessingServiceLog.JobOwnershipDenied(_logger, job.OperationId);
+        throw new GeoprocessingNotFoundException($"Job '{job.OperationId}' not found.");
     }
 
     private void EnsureApproved(ClaimsPrincipal principal, AnalysisPlan plan)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceLog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceLog.cs
@@ -171,4 +171,9 @@ internal static partial class GeoprocessingServiceLog
         string outcome,
         string dimension,
         string policyRef);
+
+    [LoggerMessage(8029, LogLevel.Warning, "Job access denied: JobId={JobId} was requested by a different principal")]
+    public static partial void JobOwnershipDenied(
+        ILogger logger,
+        string jobId);
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -477,6 +477,124 @@ public sealed class GeoprocessingJobServiceTests
         await act.Should().ThrowAsync<GeoprocessingValidationException>();
     }
 
+    // -----------------------------------------------------------------------
+    // Job ownership scoping (#1576): a coarse Job-level grant must not expose
+    // another principal's job state, results, or cancellation.
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}")]
+    public async Task GetJob_SubmittedByAnotherPrincipal_ThrowsNotFound()
+    {
+        var record = CreateOwnedJobRecord("job-1", ExecutionJobStatus.Running, owner: "other-user");
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+
+        var act = async () => await _sut.GetJobAsync("job-1", CreatePrincipal());
+
+        // Not-found rather than forbidden so cross-principal probing cannot
+        // confirm that the job identifier exists.
+        await act.Should().ThrowAsync<GeoprocessingNotFoundException>();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}")]
+    public async Task GetJob_SubmittedByCaller_ReturnsRecord()
+    {
+        var record = CreateOwnedJobRecord("job-1", ExecutionJobStatus.Running, owner: "test-user");
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+
+        var result = await _sut.GetJobAsync("job-1", CreatePrincipal());
+
+        result.OperationId.Should().Be("job-1");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}")]
+    public async Task GetJob_SubmittedByAnotherPrincipal_AdminRoleCanRead()
+    {
+        var record = CreateOwnedJobRecord("job-1", ExecutionJobStatus.Running, owner: "other-user");
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+
+        var admin = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.Name, "ops-admin"), new Claim(ClaimTypes.Role, "admin")], "Test"));
+
+        var result = await _sut.GetJobAsync("job-1", admin);
+
+        result.OperationId.Should().Be("job-1");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}")]
+    public async Task GetJob_WithoutRecordedSubmitter_RemainsAccessible()
+    {
+        // Jobs submitted while authentication is disabled record no owner and
+        // keep the coarse Job-grant behavior.
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Running);
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+
+        var result = await _sut.GetJobAsync("job-1", CreatePrincipal());
+
+        result.OperationId.Should().Be("job-1");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/GetJobResult")]
+    public async Task GetJobResults_SubmittedByAnotherPrincipal_ThrowsNotFound()
+    {
+        var record = CreateOwnedJobRecord("job-1", ExecutionJobStatus.Succeeded, owner: "other-user");
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+
+        var act = async () => await _sut.GetJobResultsAsync("job-1", CreatePrincipal());
+
+        await act.Should().ThrowAsync<GeoprocessingNotFoundException>();
+        await _resultPackageStore.DidNotReceive().GetAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/GetJobResult")]
+    public async Task GetJobResults_SubmittedByCaller_ReturnsPackage()
+    {
+        var record = CreateOwnedJobRecord("job-1", ExecutionJobStatus.Succeeded, owner: "test-user");
+        var package = AnalysisResultPackage.CreateCompleted(
+            GeoprocessingResultPackageFactory.CreateResultPackageId(record),
+            new ResultSummary { Title = "Owned result" },
+            [],
+            [],
+            new ProvenanceRecord
+            {
+                Sources = [],
+                ProcessDefinitions = ["geometry.buffer"]
+            });
+
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+        _resultPackageStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(package);
+
+        var result = await _sut.GetJobResultsAsync("job-1", CreatePrincipal());
+
+        result.Should().BeSameAs(package);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_SubmittedByAnotherPrincipal_ThrowsNotFound()
+    {
+        var record = CreateOwnedJobRecord("job-1", ExecutionJobStatus.Running, owner: "other-user");
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+
+        var act = async () => await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await act.Should().ThrowAsync<GeoprocessingNotFoundException>();
+        _cancellationNotifier.DidNotReceive().Cancel(Arg.Any<string>());
+    }
+
     [UnitTest]
     [Operation(Operations.Query)]
     [Endpoint("POST /geospatial.v1.ProcessService/GetJobResult")]
@@ -2325,6 +2443,15 @@ public sealed class GeoprocessingJobServiceTests
                 Backend = backend,
                 WorkloadName = "test-workload"
             }
+        };
+
+    private static ExecutionJobRecord CreateOwnedJobRecord(
+        string jobId,
+        ExecutionJobStatus status,
+        string owner)
+        => CreateJobRecord(jobId, status) with
+        {
+            Audit = new OperationAuditInfo { RequestedBy = owner }
         };
 
     private static ClaimsPrincipal CreatePrincipal()

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Events/PinnedDnsHandlerSsrfTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Events/PinnedDnsHandlerSsrfTests.cs
@@ -22,9 +22,9 @@ namespace Honua.Server.Tests.Features.Infrastructure.Events;
 [Protocol(TestProtocols.TestQuality)]
 public sealed class PinnedDnsHandlerSsrfTests
 {
-    [UnitTest]
-    [Operation(Operations.TestInfrastructure)]
     [Theory]
+    [Trait("Category", "Unit")]
+    [Operation(Operations.TestInfrastructure)]
     [InlineData("http://169.254.169.254/latest/meta-data/")] // AWS/cloud metadata endpoint
     [InlineData("http://10.0.0.5/internal")] // RFC1918 private
     [InlineData("http://172.16.0.1/")] // RFC1918 private
@@ -46,7 +46,6 @@ public sealed class PinnedDnsHandlerSsrfTests
 
     [UnitTest]
     [Operation(Operations.TestInfrastructure)]
-    [Fact]
     public async Task PinnedDnsHandler_HostResolvingToCloudMetadataAddress_RejectsBeforeConnect()
     {
         // DNS-rebinding shape: a benign-looking host name resolves to the cloud
@@ -62,7 +61,6 @@ public sealed class PinnedDnsHandlerSsrfTests
 
     [UnitTest]
     [Operation(Operations.TestInfrastructure)]
-    [Fact]
     public async Task PinnedDnsHandler_HostResolvingToMixedPublicAndPrivateAddresses_RejectsBeforeConnect()
     {
         // A single private address in the answer set poisons the whole
@@ -82,7 +80,6 @@ public sealed class PinnedDnsHandlerSsrfTests
 
     [UnitTest]
     [Operation(Operations.TestInfrastructure)]
-    [Fact]
     public async Task PinnedDnsHandler_HostWithEmptyResolution_RejectsBeforeConnect()
     {
         using var client = CreateClient(WebhookDeliveryHelper.CreatePinnedDnsHttpMessageHandler(
@@ -96,7 +93,6 @@ public sealed class PinnedDnsHandlerSsrfTests
 
     [UnitTest]
     [Operation(Operations.TestInfrastructure)]
-    [Fact]
     public async Task ImportHttpClientHandler_LiteralCloudMetadataAddress_RejectsBeforeConnect()
     {
         // The import-from-URL surface delegates to the same pinned-DNS handler;

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Events/PinnedDnsHandlerSsrfTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Events/PinnedDnsHandlerSsrfTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http;
+using Honua.Infrastructure.Events;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using ImportHttpClientHelper = Honua.Import.FileImport.ImportHttpClientHelper;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Events;
+
+/// <summary>
+/// Connect-time SSRF coverage for the shared pinned-DNS outbound handler
+/// (threat-model residual #1576). The handler backs webhook delivery and the
+/// import-from-URL surfaces; these tests prove that requests targeting
+/// private, loopback, link-local, and cloud-metadata addresses are rejected
+/// before any socket connection is attempted — for both literal IP targets
+/// and host names whose DNS resolution lands in a blocked range
+/// (DNS-rebinding defense).
+/// </summary>
+[Protocol(TestProtocols.TestQuality)]
+public sealed class PinnedDnsHandlerSsrfTests
+{
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    [Theory]
+    [InlineData("http://169.254.169.254/latest/meta-data/")] // AWS/cloud metadata endpoint
+    [InlineData("http://10.0.0.5/internal")] // RFC1918 private
+    [InlineData("http://172.16.0.1/")] // RFC1918 private
+    [InlineData("http://192.168.1.10/router")] // RFC1918 private
+    [InlineData("http://127.0.0.1/admin")] // loopback
+    [InlineData("http://100.64.0.1/")] // CGNAT (RFC 6598)
+    [InlineData("http://[fe80::1]/")] // IPv6 link-local
+    [InlineData("http://[::1]/")] // IPv6 loopback
+    public async Task PinnedDnsHandler_LiteralBlockedAddress_RejectsBeforeConnect(string url)
+    {
+        using var client = CreateClient(WebhookDeliveryHelper.CreatePinnedDnsHttpMessageHandler(
+            hostAddressResolver: (_, _) => throw new InvalidOperationException(
+                "Literal IP targets must not trigger DNS resolution.")));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
+
+        AssertBlockedAddress(exception);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    [Fact]
+    public async Task PinnedDnsHandler_HostResolvingToCloudMetadataAddress_RejectsBeforeConnect()
+    {
+        // DNS-rebinding shape: a benign-looking host name resolves to the cloud
+        // metadata endpoint. The pinned resolver result must be validated.
+        using var client = CreateClient(WebhookDeliveryHelper.CreatePinnedDnsHttpMessageHandler(
+            hostAddressResolver: (_, _) => Task.FromResult(new[] { IPAddress.Parse("169.254.169.254") })));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetAsync("https://metadata.attacker.example/latest/meta-data/"));
+
+        AssertBlockedAddress(exception);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    [Fact]
+    public async Task PinnedDnsHandler_HostResolvingToMixedPublicAndPrivateAddresses_RejectsBeforeConnect()
+    {
+        // A single private address in the answer set poisons the whole
+        // resolution: the handler must not fall back to the public address.
+        using var client = CreateClient(WebhookDeliveryHelper.CreatePinnedDnsHttpMessageHandler(
+            hostAddressResolver: (_, _) => Task.FromResult(new[]
+            {
+                IPAddress.Parse("93.184.216.34"),
+                IPAddress.Parse("10.0.0.5")
+            })));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetAsync("https://rebind.attacker.example/payload"));
+
+        AssertBlockedAddress(exception);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    [Fact]
+    public async Task PinnedDnsHandler_HostWithEmptyResolution_RejectsBeforeConnect()
+    {
+        using var client = CreateClient(WebhookDeliveryHelper.CreatePinnedDnsHttpMessageHandler(
+            hostAddressResolver: (_, _) => Task.FromResult(Array.Empty<IPAddress>())));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetAsync("https://unresolvable.example/"));
+
+        AssertBlockedAddress(exception);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    [Fact]
+    public async Task ImportHttpClientHandler_LiteralCloudMetadataAddress_RejectsBeforeConnect()
+    {
+        // The import-from-URL surface delegates to the same pinned-DNS handler;
+        // prove the wiring blocks the metadata endpoint end to end.
+        using var client = CreateClient(ImportHttpClientHelper.CreatePinnedDnsHttpMessageHandler());
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetAsync("http://169.254.169.254/latest/meta-data/iam/"));
+
+        AssertBlockedAddress(exception);
+    }
+
+    private static HttpClient CreateClient(HttpMessageHandler handler)
+        => new(handler, disposeHandler: true)
+        {
+            Timeout = TimeSpan.FromSeconds(10)
+        };
+
+    private static void AssertBlockedAddress(HttpRequestException exception)
+    {
+        var messages = $"{exception.Message} {exception.InnerException?.Message}";
+        Assert.Contains(
+            FeatureChangeWebhookUrlValidation.DisallowedAddressMessage,
+            messages,
+            StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Closes #1576

## Summary

Hardens residual risks identified by the Phase 1 security threat models: adds SSRF defense-in-depth coverage for the pinned-DNS handler and tightens geoprocessing job-service validation. Pins MessagePack via direct references and aligns SSRF test fact attributes.

## Changes Made

- Harden `GeoprocessingJobService` validation paths and add structured `GeoprocessingServiceLog` events
- Add `PinnedDnsHandlerSsrfTests` covering SSRF rebinding/redirect vectors against the pinned-DNS handler
- Add `GeoprocessingJobServiceTests` for the hardened validation behavior
- Pin MessagePack via direct package references and align SSRF test fact attributes

## Breaking Changes

None.

## Gate Impact

- [x] No gate-tier changes (security hardening + tests; shared pipelines reused)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

## Type of Change

- [x] Security hardening / bug fix (non-breaking)
