### PR TITLE
ci: harden merge_group server-readiness wait + WFS seed/log diagnostics (unblock queue)

### DIFF
--- a/.github/actions/setup-honua-server/action.yml
+++ b/.github/actions/setup-honua-server/action.yml
@@ -61,7 +61,11 @@ runs:
       run: |
         # Always capture stdout/stderr to a log so a failed readiness wait is
         # diagnosable. When the caller supplies an explicit log-path we honour it;
-        # otherwise fall back to a runner-temp log that the timeout branch dumps.
+        # otherwise fall back to a runner-temp log that the timeout/crash branch
+        # dumps. The runner-temp path is the contract the ci.yml job-level
+        # "Dump Honua Server log on failure" step reads (so a server that boots
+        # then dies, or a later JS 500, is also diagnosable — not just a
+        # readiness timeout). Both sides default to the same runner-temp path.
         if [ -n "$LOG_PATH" ]; then
           mkdir -p "$(dirname "$LOG_PATH")"
           SERVER_LOG="$LOG_PATH"
@@ -69,26 +73,51 @@ runs:
           SERVER_LOG="${RUNNER_TEMP:-/tmp}/honua-server-setup.log"
         fi
 
+        dump_diagnostics() {
+          # Dump the server stdout/stderr AND the DB seed status so the actual
+          # startup cause is visible regardless of whether the server crashed,
+          # hung, or simply lost the bind race under heavy concurrent load.
+          echo "----- Honua Server log (${SERVER_LOG}) -----" >&2
+          cat "$SERVER_LOG" >&2 || true
+          echo "----- DB seed status (features per layer) -----" >&2
+          PGPASSWORD=honua psql -h localhost -U honua -d honua_test \
+            -c "SELECT layer_id, COUNT(*) AS feature_count FROM features GROUP BY layer_id ORDER BY layer_id;" >&2 2>&1 || \
+            echo "(could not query feature counts — DB unreachable?)" >&2
+        }
+
         dotnet run --project src/Honua.Server --configuration Release --no-build --no-launch-profile > "$SERVER_LOG" 2>&1 &
+        SERVER_PID=$!
 
         # A cold `dotnet run --no-build` start runs the PostGIS preflight check,
         # the full database migration set, and high-frequency query preparation
         # before /healthz/ready reports 200. On CI runners seeding a fresh
-        # database this routinely exceeds the previous 30s budget and left the
-        # server unbound when the JS/Esri-Leaflet lanes began polling
-        # http://localhost:5000 (curl: (7) connection refused). Budget generously
-        # (90 iterations x 2s = 180s), mirroring load-soak-nightly's readiness wait.
+        # database this routinely exceeds a short fixed wait and, under the heavy
+        # concurrent merge_group matrix, the JS/Esri-Leaflet lanes began polling
+        # http://localhost:5000 before Kestrel bound (curl: (7) connection
+        # refused), ejecting the whole ALLGREEN batch. Budget generously
+        # (90 iterations x 2s = 180s), mirroring load-soak-nightly's readiness
+        # wait, and:
+        #   * bound each poll with --max-time so a stalled connect can't starve
+        #     the loop of attempts (curl retries are short, not wall-clock-even);
+        #   * fail fast with full diagnostics if the dotnet process exits before
+        #     readiness, so a *deterministic* startup crash surfaces its stack
+        #     trace in seconds instead of after a 180s false "timeout".
         for _ in $(seq 1 90); do
-          if curl -fsS http://localhost:5000/healthz/ready >/dev/null; then
+          if curl -fsS --max-time 5 http://localhost:5000/healthz/ready >/dev/null; then
             exit 0
+          fi
+
+          if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            echo "Honua Server process (pid ${SERVER_PID}) exited before becoming ready." >&2
+            dump_diagnostics
+            exit 1
           fi
 
           sleep 2
         done
 
-        echo "Honua Server did not become ready within the readiness budget." >&2
-        echo "----- server log (${SERVER_LOG}) -----" >&2
-        cat "$SERVER_LOG" >&2 || true
+        echo "Honua Server did not become ready within the readiness budget (180s)." >&2
+        dump_diagnostics
         exit 1
       env:
         ConnectionStrings__DefaultConnection: "Host=localhost;Database=honua_test;Username=honua;Password=honua"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1032,6 +1032,27 @@ jobs:
           cache: 'npm'
           cache-dependency-path: tests/js/package-lock.json
 
+      # The setup-honua-server action redirects the server's stdout/stderr to
+      # ${RUNNER_TEMP}/honua-server-setup.log but only dumps it when the readiness
+      # wait *fails*. When readiness succeeds and a later JS request 500s (e.g. a
+      # WFS GetFeature), the server-side exception is otherwise lost — leaving the
+      # failure undiagnosable. Surface the log (and DB seed status) on ANY later
+      # failure in this job so the actual exception/stack trace is visible.
+      - name: Dump Honua Server log on failure
+        if: failure()
+        run: |
+          SERVER_LOG="${RUNNER_TEMP:-/tmp}/honua-server-setup.log"
+          if [ -f "$SERVER_LOG" ]; then
+            echo "----- Honua Server log (${SERVER_LOG}) -----"
+            cat "$SERVER_LOG"
+          else
+            echo "No Honua Server log found at ${SERVER_LOG}."
+          fi
+          echo "----- DB seed status (features per layer) -----"
+          PGPASSWORD=honua psql -h localhost -U honua -d honua_test \
+            -c "SELECT layer_id, COUNT(*) AS feature_count FROM features GROUP BY layer_id ORDER BY layer_id;" 2>&1 || \
+            echo "(could not query feature counts — DB unreachable?)"
+
       - name: Install JavaScript test dependencies
         run: npm ci
         working-directory: tests/js
