### PR TITLE
feat: plugin SDK phase 2 remaining extension points (#1562)

### DIFF
--- a/samples/plugins/Honua.Sample.UtilityValidationPlugin/UtilityStatusEndpointPlugin.cs
+++ b/samples/plugins/Honua.Sample.UtilityValidationPlugin/UtilityStatusEndpointPlugin.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Plugins.Abstractions;
+
+namespace Honua.Sample.UtilityValidationPlugin;
+
+/// <summary>
+/// Phase-2 reference plugin (issue #1562) demonstrating the <see cref="ICustomEndpoint"/> extension
+/// point. Contributes a single read-only REST route the host mounts under
+/// <c>/plugins/utility/status</c> via <c>MapHonuaPluginEndpoints()</c>. It declares the
+/// <see cref="PluginCapability.CustomEndpoints"/> capability required to contribute routes.
+/// </summary>
+[Plugin("utility-status-endpoint", "1.0.0",
+    Description = "Exposes a read-only plugin status route.",
+    Capabilities = PluginCapability.CustomEndpoints)]
+public sealed class UtilityStatusEndpointPlugin : ICustomEndpoint
+{
+    /// <inheritdoc />
+    public IReadOnlyList<string> Methods { get; } = ["GET"];
+
+    /// <inheritdoc />
+    public string Pattern => "utility/status";
+
+    /// <inheritdoc />
+    public bool RequiresAuthorization => false;
+
+    /// <inheritdoc />
+    public ValueTask<PluginEndpointResponse> HandleAsync(
+        PluginEndpointRequest request,
+        CancellationToken cancellationToken)
+        => ValueTask.FromResult(PluginEndpointResponse.Json("{\"status\":\"ok\",\"plugin\":\"utility-status-endpoint\"}"));
+}

--- a/src/Honua.Plugins.Abstractions/ICustomEndpoint.cs
+++ b/src/Honua.Plugins.Abstractions/ICustomEndpoint.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Plugins.Abstractions;
+
+/// <summary>
+/// A plugin extension point that contributes an additional REST route to the server (issue #1562).
+/// The host maps each registered endpoint via its <c>MapHonuaPluginEndpoints()</c> extension using
+/// the AOT-safe <c>MapMethods</c> + explicit HTTP-metadata pattern, so contributed routes are
+/// statically rooted (no runtime route discovery) and pass through the shared authorization,
+/// validation, and telemetry middleware.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The contract is deliberately ASP.NET-free so the public plugin SDK package stays
+/// dependency-minimal and Native-AOT compatible: a plugin handler receives a
+/// <see cref="PluginEndpointRequest"/> and returns a <see cref="PluginEndpointResponse"/>; the host
+/// adapts these to/from <c>HttpContext</c>. Implementations are resolved as singletons and must be
+/// thread-safe.
+/// </para>
+/// <para>
+/// Contributing endpoints requires the <see cref="PluginCapability.CustomEndpoints"/> capability to
+/// be declared on the plugin's <c>[Plugin]</c> manifest; the host refuses to register an endpoint
+/// from a plugin that has not declared it. The whole feature is Enterprise-gated (<c>plugin.sdk</c>)
+/// and honors the operator kill-switch.
+/// </para>
+/// </remarks>
+public interface ICustomEndpoint
+{
+    /// <summary>
+    /// Gets the HTTP methods this endpoint handles (e.g. <c>GET</c>, <c>POST</c>). Must contain at
+    /// least one method.
+    /// </summary>
+    IReadOnlyList<string> Methods { get; }
+
+    /// <summary>
+    /// Gets the route pattern, rooted under the reserved plugin route prefix the host applies (e.g.
+    /// <c>"reports/summary"</c> becomes <c>/plugins/reports/summary</c>). Must not be null/empty.
+    /// </summary>
+    string Pattern { get; }
+
+    /// <summary>
+    /// Gets whether the host should require an authenticated, authorized caller for this route. When
+    /// <see langword="true"/> the host applies its standard authorization metadata before invoking
+    /// <see cref="HandleAsync"/>. Defaults are host-enforced; plugins cannot bypass authorization.
+    /// </summary>
+    bool RequiresAuthorization { get; }
+
+    /// <summary>
+    /// Handles a request to the contributed route.
+    /// </summary>
+    /// <param name="request">The adapted, read-only request (method, path, query, headers, body).</param>
+    /// <param name="cancellationToken">Cancellation token tied to the request lifetime.</param>
+    /// <returns>The response the host writes back to the caller.</returns>
+    ValueTask<PluginEndpointResponse> HandleAsync(PluginEndpointRequest request, CancellationToken cancellationToken);
+}

--- a/src/Honua.Plugins.Abstractions/PluginEndpointRequest.cs
+++ b/src/Honua.Plugins.Abstractions/PluginEndpointRequest.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+
+namespace Honua.Plugins.Abstractions;
+
+/// <summary>
+/// Read-only, ASP.NET-free view of an HTTP request passed to an <see cref="ICustomEndpoint"/>
+/// handler. The host populates this from the incoming <c>HttpContext</c> so plugin authors write
+/// handlers against the dependency-minimal SDK contract rather than the ASP.NET request types.
+/// </summary>
+/// <param name="Method">The HTTP method (uppercased, e.g. <c>GET</c>).</param>
+/// <param name="Path">The request path as routed (e.g. <c>/plugins/reports/summary</c>).</param>
+/// <param name="RouteValues">Matched route values for the endpoint pattern.</param>
+/// <param name="Query">The parsed query-string values (first value per key).</param>
+/// <param name="Headers">A safe subset of request headers exposed to the plugin (first value per key).</param>
+/// <param name="Body">The raw request body bytes, when present.</param>
+/// <param name="Actor">The authenticated actor performing the request, when available.</param>
+public sealed record PluginEndpointRequest(
+    string Method,
+    string Path,
+    ImmutableDictionary<string, string?> RouteValues,
+    ImmutableDictionary<string, string?> Query,
+    ImmutableDictionary<string, string?> Headers,
+    ReadOnlyMemory<byte> Body,
+    string? Actor);

--- a/src/Honua.Plugins.Abstractions/PluginEndpointResponse.cs
+++ b/src/Honua.Plugins.Abstractions/PluginEndpointResponse.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text;
+
+namespace Honua.Plugins.Abstractions;
+
+/// <summary>
+/// The response an <see cref="ICustomEndpoint"/> handler returns. The host writes the status code,
+/// content type, headers, and body back to the caller. This is a value-typed, ASP.NET-free DTO so
+/// the SDK contract stays dependency-minimal and AOT-safe.
+/// </summary>
+/// <param name="StatusCode">The HTTP status code to return.</param>
+/// <param name="ContentType">The response content type (e.g. <c>application/json</c>).</param>
+/// <param name="Body">The response body bytes.</param>
+/// <param name="Headers">Additional response headers to emit.</param>
+public sealed record PluginEndpointResponse(
+    int StatusCode,
+    string? ContentType,
+    ReadOnlyMemory<byte> Body,
+    ImmutableDictionary<string, string?> Headers)
+{
+    /// <summary>
+    /// Creates a <c>200 OK</c> JSON response from a UTF-8 string payload.
+    /// </summary>
+    /// <param name="json">The JSON payload (UTF-8 encoded by this helper).</param>
+    /// <returns>A JSON response.</returns>
+    public static PluginEndpointResponse Json(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+        return new PluginEndpointResponse(
+            StatusCode: 200,
+            ContentType: "application/json",
+            Body: Encoding.UTF8.GetBytes(json),
+            Headers: ImmutableDictionary<string, string?>.Empty);
+    }
+
+    /// <summary>
+    /// Creates a plain-text response with the given status code.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code.</param>
+    /// <param name="text">The text payload (UTF-8 encoded by this helper).</param>
+    /// <returns>A text response.</returns>
+    public static PluginEndpointResponse Text(int statusCode, string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return new PluginEndpointResponse(
+            statusCode,
+            ContentType: "text/plain; charset=utf-8",
+            Body: Encoding.UTF8.GetBytes(text),
+            Headers: ImmutableDictionary<string, string?>.Empty);
+    }
+
+    /// <summary>
+    /// Creates an empty response with the given status code (no body).
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code.</param>
+    /// <returns>An empty-bodied response.</returns>
+    public static PluginEndpointResponse Status(int statusCode)
+        => new(statusCode, ContentType: null, Body: ReadOnlyMemory<byte>.Empty, ImmutableDictionary<string, string?>.Empty);
+}

--- a/src/Honua.Plugins/ComputedFieldPipeline.cs
+++ b/src/Honua.Plugins/ComputedFieldPipeline.cs
@@ -17,14 +17,19 @@ namespace Honua.Plugins;
 /// projection seam, and gates the whole thing behind the Enterprise <c>plugin.sdk</c> entitlement
 /// plus the operator kill-switch. When unlicensed/disabled it returns features unchanged.
 /// Provider failures are isolated and logged — a faulting computed field is omitted, never failing
-/// the query.
+/// the query. A provider that faults repeatedly is auto-disabled by the per-plugin circuit breaker
+/// so a misbehaving computed field stops being retried on every queried feature. Per-provider
+/// execution metrics are emitted via <see cref="PluginMetrics"/>.
 /// </summary>
 internal sealed partial class ComputedFieldPipeline : IComputedFieldPipeline
 {
+    private const string ExtensionPoint = "compute";
+
     private readonly IComputedFieldProvider[] _providers;
     private readonly ILicenseEntitlementService _licensing;
     private readonly ILogger<ComputedFieldPipeline> _logger;
     private readonly bool _enabledByConfig;
+    private readonly PluginCircuitBreaker _circuitBreaker = new();
 
     public ComputedFieldPipeline(
         IEnumerable<IComputedFieldProvider> providers,
@@ -58,10 +63,24 @@ internal sealed partial class ComputedFieldPipeline : IComputedFieldPipeline
         foreach (var provider in _providers)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            var pluginId = PluginIdOf(provider);
+
+            // Skip providers whose breaker is currently tripped open: a repeatedly-faulting
+            // computed field is parked (auto-disabled) until the cooldown allows a half-open retry.
+            if (!_circuitBreaker.IsAllowed(pluginId))
+            {
+                continue;
+            }
+
+            using var measure = PluginMetrics.Measure(pluginId, ExtensionPoint);
             try
             {
                 var value = await provider.ComputeAsync(feature, context, cancellationToken).ConfigureAwait(false);
                 attributes = attributes.SetItem(provider.FieldName, value);
+                if (_circuitBreaker.RecordSuccess(pluginId))
+                {
+                    Log.ComputeRecovered(_logger, pluginId, provider.FieldName);
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -70,7 +89,12 @@ internal sealed partial class ComputedFieldPipeline : IComputedFieldPipeline
             catch (Exception ex)
             {
                 // Computed fields are best-effort on the read path: isolate and omit.
-                Log.ComputeFailed(_logger, PluginIdOf(provider), provider.FieldName, context.ServiceId, context.LayerId, ex);
+                measure.MarkFailed();
+                Log.ComputeFailed(_logger, pluginId, provider.FieldName, context.ServiceId, context.LayerId, ex);
+                if (_circuitBreaker.RecordFailure(pluginId))
+                {
+                    Log.ComputeAutoDisabled(_logger, pluginId, provider.FieldName);
+                }
             }
         }
 
@@ -93,5 +117,13 @@ internal sealed partial class ComputedFieldPipeline : IComputedFieldPipeline
         [LoggerMessage(EventId = 9310, Level = LogLevel.Error,
             Message = "Plugin computed-field provider '{PluginId}' failed computing '{FieldName}' for service {ServiceId} layer {LayerId}; field omitted.")]
         public static partial void ComputeFailed(ILogger logger, string pluginId, string fieldName, string serviceId, int layerId, Exception exception);
+
+        [LoggerMessage(EventId = 9311, Level = LogLevel.Warning,
+            Message = "Plugin computed-field provider '{PluginId}' ('{FieldName}') auto-disabled after repeated failures; it will be retried after a cooldown.")]
+        public static partial void ComputeAutoDisabled(ILogger logger, string pluginId, string fieldName);
+
+        [LoggerMessage(EventId = 9312, Level = LogLevel.Information,
+            Message = "Plugin computed-field provider '{PluginId}' ('{FieldName}') recovered and was re-enabled.")]
+        public static partial void ComputeRecovered(ILogger logger, string pluginId, string fieldName);
     }
 }

--- a/src/Honua.Plugins/HonuaPluginBuilder.cs
+++ b/src/Honua.Plugins/HonuaPluginBuilder.cs
@@ -39,16 +39,18 @@ internal sealed class HonuaPluginBuilder(IServiceCollection services) : IHonuaPl
         var providesEditHook = typeof(IEditHook).IsAssignableFrom(type);
         var providesComputedField = typeof(IComputedFieldProvider).IsAssignableFrom(type);
         var providesBackgroundService = typeof(IPluginBackgroundService).IsAssignableFrom(type);
+        var providesCustomEndpoint = typeof(ICustomEndpoint).IsAssignableFrom(type);
 
         if (!providesValidator && !providesFieldValidator && !providesEditHook
-            && !providesComputedField && !providesBackgroundService)
+            && !providesComputedField && !providesBackgroundService && !providesCustomEndpoint)
         {
             throw new InvalidOperationException(
                 $"Plugin '{manifest.Id}' ({type.FullName}) must implement at least one extension point "
-                + "(IFeatureValidator, IFieldValidator, IEditHook, IComputedFieldProvider, or IPluginBackgroundService).");
+                + "(IFeatureValidator, IFieldValidator, IEditHook, IComputedFieldProvider, "
+                + "IPluginBackgroundService, or ICustomEndpoint).");
         }
 
