### PR TITLE
fix(ai): analysis generator Bedrock schema/prompt so 'plan' is produced

### DIFF
--- a/src/Honua.Ai/Features/AnalysisGeneration/AnalysisGenerationPrompt.cs
+++ b/src/Honua.Ai/Features/AnalysisGeneration/AnalysisGenerationPrompt.cs
@@ -32,6 +32,7 @@ internal static class AnalysisGenerationPrompt
         sb.AppendLine("Artifact kinds: Scalar, FeatureLayer, Table, Raster, File, Report, Map, AppBundle.");
         sb.AppendLine();
         sb.AppendLine("Rules:");
+        sb.AppendLine("- When status is \"generated\" you MUST return the full analysis object, and the analysis object MUST contain a non-null \"plan\". The plan is required: always set plan.planId, plan.intentId, and a non-empty plan.steps array. Never return status \"generated\" without analysis.plan.");
         sb.AppendLine("- The core of the analysis is one or more Geoprocess steps. Each Geoprocess step MUST set processId to a method id from the catalog below, and MUST supply every required parameter for that method in its inputs. Never invent a processId or a parameter name.");
         sb.AppendLine("- Choose the method whose purpose matches the request (e.g. buffer, spatial join, clustering, density/hotspot binning, dissolve, slope/hillshade). Set parameter values from the request; for an input layer the user named but whose numeric layerId is unknown, use \"0\" and note it in the rationale — the operator binds the real layer at run/publish time.");
         sb.AppendLine("- Respect each parameter's allowed values and value type (e.g. an algorithm enum, a positive distance). Conditionally-required parameters (e.g. eps+minPoints when algorithm=dbscan, k when algorithm=kmeans, distance when predicate=dwithin) must be present when their condition holds.");

