### PR TITLE
feat(operations): consolidate map generator onto the operations toolset (strangler)

### DIFF
--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -383,6 +383,50 @@
       ]
     },
     {
+      "surfaceId": "operations-toolset",
+      "displayName": "Honua Operations Toolset API",
+      "surfaceKind": "http-route-family",
+      "protocol": "Admin API",
+      "canonicalIdentifier": "/api/v1/operations*",
+      "parentSurfaceId": "control-plane-admin",
+      "endpointPrefixes": [
+        "/api/v1/operations"
+      ],
+      "endpointExactMatches": [],
+      "endpointContains": [],
+      "operationKeys": [],
+      "proofs": [
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "EndpointRegistry coverage plus OperationsEndpointsTests integration tests assert the descriptor catalog lists the service.publish descriptor, ValidateAsync/SubmitAsync flow through the policy-gated dispatcher, and the submitted handle status surfaces the metadata-v2 revision",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/EndpointRegistry.cs",
+            "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/Operations/OperationsEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": null,
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "contract-governance",
+          "proofMechanism": "Descriptor/executor split: groundable IOperationDescriptor catalog is separate from IOperationExecutor (Validate/Submit->Handle/GetStatus); every submit flows through IOperationPolicyDecisionPoint (AllowAll pass-through default) and OperationsJsonContext keeps the operation DTOs AOT-safe",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "src/Honua.Core/Features/Operations/Abstractions/IOperationExecutor.cs",
+            "src/Honua.Core/Features/Operations/Abstractions/IOperationPolicyDecisionPoint.cs",
+            "src/Honua.Server/Features/Operations/OperationsJsonContext.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": null,
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
       "surfaceId": "console-job-observability",
       "displayName": "Console durable job observability API",
       "surfaceKind": "http-route-family",

--- a/src/Honua.Core/Features/Operations/Abstractions/IOperationCatalog.cs
+++ b/src/Honua.Core/Features/Operations/Abstractions/IOperationCatalog.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Domain;
+
+namespace Honua.Core.Features.Operations.Abstractions;
+
+/// <summary>
+/// Provider that contributes operation descriptors to the grounding catalog. Mirrors
+/// <c>IWorkflowNodeProvider</c>; the catalog aggregates every registered provider. This is
+/// the grounding surface the AI will later see. DevOps descriptors join here in a later
+/// phase (descriptors only — DevOps execution stays in the agent).
+/// </summary>
+public interface IOperationDescriptorProvider
+{
+    /// <summary>
+    /// Stable provider identifier.
+    /// </summary>
+    string ProviderId { get; }
+
+    /// <summary>
+    /// Returns the operation descriptors contributed by this provider.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<IOperationDescriptor>> ListDescriptorsAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Aggregates every registered <see cref="IOperationDescriptorProvider"/> into a single
+/// grounding catalog. Mirrors <c>WorkflowNodeRegistry</c>: it produces a versioned snapshot
+/// and resolves a single descriptor by id.
+/// </summary>
+public interface IOperationCatalog
+{
+    /// <summary>
+    /// Builds the current catalog snapshot of all available operation descriptors.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<OperationCatalogSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves a descriptor by operation id, or null when not found.
+    /// </summary>
+    /// <param name="operationId">Operation identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<OperationDescriptor?> GetDescriptorAsync(string operationId, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Operations/Abstractions/IOperationDescriptor.cs
+++ b/src/Honua.Core/Features/Operations/Abstractions/IOperationDescriptor.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Domain;
+
+namespace Honua.Core.Features.Operations.Abstractions;
+
+/// <summary>
+/// Groundable schema descriptor for a single composable operation in the Honua Operations
+/// Toolset. This is the half the AI grounds on. It is a distinct type from
+/// <see cref="IOperationExecutor"/> (which does the work): the descriptor carries only
+/// schema, execution kind, approval model, and policy metadata — never execution behavior.
+/// </summary>
+/// <remarks>
+/// The schema half is projectable from <c>WorkflowNodeDefinition</c>, but a descriptor is
+/// NOT a <c>WorkflowNodeDefinition</c>: a node definition is pure schema, while a descriptor
+/// adds the execution/approval/policy semantics the toolset and its guardrail seam require.
+/// </remarks>
+public interface IOperationDescriptor
+{
+    /// <summary>
+    /// Stable operation identifier, for example <c>service.publish</c>.
+    /// </summary>
+    string OperationId { get; }
+
+    /// <summary>
+    /// Identifier of the provider that owns this operation.
+    /// </summary>
+    string ProviderId { get; }
+
+    /// <summary>
+    /// Human-readable operation title.
+    /// </summary>
+    string Title { get; }
+
+    /// <summary>
+    /// Short operation description.
+    /// </summary>
+    string Description { get; }
+
+    /// <summary>
+    /// Palette category for grouping related operations.
+    /// </summary>
+    string Category { get; }
+
+    /// <summary>
+    /// Input parameter schema.
+    /// </summary>
+    IReadOnlyList<OperationParameterDescriptor> InputSchema { get; }
+
+    /// <summary>
+    /// Output schema describing what the operation produces.
+    /// </summary>
+    IReadOnlyList<OperationParameterDescriptor> OutputSchema { get; }
+
+    /// <summary>
+    /// How the operation is executed (synchronous / job / proposal handoff).
+    /// </summary>
+    OperationExecutionKind ExecutionKind { get; }
+
+    /// <summary>
+    /// Human-gate model the operation flows through.
+    /// </summary>
+    OperationApprovalModel ApprovalModel { get; }
+
+    /// <summary>
+    /// Policy metadata the policy decision point reasons over.
+    /// </summary>
+    OperationPolicyMetadata Policy { get; }
+
+    /// <summary>
+    /// Reserved grounding metadata; unused in the current spike.
+    /// </summary>
+    OperationGroundingMetadata? Grounding { get; }
+}

--- a/src/Honua.Core/Features/Operations/Abstractions/IOperationExecutor.cs
+++ b/src/Honua.Core/Features/Operations/Abstractions/IOperationExecutor.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Domain;
+
+namespace Honua.Core.Features.Operations.Abstractions;
+
+/// <summary>
+/// Executes a single operation. This is a SEPARATE contract from
+/// <see cref="IOperationDescriptor"/>: the descriptor is groundable schema, the executor
+/// does the work by wiring into existing server execution paths (publish, jobs, etc.).
+/// </summary>
+/// <remarks>
+/// The contract is deliberately <c>Validate / Submit→Handle / GetStatus</c> rather than a
+/// single flat <c>ExecuteAsync</c>. A flat sync execute cannot model the publish transaction,
+/// the job-based geoprocessing path, or approval-lane "queued" outcomes; the handle returned
+/// by <see cref="SubmitAsync"/> represents all three.
+/// </remarks>
+public interface IOperationExecutor
+{
+    /// <summary>
+    /// Operation identifier this executor handles (matches a descriptor's <c>OperationId</c>).
+    /// </summary>
+    string OperationId { get; }
+
+    /// <summary>
+    /// Read-only, idempotent validation/plan. Produces diagnostics without side effects.
+    /// </summary>
+    /// <param name="request">Operation request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<OperationValidation> ValidateAsync(OperationRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Submits the operation for execution and returns a handle. The handle — not a flat
+    /// result — represents a completed sync op, a queued job, or a requires-approval outcome.
+    /// </summary>
+    /// <param name="request">Operation request.</param>
+    /// <param name="context">Resolved connection/principal/tier context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<OperationHandle> SubmitAsync(
+        OperationRequest request,
+        OperationPolicyContext context,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the current status for a previously submitted handle (the async/job case).
+    /// </summary>
+    /// <param name="handle">Handle returned by <see cref="SubmitAsync"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<OperationStatus> GetStatusAsync(OperationHandle handle, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Operations/Abstractions/IOperationInvoker.cs
+++ b/src/Honua.Core/Features/Operations/Abstractions/IOperationInvoker.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Domain;
+
+namespace Honua.Core.Features.Operations.Abstractions;
+
+/// <summary>
+/// Single entry point for invoking operations from the deterministic surface (and, later,
+/// the AI orchestrator). Resolves descriptor + executor by id, runs the policy decision
+/// point, and only on Allow calls the executor. On Deny / RequireApproval / DryRunFirst it
+/// returns a handle reflecting the decision WITHOUT touching the executor.
+/// </summary>
+public interface IOperationInvoker
+{
+    /// <summary>
+    /// Validates an operation request via its executor (read-only, no policy gate).
+    /// </summary>
+    /// <param name="request">Operation request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<OperationValidation> ValidateAsync(OperationRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Submits an operation: descriptor + executor lookup, policy decision, then execute on Allow.
+    /// </summary>
+    /// <param name="request">Operation request.</param>
+    /// <param name="context">Resolved connection/principal/tier context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<OperationHandle> SubmitAsync(
+        OperationRequest request,
+        OperationPolicyContext context,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Raised when an operation id has no registered descriptor or executor.
+/// </summary>
+public sealed class OperationNotFoundException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="OperationNotFoundException"/>.
+    /// </summary>
+    /// <param name="operationId">The unresolved operation identifier.</param>
+    public OperationNotFoundException(string operationId)
+        : base($"Operation '{operationId}' is not registered.")
+        => OperationId = operationId;
+
+    /// <summary>
+    /// The operation identifier that could not be resolved.
+    /// </summary>
+    public string OperationId { get; }
+}

--- a/src/Honua.Core/Features/Operations/Abstractions/IOperationPolicyDecisionPoint.cs
+++ b/src/Honua.Core/Features/Operations/Abstractions/IOperationPolicyDecisionPoint.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Domain;
+
+namespace Honua.Core.Features.Operations.Abstractions;
+
+/// <summary>
+/// Policy seam consulted before any operation side effect. Every submit flows through this
+/// decision point; only an <see cref="PolicyDecisionKind.Allow"/> reaches the executor.
+/// </summary>
+/// <remarks>
+/// This is the guardrail seam, designed now so Phase 4's tier/role-aware policy engine is
+/// additive rather than a rewrite. The default implementation
+/// (<see cref="AllowAllPolicyDecisionPoint"/>) is a no-op pass-through = Community tier.
+/// </remarks>
+public interface IOperationPolicyDecisionPoint
+{
+    /// <summary>
+    /// Evaluates the policy decision for an operation invocation.
+    /// </summary>
+    /// <param name="descriptor">The descriptor of the operation being invoked.</param>
+    /// <param name="request">The operation request.</param>
+    /// <param name="context">Resolved connection/principal/tier context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<PolicyDecision> EvaluateAsync(
+        IOperationDescriptor descriptor,
+        OperationRequest request,
+        OperationPolicyContext context,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// No-op pass-through policy decision point: always allows. This is the Community tier
+/// behavior (bring-your-own-model, no policy gate). The seam is real even with this default —
+/// a stricter decision point swapped in (Pro/Enterprise) short-circuits the executor without
+/// any executor change.
+/// </summary>
+public sealed class AllowAllPolicyDecisionPoint : IOperationPolicyDecisionPoint
+{
+    /// <inheritdoc />
+    public Task<PolicyDecision> EvaluateAsync(
+        IOperationDescriptor descriptor,
+        OperationRequest request,
+        OperationPolicyContext context,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(PolicyDecision.Allowed);
+}

--- a/src/Honua.Core/Features/Operations/Domain/OperationDescriptorModels.cs
+++ b/src/Honua.Core/Features/Operations/Domain/OperationDescriptorModels.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.WorkflowPackages.Domain;
+
+namespace Honua.Core.Features.Operations.Domain;
+
+/// <summary>
+/// Policy metadata carried by every operation descriptor. This is the data the policy
+/// decision point reasons over and the audit story is built on. The seam exists now;
+/// the enforcement engine lands later (Phase 4) so this is additive, not a retrofit.
+/// </summary>
+public sealed record OperationPolicyMetadata
+{
+    /// <summary>
+    /// How much state an invocation of this operation can affect.
+    /// </summary>
+    public required OperationBlastRadiusClass BlastRadiusClass { get; init; }
+
+    /// <summary>
+    /// The kind of side effect this operation produces.
+    /// </summary>
+    public required OperationSideEffectClass SideEffectClass { get; init; }
+
+    /// <summary>
+    /// Whether the operation is deterministic or AI-assisted.
+    /// </summary>
+    public required OperationDeterminism Determinism { get; init; }
+
+    /// <summary>
+    /// Whether the operation supports a read-only dry run / preview before committing.
+    /// </summary>
+    public required bool SupportsDryRun { get; init; }
+}
+
+/// <summary>
+/// Schema descriptor (groundable) for a single composable operation in the Honua
+/// Operations Toolset catalog. The descriptor is the half the AI grounds on; it is a
+/// distinct type from <see cref="Abstractions.IOperationExecutor"/>, which does the work.
+/// </summary>
+/// <remarks>
+/// The schema half is projectable from <see cref="WorkflowNodeDefinition"/>, but the
+/// descriptor is its own type — it is not a <see cref="WorkflowNodeDefinition"/>. A node
+/// definition is pure schema with no execution/approval/side-effect semantics; the
+/// descriptor adds the execution kind, approval model, and policy metadata that the
+/// toolset and its guardrail seam need.
+/// </remarks>
+public sealed record OperationDescriptor : IOperationDescriptor
+{
+    /// <inheritdoc />
+    public required string OperationId { get; init; }
+
+    /// <inheritdoc />
+    public required string ProviderId { get; init; }
+
+    /// <inheritdoc />
+    public required string Title { get; init; }
+
+    /// <inheritdoc />
+    public required string Description { get; init; }
+
+    /// <inheritdoc />
+    public required string Category { get; init; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<OperationParameterDescriptor> InputSchema { get; init; } = [];
+
+    /// <inheritdoc />
+    public IReadOnlyList<OperationParameterDescriptor> OutputSchema { get; init; } = [];
+
+    /// <inheritdoc />
+    public required OperationExecutionKind ExecutionKind { get; init; }
+
+    /// <inheritdoc />
+    public required OperationApprovalModel ApprovalModel { get; init; }
+
+    /// <inheritdoc />
+    public required OperationPolicyMetadata Policy { get; init; }
+
+    /// <inheritdoc />
+    public OperationGroundingMetadata? Grounding { get; init; }
+}
+
+/// <summary>
+/// A single input or output parameter on an operation descriptor. Reuses the AOT-safe
+/// constrained <see cref="WorkflowSchemaDefinition"/> so the toolset catalog projects
+/// cleanly from the workflow node registry and serializes under source-generated JSON.
+/// </summary>
+public sealed record OperationParameterDescriptor
+{
+    /// <summary>
+    /// Machine-readable parameter name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Human-readable label.
+    /// </summary>
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Whether the parameter must be supplied.
+    /// </summary>
+    public bool Required { get; init; }
+
+    /// <summary>
+    /// Constrained value schema for the parameter.
+    /// </summary>
+    public required WorkflowSchemaDefinition Schema { get; init; }
+}
+
+/// <summary>
+/// Placeholder for grounding metadata (lexical/semantic retrieval hints, synonyms,
+/// few-shot exemplar refs). Unused in this de-risking spike — the AI grounding layer is
+/// a later phase — but reserved on the descriptor so it is not a retrofit.
+/// </summary>
+public sealed record OperationGroundingMetadata
+{
+    /// <summary>
+    /// Alternate phrasings/synonyms that should resolve to this operation. Empty for now.
+    /// </summary>
+    public IReadOnlyList<string> Synonyms { get; init; } = [];
+}
+
+/// <summary>
+/// Versioned snapshot of the operation grounding catalog: every descriptor contributed by
+/// every registered descriptor provider. Mirrors <c>WorkflowNodeRegistrySnapshot</c>.
+/// </summary>
+public sealed record OperationCatalogSnapshot
+{
+    /// <summary>
+    /// Stable version fingerprint for this catalog snapshot.
+    /// </summary>
+    public required string CatalogVersion { get; init; }
+
+    /// <summary>
+    /// UTC timestamp when the snapshot was generated.
+    /// </summary>
+    public required DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>
+    /// Provider identifiers that contributed descriptors, in sorted order.
+    /// </summary>
+    public IReadOnlyList<string> ProviderIds { get; init; } = [];
+
+    /// <summary>
+    /// All operation descriptors available in the catalog.
+    /// </summary>
+    public required IReadOnlyList<OperationDescriptor> Operations { get; init; }
+}

--- a/src/Honua.Core/Features/Operations/Domain/OperationEnums.cs
+++ b/src/Honua.Core/Features/Operations/Domain/OperationEnums.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Operations.Domain;
+
+/// <summary>
+/// How an operation is executed. The descriptor declares the kind so that callers
+/// (the deterministic console UI today, the AI orchestrator later) know whether a
+/// <see cref="Abstractions.IOperationExecutor.SubmitAsync"/> returns an inline result,
+/// queues a durable job, or hands off a proposal for out-of-band execution.
+/// </summary>
+public enum OperationExecutionKind
+{
+    /// <summary>
+    /// The operation completes inline within the request and returns its result directly.
+    /// </summary>
+    Synchronous,
+
+    /// <summary>
+    /// The operation is submitted to the durable job substrate and tracked via a job id.
+    /// </summary>
+    Job,
+
+    /// <summary>
+    /// The operation produces a proposal that is executed out-of-band (for example the
+    /// DevOps agent's gitops/delegated-session flow). Submit returns a handle describing
+    /// the handoff rather than executing the side effect.
+    /// </summary>
+    ProposalHandoff
+}
+
+/// <summary>
+/// Human-gate model an operation flows through. Approval models are plural: publish
+/// uses an operator gate at the HTTP layer, Studio publish-requests use a request lane,
+/// and DevOps uses delegated sessions. The descriptor declares which one applies.
+/// </summary>
+public enum OperationApprovalModel
+{
+    /// <summary>
+    /// No human gate; the operation runs subject only to the policy decision point.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Guarded by the operator approval gate enforced at the HTTP layer
+    /// (for example <c>LayerPublishingEndpoints</c>).
+    /// </summary>
+    OperatorGate,
+
+    /// <summary>
+    /// Routed through the Studio publish-request approval lane.
+    /// </summary>
+    StudioPublishRequest,
+
+    /// <summary>
+    /// Routed through the DevOps delegated-session approval flow.
+    /// </summary>
+    DevOpsDelegatedSession
+}
+
+/// <summary>
+/// Blast-radius classification for an operation, used by the policy seam to reason about
+/// how much state an invocation can affect.
+/// </summary>
+public enum OperationBlastRadiusClass
+{
+    /// <summary>
+    /// Affects no durable state (read-only / diagnostic).
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Affects a single resource (one layer, one style, one item).
+    /// </summary>
+    ResourceScope,
+
+    /// <summary>
+    /// Affects a single service and its contained resources.
+    /// </summary>
+    ServiceScope,
+
+    /// <summary>
+    /// Affects tenant-wide or deployment-wide state.
+    /// </summary>
+    DeploymentScope
+}
+
+/// <summary>
+/// Side-effect classification for an operation, used by the policy seam.
+/// </summary>
+public enum OperationSideEffectClass
+{
+    /// <summary>
+    /// No side effects; read-only.
+    /// </summary>
+    ReadOnly,
+
+    /// <summary>
+    /// Creates new metadata/catalog state.
+    /// </summary>
+    CreatesMetadata,
+
+    /// <summary>
+    /// Mutates existing metadata/catalog state.
+    /// </summary>
+    MutatesMetadata,
+
+    /// <summary>
+    /// Mutates underlying data (features/rows), not just metadata.
+    /// </summary>
+    MutatesData,
+
+    /// <summary>
+    /// Deletes durable state.
+    /// </summary>
+    DestroysState
+}
+
+/// <summary>
+/// Whether an operation's behavior is deterministic or AI-assisted. Deterministic mode
+/// is "the same operations with AI off"; this flag lets the policy seam and audit treat
+/// AI-assisted operations differently from deterministic ones.
+/// </summary>
+public enum OperationDeterminism
+{
+    /// <summary>
+    /// Fully deterministic given its inputs.
+    /// </summary>
+    Deterministic,
+
+    /// <summary>
+    /// Uses AI assistance and may produce non-deterministic output.
+    /// </summary>
+    AiAssisted
+}
+
+/// <summary>
+/// Lifecycle status of a submitted operation, carried by <see cref="OperationHandle"/>.
+/// </summary>
+public enum OperationHandleStatus
+{
+    /// <summary>
+    /// The operation completed synchronously and its result is available on the handle.
+    /// </summary>
+    Completed,
+
+    /// <summary>
+    /// The operation was queued as a durable job; track progress via the job id.
+    /// </summary>
+    Queued,
+
+    /// <summary>
+    /// The operation is currently running.
+    /// </summary>
+    Running,
+
+    /// <summary>
+    /// The operation requires human approval before it can proceed; an approval lane is attached.
+    /// </summary>
+    RequiresApproval,
+
+    /// <summary>
+    /// The operation failed.
+    /// </summary>
+    Failed
+}

--- a/src/Honua.Core/Features/Operations/Domain/OperationExecutionModels.cs
+++ b/src/Honua.Core/Features/Operations/Domain/OperationExecutionModels.cs
@@ -1,0 +1,258 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Operations.Domain;
+
+/// <summary>
+/// A request to validate or submit an operation. Carries the target operation id, the
+/// caller-supplied parameter values, and the connection/scope context the executor needs.
+/// Parameter values are kept as strings so the contract stays AOT-safe and provider-neutral;
+/// the executor maps them onto its concrete request type.
+/// </summary>
+public sealed record OperationRequest
+{
+    /// <summary>
+    /// Operation identifier this request targets (for example <c>service.publish</c>).
+    /// </summary>
+    public required string OperationId { get; init; }
+
+    /// <summary>
+    /// Caller-supplied parameter values keyed by parameter name.
+    /// </summary>
+    public IReadOnlyDictionary<string, string?> Parameters { get; init; } =
+        new Dictionary<string, string?>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Optional connection identifier the operation targets (for example the secure
+    /// connection whose tables are being published).
+    /// </summary>
+    public string? ConnectionId { get; init; }
+
+    /// <summary>
+    /// Optional service name the operation targets.
+    /// </summary>
+    public string? ServiceName { get; init; }
+
+    /// <summary>
+    /// Optional list of attribute fields, when the operation acts on a subset of columns.
+    /// </summary>
+    public IReadOnlyList<string> Fields { get; init; } = [];
+
+    /// <summary>
+    /// When true, the caller requested a dry-run/preview rather than a committed execution
+    /// (only honoured when the descriptor's policy advertises <c>SupportsDryRun</c>).
+    /// </summary>
+    public bool DryRun { get; init; }
+}
+
+/// <summary>
+/// Context passed to <see cref="Abstractions.IOperationExecutor.SubmitAsync"/> and the
+/// policy decision point. Carries the resolved connection string and the caller principal
+/// identity so executors and policy can act without re-resolving. Tier/role-aware policy
+/// uses the principal fields; the no-op default ignores them.
+/// </summary>
+public sealed record OperationPolicyContext
+{
+    /// <summary>
+    /// Resolved connection string for the target connection, when the operation needs one.
+    /// </summary>
+    public string? ResolvedConnectionString { get; init; }
+
+    /// <summary>
+    /// Stable identifier of the invoking principal, for audit and tier/role policy.
+    /// </summary>
+    public string? PrincipalId { get; init; }
+
+    /// <summary>
+    /// Tier the invoking tenant is on (for example <c>community</c>, <c>pro</c>, <c>enterprise</c>).
+    /// Community is pass-through; Pro/Enterprise enforce the policy engine (Phase 4).
+    /// </summary>
+    public string? Tier { get; init; }
+}
+
+/// <summary>
+/// Read-only, idempotent result of <see cref="Abstractions.IOperationExecutor.ValidateAsync"/>:
+/// a plan/diagnostics view of what the operation would do, without side effects.
+/// </summary>
+public sealed record OperationValidation
+{
+    /// <summary>
+    /// Whether validation passed without blocking errors.
+    /// </summary>
+    public required bool IsValid { get; init; }
+
+    /// <summary>
+    /// Machine-readable status (for example <c>valid</c>, <c>warning</c>, <c>invalid</c>).
+    /// </summary>
+    public required string Status { get; init; }
+
+    /// <summary>
+    /// Human-readable diagnostic messages describing the plan or the problems found.
+    /// </summary>
+    public IReadOnlyList<string> Messages { get; init; } = [];
+}
+
+/// <summary>
+/// Handle returned by <see cref="Abstractions.IOperationExecutor.SubmitAsync"/>. This is a
+/// handle, not a flat result, precisely so a single submit contract can represent a completed
+/// synchronous operation, a queued durable job, and a "requires approval" outcome — the three
+/// shapes the toolset must model (publish is sync, geoprocessing is job-based, approval lanes
+/// return queued/pending).
+/// </summary>
+public sealed record OperationHandle
+{
+    /// <summary>
+    /// Operation identifier this handle was produced for.
+    /// </summary>
+    public required string OperationId { get; init; }
+
+    /// <summary>
+    /// Lifecycle status of the operation.
+    /// </summary>
+    public required OperationHandleStatus Status { get; init; }
+
+    /// <summary>
+    /// Stable handle identifier, used to look the handle's status back up.
+    /// </summary>
+    public required string HandleId { get; init; }
+
+    /// <summary>
+    /// Synchronous result summary, populated only when <see cref="Status"/> is
+    /// <see cref="OperationHandleStatus.Completed"/>.
+    /// </summary>
+    public OperationResultSummary? Result { get; init; }
+
+    /// <summary>
+    /// Durable job identifier, populated when the operation was queued as a job.
+    /// </summary>
+    public string? JobId { get; init; }
+
+    /// <summary>
+    /// Approval lane identifier, populated when <see cref="Status"/> is
+    /// <see cref="OperationHandleStatus.RequiresApproval"/>.
+    /// </summary>
+    public string? ApprovalLane { get; init; }
+
+    /// <summary>
+    /// Metadata v2 graph revision that resulted from the operation, when it mutated the
+    /// canonical metadata graph (for example a publish that created a new layer resource).
+    /// </summary>
+    public long? MetadataRevision { get; init; }
+
+    /// <summary>
+    /// Reason describing a non-completed outcome (deny/require-approval/dry-run/failure).
+    /// </summary>
+    public string? Reason { get; init; }
+}
+
+/// <summary>
+/// Lightweight, serializable summary of a synchronous operation result carried on
+/// <see cref="OperationHandle.Result"/>. Operation-specific detail is conveyed as a flat
+/// string map so the handle stays AOT-safe and protocol-neutral.
+/// </summary>
+public sealed record OperationResultSummary
+{
+    /// <summary>
+    /// Human-readable summary of what happened.
+    /// </summary>
+    public required string Summary { get; init; }
+
+    /// <summary>
+    /// Operation-specific detail values keyed by name (for example <c>layerId</c>,
+    /// <c>serviceName</c>).
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Details { get; init; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+}
+
+/// <summary>
+/// Live status view of a previously submitted operation, returned by
+/// <see cref="Abstractions.IOperationExecutor.GetStatusAsync"/>. For the async/job case
+/// this is how a caller polls progress after the initial submit returned a queued handle.
+/// </summary>
+public sealed record OperationStatus
+{
+    /// <summary>
+    /// Operation identifier.
+    /// </summary>
+    public required string OperationId { get; init; }
+
+    /// <summary>
+    /// Handle identifier the status is for.
+    /// </summary>
+    public required string HandleId { get; init; }
+
+    /// <summary>
+    /// Current lifecycle status.
+    /// </summary>
+    public required OperationHandleStatus Status { get; init; }
+
+    /// <summary>
+    /// Result summary when the operation has completed.
+    /// </summary>
+    public OperationResultSummary? Result { get; init; }
+
+    /// <summary>
+    /// Durable job identifier when the operation is running as a job.
+    /// </summary>
+    public string? JobId { get; init; }
+
+    /// <summary>
+    /// Metadata v2 revision produced by the operation, when applicable.
+    /// </summary>
+    public long? MetadataRevision { get; init; }
+}
+
+/// <summary>
+/// Outcome of <see cref="Abstractions.IOperationPolicyDecisionPoint.EvaluateAsync"/>.
+/// </summary>
+public enum PolicyDecisionKind
+{
+    /// <summary>
+    /// Allow the operation to execute.
+    /// </summary>
+    Allow,
+
+    /// <summary>
+    /// Require human approval before executing.
+    /// </summary>
+    RequireApproval,
+
+    /// <summary>
+    /// Require a dry-run/preview before a committed execution is permitted.
+    /// </summary>
+    DryRunFirst,
+
+    /// <summary>
+    /// Deny the operation outright.
+    /// </summary>
+    Deny
+}
+
+/// <summary>
+/// Decision returned by the policy decision point. The dispatcher consults this before any
+/// executor side effect; only <see cref="PolicyDecisionKind.Allow"/> reaches the executor.
+/// </summary>
+public sealed record PolicyDecision
+{
+    /// <summary>
+    /// The policy outcome.
+    /// </summary>
+    public required PolicyDecisionKind Kind { get; init; }
+
+    /// <summary>
+    /// Optional human-readable reason for the decision.
+    /// </summary>
+    public string? Reason { get; init; }
+
+    /// <summary>
+    /// Approval lane to route to when <see cref="Kind"/> is
+    /// <see cref="PolicyDecisionKind.RequireApproval"/>.
+    /// </summary>
+    public string? ApprovalLane { get; init; }
+
+    /// <summary>
+    /// A pass-through allow decision (Community tier default).
+    /// </summary>
+    public static PolicyDecision Allowed { get; } = new() { Kind = PolicyDecisionKind.Allow };
+}

--- a/src/Honua.Core/Features/Operations/Services/OperationCatalog.cs
+++ b/src/Honua.Core/Features/Operations/Services/OperationCatalog.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Cryptography;
+using System.Text;
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+
+namespace Honua.Core.Features.Operations.Services;
+
+/// <summary>
+/// Default <see cref="IOperationCatalog"/>: aggregates every registered
+/// <see cref="IOperationDescriptorProvider"/> into a versioned grounding snapshot. Mirrors
+/// the workflow node registry's aggregation: providers are queried, descriptors are sorted
+/// for stable output, and a fingerprint version is computed over the descriptor ids.
+/// </summary>
+public sealed class OperationCatalog : IOperationCatalog
+{
+    private readonly IReadOnlyList<IOperationDescriptorProvider> _providers;
+    private readonly TimeProvider _clock;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="OperationCatalog"/>.
+    /// </summary>
+    /// <param name="providers">Registered descriptor providers.</param>
+    /// <param name="clock">Time provider for snapshot timestamps.</param>
+    public OperationCatalog(IEnumerable<IOperationDescriptorProvider> providers, TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(providers);
+        ArgumentNullException.ThrowIfNull(clock);
+        _providers = providers.ToArray();
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationCatalogSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        var descriptors = new List<OperationDescriptor>();
+        var providerIds = new List<string>();
+
+        foreach (var provider in _providers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            providerIds.Add(provider.ProviderId);
+            var contributed = await provider.ListDescriptorsAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var descriptor in contributed)
+            {
+                descriptors.Add(ToRecord(descriptor));
+            }
+        }
+
+        var sorted = descriptors
+            .OrderBy(descriptor => descriptor.Category, StringComparer.Ordinal)
+            .ThenBy(descriptor => descriptor.OperationId, StringComparer.Ordinal)
+            .ToArray();
+
+        return new OperationCatalogSnapshot
+        {
+            CatalogVersion = ComputeVersion(sorted),
+            GeneratedAt = _clock.GetUtcNow(),
+            ProviderIds = providerIds.OrderBy(id => id, StringComparer.Ordinal).ToArray(),
+            Operations = sorted
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationDescriptor?> GetDescriptorAsync(
+        string operationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(operationId))
+        {
+            return null;
+        }
+
+        var snapshot = await GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        return snapshot.Operations.FirstOrDefault(operation =>
+            string.Equals(operation.OperationId, operationId, StringComparison.Ordinal));
+    }
+
+    private static OperationDescriptor ToRecord(IOperationDescriptor descriptor)
+        => descriptor as OperationDescriptor ?? new OperationDescriptor
+        {
+            OperationId = descriptor.OperationId,
+            ProviderId = descriptor.ProviderId,
+            Title = descriptor.Title,
+            Description = descriptor.Description,
+            Category = descriptor.Category,
+            InputSchema = descriptor.InputSchema,
+            OutputSchema = descriptor.OutputSchema,
+            ExecutionKind = descriptor.ExecutionKind,
+            ApprovalModel = descriptor.ApprovalModel,
+            Policy = descriptor.Policy,
+            Grounding = descriptor.Grounding
+        };
+
+    private static string ComputeVersion(IReadOnlyList<OperationDescriptor> descriptors)
+    {
+        var builder = new StringBuilder();
+        foreach (var descriptor in descriptors)
+        {
+            builder.Append(descriptor.OperationId)
+                .Append(':')
+                .Append(descriptor.ProviderId)
+                .Append(';');
+        }
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()));
+        return "operation-catalog:" + Convert.ToHexString(hash)[..16].ToLowerInvariant();
+    }
+}

--- a/src/Honua.Core/Features/Operations/Services/OperationDispatcher.cs
+++ b/src/Honua.Core/Features/Operations/Services/OperationDispatcher.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+
+namespace Honua.Core.Features.Operations.Services;
+
+/// <summary>
+/// Default <see cref="IOperationInvoker"/>. Resolves the descriptor + executor for an
+/// operation id, runs the policy decision point, and only on
+/// <see cref="PolicyDecisionKind.Allow"/> calls the executor. For Deny / RequireApproval /
+/// DryRunFirst it returns a handle that reflects the decision WITHOUT touching the executor —
+/// proving the guardrail seam holds even with the pass-through default policy.
+/// </summary>
+public sealed class OperationDispatcher : IOperationInvoker
+{
+    private readonly IOperationCatalog _catalog;
+    private readonly Dictionary<string, IOperationExecutor> _executors;
+    private readonly IOperationPolicyDecisionPoint _policy;
+    private readonly TimeProvider _clock;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="OperationDispatcher"/>.
+    /// </summary>
+    /// <param name="catalog">Operation grounding catalog.</param>
+    /// <param name="executors">Registered operation executors.</param>
+    /// <param name="policy">Policy decision point consulted before execution.</param>
+    /// <param name="clock">Time provider used for handle id generation.</param>
+    public OperationDispatcher(
+        IOperationCatalog catalog,
+        IEnumerable<IOperationExecutor> executors,
+        IOperationPolicyDecisionPoint policy,
+        TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        ArgumentNullException.ThrowIfNull(executors);
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(clock);
+        _catalog = catalog;
+        _policy = policy;
+        _clock = clock;
+        _executors = executors.ToDictionary(executor => executor.OperationId, StringComparer.Ordinal);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationValidation> ValidateAsync(
+        OperationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var executor = ResolveExecutor(request.OperationId);
+        return await executor.ValidateAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationHandle> SubmitAsync(
+        OperationRequest request,
+        OperationPolicyContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var descriptor = await _catalog.GetDescriptorAsync(request.OperationId, cancellationToken).ConfigureAwait(false)
+            ?? throw new OperationNotFoundException(request.OperationId);
+        var executor = ResolveExecutor(request.OperationId);
+
+        var decision = await _policy
+            .EvaluateAsync(descriptor, request, context, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Guardrail seam: anything other than Allow short-circuits the executor.
+        if (decision.Kind != PolicyDecisionKind.Allow)
+        {
+            return BuildDecisionHandle(request.OperationId, decision);
+        }
+
+        return await executor.SubmitAsync(request, context, cancellationToken).ConfigureAwait(false);
+    }
+
+    private IOperationExecutor ResolveExecutor(string operationId)
+        => _executors.TryGetValue(operationId, out var executor)
+            ? executor
+            : throw new OperationNotFoundException(operationId);
+
+    private OperationHandle BuildDecisionHandle(string operationId, PolicyDecision decision)
+    {
+        var status = decision.Kind switch
+        {
+            PolicyDecisionKind.RequireApproval => OperationHandleStatus.RequiresApproval,
+            PolicyDecisionKind.DryRunFirst => OperationHandleStatus.RequiresApproval,
+            _ => OperationHandleStatus.Failed
+        };
+
+        return new OperationHandle
+        {
+            OperationId = operationId,
+            HandleId = NewHandleId(),
+            Status = status,
+            ApprovalLane = decision.ApprovalLane,
+            Reason = decision.Reason ?? decision.Kind.ToString()
+        };
+    }
+
+    private string NewHandleId()
+        => $"op-{_clock.GetUtcNow().ToUnixTimeMilliseconds():x}-{Guid.NewGuid():N}"[..32];
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -252,6 +252,12 @@ public static class EndpointRegistry
         new("POST", "/api/v1/admin/packages/preview"),
         new("GET", "/api/v1/console/workflow-node-registry"),
         new("GET", "/api/v1/console/workflow-node-registry/{nodeTypeId}"),
+
+        // Honua Operations Toolset (descriptor/executor split, policy-gated dispatcher)
+        new("GET", "/api/v1/operations"),
+        new("POST", "/api/v1/operations/{id}/validate"),
+        new("POST", "/api/v1/operations/{id}/submit"),
+        new("GET", "/api/v1/operations/handles/{handleId}"),
         new("GET", "/api/v1/console/workflow-packages"),
         new("POST", "/api/v1/console/workflow-packages"),
         new("GET", "/api/v1/console/workflow-packages/{packageId}"),

--- a/src/Honua.Server/Features/Operations/MapGenerateExecutor.cs
+++ b/src/Honua.Server/Features/Operations/MapGenerateExecutor.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Ai.MapGeneration;
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+
+namespace Honua.Server.Features.Operations;
+
+/// <summary>
+/// Concrete executor for <c>map.generate</c>. It WRAPS the existing
+/// <see cref="IMapGenerationService"/> rather than reimplementing generation:
+/// <see cref="ValidateAsync"/> validates the prompt input, and <see cref="SubmitAsync"/> calls
+/// <c>GenerateAsync</c> and wraps the produced draft map package into an
+/// <see cref="OperationHandle"/>.
+/// </summary>
+/// <remarks>
+/// This is the strangler proof. Unlike the synchronous <see cref="ServicePublishExecutor"/>
+/// (which returns a Completed handle for a committed mutation), this executor returns a
+/// Completed handle whose <see cref="OperationHandle.Result"/> carries the produced DRAFT and
+/// whose <see cref="OperationHandle.ApprovalLane"/> is the Studio publish-request lane: the
+/// generator produced a draft that now awaits the Studio draft → version → publish-request
+/// lifecycle. The same Validate / Submit→Handle / GetStatus contract that models a sync publish
+/// also models a generator-yields-a-draft-entering-a-lane — the toolset absorbs generators.
+/// Generation itself is owned by <see cref="IMapGenerationService"/> in Honua.Ai; this executor
+/// is a thin wrapper that adapts the request and frames the result as a lifecycle handle.
+/// </remarks>
+internal sealed class MapGenerateExecutor : IOperationExecutor
+{
+    private readonly IMapGenerationService _mapGenerationService;
+    private readonly TimeProvider _clock;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="MapGenerateExecutor"/>.
+    /// </summary>
+    /// <param name="mapGenerationService">Shared map generation service (reused, not reimplemented).</param>
+    /// <param name="clock">Time provider for handle id generation.</param>
+    public MapGenerateExecutor(IMapGenerationService mapGenerationService, TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(mapGenerationService);
+        ArgumentNullException.ThrowIfNull(clock);
+        _mapGenerationService = mapGenerationService;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public string OperationId => MapGenerateOperation.OperationId;
+
+    /// <inheritdoc />
+    public Task<OperationValidation> ValidateAsync(
+        OperationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Read-only, side-effect-free input validation: a non-empty prompt is required (the same
+        // precondition the Studio endpoint enforces before invoking the generator). The richer
+        // structural validation of the produced map happens inside the generation service itself.
+        var prompt = GetOptional(request, "prompt");
+        if (string.IsNullOrWhiteSpace(prompt))
+        {
+            return Task.FromResult(new OperationValidation
+            {
+                IsValid = false,
+                Status = "invalid",
+                Messages = ["Required operation parameter 'prompt' is missing or empty."]
+            });
+        }
+
+        return Task.FromResult(new OperationValidation
+        {
+            IsValid = true,
+            Status = "valid",
+            Messages = ["Prompt accepted; generation will produce a draft map package for the Studio publish-request lane."]
+        });
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationHandle> SubmitAsync(
+        OperationRequest request,
+        OperationPolicyContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var prompt = GetRequired(request, "prompt");
+
+        // WRAP the existing generator — generation is NOT reimplemented here.
+        var result = await _mapGenerationService
+            .GenerateAsync(
+                new MapGenerationRequest
+                {
+                    Prompt = prompt,
+                    Provider = GetOptional(request, "provider"),
+                    Model = GetOptional(request, "model")
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        // The generator produced a DRAFT. Frame it as a handle entering the Studio
+        // publish-request lifecycle: Status=Completed (the draft exists synchronously), with the
+        // produced draft on Result and ApprovalLane set to the Studio publish-request lane the
+        // draft now awaits. A non-"generated" outcome (clarification / unsupported / error)
+        // produced no draft, so it carries no approval lane.
+        var producedDraft = string.Equals(result.Status, GeneratedStatus, StringComparison.Ordinal)
+            && result.Package is not null;
+
+        return new OperationHandle
+        {
+            OperationId = OperationId,
+            HandleId = NewHandleId(),
+            Status = OperationHandleStatus.Completed,
+            ApprovalLane = producedDraft ? MapGenerateOperation.StudioPublishRequestLane : null,
+            Reason = producedDraft ? null : result.Rationale,
+            Result = new OperationResultSummary
+            {
+                Summary = producedDraft
+                    ? $"Generated draft map package '{result.Package!.MapPackageId}' ({result.Package.Status}); awaiting the Studio publish-request lane."
+                    : $"Generation returned status '{result.Status}' without a draft.",
+                Details = BuildDetails(result, producedDraft)
+            }
+        };
+    }
+
+    /// <inheritdoc />
+    public Task<OperationStatus> GetStatusAsync(OperationHandle handle, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(handle);
+
+        // map.generate produces the draft synchronously: the submit handle is terminal. Status
+        // mirrors it. The downstream publish-request lifecycle is tracked by the Studio lane, not
+        // by this executor's status poll.
+        return Task.FromResult(new OperationStatus
+        {
+            OperationId = OperationId,
+            HandleId = handle.HandleId,
+            Status = handle.Status,
+            Result = handle.Result,
+            JobId = handle.JobId,
+            MetadataRevision = handle.MetadataRevision
+        });
+    }
+
+    private const string GeneratedStatus = "generated";
+
+    private static Dictionary<string, string> BuildDetails(MapGenerationResult result, bool producedDraft)
+    {
+        var details = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["status"] = result.Status
+        };
+
+        if (producedDraft)
+        {
+            var draft = result.Package!;
+            details["mapPackageId"] = draft.MapPackageId;
+            details["packageStatus"] = draft.Status.ToString();
+            details["format"] = draft.Format;
+            details["approvalLane"] = MapGenerateOperation.StudioPublishRequestLane;
+        }
+
+        if (!string.IsNullOrWhiteSpace(result.Provider))
+        {
+            details["provider"] = result.Provider!;
+        }
+
+        if (!string.IsNullOrWhiteSpace(result.Model))
+        {
+            details["model"] = result.Model!;
+        }
+
+        return details;
+    }
+
+    private static string GetRequired(OperationRequest request, string name)
+        => request.Parameters.TryGetValue(name, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value!
+            : throw new ArgumentException($"Required operation parameter '{name}' is missing.");
+
+    private static string? GetOptional(OperationRequest request, string name)
+        => request.Parameters.TryGetValue(name, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value
+            : null;
+
+    private string NewHandleId()
+        => $"op-{_clock.GetUtcNow().ToUnixTimeMilliseconds():x}-{Guid.NewGuid():N}"[..32];
+}

--- a/src/Honua.Server/Features/Operations/MapGenerateOperation.cs
+++ b/src/Honua.Server/Features/Operations/MapGenerateOperation.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Domain;
+using Honua.Core.Features.WorkflowPackages.Domain;
+
+namespace Honua.Server.Features.Operations;
+
+/// <summary>
+/// Shared identity and descriptor definition for the <c>map.generate</c> Studio operation.
+/// Keeps the operation id and its groundable descriptor in one place so the descriptor
+/// provider and the executor agree on the contract.
+/// </summary>
+/// <remarks>
+/// This is the strangler proof for the toolset: <c>map.generate</c> is a Studio <em>generator</em>,
+/// not a flat sync side effect. It produces a DRAFT map package that enters the Studio
+/// draft → version → publish-request lifecycle, so its <see cref="OperationApprovalModel"/> is
+/// <see cref="OperationApprovalModel.StudioPublishRequest"/> (the lane the produced draft awaits),
+/// and its determinism is <see cref="OperationDeterminism.AiAssisted"/>. The same Validate /
+/// Submit→Handle / GetStatus contract that models the synchronous publish executor also models a
+/// generator that yields a draft-entering-a-lane — proving the toolset absorbs generators.
+/// </remarks>
+internal static class MapGenerateOperation
+{
+    /// <summary>
+    /// Stable operation identifier for generating a draft map package from a prompt.
+    /// </summary>
+    public const string OperationId = "map.generate";
+
+    /// <summary>
+    /// Provider identifier for the server-side Studio generation descriptor provider.
+    /// </summary>
+    public const string ProviderId = "honua.server.operations";
+
+    /// <summary>
+    /// Approval lane the produced draft awaits: the Studio publish-request lifecycle.
+    /// </summary>
+    public const string StudioPublishRequestLane = "studio-publish-request";
+
+    /// <summary>
+    /// Builds the groundable descriptor for <c>map.generate</c>. ExecutionKind is
+    /// <see cref="OperationExecutionKind.Synchronous"/> (the draft is produced inline within
+    /// the request); ApprovalModel is <see cref="OperationApprovalModel.StudioPublishRequest"/>
+    /// — the generated map is a draft entering the Studio draft → version → publish-request
+    /// lifecycle, NOT an operator-gated mutation. Policy advertises a draft/workspace blast
+    /// radius, a creates-draft side effect, AI-assisted determinism, and no dry run.
+    /// </summary>
+    public static OperationDescriptor BuildDescriptor() => new()
+    {
+        OperationId = OperationId,
+        ProviderId = ProviderId,
+        Title = "Generate map draft",
+        Description = "Generates a draft map package from a natural-language prompt, entering the Studio draft → version → publish-request lifecycle.",
+        Category = "Studio/Generation",
+        ExecutionKind = OperationExecutionKind.Synchronous,
+        ApprovalModel = OperationApprovalModel.StudioPublishRequest,
+        Policy = new OperationPolicyMetadata
+        {
+            // BlastRadius=Draft/Workspace scope: the generated draft is a new resource that
+            // only enters the workspace as a draft; it does not mutate published service state.
+            BlastRadiusClass = OperationBlastRadiusClass.ResourceScope,
+            SideEffectClass = OperationSideEffectClass.CreatesMetadata,
+            Determinism = OperationDeterminism.AiAssisted,
+            SupportsDryRun = false
+        },
+        InputSchema =
+        [
+            Required("prompt", "Prompt", WorkflowSchemaValueType.Text),
+            Optional("provider", "Generation provider", WorkflowSchemaValueType.Text),
+            Optional("model", "Model override", WorkflowSchemaValueType.Text)
+        ],
+        OutputSchema =
+        [
+            new OperationParameterDescriptor
+            {
+                Name = "mapPackageId",
+                Title = "Draft map package id",
+                Required = true,
+                Schema = new WorkflowSchemaDefinition { Type = WorkflowSchemaValueType.Text }
+            },
+            new OperationParameterDescriptor
+            {
+                Name = "status",
+                Title = "Generation status",
+                Required = true,
+                Schema = new WorkflowSchemaDefinition { Type = WorkflowSchemaValueType.Text }
+            }
+        ]
+    };
+
+    private static OperationParameterDescriptor Required(string name, string title, WorkflowSchemaValueType type)
+        => new()
+        {
+            Name = name,
+            Title = title,
+            Required = true,
+            Schema = new WorkflowSchemaDefinition { Type = type }
+        };
+
+    private static OperationParameterDescriptor Optional(string name, string title, WorkflowSchemaValueType type)
+        => new()
+        {
+            Name = name,
+            Title = title,
+            Required = false,
+            Schema = new WorkflowSchemaDefinition { Type = type }
+        };
+}

--- a/src/Honua.Server/Features/Operations/OperationHandleStore.cs
+++ b/src/Honua.Server/Features/Operations/OperationHandleStore.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using Honua.Core.Features.Operations.Domain;
+
+namespace Honua.Server.Features.Operations;
+
+/// <summary>
+/// Minimal in-memory store of operation handles so the status endpoint
+/// (<c>GET /api/v1/operations/handles/{handleId}</c>) can look a submitted handle back up.
+/// This is a de-risking-spike scaffold: a durable handle/job store lands with the job-based
+/// execution kinds in a later phase.
+/// </summary>
+internal sealed class OperationHandleStore
+{
+    private readonly ConcurrentDictionary<string, OperationHandle> _handles = new(StringComparer.Ordinal);
+
+    public void Record(OperationHandle handle)
+    {
+        ArgumentNullException.ThrowIfNull(handle);
+        _handles[handle.HandleId] = handle;
+    }
+
+    public OperationHandle? Get(string handleId)
+        => _handles.TryGetValue(handleId, out var handle) ? handle : null;
+}

--- a/src/Honua.Server/Features/Operations/OperationsEndpoints.cs
+++ b/src/Honua.Server/Features/Operations/OperationsEndpoints.cs
@@ -1,0 +1,208 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Exceptions;
+using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Models;
+
+namespace Honua.Server.Features.Operations;
+
+/// <summary>
+/// HTTP surface for the Honua Operations Toolset (deterministic, no AI): list the grounding
+/// catalog, validate and submit operations through the policy-gated dispatcher, and read a
+/// submitted handle's status. Admin-authorized.
+/// </summary>
+internal static class OperationsEndpoints
+{
+    internal sealed class OperationsEndpointsLog;
+
+    public static void MapOperationsEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/operations")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Operations")
+            .RequireAdminAuthorization();
+
+        group.MapGet("/", HandleListOperations)
+            .WithName("ListOperations")
+            .WithSummary("List the operation grounding catalog")
+            .Produces<ApiResponse<OperationCatalogSnapshot>>();
+
+        group.MapPost("/{id}/validate", HandleValidateOperation)
+            .WithName("ValidateOperation")
+            .WithSummary("Validate (plan) an operation without side effects")
+            .Accepts<OperationInvokeRequest>("application/json")
+            .Produces<ApiResponse<OperationValidation>>()
+            .Produces(StatusCodes.Status404NotFound);
+
+        group.MapPost("/{id}/submit", HandleSubmitOperation)
+            .WithName("SubmitOperation")
+            .WithSummary("Submit an operation through the policy-gated dispatcher")
+            .Accepts<OperationInvokeRequest>("application/json")
+            .Produces<ApiResponse<OperationHandle>>()
+            .Produces(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound);
+
+        group.MapGet("/handles/{handleId}", HandleGetHandleStatus)
+            .WithName("GetOperationHandleStatus")
+            .WithSummary("Get the status of a submitted operation handle")
+            .Produces<ApiResponse<OperationStatus>>()
+            .Produces(StatusCodes.Status404NotFound);
+    }
+
+    private static async Task<IResult> HandleListOperations(
+        HttpContext context,
+        IOperationCatalog catalog,
+        CancellationToken cancellationToken)
+    {
+        SetNoStore(context);
+        var snapshot = await catalog.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        context.Response.Headers.ETag = $"\"{snapshot.CatalogVersion}\"";
+        return Results.Json(
+            ApiResponse<OperationCatalogSnapshot>.CreateSuccess(snapshot),
+            OperationsJsonContext.Default.ApiResponseOperationCatalogSnapshot);
+    }
+
+    private static async Task<IResult> HandleValidateOperation(
+        HttpContext context,
+        string id,
+        OperationInvokeRequest request,
+        IOperationInvoker invoker,
+        CancellationToken cancellationToken)
+    {
+        SetNoStore(context);
+        try
+        {
+            var validation = await invoker
+                .ValidateAsync(ToRequest(id, request), cancellationToken)
+                .ConfigureAwait(false);
+            return Results.Json(
+                ApiResponse<OperationValidation>.CreateSuccess(validation),
+                OperationsJsonContext.Default.ApiResponseOperationValidation);
+        }
+        catch (OperationNotFoundException)
+        {
+            return NotFound(context, $"Operation '{id}' was not found.");
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(context, ex.Message);
+        }
+        catch (ResourceNotFoundException)
+        {
+            return NotFound(context, "The requested resource was not found.");
+        }
+    }
+
+    private static async Task<IResult> HandleSubmitOperation(
+        HttpContext context,
+        string id,
+        OperationInvokeRequest request,
+        IOperationInvoker invoker,
+        OperationHandleStore handleStore,
+        CancellationToken cancellationToken)
+    {
+        SetNoStore(context);
+
+        // ApprovalModel=OperatorGate: publish operations flow through the operator approval
+        // gate at the HTTP layer, matching LayerPublishingEndpoints. The policy decision point
+        // (Community pass-through today) is consulted again inside the dispatcher.
+        var gate = context.RequestServices.GetRequiredService<OperatorApprovalGate>();
+        var approvalResult = gate.EvaluateApproval(
+            context, OperatorResourceType.Catalog, OperatorOperation.Publish);
+        if (approvalResult != null)
+        {
+            return approvalResult;
+        }
+
+        try
+        {
+            var policyContext = new OperationPolicyContext
+            {
+                PrincipalId = context.User.Identity?.Name
+            };
+
+            var handle = await invoker
+                .SubmitAsync(ToRequest(id, request), policyContext, cancellationToken)
+                .ConfigureAwait(false);
+            handleStore.Record(handle);
+
+            return Results.Json(
+                ApiResponse<OperationHandle>.CreateSuccess(handle),
+                OperationsJsonContext.Default.ApiResponseOperationHandle);
+        }
+        catch (OperationNotFoundException)
+        {
+            return NotFound(context, $"Operation '{id}' was not found.");
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(context, ex.Message);
+        }
+        catch (ResourceNotFoundException)
+        {
+            return NotFound(context, "The requested resource was not found.");
+        }
+    }
+
+    private static IResult HandleGetHandleStatus(
+        HttpContext context,
+        string handleId,
+        OperationHandleStore handleStore)
+    {
+        SetNoStore(context);
+        var handle = handleStore.Get(handleId);
+        if (handle is null)
+        {
+            return NotFound(context, $"Operation handle '{handleId}' was not found.");
+        }
+
+        var status = new OperationStatus
+        {
+            OperationId = handle.OperationId,
+            HandleId = handle.HandleId,
+            Status = handle.Status,
+            Result = handle.Result,
+            JobId = handle.JobId,
+            MetadataRevision = handle.MetadataRevision
+        };
+
+        return Results.Json(
+            ApiResponse<OperationStatus>.CreateSuccess(status),
+            OperationsJsonContext.Default.ApiResponseOperationStatus);
+    }
+
+    private static OperationRequest ToRequest(string operationId, OperationInvokeRequest request)
+        => new()
+        {
+            OperationId = operationId,
+            Parameters = request.Parameters,
+            ConnectionId = request.ConnectionId,
+            ServiceName = request.ServiceName,
+            Fields = request.Fields,
+            DryRun = request.DryRun
+        };
+
+    private static IResult BadRequest(HttpContext context, string detail)
+        => ProblemDetailsHelpers.CreateAdminProblem(
+            context,
+            StatusCodes.Status400BadRequest,
+            ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+            detail);
+
+    private static IResult NotFound(HttpContext context, string detail)
+        => ProblemDetailsHelpers.CreateAdminProblem(
+            context,
+            StatusCodes.Status404NotFound,
+            ProblemDetailsHelpers.GetTitle(StatusCodes.Status404NotFound),
+            detail);
+
+    private static void SetNoStore(HttpContext context)
+        => context.Response.Headers.CacheControl = "no-store";
+}

--- a/src/Honua.Server/Features/Operations/OperationsJsonContext.cs
+++ b/src/Honua.Server/Features/Operations/OperationsJsonContext.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Operations.Domain;
+using Honua.Infrastructure.Models;
+
+namespace Honua.Server.Features.Operations;
+
+/// <summary>
+/// Source-generated JSON context for the Operations Toolset endpoints. Keeps the surface
+/// AOT-safe (the published image disables reflection-based serialization).
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true)]
+[JsonSerializable(typeof(ApiResponse<OperationCatalogSnapshot>))]
+[JsonSerializable(typeof(ApiResponse<OperationValidation>))]
+[JsonSerializable(typeof(ApiResponse<OperationHandle>))]
+[JsonSerializable(typeof(ApiResponse<OperationStatus>))]
+[JsonSerializable(typeof(ApiResponse<object>))]
+[JsonSerializable(typeof(OperationCatalogSnapshot))]
+[JsonSerializable(typeof(OperationValidation))]
+[JsonSerializable(typeof(OperationHandle))]
+[JsonSerializable(typeof(OperationStatus))]
+[JsonSerializable(typeof(OperationInvokeRequest))]
+internal sealed partial class OperationsJsonContext : JsonSerializerContext
+{
+}
+
+/// <summary>
+/// Request body for the validate and submit operation endpoints. Mirrors the
+/// <c>OperationRequest</c> domain shape with a JSON-friendly surface.
+/// </summary>
+public sealed record OperationInvokeRequest
+{
+    /// <summary>
+    /// Caller-supplied parameter values keyed by parameter name.
+    /// </summary>
+    public IReadOnlyDictionary<string, string?> Parameters { get; init; } =
+        new Dictionary<string, string?>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Connection identifier the operation targets.
+    /// </summary>
+    public string? ConnectionId { get; init; }
+
+    /// <summary>
+    /// Service name the operation targets.
+    /// </summary>
+    public string? ServiceName { get; init; }
+
+    /// <summary>
+    /// Attribute fields to act on, when the operation targets a subset of columns.
+    /// </summary>
+    public IReadOnlyList<string> Fields { get; init; } = [];
+
+    /// <summary>
+    /// Whether the caller requested a dry-run/preview.
+    /// </summary>
+    public bool DryRun { get; init; }
+}

--- a/src/Honua.Server/Features/Operations/OperationsServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Operations/OperationsServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Features.Operations;
+
+/// <summary>
+/// Registers the Honua Operations Toolset: the grounding catalog (descriptor providers +
+/// aggregator), the executors, the policy decision point seam, and the dispatcher.
+/// </summary>
+internal static class OperationsServiceCollectionExtensions
+{
+    public static IServiceCollection AddOperationsToolset(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(TimeProvider.System);
+        services.TryAddSingleton<OperationHandleStore>();
+
+        // Grounding catalog: descriptor providers aggregated by the catalog.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IOperationDescriptorProvider, ServerOperationDescriptorProvider>());
+        services.TryAddSingleton<IOperationCatalog>(sp =>
+            new OperationCatalog(
+                sp.GetServices<IOperationDescriptorProvider>(),
+                sp.GetRequiredService<TimeProvider>()));
+
+        // Executors: concrete work, registered as an enumerable for the dispatcher.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Scoped<IOperationExecutor, ServicePublishExecutor>());
+
+        // Policy seam: no-op pass-through default (Community tier). Pro/Enterprise swap this.
+        services.TryAddSingleton<IOperationPolicyDecisionPoint, AllowAllPolicyDecisionPoint>();
+
+        // Dispatcher: resolves descriptor + executor, runs policy, executes on Allow.
+        services.TryAddScoped<IOperationInvoker>(sp =>
+            new OperationDispatcher(
+                sp.GetRequiredService<IOperationCatalog>(),
+                sp.GetServices<IOperationExecutor>(),
+                sp.GetRequiredService<IOperationPolicyDecisionPoint>(),
+                sp.GetRequiredService<TimeProvider>()));
+
+        return services;
+    }
+}

--- a/src/Honua.Server/Features/Operations/OperationsServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Operations/OperationsServiceCollectionExtensions.cs
@@ -33,6 +33,11 @@ internal static class OperationsServiceCollectionExtensions
         services.TryAddEnumerable(
             ServiceDescriptor.Scoped<IOperationExecutor, ServicePublishExecutor>());
 
+        // map.generate: the strangler proof — a Studio generator that wraps IMapGenerationService
+        // and frames the produced draft as a handle entering the Studio publish-request lane.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Scoped<IOperationExecutor, MapGenerateExecutor>());
+
         // Policy seam: no-op pass-through default (Community tier). Pro/Enterprise swap this.
         services.TryAddSingleton<IOperationPolicyDecisionPoint, AllowAllPolicyDecisionPoint>();
 

--- a/src/Honua.Server/Features/Operations/ServerOperationDescriptorProvider.cs
+++ b/src/Honua.Server/Features/Operations/ServerOperationDescriptorProvider.cs
@@ -6,9 +6,11 @@ using Honua.Core.Features.Operations.Abstractions;
 namespace Honua.Server.Features.Operations;
 
 /// <summary>
-/// Surfaces the server-side operation descriptors into the grounding catalog. Today it
-/// contributes the <c>service.publish</c> descriptor; DevOps descriptors join the catalog
-/// through their own provider in a later phase (descriptors only — execution stays remote).
+/// Surfaces the server-side operation descriptors into the grounding catalog. It contributes
+/// the synchronous <c>service.publish</c> descriptor and the Studio <c>map.generate</c>
+/// generator descriptor (a draft-producing operation that enters the publish-request lane);
+/// DevOps descriptors join the catalog through their own provider in a later phase (descriptors
+/// only — execution stays remote).
 /// </summary>
 internal sealed class ServerOperationDescriptorProvider : IOperationDescriptorProvider
 {
@@ -20,6 +22,7 @@ internal sealed class ServerOperationDescriptorProvider : IOperationDescriptorPr
         CancellationToken cancellationToken = default)
         => Task.FromResult<IReadOnlyList<IOperationDescriptor>>(
         [
-            ServicePublishOperation.BuildDescriptor()
+            ServicePublishOperation.BuildDescriptor(),
+            MapGenerateOperation.BuildDescriptor()
         ]);
 }

--- a/src/Honua.Server/Features/Operations/ServerOperationDescriptorProvider.cs
+++ b/src/Honua.Server/Features/Operations/ServerOperationDescriptorProvider.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Abstractions;
+
+namespace Honua.Server.Features.Operations;
+
+/// <summary>
+/// Surfaces the server-side operation descriptors into the grounding catalog. Today it
+/// contributes the <c>service.publish</c> descriptor; DevOps descriptors join the catalog
+/// through their own provider in a later phase (descriptors only — execution stays remote).
+/// </summary>
+internal sealed class ServerOperationDescriptorProvider : IOperationDescriptorProvider
+{
+    /// <inheritdoc />
+    public string ProviderId => ServicePublishOperation.ProviderId;
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<IOperationDescriptor>> ListDescriptorsAsync(
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<IOperationDescriptor>>(
+        [
+            ServicePublishOperation.BuildDescriptor()
+        ]);
+}

--- a/src/Honua.Server/Features/Operations/ServicePublishExecutor.cs
+++ b/src/Honua.Server/Features/Operations/ServicePublishExecutor.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Admin.Abstractions;
+using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+using Honua.Core.Features.Security.Abstractions;
+
+namespace Honua.Server.Features.Operations;
+
+/// <summary>
+/// Concrete executor for <c>service.publish</c>. It WRAPS the existing
+/// <see cref="ILayerPublishingService"/> rather than reimplementing publish:
+/// <see cref="ValidateAsync"/> delegates to <c>ValidateTableForPublishAsync</c> and
+/// <see cref="SubmitAsync"/> maps the request onto a <see cref="LayerPublishRequest"/> and
+/// calls <c>PublishLayerAsync</c>. The resulting Metadata v2 revision is surfaced on the
+/// returned handle.
+/// </summary>
+internal sealed class ServicePublishExecutor : IOperationExecutor
+{
+    private readonly ILayerPublishingService _publishingService;
+    private readonly ISecureConnectionResolver _connectionResolver;
+    private readonly IMetadataV2GraphProvider _metadataGraphProvider;
+    private readonly TimeProvider _clock;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ServicePublishExecutor"/>.
+    /// </summary>
+    /// <param name="publishingService">Shared layer publishing service (reused, not reimplemented).</param>
+    /// <param name="connectionResolver">Resolves the target connection string from the request connection id.</param>
+    /// <param name="metadataGraphProvider">Read access to the Metadata v2 graph for revision surfacing.</param>
+    /// <param name="clock">Time provider for handle id generation.</param>
+    public ServicePublishExecutor(
+        ILayerPublishingService publishingService,
+        ISecureConnectionResolver connectionResolver,
+        IMetadataV2GraphProvider metadataGraphProvider,
+        TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(publishingService);
+        ArgumentNullException.ThrowIfNull(connectionResolver);
+        ArgumentNullException.ThrowIfNull(metadataGraphProvider);
+        ArgumentNullException.ThrowIfNull(clock);
+        _publishingService = publishingService;
+        _connectionResolver = connectionResolver;
+        _metadataGraphProvider = metadataGraphProvider;
+        _clock = clock;
+    }
+
+    /// <inheritdoc />
+    public string OperationId => ServicePublishOperation.OperationId;
+
+    /// <inheritdoc />
+    public async Task<OperationValidation> ValidateAsync(
+        OperationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var connectionString = await ResolveConnectionStringAsync(request.ConnectionId, cancellationToken)
+            .ConfigureAwait(false);
+        var validationRequest = new TablePublishValidationRequest
+        {
+            Schema = GetRequired(request, "schema"),
+            Table = GetRequired(request, "table"),
+            LayerName = GetOptional(request, "layerName"),
+            ServiceName = request.ServiceName,
+            TargetSrid = GetInt(request, "srid"),
+            GeometryColumn = GetOptional(request, "geometryColumn"),
+            PrimaryKey = GetOptional(request, "primaryKey"),
+            Fields = request.Fields
+        };
+
+        var result = await _publishingService
+            .ValidateTableForPublishAsync(connectionString, validationRequest, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new OperationValidation
+        {
+            IsValid = result.IsValid,
+            Status = result.Status,
+            Messages = result.Checks.Select(check => $"{check.Severity}: {check.Message}").ToArray()
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<OperationHandle> SubmitAsync(
+        OperationRequest request,
+        OperationPolicyContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var connectionString = context.ResolvedConnectionString
+            ?? await ResolveConnectionStringAsync(request.ConnectionId, cancellationToken).ConfigureAwait(false);
+        var publishRequest = new LayerPublishRequest
+        {
+            Schema = GetRequired(request, "schema"),
+            Table = GetRequired(request, "table"),
+            LayerName = GetRequired(request, "layerName"),
+            Description = GetOptional(request, "description"),
+            GeometryColumn = GetOptional(request, "geometryColumn"),
+            GeometryType = GetOptional(request, "geometryType"),
+            Srid = GetInt(request, "srid"),
+            PrimaryKey = GetOptional(request, "primaryKey"),
+            Fields = request.Fields,
+            ServiceName = request.ServiceName,
+            ConnectionId = Guid.TryParse(request.ConnectionId, out var connectionId) ? connectionId : null
+        };
+
+        var summary = await _publishingService
+            .PublishLayerAsync(connectionString, publishRequest, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Surface the resulting Metadata v2 revision in the handle. PublishedLayerSummary does
+        // not carry it today (the publish path computes graph.Revision+1 internally in
+        // PostgreSqlLayerPublishingService.MetadataV2Graph.cs and persists it without echoing it
+        // on the summary), so we read the post-publish current revision from the graph provider.
+        // The canonical source is the graph snapshot the publish just saved; surfacing it here is
+        // the cheapest read-after-write that keeps the executor a thin wrapper over the service.
+        var graph = await _metadataGraphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+
+        return new OperationHandle
+        {
+            OperationId = OperationId,
+            HandleId = NewHandleId(),
+            Status = OperationHandleStatus.Completed,
+            MetadataRevision = graph.Revision,
+            Result = new OperationResultSummary
+            {
+                Summary = $"Published layer '{summary.LayerName}' (id {summary.LayerId}) to service '{summary.ServiceName}'.",
+                Details = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["layerId"] = summary.LayerId.ToString(CultureInfo.InvariantCulture),
+                    ["layerName"] = summary.LayerName,
+                    ["serviceName"] = summary.ServiceName,
+                    ["geometryType"] = summary.GeometryType,
+                    ["metadataRevision"] = graph.Revision.ToString(CultureInfo.InvariantCulture)
+                }
+            }
+        };
+    }
+
+    /// <inheritdoc />
+    public Task<OperationStatus> GetStatusAsync(OperationHandle handle, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(handle);
+
+        // service.publish is synchronous: the submit handle is terminal. Status mirrors it.
+        return Task.FromResult(new OperationStatus
+        {
+            OperationId = OperationId,
+            HandleId = handle.HandleId,
+            Status = handle.Status,
+            Result = handle.Result,
+            JobId = handle.JobId,
+            MetadataRevision = handle.MetadataRevision
+        });
+    }
+
+    private async Task<string> ResolveConnectionStringAsync(string? connectionId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(connectionId))
+        {
+            throw new ArgumentException("service.publish requires a 'connectionId' on the operation request.");
+        }
+
+        return Guid.TryParse(connectionId, out var id)
+            ? await _connectionResolver.ResolveConnectionStringAsync(id, cancellationToken).ConfigureAwait(false)
+            : await _connectionResolver.ResolveConnectionStringAsync(connectionId, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string GetRequired(OperationRequest request, string name)
+        => request.Parameters.TryGetValue(name, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value!
+            : throw new ArgumentException($"Required operation parameter '{name}' is missing.");
+
+    private static string? GetOptional(OperationRequest request, string name)
+        => request.Parameters.TryGetValue(name, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value
+            : null;
+
+    private static int? GetInt(OperationRequest request, string name)
+        => request.Parameters.TryGetValue(name, out var value)
+            && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+
+    private string NewHandleId()
+        => $"op-{_clock.GetUtcNow().ToUnixTimeMilliseconds():x}-{Guid.NewGuid():N}"[..32];
+}

--- a/src/Honua.Server/Features/Operations/ServicePublishOperation.cs
+++ b/src/Honua.Server/Features/Operations/ServicePublishOperation.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Domain;
+using Honua.Core.Features.WorkflowPackages.Domain;
+
+namespace Honua.Server.Features.Operations;
+
+/// <summary>
+/// Shared identity and descriptor definition for the <c>service.publish</c> operation. Keeps
+/// the operation id and its groundable descriptor in one place so the descriptor provider and
+/// the executor agree on the contract.
+/// </summary>
+internal static class ServicePublishOperation
+{
+    /// <summary>
+    /// Stable operation identifier for publishing a PostGIS table as a Honua layer.
+    /// </summary>
+    public const string OperationId = "service.publish";
+
+    /// <summary>
+    /// Provider identifier for the server-side publish descriptor provider.
+    /// </summary>
+    public const string ProviderId = "honua.server.operations";
+
+    /// <summary>
+    /// Builds the groundable descriptor for <c>service.publish</c>. ExecutionKind is
+    /// synchronous (publish is a 12-step inline transaction); ApprovalModel is
+    /// <see cref="OperationApprovalModel.OperatorGate"/> — publish is gated by the operator
+    /// approval gate at the HTTP layer, NOT the Studio publish-request lane.
+    /// </summary>
+    public static OperationDescriptor BuildDescriptor() => new()
+    {
+        OperationId = OperationId,
+        ProviderId = ProviderId,
+        Title = "Publish service layer",
+        Description = "Publishes a PostGIS table as a Honua layer in a service, projecting it into the Metadata v2 graph.",
+        Category = "service",
+        ExecutionKind = OperationExecutionKind.Synchronous,
+        ApprovalModel = OperationApprovalModel.OperatorGate,
+        Policy = new OperationPolicyMetadata
+        {
+            BlastRadiusClass = OperationBlastRadiusClass.ServiceScope,
+            SideEffectClass = OperationSideEffectClass.CreatesMetadata,
+            Determinism = OperationDeterminism.Deterministic,
+            SupportsDryRun = true
+        },
+        InputSchema =
+        [
+            Required("schema", "Source schema", WorkflowSchemaValueType.Text),
+            Required("table", "Source table", WorkflowSchemaValueType.Text),
+            Required("layerName", "Layer name", WorkflowSchemaValueType.Text),
+            Optional("geometryColumn", "Geometry column", WorkflowSchemaValueType.Text),
+            Optional("geometryType", "Geometry type", WorkflowSchemaValueType.Text),
+            Optional("primaryKey", "Primary key", WorkflowSchemaValueType.Text),
+            Optional("srid", "Target SRID", WorkflowSchemaValueType.WholeNumber),
+            Optional("description", "Description", WorkflowSchemaValueType.Text)
+        ],
+        OutputSchema =
+        [
+            new OperationParameterDescriptor
+            {
+                Name = "layerId",
+                Title = "Published layer id",
+                Required = true,
+                Schema = new WorkflowSchemaDefinition { Type = WorkflowSchemaValueType.WholeNumber }
+            },
+            new OperationParameterDescriptor
+            {
+                Name = "metadataRevision",
+                Title = "Metadata v2 revision",
+                Required = true,
+                Schema = new WorkflowSchemaDefinition { Type = WorkflowSchemaValueType.WholeNumber }
+            }
+        ]
+    };
+
+    private static OperationParameterDescriptor Required(string name, string title, WorkflowSchemaValueType type)
+        => new()
+        {
+            Name = name,
+            Title = title,
+            Required = true,
+            Schema = new WorkflowSchemaDefinition { Type = type }
+        };
+
+    private static OperationParameterDescriptor Optional(string name, string title, WorkflowSchemaValueType type)
+        => new()
+        {
+            Name = name,
+            Title = title,
+            Required = false,
+            Schema = new WorkflowSchemaDefinition { Type = type }
+        };
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -65,6 +65,7 @@ using Honua.Server.Features.Mobile.FieldCollection;
 using Honua.Server.Features.Orchestration;
 using Honua.Server.Features.Studio;
 using Honua.PackageReview;
+using Honua.Server.Features.Operations;
 using Honua.Server.Features.Streaming;
 using Honua.Server.Features.WorkflowPackages;
 using Honua.Server.Startup;
@@ -561,6 +562,7 @@ builder.Services.AddValidationServices();
 builder.Services.AddServerFeatures(builder.Configuration);
 builder.Services.AddOperateObservabilityFixtures(builder.Configuration, builder.Environment);
 builder.Services.AddWorkflowPackages();
+builder.Services.AddOperationsToolset();
 builder.Services.AddAdminRealtime();
 if (!isTestEnvironment)
 {
@@ -737,6 +739,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Ai.AnalysisContent.AnalysisContentApiJsonContext.Default,
         Honua.Server.Features.Capabilities.Models.CapabilityManifestJsonContext.Default,
         Honua.Server.Features.WorkflowPackages.WorkflowPackagesJsonContext.Default,
+        Honua.Server.Features.Operations.OperationsJsonContext.Default,
         Honua.Server.Features.Admin.Models.AdminApiKeyJsonContext.Default,
         Honua.Server.Features.Admin.Models.SceneDatasetJsonContext.Default,
         Honua.Server.Features.Admin.Models.SceneGenerationJsonContext.Default,
@@ -1256,6 +1259,7 @@ app.MapConsoleOpenDataPublicEndpoints();
 app.MapStudioPackageEndpoints();
 app.MapStudioMapCollaborationEndpoints();
 app.MapWorkflowPackageEndpoints();
+app.MapOperationsEndpoints();
 Honua.Server.Features.Console.Publications.ContentPublicationEndpoints.MapContentPublicationEndpoints(app);
 Honua.Server.Features.Console.Publications.PublishedRouteEndpoints.MapPublishedRouteEndpoints(app);
 app.MapAdminApiKeyEndpoints();

--- a/src/Honua.Server/Startup/JsonContextRegistration.cs
+++ b/src/Honua.Server/Startup/JsonContextRegistration.cs
@@ -67,6 +67,7 @@ internal static class JsonContextRegistration
                 Honua.Ai.AnalysisContent.AnalysisContentApiJsonContext.Default,
                 Honua.Server.Features.Capabilities.Models.CapabilityManifestJsonContext.Default,
                 Honua.Server.Features.WorkflowPackages.WorkflowPackagesJsonContext.Default,
+                Honua.Server.Features.Operations.OperationsJsonContext.Default,
                 Honua.Server.Features.Admin.Models.AdminApiKeyJsonContext.Default,
                 Honua.Server.Features.Admin.Models.SceneDatasetJsonContext.Default,
                 Honua.Server.Features.Admin.Models.SceneGenerationJsonContext.Default,

--- a/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
@@ -54,6 +54,7 @@ public sealed class VerticalSliceIsolationTests
         "Studio",
         "Styling", // Relocated out of the Infrastructure grab-bag into its own top-level slice.
         "WorkflowPackages",
+        "Operations", // Honua Operations Toolset slice: descriptor/executor split + policy-gated dispatcher over composable operations.
         "Temporal", // Temporal data history slice (honua-server#1166): capability discovery + as-of read.
         "FieldWorkflows" // Back-office field workflow slice (honua-server#1158/#1159/#1160): review/QA + exports over form submissions.
     };

--- a/tests/dotnet/Honua.Server.Tests/Features/Operations/MapGenerateOperationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Operations/MapGenerateOperationTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Ai.MapGeneration;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+using Honua.Core.Features.Operations.Services;
+using Honua.Server.Features.Operations;
+using Honua.TestKit.Attributes;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.OperationsToolset;
+
+/// <summary>
+/// In-memory unit coverage for the <c>map.generate</c> strangler proof: the grounding catalog
+/// lists the Studio generator descriptor with Studio/Generation + StudioPublishRequest +
+/// AiAssisted metadata; the executor WRAPS the real <see cref="IMapGenerationService"/> and
+/// frames the produced draft as a Completed handle whose <see cref="OperationHandle.Result"/>
+/// carries the draft and whose <see cref="OperationHandle.ApprovalLane"/> is the Studio
+/// publish-request lane; and the dispatcher consults the policy decision point, short-circuiting
+/// the executor on a Deny decision (the guardrail seam).
+/// </summary>
+public sealed class MapGenerateOperationTests
+{
+    [UnitTest]
+    public async Task Catalog_Lists_MapGenerate_With_StudioGeneration_StudioPublishRequest_And_AiAssisted()
+    {
+        var catalog = new OperationCatalog(
+            [new ServerOperationDescriptorProvider()],
+            TimeProvider.System);
+
+        var snapshot = await catalog.GetSnapshotAsync(CancellationToken.None);
+
+        var descriptor = snapshot.Operations.Should().ContainSingle(op => op.OperationId == "map.generate").Subject;
+        descriptor.Category.Should().Be("Studio/Generation");
+        descriptor.ExecutionKind.Should().Be(OperationExecutionKind.Synchronous);
+        descriptor.ApprovalModel.Should().Be(OperationApprovalModel.StudioPublishRequest);
+        descriptor.Policy.BlastRadiusClass.Should().Be(OperationBlastRadiusClass.ResourceScope);
+        descriptor.Policy.SideEffectClass.Should().Be(OperationSideEffectClass.CreatesMetadata);
+        descriptor.Policy.Determinism.Should().Be(OperationDeterminism.AiAssisted);
+        descriptor.Policy.SupportsDryRun.Should().BeFalse();
+
+        var resolved = await catalog.GetDescriptorAsync("map.generate", CancellationToken.None);
+        resolved.Should().NotBeNull();
+        resolved!.ProviderId.Should().Be("honua.server.operations");
+    }
+
+    [UnitTest]
+    public async Task SubmitAsync_With_AllowAll_Wraps_Generator_And_Handle_Carries_Draft_And_StudioPublishRequest_Lane()
+    {
+        var generation = Substitute.For<IMapGenerationService>();
+        generation
+            .GenerateAsync(Arg.Any<MapGenerationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new MapGenerationResult
+            {
+                Status = "generated",
+                Provider = "bedrock",
+                Model = "test-model",
+                Package = new MapPackage
+                {
+                    MapPackageId = "map-pkg-123",
+                    Format = "honua_map_package.v1",
+                    Status = PackageStatus.Draft,
+                    CreatedAt = DateTimeOffset.UtcNow
+                }
+            });
+
+        var executor = new MapGenerateExecutor(generation, TimeProvider.System);
+        var dispatcher = BuildDispatcher(executor, new AllowAllPolicyDecisionPoint());
+
+        var handle = await dispatcher.SubmitAsync(BuildRequest(), new OperationPolicyContext(), CancellationToken.None);
+
+        // The generator produced a draft that enters the Studio publish-request lane: the handle
+        // models generate → draft → lifecycle, not a flat sync result.
+        handle.Status.Should().Be(OperationHandleStatus.Completed);
+        handle.ApprovalLane.Should().Be("studio-publish-request");
+        handle.Result.Should().NotBeNull();
+        handle.Result!.Details["mapPackageId"].Should().Be("map-pkg-123");
+        handle.Result.Details["packageStatus"].Should().Be("Draft");
+        handle.Result.Details["status"].Should().Be("generated");
+
+        // Policy was Allow → the wrapped generator was actually invoked with the mapped prompt.
+        await generation.Received(1).GenerateAsync(
+            Arg.Is<MapGenerationRequest>(r => r.Prompt == "a map of parcels"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    public async Task SubmitAsync_When_Generator_Returns_NonGenerated_Status_Produces_No_Lane()
+    {
+        var generation = Substitute.For<IMapGenerationService>();
+        generation
+            .GenerateAsync(Arg.Any<MapGenerationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new MapGenerationResult
+            {
+                Status = "clarification",
+                Rationale = "Which basemap should the map use?"
+            });
+
+        var executor = new MapGenerateExecutor(generation, TimeProvider.System);
+        var dispatcher = BuildDispatcher(executor, new AllowAllPolicyDecisionPoint());
+
+        var handle = await dispatcher.SubmitAsync(BuildRequest(), new OperationPolicyContext(), CancellationToken.None);
+
+        handle.Status.Should().Be(OperationHandleStatus.Completed);
+        handle.ApprovalLane.Should().BeNull();
+        handle.Reason.Should().Be("Which basemap should the map use?");
+        handle.Result!.Details.Should().NotContainKey("mapPackageId");
+    }
+
+    [UnitTest]
+    public async Task SubmitAsync_With_Deny_Policy_ShortCircuits_Executor_And_Generator_Is_Never_Called()
+    {
+        var generation = Substitute.For<IMapGenerationService>();
+        var executor = new MapGenerateExecutor(generation, TimeProvider.System);
+        var dispatcher = BuildDispatcher(executor, new DenyAllPolicyDecisionPoint());
+
+        var handle = await dispatcher.SubmitAsync(BuildRequest(), new OperationPolicyContext(), CancellationToken.None);
+
+        // The guardrail seam: the wrapped generator is NEVER reached.
+        await generation.DidNotReceive().GenerateAsync(
+            Arg.Any<MapGenerationRequest>(), Arg.Any<CancellationToken>());
+        handle.Status.Should().Be(OperationHandleStatus.Failed);
+        handle.ApprovalLane.Should().BeNull();
+        handle.Reason.Should().Contain("blocked by policy");
+    }
+
+    [UnitTest]
+    public async Task ValidateAsync_Rejects_Empty_Prompt_Without_Calling_Generator()
+    {
+        var generation = Substitute.For<IMapGenerationService>();
+        var executor = new MapGenerateExecutor(generation, TimeProvider.System);
+
+        var validation = await executor.ValidateAsync(
+            new OperationRequest
+            {
+                OperationId = "map.generate",
+                Parameters = new Dictionary<string, string?>(StringComparer.Ordinal) { ["prompt"] = "  " }
+            },
+            CancellationToken.None);
+
+        validation.IsValid.Should().BeFalse();
+        validation.Status.Should().Be("invalid");
+        await generation.DidNotReceive().GenerateAsync(
+            Arg.Any<MapGenerationRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    private static OperationDispatcher BuildDispatcher(
+        IOperationExecutor executor,
+        IOperationPolicyDecisionPoint policy)
+    {
+        var catalog = new OperationCatalog([new ServerOperationDescriptorProvider()], TimeProvider.System);
+        return new OperationDispatcher(catalog, [executor], policy, TimeProvider.System);
+    }
+
+    private static OperationRequest BuildRequest()
+        => new()
+        {
+            OperationId = "map.generate",
+            Parameters = new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["prompt"] = "a map of parcels"
+            }
+        };
+
+    /// <summary>
+    /// Stub policy decision point that denies every operation, used to prove the dispatcher
+    /// short-circuits the executor even though the production default is pass-through Allow.
+    /// </summary>
+    private sealed class DenyAllPolicyDecisionPoint : IOperationPolicyDecisionPoint
+    {
+        public Task<PolicyDecision> EvaluateAsync(
+            IOperationDescriptor descriptor,
+            OperationRequest request,
+            OperationPolicyContext context,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new PolicyDecision
+            {
+                Kind = PolicyDecisionKind.Deny,
+                Reason = "blocked by policy (test stub)"
+            });
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Operations/OperationsEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Operations/OperationsEndpointsTests.cs
@@ -1,0 +1,241 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Admin.Abstractions;
+using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.OperationsToolset;
+
+/// <summary>
+/// Endpoint coverage for the Operations Toolset HTTP surface: the descriptor catalog lists
+/// over <c>GET /api/v1/operations</c>, and an operation submits over
+/// <c>POST /api/v1/operations/{id}/submit</c> through the policy-gated dispatcher.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+public sealed class OperationsEndpointsTests
+{
+    [IntegrationTest]
+    [Operation(Operations.Configuration)]
+    [Endpoint("GET /api/v1/operations")]
+    public async Task ListOperations_ReturnsCatalog_WithServicePublishDescriptor()
+    {
+        var fixture = new WebAppFixture();
+        await fixture.InitializeAsync();
+        try
+        {
+            var response = await fixture.CreateAdminClient().GetAsync("/api/v1/operations");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var data = document.RootElement.GetProperty("data");
+            data.GetProperty("catalogVersion").GetString().Should().NotBeNullOrEmpty();
+
+            var operations = data.GetProperty("operations").EnumerateArray().ToArray();
+            var publish = operations.Should().ContainSingle(op =>
+                op.GetProperty("operationId").GetString() == "service.publish").Subject;
+            publish.GetProperty("executionKind").GetString().Should().Be("Synchronous");
+            publish.GetProperty("approvalModel").GetString().Should().Be("OperatorGate");
+            publish.GetProperty("policy").GetProperty("supportsDryRun").GetBoolean().Should().BeTrue();
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Configuration)]
+    [Endpoint("POST /api/v1/operations/{id}/submit")]
+    public async Task SubmitOperation_ServicePublish_ReturnsCompletedHandle_WithMetadataRevision()
+    {
+        var publishing = Substitute.For<ILayerPublishingService>();
+        publishing
+            .PublishLayerAsync(Arg.Any<string>(), Arg.Any<LayerPublishRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new PublishedLayerSummary
+            {
+                LayerId = 99,
+                LayerName = "Parcels",
+                Schema = "public",
+                Table = "parcels",
+                GeometryType = "Polygon",
+                Srid = 4326,
+                ServiceName = "default"
+            });
+
+        var resolver = Substitute.For<ISecureConnectionResolver>();
+        resolver.ResolveConnectionStringAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns("Host=localhost;Database=test");
+        resolver.ResolveConnectionStringAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("Host=localhost;Database=test");
+
+        var fixture = new WebAppFixture()
+            .ReplaceService<ILayerPublishingService>(publishing)
+            .ReplaceService<ISecureConnectionResolver>(resolver);
+        await fixture.InitializeAsync();
+        try
+        {
+            var body = new
+            {
+                connectionId = Guid.NewGuid().ToString(),
+                serviceName = "default",
+                parameters = new Dictionary<string, string>
+                {
+                    ["schema"] = "public",
+                    ["table"] = "parcels",
+                    ["layerName"] = "Parcels"
+                }
+            };
+
+            var response = await fixture.CreateAdminClient()
+                .PostAsJsonAsync("/api/v1/operations/service.publish/submit", body);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var data = document.RootElement.GetProperty("data");
+            data.GetProperty("operationId").GetString().Should().Be("service.publish");
+            data.GetProperty("status").GetString().Should().Be("Completed");
+            data.TryGetProperty("metadataRevision", out var revision).Should().BeTrue();
+            revision.GetInt64().Should().BeGreaterThanOrEqualTo(0);
+
+            await publishing.Received(1).PublishLayerAsync(
+                Arg.Any<string>(), Arg.Any<LayerPublishRequest>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Configuration)]
+    [Endpoint("GET /api/v1/operations/handles/{handleId}")]
+    public async Task GetHandleStatus_AfterSubmit_ReturnsCompletedStatus()
+    {
+        var publishing = Substitute.For<ILayerPublishingService>();
+        publishing
+            .PublishLayerAsync(Arg.Any<string>(), Arg.Any<LayerPublishRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new PublishedLayerSummary
+            {
+                LayerId = 123,
+                LayerName = "Parcels",
+                Schema = "public",
+                Table = "parcels",
+                GeometryType = "Polygon",
+                Srid = 4326,
+                ServiceName = "default"
+            });
+
+        var resolver = Substitute.For<ISecureConnectionResolver>();
+        resolver.ResolveConnectionStringAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns("Host=localhost;Database=test");
+        resolver.ResolveConnectionStringAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("Host=localhost;Database=test");
+
+        var fixture = new WebAppFixture()
+            .ReplaceService<ILayerPublishingService>(publishing)
+            .ReplaceService<ISecureConnectionResolver>(resolver);
+        await fixture.InitializeAsync();
+        try
+        {
+            var client = fixture.CreateAdminClient();
+            var body = new
+            {
+                connectionId = Guid.NewGuid().ToString(),
+                serviceName = "default",
+                parameters = new Dictionary<string, string>
+                {
+                    ["schema"] = "public",
+                    ["table"] = "parcels",
+                    ["layerName"] = "Parcels"
+                }
+            };
+
+            var submit = await client.PostAsJsonAsync("/api/v1/operations/service.publish/submit", body);
+            submit.StatusCode.Should().Be(HttpStatusCode.OK);
+            using var submitDocument = JsonDocument.Parse(await submit.Content.ReadAsStringAsync());
+            var handleId = submitDocument.RootElement.GetProperty("data").GetProperty("handleId").GetString();
+            handleId.Should().NotBeNullOrEmpty();
+
+            var status = await client.GetAsync($"/api/v1/operations/handles/{handleId}");
+            status.StatusCode.Should().Be(HttpStatusCode.OK);
+            using var statusDocument = JsonDocument.Parse(await status.Content.ReadAsStringAsync());
+            var statusData = statusDocument.RootElement.GetProperty("data");
+            statusData.GetProperty("handleId").GetString().Should().Be(handleId);
+            statusData.GetProperty("status").GetString().Should().Be("Completed");
+            statusData.GetProperty("operationId").GetString().Should().Be("service.publish");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Configuration)]
+    [Endpoint("POST /api/v1/operations/{id}/validate")]
+    public async Task ValidateOperation_ServicePublish_DelegatesToValidator()
+    {
+        var publishing = Substitute.For<ILayerPublishingService>();
+        publishing
+            .ValidateTableForPublishAsync(Arg.Any<string>(), Arg.Any<TablePublishValidationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TablePublishValidationResult
+            {
+                IsValid = true,
+                Status = "valid",
+                Schema = "public",
+                Table = "parcels",
+                ServiceName = "default"
+            });
+
+        var resolver = Substitute.For<ISecureConnectionResolver>();
+        resolver.ResolveConnectionStringAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns("Host=localhost;Database=test");
+        resolver.ResolveConnectionStringAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("Host=localhost;Database=test");
+
+        var fixture = new WebAppFixture()
+            .ReplaceService<ILayerPublishingService>(publishing)
+            .ReplaceService<ISecureConnectionResolver>(resolver);
+        await fixture.InitializeAsync();
+        try
+        {
+            var body = new
+            {
+                connectionId = Guid.NewGuid().ToString(),
+                serviceName = "default",
+                parameters = new Dictionary<string, string>
+                {
+                    ["schema"] = "public",
+                    ["table"] = "parcels",
+                    ["layerName"] = "Parcels"
+                }
+            };
+
+            var response = await fixture.CreateAdminClient()
+                .PostAsJsonAsync("/api/v1/operations/service.publish/validate", body);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var data = document.RootElement.GetProperty("data");
+            data.GetProperty("isValid").GetBoolean().Should().BeTrue();
+            data.GetProperty("status").GetString().Should().Be("valid");
+
+            await publishing.Received(1).ValidateTableForPublishAsync(
+                Arg.Any<string>(), Arg.Any<TablePublishValidationRequest>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Operations/OperationsToolsetTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Operations/OperationsToolsetTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Admin.Abstractions;
+using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+using Honua.Core.Features.Operations.Services;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.Server.Features.Operations;
+using Honua.TestKit.Attributes;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.OperationsToolset;
+
+/// <summary>
+/// In-memory unit coverage for the Honua Operations Toolset de-risking spike: the grounding
+/// catalog lists the <c>service.publish</c> descriptor; the executor wraps the real
+/// <see cref="ILayerPublishingService"/>; the dispatcher consults the policy decision point
+/// and short-circuits the executor on a Deny decision (the guardrail seam).
+/// </summary>
+public sealed class OperationsToolsetTests
+{
+    private const string TestConnectionId = "11111111-1111-1111-1111-111111111111";
+
+    [UnitTest]
+    public async Task Catalog_Lists_ServicePublish_Descriptor_With_ExecutionKind_ApprovalModel_And_Policy()
+    {
+        var catalog = new OperationCatalog(
+            [new ServerOperationDescriptorProvider()],
+            TimeProvider.System);
+
+        var snapshot = await catalog.GetSnapshotAsync(CancellationToken.None);
+
+        var descriptor = snapshot.Operations.Should().ContainSingle(op => op.OperationId == "service.publish").Subject;
+        descriptor.ExecutionKind.Should().Be(OperationExecutionKind.Synchronous);
+        descriptor.ApprovalModel.Should().Be(OperationApprovalModel.OperatorGate);
+        descriptor.Policy.BlastRadiusClass.Should().Be(OperationBlastRadiusClass.ServiceScope);
+        descriptor.Policy.SideEffectClass.Should().Be(OperationSideEffectClass.CreatesMetadata);
+        descriptor.Policy.Determinism.Should().Be(OperationDeterminism.Deterministic);
+        descriptor.Policy.SupportsDryRun.Should().BeTrue();
+
+        // GetDescriptorAsync resolves the same descriptor by id.
+        var resolved = await catalog.GetDescriptorAsync("service.publish", CancellationToken.None);
+        resolved.Should().NotBeNull();
+        resolved!.ProviderId.Should().Be("honua.server.operations");
+    }
+
+    [UnitTest]
+    public async Task ValidateAsync_Delegates_To_ValidateTableForPublishAsync()
+    {
+        var publishing = Substitute.For<ILayerPublishingService>();
+        publishing
+            .ValidateTableForPublishAsync(Arg.Any<string>(), Arg.Any<TablePublishValidationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new TablePublishValidationResult
+            {
+                IsValid = true,
+                Status = "valid",
+                Schema = "public",
+                Table = "parcels",
+                ServiceName = "default"
+            });
+        var executor = BuildExecutor(publishing);
+
+        var validation = await executor.ValidateAsync(BuildRequest(), CancellationToken.None);
+
+        validation.IsValid.Should().BeTrue();
+        validation.Status.Should().Be("valid");
+        await publishing.Received(1).ValidateTableForPublishAsync(
+            Arg.Any<string>(),
+            Arg.Is<TablePublishValidationRequest>(r => r.Schema == "public" && r.Table == "parcels"),
+            Arg.Any<CancellationToken>());
+        await publishing.DidNotReceive().PublishLayerAsync(
+            Arg.Any<string>(), Arg.Any<LayerPublishRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    public async Task SubmitAsync_With_AllowAll_Calls_PublishLayer_And_Handle_Carries_MetadataRevision()
+    {
+        var publishing = Substitute.For<ILayerPublishingService>();
+        publishing
+            .PublishLayerAsync(Arg.Any<string>(), Arg.Any<LayerPublishRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new PublishedLayerSummary
+            {
+                LayerId = 7,
+                LayerName = "Parcels",
+                Schema = "public",
+                Table = "parcels",
+                GeometryType = "Polygon",
+                Srid = 4326,
+                ServiceName = "default"
+            });
+
+        const long expectedRevision = 42;
+        var snapshot = new MetadataV2GraphSnapshot(
+            new MetadataV2Graph { Revision = expectedRevision }, "\"etag\"", DateTimeOffset.UtcNow);
+        var graphProvider = Substitute.For<IMetadataV2GraphProvider>();
+        graphProvider
+            .GetCurrentAsync(Arg.Any<CancellationToken>())
+            .Returns(snapshot);
+
+        var executor = BuildExecutor(publishing, graphProvider);
+        var dispatcher = BuildDispatcher(executor, new AllowAllPolicyDecisionPoint());
+
+        var handle = await dispatcher.SubmitAsync(BuildRequest(), new OperationPolicyContext(), CancellationToken.None);
+
+        handle.Status.Should().Be(OperationHandleStatus.Completed);
+        handle.MetadataRevision.Should().Be(expectedRevision);
+        handle.Result.Should().NotBeNull();
+        handle.Result!.Details["layerId"].Should().Be("7");
+        handle.Result.Details["metadataRevision"].Should().Be("42");
+
+        // Policy was Allow → publish was actually invoked with the mapped request.
+        await publishing.Received(1).PublishLayerAsync(
+            Arg.Any<string>(),
+            Arg.Is<LayerPublishRequest>(r => r.Schema == "public" && r.Table == "parcels" && r.LayerName == "Parcels"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    public async Task SubmitAsync_With_Deny_Policy_ShortCircuits_Executor_And_Returns_Deny_Handle()
+    {
+        var publishing = Substitute.For<ILayerPublishingService>();
+        var executor = BuildExecutor(publishing);
+        var dispatcher = BuildDispatcher(executor, new DenyAllPolicyDecisionPoint());
+
+        var handle = await dispatcher.SubmitAsync(BuildRequest(), new OperationPolicyContext(), CancellationToken.None);
+
+        // The guardrail seam: the executor's publish path is NEVER reached.
+        await publishing.DidNotReceive().PublishLayerAsync(
+            Arg.Any<string>(), Arg.Any<LayerPublishRequest>(), Arg.Any<CancellationToken>());
+        handle.Status.Should().Be(OperationHandleStatus.Failed);
+        handle.Result.Should().BeNull();
+        handle.MetadataRevision.Should().BeNull();
+        handle.Reason.Should().Contain("blocked by policy");
+    }
+
+    private static ServicePublishExecutor BuildExecutor(
+        ILayerPublishingService publishing,
+        IMetadataV2GraphProvider? graphProvider = null)
+    {
+        var resolver = Substitute.For<ISecureConnectionResolver>();
+        resolver.ResolveConnectionStringAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns("Host=localhost;Database=test");
+        resolver.ResolveConnectionStringAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("Host=localhost;Database=test");
+
+        return new ServicePublishExecutor(
+            publishing,
+            resolver,
+            graphProvider ?? Substitute.For<IMetadataV2GraphProvider>(),
+            TimeProvider.System);
+    }
+
+    private static OperationDispatcher BuildDispatcher(
+        IOperationExecutor executor,
+        IOperationPolicyDecisionPoint policy)
+    {
+        var catalog = new OperationCatalog([new ServerOperationDescriptorProvider()], TimeProvider.System);
+        return new OperationDispatcher(catalog, [executor], policy, TimeProvider.System);
+    }
+
+    private static OperationRequest BuildRequest()
+        => new()
+        {
+            OperationId = "service.publish",
+            ConnectionId = TestConnectionId,
+            ServiceName = "default",
+            Parameters = new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["schema"] = "public",
+                ["table"] = "parcels",
+                ["layerName"] = "Parcels"
+            }
+        };
+
+    /// <summary>
+    /// Stub policy decision point that denies every operation, used to prove the dispatcher
+    /// short-circuits the executor even though the production default is pass-through Allow.
+    /// </summary>
+    private sealed class DenyAllPolicyDecisionPoint : IOperationPolicyDecisionPoint
+    {
+        public Task<PolicyDecision> EvaluateAsync(
+            IOperationDescriptor descriptor,
+            OperationRequest request,
+            OperationPolicyContext context,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new PolicyDecision
+            {
+                Kind = PolicyDecisionKind.Deny,
+                Reason = "blocked by policy (test stub)"
+            });
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1759

## Summary
Proves the **operations toolset strangler** by consolidating one real Studio generator (`MapGenerationService`) onto the toolset built in #1761. The reviewer flagged that the toolset had only been exercised with the synchronous `service.publish` executor — a flat commit-and-return shape. This PR demonstrates the contract also models the shape that matters for generators: **a generator produces a DRAFT that enters a lifecycle lane**, not a flat sync result.

`map.generate` is an `IOperationExecutor` that **wraps** the existing `IMapGenerationService.GenerateAsync` (generation is not reimplemented) and frames the produced draft as an `OperationHandle` whose `Result` carries the draft and whose `ApprovalLane` is the Studio publish-request lane. The old `/studio/map-packages/generate` endpoint is left working unchanged — both paths coexist (additive strangler). No AI/Bedrock calls are made in the tests (the generator is mocked).

This is branched off `integration/demo-deploy` (generators + Bedrock) with `operations-toolset-v2` (the toolset) merged in; the merge was clean (toolset files are all new under `Features/Operations`).

The remaining 7 Studio generators (app/forms/analysis/query/etc.) are the documented roadmap, not this PR.

## Changes Made
- **`MapGenerateOperation`** (descriptor identity): `map.generate`, Category=`Studio/Generation`, ExecutionKind=`Synchronous`, ApprovalModel=`StudioPublishRequest`, policy { BlastRadius=ResourceScope (draft/workspace), SideEffect=CreatesMetadata (creates draft), Determinism=`AiAssisted`, SupportsDryRun=false }.
- **`MapGenerateExecutor : IOperationExecutor`**: `ValidateAsync` validates the prompt input; `SubmitAsync` calls `MapGenerationService.GenerateAsync` and wraps the produced draft into `OperationHandle { Status=Completed, Result=<draft summary>, ApprovalLane=studio-publish-request }`; `GetStatusAsync` mirrors the terminal handle.
- Registered the descriptor in `ServerOperationDescriptorProvider` and the executor in `OperationsServiceCollectionExtensions` (DI), so `map.generate` is listed by `GET /api/v1/operations` and invokable via `POST /api/v1/operations/map.generate/submit` through the policy-gated dispatcher.
- **Strangler:** `/studio/map-packages/generate` is untouched.
- Tests: catalog metadata; generate→draft→`StudioPublishRequest` handle shape (mocked generator); policy decision point consulted (AllowAll proceeds, Deny stub short-circuits the wrapped generator); non-generated outcome carries no lane; prompt validation.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
