### PR TITLE
feat: classify geometry-only disconnected-sync conflicts (#1287)

### DIFF
--- a/src/Honua.Core/Features/FeatureStore/Services/ReplicaConflictClassifier.cs
+++ b/src/Honua.Core/Features/FeatureStore/Services/ReplicaConflictClassifier.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.FeatureStore.Services;
+
+/// <summary>
+/// Refines the coarse, detection-time classification of a disconnected-sync conflict once the client
+/// (uploaded) and server (pre-apply) feature states have been captured (#1287). The canonical
+/// <see cref="ReplicaSyncService"/> classifies conflicts from operation kinds alone (it cannot see
+/// geometry or attribute values), so an <c>update vs concurrent server update</c> is recorded as the
+/// generic <see cref="ReplicaConflictType.Attribute"/>. When the captured states show the client
+/// changed no attribute but the geometry differs, the protocol adapter re-classifies the conflict as
+/// <see cref="ReplicaConflictType.Geometry"/> before persisting the durable record.
+/// </summary>
+/// <remarks>
+/// The states are the conflict-review envelope <c>{"attributes": { ... }, "geometry": ...}</c> produced
+/// by the protocol adapter, with geometry serialized identically on both sides so it is directly
+/// comparable. This classifier answers the single yes/no question "is this geometry-only?"; the richer
+/// field-level detail surfaced by the review API is computed separately by <c>ReplicaConflictDiff</c> on
+/// the server. "The client changed no attribute" is evaluated against the fields the client actually
+/// supplied — server-only business/system fields the client did not touch are ignored, and field-name
+/// matching is case-insensitive (Esri field-name convention). Structural conflict types
+/// (<see cref="ReplicaConflictType.DeleteUpdate"/>/<see cref="ReplicaConflictType.UpdateDelete"/>) and
+/// the not-yet-detectable types (<see cref="ReplicaConflictType.DuplicateInsert"/>,
+/// <see cref="ReplicaConflictType.Attachment"/>, <see cref="ReplicaConflictType.Relationship"/>, which
+/// the replica upload model does not carry the inputs to detect) are never reclassified here.
+/// </remarks>
+public static class ReplicaConflictClassifier
+{
+    private const string AttributesProperty = "attributes";
+    private const string GeometryProperty = "geometry";
+
+    /// <summary>
+    /// Returns a refined conflict type for the captured states, or <paramref name="current"/> unchanged
+    /// when no refinement applies (non-attribute conflict, missing/unparseable states, the client
+    /// changed an attribute, or the geometry is unknown/unchanged).
+    /// </summary>
+    /// <param name="current">The detection-time classification recorded by the sync service.</param>
+    /// <param name="clientStateJson">The client (uploaded) state envelope, when captured.</param>
+    /// <param name="serverStateJson">The pre-apply server state envelope, when captured.</param>
+    public static ReplicaConflictType Refine(
+        ReplicaConflictType current,
+        string? clientStateJson,
+        string? serverStateJson)
+    {
+        // Only the generic attribute bucket is a refinement candidate; delete/update and the structural
+        // types are already specific. Both sides must be present to compare.
+        if (current != ReplicaConflictType.Attribute ||
+            string.IsNullOrWhiteSpace(clientStateJson) ||
+            string.IsNullOrWhiteSpace(serverStateJson))
+        {
+            return current;
+        }
+
+        try
+        {
+            using var clientDoc = JsonDocument.Parse(clientStateJson);
+            using var serverDoc = JsonDocument.Parse(serverStateJson);
+            var client = clientDoc.RootElement;
+            var server = serverDoc.RootElement;
+
+            // Geometry-only divergence: the client changed no attribute but the geometry differs.
+            return !ClientChangedAttributes(client, server) && GeometryDiffers(client, server)
+                ? ReplicaConflictType.Geometry
+                : current;
+        }
+        catch (JsonException)
+        {
+            // Malformed envelopes are never reclassified; the coarse type stands.
+            return current;
+        }
+    }
+
+    private static bool ClientChangedAttributes(JsonElement client, JsonElement server)
+    {
+        var clientAttributes = TryGetObject(client, AttributesProperty);
+        var serverAttributes = TryGetObject(server, AttributesProperty);
+
+        // If either attribute set is absent we cannot prove the client made no attribute change.
+        if (clientAttributes is null || serverAttributes is null)
+        {
+            return true;
+        }
+
+        // Compare only the fields the client supplied; server-only fields the client did not touch are
+        // not a client-side change. A client field missing on the server (or with a different value) is.
+        foreach (var clientField in clientAttributes.Value.EnumerateObject())
+        {
+            var serverValue = FindProperty(serverAttributes.Value, clientField.Name);
+            if (serverValue is null || !ValuesEqual(clientField.Value, serverValue.Value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool GeometryDiffers(JsonElement client, JsonElement server)
+    {
+        var clientGeometry = TryGetGeometryRaw(client);
+        var serverGeometry = TryGetGeometryRaw(server);
+
+        // Unknown on either side → not classifiable as a geometry conflict.
+        if (clientGeometry is null || serverGeometry is null)
+        {
+            return false;
+        }
+
+        return !string.Equals(clientGeometry, serverGeometry, StringComparison.Ordinal);
+    }
+
+    private static string? TryGetGeometryRaw(JsonElement state)
+    {
+        if (state.ValueKind == JsonValueKind.Object &&
+            state.TryGetProperty(GeometryProperty, out var geometry) &&
+            geometry.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
+        {
+            return geometry.GetRawText();
+        }
+
+        return null;
+    }
+
+    private static JsonElement? TryGetObject(JsonElement state, string property)
+    {
+        if (state.ValueKind == JsonValueKind.Object &&
+            state.TryGetProperty(property, out var value) &&
+            value.ValueKind == JsonValueKind.Object)
+        {
+            return value;
+        }
+
+        return null;
+    }
+
+    private static JsonElement? FindProperty(JsonElement container, string name)
+    {
+        if (container.TryGetProperty(name, out var exact))
+        {
+            return exact;
+        }
+
+        // Esri attribute names are conventionally case-insensitive; fall back to a case-insensitive scan.
+        foreach (var property in container.EnumerateObject())
+        {
+            if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                return property.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool ValuesEqual(JsonElement left, JsonElement right)
+        // Raw-text comparison is sufficient for the scalar/array/object attribute values stored in the
+        // state envelope.
+        => string.Equals(left.GetRawText(), right.GetRawText(), StringComparison.Ordinal);
+}

--- a/src/Honua.Core/Features/FeatureStore/Services/ReplicaSyncService.cs
+++ b/src/Honua.Core/Features/FeatureStore/Services/ReplicaSyncService.cs
@@ -186,9 +186,12 @@ public sealed partial class ReplicaSyncService : IReplicaSyncService
         {
             (FeatureEditOperationKind.Delete, FeatureChangeOperation.Update) => ReplicaConflictType.DeleteUpdate,
             (FeatureEditOperationKind.Update, FeatureChangeOperation.Delete) => ReplicaConflictType.UpdateDelete,
-            // Update vs concurrent server insert/update: an attribute-level conflict. Geometry-only
-            // classification requires a field-level diff that is owned by the conflict-resolution
-            // surface (#1287); the upload path records the coarser Attribute classification.
+            // Update vs concurrent server insert/update: the coarse attribute classification. The sync
+            // service sees only operation kinds, not values, so it cannot distinguish a geometry-only
+            // conflict here. The protocol adapter refines this to ReplicaConflictType.Geometry once it
+            // has captured the client/server states (ReplicaConflictClassifier, #1287). DuplicateInsert,
+            // Attachment, and Relationship remain undetected: inserts use server-assigned ids, and the
+            // replica upload model carries no attachment/related-record inputs to detect them.
             _ => ReplicaConflictType.Attribute,
         };
 

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresReplicaConflictRepository.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresReplicaConflictRepository.cs
@@ -41,6 +41,7 @@ internal sealed class PostgresReplicaConflictRepository : IReplicaConflictReposi
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
             ON CONFLICT (conflict_id) DO UPDATE SET
                 status = EXCLUDED.status,
+                conflict_type = EXCLUDED.conflict_type,
                 base_state_json = EXCLUDED.base_state_json,
                 client_state_json = EXCLUDED.client_state_json,
                 server_state_json = EXCLUDED.server_state_json,

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -3,6 +3,7 @@
 
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
@@ -914,8 +915,21 @@ internal static partial class FeatureServerEndpoints
                 if (!report.Conflicts.IsDefaultOrEmpty)
                 {
                     var conflictRepository = context.RequestServices.GetRequiredService<IReplicaConflictRepository>();
-                    await AttachConflictStatesAsync(
+                    var refinedTypes = await AttachConflictStatesAsync(
                         conflictRepository, report.Conflicts, layerEdits, serverConflictStates, cancellationToken);
+
+                    // Mirror the refined classification onto the transient synchronize response so the
+                    // wire hint matches the durable conflict record the review API returns (#1287).
+                    if (conflicts is not null && refinedTypes.Count > 0)
+                    {
+                        foreach (var wireConflict in conflicts)
+                        {
+                            if (refinedTypes.TryGetValue((wireConflict.LayerId, wireConflict.ObjectId), out var refined))
+                            {
+                                wireConflict.ConflictType = (int)refined;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -981,9 +995,10 @@ internal static partial class FeatureServerEndpoints
 
     /// <summary>
     /// Reads the current server state of every uploaded update/delete target, keyed by
-    /// (public layer id, object id), as a <c>{"attributes": {...}}</c> envelope. Must run before the
-    /// edits are applied so the captured server side is the pre-conflict state, not the just-applied
-    /// client value (#1287). A target the server has already deleted yields no entry.
+    /// (public layer id, object id), as a <c>{"attributes": {...}, "geometry": ...}</c> envelope. Must
+    /// run before the edits are applied so the captured server side is the pre-conflict state, not the
+    /// just-applied client value (#1287). The geometry is converted to GeoServices (Esri) JSON so it is
+    /// comparable to the uploaded client geometry. A target the server has already deleted yields no entry.
     /// </summary>
     private static async Task<Dictionary<(int PublicLayerId, long ObjectId), string>> CaptureServerConflictStatesAsync(
         IFeatureReader featureReader,
@@ -1012,7 +1027,11 @@ internal static partial class FeatureServerEndpoints
                     .ConfigureAwait(false);
                 if (feature is { } found)
                 {
-                    states[key] = SerializeStateEnvelope(found.Attributes);
+                    // Match the Z/M handling ConvertFeatureToGeoServices uses elsewhere so the captured
+                    // server geometry is the same shape the rest of the GeoServices surface emits.
+                    var geometry = GeoServicesGeometryConverter.ConvertWkbToGeoServicesGeometry(
+                        found.Geometry, srid: null, geometryLimits: null, includeZ: false, includeM: false);
+                    states[key] = SerializeStateEnvelope(found.Attributes, geometry);
                 }
             }
         }
@@ -1023,16 +1042,21 @@ internal static partial class FeatureServerEndpoints
     /// <summary>
     /// Updates the durable conflict records written by the sync service with the client (uploaded) and
     /// pre-apply server state snapshots, so the conflict-review detail API can compute the field- and
-    /// geometry-level comparison (#1287). Conflicts whose record cannot be loaded, or for which neither
-    /// side has a captured state (e.g. delete-vs-delete), are left unchanged.
+    /// geometry-level comparison (#1287). Now that both states are captured, the coarse detection-time
+    /// classification is also refined (a geometry-only divergence becomes a geometry conflict). Returns
+    /// the refined classification for each conflict whose type changed, keyed by (public layer id,
+    /// object id), so the caller can mirror it onto the transient synchronize response. Conflicts whose
+    /// record cannot be loaded, or for which neither side has a captured state (e.g. delete-vs-delete),
+    /// are left unchanged.
     /// </summary>
-    private static async Task AttachConflictStatesAsync(
+    private static async Task<Dictionary<(int PublicLayerId, long ObjectId), ReplicaConflictType>> AttachConflictStatesAsync(
         IReplicaConflictRepository conflictRepository,
         ImmutableArray<ReplicaSyncConflict> conflicts,
         ImmutableArray<ReplicaUploadLayerEdits> layerEdits,
         Dictionary<(int PublicLayerId, long ObjectId), string> serverStates,
         CancellationToken cancellationToken)
     {
+        var refinedTypes = new Dictionary<(int PublicLayerId, long ObjectId), ReplicaConflictType>();
         var clientStates = BuildClientConflictStates(layerEdits);
         foreach (var conflict in conflicts)
         {
@@ -1055,10 +1079,25 @@ internal static partial class FeatureServerEndpoints
                 continue;
             }
 
+            // Refine the sync service's operation-only classification now that the geometry/attribute
+            // values are available: attributes-agree + geometry-differs is a geometry conflict (#1287).
+            var refinedType = ReplicaConflictClassifier.Refine(existing.ConflictType, clientState, serverState);
+            if (refinedType != existing.ConflictType)
+            {
+                refinedTypes[key] = refinedType;
+            }
+
             await conflictRepository.UpsertAsync(
-                existing with { ClientStateJson = clientState, ServerStateJson = serverState },
+                existing with
+                {
+                    ConflictType = refinedType,
+                    ClientStateJson = clientState,
+                    ServerStateJson = serverState,
+                },
                 cancellationToken).ConfigureAwait(false);
         }
+
+        return refinedTypes;
     }
 
     /// <summary>
@@ -1076,7 +1115,8 @@ internal static partial class FeatureServerEndpoints
             {
                 if (edit.ObjectId is { } objectId && edit.Payload is GeoServicesFeature feature)
                 {
-                    states[(layer.PublicLayerId, objectId)] = SerializeStateEnvelope(feature.Attributes);
+                    states[(layer.PublicLayerId, objectId)] =
+                        SerializeStateEnvelope(feature.Attributes, feature.Geometry);
                 }
             }
         }
@@ -1085,16 +1125,27 @@ internal static partial class FeatureServerEndpoints
     }
 
     /// <summary>
-    /// Serializes a feature's attributes into the conflict-state envelope
-    /// <c>{"attributes": {...}}</c> consumed by the conflict-review diff, AOT-safely via the
-    /// source-generated dictionary serializer.
+    /// Serializes a feature's attributes and (when present) geometry into the conflict-state envelope
+    /// <c>{"attributes": {...}, "geometry": ...}</c> consumed by the conflict-review diff and the
+    /// geometry-conflict classifier, AOT-safely via the source-generated serializers. The geometry is
+    /// emitted as GeoServices (Esri) JSON on both the client and server sides so the two are directly
+    /// comparable (#1287); it is omitted entirely when the feature has no geometry.
     /// </summary>
-    private static string SerializeStateEnvelope(IReadOnlyDictionary<string, object?> attributes)
+    private static string SerializeStateEnvelope(
+        IReadOnlyDictionary<string, object?> attributes,
+        GeoServicesGeometry? geometry)
     {
         var attributeMap = attributes as Dictionary<string, object?> ?? new Dictionary<string, object?>(attributes);
         var attributesJson = System.Text.Json.JsonSerializer.Serialize(
             attributeMap, FeatureServerJsonContext.Default.DictionaryStringObject);
-        return $"{{\"attributes\":{attributesJson}}}";
+        if (geometry is null)
+        {
+            return $"{{\"attributes\":{attributesJson}}}";
+        }
+
+        var geometryJson = System.Text.Json.JsonSerializer.Serialize(
+            geometry, FeatureServerJsonContext.Default.GeoServicesGeometry);
+        return $"{{\"attributes\":{attributesJson},\"geometry\":{geometryJson}}}";
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Core.Tests/Features/FeatureStore/ReplicaConflictClassifierTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/FeatureStore/ReplicaConflictClassifierTests.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.Services;
+
+namespace Honua.Core.Tests.Features.FeatureStore;
+
+/// <summary>
+/// Unit tests for <see cref="ReplicaConflictClassifier"/>: the attach-time refinement of the coarse,
+/// detection-time disconnected-sync conflict classification (#1287). The classifier only promotes the
+/// generic <see cref="ReplicaConflictType.Attribute"/> bucket to
+/// <see cref="ReplicaConflictType.Geometry"/> when the captured states show the attributes agree but
+/// the geometry differs.
+/// </summary>
+public sealed class ReplicaConflictClassifierTests
+{
+    [Fact]
+    public void Refine_AttributesAgreeAndGeometryDiffers_ReturnsGeometry()
+    {
+        var client = """{"attributes":{"OBJECTID":1,"name":"same"},"geometry":{"x":1.0,"y":2.0}}""";
+        var server = """{"attributes":{"OBJECTID":1,"name":"same"},"geometry":{"x":9.0,"y":8.0}}""";
+
+        ReplicaConflictClassifier.Refine(ReplicaConflictType.Attribute, client, server)
+            .Should().Be(ReplicaConflictType.Geometry);
+    }
+
+    [Fact]
+    public void Refine_AttributesAgreeIgnoringFieldOrderAndGeometryDiffers_ReturnsGeometry()
+    {
+        // Field ordering must not be treated as an attribute divergence.
+        var client = """{"attributes":{"OBJECTID":1,"name":"same"},"geometry":{"x":1.0,"y":2.0}}""";
+        var server = """{"attributes":{"name":"same","OBJECTID":1},"geometry":{"x":1.0,"y":3.0}}""";
+
+        ReplicaConflictClassifier.Refine(ReplicaConflictType.Attribute, client, server)
+            .Should().Be(ReplicaConflictType.Geometry);
+    }
+
+    [Fact]
+    public void Refine_AttributesDiffer_KeepsAttribute()
+    {
+        var client = """{"attributes":{"OBJECTID":1,"name":"client"},"geometry":{"x":1.0,"y":2.0}}""";
+        var server = """{"attributes":{"OBJECTID":1,"name":"server"},"geometry":{"x":9.0,"y":8.0}}""";
+
+        ReplicaConflictClassifier.Refine(ReplicaConflictType.Attribute, client, server)
+            .Should().Be(ReplicaConflictType.Attribute);
+    }
+
+    [Fact]
+    public void Refine_AttributesAgreeButGeometryEqual_KeepsAttribute()
+    {
+        var client = """{"attributes":{"OBJECTID":1,"name":"same"},"geometry":{"x":1.0,"y":2.0}}""";
+        var server = """{"attributes":{"OBJECTID":1,"name":"same"},"geometry":{"x":1.0,"y":2.0}}""";
+
+        ReplicaConflictClassifier.Refine(ReplicaConflictType.Attribute, client, server)
+            .Should().Be(ReplicaConflictType.Attribute);
+    }
+
+    [Fact]
+    public void Refine_GeometryMissingOnOneSide_KeepsAttribute()
+    {
+        var client = """{"attributes":{"OBJECTID":1,"name":"same"},"geometry":{"x":1.0,"y":2.0}}""";
+        var server = """{"attributes":{"OBJECTID":1,"name":"same"}}""";
+
+        ReplicaConflictClassifier.Refine(ReplicaConflictType.Attribute, client, server)
+            .Should().Be(ReplicaConflictType.Attribute);
+    }
+
+    [Theory]
+    [InlineData(ReplicaConflictType.DeleteUpdate)]
+    [InlineData(ReplicaConflictType.UpdateDelete)]
+    [InlineData(ReplicaConflictType.DuplicateInsert)]
+    public void Refine_NonAttributeConflict_IsNeverReclassified(ReplicaConflictType current)
+    {
+        // A geometry-only divergence must not promote an already-specific structural conflict type.
+        var client = """{"attributes":{"OBJECTID":1,"name":"same"},"geometry":{"x":1.0,"y":2.0}}""";
+        var server = """{"attributes":{"OBJECTID":1,"name":"same"},"geometry":{"x":9.0,"y":8.0}}""";
+
+        ReplicaConflictClassifier.Refine(current, client, server).Should().Be(current);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("""{"attributes":{"name":"a"},"geometry":{"x":1,"y":2}}""", null)]
+    [InlineData(null, """{"attributes":{"name":"a"},"geometry":{"x":1,"y":2}}""")]
+    public void Refine_MissingState_KeepsAttribute(string? client, string? server)
+    {
+        ReplicaConflictClassifier.Refine(ReplicaConflictType.Attribute, client, server)
+            .Should().Be(ReplicaConflictType.Attribute);
+    }
+
+    [Fact]
+    public void Refine_MalformedJson_KeepsAttribute()
+    {
+        ReplicaConflictClassifier.Refine(ReplicaConflictType.Attribute, "{not json", "{also not json")
+            .Should().Be(ReplicaConflictType.Attribute);
+    }
+
+    [Fact]
+    public void Refine_ServerHasUntouchedExtraFields_StillReturnsGeometry()
+    {
+        // The client supplied only objectid + name (both matching the server); the server's extra
+        // business field is not a client-side change and must not block geometry classification.
+        var client = """{"attributes":{"OBJECTID":1,"name":"same"},"geometry":{"x":1.0,"y":2.0}}""";
+        var server = """{"attributes":{"OBJECTID":1,"name":"same","category":"server-only"},"geometry":{"x":9.0,"y":8.0}}""";
+
+        ReplicaConflictClassifier.Refine(ReplicaConflictType.Attribute, client, server)
+            .Should().Be(ReplicaConflictType.Geometry);
+    }
+
+    [Fact]
+    public void Refine_ClientSuppliedOnlyObjectIdAndGeometry_ReturnsGeometry()
+    {
+        var client = """{"attributes":{"OBJECTID":1},"geometry":{"x":1.0,"y":2.0}}""";
+        var server = """{"attributes":{"OBJECTID":1,"name":"server"},"geometry":{"x":9.0,"y":8.0}}""";
+
+        ReplicaConflictClassifier.Refine(ReplicaConflictType.Attribute, client, server)
+            .Should().Be(ReplicaConflictType.Geometry);
+    }
+
+    [Fact]
+    public void Refine_FieldNameCasingDiffers_TreatedAsSameField()
+    {
+        // objectid vs OBJECTID is the same field; only geometry changed → geometry conflict.
+        var client = """{"attributes":{"objectid":1,"NAME":"same"},"geometry":{"x":1.0,"y":2.0}}""";
+        var server = """{"attributes":{"OBJECTID":1,"name":"same"},"geometry":{"x":9.0,"y":8.0}}""";
+
+        ReplicaConflictClassifier.Refine(ReplicaConflictType.Attribute, client, server)
+            .Should().Be(ReplicaConflictType.Geometry);
+    }
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicaSyncTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicaSyncTests.cs
@@ -162,6 +162,99 @@ public sealed class FeatureServerReplicaSyncTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.SynchronizeReplica)]
     [Endpoint("POST /rest/services/{serviceId}/FeatureServer/synchronizeReplica")]
+    public async Task SynchronizeReplica_GeometryOnlyConflict_ClassifiesAsGeometry()
+    {
+        // Seed a feature with geometry that both client and server will edit.
+        var objectId = await AddFeatureWithGeometryAsync("geo-base", 1.0, 2.0);
+
+        var replicaId = await CreateReplicaAsync("GeometryConflictTest", "0");
+        await SynchronizeDownloadAsync(replicaId);
+
+        // Server-side concurrent edit changes ONLY the geometry; the attribute is left unchanged.
+        await UpdateFeatureGeometryAsync(objectId, "geo-base", 5.0, 6.0);
+
+        // Client uploads the same attribute value but a different geometry → geometry-only divergence.
+        var edits = JsonSerializer.Serialize(new object[]
+        {
+            new
+            {
+                id = 0,
+                updates = new[]
+                {
+                    new
+                    {
+                        attributes = new Dictionary<string, object?> { ["objectid"] = objectId, ["name"] = "geo-base" },
+                        geometry = new { x = 9.0, y = 9.0 }
+                    }
+                }
+            }
+        });
+        var root = await SynchronizeUploadAsync(replicaId, edits);
+
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+        root.TryGetProperty("conflicts", out var conflicts).Should().BeTrue();
+        conflicts.GetArrayLength().Should().Be(1);
+        var conflict = conflicts[0];
+
+        // The transient synchronize response reflects the refined geometry classification (#1287).
+        conflict.GetProperty("conflictType").GetInt32().Should().Be((int)ReplicaConflictType.Geometry);
+
+        // The durable conflict record is also refined to a geometry conflict.
+        var conflictId = conflict.GetProperty("conflictId").GetString();
+        conflictId.Should().NotBeNullOrWhiteSpace();
+        var conflictRepo = _fixture.GetService<IReplicaConflictRepository>();
+        var record = await conflictRepo.GetAsync(conflictId!);
+        record.Should().NotBeNull();
+        record!.Value.ConflictType.Should().Be(ReplicaConflictType.Geometry);
+
+        // Both captured states carry geometry so the review API can render the comparison.
+        using var clientState = JsonDocument.Parse(record.Value.ClientStateJson!);
+        using var serverState = JsonDocument.Parse(record.Value.ServerStateJson!);
+        clientState.RootElement.TryGetProperty("geometry", out _).Should().BeTrue();
+        serverState.RootElement.TryGetProperty("geometry", out _).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.SynchronizeReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/synchronizeReplica")]
+    public async Task SynchronizeReplica_AttributeConflict_RemainsClassifiedAsAttribute()
+    {
+        // Regression guard: when the attribute changes (not only geometry) the conflict stays Attribute.
+        var objectId = await AddFeatureWithGeometryAsync("attr-base", 1.0, 2.0);
+
+        var replicaId = await CreateReplicaAsync("AttributeConflictTest", "0");
+        await SynchronizeDownloadAsync(replicaId);
+
+        await UpdateFeatureGeometryAsync(objectId, "server-name", 5.0, 6.0);
+
+        var edits = JsonSerializer.Serialize(new object[]
+        {
+            new
+            {
+                id = 0,
+                updates = new[]
+                {
+                    new
+                    {
+                        attributes = new Dictionary<string, object?> { ["objectid"] = objectId, ["name"] = "client-name" },
+                        geometry = new { x = 9.0, y = 9.0 }
+                    }
+                }
+            }
+        });
+        var root = await SynchronizeUploadAsync(replicaId, edits);
+
+        var conflict = root.GetProperty("conflicts")[0];
+        conflict.GetProperty("conflictType").GetInt32().Should().Be((int)ReplicaConflictType.Attribute);
+
+        var conflictRepo = _fixture.GetService<IReplicaConflictRepository>();
+        var record = await conflictRepo.GetAsync(conflict.GetProperty("conflictId").GetString()!);
+        record!.Value.ConflictType.Should().Be(ReplicaConflictType.Attribute);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.SynchronizeReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/synchronizeReplica")]
     public async Task SynchronizeReplica_NoConcurrentServerEdit_AppliesWithoutConflict()
     {
         var objectId = await AddFeatureAsync("no-conflict-base");
@@ -258,6 +351,48 @@ public sealed class FeatureServerReplicaSyncTests : IAsyncLifetime
         addResults.GetArrayLength().Should().Be(1);
         addResults[0].GetProperty("success").GetBoolean().Should().BeTrue();
         return addResults[0].GetProperty("objectId").GetInt64();
+    }
+
+    private async Task<long> AddFeatureWithGeometryAsync(string name, double x, double y)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            adds = new[] { new { attributes = new { name }, geometry = new { x, y } } },
+            f = "json"
+        });
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/applyEdits",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var addResults = doc.RootElement.GetProperty("addResults");
+        addResults.GetArrayLength().Should().Be(1);
+        addResults[0].GetProperty("success").GetBoolean().Should().BeTrue();
+        return addResults[0].GetProperty("objectId").GetInt64();
+    }
+
+    private async Task UpdateFeatureGeometryAsync(long objectId, string name, double x, double y)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            updates = new[]
+            {
+                new
+                {
+                    attributes = new Dictionary<string, object?> { ["objectid"] = objectId, ["name"] = name },
+                    geometry = new { x, y }
+                }
+            },
+            f = "json"
+        });
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/applyEdits",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("updateResults")[0].GetProperty("success").GetBoolean().Should().BeTrue();
     }
 
     private async Task UpdateFeatureAsync(long objectId, string name)


### PR DESCRIPTION
## Issue Link
Related to #1287

## Summary
Implements the pragmatic remaining slice of #1287 (the core durable conflict-review API shipped in #1349/#1534): finer **conflict classification at detection**. A disconnected-replica update-vs-update conflict whose attributes agree but whose geometry differs is now recorded as a **geometry** conflict instead of the generic **attribute** conflict, so the Console conflict reviewer can bucket and present geometry conflicts correctly.

The canonical `ReplicaSyncService` only sees operation kinds (not values), so it cannot distinguish geometry conflicts. This refines the coarse classification at the point where the client (uploaded) and pre-apply server states are captured, and — to make that comparison possible — captures geometry in the conflict-state envelope (it was attributes-only before, which left the review API's `GeometryChanged` signal permanently null).

## Changes Made
- Add `ReplicaConflictClassifier` (`Honua.Core`): refines `Attribute` → `Geometry` when the client changed no attribute (comparing only client-supplied fields, case-insensitive, so server-only business fields don't block it) and the geometry differs. Structural types (`DeleteUpdate`/`UpdateDelete`) and the not-yet-detectable types are never reclassified.
- Capture geometry in the conflict-state envelope on **both** sides as GeoServices (Esri) JSON so client and pre-apply server geometry are directly comparable; this also activates the previously-inert `GeometryChanged` field in the review detail API.
- Apply the refinement at attach time in the GeoServices `synchronizeReplica` upload adapter and mirror the refined type onto the transient synchronize response.
- Fix `PostgresReplicaConflictRepository` upsert to persist `conflict_type` on conflict, so the attach-time refinement is durable.
- Tests: classifier unit tests (`Honua.Core.Tests`) and live-path integration tests for geometry-only vs attribute classification (`Honua.Protocols.GeoServices.Tests`).

### Explicitly deferred (unchanged here, documented in code)
- `DuplicateInsert` / `Attachment` / `Relationship` classification — the replica upload model carries no attachment/related-record inputs and inserts use server-assigned ids, so these are not detectable from the upload.
- Value-level **base-state** reconstruction — the change log records operations only (no historical values); reconstructing base attribute/geometry belongs to the #1166 temporal surface.
- Resolution → temporal change-set attribution — the resolve endpoint records the decision/generation but does not itself apply an edit through the pipeline; wiring real temporal attribution is a #1166-coordinated follow-up.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
