### PR TITLE
feat(observability): Lambda cold-start metrics + X-Ray tracing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -85,6 +85,7 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.AWS" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />

--- a/src/Honua.ServiceDefaults/Extensions.cs
+++ b/src/Honua.ServiceDefaults/Extensions.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Options;
 using Npgsql;
 using OpenTelemetry;
 using OpenTelemetry.Exporter;
+using OpenTelemetry.Extensions.AWS.Trace;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -34,7 +35,8 @@ public static partial class Extensions
         HonuaTelemetry.ServiceName,
         "Honua.Wfs20.Transactions",
         "Honua.Database.ConnectionPool",
-        "Honua.Production.Metrics"
+        "Honua.Production.Metrics",
+        LambdaTelemetry.MeterName
     ];
     private static readonly string[] _activitySourceNames =
     [
@@ -114,6 +116,12 @@ public static partial class Extensions
         var otlpEndpoint = ResolveOtlpEndpoint(builder.Configuration, tracingOptions);
         var otlpHeaders = ResolveOtlpHeaders(builder.Configuration, tracingOptions);
         var useOtlp = !string.IsNullOrWhiteSpace(otlpEndpoint);
+        var useXRay = ResolveXRayEnabled(builder.Configuration, tracingOptions);
+
+        // Record the Lambda cold start once during process initialization so the
+        // counter/init-duration histogram are emitted through the shared meter.
+        // No-op off Lambda.
+        LambdaTelemetry.RecordColdStart();
 
         builder.Logging.AddOpenTelemetry(logging =>
         {
@@ -177,14 +185,33 @@ public static partial class Extensions
                     return new AlwaysOnSampler();
                 });
 
+                // AWS X-Ray-compatible trace IDs + propagation. Gated so non-AWS
+                // runs are unaffected. Spans still export through the existing
+                // OTLP exporter (pointed at an ADOT/X-Ray collector); this only
+                // changes ID generation and context propagation so HTTP -> DB ->
+                // render spans nest into the Lambda/API Gateway X-Ray trace.
+                if (useXRay)
+                {
+                    tracing.AddXRayTraceId();
+                    Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator());
+                }
+
+                var resourceBuilder = ResourceBuilder.CreateDefault()
+                    .AddService(
+                        serviceName: HonuaTelemetry.ServiceName,
+                        serviceVersion: HonuaTelemetry.ServiceVersion,
+                        serviceInstanceId: Environment.MachineName);
+
+                if (useXRay)
+                {
+                    // Surface FaaS/cloud resource attributes so the X-Ray service
+                    // map is correctly attributed to the Lambda function.
+                    resourceBuilder.AddAttributes(BuildAwsResourceAttributes());
+                }
+
                 tracing
                     .AddSource(_activitySourceNames)
