### PR TITLE
fix: preserve empty-string Esri attributes so IS NOT NULL matches Esri (#1703)

### DIFF
--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
@@ -692,7 +692,7 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
                 return sql.AddParameter(sqlFilter.Parameters[index]);
             });
 
-        converted = RewriteAttributeTextAccessExpressions(converted, ResolveColumnExpression);
+        converted = RewriteAttributeTextAccessExpressions(converted, ResolveColumnExpression, TryResolveFieldType);
 
         return QuotedIdentifierRegex().Replace(
             converted,
@@ -705,14 +705,49 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
 
     internal static string RewriteAttributeTextAccessExpressions(
         string sql,
-        Func<string, string> resolveColumnExpression)
+        Func<string, string> resolveColumnExpression,
+        Func<string, MetadataV2FieldType?>? resolveFieldType = null)
         => AttributeTextAccessRegex().Replace(
             sql,
             match =>
             {
                 var fieldName = match.Groups["field"].Value.Replace("''", "'", StringComparison.Ordinal);
-                return $"NULLIF(({resolveColumnExpression(fieldName)})::text, '')";
+                var column = $"({resolveColumnExpression(fieldName)})::text";
+
+                // The translator emits `attributes ->> 'field'` text accessors for filter
+                // operands. For numeric/temporal/boolean/uuid fields the empty-string-to-NULL
+                // coercion is required so a downstream `::numeric`/`::timestamptz` cast does
+                // not choke on empty text (and so Esri's "empty numeric == null" semantics
+                // hold). For text/string fields it must NOT be applied: Esri and PostgreSQL
+                // treat an empty string as a non-NULL value, so wrapping a string column in
+                // NULLIF(..., '') would make `field IS NOT NULL` (and `field = ''`) silently
+                // drop empty-string rows, diverging from the source service (#1703).
+                var fieldType = resolveFieldType?.Invoke(fieldName);
+                if (PreservesEmptyString(fieldType))
+                {
+                    return column;
+                }
+
+                return $"NULLIF({column}, '')";
             });
+
+    // String-like fields whose empty-string values must survive filter translation as a
+    // non-NULL value. Null (unresolved) field type keeps the legacy NULLIF behavior so the
+    // change is scoped to fields whose type is known to be textual.
+    private static bool PreservesEmptyString(MetadataV2FieldType? fieldType)
+        => fieldType is MetadataV2FieldType.String or MetadataV2FieldType.Uuid;
+
+    private MetadataV2FieldType? TryResolveFieldType(string fieldName)
+    {
+        if (fieldName.Equals("objectid", StringComparison.OrdinalIgnoreCase) ||
+            fieldName.Equals("object_id", StringComparison.OrdinalIgnoreCase))
+        {
+            return MetadataV2FieldType.BigInteger;
+        }
+
+        return _resource.SchemaFields.FirstOrDefault(candidate =>
+            candidate.Name.Equals(fieldName, StringComparison.OrdinalIgnoreCase))?.Type;
+    }
 
     private string BuildSpatialFilter(SpatialFilter filter, SqlBuilder sql)
     {

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/PostgresStorageMappedFeatureReaderSqlTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/PostgresStorageMappedFeatureReaderSqlTests.cs
@@ -27,6 +27,38 @@ public sealed class PostgresStorageMappedFeatureReaderSqlTests
     }
 
     [Fact]
