### PR TITLE
fix(audit): run relocated protocol tests in production audit via solution filter (#1579)

### DIFF
--- a/scripts/conformance/run-production-audit.sh
+++ b/scripts/conformance/run-production-audit.sh
@@ -247,8 +247,12 @@ run_geodesy_agent() {
         run_check "geodesy" "1" "postgres-crs-transform-tests" "required" \
             "dotnet test tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj --configuration Release --filter 'FullyQualifiedName~Crs|FullyQualifiedName~SpatialReference|FullyQualifiedName~Wkt|FullyQualifiedName~Wkb|FullyQualifiedName~Transform' --logger \"trx;LogFileName=geodesy-postgres.trx\"" || return $?
 
+        # Run against the solution so the filter also covers OGC/MVT/CRS tests that the
+        # protocol seam split relocated out of Honua.Server.Tests into the protocol test
+        # projects (Wmts/OgcCrsResolver -> OgcApi/OgcClassic, Mvt -> GeoServices). Targeting
+        # only Honua.Server.Tests silently matched 0 of those and under-audited geodesy.
         run_check "geodesy" "1" "server-spatial-query-tests" "required" \
-            "dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --configuration Release --filter 'FullyQualifiedName~AdvancedSpatialQuery|FullyQualifiedName~SpatialReference|FullyQualifiedName~OgcCrsResolver|FullyQualifiedName~Wms|FullyQualifiedName~Wmts|FullyQualifiedName~Mvt' --logger \"trx;LogFileName=geodesy-server.trx\"" || return $?
+            "dotnet test Honua.sln --configuration Release --filter 'FullyQualifiedName~AdvancedSpatialQuery|FullyQualifiedName~SpatialReference|FullyQualifiedName~OgcCrsResolver|FullyQualifiedName~Wms|FullyQualifiedName~Wmts|FullyQualifiedName~Mvt' --logger \"trx;LogFileName=geodesy-server.trx\"" || return $?
 
         run_check "geodesy" "1" "core-bbox-tiling-tests" "required" \
             "dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --configuration Release --filter 'FullyQualifiedName~BoundingBox|FullyQualifiedName~TileMath|FullyQualifiedName~Cql2' --logger \"trx;LogFileName=geodesy-core.trx\"" || return $?
@@ -318,8 +322,12 @@ run_protocol_agent() {
     fi
 
     if phase_selected "3"; then
+        # Run against the solution so the filter also covers OData/MapServer/FeatureServer
+        # tests the protocol seam split relocated into the protocol test projects
+        # (Honua.Protocols.OData.Tests / Honua.Protocols.GeoServices.Tests). Targeting only
+        # Honua.Server.Tests silently skipped the relocated protocol coverage.
         run_check "protocol" "3" "integration-protocol-tests" "required" \
-            "dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --configuration Release --filter 'FullyQualifiedName~OgcFeaturesEndpointTests|FullyQualifiedName~OData|FullyQualifiedName~MapServer|FullyQualifiedName~FeatureServer|FullyQualifiedName~ApiSurfaceComplianceTests'" || return $?
+            "dotnet test Honua.sln --configuration Release --filter 'FullyQualifiedName~OgcFeaturesEndpointTests|FullyQualifiedName~OData|FullyQualifiedName~MapServer|FullyQualifiedName~FeatureServer|FullyQualifiedName~ApiSurfaceComplianceTests'" || return $?
 
         record_skip "protocol" "3" "desktop-gis-client-validation" "optional" \
             "manual validation required with QGIS, ArcGIS Pro, and web clients"


### PR DESCRIPTION
## Issue Link
Related to #1579

## Summary
The protocol seam split relocated OGC/MVT/CRS integration tests out of `Honua.Server.Tests` into the protocol test projects (`Honua.Protocols.OgcApi.Tests`, `Honua.Protocols.OgcClassic.Tests`, `Honua.Protocols.GeoServices.Tests`, `Honua.Protocols.OData.Tests`). `scripts/conformance/run-production-audit.sh` still ran its geodesy server-spatial-query and protocol-integration steps against only `Honua.Server.Tests`, so filters like `Wmts`, `Mvt`, `OgcCrsResolver`, and the protocol portions of `OData`/`MapServer`/`FeatureServer` silently matched 0 tests (`dotnet test` exits 0 on no-match), under-auditing those areas. This is the same relocation gotcha that hard-failed the OGC API Maps nightly (fixed in #1701) — here it failed quietly. Both affected steps now run against `Honua.sln` so the filter spans all test projects and is robust to future relocations.

## Changes Made
- `scripts/conformance/run-production-audit.sh`: geodesy `server-spatial-query-tests` step now targets `Honua.sln` (was `Honua.Server.Tests`).
- Same script: protocol-phase `integration-protocol-tests` step now targets `Honua.sln`.
- Added explanatory comments on both steps.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] Nightly gates (conformance, performance, security)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (N/A — CI audit-script-only change, no .NET source impact; validated with `bash -n` and `--list-tests` proof that the relocated Wmts (62) and Mvt tests now match under the solution filter)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
