### PR TITLE
fix(geoservices): serialization/format conformance for pbf count, applyEdits, GP defaultValue, MapServer gif

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerQueryHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerQueryHandler.cs
@@ -683,6 +683,16 @@ internal sealed partial class FeatureServerQueryHandler(
                 FeatureServerLog.QueryExecuted(_logger, "count", serviceId, layerId, stopwatch.Elapsed.TotalMilliseconds);
                 var safeCount = (int)Math.Min(count, int.MaxValue);
                 HonuaTelemetry.SetSuccess(featureActivity, safeCount);
+
+                // f=pbf must return a protobuf-encoded count (CountResult arm of the
+                // FeatureCollectionPBuffer QueryResult oneof), mirroring the feature path;
+                // otherwise the count branch silently degrades to JSON. (#1775)
+                if (string.Equals(format, "pbf", StringComparison.OrdinalIgnoreCase))
+                {
+                    var (countPayload, countContentType) = PbfQueryFormatter.FormatCountAsPbf(count);
+                    return await CreateCachedBytesResultAsync(countPayload, countContentType);
+                }
+
                 var response = new QueryResponse
                 {
                     Count = count,

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Edits.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Edits.cs
@@ -640,12 +640,16 @@ internal static partial class FeatureServerEndpoints
             if (layerResult is Microsoft.AspNetCore.Http.HttpResults.JsonHttpResult<ApplyEditsResponse> jsonResult)
             {
                 var response = jsonResult.Value;
+                // A real Esri FeatureServer always emits all three per-layer arrays
+                // (empty when the layer had no edits of that kind); arcpy's `da` driver
+                // raises KeyError without them. Coalesce nulls to empty arrays so the
+                // service-level response never omits updateResults/deleteResults. (#1775)
                 results[i] = new ServiceLayerEditResult
                 {
                     Id = entry.Id,
-                    AddResults = response?.AddResults,
-                    UpdateResults = response?.UpdateResults,
-                    DeleteResults = response?.DeleteResults
+                    AddResults = response?.AddResults ?? [],
+                    UpdateResults = response?.UpdateResults ?? [],
+                    DeleteResults = response?.DeleteResults ?? []
                 };
             }
             else if (i == 0)
@@ -668,9 +672,9 @@ internal static partial class FeatureServerEndpoints
                 results[i] = new ServiceLayerEditResult
                 {
                     Id = entry.Id,
-                    AddResults = BuildAddFailureResults(entry.Adds, description),
-                    UpdateResults = BuildFeatureFailureResults(entry.Updates, description),
-                    DeleteResults = BuildDeleteFailureResults(entry.Deletes, description)
+                    AddResults = BuildAddFailureResults(entry.Adds, description) ?? [],
+                    UpdateResults = BuildFeatureFailureResults(entry.Updates, description) ?? [],
+                    DeleteResults = BuildDeleteFailureResults(entry.Deletes, description) ?? []
                 };
             }
         }

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/PbfQueryFormatter.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/PbfQueryFormatter.cs
@@ -44,6 +44,54 @@ internal sealed class PbfQueryFormatter
         _geometryLimits = limitsOptions?.Value?.Geometry ?? new GeometryLimits();
     }
 