+    public void RewriteAttributeTextAccessExpressions_WithStringField_PreservesEmptyStringForIsNotNull()
+    {
+        // Esri/PostgreSQL treat an empty string as a non-NULL value. The storage-mapped
+        // reader must not wrap a text/string column in NULLIF(..., '') when translating an
+        // IS NOT NULL filter, or empty-string rows would be silently dropped (#1703).
+        var rewritten = PostgresStorageMappedFeatureReader.RewriteAttributeTextAccessExpressions(
+            "\"attributes\" ->> 'uniquedesignation' IS NOT NULL",
+            field =>
+            {
+                field.Should().Be("uniquedesignation");
+                return "\"uniquedesignation\"";
+            },
+            _ => MetadataV2FieldType.String);
+
+        rewritten.Should().Be("(\"uniquedesignation\")::text IS NOT NULL");
+    }
+
+    [Fact]
+    public void RewriteAttributeTextAccessExpressions_WithNumericField_KeepsEmptyStringCoercion()
+    {
+        // Numeric/temporal fields keep NULLIF(..., '') so empty text does not break a
+        // downstream ::numeric/::timestamptz cast and Esri's "empty numeric == null"
+        // semantics still hold.
+        var rewritten = PostgresStorageMappedFeatureReader.RewriteAttributeTextAccessExpressions(
+            "\"attributes\" ->> 'shape__length' IS NOT NULL",
+            _ => "\"shape__length\"",
+            _ => MetadataV2FieldType.Double);
+
+        rewritten.Should().Be("NULLIF((\"shape__length\")::text, '') IS NOT NULL");
+    }
+
+    [Fact]
     public void BuildStatisticsAggregateExpression_WithNumericAggregate_CastsMappedSourceColumn()
     {
         var expression = PostgresStorageMappedFeatureReader.BuildStatisticsAggregateExpression(


### PR DESCRIPTION
## Issue Link
Fixes #1703

## Summary
Honua's FeatureServer `query?where=<stringField> IS NOT NULL` diverged from Esri/PostgreSQL for imported string attributes that contain empty strings (`""`). Esri and PostgreSQL count `""` as NON-NULL; Honua was dropping those rows. This surfaced as the "GeoServices Parity (External, On-Demand)" nightly failing with `Expected value to be 12, but found 10` on Military ops_line (`uniquedesignation` has 2 empty-string values among its 12 non-null values).

Root cause (verified by reproduction, not the original "live-source drift" theory in #1703): the import is faithful — empty strings are stored as `""` (confirmed `jsonb_typeof = string` for all 12 rows). The bug is in the storage-mapped feature reader's filter translation. `PostgresStorageMappedFeatureReader.RewriteAttributeTextAccessExpressions` rewrote every translated `attributes ->> 'field'` text accessor into `NULLIF((col)::text, '')` unconditionally. For a string column that coerces `""` → NULL, so `field IS NOT NULL` (and `field = ''`) silently excluded the empty-string rows → 10 instead of 12.

## Changes Made
- Make `PostgresStorageMappedFeatureReader.RewriteAttributeTextAccessExpressions` type-aware: it now takes an optional field-type resolver and emits the raw `(col)::text` (no `NULLIF`) for String/Uuid fields so empty strings survive as non-NULL, while keeping `NULLIF((col)::text, '')` for numeric/temporal/boolean fields (so downstream `::numeric`/`::timestamptz` casts still work and Esri's "empty numeric == null" semantics hold).
- Wire the reader's existing schema to a `TryResolveFieldType` helper passed into the rewrite.
- Add focused unit tests in `PostgresStorageMappedFeatureReaderSqlTests`: a String field preserves `""` (no NULLIF) for `IS NOT NULL`, and a Double field keeps the empty-string coercion. Existing tests (legacy 2-arg overload, unresolved type) keep prior NULLIF behavior.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Verified end-to-end: temporarily scoped the external parity suite to the Military ops_line case and re-ran `ImportAndPublish_FromCandidateServices_PreservesFeatureServerQueryParity` (HONUA_TEST_ESRI_PARITY=1, Docker) — it now passes (`IS NOT NULL` returns 12). Scaffolding reverted; the committed change is the fix + unit tests only.

## Gate Impact
- [x] Nightly gates (conformance, performance, security)
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] None — standard merge-and-release flow

## Breaking Changes
This changes `IS NULL`/`IS NOT NULL` (and string `= ''`) semantics for imported/storage-mapped string fields whose values are empty strings: an empty string is now treated as NON-NULL (matching Esri and PostgreSQL), where it was previously treated as NULL. Filters and counts over such fields will now include empty-string rows in `IS NOT NULL` results. This is a correctness fix to match Esri parity; numeric/date/boolean field NULL semantics are unchanged.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