-                    .SetResourceBuilder(
-                        ResourceBuilder.CreateDefault()
-                            .AddService(
-                                serviceName: HonuaTelemetry.ServiceName,
-                                serviceVersion: HonuaTelemetry.ServiceVersion,
-                                serviceInstanceId: Environment.MachineName))
+                    .SetResourceBuilder(resourceBuilder)
                     .AddAspNetCoreInstrumentation(options =>
                     {
                         options.EnrichWithHttpResponse = (activity, response) =>
@@ -272,6 +299,72 @@ public static partial class Extensions
         }
 
         return configuration["OTEL_EXPORTER_OTLP_HEADERS"];
+    }
+
+    /// <summary>
+    /// Resolves whether AWS X-Ray tracing should be enabled. Precedence:
+    /// explicit <c>Tracing:XRay:Enabled</c> configuration first, then the
+    /// AWS-provided environment signals (<c>AWS_XRAY_TRACING_ENABLED</c>, or an
+    /// <c>AWS_XRAY_DAEMON_ADDRESS</c> present alongside a Lambda runtime).
+    /// </summary>
+    private static bool ResolveXRayEnabled(IConfiguration configuration, TracingOptions tracingOptions)
+    {
+        if (tracingOptions.XRay.Enabled)
+        {
+            return true;
+        }
+
+        // Explicit opt-out via configuration wins over environment inference.
+        var configured = configuration["Tracing:XRay:Enabled"];
+        if (bool.TryParse(configured, out var configuredEnabled))
+        {
+            return configuredEnabled;
+        }
+
+        var envFlag = configuration["AWS_XRAY_TRACING_ENABLED"];
+        if (bool.TryParse(envFlag, out var envEnabled))
+        {
+            return envEnabled;
+        }
+
+        // The Lambda/ECS runtime injects AWS_XRAY_DAEMON_ADDRESS only when
+        // active tracing is turned on, so treat its presence on Lambda as opt-in.
+        return LambdaTelemetry.IsRunningOnLambda
+            && !string.IsNullOrEmpty(configuration["AWS_XRAY_DAEMON_ADDRESS"]);
+    }
+
+    private static KeyValuePair<string, object>[] BuildAwsResourceAttributes()
+    {
+        var attributes = new List<KeyValuePair<string, object>>
+        {
+            new("cloud.provider", "aws"),
+        };
+
+        if (LambdaTelemetry.FunctionName is { Length: > 0 } functionName)
+        {
+            attributes.Add(new KeyValuePair<string, object>("cloud.platform", "aws_lambda"));
+            attributes.Add(new KeyValuePair<string, object>("faas.name", functionName));
+
+            if (LambdaTelemetry.FunctionVersion is { Length: > 0 } functionVersion)
+            {
+                attributes.Add(new KeyValuePair<string, object>("faas.version", functionVersion));
+            }
+
+            if (LambdaTelemetry.MemoryLimitMib > 0)
+            {
+                attributes.Add(new KeyValuePair<string, object>(
+                    "faas.max_memory",
+                    LambdaTelemetry.MemoryLimitMib * 1024L * 1024L));
+            }
+        }
+
+        var region = Environment.GetEnvironmentVariable("AWS_REGION");
+        if (!string.IsNullOrEmpty(region))
+        {
+            attributes.Add(new KeyValuePair<string, object>("cloud.region", region));
+        }
+
+        return [.. attributes];
     }
 
     private static void ConfigureOtlpExporter(OtlpExporterOptions options, string? endpoint, string? headers)

--- a/src/Honua.ServiceDefaults/Honua.ServiceDefaults.csproj
+++ b/src/Honua.ServiceDefaults/Honua.ServiceDefaults.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Extensions.AWS" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" />

