### PR TITLE
feat(licensing): load signed license from inline content (read-only/serverless FS)

### DIFF
--- a/src/Honua.Hosting/Features/Licensing/FileBackedLicenseService.cs
+++ b/src/Honua.Hosting/Features/Licensing/FileBackedLicenseService.cs
@@ -216,6 +216,34 @@ internal sealed class FileBackedLicenseService :
     private async Task LoadConfiguredLicenseAsync(CancellationToken cancellationToken)
     {
         var options = _options.Value;
+
+        // Inline content takes precedence over a file path so the license can be
+        // delivered on a read-only/serverless filesystem (e.g. AWS Lambda), typically
+        // via a Licensing:LicenseContent=aws:secretsmanager:<arn> secret reference.
+        if (!string.IsNullOrWhiteSpace(options.LicenseContent))
+        {
+            try
+            {
+                var inlineData = System.Text.Encoding.UTF8.GetBytes(options.LicenseContent);
+                var inlineResult = ValidateLicenseData(inlineData, options);
+                PublishSnapshot(inlineResult.Snapshot);
+                LogValidationResult(inlineResult);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                var snapshot = CreateCommunitySnapshot(
+                    LicenseValidationState.Malformed,
+                    isValid: false,
+                    NextSnapshotVersion(),
+                    payload: null,
+                    keyId: null);
+                PublishSnapshot(snapshot);
+                LicenseRuntimeLog.LicenseMalformed(_logger, ex.GetType().Name);
+            }
+
+            return;
+        }
+
         if (string.IsNullOrWhiteSpace(options.LicensePath))
         {
             PublishCommunity(LicenseValidationState.NoLicenseConfigured, isValid: true, payload: null, keyId: null);

--- a/src/Honua.Hosting/Features/Licensing/LicenseOptions.cs
+++ b/src/Honua.Hosting/Features/Licensing/LicenseOptions.cs
@@ -9,6 +9,15 @@ internal sealed class LicenseOptions
 
     public string? LicensePath { get; set; }
 
+    /// <summary>
+    /// Inline signed license envelope JSON. When set (non-empty) it takes precedence over
+    /// <see cref="LicensePath"/>, so a license can be delivered without a writable filesystem —
+    /// e.g. on AWS Lambda / serverless where the image is read-only. Pair it with a secret
+    /// reference (<c>Licensing:LicenseContent=aws:secretsmanager:&lt;arn&gt;</c>) so the envelope is
+    /// resolved from a secret store at startup rather than baked into the image or env in clear text.
+    /// </summary>
+    public string? LicenseContent { get; set; }
+
     public Dictionary<string, string> TrustedKeys { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
     public bool AllowAdminUpload { get; set; }

--- a/tests/dotnet/Honua.Server.Tests/Features/Licensing/FileBackedLicenseServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Licensing/FileBackedLicenseServiceTests.cs
@@ -93,6 +93,68 @@ public sealed class FileBackedLicenseServiceTests
     }
 
     [UnitTest]
+    public async Task StartAsync_InlineLicenseContent_LoadsEditionWithoutAFile()
+    {
+        var license = LicenseTestSupport.CreateSignedLicense(
+            HonuaEdition.Pro,
+            expiresAt: DateTimeOffset.UtcNow.AddDays(30),
+            entitlements: ["analytics.clustering", "staticmap.high-dpi"]);
+
+        var logger = new RecordingLogger<FileBackedLicenseService>();
+        var service = CreateService(
+            new LicenseOptions
+            {
+                // No LicensePath: the envelope is supplied inline (e.g. resolved from a
+                // secret reference on a read-only/serverless filesystem).
+                LicenseContent = System.Text.Encoding.UTF8.GetString(license.LicenseData),
+                TrustedKeys = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [LicenseTestSupport.KeyId] = license.PublicKeySetting
+                }
+            },
+            logger);
+
+        await service.StartAsync(CancellationToken.None);
+
+        var snapshot = service.GetSnapshot();
+        snapshot.Edition.Should().Be(HonuaEdition.Pro);
+        snapshot.IsValid.Should().BeTrue();
+        snapshot.ValidationState.Should().Be(LicenseValidationState.Valid);
+        snapshot.HasEntitlement("analytics.clustering").Should().BeTrue();
+        snapshot.HasEntitlement("staticmap.high-dpi").Should().BeTrue();
+    }
+
+    [UnitTest]
+    public async Task StartAsync_InlineLicenseContent_TakesPrecedenceOverLicensePath()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory();
+        var licensePath = Path.Combine(tempDirectory.FullName, "missing.honua-license.json");
+        var license = LicenseTestSupport.CreateSignedLicense(
+            HonuaEdition.Pro,
+            expiresAt: DateTimeOffset.UtcNow.AddDays(30),
+            entitlements: ["analytics.clustering"]);
+
+        var logger = new RecordingLogger<FileBackedLicenseService>();
+        var service = CreateService(
+            new LicenseOptions
+            {
+                LicensePath = licensePath, // does not exist; inline content must win
+                LicenseContent = System.Text.Encoding.UTF8.GetString(license.LicenseData),
+                TrustedKeys = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [LicenseTestSupport.KeyId] = license.PublicKeySetting
+                }
+            },
+            logger);
+
+        await service.StartAsync(CancellationToken.None);
+
+        var snapshot = service.GetSnapshot();
+        snapshot.Edition.Should().Be(HonuaEdition.Pro);
+        snapshot.ValidationState.Should().Be(LicenseValidationState.Valid);
+    }
+
+    [UnitTest]
     public async Task StartAsync_MalformedLicenseFile_PublishesSafeCommunitySnapshot()
     {
         var tempDirectory = Directory.CreateTempSubdirectory();


### PR DESCRIPTION
## Issue Link
Related to #1688

## Summary
`FileBackedLicenseService` could only read the signed license envelope from a local file (`Licensing:LicensePath`). That doesn't work on a read-only / serverless filesystem (e.g. the AWS Lambda demo `demo.honua.io`): there's nowhere durable to place the file, and admin-upload writes to the container's ephemeral `/tmp` — lost on cold start and not shared across concurrent execution environments. This adds `Licensing:LicenseContent`: when set, it takes precedence over `LicensePath` and the envelope is validated directly from the config value (no file). It is read as a plain config/env value with no cloud SDK coupling, so each platform injects it from its own secret store (AWS Secrets Manager → env, Azure Key Vault reference, GCP/k8s secret, or an `env:` reference) — keeping licensing a runtime concern (rotate the value + recycle) rather than a build-time bake-in, uniformly across clouds.

## Changes Made
- Add `LicenseOptions.LicenseContent` (documented; inline signed envelope, precedence over `LicensePath`).
- `FileBackedLicenseService.LoadConfiguredLicenseAsync` validates from inline content when present, with the same malformed-→-safe-Community fallback as the file path.
- Unit tests: inline content grants the edition without a file; inline content takes precedence over a (missing) `LicensePath`.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed
- `dotnet test … --filter FileBackedLicenseServiceTests` → 11 passed, 0 failed (full solution compiled).

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [x] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

(Consumers opting in set `Licensing__LicenseContent` from their secret store; no change for existing `LicensePath` users.)

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
