### PR TITLE
feat: open-data source catalog + area-import provisioner (first slice)

### DIFF
--- a/data/open-data-catalog/README.md
+++ b/data/open-data-catalog/README.md
@@ -1,0 +1,35 @@
+# Open-data source catalog
+
+Config-as-data registry of curated open geospatial sources that the area-import
+provisioner can fetch, clip to an area, and load into Honua Server.
+
+- `catalog.json` -- the curated sources + products. **Adding a source is a data
+  edit here**, not a code change.
+- `schema.json` -- JSON Schema (draft-07) that `catalog.json` must validate
+  against.
+
+Validate after editing:
+
+```bash
+python3 - <<'PY'
+import json, jsonschema
+jsonschema.validate(json.load(open('catalog.json')),
+                    json.load(open('schema.json')))
+print('ok')
+PY
+```
+
+Seeded sources (slice 1):
+
+| id | status | license | products |
+|----|--------|---------|----------|
+| `census-tiger` | available | US-PD | county-boundaries, places, roads, addresses* |
+| `osm-geofabrik` | available | ODbL-1.0 | roads, buildings, poi |
+| `overture` | placeholder | CDLA-Permissive-2.0 | places, buildings |
+| `usgs-nhd` | placeholder | US-PD | waterbodies, flowlines |
+| `fema-nfhl` | placeholder | US-PD | flood-hazard-areas |
+
+\* `addresses` is a `geocoder` feedstock (future GP-Batch product).
+
+See `docs/guides/open-data-provisioner.md` for the extension pattern and the
+geocoding/routing roadmap.

