### PR TITLE
feat(scene): wire Enterprise-gated CityGML/BIM ingest endpoint (#1207)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -318,3 +318,6 @@ tests/js/test-results/
 # Local audit artifacts
 .audit/runs/
 .claude/worktrees/
+
+# Generated 3D Tiles scene output (publish/ingest executors)
+scenes-generated/

--- a/docs/internal/spikes/citygml-bim-building-scene-layer-ingest.md
+++ b/docs/internal/spikes/citygml-bim-building-scene-layer-ingest.md
@@ -31,6 +31,37 @@ The output is byte-stable: features keep document order, BSL attribute columns
 are emitted in a fixed schema order, and the GLB/tileset writers are
 deterministic, so identical input produces identical bytes across runs.
 
+## Wired ingest endpoint (Enterprise)
+
+The reader + builder are wired behind an admin ingest endpoint so an operator can
+upload a CityGML document and get back a servable scene:
+
+```
+POST /api/v1/admin/scenes/ingest/citygml      (multipart/form-data, admin auth)
+```
+
+| Form field | Required | Meaning |
+| --- | --- | --- |
+| `file` | yes | The CityGML document (UTF-8 XML), up to 64 MiB |
+| `sceneId` | no | Explicit scene slug; derived from the first building when omitted |
+| `displayName` | no | Display name; derived from the first building when omitted |
+| `description` | no | Human-readable description |
+| `editionGate` | no | Edition gate slug recorded on the dataset |
+| `cacheMaxAgeSeconds` | no | Cache `max-age`; defaults to 3600 |
+| `requiresAuth` | no | `true` registers a protected (auth-required) scene instead of public |
+
+The endpoint is **Enterprise-gated** through the `scene.bim-ingest` entitlement
+(`FeatureCatalog.SceneBimIngestKey`): an authenticated non-Enterprise operator
+receives `402 Payment Required` with an upgrade message. On success it returns
+`201 Created` with the `sceneId`, the routable `tilesetUrl`, building/surface/tile
+counts, the distinct disciplines, and the bounding region. The
+`CityGmlScenePublishExecutor` stages the generated `tileset.json` + GLB, registers
+the dataset (the canonical collision authority — duplicate ids return `409`), then
+atomically promotes the staged bytes, so the standard scene serving path
+(`GET /scenes/{sceneId}/tileset.json`) streams them immediately. The endpoint and
+executor are registered only on Postgres profiles (registration-backed), matching
+the feature-layer scene generation surface.
+
 ## Supported CityGML subset
 
 | Aspect | Supported in this slice |
@@ -70,19 +101,17 @@ emitted as a dedicated `bsl_*` metadata property on every feature.
   feature-layer scene path).
 - **No textures/appearances.** CityGML `app:Appearance` (textures, materials) is
   not read.
-- **No in-reader CRS transform.** A projected-CRS document needs the caller to
-  supply an inverse-projection geo-transform; geographic documents pass through.
-- **No ingest endpoint yet.** This slice ships the reader + builder library and
-  unit tests. Wiring it behind an admin ingest executor + endpoint (mirroring
-  the feature-layer publish executor) is a tracked follow-up so it lands with the
-  full endpoint/operation registry + proof-ledger gates.
+- **Geographic source CRS only.** The wired ingest path projects geographic
+  documents (EPSG:4326 / EPSG:4979 / OGC CRS84, in either axis order) straight to
+  the ellipsoid. A projected-CRS document is rejected with
+  `SCENE_LAYER_CRS_UNKNOWN` (`400`); inverse-projection of projected coordinates
+  is a follow-up.
 
 ## Deferred follow-ups
 
 - **IFC / native BIM reader** — `.ifc` STEP parsing and property-set mapping.
-- **Ingest executor + admin endpoint** — `POST` ingest path that streams an
-  uploaded CityGML document through the reader/builder, registers the resulting
-  tileset in the scene dataset registry, and gates on the Enterprise edition.
+- **Projected-CRS reprojection** — accept projected source documents by
+  inverse-projecting through the shared coordinate-transform service.
 - **Storey decomposition** — derive real storeys from `bldg:Room` /
   `bldg:storey` so the BSL level sub-layer reflects the model.
 - **Interior rings + robust triangulation** — honour holes and use a proper

--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -64,6 +64,9 @@ public static class FeatureCatalog
         /// <summary>Real-time feature streaming and subscriptions.</summary>
         public const string Streaming = "Streaming";
 
+        /// <summary>3D scene features — CityGML/BIM ingest and Building Scene Layer publishing.</summary>
+        public const string Scene = "Scene";
+
         /// <summary>Temporal animation, time-aware filtering, and time-series tile features.</summary>
         public const string Temporal = "Temporal";
 
@@ -178,6 +181,15 @@ public static class FeatureCatalog
     /// governance; default role assignment for basic single-provider OIDC remains Pro.
     /// </summary>
     public const string OidcClaimsMappingKey = "identity.claims-mapping";
+
+    /// <summary>
+    /// Entitlement key for CityGML/BIM ingest into a servable Building Scene
+    /// Layer 3D Tiles tileset (#1207). Enterprise-only: gates the admin
+    /// <c>POST /api/v1/admin/scenes/ingest/citygml</c> surface that parses a
+    /// CityGML document and publishes a deterministic tileset with per-feature
+    /// discipline / sub-layer semantics. Postgres-only (registration-backed).
+    /// </summary>
+    public const string SceneBimIngestKey = "scene.bim-ingest";
 
     /// <summary>
     /// All edition-gated features in the platform.
@@ -348,6 +360,10 @@ public static class FeatureCatalog
             HonuaEdition.Pro, "Ground natural-language turns into validated spec mutation plans."),
         new(AiWorkflowGenerationKey, "AI Workflow and Content Generation", Categories.Ai,
             HonuaEdition.Pro, "Generate or refine workflows, maps, apps, forms, reports, dashboards, saved queries, and analysis packages from natural-language prompts."),
