### PR TITLE
ci: decouple CI validation from PR-template check + minutes review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,14 @@ jobs:
 
   pr-readiness:
     name: PR Mergeability & Freshness
-    needs: pr-template-check
+    # Decoupled from pr-template-check (was: `needs: pr-template-check`).
+    # Chaining the build/test graph behind the PR-body template check meant a
+    # single template miss SKIPPED every downstream job and published a RED
+    # "CI Gate" with no actual validation run — the most common reason an
+    # otherwise-correct PR looked broken (see Pull Request Policy in CLAUDE.md;
+    # #1736/#1737 needed a manual re-trigger). pr-template-check is still a
+    # first-class job and still feeds CI Gate (so a template failure still
+    # fails the gate), but it no longer gates whether the code is validated.
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/internal/ci/merge-queue.md
+++ b/docs/internal/ci/merge-queue.md
@@ -183,3 +183,40 @@ Map these localizable orphans to owning shards (mirroring the `_comment`'s
 `Import/Features/Migration/` still escalated despite the Migration shard mapping.
 Keep truly-shared infra (`Program.cs`, `Startup/`, shared `FeatureStore` reader)
 escalating — those legitimately need broad runs.
+
+## 5. CI minutes review (2026-06, ~159k Actions-min/mo on honua-server)
+
+Attribution from the GitHub billing usage API + per-run job timing (sample
+window Jun 6–18, n=321 `CI` runs). Numbers are billable Linux-runner minutes.
+
+| Finding | Evidence | Lever |
+|---|---|---|
+| **CI is ~essentially all the cost.** | honua-server burned **158,706** "Actions Linux" min in June (next repo: honua-console at 1,286). macOS/Windows multipliers are negligible (188 + 93 min org-wide). | Everything below is the `CI` workflow. |
+| **A full `CI` run = ~449 billable min across ~50 jobs.** | Measured mean over 19 full runs (range 420–550). Dominated by `.NET Foundation Tests` (~22m) + `Postgres Compatibility` (~17–19m) + the 30-shard `Server Tests` matrix. | — |
+| **~48% of PRs still run the FULL matrix.** | 146 of 304 PR `CI` runs were ≥40 jobs (full `run_all`, 30 shards); the other ~50% ran the scoped ~mid lane (~75 min). Affected-scoping works (docs PRs hit ~0 min, verified on #1736) but most *source* PRs escalate. | Root cause: `unmapped_source_run_all_prefixes` + `infrastructure_paths` in `ci-shards.json` include the most-edited dirs (`src/Honua.Core/`, `src/Honua.Postgres/`, `src/Honua.Server/`, `Core/Models`, `Core/Queries`, `Postgres/Migrations`). Any source change those don't map to a shard's explicit `paths` → `run_all`. Tightening this is the single biggest minute lever; **needs sign-off** (under-testing risk). |
+| **Per-shard fixed build overhead.** | On small shards the `dotnet restore`+`Build server test binaries` step is ~3 min for ~0–4 min of actual testing (Performance 87% overhead, MCP 61%, STAC 40%). 30 shards each rebuild from source (`enable-build-cache` defaults to `false`). | Consolidate the ~8–10 sub-6-min shards into ~3–4; or enable the cross-job binary cache for shards. Wall-clock is set by `Core`/`FeatureServer Endpoints` (long pole), so consolidating tiny shards costs ~0 wall-clock. **Coordinate with in-flight shard work (#1724 follow-ups).** |
+| **Merge-queue lane duplicates full CI per queued PR (~428 min each).** | A `merge_group` event is non-`pull_request` → routes down the full lane unconditionally. The PR already ran (selective or full) on `pull_request`; the queue re-runs full. Currently low volume (6 `merge_group` vs 124 direct trunk pushes in-window), so this is latent, not yet dominant — but each queued PR pays full CI twice. | If queue volume grows, scope the `merge_group` lane to the union of its batched PRs' affected shards instead of `run_all`. |
+| **`ALLGREEN` grouping + 60-min check timeout amplifies queue stalls.** | Ruleset: `max_entries_to_build=5`, `grouping_strategy=ALLGREEN`, `check_response_timeout_minutes=60`. One failing PR in a batch invalidates the whole group → full CI re-runs on the smaller group. A hung shard can hold the group for up to 60 min. | Keep batching; consider lowering `check_response_timeout` once shard timeouts are tightened, and ensure no shard's `timeout_minutes` exceeds it. |
+| **Gate fragility: template-check failure skipped ALL validation and published a RED CI Gate.** | Verified on docs PR #1736: `pr-template-check` failed → `pr-readiness`/`changes`/every build+test job SKIPPED → `CI Gate` FAILED with 0 min of real validation. Documented in CLAUDE.md as the #1 agent-PR failure (#1736/#1737 needed manual re-trigger). | **Fixed in this PR** (§ below): decouple `pr-readiness`/build graph from `pr-template-check` so real validation runs; template-check stays a first-class job feeding CI Gate (a template failure still fails the gate, but now alongside real results). |
+
+### Already-good (no action)
+- Concurrency hygiene is solid: `CI`/`CodeQL`/`trunk-sanity` use
+  `cancel-in-progress: true` (59 of 304 PR runs were correctly cancelled on
+  re-push, saving minutes); deploy/release workflows correctly do *not* cancel.
+- `CodeQL` is path-filtered (`src/**`,`tests/**`,…) and PR-only — it does not
+  re-run in the merge queue and skips docs PRs.
+- `nightly-container-build`: `build-aot` and `build-lambda-aot` both
+  `needs: mirror-base-images` with **separate** GHA cache scopes
+  (`nightly-aot-*` vs `nightly-lambda-aot-*`) — no ordering/cache race; the
+  earlier "missing `needs: build-aot`" follow-up is stale on `trunk`.
+- Adding a `push: [trunk]` trigger to `ci.yml` would *increase* minutes;
+  `trunk-sanity` (5-min build) already covers post-merge push.
+
+### Top-3 by monthly-minute impact
+1. **Tighten `run_all` escalation** (`unmapped_source_run_all_prefixes` /
+   `infrastructure_paths`): if ~half the 146 full PR runs/window drop to the
+   scoped lane (449→~120 min), that is **~24k min/mo**. Needs sign-off.
+2. **Consolidate tiny shards** (~8 sub-6-min shards → ~3): saves ~5 shards ×
+   ~5 min × full-run count ≈ **~6–8k min/mo**, ~0 wall-clock cost.
+3. **Scope the `merge_group` lane** to batched-PR affected shards once queue
+   volume rises: avoids a full ~428-min re-run per queued PR.


### PR DESCRIPTION
## Summary

CI-minutes + reliability review of the GitHub Actions setup (honua-server burned
~159k Actions-minutes in June 2026). This PR ships the one **clearly-safe,
high-impact reliability win** — fixing the gate-fragility that makes
otherwise-correct PRs look broken — and records the full cost-attribution review
in the merge-queue runbook so the bigger (sign-off-gated) levers are actionable.

Related to #1724, #1735.

The build/test job graph chained behind `pr-template-check`, so a single PR-body
template miss SKIPPED every downstream job and published a RED `CI Gate` with
**zero** actual validation. Verified on docs PR #1736 (template-check failed →
everything skipped → CI Gate failed, 0 validation minutes). This is documented in
CLAUDE.md as the #1 agent-PR failure (#1736/#1737 needed manual re-trigger).

This decouples `pr-readiness` (and thus the `changes`/build/test graph) from
`pr-template-check`. The template check stays a first-class job and still feeds
`CI Gate`, so a template failure **still fails the gate** — but the code is now
actually validated alongside it instead of all-skipped.

## Changes Made

- Remove `needs: pr-template-check` from the `pr-readiness` job so the
  build/test graph runs regardless of PR-template-body status.
- Keep `pr-template-check` in `ci-gate`'s `needs` (policy preserved: a template
  failure still fails the gate).
- Append a "CI minutes review" appendix to `docs/internal/ci/merge-queue.md`:
  billing attribution, the `run_all`-escalation and tiny-shard levers, the
  `merge_group` full-lane duplication, the `ALLGREEN`/60-min queue-stall
  amplifier, and the gate-fragility evidence + top-3 minute-savings.

## Breaking Changes

None. No change to which tests run or to required-check semantics; the only
behavior change is that real validation now runs even when the PR-body template
check fails.

## Gate Impact

- [x] No gate-tier change (CI Gate still aggregates `pr-template-check`; same required check)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

(YAML validated with `yaml.safe_load`; the change is workflow-graph-only. The
gate-decoupling is only fully exercised by a live Actions run — see the runbook
validation steps.)

## Notes for reviewer (DRAFT)

Opened as **draft**. The larger minute levers (tightening `run_all` escalation,
consolidating tiny shards, scoping the `merge_group` lane) are documented in the
runbook as **recommendations needing sign-off / coordination with #1724**, not
implemented here. Do not merge into the queue while shard work is in flight.
