### PR TITLE
feat(ai): complete Bedrock rollout for map/app/forms/analysis/query studio generators

### DIFF
--- a/src/Honua.Ai/Features/AnalysisGeneration/AnalysisGenerationService.cs
+++ b/src/Honua.Ai/Features/AnalysisGeneration/AnalysisGenerationService.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Honua.Ai.Providers.Bedrock;
 using Honua.Ai.WorkflowGeneration;
 using Honua.Ai.WorkflowGeneration.Models;
 using Honua.Core.Features.AnalysisContent.Domain;
@@ -27,6 +28,7 @@ public sealed class AnalysisGenerationService : IAnalysisGenerationService
     private readonly WorkflowGenerationConfiguration _configuration;
     private readonly IProcessCatalog _processCatalog;
     private readonly WorkflowGenerationApiKeyResolver _apiKeyResolver;
+    private readonly IBedrockChatClientFactory _bedrockChatClientFactory;
     private readonly ILogger<AnalysisGenerationService> _logger;
 
     public AnalysisGenerationService(
@@ -34,12 +36,14 @@ public sealed class AnalysisGenerationService : IAnalysisGenerationService
         IOptions<WorkflowGenerationConfiguration> options,
         IProcessCatalog processCatalog,
         WorkflowGenerationApiKeyResolver apiKeyResolver,
+        IBedrockChatClientFactory bedrockChatClientFactory,
         ILogger<AnalysisGenerationService> logger)
     {
         _httpClientFactory = httpClientFactory;
         _configuration = options.Value;
         _processCatalog = processCatalog;
         _apiKeyResolver = apiKeyResolver;
+        _bedrockChatClientFactory = bedrockChatClientFactory;
         _logger = logger;
     }
 
@@ -55,7 +59,12 @@ public sealed class AnalysisGenerationService : IAnalysisGenerationService
 
         var providerId = string.IsNullOrWhiteSpace(request.Provider) ? _configuration.DefaultProvider : request.Provider!;
         var options = _configuration.GetProvider(providerId);
-        if (options is null || string.IsNullOrWhiteSpace(options.Endpoint) || string.IsNullOrWhiteSpace(options.Model))
+
+        // Bedrock targets the regional runtime endpoint via the AWS credential chain, so it needs no
+        // endpoint URL — only a model id. OpenAI-compatible/Anthropic providers require an endpoint.
+        var isBedrock = string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase);
+        var endpointMissing = !isBedrock && string.IsNullOrWhiteSpace(options?.Endpoint);
+        if (options is null || endpointMissing || string.IsNullOrWhiteSpace(options.Model))
         {
             return Unsupported($"Analysis generation provider '{providerId}' is not configured on this server.");
         }
@@ -150,6 +159,13 @@ public sealed class AnalysisGenerationService : IAnalysisGenerationService
         string model,
         CancellationToken cancellationToken)
     {
+        // The AWS Bedrock (Claude) provider has no OpenAI-compatible /chat/completions surface;
+        // route it through the Converse API (forced tool call for structured output) instead.
+        if (string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase))
+        {
+            return await CallBedrockAsync(request, options, providerId, model, cancellationToken).ConfigureAwait(false);
+        }
+
         try
         {
             var apiKey = await _apiKeyResolver.ResolveAsync(providerId, options, cancellationToken).ConfigureAwait(false);
@@ -227,6 +243,50 @@ public sealed class AnalysisGenerationService : IAnalysisGenerationService
         {
             GenerationProviderLog.ProviderResponseParseFailed(_logger, providerId, ex);
             return ErrorProposal("Provider response could not be parsed.");
+        }
+    }
+
+    private async Task<AnalysisGenerationModelProposal> CallBedrockAsync(
+        AnalysisGenerationProviderRequest request,
+        WorkflowGenerationProviderOptions options,
+        string providerId,
+        string model,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await BedrockStructuredGenerationClient.GenerateAsync(
+                options,
+                model,
+                AnalysisGenerationPrompt.BuildSystem(request, _processCatalog),
+                AnalysisGenerationPrompt.BuildUser(request),
+                AnalysisGenerationSchema.Build(_processCatalog),
+                "Emit the proposed analysis.package (or a clarification/refusal).",
+                _bedrockChatClientFactory.Create,
+                cancellationToken).ConfigureAwait(false);
+
+            if (!result.Succeeded)
+            {
+                GenerationProviderLog.ProviderRequestFailed(_logger, providerId, new InvalidOperationException(result.Error));
+                return ErrorProposal(result.Error ?? "Bedrock request failed.");
+            }
+
+            var proposal = JsonSerializer.Deserialize(result.Json!, AnalysisGenerationJsonContext.Default.AnalysisGenerationModelProposal);
+            return proposal ?? ErrorProposal("Failed to deserialize the analysis proposal from the Bedrock response.");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            GenerationProviderLog.ProviderResponseParseFailed(_logger, providerId, ex);
+            return ErrorProposal("Bedrock response could not be parsed.");
+        }
+        catch (Exception ex)
+        {
+            GenerationProviderLog.ProviderRequestFailed(_logger, providerId, ex);
+            return ErrorProposal("Bedrock request failed.");
         }
     }
 

