### PR TITLE
fix: unblock merge queue — WFS GetFeature 500 + latent AOT trim violations

### DIFF
--- a/src/Honua.Core/Features/Infrastructure/Resilience/StartupDatabaseResilience.cs
+++ b/src/Honua.Core/Features/Infrastructure/Resilience/StartupDatabaseResilience.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace Honua.Core.Features.Infrastructure.Resilience;
@@ -146,12 +147,16 @@ public static class StartupDatabaseResilience
         return false;
     }
 
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2075:'this' argument does not satisfy 'DynamicallyAccessedMemberTypes' in call to 'System.Type.GetProperty(String)'",
+        Justification = "Best-effort cold-startup read of PostgresException.SqlState by name, used only to classify transient DB errors for degraded start without a compile-time Npgsql dependency in Core. If the property is trimmed away the lookup returns null and the failure is treated as non-transient — the safe default — so the access is correctness-neutral under trimming/AOT.")]
     private static string? TryReadSqlState(Exception exception)
     {
         // PostgresException exposes a public string SqlState property. Reading it via the runtime
         // property avoids a compile-time dependency on Npgsql from Core. Reflection here runs only
-        // on the cold startup path (never in request hot paths) and is guarded against trimming by
-        // the fact that the failing type is already materialized in the exception instance.
+        // on the cold startup path (never in request hot paths); a trimmed-away property simply
+        // yields null, which is treated as a non-transient error (the safe default).
         var property = exception.GetType().GetProperty("SqlState");
         return property?.GetValue(exception) as string;
     }