+    /// <summary>
+    /// Formats a <c>returnCountOnly=true</c> result as an Esri-compatible PBF response
+    /// (<c>FeatureCollectionPBuffer</c> with the <c>countResult</c> arm of the
+    /// <c>QueryResult</c> oneof), mirroring how the feature path emits protobuf so that
+    /// <c>f=pbf</c> on the count path returns <c>application/x-protobuf</c> rather than JSON.
+    /// </summary>
+    public static (byte[] response, string contentType) FormatCountAsPbf(long count)
+    {
+        // Schema (github.com/Esri/arcgis-pbf FeatureCollection.proto):
+        //   FeatureCollectionPBuffer { string version = 1; QueryResult queryResult = 2; }
+        //   QueryResult { oneof Results { ... CountResult countResult = 2; ... } }
+        //   CountResult { uint64 count = 1; }
+        var countMsg = new ProtobufWriter(16);
+        try
+        {
+            // count is the selected oneof arm, so emit it unconditionally (including 0)
+            // to keep the CountResult message present on the wire.
+            countMsg.WriteUInt64Always(1, (ulong)Math.Max(count, 0));
+
+            var queryResult = new ProtobufWriter(countMsg.Position + 8);
+            try
+            {
+                queryResult.WriteMessage(2, ref countMsg);
+
+                var outer = new ProtobufWriter(queryResult.Position + 16);
+                try
+                {
+                    outer.WriteString(1, PbfVersion);
+                    outer.WriteMessage(2, ref queryResult);
+                    return (outer.ToArrayAndDispose(), "application/x-protobuf");
+                }
+                catch
+                {
+                    outer.Dispose();
+                    throw;
+                }
+            }
+            finally
+            {
+                queryResult.Dispose();
+            }
+        }
+        finally
+        {
+            countMsg.Dispose();
+        }
+    }
+
     public (byte[] response, string contentType) FormatAsPbf(
         QueryResult<Feature> result,
         MetadataV2Resource resource,

--- a/src/Honua.Protocols.GeoServices/GPServer/Models/GPServerModels.cs
+++ b/src/Honua.Protocols.GeoServices/GPServer/Models/GPServerModels.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Text.Json.Serialization;
+
 namespace Honua.Protocols.GeoServices.GPServer.Models;
 
 /// <summary>
@@ -77,7 +79,13 @@ internal sealed class GPParameterInfo
     /// <summary>Parameter direction (esriGPParameterDirectionInput or esriGPParameterDirectionOutput).</summary>
     public string? Direction { get; set; }
 
-    /// <summary>Default value.</summary>
+    /// <summary>
+    /// Default value. Esri GP task metadata always carries a <c>defaultValue</c> key
+    /// (JSON <c>null</c> when the parameter has no default); arcgis.geoprocessing's
+    /// <c>import_toolbox()</c> raises <c>KeyError('defaultValue')</c> when it is absent,
+    /// so this property is always serialized even when null. (#1775)
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public string? DefaultValue { get; set; }
 
     /// <summary>Parameter type (esriGPParameterTypeRequired, esriGPParameterTypeOptional).</summary>

--- a/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Metadata.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Metadata.cs
@@ -255,7 +255,10 @@ internal static partial class MapServerEndpoints
                 Name = layer.Name
             })],
             CopyrightText = string.Empty,