@@ -1113,6 +1134,24 @@ jobs:
           cache: 'npm'
           cache-dependency-path: tests/js-browser/package-lock.json
 
+      # Surface the server log + DB seed status on ANY later failure in this job
+      # (not just a readiness timeout) so a boot-then-die or later 500 is
+      # diagnosable. See the matching step in the JS Integration Tests job.
+      - name: Dump Honua Server log on failure
+        if: failure()
+        run: |
+          SERVER_LOG="${RUNNER_TEMP:-/tmp}/honua-server-setup.log"
+          if [ -f "$SERVER_LOG" ]; then
+            echo "----- Honua Server log (${SERVER_LOG}) -----"
+            cat "$SERVER_LOG"
+          else
+            echo "No Honua Server log found at ${SERVER_LOG}."
+          fi
+          echo "----- DB seed status (features per layer) -----"
+          PGPASSWORD=honua psql -h localhost -U honua -d honua_test \
+            -c "SELECT layer_id, COUNT(*) AS feature_count FROM features GROUP BY layer_id ORDER BY layer_id;" 2>&1 || \
+            echo "(could not query feature counts — DB unreachable?)"
+
       - name: Install dependencies
         run: npm ci
         working-directory: tests/js-browser
@@ -1191,6 +1230,24 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: tests/js-browser/package-lock.json
+
+      # Surface the server log + DB seed status on ANY later failure in this job
+      # (not just a readiness timeout) so a boot-then-die or later 500 is
+      # diagnosable. See the matching step in the JS Integration Tests job.
+      - name: Dump Honua Server log on failure
+        if: failure()
+        run: |
+          SERVER_LOG="${RUNNER_TEMP:-/tmp}/honua-server-setup.log"
+          if [ -f "$SERVER_LOG" ]; then
+            echo "----- Honua Server log (${SERVER_LOG}) -----"
+            cat "$SERVER_LOG"
+          else
+            echo "No Honua Server log found at ${SERVER_LOG}."
+          fi
+          echo "----- DB seed status (features per layer) -----"
+          PGPASSWORD=honua psql -h localhost -U honua -d honua_test \
+            -c "SELECT layer_id, COUNT(*) AS feature_count FROM features GROUP BY layer_id ORDER BY layer_id;" 2>&1 || \
+            echo "(could not query feature counts — DB unreachable?)"
 
       - name: Install dependencies
         run: npm ci

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderSelectProjectionTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderSelectProjectionTests.cs
@@ -156,6 +156,35 @@ public sealed class FeatureQueryBuilderSelectProjectionTests
         result.WhereParameters.Should().Contain("id");
     }
 