--- a/src/Honua.Ai/Features/AppGeneration/AppGenerationService.cs
+++ b/src/Honua.Ai/Features/AppGeneration/AppGenerationService.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Honua.Ai.Providers.Bedrock;
 using Honua.Ai.WorkflowGeneration;
 using Honua.Ai.WorkflowGeneration.Models;
 using Honua.Core.Features.WorkflowPackages.Generation;
@@ -27,17 +28,20 @@ public sealed class AppGenerationService : IAppGenerationService
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly WorkflowGenerationConfiguration _configuration;
     private readonly WorkflowGenerationApiKeyResolver _apiKeyResolver;
+    private readonly IBedrockChatClientFactory _bedrockChatClientFactory;
     private readonly ILogger<AppGenerationService> _logger;
 
     public AppGenerationService(
         IHttpClientFactory httpClientFactory,
         IOptions<WorkflowGenerationConfiguration> options,
         WorkflowGenerationApiKeyResolver apiKeyResolver,
+        IBedrockChatClientFactory bedrockChatClientFactory,
         ILogger<AppGenerationService> logger)
     {
         _httpClientFactory = httpClientFactory;
         _configuration = options.Value;
         _apiKeyResolver = apiKeyResolver;
+        _bedrockChatClientFactory = bedrockChatClientFactory;
         _logger = logger;
     }
 
@@ -53,7 +57,12 @@ public sealed class AppGenerationService : IAppGenerationService
 
         var providerId = string.IsNullOrWhiteSpace(request.Provider) ? _configuration.DefaultProvider : request.Provider!;
         var options = _configuration.GetProvider(providerId);
-        if (options is null || string.IsNullOrWhiteSpace(options.Endpoint) || string.IsNullOrWhiteSpace(options.Model))
+
+        // Bedrock targets the regional runtime endpoint via the AWS credential chain, so it needs no
+        // endpoint URL — only a model id. OpenAI-compatible/Anthropic providers require an endpoint.
+        var isBedrock = string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase);
+        var endpointMissing = !isBedrock && string.IsNullOrWhiteSpace(options?.Endpoint);
+        if (options is null || endpointMissing || string.IsNullOrWhiteSpace(options.Model))
         {
             return Unsupported($"App generation provider '{providerId}' is not configured on this server.");
         }
@@ -139,6 +148,13 @@ public sealed class AppGenerationService : IAppGenerationService
         string model,
         CancellationToken cancellationToken)
     {
+        // The AWS Bedrock (Claude) provider has no OpenAI-compatible /chat/completions surface;
+        // route it through the Converse API (forced tool call for structured output) instead.
+        if (string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase))
+        {
+            return await CallBedrockAsync(request, options, providerId, model, cancellationToken).ConfigureAwait(false);
+        }
+
         try
         {
             var apiKey = await _apiKeyResolver.ResolveAsync(providerId, options, cancellationToken).ConfigureAwait(false);
@@ -216,6 +232,50 @@ public sealed class AppGenerationService : IAppGenerationService
         {
             GenerationProviderLog.ProviderResponseParseFailed(_logger, providerId, ex);
             return ErrorProposal("Provider response could not be parsed.");
+        }
+    }
+
+    private async Task<AppGenerationModelProposal> CallBedrockAsync(
+        AppGenerationProviderRequest request,
+        WorkflowGenerationProviderOptions options,
+        string providerId,
+        string model,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await BedrockStructuredGenerationClient.GenerateAsync(
+                options,
+                model,
+                AppGenerationPrompt.BuildSystem(request),
+                AppGenerationPrompt.BuildUser(request),
+                AppGenerationSchema.Build(),
+                "Emit the proposed app.package (or a clarification/refusal).",
+                _bedrockChatClientFactory.Create,
+                cancellationToken).ConfigureAwait(false);
+
+            if (!result.Succeeded)
+            {
+                GenerationProviderLog.ProviderRequestFailed(_logger, providerId, new InvalidOperationException(result.Error));
+                return ErrorProposal(result.Error ?? "Bedrock request failed.");
+            }
+
+            var proposal = JsonSerializer.Deserialize(result.Json!, AppGenerationJsonContext.Default.AppGenerationModelProposal);
+            return proposal ?? ErrorProposal("Failed to deserialize the app proposal from the Bedrock response.");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            GenerationProviderLog.ProviderResponseParseFailed(_logger, providerId, ex);
+            return ErrorProposal("Bedrock response could not be parsed.");
+        }
+        catch (Exception ex)
+        {
+            GenerationProviderLog.ProviderRequestFailed(_logger, providerId, ex);
+            return ErrorProposal("Bedrock request failed.");
         }
     }
 

