### PR TITLE
fix(geoservices): accept all Esri timeRelation values + timeFilter alias

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Query.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Query.cs
@@ -393,7 +393,9 @@ internal static partial class FeatureServerEndpoints
             Units = GetValueString(values, "units"),
             F = GetValueString(values, "f") ?? "json",
             FormatSpecified = values.ContainsKey("f"),
-            Time = GetValueString(values, "time"),
+            // arcgis 2.4.x serializes query(time_filter=) to the "timeFilter" query
+            // parameter; accept it as an alias of "time" (explicit "time" wins). #1775
+            Time = GetValueString(values, "time") ?? GetValueString(values, "timeFilter"),
             TimeRelation = GetValueString(values, "timeRelation"),
             ReturnGeometry = returnGeometry,
             ReturnIdsOnly = returnIdsOnly,

--- a/src/Honua.Protocols.GeoServices/GeoServicesRequestValueHelpers.cs
+++ b/src/Honua.Protocols.GeoServices/GeoServicesRequestValueHelpers.cs
@@ -46,6 +46,10 @@ internal static class GeoServicesRequestValueHelpers
             "returnTrueCurves",
             "returnExceededLimitFeatures",
             "time",
+            // The ArcGIS API for Python (arcgis 2.4.x) serializes the query(time_filter=)
+            // kwarg to the "timeFilter" query parameter. Accept it as an alias of "time"
+            // so the Python SDK's time-aware queries are not rejected with HTTP 400 (#1775).
+            "timeFilter",
             "timeRelation",
             "geometryPrecision",
             "maxAllowableOffset",

--- a/src/Honua.Protocols.GeoServices/GeoServicesTemporalQueryBuilder.cs
+++ b/src/Honua.Protocols.GeoServices/GeoServicesTemporalQueryBuilder.cs
@@ -30,7 +30,21 @@ internal static class GeoServicesTemporalQueryBuilder
         Meets,
         MetBy,
         OverlapsStartWithinEnd,
-        OverlapsEndWithinStart
+        OverlapsEndWithinStart,
+
+        // Esri start/end-relative relations (ArcObjects esriTimeRelation vocabulary).
+        // ArcGIS clients (ArcGIS Pro, the ArcGIS API for Python, Maps SDKs) send these
+        // spellings on time-aware queries; map them onto the interval engine so the
+        // queries succeed instead of returning HTTP 400. The feature interval is
+        // [start, COALESCE(end, start)] and the query interval is [queryStart, queryEnd].
+        // Feature start time is after the query start time.
+        AfterStartTime,
+        // Feature ends before the query start time.
+        BeforeStartTime,
+        // Feature start time is after the query end time.
+        AfterEndTime,
+        // Feature ends before the query end time.
+        BeforeEndTime
     }
 
     /// <summary>
@@ -165,6 +179,10 @@ internal static class GeoServicesTemporalQueryBuilder
             "esritimerelationmetby" or "metby" => TimeRelation.MetBy,
             "esritimerelationoverlapsstartwithinend" or "overlapsstartwithinend" => TimeRelation.OverlapsStartWithinEnd,
             "esritimerelationoverlapsendwithinstart" or "overlapsendwithinstart" => TimeRelation.OverlapsEndWithinStart,
+            "esritimerelationafterstarttime" or "afterstarttime" => TimeRelation.AfterStartTime,
+            "esritimerelationbeforestarttime" or "beforestarttime" => TimeRelation.BeforeStartTime,
+            "esritimerelationafterendtime" or "afterendtime" => TimeRelation.AfterEndTime,
+            "esritimerelationbeforeendtime" or "beforeendtime" => TimeRelation.BeforeEndTime,
             _ => throw new ArgumentException($"Unsupported timeRelation '{timeRelation}'.")
         };
     }
@@ -221,6 +239,10 @@ internal static class GeoServicesTemporalQueryBuilder
                 BuildOverlapEndWithinStart(startExpression, endExpression, queryStart, queryEnd, relation)),
             TimeRelation.OverlapsStartWithinEnd => BuildOverlapStartWithinEnd(startExpression, endExpression, queryStart, queryEnd, relation),
             TimeRelation.OverlapsEndWithinStart => BuildOverlapEndWithinStart(startExpression, endExpression, queryStart, queryEnd, relation),
