### PR TITLE
fix(featureserver): empty-id bound connection always falls back to default

### DIFF
--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
@@ -1176,6 +1176,19 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
                     : "The connection has encrypted or externally referenced credentials that could not be decrypted."));
         }
 
+        // An empty/whitespace connection ID is the "use the default connection" sentinel
+        // (the pre-#1662 behavior). When such a binding also carries leftover credential
+        // material we could not unlock — e.g. stale encrypted bytes that won't decrypt with
+        // the current master key — we still fall back to the default connection, but log a
+        // Warning so a genuine misconfiguration (an empty ID that was meant to be a real,
+        // distinct source) remains visible in operations.
+        if (string.IsNullOrWhiteSpace(_connection.Id)
+            && (_connection.EncryptedConnectionString.Length > 0 || !string.IsNullOrWhiteSpace(_connection.SecretRef)))
+        {
+            LogEmptyIdFallbackPastUnresolvedCredentials(_logger, _qualifiedTableName);
+            return null;
+        }
+
         // Empty/placeholder binding — use the default connection (single-DB deployment).
         LogDefaultConnectionFallback(_logger, _qualifiedTableName, _connection.Id);
         return null;
@@ -1188,6 +1201,15 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
             + "connection-string material; falling back to the default database connection.")]
     private static partial void LogDefaultConnectionFallback(ILogger logger, string table, string connectionId);
 
+    [LoggerMessage(
+        EventId = 7111,
+        Level = LogLevel.Warning,
+        Message = "Storage-mapped table {Table} is bound to a data connection with an empty ID (the "
+            + "default-connection sentinel) that still carries unresolved encrypted or externally "
+            + "referenced credentials. Falling back to the default database connection; if this binding "
+            + "was meant to target a distinct source, give it a non-empty connection ID.")]
+    private static partial void LogEmptyIdFallbackPastUnresolvedCredentials(ILogger logger, string table);
+
     /// <summary>
     /// Decides whether an unresolved bound connection represents a genuine misconfiguration
     /// (a layer pinned to a distinct source whose credentials we cannot unlock) that must fail
@@ -1195,16 +1217,28 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
     /// </summary>
     /// <remarks>
     /// Only reached when no plaintext string was present and no encrypted string could be