--- a/src/Honua.Ai/Features/FormGeneration/FormGenerationService.cs
+++ b/src/Honua.Ai/Features/FormGeneration/FormGenerationService.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Honua.Ai.Providers.Bedrock;
 using Honua.Ai.WorkflowGeneration;
 using Honua.Ai.WorkflowGeneration.Models;
 using Honua.Core.Configuration;
@@ -26,6 +27,7 @@ public sealed class FormGenerationService : IFormGenerationService
     private readonly WorkflowGenerationConfiguration _configuration;
     private readonly FormPackageValidator _validator;
     private readonly WorkflowGenerationApiKeyResolver _apiKeyResolver;
+    private readonly IBedrockChatClientFactory _bedrockChatClientFactory;
     private readonly ILogger<FormGenerationService> _logger;
 
     public FormGenerationService(
@@ -33,11 +35,13 @@ public sealed class FormGenerationService : IFormGenerationService
         IOptions<WorkflowGenerationConfiguration> options,
         IOptions<LimitsOptions> limitsOptions,
         WorkflowGenerationApiKeyResolver apiKeyResolver,
+        IBedrockChatClientFactory bedrockChatClientFactory,
         ILogger<FormGenerationService> logger)
     {
         _httpClientFactory = httpClientFactory;
         _configuration = options.Value;
         _apiKeyResolver = apiKeyResolver;
+        _bedrockChatClientFactory = bedrockChatClientFactory;
         _logger = logger;
 
         // Generation-only validator: a stub target resolver runs the DB-free structural checks and
@@ -57,7 +61,12 @@ public sealed class FormGenerationService : IFormGenerationService
 
         var providerId = string.IsNullOrWhiteSpace(request.Provider) ? _configuration.DefaultProvider : request.Provider!;
         var options = _configuration.GetProvider(providerId);
-        if (options is null || string.IsNullOrWhiteSpace(options.Endpoint) || string.IsNullOrWhiteSpace(options.Model))
+
+        // Bedrock targets the regional runtime endpoint via the AWS credential chain, so it needs no
+        // endpoint URL — only a model id. OpenAI-compatible/Anthropic providers require an endpoint.
+        var isBedrock = string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase);
+        var endpointMissing = !isBedrock && string.IsNullOrWhiteSpace(options?.Endpoint);
+        if (options is null || endpointMissing || string.IsNullOrWhiteSpace(options.Model))
         {
             return Unsupported($"Form generation provider '{providerId}' is not configured on this server.");
         }