--- a/src/Honua.Ai/Features/AnalysisGeneration/AnalysisGenerationSchema.cs
+++ b/src/Honua.Ai/Features/AnalysisGeneration/AnalysisGenerationSchema.cs
@@ -40,6 +40,7 @@ internal static class AnalysisGenerationSchema
                 "rationale": { "type": "string" },
                 "analysis": {
                   "type": ["object", "null"],
+                  "description": "The proposed analysis package. REQUIRED and non-null whenever status is \"generated\"; omit (null) only for needs-clarification/unsupported/refused. Must always contain a non-null \"plan\".",
                   "properties": {
                     "intent": {
                       "type": ["object", "null"],
@@ -55,11 +56,13 @@ internal static class AnalysisGenerationSchema
                     },
                     "plan": {
                       "type": "object",
+                      "description": "The executable analysis plan. REQUIRED whenever an analysis is produced (status \"generated\"). Must declare planId, intentId, and a non-empty steps array.",
                       "properties": {
                         "planId": { "type": "string" },
                         "intentId": { "type": "string" },
                         "steps": {
                           "type": "array",
+                          "minItems": 1,
                           "items": {
                             "type": "object",
                             "properties": {

--- a/tests/dotnet/Honua.Ai.Tests/Source/BedrockStudioProviderTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/BedrockStudioProviderTests.cs
@@ -243,6 +243,56 @@ public sealed class BedrockStudioProviderTests
     }
 
     [UnitTest]
+    public async Task AnalysisService_WithBedrockProvider_DeserializesAGeneratedPlanProposal()
+    {
+        // Regression for the analysis-only Bedrock deserialization failure (#1763 fallout): a
+        // "generated" proposal carrying a full analysis.plan must round-trip through the Converse
+        // forced-tool path into AnalysisPackageContent (whose Plan is a required member). Previously
+        // the model omitted analysis.plan and the proposal failed deserialization
+        // ("missing required properties including: 'plan'"); the schema/prompt now require the plan
+        // and a representative response with it must deserialize cleanly into a generated plan.
+        const string ToolJson = """
+        {
+          "status": "generated",
+          "rationale": "Buffer each parcel geometry by 100 meters and emit a feature layer.",
+          "analysis": {
+            "intent": { "intentId": "buffer-intent", "goal": "buffer parcels by 100 meters", "mode": "analysis", "inputs": ["parcels"], "requestedOutputs": ["FeatureLayer"] },
+            "plan": {
+              "planId": "buffer-plan",
+              "intentId": "buffer-intent",
+              "steps": [
+                { "stepId": "s1", "kind": "Geoprocess", "processId": "geometry.buffer", "inputs": { "wkb": "AAAA", "srid": "4326", "distance": "100" }, "dependsOn": [] }
+              ],
+              "outputs": ["FeatureLayer"],
+              "warnings": []
+            },
+            "requestedArtifacts": ["FeatureLayer"]
+          }
+        }
+        """;
+
+        var factory = FakeFactoryReturning(ToolJson, out _, out _);
+        var service = new AnalysisGenerationService(
+            httpClientFactory: Substitute.For<IHttpClientFactory>(),
+            options: BedrockOptions(),
+            processCatalog: new BuiltInProcessCatalog(),
+            apiKeyResolver: new WorkflowGenerationApiKeyResolver(),
+            bedrockChatClientFactory: factory,
+            logger: NullLogger<AnalysisGenerationService>.Instance);
+
+        var result = await service.GenerateAsync(new AnalysisGenerationRequest { Prompt = "buffer parcels by 100m" });
+
+        result.Status.Should().Be("generated", because: "a generated proposal carrying analysis.plan must not collapse into a parse error");
+        result.Provider.Should().Be(WorkflowGenerationConfiguration.BedrockProviderId);
+        result.Analysis.Should().NotBeNull();
+        result.Analysis!.Plan.Should().NotBeNull(because: "the required 'plan' property must deserialize from the Bedrock tool output");
+        result.Analysis.Plan.PlanId.Should().Be("buffer-plan");
+        result.Analysis.Plan.Steps.Should().ContainSingle()
+            .Which.ProcessId.Should().Be("geometry.buffer");
+        result.Rationale.Should().NotBe("Bedrock response could not be parsed.");
+    }
+
+    [UnitTest]
     public async Task QueryService_WithBedrockProvider_RoutesThroughConverseAndSurfacesTheProposal()
     {
         const string ToolJson = """


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1763

## Summary
The analysis AI-studio generator regressed after the Bedrock rollout (#1763). With a Bedrock provider, `analysis/content/generate` reaches `CallBedrockAsync` (the Converse forced-tool path) but fails deserialization with `JsonException: deserialization for type 'AnalysisPackageContent' was missing required properties including: 'plan'`. The model returns a valid `generated` analysis but omits the required `plan` property.

Root cause: unlike the OpenAI-compatible path (`json_schema` with `strict: true` and constrained decoding that guarantees required fields), the Bedrock Converse forced-tool path treats the tool `input_schema` as advisory. On the analysis schema — the deepest/most-nested of all the studio generators (intent + plan + steps + enums) — the model omits `plan` because nothing forces it. `plan` is genuinely required in the domain (`AnalysisPackageContent.Plan`), so the fix drives the model to produce it (mirroring dashboard/report/form) rather than relaxing the contract. Isolated to the analysis generator.

## Changes Made
- Prompt (`AnalysisGenerationPrompt`): add an explicit rule that a `generated` status MUST return the full analysis with a non-null `plan` (planId, intentId, non-empty steps) — mirroring the "ALWAYS set X; X is required" pattern dashboard/report use.
- Schema (`AnalysisGenerationSchema`): add `description` annotations on `analysis` and `plan` stating `plan` is required when an analysis is produced, and set `plan.steps` `minItems` to 1. Anthropic tool-use reads `input_schema` descriptions, reinforcing the required field on the advisory path.
- Test (`BedrockStudioProviderTests`): add `AnalysisService_WithBedrockProvider_DeserializesAGeneratedPlanProposal`, a mocked Bedrock-path test (no live calls) asserting a representative `generated` proposal carrying `analysis.plan` deserializes into `AnalysisPackageContent` bound to `geometry.buffer`.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

`dotnet test Honua.Ai.Tests` (BedrockStudioProviderTests + AnalysisGenerationServiceTests): 24/24 passed including the new test. Release build (warnings-as-errors) clean. `dotnet format --verify-no-changes` clean. Architecture tests: the only 2 failures are pre-existing on the base branch (`Honua.Server.Features.Provisioner` namespace from commit c5dd6c136, unrelated); this PR neither introduces nor touches them.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

Live end-to-end validation requires a redeploy of the Bedrock environment (the fix changes the prompt + schema the model receives). This PR does not deploy — flagging that a redeploy is needed to confirm against real Bedrock.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