+            TimeRelation.AfterStartTime => CompareRequired(startExpression, BinaryOperator.GreaterThan, queryStart, relation, "start"),
+            TimeRelation.BeforeStartTime => CompareRequired(endExpression, BinaryOperator.LessThan, queryStart, relation, "start"),
+            TimeRelation.AfterEndTime => CompareRequired(startExpression, BinaryOperator.GreaterThan, queryEnd, relation, "end"),
+            TimeRelation.BeforeEndTime => CompareRequired(endExpression, BinaryOperator.LessThan, queryEnd, relation, "end"),
             _ => throw new ArgumentException($"Unsupported timeRelation '{relation}'.")
         };
     }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerTemporalTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerTemporalTests.cs
@@ -336,6 +336,43 @@ public sealed class FeatureServerTemporalTests : IClassFixture<WebAppFixture>
             "esriTimeRelationOverlaps",
             new long[] { 1, 3 }
         };
+
+        // Start/end-relative Esri relations (ArcObjects esriTimeRelation vocabulary).
+        // Feature interval = [timestamp, COALESCE(event_date, timestamp)]; a single time
+        // value sets queryStart == queryEnd. ArcGIS Pro / arcpy send these spellings and
+        // previously got HTTP 400 because only Overlaps/OverlapsStartWithinEnd were mapped.
+
+        // start > queryStart (2023-01-04): OID 2,3,5.
+        yield return new object[]
+        {
+            "2023-01-04T00:00:00Z",
+            "esriTimeRelationAfterStartTime",
+            new long[] { 2, 3, 5 }
+        };
+
+        // end < queryStart (2024-01-15): OID 1,3,5.
+        yield return new object[]
+        {
+            "2024-01-15T00:00:00Z",
+            "esriTimeRelationBeforeStartTime",
+            new long[] { 1, 3, 5 }
+        };
+
+        // start > queryEnd (2023-01-10): OID 3,5.
+        yield return new object[]
+        {
+            "2023-01-10T00:00:00Z",
+            "esriTimeRelationAfterEndTime",
+            new long[] { 3, 5 }
+        };
+
+        // end < queryEnd (2024-02-15): OID 1,3,5.
+        yield return new object[]
+        {
+            "2024-02-15T00:00:00Z",
+            "esriTimeRelationBeforeEndTime",
+            new long[] { 1, 3, 5 }
+        };
     }
 
     [Theory]
@@ -363,6 +400,57 @@ public sealed class FeatureServerTemporalTests : IClassFixture<WebAppFixture>
 
         var objectIds = ExtractObjectIds(document);
         objectIds.Should().BeEquivalentTo(expectedObjectIds);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task GeoServicesQuery_TimeRelation_OverlapsStartWithinEnd_IsAccepted()