-    /// decrypted. A binding with encrypted bytes (regardless of whether a decryption service is
-    /// available) or an external secret reference is pointing at a specific source, so we must
-    /// not silently read from the default database. A binding with none of that material is a
-    /// placeholder for the default connection.
+    /// decrypted. An empty/whitespace connection ID is the "use the default connection"
+    /// sentinel: such a binding always falls back to the default database regardless of any
+    /// leftover (and unresolvable) credential material, because it never identified a distinct
+    /// source. A binding with a *non-empty* ID and encrypted bytes (regardless of whether a
+    /// decryption service is available) or an external secret reference is pointing at a
+    /// specific source, so we must not silently read from the default database. A binding with
+    /// none of that material is a placeholder for the default connection.
     /// </remarks>
     internal static bool ShouldFailInsteadOfDefaultFallback(
         DataConnection connection,
         IConnectionEncryptionService? connectionEncryptionService)
     {
         ArgumentNullException.ThrowIfNull(connection);
+
+        if (string.IsNullOrWhiteSpace(connection.Id))
+        {
+            // Empty/whitespace ID is the default-connection sentinel — it never named a
+            // distinct source, so fall back to the default database even if stale encrypted
+            // bytes or a secret reference linger on the record. (ResolveBoundConnectionStringAsync
+            // logs a Warning for that case so a real misconfiguration stays visible.)
+            return false;
+        }
 
         if (connection.EncryptedConnectionString.Length > 0)
         {

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/PostgresStorageMappedFeatureReaderConnectionTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/PostgresStorageMappedFeatureReaderConnectionTests.cs
@@ -51,6 +51,52 @@ public sealed class PostgresStorageMappedFeatureReaderConnectionTests
     }
 
     [Fact]
+    public async Task ResolveBoundConnectionString_EmptyIdWithUndecryptableEncryptedBytes_FallsBackToDefaultConnection()
+    {
+        // The exact demo.honua.io situation: the maui layers are bound to a connection whose
+        // ID is empty ('' — the default-connection sentinel) but which still carries stale
+        // encrypted credentials that won't decrypt with the current master key. An empty ID
+        // means "use the default connection", so it must fall back regardless of the leftover
+        // (and unusable) encrypted bytes rather than failing the FeatureServer / OGC query.
+        var connection = new DataConnection
+        {
+            Id = string.Empty,
+            IsEncrypted = true,
+            EncryptedConnectionString = Encoding.UTF8.GetBytes("stale-cipher-text"),
+            EncryptionKeyVersion = 1,
+        };
+
+        // Encryption service present but unable to unlock the stale bytes (wrong master key).
+        var encryptionService = Substitute.For<IConnectionEncryptionService>();
+        encryptionService
+            .DecryptConnectionStringAsync(Arg.Any<byte[]>(), Arg.Any<int>())
+            .Returns(Task.FromResult(string.Empty));
+
+        var resolved = await ResolveBoundConnectionStringAsync(connection, encryptionService);
+
+        // null is the "use the default connection provider" signal honored by
+        // OpenConnectionAsync, restoring the pre-#1662 behavior for the empty-ID sentinel.
+        resolved.Should().BeNull();
+    }
+
+    [Fact]
+    public void ShouldFailInsteadOfDefaultFallback_EmptyIdWithEncryptedBytes_AllowsFallback()
+    {
+        // Empty/whitespace ID is the default-connection sentinel — fall back even when stale
+        // encrypted bytes linger on the record (the precise demo.honua.io misconfiguration).
+        var connection = new DataConnection
+        {
+            Id = string.Empty,
+            IsEncrypted = true,
+            EncryptedConnectionString = Encoding.UTF8.GetBytes("stale-cipher-text"),
+        };
+
+        PostgresStorageMappedFeatureReader
+            .ShouldFailInsteadOfDefaultFallback(connection, connectionEncryptionService: null)
+            .Should().BeFalse();
+    }
+
+    [Fact]
     public async Task ResolveBoundConnectionString_RealEncryptedConnection_UsesThatSource()
     {
         const string decryptedConnectionString =


### PR DESCRIPTION
## Problem

Follow-up to #1733 (merged). That PR restored the default-connection fallback for *placeholder* bindings (no plaintext, no encrypted bytes, no secret-ref) but still **threw** whenever encrypted bytes were present — even if they were undecryptable.

The live demo.honua.io situation hits exactly that gap: the maui layers are bound to a data connection whose **ID is empty (`''`)** AND which carries **stale encrypted credentials that won't decrypt** with the current master key. So FeatureServer / OGC query still 500s:

> Storage-mapped table '...' is bound to data connection '' but no usable connection string ... encrypted or externally referenced credentials that could not be decrypted.

An empty/whitespace connection ID is the "use the default connection" sentinel (the pre-#1662 behavior used the default for it). It should fall back to the default regardless of any leftover/undecryptable encrypted material.

## Fix

In `PostgresStorageMappedFeatureReader`:

- **`ShouldFailInsteadOfDefaultFallback(...)`**: short-circuit to `false` (fall back) when `connection.Id` is empty/whitespace, *before* the encrypted-bytes / secret-ref checks. An empty ID never identified a distinct source, so falling back to the default DB is correct.
- **`ResolveBoundConnectionStringAsync()`**: when an empty-ID binding still carries unresolved encrypted bytes or a secret-ref, fall back (return `null`) but log a **Warning** (`LogEmptyIdFallbackPastUnresolvedCredentials`, EventId 7111) so a genuine misconfiguration stays visible.
- The throw is retained for **non-empty** connection IDs with undecryptable encrypted creds or external secret-refs (genuine pinned sources — never silently bypassed).

## Tests (`PostgresStorageMappedFeatureReaderConnectionTests`)

New:
- `ResolveBoundConnectionString_EmptyIdWithUndecryptableEncryptedBytes_FallsBackToDefaultConnection` — the exact demo situation: empty-ID + undecryptable encrypted bytes → returns `null` (default fallback). **Previously threw.**
- `ShouldFailInsteadOfDefaultFallback_EmptyIdWithEncryptedBytes_AllowsFallback` — classifier returns `false` for empty-ID with encrypted bytes.

All #1733 tests still pass (real non-empty encrypted → still uses it; non-empty undecryptable → still throws; non-empty secret-ref → still throws). 8/8 pass; `dotnet build` clean (0 warnings, 0 errors).

## Impact

This is the last gate for promoting the render-fixed image to demo.honua.io — it unblocks FeatureServer query / OGC query for the demo's empty-ID + stale-encrypted maui layers. No change for layers bound to real (decryptable) or genuinely-pinned non-empty connections.

**DO NOT MERGE** — draft for review.