### PR TITLE
feat: serve registered Zarr/HDF5/NetCDF multidim coverages (#1590)

### DIFF
--- a/src/Honua.Core/Features/Raster/ZarrParser/ZarrCoverageSubsetPlanner.cs
+++ b/src/Honua.Core/Features/Raster/ZarrParser/ZarrCoverageSubsetPlanner.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Raster.Domain;
+
+namespace Honua.Core.Features.Raster.ZarrParser;
+
+/// <summary>
+/// One named-dimension subset over a Zarr array expressed as grid indices:
+/// inclusive <paramref name="Start"/>, exclusive <paramref name="Stop"/>.
+/// </summary>
+/// <param name="Dimension">Dimension name as discovered in the store metadata.</param>
+/// <param name="Start">Inclusive start index.</param>
+/// <param name="Stop">Exclusive stop index.</param>
+public sealed record ZarrCoverageDimensionSubset(string Dimension, int Start, int Stop);
+
+/// <summary>
+/// Validated plan for one bounded Zarr coverage read: the resolved array and
+/// the per-dimension subset request ready for <see cref="Abstractions.IZarrSubsetReader"/>.
+/// </summary>
+/// <param name="Array">Array (variable) metadata the plan targets.</param>
+/// <param name="Request">Bounded subset request covering every dimension of the array.</param>
+public sealed record ZarrCoverageSubsetPlan(ZarrArrayMetadata Array, ZarrSubsetRequest Request);
+
+/// <summary>
+/// Translates protocol-level coverage subset requests (named dimensions, grid
+/// indices) into bounded <see cref="ZarrSubsetRequest"/> reads. Shared by every
+/// protocol adapter that serves registered Zarr stores so variable selection,
+/// dimension matching, bounds validation, and output-size limits stay consistent.
+/// </summary>
+public static class ZarrCoverageSubsetPlanner
+{
+    /// <summary>
+    /// Attempts to build a bounded subset plan for one variable of a Zarr store.
+    /// Dimensions without an explicit subset default to their full index range.
+    /// </summary>
+    /// <param name="metadata">Scanned store metadata.</param>
+    /// <param name="variable">Variable name, or null to use the store's primary variable.</param>
+    /// <param name="subsets">Named-dimension subsets; may be empty.</param>
+    /// <param name="maxOutputBytes">Upper bound for the raw decoded subset payload.</param>
+    /// <param name="plan">Validated plan when the method returns true.</param>
+    /// <param name="error">Client-safe validation error when the method returns false.</param>
+    /// <returns>True when the request is valid and within limits.</returns>
+    public static bool TryPlan(
+        ZarrStoreMetadata metadata,
+        string? variable,
+        IReadOnlyList<ZarrCoverageDimensionSubset> subsets,
+        long maxOutputBytes,
+        out ZarrCoverageSubsetPlan? plan,
+        out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+        ArgumentNullException.ThrowIfNull(subsets);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxOutputBytes);
+
+        plan = null;
+        error = null;
+
+        if (metadata.Arrays.Length == 0)
+        {
+            error = "The Zarr store does not expose any variables.";
+            return false;
+        }
+
+        var resolvedVariable = string.IsNullOrWhiteSpace(variable)
+            ? metadata.PrimaryVariable ?? metadata.Arrays[0].Name
+            : variable;
+
+        ZarrArrayMetadata? array = null;
+        foreach (var candidate in metadata.Arrays)
+        {
+            if (string.Equals(candidate.Name, resolvedVariable, StringComparison.Ordinal))
+            {
+                array = candidate;
+                break;
+            }
+        }
+
+        if (array is null)
+        {
+            error = $"Variable '{resolvedVariable}' is not available. Available variables: {JoinNames(metadata.Arrays)}.";
+            return false;
+        }
+
+        var rank = array.Shape.Length;
+        var start = new int[rank];
+        var stop = new int[rank];
+        for (var i = 0; i < rank; i++)
+        {
+            start[i] = 0;
+            stop[i] = array.Shape[i];
+        }
+
+        var seen = new HashSet<int>();
+        foreach (var subset in subsets)
+        {
+            var dimensionIndex = FindDimension(array, subset.Dimension);
+            if (dimensionIndex < 0)
+            {
+                error = $"Unknown subset dimension '{subset.Dimension}'. Available dimensions: {string.Join(", ", array.DimensionNames)}.";
+                return false;
+            }
+
+            if (!seen.Add(dimensionIndex))
+            {
+                error = $"Subset dimension '{subset.Dimension}' was specified more than once.";
+                return false;
+            }
+
+            if (subset.Start < 0 || subset.Stop <= subset.Start || subset.Stop > array.Shape[dimensionIndex])
+            {
+                error = string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"Subset bounds for dimension '{subset.Dimension}' must satisfy 0 <= low <= high < {array.Shape[dimensionIndex]}.");
+                return false;
+            }
+
+            start[dimensionIndex] = subset.Start;
+            stop[dimensionIndex] = subset.Stop;
+        }
+
+        int elementSize;
+        try
+        {
+            elementSize = ZarrSubsetReader.ResolveElementSize(array.DataType);
+        }
+        catch (Exception ex) when (ex is InvalidDataException or InvalidOperationException)
+        {
+            error = $"Variable '{array.Name}' uses a data type that is not supported for coverage output.";
+            return false;
+        }
+
+        var totalBytes = (long)elementSize;
+        for (var i = 0; i < rank; i++)
+        {
+            totalBytes = checked(totalBytes * (stop[i] - start[i]));
+        }
+
+        if (totalBytes > maxOutputBytes)
+        {
+            error = string.Create(
+                CultureInfo.InvariantCulture,
+                $"The requested subset decodes to {totalBytes:N0} bytes, exceeding the {maxOutputBytes:N0} byte limit. Add or tighten subset bounds.");
+            return false;
+        }
+
+        plan = new ZarrCoverageSubsetPlan(array, new ZarrSubsetRequest
+        {
+            Variable = array.Name,
+            Start = start,
+            Stop = stop
+        });
+        return true;
+    }
+
+    private static int FindDimension(ZarrArrayMetadata array, string dimension)
+    {
+        for (var i = 0; i < array.DimensionNames.Length; i++)
+        {
+            if (string.Equals(array.DimensionNames[i], dimension, StringComparison.OrdinalIgnoreCase))
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static string JoinNames(ZarrArrayMetadata[] arrays)
+    {
+        var names = new string[arrays.Length];
+        for (var i = 0; i < arrays.Length; i++)
+        {
+            names[i] = arrays[i].Name;
+        }
+        return string.Join(", ", names);
+    }
+}

--- a/src/Honua.Core/Features/Raster/ZarrParser/ZarrSubsetReader.cs
+++ b/src/Honua.Core/Features/Raster/ZarrParser/ZarrSubsetReader.cs
@@ -156,7 +156,11 @@ public sealed class ZarrSubsetReader : IZarrSubsetReader
             $"Zarr compressor '{compressor}' is not supported by the MVP reader. Use uncompressed or zlib chunks.");
     }
 