+    [Fact]
+    public void BuildOptimizedSelectGmlQuery_WithCountAndStartIndex_DoesNotDoubleBindPagination()
+    {
+        // Regression for honua-server#1749/#1750: WFS GetFeature (and OGC Features/KML) reads with a
+        // count + startIndex route through the optimized window-count GML builder
+        // (PostgresFeatureStore.BuildGmlFeatureCollection -> BuildOptimizedSelectGmlQuery). It
+        // previously appended the LIMIT/OFFSET *values* to WhereParameters in addition to emitting
+        // their placeholders, while FeatureDataAccess.AddQueryParameters binds pagination too —
+        // leaving more bound parameters than SQL placeholders. On the prepared-statement cache path
+        // the misalignment left a pagination placeholder unbound -> "Parameter cannot be null" ->
+        // HTTP 500 on the advertised WFS type. The sibling Esri-JSON builder is covered above; this
+        // locks the GML path (the one the WFS JS suite hits) against the same re-regression.
+        var queryBuilder = CreateQueryBuilder();
+        var query = new FeatureQuery
+        {
+            Limit = 5,
+            Offset = 10,
+        };
+
+        var result = queryBuilder.BuildOptimizedSelectGmlQuery(layerId: 1, query);
+
+        result.Sql.Should().Contain("COUNT(*) OVER()");
+        result.Sql.Should().Contain("LIMIT $").And.Contain("OFFSET $");
+        // No OutFields/WHERE/spatial params here, so the LIMIT/OFFSET values must be the only thing
+        // that could land in WhereParameters — and they must NOT, since AddQueryParameters binds
+        // them positionally. An empty list proves the double-bind is gone.
+        result.WhereParameters.Should().BeEmpty();
+    }
+
     private static FeatureQueryBuilder CreateQueryBuilder()
     {
         var poolProvider = new DefaultObjectPoolProvider();

--- a/tests/seed/base-schema.sql
+++ b/tests/seed/base-schema.sql
@@ -1073,6 +1073,48 @@ INSERT INTO honua.service_layers (service_name, layer_id, layer_order)
 VALUES ('test_service', 1, 1)
 ON CONFLICT (service_name, layer_id) DO NOTHING;
 
+-- Deterministic feature rows for the dedicated 'Mixed' layer (layer 1). Layer 1
+-- is advertised as the 'mixed_geometry_test_layer' WFS/OGC feature type, but it
+-- was previously seeded empty and only populated at runtime by the geometry
+-- round-trip applyEdits suite. That left every read-only consumer of layer 1 —
+-- notably the WFS GetFeature suite's discoverTypeWithFeatures(), which scans the
+-- advertised types for one that returns parseable features — depending solely on
+-- layer 0 ('test_layer'). Layer 0 is the single Point layer every other
+-- concurrent JS lane (apply-edits/query/geometry, all HONUA_LAYER_ID=0) mutates,
+-- so a single transient failure on its first GetFeature left the WFS suite with
+-- no populated fallback type and failed the whole lane ("No WFS FeatureType
+-- produced parseable features"). Seed layer 1 with stable, heterogeneous
+-- geometries (point/line/polygon — valid for a Mixed layer) so the suite always
+-- has a second populated, low-contention type and additionally exercises GML
+-- decode of non-point geometry. Runtime applyEdits rows are additive on top.
+WITH mixed_seed AS (
+    SELECT *
+    FROM (
+        VALUES
+            ('mixed_point',   'active',   1, 1.25, true,  '00000000-0000-0000-0000-000000000101', 'POINT(-122.4400 37.7600)'),
+            ('mixed_line',    'active',   2, 2.50, true,  '00000000-0000-0000-0000-000000000102', 'LINESTRING(-122.4500 37.7500, -122.4300 37.7700)'),
+            ('mixed_polygon', 'inactive', 3, 3.75, false, '00000000-0000-0000-0000-000000000103', 'POLYGON((-122.4600 37.7400, -122.4200 37.7400, -122.4200 37.7800, -122.4600 37.7800, -122.4600 37.7400))')
+    ) AS seed(name, status, feature_count, ratio, active_flag, uid, wkt)
+)
+INSERT INTO features (layer_id, geometry, attributes)
+SELECT
+    1,
+    ST_SetSRID(ST_GeomFromText(wkt), 4326),
+    jsonb_build_object(
+        'name', name,
+        'status', status,
+        'count', feature_count,
+        'ratio', ratio,
+        'active', active_flag,
+        'uid', uid
+    )
+FROM mixed_seed
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM features
+    WHERE layer_id = 1
+);
+
 -- Deterministic feature rows for CI lanes that only apply base-schema.sql.
 -- Keep these aligned with the JS/Python shared test attributes so query
 -- contracts validate against a populated layer instead of an empty catalog.


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1766

## Summary
The `merge_group` CI matrix intermittently fails to drain the merge queue because jobs that boot an out-of-process Honua test server (JavaScript Integration Tests, Esri Leaflet, MapLibre compat) occasionally lose a startup/readiness race under the heavy concurrent matrix: the JS lane polls `http://localhost:5000` before Kestrel binds and the readiness wait fails with `curl: (7) Failed to connect to localhost port 5000`. Because merge_group failures eject the whole ALLGREEN batch, one transient flake blocks the queue.

This PR hardens the `setup-honua-server` readiness wait, makes any later server failure diagnosable, and removes a fixture single-point-of-failure that turned a transient layer-0 hiccup into a hard WFS-suite failure. It is CI/test-harness-scoped only — no product runtime behavior changes.

## Changes Made
- **Readiness wait (`setup-honua-server` action):** bound each `/healthz/ready` poll with `curl --max-time 5` so a stalled connect cannot starve the 180s budget; detect early server death via `kill -0` on the `dotnet run` PID and fail fast with full diagnostics (a deterministic startup crash now surfaces its stack in seconds instead of after a false 180s "timeout"); on any readiness failure dump the server log AND the per-layer feature count (DB seed status).
- **Job-level diagnostics (`ci.yml`):** added a `Dump Honua Server log on failure` step (server log + DB seed status, `if: failure()`) to every job that boots the server — JavaScript Integration, Esri Leaflet, MapLibre compat — so a boot-then-die or a later JS 500 (e.g. a WFS GetFeature) is diagnosable, not only a readiness timeout.
- **WFS seed robustness (`tests/seed/base-schema.sql`):** seed layer 1 (`mixed_geometry_test_layer`) with stable point/line/polygon rows so the WFS GetFeature suite always has a populated, low-contention fallback type instead of depending solely on layer 0 (the Point layer every concurrent `HONUA_LAYER_ID=0` lane mutates). Idempotent `WHERE NOT EXISTS`, mirrors the existing layer-0 seed.
- **GML regression test:** added a direct unit test for `BuildOptimizedSelectGmlQuery` (the WFS GetFeature builder path, previously untested) proving count+startIndex does not double-bind pagination (honua-server#1749/#1750).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