-            SupportedImageFormatTypes = "PNG,PNG8,PNG24,PNG32,JPG,GIF",
+            // GIF is intentionally omitted: the SkiaSharp-backed export renderer ships no
+            // GIF encoder and the export handler rejects format=gif, so advertising it here
+            // would let capabilities claim an output the service cannot produce. (#1772)
+            SupportedImageFormatTypes = "PNG,PNG8,PNG24,PNG32,JPG",
             // The current MapServer implementation only accepts a narrow dynamicLayers subset
             // for interoperability; do not advertise the full ArcGIS dynamic-layer contract.
             SupportsDynamicLayers = false,

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerEndpointTests.cs
@@ -207,6 +207,30 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.GetServiceInfo)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}")]
+    public async Task TaskInfo_KnownTask_EveryParameterIncludesDefaultValueKey()
+    {
+        // Regression (#1775): a missing defaultValue key makes
+        // arcgis.geoprocessing.import_toolbox() raise KeyError('defaultValue').
+        // Esri always emits the key (null when unset) on every parameter.
+        var response = await _client.GetAsync($"/rest/services/{ServiceId}/GPServer/geometry.buffer");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        var parameters = doc.RootElement.GetProperty("parameters").EnumerateArray().ToArray();
+        parameters.Should().NotBeEmpty();
+        foreach (var parameter in parameters)
+        {
+            parameter.TryGetProperty("defaultValue", out _)
+                .Should().BeTrue(
+                    "every GP parameter must carry a defaultValue key (parameter '{0}')",
+                    parameter.GetProperty("name").GetString());
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetServiceInfo)]
     [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}")]
     public async Task TaskInfo_Post_KnownTask_ReturnsTaskMetadata()
     {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
@@ -186,6 +186,40 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer")]
+    public async Task MapServer_Metadata_SupportedImageFormatTypes_DoesNotAdvertiseGif()
+    {
+        // Regression (#1772): GIF was advertised in supportedImageFormatTypes but the
+        // SkiaSharp export renderer ships no GIF encoder, so export?format=gif was
+        // rejected. Capabilities must match behavior -> GIF must not be advertised.
+        var response = await _fixture.Client.GetAsync($"/rest/services/{WebAppFixture.TestServiceId}/MapServer?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        var service = JsonSerializer.Deserialize(content, MapServerJsonContext.Default.MapServerResponse);
+
+        service.Should().NotBeNull();
+        service!.SupportedImageFormatTypes.Should().NotBeNullOrWhiteSpace();
+        service.SupportedImageFormatTypes!
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Should().NotContain(format => string.Equals(format, "GIF", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Export)]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/export")]
+    public async Task MapServer_Export_WithGifFormat_ReturnsBadRequest()
+    {
+        // Regression (#1772): format=gif must be rejected cleanly (400), and the
+        // capability advertisement above must not promise it.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/export?bbox=-180,-90,180,90&size=256,256&format=gif&f=image");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
     [Operation(Operations.Export)]
     [Endpoint("GET /rest/services/{serviceId}/MapServer/export")]
     public async Task MapServer_Export_ReturnsImageJson()

--- a/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -1010,6 +1010,126 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query?returnCountOnly=true&f=pbf")]
+    public async Task QueryFeatures_WithReturnCountOnlyAndPbf_ReturnsProtobufCount()
+    {
+        // Regression (#1775): the count-only path ignored f=pbf and returned JSON. It must
+        // emit a protobuf-encoded count (CountResult arm of the FeatureCollectionPBuffer
+        // QueryResult oneof) with Content-Type application/x-protobuf, mirroring the
+        // feature query pbf path.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?returnCountOnly=true&f=pbf");
+
+        response.Be200Ok();
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/x-protobuf");
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        bytes.Should().NotBeEmpty();
+        DecodePbfCount(bytes).Should().Be(5);
+    }
+
+    // Minimal protobuf reader for the FeatureCollectionPBuffer count-only response:
+    //   FeatureCollectionPBuffer { string version = 1; QueryResult queryResult = 2; }
+    //   QueryResult { CountResult countResult = 2; }  CountResult { uint64 count = 1; }
+    private static ulong DecodePbfCount(byte[] bytes)
+    {
+        var queryResult = ReadMessageField(bytes, 2);
+        queryResult.Should().NotBeNull("the outer message must carry queryResult (field 2)");
+        var countResult = ReadMessageField(queryResult!, 2);
+        countResult.Should().NotBeNull("queryResult must carry the countResult arm (field 2)");
+        return ReadVarintField(countResult!, 1)
+            ?? throw new Xunit.Sdk.XunitException("countResult.count (field 1) was not present");
+    }
+
+    private static byte[]? ReadMessageField(byte[] data, int fieldNumber)
+    {
+        int pos = 0;
+        while (pos < data.Length)
+        {
+            ulong tag = ReadVarint(data, ref pos);
+            int field = (int)(tag >> 3);
+            int wireType = (int)(tag & 0x7);
+            if (wireType == 2)
+            {
+                int len = (int)ReadVarint(data, ref pos);
+                if (field == fieldNumber)
+                {
+                    return data[pos..(pos + len)];
+                }
+
+                pos += len;
+            }
+            else
+            {
+                SkipField(data, ref pos, wireType);
+            }
+        }
+
+        return null;
+    }
+
+    private static ulong? ReadVarintField(byte[] data, int fieldNumber)
+    {
+        int pos = 0;
+        while (pos < data.Length)
+        {
+            ulong tag = ReadVarint(data, ref pos);
+            int field = (int)(tag >> 3);
+            int wireType = (int)(tag & 0x7);
+            if (wireType == 0 && field == fieldNumber)
+            {
+                return ReadVarint(data, ref pos);
+            }
+
+            SkipField(data, ref pos, wireType);
+        }
+
+        return null;
+    }
+
+    private static void SkipField(byte[] data, ref int pos, int wireType)
+    {
+        switch (wireType)
+        {
+            case 0:
+                ReadVarint(data, ref pos);
+                break;
+            case 1:
+                pos += 8;
+                break;
+            case 2:
+                int len = (int)ReadVarint(data, ref pos);
+                pos += len;
+                break;
+            case 5:
+                pos += 4;
+                break;
+            default:
+                throw new Xunit.Sdk.XunitException($"Unsupported wire type {wireType}");
+        }
+    }
+
+    private static ulong ReadVarint(byte[] data, ref int pos)
+    {
+        ulong result = 0;
+        int shift = 0;
+        while (true)
+        {
+            byte b = data[pos++];
+            result |= (ulong)(b & 0x7F) << shift;
+            if ((b & 0x80) == 0)
+            {
+                break;
+            }
+
+            shift += 7;
+        }
+
+        return result;
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query?returnIdsOnly=true")]
     public async Task QueryFeatures_WithReturnIdsOnly_ReturnsIds()
     {
@@ -2669,6 +2789,59 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         response.Be200Ok();
         var responseContent = await response.Content.ReadAsStringAsync();
         responseContent.Should().Contain("editResults");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/applyEdits")]
+    public async Task ApplyEdits_ServiceLevel_AddsOnly_IncludesEmptyUpdateAndDeleteResults()
+    {
+        // Regression (#1775): a real Esri FeatureServer always includes per-layer
+        // updateResults and deleteResults (empty arrays when none). arcpy's `da` driver
+        // raises without them. An adds-only payload must still emit all three arrays.
+        var request = """
+            [
+                {
+                    "id": 0,
+                    "adds": [
+                        {
+                            "attributes": {
+                                "name": "Service-level all-arrays feature"
+                            },
+                            "geometry": {
+                                "x": -122.4194,
+                                "y": 37.7749
+                            }
+                        }
+                    ]
+                }
+            ]
+            """;
+        var content = new StringContent(request, Encoding.UTF8, "application/json");
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/applyEdits",
+            content);
+
+        response.Be200Ok();
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        using var jsonDoc = JsonDocument.Parse(responseContent);
+        var editResults = jsonDoc.RootElement.GetProperty("editResults");
+        editResults.GetArrayLength().Should().BeGreaterThan(0);
+        var layerResult = editResults[0];
+
+        layerResult.TryGetProperty("addResults", out var addResults).Should().BeTrue();
+        addResults.ValueKind.Should().Be(JsonValueKind.Array);
+        addResults.GetArrayLength().Should().Be(1);
+
+        layerResult.TryGetProperty("updateResults", out var updateResults).Should().BeTrue();
+        updateResults.ValueKind.Should().Be(JsonValueKind.Array);
+        updateResults.GetArrayLength().Should().Be(0);
+
+        layerResult.TryGetProperty("deleteResults", out var deleteResults).Should().BeTrue();
+        deleteResults.ValueKind.Should().Be(JsonValueKind.Array);
+        deleteResults.GetArrayLength().Should().Be(0);
     }
 
     [IntegrationTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to honua-io/honua-server#1775
Related to honua-io/honua-server#1772

## Summary
Fixes four GeoServices serialization/format conformance bugs in the
`Honua.Protocols.GeoServices` adapters where the response wire format diverged
from a real Esri ArcGIS Server and broke ArcGIS Python client integration
(`arcpy` / `arcgis.geoprocessing`). Each fix is covered by a failing-first
integration test.

## Changes Made
- **`returnCountOnly=true&f=pbf` returned JSON (#1775):** the count-only branch ignored `f=pbf` and always serialized `{"count":N}` as `application/json`. Added `PbfQueryFormatter.FormatCountAsPbf` (emits the `CountResult` arm of the `FeatureCollectionPBuffer` `QueryResult` oneof) and routed the count branch through it so `f=pbf` returns a protobuf-encoded count with `Content-Type: application/x-protobuf`, mirroring the feature query pbf path.
- **Service-level `applyEdits` omitted empty `updateResults`/`deleteResults` (#1775):** an adds-only layer returned only `addResults`, so the other two keys were dropped (null) and `arcpy`'s `da` driver failed. Coalesced all three per-layer arrays to empty arrays so every layer result always carries `addResults`, `updateResults`, and `deleteResults`.
- **GP task-info omitted `defaultValue` (#1775):** `defaultValue` was dropped when null (global `DefaultIgnoreCondition=WhenWritingNull`), making `arcgis.geoprocessing.import_toolbox()` raise `KeyError('defaultValue')`. Forced `GPParameterInfo.DefaultValue` to always serialize (`[JsonIgnore(Condition = Never)]`), so every input and output parameter emits the key (null when unset).
- **MapServer advertised GIF but rejected it (#1772):** the SkiaSharp-backed export renderer ships no GIF encoder and the export handler returns 400 for `format=gif`, yet `supportedImageFormatTypes` listed `GIF`. Dropped `GIF` from the advertised formats so capabilities match behavior.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Added/extended integration tests:
- `QueryFeatures_WithReturnCountOnlyAndPbf_ReturnsProtobufCount` (decodes the pbf and asserts count + content-type)
- `ApplyEdits_ServiceLevel_AddsOnly_IncludesEmptyUpdateAndDeleteResults`
- `TaskInfo_KnownTask_EveryParameterIncludesDefaultValueKey`
- `MapServer_Metadata_SupportedImageFormatTypes_DoesNotAdvertiseGif` + `MapServer_Export_WithGifFormat_ReturnsBadRequest`

Targeted results: GeoServices source builds Release with `TreatWarningsAsErrors=true` (0 warnings); the 3 new GeoServices tests pass (3/3) and the 2 new FeatureServer tests pass (2/2) against Testcontainers PostGIS.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review


---
<!-- Body brought into PR-template conformance; no code changed. CI re-runs full validation. -->

Related to #1775