-    private static int ResolveElementSize(string dtype)
+    /// <summary>
+    /// Resolves the element size in bytes for a numpy-style dtype string
+    /// (e.g. <c>&lt;f4</c>). Rejects big-endian and non-numeric dtypes.
+    /// </summary>
+    internal static int ResolveElementSize(string dtype)
     {
         var span = dtype.AsSpan();
         if (span.IsEmpty)

--- a/src/Honua.Protocols.OgcApi/Coverages/Handlers/OgcCoveragesHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Coverages/Handlers/OgcCoveragesHandler.cs
@@ -67,6 +67,7 @@ internal sealed class OgcCoveragesHandler
     private readonly IRasterStore _rasterStore;
     private readonly ICoordinateTransformService _coordinateTransformService;
     private readonly ICrsRegistry _crsRegistry;
+    private readonly Services.ZarrCoverageService _zarrCoverages;
     private readonly ILogger<OgcCoveragesHandler> _logger;
 
     public OgcCoveragesHandler(
@@ -79,6 +80,7 @@ internal sealed class OgcCoveragesHandler
         _rasterStore = dependencies.RasterStore;
         _coordinateTransformService = dependencies.CoordinateTransformService;
         _crsRegistry = dependencies.CrsRegistry;
+        _zarrCoverages = dependencies.ZarrCoverages;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -270,7 +272,10 @@ internal sealed class OgcCoveragesHandler
                     var raster = await GetPrimaryRasterWithExtentAsync(storageLayerId.Value, ct).ConfigureAwait(false);
                     if (raster is null)
                     {
-                        return null;
+                        var zarr = await _zarrCoverages.FindServableRegistrationAsync(storageLayerId.Value, ct).ConfigureAwait(false);
+                        return zarr is null
+                            ? null
+                            : _zarrCoverages.CreateCollection(entry.Resource, storageLayerId.Value, zarr, baseUrl);
                     }
                     return await CreateCollectionAsync(entry.Resource, entry.Service, storageLayerId.Value, raster.Value, baseUrl, ct)
                         .ConfigureAwait(false);
@@ -551,7 +556,7 @@ internal sealed class OgcCoveragesHandler
             .ConfigureAwait(false);
         if (!validation.IsValid)
         {
-            return new CoverageResolution(null, null, null, null, validation.ErrorResult);
+            return new CoverageResolution(null, null, null, null, null, validation.ErrorResult);
         }
 
         var resource = validation.Resource!;
@@ -566,13 +571,21 @@ internal sealed class OgcCoveragesHandler
                 null,
                 null,
                 null,
+                null,
                 StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' does not expose a raster coverage."));
         }
 
         var raster = await GetPrimaryRasterWithExtentAsync(storageLayerId.Value, cancellationToken).ConfigureAwait(false);
         if (raster is null)
         {
+            var zarr = await _zarrCoverages.FindServableRegistrationAsync(storageLayerId.Value, cancellationToken).ConfigureAwait(false);
+            if (zarr is not null)
+            {
+                return new CoverageResolution(resource, service, storageLayerId.Value, null, zarr, null);
+            }
+
             return new CoverageResolution(
+                null,
                 null,
                 null,
                 null,
@@ -580,7 +593,7 @@ internal sealed class OgcCoveragesHandler
                 StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' does not expose a raster coverage."));
         }
 
-        return new CoverageResolution(resource, service, storageLayerId.Value, raster.Value, null);
+        return new CoverageResolution(resource, service, storageLayerId.Value, raster.Value, null, null);
     }
 
     private async Task<RasterInfo?> GetPrimaryRasterWithExtentAsync(int layerId, CancellationToken cancellationToken)
@@ -1770,5 +1783,6 @@ internal sealed class OgcCoveragesHandler
         MetadataV2Service? Service,
         int? StorageLayerId,
         RasterInfo? Raster,
+        ZarrRegistration? ZarrRegistration,
         IResult? Error);
 }

--- a/src/Honua.Protocols.OgcApi/Coverages/Handlers/OgcCoveragesHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Coverages/Handlers/OgcCoveragesHandler.cs
@@ -275,7 +275,7 @@ internal sealed class OgcCoveragesHandler
                         var zarr = await _zarrCoverages.FindServableRegistrationAsync(storageLayerId.Value, ct).ConfigureAwait(false);
                         return zarr is null
                             ? null
-                            : _zarrCoverages.CreateCollection(entry.Resource, storageLayerId.Value, zarr, baseUrl);
+                            : Services.ZarrCoverageService.CreateCollection(entry.Resource, storageLayerId.Value, zarr, baseUrl);
                     }
                     return await CreateCollectionAsync(entry.Resource, entry.Service, storageLayerId.Value, raster.Value, baseUrl, ct)
                         .ConfigureAwait(false);
@@ -347,14 +347,26 @@ internal sealed class OgcCoveragesHandler
             }
 
             var baseUrl = BaseUrlResolver.GetBaseUrl(context);