@@ -143,6 +152,13 @@ public sealed class FormGenerationService : IFormGenerationService
         string model,
         CancellationToken cancellationToken)
     {
+        // The AWS Bedrock (Claude) provider has no OpenAI-compatible /chat/completions surface;
+        // route it through the Converse API (forced tool call for structured output) instead.
+        if (string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase))
+        {
+            return await CallBedrockAsync(request, options, providerId, model, cancellationToken).ConfigureAwait(false);
+        }
+
         try
         {
             var apiKey = await _apiKeyResolver.ResolveAsync(providerId, options, cancellationToken).ConfigureAwait(false);
@@ -220,6 +236,50 @@ public sealed class FormGenerationService : IFormGenerationService
         {
             GenerationProviderLog.ProviderResponseParseFailed(_logger, providerId, ex);
             return ErrorProposal("Provider response could not be parsed.");
+        }
+    }
+
+    private async Task<FormGenerationModelProposal> CallBedrockAsync(
+        FormGenerationProviderRequest request,
+        WorkflowGenerationProviderOptions options,
+        string providerId,
+        string model,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await BedrockStructuredGenerationClient.GenerateAsync(
+                options,
+                model,
+                FormGenerationPrompt.BuildSystem(request),
+                FormGenerationPrompt.BuildUser(request),
+                FormGenerationSchema.Build(),
+                "Emit the proposed form.package (or a clarification/refusal).",
+                _bedrockChatClientFactory.Create,
+                cancellationToken).ConfigureAwait(false);
+
+            if (!result.Succeeded)
+            {
+                GenerationProviderLog.ProviderRequestFailed(_logger, providerId, new InvalidOperationException(result.Error));
+                return ErrorProposal(result.Error ?? "Bedrock request failed.");
+            }
+
+            var proposal = JsonSerializer.Deserialize(result.Json!, FormGenerationJsonContext.Default.FormGenerationModelProposal);
+            return proposal ?? ErrorProposal("Failed to deserialize the form proposal from the Bedrock response.");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            GenerationProviderLog.ProviderResponseParseFailed(_logger, providerId, ex);
+            return ErrorProposal("Bedrock response could not be parsed.");
+        }
+        catch (Exception ex)
+        {
+            GenerationProviderLog.ProviderRequestFailed(_logger, providerId, ex);
+            return ErrorProposal("Bedrock request failed.");
         }
     }
 

--- a/src/Honua.Ai/Features/MapGeneration/MapGenerationService.cs
+++ b/src/Honua.Ai/Features/MapGeneration/MapGenerationService.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Honua.Ai.Providers.Bedrock;
 using Honua.Ai.WorkflowGeneration;
 using Honua.Ai.WorkflowGeneration.Models;
 using Honua.Core.Features.Geoprocessing.Domain;
@@ -25,17 +26,20 @@ public sealed class MapGenerationService : IMapGenerationService
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly WorkflowGenerationConfiguration _configuration;
     private readonly WorkflowGenerationApiKeyResolver _apiKeyResolver;
+    private readonly IBedrockChatClientFactory _bedrockChatClientFactory;
     private readonly ILogger<MapGenerationService> _logger;
 
     public MapGenerationService(
         IHttpClientFactory httpClientFactory,
         IOptions<WorkflowGenerationConfiguration> options,
         WorkflowGenerationApiKeyResolver apiKeyResolver,
+        IBedrockChatClientFactory bedrockChatClientFactory,
         ILogger<MapGenerationService> logger)
     {
         _httpClientFactory = httpClientFactory;
         _configuration = options.Value;
         _apiKeyResolver = apiKeyResolver;
+        _bedrockChatClientFactory = bedrockChatClientFactory;
         _logger = logger;
     }
 
@@ -51,7 +55,12 @@ public sealed class MapGenerationService : IMapGenerationService
 
         var providerId = string.IsNullOrWhiteSpace(request.Provider) ? _configuration.DefaultProvider : request.Provider!;
         var options = _configuration.GetProvider(providerId);
-        if (options is null || string.IsNullOrWhiteSpace(options.Endpoint) || string.IsNullOrWhiteSpace(options.Model))
+
+        // Bedrock targets the regional runtime endpoint via the AWS credential chain, so it needs no
+        // endpoint URL — only a model id. OpenAI-compatible/Anthropic providers require an endpoint.
+        var isBedrock = string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase);
+        var endpointMissing = !isBedrock && string.IsNullOrWhiteSpace(options?.Endpoint);
+        if (options is null || endpointMissing || string.IsNullOrWhiteSpace(options.Model))
         {
             return Unsupported($"Map generation provider '{providerId}' is not configured on this server.");
         }
