### PR TITLE
fix(docker): install fontconfig/freetype in Lambda images so SkiaSharp map rendering works on demo.honua.io

### DIFF
--- a/docker/Dockerfile.lambda
+++ b/docker/Dockerfile.lambda
@@ -103,7 +103,12 @@ COPY docker/cloud/lambda/bootstrap.sh /var/runtime/bootstrap
 # Microsoft.Data.SqlClient and Oracle.ManagedDataAccess throw
 # "Globalization Invariant Mode is not supported" at connect time without ICU.
 # See honua-server#1369.
-RUN dnf install -y krb5-libs libicu && \
+#
+# fontconfig + freetype are required by SkiaSharp.NativeAssets.Linux: libSkiaSharp.so
+# is dynamically linked against libfontconfig.so.1 / libfreetype.so.6, so the first
+# Skia P/Invoke (any map render: MapServer export, OGC API Maps, WMS GetMap) fails to
+# dlopen the native lib and surfaces as a generic 500 without them.
+RUN dnf install -y krb5-libs libicu fontconfig freetype && \
     dnf clean all && \
     chmod +x /var/runtime/bootstrap /var/task/Honua.Server
 

--- a/docker/Dockerfile.lambda.aot
+++ b/docker/Dockerfile.lambda.aot
@@ -133,8 +133,15 @@ COPY --from=build /app /var/task
 # The Debian-based dotnet runtime-deps base already ships ICU, which is required
 # because Honua.Server runs with InvariantGlobalization=false (Microsoft.Data.SqlClient
 # and Oracle.ManagedDataAccess fail to connect without ICU). See honua-server#1369.
+#
+# libfontconfig1 + libfreetype6 are required by SkiaSharp.NativeAssets.Linux:
+# libSkiaSharp.so is dynamically linked against libfontconfig.so.1 / libfreetype.so.6,
+# so the first P/Invoke into Skia (any map render: MapServer export, OGC API Maps,
+# WMS GetMap) fails to dlopen the native lib and surfaces as a generic 500. The
+# runtime-deps base does not ship them. The non-Lambda images (Dockerfile,
+# Dockerfile.aot) already install fontconfig for the same reason.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libgssapi-krb5-2 && \
+    apt-get install -y --no-install-recommends libgssapi-krb5-2 libfontconfig1 libfreetype6 && \
     rm -rf /var/lib/apt/lists/* && \
     chmod +x /var/task/Honua.Server
 

--- a/docker/Dockerfile.lambda.aot.simple
+++ b/docker/Dockerfile.lambda.aot.simple
@@ -111,7 +111,12 @@ COPY --from=build /app ${LAMBDA_TASK_ROOT}
 # Microsoft.Data.SqlClient and Oracle.ManagedDataAccess throw
 # "Globalization Invariant Mode is not supported" at connect time without ICU.
 # See honua-server#1369.
-RUN yum install -y krb5-libs libicu && \
+#
+# fontconfig + freetype are required by SkiaSharp.NativeAssets.Linux: libSkiaSharp.so
+# is dynamically linked against libfontconfig.so.1 / libfreetype.so.6, so the first
+# Skia P/Invoke (any map render: MapServer export, OGC API Maps, WMS GetMap) fails to
+# dlopen the native lib and surfaces as a generic 500 without them.
+RUN yum install -y krb5-libs libicu fontconfig freetype && \
     yum clean all && \
     chmod +x ${LAMBDA_TASK_ROOT}/Honua.Server
 


### PR DESCRIPTION
## Diagnosis

`map-image / raster rendering fails on live demo.honua.io` — every "see the map draw" endpoint 500s while vector tiles / FeatureServer query are healthy.

Captured live error bodies (2026-06-17):
- Esri `…/MapServer/export` → **500** `{"error":{"code":500,"details":["MapServer export failed."…]}}` — on vector services too (parcels/zoning/roads), so **not** a missing-imagery/seed issue.
- OGC API Maps `…/ogc/maps/map` → **500** `"An error occurred while rendering the dataset map."`
- ImageServer `exportImage` → **404** "No rasters found for layer" — *separate*, a real seed gap (tracked by #1688 / PR #1721).
- OGC `…/collections/1/map` → **404** "No map data found for collection 1" — collection-lookup, separate.

### Root cause
All rendered-raster paths (MapServer export, OGC API Maps, WMS GetMap) funnel through `SkiaMapRenderer` / `RasterMapRenderingPipeline`, which uses **SkiaSharp** + `SkiaSharp.NativeAssets.Linux`. That package's `libSkiaSharp.so` is dynamically linked against `libfontconfig.so.1` and `libfreetype.so.6`.

demo.honua.io runs the **AWS Lambda AOT image** (`honua-iac` `examples/aws-demo`, `*-lambda-aot` tag). The Lambda runtime stages install **only** krb5 + ICU and **omit fontconfig/freetype**, so the first Skia P/Invoke fails to `dlopen` the native lib → exception → generic 500. The non-Lambda images (`Dockerfile`, `Dockerfile.aot`) already install `fontconfig` for this exact reason — the Lambda images were never brought in line.

This is a **deployment/runtime-config defect in the Lambda image**, not an application code bug and not the #1688/#1721 seed work (that fixes the *separate* ImageServer/STAC 404s).

### Fix
Install `fontconfig`/`freetype` in all three Lambda Dockerfiles (`Dockerfile.lambda.aot` = demo, `Dockerfile.lambda`, `Dockerfile.lambda.aot.simple`). Rebuild + redeploy the demo image. Effort: ~1 line each + a demo redeploy.

Refs #1688 (separate imagery-seed track).

> DRAFT — do not merge. Diagnosis-first PR; needs a rebuilt-image smoke test confirming `…/export` returns 200 PNG.
