### PR TITLE
fix(featureserver): fall back to default connection for storage-mapped layers

### DIFF
--- a/src/Honua.Postgres/Features/FeatureStore/PostgresFeatureStore.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/PostgresFeatureStore.cs
@@ -16,6 +16,7 @@ using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Queries.Filters;
 using Honua.Postgres.Features.FeatureStore.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
 using CoreGeometryStorageType = Honua.Core.Features.FeatureStore.Abstractions.GeometryStorageType;
 
@@ -47,6 +48,7 @@ internal sealed class PostgresFeatureStoreRefactored : IFeatureDataProvider, IFe
     private readonly ObjectPool<Dictionary<string, object?>>? _dictionaryPool;
     private readonly IConnectionEncryptionService? _connectionEncryptionService;
     private readonly IFilterExpressionService? _filterExpressionService;
+    private readonly ILogger<PostgresStorageMappedFeatureReader>? _storageMappedReaderLogger;
 
     public PostgresFeatureStoreRefactored(
         IFeatureQueryBuilder queryBuilder,
@@ -71,7 +73,8 @@ internal sealed class PostgresFeatureStoreRefactored : IFeatureDataProvider, IFe
         ObjectPool<Dictionary<string, object?>>? dictionaryPool,
         IConnectionEncryptionService? connectionEncryptionService,
         IFilterExpressionService? filterExpressionService = null,
-        IMetadataV2GraphProvider? v2Provider = null)
+        IMetadataV2GraphProvider? v2Provider = null,
+        ILogger<PostgresStorageMappedFeatureReader>? storageMappedReaderLogger = null)
     {
         _queryBuilder = queryBuilder ?? throw new ArgumentNullException(nameof(queryBuilder));
         _dataAccess = dataAccess ?? throw new ArgumentNullException(nameof(dataAccess));
@@ -81,6 +84,7 @@ internal sealed class PostgresFeatureStoreRefactored : IFeatureDataProvider, IFe
         _dictionaryPool = dictionaryPool;
         _connectionEncryptionService = connectionEncryptionService;
         _filterExpressionService = filterExpressionService;
+        _storageMappedReaderLogger = storageMappedReaderLogger;
     }
 
     public string ProviderName => DataProviderNames.Postgis;
@@ -106,7 +110,8 @@ internal sealed class PostgresFeatureStoreRefactored : IFeatureDataProvider, IFe
             binding.Resource,
             binding.StorageMapping,
             binding.Connection,
-            _connectionEncryptionService);
+            _connectionEncryptionService,
+            _storageMappedReaderLogger);
     }
 
     #region Core CRUD Operations

--- a/src/Honua.Postgres/Features/FeatureStore/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/ServiceCollectionExtensions.cs
@@ -93,7 +93,8 @@ internal static class ServiceCollectionExtensions
                 provider.GetRequiredService<ObjectPool<Dictionary<string, object?>>>(),
                 provider.GetService<IConnectionEncryptionService>(),
                 provider.GetService<IFilterExpressionService>(),
-                provider.GetService<IMetadataV2GraphProvider>()));
+                provider.GetService<IMetadataV2GraphProvider>(),
+                provider.GetService<ILogger<PostgresStorageMappedFeatureReader>>()));
 
         // Register segregated interfaces
         services.AddScoped<IFeatureDataProvider>(provider => provider.GetRequiredService<PostgresFeatureStoreRefactored>());

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
@@ -16,6 +16,8 @@ using Honua.Core.Features.Security.Domain;
 using Honua.Core.Features.Shared.Models;
 using Honua.Core.Queries.Filters;
 using Honua.Postgres.Features.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.ObjectPool;
 using Npgsql;
 
@@ -36,6 +38,7 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
     private readonly FeatureStorageMapping _mapping;
     private readonly DataConnection? _connection;
     private readonly IConnectionEncryptionService? _connectionEncryptionService;
+    private readonly ILogger _logger;
     private readonly string _qualifiedTableName;
     private readonly string _primaryKeyColumn;
     private readonly string? _geometryColumn;
@@ -50,7 +53,8 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
         MetadataV2Resource resource,
         FeatureStorageMapping mapping,
         DataConnection? connection,
-        IConnectionEncryptionService? connectionEncryptionService)
+        IConnectionEncryptionService? connectionEncryptionService,
+        ILogger? logger = null)
     {
         _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
         _dictionaryPool = dictionaryPool ?? throw new ArgumentNullException(nameof(dictionaryPool));
@@ -58,6 +62,7 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
         _mapping = mapping ?? throw new ArgumentNullException(nameof(mapping));
         _connection = connection;
         _connectionEncryptionService = connectionEncryptionService;
+        _logger = logger ?? NullLogger.Instance;
         _qualifiedTableName = QuoteQualifiedTableName(_mapping);
         _primaryKeyColumn = ValidateAndQuoteIdentifier(_mapping.PrimaryKeyColumn);
         _geometryColumn = string.IsNullOrWhiteSpace(_mapping.GeometryColumn)
@@ -1148,17 +1153,76 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
             }
         }
 