--- a/src/Honua.ServiceDefaults/LambdaTelemetry.cs
+++ b/src/Honua.ServiceDefaults/LambdaTelemetry.cs
@@ -1,0 +1,251 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+
+namespace Honua.ServiceDefaults;
+
+/// <summary>
+/// Emits AWS Lambda cold-start and runtime metrics through a dedicated meter
+/// (<see cref="MeterName"/>) that the shared OpenTelemetry pipeline registers,
+/// so they flow to the existing Prometheus and OTLP exporters without any
+/// additional wiring.
+/// </summary>
+/// <remarks>
+/// Honua runs on Lambda behind the AWS Lambda Web Adapter, so the host is a
+/// long-lived ASP.NET process: the cold start is the process initialization
+/// (an invocation reusing a warm execution environment skips it). This type
+/// observes the standard <c>AWS_LAMBDA_*</c> environment variables that the
+/// Lambda runtime injects and records:
+/// <list type="bullet">
+///   <item><description><c>honua.lambda.cold_start</c> — counter incremented once per cold start.</description></item>
+///   <item><description><c>honua.lambda.init_duration_ms</c> — histogram of process initialization duration.</description></item>
+///   <item><description><c>honua.lambda.memory_limit_mib</c> — observable gauge of the configured Lambda memory limit.</description></item>
+/// </list>
+/// All instruments are tagged with the function name, version and init type so
+/// they slice cleanly alongside the AWS/Lambda namespace metrics in CloudWatch
+/// and the custom Honua metrics namespace.
+/// </remarks>
+public static class LambdaTelemetry
+{
+    /// <summary>
+    /// The meter name registered with OpenTelemetry for Lambda runtime metrics.
+    /// </summary>
+    public const string MeterName = "Honua.Lambda";
+
+    private static readonly Meter Meter = new(MeterName, HonuaTelemetry.ServiceVersion);
+
+    private static readonly Counter<long> ColdStartCounter = Meter.CreateCounter<long>(
+        "honua.lambda.cold_start",
+        unit: "{cold_start}",
+        description: "Number of Lambda cold starts observed by the Honua process.");
+
+    private static readonly Histogram<double> InitDurationHistogram = Meter.CreateHistogram<double>(
+        "honua.lambda.init_duration_ms",
+        unit: "ms",
+        description: "Duration of Lambda process initialization (cold start) in milliseconds.");
+
+    private static int _coldStartRecorded;
+
+    static LambdaTelemetry()
+    {
+        // Observable gauge for the configured memory limit. Tagged so it can be
+        // correlated with AWS/Lambda's MaxMemoryUsed without re-deriving labels.
+        Meter.CreateObservableGauge(
+            "honua.lambda.memory_limit_mib",
+            ObserveMemoryLimit,
+            unit: "MiB",
+            description: "Configured Lambda memory limit in MiB (0 when not running on Lambda).");
+    }
+
+    /// <summary>
+    /// Gets the Lambda context resolved from the process environment, used by
+    /// the production cold-start recording path.
+    /// </summary>
+    public static LambdaContext Context { get; } = LambdaContext.FromEnvironment();
+
+    /// <summary>
+    /// Gets a value indicating whether the process is running inside the AWS
+    /// Lambda runtime, detected via the runtime-injected environment variables.
+    /// </summary>
+    public static bool IsRunningOnLambda => Context.IsLambda;
+
+    /// <summary>
+    /// Gets the Lambda function name, or <see langword="null"/> when not on Lambda.
+    /// </summary>
+    public static string? FunctionName => Context.FunctionName;
+
+    /// <summary>
+    /// Gets the Lambda function version, or <see langword="null"/> when not on Lambda.
+    /// </summary>
+    public static string? FunctionVersion => Context.FunctionVersion;
+
+    /// <summary>
+    /// Gets the Lambda initialization type (for example <c>on-demand</c> or
+    /// <c>provisioned-concurrency</c>), or <see langword="null"/> when not on Lambda.
+    /// </summary>
+    public static string? InitializationType => Context.InitializationType;
+
+    /// <summary>
+    /// Gets the configured Lambda memory limit in MiB, or <c>0</c> when not on Lambda.
+    /// </summary>
+    public static int MemoryLimitMib => Context.MemoryLimitMib;
+
+    /// <summary>
+    /// Records the cold start exactly once for the lifetime of the process.
+    /// Subsequent calls are no-ops, so this is safe to invoke from startup and
+    /// from a warmup handler. When not running on Lambda the call is ignored.
+    /// </summary>
+    /// <param name="processStartUtc">
+    /// The UTC timestamp the process began initializing. Defaults to the OS
+    /// process start time, which captures the full cold-start window.
+    /// </param>
+    /// <returns><see langword="true"/> when this call recorded the cold start.</returns>
+    public static bool RecordColdStart(DateTime? processStartUtc = null)
+    {
+        if (!Context.IsLambda)
+        {
+            return false;
+        }
+
+        // Guard against double-counting if startup and a warmup path both call in.
+        if (Interlocked.CompareExchange(ref _coldStartRecorded, 1, 0) != 0)
+        {
+            return false;
+        }
+
+        var initDurationMs = ResolveInitDurationMs(processStartUtc);
+        EmitColdStart(Context, initDurationMs);
+        return true;
+    }
+
+    /// <summary>
+    /// Emits the cold-start counter and init-duration histogram for the supplied
+    /// context. Exposed for deterministic unit testing of metric emission; the
+    /// production path goes through <see cref="RecordColdStart(DateTime?)"/>.
+    /// </summary>
+    /// <param name="context">The Lambda context whose tags are applied.</param>
+    /// <param name="initDurationMs">
+    /// Initialization duration in milliseconds, or a negative value to skip the
+    /// histogram sample.
+    /// </param>
+    public static void EmitColdStart(LambdaContext context, double initDurationMs)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var tags = context.BuildTags();
+        ColdStartCounter.Add(1, tags);
+
+        if (initDurationMs >= 0)
+        {
+            InitDurationHistogram.Record(initDurationMs, tags);
+        }
+    }
+
+    private static Measurement<long> ObserveMemoryLimit()
+    {
+        return new Measurement<long>(Context.MemoryLimitMib, Context.BuildTags());
+    }
+
+    private static double ResolveInitDurationMs(DateTime? processStartUtc)
+    {
+        DateTime start;
+        try
+        {
+            start = processStartUtc
+                ?? Process.GetCurrentProcess().StartTime.ToUniversalTime();
+        }
+        catch (InvalidOperationException)
+        {
+            // Process start time is unavailable in some sandboxed runtimes.
+            return -1;
+        }
+
+        var elapsed = (DateTime.UtcNow - start).TotalMilliseconds;
+
+        // Clamp pathological clock-skew values rather than emit negatives.
+        return elapsed < 0 ? -1 : elapsed;
+    }
+}
+
+/// <summary>
+/// Immutable snapshot of the AWS Lambda execution context derived from the
+/// runtime-injected environment variables. Constructing one explicitly makes
+/// the cold-start metric emission deterministically unit-testable without
+/// mutating process-global environment state.
+/// </summary>
+public sealed class LambdaContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LambdaContext"/> class.
+    /// </summary>
+    /// <param name="functionName">The Lambda function name, if present.</param>
+    /// <param name="functionVersion">The Lambda function version, if present.</param>
+    /// <param name="initializationType">The Lambda initialization type, if present.</param>
+    /// <param name="memoryLimitMib">The configured memory limit in MiB (0 when unknown).</param>
+    public LambdaContext(
+        string? functionName,
+        string? functionVersion,
+        string? initializationType,
+        int memoryLimitMib)
+    {
+        FunctionName = functionName;
+        FunctionVersion = functionVersion;
+        InitializationType = initializationType;
+        MemoryLimitMib = memoryLimitMib;
+    }
+
+    /// <summary>Gets the Lambda function name, or <see langword="null"/> off Lambda.</summary>
+    public string? FunctionName { get; }
+
+    /// <summary>Gets the Lambda function version, or <see langword="null"/> off Lambda.</summary>
+    public string? FunctionVersion { get; }
+
+    /// <summary>Gets the Lambda initialization type, or <see langword="null"/> off Lambda.</summary>
+    public string? InitializationType { get; }
+
+    /// <summary>Gets the configured memory limit in MiB (0 when unknown).</summary>
+    public int MemoryLimitMib { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this context represents an active Lambda
+    /// execution environment (a function name is present).
+    /// </summary>
+    public bool IsLambda => !string.IsNullOrEmpty(FunctionName)
+        || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("LAMBDA_TASK_ROOT"));
+
+    /// <summary>
+    /// Builds a <see cref="LambdaContext"/> from the current process environment.
+    /// </summary>
+    /// <returns>The resolved context.</returns>
+    public static LambdaContext FromEnvironment()
+    {
+        var memoryRaw = Environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_MEMORY_SIZE");
+        var memory = int.TryParse(memoryRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+            ? value
+            : 0;
+
+        return new LambdaContext(
+            Environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME"),
+            Environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_VERSION"),
+            Environment.GetEnvironmentVariable("AWS_LAMBDA_INITIALIZATION_TYPE"),
+            memory);
+    }
+
+    /// <summary>
+    /// Builds the common tag set applied to every Lambda instrument.
+    /// </summary>
+    /// <returns>The tag array (function name, version, init type, memory limit).</returns>
+    public KeyValuePair<string, object?>[] BuildTags()
+    {
+        return
+        [
+            new KeyValuePair<string, object?>("function.name", FunctionName ?? "unknown"),
+            new KeyValuePair<string, object?>("function.version", FunctionVersion ?? "unknown"),
+            new KeyValuePair<string, object?>("init.type", InitializationType ?? "on-demand"),
+            new KeyValuePair<string, object?>("memory.limit_mib", MemoryLimitMib),
+        ];
+    }
+}