+
+        // Scene — Enterprise (CityGML/BIM ingest + Building Scene Layer publishing)
+        new(SceneBimIngestKey, "CityGML/BIM Scene Ingest", Categories.Scene,
+            HonuaEdition.Enterprise, "Ingest CityGML building models into a servable Building Scene Layer 3D Tiles tileset with per-feature discipline / sub-layer semantics."),
 
         // Extensibility — Enterprise (plugin/extension SDK)
         new(PluginSdkKey, "Plugin/Extension SDK", Categories.Extensibility,

--- a/src/Honua.Scene/Publishing/CityGmlScenePublishExecutor.cs
+++ b/src/Honua.Scene/Publishing/CityGmlScenePublishExecutor.cs
@@ -1,0 +1,521 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Globalization;
+using Honua.Core.Exceptions;
+using Honua.Core.Features.Scene;
+using Honua.Core.Features.Scene.Abstractions;
+using Honua.Core.Features.Scene.Bim;
+using Honua.Core.Features.Scene.Domain;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.Scene;
+
+/// <summary>
+/// Publishing executor that converts an uploaded CityGML building document into a
+/// deterministic Building Scene Layer (BSL) 3D Tiles tileset and registers it
+/// with the hosted scene registry (#1207). This is the wired ingest path on top
+/// of the <see cref="CityGmlReader"/> + <see cref="BuildingSceneLayerBuilder"/>
+/// vertical slice: it stages the generated <c>tileset.json</c> and GLB tile,
+/// registers the dataset (the canonical collision authority), then atomically
+/// promotes the staged bytes to the final scene asset root so the standard scene
+/// serving path can stream them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The executor reuses <see cref="SceneTilesetStaging"/> for the stage → register
+/// → promote → compensate mechanics so its durability semantics match the
+/// feature-layer generation path. CRS handling is intentionally conservative for
+/// v1: geographic source documents (EPSG:4326/4979 or OGC CRS84, in either axis
+/// order) pass through to the ellipsoid; projected documents are rejected with
+/// <see cref="SceneGenerationErrorCodes.LayerCrsUnknown"/> and are a documented
+/// follow-up.
+/// </para>
+/// </remarks>
+internal sealed partial class CityGmlScenePublishExecutor
+{
+    private readonly IHostEnvironment _environment;
+    private readonly IOptions<SceneGenerationServerOptions> _options;
+    private readonly ILogger<CityGmlScenePublishExecutor> _logger;
+    private readonly ISceneRegistrationService? _registration;
+
+    public CityGmlScenePublishExecutor(
+        IHostEnvironment environment,
+        IOptions<SceneGenerationServerOptions> options,
+        ILogger<CityGmlScenePublishExecutor> logger,
+        ISceneRegistrationService? registration = null)
+    {
+        _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _registration = registration;
+    }
+
+    /// <summary>
+    /// Parses, tiles, registers, and promotes a CityGML document into a servable
+    /// Building Scene Layer scene.
+    /// </summary>
+    /// <param name="request">The ingest request carrying the document bytes and target metadata.</param>
+    /// <param name="cancellationToken">Cancels the ingest before promotion.</param>
+    /// <returns>The ingest outcome with the resolved scene id, asset root, and BSL summary.</returns>
+    /// <exception cref="CityGmlFormatException">The document is malformed or carries no parseable building geometry.</exception>
+    /// <exception cref="ValidationException">An option is invalid, the source CRS is unsupported, or the scene id/name collides with an existing dataset.</exception>
+    public async Task<CityGmlSceneIngestOutcome> IngestAsync(
+        CityGmlSceneIngestRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Document);
+
+        var serverOptions = _options.Value;
+        var intentId = Guid.NewGuid().ToString("N");
+
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity(
+            HonuaTelemetry.Activities.TileGeneration,
+            ActivityKind.Internal);
+        activity?.SetTag("honua.scene.intent_id", intentId);
+        activity?.SetTag("honua.scene.source_kind", "citygml");
+
+        CityGmlIngestLog.Started(_logger, intentId, request.Document.Length);
+        var stopwatch = Stopwatch.StartNew();
+
+        // 1. Parse + tile before any I/O so a malformed document or unsupported
+        //    CRS fails fast without creating a staging directory.
+        var model = CityGmlReader.Read(request.Document);
+        var transform = BuildGeoTransform(model);
+
+        BuildingSceneLayerResult tileset;
+        try
+        {
+            tileset = BuildingSceneLayerBuilder.Build(model, transform, serverOptions.GeneratorTag);
+        }
+        catch (ArgumentException ex)
+        {
+            // The builder rejects a model with no renderable boundary surfaces.
+            // Surface it as the documented options-invalid 400 rather than a 500.
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.OptionsInvalid}: CityGML document produced no renderable boundary surfaces.",
+                ex);
+        }
+
+        // 2. Resolve + validate the registry-bound identifiers and options.
+        var sceneId = ResolveSceneId(request.SceneId, model, intentId);
+        var displayName = ResolveDisplayName(request.DisplayName, model, sceneId);
+        ValidateOptions(displayName, request.EditionGate, request.CacheMaxAgeSeconds);
+        var cacheMaxAge = request.CacheMaxAgeSeconds ?? DefaultCacheMaxAgeSeconds;
+
+        await PreflightSceneRegistrationConflictAsync(sceneId, cancellationToken).ConfigureAwait(false);
+
+        // 3. Stage → register → promote, reusing the shared durability mechanics.
+        var outputDirectory = SceneTilesetStaging.ResolveOutputDirectory(
+            _environment.ContentRootPath, serverOptions.OutputRoot, sceneId);
+        var stagingDirectory = SceneTilesetStaging.ResolveStagingDirectory(
+            _environment.ContentRootPath, serverOptions.OutputRoot, intentId);
+        string? stagingToCleanup = stagingDirectory;
+        try
+        {
+            Directory.CreateDirectory(stagingDirectory);
+            await File.WriteAllBytesAsync(
+                Path.Combine(stagingDirectory, "tileset.json"),
+                tileset.TilesetJsonBytes,
+                cancellationToken).ConfigureAwait(false);
+            foreach (var (uri, bytes) in tileset.Tiles)
+            {
+                await File.WriteAllBytesAsync(
+                    Path.Combine(stagingDirectory, uri),
+                    bytes,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            var registeredDatasetId = await TryRegisterSceneAsync(
+                sceneId,
+                displayName,
+                request.Description,
+                outputDirectory,
+                tileset.BoundsDegrees,
+                cacheMaxAge,
+                request.EditionGate,
+                request.RequiresAuth,
+                request.CreatedBy ?? "publisher",
+                cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                SceneTilesetStaging.PromoteStagingToFinal(
+                    stagingDirectory,
+                    outputDirectory,
+                    stale => CityGmlIngestLog.PromotionOverwroteStaleFinalDir(_logger, stale));
+            }
+            catch
+            {
+                if (registeredDatasetId is { } datasetId)
+                {
+                    await CompensateRegistrationAsync(datasetId, sceneId).ConfigureAwait(false);
+                }
+                throw;
+            }
+            stagingToCleanup = null;
+
+            stopwatch.Stop();
+            activity?.SetTag("honua.scene.id", sceneId);
+            activity?.SetTag("honua.scene.building_count", tileset.BuildingCount);
+            activity?.SetTag("honua.scene.surface_count", tileset.SurfaceCount);
+            CityGmlIngestLog.Completed(
+                _logger, intentId, sceneId, tileset.BuildingCount, tileset.SurfaceCount, stopwatch.ElapsedMilliseconds);
+
+            return new CityGmlSceneIngestOutcome(
+                sceneId,
+                outputDirectory,
+                tileset.BoundsDegrees,
+                tileset.BuildingCount,
+                tileset.SurfaceCount,
+                tileset.Tiles.Count,
+                tileset.Disciplines,
+                tileset.Warnings);
+        }
+        finally
+        {
+            if (stagingToCleanup is not null)
+            {
+                SceneTilesetStaging.TryDeleteStaging(
+                    stagingToCleanup,
+                    ex => CityGmlIngestLog.StagingCleanupFailed(_logger, stagingToCleanup, ex));
+            }
+        }
+    }
+
+    /// <summary>Default scene cache <c>max-age</c> when the request omits one.</summary>
+    private const int DefaultCacheMaxAgeSeconds = 3600;
+
+    /// <summary>
+    /// Builds the geographic projection delegate for the parsed document. v1
+    /// supports geographic source CRS only (EPSG:4326/4979 or OGC CRS84); axis
+    /// order is taken from the reader's <see cref="CityGmlModel.LatitudeFirst"/>
+    /// flag. A projected/unknown CRS is rejected as a documented limitation.
+    /// </summary>
+    private static CityGmlGeoTransform BuildGeoTransform(CityGmlModel model)
+    {
+        if (!IsGeographic(model.SourceCrs))
+        {
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.LayerCrsUnknown}: CityGML source CRS " +
+                $"'{model.SourceCrs}' is projected or unsupported. v1 BIM ingest supports " +
+                "geographic coordinates only (EPSG:4326, EPSG:4979, or OGC CRS84).");
+        }
+
+        var latitudeFirst = model.LatitudeFirst;
+        // Geographic pass-through: keep height (ellipsoidal meters) untouched and
+        // swap the horizontal ordinates when the document declares latitude-first
+        // axis order so the builder always receives (longitude, latitude, height).
+        return latitudeFirst
+            ? (x, y, z) => (y, x, z)
+            : (x, y, z) => (x, y, z);
+    }
+
+    private static bool IsGeographic(string? srsName)
+    {
+        // A document with no declared CRS is assumed to already be in lon/lat
+        // degrees (the inline-fixture / pre-projected case), matching the
+        // builder's identity-transform unit tests.
+        if (string.IsNullOrWhiteSpace(srsName))
+        {
+            return true;
+        }
+
+        if (srsName.Contains("CRS84", StringComparison.OrdinalIgnoreCase)
+            || srsName.Contains("WGS84", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var epsg = TryParseEpsgCode(srsName);
+        return epsg is 4326 or 4979 or 4327;
+    }
+
+    private static int? TryParseEpsgCode(string srsName)
+    {
+        // Accept both the URN form (urn:ogc:def:crs:EPSG::4979) and the short
+        // form (EPSG:4326) by taking the last colon-delimited token that parses
+        // as an integer.
+        var tokens = srsName.Split(':', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (var i = tokens.Length - 1; i >= 0; i--)
+        {
+            if (int.TryParse(tokens[i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var code))
+            {
+                return code;
+            }
+        }
+        return null;
+    }
+
+    private static string ResolveSceneId(string? explicitId, CityGmlModel model, string intentId)
+    {
+        if (!string.IsNullOrEmpty(explicitId))
+        {
+            var normalized = explicitId.ToLowerInvariant();
+            if (!SceneDatasetValidator.TryValidateSceneId(normalized, out var error))
+            {
+                throw new ValidationException(
+                    $"{SceneGenerationErrorCodes.OptionsInvalid}: sceneId is invalid: {error}");
+            }
+            return normalized;
+        }
+
+        var suffix = intentId.Length >= 8 ? intentId[..8] : intentId;
+        var slugBudget = SceneDatasetValidator.MaxSceneIdLength - 1 - suffix.Length;
+        var seed = model.Buildings.Count > 0
+            ? (model.Buildings[0].Name ?? model.Buildings[0].Id)
+            : "citygml";
+        var slug = Slugify(seed, Math.Max(1, slugBudget));
+        var candidate = $"{slug}-{suffix}".ToLowerInvariant();
+        if (!SceneDatasetValidator.TryValidateSceneId(candidate, out var autoError))
+        {
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.OptionsInvalid}: derived sceneId '{candidate}' is invalid: {autoError}. Supply an explicit sceneId.");
+        }
+        return candidate;
+    }
+
+    private static string ResolveDisplayName(string? explicitName, CityGmlModel model, string sceneId)
+    {
+        if (!string.IsNullOrEmpty(explicitName))
+        {
+            return explicitName;
+        }
+
+        var baseName = model.Buildings.Count > 0
+            ? (model.Buildings[0].Name ?? model.Buildings[0].Id)
+            : "CityGML Scene";
+        // Suffix with the resolved sceneId so the default name is unique by
+        // construction (the registry enforces name uniqueness), mirroring the
+        // feature-layer generation default.
+        var suffix = $" ({sceneId})";
+        var available = SceneDatasetValidator.MaxSceneNameLength - suffix.Length;
+        if (available <= 0)
+        {
+            return sceneId;
+        }
+        if (baseName.Length > available)
+        {
+            baseName = baseName[..available];
+        }
+        return baseName + suffix;
+    }
+
+    private static void ValidateOptions(string displayName, string? editionGate, int? cacheMaxAgeSeconds)
+    {
+        if (!SceneDatasetValidator.TryValidateName(displayName, out var nameError))
+        {
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.OptionsInvalid}: displayName is invalid: {nameError}");
+        }
+
+        if (!SceneDatasetValidator.TryValidateEditionGate(editionGate, out var editionError))
+        {
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.OptionsInvalid}: editionGate is invalid: {editionError}");
+        }
+
+        if (cacheMaxAgeSeconds is { } cache)
+        {
+            var policy = new SceneCachePolicy(cache, NoStore: false);
+            if (!SceneDatasetValidator.TryValidateCachePolicy(policy, out var cacheError))
+            {
+                throw new ValidationException(
+                    $"{SceneGenerationErrorCodes.OptionsInvalid}: cacheMaxAgeSeconds is invalid: {cacheError}");
+            }
+        }
+    }
+
+    private async Task PreflightSceneRegistrationConflictAsync(string sceneId, CancellationToken cancellationToken)
+    {
+        if (_registration is null)
+        {
+            return;
+        }
+        var existing = await _registration.GetBySceneIdAsync(sceneId, cancellationToken).ConfigureAwait(false);
+        if (existing is not null)
+        {
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.SceneRegistrationConflict}: A scene dataset with id '{sceneId}' already exists.");
+        }
+    }
+
+    private async Task<Guid?> TryRegisterSceneAsync(
+        string sceneId,
+        string displayName,
+        string? description,
+        string outputDirectory,
+        double[] bounds,
+        int cacheMaxAgeSeconds,
+        string? editionGate,
+        bool requiresAuth,
+        string createdBy,
+        CancellationToken cancellationToken)
+    {
+        if (_registration is null)
+        {
+            return null;
+        }
+
+        var record = new SceneDatasetRecord
+        {
+            DatasetId = Guid.NewGuid(),
+            Id = sceneId,
+            Name = displayName,
+            Description = description,
+            AssetRoot = outputDirectory,
+            TilesetFileName = "tileset.json",
+            DatasetType = SceneDatasetType.HostedTiles,
+            Extent = new SceneExtent(bounds[0], bounds[1], bounds[2], bounds[3]),
+            // BSL coordinates are placed on the WGS-84 ellipsoid with ellipsoidal
+            // height in meters, so the registered CRS is the 3D geographic 4979.
+            Crs = "EPSG:4979",
+            CachePolicy = new SceneCachePolicy(cacheMaxAgeSeconds, NoStore: false),
+            EditionGate = editionGate,
+            RequiresAuth = requiresAuth,
+            IsPublic = !requiresAuth,
+            AllowedRoles = null,
+            Status = SceneDatasetStatus.Active,
+            ValidationMessage = null,
+            Revision = 1,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBy = createdBy,
+            UpdatedAt = null
+        };
+
+        try
+        {
+            var saved = await _registration.RegisterAsync(record, cancellationToken).ConfigureAwait(false);
+            return saved?.DatasetId is { } id && id != Guid.Empty ? id : record.DatasetId;
+        }
+        catch (SceneDatasetAlreadyExistsException ex)
+        {
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.SceneRegistrationConflict}: A scene dataset with id '{sceneId}' or name '{displayName}' already exists.",
+                ex);
+        }
+    }
+
+    private async Task CompensateRegistrationAsync(Guid datasetId, string sceneId)
+    {
+        if (_registration is null)
+        {
+            return;
+        }
+        try
+        {
+            var deactivated = await _registration.DeactivateAsync(datasetId, CancellationToken.None).ConfigureAwait(false);
+            CityGmlIngestLog.RegistrationCompensated(_logger, sceneId, datasetId, deactivated);
+        }
+        catch (Exception ex)
+        {
+            CityGmlIngestLog.RegistrationCompensationFailed(_logger, sceneId, datasetId, ex);
+        }
+    }
+
+    private static string Slugify(string name, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(name) || maxLength <= 0)
+        {
+            return "citygml";
+        }
+        var span = name.AsSpan();
+        var capacity = Math.Min(span.Length, maxLength);
+        var buffer = new char[capacity];
+        var written = 0;
+        var lastDash = false;
+        for (var i = 0; i < span.Length && written < capacity; i++)
+        {
+            var c = span[i];
+            if (char.IsAsciiLetterOrDigit(c))
+            {
+                buffer[written++] = char.ToLowerInvariant(c);
+                lastDash = false;
+            }
+            else if (!lastDash && written > 0)
+            {
+                buffer[written++] = '-';
+                lastDash = true;
+            }
+        }
+        if (written == 0) return "citygml";
+        if (lastDash) written--;
+        return new string(buffer, 0, written);
+    }
+
+    internal static partial class CityGmlIngestLog
+    {
+        [LoggerMessage(EventId = 8450, Level = LogLevel.Information,
+            Message = "CityGML scene ingest started: intent {IntentId}, document {ByteCount} bytes")]
+        public static partial void Started(ILogger logger, string intentId, int byteCount);
+
+        [LoggerMessage(EventId = 8451, Level = LogLevel.Information,
+            Message = "CityGML scene ingest completed: intent {IntentId}, scene {SceneId}, buildings {BuildingCount}, surfaces {SurfaceCount}, elapsed {ElapsedMs}ms")]
+        public static partial void Completed(ILogger logger, string intentId, string sceneId, int buildingCount, int surfaceCount, long elapsedMs);
+
+        [LoggerMessage(EventId = 8452, Level = LogLevel.Warning,
+            Message = "CityGML scene ingest overwrote stale final directory {FinalDirectory} during staging promotion; the registry record now points at the new bytes.")]
+        public static partial void PromotionOverwroteStaleFinalDir(ILogger logger, string finalDirectory);
+
+        [LoggerMessage(EventId = 8453, Level = LogLevel.Warning,
+            Message = "CityGML scene ingest could not delete staging directory {StagingDirectory}; subsequent ingests are unaffected but the directory may need a manual sweep.")]
+        public static partial void StagingCleanupFailed(ILogger logger, string stagingDirectory, Exception exception);
+
+        [LoggerMessage(EventId = 8454, Level = LogLevel.Warning,
+            Message = "CityGML scene ingest deactivated registry record for scene {SceneId} ({DatasetId}) after staging promotion failed; deactivated={Deactivated}.")]
+        public static partial void RegistrationCompensated(ILogger logger, string sceneId, Guid datasetId, bool deactivated);
+
+        [LoggerMessage(EventId = 8455, Level = LogLevel.Error,
+            Message = "CityGML scene ingest could not deactivate registry record for scene {SceneId} ({DatasetId}) after staging promotion failed; record remains Active and must be cleaned up via the admin scene CRUD path.")]
+        public static partial void RegistrationCompensationFailed(ILogger logger, string sceneId, Guid datasetId, Exception exception);
+    }
+}
+
+/// <summary>
+/// Request to ingest a CityGML document into a servable Building Scene Layer
+/// scene (#1207).
+/// </summary>
+/// <param name="Document">The CityGML document bytes (UTF-8 or BOM-prefixed).</param>
+/// <param name="SceneId">Optional explicit scene slug; derived from the first building when omitted.</param>
+/// <param name="DisplayName">Optional display name; derived from the first building when omitted.</param>
+/// <param name="Description">Optional human-readable description.</param>
+/// <param name="EditionGate">Optional edition gate slug recorded on the dataset.</param>
+/// <param name="CacheMaxAgeSeconds">Optional cache <c>max-age</c>; defaults to 3600 when omitted.</param>
+/// <param name="RequiresAuth">When true, the registered scene requires authentication instead of being public.</param>
+/// <param name="CreatedBy">Optional audit identity for the registration record.</param>
+internal sealed record CityGmlSceneIngestRequest(
+    byte[] Document,
+    string? SceneId = null,
+    string? DisplayName = null,
+    string? Description = null,
+    string? EditionGate = null,
+    int? CacheMaxAgeSeconds = null,
+    bool RequiresAuth = false,
+    string? CreatedBy = null);
+
+/// <summary>
+/// Outcome of a CityGML scene ingest: the resolved scene id, on-disk asset root,
+/// and the Building Scene Layer summary surfaced to the admin response.
+/// </summary>
+/// <param name="SceneId">Resolved scene slug used in the tileset URL.</param>
+/// <param name="AssetRoot">Final on-disk directory holding the promoted tileset.</param>
+/// <param name="BoundsDegrees">Dataset envelope [west, south, east, north] in degrees.</param>
+/// <param name="BuildingCount">Number of buildings ingested.</param>
+/// <param name="SurfaceCount">Number of boundary-surface components emitted.</param>
+/// <param name="TileCount">Number of tile content files written.</param>
+/// <param name="Disciplines">Distinct BSL disciplines / sub-layers present, sorted.</param>
+/// <param name="Warnings">Non-fatal warnings raised during tiling.</param>
+internal sealed record CityGmlSceneIngestOutcome(
+    string SceneId,
+    string AssetRoot,
+    double[] BoundsDegrees,
+    int BuildingCount,
+    int SurfaceCount,
+    int TileCount,
+    IReadOnlyList<string> Disciplines,
+    IReadOnlyList<string> Warnings);

