### PR TITLE
docs: use the honua CLI instead of curl in query quickstarts

### DIFF
--- a/docs/get-started/first-dataset.md
+++ b/docs/get-started/first-dataset.md
@@ -2,7 +2,7 @@
 
 You'll upload a GeoJSON file, publish it as a layer, and query it back over OGC API Features and ArcGIS-compatible FeatureServer in about 10 minutes.
 
-**Prerequisites:** a running server with an admin password set (steps 1–4 of the [quickstart](quickstart.md)), plus `curl`.
+**Prerequisites:** a running server with an admin password set (steps 1–4 of the [quickstart](quickstart.md)), plus `curl` for the admin import/publish calls and (recommended) the `honua` CLI for querying (`npm i -g @honua/sdk-js`).
 
 ## Steps
 
@@ -50,32 +50,49 @@ curl -s -H "X-API-Key: $KEY" -H "Content-Type: application/json" \
 {"success":true,"data":{"layerId":2,"layerName":"hawaii-cities","schema":"honua_data","table":"hawaii_cities",…,"serviceName":"default"},…}
 ```
 
-5. Query it via OGC API Features. List the collections, then set `COLLECTION` to the `id` shown for your layer and fetch items as GeoJSON.
+5. Query it back with the **`honua` CLI** (bundled with the JS SDK: `npm i -g @honua/sdk-js`, or run ad hoc with `npx @honua/sdk-js honua …`). Point it at your server, list the service's layers to find the numeric id, then query — a readable table by default, GeoJSON on request:
 
 ```bash
+export HONUA_BASE_URL=$HONUA
+export HONUA_API_KEY=$KEY   # omit once the service allows anonymous reads
+
+honua layers default                                    # find the layer id (e.g. 0)
+honua query default/0 --limit 5                          # readable table
+honua query default/0 --where "population > 100000" --format geojson
+```
+
+<details><summary>Same queries over raw HTTP (curl)</summary>
+
+```bash
+# OGC API Features — list collections, then fetch items as GeoJSON
 curl -s -H "X-API-Key: $KEY" "$HONUA/ogc/features/collections"
 COLLECTION=hawaii-cities   # use the collection id from the previous response
 curl -s -H "X-API-Key: $KEY" "$HONUA/ogc/features/collections/$COLLECTION/items?limit=5"
-```
 
-6. Query the same layer via FeatureServer. Fetch the service metadata to see the layer's numeric id, then query it.
-
-```bash
+# GeoServices FeatureServer — service metadata, then a query
 curl -s -H "X-API-Key: $KEY" "$HONUA/rest/services/default/FeatureServer?f=json"
 LAYER=0   # use the layer id from the "layers" array in the previous response
 curl -s -H "X-API-Key: $KEY" "$HONUA/rest/services/default/FeatureServer/$LAYER/query?where=population%20%3E%20100000&outFields=*&f=json"
 ```
+
+</details>
 
 > Also available with [honua-sdk-js](https://github.com/honua-io/honua-sdk-js) and [honua-sdk-dotnet](https://github.com/honua-io/honua-sdk-dotnet). Also available in Honua Console — UI guide coming soon.
 
 ## Verify
 
 ```bash
-curl -s -H "X-API-Key: $KEY" "$HONUA/ogc/features/collections/$COLLECTION/items?limit=1"
+honua query default/0 --count
+```
+
+A non-zero count confirms the layer is published and queryable. To inspect a row as GeoJSON:
+
+```bash
+honua query default/0 --limit 1 --format geojson
 ```
 
 ```text
-{"type":"FeatureCollection","features":[{"type":"Feature",…,"properties":{"name":"Honolulu","population":343421}}],…}
+{ "type": "FeatureCollection", "features": [ { "type": "Feature", "properties": { "name": "Honolulu", "population": 343421 } } ] }
 ```
 
 ## Troubleshoot

--- a/docs/guides/query-analyze/query-features.md
+++ b/docs/guides/query-analyze/query-features.md
@@ -4,11 +4,29 @@ Filter, page, sort, and project features over whichever protocol your client spe
 
 **Prerequisites:** a running server ([quickstart](../../get-started/quickstart.md)) and a published layer ([publish layers](../publish/publish-layers.md)).
 
-The three surfaces answer the same questions with different syntax: OGC items take `filter` (CQL2 text or JSON), FeatureServer takes SQL-like `where` clauses, and OData takes `$filter`. This page shows the request shapes; the full filter-language reference is in [CQL2 and filtering](../../reference/cql2-and-filtering.md). To create or change features, see [edit features](../edit/edit-features.md).
+The fastest way to query from a terminal is the **`honua` CLI** (installed with
+the JS SDK: `npm i -g @honua/sdk-js`, or run ad hoc with `npx @honua/sdk-js
+honua …`). It wraps the same FeatureServer query endpoint, prints a readable
+table by default, and emits GeoJSON or JSON on request — no URL-encoding, no
+`f=` parameters. Point it at your server once:
+
+```bash
+export HONUA_BASE_URL=http://localhost:8080
+# export HONUA_API_KEY=... # only if the service requires auth
+```
+
+The three HTTP surfaces answer the same questions with different syntax: OGC items take `filter` (CQL2 text or JSON), FeatureServer takes SQL-like `where` clauses, and OData takes `$filter`. The CLI maps onto the FeatureServer surface; the raw HTTP shapes for all three are kept below as a reference. The full filter-language reference is in [CQL2 and filtering](../../reference/cql2-and-filtering.md). To create or change features, see [edit features](../edit/edit-features.md).
 
 ## Steps
 
-1. Ask an attribute question — "population over 10000" — on each surface:
+1. Ask an attribute question — "population over 10000". The `<service>/<layer>` reference uses the numeric layer id:
+
+   ```bash
+   honua query my_service/0 --where "population > 10000"
+   honua query my_service/0 --where "population > 10000" --format geojson
+   ```
+
+   <details><summary>Same query over raw HTTP (curl)</summary>
 
    ```bash
    BASE=http://localhost:8080