-        // A resource bound to a specific DataConnection MUST read that source. Falling back
-        // to the default catalog connection would silently query a same-named table in the
-        // wrong database — a tenant/data-source isolation hazard — so fail loudly instead
-        // (e.g. when the connection is encrypted but no IConnectionEncryptionService is
-        // registered, or the binding carries no usable connection string).
-        throw new InvalidOperationException(
-            $"Storage-mapped table '{_qualifiedTableName}' is bound to data connection '{_connection.Id}' "
-            + "but no usable connection string could be resolved for it. "
-            + (_connection.IsEncrypted && _connectionEncryptionService is null
-                ? "The connection is encrypted and no connection encryption service is registered."
-                : "The connection has no plaintext or decryptable connection string."));
+        // No bound connection string could be resolved. Decide whether to fall back to the
+        // default catalog connection (the same source render + OGC reads use) or to fail
+        // loudly. The single-DB / default-connection deployment is the common case: a layer
+        // is bound to a placeholder connection that carries no distinct connection-string
+        // material at all, which means "read from the default database". Falling back there
+        // is correct and restores the pre-#1662 behavior (the resolver returned null, and
+        // OpenConnectionAsync opened the default connection).
+        //
+        // When the binding *does* carry connection-string material that we simply cannot
+        // unlock (encrypted bytes with no/failed decryption service, or an external secret
+        // reference), the resource genuinely points at a specific, distinct source. Falling
+        // back would silently query a same-named table in the wrong database — a tenant /
+        // data-source isolation hazard — so fail loudly instead.
+        if (ShouldFailInsteadOfDefaultFallback(_connection, _connectionEncryptionService))
+        {
+            throw new InvalidOperationException(
+                $"Storage-mapped table '{_qualifiedTableName}' is bound to data connection '{_connection.Id}' "
+                + "but no usable connection string could be resolved for it. "
+                + (_connection.IsEncrypted && _connection.EncryptedConnectionString.Length > 0 && _connectionEncryptionService is null
+                    ? "The connection is encrypted and no connection encryption service is registered."
+                    : "The connection has encrypted or externally referenced credentials that could not be decrypted."));
+        }
+
+        // Empty/placeholder binding — use the default connection (single-DB deployment).
+        LogDefaultConnectionFallback(_logger, _qualifiedTableName, _connection.Id);
+        return null;
+    }
+
+    [LoggerMessage(
+        EventId = 7110,
+        Level = LogLevel.Warning,
+        Message = "Storage-mapped table {Table} is bound to data connection '{ConnectionId}' which carries no "
+            + "connection-string material; falling back to the default database connection.")]
+    private static partial void LogDefaultConnectionFallback(ILogger logger, string table, string connectionId);
+
+    /// <summary>
+    /// Decides whether an unresolved bound connection represents a genuine misconfiguration
+    /// (a layer pinned to a distinct source whose credentials we cannot unlock) that must fail
+    /// loudly, versus an empty/placeholder binding that means "use the default connection".
+    /// </summary>
+    /// <remarks>
+    /// Only reached when no plaintext string was present and no encrypted string could be
+    /// decrypted. A binding with encrypted bytes (regardless of whether a decryption service is
+    /// available) or an external secret reference is pointing at a specific source, so we must
+    /// not silently read from the default database. A binding with none of that material is a
+    /// placeholder for the default connection.
+    /// </remarks>
+    internal static bool ShouldFailInsteadOfDefaultFallback(
+        DataConnection connection,
+        IConnectionEncryptionService? connectionEncryptionService)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+
+        if (connection.EncryptedConnectionString.Length > 0)
+        {
+            // Encrypted credentials exist but could not be turned into a usable string
+            // (no service, or decryption returned empty) — a real, distinct source we
+            // cannot reach. Fail rather than fall back to the wrong database.
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(connection.SecretRef))
+        {
+            // Credentials live in an external secret store the runtime did not resolve.
+            return true;
+        }
+
+        // No connection-string material of any kind: an empty/placeholder binding standing
+        // in for the default connection. Safe to fall back.
+        return false;
     }
 
     private static NpgsqlCommand CreateReadCommand(NpgsqlConnection connection, SqlBuilder sql)

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/PostgresStorageMappedFeatureReaderConnectionTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/PostgresStorageMappedFeatureReaderConnectionTests.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Reflection;
+using System.Text;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.Core.Features.Security.Domain;
+using Honua.Postgres.Features.FeatureStore.Services;
+using Microsoft.Extensions.ObjectPool;
+using NSubstitute;
+
+namespace Honua.Postgres.Tests.Features.FeatureStore;
+
+/// <summary>
+/// Connection-resolution behavior for the storage-mapped reader. Regression coverage for
+/// the single-DB / default-connection deployment (demo.honua.io): a layer bound to an
+/// empty/placeholder data connection must fall back to the default database connection
+/// (the same source render + OGC reads use) instead of failing the FeatureServer query,
+/// while a layer bound to a real (decryptable) connection still uses that source, and a
+/// genuinely unresolvable binding still fails loudly.
+/// </summary>
+public sealed class PostgresStorageMappedFeatureReaderConnectionTests
+{
+    private static readonly ObjectPool<Dictionary<string, object?>> DictionaryPool =
+        new DefaultObjectPoolProvider().Create(
+            new Honua.Core.Features.Infrastructure.ServiceRegistration.DictionaryPooledObjectPolicy());
+
+    [Fact]
+    public async Task ResolveBoundConnectionString_EmptyOrDefaultBinding_FallsBackToDefaultConnection()
+    {
+        // A placeholder connection that carries no connection-string material at all
+        // (no plaintext, no encrypted bytes, no secret reference). This is the common
+        // single-DB case: the layer is bound to '' / the default connection.
+        var connection = new DataConnection
+        {
+            Id = string.Empty,
+            IsEncrypted = false,
+            ConnectionString = string.Empty,
+        };
+
+        var resolved = await ResolveBoundConnectionStringAsync(
+            connection,
+            connectionEncryptionService: null);
+
+        // null is the "use the default connection provider" signal honored by
+        // OpenConnectionAsync, restoring the pre-#1662 behavior.
+        resolved.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveBoundConnectionString_RealEncryptedConnection_UsesThatSource()
+    {
+        const string decryptedConnectionString =
+            "Host=tenant-db;Port=5432;Database=tenant;Username=svc;Password=secret";
+        var encryptedBytes = Encoding.UTF8.GetBytes("cipher-text");
+
+        var connection = new DataConnection
+        {
+            Id = "tenant-connection",
+            IsEncrypted = true,
+            EncryptedConnectionString = encryptedBytes,
+            EncryptionKeyVersion = 3,
+        };
+
+        var encryptionService = Substitute.For<IConnectionEncryptionService>();
+        encryptionService
+            .DecryptConnectionStringAsync(encryptedBytes, 3)
+            .Returns(Task.FromResult(decryptedConnectionString));
+
+        var resolved = await ResolveBoundConnectionStringAsync(connection, encryptionService);
+
+        // The bound, distinct source is honored — it must NOT fall back to the default DB.
+        resolved.Should().Be(decryptedConnectionString);
+    }
+
+    [Fact]
+    public async Task ResolveBoundConnectionString_EncryptedButUndecryptable_ThrowsClearError()
+    {
+        // Encrypted credentials exist but no encryption service is registered to unlock
+        // them. The layer points at a specific, distinct source we cannot reach; silently
+        // reading the default database would be a data-source isolation hazard, so fail.
+        var connection = new DataConnection
+        {
+            Id = "encrypted-no-service",
+            IsEncrypted = true,
+            EncryptedConnectionString = Encoding.UTF8.GetBytes("cipher-text"),
+            EncryptionKeyVersion = 1,
+        };
+
+        var act = () => ResolveBoundConnectionStringAsync(connection, connectionEncryptionService: null);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .Which.Message.Should().Contain("encrypted-no-service");
+    }
+
+    [Fact]
+    public void ShouldFailInsteadOfDefaultFallback_PlaceholderBinding_AllowsFallback()
+    {
+        var connection = new DataConnection { Id = string.Empty, IsEncrypted = false };
+
+        PostgresStorageMappedFeatureReader
+            .ShouldFailInsteadOfDefaultFallback(connection, connectionEncryptionService: null)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldFailInsteadOfDefaultFallback_EncryptedBytesPresent_RequiresFailure()
+    {
+        var connection = new DataConnection
+        {
+            Id = "encrypted",
+            IsEncrypted = true,
+            EncryptedConnectionString = Encoding.UTF8.GetBytes("cipher-text"),
+        };
+
+        PostgresStorageMappedFeatureReader
+            .ShouldFailInsteadOfDefaultFallback(connection, connectionEncryptionService: null)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldFailInsteadOfDefaultFallback_ExternalSecretReference_RequiresFailure()
+    {
+        var connection = new DataConnection
+        {
+            Id = "secret-backed",
+            IsEncrypted = false,
+            SecretRef = "kv://tenant/db",
+            SecretType = "AzureKeyVault",
+        };
+
+        PostgresStorageMappedFeatureReader
+            .ShouldFailInsteadOfDefaultFallback(connection, connectionEncryptionService: null)
+            .Should().BeTrue();
+    }
+
+    private static async Task<string?> ResolveBoundConnectionStringAsync(
+        DataConnection connection,
+        IConnectionEncryptionService? connectionEncryptionService)
+    {
+        var reader = new PostgresStorageMappedFeatureReader(
+            Substitute.For<IAdoNetDatabaseConnectionProvider>(),
+            DictionaryPool,
+            new MetadataV2Resource(),
+            new FeatureStorageMapping(TableName: "maui_features", PrimaryKeyColumn: "objectid"),
+            connection,
+            connectionEncryptionService);
+
+        var method = typeof(PostgresStorageMappedFeatureReader).GetMethod(
+            "ResolveBoundConnectionStringAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        method.Should().NotBeNull();
+
+        try
+        {
+            var task = (Task<string?>)method!.Invoke(reader, Array.Empty<object>())!;
+            return await task;
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            // Surface the real exception (e.g. InvalidOperationException) to the assertion.
+            throw ex.InnerException;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Promoting the latest trunk image broke `FeatureServer/{layer}/query` with HTTP 500 for **single-DB / default-connection deployments** (surfaced on demo.honua.io), while map render and OGC API Features kept working. The demo's maui layers are bound to an empty/placeholder data connection (`''`) and worked on the prior image.

## Root cause (regression)

`PostgresStorageMappedFeatureReader.ResolveBoundConnectionStringAsync()` is the only FeatureServer-query connection path that consults a layer's bound `DataConnection`. Render + OGC read through `FeatureDataAccess`, which always uses the default `IAdoNetDatabaseConnectionProvider` (`ConnectionStrings:DefaultConnection`).

The cross-cutting sweep #1662 (`8964d2d86`, 2026-06-14) changed the resolver's final `return null` into an unconditional `throw`:

- **Before:** when a bound connection had no usable (plaintext / decryptable) connection string, the resolver returned `null`, and `OpenConnectionAsync` opened the **default** connection — the same source render + OGC use.
- **After:** the same condition throws `InvalidOperationException` ("…bound to data connection '' but no usable connection string could be resolved…") → 500.

A `DataConnection` with empty `ConnectionString`, empty `EncryptedConnectionString`, and the default `IsEncrypted = true` falls straight through to the throw. That is exactly the single-DB / default-binding case.

`git blame`/`git log -L` on lines 1120–1162 confirms the throw originated in #1662; `4784076cb` (the original reader) used the `return null` fallback.

## Fix

Restore the default-connection fallback for **empty/placeholder** bindings while keeping the sweep's legitimate data-source isolation guard for genuinely-pinned sources:

- No plaintext, no encrypted bytes, no secret reference → empty/placeholder binding standing in for the default connection → return `null` (default fallback) and log a clear `Warning`.
- Encrypted credential bytes present (decryptable or not), or an external `SecretRef` → the layer points at a distinct source → still **throw** with a clear message (never silently read the wrong DB).

The security-critical decision is extracted into a pure, unit-testable `ShouldFailInsteadOfDefaultFallback(...)`. A source-generated `[LoggerMessage]` warning (CA1848-compliant) is emitted on fallback. The reader gains an optional `ILogger`, threaded through the factory and DI registration.

## Tests (`PostgresStorageMappedFeatureReaderConnectionTests`)

- `ResolveBoundConnectionString_EmptyOrDefaultBinding_FallsBackToDefaultConnection` — empty/default binding resolves via the default connection (returns `null`).
- `ResolveBoundConnectionString_RealEncryptedConnection_UsesThatSource` — a real (decryptable) connection still uses that source.
- `ResolveBoundConnectionString_EncryptedButUndecryptable_ThrowsClearError` — genuinely unresolvable binding errors clearly.
- Plus three direct cases on the `ShouldFailInsteadOfDefaultFallback` classifier (placeholder / encrypted-bytes / external-secret).

All 6 new + 6 existing reader tests pass; `dotnet build` is clean (0 warnings, 0 errors).

## Impact

Unblocks FeatureServer query for default-connection layers, restoring the prior image's behavior — what demo.honua.io needs to promote the render-fixed image. No change for layers bound to real (encrypted) connections.

**DO NOT MERGE** — draft for review.