### PR TITLE
ci(nightly): mirror .NET base images to GHCR to stop MCR rate-limit flakes

### DIFF
--- a/.github/workflows/nightly-container-build.yml
+++ b/.github/workflows/nightly-container-build.yml
@@ -10,16 +10,73 @@ env:
   REGISTRY_GHCR: ghcr.io
   IMAGE_NAME_GHCR: ${{ github.repository }}
   IMAGE_NAME_DOCKERHUB: honuaio/honua-server
+  # .NET base images are pulled from Microsoft's anonymous-only registry
+  # (mcr.microsoft.com -> mcrprod.azurecr.io), which rate-limits (429/401) and
+  # has flaked nightly builds. There is no MCR login that raises the limit, so
+  # we mirror the digest-pinned base images into GHCR once (the mirror-base-images
+  # job below, with retries) and the build jobs pull them from GHCR (authenticated,
+  # no anonymous limit) via the Dockerfiles' DOTNET_*_IMAGE build args.
+  # NOTE: keep these digests in sync with the ARG defaults in Dockerfile,
+  # docker/Dockerfile.aot, and docker/Dockerfile.lambda.aot.
+  BASE_REPO: ghcr.io/${{ github.repository }}-base
+  SDK_10_0: mcr.microsoft.com/dotnet/sdk:10.0@sha256:dc8430e6024d454edadad1e160e1973be3cabbb7125998ef190d9e5c6adf7dbb
+  ASPNET_10_0_ALPINE: mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:1e37a8236c558ae31bd6bc8144e38e6036b73cf1b0616fe56d79e60babb9d93b
+  SDK_10_0_ALPINE: mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:0191ff386e93923edf795d363ea0ae0669ce467ada4010b370644b670fa495c1
+  RUNTIMEDEPS_10_0_ALPINE: mcr.microsoft.com/dotnet/runtime-deps:10.0-alpine@sha256:4f08c162590324de60f31937f5b5fa9f2b5eddaa4f0aaec3c872f855bf16c36c
+  SDK_10_0_LAMBDA: mcr.microsoft.com/dotnet/sdk:10.0@sha256:8a90a473da5205a16979de99d2fc20975e922c68304f5c79d564e666dc3982fc
+  RUNTIMEDEPS_10_0: mcr.microsoft.com/dotnet/runtime-deps:10.0@sha256:962ef681468320cc5ef25fa18259cf3200247cec2ee96c2574174d4824272151
 
 concurrency:
   group: nightly-container-build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  mirror-base-images:
+    name: Mirror .NET base images (MCR -> GHCR)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY_GHCR }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror digest-pinned base images to GHCR (with retries)
+        run: |
+          set -euo pipefail
+          mirror() {
+            local src="$1" dst="$2"
+            for attempt in 1 2 3 4 5; do
+              if docker buildx imagetools create --tag "$dst" "$src"; then
+                echo "mirrored $src -> $dst"
+                return 0
+              fi
+              echo "::warning::mirror attempt $attempt failed for $src; retrying after backoff"
+              sleep $((attempt * 20))
+            done
+            echo "::error::failed to mirror $src to $dst after 5 attempts"
+            return 1
+          }
+          mirror "${SDK_10_0}"                "${BASE_REPO}:sdk-10.0"
+          mirror "${ASPNET_10_0_ALPINE}"      "${BASE_REPO}:aspnet-10.0-alpine"
+          mirror "${SDK_10_0_ALPINE}"         "${BASE_REPO}:sdk-10.0-alpine"
+          mirror "${RUNTIMEDEPS_10_0_ALPINE}" "${BASE_REPO}:runtime-deps-10.0-alpine"
+          mirror "${SDK_10_0_LAMBDA}"         "${BASE_REPO}:sdk-10.0-lambda"
+          mirror "${RUNTIMEDEPS_10_0}"        "${BASE_REPO}:runtime-deps-10.0"
+
   build-aot:
     name: Build & Push AOT (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
+    needs: mirror-base-images
     strategy:
       fail-fast: false
       matrix:
@@ -72,6 +129,9 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.aot
+          build-args: |
+            DOTNET_SDK_IMAGE=${{ env.BASE_REPO }}:sdk-10.0-alpine
+            DOTNET_RUNTIME_DEPS_IMAGE=${{ env.BASE_REPO }}:runtime-deps-10.0-alpine
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -92,6 +152,7 @@ jobs:
     name: Build & Push Lambda AOT (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
+    needs: mirror-base-images
     strategy:
       fail-fast: false
       matrix:
@@ -144,6 +205,9 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.lambda.aot
+          build-args: |
+            DOTNET_SDK_IMAGE=${{ env.BASE_REPO }}:sdk-10.0-lambda
+            DOTNET_RUNTIME_DEPS_IMAGE=${{ env.BASE_REPO }}:runtime-deps-10.0
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -212,6 +276,7 @@ jobs:
     name: Build & Push JIT (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
+    needs: mirror-base-images
     strategy:
       fail-fast: false
       matrix:
@@ -264,6 +329,9 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          build-args: |
+            DOTNET_SDK_IMAGE=${{ env.BASE_REPO }}:sdk-10.0
+            DOTNET_ASPNET_IMAGE=${{ env.BASE_REPO }}:aspnet-10.0-alpine
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Issue Link
Related to #1688

## Summary
The Nightly Container Build keeps failing at the `FROM` step pulling .NET base images from Microsoft's registry (`mcr.microsoft.com` → `mcrprod.azurecr.io`), which is **anonymous-only and rate-limits** (`429 Too Many Requests` / `401`). It flaked all 6 build variants recently with zero code involved. **MCR has no login that raises the limit**, so "authenticate to MCR" is not an option — the fix is to mirror the base images.

This adds a `mirror-base-images` job that copies the digest-pinned .NET base images into **GHCR** (which the workflow already authenticates to), with retries — the *only* step that touches MCR. The three build jobs then `needs:` it and pull their base images **from GHCR** (authenticated, no anonymous rate limit) via the Dockerfiles' existing `DOTNET_SDK_IMAGE` / `DOTNET_ASPNET_IMAGE` / `DOTNET_RUNTIME_DEPS_IMAGE` build args. After this, build+push never touches anonymous MCR.

## Changes Made
- New `mirror-base-images` job: `docker buildx imagetools create` MCR→`ghcr.io/${{ github.repository }}-base:*` for the 6 distinct base images, with a 5-attempt backoff retry.
- `build-aot`, `build-lambda-aot`, `build-jit` now `needs: mirror-base-images` and pass `build-args` pointing the base images at the GHCR mirror.
- Base-image digests are duplicated into workflow `env` with a "keep in sync with the Dockerfile ARG defaults" note (Dockerfiles already expose these build args — no Dockerfile changes).

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed
- Workflow YAML validated (`yaml.safe_load`); job graph: `mirror-base-images → {build-aot, build-lambda-aot, build-jit} → manifests`. **Needs a `workflow_dispatch` run of this branch to validate end-to-end before merge** (can't exercise GitHub Actions locally).

## Gate Impact
- [ ] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [x] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires infrastructure changes
- [ ] None — standard merge-and-release flow

(Creates a new GHCR package `honua-server-base` for the mirrored base images; the build's existing `GITHUB_TOKEN` `packages:write` covers it.)

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (N/A for this CI-workflow-only change; validated by YAML lint of nightly-container-build.yml — no .NET source impact)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality (CI-only change; needs a dispatch test-run)


