### PR TITLE
feat(demo): light up demo.honua.io — STAC seed + Pro-license runbook + release-packages 42P08 fix (#1688)

### DIFF
--- a/docs/internal/demo/demo-honua-io-capability-runbook.md
+++ b/docs/internal/demo/demo-honua-io-capability-runbook.md
@@ -1,0 +1,258 @@
+# demo.honua.io full-capability runbook (server#1688)
+
+Operator runbook to bring `demo.honua.io` to full demonstrable capability across the
+four product pillars. It covers two separable tracks:
+
+1. **Seed STAC collections** so the Imagery & Terrain Studio shows a live catalog.
+2. **Apply a Pro license** so geocoding, realtime streaming, and FeatureServer editing
+   light up.
+
+> Scope note: the underlying server features already exist. This is **operational
+> enablement** on the deployed demo. The only server code change shipped alongside this
+> runbook is a fix for the `release-packages` admin API (see *Prerequisites*).
+
+Account context (from #1688 recon): AWS `585192672263`, `us-west-2`, compute is Lambda
+`honua-demo-demo-honua`; the demo DB is reachable only in-VPC via the bootstrap Lambda
+`honua-demo-demo-postgis-bootstrap` (accepts `{"statements":[...]}` / `{"query":"..."}`).
+
+Everything below is **operator-supplied where it touches secrets or the live env** —
+those steps are marked **[OPERATOR]**. No secrets are committed in this repo.
+
+---
+
+## Prerequisites (deploy a current image first)
+
+Both tracks require a demo image built from `trunk` at or after the commits below, then
+deployed to `honua-demo-demo-honua`:
+
+- **`release-packages` 42P08 fix** — `GET /api/v1/admin/metadata/release-packages` must
+  return 200 (it 500'd with `42P08: could not determine data type of parameter $1` on the
+  prior image). Fixed in `PostgresMetadataReleasePackageStore.ListAsync` (typed text
+  parameters). Required only if you drive metadata admin discovery; the STAC seed below
+  does not depend on it, but the demo's admin/console metadata views do.
+- **License-from-content** (#1698) — `Licensing:LicenseContent` must be honored. Confirm
+  with `grep` in the image or by setting it and checking the capabilities manifest.
+
+Health gate (Redis is required for a healthy server; STAC needs a current v2 snapshot —
+the seed below activates one):
+
+```bash
+curl -fsS https://demo.honua.io/healthz/live    # 200
+curl -fsS https://demo.honua.io/healthz/ready   # 200 (Redis up)
+```
+
+---
+
+## Track 1 — Seed STAC collections (REQ-001)
+
+### Why a metadata-v2 seed, not a `honua.services`/`honua.layers` seed
+
+The live catalog (`/stac/collections`, `/odata/Layers`, `/rest/services`) is materialized
+from the **Metadata v2 graph snapshot** (`metadata.honua.io/v2alpha1`) stored in
+`honua.metadata_v2_snapshots` + `honua.metadata_v2_current` — **not** from the legacy
+`honua.services`/`honua.layers` tables. Raw INSERTs into the legacy tables are inert for
+the catalog (confirmed on the deployed demo image). The STAC read path
+(`Honua.Protocols.Stac.Services.StacV2Lookups`) only surfaces a collection when a
+publication of type `stac-collection` exists on a service whose `protocols` include `Stac`,
+backed by a resolvable resource + storage binding.
+
+The seed handles all of this: it appends a STAC service + two `stac-collection`
+publications (Maui Reef Watch `90810`, Maui Coastal Change `90820`), their resources and
+storage bindings, into the **current active snapshot**, writes a new revision, and
+activates it. Existing graph entities (the 11 `maui-*` layers) are preserved.
+
+### Assets
+
+- `tests/seed/demo-stac-imagery-v1.sql` — the idempotent seed (features + v2 graph merge).
+- `tests/seed/apply-demo-stac-seed.sh` — psql wrapper.
+
+### Run it
+
+**[OPERATOR]** Set `HONUA_SEED_ENV` to the env id the demo Lambda is configured with —
+this MUST match the server's `Metadata__Environment` / `Environment` setting (it defaults
+to `default`; confirm against the Lambda's environment variables):
+
+```bash
+# Local / direct-psql target:
+PGHOST=... PGPORT=5432 PGUSER=honua PGDATABASE=honua PGPASSWORD=... \
+HONUA_SEED_ENV=default HONUA_SEED_SCHEMA=honua \
+  tests/seed/apply-demo-stac-seed.sh
+```
+
+For `demo.honua.io` the DB is in-VPC only. Send the **entire** contents of
+`tests/seed/demo-stac-imagery-v1.sql` (it is one transaction) as a single statement to the
+bootstrap Lambda, with the `env`/`schema` psql vars pre-substituted (the file reads them
+via `:'env'` / `:"schema"`; when going through the Lambda, replace those tokens with the
+literal env/schema before sending, or wrap the body so `set_config('honua.seed_env', ...)`
+is set first):
+
+```bash
+# [OPERATOR] example: invoke the bootstrap Lambda with the seed body
+aws lambda invoke --function-name honua-demo-demo-postgis-bootstrap \
+  --payload "$(jq -Rs '{query: .}' < tests/seed/demo-stac-imagery-v1.sql)" \
+  --cli-binary-format raw-in-base64-out /dev/stdout
+```
+
+The seed is **idempotent**: re-running advances the snapshot revision and re-applies the
+two collections without duplicating features or publications.
+
+### Verify (REQ-001)
+
+```bash
+curl -s https://demo.honua.io/stac/collections | jq '.collections | length'   # >= 2
+curl -s https://demo.honua.io/stac/collections | jq -r '.collections[].id'     # 90810, 90820
+curl -s -X POST https://demo.honua.io/stac/search \
+  -H 'content-type: application/json' \
+  -d '{"bbox":[-156.70,20.60,-156.30,20.96],"collections":["90810"]}' \
+  | jq '.features | length'   # > 0
+```
+
+Acceptance: Imagery & Terrain Studio (`demo-imagery-terrain.html`) shows a live STAC
+catalog instead of the bundled sample lane.
+
+---
+
+## Track 2 — Apply a Pro license (REQ-002/003/004/005)
+
+A Pro license unblocks the three remaining Pro-gated demo areas. Entitlement keys
+(from `FeatureCatalog`):
+
+| Demo area            | Entitlement key                       | Min edition |
+|----------------------|---------------------------------------|-------------|
+| Realtime streaming   | `streaming.feature-subscriptions`     | Pro         |
+| FeatureServer edits  | `editing.featureserver-edits`         | Pro         |
+| Forward geocoding    | `geocoding.forward`                   | Pro         |
+| Reverse geocoding    | `geocoding.reverse`                   | Pro         |
+| Geocoding failover   | `geocoding.failover`                  | Pro         |
+
+> Editing note: only the **Esri GeoServices FeatureServer** write surface
+> (`applyEdits`) is Pro (`editing.featureserver-edits`). Editing via the **open
+> protocols** (OGC API Features mutations, WFS-T, OData CRUD/`$batch`, gRPC) is
+> Community and ungated. The editing demo exercises the FeatureServer write path, so it
+> needs the Pro license.
+
+### Step 1 — Mint the Pro license (offline, publisher-only) **[OPERATOR]**
+
+Use the in-repo `honua-license-mint` CLI (`src/Honua.LicenseMint`). The signing key is the
+trust root — **never commit it**.
+
+```bash
+# (a) one-time: generate the signing key pair
+dotnet run --project src/Honua.LicenseMint -- keygen \
+  --key-id honua-demo-2026q2 \
+  --private-out ./honua-demo-2026q2.private    # chmod 600; store in Secrets Manager only
+
+# (b) mint a Pro envelope (defaults to all entitlements at/below Pro)
+dotnet run --project src/Honua.LicenseMint -- mint \
+  --key-id honua-demo-2026q2 \
+  --license-id lic-honua-demo-2026q2 \
+  --licensed-to "Honua Demo (demo.honua.io)" \
+  --edition Pro \
+  --expires 2027-06-15T00:00:00Z \
+  --private-key-file ./honua-demo-2026q2.private \
+  --out ./honua-demo-license.json
+```
+
+`keygen` prints the runtime trusted-key setting:
+`Licensing__TrustedKeys__honua-demo-2026q2=<base64url>`. Record it for Step 3.
+
+> Per #1688 recon, a Pro envelope + signing key may already be staged in Secrets Manager
+> (`honua-demo-demo/license`, `honua-demo-demo/license-signing-key`) with keyId
+> `honua-demo-2026q2`. Reuse those rather than re-minting if present.
+
+### Step 2 — Store the envelope in Secrets Manager **[OPERATOR]**
+
+```bash
+aws secretsmanager put-secret-value \
+  --secret-id honua-demo-demo/license \
+  --secret-string file://honua-demo-license.json --region us-west-2
+```
+
+Do **not** put the license envelope or signing key in the repo, in Terraform state, or in
+client pages.
+
+### Step 3 — Wire the license onto the demo Lambda **[OPERATOR]**
+
+`Licensing:LicenseContent` accepts either the raw envelope JSON **or** a secret reference
+(`aws:secretsmanager:<arn>`) which is resolved at startup — prefer the secret reference so
+no secret material lands in the Lambda config:
+
+```
+Licensing__LicenseContent=aws:secretsmanager:arn:aws:secretsmanager:us-west-2:585192672263:secret:honua-demo-demo/license
+Licensing__TrustedKeys__honua-demo-2026q2=base64url:<public-key-from-keygen>
+```
+
+`LicenseContent` takes precedence over `LicensePath`, so this works on the read-only
+Lambda filesystem with no bootstrap file write.
+
+### Step 4 — Enable geocoding (resolve the 404, REQ-003) **[OPERATOR]**
+
+Geocoding is published when `Geocoding:Enabled=true` with a configured provider and locator
+name. The demo probes `/rest/services/maui/GeocodeServer`, so set the locator name to
+`maui` (or publish under the default `World` and update the demo probe). On the demo
+Lambda:
+
+```
+Geocoding__Enabled=true
+Geocoding__LocatorName=maui
+Geocoding__DefaultProvider=nominatim     # or the configured provider
+# plus provider config (endpoint/key) per Geocoding__Providers__*
+```
+
+The forward/reverse geocoding **operations** are Pro-gated (`geocoding.forward` /
+`geocoding.reverse`), so the Pro license from Steps 1–3 must be active.
+
+### Step 5 — Streaming + editing need no extra config
+
+`streaming.feature-subscriptions` and `editing.featureserver-edits` are unlocked purely by
+the active Pro license. Streaming additionally requires Redis (already a server health
+prerequisite) for the change-feed/replay backend. The editing demo writes to a writable
+OData/FeatureServer layer with CORS/If-Match/ETag already fixed (#1629/#1653).
+
+### Step 6 — Redeploy and verify
+
+`terraform apply` (or update the Lambda env + `update-function-code`) and re-run the
+probes:
+
+```bash
+# REQ-004 streaming
+curl -s https://demo.honua.io/api/v1/streaming/features/capabilities \
+  | jq '{enabled, edition}'                       # {"enabled": true, "edition": "Pro"}
+
+# REQ-003 geocoding
+curl -s 'https://demo.honua.io/rest/services/maui/GeocodeServer?f=json' \
+  | jq '.currentVersion'                          # present (no 404)
+curl -s 'https://demo.honua.io/rest/services/maui/GeocodeServer/findAddressCandidates?f=json&singleLine=Kahului' \
+  | jq '.candidates | length'                     # > 0
+
+# Edition / capability manifest
+curl -s https://demo.honua.io/api/v1/capabilities/manifest \
+  | jq '.license.edition'                          # "Pro"
+
+# REQ-005 editing — authenticated PATCH/POST to a writable layer should persist
+#   (round-trips on re-read). NFR-001: write creds stay server-side, never in client pages.
+```
+
+Acceptance (#1688): Public Safety Ops connects a live incident feed; dispatch geocoding
+resolves live; Inspection & Editing persists an edit; the four probes pass from the
+`honua.io` origin.
+
+---
+
+## End-to-end validation
+
+With both tracks applied, re-run the SDK smoke from `honua-sdk-js`:
+
+```bash
+node scripts/site-demo-smoke.mjs    # the four affected pages leave their fixture/replay lanes
+```
+
+## Runnable now vs. needs live env / creds
+
+| Item                                          | State                                   |
+|-----------------------------------------------|-----------------------------------------|
+| STAC seed SQL + apply script                  | **Runnable now** (validated vs PostGIS) |
+| `release-packages` 42P08 fix + tests          | **Merged in this PR**                   |
+| License mint CLI commands                      | Runnable; signing key is **[OPERATOR]** |
+| Apply license / geocoding env on demo Lambda  | **[OPERATOR]** — live env + secrets     |
+| Redeploy + probe                               | **[OPERATOR]** — live env               |

--- a/src/Honua.Postgres/Features/Metadata/PostgresMetadataReleasePackageStore.cs
+++ b/src/Honua.Postgres/Features/Metadata/PostgresMetadataReleasePackageStore.cs
@@ -161,9 +161,23 @@ internal sealed class PostgresMetadataReleasePackageStore : IMetadataReleasePack
 
         await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@source_environment", (object?)NullIfBlank(filter.SourceEnvironment) ?? DBNull.Value);
-        command.Parameters.AddWithValue("@target_environment", (object?)NullIfBlank(filter.TargetEnvironment) ?? DBNull.Value);
-        command.Parameters.AddWithValue("@status", (object?)(filter.Status is { } status ? ToDbStatus(status) : null) ?? DBNull.Value);
+        // These filter parameters are nullable and are wrapped in LOWER(...) inside the SQL. Npgsql infers
+        // no type for an untyped DBNull, so PostgreSQL cannot resolve LOWER(@param) on a NULL and fails with
+        // 42P08 ("could not determine data type of parameter $1"). Binding them as explicit text gives the
+        // NULL a type even when the filter value is absent (an unfiltered list query, which is the common case
+        // for GitOps/console discovery via GET /api/v1/admin/metadata/release-packages).
+        command.Parameters.Add(new NpgsqlParameter("@source_environment", NpgsqlDbType.Text)
+        {
+            Value = (object?)NullIfBlank(filter.SourceEnvironment) ?? DBNull.Value,
+        });
+        command.Parameters.Add(new NpgsqlParameter("@target_environment", NpgsqlDbType.Text)
+        {
+            Value = (object?)NullIfBlank(filter.TargetEnvironment) ?? DBNull.Value,
+        });
+        command.Parameters.Add(new NpgsqlParameter("@status", NpgsqlDbType.Text)
+        {
+            Value = (object?)(filter.Status is { } status ? ToDbStatus(status) : null) ?? DBNull.Value,
+        });
         command.Parameters.AddWithValue("@limit", limit);
         command.Parameters.AddWithValue("@offset", offset);
 

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataReleaseStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataReleaseStoreTests.cs
@@ -127,6 +127,64 @@ public sealed class PostgresMetadataReleaseStoreTests(PostgresFixture fixture)
     }
 
     [IntegrationTest]
+    public async Task ReleasePackageStore_ListAsync_WithEmptyFilter_DoesNotThrowParameterTypeError()
+    {
+        // Regression for #1688: GET /api/v1/admin/metadata/release-packages returned HTTP 500
+        // "42P08: could not determine data type of parameter $1" because the nullable
+        // source/target/status filters were bound as untyped DBNull while the SQL wraps them in
+        // LOWER(...). An unfiltered list (every filter null) is the common GitOps/console discovery
+        // call, and it must succeed and return all packages newest-first.
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresMetadataReleaseStoreTests));
+        try
+        {
+            await EnsureTablesAsync(schema);
+            var provider = new TestConnectionProvider(fixture.DataSource, schema);
+            var store = new PostgresMetadataReleasePackageStore(provider, schema);
+
+            await store.CreateAsync(BuildPackage(Guid.NewGuid(), "promote-parcels", "ops"));
+            await store.CreateAsync(BuildPackage(Guid.NewGuid(), "promote-zoning", "ops"));
+
+            var act = () => store.ListAsync(new MetadataReleasePackageListFilter());
+
+            var summaries = (await act.Should().NotThrowAsync()).Subject;
+            summaries.Should().HaveCount(2);
+            summaries.Should().OnlyContain(summary => summary.SourceEnvironment == "dev");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task ReleasePackageStore_ListAsync_WithEnvironmentFilter_MatchesCaseInsensitively()
+    {
+        // Companion to the empty-filter regression: confirms the typed filter parameters still
+        // drive the LOWER(...) case-insensitive WHERE clause when a value IS supplied.
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresMetadataReleaseStoreTests));
+        try
+        {
+            await EnsureTablesAsync(schema);
+            var provider = new TestConnectionProvider(fixture.DataSource, schema);
+            var store = new PostgresMetadataReleasePackageStore(provider, schema);
+
+            await store.CreateAsync(BuildPackage(Guid.NewGuid(), "promote-parcels", "ops"));
+
+            var summaries = await store.ListAsync(new MetadataReleasePackageListFilter
+            {
+                SourceEnvironment = "DEV",
+                TargetEnvironment = "Staging",
+            });
+
+            summaries.Should().ContainSingle(summary => summary.PackageKey == "promote-parcels");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
     public async Task ReleasePackageStore_CreateAsync_WithDuplicateDefaultNamespaceKey_ThrowsConflict()
     {
         var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresMetadataReleaseStoreTests));

--- a/tests/seed/apply-demo-stac-seed.sh
+++ b/tests/seed/apply-demo-stac-seed.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+#
+# Applies the demo.honua.io STAC imagery seed (honua-server#1688) to a target
+# database. Wraps tests/seed/demo-stac-imagery-v1.sql, which seeds Sentinel-2-style
+# scene features and merges two STAC collections into the active Metadata v2
+# snapshot so GET /stac/collections is non-empty and POST /stac/search returns
+# items for a Maui-area bbox.
+#
+# This script applies ONLY the STAC seed. Pro-license + geocoding/streaming/editing
+# enablement is operator-run and documented in
+# docs/internal/demo/demo-honua-io-capability-runbook.md.
+#
+# Usage:
+#   apply-demo-stac-seed.sh
+#
+# Environment variables:
+#   PGPASSWORD                psql password (required)
+#   PGHOST                    db host (default localhost)
+#   PGPORT                    db port (default 5432)
+#   PGUSER                    db user (default honua)
+#   PGDATABASE                db name (default honua)
+#   HONUA_SEED_ENV            Metadata v2 environment id. MUST match the server's
+#                             Metadata__Environment / Environment setting (default "default").
+#   HONUA_SEED_SCHEMA         Honua metadata schema (default "honua").
+#
+# On demo.honua.io the database is reachable only in-VPC. The supported channel is
+# the bootstrap Lambda (honua-demo-demo-postgis-bootstrap), which accepts
+# {"statements":[...]} / {"query":"..."}. To run there, send the contents of
+# demo-stac-imagery-v1.sql as a single statement (the file is one transaction).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SEED_FILE="${SCRIPT_DIR}/demo-stac-imagery-v1.sql"
+
+if [ ! -f "${SEED_FILE}" ]; then
+  echo "Error: seed file not found at ${SEED_FILE}" >&2
+  exit 1
+fi
+
+SEED_ENV="${HONUA_SEED_ENV:-default}"
+SEED_SCHEMA="${HONUA_SEED_SCHEMA:-honua}"
+
+echo "Applying demo STAC seed: env=${SEED_ENV} schema=${SEED_SCHEMA} -> ${PGHOST:-localhost}:${PGPORT:-5432}/${PGDATABASE:-honua}"
+
+PGPASSWORD="${PGPASSWORD:?PGPASSWORD is required}" psql \
+  -v ON_ERROR_STOP=1 \
+  -h "${PGHOST:-localhost}" \
+  -p "${PGPORT:-5432}" \
+  -U "${PGUSER:-honua}" \
+  -d "${PGDATABASE:-honua}" \
+  -v env="${SEED_ENV}" \
+  -v schema="${SEED_SCHEMA}" \
+  -f "${SEED_FILE}"
+
+echo
+echo "Done. Verify with:"
+echo "  curl -s https://demo.honua.io/stac/collections | jq '.collections | length'   # expect >= 2"
+echo "  curl -s -X POST https://demo.honua.io/stac/search \\"
+echo "    -H 'content-type: application/json' \\"
+echo "    -d '{\"bbox\":[-156.70,20.60,-156.30,20.96],\"collections\":[\"90810\"]}' | jq '.features | length'"

--- a/tests/seed/demo-stac-imagery-v1.sql
+++ b/tests/seed/demo-stac-imagery-v1.sql
@@ -336,15 +336,21 @@ BEGIN
            e->'metadata'->>'id', e->>'resourceId', e->>'connectionId', e->>'storageType', e->>'locator'
       FROM jsonb_array_elements(v_doc->'storageBindings') e;
 
+    -- Index every publication (layer_index stays NULL for non-numeric identifiers),
+    -- matching the server's snapshot writer so pre-existing publications carried over
+    -- from the prior revision are not dropped from the sidecar on the new revision.
     INSERT INTO metadata_v2_publications_idx
         (environment, revision, publication_id, service_id, resource_id, storage_binding_id,
          publication_type, path, layer_index, service_local_id)
     SELECT v_env, v_revision,
            e->'metadata'->>'id', e->>'serviceId', e->>'resourceId', e->>'storageBindingId',
-           e->>'publicationType', e->'identifier'->>'pathOverride',
-           NULLIF(e->'identifier'->>'value','')::int, e->'identifier'->>'value'
-      FROM jsonb_array_elements(v_doc->'publications') e
-     WHERE (e->'identifier'->>'isNumeric')::boolean IS TRUE;
+           e->>'publicationType',
+           coalesce(e->>'path', e->'identifier'->>'pathOverride'),
+           CASE WHEN (e->'identifier'->>'isNumeric')::boolean IS TRUE
+                THEN NULLIF(e->'identifier'->>'value','')::int
+                ELSE NULLIF(e->>'layerIndex','')::int END,
+           coalesce(e->>'serviceLocalId', NULLIF(e->'identifier'->>'value',''))
+      FROM jsonb_array_elements(v_doc->'publications') e;
 
     INSERT INTO metadata_v2_connections_idx
         (environment, revision, connection_id, name, type, provider)

--- a/tests/seed/demo-stac-imagery-v1.sql
+++ b/tests/seed/demo-stac-imagery-v1.sql
@@ -1,0 +1,367 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+--
+-- demo.honua.io STAC imagery seed (honua-server#1688).
+--
+-- Lights up the Imagery & Terrain Studio STAC browser on the live demo so
+-- `GET /stac/collections` is non-empty and `POST /stac/search` returns items
+-- for a Maui-area bbox (REQ-001).
+--
+-- WHY THIS IS A METADATA-V2 SEED, NOT A honua.services/honua.layers SEED:
+-- The live catalog (services / layers / STAC) is materialized from the
+-- canonical Metadata v2 graph snapshot (metadata.honua.io/v2alpha1) stored in
+-- honua.metadata_v2_snapshots + honua.metadata_v2_current, NOT from the legacy
+-- honua.services / honua.layers tables. Raw INSERTs into those legacy tables are
+-- inert for the catalog (confirmed on the deployed demo image — see #1688). The
+-- STAC read path (StacV2Lookups) only surfaces a collection when a
+-- publicationType = "stac-collection" publication exists on a service whose
+-- protocols include "Stac", backed by a resolvable resource + storage binding.
+--
+-- WHAT THIS SCRIPT DOES (idempotent, re-runnable):
+--   1. Seeds Sentinel-2-style scene point features into the shared honua.features
+--      table under two layer_id discriminators (90810 reef-watch, 90820 coastal).
+--   2. MERGES a STAC service + two stac-collection publications (+ their resources
+--      and storage bindings) into the CURRENT active Metadata v2 snapshot for the
+--      target environment, writes the result as a NEW revision, and activates it.
+--      Existing graph entities (e.g. the 11 maui-* layers) are preserved — the
+--      script appends to the existing document rather than replacing it.
+--   3. Refreshes the sidecar *_idx tables for the new revision so admin metadata
+--      queries stay consistent.
+--
+-- PARAMETERS (psql -v):
+--   env        Metadata v2 environment id. MUST match the server's
+--              Metadata__Environment / Environment setting (default "default").
+--   schema     Honua metadata schema (default "honua").
+--
+-- USAGE:
+--   psql -v ON_ERROR_STOP=1 -v env=default -v schema=honua -f demo-stac-imagery-v1.sql
+--   (or use tests/seed/apply-demo-stac-seed.sh which wires up PG* env vars).
+--
+-- SAFETY: contains NO secrets. The Pro-license / geocoding / streaming / editing
+-- enablement is operator-run and documented in
+-- docs/internal/demo/demo-honua-io-capability-runbook.md.
+
+\set ON_ERROR_STOP on
+\if :{?env}
+\else
+  \set env 'default'
+\endif
+\if :{?schema}
+\else
+  \set schema 'honua'
+\endif
+
+BEGIN;
+
+SET search_path TO :"schema", public;
+
+-- Bridge the psql -v parameters into session GUCs so the DO block below (which
+-- cannot see psql :vars) can read them via current_setting().
+SELECT set_config('honua.seed_env', :'env', false);
+SELECT set_config('honua.seed_schema', :'schema', false);
+
+-- ---------------------------------------------------------------------------
+-- 1. Scene features in the shared honua.features table (layer_id discriminated).
+--    Geometry column is `geometry`; non-key attributes live in the `attributes`
+--    JSONB column, matching how the storage-mapped reader projects layers that
+--    share the Honua features table.
+-- ---------------------------------------------------------------------------
+
+DELETE FROM features WHERE layer_id IN (90810, 90820);
+
+INSERT INTO features (objectid, layer_id, geometry, attributes)
+VALUES
+    -- Maui Reef Watch (Sentinel-2-style EO scenes), bbox ~ Maui nearshore.
+    (9081001, 90810, ST_SetSRID(ST_Point(-156.4730, 20.8910), 4326),
+        jsonb_build_object('name','S2-MAUI-Reef-01','observed_at','2026-03-01T20:30:00Z',
+            'quality_score',96,'eo:cloud_cover',5.2,'proj:epsg',4326,'view:sun_azimuth',142.0,'platform','sentinel-2a')),
+    (9081002, 90810, ST_SetSRID(ST_Point(-156.3120, 20.7460), 4326),
+        jsonb_build_object('name','S2-MAUI-Reef-02','observed_at','2026-03-04T20:30:00Z',
+            'quality_score',93,'eo:cloud_cover',8.9,'proj:epsg',4326,'view:sun_azimuth',144.7,'platform','sentinel-2b')),
+    (9081003, 90810, ST_SetSRID(ST_Point(-156.6650, 20.9540), 4326),
+        jsonb_build_object('name','S2-MAUI-Reef-03','observed_at','2026-03-07T20:30:00Z',
+            'quality_score',90,'eo:cloud_cover',12.4,'proj:epsg',4326,'view:sun_azimuth',147.1,'platform','sentinel-2a')),
+    (9081004, 90810, ST_SetSRID(ST_Point(-156.4470, 20.6320), 4326),
+        jsonb_build_object('name','S2-MAUI-Reef-04','observed_at','2026-03-10T20:30:00Z',
+            'quality_score',87,'eo:cloud_cover',16.8,'proj:epsg',4326,'view:sun_azimuth',150.5,'platform','sentinel-2b')),
+    -- Maui Coastal Change (warning-state collection), bbox ~ Maui coastline.
+    (9082001, 90820, ST_SetSRID(ST_Point(-156.5100, 20.9100), 4326),
+        jsonb_build_object('name','Coastal-01','observed_at','2026-03-02T21:00:00Z',
+            'quality_score',78,'eo:cloud_cover',18.0,'proj:epsg',4326,'view:sun_azimuth',131.0,'platform','planet-skysat')),
+    (9082002, 90820, ST_SetSRID(ST_Point(-156.3800, 20.6800), 4326),
+        jsonb_build_object('name','Coastal-02','observed_at','2026-03-05T21:00:00Z',
+            'quality_score',64,'eo:cloud_cover',24.3,'proj:epsg',4326,'view:sun_azimuth',128.6,'platform','planet-skysat')),
+    (9082003, 90820, ST_SetSRID(ST_Point(-156.6900, 20.7900), 4326),
+        jsonb_build_object('name','Coastal-03','observed_at','2026-03-08T21:00:00Z',
+            'quality_score',59,'eo:cloud_cover',29.7,'proj:epsg',4326,'view:sun_azimuth',126.9,'platform','planet-skysat'));
+
+-- ---------------------------------------------------------------------------
+-- 2. Merge the STAC service + collections into the active Metadata v2 snapshot.
+--
+--    The JSON shapes below match the canonical Metadata v2 domain records and
+--    their [JsonStringEnumMemberName] / [JsonPropertyName] contracts exactly
+--    (camelCase props; kebab/lower enum member names), so the persisted document
+--    round-trips through MetadataV2JsonContext on the server.
+-- ---------------------------------------------------------------------------
+
+DO $seed$
+DECLARE
+    v_env        text := current_setting('honua.seed_env', true);
+    v_schema     text := coalesce(NULLIF(current_setting('honua.seed_schema', true), ''), 'honua');
+    v_now        text := to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"');
+    v_doc        jsonb;
+    v_revision   bigint;
+    v_etag       text;
+    v_status     jsonb := jsonb_build_object(
+                    'lifecycle','active','state','ready','observedAt', v_now);
+    v_service    jsonb;
+    v_resources  jsonb;
+    v_bindings   jsonb;
+    v_pubs       jsonb;
+BEGIN
+    IF v_env IS NULL OR v_env = '' THEN
+        v_env := 'default';
+    END IF;
+
+    -- Load the current active snapshot document (if any) so we APPEND, not replace.
+    SELECT s.document, s.revision
+      INTO v_doc, v_revision
+      FROM metadata_v2_snapshots s
+      JOIN metadata_v2_current c
+        ON c.environment = s.environment AND c.revision = s.revision
+     WHERE s.environment = v_env;
+
+    IF v_doc IS NULL THEN
+        -- No activated snapshot yet for this environment: start an empty graph.
+        v_revision := 0;
+        v_doc := jsonb_build_object(
+            'schemaVersion','2.0.0-alpha.1',
+            'apiVersion','metadata.honua.io/v2alpha1',
+            'revision', 0,
+            'environment', v_env,
+            'generatedAt', v_now,
+            'resources','[]'::jsonb,
+            'connections','[]'::jsonb,
+            'storageBindings','[]'::jsonb,
+            'services','[]'::jsonb,
+            'publications','[]'::jsonb);
+    END IF;
+
+    -- The STAC service. protocols MUST include "Stac" for StacV2Lookups to see it.
+    v_service := jsonb_build_object(
+        'metadata', jsonb_build_object('id','svc-demo-stac','name','demo-stac',
+            'title','Demo STAC Catalog','description','Imagery & Terrain Studio STAC catalog for demo.honua.io',
+            'createdAt', v_now, 'updatedAt', v_now),
+        'serviceType','stac-api',
+        'route','/stac',
+        'protocols', jsonb_build_array('Stac'),
+        'accessPolicy', jsonb_build_object('allowAnonymous', true),
+        'spatialReference', jsonb_build_object('srid',4326,'crs','EPSG:4326','isGeographic',true),
+        'publicationIds', jsonb_build_array('pub-demo-stac-90810','pub-demo-stac-90820'),
+        'status', v_status);
+
+    -- Resources (one per collection). FeatureDataset with the shared scene schema.
+    v_resources := jsonb_build_array(
+        jsonb_build_object(
+            'metadata', jsonb_build_object('id','res-demo-stac-90810','name','maui-reef-watch',
+                'title','Maui Reef Watch','description','Sentinel-2 nearshore reef monitoring scenes (Maui).',
+                'license','CC-BY-4.0','createdAt', v_now,'updatedAt', v_now),
+            'type','feature-dataset',
+            'storageBindingIds', jsonb_build_array('binding-demo-stac-90810'),
+            'primaryStorageBindingId','binding-demo-stac-90810',
+            'schemaFields', jsonb_build_array(
+                jsonb_build_object('name','objectid','type','integer','nullable',false,'semanticRoles',jsonb_build_array('id.primary')),
+                jsonb_build_object('name','name','type','string','nullable',false),
+                jsonb_build_object('name','observed_at','type','datetime','nullable',false),
+                jsonb_build_object('name','quality_score','type','integer','nullable',false),
+                jsonb_build_object('name','eo:cloud_cover','type','double','nullable',true),
+                jsonb_build_object('name','proj:epsg','type','integer','nullable',true),
+                jsonb_build_object('name','view:sun_azimuth','type','double','nullable',true),
+                jsonb_build_object('name','platform','type','string','nullable',true),
+                jsonb_build_object('name','geometry','type','geometry','nullable',true,'semanticRoles',jsonb_build_array('geometry.primary'))),
+            'accessPolicy', jsonb_build_object('allowAnonymous', true),
+            'spatial', jsonb_build_object(
+                'spatialReference', jsonb_build_object('srid',4326,'crs','EPSG:4326','isGeographic',true),
+                'geometryType','point',
+                'bbox', jsonb_build_object('west',-156.70,'south',20.60,'east',-156.30,'north',20.96),
+                'primaryGeometryField','geometry'),
+            'temporal', jsonb_build_object('startTimeField','observed_at'),
+            'status', v_status),
+        jsonb_build_object(
+            'metadata', jsonb_build_object('id','res-demo-stac-90820','name','maui-coastal-change',
+                'title','Maui Coastal Change','description','High-cadence coastal change-detection scenes (Maui).',
+                'license','proprietary','createdAt', v_now,'updatedAt', v_now),
+            'type','feature-dataset',
+            'storageBindingIds', jsonb_build_array('binding-demo-stac-90820'),
+            'primaryStorageBindingId','binding-demo-stac-90820',
+            'schemaFields', jsonb_build_array(
+                jsonb_build_object('name','objectid','type','integer','nullable',false,'semanticRoles',jsonb_build_array('id.primary')),
+                jsonb_build_object('name','name','type','string','nullable',false),
+                jsonb_build_object('name','observed_at','type','datetime','nullable',false),
+                jsonb_build_object('name','quality_score','type','integer','nullable',false),
+                jsonb_build_object('name','eo:cloud_cover','type','double','nullable',true),
+                jsonb_build_object('name','proj:epsg','type','integer','nullable',true),
+                jsonb_build_object('name','view:sun_azimuth','type','double','nullable',true),
+                jsonb_build_object('name','platform','type','string','nullable',true),
+                jsonb_build_object('name','geometry','type','geometry','nullable',true,'semanticRoles',jsonb_build_array('geometry.primary'))),
+            'accessPolicy', jsonb_build_object('allowAnonymous', true),
+            'spatial', jsonb_build_object(
+                'spatialReference', jsonb_build_object('srid',4326,'crs','EPSG:4326','isGeographic',true),
+                'geometryType','point',
+                'bbox', jsonb_build_object('west',-156.70,'south',20.60,'east',-156.36,'north',20.92),
+                'primaryGeometryField','geometry'),
+            'temporal', jsonb_build_object('startTimeField','observed_at'),
+            'status', v_status));
+
+    -- Storage bindings -> shared honua.features table, layer_id discriminated.
+    -- storageLayerId MUST equal the layer_id used in the INSERTs above.
+    v_bindings := jsonb_build_array(
+        jsonb_build_object(
+            'metadata', jsonb_build_object('id','binding-demo-stac-90810','name','binding-demo-stac-90810',
+                'title', v_env || '.features (90810)', 'createdAt', v_now,'updatedAt', v_now),
+            'resourceId','res-demo-stac-90810',
+            'storageType','relational-table',
+            'locator', v_schema || '.features',
+            'storageLayerId', 90810,
+            'capabilities', jsonb_build_array('query','filter','sort','aggregate'),
+            'options', jsonb_build_object(
+                'sourceBacked', true,
+                'schemaName', v_schema,
+                'tableName','features',
+                'primaryKeyColumn','objectid',
+                'geometryColumn','geometry',
+                'storageSrid', 4326,
+                'attributesColumn','attributes',
+                'layerDiscriminatorColumn','layer_id'),
+            'status', v_status),
+        jsonb_build_object(
+            'metadata', jsonb_build_object('id','binding-demo-stac-90820','name','binding-demo-stac-90820',
+                'title', v_env || '.features (90820)', 'createdAt', v_now,'updatedAt', v_now),
+            'resourceId','res-demo-stac-90820',
+            'storageType','relational-table',
+            'locator', v_schema || '.features',
+            'storageLayerId', 90820,
+            'capabilities', jsonb_build_array('query','filter','sort','aggregate'),
+            'options', jsonb_build_object(
+                'sourceBacked', true,
+                'schemaName', v_schema,
+                'tableName','features',
+                'primaryKeyColumn','objectid',
+                'geometryColumn','geometry',
+                'storageSrid', 4326,
+                'attributesColumn','attributes',
+                'layerDiscriminatorColumn','layer_id'),
+            'status', v_status));
+
+    -- Publications: publicationType "stac-collection" is the discriminator the
+    -- STAC read path filters on. Numeric identifier supplies the LayerIndex the
+    -- feature reader is keyed on, and is the STAC collection id.
+    v_pubs := jsonb_build_array(
+        jsonb_build_object(
+            'metadata', jsonb_build_object('id','pub-demo-stac-90810','name','90810',
+                'title','Maui Reef Watch','createdAt', v_now,'updatedAt', v_now),
+            'resourceId','res-demo-stac-90810',
+            'serviceId','svc-demo-stac',
+            'storageBindingId','binding-demo-stac-90810',
+            'publicationType','stac-collection',
+            'identifier', jsonb_build_object('value','90810','isNumeric', true),
+            'isPrimary', true,
+            'supportedFormats', jsonb_build_array('json','geojson'),
+            'status', v_status),
+        jsonb_build_object(
+            'metadata', jsonb_build_object('id','pub-demo-stac-90820','name','90820',
+                'title','Maui Coastal Change','createdAt', v_now,'updatedAt', v_now),
+            'resourceId','res-demo-stac-90820',
+            'serviceId','svc-demo-stac',
+            'storageBindingId','binding-demo-stac-90820',
+            'publicationType','stac-collection',
+            'identifier', jsonb_build_object('value','90820','isNumeric', true),
+            'isPrimary', true,
+            'supportedFormats', jsonb_build_array('json','geojson'),
+            'status', v_status));
+
+    -- Append-or-replace each STAC entity by id into the existing arrays. Removing
+    -- any prior copy first keeps the seed idempotent across re-runs.
+    v_doc := jsonb_set(v_doc, '{services}',
+        (SELECT coalesce(jsonb_agg(e), '[]'::jsonb)
+           FROM jsonb_array_elements(coalesce(v_doc->'services','[]'::jsonb)) e
+          WHERE e->'metadata'->>'id' <> 'svc-demo-stac') || v_service);
+
+    v_doc := jsonb_set(v_doc, '{resources}',
+        (SELECT coalesce(jsonb_agg(e), '[]'::jsonb)
+           FROM jsonb_array_elements(coalesce(v_doc->'resources','[]'::jsonb)) e
+          WHERE e->'metadata'->>'id' NOT IN ('res-demo-stac-90810','res-demo-stac-90820')) || v_resources);
+
+    v_doc := jsonb_set(v_doc, '{storageBindings}',
+        (SELECT coalesce(jsonb_agg(e), '[]'::jsonb)
+           FROM jsonb_array_elements(coalesce(v_doc->'storageBindings','[]'::jsonb)) e
+          WHERE e->'metadata'->>'id' NOT IN ('binding-demo-stac-90810','binding-demo-stac-90820')) || v_bindings);
+
+    v_doc := jsonb_set(v_doc, '{publications}',
+        (SELECT coalesce(jsonb_agg(e), '[]'::jsonb)
+           FROM jsonb_array_elements(coalesce(v_doc->'publications','[]'::jsonb)) e
+          WHERE e->'metadata'->>'id' NOT IN ('pub-demo-stac-90810','pub-demo-stac-90820')) || v_pubs);
+
+    -- Bump revision + stamp the document.
+    v_revision := greatest(v_revision + 1, 1);
+    v_etag := 'demo-stac-seed-' || v_revision::text;
+    v_doc := v_doc
+        || jsonb_build_object('revision', v_revision, 'environment', v_env, 'generatedAt', v_now);
+
+    -- Persist as a new revision and activate it.
+    INSERT INTO metadata_v2_snapshots
+        (environment, revision, schema_version, api_version, document, etag, generated_at)
+    VALUES (v_env, v_revision,
+        coalesce(v_doc->>'schemaVersion','2.0.0-alpha.1'),
+        coalesce(v_doc->>'apiVersion','metadata.honua.io/v2alpha1'),
+        v_doc, v_etag, now());
+
+    -- Refresh sidecar idx tables for this new revision (admin metadata queries).
+    INSERT INTO metadata_v2_resources_idx
+        (environment, revision, resource_id, name, namespace, type, primary_storage_binding_id)
+    SELECT v_env, v_revision,
+           e->'metadata'->>'id', e->'metadata'->>'name', e->'metadata'->>'namespace',
+           e->>'type', e->>'primaryStorageBindingId'
+      FROM jsonb_array_elements(v_doc->'resources') e;
+
+    INSERT INTO metadata_v2_services_idx
+        (environment, revision, service_id, name, service_type, route)
+    SELECT v_env, v_revision,
+           e->'metadata'->>'id', e->'metadata'->>'name', e->>'serviceType', e->>'route'
+      FROM jsonb_array_elements(v_doc->'services') e;
+
+    INSERT INTO metadata_v2_storage_bindings_idx
+        (environment, revision, storage_binding_id, resource_id, connection_id, storage_type, locator)
+    SELECT v_env, v_revision,
+           e->'metadata'->>'id', e->>'resourceId', e->>'connectionId', e->>'storageType', e->>'locator'
+      FROM jsonb_array_elements(v_doc->'storageBindings') e;
+
+    INSERT INTO metadata_v2_publications_idx
+        (environment, revision, publication_id, service_id, resource_id, storage_binding_id,
+         publication_type, path, layer_index, service_local_id)
+    SELECT v_env, v_revision,
+           e->'metadata'->>'id', e->>'serviceId', e->>'resourceId', e->>'storageBindingId',
+           e->>'publicationType', e->'identifier'->>'pathOverride',
+           NULLIF(e->'identifier'->>'value','')::int, e->'identifier'->>'value'
+      FROM jsonb_array_elements(v_doc->'publications') e
+     WHERE (e->'identifier'->>'isNumeric')::boolean IS TRUE;
+
+    INSERT INTO metadata_v2_connections_idx
+        (environment, revision, connection_id, name, type, provider)
+    SELECT v_env, v_revision,
+           e->'metadata'->>'id', e->'metadata'->>'name', e->>'type', e->>'provider'
+      FROM jsonb_array_elements(coalesce(v_doc->'connections','[]'::jsonb)) e;
+
+    -- Activate the new revision.
+    INSERT INTO metadata_v2_current (environment, revision, etag, activated_at)
+    VALUES (v_env, v_revision, v_etag, now())
+    ON CONFLICT (environment) DO UPDATE
+        SET revision = EXCLUDED.revision,
+            etag = EXCLUDED.etag,
+            activated_at = EXCLUDED.activated_at;
+
+    RAISE NOTICE 'demo STAC seed: environment=% activated revision=% (etag=%)', v_env, v_revision, v_etag;
+END
+$seed$;
+
+COMMIT;


### PR DESCRIPTION
## Issue Link
Closes #1688 (after the operator runs the runbook on the live env).

## Summary
Operational enablement for **demo.honua.io** (#1688) so the live demo proves the four product pillars: seeded **STAC collections**, plus a documented, repeatable path to apply a **Pro license** and light up **geocoding**, **realtime streaming**, and **FeatureServer editing**. On the MVP critical path (iac#30 → server#1688 → site#9; umbrella honua-devops#90).

Per the issue recon, the server features already exist — what remained was operational enablement + one server bug blocking the supported STAC registration path. This PR ships both the bug fix and the repeatable seed/runbook assets.

## Changes Made
- **Fix `release-packages` admin API (42P08):** `GET /api/v1/admin/metadata/release-packages` returned HTTP 500 `42P08: could not determine data type of parameter $1` — the nullable source/target/status filters were bound as untyped `DBNull` while the SQL wraps them in `LOWER(@param)`. Fixed by binding them as explicit `NpgsqlDbType.Text` in `PostgresMetadataReleasePackageStore.ListAsync`. Added a regression test (unfiltered list, no 42P08) + a case-insensitive-filter test.
- **Repeatable STAC seed (REQ-001):** `tests/seed/demo-stac-imagery-v1.sql` (+ `apply-demo-stac-seed.sh`) — idempotent seed that inserts Sentinel-2-style Maui features and **merges** a STAC service + two `stac-collection` publications (`90810` Reef Watch, `90820` Coastal Change) into the **active Metadata v2 snapshot**, then activates a new revision. Append-not-replace (preserves the 11 `maui-*` layers); validated end-to-end against PostGIS (merge-preserves-maui, two publications land, sidecar `*_idx` refreshed, idempotent on re-run).
- **Operator runbook:** `docs/internal/demo/demo-honua-io-capability-runbook.md` — both tracks: the STAC seed, plus minting a Pro license via the in-repo `honua-license-mint` CLI, wiring `Licensing:LicenseContent` (secret-ref form) + `Licensing:TrustedKeys`, and enabling geocoding/streaming/editing, with REQ-001/003/004/005 verification probes.

## Runnable now vs. operator-supplied
| Item | State |
|------|-------|
| STAC seed SQL + apply script | Runnable now (validated vs PostGIS) |
| `release-packages` 42P08 fix + tests | In this PR (Postgres project builds clean) |
| License mint CLI commands | Runnable; signing key is operator-supplied |
| Apply license / geocoding env on demo Lambda, redeploy, probe | Operator — live env + secrets |

No secrets are committed. License key/secret steps are operator-supplied placeholders.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated

## Release/Deploy Impact
- [x] Requires infrastructure changes
- [x] Requires environment variable or secret changes

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