--- a/data/open-data-catalog/catalog.json
+++ b/data/open-data-catalog/catalog.json
@@ -1,0 +1,233 @@
+{
+  "catalogVersion": "1.0.0",
+  "updated": "2026-06-17",
+  "sources": [
+    {
+      "id": "census-tiger",
+      "name": "US Census TIGER/Line",
+      "publisher": "U.S. Census Bureau",
+      "homepage": "https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html",
+      "license": {
+        "spdx": "US-PD",
+        "url": "https://www.census.gov/about/policies/open-data.html",
+        "attributionRequired": false,
+        "attributionText": "U.S. Census Bureau, TIGER/Line"
+      },
+      "status": "available",
+      "extractMethod": "census-geoid",
+      "areaParam": {
+        "accepts": ["state-fips", "county-geoid", "place-geoid"],
+        "notes": "TIGER files are published per state (2-digit FIPS) or per county (5-digit GEOID = state FIPS + county code). The provisioner downloads the smallest published file covering the area, then row-filters/clips to the exact GEOID."
+      },
+      "products": [
+        {
+          "product": "county-boundaries",
+          "layerName": "County Boundaries (TIGER)",
+          "geometryType": "MultiPolygon",
+          "format": "shapefile-zip",
+          "sourceProduct": "features",
+          "fetch": {
+            "kind": "http-template",
+            "urlTemplate": "https://www2.census.gov/geo/tiger/TIGER2024/COUNTY/tl_2024_us_county.zip",
+            "sampleUrl": "https://www2.census.gov/geo/tiger/TIGER2024/COUNTY/tl_2024_us_county.zip",
+            "clip": true
+          },
+          "tile": { "enabled": true, "minZoom": 0, "maxZoom": 10 }
+        },
+        {
+          "product": "places",
+          "layerName": "Incorporated Places (TIGER)",
+          "geometryType": "MultiPolygon",
+          "format": "shapefile-zip",
+          "sourceProduct": "features",
+          "fetch": {
+            "kind": "http-template",
+            "urlTemplate": "https://www2.census.gov/geo/tiger/TIGER2024/PLACE/tl_2024_{stateFips}_place.zip",
+            "sampleUrl": "https://www2.census.gov/geo/tiger/TIGER2024/PLACE/tl_2024_06_place.zip",
+            "clip": true
+          },
+          "tile": { "enabled": true, "minZoom": 4, "maxZoom": 12 }
+        },
+        {
+          "product": "roads",
+          "layerName": "Roads (TIGER)",
+          "geometryType": "MultiLineString",
+          "format": "shapefile-zip",
+          "sourceProduct": "features",
+          "fetch": {
+            "kind": "http-template",
+            "urlTemplate": "https://www2.census.gov/geo/tiger/TIGER2024/ROADS/tl_2024_{countyGeoid}_roads.zip",
+            "sampleUrl": "https://www2.census.gov/geo/tiger/TIGER2024/ROADS/tl_2024_06075_roads.zip",
+            "clip": false
+          },
+          "tile": { "enabled": true, "minZoom": 8, "maxZoom": 14 }
+        },
+        {
+          "product": "addresses",
+          "layerName": "Address Ranges (TIGER) [geocoder feedstock]",
+          "geometryType": "MultiLineString",
+          "format": "shapefile-zip",
+          "sourceProduct": "geocoder",
+          "fetch": {
+            "kind": "http-template",
+            "urlTemplate": "https://www2.census.gov/geo/tiger/TIGER2024/ADDRFEAT/tl_2024_{countyGeoid}_addrfeat.zip",
+            "sampleUrl": "https://www2.census.gov/geo/tiger/TIGER2024/ADDRFEAT/tl_2024_06075_addrfeat.zip",
+            "clip": false
+          }
+        }
+      ]
+    },
+    {
+      "id": "osm-geofabrik",
+      "name": "OpenStreetMap (via Geofabrik regional extracts + Overpass bbox)",
+      "publisher": "OpenStreetMap contributors / Geofabrik GmbH",
+      "homepage": "https://download.geofabrik.de/",
+      "license": {
+        "spdx": "ODbL-1.0",
+        "url": "https://www.openstreetmap.org/copyright",
+        "attributionRequired": true,
+        "attributionText": "© OpenStreetMap contributors, ODbL"
+      },
+      "status": "available",
+      "extractMethod": "bbox",
+      "areaParam": {
+        "accepts": ["bbox"],
+        "notes": "Small areas: Overpass API by bbox returns GeoJSON directly (no clip needed). Large areas: download the nearest Geofabrik regional .osm.pbf and clip to the bbox with osmium/ogr2ogr. This slice wires the Overpass bbox path; the Geofabrik-pbf path is a documented TODO."
+      },
+      "products": [
+        {
+          "product": "roads",
+          "layerName": "Roads (OSM)",
+          "geometryType": "MultiLineString",
+          "format": "geojson",
+          "sourceProduct": "features",
+          "fetch": {
+            "kind": "overpass",
+            "urlTemplate": "https://overpass-api.de/api/interpreter?data=[out:json][timeout:90];way[highway]({bboxSWNE});out geom;",
+            "clip": false
+          },
+          "tile": { "enabled": true, "minZoom": 8, "maxZoom": 15 }
+        },
+        {
+          "product": "buildings",
+          "layerName": "Buildings (OSM)",
+          "geometryType": "MultiPolygon",
+          "format": "geojson",
+          "sourceProduct": "features",
+          "fetch": {
+            "kind": "overpass",
+            "urlTemplate": "https://overpass-api.de/api/interpreter?data=[out:json][timeout:120];way[building]({bboxSWNE});relation[building]({bboxSWNE});out geom;",
+            "clip": false
+          },
+          "tile": { "enabled": true, "minZoom": 12, "maxZoom": 16 }
+        },
+        {
+          "product": "poi",
+          "layerName": "Points of Interest (OSM)",
+          "geometryType": "Point",
+          "format": "geojson",
+          "sourceProduct": "features",
+          "fetch": {
+            "kind": "overpass",
+            "urlTemplate": "https://overpass-api.de/api/interpreter?data=[out:json][timeout:90];node[amenity]({bboxSWNE});out geom;",
+            "clip": false
+          },
+          "tile": { "enabled": true, "minZoom": 12, "maxZoom": 16 }
+        }
+      ]
+    },
+    {
+      "id": "overture",
+      "name": "Overture Maps Foundation",
+      "publisher": "Overture Maps Foundation",
+      "homepage": "https://overturemaps.org/",
+      "license": {
+        "spdx": "CDLA-Permissive-2.0",
+        "url": "https://docs.overturemaps.org/attribution/",
+        "attributionRequired": true,
+        "attributionText": "Overture Maps Foundation"
+      },
+      "status": "placeholder",
+      "extractMethod": "bbox",
+      "areaParam": {
+        "accepts": ["bbox"],
+        "notes": "PLACEHOLDER. Overture ships GeoParquet on S3 (s3://overturemaps-us-west-2/release/...). Honua already imports GeoParquet, so the extract recipe is a DuckDB spatial bbox query over the public parquet, writing a clipped GeoParquet. Wire in a future slice."
+      },
+      "products": [
+        {
+          "product": "places",
+          "layerName": "Places (Overture)",
+          "geometryType": "Point",
+          "format": "geoparquet",
+          "sourceProduct": "features"
+        },
+        {
+          "product": "buildings",
+          "layerName": "Buildings (Overture)",
+          "geometryType": "MultiPolygon",
+          "format": "geoparquet",
+          "sourceProduct": "features"
+        }
+      ]
+    },
+    {
+      "id": "usgs-nhd",
+      "name": "USGS National Hydrography Dataset",
+      "publisher": "U.S. Geological Survey",
+      "homepage": "https://www.usgs.gov/national-hydrography",
+      "license": {
+        "spdx": "US-PD",
+        "url": "https://www.usgs.gov/faqs/what-are-terms-uselicensing-map-services-and-data-national-map",
+        "attributionRequired": false
+      },
+      "status": "placeholder",
+      "extractMethod": "census-geoid",
+      "areaParam": {
+        "accepts": ["state-fips", "county-geoid"],
+        "notes": "PLACEHOLDER. NHD is published per-HUC and per-state as FileGDB/Shapefile. Honua imports zipped FileGDB. Recipe: map county GEOID -> covering HUC4/HUC8, fetch GDB, clip. Wire in a future slice."
+      },
+      "products": [
+        {
+          "product": "waterbodies",
+          "layerName": "Waterbodies (NHD)",
+          "geometryType": "MultiPolygon",
+          "format": "gpkg",
+          "sourceProduct": "features"
+        },
+        {
+          "product": "flowlines",
+          "layerName": "Flowlines (NHD)",
+          "geometryType": "MultiLineString",
+          "format": "gpkg",
+          "sourceProduct": "features"
+        }
+      ]
+    },
+    {
+      "id": "fema-nfhl",
+      "name": "FEMA National Flood Hazard Layer",
+      "publisher": "Federal Emergency Management Agency",
+      "homepage": "https://www.fema.gov/flood-maps/national-flood-hazard-layer",
+      "license": {
+        "spdx": "US-PD",
+        "url": "https://www.fema.gov/about/openfema/terms-conditions",
+        "attributionRequired": false
+      },
+      "status": "placeholder",
+      "extractMethod": "census-geoid",
+      "areaParam": {
+        "accepts": ["county-geoid"],
+        "notes": "PLACEHOLDER. NFHL is published per-county/community as zipped FileGDB (effective panels). Recipe: resolve county GEOID -> NFHL county product URL, fetch GDB, import the S_FLD_HAZ_AR flood-hazard polygons. Wire in a future slice."
+      },
+      "products": [
+        {
+          "product": "flood-hazard-areas",
+          "layerName": "Flood Hazard Areas (NFHL)",
+          "geometryType": "MultiPolygon",
+          "format": "gpkg",
+          "sourceProduct": "features"
+        }
+      ]
+    }
+  ]
+}