--- a/src/Honua.ServiceDefaults/TracingOptions.cs
+++ b/src/Honua.ServiceDefaults/TracingOptions.cs
@@ -73,4 +73,26 @@ public sealed class TracingOptions
     /// Format: "key1=value1,key2=value2"
     /// </summary>
     public string? OtlpHeaders { get; set; }
+
+    /// <summary>
+    /// Gets or sets the AWS X-Ray tracing options. When enabled, the tracer
+    /// emits X-Ray-compatible trace IDs and propagation so spans nest into the
+    /// Lambda/API Gateway trace and surface in the X-Ray service map.
+    /// </summary>
+    public XRayTracingOptions XRay { get; set; } = new();
+}
+
+/// <summary>
+/// Configuration options for AWS X-Ray distributed tracing.
+/// </summary>
+public sealed class XRayTracingOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether X-Ray-compatible trace ID
+    /// generation and propagation are enabled. Default is false so non-AWS
+    /// runs are unaffected. When unset in configuration, the
+    /// <c>AWS_XRAY_TRACING_ENABLED</c> / <c>AWS_XRAY_DAEMON_ADDRESS</c>
+    /// environment signals can opt the process in (see resolution logic).
+    /// </summary>
+    public bool Enabled { get; set; }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/LambdaTelemetryTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/LambdaTelemetryTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics.Metrics;
+using Honua.ServiceDefaults;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Monitoring;
+
+/// <summary>
+/// Verifies that the Lambda cold-start counter and init-duration histogram are
+/// emitted through the shared <see cref="LambdaTelemetry.MeterName"/> meter so
+/// they reach the existing Prometheus/OTLP exporters.
+/// </summary>
+[Protocol(TestProtocols.TestQuality)]
+[Collection("HonuaTelemetry")]
+public sealed class LambdaTelemetryTests
+{
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void EmitColdStart_RecordsCounterAndHistogram_WithLambdaTags()
+    {
+        var context = new LambdaContext(
+            functionName: "honua-demo",
+            functionVersion: "7",
+            initializationType: "on-demand",
+            memoryLimitMib: 2048);
+
+        var coldStarts = new List<MeasurementSample<long>>();
+        var initDurations = new List<MeasurementSample<double>>();
+
+        using (var listener = new MeterListener())
+        {
+            listener.InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == LambdaTelemetry.MeterName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            };
+
+            listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+            {
+                if (instrument.Name == "honua.lambda.cold_start")
+                {
+                    coldStarts.Add(new MeasurementSample<long>(value, TagsToDictionary(tags)));
+                }
+            });
+
+            listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) =>
+            {
+                if (instrument.Name == "honua.lambda.init_duration_ms")
+                {
+                    initDurations.Add(new MeasurementSample<double>(value, TagsToDictionary(tags)));
+                }
+            });
+
+            listener.Start();
+
+            LambdaTelemetry.EmitColdStart(context, initDurationMs: 1234.5);
+        }
+
+        var coldStart = Assert.Single(coldStarts);
+        Assert.Equal(1, coldStart.Value);
+        Assert.Equal("honua-demo", coldStart.Tags["function.name"]);
+        Assert.Equal("7", coldStart.Tags["function.version"]);
+        Assert.Equal("on-demand", coldStart.Tags["init.type"]);
+        Assert.Equal(2048, coldStart.Tags["memory.limit_mib"]);
+
+        var initDuration = Assert.Single(initDurations);
+        Assert.Equal(1234.5, initDuration.Value);
+        Assert.Equal("honua-demo", initDuration.Tags["function.name"]);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void EmitColdStart_NegativeDuration_SkipsHistogramSample()
+    {
+        var context = new LambdaContext("honua-demo", "1", "on-demand", 512);
+
+        var initDurations = new List<double>();
+
+        using (var listener = new MeterListener())
+        {
+            listener.InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == LambdaTelemetry.MeterName
+                    && instrument.Name == "honua.lambda.init_duration_ms")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            };
+
+            listener.SetMeasurementEventCallback<double>((_, value, _, _) => initDurations.Add(value));
+            listener.Start();
+
+            LambdaTelemetry.EmitColdStart(context, initDurationMs: -1);
+        }
+
+        Assert.Empty(initDurations);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void RecordColdStart_OffLambda_IsNoOp()
+    {
+        // The host test runner is not a Lambda execution environment, so the
+        // production entry point must not emit anything.
+        Assert.False(LambdaTelemetry.Context.IsLambda);
+        Assert.False(LambdaTelemetry.RecordColdStart());
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void BuildTags_DefaultsUnknownValues_WhenContextEmpty()
+    {
+        var context = new LambdaContext(null, null, null, 0);
+
+        var tags = context.BuildTags().ToDictionary(t => t.Key, t => t.Value);
+
+        Assert.Equal("unknown", tags["function.name"]);
+        Assert.Equal("unknown", tags["function.version"]);
+        Assert.Equal("on-demand", tags["init.type"]);
+        Assert.Equal(0, tags["memory.limit_mib"]);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void XRayTracingOptions_DefaultsDisabled()
+    {
+        var options = new TracingOptions();
+
+        Assert.NotNull(options.XRay);
+        Assert.False(options.XRay.Enabled);
+    }
+
+    private static Dictionary<string, object?> TagsToDictionary(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    {
+        var dictionary = new Dictionary<string, object?>(tags.Length);
+        foreach (var tag in tags)
+        {
+            dictionary[tag.Key] = tag.Value;
+        }
+
+        return dictionary;
+    }
+
+    private readonly record struct MeasurementSample<T>(T Value, Dictionary<string, object?> Tags)
+        where T : struct;
+}


### PR DESCRIPTION
## Issue Link

Fixes #1730

## Summary

Adds serverless observability to Honua on AWS Lambda by extending the existing OTel/Prometheus telemetry seam (`ConfigureOpenTelemetry` / `HonuaTelemetry`) rather than introducing a parallel stack. Emits Lambda cold-start metrics through the shared meter and adds opt-in AWS X-Ray distributed tracing alongside the existing OTLP exporter so a request nests its PostGIS query and render spans into one trace.

Pairs with honua-iac PR (CloudWatch serverless dashboard + X-Ray IAM/toggle).

## Changes Made

- Add `LambdaTelemetry` (`Honua.ServiceDefaults`): detects the Lambda runtime via `AWS_LAMBDA_*` env vars and a first-invocation flag, then emits `honua.lambda.cold_start` (counter), `honua.lambda.init_duration_ms` (histogram) once per cold start, and a `honua.lambda.memory_limit_mib` observable gauge — all tagged with function name/version/init-type. Emitted through a dedicated `Honua.Lambda` meter registered in the shared metrics pipeline, so signals flow to Prometheus and OTLP with no extra wiring.
- Record the cold start from `ConfigureOpenTelemetry` during startup (no-op off Lambda).
- Add AWS X-Ray tracing gated on `Tracing:XRay:Enabled` / `AWS_XRAY_*` env signals: register the X-Ray trace-id generator + propagator and FaaS/cloud resource attributes alongside the existing OTLP exporter. ASP.NET + `AddNpgsql` instrumentation are already enabled, so request -> DB query -> render spans nest into one X-Ray trace. Off by default; non-AWS runs unaffected.
- Add `OpenTelemetry.Extensions.AWS` 1.15.1 to central package management + the ServiceDefaults project; extend `TracingOptions` with an `XRay` sub-section.
- Unit tests: cold-start counter/histogram emission with Lambda tags, negative-duration histogram skip, off-Lambda no-op, tag defaults, and X-Ray options default.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

`Honua.ServiceDefaults` Release build (warnings-as-errors) is clean; `Honua.Server.Tests` builds clean; the 5 new `LambdaTelemetryTests` pass and the existing `HonuaTelemetryTests` still pass; `dotnet format --verify-no-changes` is clean on the changed files.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [x] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

Enable X-Ray with `Tracing__XRay__Enabled=true` (the paired honua-iac toggle sets this and turns on Lambda Active tracing). Default off.

## Breaking Changes

None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