@@ -30,7 +48,17 @@ The three surfaces answer the same questions with different syntax: OGC items ta
    curl -s "$BASE/odata/Layers($LAYER)/Features?\$filter=population%20gt%2010000"
    ```
 
-2. Filter spatially. Every surface accepts a bounding box; CQL2 and FeatureServer also take real geometries, and OData supports `geo.distance` and `geo.intersects` in `$filter` (see [CQL2 and filtering](../../reference/cql2-and-filtering.md)):
+   </details>
+
+2. Filter spatially with a bounding box (lon,lat order: `minLon,minLat,maxLon,maxLat`):
+
+   ```bash
+   honua query my_service/0 --bbox -122.5,37.7,-122.3,37.8 --format geojson
+   ```
+
+   CQL2 and FeatureServer also take real geometries, and OData supports `geo.distance` and `geo.intersects` in `$filter` (see [CQL2 and filtering](../../reference/cql2-and-filtering.md)):
+
+   <details><summary>Spatial filters over raw HTTP (curl)</summary>
 
    ```bash
    # OGC: bbox (minLon,minLat,maxLon,maxLat) or CQL2 S_INTERSECTS
@@ -42,7 +70,15 @@ The three surfaces answer the same questions with different syntax: OGC items ta
    curl -s "$BASE/rest/services/$SVC/FeatureServer/0/query?geometry=-122.5,37.7,-122.3,37.8&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&inSR=4326&f=geojson"
    ```
 
-3. Page through large results:
+   </details>
+
+3. Page through large results with `--limit` (the response notes when more rows are available):
+
+   ```bash
+   honua query my_service/0 --limit 100
+   ```
+
+   <details><summary>Paging over raw HTTP (curl)</summary>
 
    ```bash
    curl -s "$BASE/ogc/features/collections/$COLL/items?limit=100&offset=200"
@@ -52,7 +88,15 @@ The three surfaces answer the same questions with different syntax: OGC items ta
 
    OGC responses include `next` links — follow those instead of computing offsets yourself when possible.
 
-4. Sort and select only the properties you need:
+   </details>
+
+4. Select only the properties you need with repeated `--fields`:
+
+   ```bash
+   honua query my_service/0 --fields name --fields population
+   ```
+
+   <details><summary>Sort + project over raw HTTP (curl)</summary>
 
    ```bash
    curl -s "$BASE/ogc/features/collections/$COLL/items?sortby=-population&properties=name,population"
@@ -62,17 +106,27 @@ The three surfaces answer the same questions with different syntax: OGC items ta
 
    `sortby` takes comma-separated fields with an optional `-` prefix for descending; `orderByFields` takes `field ASC|DESC`.
 
+   </details>
+
 5. Count without fetching when you only need a number:
+
+   ```bash
+   honua query my_service/0 --where "population > 10000" --count
+   ```
+
+   <details><summary>Count over raw HTTP (curl)</summary>
 
    ```bash
    curl -s "$BASE/rest/services/$SVC/FeatureServer/0/query?where=population%20%3E%2010000&returnCountOnly=true&f=json"
    curl -s "$BASE/odata/Layers($LAYER)/Features/\$count?\$filter=population%20gt%2010000"
    ```
 
+   </details>
+
 ## Verify
 
 ```bash
-curl -s "$BASE/ogc/features/collections/$COLL/items?limit=1"
+honua query my_service/0 --limit 1 --format geojson
 ```
 
 Expected (trimmed): a GeoJSON FeatureCollection with `numberMatched` and paging links.


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1740

## Summary
Rewrites the read/query examples in Honua's two primary query-oriented quickstarts to use the new `honua` CLI (from `@honua/sdk-js`, see honua-io/honua-sdk-js#292) instead of `curl`, so new users get the intended first-run experience. The raw curl/HTTP shapes are retained in collapsible `<details>` fallback blocks. Admin import/publish curls (not yet wrapped by the CLI) are unchanged. Docs-only change — no code, contract, or runtime behavior is touched.

## Changes Made
- `docs/get-started/first-dataset.md`: steps 5-6 (query via OGC/FeatureServer) and Verify now lead with `honua layers` / `honua query --count`; curl kept in a fallback block. Prerequisites note the CLI.
- `docs/guides/query-analyze/query-features.md`: attribute, spatial, paging, projection, and count examples now lead with `honua query`; curl/OData/OGC shapes kept in fallback blocks.
- Remaining curl-based docs (quickstart admin flow, export-data, protocol references) left as a follow-on, per the issue's non-goals.

## Testing
- [x] Manual testing performed

(Docs-only; the CLI commands shown were run against the live demo `https://demo.honua.io` while authoring honua-io/honua-sdk-js#292.)

## Gate Impact
- [x] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