-        EnforceCapabilities(manifest, providesBackgroundService);
+        EnforceCapabilities(manifest, providesBackgroundService, providesCustomEndpoint);
 
         if (_registrations.Exists(r => string.Equals(r.Id, manifest.Id, StringComparison.OrdinalIgnoreCase)))
         {
@@ -82,6 +84,11 @@ internal sealed class HonuaPluginBuilder(IServiceCollection services) : IHonuaPl
             _services.AddSingleton<IPluginBackgroundService>(sp => (IPluginBackgroundService)sp.GetRequiredService<TPlugin>());
         }
 
+        if (providesCustomEndpoint)
+        {
+            _services.AddSingleton<ICustomEndpoint>(sp => (ICustomEndpoint)sp.GetRequiredService<TPlugin>());
+        }
+
         _registrations.Add(new PluginRegistration(
             manifest,
             type,
@@ -89,12 +96,16 @@ internal sealed class HonuaPluginBuilder(IServiceCollection services) : IHonuaPl
             providesFieldValidator,
             providesEditHook,
             providesComputedField,
-            providesBackgroundService));
+            providesBackgroundService,
+            providesCustomEndpoint));
 
         return this;
     }
 
-    private static void EnforceCapabilities(PluginManifest manifest, bool providesBackgroundService)
+    private static void EnforceCapabilities(
+        PluginManifest manifest,
+        bool providesBackgroundService,
+        bool providesCustomEndpoint)
     {
         if (providesBackgroundService
             && !manifest.Capabilities.HasFlag(PluginCapability.BackgroundExecution))
@@ -102,6 +113,15 @@ internal sealed class HonuaPluginBuilder(IServiceCollection services) : IHonuaPl
             throw new InvalidOperationException(
                 $"Plugin '{manifest.Id}' implements IPluginBackgroundService but does not declare the "
                 + "BackgroundExecution capability. Add Capabilities = PluginCapability.BackgroundExecution "
+                + "to its [Plugin] attribute.");
+        }
+
+        if (providesCustomEndpoint
+            && !manifest.Capabilities.HasFlag(PluginCapability.CustomEndpoints))
+        {
+            throw new InvalidOperationException(
+                $"Plugin '{manifest.Id}' implements ICustomEndpoint but does not declare the "
+                + "CustomEndpoints capability. Add Capabilities = PluginCapability.CustomEndpoints "
                 + "to its [Plugin] attribute.");
         }
     }