-            var collection = await CreateCollectionAsync(
+            OgcCoverageCollection collection;
+            if (resolution.ZarrRegistration is { } zarrCollection)
+            {
+                collection = Services.ZarrCoverageService.CreateCollection(
                     resolution.Resource!,
-                    resolution.Service,
                     resolution.StorageLayerId!.Value,
-                    resolution.Raster!.Value,
-                    baseUrl,
-                    cancellationToken)
-                .ConfigureAwait(false);
+                    zarrCollection,
+                    baseUrl);
+            }
+            else
+            {
+                collection = await CreateCollectionAsync(
+                        resolution.Resource!,
+                        resolution.Service,
+                        resolution.StorageLayerId!.Value,
+                        resolution.Raster!.Value,
+                        baseUrl,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
 
             return OgcCommonUtilities.FormatMetadataResponse(
                 collection,
@@ -401,12 +413,17 @@ internal sealed class OgcCoveragesHandler
                 return resolution.Error;
             }
 
-            var schema = await CreateSchemaAsync(
+            var schema = resolution.ZarrRegistration is { } zarrSchema
+                ? Services.ZarrCoverageService.CreateSchema(
                     resolution.Resource!,
                     resolution.StorageLayerId!.Value,
-                    resolution.Raster!.Value,
-                    cancellationToken)
-                .ConfigureAwait(false);
+                    zarrSchema)
+                : await CreateSchemaAsync(
+                        resolution.Resource!,
+                        resolution.StorageLayerId!.Value,
+                        resolution.Raster!.Value,
+                        cancellationToken)
+                    .ConfigureAwait(false);
 
             return OgcCommonUtilities.FormatMetadataResponse(
                 schema,
@@ -446,17 +463,30 @@ internal sealed class OgcCoveragesHandler
 
         try
         {
+            var resolution = await ResolveCoverageAsync(context, collectionId, cancellationToken).ConfigureAwait(false);
+            if (resolution.Error is not null)
+            {
+                return resolution.Error;
+            }
+
+            if (resolution.ZarrRegistration is { } zarrRegistration)
+            {
+                var zarrResult = await _zarrCoverages.GetCoverageAsync(
+                        context,
+                        collectionId,
+                        zarrRegistration,
+                        f,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                telemetry.SetSuccess(1);
+                return zarrResult;
+            }
+
             var parameterError = ValidateCoverageQueryParameters(context);
             if (parameterError is not null)
             {
                 OgcCoveragesLog.ValidationFailed(_logger, collectionId, parameterError);
                 return StandardErrorHelpers.CreateBadRequest(context, parameterError);
-            }
-
-            var resolution = await ResolveCoverageAsync(context, collectionId, cancellationToken).ConfigureAwait(false);
-            if (resolution.Error is not null)
-            {
-                return resolution.Error;
             }
 
             var storageSrid = ResolveStorageSrid(resolution.Resource!, resolution.Raster!.Value);

--- a/src/Honua.Protocols.OgcApi/Coverages/OgcCoveragesDependencies.cs
+++ b/src/Honua.Protocols.OgcApi/Coverages/OgcCoveragesDependencies.cs
@@ -4,6 +4,7 @@
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Raster.Abstractions;
+using Honua.Protocols.Ogc.Api.Coverages.Services;
 
 namespace Honua.Protocols.Ogc.Api.Coverages;
 
@@ -13,16 +14,19 @@ internal sealed class OgcCoveragesDependencies
         IMetadataV2GraphProvider graphProvider,
         IRasterStore rasterStore,
         ICoordinateTransformService coordinateTransformService,
-        ICrsRegistry crsRegistry)
+        ICrsRegistry crsRegistry,
+        ZarrCoverageService zarrCoverages)
     {
         GraphProvider = graphProvider ?? throw new ArgumentNullException(nameof(graphProvider));
         RasterStore = rasterStore ?? throw new ArgumentNullException(nameof(rasterStore));
         CoordinateTransformService = coordinateTransformService ?? throw new ArgumentNullException(nameof(coordinateTransformService));
         CrsRegistry = crsRegistry ?? throw new ArgumentNullException(nameof(crsRegistry));
+        ZarrCoverages = zarrCoverages ?? throw new ArgumentNullException(nameof(zarrCoverages));
     }
 
     public IMetadataV2GraphProvider GraphProvider { get; }
     public IRasterStore RasterStore { get; }
     public ICoordinateTransformService CoordinateTransformService { get; }
     public ICrsRegistry CrsRegistry { get; }
+    public ZarrCoverageService ZarrCoverages { get; }
 }

--- a/src/Honua.Protocols.OgcApi/Coverages/OgcCoveragesServiceCollectionExtensions.cs
+++ b/src/Honua.Protocols.OgcApi/Coverages/OgcCoveragesServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Protocols.Ogc.Api.Coverages.Handlers;
+using Honua.Protocols.Ogc.Api.Coverages.Services;
 
 namespace Honua.Protocols.Ogc.Api.Coverages;
 
@@ -17,6 +18,7 @@ internal static class OgcCoveragesServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        services.AddScoped<ZarrCoverageService>();
         services.AddScoped<OgcCoveragesDependencies>();
         services.AddScoped<OgcCoveragesHandler>();
 

--- a/src/Honua.Protocols.OgcApi/Coverages/Services/CoverageJsonWriter.cs
+++ b/src/Honua.Protocols.OgcApi/Coverages/Services/CoverageJsonWriter.cs
@@ -1,0 +1,238 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using System.Text.Json;
+using Honua.Core.Features.Raster.Domain;
+
+namespace Honua.Protocols.Ogc.Api.Coverages.Services;
+
+/// <summary>
+/// One domain axis of a CoverageJSON grid response. Values are regularly
+/// spaced and described by start/stop/num; spatial axes carry CRS coordinates
+/// while non-referenced axes carry grid indices.
+/// </summary>
+/// <param name="Name">Axis name (matches the source dimension name).</param>
+/// <param name="Start">First cell value.</param>
+/// <param name="Stop">Last cell value.</param>
+/// <param name="Count">Cell count.</param>
+internal sealed record CoverageJsonAxis(string Name, double Start, double Stop, int Count);
+
+/// <summary>
+/// AOT-safe CoverageJSON (CovJSON 1.0) writer for Zarr-backed coverage
+/// subsets. Emits a Grid-domain coverage with one NdArray range built with
+/// <see cref="Utf8JsonWriter"/> because the document shape (axis names, value
+/// arrays) is data-driven and unsuitable for source-generated serializer types.
+/// </summary>
+internal static class CoverageJsonWriter
+{
+    /// <summary>
+    /// Writes a CoverageJSON document for one decoded Zarr subset.
+    /// </summary>
+    /// <param name="result">Decoded subset payload (little-endian buffer).</param>
+    /// <param name="axes">Domain axes in the same order as the subset shape.</param>
+    /// <param name="xAxisName">Axis name carrying CRS x coordinates, when georeferenced.</param>
+    /// <param name="yAxisName">Axis name carrying CRS y coordinates, when georeferenced.</param>
+    /// <param name="srid">EPSG SRID for the spatial axes; 0 when not georeferenced.</param>
+    /// <returns>UTF-8 encoded CoverageJSON payload.</returns>
+    public static byte[] Write(
+        ZarrSubsetResult result,
+        IReadOnlyList<CoverageJsonAxis> axes,
+        string? xAxisName,
+        string? yAxisName,
+        int srid)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(axes);
+
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "Coverage");
+
+            WriteDomain(writer, axes, xAxisName, yAxisName, srid);
+            WriteParameters(writer, result.Variable);
+            WriteRanges(writer, result, axes);
+
+            writer.WriteEndObject();
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static void WriteDomain(
+        Utf8JsonWriter writer,
+        IReadOnlyList<CoverageJsonAxis> axes,
+        string? xAxisName,
+        string? yAxisName,
+        int srid)
+    {
+        writer.WriteStartObject("domain");
+        writer.WriteString("type", "Domain");
+        writer.WriteString("domainType", "Grid");
+
+        writer.WriteStartObject("axes");
+        foreach (var axis in axes)
+        {
+            writer.WriteStartObject(axis.Name);
+            writer.WriteNumber("start", axis.Start);
+            writer.WriteNumber("stop", axis.Stop);
+            writer.WriteNumber("num", axis.Count);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndObject();
+
+        if (srid > 0 && xAxisName is not null && yAxisName is not null)
+        {
+            writer.WriteStartArray("referencing");
+            writer.WriteStartObject();
+            writer.WriteStartArray("coordinates");
+            writer.WriteStringValue(xAxisName);
+            writer.WriteStringValue(yAxisName);
+            writer.WriteEndArray();
+            writer.WriteStartObject("system");
+            writer.WriteString("type", srid == 4326 ? "GeographicCRS" : "ProjectedCRS");
+            writer.WriteString("id", FormattableString.Invariant($"http://www.opengis.net/def/crs/EPSG/0/{srid}"));
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+            writer.WriteEndArray();
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteParameters(Utf8JsonWriter writer, string variable)
+    {
+        writer.WriteStartObject("parameters");
+        writer.WriteStartObject(variable);
+        writer.WriteString("type", "Parameter");
+        writer.WriteStartObject("observedProperty");
+        writer.WriteStartObject("label");
+        writer.WriteString("en", variable);
+        writer.WriteEndObject();
+        writer.WriteEndObject();
+        writer.WriteEndObject();
+        writer.WriteEndObject();
+    }
+
+    private static void WriteRanges(Utf8JsonWriter writer, ZarrSubsetResult result, IReadOnlyList<CoverageJsonAxis> axes)
+    {
+        writer.WriteStartObject("ranges");
+        writer.WriteStartObject(result.Variable);
+        writer.WriteString("type", "NdArray");
+        writer.WriteString("dataType", ResolveCovJsonDataType(result.DataType));
+
+        writer.WriteStartArray("axisNames");
+        foreach (var axis in axes)
+        {
+            writer.WriteStringValue(axis.Name);
+        }
+        writer.WriteEndArray();
+
+        writer.WriteStartArray("shape");
+        foreach (var size in result.Shape)
+        {
+            writer.WriteNumberValue(size);
+        }
+        writer.WriteEndArray();
+
+        writer.WriteStartArray("values");
+        WriteValues(writer, result);
+        writer.WriteEndArray();
+
+        writer.WriteEndObject();
+        writer.WriteEndObject();
+    }
+
+    private static string ResolveCovJsonDataType(string dtype)
+        => NormalizeDataType(dtype) is ['f', ..] ? "float" : "integer";
+
+    private static void WriteValues(Utf8JsonWriter writer, ZarrSubsetResult result)
+    {
+        var data = result.Data.AsSpan();
+        switch (NormalizeDataType(result.DataType))
+        {
+            case "f4":
+                for (var offset = 0; offset + 4 <= data.Length; offset += 4)
+                {
+                    WriteFloatingPoint(writer, BinaryPrimitives.ReadSingleLittleEndian(data[offset..]));
+                }
+                break;
+            case "f8":
+                for (var offset = 0; offset + 8 <= data.Length; offset += 8)
+                {
+                    WriteFloatingPoint(writer, BinaryPrimitives.ReadDoubleLittleEndian(data[offset..]));
+                }
+                break;
+            case "i1":
+                foreach (var value in data)
+                {
+                    writer.WriteNumberValue((sbyte)value);
+                }
+                break;
+            case "u1":
+            case "b1":
+                foreach (var value in data)
+                {
+                    writer.WriteNumberValue(value);
+                }
+                break;
+            case "i2":
+                for (var offset = 0; offset + 2 <= data.Length; offset += 2)
+                {
+                    writer.WriteNumberValue(BinaryPrimitives.ReadInt16LittleEndian(data[offset..]));
+                }
+                break;
+            case "u2":
+                for (var offset = 0; offset + 2 <= data.Length; offset += 2)
+                {
+                    writer.WriteNumberValue(BinaryPrimitives.ReadUInt16LittleEndian(data[offset..]));
+                }
+                break;
+            case "i4":
+                for (var offset = 0; offset + 4 <= data.Length; offset += 4)
+                {
+                    writer.WriteNumberValue(BinaryPrimitives.ReadInt32LittleEndian(data[offset..]));
+                }
+                break;
+            case "u4":
+                for (var offset = 0; offset + 4 <= data.Length; offset += 4)
+                {
+                    writer.WriteNumberValue(BinaryPrimitives.ReadUInt32LittleEndian(data[offset..]));
+                }
+                break;
+            case "i8":
+                for (var offset = 0; offset + 8 <= data.Length; offset += 8)
+                {
+                    writer.WriteNumberValue(BinaryPrimitives.ReadInt64LittleEndian(data[offset..]));
+                }
+                break;
+            case "u8":
+                for (var offset = 0; offset + 8 <= data.Length; offset += 8)
+                {
+                    writer.WriteNumberValue(BinaryPrimitives.ReadUInt64LittleEndian(data[offset..]));
+                }
+                break;
+            default:
+                throw new InvalidOperationException(
+                    $"Zarr dtype '{result.DataType}' is not supported for CoverageJSON output.");
+        }
+    }
+
+    private static void WriteFloatingPoint(Utf8JsonWriter writer, double value)
+    {
+        if (double.IsFinite(value))
+        {
+            writer.WriteNumberValue(value);
+        }
+        else
+        {
+            // NaN / Infinity are not representable in JSON; CovJSON uses null for missing data.
+            writer.WriteNullValue();
+        }
+    }
+
+    private static string NormalizeDataType(string dtype)
+        => dtype.Length > 0 && dtype[0] is '<' or '|' or '=' ? dtype[1..] : dtype;
+}

--- a/src/Honua.Protocols.OgcApi/Coverages/Services/ZarrCoverageLog.cs
+++ b/src/Honua.Protocols.OgcApi/Coverages/Services/ZarrCoverageLog.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Protocols.Ogc.Api.Coverages.Services;
+
+/// <summary>
+/// Source-generated log messages for Zarr-backed OGC API Coverages serving (#1590).
+/// </summary>
+internal static partial class ZarrCoverageLog
+{
+    [LoggerMessage(EventId = 575230, Level = LogLevel.Information, Message = "Zarr coverage served: collection={CollectionId}, variable={Variable}, bytes={ByteCount}")]
+    public static partial void CoverageServed(ILogger logger, string collectionId, string variable, int byteCount);
+
+    [LoggerMessage(EventId = 575231, Level = LogLevel.Warning, Message = "Zarr coverage subset rejected: collection={CollectionId}, detail={Detail}")]
+    public static partial void SubsetRejected(ILogger logger, string collectionId, string detail);
+
+    [LoggerMessage(EventId = 575232, Level = LogLevel.Error, Message = "Zarr coverage subset read failed: collection={CollectionId}")]
+    public static partial void SubsetReadFailed(ILogger logger, Exception exception, string collectionId);
+
+    [LoggerMessage(EventId = 575233, Level = LogLevel.Error, Message = "Zarr coverage range reader missing: collection={CollectionId}, provider={Provider}")]
+    public static partial void RangeReaderMissing(ILogger logger, string collectionId, string provider);
+}

--- a/src/Honua.Protocols.OgcApi/Coverages/Services/ZarrCoverageService.cs
+++ b/src/Honua.Protocols.OgcApi/Coverages/Services/ZarrCoverageService.cs
@@ -11,6 +11,7 @@ using Honua.Core.Features.Raster.ZarrParser;
 using Honua.Infrastructure.Helpers;
 using Honua.Infrastructure.Models;
 using Honua.Protocols.Ogc.Api.Coverages.Models;
+using Honua.Protocols.Ogc.Api.Features;
 using Honua.Protocols.Ogc.Common;
 using Microsoft.Extensions.Primitives;
 
@@ -78,7 +79,7 @@ internal sealed class ZarrCoverageService
     /// <summary>
     /// Builds the OGC API Coverages collection document for a Zarr-backed layer.
     /// </summary>
-    public OgcCoverageCollection CreateCollection(
+    public static OgcCoverageCollection CreateCollection(
         MetadataV2Resource resource,
         int storageLayerId,
         ZarrRegistration registration,
@@ -119,7 +120,7 @@ internal sealed class ZarrCoverageService
         {
             if (metadata.Srid == 4326)
             {
-                crs.Add(SpatialReferenceHelpers.Crs84Uri);
+                crs.Add(OgcFeaturesUtilities.Crs84Uri);
             }
             crs.Add(epsgUri);
         }
@@ -144,7 +145,7 @@ internal sealed class ZarrCoverageService
     /// Builds the field-selection schema for a Zarr-backed collection: one
     /// selectable property per discovered variable.
     /// </summary>
-    public CoverageSchema CreateSchema(MetadataV2Resource resource, int storageLayerId, ZarrRegistration registration)
+    public static CoverageSchema CreateSchema(MetadataV2Resource resource, int storageLayerId, ZarrRegistration registration)
     {
         ArgumentNullException.ThrowIfNull(resource);
         ArgumentNullException.ThrowIfNull(registration);
@@ -308,7 +309,7 @@ internal sealed class ZarrCoverageService
             {
                 BoundingBox = bbox,
                 StorageCrsBoundingBox = bbox,
-                Crs = metadata.Srid == 4326 ? SpatialReferenceHelpers.Crs84Uri : epsgUri
+                Crs = metadata.Srid == 4326 ? OgcFeaturesUtilities.Crs84Uri : epsgUri
             }
         };
     }
@@ -340,7 +341,7 @@ internal sealed class ZarrCoverageService
         };
     }
 
-    private CoverageDomain CreateDomain(ZarrStoreMetadata metadata, ZarrArrayMetadata primary, bool georeferenced)
+    private static CoverageDomain CreateDomain(ZarrStoreMetadata metadata, ZarrArrayMetadata primary, bool georeferenced)
     {
         var fullPlan = new ZarrCoverageSubsetPlan(primary, new ZarrSubsetRequest
         {
@@ -536,7 +537,7 @@ internal sealed class ZarrCoverageService
     private static bool TryParseIndex(string value, out int index)
         => int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out index) && index >= 0;
 
-    private (List<CoverageJsonAxis> Axes, string? XAxis, string? YAxis) BuildAxes(
+    private static (List<CoverageJsonAxis> Axes, string? XAxis, string? YAxis) BuildAxes(
         ZarrStoreMetadata metadata,
         ZarrCoverageSubsetPlan plan)
     {
@@ -594,7 +595,7 @@ internal sealed class ZarrCoverageService
             ? string.Equals(declared, name, StringComparison.OrdinalIgnoreCase)
             : name.ToLowerInvariant() is "y" or "lat" or "latitude";
 
-    private void WriteCoverageHeaders(HttpContext context, ZarrStoreMetadata metadata, ZarrCoverageSubsetPlan plan)
+    private static void WriteCoverageHeaders(HttpContext context, ZarrStoreMetadata metadata, ZarrCoverageSubsetPlan plan)
     {
         if (metadata.Srid <= 0)
         {

--- a/src/Honua.Protocols.OgcApi/Coverages/Services/ZarrCoverageService.cs
+++ b/src/Honua.Protocols.OgcApi/Coverages/Services/ZarrCoverageService.cs
@@ -1,0 +1,658 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Raster.ZarrParser;
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Models;
+using Honua.Protocols.Ogc.Api.Coverages.Models;
+using Honua.Protocols.Ogc.Common;
+using Microsoft.Extensions.Primitives;
+
+namespace Honua.Protocols.Ogc.Api.Coverages.Services;
+
+/// <summary>
+/// Serves registered Zarr stores through the OGC API Coverages surface
+/// (read-only, chunked-read access pattern, #1590). Adapts coverage collection
+/// metadata, field schemas, and grid-index subset requests onto the shared
+/// Zarr read pipeline (<see cref="ZarrCoverageSubsetPlanner"/> +
+/// <see cref="IZarrSubsetReader"/>); it never builds a parallel data path.
+/// </summary>
+internal sealed class ZarrCoverageService
+{
+    /// <summary>
+    /// CoverageJSON media type served for Zarr-backed collections.
+    /// </summary>
+    internal const string CoverageJsonContentType = "application/prs.coverage+json";
+
+    /// <summary>
+    /// Raw decoded payload cap. CoverageJSON expands roughly 3-4x over the
+    /// binary buffer, so this keeps responses comfortably bounded.
+    /// </summary>
+    private const long MaxCoverageOutputBytes = 16L * 1024L * 1024L;
+
+    private static readonly ImmutableHashSet<string> SupportedQueryParameters =
+        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "f", "subset", "properties");
+
+    private static readonly string[] AcceptableMediaTypes = [CoverageJsonContentType, MediaTypes.Json];
+
+    private readonly IZarrStore _zarrStore;
+    private readonly IZarrSubsetReader _subsetReader;
+    private readonly IEnumerable<ICloudRangeReader> _rangeReaders;
+    private readonly ILogger<ZarrCoverageService> _logger;
+
+    public ZarrCoverageService(
+        IZarrStore zarrStore,
+        IZarrSubsetReader subsetReader,
+        IEnumerable<ICloudRangeReader> rangeReaders,
+        ILogger<ZarrCoverageService> logger)
+    {
+        _zarrStore = zarrStore ?? throw new ArgumentNullException(nameof(zarrStore));
+        _subsetReader = subsetReader ?? throw new ArgumentNullException(nameof(subsetReader));
+        _rangeReaders = rangeReaders ?? throw new ArgumentNullException(nameof(rangeReaders));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Returns the first registered Zarr store for the storage layer whose
+    /// metadata scan has completed, or null when the layer has no servable store.
+    /// </summary>
+    public async Task<ZarrRegistration?> FindServableRegistrationAsync(int storageLayerId, CancellationToken cancellationToken)
+    {
+        var registrations = await _zarrStore.ListByLayerAsync(storageLayerId, cancellationToken).ConfigureAwait(false);
+        foreach (var registration in registrations)
+        {
+            if (registration.Metadata is not null)
+            {
+                return registration;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Builds the OGC API Coverages collection document for a Zarr-backed layer.
+    /// </summary>
+    public OgcCoverageCollection CreateCollection(
+        MetadataV2Resource resource,
+        int storageLayerId,
+        ZarrRegistration registration,
+        string baseUrl)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentNullException.ThrowIfNull(registration);
+        var metadata = RequireMetadata(registration);
+
+        var collectionId = storageLayerId.ToString(CultureInfo.InvariantCulture);
+        var basePath = $"{baseUrl}/ogc/coverages/collections/{Uri.EscapeDataString(collectionId)}";
+        var displayName = resource.Metadata.Title ?? resource.Metadata.Name;
+
+        var links = ImmutableArray.CreateBuilder<Link>();
+        links.Add(Link.Create(href: basePath, rel: RelationTypes.Self, type: MediaTypes.Json, title: displayName));
+        links.Add(Link.Create(
+            href: $"{baseUrl}/ogc/coverages/collections",
+            rel: "parent",
+            type: MediaTypes.Json,
+            title: "Coverage collections"));
+        links.Add(Link.Create(
+            href: $"{basePath}/schema",
+            rel: RelationTypes.Schema,
+            type: MediaTypes.SchemaJson,
+            title: "Coverage schema"));
+        links.Add(Link.Create(
+            href: $"{basePath}/coverage",
+            rel: RelationTypes.Coverage,
+            type: CoverageJsonContentType,
+            title: "Coverage data as CoverageJSON"));
+
+        var primary = ResolvePrimaryArray(metadata);
+        var georeferenced = metadata.Srid > 0;
+        var epsgUri = CreateEpsgUri(metadata.Srid);
+
+        var crs = ImmutableArray.CreateBuilder<string>();
+        if (georeferenced)
+        {
+            if (metadata.Srid == 4326)
+            {
+                crs.Add(SpatialReferenceHelpers.Crs84Uri);
+            }
+            crs.Add(epsgUri);
+        }
+
+        return new OgcCoverageCollection
+        {
+            Id = collectionId,
+            Title = displayName,
+            Description = resource.Metadata.Description ?? registration.Description,
+            ItemType = "coverage",
+            Extent = georeferenced ? CreateExtent(metadata, epsgUri) : null,
+            Links = links.ToImmutable(),
+            Crs = crs.ToImmutable(),
+            StorageCrs = georeferenced ? epsgUri : null,
+            Grid = CreateGrid(metadata, primary, georeferenced),
+            Domain = CreateDomain(metadata, primary, georeferenced),
+            DefaultFields = metadata.Arrays.Select(static array => array.Name).ToImmutableArray()
+        };
+    }
+
+    /// <summary>
+    /// Builds the field-selection schema for a Zarr-backed collection: one
+    /// selectable property per discovered variable.
+    /// </summary>
+    public CoverageSchema CreateSchema(MetadataV2Resource resource, int storageLayerId, ZarrRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentNullException.ThrowIfNull(registration);
+        var metadata = RequireMetadata(registration);
+
+        var properties = ImmutableDictionary.CreateBuilder<string, CoverageSchemaProperty>(StringComparer.Ordinal);
+        for (var i = 0; i < metadata.Arrays.Length; i++)
+        {
+            var array = metadata.Arrays[i];
+            properties[array.Name] = new CoverageSchemaProperty
+            {
+                Type = IsFloatingPoint(array.DataType) ? "number" : "integer",
+                Title = array.Name,
+                Description = "Zarr variable over dimensions [" + string.Join(", ", array.DimensionNames) + "]",
+                PropertySequence = i + 1,
+                PixelType = array.DataType,
+                NoDataValue = array.FillValue as double?
+            };
+        }
+
+        var displayName = resource.Metadata.Title ?? resource.Metadata.Name;
+        return new CoverageSchema
+        {
+            Title = "Coverage schema for " + displayName,
+            Description = "Field selection schema for OGC API Coverages collection " +
+                storageLayerId.ToString(CultureInfo.InvariantCulture),
+            Properties = properties.ToImmutable()
+        };
+    }
+
+    /// <summary>
+    /// Serves a CoverageJSON subset of a Zarr-backed collection. Supports
+    /// <c>properties</c> single-variable selection and OGC-style
+    /// <c>subset=dim(low:high)</c> parameters expressed as inclusive grid indices.
+    /// </summary>
+    public async Task<IResult> GetCoverageAsync(
+        HttpContext context,
+        string collectionId,
+        ZarrRegistration registration,
+        string? f,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(registration);
+        var metadata = RequireMetadata(registration);
+
+        foreach (var parameter in context.Request.Query.Keys)
+        {
+            if (!SupportedQueryParameters.Contains(parameter))
+            {
+                return StandardErrorHelpers.CreateBadRequest(
+                    context,
+                    $"Parameter '{parameter}' is not supported for Zarr-backed coverage collections. Use properties and subset=dim(low:high) grid-index subsetting.");
+            }
+        }
+
+        if (!TryNegotiateFormat(context, f, out var formatError, out var notAcceptable))
+        {
+            return notAcceptable
+                ? StandardErrorHelpers.CreateNotAcceptable(context, formatError!)
+                : StandardErrorHelpers.CreateBadRequest(context, formatError!);
+        }
+
+        if (!TryResolveVariable(context, out var variable, out var variableError))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, variableError!);
+        }
+
+        if (!TryParseSubsets(context.Request.Query["subset"], out var subsets, out var subsetError))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, subsetError!);
+        }
+
+        if (!ZarrCoverageSubsetPlanner.TryPlan(metadata, variable, subsets, MaxCoverageOutputBytes, out var plan, out var planError))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, planError!);
+        }
+
+        var rangeReader = _rangeReaders.FirstOrDefault(reader => reader.Provider == registration.Provider);
+        if (rangeReader is null)
+        {
+            ZarrCoverageLog.RangeReaderMissing(_logger, collectionId, registration.Provider.ToString());
+            return StandardErrorHelpers.CreateInternalServerError(
+                context,
+                "The storage backend for this coverage collection is not configured.");
+        }
+
+        ZarrSubsetResult result;
+        try
+        {
+            result = await _subsetReader.ReadSubsetAsync(
+                    rangeReader,
+                    registration.Bucket,
+                    registration.RootPath,
+                    metadata,
+                    plan!.Request,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
+        {
+            // Subset reader validation messages are client-safe (codec, dtype, bounds, caps).
+            ZarrCoverageLog.SubsetRejected(_logger, collectionId, ex.Message);
+            return StandardErrorHelpers.CreateBadRequest(context, ex.Message);
+        }
+        catch (InvalidDataException ex)
+        {
+            ZarrCoverageLog.SubsetReadFailed(_logger, ex, collectionId);
+            return StandardErrorHelpers.CreateInternalServerError(
+                context,
+                "The Zarr store backing this coverage collection returned invalid data.");
+        }
+
+        var (axes, xAxis, yAxis) = BuildAxes(metadata, plan!);
+        byte[] payload;
+        try
+        {
+            payload = CoverageJsonWriter.Write(result, axes, xAxis, yAxis, metadata.Srid);
+        }
+        catch (InvalidOperationException ex)
+        {
+            ZarrCoverageLog.SubsetRejected(_logger, collectionId, ex.Message);
+            return StandardErrorHelpers.CreateBadRequest(context, ex.Message);
+        }
+
+        WriteCoverageHeaders(context, metadata, plan!);
+        ZarrCoverageLog.CoverageServed(_logger, collectionId, result.Variable, payload.Length);
+        return Results.Bytes(payload, CoverageJsonContentType);
+    }
+
+    private static ZarrStoreMetadata RequireMetadata(ZarrRegistration registration)
+        => registration.Metadata ?? throw new InvalidOperationException(
+            "Zarr registration has no scanned metadata; callers must resolve servable registrations first.");
+
+    private static ZarrArrayMetadata ResolvePrimaryArray(ZarrStoreMetadata metadata)
+    {
+        if (metadata.PrimaryVariable is { } primary)
+        {
+            foreach (var array in metadata.Arrays)
+            {
+                if (string.Equals(array.Name, primary, StringComparison.Ordinal))
+                {
+                    return array;
+                }
+            }
+        }
+        return metadata.Arrays[0];
+    }
+
+    private static Extent CreateExtent(ZarrStoreMetadata metadata, string epsgUri)
+    {
+        var extent = metadata.Extent;
+        var bbox = ImmutableArray.Create(ImmutableArray.Create(extent.XMin, extent.YMin, extent.XMax, extent.YMax));
+        return new Extent
+        {
+            Spatial = new SpatialExtent
+            {
+                BoundingBox = bbox,
+                StorageCrsBoundingBox = bbox,
+                Crs = metadata.Srid == 4326 ? SpatialReferenceHelpers.Crs84Uri : epsgUri
+            }
+        };
+    }
+
+    private static CoverageGrid CreateGrid(ZarrStoreMetadata metadata, ZarrArrayMetadata primary, bool georeferenced)
+    {
+        var rank = primary.Shape.Length;
+        var width = primary.Shape[rank - 1];
+        var height = rank >= 2 ? primary.Shape[rank - 2] : 1;
+
+        ImmutableArray<double>? origin = null;
+        ImmutableArray<double>? resolution = null;
+        if (georeferenced && width > 0 && height > 0)
+        {
+            var extent = metadata.Extent;
+            origin = ImmutableArray.Create(extent.XMin, extent.YMax);
+            resolution = ImmutableArray.Create(
+                (extent.XMax - extent.XMin) / width,
+                (extent.YMin - extent.YMax) / height);
+        }
+
+        return new CoverageGrid
+        {
+            AxisLabels = primary.DimensionNames.ToImmutableArray(),
+            Width = width,
+            Height = height,
+            Origin = origin,
+            Resolution = resolution
+        };
+    }
+
+    private CoverageDomain CreateDomain(ZarrStoreMetadata metadata, ZarrArrayMetadata primary, bool georeferenced)
+    {
+        var fullPlan = new ZarrCoverageSubsetPlan(primary, new ZarrSubsetRequest
+        {
+            Variable = primary.Name,
+            Start = new int[primary.Shape.Length],
+            Stop = (int[])primary.Shape.Clone()
+        });
+
+        var (axes, _, _) = BuildAxes(metadata, fullPlan);
+        var builder = ImmutableDictionary.CreateBuilder<string, CoverageAxis>(StringComparer.Ordinal);
+        foreach (var axis in axes)
+        {
+            builder[axis.Name] = new CoverageAxis
+            {
+                Start = axis.Start,
+                Stop = axis.Stop,
+                Count = axis.Count,
+                Resolution = georeferenced && axis.Count > 1
+                    ? Math.Abs(axis.Stop - axis.Start) / (axis.Count - 1)
+                    : null
+            };
+        }
+
+        return new CoverageDomain { Axes = builder.ToImmutable() };
+    }
+
+    private static bool TryNegotiateFormat(HttpContext context, string? f, out string? error, out bool notAcceptable)
+    {
+        error = null;
+        notAcceptable = false;
+
+        if (!string.IsNullOrWhiteSpace(f))
+        {
+            switch (f.Trim().ToLowerInvariant())
+            {
+                case "covjson":
+                case "coveragejson":
+                case "json":
+                case CoverageJsonContentType:
+                    return true;
+                default:
+                    error = $"Unsupported coverage format '{f}' for a Zarr-backed collection. Zarr-backed collections currently serve CoverageJSON; use f=covjson.";
+                    return false;
+            }
+        }
+
+        var acceptHeader = context.Request.Headers.Accept;
+        if (!StringValues.IsNullOrEmpty(acceptHeader) &&
+            !ContentNegotiationHelpers.TrySelectBestMediaType(AcceptableMediaTypes, acceptHeader, out _))
+        {
+            error = "Zarr-backed coverage collections serve application/prs.coverage+json.";
+            notAcceptable = true;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryResolveVariable(HttpContext context, out string? variable, out string? error)
+    {
+        variable = null;
+        error = null;
+        var properties = OgcCommonUtilities.GetQueryValue(context.Request, "properties");
+        if (string.IsNullOrWhiteSpace(properties))
+        {
+            return true;
+        }
+
+        var tokens = properties.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length != 1)
+        {
+            error = "properties must select exactly one variable per request for Zarr-backed collections.";
+            return false;
+        }
+
+        variable = tokens[0];
+        return true;
+    }
+
+    private static bool TryParseSubsets(
+        StringValues raw,
+        out List<ZarrCoverageDimensionSubset> subsets,
+        out string? error)
+    {
+        subsets = [];
+        error = null;
+
+        foreach (var value in raw)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            foreach (var segment in SplitTopLevel(value))
+            {
+                if (!TryParseSubsetSegment(segment, out var subset, out error))
+                {
+                    return false;
+                }
+                subsets.Add(subset!);
+            }
+        }
+
+        return true;
+    }
+
+    private static List<string> SplitTopLevel(string value)
+    {
+        var segments = new List<string>();
+        var depth = 0;
+        var start = 0;
+        for (var i = 0; i < value.Length; i++)
+        {
+            switch (value[i])
+            {
+                case '(':
+                    depth++;
+                    break;
+                case ')':
+                    depth--;
+                    break;
+                case ',' when depth == 0:
+                    segments.Add(value[start..i]);
+                    start = i + 1;
+                    break;
+            }
+        }
+        segments.Add(value[start..]);
+        return segments;
+    }
+
+    private static bool TryParseSubsetSegment(
+        string segment,
+        out ZarrCoverageDimensionSubset? subset,
+        out string? error)
+    {
+        subset = null;
+        error = null;
+        var trimmed = segment.Trim();
+
+        var open = trimmed.IndexOf('(', StringComparison.Ordinal);
+        if (open <= 0 || !trimmed.EndsWith(')'))
+        {
+            error = $"Invalid subset expression '{trimmed}'. Use subset=dimension(low:high) with grid indices.";
+            return false;
+        }
+
+        var dimension = trimmed[..open].Trim();
+        var spec = trimmed[(open + 1)..^1].Trim();
+        if (dimension.Length == 0 || spec.Length == 0)
+        {
+            error = $"Invalid subset expression '{trimmed}'. Use subset=dimension(low:high) with grid indices.";
+            return false;
+        }
+
+        int low;
+        int high;
+        var separator = spec.IndexOf(':', StringComparison.Ordinal);
+        if (separator < 0)
+        {
+            if (!TryParseIndex(spec, out low))
+            {
+                error = CreateIndexError(trimmed);
+                return false;
+            }
+            high = low;
+        }
+        else
+        {
+            if (!TryParseIndex(spec[..separator].Trim(), out low) ||
+                !TryParseIndex(spec[(separator + 1)..].Trim(), out high))
+            {
+                error = CreateIndexError(trimmed);
+                return false;
+            }
+        }
+
+        if (high < low)
+        {
+            error = $"Subset bounds for '{dimension}' must satisfy low <= high.";
+            return false;
+        }
+
+        // OGC subset bounds are closed intervals; convert to exclusive stop.
+        subset = new ZarrCoverageDimensionSubset(dimension, low, high + 1);
+        return true;
+    }
+
+    private static string CreateIndexError(string segment)
+        => $"Subset bounds in '{segment}' must be non-negative integer grid indices. Coordinate-based subsetting is not yet supported for Zarr-backed collections.";
+
+    private static bool TryParseIndex(string value, out int index)
+        => int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out index) && index >= 0;
+
+    private (List<CoverageJsonAxis> Axes, string? XAxis, string? YAxis) BuildAxes(
+        ZarrStoreMetadata metadata,
+        ZarrCoverageSubsetPlan plan)
+    {
+        var array = plan.Array;
+        var request = plan.Request;
+        var georeferenced = metadata.Srid > 0;
+        var extent = metadata.Extent;
+
+        string? xAxis = null;
+        string? yAxis = null;
+        var axes = new List<CoverageJsonAxis>(array.Shape.Length);
+        for (var i = 0; i < array.Shape.Length; i++)
+        {
+            var name = array.DimensionNames[i];
+            var count = request.Stop[i] - request.Start[i];
+
+            if (georeferenced && IsXDimension(metadata, name) && array.Shape[i] > 0)
+            {
+                xAxis = name;
+                var cellWidth = (extent.XMax - extent.XMin) / array.Shape[i];
+                axes.Add(new CoverageJsonAxis(
+                    name,
+                    extent.XMin + ((request.Start[i] + 0.5) * cellWidth),
+                    extent.XMin + ((request.Stop[i] - 0.5) * cellWidth),
+                    count));
+                continue;
+            }
+
+            if (georeferenced && IsYDimension(metadata, name) && array.Shape[i] > 0)
+            {
+                yAxis = name;
+                var cellHeight = (extent.YMax - extent.YMin) / array.Shape[i];
+                // Row 0 is the northernmost row (north-up convention).
+                axes.Add(new CoverageJsonAxis(
+                    name,
+                    extent.YMax - ((request.Start[i] + 0.5) * cellHeight),
+                    extent.YMax - ((request.Stop[i] - 0.5) * cellHeight),
+                    count));
+                continue;
+            }
+
+            axes.Add(new CoverageJsonAxis(name, request.Start[i], request.Stop[i] - 1, count));
+        }
+
+        return (axes, xAxis, yAxis);
+    }
+
+    private static bool IsXDimension(ZarrStoreMetadata metadata, string name)
+        => metadata.SpatialXDimension is { } declared
+            ? string.Equals(declared, name, StringComparison.OrdinalIgnoreCase)
+            : name.ToLowerInvariant() is "x" or "lon" or "longitude";
+
+    private static bool IsYDimension(ZarrStoreMetadata metadata, string name)
+        => metadata.SpatialYDimension is { } declared
+            ? string.Equals(declared, name, StringComparison.OrdinalIgnoreCase)
+            : name.ToLowerInvariant() is "y" or "lat" or "latitude";
+
+    private void WriteCoverageHeaders(HttpContext context, ZarrStoreMetadata metadata, ZarrCoverageSubsetPlan plan)
+    {
+        if (metadata.Srid <= 0)
+        {
+            return;
+        }
+
+        var array = plan.Array;
+        var request = plan.Request;
+        var extent = metadata.Extent;
+        double? xMin = null, xMax = null, yMin = null, yMax = null;
+        for (var i = 0; i < array.Shape.Length; i++)
+        {
+            if (array.Shape[i] <= 0)
+            {
+                continue;
+            }
+
+            var name = array.DimensionNames[i];
+            if (IsXDimension(metadata, name))
+            {
+                var cellWidth = (extent.XMax - extent.XMin) / array.Shape[i];
+                xMin = extent.XMin + (request.Start[i] * cellWidth);
+                xMax = extent.XMin + (request.Stop[i] * cellWidth);
+            }
+            else if (IsYDimension(metadata, name))
+            {
+                var cellHeight = (extent.YMax - extent.YMin) / array.Shape[i];
+                yMax = extent.YMax - (request.Start[i] * cellHeight);
+                yMin = extent.YMax - (request.Stop[i] * cellHeight);
+            }
+        }
+
+        if (xMin.HasValue && xMax.HasValue && yMin.HasValue && yMax.HasValue)
+        {
+            context.Response.Headers.Append(
+                "Content-Bbox",
+                string.Join(
+                    ",",
+                    FormatDouble(xMin.Value),
+                    FormatDouble(yMin.Value),
+                    FormatDouble(xMax.Value),
+                    FormatDouble(yMax.Value)));
+        }
+
+        if (metadata.Srid != 4326)
+        {
+            context.Response.Headers.Append(
+                "Content-Crs",
+                FormattableString.Invariant($"<https://www.opengis.net/def/crs/EPSG/0/{metadata.Srid}>"));
+        }
+    }
+
+    private static bool IsFloatingPoint(string dtype)
+        => dtype.Length >= 2 && dtype[0] is '<' or '|' or '=' ? dtype[1] == 'f' : dtype.StartsWith('f');
+
+    private static string CreateEpsgUri(int srid)
+        => FormattableString.Invariant($"http://www.opengis.net/def/crs/EPSG/0/{srid}");
+
+    private static string FormatDouble(double value)
+        => value.ToString("G17", CultureInfo.InvariantCulture);
+}


### PR DESCRIPTION
## Issue Link

Closes #1590

## Summary

Registered Zarr (and HDF5/NetCDF) multidimensional coverages are now actually served through the OGC API Coverages protocol. The prior WIP added a fully-implemented `ZarrCoverageService` but only the collections-list endpoint dispatched to it; the single-collection, schema, and coverage-data endpoints unconditionally dereferenced the (null) raster resolution, so any Zarr-backed collection would have thrown a NullReferenceException. The service's `CreateSchema`/`GetCoverageAsync` methods were effectively dead code. This PR wires those request paths to the service and fixes the build so the assembly compiles under warnings-as-errors.

## Changes Made

- Dispatch `GET /ogc/coverages/collections/{id}` to `ZarrCoverageService.CreateCollection` when the resolution is a Zarr registration.
- Dispatch `GET /ogc/coverages/collections/{id}/schema` to `ZarrCoverageService.CreateSchema` for Zarr registrations.
- Dispatch `GET /ogc/coverages/collections/{id}/coverage` to `ZarrCoverageService.GetCoverageAsync` (CoverageJSON, `properties`/`subset` grid subsetting) for Zarr registrations, resolving before the raster-only parameter validation so `subset` is no longer wrongly rejected.
- Replace the inaccessible `SpatialReferenceHelpers.Crs84Uri` (lives in higher assembly `Honua.Hosting`) with the same-assembly `OgcFeaturesUtilities.Crs84Uri` in `ZarrCoverageService`.
- Mark stateless `ZarrCoverageService` members (`CreateCollection`, `CreateSchema`, `CreateDomain`, `BuildAxes`, `WriteCoverageHeaders`) static to satisfy CA1822 under `TreatWarningsAsErrors=true`; update call sites accordingly.
- Rebased the two prior #1590 commits onto current `trunk` (dropped already-landed assembly-sweep base commits).

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Ran `dotnet build Honua.sln --configuration Release /p:TreatWarningsAsErrors=true` (0 warnings, 0 errors), `dotnet format Honua.sln --verify-no-changes` (clean), `Honua.Protocols.OgcApi.Tests` Coverages suite (7 passed), `Honua.Core.Tests` Zarr/Coverage suite (79 passed), and `Honua.Architecture.Tests` (109 passed, 1 Docker skip).

## Gate Impact

- [x] PR gates (build, test, governance)

## Docs or Contract Impact

- [ ] None — no docs or contract impact

## Release/Deploy Impact

- [x] None — standard merge-and-release flow

## Breaking Changes

None.

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