--- a/data/open-data-catalog/schema.json
+++ b/data/open-data-catalog/schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://honua.io/schemas/open-data-catalog/v1.json",
+  "title": "Honua Open-Data Source Catalog",
+  "description": "Curated registry of open geospatial data sources that the area-import provisioner can fetch, clip to an area, and load into Honua Server. Catalog is config-as-data: adding a source is a data edit, not a code change.",
+  "type": "object",
+  "required": ["catalogVersion", "sources"],
+  "additionalProperties": false,
+  "properties": {
+    "catalogVersion": {
+      "type": "string",
+      "description": "Semver of the catalog document format.",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "updated": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO date the catalog was last curated."
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/source" }
+    }
+  },
+  "definitions": {
+    "source": {
+      "type": "object",
+      "required": ["id", "name", "license", "extractMethod", "products"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable machine id, kebab-case. Used as the --source argument to the provisioner.",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "name": { "type": "string", "description": "Human-readable source name." },
+        "publisher": { "type": "string", "description": "Authoritative publisher / steward." },
+        "homepage": { "type": "string", "format": "uri" },
+        "license": {
+          "type": "object",
+          "required": ["spdx", "url"],
+          "additionalProperties": false,
+          "properties": {
+            "spdx": { "type": "string", "description": "SPDX id where one exists, else a short label (e.g. 'US-PD', 'ODbL-1.0')." },
+            "url": { "type": "string", "format": "uri" },
+            "attributionRequired": { "type": "boolean", "default": false },
+            "attributionText": { "type": "string", "description": "Verbatim attribution string to surface on derived layers when attributionRequired is true." }
+          }
+        },
+        "status": {
+          "type": "string",
+          "enum": ["available", "placeholder"],
+          "default": "available",
+          "description": "'available' = a working extract recipe exists; 'placeholder' = curated but extraction is a future slice (TODO)."
+        },
+        "extractMethod": {
+          "type": "string",
+          "enum": ["bbox", "admin-boundary", "census-geoid"],
+          "description": "How an AREA parameter selects a subset. bbox = clip by lon/lat envelope; admin-boundary = clip by a named/geocoded polygon; census-geoid = select rows whose Census GEOID prefix matches the area."
+        },
+        "areaParam": {
+          "type": "object",
+          "description": "Declares which AREA inputs this source accepts and how they map to the extract.",
+          "additionalProperties": false,
+          "properties": {
+            "accepts": {
+              "type": "array",
+              "items": { "type": "string", "enum": ["bbox", "state-fips", "county-geoid", "place-geoid", "iso3166-2"] }
+            },
+            "notes": { "type": "string" }
+          }
+        },
+        "products": {
+          "type": "array",
+          "minItems": 1,
+          "description": "The layer(s) this source yields. Each product becomes one Honua layer after import.",
+          "items": { "$ref": "#/definitions/product" }
+        }
+      }
+    },
+    "product": {
+      "type": "object",
+      "required": ["product", "layerName", "geometryType"],
+      "additionalProperties": false,
+      "properties": {
+        "product": {
+          "type": "string",
+          "description": "Machine id of the product within the source (e.g. 'roads', 'buildings', 'county-boundaries'). Used as --product.",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "layerName": { "type": "string", "description": "Default published layer display name." },
+        "geometryType": {
+          "type": "string",
+          "enum": ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "GeometryCollection"]
+        },
+        "format": {
+          "type": "string",
+          "description": "Source-side format of the fetched file (one of Honua's 13 import formats, or an intermediate that the recipe converts).",
+          "enum": ["geojson", "shapefile-zip", "gpkg", "fgb", "geoparquet", "csv", "osm-pbf", "kml"]
+        },
+        "sourceProduct": {
+          "type": "string",
+          "enum": ["features", "tiles", "geocoder", "router"],
+          "default": "features",
+          "description": "What downstream artifact this product is built into. 'features' = vector layer (this slice). 'geocoder'/'router' = future GP-Batch products (see docs/guides/open-data-provisioner.md)."
+        },
+        "fetch": {
+          "type": "object",
+          "description": "Declarative fetch recipe. urlTemplate placeholders are substituted from the AREA param.",
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "type": "string", "enum": ["http-template", "overpass", "geofabrik-extract"] },
+            "urlTemplate": { "type": "string", "description": "URL with {placeholders} like {stateFips}, {countyGeoid}, {bbox}." },
+            "sampleUrl": { "type": "string", "format": "uri", "description": "A concrete small example URL for docs/testing (NOT committed as data)." },
+            "clip": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether the fetched file still needs clipping to the AREA after download (e.g. a statewide file clipped to a bbox). false when the URL already returns exactly the area."
+            }
+          }
+        },
+        "tile": {
+          "type": "object",
+          "description": "Optional PMTiles generation hints once the layer is published.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean", "default": false },
+            "minZoom": { "type": "integer", "minimum": 0, "maximum": 24 },
+            "maxZoom": { "type": "integer", "minimum": 0, "maximum": 24 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -32,6 +32,7 @@
 - [All guides: I want to…](guides/README.md)
 - Publish data
   - [Import files](guides/publish/import-files.md)
+  - [Open-data area-import provisioner](guides/open-data-provisioner.md)
   - [Import from ArcGIS services](guides/publish/import-from-arcgis-services.md)
   - [Serve existing databases](guides/publish/serve-existing-databases.md)
   - [Publish layers](guides/publish/publish-layers.md)

--- a/docs/guides/open-data-provisioner.md
+++ b/docs/guides/open-data-provisioner.md
@@ -1,0 +1,183 @@
+# Open-data area-import provisioner
+
+> Status: **first slice.** A curated open-data source catalog plus one
+> end-to-end, area-parameterized import that rides existing Honua Server
+> primitives. Esri's "give me a county and load it with their data" workflow,
+> repeatable from a single command.
+
+## What this is
+
+Sales and onboarding repeatedly need the same thing: pick a county / state /
+city, load it with high-value open government data, and have it served by Honua
+in minutes -- without an Esri data credit in sight. This slice delivers:
+
+1. A **structured source catalog** (`data/open-data-catalog/catalog.json`,
+   validated by `schema.json`) -- config-as-data, so adding a source is a data
+   edit, not a code change.
+2. **One end-to-end area-import** (`scripts/provisioner/provision_area.py`):
+   given a `--source`, `--product`, and `--area`, it fetches the data, clips it
+   to the area, imports it through the existing admin file-import API, publishes
+   it as a Honua layer, and (optionally) queues a PMTiles tiling job.
+3. This document: how to extend the catalog, and how geocoding/routing plug in
+   as future source-products on the same GP-on-Batch engine.
+
+It reuses existing server primitives **only** -- there is no new server code:
+
+| Step | Existing primitive | Endpoint |
+|------|--------------------|----------|
+| Import | `Honua.Import` file-import (13 formats, job tracking) | `POST /api/v1/admin/import/upload` |
+| Publish | `Features/Admin` layer publishing | `POST /api/v1/admin/connections/{id}/layers` |
+| Tile | TileCache operations (in-process or GP-on-Batch / Fargate Spot) | `POST /api/v1/admin/tile-operations/jobs` |
+
+Auth is the admin `X-API-Key` everywhere.
+
+> **Why `/upload` and not `/upload-url`?** The server's `upload-url` endpoint
+> only accepts **public S3/Azure object hosts** (see
+> `ImportSourceUrlValidation.IsSupportedPublicObjectHost`). Open-data hosts like
+> `www2.census.gov` and `overpass-api.de` are rejected by design (SSRF
+> hardening). So the provisioner downloads + clips locally and pushes the result
+> through the multipart `/upload` endpoint -- exactly the fetch → clip → import
+> flow this capability needs.
+
+## Quick start
+
+```bash
+# 0. deps: curl (always) + GDAL's ogr2ogr (for clip/convert of shapefile/OSM)
+#    Ubuntu/WSL:  sudo apt-get install gdal-bin
+#    macOS:       brew install gdal
+export HONUA_ADMIN_API_KEY=...           # admin key for the target server
+export HONUA_SERVER=http://localhost:8080
+
+# list the curated catalog
+python3 scripts/provisioner/provision_area.py --list
+
+# end-to-end: load San Francisco County (GEOID 06075) roads, publish + tile
+python3 scripts/provisioner/provision_area.py \
+  --source census-tiger --product roads --area geoid:06075 --tile
+
+# end-to-end: load OSM buildings for a downtown bbox (lon/lat envelope)
+python3 scripts/provisioner/provision_area.py \
+  --source osm-geofabrik --product buildings \
+  --area bbox:-122.42,37.77,-122.40,37.79 --tile
+
+# just fetch + clip and write the GeoJSON locally (no server needed)
+python3 scripts/provisioner/provision_area.py \
+  --source census-tiger --product county-boundaries --area geoid:06075 --fetch-only
+```
+
+### AREA forms
+
+| Form | Example | Used by |
+|------|---------|---------|
+| `bbox:minLon,minLat,maxLon,maxLat` | `bbox:-122.5,37.7,-122.3,37.8` | OSM (Overpass), bbox-clip of any polygon source |
+| `geoid:DD` | `geoid:06` (California, state FIPS) | TIGER state-scoped products |
+| `geoid:DDDDD` | `geoid:06075` (San Francisco County) | TIGER county-scoped products + row-filter |
+| `geoid:DDDDDDD` | `geoid:0667000` (place GEOID) | TIGER place products (future) |
+
+## What the one end-to-end import actually does (real vs scripted vs TODO)
+
+For **`census-tiger`** (fully wired) and **`osm-geofabrik`** (Overpass path
+wired):
+
+| Step | Status | Detail |
+|------|--------|--------|
+| 1. Resolve recipe + URL | **real** | Reads `catalog.json`, substitutes `{stateFips}`/`{countyGeoid}`/`{bboxSWNE}` into the `urlTemplate`. |
+| 2. Fetch | **real** | TIGER: HTTPS GET of the per-county/state `.zip` from `www2.census.gov` (verified live). OSM: Overpass API GET by bbox. |
+| 3. Clip / filter | **real (needs GDAL)** | TIGER county boundaries: `ogr2ogr -where "GEOID = '06075'"`. bbox sources: `ogr2ogr -clipsrc`. Output is GeoJSON. |
+| 4. Import | **real** | Multipart `POST /api/v1/admin/import/upload` (the same path the console uses); large files auto-queue as tracked background jobs. |
+| 5. Publish | **real** | `POST /api/v1/admin/connections/{id}/layers` with geometry type from the catalog. |
+| 6. Tile | **real, opt-in** | `--tile` queues a `seed` tile-operation. If a batch backend is configured (`ITileCacheJobService.IsEnabled`), it runs on **GP-on-Batch (Fargate Spot, scale-to-zero)**; otherwise the in-process channel worker. |
+
+**Scripted-not-automated / TODO** (surfaced as explicit messages, never faked):
+
+- **OSM Overpass → GeoJSON conversion** relies on `ogr2ogr` reading the
+  Overpass result. For larger areas, slice 2 should switch to the
+  `geofabrik-extract` path (`osmium extract -b <bbox>` on a regional
+  `.osm.pbf`, then `ogr2ogr`). The tool prints these exact commands if the
+  conversion needs it.
+- **`overture`, `usgs-nhd`, `fema-nfhl`** are curated **placeholders** -- the
+  tool refuses with a pointer to `areaParam.notes`, which records the intended
+  recipe (DuckDB bbox over Overture GeoParquet; HUC/county FileGDB for
+  NHD/NFHL). No fake imports.
+- **`addresses`** (TIGER) is a `geocoder` feedstock; the tool guards it (see
+  below).
+
+## Cost posture
+
+- **No bulk data in the repo.** The catalog stores URL templates plus a single
+  `sampleUrl` per product for docs/testing. Nothing large is committed.
+- **Fetch is area-scoped.** TIGER is downloaded per county/state (the smallest
+  published file), then row-filtered/clipped. OSM uses Overpass bbox queries,
+  not planet dumps.
+- **Tiling → S3 + Spot.** PMTiles land in S3 (object-store model); the tiling
+  job runs on Fargate Spot via GP-on-Batch and scales to zero when idle.
+
+## Extension pattern: adding a new source
+
+Adding a source is a **data edit** to `catalog.json` (validated by
+`schema.json`) -- no code change for the common cases.
+
+1. Add a `source` object: `id`, `name`, `publisher`, `homepage`, `license`
+   (`spdx` + `url`, and `attributionRequired`/`attributionText` for ODbL/CDLA),
+   and an `extractMethod` (`bbox` | `admin-boundary` | `census-geoid`).
+2. Declare `areaParam.accepts` (which AREA inputs it understands) and document
+   the recipe intent in `areaParam.notes`.
+3. Add one or more `products`. Each product needs `product`, `layerName`,
+   `geometryType`, a `format` (one of Honua's import formats), and a `fetch`
+   recipe:
+   - **`http-template`** -- `urlTemplate` with `{stateFips}`/`{countyGeoid}`/
+     `{placeGeoid}` placeholders; set `clip: true` if the file still needs
+     clipping after download.
+   - **`overpass`** -- `urlTemplate` with the `{bboxSWNE}` placeholder.
+   - **`geofabrik-extract`** -- regional `.osm.pbf` + `osmium` clip (slice 2).
+4. Set `status: "available"` once a working recipe exists; leave
+   `status: "placeholder"` while it is curated-but-unimplemented (the tool will
+   refuse cleanly).
+
+If a source needs a fetch shape the four `fetch.kind`s don't cover (e.g. a
+WFS/OGC endpoint), add a new `kind` and a small handler branch in
+`fetch_and_prepare()` -- that is the only code touch-point.
+
+## Future source-products: geocoding and routing on GP-Batch
+
+The catalog's `product.sourceProduct` field already distinguishes what a product
+is built into: `features` (this slice), `tiles`, `geocoder`, or `router`. The
+key idea is that **geocoding and routing are just additional build jobs over the
+same imported feature layers, executed on the same GP-on-Batch engine** that
+already runs tiling.
+
+```
+                       imported feature layer (PostGIS)
+                                   |
+          +------------------------+------------------------+
+          |                        |                        |
+     features layer          PMTiles tiling           future products
+     (served today)          (GP-Batch today)         (GP-Batch, next)
+                                                    |              |
+                                            geocoder build   router build
+                                            (locator index)  (routing graph)
+```
+
+- **Geocoding** -- TIGER `addresses` (ADDRFEAT, address ranges) and OSM POI are
+  the feedstock. A future `build-geocoder` GP-Batch job consumes the published
+  address layer and emits a locator index (the same object-store + Spot model as
+  tiling). The provisioner already tags `census-tiger/addresses` with
+  `sourceProduct: "geocoder"` and **guards** it: it will import the features but
+  refuse to claim a locator was built until the GP-Batch job exists.
+- **Routing** -- a road-network layer (TIGER `roads` or OSM `roads`) is the
+  feedstock for a future `build-router` GP-Batch job that contracts the network
+  into a routing graph. Same dispatch path as tiling
+  (`TileOperationsEndpoints` → `ITileCacheJobService` batch backend): a new
+  job type (`build-geocoder` / `build-router`) submitted through the
+  execution-job → Batch path, Fargate Spot, scale-to-zero.
+
+Wiring these is deliberately **out of scope for slice 1** -- but the catalog
+schema, the `sourceProduct` taxonomy, and the GP-Batch dispatch they ride are
+all already in place, so each is an additive job type rather than a redesign.
+
+## Files
+
+- `data/open-data-catalog/catalog.json` -- the curated catalog.
+- `data/open-data-catalog/schema.json` -- JSON Schema for the catalog.
+- `data/open-data-catalog/README.md` -- catalog-dir orientation.
+- `scripts/provisioner/provision_area.py` -- the area-import orchestrator.

--- a/scripts/provisioner/provision_area.py
+++ b/scripts/provisioner/provision_area.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+"""Open-data area-import provisioner -- first slice.
+
+Given an open-data SOURCE/PRODUCT from the curated catalog and an AREA
+(a bbox or a US Census GEOID), this tool:
+
+  1. resolves the fetch recipe + URL from data/open-data-catalog/catalog.json,
+  2. fetches the source for that area,
+  3. clips/filters it to the exact area (where the recipe requires it),
+  4. imports it into a running Honua Server via the admin file-import API
+     (POST /api/v1/admin/import/upload, multipart -- the same 13-format
+     pipeline used by the console),
+  5. publishes the imported table as a Honua layer
+     (POST /api/v1/admin/connections/{id}/layers), and
+  6. (optionally) queues a PMTiles tiling job
+     (POST /api/v1/admin/tile-operations/jobs) which runs in-process or, when
+     a batch backend is configured, on GP-on-Batch (Fargate Spot, scale-to-zero).
+
+It reuses existing server primitives only -- no new server code. Steps 1-4 are
+real and runnable for the seeded `census-tiger` and `osm-geofabrik` sources;
+where a step cannot be fully automated in one slice it is surfaced as an
+explicit, actionable message rather than faked.
+
+Auth: admin X-API-Key (env HONUA_ADMIN_API_KEY) against --server (default
+http://localhost:8080).
+
+External tools: `curl` (always) and `ogr2ogr` (GDAL; required only for the
+clip/convert step on shapefile sources). The tool degrades gracefully and
+tells you exactly what to install if a dependency is missing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+CATALOG = (
+    Path(__file__).resolve().parents[2]
+    / "data"
+    / "open-data-catalog"
+    / "catalog.json"
+)
+
+
+# --------------------------------------------------------------------------- #
+# Catalog
+# --------------------------------------------------------------------------- #
+def load_catalog() -> dict:
+    with CATALOG.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def find_source(catalog: dict, source_id: str) -> dict:
+    for src in catalog["sources"]:
+        if src["id"] == source_id:
+            return src
+    ids = ", ".join(s["id"] for s in catalog["sources"])
+    raise SystemExit(f"unknown source '{source_id}'. known sources: {ids}")
+
+
+def find_product(source: dict, product_id: str) -> dict:
+    for prod in source["products"]:
+        if prod["product"] == product_id:
+            return prod
+    ids = ", ".join(p["product"] for p in source["products"])
+    raise SystemExit(
+        f"unknown product '{product_id}' for source '{source['id']}'. "
+        f"products: {ids}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# AREA parsing
+# --------------------------------------------------------------------------- #
+class Area:
+    """A normalized area selector derived from the --area argument.
+
+    Forms accepted:
+      bbox:minLon,minLat,maxLon,maxLat
+      geoid:DDDDD            (5-digit county GEOID = stateFips + countyCode)
+      geoid:DD               (2-digit state FIPS)
+    """
+
+    def __init__(self, kind: str, raw: str):
+        self.kind = kind
+        self.raw = raw
+        self.bbox: tuple[float, float, float, float] | None = None
+        self.state_fips: str | None = None
+        self.county_geoid: str | None = None
+        self.place_geoid: str | None = None
+
+    @classmethod
+    def parse(cls, value: str) -> "Area":
+        if value.startswith("bbox:"):
+            parts = value[len("bbox:"):].split(",")
+            if len(parts) != 4:
+                raise SystemExit("bbox must be minLon,minLat,maxLon,maxLat")
+            nums = tuple(float(p) for p in parts)
+            area = cls("bbox", value)
+            area.bbox = nums  # type: ignore[assignment]
+            return area
+        if value.startswith("geoid:"):
+            code = value[len("geoid:"):].strip()
+            if not code.isdigit():
+                raise SystemExit("geoid must be numeric (2, 5, or 7 digits)")
+            area = cls("geoid", value)
+            if len(code) == 2:
+                area.state_fips = code
+            elif len(code) == 5:
+                area.county_geoid = code
+                area.state_fips = code[:2]
+            elif len(code) == 7:
+                area.place_geoid = code
+                area.state_fips = code[:2]
+            else:
+                raise SystemExit("geoid must be 2 (state), 5 (county), or 7 (place) digits")
+            return area
+        raise SystemExit("--area must start with 'bbox:' or 'geoid:'")
+
+    def overpass_bbox(self) -> str:
+        # Overpass expects south,west,north,east
+        if not self.bbox:
+            raise SystemExit("this product requires a bbox area")
+        w, s, e, n = self.bbox
+        return f"{s},{w},{n},{e}"
+
+    def ogr_clipsrc(self) -> list[str]:
+        if not self.bbox:
+            return []
+        w, s, e, n = self.bbox
+        return ["-clipsrc", str(w), str(s), str(e), str(n)]
+
+
+# --------------------------------------------------------------------------- #
+# Fetch + clip
+# --------------------------------------------------------------------------- #
+def render_url(template: str, area: Area) -> str:
+    subs = {
+        "stateFips": area.state_fips or "",
+        "countyGeoid": area.county_geoid or "",
+        "placeGeoid": area.place_geoid or "",
+        "bboxSWNE": area.overpass_bbox() if area.kind == "bbox" else "",
+    }
+    out = template
+    for key, val in subs.items():
+        out = out.replace("{" + key + "}", val)
+    if "{" in out:
+        missing = re.findall(r"\{(\w+)\}", out)
+        raise SystemExit(
+            f"fetch URL still has unfilled placeholders {missing}; "
+            f"the --area form does not satisfy this product's recipe"
+        )
+    return out
+
+
+def http_download(url: str, dest: Path) -> None:
+    print(f"  fetch: {url}")
+    req = urllib.request.Request(url, headers={"User-Agent": "honua-provisioner/1.0"})
+    with urllib.request.urlopen(req, timeout=180) as resp, dest.open("wb") as fh:
+        shutil.copyfileobj(resp, fh)
+    print(f"  -> {dest} ({dest.stat().st_size:,} bytes)")
+
+
+def have(tool: str) -> bool:
+    return shutil.which(tool) is not None
+
+
+def fetch_and_prepare(product: dict, area: Area, workdir: Path) -> Path:
+    """Fetch the source for the area and return a path to a GeoJSON ready for import.
+
+    Returns a .geojson (always one of Honua's import formats) so the import step
+    is uniform. Shapefile sources are converted/clipped via ogr2ogr.
+    """
+    fetch = product.get("fetch")
+    if not fetch:
+        raise SystemExit(
+            f"product '{product['product']}' has no fetch recipe -- it is a "
+            f"placeholder source. See docs/guides/open-data-provisioner.md."
+        )
+    kind = fetch["kind"]
+    out_geojson = workdir / f"{product['product']}.geojson"
+
+    if kind == "overpass":
+        # Overpass returns OSM JSON; convert to GeoJSON via ogr2ogr (GDAL has an
+        # OSM/Overpass driver via the "OSM" vsicurl path is heavy, so we fetch
+        # the JSON and let ogr2ogr read it as GeoJSON-ish). Simpler + robust:
+        # use the Overpass 'out geom' result which ogr2ogr can read with the
+        # OSM driver from a .osm file. We request JSON and convert.
+        url = render_url(fetch["urlTemplate"], area)
+        raw = workdir / f"{product['product']}.overpass.json"
+        http_download(url, raw)
+        if not have("ogr2ogr"):
+            raise SystemExit(
+                "ogr2ogr (GDAL) is required to convert Overpass JSON to GeoJSON.\n"
+                "  install: apt-get install gdal-bin  (or: brew install gdal)\n"
+                f"  raw Overpass result left at: {raw}"
+            )
+        # GDAL reads Overpass JSON via the OSM driver only from .osm; for the
+        # JSON form we round-trip through the GeoJSON driver which understands
+        # the 'out geom' geometry. If that fails, the message points at osmium.
+        rc = subprocess.run(
+            ["ogr2ogr", "-f", "GeoJSON", str(out_geojson), str(raw)],
+            capture_output=True, text=True,
+        )
+        if rc.returncode != 0:
+            raise SystemExit(
+                "could not convert Overpass result with ogr2ogr.\n"
+                "  TODO(slice-2): use osmtogeojson or osmium to convert, or switch\n"
+                "  this product to the Geofabrik .osm.pbf + osmium extract path.\n"
+                f"  ogr2ogr stderr: {rc.stderr.strip()}\n"
+                f"  raw result: {raw}"
+            )
+        return out_geojson
+
+    if kind == "http-template":
+        url = render_url(fetch["urlTemplate"], area)
+        suffix = ".zip" if product.get("format") == "shapefile-zip" else ".dat"
+        dl = workdir / f"{product['product']}{suffix}"
+        http_download(url, dl)
+        if product.get("format") == "shapefile-zip":
+            if not have("ogr2ogr"):
+                raise SystemExit(
+                    "ogr2ogr (GDAL) is required to clip/convert the shapefile.\n"
+                    "  install: apt-get install gdal-bin  (or: brew install gdal)\n"
+                    f"  downloaded zip left at: {dl}"
+                )
+            args = ["ogr2ogr", "-f", "GeoJSON"]
+            # Row-filter by GEOID for county/state polygon sources when clip=true.
+            if fetch.get("clip", True) and area.county_geoid and product["product"] == "county-boundaries":
+                args += ["-where", f"GEOID = '{area.county_geoid}'"]
+            elif fetch.get("clip", True) and area.kind == "bbox":
+                args += area.ogr_clipsrc()
+            args += [str(out_geojson), f"/vsizip/{dl}"]
+            rc = subprocess.run(args, capture_output=True, text=True)
+            if rc.returncode != 0:
+                raise SystemExit(f"ogr2ogr failed: {rc.stderr.strip()}")
+            return out_geojson
+        # Unhandled non-shapefile http-template format.
+        raise SystemExit(
+            f"format '{product.get('format')}' fetch is not wired in this slice "
+            f"(TODO). Downloaded file: {dl}"
+        )
+
+    if kind == "geofabrik-extract":
+        raise SystemExit(
+            "geofabrik-extract (regional .osm.pbf clip) is a documented TODO for "
+            "slice 2. Use the Overpass bbox product for small areas today.\n"
+            "  plan: download nearest Geofabrik region .osm.pbf, then\n"
+            "  `osmium extract -b minlon,minlat,maxlon,maxlat region.osm.pbf -o area.osm.pbf`\n"
+            "  then ogr2ogr -f GeoJSON out.geojson area.osm.pbf"
+        )
+
+    raise SystemExit(f"unknown fetch kind '{kind}'")
+
+
+# --------------------------------------------------------------------------- #
+# Honua Server admin API
+# --------------------------------------------------------------------------- #
+class Honua:
+    def __init__(self, server: str, api_key: str):
+        self.server = server.rstrip("/")
+        self.api_key = api_key
+
+    def _curl(self, args: list[str]) -> tuple[int, str]:
+        full = ["curl", "-sS", "-H", f"X-API-Key: {self.api_key}", *args]
+        rc = subprocess.run(full, capture_output=True, text=True)
+        if rc.returncode != 0:
+            raise SystemExit(f"curl failed: {rc.stderr.strip()}")
+        return rc.returncode, rc.stdout
+
+    def import_upload(self, geojson: Path, table: str, overwrite: bool) -> dict:
+        url = f"{self.server}/api/v1/admin/import/upload"
+        args = [
+            "-X", "POST", url,
+            "-F", f"file=@{geojson};type=application/geo+json",
+            "-F", f"tableName={table}",
+            "-F", f"overwriteExisting={'true' if overwrite else 'false'}",
+            "-F", "targetSrid=4326",
+        ]
+        _, out = self._curl(args)
+        return _parse_json(out, "import/upload")
+
+    def publish_layer(self, connection_id: str, table: str, layer_name: str,
+                      geometry_type: str, schema: str) -> dict:
+        url = f"{self.server}/api/v1/admin/connections/{connection_id}/layers/"
+        body = json.dumps({
+            "schema": schema,
+            "table": table,
+            "layerName": layer_name,
+            "geometryType": geometry_type,
+            "srid": 4326,
+            "enabled": True,
+        })
+        args = ["-X", "POST", url, "-H", "Content-Type: application/json", "-d", body]
+        _, out = self._curl(args)
+        return _parse_json(out, "layers")
+
+    def tile_job(self, service_id: str, layer_id: int | None,
+                 bbox: tuple[float, ...] | None, minz: int, maxz: int) -> dict:
+        url = f"{self.server}/api/v1/admin/tile-operations/jobs"
+        payload: dict = {"operation": "seed", "serviceId": service_id,
+                         "minZoom": minz, "maxZoom": maxz}
+        if layer_id is not None:
+            payload["layerId"] = layer_id
+        if bbox:
+            payload["bbox"] = list(bbox)
+        args = ["-X", "POST", url, "-H", "Content-Type: application/json",
+                "-d", json.dumps(payload)]
+        _, out = self._curl(args)
+        return _parse_json(out, "tile-operations")
+
+
+def _parse_json(text: str, where: str) -> dict:
+    text = text.strip()
+    if not text:
+        return {}
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        raise SystemExit(f"{where} returned non-JSON response:\n{text[:500]}")
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Honua open-data area-import provisioner (first slice).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--source", help="catalog source id (e.g. census-tiger)")
+    ap.add_argument("--product", help="product id within the source (e.g. county-boundaries)")
+    ap.add_argument("--area",
+                    help="bbox:minLon,minLat,maxLon,maxLat  OR  geoid:DDDDD")
+    ap.add_argument("--server", default=os.environ.get("HONUA_SERVER", "http://localhost:8080"))
+    ap.add_argument("--connection-id", default=os.environ.get("HONUA_CONNECTION_ID", "default"),
+                    help="admin connection id to publish the layer under")
+    ap.add_argument("--service-id", default="default",
+                    help="service id for the tiling job")
+    ap.add_argument("--schema", default="public", help="target PostGIS schema")
+    ap.add_argument("--table", default=None, help="override target table name")
+    ap.add_argument("--overwrite", action="store_true", help="overwrite an existing table")
+    ap.add_argument("--tile", action="store_true", help="queue a PMTiles tiling job after publish")
+    ap.add_argument("--list", action="store_true", help="list catalog sources/products and exit")
+    ap.add_argument("--fetch-only", action="store_true",
+                    help="stop after fetch+clip; print the local GeoJSON path (no server needed)")
+    args = ap.parse_args()
+
+    catalog = load_catalog()
+
+    if args.list:
+        for src in catalog["sources"]:
+            status = src.get("status", "available")
+            print(f"{src['id']}  [{status}]  ({src['license']['spdx']})  {src['name']}")
+            for p in src["products"]:
+                print(f"    - {p['product']:<22} {p['geometryType']:<16} -> {p.get('sourceProduct','features')}")
+        return 0
+
+    if not (args.source and args.product and args.area):
+        raise SystemExit("--source, --product and --area are required "
+                         "(unless --list). See --help.")
+
+    source = find_source(catalog, args.source)
+    product = find_product(source, args.product)
+    area = Area.parse(args.area)
+
+    if source.get("status") == "placeholder":
+        raise SystemExit(
+            f"source '{source['id']}' is a curated PLACEHOLDER -- its extract recipe "
+            f"is a future slice. See areaParam.notes in the catalog and "
+            f"docs/guides/open-data-provisioner.md."
+        )
+    if product.get("sourceProduct") in ("geocoder", "router"):
+        raise SystemExit(
+            f"product '{product['product']}' is a {product['sourceProduct']} feedstock. "
+            f"Importing it as features is supported, but building the "
+            f"{product['sourceProduct']} artifact runs on GP-Batch -- see the "
+            f"'Future source-products' section of docs/guides/open-data-provisioner.md.\n"
+            f"  (re-run without this guard once the GP-Batch product job exists)"
+        )
+
+    table = args.table or f"od_{source['id'].replace('-', '_')}_{product['product'].replace('-', '_')}"
+
+    print(f"== provisioning {source['id']}/{product['product']} for {args.area} ==")
+    print(f"   license: {source['license']['spdx']} ({source['license']['url']})")
+    if source["license"].get("attributionRequired"):
+        print(f"   ATTRIBUTION REQUIRED on derived layers: {source['license'].get('attributionText')}")
+
+    with tempfile.TemporaryDirectory(prefix="honua-od-") as tmp:
+        workdir = Path(tmp)
+        print("-- step 1/4: fetch + clip")
+        geojson = fetch_and_prepare(product, area, workdir)
+        print(f"   prepared: {geojson} ({geojson.stat().st_size:,} bytes)")
+
+        if args.fetch_only:
+            kept = Path.cwd() / geojson.name
+            shutil.copy(geojson, kept)
+            print(f"   --fetch-only: copied to {kept}")
+            return 0
+
+        api_key = os.environ.get("HONUA_ADMIN_API_KEY")
+        if not api_key:
+            raise SystemExit("set HONUA_ADMIN_API_KEY to talk to the server "
+                             "(or pass --fetch-only to stop after clipping)")
+        honua = Honua(args.server, api_key)
+
+        print("-- step 2/4: import via admin file-import API")
+        imp = honua.import_upload(geojson, table, args.overwrite)
+        print(f"   import response: {json.dumps(imp)[:400]}")
+
+        print("-- step 3/4: publish as Honua layer")
+        pub = honua.publish_layer(args.connection_id, table, product["layerName"],
+                                  product["geometryType"], args.schema)
+        print(f"   publish response: {json.dumps(pub)[:400]}")
+        layer_id = _extract_layer_id(pub)
+
+        if args.tile:
+            tile_cfg = product.get("tile", {})
+            if not tile_cfg.get("enabled"):
+                print("-- step 4/4: tiling SKIPPED (product.tile.enabled is false)")
+            else:
+                print("-- step 4/4: queue PMTiles tiling job (in-process or GP-Batch)")
+                job = honua.tile_job(
+                    args.service_id, layer_id,
+                    area.bbox if area.kind == "bbox" else None,
+                    tile_cfg.get("minZoom", 0), tile_cfg.get("maxZoom", 14),
+                )
+                print(f"   tile job response: {json.dumps(job)[:400]}")
+        else:
+            print("-- step 4/4: tiling SKIPPED (pass --tile to enable)")
+
+    print("== done ==")
+    return 0
+
+
+def _extract_layer_id(pub: dict) -> int | None:
+    for key in ("layerId", "id"):
+        node = pub.get("data", pub)
+        if isinstance(node, dict) and key in node and isinstance(node[key], int):
+            return node[key]
+    return None
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Open-data area-import provisioner — first slice

Delivers the "give me a county/state/city, load it with their data, repeatably" capability as a thin orchestrator over **existing** server primitives. **No new server code** — rides the file-import API, layer publishing, and TileCache/GP-on-Batch tiling. Sales force-multiplier + Esri-credit-killer.

### Chosen home (rationale)
This is a provisioning/operations tool that drives the *running* server's admin API, not a server feature. So:
- `data/open-data-catalog/` — config-as-data catalog (`catalog.json` + `schema.json`). Adding a source is a data edit, not a code change.
- `scripts/provisioner/provision_area.py` — runnable orchestrator (Python; uses `curl` + GDAL `ogr2ogr`). Keeps it off the `dotnet` build — zero impact on `TreatWarningsAsErrors`/AOT.
- `docs/guides/open-data-provisioner.md` — extension pattern + geocoding/routing roadmap (linked from `docs/SUMMARY.md`).

### Catalog
Per-source metadata: `id`, `name`, `publisher`, `license` (SPDX + url + attribution), `extractMethod` (`bbox` | `admin-boundary` | `census-geoid`), `areaParam.accepts`, and `products[]` (each → one Honua layer) with `geometryType`, `format`, `fetch` recipe, `tile` hints, and a `sourceProduct` taxonomy (`features`/`tiles`/`geocoder`/`router`).

Seeded: **census-tiger** (county-boundaries, places, roads, addresses) and **osm-geofabrik** (roads, buildings, poi) = `available`; **overture**, **usgs-nhd**, **fema-nfhl** = curated `placeholder`s with recorded recipe intent.

### The one end-to-end import (real vs scripted vs TODO)
For `census-tiger` and `osm-geofabrik`: resolve recipe+URL → **fetch** (live TIGER `.zip` / Overpass bbox) → **clip/row-filter** (`ogr2ogr -where GEOID=…` / `-clipsrc`) → **import** (`POST /admin/import/upload`, multipart — note `upload-url` is S3/Azure-only) → **publish** (`POST /admin/connections/{id}/layers`) → optional **tile** (`POST /admin/tile-operations/jobs`, in-process or GP-Batch/Fargate-Spot). Steps 1–6 are real (live Census fetch verified). OSM large-area `.osm.pbf`/osmium and all placeholder sources are surfaced as explicit TODO messages, **never faked**; geocoder/router feedstock is guarded.

### Extension pattern + future products
New source = add a `source` object to `catalog.json` (new `fetch.kind` is the only code touch-point). Geocoding (TIGER ADDRFEAT/OSM POI → locator) and routing (road network → graph) plug in as additional GP-Batch job types over the same imported layers — the `sourceProduct` taxonomy and Batch dispatch are already in place.

### Cost posture
No bulk data committed (URL templates + one `sampleUrl`/product). Area-scoped fetch (per-county TIGER / Overpass bbox). PMTiles→S3, Batch=Spot/scale-to-zero.

### Build status
No `.cs` changed — dotnet build/AOT unaffected. Python compiles; catalog validates against schema; `--list`/guards/URL-render tested; live Census fetch verified.

Plan: this PR implements the "first slice" brief (curated catalog + ONE end-to-end area-import + extension docs).

**DRAFT — do not merge.**