--- a/src/Honua.Plugins/ServiceCollectionExtensions.cs
+++ b/src/Honua.Plugins/ServiceCollectionExtensions.cs
@@ -78,8 +78,12 @@ public static class ServiceCollectionExtensions
     /// <param name="configuration">Application configuration.</param>
     /// <param name="pluginId">The plugin id whose section to bind.</param>
     /// <returns>The same service collection for chaining.</returns>
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026:RequiresUnreferencedCode",
+        Justification = "ValidateDataAnnotations reflects over the options type, whose public and non-public properties are preserved by the DynamicallyAccessedMembers annotation on TOptions.")]
     public static IServiceCollection AddPluginOptions<[DynamicallyAccessedMembers(
-        DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(
+        DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(
         this IServiceCollection services,
         IConfiguration configuration,
         string pluginId)
@@ -109,8 +113,14 @@ public static class ServiceCollectionExtensions
     // source generator's syntactic match, which cannot emit a typed binder for the open generic
     // TOptions (SYSLIB1104). The concrete services.Configure<PluginOptions>(...) bind elsewhere in
     // this file still benefits from the generator.
-    private static readonly System.Reflection.MethodInfo BindMethod =
-        typeof(ConfigurationBinder).GetMethod(
+    private static readonly System.Reflection.MethodInfo BindMethod = ResolveBindMethod();
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026:RequiresUnreferencedCode",
+        Justification = "Resolves the ConfigurationBinder.Bind(IConfiguration, object) overload by reflection so the bind stays out of the configuration-binding source generator's match; the bound options type's members are preserved by the DynamicallyAccessedMembers annotation on AddPluginOptions' TOptions parameter.")]
+    private static System.Reflection.MethodInfo ResolveBindMethod()
+        => typeof(ConfigurationBinder).GetMethod(
             nameof(ConfigurationBinder.Bind),
             [typeof(IConfiguration), typeof(object)])
         ?? throw new InvalidOperationException("ConfigurationBinder.Bind(IConfiguration, object) overload was not found.");

--- a/src/Honua.Postgres.Shared/Features/Infrastructure/Caching/PreparedStatementCache.cs
+++ b/src/Honua.Postgres.Shared/Features/Infrastructure/Caching/PreparedStatementCache.cs
@@ -631,7 +631,11 @@ internal sealed class PreparedStatementCache : IPreparedStatementCacheStatistics
         {
             // Configure parameters exactly once; reuse the result for both value-application
             // and distribution tracking so configureParameters is never called twice per request.
-            using var configured = new NpgsqlCommand();
+            // The scratch command must carry the statement text: some parameter-binding callbacks
+            // gate on CommandText (e.g. only binding OFFSET when the SQL actually emitted an OFFSET
+            // clause). Without it those callbacks silently skip parameters, leaving cloned slots
+            // unset (null) and triggering an Npgsql "Parameter cannot be null" failure at execution.
+            using var configured = new NpgsqlCommand { CommandText = cloned.CommandText };
             configureParameters(configured);
 
             ApplyParameterValues(cloned, configured);

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.EncodedFormats.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.EncodedFormats.cs
@@ -197,17 +197,13 @@ internal sealed partial class FeatureQueryBuilder
             AppendSpatialFilter(sql, query, geometryStorageType, ref paramIndex, parameters);
             AppendOrderByClause(sql, query, ref paramIndex, parameters);
 
-            if (query.Limit.HasValue)
-            {
-                sql.Append(CultureInfo.InvariantCulture, $" LIMIT ${paramIndex++}");
-                parameters.Add(query.Limit.Value);
-            }
-
-            if (query.Offset.HasValue)
-            {
-                sql.Append(CultureInfo.InvariantCulture, $" OFFSET ${paramIndex++}");
-                parameters.Add(query.Offset.Value);
-            }
+            // Emit LIMIT/OFFSET placeholders only; the pagination values are bound by
+            // AddQueryParameters (AddRegularPaginationParameters / AddOffsetParameterIfEmitted),
+            // matching the convention every other builder uses via AppendPagination. Adding them
+            // to `parameters` here as well double-binds pagination, producing more bound parameters
+            // than SQL placeholders and an Npgsql "Parameter '' cannot be null" 500 on WFS
+            // GetFeature (which sets both count -> Limit and startIndex -> Offset).
+            AppendPagination(sql, isKnnQuery: false, query, spatialFilter: null, ref paramIndex);
 
             return new CoreParameterizedQuery(sql.ToString(), parameters);
         }

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderSelectProjectionTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderSelectProjectionTests.cs
@@ -59,7 +59,13 @@ public sealed class FeatureQueryBuilderSelectProjectionTests
 
         result.Sql.Should().Contain("jsonb_build_object('category', attributes -> $2)::text AS attributes");
         result.Sql.Should().Contain("COUNT(*) OVER()");
-        result.WhereParameters.Should().Equal("category", 10);
+        result.Sql.Should().Contain("LIMIT $");
+        // The optimized builder emits the LIMIT placeholder but does not append the pagination
+        // value to WhereParameters — pagination is bound by AddQueryParameters, matching the
+        // non-optimized BuildSelectQuery convention. Appending it here previously double-bound
+        // pagination at execution (honua-server#1749). Only the OutFields projection parameter
+        // ("category") belongs in WhereParameters.
+        result.WhereParameters.Should().Equal("category");
     }
 
     [Fact]

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Infrastructure/Caching/PreparedStatementCacheTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Infrastructure/Caching/PreparedStatementCacheTests.cs
@@ -145,6 +145,43 @@ public class PreparedStatementCacheTests : IDisposable
     }
 
     [Fact]