@@ -137,6 +146,13 @@ public sealed class MapGenerationService : IMapGenerationService
         string model,
         CancellationToken cancellationToken)
     {
+        // The AWS Bedrock (Claude) provider has no OpenAI-compatible /chat/completions surface;
+        // route it through the Converse API (forced tool call for structured output) instead.
+        if (string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase))
+        {
+            return await CallBedrockAsync(request, options, providerId, model, cancellationToken).ConfigureAwait(false);
+        }
+
         try
         {
             var apiKey = await _apiKeyResolver.ResolveAsync(providerId, options, cancellationToken).ConfigureAwait(false);
@@ -214,6 +230,50 @@ public sealed class MapGenerationService : IMapGenerationService
         {
             GenerationProviderLog.ProviderResponseParseFailed(_logger, providerId, ex);
             return ErrorProposal("Provider response could not be parsed.");
+        }
+    }
+
+    private async Task<MapGenerationModelProposal> CallBedrockAsync(
+        MapGenerationProviderRequest request,
+        WorkflowGenerationProviderOptions options,
+        string providerId,
+        string model,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await BedrockStructuredGenerationClient.GenerateAsync(
+                options,
+                model,
+                MapGenerationPrompt.BuildSystem(request),
+                MapGenerationPrompt.BuildUser(request),
+                MapGenerationSchema.Build(),
+                "Emit the proposed map.package (or a clarification/refusal).",
+                _bedrockChatClientFactory.Create,
+                cancellationToken).ConfigureAwait(false);
+
+            if (!result.Succeeded)
+            {
+                GenerationProviderLog.ProviderRequestFailed(_logger, providerId, new InvalidOperationException(result.Error));
+                return ErrorProposal(result.Error ?? "Bedrock request failed.");
+            }
+
+            var proposal = JsonSerializer.Deserialize(result.Json!, MapGenerationJsonContext.Default.MapGenerationModelProposal);
+            return proposal ?? ErrorProposal("Failed to deserialize the map proposal from the Bedrock response.");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            GenerationProviderLog.ProviderResponseParseFailed(_logger, providerId, ex);
+            return ErrorProposal("Bedrock response could not be parsed.");
+        }
+        catch (Exception ex)
+        {
+            GenerationProviderLog.ProviderRequestFailed(_logger, providerId, ex);
+            return ErrorProposal("Bedrock request failed.");
         }
     }
 

--- a/src/Honua.Ai/Features/QueryGeneration/QueryGenerationService.cs
+++ b/src/Honua.Ai/Features/QueryGeneration/QueryGenerationService.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Honua.Ai.Providers.Bedrock;
 using Honua.Ai.WorkflowGeneration;
 using Honua.Ai.WorkflowGeneration.Models;
 using Honua.Core.Features.AnalysisContent.Domain;
@@ -25,17 +26,20 @@ public sealed class QueryGenerationService : IQueryGenerationService
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly WorkflowGenerationConfiguration _configuration;
     private readonly WorkflowGenerationApiKeyResolver _apiKeyResolver;
+    private readonly IBedrockChatClientFactory _bedrockChatClientFactory;
     private readonly ILogger<QueryGenerationService> _logger;
 
     public QueryGenerationService(
         IHttpClientFactory httpClientFactory,
         IOptions<WorkflowGenerationConfiguration> options,
         WorkflowGenerationApiKeyResolver apiKeyResolver,
+        IBedrockChatClientFactory bedrockChatClientFactory,
         ILogger<QueryGenerationService> logger)
     {
         _httpClientFactory = httpClientFactory;
         _configuration = options.Value;
         _apiKeyResolver = apiKeyResolver;
+        _bedrockChatClientFactory = bedrockChatClientFactory;
         _logger = logger;
     }
 
@@ -51,7 +55,12 @@ public sealed class QueryGenerationService : IQueryGenerationService
 
         var providerId = string.IsNullOrWhiteSpace(request.Provider) ? _configuration.DefaultProvider : request.Provider!;
         var options = _configuration.GetProvider(providerId);
-        if (options is null || string.IsNullOrWhiteSpace(options.Endpoint) || string.IsNullOrWhiteSpace(options.Model))
+
+        // Bedrock targets the regional runtime endpoint via the AWS credential chain, so it needs no
+        // endpoint URL — only a model id. OpenAI-compatible/Anthropic providers require an endpoint.
+        var isBedrock = string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase);
+        var endpointMissing = !isBedrock && string.IsNullOrWhiteSpace(options?.Endpoint);
+        if (options is null || endpointMissing || string.IsNullOrWhiteSpace(options.Model))
         {
             return Unsupported($"Query generation provider '{providerId}' is not configured on this server.");
         }