--- a/src/Honua.Plugins/PluginBackgroundServiceHost.cs
+++ b/src/Honua.Plugins/PluginBackgroundServiceHost.cs
@@ -2,9 +2,11 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Reflection;
+using Honua.Core.Features.AuditLog.Abstractions;
 using Honua.Core.Features.Licensing.Abstractions;
 using Honua.Core.Features.Licensing.Domain;
 using Honua.Plugins.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -20,8 +22,11 @@ namespace Honua.Plugins;
 /// </summary>
 internal sealed partial class PluginBackgroundServiceHost : IHostedService
 {
+    private const string ExtensionPoint = "background";
+
     private readonly IPluginBackgroundService[] _services;
     private readonly ILicenseEntitlementService _licensing;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<PluginBackgroundServiceHost> _logger;
     private readonly bool _enabledByConfig;
     private readonly List<Task> _runners = [];
@@ -30,12 +35,14 @@ internal sealed partial class PluginBackgroundServiceHost : IHostedService
     public PluginBackgroundServiceHost(
         IEnumerable<IPluginBackgroundService> services,
         ILicenseEntitlementService licensing,
+        IServiceScopeFactory scopeFactory,
         IOptions<PluginOptions> options,
         ILogger<PluginBackgroundServiceHost> logger)
     {
         ArgumentNullException.ThrowIfNull(options);
         _services = [.. services];
         _licensing = licensing ?? throw new ArgumentNullException(nameof(licensing));
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _enabledByConfig = options.Value.Enabled;
     }
@@ -91,6 +98,11 @@ internal sealed partial class PluginBackgroundServiceHost : IHostedService
     {
         var pluginId = PluginIdOf(service);
         Log.Starting(_logger, pluginId);
+        await AuditAsync(
+            (auditLog, ct) => PluginExecutionAudit.RecordBackgroundStartedAsync(auditLog, pluginId, ct),
+            stoppingToken).ConfigureAwait(false);
+
+        using var measure = PluginMetrics.Measure(pluginId, ExtensionPoint);
         try
         {
             await service.ExecuteAsync(stoppingToken).ConfigureAwait(false);
@@ -103,7 +115,32 @@ internal sealed partial class PluginBackgroundServiceHost : IHostedService
         {
             // Failure isolation: a faulting background service is logged and disabled, never
             // propagated to the host (which would tear down the process).
+            measure.MarkFailed();
             Log.Faulted(_logger, pluginId, ex);
+            await AuditAsync(
+                (auditLog, ct) => PluginExecutionAudit.RecordBackgroundFaultedAsync(auditLog, pluginId, ct),
+                CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    // Background services are hosted as a singleton, so the scoped IAuditLog (PostgresAuditLog needs
+    // a per-operation DB connection) is resolved from a transient scope per audit write rather than
+    // captured as a captive dependency.
+    private async Task AuditAsync(Func<IAuditLog, CancellationToken, Task> record, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var auditLog = scope.ServiceProvider.GetRequiredService<IAuditLog>();
+            await record(auditLog, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            // Auditing a background-service lifecycle transition must never crash the host.
         }
     }
 

--- a/src/Honua.Plugins/PluginCircuitBreaker.cs
+++ b/src/Honua.Plugins/PluginCircuitBreaker.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+
+namespace Honua.Plugins;
+
+/// <summary>
+/// Per-plugin failure-isolation circuit breaker (issue #1562). Tracks consecutive faults of a
+/// plugin's best-effort extension point (after-edit hooks, computed-field providers) and, once a
+/// threshold of consecutive failures is reached, trips open so the host stops invoking the faulting
+/// plugin until a cooldown elapses. This bounds the cost of a misbehaving plugin: rather than
+/// throwing on every request, a repeatedly-faulting plugin is auto-disabled and periodically
+/// retried (half-open) so a transient fault self-heals while a persistent one stays parked.
+/// </summary>
+/// <remarks>
+/// The breaker is keyed by plugin id and is safe for concurrent use. A successful execution resets
+/// the consecutive-failure count and closes the breaker. State transitions are reported to the
+/// supplied callbacks so the host can audit/log auto-disable and recovery without coupling the
+/// breaker to a specific sink.
+/// </remarks>
+internal sealed class PluginCircuitBreaker
+{
+    /// <summary>Default consecutive failures before the breaker trips open.</summary>
+    public const int DefaultFailureThreshold = 3;
+
+    private static readonly TimeSpan DefaultCooldown = TimeSpan.FromMinutes(5);
+
+    private readonly int _failureThreshold;
+    private readonly TimeSpan _cooldown;
+    private readonly TimeProvider _timeProvider;
+    private readonly ConcurrentDictionary<string, State> _states = new(StringComparer.Ordinal);
+
+    /// <summary>Initializes a new instance of the <see cref="PluginCircuitBreaker"/> class.</summary>
+    /// <param name="failureThreshold">Consecutive failures that trip the breaker open. Must be positive.</param>
+    /// <param name="cooldown">How long the breaker stays open before a half-open retry is allowed.</param>
+    /// <param name="timeProvider">Time source (injectable for tests); defaults to <see cref="TimeProvider.System"/>.</param>
+    public PluginCircuitBreaker(
+        int failureThreshold = DefaultFailureThreshold,
+        TimeSpan? cooldown = null,
+        TimeProvider? timeProvider = null)
+    {
+        if (failureThreshold <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(failureThreshold), "Failure threshold must be positive.");
+        }
+
+        _failureThreshold = failureThreshold;
+        _cooldown = cooldown ?? DefaultCooldown;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    /// Returns whether the plugin may currently be invoked. A closed breaker always allows; an open
+    /// breaker allows a single half-open trial once the cooldown has elapsed, otherwise blocks.
+    /// </summary>
+    /// <param name="pluginId">The plugin id.</param>
+    /// <returns><see langword="true"/> when invocation is permitted.</returns>
+    public bool IsAllowed(string pluginId)
+    {
+        if (!_states.TryGetValue(pluginId, out var state) || !state.IsOpen)
+        {
+            return true;
+        }
+
+        return _timeProvider.GetUtcNow() >= state.OpenedUntil;
+    }
+
+    /// <summary>Records a successful execution, resetting failures and closing the breaker.</summary>
+    /// <param name="pluginId">The plugin id.</param>
+    /// <returns><see langword="true"/> when this success closed a previously-open breaker.</returns>
+    public bool RecordSuccess(string pluginId)
+    {
+        var recovered = false;
+        _states.AddOrUpdate(
+            pluginId,
+            static _ => State.Closed,
+            (_, existing) =>
+            {
+                recovered = existing.IsOpen;
+                return State.Closed;
+            });
+        return recovered;
+    }
+
+    /// <summary>
+    /// Records a failed execution. Returns <see langword="true"/> when this failure tripped the
+    /// breaker open (i.e. the plugin was just auto-disabled), so the caller can audit/log the
+    /// transition exactly once.
+    /// </summary>
+    /// <param name="pluginId">The plugin id.</param>
+    /// <returns><see langword="true"/> when the breaker transitioned to open on this failure.</returns>
+    public bool RecordFailure(string pluginId)
+    {
+        var tripped = false;
+        _states.AddOrUpdate(
+            pluginId,
+            _ =>
+            {
+                var first = State.Closed.WithFailure(_failureThreshold, _timeProvider.GetUtcNow(), _cooldown, out tripped);
+                return first;
+            },
+            (_, existing) => existing.WithFailure(_failureThreshold, _timeProvider.GetUtcNow(), _cooldown, out tripped));
+        return tripped;
+    }
+
+    /// <summary>Gets whether the breaker for the given plugin is currently tripped open.</summary>
+    /// <param name="pluginId">The plugin id.</param>
+    /// <returns><see langword="true"/> when the breaker is open.</returns>
+    public bool IsOpen(string pluginId)
+        => _states.TryGetValue(pluginId, out var state) && state.IsOpen;
+
+    private readonly record struct State(int ConsecutiveFailures, bool IsOpen, DateTimeOffset OpenedUntil)
+    {
+        public static State Closed { get; } = new(0, IsOpen: false, OpenedUntil: default);
+
+        public State WithFailure(int threshold, DateTimeOffset now, TimeSpan cooldown, out bool tripped)
+        {
+            var failures = ConsecutiveFailures + 1;
+            if (failures >= threshold)
+            {
+                // Trip (or re-arm an already-open breaker after a failed half-open trial). Report
+                // "tripped" only on the closed -> open transition so the host audits it once.
+                tripped = !IsOpen;
+                return new State(failures, IsOpen: true, now + cooldown);
+            }
+
+            tripped = false;
+            return new State(failures, IsOpen: false, OpenedUntil: default);
+        }
+    }
+}

--- a/src/Honua.Plugins/PluginEditPipeline.cs
+++ b/src/Honua.Plugins/PluginEditPipeline.cs
@@ -20,6 +20,11 @@ namespace Honua.Plugins;
 /// </summary>
 internal sealed partial class PluginEditPipeline : IPluginEditPipeline
 {
+    private const string ValidateExtensionPoint = "validate";
+    private const string FieldValidateExtensionPoint = "validate-field";
+    private const string BeforeHookExtensionPoint = "before-hook";
+    private const string AfterHookExtensionPoint = "after-hook";
+
     private readonly IFeatureValidator[] _validators;
     private readonly IFieldValidator[] _fieldValidators;
     private readonly IEditHook[] _hooks;
@@ -27,6 +32,7 @@ internal sealed partial class PluginEditPipeline : IPluginEditPipeline
     private readonly IAuditLog _auditLog;
     private readonly ILogger<PluginEditPipeline> _logger;
     private readonly bool _enabledByConfig;
+    private readonly PluginCircuitBreaker _afterHookBreaker = new();
     private int _unlicensedLogged;
 
     public PluginEditPipeline(
@@ -86,8 +92,19 @@ internal sealed partial class PluginEditPipeline : IPluginEditPipeline
             foreach (var validator in _validators)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var result = await validator.ValidateAsync(item.Feature, validationContext, cancellationToken)
-                    .ConfigureAwait(false);
+                using var measure = PluginMetrics.Measure(PluginIdOf(validator), ValidateExtensionPoint);
+                PluginValidationResult result;
+                try
+                {
+                    result = await validator.ValidateAsync(item.Feature, validationContext, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch
+                {
+                    measure.MarkFailed();
+                    throw;
+                }
+
                 if (!result.IsValid)
                 {
                     rejections.Add(new PluginEditRejection(
@@ -111,9 +128,20 @@ internal sealed partial class PluginEditPipeline : IPluginEditPipeline
                     }
 
                     cancellationToken.ThrowIfCancellationRequested();
-                    var result = await fieldValidator
-                        .ValidateFieldAsync(value, item.Feature, validationContext, cancellationToken)
-                        .ConfigureAwait(false);
+                    using var measure = PluginMetrics.Measure(PluginIdOf(fieldValidator), FieldValidateExtensionPoint);
+                    PluginValidationResult result;
+                    try
+                    {
+                        result = await fieldValidator
+                            .ValidateFieldAsync(value, item.Feature, validationContext, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        measure.MarkFailed();
+                        throw;
+                    }
+
                     if (!result.IsValid)
                     {
                         rejections.Add(new PluginEditRejection(
@@ -131,7 +159,20 @@ internal sealed partial class PluginEditPipeline : IPluginEditPipeline
         foreach (var hook in _hooks)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var hookResult = await hook.OnBeforeEditAsync(context, cancellationToken).ConfigureAwait(false);
+            EditHookResult hookResult;
+            using (var measure = PluginMetrics.Measure(PluginIdOf(hook), BeforeHookExtensionPoint))
+            {
+                try
+                {
+                    hookResult = await hook.OnBeforeEditAsync(context, cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    measure.MarkFailed();
+                    throw;
+                }
+            }
+
             if (hookResult.IsRejected)
             {
                 await AuditRejectionAsync(context, objectId: null, hookResult.Reason!, cancellationToken)
@@ -163,9 +204,27 @@ internal sealed partial class PluginEditPipeline : IPluginEditPipeline
 
         foreach (var hook in _hooks)
         {
+            var pluginId = PluginIdOf(hook);
+
+            // Skip after-hooks whose breaker is tripped open: a repeatedly-faulting after-hook is
+            // parked (auto-disabled) until the cooldown allows a half-open retry, so a misbehaving
+            // hook stops being invoked on every committed edit.
+            if (!_afterHookBreaker.IsAllowed(pluginId))
+            {
+                continue;
+            }
+
+            using var measure = PluginMetrics.Measure(pluginId, AfterHookExtensionPoint);
             try
             {
                 await hook.OnAfterEditAsync(context, cancellationToken).ConfigureAwait(false);
+                if (_afterHookBreaker.RecordSuccess(pluginId))
+                {
+                    Log.AfterHookRecovered(_logger, pluginId);
+                    await PluginExecutionAudit
+                        .RecordRecoveredAsync(_auditLog, pluginId, AfterHookExtensionPoint, cancellationToken)
+                        .ConfigureAwait(false);
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -174,7 +233,15 @@ internal sealed partial class PluginEditPipeline : IPluginEditPipeline
             catch (Exception ex)
             {
                 // After-hooks are best-effort: the edit is already committed. Never propagate.
-                Log.AfterHookFailed(_logger, PluginIdOf(hook), context.ServiceId, context.LayerId, ex);
+                measure.MarkFailed();
+                Log.AfterHookFailed(_logger, pluginId, context.ServiceId, context.LayerId, ex);
+                if (_afterHookBreaker.RecordFailure(pluginId))
+                {
+                    Log.AfterHookAutoDisabled(_logger, pluginId);
+                    await PluginExecutionAudit
+                        .RecordAutoDisabledAsync(_auditLog, pluginId, AfterHookExtensionPoint, cancellationToken)
+                        .ConfigureAwait(false);
+                }
             }
         }
     }
@@ -263,5 +330,13 @@ internal sealed partial class PluginEditPipeline : IPluginEditPipeline
         [LoggerMessage(EventId = 9301, Level = LogLevel.Error,
             Message = "Plugin after-edit hook '{PluginId}' failed for service {ServiceId} layer {LayerId}; edit already committed.")]
         public static partial void AfterHookFailed(ILogger logger, string pluginId, string serviceId, int layerId, Exception exception);
+
+        [LoggerMessage(EventId = 9302, Level = LogLevel.Warning,
+            Message = "Plugin after-edit hook '{PluginId}' auto-disabled after repeated failures; it will be retried after a cooldown.")]
+        public static partial void AfterHookAutoDisabled(ILogger logger, string pluginId);
+
+        [LoggerMessage(EventId = 9303, Level = LogLevel.Information,
+            Message = "Plugin after-edit hook '{PluginId}' recovered and was re-enabled.")]
+        public static partial void AfterHookRecovered(ILogger logger, string pluginId);
     }
 }

--- a/src/Honua.Plugins/PluginExecutionAudit.cs
+++ b/src/Honua.Plugins/PluginExecutionAudit.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.AuditLog.Abstractions;
+
+namespace Honua.Plugins;
+
+/// <summary>
+/// Emits plugin execution / lifecycle audit events (issue #1562). Phase 1 audited only the
+/// edit-rejection case; this helper records the fuller lifecycle — a plugin auto-disabled by the
+/// failure-isolation circuit breaker, its subsequent recovery, and background-service start/stop —
+/// so an operator can reconstruct what a plugin did and when it was parked, without leaking plugin
+/// internals to clients.
+/// </summary>
+/// <remarks>
+/// Lifecycle events are recorded as <see cref="AuditEventType.AdminAction"/> against a synthetic
+/// <c>plugin</c> resource keyed by plugin id. The system itself is the actor (these are host-driven
+/// transitions, not user actions). Failures to write the audit log are swallowed: auditing a
+/// best-effort lifecycle transition must never become a new failure source.
+/// </remarks>
+internal static class PluginExecutionAudit
+{
+    private const string SystemActor = "system";
+    private const string PluginResourceType = "plugin";
+    private const string NoCorrelation = "-";
+
+    /// <summary>Audits a plugin being auto-disabled by the circuit breaker after repeated faults.</summary>
+    public static Task RecordAutoDisabledAsync(
+        IAuditLog auditLog,
+        string pluginId,
+        string extensionPoint,
+        CancellationToken cancellationToken)
+        => RecordAsync(
+            auditLog,
+            pluginId,
+            action: "plugin.autodisabled",
+            outcome: AuditOutcome.Failure,
+            details: $"Plugin '{pluginId}' {extensionPoint} extension point auto-disabled after repeated failures.",
+            cancellationToken);
+
+    /// <summary>Audits a previously auto-disabled plugin recovering and being re-enabled.</summary>
+    public static Task RecordRecoveredAsync(
+        IAuditLog auditLog,
+        string pluginId,
+        string extensionPoint,
+        CancellationToken cancellationToken)
+        => RecordAsync(
+            auditLog,
+            pluginId,
+            action: "plugin.recovered",
+            outcome: AuditOutcome.Success,
+            details: $"Plugin '{pluginId}' {extensionPoint} extension point recovered and was re-enabled.",
+            cancellationToken);
+
+    /// <summary>Audits a plugin background service starting.</summary>
+    public static Task RecordBackgroundStartedAsync(
+        IAuditLog auditLog,
+        string pluginId,
+        CancellationToken cancellationToken)
+        => RecordAsync(
+            auditLog,
+            pluginId,
+            action: "plugin.background.started",
+            outcome: AuditOutcome.Success,
+            details: $"Plugin '{pluginId}' background service started.",
+            cancellationToken);
+
+    /// <summary>Audits a plugin background service faulting and being disabled.</summary>
+    public static Task RecordBackgroundFaultedAsync(
+        IAuditLog auditLog,
+        string pluginId,
+        CancellationToken cancellationToken)
+        => RecordAsync(
+            auditLog,
+            pluginId,
+            action: "plugin.background.faulted",
+            outcome: AuditOutcome.Failure,
+            details: $"Plugin '{pluginId}' background service faulted and was disabled.",
+            cancellationToken);
+
+    private static async Task RecordAsync(
+        IAuditLog auditLog,
+        string pluginId,
+        string action,
+        AuditOutcome outcome,
+        string details,
+        CancellationToken cancellationToken)
+    {
+        var auditEvent = new AuditEvent
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            EventType = AuditEventType.AdminAction,
+            Actor = SystemActor,
+            ActorType = AuditActorType.System,
+            ResourceType = PluginResourceType,
+            ResourceId = pluginId,
+            Action = action,
+            Outcome = outcome,
+            CorrelationId = NoCorrelation,
+            Details = details,
+        };
+
+        try
+        {
+            await auditLog.RecordAsync(auditEvent, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            // Auditing a best-effort lifecycle transition must never become a new failure source.
+        }
+    }
+}

--- a/src/Honua.Plugins/PluginMetrics.cs
+++ b/src/Honua.Plugins/PluginMetrics.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Honua.Plugins;
+
+/// <summary>
+/// OpenTelemetry instrumentation for plugin extension-point execution (issue #1562). Emits
+/// invocation counters, a failure counter, and a duration histogram on the shared <c>Honua</c>
+/// meter so the OpenTelemetry exporter wired in <c>HonuaTelemetry</c> picks them up alongside the
+/// rest of the server's metrics. All series carry a low-cardinality <c>plugin_id</c> and
+/// <c>extension_point</c> dimension so dashboards can compute per-plugin latency and error rates.
+/// </summary>
+/// <remarks>
+/// Plugin ids and extension-point names are bounded (compile-time registered, one series per
+/// plugin/extension), so the resulting metric cardinality stays small. Recording is allocation-light
+/// on the hot path: callers wrap an execution in <see cref="Measure"/> and dispose the returned
+/// scope, which records duration and a failure when <see cref="Scope.MarkFailed"/> was called.
+/// </remarks>
+internal static class PluginMetrics
+{
+    /// <summary>Tag key identifying the plugin that owns the executed extension point.</summary>
+    public const string PluginIdTag = "plugin_id";
+
+    /// <summary>Tag key identifying the extension-point family being executed.</summary>
+    public const string ExtensionPointTag = "extension_point";
+
+    private const string UnknownPluginId = "unknown";
+
+    // Independent Meter instance sharing the canonical "Honua" meter name (see HonuaCacheMetrics)
+    // so a single exporter selector collects every Honua counter without Honua.Plugins taking a
+    // dependency on Honua.ServiceDefaults.
+    private static readonly Meter Meter = new("Honua");
+
+    private static readonly Counter<long> Invocations = Meter.CreateCounter<long>(
+        "honua_plugin_invocations_total",
+        "operations",
+        "Total plugin extension-point invocations, partitioned by plugin_id and extension_point.");
+
+    private static readonly Counter<long> Failures = Meter.CreateCounter<long>(
+        "honua_plugin_failures_total",
+        "operations",
+        "Total plugin extension-point invocations that faulted, partitioned by plugin_id and extension_point.");
+
+    private static readonly Histogram<double> Duration = Meter.CreateHistogram<double>(
+        "honua_plugin_duration_ms",
+        "ms",
+        "Plugin extension-point execution duration in milliseconds, partitioned by plugin_id and extension_point.");
+
+    /// <summary>
+    /// Begins timing a single plugin extension-point execution. Increments the invocation counter
+    /// immediately and records duration (plus a failure when <see cref="Scope.MarkFailed"/> was
+    /// called) when the returned scope is disposed.
+    /// </summary>
+    /// <param name="pluginId">The owning plugin id; falls back to <c>"unknown"</c> when null/empty.</param>
+    /// <param name="extensionPoint">The extension-point family (e.g. <c>validate</c>, <c>compute</c>).</param>
+    /// <returns>A disposable measurement scope.</returns>
+    public static Scope Measure(string? pluginId, string extensionPoint)
+    {
+        var id = Normalize(pluginId);
+        var tags = Tags(id, extensionPoint);
+        Invocations.Add(1, tags[0], tags[1]);
+        return new Scope(id, extensionPoint);
+    }
+
+    private static KeyValuePair<string, object?>[] Tags(string pluginId, string extensionPoint) =>
+    [
+        new(PluginIdTag, pluginId),
+        new(ExtensionPointTag, extensionPoint),
+    ];
+
+    private static string Normalize(string? pluginId)
+        => string.IsNullOrWhiteSpace(pluginId) ? UnknownPluginId : pluginId;
+
+    /// <summary>
+    /// Disposable measurement of one plugin extension-point execution. Records elapsed time and, when
+    /// <see cref="MarkFailed"/> was called, a failure on dispose.
+    /// </summary>
+    public struct Scope : IDisposable
+    {
+        private readonly string _pluginId;
+        private readonly string _extensionPoint;
+        private readonly long _startTimestamp;
+        private bool _failed;
+        private bool _disposed;
+
+        internal Scope(string pluginId, string extensionPoint)
+        {
+            _pluginId = pluginId;
+            _extensionPoint = extensionPoint;
+            _startTimestamp = Stopwatch.GetTimestamp();
+            _failed = false;
+            _disposed = false;
+        }
+
+        /// <summary>Flags this execution as failed so a failure counter is emitted on dispose.</summary>
+        public void MarkFailed() => _failed = true;
+
+        /// <summary>Records duration and (when flagged) a failure for this execution.</summary>
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            var elapsedMs = Stopwatch.GetElapsedTime(_startTimestamp).TotalMilliseconds;
+            var tags = Tags(_pluginId, _extensionPoint);
+            Duration.Record(elapsedMs, tags[0], tags[1]);
+            if (_failed)
+            {
+                Failures.Add(1, tags[0], tags[1]);
+            }
+        }
+    }
+}

--- a/src/Honua.Plugins/PluginRegistration.cs
+++ b/src/Honua.Plugins/PluginRegistration.cs
@@ -15,6 +15,7 @@ namespace Honua.Plugins;
 /// <param name="ProvidesEditHook">Whether the plugin implements <c>IEditHook</c>.</param>
 /// <param name="ProvidesComputedField">Whether the plugin implements <c>IComputedFieldProvider</c>.</param>
 /// <param name="ProvidesBackgroundService">Whether the plugin implements <c>IPluginBackgroundService</c>.</param>
+/// <param name="ProvidesCustomEndpoint">Whether the plugin implements <c>ICustomEndpoint</c>.</param>
 public sealed record PluginRegistration(
     PluginManifest Manifest,
     Type ImplementationType,
@@ -22,7 +23,8 @@ public sealed record PluginRegistration(
     bool ProvidesFieldValidator,
     bool ProvidesEditHook,
     bool ProvidesComputedField,
-    bool ProvidesBackgroundService)
+    bool ProvidesBackgroundService,
+    bool ProvidesCustomEndpoint)
 {
     /// <summary>Gets the stable plugin identifier.</summary>
     public string Id => Manifest.Id;

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -39,6 +39,7 @@ using Honua.Ai.Protocols.Mcp;
 using Honua.Ai.NlQuery;
 using Honua.Ai.WorkflowGeneration;
 using Honua.Plugins;
+using Honua.Server.Features.Plugins;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Honua.Protocols.OData;
 using Honua.Protocols.Ogc.Api.Coverages;
@@ -239,6 +240,10 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapMcpOperatorSurface();
         endpoints.MapSpecGroundingEndpoints();
         endpoints.MapSpecEndpoints();
+        // Plugin-contributed REST routes (ICustomEndpoint, #1562). A no-op unless a custom build
+        // compiled in a plugin that contributes endpoints; gated per request behind the Enterprise
+        // plugin.sdk entitlement and the operator kill-switch.
+        endpoints.MapHonuaPluginEndpoints();
 
         return endpoints;
     }

--- a/src/Honua.Server/Features/Plugins/PluginCustomEndpoints.cs
+++ b/src/Honua.Server/Features/Plugins/PluginCustomEndpoints.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Infrastructure.Licensing;
+using Honua.Plugins;
+using Honua.Plugins.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Plugins;
+
+/// <summary>
+/// Maps plugin-contributed REST routes (<see cref="ICustomEndpoint"/>, issue #1562). Each registered
+/// custom endpoint is mapped once at startup under the reserved <c>/plugins</c> prefix using the
+/// AOT-safe <c>MapMethods</c> + explicit HTTP-metadata pattern (no runtime route discovery). Routes
+/// are gated, at request time, behind the Enterprise <c>plugin.sdk</c> entitlement and the operator
+/// kill-switch, and pass through the host's authorization metadata when the plugin requests it — a
+/// plugin cannot bypass the shared authorization pipeline.
+/// </summary>
+public static class PluginCustomEndpoints
+{
+    /// <summary>Reserved route prefix all plugin-contributed endpoints are mounted under.</summary>
+    public const string RoutePrefix = "/plugins";
+
+    /// <summary>
+    /// Maps every registered <see cref="ICustomEndpoint"/> under the reserved <c>/plugins</c> prefix.
+    /// A no-op when no plugins contribute endpoints. Safe to call unconditionally in the host
+    /// composition root: the per-request license/kill-switch gate keeps contributed routes inert
+    /// unless the SDK is licensed and enabled.
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public static IEndpointRouteBuilder MapHonuaPluginEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var catalog = endpoints.ServiceProvider.GetService<PluginCatalog>();
+        if (catalog is null || !catalog.Plugins.Any(p => p.ProvidesCustomEndpoint))
+        {
+            return endpoints;
+        }
+
+        var customEndpoints = endpoints.ServiceProvider.GetServices<ICustomEndpoint>().ToArray();
+        foreach (var endpoint in customEndpoints)
+        {
+            MapOne(endpoints, endpoint);
+        }
+
+        return endpoints;
+    }
+
+    private static void MapOne(IEndpointRouteBuilder endpoints, ICustomEndpoint endpoint)
+    {
+        var methods = endpoint.Methods is { Count: > 0 }
+            ? endpoint.Methods.ToArray()
+            : throw new InvalidOperationException(
+                $"Plugin custom endpoint '{endpoint.GetType().FullName}' must declare at least one HTTP method.");
+
+        if (string.IsNullOrWhiteSpace(endpoint.Pattern))
+        {
+            throw new InvalidOperationException(
+                $"Plugin custom endpoint '{endpoint.GetType().FullName}' must declare a non-empty route pattern.");
+        }
+
+        var pattern = $"{RoutePrefix}/{endpoint.Pattern.TrimStart('/')}";
+
+        // Capture the singleton endpoint instance so the handler delegate is static-rooted and
+        // AOT-safe (no per-request service resolution of the plugin type, no reflection).
+        var builder = endpoints.MapMethods(pattern, methods, (HttpContext context, CancellationToken ct)
+            => HandleAsync(endpoint, context, ct))
+            .WithTags("Plugins")
+            .WithDisplayName($"Plugin endpoint: {pattern}");
+
+        if (endpoint.RequiresAuthorization)
+        {
+            builder.RequireAuthorization();
+        }
+    }
+
+    private static async Task<IResult> HandleAsync(
+        ICustomEndpoint endpoint,
+        HttpContext context,
+        CancellationToken cancellationToken)
+    {
+        // License + kill-switch gate, enforced per request so a license change takes effect without
+        // a restart. Contributed routes are Enterprise-gated like the rest of the plugin SDK.
+        var options = context.RequestServices.GetService<IOptions<PluginOptions>>();
+        if (options is { Value.Enabled: false })
+        {
+            return Results.NotFound();
+        }
+
+        if (!LicenseGate.IsEntitlementActive(context.RequestServices, FeatureCatalog.PluginSdkKey))
+        {
+            return Results.NotFound();
+        }
+
+        var request = await BuildRequestAsync(context, cancellationToken).ConfigureAwait(false);
+        var response = await endpoint.HandleAsync(request, cancellationToken).ConfigureAwait(false);
+        return new PluginEndpointResult(response);
+    }
+
+    private static async Task<PluginEndpointRequest> BuildRequestAsync(HttpContext context, CancellationToken cancellationToken)
+    {
+        var routeValues = ImmutableDictionary.CreateBuilder<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in context.Request.RouteValues)
+        {
+            routeValues[key] = value?.ToString();
+        }
+
+        var query = ImmutableDictionary.CreateBuilder<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in context.Request.Query)
+        {
+            query[key] = value.ToString();
+        }
+
+        var headers = ImmutableDictionary.CreateBuilder<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in context.Request.Headers)
+        {
+            headers[key] = value.ToString();
+        }
+
+        var body = await ReadBodyAsync(context, cancellationToken).ConfigureAwait(false);
+
+        return new PluginEndpointRequest(
+            context.Request.Method.ToUpperInvariant(),
+            context.Request.Path.Value ?? string.Empty,
+            routeValues.ToImmutable(),
+            query.ToImmutable(),
+            headers.ToImmutable(),
+            body,
+            context.User?.Identity?.Name);
+    }
+
+    private static async Task<ReadOnlyMemory<byte>> ReadBodyAsync(HttpContext context, CancellationToken cancellationToken)
+    {
+        if (context.Request.ContentLength is null or 0)
+        {
+            return ReadOnlyMemory<byte>.Empty;
+        }
+
+        using var buffer = new MemoryStream();
+        await context.Request.Body.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a plugin-produced <see cref="PluginEndpointResponse"/> back to the caller. Implemented
+    /// as an <see cref="IResult"/> so the contributed route participates in the standard response
+    /// pipeline (logging, telemetry, exception handling) like every other endpoint.
+    /// </summary>
+    private sealed class PluginEndpointResult(PluginEndpointResponse response) : IResult
+    {
+        public async Task ExecuteAsync(HttpContext httpContext)
+        {
+            ArgumentNullException.ThrowIfNull(httpContext);
+
+            httpContext.Response.StatusCode = response.StatusCode;
+            if (!string.IsNullOrEmpty(response.ContentType))
+            {
+                httpContext.Response.ContentType = response.ContentType;
+            }
+
+            foreach (var (key, value) in response.Headers)
+            {
+                httpContext.Response.Headers[key] = value;
+            }
+
+            if (!response.Body.IsEmpty)
+            {
+                await httpContext.Response.Body
+                    .WriteAsync(response.Body, httpContext.RequestAborted)
+                    .ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
@@ -32,6 +32,7 @@ public sealed class VerticalSliceIsolationTests
         "Grounding",
         "Orchestration",
         "PackageReview",
+        "Plugins", // Plugin/extension SDK host slice (honua-server#1562): maps plugin-contributed ICustomEndpoint routes.
         "Protocols",
         "Mobile", // Parent container for mobile sub-feature slices (e.g. FieldCollection sync)
         "NlQuery",

--- a/tests/dotnet/Honua.Plugins.Tests/AddHonuaPluginsTests.cs
+++ b/tests/dotnet/Honua.Plugins.Tests/AddHonuaPluginsTests.cs
@@ -119,6 +119,49 @@ public sealed class AddHonuaPluginsTests
         feature.Category.Should().Be(FeatureCatalog.Categories.Extensibility);
     }
 
+    [Fact]
+    public void RegistersCustomEndpoint_WhenCapabilityDeclared()
+    {
+        using var provider = BuildProvider(HonuaEdition.Enterprise, p => p.Add<UtilityStatusEndpointPlugin>());
+
+        provider.GetServices<ICustomEndpoint>().Should().ContainSingle();
+        var registration = provider.GetRequiredService<PluginCatalog>().Plugins.Single();
+        registration.ProvidesCustomEndpoint.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Add_Throws_WhenCustomEndpointCapabilityNotDeclared()
+    {
+        var act = () => BuildProvider(HonuaEdition.Enterprise, p => p.Add<UndeclaredEndpointPlugin>());
+        act.Should().Throw<InvalidOperationException>().WithMessage("*CustomEndpoints capability*");
+    }
+
+    [Fact]
+    public void Add_Throws_WhenBackgroundCapabilityNotDeclared()
+    {
+        var act = () => BuildProvider(HonuaEdition.Enterprise, p => p.Add<UndeclaredBackgroundPlugin>());
+        act.Should().Throw<InvalidOperationException>().WithMessage("*BackgroundExecution capability*");
+    }
+
+    [Plugin("undeclared-endpoint", "1.0.0")]
+    private sealed class UndeclaredEndpointPlugin : ICustomEndpoint
+    {
+        public IReadOnlyList<string> Methods { get; } = ["GET"];
+
+        public string Pattern => "x";
+
+        public bool RequiresAuthorization => false;
+
+        public ValueTask<PluginEndpointResponse> HandleAsync(PluginEndpointRequest request, CancellationToken cancellationToken)
+            => ValueTask.FromResult(PluginEndpointResponse.Status(204));
+    }
+
+    [Plugin("undeclared-background", "1.0.0")]
+    private sealed class UndeclaredBackgroundPlugin : IPluginBackgroundService
+    {
+        public Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
+    }
+
     [Plugin("validator-and-hook", "1.0.0")]
     private sealed class ValidatorAndHookPlugin : IFeatureValidator, IEditHook
     {

--- a/tests/dotnet/Honua.Plugins.Tests/ComputedFieldPipelineTests.cs
+++ b/tests/dotnet/Honua.Plugins.Tests/ComputedFieldPipelineTests.cs
@@ -86,6 +86,24 @@ public sealed class ComputedFieldPipelineTests
     }
 
     [Fact]
+    public async Task RepeatedlyFaultingProvider_IsAutoDisabled_AfterThreshold()
+    {
+        var faulting = new CountingThrowingProvider();
+        var pipeline = CreatePipeline(providers: [faulting]);
+
+        // Default circuit-breaker threshold is 3 consecutive failures; afterwards the provider is
+        // parked and no longer invoked on subsequent features.
+        for (var i = 0; i < 6; i++)
+        {
+            await pipeline.ProjectAsync(FeatureWith(("X", (double)i)), Context(), CancellationToken.None);
+        }
+
+        faulting.Calls.Should().Be(
+            PluginCircuitBreaker.DefaultFailureThreshold,
+            "once the breaker trips open the faulting computed field is no longer computed");
+    }
+
+    [Fact]
     public async Task Providers_RunInPluginIdOrder_LastWinsForSameField()
     {
         // "aaa-first" sets Tag=first; "zzz-second" sets Tag=second; ordered by id, second wins.
@@ -115,6 +133,20 @@ public sealed class ComputedFieldPipelineTests
 
         public ValueTask<object?> ComputeAsync(Feature feature, ComputedFieldContext context, CancellationToken cancellationToken)
             => throw new InvalidOperationException("compute failed");
+    }
+
+    [Plugin("counting-boom", "1.0.0")]
+    private sealed class CountingThrowingProvider : IComputedFieldProvider
+    {
+        public int Calls { get; private set; }
+
+        public string FieldName => "Boom";
+
+        public ValueTask<object?> ComputeAsync(Feature feature, ComputedFieldContext context, CancellationToken cancellationToken)
+        {
+            Calls++;
+            throw new InvalidOperationException("compute failed");
+        }
     }
 
     [Plugin("aaa-first", "1.0.0")]

--- a/tests/dotnet/Honua.Plugins.Tests/PluginBackgroundServiceHostTests.cs
+++ b/tests/dotnet/Honua.Plugins.Tests/PluginBackgroundServiceHostTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using FluentAssertions;
+using Honua.Core.Features.AuditLog.Abstractions;
 using Honua.Core.Features.Licensing.Domain;
 using Honua.Plugins.Abstractions;
 using Honua.TestKit.Helpers;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -13,13 +15,22 @@ namespace Honua.Plugins.Tests;
 
 public sealed class PluginBackgroundServiceHostTests
 {
+    private static IServiceScopeFactory ScopeFactory(IAuditLog? auditLog = null)
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => auditLog ?? new RecordingAuditLog());
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+
     private static PluginBackgroundServiceHost CreateHost(
         IEnumerable<IPluginBackgroundService> services,
         HonuaEdition edition = HonuaEdition.Enterprise,
-        bool enabled = true)
+        bool enabled = true,
+        IAuditLog? auditLog = null)
         => new(
             services,
             new TestLicenseEntitlementService(edition),
+            ScopeFactory(auditLog),
             Options.Create(new PluginOptions { Enabled = enabled }),
             NullLogger<PluginBackgroundServiceHost>.Instance);
 

--- a/tests/dotnet/Honua.Plugins.Tests/PluginCircuitBreakerTests.cs
+++ b/tests/dotnet/Honua.Plugins.Tests/PluginCircuitBreakerTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Xunit;
+
+namespace Honua.Plugins.Tests;
+
+public sealed class PluginCircuitBreakerTests
+{
+    private const string Plugin = "p1";
+
+    [Fact]
+    public void ClosedByDefault_AllowsAndReportsNotOpen()
+    {
+        var breaker = new PluginCircuitBreaker();
+        breaker.IsAllowed(Plugin).Should().BeTrue();
+        breaker.IsOpen(Plugin).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TripsOpen_AfterThresholdConsecutiveFailures()
+    {
+        var breaker = new PluginCircuitBreaker(failureThreshold: 3);
+
+        breaker.RecordFailure(Plugin).Should().BeFalse();
+        breaker.RecordFailure(Plugin).Should().BeFalse();
+        breaker.RecordFailure(Plugin).Should().BeTrue("the third consecutive failure trips the breaker open");
+
+        breaker.IsOpen(Plugin).Should().BeTrue();
+        breaker.IsAllowed(Plugin).Should().BeFalse("an open breaker blocks until the cooldown elapses");
+    }
+
+    [Fact]
+    public void Trip_IsReportedOnlyOnce_OnClosedToOpenTransition()
+    {
+        var breaker = new PluginCircuitBreaker(failureThreshold: 2);
+        breaker.RecordFailure(Plugin);
+        breaker.RecordFailure(Plugin).Should().BeTrue();
+
+        // Already open: further failures must not re-report the transition.
+        breaker.RecordFailure(Plugin).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Success_ResetsFailures_AndReportsRecoveryWhenWasOpen()
+    {
+        var breaker = new PluginCircuitBreaker(failureThreshold: 2);
+        breaker.RecordFailure(Plugin);
+        breaker.RecordFailure(Plugin).Should().BeTrue();
+
+        breaker.RecordSuccess(Plugin).Should().BeTrue("recovering a previously-open breaker reports the transition");
+        breaker.IsOpen(Plugin).Should().BeFalse();
+        breaker.IsAllowed(Plugin).Should().BeTrue();
+
+        // A success on an already-closed breaker is not a recovery transition.
+        breaker.RecordSuccess(Plugin).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IntermittentSuccess_ResetsTheConsecutiveCount()
+    {
+        var breaker = new PluginCircuitBreaker(failureThreshold: 3);
+        breaker.RecordFailure(Plugin);
+        breaker.RecordFailure(Plugin);
+        breaker.RecordSuccess(Plugin);
+
+        // Count reset: two fresh failures must not trip (would need a third).
+        breaker.RecordFailure(Plugin).Should().BeFalse();
+        breaker.RecordFailure(Plugin).Should().BeFalse();
+        breaker.IsOpen(Plugin).Should().BeFalse();
+    }
+
+    [Fact]
+    public void HalfOpen_AllowsRetry_AfterCooldownElapses()
+    {
+        var time = new MutableTimeProvider(new DateTimeOffset(2026, 6, 14, 0, 0, 0, TimeSpan.Zero));
+        var breaker = new PluginCircuitBreaker(failureThreshold: 1, cooldown: TimeSpan.FromMinutes(5), timeProvider: time);
+
+        breaker.RecordFailure(Plugin).Should().BeTrue();
+        breaker.IsAllowed(Plugin).Should().BeFalse("still within cooldown");
+
+        time.Advance(TimeSpan.FromMinutes(5));
+        breaker.IsAllowed(Plugin).Should().BeTrue("cooldown elapsed: a half-open trial is permitted");
+    }
+
+    [Fact]
+    public void IsolatesPerPlugin()
+    {
+        var breaker = new PluginCircuitBreaker(failureThreshold: 1);
+        breaker.RecordFailure("a");
+
+        breaker.IsAllowed("a").Should().BeFalse();
+        breaker.IsAllowed("b").Should().BeTrue("a different plugin's breaker is unaffected");
+    }
+
+    [Fact]
+    public void Ctor_RejectsNonPositiveThreshold()
+    {
+        var act = () => new PluginCircuitBreaker(failureThreshold: 0);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>Minimal advanceable <see cref="TimeProvider"/> (the suite defines its own per-project).</summary>
+    private sealed class MutableTimeProvider(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan delta) => _now += delta;
+    }
+}

--- a/tests/dotnet/Honua.Plugins.Tests/PluginEditPipelineTests.cs
+++ b/tests/dotnet/Honua.Plugins.Tests/PluginEditPipelineTests.cs
@@ -148,4 +148,44 @@ public sealed class PluginEditPipelineTests
         entry.Outcome.Should().Be(AuditOutcome.Denied);
         entry.CorrelationId.Should().Be("corr-1");
     }
+
+    [Fact]
+    public async Task FaultingAfterHook_IsIsolated_AndNeverPropagates()
+    {
+        var hook = new FaultingAfterHook();
+        var pipeline = CreatePipeline(hooks: [hook]);
+
+        // A best-effort after-hook that throws must never surface to the caller.
+        var act = async () => await pipeline.RunAfterHooksAsync(
+            TestData.Context(TestData.Create(TestData.Transformer(1))), CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        hook.AfterAttempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RepeatedlyFaultingAfterHook_IsAutoDisabled_AndAudited()
+    {
+        var hook = new FaultingAfterHook();
+        var audit = new RecordingAuditLog();
+        var pipeline = CreatePipeline(hooks: [hook], auditLog: audit);
+
+        // Default circuit-breaker threshold is 3 consecutive failures. After it trips, the
+        // after-hook is parked and no longer invoked.
+        for (var i = 0; i < 6; i++)
+        {
+            await pipeline.RunAfterHooksAsync(
+                TestData.Context(TestData.Create(TestData.Transformer(i))), CancellationToken.None);
+        }
+
+        hook.AfterAttempts.Should().Be(
+            PluginCircuitBreaker.DefaultFailureThreshold,
+            "once the breaker trips open the faulting after-hook is no longer invoked");
+
+        audit.Events.Should().ContainSingle(e => e.Action == "plugin.autodisabled");
+        var disabled = audit.Events.Single(e => e.Action == "plugin.autodisabled");
+        disabled.Outcome.Should().Be(AuditOutcome.Failure);
+        disabled.ResourceType.Should().Be("plugin");
+        disabled.ResourceId.Should().Be("faulting-after-hook");
+    }
 }

--- a/tests/dotnet/Honua.Plugins.Tests/PluginMetricsTests.cs
+++ b/tests/dotnet/Honua.Plugins.Tests/PluginMetricsTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics.Metrics;
+using FluentAssertions;
+using Xunit;
+
+namespace Honua.Plugins.Tests;
+
+public sealed class PluginMetricsTests
+{
+    [Fact]
+    public void Measure_EmitsInvocationAndDuration_WithPluginTags()
+    {
+        var invocations = new List<(string Plugin, string Extension)>();
+        var durations = new List<(string Plugin, string Extension)>();
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == "Honua" && instrument.Name.StartsWith("honua_plugin_", StringComparison.Ordinal))
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+        {
+            if (instrument.Name == "honua_plugin_invocations_total")
+            {
+                invocations.Add(ReadTags(tags));
+            }
+        });
+        listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) =>
+        {
+            if (instrument.Name == "honua_plugin_duration_ms")
+            {
+                durations.Add(ReadTags(tags));
+            }
+        });
+        listener.Start();
+
+        using (PluginMetrics.Measure("p1", "validate"))
+        {
+        }
+
+        listener.Dispose();
+
+        invocations.Should().ContainSingle()
+            .Which.Should().Be(("p1", "validate"));
+        durations.Should().ContainSingle()
+            .Which.Should().Be(("p1", "validate"));
+    }
+
+    [Fact]
+    public void Measure_EmitsFailure_WhenMarkedFailed()
+    {
+        var failures = new List<(string Plugin, string Extension)>();
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Name == "honua_plugin_failures_total")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) => failures.Add(ReadTags(tags)));
+        listener.Start();
+
+        using (var scope = PluginMetrics.Measure("p2", "compute"))
+        {
+            scope.MarkFailed();
+        }
+
+        listener.Dispose();
+
+        failures.Should().ContainSingle().Which.Should().Be(("p2", "compute"));
+    }
+
+    private static (string Plugin, string Extension) ReadTags(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    {
+        string plugin = string.Empty;
+        string extension = string.Empty;
+        foreach (var tag in tags)
+        {
+            if (tag.Key == PluginMetrics.PluginIdTag)
+            {
+                plugin = tag.Value?.ToString() ?? string.Empty;
+            }
+            else if (tag.Key == PluginMetrics.ExtensionPointTag)
+            {
+                extension = tag.Value?.ToString() ?? string.Empty;
+            }
+        }
+
+        return (plugin, extension);
+    }
+}

--- a/tests/dotnet/Honua.Plugins.Tests/PluginOptionsBindingTests.cs
+++ b/tests/dotnet/Honua.Plugins.Tests/PluginOptionsBindingTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Honua.Plugins.Tests;
+
+public sealed class PluginOptionsBindingTests
+{
+    private static IConfiguration Config(params (string Key, string Value)[] pairs)
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(pairs.Select(p => new KeyValuePair<string, string?>(p.Key, p.Value)))
+            .Build();
+
+    [Fact]
+    public void AddPluginOptions_BindsPerPluginSection()
+    {
+        var services = new ServiceCollection();
+        var configuration = Config(
+            ("Plugins:utility-audit:Threshold", "42"),
+            ("Plugins:utility-audit:Label", "high"));
+        services.AddPluginOptions<SampleOptions>(configuration, "utility-audit");
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<SampleOptions>>().Value;
+
+        options.Threshold.Should().Be(42);
+        options.Label.Should().Be("high");
+    }
+
+    [Fact]
+    public void AddPluginOptions_IsolatesPluginsByIdSection()
+    {
+        var services = new ServiceCollection();
+        var configuration = Config(("Plugins:other-plugin:Threshold", "99"));
+        services.AddPluginOptions<SampleOptions>(configuration, "utility-audit");
+
+        using var provider = services.BuildServiceProvider();
+        // No section for utility-audit -> defaults, not the other plugin's value.
+        provider.GetRequiredService<IOptions<SampleOptions>>().Value.Threshold.Should().Be(0);
+    }
+
+    [Fact]
+    public void AddPluginOptions_ValidatesDataAnnotations_OnStart()
+    {
+        var services = new ServiceCollection();
+        // Label is [Required]; omitting it must fail eager ValidateOnStart.
+        var configuration = Config(("Plugins:utility-audit:Threshold", "5"));
+        services.AddPluginOptions<RequiredLabelOptions>(configuration, "utility-audit");
+
+        using var provider = services.BuildServiceProvider();
+        var act = () => provider.GetRequiredService<IOptions<RequiredLabelOptions>>().Value;
+        act.Should().Throw<OptionsValidationException>();
+    }
+
+    private sealed class SampleOptions
+    {
+        public int Threshold { get; set; }
+
+        public string? Label { get; set; }
+    }
+
+    private sealed class RequiredLabelOptions
+    {
+        public int Threshold { get; set; }
+
+        [Required]
+        public string Label { get; set; } = null!;
+    }
+}

--- a/tests/dotnet/Honua.Plugins.Tests/TestDoubles.cs
+++ b/tests/dotnet/Honua.Plugins.Tests/TestDoubles.cs
@@ -65,6 +65,22 @@ internal sealed class CountingValidator : IFeatureValidator
     }
 }
 
+/// <summary>After-hook that throws on every after-edit invocation, counting attempts.</summary>
+[Plugin("faulting-after-hook", "1.0.0")]
+internal sealed class FaultingAfterHook : IEditHook
+{
+    public int AfterAttempts { get; private set; }
+
+    public ValueTask<EditHookResult> OnBeforeEditAsync(EditHookContext context, CancellationToken cancellationToken)
+        => ValueTask.FromResult(EditHookResult.Continue());
+
+    public ValueTask OnAfterEditAsync(EditHookContext context, CancellationToken cancellationToken)
+    {
+        AfterAttempts++;
+        throw new InvalidOperationException("after-hook boom");
+    }
+}
+
 /// <summary>Edit hook that records before/after invocations and can reject the batch.</summary>
 [Plugin("hook", "1.0.0")]
 internal sealed class RecordingEditHook(bool rejectBatch = false) : IEditHook

--- a/tests/dotnet/Honua.Server.Tests/Features/Plugins/PluginCustomEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Plugins/PluginCustomEndpointsTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using FluentAssertions;
+using Honua.Core.Features.AuditLog;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Plugins;
+using Honua.Plugins.Abstractions;
+using Honua.Sample.UtilityValidationPlugin;
+using Honua.Server.Features.Plugins;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Plugins;
+
+/// <summary>
+/// Integration coverage for plugin-contributed REST routes (<see cref="ICustomEndpoint"/>, #1562)
+/// mapped via <see cref="PluginCustomEndpoints.MapHonuaPluginEndpoints"/>. Uses a minimal
+/// self-hosted <see cref="TestServer"/> rather than the full server factory: the route is only
+/// present when a custom-endpoint plugin is compiled in, which the default host does not do.
+/// </summary>
+[Protocol(TestProtocols.Admin)]
+public sealed class PluginCustomEndpointsTests
+{
+    private const string Route = "/plugins/utility/status";
+
+    private static TestServer CreateServer(HonuaEdition edition, bool enabled = true)
+    {
+        var host = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddRouting();
+                        services.AddLogging();
+                        services.AddSingleton<ILicenseEntitlementService>(new TestLicenseEntitlementService(edition));
+                        services.AddSingleton<IAuditLog, NullAuditLog>();
+
+                        var configuration = new ConfigurationBuilder()
+                            .AddInMemoryCollection(new Dictionary<string, string?>
+                            {
+                                ["Plugins:Enabled"] = enabled ? "true" : "false",
+                            })
+                            .Build();
+                        services.AddHonuaPlugins(configuration, p => p.Add<UtilityStatusEndpointPlugin>());
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseEndpoints(endpoints => endpoints.MapHonuaPluginEndpoints());
+                    });
+            })
+            .Build();
+
+        host.Start();
+        return host.GetTestServer();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /plugins/utility/status")]
+    public async Task CustomEndpoint_ReturnsPluginResponse_WhenEntitled()
+    {
+        using var server = CreateServer(HonuaEdition.Enterprise);
+        using var client = server.CreateClient();
+
+        var response = await client.GetAsync(Route);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("utility-status-endpoint");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /plugins/utility/status")]
+    public async Task CustomEndpoint_NotFound_WhenUnlicensed()
+    {
+        using var server = CreateServer(HonuaEdition.Community);
+        using var client = server.CreateClient();
+
+        var response = await client.GetAsync(Route);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "plugin-contributed routes are gated behind the Enterprise plugin.sdk entitlement");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /plugins/utility/status")]
+    public async Task CustomEndpoint_NotFound_WhenKillSwitchDisabled()
+    {
+        using var server = CreateServer(HonuaEdition.Enterprise, enabled: false);
+        using var client = server.CreateClient();
+
+        var response = await client.GetAsync(Route);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "the operator kill-switch (Plugins:Enabled=false) disables contributed routes");
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj
+++ b/tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj
@@ -36,6 +36,10 @@
     <ProjectReference Include="..\..\..\src\Honua.Server\Honua.Server.csproj" />
     <ProjectReference Include="..\..\..\src\Honua.Postgres\Honua.Postgres.csproj" />
     <ProjectReference Include="..\Honua.TestKit\Honua.TestKit.csproj" />
+    <!-- Sample plugins exercised by the plugin custom-endpoint integration tests (#1562).
+         The default host does not compile in plugins, so the contributed routes are only
+         present in a test host that explicitly registers a sample plugin. -->
+    <ProjectReference Include="..\..\..\samples\plugins\Honua.Sample.UtilityValidationPlugin\Honua.Sample.UtilityValidationPlugin.csproj" />
     <!-- Referenced solely so the Comprehensive ContractCoverageMatrixTests can
          reflect over the GeometryService scenario tests that moved into the
          extracted Honua.Protocols.GeoServices.Tests project. xUnit does not run


### PR DESCRIPTION
## Issue Link
Related to #1562

## Summary
Adds the remaining phase-2 plugin/extension SDK surfaces on top of the already-landed phase-2 core (computed fields, field validation, manifest, background services — #1668). This delivers custom REST endpoints, a declarative capability gate for them, per-plugin failure isolation (circuit breaker / auto-disable), plugin performance metrics, and fuller execution audit logging. All new surfaces are compile-time / Native-AOT safe (no runtime reflection in hot paths, no runtime assembly loading) and consistent with the Enterprise `plugin.sdk` gating.

This lands the cleanly-completable subset; two items are deliberately deferred (see Non-Goals) rather than half-implemented.

## Changes Made
- **`ICustomEndpoint`** — new AOT-safe, ASP.NET-free contract (`ICustomEndpoint` + `PluginEndpointRequest`/`PluginEndpointResponse` DTOs in `Honua.Plugins.Abstractions`) plus a `MapHonuaPluginEndpoints()` host extension (`src/Honua.Server/Features/Plugins/PluginCustomEndpoints.cs`) that maps contributed routes under the reserved `/plugins` prefix via `MapMethods` + explicit HTTP metadata, gated per request behind the Enterprise `plugin.sdk` entitlement and the operator kill-switch.
- **Declarative capability / API-surface control** — extended `HonuaPluginBuilder.EnforceCapabilities` so a plugin contributing `ICustomEndpoint` must declare `PluginCapability.CustomEndpoints` (fails fast otherwise), mirroring the existing `BackgroundExecution` gate; `PluginRegistration`/`PluginCatalog` now track `ProvidesCustomEndpoint`.
- **Failure isolation / auto-disable** — new `PluginCircuitBreaker` parks repeatedly-faulting best-effort surfaces (after-edit hooks, computed-field providers) after a consecutive-failure threshold and retries them after a cooldown; wired into `PluginEditPipeline` (after-hooks) and `ComputedFieldPipeline`.
- **Performance monitoring** — new `PluginMetrics` emits invocation/failure counters and a duration histogram on the shared `Honua` OpenTelemetry meter, tagged by `plugin_id` + `extension_point`, across validators, field validators, before/after hooks, computed fields, and background services.
- **Fuller audit logging** — new `PluginExecutionAudit` records plugin lifecycle transitions (auto-disabled, recovered, background started/faulted) beyond the phase-1 edit-rejection audit; background-service host now resolves the scoped `IAuditLog` via a scope factory.
- **Per-plugin configuration** — confirmed/covered the existing `AddPluginOptions<T>` (`Plugins:<id>:*` binding with `ValidateDataAnnotations` + `ValidateOnStart`) with new tests.
- **Sample + tests** — added a sample `ICustomEndpoint` plugin and unit/integration tests.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

## Non-Goals (deferred remaining #1562 items)
- **`[Plugin]` source generator** — a full Roslyn generator is too large to land cleanly here; registration stays explicit via `AddHonuaPlugins(..., p => p.Add<T>())`. Track as a follow-up.
- **Wiring `IPluginEditPipeline` into OGC API Features / OData / WFS edit paths** — each protocol has a distinct edit pipeline with no shared orchestrator above `IFeatureWriter.ApplyEditsAsync`, so correct per-protocol wiring (rejection mapping, before/after hooks, partial-failure semantics) plus integration tests is XL work; GeoServices `applyEdits` remains the only wired path. Best done as a dedicated follow-up PR.

---

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