+    {
+        // esriTimeRelationOverlapsStartWithinEnd is one of the six standard Esri
+        // start/end-relative spellings; confirm it is accepted (not rejected with 400).
+        var serviceId = WebAppFixture.TestServiceId;
+        var layerId = WebAppFixture.TestLayerId;
+        var encodedTime = Uri.EscapeDataString("2023-12-15T00:00:00Z,2024-02-15T00:00:00Z");
+
+        var response = await _client.GetAsync(
+            $"/rest/services/{serviceId}/FeatureServer/{layerId}/query?" +
+            $"time={encodedTime}&timeRelation=esriTimeRelationOverlapsStartWithinEnd&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(content);
+        document.RootElement.TryGetProperty("features", out _).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task GeoServicesQuery_TimeFilterAlias_IsAcceptedAndEquivalentToTime()
+    {
+        // The ArcGIS API for Python (arcgis 2.4.x) serializes query(time_filter=) to the
+        // "timeFilter" query parameter. It must be accepted as an alias of "time" rather
+        // than rejected with HTTP 400 "Unknown query parameter: timeFilter" (#1775).
+        var serviceId = WebAppFixture.TestServiceId;
+        var layerId = WebAppFixture.TestLayerId;
+        var encodedTime = Uri.EscapeDataString("2023-12-15T00:00:00Z,2024-02-15T00:00:00Z");
+
+        var timeFilterResponse = await _client.GetAsync(
+            $"/rest/services/{serviceId}/FeatureServer/{layerId}/query?" +
+            $"timeFilter={encodedTime}&timeRelation=esriTimeRelationOverlaps&f=json");
+
+        timeFilterResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // The alias must produce the same result set as the canonical "time" parameter.
+        var timeResponse = await _client.GetAsync(
+            $"/rest/services/{serviceId}/FeatureServer/{layerId}/query?" +
+            $"time={encodedTime}&timeRelation=esriTimeRelationOverlaps&f=json");
+        timeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var timeFilterDocument = JsonDocument.Parse(await timeFilterResponse.Content.ReadAsStringAsync());
+        using var timeDocument = JsonDocument.Parse(await timeResponse.Content.ReadAsStringAsync());
+
+        ExtractObjectIds(timeFilterDocument).Should().BeEquivalentTo(ExtractObjectIds(timeDocument));
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/GeoServicesTemporalQueryBuilderTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/GeoServicesTemporalQueryBuilderTests.cs
@@ -62,6 +62,44 @@ public sealed class GeoServicesTemporalQueryBuilderTests
         expression.Should().NotBeNull();
     }
 
+    [Theory]
+    [InlineData("esriTimeRelationAfterStartTime")]
+    [InlineData("esriTimeRelationBeforeStartTime")]
+    [InlineData("esriTimeRelationAfterEndTime")]
+    [InlineData("esriTimeRelationBeforeEndTime")]
+    [InlineData("esriTimeRelationOverlaps")]
+    [InlineData("esriTimeRelationOverlapsStartWithinEnd")]
+    [Operation(Operations.Query)]
+    public void BuildTemporalExpression_StandardEsriTimeRelations_ProduceAPredicate(string timeRelation)
+    {
+        // All six standard Esri start/end-relative timeRelation spellings must map onto the
+        // interval engine and produce a real predicate (not throw ArgumentException -> 400).
+        var resource = BuildTemporalResource();
+
+        var expression = GeoServicesTemporalQueryBuilder.BuildTemporalExpression(
+            "0,86400000", timeRelation, resource);
+
+        expression.Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData("afterStartTime")]
+    [InlineData("beforeStartTime")]
+    [InlineData("afterEndTime")]
+    [InlineData("beforeEndTime")]
+    [Operation(Operations.Query)]
+    public void BuildTemporalExpression_StartEndRelativeShortSpellings_AreAccepted(string timeRelation)
+    {
+        // The short (non-"esriTimeRelation"-prefixed) spellings are also accepted, mirroring
+        // the existing case-insensitive vocabulary; none should throw ArgumentException.
+        var resource = BuildTemporalResource();
+
+        var act = () => GeoServicesTemporalQueryBuilder.BuildTemporalExpression(
+            "0,86400000", timeRelation, resource);
+
+        act.Should().NotThrow();
+    }
+
     private static MetadataV2Resource BuildNonTemporalResource()
         => new()
         {


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to honua-io/honua-server#1775

## Summary
The FeatureServer temporal-query path rejected real ArcGIS client requests with
HTTP 400 in two cases, breaking temporal conformance:

1. Four of the six standard Esri start/end-relative `timeRelation` spellings
   (`esriTimeRelationAfterStartTime`, `BeforeStartTime`, `AfterEndTime`,
   `BeforeEndTime`) were not recognized — only `esriTimeRelationOverlaps` and
   `esriTimeRelationOverlapsStartWithinEnd` were accepted, so ArcGIS Pro / arcpy
   temporal queries returned 400 "Invalid time parameter."
2. The ArcGIS API for Python (arcgis 2.4.x) serializes the `query(time_filter=)`
   kwarg to a `timeFilter` query parameter, which the strict allowlist rejected
   with 400 "Unknown query parameter."

This PR maps the four start/end-relative spellings onto the existing interval
engine and accepts `timeFilter` as an alias of `time`, so standard ArcGIS
clients can run time-aware FeatureServer queries.

## Changes Made
- Added `AfterStartTime`, `BeforeStartTime`, `AfterEndTime`, `BeforeEndTime` to the `TimeRelation` enum in `GeoServicesTemporalQueryBuilder` and mapped each onto the interval engine (feature interval `[timestamp, COALESCE(end, start)]` vs query `[queryStart, queryEnd]`).
- Recognized the `esriTimeRelation…` and short spellings for those four relations in `ParseTimeRelation` (case-insensitive), so they no longer throw `ArgumentException` (HTTP 400).
- Added `timeFilter` to the FeatureServer layer-query allowed-parameter set and read it as a fallback alias for `time` in `TryParseQueryParameters` (explicit `time` still wins).
- Added integration tests for all four new `timeRelation` values (with seed-verified object-id expectations), an explicit `OverlapsStartWithinEnd` acceptance test, and a `timeFilter`-alias equivalence test; added builder unit tests covering all six standard spellings.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review


---
<!-- Body brought into PR-template conformance; no code changed. CI re-runs full validation. -->

Related to #1775