@@ -150,6 +159,13 @@ public sealed class QueryGenerationService : IQueryGenerationService
         string model,
         CancellationToken cancellationToken)
     {
+        // The AWS Bedrock (Claude) provider has no OpenAI-compatible /chat/completions surface;
+        // route it through the Converse API (forced tool call for structured output) instead.
+        if (string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase))
+        {
+            return await CallBedrockAsync(request, options, providerId, model, cancellationToken).ConfigureAwait(false);
+        }
+
         try
         {
             var apiKey = await _apiKeyResolver.ResolveAsync(providerId, options, cancellationToken).ConfigureAwait(false);
@@ -227,6 +243,50 @@ public sealed class QueryGenerationService : IQueryGenerationService
         {
             GenerationProviderLog.ProviderResponseParseFailed(_logger, providerId, ex);
             return ErrorProposal("Provider response could not be parsed.");
+        }
+    }
+
+    private async Task<QueryGenerationModelProposal> CallBedrockAsync(
+        QueryGenerationProviderRequest request,
+        WorkflowGenerationProviderOptions options,
+        string providerId,
+        string model,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await BedrockStructuredGenerationClient.GenerateAsync(
+                options,
+                model,
+                QueryGenerationPrompt.BuildSystem(request),
+                QueryGenerationPrompt.BuildUser(request),
+                QueryGenerationSchema.Build(),
+                "Emit the proposed query.content (or a clarification/refusal).",
+                _bedrockChatClientFactory.Create,
+                cancellationToken).ConfigureAwait(false);
+
+            if (!result.Succeeded)
+            {
+                GenerationProviderLog.ProviderRequestFailed(_logger, providerId, new InvalidOperationException(result.Error));
+                return ErrorProposal(result.Error ?? "Bedrock request failed.");
+            }
+
+            var proposal = JsonSerializer.Deserialize(result.Json!, QueryGenerationJsonContext.Default.QueryGenerationModelProposal);
+            return proposal ?? ErrorProposal("Failed to deserialize the query proposal from the Bedrock response.");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            GenerationProviderLog.ProviderResponseParseFailed(_logger, providerId, ex);
+            return ErrorProposal("Bedrock response could not be parsed.");
+        }
+        catch (Exception ex)
+        {
+            GenerationProviderLog.ProviderRequestFailed(_logger, providerId, ex);
+            return ErrorProposal("Bedrock request failed.");
         }
     }
 

--- a/tests/dotnet/Honua.Ai.Tests/Source/AnalysisGenerationServiceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/AnalysisGenerationServiceTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using Honua.Ai.AnalysisGeneration;
+using Honua.Ai.Providers.Bedrock;
 using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.WorkflowPackages.Generation;
@@ -13,6 +14,7 @@ using Honua.Geoprocessing;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.Ai.WorkflowGeneration;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -373,12 +375,20 @@ public sealed class AnalysisGenerationServiceTests
         var handler = new StubChatHandler(cannedResponses, throwIfCalled);
         var factory = new StubHttpClientFactory(handler);
 