+    public async Task GetOrCreatePreparedCommandAsync_ConfigureParametersGatedOnCommandText_BindsThroughCache()
+    {
+        // Regression (honua-server#1749): the cache gathers parameter values on a scratch
+        // command before applying them onto the cloned execution command. Parameter-binding
+        // callbacks that gate on CommandText (e.g. WFS GetFeature only binds OFFSET when the
+        // emitted SQL actually contains an OFFSET clause) silently skipped their parameter when
+        // that scratch command had no CommandText, leaving the cloned parameter null and
+        // failing execution with "Parameter '' cannot be null, DBNull.Value should be used".
+        await using var connection = await _dataSource.OpenConnectionAsync();
+        const string sql = "SELECT $1::integer AS gated_value";
+
+        Action<NpgsqlCommand> configureParams = cmd =>
+        {
+            // Mirror AddOffsetParameterIfEmitted: only bind when the command carries the SQL.
+            if (cmd.CommandText.Contains("gated_value", StringComparison.Ordinal))
+            {
+                cmd.Parameters.AddWithValue(7);
+            }
+        };
+
+        // First call primes the cache (MinExecutionsForCaching=2); the second returns the
+        // cloned, parameter-applied execution command that previously dropped the value.
+        await _cache.GetOrCreatePreparedCommandAsync((NpgsqlConnection)connection, sql, configureParams);
+        await using var preparedCommand = await _cache.GetOrCreatePreparedCommandAsync(
+            (NpgsqlConnection)connection,
+            sql,
+            configureParams);
+
+        preparedCommand.Should().NotBeNull();
+        preparedCommand!.Parameters.Should().ContainSingle("the CommandText-gated parameter must survive the cache clone/apply path");
+        preparedCommand.Parameters[0].Value.Should().Be(7);
+
+        var result = await preparedCommand.ExecuteScalarAsync();
+        result.Should().Be(7);
+    }
+
+    [Fact]
     public async Task PreparePriorityStatementAsync_ValidStatement_CreatesPreparedStatement()
     {
         // Arrange


### PR DESCRIPTION
## Issue Link
Fixes #1749

## Summary

Unblocks the merge queue, whose `merge_group` run executes checks that are **conditionally skipped on normal PR CI** (`js-integration-tests`, `aot-build`) — so latent trunk breaks in them blocked every PR routed through the queue. This PR fixes the two that were failing:

### 1. WFS 2.0 GetFeature → HTTP 500 (caught by `js-integration-tests`)
`"Parameter '' cannot be null, DBNull.Value should be used instead"` on paginated Postgres queries. Two compounding defects:
- **Pagination double-bind** — `BuildOptimizedSelectWithWindowCountQuery` appended `LIMIT`/`OFFSET` values to `WhereParameters` *and* emitted the placeholders, while `AddQueryParameters` also binds pagination. Now uses `AppendPagination` (placeholder-only) like every other builder.
- **Prepared-statement cache lost `CommandText`** — `CreatePreparedExecutionCommandAsync` gathered parameter values on a scratch `new NpgsqlCommand()` with empty `CommandText`, so `AddOffsetParameterIfEmitted`'s `CommandText.Contains("OFFSET")` guard skipped the OFFSET value, leaving a cloned parameter null. The scratch command now carries the statement text.

### 2. Latent AOT trim violations (caught by `aot-build`)
- `StartupDatabaseResilience.TryReadSqlState` — IL2075 reflective `SqlState` read; justified `UnconditionalSuppressMessage` (null on trim → safe non-transient default).
- `Honua.Plugins.AddPluginOptions` — IL2026/IL2091 from `ValidateDataAnnotations` + reflective `ConfigurationBinder.Bind`; added `NonPublicProperties` to the `TOptions` annotation and justified suppressions.

## Changes Made
- `FeatureQueryBuilder.EncodedFormats.cs`: pagination via `AppendPagination` (no double-bind).
- `PreparedStatementCache.cs`: scratch command carries `CommandText`.
- `StartupDatabaseResilience.cs`, `Honua.Plugins/ServiceCollectionExtensions.cs`: AOT trim annotations/suppressions.
- Tests: cache regression test (CommandText-gated binding through the cache) + updated optimized-builder projection assertion.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

Verified locally against PostGIS seeded with `tests/seed/base-schema.sql` (the CI fixture): WFS GetFeature (incl. `startIndex`) → 200 with features; `tests/js/openlayers/wfs/` → 7/7 pass; GeoJSON/GeoServices regressions → 200. **AOT publish completes (native codegen) cleanly.** 21 affected `Honua.Postgres.Tests` pass; warnings-as-errors Release build clean.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None.

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed