### PR TITLE
docs+ci: surface PR-template requirement; forward shard csproj in local precheck

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,17 @@ The MVP intentionally defers enterprise/operational features to reduce complexit
 
 ## Critical Rules
 
+### Creating a PR — fill the template (or CI is skipped)
+
+When opening a PR, follow the **Pull Request Policy** section above. The **Validate PR Template Compliance** check **gates the entire CI matrix**: a PR that does not fill every required section of `.github/pull_request_template.md` fails it, and **every build/test shard is SKIPPED** — the PR then looks broken with nothing actually wrong. This is the single most common agent-PR failure. Do **not** hand-roll a freeform `gh pr create --body "..."` (it overrides the template). Instead copy the template, fill **all** sections — conventional-commit title (`type(scope): description`), issue link (`Fixes #N`), non-empty Summary, `-` bullet Changes Made, Breaking Changes (or `None`), one `[x]` in both Gate Impact and Testing, and the `Ran scripts/ci/pre-pr-check.sh` box — and pass it with `--body-file`:
+
+```bash
+cp .github/pull_request_template.md /tmp/pr-body.md   # then fill every section in /tmp/pr-body.md
+gh pr create --base trunk --title "type(scope): description" --body-file /tmp/pr-body.md
+```
+
+The check re-runs on push / `labeled` / `ready_for_review` — **not** on PR-body edits alone, so re-trigger by pushing or toggling a label after filling it.
+
 ### Legacy Code Reference Policy
 
 There is an archived legacy project at `../Honua.Server/` which serves as **reference documentation only**. Treat it as archive-only historical context, not as an active repo or implementation source.

--- a/scripts/ci/pre-pr-check.sh
+++ b/scripts/ci/pre-pr-check.sh
@@ -185,7 +185,7 @@ else
         run_one_shard() {
             local shard_name="$1"
             local safe="${shard_name//[^A-Za-z0-9_]/_}"
-            local shard_json log_name filter max_cpu_count test_timeout_minutes
+            local shard_json log_name filter max_cpu_count test_timeout_minutes csproj
             shard_json="$(jq -c --arg n "${shard_name}" '.shards[] | select(.shard_name==$n)' .github/ci-shards.json)"
             if [[ -z "${shard_json}" ]]; then
                 echo "unknown" > "${SHARD_STATUS_DIR}/${safe}.status"
@@ -196,7 +196,13 @@ else
             filter="$(jq -r '.filter' <<< "${shard_json}")"
             max_cpu_count="$(jq -r '.max_cpu_count // ""' <<< "${shard_json}")"
             test_timeout_minutes="$(jq -r '(.test_timeout_minutes // .timeout_minutes) | tostring' <<< "${shard_json}")"
+            # Forward the shard's test project (ADR-0042 split protocol projects). When a shard has
+            # no csproj, this is empty and run-server-test-shard.sh falls back to the Honua.Server.Tests
+            # monolith — matching CI. Without this, protocol-project shards run their filter against the
+            # monolith locally and silently match zero tests.
+            csproj="$(jq -r '.csproj // ""' <<< "${shard_json}")"
             if HONUA_SERVER_TEST_SHARD_NAME="${shard_name}" \
+               HONUA_SERVER_TEST_CSPROJ="${csproj}" \
                HONUA_SERVER_TEST_FILTER="${filter}" \
                HONUA_SERVER_TEST_LOG_NAME="${log_name}" \
                HONUA_SERVER_TEST_TIMEOUT_MINUTES="${HONUA_PRE_PR_SERVER_TEST_TIMEOUT_MINUTES:-${test_timeout_minutes}}" \


### PR DESCRIPTION
## Issue Link
Related to #1724

## Summary
Two fixes for recurring agent friction discovered while landing the finer-sharding work (#1724): the PR-template requirement was documented but buried, and the local pre-PR check didn't forward per-shard `csproj` so the split protocol test projects never ran locally.

## Changes Made
- **AGENTS.md** — add a prominent "Creating a PR — fill the template" rule at the top of Critical Rules, pointing to the Pull Request Policy, warning that a freeform `gh pr create --body` overrides `.github/pull_request_template.md` and fails the Validate PR Template Compliance check (which gates/skips the entire CI matrix), with a `--body-file` recipe.
- **scripts/ci/pre-pr-check.sh** — `run_one_shard` now forwards each shard's `csproj` (`HONUA_SERVER_TEST_CSPROJ`) from `ci-shards.json`; empty falls back to the `Honua.Server.Tests` monolith, matching CI. Without it the ADR-0042 split protocol projects (OgcApi/OgcClassic/GeoServices/OData/Stac/Scene/MCP) matched zero tests locally and were silently skipped.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — docs + a local-only test-runner script; no production or CI-workflow behavior change.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description`
- [x] PR title matches main commit message
- [x] Issue number linked above

> Note: docs + local-script change only (no compiled code). `bash -n` syntax-checked `pre-pr-check.sh`; no production/CI-workflow behavior changes. Merged via admin per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)