-        return new AnalysisGenerationService(factory, configuration, _catalog, new WorkflowGenerationApiKeyResolver(), NullLogger<AnalysisGenerationService>.Instance);
+        return new AnalysisGenerationService(factory, configuration, _catalog, new WorkflowGenerationApiKeyResolver(), new ThrowingBedrockChatClientFactory(), NullLogger<AnalysisGenerationService>.Instance);
     }
 
     private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
     {
         public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    // These tests exercise the OpenAI-compatible (local) path only; the Bedrock branch must never be
+    // reached, so the factory throws if invoked. (Bedrock routing is covered by BedrockStudioProviderTests.)
+    private sealed class ThrowingBedrockChatClientFactory : IBedrockChatClientFactory
+    {
+        public IChatClient Create(string model, string region, string? apiKey) =>
+            throw new InvalidOperationException("Bedrock must not be invoked on the OpenAI-compatible path.");
     }
 
     // Returns the next canned chat-completion body per call so the repair loop can be exercised.

--- a/tests/dotnet/Honua.Ai.Tests/Source/BedrockStudioProviderTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/BedrockStudioProviderTests.cs
@@ -4,13 +4,20 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Ai.AnalysisGeneration;
+using Honua.Ai.AppGeneration;
 using Honua.Ai.DashboardGeneration;
+using Honua.Ai.FormGeneration;
+using Honua.Ai.MapGeneration;
 using Honua.Ai.Providers.Bedrock;
+using Honua.Ai.QueryGeneration;
 using Honua.Ai.ReportGeneration;
 using Honua.Ai.WorkflowGeneration;
+using Honua.Core.Configuration;
 using Honua.Core.Features.Publishing.Dashboards;
 using Honua.Core.Features.Publishing.Reports;
 using Honua.Core.Features.WorkflowPackages.Generation;
+using Honua.Geoprocessing;
 using Honua.TestKit.Attributes;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -131,6 +138,130 @@ public sealed class BedrockStudioProviderTests
 
         result.Status.Should().Be("needs-clarification");
         result.Provider.Should().Be(WorkflowGenerationConfiguration.BedrockProviderId);
+    }
+
+    [UnitTest]
+    public async Task MapService_WithBedrockProvider_RoutesThroughConverseAndSurfacesTheProposal()
+    {
+        const string ToolJson = """
+        { "status": "needs-clarification", "rationale": "Which basemap?", "clarifications": [] }
+        """;
+
+        var factory = FakeFactoryReturning(ToolJson, out var capturedModel, out var capturedRegion);
+        var service = new MapGenerationService(
+            httpClientFactory: Substitute.For<IHttpClientFactory>(),
+            options: BedrockOptions(),
+            apiKeyResolver: new WorkflowGenerationApiKeyResolver(),
+            bedrockChatClientFactory: factory,
+            logger: NullLogger<MapGenerationService>.Instance);
+
+        var result = await service.GenerateAsync(new MapGenerationRequest { Prompt = "fleet map" });
+
+        // The Endpoint guard no longer rejects Bedrock (which has no endpoint) with "unsupported";
+        // the call routed through the Converse backend instead of the HTTP-only path.
+        result.Status.Should().Be("needs-clarification");
+        result.Provider.Should().Be(WorkflowGenerationConfiguration.BedrockProviderId);
+        result.Model.Should().Be("test-bedrock-model");
+        capturedModel.Value.Should().Be("test-bedrock-model");
+        capturedRegion.Value.Should().Be("us-west-2");
+    }
+
+    [UnitTest]
+    public async Task AppService_WithBedrockProvider_RoutesThroughConverseAndSurfacesTheProposal()
+    {
+        const string ToolJson = """
+        { "status": "needs-clarification", "rationale": "Which components?", "clarifications": [] }
+        """;
+
+        var factory = FakeFactoryReturning(ToolJson, out var capturedModel, out var capturedRegion);
+        var service = new AppGenerationService(
+            httpClientFactory: Substitute.For<IHttpClientFactory>(),
+            options: BedrockOptions(),
+            apiKeyResolver: new WorkflowGenerationApiKeyResolver(),
+            bedrockChatClientFactory: factory,
+            logger: NullLogger<AppGenerationService>.Instance);
+
+        var result = await service.GenerateAsync(new AppGenerationRequest { Prompt = "field app" });
+
+        result.Status.Should().Be("needs-clarification");
+        result.Provider.Should().Be(WorkflowGenerationConfiguration.BedrockProviderId);
+        result.Model.Should().Be("test-bedrock-model");
+        capturedModel.Value.Should().Be("test-bedrock-model");
+        capturedRegion.Value.Should().Be("us-west-2");
+    }
+
+    [UnitTest]
+    public async Task FormService_WithBedrockProvider_RoutesThroughConverseAndSurfacesTheProposal()
+    {
+        const string ToolJson = """
+        { "status": "needs-clarification", "rationale": "Which fields?", "clarifications": [] }
+        """;
+
+        var factory = FakeFactoryReturning(ToolJson, out var capturedModel, out var capturedRegion);
+        var service = new FormGenerationService(
+            httpClientFactory: Substitute.For<IHttpClientFactory>(),
+            options: BedrockOptions(),
+            limitsOptions: Options.Create(new LimitsOptions()),
+            apiKeyResolver: new WorkflowGenerationApiKeyResolver(),
+            bedrockChatClientFactory: factory,
+            logger: NullLogger<FormGenerationService>.Instance);
+
+        var result = await service.GenerateAsync(new FormGenerationRequest { Prompt = "inspection form" });
+
+        result.Status.Should().Be("needs-clarification");
+        result.Provider.Should().Be(WorkflowGenerationConfiguration.BedrockProviderId);
+        result.Model.Should().Be("test-bedrock-model");
+        capturedModel.Value.Should().Be("test-bedrock-model");
+        capturedRegion.Value.Should().Be("us-west-2");
+    }
+
+    [UnitTest]
+    public async Task AnalysisService_WithBedrockProvider_RoutesThroughConverseAndSurfacesTheProposal()
+    {
+        const string ToolJson = """
+        { "status": "needs-clarification", "rationale": "Which layers?", "clarifications": [] }
+        """;
+
+        var factory = FakeFactoryReturning(ToolJson, out var capturedModel, out var capturedRegion);
+        var service = new AnalysisGenerationService(
+            httpClientFactory: Substitute.For<IHttpClientFactory>(),
+            options: BedrockOptions(),
+            processCatalog: new BuiltInProcessCatalog(),
+            apiKeyResolver: new WorkflowGenerationApiKeyResolver(),
+            bedrockChatClientFactory: factory,
+            logger: NullLogger<AnalysisGenerationService>.Instance);
+
+        var result = await service.GenerateAsync(new AnalysisGenerationRequest { Prompt = "buffer parcels by 100m" });
+
+        result.Status.Should().Be("needs-clarification");
+        result.Provider.Should().Be(WorkflowGenerationConfiguration.BedrockProviderId);
+        result.Model.Should().Be("test-bedrock-model");
+        capturedModel.Value.Should().Be("test-bedrock-model");
+        capturedRegion.Value.Should().Be("us-west-2");
+    }
+
+    [UnitTest]
+    public async Task QueryService_WithBedrockProvider_RoutesThroughConverseAndSurfacesTheProposal()
+    {
+        const string ToolJson = """
+        { "status": "needs-clarification", "rationale": "Which layer?", "clarifications": [] }
+        """;
+
+        var factory = FakeFactoryReturning(ToolJson, out var capturedModel, out var capturedRegion);
+        var service = new QueryGenerationService(
+            httpClientFactory: Substitute.For<IHttpClientFactory>(),
+            options: BedrockOptions(),
+            apiKeyResolver: new WorkflowGenerationApiKeyResolver(),
+            bedrockChatClientFactory: factory,
+            logger: NullLogger<QueryGenerationService>.Instance);
+
+        var result = await service.GenerateAsync(new QueryGenerationRequest { Prompt = "parcels within 500m of rivers" });
+
+        result.Status.Should().Be("needs-clarification");
+        result.Provider.Should().Be(WorkflowGenerationConfiguration.BedrockProviderId);
+        result.Model.Should().Be("test-bedrock-model");
+        capturedModel.Value.Should().Be("test-bedrock-model");
+        capturedRegion.Value.Should().Be("us-west-2");
     }
 
     [UnitTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1760

## Summary
The dashboard and report studio generators already supported the AWS Bedrock (Claude) provider, but the map, app, form, analysis, and query generators did not. The five remaining services kept the HTTP-only path and a strict `Endpoint` guard that rejected Bedrock (which has no HTTP endpoint, only a model id) by returning `unsupported` before any model call.

This PR mirrors the existing dashboard/report retrofit into the five remaining studio generators so Bedrock is selectable for all of them. The change is purely additive: the OpenAI-compatible HTTP path is preserved unchanged for non-Bedrock providers (local/openai/anthropic).

## Changes Made
- Inject `IBedrockChatClientFactory` into `MapGenerationService`, `AppGenerationService`, `FormGenerationService`, `AnalysisGenerationService`, and `QueryGenerationService` (the factory is already registered globally by `AddWorkflowGeneration`; constructor injection resolves it, so no DI registration change was needed).
- Relax each service's config guard with an `isBedrock` check so the `string.IsNullOrWhiteSpace(options.Endpoint)` rejection is bypassed for Bedrock, which targets the regional runtime via the AWS credential chain and needs only a `Model`.
- Branch each `CallModelAsync` to a new `CallBedrockAsync` path via `BedrockStructuredGenerationClient` (Converse API forced tool call for structured output) when the provider id is `bedrock`; the OpenAI-compatible `/chat/completions` path is left intact for all other providers.
- Each service keeps its own prompt/grounding/schema/result shape (e.g. analysis still grounds in the process catalog). No grounding/architecture refactor.
- Add unit tests in `BedrockStudioProviderTests` for all five services (assert the Bedrock branch is taken — model/region captured — and that the Endpoint guard no longer rejects when `providerId=bedrock` with a model configured). Mock the chat client; no live Bedrock calls.
- Update the pre-existing `AnalysisGenerationServiceTests` constructor call for the new parameter (passes a throwing factory to prove the OpenAI-compatible path never touches Bedrock).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires environment variable or secret changes

Live end-to-end validation against real Bedrock requires a redeploy of the `integration/demo-deploy` image (the running demo image predates this change) plus the `bedrock` provider configured for each studio generator. This PR does not trigger that redeploy. No DB migration; no coordinated cross-repo release.

## Breaking Changes
None — additive only. The OpenAI-compatible HTTP path is unchanged for non-Bedrock providers.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
