### PR TITLE
docs: SDK getting-started and common-tasks guides (.NET, Python, JS)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -14,6 +14,19 @@
 - [Ecosystem & SDKs](concepts/ecosystem.md)
 - [Editions & licensing](concepts/editions-and-licensing.md)
 
+## SDKs
+
+- [SDK overview](sdks/README.md)
+- .NET
+  - [Get started](sdks/dotnet/getting-started.md)
+  - [Common tasks](sdks/dotnet/common-tasks.md)
+- Python
+  - [Get started](sdks/python/getting-started.md)
+  - [Common tasks](sdks/python/common-tasks.md)
+- JavaScript / TypeScript
+  - [Get started](sdks/javascript/getting-started.md)
+  - [Common tasks](sdks/javascript/common-tasks.md)
+
 ## Guides
 
 - [All guides: I want to…](guides/README.md)

--- a/docs/sdks/README.md
+++ b/docs/sdks/README.md
@@ -1,0 +1,53 @@
+# SDKs
+
+The Honua SDKs are typed clients for the same server you run from the [quickstart](../get-started/quickstart.md). They wrap the protocols Honua already speaks — GeoServices REST (FeatureServer), OGC API Features, STAC, OData, vector tiles, and the admin control plane — so you call methods instead of hand-building URLs. Everything an SDK does, the [HTTP API](../reference/README.md) can do too; the SDKs add types, paging, retries, and authentication handling.
+
+There are three first-party SDKs, plus a .NET MAUI mobile SDK. They are generated and tested against the same admin OpenAPI contract and released as a coordinated set — see [Ecosystem & SDKs](../concepts/ecosystem.md) for the repository map and the [SDK-to-server compatibility rules](../concepts/ecosystem.md#sdk-to-server-compatibility).
+
+## Pick your SDK
+
+| SDK | Package | Latest | Runtime | Start here |
+|---|---|---|---|---|
+| **.NET** | `Honua.Sdk` (NuGet) | 1.2.1 | net10.0 | [.NET getting started](dotnet/getting-started.md) |
+| **Python** | `honua-sdk` (PyPI) | 0.1.4 | Python ≥ 3.11 | [Python getting started](python/getting-started.md) |
+| **JavaScript / TypeScript** | `@honua/sdk-js` (npm) | 0.0.14-alpha | Node ≥ 20 | [JavaScript getting started](javascript/getting-started.md) |
+| Mobile (.NET MAUI) | [honua-mobile](https://github.com/honua-io/honua-mobile) | — | — | repo README |
+
+The SDK package lines are pre-release. Pin exact versions and validate against your target server before broad rollout. All three SDKs expose a runtime capability handshake (`GET /api/v1/admin/capabilities`) so clients negotiate features instead of inferring them from version numbers.
+
+## Authentication
+
+Every SDK authenticates the same way the server does — see [Authenticate clients](../guides/secure/authentication.md) for the full picture. In short:
+
+- **API key** — sent as the `X-API-Key` header. Use a scoped key for automation; the admin password is the root key for `/api/v1/admin/*`. This is the default path for the SDKs and what the getting-started pages use.
+- **Bearer token** — `Authorization: Bearer <token>` for OIDC sign-in. Each SDK takes a static token or a refreshable token provider.
+- **ArcGIS portal tokens** — for Esri clients; not needed when you use an SDK directly.
+
+Mint a scoped key once and reuse it across SDKs:
+
+```bash
+curl -X POST "$BASE/api/v1/admin/api-keys" \
+  -H "X-API-Key: $HONUA_ADMIN_PASSWORD" -H "Content-Type: application/json" \
+  -d '{"name":"sdk-quickstart","permissions":[],"expiresAt":null}'
+```
+
+The response's `data.key` is shown once — store it as the API key your SDK client uses.
+
+## What the SDKs share
+
+All three follow the same shape so concepts transfer between languages:
+
+- A **client** is constructed with a base URL and credentials, then reused.
+- A **protocol-neutral data API** — `Source` / `Query` / `Result` (Python and JavaScript) — lets you query any published layer the same way regardless of whether it is served as a FeatureServer, OGC API Features collection, or STAC collection.
+- **Protocol-specific clients** (FeatureServer, OGC Features, STAC, OData) are available as escape hatches when you want the native shape of one protocol.
+- An **admin client** wraps the control plane (`/api/v1/admin/*`) for connections, imports, layers, and keys.
+
+## Common tasks
+
+Each SDK has a short common-tasks page covering the two most common reads — query a FeatureServer layer and run a STAC search:
+
+- [.NET common tasks](dotnet/common-tasks.md)
+- [Python common tasks](python/common-tasks.md)
+- [JavaScript common tasks](javascript/common-tasks.md)
+
+The underlying protocols are documented under [Reference → Protocols](../reference/README.md): [GeoServices REST](../reference/protocols/geoservices-rest.md), [OGC APIs](../reference/protocols/ogc-apis.md), and [STAC](../reference/protocols/stac.md). For the raw HTTP equivalents of these calls, see [Query features](../guides/query-analyze/query-features.md).

--- a/docs/sdks/dotnet/common-tasks.md
+++ b/docs/sdks/dotnet/common-tasks.md
@@ -1,0 +1,81 @@
+# .NET SDK: common tasks
+
+Two of the most common reads with the Honua .NET SDK: querying a FeatureServer layer and searching a STAC catalog. Both assume a registered client — see [Get started with the .NET SDK](getting-started.md).
+
+## Query a FeatureServer layer
+
+`IHonuaFeatureServerClient` wraps the ArcGIS-compatible [GeoServices REST](../../reference/protocols/geoservices-rest.md) FeatureServer. Register it (`AddHonua(o => o.UseGeoServices = true)` or `AddHonuaFeatureServer()`), then query by service id and numeric layer id:
+
+```csharp
+using Honua.Sdk.GeoServices.FeatureServer;
+
+var fs = host.Services.GetRequiredService<IHonuaFeatureServerClient>();
+
+var result = await fs.QueryAsync(
+    serviceId: "default",
+    layerId: 0,
+    query: new FeatureServerQueryParams
+    {
+        Where          = "status = 'open'",
+        OutFields      = new[] { "name", "status" },
+        ReturnGeometry = true,
+        ResultRecordCount = 100,
+    });
+
+foreach (var feature in result.Features)
+{
+    Console.WriteLine(feature.Attributes["name"]);
+}
+```
+
+Related calls on the same client:
+
+- `GetServiceInfoAsync(serviceId)` / `GetLayerInfoAsync(serviceId, layerId)` — metadata and field definitions.
+- `QueryCountAsync(...)` — a count without fetching rows (`returnCountOnly`).
+- `QueryIdsAsync(...)` — object ids only, for client-side paging.
+- `GetFeatureAsync(serviceId, layerId, objectId)` — a single feature by id.
+
+The `Where`, `OutFields`, and paging fields map directly onto the FeatureServer query parameters documented in [Query features](../../guides/query-analyze/query-features.md).
+
+## Run a STAC search
+
+`IHonuaStacClient` wraps Honua's [STAC API](../../reference/protocols/stac.md). Register it (`AddHonua(o => o.UseStac = true)` or `AddHonuaStac()`), then search across collections:
+
+```csharp
+using Honua.Sdk.Catalogs.Stac;
+
+var stac = host.Services.GetRequiredService<IHonuaStacClient>();
+
+// List what's available first.
+var collections = await stac.ListCollectionsAsync();
+
+// Search items by bounding box and time, POSTing a search request.
+var items = await stac.SearchPostAsync(new StacSearchRequest
+{
+    Collections = new[] { "imagery" },
+    Bbox        = new[] { -122.5, 37.7, -122.3, 37.9 },
+    Datetime    = "2025-01-01T00:00:00Z/..",
+    Limit       = 10,
+});
+
+foreach (var item in items.Features)
+{
+    Console.WriteLine($"{item.Id} @ {item.Collection}");
+}
+```
+
+Other STAC helpers:
+
+- `SearchAsync(StacSearchQuery)` — the same search over `GET /stac/search` (query string form).
+- `GetCollectionAsync(collectionId)` / `GetItemsAsync(collectionId, query)` — browse one collection.
+- `GetItemAsync(collectionId, itemId)` — fetch a single item.
+- `GetLandingPageAsync()` — the catalog root.
+
+`Bbox`, `Datetime`, `Collections`, and `Limit` correspond to the [STAC search parameters](../../reference/protocols/stac.md#search-parameters).
+
+## Next steps
+
+- [Get started with the .NET SDK](getting-started.md)
+- [GeoServices REST reference](../../reference/protocols/geoservices-rest.md)
+- [STAC reference](../../reference/protocols/stac.md)
+- [SDK overview](../README.md)

--- a/docs/sdks/dotnet/getting-started.md
+++ b/docs/sdks/dotnet/getting-started.md
@@ -1,0 +1,102 @@
+# Get started with the .NET SDK
+
+Install the Honua .NET SDK, point a client at your server, authenticate with an API key, and make your first feature query.
+
+**Prerequisites:** A running Honua server ([quickstart](../../get-started/quickstart.md)) with at least one published layer ([publish layers](../../guides/publish/publish-layers.md)), the .NET 10 SDK, and an API key (see [Authenticate clients](../../guides/secure/authentication.md) — the SDK landing page shows how to [mint a scoped key](../README.md#authentication)).
+
+The .NET SDK ships as `Honua.Sdk` — an umbrella package over a family of `Honua.Sdk.*` libraries (`Honua.Sdk.Grpc`, `Honua.Sdk.Admin`, `Honua.Sdk.GeoServices`, `Honua.Sdk.Catalogs`, and more). It is built for dependency injection and `Microsoft.Extensions.Hosting`. The current release is **1.2.1**, targeting **net10.0**.
+
+## Steps
+
+### 1. Install the package
+
+```bash
+dotnet add package Honua.Sdk
+```
+
+The umbrella package pulls in the per-protocol clients. If you only need one surface — for example the gRPC feature client — you can reference it directly instead (`dotnet add package Honua.Sdk.Grpc`).
+
+### 2. Register a client
+
+`Honua.Sdk` integrates with the .NET service container. Call `AddHonua` and set the base address and credentials. The SDK sends the API key on every request:
+
+```csharp
+using Honua.Sdk;            // AddHonua
+using Honua.Sdk.Grpc;       // IHonuaGrpcClient, query models
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddHonua(options =>
+{
+    options.BaseAddress = new Uri("http://localhost:8080");
+    options.ApiKey = Environment.GetEnvironmentVariable("HONUA_API_KEY");
+    // For OIDC instead of an API key, set options.BearerToken or
+    // options.BearerTokenProvider = ct => tokenCache.GetAccessTokenAsync(ct);
+});
+
+using var host = builder.Build();
+```
+
+`ApiKey` is sent as the `X-API-Key` header. The options also accept `ApiKeyProvider` and `BearerTokenProvider` delegates if you resolve credentials dynamically.
+
+### 3. Make your first call
+
+Resolve a client from the container and query a published layer. This uses the gRPC feature client; swap `serviceId`/`layerId` for one of your own layers:
+
+```csharp
+var grpc = host.Services.GetRequiredService<IHonuaGrpcClient>();
+
+var response = await grpc.QueryFeaturesAsync(new QueryFeaturesRequest
+{
+    ServiceId      = "default",
+    LayerId        = 0,
+    Where          = "1=1",
+    OutFields      = new[] { "*" },
+    ReturnGeometry = true,
+});
+
+foreach (var feature in response.Features)
+{
+    Console.WriteLine($"{feature.Id}: {feature.Attributes["name"]}");
+}
+```
+
+## Verify
+
+Print how many features came back:
+
+```csharp
+Console.WriteLine($"Returned {response.Features.Count} features.");
+```
+
+A wrong or missing API key surfaces as an unauthenticated error from the client — confirm `HONUA_API_KEY` is set and matches a key the server accepts (test it with `curl -H "X-API-Key: $HONUA_API_KEY" http://localhost:8080/api/v1/admin/version`).
+
+## Available clients
+
+`AddHonua` can register the per-protocol clients you need; resolve them from the container:
+
+| Client interface | Registered by | Use it for |
+|---|---|---|
+| `IHonuaGrpcClient` | `AddHonua()` / `AddHonuaGrpc()` | Streaming feature queries over gRPC |
+| `IHonuaAdminClient` | `AddHonua()` / `AddHonuaAdmin()` | Control plane — connections, imports, layers, keys |
+| `IHonuaFeatureServerClient` | `AddHonuaFeatureServer()` / `AddHonua(o => o.UseGeoServices = true)` | ArcGIS-style FeatureServer queries |
+| `IHonuaStacClient` | `AddHonuaStac()` / `AddHonua(o => o.UseStac = true)` | STAC collections and item search |
+
+## Troubleshoot
+
+| Symptom | Fix |
+|---|---|
+| Unauthenticated / 401 from the client | `ApiKey` unset or wrong; verify with `curl -H "X-API-Key: $KEY" .../api/v1/admin/version`. |
+| `IHonuaFeatureServerClient` / `IHonuaStacClient` not resolvable | Enable the surface — `AddHonua(o => { o.UseGeoServices = true; o.UseStac = true; })` or call the per-package `AddHonua*` method. |
+| Empty result set | The `Where` clause filtered everything out, or the layer is empty; try `Where = "1=1"` and check the layer in [the console](../../concepts/ecosystem.md) or via the HTTP API. |
+
+More general failures: [Troubleshooting](../../guides/deploy/troubleshooting.md).
+
+## Next steps
+
+- [.NET common tasks](common-tasks.md) — query a FeatureServer layer and run a STAC search
+- [honua-sdk-dotnet on GitHub](https://github.com/honua-io/honua-sdk-dotnet) — full package list and samples
+- [Query features over HTTP](../../guides/query-analyze/query-features.md) — the protocol surfaces the SDK wraps
+- [SDK overview](../README.md)

--- a/docs/sdks/javascript/common-tasks.md
+++ b/docs/sdks/javascript/common-tasks.md
@@ -1,0 +1,99 @@
+# JavaScript SDK: common tasks
+
+Two of the most common reads with the Honua JavaScript SDK: querying a FeatureServer layer and searching a STAC catalog. Both assume a constructed client — see [Get started with the JavaScript SDK](getting-started.md).
+
+## Query a FeatureServer layer
+
+Honua serves layers over the ArcGIS-compatible [GeoServices REST](../../reference/protocols/geoservices-rest.md) FeatureServer. Two ways to query it:
+
+**Directly on the client** — the GeoServices shape:
+
+```ts
+import { HonuaClient } from "@honua/sdk-js/honua";
+
+const client = new HonuaClient({ baseUrl: "http://localhost:8080", apiKey: API_KEY });
+
+const { features } = await client.queryFeatures({
+  serviceId: "parcels",
+  layerId: 0,
+  where: "status = 'active'",
+  outFields: ["OBJECTID", "NAME"],
+  returnGeometry: true,
+  resultRecordCount: 100,
+});
+
+console.log(`${features.length} features`);
+```
+
+**Protocol-neutral (`Dataset` / `Source`)** — the same code shape for any protocol, with built-in paging via `queryAll`:
+
+```ts
+import { createDataset, PROTOCOL_DEFAULT_CAPABILITIES } from "@honua/sdk-js/contract";
+import { HonuaClient } from "@honua/sdk-js/honua";
+
+const client = new HonuaClient({ baseUrl: "http://localhost:8080", apiKey: API_KEY });
+
+const dataset = createDataset({
+  id: "parcels",
+  client,
+  sources: [{
+    id: "parcels-fs",
+    protocol: "geoservices-feature-service",
+    locator: { url: "http://localhost:8080", serviceId: "parcels", layerId: 0 },
+    capabilities: PROTOCOL_DEFAULT_CAPABILITIES["geoservices-feature-service"],
+  }],
+});
+
+const result = await dataset.source("parcels-fs")!.queryAll({
+  where: "STATUS = 'ACTIVE'",
+  outFields: ["OBJECTID", "NAME"],
+  returnGeometry: true,
+  pagination: { limit: 500 },
+});
+
+console.log(`Loaded ${result.features.length} features`);
+```
+
+`HonuaFeatureLayer` (from the `honua` subpath) also offers `query`, `stream`, `queryCount`, and `queryObjectIds`. The query fields map onto the FeatureServer parameters in [Query features](../../guides/query-analyze/query-features.md).
+
+## Run a STAC search
+
+Honua exposes a [STAC API](../../reference/protocols/stac.md) for spatiotemporal discovery. Use the dedicated STAC search helper:
+
+```ts
+import { createHonuaStacSearch } from "@honua/sdk-js";
+
+const stac = createHonuaStacSearch({ baseUrl: "http://localhost:8080" });
+
+const results = await stac.searchAll({
+  collections: ["imagery"],
+  bbox: [-122.5, 37.7, -122.3, 37.9],
+  datetime: "2025-01-01T00:00:00Z/..",
+  limit: 10,
+});
+
+for (const item of results.features) {
+  console.log(item.id, item.collection);
+}
+```
+
+`searchAll` follows the catalog's paging links so you get every matching item. `collections`, `bbox`, and `datetime` correspond to the [STAC search parameters](../../reference/protocols/stac.md#search-parameters). You can also wire a STAC collection into the protocol-neutral contract with the `stacSearchSource()` factory from `@honua/sdk-js/contract`.
+
+## Migrate ArcGIS JS code
+
+The `honua-migrate` codemod scans and rewrites ArcGIS JS API imports toward the Honua SDK:
+
+```bash
+npx @honua/honua-migrate scan ./src
+npx @honua/honua-migrate codemod ./src --write --report migration-report.json
+```
+
+See [ArcGIS apps & SDKs](../../guides/migrate/arcgis-apps-and-sdks.md) for the migration path and the `esri-compat` layer.
+
+## Next steps
+
+- [Get started with the JavaScript SDK](getting-started.md)
+- [GeoServices REST reference](../../reference/protocols/geoservices-rest.md)
+- [STAC reference](../../reference/protocols/stac.md)
+- [MapLibre web maps](../../guides/connect/maplibre-web-maps.md)
+- [SDK overview](../README.md)

--- a/docs/sdks/javascript/getting-started.md
+++ b/docs/sdks/javascript/getting-started.md
@@ -1,0 +1,97 @@
+# Get started with the JavaScript SDK
+
+Install the Honua JavaScript/TypeScript SDK, construct a client, authenticate with an API key, and make your first feature query.
+
+**Prerequisites:** A running Honua server ([quickstart](../../get-started/quickstart.md)) with at least one published layer ([publish layers](../../guides/publish/publish-layers.md)), Node.js 20 or newer, and an API key (see [Authenticate clients](../../guides/secure/authentication.md) — the SDK landing page shows how to [mint a scoped key](../README.md#authentication)).
+
+The SDK ships as `@honua/sdk-js` on npm. It is **ESM-only** and targets **Node ≥ 20**. The current release is **0.0.14-alpha** — pin the exact version and expect breaking changes in minor releases for symbols marked experimental. A companion [MCP server](https://github.com/honua-io/honua-sdk-js) package (`@honua/mcp-server`) exposes the same surface to AI agents (see [AI agents (MCP)](../../guides/connect/ai-agents-mcp.md)), and a `honua-migrate` codemod ports ArcGIS JS code (see [ArcGIS apps & SDKs](../../guides/migrate/arcgis-apps-and-sdks.md)).
+
+## Steps
+
+### 1. Install the package
+
+```bash
+npm install @honua/sdk-js
+```
+
+For a build-less browser page you can import it from a CDN instead:
+
+```html
+<script type="module">
+  import { HonuaClient } from "https://esm.sh/@honua/sdk-js/browser";
+</script>
+```
+
+### 2. Construct a client
+
+`HonuaClient` is constructed with the server base URL and credentials. The API key is sent as the `X-API-Key` header. Import it from the `honua` subpath:
+
+```ts
+import { HonuaClient } from "@honua/sdk-js/honua";
+
+const client = new HonuaClient({
+  baseUrl: "http://localhost:8080",
+  apiKey: process.env.HONUA_API_KEY,   // sent as X-API-Key
+  transport: "rest",                    // or "grpc-web"
+});
+```
+
+For OIDC, pass `bearerToken: "..."` or an `auth` callback that returns refreshable credentials. Browser apps that talk to a public layer can omit credentials entirely.
+
+### 3. Make your first call
+
+Optionally check server compatibility, then query a published layer. This uses the GeoServices/FeatureServer shape — swap `serviceId`/`layerId` for one of your own layers:
+
+```ts
+const { supported, reasons } = await client.checkCompatibility();
+if (!supported) throw new Error(`Unsupported Honua server: ${reasons.join("; ")}`);
+
+const { features } = await client.queryFeatures({
+  serviceId: "default",
+  layerId: 0,
+  where: "1=1",
+  outFields: ["*"],
+  returnGeometry: true,
+  resultRecordCount: 25,
+});
+
+console.log(`Returned ${features.length} features`);
+for (const f of features.slice(0, 5)) console.log(f.attributes);
+```
+
+## Verify
+
+```ts
+console.log(`Returned ${features.length} features`);
+```
+
+A wrong or missing API key surfaces as an authentication error from the client — confirm `HONUA_API_KEY` is set and accepted (`curl -H "X-API-Key: $HONUA_API_KEY" http://localhost:8080/api/v1/admin/version`).
+
+## Available surfaces
+
+`@honua/sdk-js` ships several entrypoints; import only what you need:
+
+| Import | Provides |
+|---|---|
+| `@honua/sdk-js/honua` | `HonuaClient` plus native wrappers — `HonuaFeatureLayer`, `HonuaStacSearch`, `HonuaOgcFeatures`, `HonuaWms`, `HonuaOdataEntitySet`, … |
+| `@honua/sdk-js/contract` | Protocol-neutral `Dataset` / `Source` / `Query` / `Result` and source factories |
+| `@honua/sdk-js/esri-compat` | ArcGIS compatibility layer for gradual migration |
+| `@honua/sdk-js/migration` | `honua-migrate` scanner and codemod |
+
+## Troubleshoot
+
+| Symptom | Fix |
+|---|---|
+| Authentication error / 401 | `apiKey` unset or wrong; verify with `curl -H "X-API-Key: $KEY" .../api/v1/admin/version`. |
+| `ERR_REQUIRE_ESM` / import errors | The SDK is ESM-only; use `import`, `"type": "module"`, and Node ≥ 20. |
+| `checkCompatibility()` reports unsupported | The server is older than the SDK's minimum supported version; align release channels per the [compatibility rules](../../concepts/ecosystem.md#sdk-to-server-compatibility). |
+| CORS errors in the browser | Add your page origin to the server's allowed origins (see the [quickstart](../../get-started/quickstart.md) CORS note). |
+
+More general failures: [Troubleshooting](../../guides/deploy/troubleshooting.md).
+
+## Next steps
+
+- [JavaScript common tasks](common-tasks.md) — query a FeatureServer layer and run a STAC search
+- [honua-sdk-js on GitHub](https://github.com/honua-io/honua-sdk-js) — full package list, MCP server, and codemod
+- [MapLibre web maps](../../guides/connect/maplibre-web-maps.md) — render SDK results on a map
+- [SDK overview](../README.md)

--- a/docs/sdks/python/common-tasks.md
+++ b/docs/sdks/python/common-tasks.md
@@ -1,0 +1,89 @@
+# Python SDK: common tasks
+
+Two of the most common reads with the Honua Python SDK: querying a FeatureServer layer and searching a STAC catalog. Both assume a constructed client — see [Get started with the Python SDK](getting-started.md). Examples use the synchronous `HonuaClient`; `AsyncHonuaClient` exposes the same calls with `await`.
+
+## Query a FeatureServer layer
+
+Honua serves layers over the ArcGIS-compatible [GeoServices REST](../../reference/protocols/geoservices-rest.md) FeatureServer. Two ways to query it:
+
+**Protocol-neutral (`source` + `Query`)** — the same code shape for any protocol:
+
+```python
+from honua_sdk import HonuaClient, Query, SourceDescriptor, SourceLocator
+
+with HonuaClient("http://localhost:8080", api_key=API_KEY) as client:
+    source = client.source(
+        SourceDescriptor(
+            id="parcels",
+            protocol="geoservices-feature-service",
+            locator=SourceLocator(service_id="parcels", layer_id=0),
+        )
+    )
+    result = source.query(Query(where="status = 'active'", out_fields=["*"]))
+    print(f"{len(result.features)} features")
+```
+
+**FeatureServer client (native shape)** — when you want the protocol's own surface:
+
+```python
+with HonuaClient("http://localhost:8080", api_key=API_KEY) as client:
+    fs = client.feature_server("parcels")
+    # query, count, and layer metadata against layer 0
+```
+
+The `where` and `out_fields` map onto the FeatureServer query parameters in [Query features](../../guides/query-analyze/query-features.md). With the `[geopandas]` extra installed, results can be loaded into a `GeoDataFrame`.
+
+## Run a STAC search
+
+Honua exposes a [STAC API](../../reference/protocols/stac.md) for spatiotemporal discovery. Search it through the dedicated STAC client or the `source` facade.
+
+**STAC client:**
+
+```python
+with HonuaClient("http://localhost:8080", api_key=API_KEY) as client:
+    stac = client.stac()
+    # browse collections, then search items by bbox / datetime / collections
+```
+
+**Protocol-neutral (`source` + `Query`)** — point a source at a STAC collection:
+
+```python
+from honua_sdk import HonuaClient, Query, SourceDescriptor, SourceLocator
+
+with HonuaClient("http://localhost:8080", api_key=API_KEY) as client:
+    stac_source = client.source(
+        SourceDescriptor(
+            id="imagery",
+            protocol="stac",
+            locator=SourceLocator(collection_id="imagery"),
+        )
+    )
+    result = stac_source.query(Query(), limit=10)
+    for item in result.features:
+        print(item.properties)
+```
+
+`bbox`, `datetime`, and `collections` correspond to the [STAC search parameters](../../reference/protocols/stac.md#search-parameters). The `limit` keyword caps the page size.
+
+## Query OGC API Features
+
+The same layer is also reachable as an [OGC API Features](../../reference/protocols/ogc-apis.md) collection:
+
+```python
+with HonuaClient("http://localhost:8080", api_key=API_KEY) as client:
+    ogc = client.ogc_features()
+    collections = ogc.collections()
+
+    parcels = ogc.collection("parcels")
+    items = parcels.items(limit=100, filter="status = 'active'")
+    all_items = parcels.items_all(page_size=500, max_pages=20)
+```
+
+`items_all` handles paging for you, following the `next` links the server returns.
+
+## Next steps
+
+- [Get started with the Python SDK](getting-started.md)
+- [GeoServices REST reference](../../reference/protocols/geoservices-rest.md)
+- [STAC reference](../../reference/protocols/stac.md)
+- [SDK overview](../README.md)

--- a/docs/sdks/python/getting-started.md
+++ b/docs/sdks/python/getting-started.md
@@ -1,0 +1,99 @@
+# Get started with the Python SDK
+
+Install the Honua Python SDK, construct a client, authenticate with an API key, and make your first feature query.
+
+**Prerequisites:** A running Honua server ([quickstart](../../get-started/quickstart.md)) with at least one published layer ([publish layers](../../guides/publish/publish-layers.md)), Python 3.11 or newer, and an API key (see [Authenticate clients](../../guides/secure/authentication.md) — the SDK landing page shows how to [mint a scoped key](../README.md#authentication)).
+
+The data-plane SDK ships as `honua-sdk` on PyPI and is imported as `honua_sdk`. The current release is **0.1.4** and requires **Python ≥ 3.11**. A companion control-plane package, `honua-admin` (imported as `honua_admin`, class `HonuaAdminClient`), wraps `/api/v1/admin/*`.
+
+## Steps
+
+### 1. Install the package
+
+```bash
+pip install honua-sdk
+```
+
+Optional extras add helpers:
+
+```bash
+pip install "honua-sdk[geopandas]"   # GeoDataFrame helpers
+pip install "honua-sdk[grpc]"        # streaming gRPC client
+```
+
+### 2. Construct a client
+
+`HonuaClient` takes the server base URL and credentials. The API key is sent as the `X-API-Key` header. Use it as a context manager so the underlying HTTP connection is closed for you:
+
+```python
+import os
+from honua_sdk import HonuaClient
+
+with HonuaClient(
+    "http://localhost:8080",
+    api_key=os.environ["HONUA_API_KEY"],
+) as client:
+    services = client.list_services()
+    print(services)
+```
+
+For OIDC instead of an API key, pass `bearer_token=...` or an `auth_provider` callable. An `AsyncHonuaClient` with the same constructor is available for `async`/`await` code.
+
+### 3. Make your first call
+
+Query a published layer through the protocol-neutral `Source` / `Query` API. This works against any published layer regardless of which protocol serves it — point the `SourceLocator` at one of your own services:
+
+```python
+from honua_sdk import HonuaClient, Query, SourceDescriptor, SourceLocator
+
+with HonuaClient("http://localhost:8080", api_key=os.environ["HONUA_API_KEY"]) as client:
+    source = client.source(
+        SourceDescriptor(
+            id="default",
+            protocol="geoservices-feature-service",
+            locator=SourceLocator(service_id="default", layer_id=0),
+        )
+    )
+    result = source.query(Query(where="1=1", out_fields=["*"]))
+
+    print(f"Found {len(result.features)} features")
+    for feature in result.features[:5]:
+        print(feature.properties)
+```
+
+## Verify
+
+```python
+print(f"Found {len(result.features)} features")
+```
+
+A wrong or missing key raises an authentication error from the client — confirm `HONUA_API_KEY` is set and accepted (`curl -H "X-API-Key: $HONUA_API_KEY" http://localhost:8080/api/v1/admin/version`).
+
+## Available surfaces
+
+`HonuaClient` exposes both the protocol-neutral `source()` facade and protocol-specific clients:
+
+| Accessor | Returns | Use it for |
+|---|---|---|
+| `client.source(SourceDescriptor(...))` | a `Source` | Protocol-neutral `Query` / `Result` over any layer |
+| `client.feature_server(service_id)` | FeatureServer client | ArcGIS-style FeatureServer queries |
+| `client.ogc_features()` | OGC Features client | OGC API Features collections and items |
+| `client.stac()` | STAC client | STAC collections and item search |
+| `HonuaAdminClient(base_url, api_key=...)` (from `honua_admin`) | admin client | Control plane — compatibility, connections, imports |
+
+## Troubleshoot
+
+| Symptom | Fix |
+|---|---|
+| Authentication error / 401 | `api_key` unset or wrong; verify with `curl -H "X-API-Key: $KEY" .../api/v1/admin/version`. |
+| `ModuleNotFoundError: honua_sdk` | The import name uses an underscore (`honua_sdk`), the package name a hyphen (`honua-sdk`). |
+| Empty `result.features` | The `where` filtered everything out, or the layer is empty; try `Query(where="1=1")`. |
+
+More general failures: [Troubleshooting](../../guides/deploy/troubleshooting.md).
+
+## Next steps
+
+- [Python common tasks](common-tasks.md) — query a FeatureServer layer and run a STAC search
+- [honua-sdk-python on GitHub](https://github.com/honua-io/honua-sdk-python) — examples and the admin client
+- [Query features over HTTP](../../guides/query-analyze/query-features.md) — the protocol surfaces the SDK wraps
+- [SDK overview](../README.md)


### PR DESCRIPTION
## What

Adds SDK documentation to the GitBook docs source (this repo's `docs/` tree, which is the Git-Synced source for **honua.gitbook.io/honuaio**). Advances honua-io/honua-site#2 (MVP docs hub). Server docs already exist and are not duplicated — these pages **link** into them.

## Where the GitBook content lives

The honua-site repo is a static HTML marketing site that links **out** to GitBook; it does not contain GitBook source. The actual GitBook Git-Sync source (`.gitbook.yaml` + `SUMMARY.md` + `README.md`) lives in **`honua-server/docs/`**. So the substantive SDK docs land here; the honua-site hub gets a pointer in a companion PR (honua-io/honua-site#2 branch `mvp/site-2-sdk-docs`).

## New pages (`docs/sdks/`)

- `sdks/README.md` — SDK overview tying the three SDKs together; links to `concepts/ecosystem.md`, `guides/secure/authentication.md`, and the protocol references.
- `sdks/dotnet/` — getting-started + common-tasks
- `sdks/python/` — getting-started + common-tasks
- `sdks/javascript/` — getting-started + common-tasks

Each getting-started covers install → construct client → **X-API-Key** auth → first feature query → verify → troubleshoot, mirroring the existing doc style (e.g. `guides/secure/authentication.md`). Each common-tasks covers a FeatureServer query and a STAC search. Wired into `SUMMARY.md` as a new top-level **SDKs** section after Concepts.

## Real package facts used (pulled from the SDK repos, not invented)

| SDK | Package | Version | Runtime | Install |
|---|---|---|---|---|
| .NET | `Honua.Sdk` (NuGet umbrella over `Honua.Sdk.*`) | 1.2.1 | net10.0 | `dotnet add package Honua.Sdk` |
| Python | `honua-sdk` (PyPI; import `honua_sdk`) | 0.1.4 | Python ≥ 3.11 | `pip install honua-sdk` |
| JavaScript | `@honua/sdk-js` (npm, ESM; + `@honua/mcp-server`, `honua-migrate`) | 0.0.14-alpha | Node ≥ 20 | `npm install @honua/sdk-js` |

Client construction/auth and first-call snippets are taken from each repo's README/source: .NET `AddHonua(o => { o.BaseAddress; o.ApiKey; })` + `IHonuaGrpcClient.QueryFeaturesAsync`; Python `HonuaClient(base_url, api_key=...)` + `source(...).query(Query(...))`; JS `new HonuaClient({ baseUrl, apiKey })` + `queryFeatures(...)` / `createDataset(...)`. FeatureServer + STAC helper names (`IHonuaFeatureServerClient`/`IHonuaStacClient`, `client.feature_server`/`client.stac`, `HonuaFeatureLayer`/`createHonuaStacSearch`) are the real surfaces in each repo.

## Notes

- All three SDKs are documented (none stubbed).
- Versions differ from the issue's estimates (.NET 1.2.0→1.2.1, Python 0.1.3→0.1.4) — docs use the actual current repo versions.
- No automated docs link-check workflow exists in this repo; relative links were validated locally against `SUMMARY.md` targets and all resolve.

Refs honua-io/honua-site#2 · umbrella honua-io/honua-devops#90