--- a/src/Honua.Scene/Publishing/SceneTilesPublishExecutor.cs
+++ b/src/Honua.Scene/Publishing/SceneTilesPublishExecutor.cs
@@ -1011,59 +1011,24 @@ internal sealed partial class SceneTilesPublishExecutor : IPublishExecutor
             : null;
 
     private string ResolveOutputDirectory(SceneGenerationServerOptions serverOptions, string sceneId)
-    {
-        var rooted = Path.IsPathRooted(serverOptions.OutputRoot)
-            ? serverOptions.OutputRoot
-            : Path.Combine(_environment.ContentRootPath, serverOptions.OutputRoot);
-        return Path.GetFullPath(Path.Combine(rooted, sceneId));
-    }
+        => SceneTilesetStaging.ResolveOutputDirectory(_environment.ContentRootPath, serverOptions.OutputRoot, sceneId);
 
     private string ResolveStagingDirectory(SceneGenerationServerOptions serverOptions, string intentId)
-    {
-        var rooted = Path.IsPathRooted(serverOptions.OutputRoot)
-            ? serverOptions.OutputRoot
-            : Path.Combine(_environment.ContentRootPath, serverOptions.OutputRoot);
-        // Prefix with '.' so the directory name cannot collide with any valid
-        // sceneId (the canonical validator forbids leading dots/hyphens).
-        return Path.GetFullPath(Path.Combine(rooted, $".staging-{intentId}"));
-    }
+        => SceneTilesetStaging.ResolveStagingDirectory(_environment.ContentRootPath, serverOptions.OutputRoot, intentId);
 
     private void PromoteStagingToFinal(string stagingDirectory, string finalDirectory)
