### PR TITLE
feat(metadata-release): close the Demo B safe-rollback loop (fault injection + sequence)

### DIFF
--- a/docs/internal/demo/demo-b-safe-rollback.md
+++ b/docs/internal/demo/demo-b-safe-rollback.md
@@ -1,0 +1,249 @@
+# Demo B — Flagship beat: AI-DevOps safe layer evolution with DB-inclusive rollback
+
+> This is the runnable sequence behind **Demo B Beat 8** (the flagship "safe layer
+> evolution with reversible rollback" beat that the ops-champion runbook
+> `demo-b-ops-runbook.md` lists as the closing moment). It documents the exact
+> endpoints/commands the L3 E2E harness calls. The harness owns the *assertions*;
+> this document + `scripts/demo-b-safe-rollback.sh` own the *capability and the
+> sequence*.
+>
+> **The beat:** a metadata/layer change is deployed → a post-publish health check
+> fails (deterministically injected) → everything rolls back safely (metadata
+> revision reactivated AND the operational schema reverted via the down-script) →
+> the DevOps AI detects the failed health check, diagnoses it, and proposes a
+> human-approved resolve.
+
+## What is real (shipped on the feature branches)
+
+| Piece | Where | Status |
+|---|---|---|
+| Additive metadata-release lifecycle (Preflight → Backup → ScriptMigration → ETL → MetadataApply → Smoke → Complete) | honua-server `Features/ControlPlane/MetadataReleaseReconciler.cs` (#1738/#1739) | Real (draft PR) |
+| Health gate = post-publish **Smoke** check via the canonical query pipeline | `MetadataReleaseStageActions.cs` (`MetadataReleaseSmokeChecker`) | Real |
+| Smoke failure → **rollback**: reactivate prior Metadata v2 revision **+ run the reversible down-script (drop-added-column)** | `MetadataReleaseReconciler.ExecuteRollbackAsync` + `MetadataReleaseScriptExecutor.ApplyInverseAsync` | Real (metadata + DB-inclusive) |
+| Deterministic **fault injection** for the Smoke gate (demo only, fenced to non-prod) | `MetadataReleaseFaultInjectionOptions` + `MetadataReleaseSmokeChecker` | Real (this PR) |
+| Durable op storage (required) | Redis-backed `RedisWorkflowOperationStore` | Real |
+| AI **detect** seam: read the rolled-back operation + smoke evidence | honua-devops `inspect_metadata_release` tool + `DeployOperationReader` metadata-release readers | Real (this PR, honua-devops) |
+| AI **diagnose + propose resolve** (human-approved) | honua-devops `GuidedFixPlanner` / `triage_support_ticket` / `auto_remediation_plan` | Real (plan-mode, pr-first) |
+
+**Snapshot-required (data-affecting, non-reversible) rollback is deferred** — the
+server refuses it at Preflight with a clear message and parks the op at
+`ManualInterventionRequired`. Demo B uses the **additive/reversible** path only.
+
+## Durable op storage decision (Redis vs Postgres) — and cost
+
+The metadata-release lifecycle persists every workflow operation through
+`IWorkflowOperationStore`. The **only** implementation is
+`RedisWorkflowOperationStore`; there is no Postgres-backed op store today. So the
+rollback beat needs Redis.
+
+Cheapest viable path, in order:
+
+1. **Local Docker Redis ($0)** — for recording the demo or running the L3 harness
+   against a local server, `docker compose up -d` already starts Redis. The
+   lifecycle, smoke gate, rollback, and down-script all run with zero cloud spend.
+   The unit/integration tests in this PR prove the closed loop here. **Prefer this
+   for recording.**
+2. **Ephemeral ElastiCache, record-and-teardown** — only if the beat must run
+   against the deployed AWS env. Stand up a single `cache.t3.micro` node, point the
+   server at it, run the sequence, then **destroy it**. Discipline: it is created
+   for the take and torn down immediately after. See "Ephemeral Redis" below.
+
+A Postgres-backed op store would avoid the extra Redis cost, but building it is a
+separate, larger change (owned by the durable-stores work, honua-server#1593) and
+is **not** required for the demo: option 1 is already $0. Recommendation: **record
+Beat 8 against the local Docker stack (option 1)**; reserve option 2 for a live
+AWS take and tear it down the same hour.
+
+### Ephemeral Redis (only for a live-AWS take; record-and-teardown)
+
+Use the AWS CLI directly (do NOT edit the iac `aws-serverless` module — Track 1
+owns it; this avoids colliding with the in-flight iac PRs):
+
+```bash
+# Create — single node, no replicas, smallest type. ~$0.017/hr on-demand
+# (cache.t3.micro, us-west-2). A 1-hour take is ~$0.02. TEAR IT DOWN after.
+aws elasticache create-cache-cluster \
+  --cache-cluster-id honua-demo-b-ephemeral \
+  --engine redis --cache-node-type cache.t3.micro --num-cache-nodes 1 \
+  --security-group-ids <sg-with-server-ingress> \
+  --cache-subnet-group-name <demo-subnet-group>
+
+# ... point the server at it (Cache:Redis:ConnectionString / Aspire Redis CS),
+#     run the sequence below, capture the recording ...
+
+# TEARDOWN (do this the same hour — the founder is watching the bill):
+aws elasticache delete-cache-cluster --cache-cluster-id honua-demo-b-ephemeral
+```
+
+Cost guardrail: a forgotten `cache.t3.micro` is ~**$12/mo**. The ephemeral node
+exists only for the take. The default demo footprint stays ~$25/mo (per devops#97)
+because we do **not** leave Redis running.
+
+## Deploy target: never run fault injection on `live`
+
+Fault injection is hard-fenced two ways:
+
+1. `MetadataReleaseFaultInjectionOptions.Enabled` + `ForceSmokeFailure` are both
+   **off by default**; nothing injects unless explicitly configured.
+2. Even when enabled, injection only fires for a target environment on
+   `AllowedEnvironments` (default `staging`, `dev`, `demo-staging`, `demo-dev`).
+   `production` / `live` are never on the list, so a misconfiguration cannot fail a
+   real release.
+
+On AWS, Demo B runs against the **`staging`** Lambda alias
+(`honua-demo-demo-honua:staging`), created additively for exactly this purpose —
+never the customer-facing `live` alias.
+
+## Configuration to arm the beat (demo only)
+
+```jsonc
+// appsettings / env (server side). Off by default; set ONLY for the demo run.
+{
+  "ControlPlane": {
+    "MetadataRelease": {
+      "FaultInjection": {
+        "Enabled": true,
+        "ForceSmokeFailure": true,
+        "AllowedEnvironments": [ "staging" ],
+        "Reason": "Injected smoke failure (Demo B safe-rollback fault injection)."
+      }
+    }
+  }
+}
+```
+
+Env-var form:
+
+```bash
+export ControlPlane__MetadataRelease__FaultInjection__Enabled=true
+export ControlPlane__MetadataRelease__FaultInjection__ForceSmokeFailure=true
+export ControlPlane__MetadataRelease__FaultInjection__AllowedEnvironments__0=staging
+```
+
+## The sequence (endpoints the harness calls)
+
+All admin endpoints are gated by `X-API-Key: $HONUA_DEMO_API_KEY`.
+
+### 1. Submit the layer change (add a field + optional ETL populate)
+
+`POST /api/v1/admin/metadata/releases/operations`
+
+```bash
+curl -s -X POST "$BASE/api/v1/admin/metadata/releases/operations" \
+  -H "X-API-Key: $HONUA_DEMO_API_KEY" -H 'Content-Type: application/json' \
+  -d '{
+        "packageId": "demo-b-add-owner-email",
+        "targetEnvironment": "staging",
+        "resourceSemanticId": "maui-parcels",
+        "newFieldName": "owner_email",
+        "newFieldType": "String",
+        "dataPopulateWorkloadId": "populate-owner-email",
+        "reason": "Demo B: additive layer evolution",
+        "idempotencyKey": "demo-b-add-owner-email"
+      }' | jq .
+```
+
+Returns a `201` with a `DeployOperationResponse` (`operationId`, `status:
+Submitted`, `metadataRelease.currentStage: Preflight`). The background reconciler
+then walks the additive stages.
+
+### 2. Watch the lifecycle health-gate and roll back
+
+`GET /api/v1/admin/metadata/releases/{packageId}/operation` (reconciles on read)
+
+```bash
+curl -s "$BASE/api/v1/admin/metadata/releases/demo-b-add-owner-email/operation" \
+  -H "X-API-Key: $HONUA_DEMO_API_KEY" | jq '{status, currentPhase, stage: .metadataRelease.currentStage, rollback: .metadataRelease.rollbackPlan, evidence: .metadataRelease.evidenceRefs}'
+```
+
+Poll until terminal. With fault injection armed the Smoke gate fails and the
+operation lands at:
+
+- `status: RolledBack`
+- `currentPhase: "Reversible rollback complete (ScriptRollback): reactivated prior revision and executed the inverse script."`
+- `metadataRelease.evidenceRefs[]` contains a `kind: "smoke"` ref (the health-gate proof)
+- the added field `owner_email` is **gone** from the activated schema (down-script ran)
+
+This is the **metadata + DB-inclusive rollback**: the prior Metadata v2 revision is
+reactivated *and* the reversible down-script drops the added column.
+
+### 3. AI detects → diagnoses → proposes resolve (human-approved)
+
+The DevOps agent (honua-devops, plan mode + pr-first by default) reads the
+rolled-back operation and proposes a resolve:
+
+```bash
+cd honua-devops
+export HONUA_DEVOPS_HONUA_API_BASE_URL="$BASE"
+export HONUA_DEVOPS_HONUA_API_KEY="$HONUA_DEMO_API_KEY"
+
+# Detect + diagnose the safe-rollback outcome (read-only):
+dotnet run --project src/Honua.DevOps.Agent -- \
+  --prompt "inspect the metadata release for package demo-b-add-owner-email and tell me what happened and how to resolve it"
+```
+
+The agent calls the `inspect_metadata_release` tool, which surfaces: the health
+gate ran (smoke evidence present), the deploy was rolled back (metadata + DB
+down-script), the rollback class, and the failing phase. It then proposes a
+human-approved resolve (fix the layer change / ETL and re-submit through the
+governed create path). It never auto-mutates: re-submission is human-approved.
+
+Programmatic detect (what the harness asserts on) — the same JSON the tool reads:
+
+```bash
+curl -s "$BASE/api/v1/admin/metadata/releases/demo-b-add-owner-email/operation" \
+  -H "X-API-Key: $HONUA_DEMO_API_KEY" \
+  | jq '{detected: (.status=="RolledBack"),
+         health_gate_ran: ([.metadataRelease.evidenceRefs[].kind] | index("smoke") != null),
+         db_inclusive_revert: (.currentPhase | test("Reversible rollback complete")),
+         rollback_class: .metadataRelease.rollbackPlan.class}'
+```
+
+### 4. Disarm fault injection (clean up after the take)
+
+```bash
+unset ControlPlane__MetadataRelease__FaultInjection__Enabled
+unset ControlPlane__MetadataRelease__FaultInjection__ForceSmokeFailure
+# (and tear down the ephemeral Redis if you stood one up — see above)
+```
+
+A re-run with injection **disarmed** completes the same release `Succeeded`
+(smoke passes, `owner_email` stays live) — proving the additive path works and the
+rollback was purely the injected fault, not a real defect.
+
+## Endpoints summary (what the L3 harness calls)
+
+| Method | Route | Purpose |
+|---|---|---|
+| POST | `/api/v1/admin/metadata/releases/operations` | Submit the additive layer change (+ ETL) |
+| GET | `/api/v1/admin/metadata/releases/{packageId}/operation` | Detect lifecycle/health-gate/rollback state (reconciles on read) |
+| GET | `/api/v1/admin/deploy/operations/{operationId}` | Inspect the same operation by id |
+| POST | `/api/v1/admin/deploy/operations/{operationId}/rollback` | (Optional) operator-initiated rollback of the same op |
+
+DevOps AI tool: `inspect_metadata_release` (honua-devops) — read-only detect +
+diagnose + propose human-approved resolve.
+
+## Where the closed loop is proven without the deployed env
+
+- `tests/dotnet/Honua.Core.Tests/.../MetadataReleaseFaultInjectionOptionsTests.cs`
+  — the fault-injection fence (off by default; never fires on prod/live).
+- `tests/dotnet/Honua.Server.Tests/.../MetadataReleaseReconcilerTests.cs`
+  — `ReconcileAsync_InjectedSmokeFailure_DrivesReversibleRollbackClosedLoop`: an
+  injected smoke failure drives the reversible rollback (prior revision reactivated
+  + down-script run), plus the existing forward/rollback/snapshot-refusal coverage.
+- honua-devops `MetadataReleaseDetectReaderTests` — the AI detect seam reads
+  RolledBack/Succeeded/ManualInterventionRequired + smoke evidence from the
+  operation JSON.
+
+Run them:
+
+```bash
+# honua-server
+dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj \
+  --filter FullyQualifiedName~MetadataReleaseFaultInjectionOptions
+dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj \
+  --filter FullyQualifiedName~MetadataReleaseReconcilerTests
+# honua-devops
+dotnet test tests/Honua.DevOps.Agent.Tests/Honua.DevOps.Agent.Tests.csproj \
+  --filter FullyQualifiedName~MetadataReleaseDetectReader
+```

--- a/docs/internal/demo/scripts/demo-b-safe-rollback.sh
+++ b/docs/internal/demo/scripts/demo-b-safe-rollback.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Demo B — flagship safe-rollback sequence (Beat 8).
+#
+# Drives the AI-DevOps safe layer-evolution loop end to end against a running
+# Honua server: submit an additive layer change → the post-publish Smoke health
+# gate fails (deterministically injected) → the deploy rolls back safely (metadata
+# revision reactivated + reversible down-script reverts the schema) → the script
+# emits the same JSON the DevOps AI `inspect_metadata_release` tool reads so the
+# agent can detect, diagnose, and propose a human-approved resolve.
+#
+# The L3 E2E harness owns the pass/fail ASSERTIONS; this script owns the SEQUENCE
+# and prints a machine-readable detect summary the harness can assert on.
+#
+# Prerequisites:
+#   * A Honua server reachable at $BASE with Redis-backed durable op storage.
+#   * Fault injection ARMED for the target environment (demo only):
+#       ControlPlane__MetadataRelease__FaultInjection__Enabled=true
+#       ControlPlane__MetadataRelease__FaultInjection__ForceSmokeFailure=true
+#       ControlPlane__MetadataRelease__FaultInjection__AllowedEnvironments__0=staging
+#   * $HONUA_DEMO_API_KEY exported (admin X-API-Key). Never echoed by this script.
+#
+# Env (all optional, with safe demo defaults):
+#   BASE                 default http://localhost:8080
+#   TARGET_ENVIRONMENT   default staging   (MUST be on the fault-injection allow-list)
+#   PACKAGE_ID           default demo-b-add-owner-email
+#   RESOURCE_ID          default maui-parcels
+#   NEW_FIELD            default owner_email
+#   NEW_FIELD_TYPE       default String
+#   ETL_WORKLOAD         default populate-owner-email   (empty to skip ETL populate)
+#   POLL_ATTEMPTS        default 40
+#   POLL_INTERVAL_SECS   default 3
+#
+# Exit codes: 0 = safe rollback detected (metadata + DB), 2 = unexpected terminal
+# state, 3 = never reached terminal, 4 = submit failed, 5 = missing prerequisites.
+
+set -euo pipefail
+
+BASE="${BASE:-http://localhost:8080}"
+TARGET_ENVIRONMENT="${TARGET_ENVIRONMENT:-staging}"
+PACKAGE_ID="${PACKAGE_ID:-demo-b-add-owner-email}"
+RESOURCE_ID="${RESOURCE_ID:-maui-parcels}"
+NEW_FIELD="${NEW_FIELD:-owner_email}"
+NEW_FIELD_TYPE="${NEW_FIELD_TYPE:-String}"
+ETL_WORKLOAD="${ETL_WORKLOAD:-populate-owner-email}"
+POLL_ATTEMPTS="${POLL_ATTEMPTS:-40}"
+POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-3}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FATAL: jq is required." >&2
+  exit 5
+fi
+if [[ -z "${HONUA_DEMO_API_KEY:-}" ]]; then
+  echo "FATAL: export HONUA_DEMO_API_KEY (admin X-API-Key) first." >&2
+  exit 5
+fi
+
+AUTH=(-H "X-API-Key: ${HONUA_DEMO_API_KEY}")
+OP_URL="${BASE}/api/v1/admin/metadata/releases"
+
+echo "== Demo B safe-rollback sequence =="
+echo "base=${BASE} target=${TARGET_ENVIRONMENT} package=${PACKAGE_ID} resource=${RESOURCE_ID} field=${NEW_FIELD}"
+
+# ---- 1. Submit the additive layer change (+ optional ETL) --------------------
+populate_field=""
+if [[ -n "${ETL_WORKLOAD}" ]]; then
+  populate_field=", \"dataPopulateWorkloadId\": \"${ETL_WORKLOAD}\""
+fi
+
+submit_body=$(cat <<JSON
+{
+  "packageId": "${PACKAGE_ID}",
+  "targetEnvironment": "${TARGET_ENVIRONMENT}",
+  "resourceSemanticId": "${RESOURCE_ID}",
+  "newFieldName": "${NEW_FIELD}",
+  "newFieldType": "${NEW_FIELD_TYPE}"${populate_field},
+  "reason": "Demo B: additive layer evolution with reversible rollback",
+  "idempotencyKey": "${PACKAGE_ID}"
+}
+JSON
+)
+
+echo "-- submit POST ${OP_URL}/operations"
+submit_resp=$(curl -s -w '\n%{http_code}' -X POST "${OP_URL}/operations" \
+  "${AUTH[@]}" -H 'Content-Type: application/json' -d "${submit_body}")
+submit_code=$(tail -n1 <<<"${submit_resp}")
+submit_json=$(sed '$d' <<<"${submit_resp}")
+
+if [[ "${submit_code}" != "201" && "${submit_code}" != "200" ]]; then
+  echo "FATAL: submit failed (HTTP ${submit_code}): ${submit_json}" >&2
+  exit 4
+fi
+
+operation_id=$(jq -r '.operationId // empty' <<<"${submit_json}")
+echo "submitted operationId=${operation_id} status=$(jq -r '.status // "?"' <<<"${submit_json}")"
+
+# ---- 2. Poll the lifecycle until terminal (reconciles on read) ---------------
+terminal_json=""
+for ((attempt = 1; attempt <= POLL_ATTEMPTS; attempt++)); do
+  op_json=$(curl -s "${OP_URL}/${PACKAGE_ID}/operation" "${AUTH[@]}")
+  status=$(jq -r '.status // "unknown"' <<<"${op_json}")
+  stage=$(jq -r '.metadataRelease.currentStage // "unknown"' <<<"${op_json}")
+  echo "  poll ${attempt}/${POLL_ATTEMPTS}: status=${status} stage=${stage}"
+  case "${status}" in
+    Succeeded|Failed|RolledBack|ManualInterventionRequired)
+      terminal_json="${op_json}"; break ;;
+  esac
+  sleep "${POLL_INTERVAL_SECS}"
+done
+
+if [[ -z "${terminal_json}" ]]; then
+  echo "FATAL: operation never reached a terminal state." >&2
+  exit 3
+fi
+
+# ---- 3. Emit the detect summary the AI / harness asserts on ------------------
+detect=$(jq '{
+  operationId: .operationId,
+  detected_rolled_back: (.status == "RolledBack"),
+  status: .status,
+  stage: .metadataRelease.currentStage,
+  health_gate_ran: ([.metadataRelease.evidenceRefs[]?.kind] | index("smoke") != null),
+  db_inclusive_revert: ((.currentPhase // "") | test("Reversible rollback complete")),
+  rollback_class: (.metadataRelease.rollbackPlan.class // "unclassified"),
+  current_phase: .currentPhase
+}' <<<"${terminal_json}")
+
+echo "== detect summary (same fields the inspect_metadata_release tool reads) =="
+echo "${detect}"
+
+final_status=$(jq -r '.status' <<<"${detect}")
+rolled_back=$(jq -r '.detected_rolled_back' <<<"${detect}")
+db_revert=$(jq -r '.db_inclusive_revert' <<<"${detect}")
+gate_ran=$(jq -r '.health_gate_ran' <<<"${detect}")
+
+if [[ "${rolled_back}" == "true" && "${db_revert}" == "true" && "${gate_ran}" == "true" ]]; then
+  echo "RESULT: SAFE ROLLBACK CONFIRMED — health gate fired, metadata + DB reverted."
+  echo "Next: run the DevOps agent to diagnose + propose a human-approved resolve:"
+  echo "  (honua-devops) dotnet run --project src/Honua.DevOps.Agent -- \\"
+  echo "    --prompt \"inspect the metadata release for package ${PACKAGE_ID} and propose a resolve\""
+  exit 0
+fi
+
+echo "RESULT: unexpected terminal state '${final_status}' (expected RolledBack with DB revert)." >&2
+echo "Hint: is fault injection ARMED for target '${TARGET_ENVIRONMENT}'? It is off by default." >&2
+exit 2

--- a/src/Honua.Core/Features/ControlPlane/Domain/MetadataReleaseOperationOptions.cs
+++ b/src/Honua.Core/Features/ControlPlane/Domain/MetadataReleaseOperationOptions.cs
@@ -17,4 +17,70 @@ public sealed class MetadataReleaseOperationOptions
     /// Retention for metadata release operation records and their package-ID index entries.
     /// </summary>
     public TimeSpan OperationRetention { get; set; } = TimeSpan.FromDays(30);
+
+    /// <summary>
+    /// Demo-only fault-injection controls that deterministically fail the post-publish Smoke health
+    /// gate so the reversible-rollback closed loop (metadata reactivation + down-script) can be
+    /// exercised and recorded without depending on a naturally broken layer. Safe by default: every
+    /// field is inert unless explicitly configured, and injection is refused outside
+    /// <see cref="FaultInjection"/>'s allowed-environment list so it can never fire against
+    /// production. See <c>docs/internal/demo/demo-b-safe-rollback.md</c>.
+    /// </summary>
+    public MetadataReleaseFaultInjectionOptions FaultInjection { get; set; } = new();
+}
+
+/// <summary>
+/// Demo-only fault-injection controls for the metadata-release Smoke health gate. Used to make
+/// Demo B's safe-rollback beat deterministic and repeatable. This is not a production capability;
+/// it is gated off by default and hard-fenced to non-production target environments.
+/// </summary>
+public sealed class MetadataReleaseFaultInjectionOptions
+{
+    /// <summary>
+    /// Master switch. When false (default) no fault is ever injected regardless of the other fields.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// When true and <see cref="Enabled"/> is true, the post-publish Smoke check reports failure for
+    /// releases whose target environment is in <see cref="AllowedEnvironments"/>. This drives the
+    /// reconciler down its existing reversible-rollback path (reactivate prior revision + run the
+    /// down-script) so the closed loop can be validated end-to-end.
+    /// </summary>
+    public bool ForceSmokeFailure { get; set; }
+
+    /// <summary>
+    /// Target environments in which fault injection is permitted. Injection is refused for any other
+    /// target environment, so a misconfiguration cannot fail a real release. Defaults to the
+    /// non-customer-facing demo deploy targets.
+    /// </summary>
+    public IReadOnlyList<string> AllowedEnvironments { get; set; } = new[] { "staging", "dev", "demo-staging", "demo-dev" };
+
+    /// <summary>
+    /// Operator-facing reason recorded on the injected smoke failure so the DevOps AI loop and the
+    /// audit trail can see this was a deliberately injected fault.
+    /// </summary>
+    public string Reason { get; set; } = "Injected smoke failure (Demo B safe-rollback fault injection).";
+
+    /// <summary>
+    /// Returns true when an injected smoke failure is permitted for the supplied target environment.
+    /// </summary>
+    /// <param name="targetEnvironment">The release's target environment.</param>
+    public bool ShouldFailSmoke(string? targetEnvironment)
+    {
+        if (!Enabled || !ForceSmokeFailure || string.IsNullOrWhiteSpace(targetEnvironment))
+        {
+            return false;
+        }
+
+        foreach (var allowed in AllowedEnvironments)
+        {
+            if (string.Equals(allowed, targetEnvironment, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Honua.Server/Features/ControlPlane/MetadataReleaseStageActions.cs
+++ b/src/Honua.Server/Features/ControlPlane/MetadataReleaseStageActions.cs
@@ -9,6 +9,7 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Honua.ControlPlane;
 
@@ -231,12 +232,30 @@ internal sealed class MetadataReleaseActivator(IServiceScopeFactory scopeFactory
 /// (<see cref="IFeatureReader.QueryAsync"/>) and asserts rows return and the activated revision's
 /// schema includes the new field. Records nothing itself — the reconciler captures the evidence ref.
 /// </summary>
-internal sealed class MetadataReleaseSmokeChecker(IServiceScopeFactory scopeFactory) : IMetadataReleaseSmokeChecker
+internal sealed class MetadataReleaseSmokeChecker(
+    IServiceScopeFactory scopeFactory,
+    IOptions<MetadataReleaseOperationOptions> options) : IMetadataReleaseSmokeChecker
 {
+    private readonly MetadataReleaseFaultInjectionOptions _faultInjection = options.Value.FaultInjection;
+
     public async Task<MetadataReleaseSmokeResult> RunAsync(
         MetadataReleaseExecutionPlan plan,
         CancellationToken cancellationToken = default)
     {
+        // Demo-only deterministic fault injection: when explicitly enabled for an allowed (non-prod)
+        // target environment, report smoke failure so the reversible-rollback closed loop runs. This
+        // is hard-fenced — ShouldFailSmoke returns false unless Enabled+ForceSmokeFailure and the
+        // target environment is on the allow-list — so it can never fail a real release.
+        if (_faultInjection.ShouldFailSmoke(plan.TargetEnvironment))
+        {
+            return new MetadataReleaseSmokeResult
+            {
+                Passed = false,
+                NewFieldPresent = true,
+                Message = _faultInjection.Reason
+            };
+        }
+
         await using var scope = scopeFactory.CreateAsyncScope();
         var provider = scope.ServiceProvider.GetRequiredService<IMetadataV2GraphProvider>();
         var reader = scope.ServiceProvider.GetRequiredService<IFeatureReader>();

--- a/tests/dotnet/Honua.Core.Tests/Features/ControlPlane/MetadataReleaseFaultInjectionOptionsTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/ControlPlane/MetadataReleaseFaultInjectionOptionsTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Core.Tests.Features.ControlPlane;
+
+/// <summary>
+/// Fence coverage for the Demo B smoke-gate fault injection. The injection must be inert by default
+/// and must never fire against an environment that is not on the explicit allow-list, so a
+/// misconfiguration can never fail a real (e.g. production / live) metadata release.
+/// </summary>
+public sealed class MetadataReleaseFaultInjectionOptionsTests
+{
+    [Fact]
+    public void ShouldFailSmoke_DefaultOptions_IsInert()
+    {
+        var options = new MetadataReleaseFaultInjectionOptions();
+
+        options.Enabled.Should().BeFalse();
+        options.ForceSmokeFailure.Should().BeFalse();
+        options.ShouldFailSmoke("staging").Should().BeFalse();
+        options.ShouldFailSmoke("production").Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldFailSmoke_EnabledButNotForced_DoesNotInject()
+    {
+        var options = new MetadataReleaseFaultInjectionOptions { Enabled = true, ForceSmokeFailure = false };
+
+        options.ShouldFailSmoke("staging").Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldFailSmoke_EnabledAndForced_InjectsForAllowedEnvironmentOnly()
+    {
+        var options = new MetadataReleaseFaultInjectionOptions
+        {
+            Enabled = true,
+            ForceSmokeFailure = true,
+            AllowedEnvironments = new[] { "staging", "dev" }
+        };
+
+        options.ShouldFailSmoke("staging").Should().BeTrue();
+        options.ShouldFailSmoke("STAGING").Should().BeTrue("the allow-list match is case-insensitive");
+        options.ShouldFailSmoke("dev").Should().BeTrue();
+
+        // Hard fence: any environment not on the allow-list is refused even with injection enabled.
+        options.ShouldFailSmoke("production").Should().BeFalse();
+        options.ShouldFailSmoke("live").Should().BeFalse();
+        options.ShouldFailSmoke(null).Should().BeFalse();
+        options.ShouldFailSmoke("  ").Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldFailSmoke_EmptyAllowList_NeverInjects()
+    {
+        var options = new MetadataReleaseFaultInjectionOptions
+        {
+            Enabled = true,
+            ForceSmokeFailure = true,
+            AllowedEnvironments = Array.Empty<string>()
+        };
+
+        options.ShouldFailSmoke("staging").Should().BeFalse();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/MetadataReleaseReconcilerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/MetadataReleaseReconcilerTests.cs
@@ -120,6 +120,42 @@ public sealed class MetadataReleaseReconcilerTests
     }
 
     [Fact]
+    public async Task ReconcileAsync_InjectedSmokeFailure_DrivesReversibleRollbackClosedLoop()
+    {
+        // Demo B closed loop: a deterministically injected smoke failure (what the
+        // MetadataReleaseSmokeChecker returns when fault injection is enabled for a non-prod target)
+        // must drive the same reversible-rollback path — reactivate the prior revision AND run the
+        // down-script — proving the metadata + DB-inclusive revert without a naturally broken layer.
+        var store = new InMemoryWorkflowOperationStore();
+        var operation = CreateOperation(WorkflowOperationStatus.Submitted, MetadataReleaseStage.Preflight);
+        await store.TryCreateAsync(operation);
+
+        var script = new RecordingScriptExecutor();
+        var activator = new RecordingActivator(currentRevision: 12);
+        var injectedSmoke = new FakeSmokeChecker(
+            passed: false,
+            message: "Injected smoke failure (Demo B safe-rollback fault injection).");
+        var reconciler = CreateReconciler(
+            store,
+            new FakePreflightGate(MetadataRollbackReadinessClassification.ScriptReversible, canProceed: true),
+            script,
+            new FakeDataJobDispatcher(dispatched: true),
+            activator,
+            injectedSmoke);
+
+        var final = await DriveToTerminalAsync2(reconciler, store, operation.OperationId);
+
+        // The deploy was health-gated, failed, and rolled back metadata + DB (down-script).
+        final.Status.Should().Be(WorkflowOperationStatus.RolledBack);
+        final.CurrentPhase.Should().Contain("Reversible rollback complete");
+        final.MetadataRelease!.EvidenceRefs.Should().ContainSingle(evidence => evidence.Kind == "smoke");
+        script.ForwardCalls.Should().Be(1);
+        script.InverseCalls.Should().Be(1, "the down-script (drop-added-column) reverts the schema");
+        activator.ReactivateCalls.Should().Be(1, "the prior metadata revision is reactivated");
+        activator.ReactivatedRevision.Should().Be(12);
+    }
+
+    [Fact]
     public async Task ReconcileAsync_WhenSnapshotRequired_RefusesAtPreflight()
     {
         var store = new InMemoryWorkflowOperationStore();


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1738

## Summary
Closes the Demo B flagship "safe layer evolution with reversible rollback" loop on top of the additive metadata-release lifecycle (#1738/#1739). The lifecycle already health-gates a layer change on a post-publish Smoke check and, on failure, rolls back metadata AND the operational schema (reactivate prior Metadata v2 revision + run the reversible down-script). This PR adds the missing piece needed to **validate** that beat repeatably: a deterministic, hard-fenced fault-injection seam for the Smoke gate, plus the documented runnable Demo B sequence the L3 E2E harness calls. It also records the Redis-vs-Postgres durability decision and the ephemeral-Redis cost/teardown discipline.

Stacked on `feat/metadata-release-additive-lifecycle` (#1739); retarget to `trunk` once that merges.

## Changes Made
- `MetadataReleaseFaultInjectionOptions` (Core): off by default; injection only fires for a target environment on an explicit allow-list (default `staging`/`dev`), so it can never fail a real/`live` release. `ShouldFailSmoke` is the single fence.
- `MetadataReleaseSmokeChecker` honors the option: when armed for an allowed environment it reports smoke failure, riding the **existing** reversible-rollback path (reactivate prior revision + down-script) — no new rollback machinery.
- Tests: fault-injection fence unit tests (Core.Tests, 4) and an injected-smoke-failure closed-loop reconciler test asserting metadata + DB-inclusive revert (Server.Tests).
- Docs: `docs/internal/demo/demo-b-safe-rollback.md` + runnable `docs/internal/demo/scripts/demo-b-safe-rollback.sh` documenting the endpoints/commands the harness calls, the durability decision, and ephemeral-Redis cost ($0 local Docker preferred; ephemeral `cache.t3.micro` record-and-teardown for a live take).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — fault injection is additive and off by default; the new option fields default to inert.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
