### PR TITLE
test(cesium): pin transitive dompurify to 3.4.1 (fix js-cesium WMS render cert)

### DIFF
--- a/tests/js-browser/cesium/package-lock.json
+++ b/tests/js-browser/cesium/package-lock.json
@@ -51,6 +51,15 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@cesium/engine/node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/@cesium/wasm-splats": {
       "version": "0.1.0-alpha.2",
       "resolved": "https://registry.npmjs.org/@cesium/wasm-splats/-/wasm-splats-0.1.0-alpha.2.tgz",
@@ -171,15 +180,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
-    },
-    "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
     },
     "node_modules/draco3d": {
       "version": "1.5.7",

--- a/tests/js-browser/cesium/package.json
+++ b/tests/js-browser/cesium/package.json
@@ -19,5 +19,8 @@
     "@playwright/test": "^1.52.0",
     "@types/node": "^20.10.0",
     "typescript": "^5.3.0"
+  },
+  "overrides": {
+    "dompurify": "3.4.1"
   }
 }


### PR DESCRIPTION
## Root cause
The **Real-Client Interop Matrix (Nightly)** release gate regressed (runs [27616613043] x2, 2026-06-16) with exactly one cell: `js-cesium/wms: CERT-RNDR-01 pass → fail` ("Map/table renders without client error"). Confirmed **deterministic** (reproduced on re-run), **not** a flake.

Traced to dependabot **#1705**, which floated Cesium's **transitive** `dompurify` dependency (`cesium@1.119.0` requires `^3.3.0`) from **3.4.1 → 3.4.10** via a lockfile-only change. dompurify 3.4.10 is an internal refactor with no documented public API break, but Cesium 1.119.0's internal sanitize path errors against it during WMS imagery rendering → the browser client error CERT-RNDR-01 asserts on.

`dompurify` is **not imported by this harness and is not a shipped product dependency** — it's a transitive dep of a test-only browser fixture, so there is no product-security impact to pinning it.

## Fix
Add `overrides: { "dompurify": "3.4.1" }` to `tests/js-browser/cesium/package.json` and regenerate the lockfile, holding dompurify at the last-green version. Lock now resolves `@cesium/engine/node_modules/dompurify@3.4.1`.

## Validation
- Lockfile resolves dompurify → 3.4.1 (was 3.4.10). ✅
- Full validation is the **interop nightly going green** on this branch / after merge (the Playwright WMS spec requires a live server backend, not run locally).

## Follow-up
Tracked separately: re-bump dompurify properly (either to a 3.4.x that Cesium 1.119 tolerates, or bump Cesium) instead of pinning indefinitely.