-    {
-        var parentDir = Path.GetDirectoryName(finalDirectory);
-        if (!string.IsNullOrEmpty(parentDir))
-        {
-            Directory.CreateDirectory(parentDir);
-        }
-        if (Directory.Exists(finalDirectory))
-        {
+        => SceneTilesetStaging.PromoteStagingToFinal(
+            stagingDirectory,
+            finalDirectory,
             // Detritus from a prior partial run that did not register; the
-            // canonical registry now points at the staging contents, so clear
-            // the stale path before the rename.
-            SceneGenerationLog.PromotionOverwroteStaleFinalDir(_logger, finalDirectory);
-            Directory.Delete(finalDirectory, recursive: true);
-        }
-        Directory.Move(stagingDirectory, finalDirectory);
-    }
+            // canonical registry now points at the staging contents, so the
+            // stale path is cleared before the rename. Surface that as a warning.
+            stale => SceneGenerationLog.PromotionOverwroteStaleFinalDir(_logger, stale));
 
     private void TryDeleteStaging(string stagingDirectory)
-    {
-        try
-        {
-            if (Directory.Exists(stagingDirectory))
-            {
-                Directory.Delete(stagingDirectory, recursive: true);
-            }
-        }
-        catch (Exception ex)
-        {
-            // Cleanup is best-effort: a failed delete leaves a hidden staging
-            // dir that is harmless (it never gets served, no registry record
-            // points at it). Log so operators can sweep with a janitor job if
-            // it accumulates.
-            SceneGenerationLog.StagingCleanupFailed(_logger, stagingDirectory, ex);
-        }
-    }
+        => SceneTilesetStaging.TryDeleteStaging(
+            stagingDirectory,
+            ex => SceneGenerationLog.StagingCleanupFailed(_logger, stagingDirectory, ex));
 
     private async Task<Guid?> TryRegisterSceneAsync(
         string sceneId,

--- a/src/Honua.Scene/Publishing/SceneTilesetStaging.cs
+++ b/src/Honua.Scene/Publishing/SceneTilesetStaging.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Scene;
+
+/// <summary>
+/// Shared filesystem mechanics for the scene publishing pipeline: resolving the
+/// final and staging output directories, atomically promoting a staged tileset
+/// to its final path, and best-effort staging cleanup. Both the feature-layer
+/// generation path (<see cref="SceneTilesPublishExecutor"/>) and the CityGML/BIM
+/// ingest path (<see cref="CityGmlScenePublishExecutor"/>) write tileset bytes to
+/// an intent-scoped staging directory, register the dataset, then promote — so
+/// the directory mechanics live here once rather than being duplicated per
+/// executor.
+/// </summary>
+internal static class SceneTilesetStaging
+{
+    /// <summary>
+    /// Resolves the final asset directory for <paramref name="sceneId"/> under the
+    /// configured output root, rooting a relative output root against the host
+    /// content root.
+    /// </summary>
+    public static string ResolveOutputDirectory(string contentRootPath, string outputRoot, string sceneId)
+    {
+        var rooted = Path.IsPathRooted(outputRoot)
+            ? outputRoot
+            : Path.Combine(contentRootPath, outputRoot);
+        return Path.GetFullPath(Path.Combine(rooted, sceneId));
+    }
+
+    /// <summary>
+    /// Resolves an intent-scoped staging directory under the configured output
+    /// root. The name is prefixed with '.' so it can never collide with a valid
+    /// sceneId (the canonical validator forbids leading dots/hyphens), letting
+    /// concurrent publishes for the same sceneId stage independently.
+    /// </summary>
+    public static string ResolveStagingDirectory(string contentRootPath, string outputRoot, string intentId)
+    {
+        var rooted = Path.IsPathRooted(outputRoot)
+            ? outputRoot
+            : Path.Combine(contentRootPath, outputRoot);
+        return Path.GetFullPath(Path.Combine(rooted, $".staging-{intentId}"));
+    }
+
+    /// <summary>
+    /// Atomically promotes a fully-written staging directory to its final path.
+    /// If the final path already holds detritus from a prior partial run it is
+    /// cleared first (the registry record is the canonical authority and now
+    /// points at the staged bytes). <paramref name="onOverwroteStaleFinalDir"/>
+    /// is invoked when a stale final directory is removed so the caller can log it.
+    /// </summary>
+    public static void PromoteStagingToFinal(
+        string stagingDirectory,
+        string finalDirectory,
+        Action<string>? onOverwroteStaleFinalDir = null)
+    {
+        var parentDir = Path.GetDirectoryName(finalDirectory);
+        if (!string.IsNullOrEmpty(parentDir))
+        {
+            Directory.CreateDirectory(parentDir);
+        }
+        if (Directory.Exists(finalDirectory))
+        {
+            onOverwroteStaleFinalDir?.Invoke(finalDirectory);
+            Directory.Delete(finalDirectory, recursive: true);
+        }
+        Directory.Move(stagingDirectory, finalDirectory);
+    }
+
+    /// <summary>
+    /// Best-effort delete of a staging directory. A failed delete is harmless (no
+    /// registry record points at it, so it is never served);
+    /// <paramref name="onError"/> is invoked so the caller can log it for a janitor sweep.
+    /// </summary>
+    public static void TryDeleteStaging(string stagingDirectory, Action<Exception>? onError = null)
+    {
+        try
+        {
+            if (Directory.Exists(stagingDirectory))
+            {
+                Directory.Delete(stagingDirectory, recursive: true);
+            }
+        }
+        catch (Exception ex)
+        {
+            onError?.Invoke(ex);
+        }
+    }
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -761,6 +761,9 @@ public static class EndpointRegistry
         // 3D Tiles generation admin endpoint (#842).
         new("POST", "/api/v1/admin/scenes/generate"),
 
+        // CityGML/BIM scene ingest admin endpoint (#1207).
+        new("POST", "/api/v1/admin/scenes/ingest/citygml"),
+
         new("GET", "/elevation/{datasetId}/value"),
         new("GET", "/elevation/{datasetId}/profile"),
 

--- a/src/Honua.Server/Features/Admin/Models/SceneBimIngestJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/SceneBimIngestJsonContext.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Source-generated JSON context for the CityGML/BIM scene ingest admin API
+/// response (#1207). The request is multipart/form-data, so only the response
+/// model needs source-generated serialization.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(CityGmlIngestResponse))]
+internal sealed partial class SceneBimIngestJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Admin/Models/SceneBimIngestModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/SceneBimIngestModels.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Response payload returned by POST /api/v1/admin/scenes/ingest/citygml (#1207).
+/// </summary>
+public sealed class CityGmlIngestResponse
+{
+    /// <summary>Stable identifier used in the resulting scene URL.</summary>
+    public string SceneId { get; set; } = string.Empty;
+
+    /// <summary>Routable URL for the generated Building Scene Layer tileset's root document.</summary>
+    public string TilesetUrl { get; set; } = string.Empty;
+
+    /// <summary>Number of buildings ingested from the CityGML document.</summary>
+    public int BuildingCount { get; set; }
+
+    /// <summary>Number of boundary-surface components emitted with BSL attributes.</summary>
+    public int SurfaceCount { get; set; }
+
+    /// <summary>Number of tile content files written under the scene asset root.</summary>
+    public int TileCount { get; set; }
+
+    /// <summary>Distinct Building Scene Layer disciplines / sub-layers present, sorted.</summary>
+    public string[] Disciplines { get; set; } = Array.Empty<string>();
+
+    /// <summary>Bounding region of the dataset in WGS-84 degrees [west, south, east, north].</summary>
+    public double[] BoundingRegionDegrees { get; set; } = [0, 0, 0, 0];
+
+    /// <summary>Non-fatal warnings collected during ingest.</summary>
+    public string[] Warnings { get; set; } = Array.Empty<string>();
+}

--- a/src/Honua.Server/Features/Admin/SceneBimIngestEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/SceneBimIngestEndpoints.cs
@@ -1,0 +1,286 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Exceptions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Scene.Bim;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Caching;
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Licensing;
+using Honua.Infrastructure.Models;
+using Honua.Infrastructure.Scene;
+using Honua.Server.Features.Admin.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Admin endpoint for CityGML/BIM scene ingest (#1207). Parses an uploaded
+/// CityGML document into a Building Scene Layer 3D Tiles tileset, registers it,
+/// and returns the servable tileset URL. Enterprise-gated.
+/// </summary>
+/// <remarks>
+/// The endpoint is mapped only when the CityGML ingest executor is registered
+/// (Postgres profiles), mirroring the feature-layer scene generation surface.
+/// Admin authentication is enforced by the group policy; the Enterprise
+/// entitlement is enforced inside the handler so an authenticated non-Enterprise
+/// operator receives a 402 with an upgrade message rather than a silent 404.
+/// </remarks>
+internal static partial class SceneBimIngestEndpoints
+{
+    private const string TagAdmin = "Admin";
+    private const string TagScenes = "Scene Ingest";
+
+    /// <summary>Upper bound on the uploaded CityGML document size (64 MiB) for the admin surface.</summary>
+    private const long MaxUploadBytes = 64L * 1024 * 1024;
+
+    /// <summary>
+    /// Maps the admin CityGML ingest endpoint. No-op when the executor is not
+    /// registered (non-Postgres profiles).
+    /// </summary>
+    public static IEndpointRouteBuilder MapSceneBimIngestEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var inspector = endpoints.ServiceProvider.GetService<IServiceProviderIsService>();
+        if (inspector is not null && !inspector.IsService(typeof(CityGmlScenePublishExecutor)))
+        {
+            return endpoints;
+        }
+
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/scenes/ingest")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags(TagAdmin, TagScenes)
+            .RequireAdminAuthorization();
+
+        _ = group.MapPost("/citygml", HandleIngestCityGml)
+            .WithName("IngestCityGmlScene")
+            .WithSummary("Ingest a CityGML document into a servable Building Scene Layer tileset (Enterprise).")
+            .Accepts<IFormFile>("multipart/form-data")
+            .Produces<CityGmlIngestResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status402PaymentRequired)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .DisableAntiforgery();
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleIngestCityGml(
+        HttpContext context,
+        CancellationToken cancellationToken)
+    {
+        var logger = context.RequestServices.GetRequiredService<ILogger<SceneBimIngestEndpointsLogCategory>>();
+
+        // Enterprise gate first: an authenticated non-Enterprise operator gets a
+        // 402 with an upgrade message before any document is read.
+        var gateError = LicenseGate.RequireEntitlement(
+            context, FeatureCatalog.SceneBimIngestKey, "CityGML/BIM Scene Ingest", logger);
+        if (gateError is not null)
+        {
+            return gateError;
+        }
+
+        if (!context.Request.HasFormContentType)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest,
+                "Request must be multipart/form-data with a 'file' field carrying the CityGML document.");
+        }
+
+        var form = await context.Request.ReadFormAsync(cancellationToken).ConfigureAwait(false);
+        var file = form.Files["file"] ?? (form.Files.Count > 0 ? form.Files[0] : null);
+        if (file is null || file.Length == 0)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest,
+                "A non-empty 'file' field carrying the CityGML document is required.");
+        }
+        if (file.Length > MaxUploadBytes)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest,
+                $"CityGML document exceeds the {MaxUploadBytes}-byte upload limit.");
+        }
+
+        if (!TryParseOptionalInt(form, "cacheMaxAgeSeconds", out var cacheMaxAge, out var cacheError))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, cacheError!);
+        }
+        if (!TryParseOptionalBool(form, "requiresAuth", out var requiresAuth, out var authError))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, authError!);
+        }
+
+        byte[] document;
+        await using (var stream = file.OpenReadStream())
+        {
+            using var buffer = new MemoryStream(file.Length > 0 ? (int)file.Length : 0);
+            await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+            document = buffer.ToArray();
+        }
+
+        var request = new CityGmlSceneIngestRequest(
+            Document: document,
+            SceneId: NullIfBlank(form["sceneId"]),
+            DisplayName: NullIfBlank(form["displayName"]),
+            Description: NullIfBlank(form["description"]),
+            EditionGate: NullIfBlank(form["editionGate"]),
+            CacheMaxAgeSeconds: cacheMaxAge,
+            RequiresAuth: requiresAuth ?? false,
+            CreatedBy: context.User.Identity?.Name);
+
+        var executor = context.RequestServices.GetRequiredService<CityGmlScenePublishExecutor>();
+
+        try
+        {
+            var outcome = await executor.IngestAsync(request, cancellationToken).ConfigureAwait(false);
+            await InvalidateSceneCacheAsync(context, outcome.SceneId, logger, cancellationToken).ConfigureAwait(false);
+
+            var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+            var tilesetUrl = string.Concat(
+                baseUrl.AsSpan().TrimEnd('/'),
+                "/scenes/".AsSpan(),
+                outcome.SceneId.AsSpan(),
+                "/tileset.json".AsSpan());
+
+            var response = new CityGmlIngestResponse
+            {
+                SceneId = outcome.SceneId,
+                TilesetUrl = tilesetUrl,
+                BuildingCount = outcome.BuildingCount,
+                SurfaceCount = outcome.SurfaceCount,
+                TileCount = outcome.TileCount,
+                Disciplines = outcome.Disciplines.ToArray(),
+                BoundingRegionDegrees = outcome.BoundsDegrees,
+                Warnings = outcome.Warnings.ToArray()
+            };
+
+            SceneBimIngestLog.IngestCompleted(
+                logger, outcome.SceneId, outcome.BuildingCount, outcome.SurfaceCount);
+
+            return Results.Json(
+                response,
+                SceneBimIngestJsonContext.Default.CityGmlIngestResponse,
+                statusCode: StatusCodes.Status201Created);
+        }
+        catch (CityGmlFormatException fex)
+        {
+            SceneBimIngestLog.IngestRejected(logger, fex.Code, fex.Message);
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest,
+                $"{fex.Code}: {fex.Message}");
+        }
+        catch (ValidationException vex)
+        {
+            SceneBimIngestLog.IngestRejected(logger, "VALIDATION", vex.Message);
+            var (status, detail) = ClassifyValidationError(vex.Message);
+            return ProblemDetailsHelpers.CreateAdminProblem(context, status, detail);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return Results.StatusCode(StatusCodes.Status499ClientClosedRequest);
+        }
+        catch (Exception ex)
+        {
+            SceneBimIngestLog.IngestFailed(logger, ex);
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status500InternalServerError,
+                "Failed to ingest CityGML document.");
+        }
+    }
+
+    private static (int Status, string Detail) ClassifyValidationError(string message)
+    {
+        if (message.StartsWith($"{SceneGenerationErrorCodes.SceneRegistrationConflict}:", StringComparison.Ordinal))
+        {
+            return (StatusCodes.Status409Conflict, message);
+        }
+        return (StatusCodes.Status400BadRequest, message);
+    }
+
+    private static bool TryParseOptionalInt(
+        IFormCollection form, string key, out int? value, out string? error)
+    {
+        value = null;
+        error = null;
+        var raw = form[key];
+        if (raw.Count == 0 || string.IsNullOrWhiteSpace(raw[0]))
+        {
+            return true;
+        }
+        if (!int.TryParse(raw[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            error = $"{key} must be an integer.";
+            return false;
+        }
+        value = parsed;
+        return true;
+    }
+
+    private static bool TryParseOptionalBool(
+        IFormCollection form, string key, out bool? value, out string? error)
+    {
+        value = null;
+        error = null;
+        var raw = form[key];
+        if (raw.Count == 0 || string.IsNullOrWhiteSpace(raw[0]))
+        {
+            return true;
+        }
+        if (!bool.TryParse(raw[0], out var parsed))
+        {
+            error = $"{key} must be 'true' or 'false'.";
+            return false;
+        }
+        value = parsed;
+        return true;
+    }
+
+    private static string? NullIfBlank(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private static async Task InvalidateSceneCacheAsync(
+        HttpContext context,
+        string sceneId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var invalidator = context.RequestServices.GetService<OutputCacheInvalidationService>();
+        if (invalidator is null)
+        {
+            return;
+        }
+        try
+        {
+            await invalidator.InvalidateSceneAsync(sceneId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            SceneBimIngestLog.CacheInvalidationFailed(logger, sceneId, ex);
+        }
+    }
+
+    /// <summary>
+    /// Log category marker used by <see cref="ILogger{TCategoryName}"/> bindings.
+    /// </summary>
+    internal sealed class SceneBimIngestEndpointsLogCategory;
+
+    internal static partial class SceneBimIngestLog
+    {
+        [LoggerMessage(EventId = 8460, Level = LogLevel.Information,
+            Message = "CityGML ingest request completed: scene {SceneId}, buildings {BuildingCount}, surfaces {SurfaceCount}")]
+        public static partial void IngestCompleted(ILogger logger, string sceneId, int buildingCount, int surfaceCount);
+
+        [LoggerMessage(EventId = 8461, Level = LogLevel.Warning,
+            Message = "CityGML ingest request rejected: code {Code}, reason {Reason}")]
+        public static partial void IngestRejected(ILogger logger, string code, string reason);
+
+        [LoggerMessage(EventId = 8462, Level = LogLevel.Error,
+            Message = "CityGML ingest request failed unexpectedly.")]
+        public static partial void IngestFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(EventId = 8463, Level = LogLevel.Warning,
+            Message = "CityGML ingest scene cache invalidation failed for scene {SceneId}; subsequent reads may serve stale content until cache expires.")]
+        public static partial void CacheInvalidationFailed(ILogger logger, string sceneId, Exception exception);
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -211,6 +211,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapSceneAnalysisEndpoints();
         endpoints.MapVisibilityAnalysisEndpoints();
         endpoints.MapSceneGenerationEndpoints();
+        endpoints.MapSceneBimIngestEndpoints();
         endpoints.MapPMTilesProxyEndpoints();
         endpoints.MapStyleEndpoints();
         endpoints.MapOgcCoveragesEndpoints();

--- a/src/Honua.Server/Features/Infrastructure/Scene/SceneGenerationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Scene/SceneGenerationServiceCollectionExtensions.cs
@@ -44,6 +44,10 @@ internal static class SceneGenerationServiceCollectionExtensions
         services.TryAddScoped<SceneTilesPublishExecutor>();
         services.TryAddEnumerable(ServiceDescriptor.Scoped<IPublishExecutor, SceneTilesPublishExecutor>());
 
+        // CityGML/BIM ingest path (#1207): registered alongside the feature-layer
+        // executor so the Enterprise-gated admin ingest endpoint can resolve it.
+        services.TryAddScoped<CityGmlScenePublishExecutor>();
+
         return services;
     }
 

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -707,6 +707,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Admin.Models.AdminApiKeyJsonContext.Default,
         Honua.Server.Features.Admin.Models.SceneDatasetJsonContext.Default,
         Honua.Server.Features.Admin.Models.SceneGenerationJsonContext.Default,
+        Honua.Server.Features.Admin.Models.SceneBimIngestJsonContext.Default,
         Honua.Protocols.Scene.Models.PublicSceneDiscoveryJsonContext.Default,
         Honua.Server.Features.Admin.Models.RateLimitJsonContext.Default,
         Honua.Server.Features.Admin.Models.TableDiscoveryJsonContext.Default,

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/SceneBimIngestEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/SceneBimIngestEndpointsTests.cs
@@ -145,6 +145,25 @@ public class SceneBimIngestEndpointsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/scenes/ingest/citygml")]
+    public async Task Ingest_LiteralRoute_AcceptsValidUpload()
+    {
+        // Issues the POST against the literal route string so the API-surface
+        // drift scanner (EndpointRegistryDriftTests) can match this method body
+        // to the "POST /api/v1/admin/scenes/ingest/citygml" registry entry; the
+        // other tests in this class reach the route through the IngestUrl
+        // constant, which the source scanner cannot resolve.
+        using var upload = BuildUpload(
+            CityGmlSceneFixtures.SingleBuildingGeographic(),
+            ("sceneId", "bim-ingest-literal"),
+            ("editionGate", "enterprise"));
+
+        var response = await _client.PostAsync("/api/v1/admin/scenes/ingest/citygml", upload);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/citygml")]
     public async Task Ingest_NonEnterpriseEdition_Returns402()
     {
         // A fresh fixture without the Enterprise entitlement: the admin operator

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/SceneBimIngestEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/SceneBimIngestEndpointsTests.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Tests.Features.Infrastructure.Scene;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+/// <summary>
+/// Integration tests for the Enterprise-gated CityGML/BIM scene ingest endpoint
+/// (#1207). Covers the HTTP-surface contract — admin authentication, the
+/// Enterprise entitlement gate, malformed-upload rejection — and the end-to-end
+/// happy path that ingests a CityGML fixture and serves the resulting tileset.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Configuration)]
+public class SceneBimIngestEndpointsTests : IAsyncLifetime
+{
+    private const string AdminPassword = "scene-bim-ingest-admin-key";
+    private const string IngestUrl = "/api/v1/admin/scenes/ingest/citygml";
+
+    private readonly WebAppFixture _fixture;
+    private readonly string _outputRoot;
+    private HttpClient _client = null!;
+
+    public SceneBimIngestEndpointsTests()
+    {
+        // Generated tilesets must land in a temp directory rather than the
+        // server's default content-root-relative "scenes-generated" folder, so
+        // an end-to-end ingest never leaks artifacts into the source tree.
+        _outputRoot = Path.Combine(Path.GetTempPath(), $"honua-bim-it-{Guid.NewGuid():N}");
+        _fixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .WithTestLicense(HonuaEdition.Enterprise)
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+                builder.UseSetting("SceneGeneration:OutputRoot", _outputRoot);
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+        if (Directory.Exists(_outputRoot))
+        {
+            Directory.Delete(_outputRoot, recursive: true);
+        }
+    }
+
+    private static MultipartFormDataContent BuildUpload(byte[] document, params (string Key, string Value)[] fields)
+    {
+        var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(document);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/xml");
+        content.Add(fileContent, "file", "building.gml");
+        foreach (var (key, value) in fields)
+        {
+            content.Add(new StringContent(value, Encoding.UTF8), key);
+        }
+        return content;
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/citygml")]
+    public async Task Ingest_Unauthenticated_Returns401()
+    {
+        using var unauth = _fixture.CreateClient();
+        using var upload = BuildUpload(CityGmlSceneFixtures.SingleBuildingGeographic());
+
+        var response = await unauth.PostAsync(IngestUrl, upload);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/citygml")]
+    public async Task Ingest_EmptyFile_Returns400()
+    {
+        using var upload = BuildUpload(Array.Empty<byte>());
+
+        var response = await _client.PostAsync(IngestUrl, upload);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/citygml")]
+    public async Task Ingest_MalformedDocument_Returns400()
+    {
+        using var upload = BuildUpload(Encoding.UTF8.GetBytes("this is not citygml"));
+
+        var response = await _client.PostAsync(IngestUrl, upload);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/citygml")]
+    public async Task Ingest_ValidCityGml_Returns201AndServesTileset()
+    {
+        using var upload = BuildUpload(
+            CityGmlSceneFixtures.SingleBuildingGeographic(),
+            ("sceneId", "bim-ingest-it"),
+            ("displayName", "BIM Ingest IT"),
+            ("editionGate", "enterprise"));
+
+        var response = await _client.PostAsync(IngestUrl, upload);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<CityGmlIngestResponse>();
+        Assert.NotNull(body);
+        Assert.Equal("bim-ingest-it", body!.SceneId);
+        Assert.Equal(1, body.BuildingCount);
+        Assert.Equal(4, body.SurfaceCount);
+        Assert.Contains("Architectural", body.Disciplines);
+        Assert.Contains("Structural", body.Disciplines);
+        Assert.EndsWith("/scenes/bim-ingest-it/tileset.json", body.TilesetUrl);
+
+        // The registered tileset must be servable through the standard scene path.
+        var tileset = await _client.GetAsync("/scenes/bim-ingest-it/tileset.json");
+        Assert.Equal(HttpStatusCode.OK, tileset.StatusCode);
+        var tilesetBody = await tileset.Content.ReadAsStringAsync();
+        Assert.Contains("geometricError", tilesetBody);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/citygml")]
+    public async Task Ingest_NonEnterpriseEdition_Returns402()
+    {
+        // A fresh fixture without the Enterprise entitlement: the admin operator
+        // is authenticated but the entitlement gate must deny the ingest.
+        var proFixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .WithTestLicense(HonuaEdition.Pro)
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+            });
+        await proFixture.InitializeAsync();
+        try
+        {
+            using var proClient = proFixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
+            using var upload = BuildUpload(CityGmlSceneFixtures.SingleBuildingGeographic(), ("sceneId", "pro-denied"));
+
+            var response = await proClient.PostAsync(IngestUrl, upload);
+
+            Assert.Equal(HttpStatusCode.PaymentRequired, response.StatusCode);
+        }
+        finally
+        {
+            await proFixture.DisposeAsync();
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/CityGmlSceneFixtures.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/CityGmlSceneFixtures.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Scene;
+
+/// <summary>
+/// Inline CityGML documents for the wired ingest tests (#1207). Kept in source
+/// so the exact XML driving the ingest executor and admin endpoint is visible
+/// alongside the assertions.
+/// </summary>
+internal static class CityGmlSceneFixtures
+{
+    /// <summary>
+    /// A minimal CityGML 2.0 city model with one building (ground + roof + two
+    /// walls) in geographic EPSG:4326 lon/lat degrees, carrying a building-level
+    /// generic attribute and storey count. The small lon/lat coordinates place
+    /// the building on the ellipsoid through the geographic pass-through.
+    /// </summary>
+    public static byte[] SingleBuildingGeographic()
+        => Encoding.UTF8.GetBytes(BuildXml("urn:ogc:def:crs:EPSG::4326"));
+
+    /// <summary>
+    /// The same building declared in a projected CRS (EPSG:25832, UTM 32N) to
+    /// exercise the v1 unsupported-CRS rejection path.
+    /// </summary>
+    public static byte[] SingleBuildingProjected()
+        => Encoding.UTF8.GetBytes(BuildXml("urn:ogc:def:crs:EPSG::25832"));
+
+    private static string BuildXml(string srsName) => $$"""
+<?xml version="1.0" encoding="UTF-8"?>
+<core:CityModel
+    xmlns:core="http://www.opengis.net/citygml/2.0"
+    xmlns:bldg="http://www.opengis.net/citygml/building/2.0"
+    xmlns:gen="http://www.opengis.net/citygml/generics/2.0"
+    xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Envelope srsName="{{srsName}}" srsDimension="3">
+      <gml:lowerCorner>0.0 0.0 0.0</gml:lowerCorner>
+      <gml:upperCorner>0.001 0.001 10.0</gml:upperCorner>
+    </gml:Envelope>
+  </gml:boundedBy>
+  <core:cityObjectMember>
+    <bldg:Building gml:id="BLDG_1">
+      <gml:name>Test Tower</gml:name>
+      <bldg:storeysAboveGround>3</bldg:storeysAboveGround>
+      <gen:stringAttribute name="usage">office</gen:stringAttribute>
+      <bldg:boundedBy>
+        <bldg:GroundSurface gml:id="GND_1">
+          <bldg:lod2MultiSurface>
+            <gml:MultiSurface>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList srsDimension="3">0.0 0.0 0.0 0.001 0.0 0.0 0.001 0.001 0.0 0.0 0.001 0.0 0.0 0.0 0.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+            </gml:MultiSurface>
+          </bldg:lod2MultiSurface>
+        </bldg:GroundSurface>
+      </bldg:boundedBy>
+      <bldg:boundedBy>
+        <bldg:RoofSurface gml:id="ROOF_1">
+          <gen:stringAttribute name="material">concrete</gen:stringAttribute>
+          <bldg:lod2MultiSurface>
+            <gml:MultiSurface>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList srsDimension="3">0.0 0.0 10.0 0.001 0.0 10.0 0.001 0.001 10.0 0.0 0.001 10.0 0.0 0.0 10.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+            </gml:MultiSurface>
+          </bldg:lod2MultiSurface>
+        </bldg:RoofSurface>
+      </bldg:boundedBy>
+      <bldg:boundedBy>
+        <bldg:WallSurface gml:id="WALL_1">
+          <bldg:lod2MultiSurface>
+            <gml:MultiSurface>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList srsDimension="3">0.0 0.0 0.0 0.001 0.0 0.0 0.001 0.0 10.0 0.0 0.0 10.0 0.0 0.0 0.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+            </gml:MultiSurface>
+          </bldg:lod2MultiSurface>
+        </bldg:WallSurface>
+      </bldg:boundedBy>
+      <bldg:boundedBy>
+        <bldg:WallSurface gml:id="WALL_2">
+          <bldg:lod2MultiSurface>
+            <gml:MultiSurface>
+              <gml:surfaceMember>
+                <gml:Polygon>
+                  <gml:exterior>
+                    <gml:LinearRing>
+                      <gml:posList srsDimension="3">0.001 0.0 0.0 0.001 0.001 0.0 0.001 0.001 10.0 0.001 0.0 10.0 0.001 0.0 0.0</gml:posList>
+                    </gml:LinearRing>
+                  </gml:exterior>
+                </gml:Polygon>
+              </gml:surfaceMember>
+            </gml:MultiSurface>
+          </bldg:lod2MultiSurface>
+        </bldg:WallSurface>
+      </bldg:boundedBy>
+    </bldg:Building>
+  </core:cityObjectMember>
+</core:CityModel>
+""";
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/CityGmlScenePublishExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/CityGmlScenePublishExecutorTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Exceptions;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Infrastructure.Scene;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Scene;
+
+/// <summary>
+/// Hermetic unit tests for the wired CityGML/BIM ingest executor (#1207). They
+/// exercise the full parse → tile → register → promote pipeline against a temp
+/// output root and an in-memory registration stub, proving the produced tileset
+/// is written to a servable asset root with Building Scene Layer semantics
+/// without standing up Postgres or an HTTP host.
+/// </summary>
+public sealed class CityGmlScenePublishExecutorTests : IDisposable
+{
+    private readonly string _outputRoot;
+    private readonly StubRegistrationService _registration;
+    private readonly CityGmlScenePublishExecutor _executor;
+
+    public CityGmlScenePublishExecutorTests()
+    {
+        _outputRoot = Path.Combine(Path.GetTempPath(), $"honua-citygml-{Guid.NewGuid():N}");
+        _registration = new StubRegistrationService();
+
+        var options = Options.Create(new SceneGenerationServerOptions
+        {
+            OutputRoot = _outputRoot,
+            GeneratorTag = "honua-test-generator/1.0"
+        });
+
+        _executor = new CityGmlScenePublishExecutor(
+            new TestHostEnvironment(),
+            options,
+            NullLogger<CityGmlScenePublishExecutor>.Instance,
+            _registration);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_outputRoot))
+        {
+            Directory.Delete(_outputRoot, recursive: true);
+        }
+    }
+
+    [UnitTest]
+    public async Task Ingest_SingleBuilding_WritesServableTilesetAndRegistersDataset()
+    {
+        var outcome = await _executor.IngestAsync(
+            new CityGmlSceneIngestRequest(
+                CityGmlSceneFixtures.SingleBuildingGeographic(),
+                SceneId: "bim-tower",
+                DisplayName: "BIM Tower",
+                EditionGate: "enterprise"),
+            CancellationToken.None);
+
+        outcome.SceneId.Should().Be("bim-tower");
+        outcome.BuildingCount.Should().Be(1);
+        outcome.SurfaceCount.Should().Be(4, "ground + roof + two walls each emit one BSL component.");
+        outcome.TileCount.Should().Be(1);
+        outcome.Disciplines.Should().Contain("Architectural").And.Contain("Structural");
+
+        // The tileset.json and the GLB tile must exist under the promoted asset
+        // root so the standard scene serving path can stream them.
+        File.Exists(Path.Combine(outcome.AssetRoot, "tileset.json")).Should().BeTrue();
+        File.Exists(Path.Combine(outcome.AssetRoot, "building_0000.glb")).Should().BeTrue();
+
+        // No staging directory should survive a successful promotion.
+        Directory.GetDirectories(_outputRoot, ".staging-*").Should().BeEmpty();
+
+        _registration.Records.Should().ContainSingle();
+        var record = _registration.Records[0];
+        record.Id.Should().Be("bim-tower");
+        record.Name.Should().Be("BIM Tower");
+        record.AssetRoot.Should().Be(outcome.AssetRoot);
+        record.TilesetFileName.Should().Be("tileset.json");
+        record.DatasetType.Should().Be(SceneDatasetType.HostedTiles);
+        record.Crs.Should().Be("EPSG:4979");
+        record.EditionGate.Should().Be("enterprise");
+        record.IsPublic.Should().BeTrue();
+        record.RequiresAuth.Should().BeFalse();
+        record.Status.Should().Be(SceneDatasetStatus.Active);
+    }
+
+    [UnitTest]
+    public async Task Ingest_SameDocumentTwice_ProducesByteIdenticalTiles()
+    {
+        var first = await _executor.IngestAsync(
+            new CityGmlSceneIngestRequest(CityGmlSceneFixtures.SingleBuildingGeographic(), SceneId: "det-a"),
+            CancellationToken.None);
+        var second = await _executor.IngestAsync(
+            new CityGmlSceneIngestRequest(CityGmlSceneFixtures.SingleBuildingGeographic(), SceneId: "det-b"),
+            CancellationToken.None);
+
+        var glb1 = await File.ReadAllBytesAsync(Path.Combine(first.AssetRoot, "building_0000.glb"));
+        var glb2 = await File.ReadAllBytesAsync(Path.Combine(second.AssetRoot, "building_0000.glb"));
+        glb1.Should().Equal(glb2, "identical CityGML input must produce byte-identical GLB output.");
+
+        var tileset1 = await File.ReadAllBytesAsync(Path.Combine(first.AssetRoot, "tileset.json"));
+        var tileset2 = await File.ReadAllBytesAsync(Path.Combine(second.AssetRoot, "tileset.json"));
+        tileset1.Should().Equal(tileset2, "identical CityGML input must produce byte-identical tileset.json output.");
+    }
+
+    [UnitTest]
+    public async Task Ingest_RequiresAuth_RegistersProtectedScene()
+    {
+        var outcome = await _executor.IngestAsync(
+            new CityGmlSceneIngestRequest(
+                CityGmlSceneFixtures.SingleBuildingGeographic(),
+                SceneId: "protected-bim",
+                RequiresAuth: true),
+            CancellationToken.None);
+
+        outcome.SceneId.Should().Be("protected-bim");
+        var record = _registration.Records.Single();
+        record.RequiresAuth.Should().BeTrue();
+        record.IsPublic.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task Ingest_DuplicateSceneId_ThrowsRegistrationConflict()
+    {
+        await _executor.IngestAsync(
+            new CityGmlSceneIngestRequest(CityGmlSceneFixtures.SingleBuildingGeographic(), SceneId: "dup"),
+            CancellationToken.None);
+
+        var act = async () => await _executor.IngestAsync(
+            new CityGmlSceneIngestRequest(CityGmlSceneFixtures.SingleBuildingGeographic(), SceneId: "dup"),
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationException>();
+        ex.Which.Message.Should().StartWith(SceneGenerationErrorCodes.SceneRegistrationConflict);
+    }
+
+    [UnitTest]
+    public async Task Ingest_ProjectedCrs_ThrowsLayerCrsUnknown()
+    {
+        var act = async () => await _executor.IngestAsync(
+            new CityGmlSceneIngestRequest(CityGmlSceneFixtures.SingleBuildingProjected(), SceneId: "projected"),
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationException>();
+        ex.Which.Message.Should().StartWith(SceneGenerationErrorCodes.LayerCrsUnknown);
+
+        // A rejected ingest must not leave any registration or output behind.
+        _registration.Records.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public async Task Ingest_InvalidCacheMaxAge_ThrowsOptionsInvalid()
+    {
+        var act = async () => await _executor.IngestAsync(
+            new CityGmlSceneIngestRequest(
+                CityGmlSceneFixtures.SingleBuildingGeographic(),
+                SceneId: "bad-cache",
+                CacheMaxAgeSeconds: -1),
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationException>();
+        ex.Which.Message.Should().StartWith(SceneGenerationErrorCodes.OptionsInvalid);
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #1207

## Summary
The #1473 vertical slice landed a CityGML reader + Building Scene Layer (BSL) builder but left them unwired (library + unit tests only). This PR delivers the keystone follow-up: an end-to-end, **Enterprise-gated** admin ingest path that turns an uploaded CityGML document into a **servable** BSL 3D Tiles scene, satisfying the issue's acceptance criteria (a CityGML fixture ingests to a servable scene with semantic attributes; discipline/sub-layer structure preserved; Enterprise gating + tests).

A new `CityGmlScenePublishExecutor` parses the document, builds the deterministic BSL tileset, then stages → registers → atomically promotes it — reusing a new shared `SceneTilesetStaging` helper (also adopted by the existing `SceneTilesPublishExecutor`) so its durability semantics match the feature-layer publish path. The new admin endpoint is admin-authorized and gated behind a new `scene.bim-ingest` Enterprise entitlement.

CRS handling is conservative for v1: geographic source documents (EPSG:4326/4979/CRS84, either axis order) project straight to the ellipsoid; projected CRS is rejected with `SCENE_LAYER_CRS_UNKNOWN` and documented as a follow-up.

Deeper follow-ups from the original audit remain separate scope and are documented in the CityGML/BIM reference: IFC/native-BIM reader, projected-CRS reprojection, real `bldg:Room` storey decomposition, interior rings, and CityGML appearances/textures.

## Changes Made
- Add `CityGmlScenePublishExecutor` (parse → BSL tileset → stage → register → promote, with compensation on promotion failure).
- Extract shared `SceneTilesetStaging` helper for output/staging dir resolution, atomic promotion, and cleanup; refactor `SceneTilesPublishExecutor` to use it.
- Add admin endpoint `POST /api/v1/admin/scenes/ingest/citygml` (multipart), admin-authorized + Enterprise-gated via `LicenseGate` / `scene.bim-ingest`.
- Add `scene.bim-ingest` entitlement and a `Scene` category to `FeatureCatalog`.
- Register the executor (Postgres profiles), map the endpoint, add it to `EndpointRegistry`, and register the response JSON context.
- Tests: hermetic executor unit tests + HTTP integration tests (401/402/400 and 201 + end-to-end tileset serve).
- Docs: update the CityGML/BIM ingest reference for the wired endpoint, supported subset, and limits.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality