### PR TITLE
fix(geoservices): synchronizeReplica download delivers changes and advances serverGen

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/DistributedReplicaStore.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/DistributedReplicaStore.cs
@@ -30,6 +30,13 @@ internal interface IReplicaStore
 
     Task<ReplicaState?> GetAsync(string replicaId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Lists the registered replicas for a service from the live registry. The <c>/replicas</c>
+    /// enumeration is served from here so it reflects createReplica / unRegisterReplica immediately,
+    /// rather than from a lagging cached snapshot.
+    /// </summary>
+    Task<IReadOnlyList<ReplicaState>> ListByServiceAsync(string serviceId, CancellationToken cancellationToken = default);
+
     Task<bool> RemoveAsync(string replicaId, CancellationToken cancellationToken = default);
 }
 
@@ -192,6 +199,32 @@ internal sealed partial class DistributedReplicaStore : IReplicaStore
         }
 
         return null;
+    }
+
+    public Task<IReadOnlyList<ReplicaState>> ListByServiceAsync(string serviceId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceId);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // IDistributedCache cannot enumerate keys, so the distributed cache tier can only enumerate the
+        // in-process fallback registry. When a distributed cache is configured the authoritative
+        // enumeration is served by CachingReplicaStore through IReplicaRepository.
+        var now = DateTimeOffset.UtcNow;
+        if (_cache != null)
+        {
+            return Task.FromResult<IReadOnlyList<ReplicaState>>([]);
+        }
+
+        CleanupFallback(now, enforceLimit: false);
+        var matches = _fallback.Values
+            .Where(entry => entry.ExpiresAt > now
+                && string.Equals(entry.Replica.ServiceId, serviceId, StringComparison.OrdinalIgnoreCase))
+            .Select(entry => entry.Replica)
+            .OrderByDescending(replica => replica.CreatedAt)
+            .ThenBy(replica => replica.ReplicaId, StringComparer.Ordinal)
+            .ToArray();
+
+        return Task.FromResult<IReadOnlyList<ReplicaState>>(matches);
     }
 
     public async Task<bool> RemoveAsync(string replicaId, CancellationToken cancellationToken = default)

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -87,8 +87,10 @@ internal static partial class FeatureServerEndpoints
             .Select(layer => layer.PublicLayerId)
             .ToHashSet();
 
-        var replicaRepository = context.RequestServices.GetRequiredService<IReplicaRepository>();
-        var replicas = await replicaRepository.ListByServiceAsync(serviceId, cancellationToken).ConfigureAwait(false);
+        // Serve /replicas from the live registry (IReplicaStore) rather than a lagging cached snapshot, so
+        // the enumeration reflects createReplica / unRegisterReplica immediately (#1775).
+        var replicaStore = context.RequestServices.GetRequiredService<IReplicaStore>();
+        var replicas = await replicaStore.ListByServiceAsync(serviceId, cancellationToken).ConfigureAwait(false);
 
         var response = replicas
             .Where(record => record.LayerIds.Length > 0 && record.LayerIds.All(accessibleLayerIds.Contains))
@@ -379,14 +381,65 @@ internal static partial class FeatureServerEndpoints
 
         var changeTracker = context.RequestServices.GetRequiredService<IChangeTracker>();
         var currentGen = await changeTracker.GetCurrentGenerationAsync(cancellationToken);
-        var layerChanges = new List<LayerChanges>();
+
+        // Assemble the per-layer delta since the replica's last-sync generation. The same
+        // change-tracking delta-assembly serves the synchronizeReplica(download) path so both
+        // directions deliver identical changes (the download bug, #1775, was that the download
+        // path never assembled this delta).
+        var (layerChanges, deltaError) = await BuildReplicaLayerChangesAsync(
+            context,
+            replicaId,
+            replica.LastSyncGeneration,
+            replicaLayers,
+            changeTracker,
+            cancellationToken);
+        if (deltaError is not null)
+        {
+            return deltaError;
+        }
+
+        var minGen = replica.LastSyncGeneration;
+        var maxGen = currentGen;
+
+        var response = new ExtractChangesResponse
+        {
+            Success = true,
+            ReplicaId = replicaId,
+            LayerChanges = layerChanges!,
+            ServerGen = currentGen,
+            MinServerGen = minGen,
+            MaxServerGen = maxGen
+        };
+
+        return Results.Json(response, FeatureServerJsonContext.Default.ExtractChangesResponse, contentType: "application/json");
+    }
+
+    /// <summary>
+    /// Assembles the per-layer server-to-client change delta for a replica since
+    /// <paramref name="sinceGeneration"/>, reusing the change-tracking engine that backs
+    /// <c>extractChanges</c>. Returns the per-layer adds/updates/deletes (with the actual inserted and
+    /// updated feature payloads), or a bad-request <see cref="IResult"/> when a layer's change set exceeds
+    /// the configured per-layer record limit. A <paramref name="sinceGeneration"/> of 0 means pre-migration
+    /// or first sync and falls back to "all current features as adds" for backward compatibility. This is
+    /// the shared download-assembly path consumed by both <c>extractChanges</c> and the
+    /// <c>synchronizeReplica</c> download direction (#1775).
+    /// </summary>
+    private static async Task<(LayerChanges[]? LayerChanges, IResult? Error)> BuildReplicaLayerChangesAsync(
+        HttpContext context,
+        string replicaId,
+        long sinceGeneration,
+        ReplicaLayerV2[] replicaLayers,
+        IChangeTracker changeTracker,
+        CancellationToken cancellationToken)
+    {
+        var layerChanges = new List<LayerChanges>(replicaLayers.Length);
 
         var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
         var queryLimits = context.RequestServices.GetRequiredService<IOptions<LimitsOptions>>().Value.Query;
 
-        // Special case: LastSyncGeneration == 0 means pre-migration data or first sync;
+        // Special case: sinceGeneration == 0 means pre-migration data or first sync;
         // fall back to "all features as adds" for backward compatibility.
-        if (replica.LastSyncGeneration == 0)
+        if (sinceGeneration == 0)
         {
             foreach (var layer in replicaLayers)
             {
@@ -396,10 +449,10 @@ internal static partial class FeatureServerEndpoints
                     cancellationToken);
                 if (result.HasMoreResults || result.Items.Length > queryLimits.MaxRecordCount)
                 {
-                    return StandardErrorHelpers.CreateBadRequest(
+                    return (null, StandardErrorHelpers.CreateBadRequest(
                         context,
                         $"Replica '{replicaId}' initial extract exceeds the configured per-layer record limit.",
-                        [$"Layer {layer.PublicLayerId} returned more than {queryLimits.MaxRecordCount} features."]);
+                        [$"Layer {layer.PublicLayerId} returned more than {queryLimits.MaxRecordCount} features."]));
                 }
 
                 var addFeatures = result.Items
@@ -417,109 +470,96 @@ internal static partial class FeatureServerEndpoints
                     DeleteIds = null
                 });
             }
+
+            return (layerChanges.ToArray(), null);
         }
-        else
+
+        // Query real incremental deltas from the change log
+        var changes = await changeTracker.GetChangesSinceAsync(
+            sinceGeneration,
+            replicaLayers.Select(layer => layer.StorageLayerId).Distinct().ToArray(),
+            cancellationToken);
+
+        // Group collapsed changes by layer
+        var changesByLayer = changes
+            .GroupBy(c => c.LayerId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        foreach (var layer in replicaLayers)
         {
-            // Query real incremental deltas from the change log
-            var changes = await changeTracker.GetChangesSinceAsync(
-                replica.LastSyncGeneration,
-                replicaLayers.Select(layer => layer.StorageLayerId).Distinct().ToArray(),
-                cancellationToken);
-
-            // Group collapsed changes by layer
-            var changesByLayer = changes
-                .GroupBy(c => c.LayerId)
-                .ToDictionary(g => g.Key, g => g.ToList());
-
-            foreach (var layer in replicaLayers)
+            if (changesByLayer.TryGetValue(layer.StorageLayerId, out var layerChangeList))
             {
-                if (changesByLayer.TryGetValue(layer.StorageLayerId, out var layerChangeList))
+                // Collect objectIds by operation type
+                var insertIds = layerChangeList
+                    .Where(c => c.Operation == FeatureChangeOperation.Insert)
+                    .Select(c => c.ObjectId)
+                    .ToArray();
+
+                var updateIds = layerChangeList
+                    .Where(c => c.Operation == FeatureChangeOperation.Update)
+                    .Select(c => c.ObjectId)
+                    .ToArray();
+
+                var deleteIds = layerChangeList
+                    .Where(c => c.Operation == FeatureChangeOperation.Delete)
+                    .Select(c => c.ObjectId)
+                    .ToArray();
+
+                if (insertIds.Length > queryLimits.MaxRecordCount ||
+                    updateIds.Length > queryLimits.MaxRecordCount ||
+                    deleteIds.Length > queryLimits.MaxRecordCount)
                 {
-                    // Collect objectIds by operation type
-                    var insertIds = layerChangeList
-                        .Where(c => c.Operation == FeatureChangeOperation.Insert)
-                        .Select(c => c.ObjectId)
-                        .ToArray();
-
-                    var updateIds = layerChangeList
-                        .Where(c => c.Operation == FeatureChangeOperation.Update)
-                        .Select(c => c.ObjectId)
-                        .ToArray();
-
-                    var deleteIds = layerChangeList
-                        .Where(c => c.Operation == FeatureChangeOperation.Delete)
-                        .Select(c => c.ObjectId)
-                        .ToArray();
-
-                    if (insertIds.Length > queryLimits.MaxRecordCount ||
-                        updateIds.Length > queryLimits.MaxRecordCount ||
-                        deleteIds.Length > queryLimits.MaxRecordCount)
-                    {
-                        return StandardErrorHelpers.CreateBadRequest(
-                            context,
-                            $"Replica '{replicaId}' extract exceeds the configured per-layer change limit.",
-                            [$"Layer {layer.PublicLayerId} exceeded {queryLimits.MaxRecordCount} adds, updates, or deletes in a single extract."]);
-                    }
-
-                    // Query actual features for inserts and updates
-                    GeoServicesFeature[]? addFeatures = null;
-                    if (insertIds.Length > 0)
-                    {
-                        var query = new FeatureQuery { ObjectIds = ImmutableArray.Create(insertIds) };
-                        var result = await featureReader.QueryAsync(layer.StorageLayerId, query, cancellationToken);
-                        addFeatures = result.Items
-                            .Select(f => ConvertFeatureToGeoServices(f, layer.Resource))
-                            .ToArray();
-                    }
-
-                    GeoServicesFeature[]? updateFeatures = null;
-                    if (updateIds.Length > 0)
-                    {
-                        var query = new FeatureQuery { ObjectIds = ImmutableArray.Create(updateIds) };
-                        var result = await featureReader.QueryAsync(layer.StorageLayerId, query, cancellationToken);
-                        updateFeatures = result.Items
-                            .Select(f => ConvertFeatureToGeoServices(f, layer.Resource))
-                            .ToArray();
-                    }
-
-                    layerChanges.Add(new LayerChanges
-                    {
-                        Id = layer.PublicLayerId,
-                        Adds = insertIds.Length,
-                        Updates = updateIds.Length,
-                        Deletes = deleteIds.Length,
-                        AddFeatures = addFeatures,
-                        UpdateFeatures = updateFeatures,
-                        DeleteIds = deleteIds.Length > 0 ? deleteIds : null
-                    });
+                    return (null, StandardErrorHelpers.CreateBadRequest(
+                        context,
+                        $"Replica '{replicaId}' extract exceeds the configured per-layer change limit.",
+                        [$"Layer {layer.PublicLayerId} exceeded {queryLimits.MaxRecordCount} adds, updates, or deletes in a single extract."]));
                 }
-                else
+
+                // Query actual features for inserts and updates
+                GeoServicesFeature[]? addFeatures = null;
+                if (insertIds.Length > 0)
                 {
-                    layerChanges.Add(new LayerChanges
-                    {
-                        Id = layer.PublicLayerId,
-                        Adds = 0,
-                        Updates = 0,
-                        Deletes = 0
-                    });
+                    var query = new FeatureQuery { ObjectIds = ImmutableArray.Create(insertIds) };
+                    var result = await featureReader.QueryAsync(layer.StorageLayerId, query, cancellationToken);
+                    addFeatures = result.Items
+                        .Select(f => ConvertFeatureToGeoServices(f, layer.Resource))
+                        .ToArray();
                 }
+
+                GeoServicesFeature[]? updateFeatures = null;
+                if (updateIds.Length > 0)
+                {
+                    var query = new FeatureQuery { ObjectIds = ImmutableArray.Create(updateIds) };
+                    var result = await featureReader.QueryAsync(layer.StorageLayerId, query, cancellationToken);
+                    updateFeatures = result.Items
+                        .Select(f => ConvertFeatureToGeoServices(f, layer.Resource))
+                        .ToArray();
+                }
+
+                layerChanges.Add(new LayerChanges
+                {
+                    Id = layer.PublicLayerId,
+                    Adds = insertIds.Length,
+                    Updates = updateIds.Length,
+                    Deletes = deleteIds.Length,
+                    AddFeatures = addFeatures,
+                    UpdateFeatures = updateFeatures,
+                    DeleteIds = deleteIds.Length > 0 ? deleteIds : null
+                });
+            }
+            else
+            {
+                layerChanges.Add(new LayerChanges
+                {
+                    Id = layer.PublicLayerId,
+                    Adds = 0,
+                    Updates = 0,
+                    Deletes = 0
+                });
             }
         }
 
-        var minGen = replica.LastSyncGeneration;
-        var maxGen = currentGen;
-
-        var response = new ExtractChangesResponse
-        {
-            Success = true,
-            ReplicaId = replicaId,
-            LayerChanges = layerChanges.ToArray(),
-            ServerGen = currentGen,
-            MinServerGen = minGen,
-            MaxServerGen = maxGen
-        };
-
-        return Results.Json(response, FeatureServerJsonContext.Default.ExtractChangesResponse, contentType: "application/json");
+        return (layerChanges.ToArray(), null);
     }
 
     /// <summary>
@@ -846,7 +886,11 @@ internal static partial class FeatureServerEndpoints
 
         var syncDirection = GetValueString(values, "syncDirection") ?? "download";
         var editsJson = GetValueString(values, "edits");
+        // "upload" and "bidirectional" carry client edits to apply; "download" and "bidirectional" return
+        // a server-to-client delta. The default (download) delivers the delta only.
         var isUploadDirection = !string.Equals(syncDirection, "download", StringComparison.OrdinalIgnoreCase);
+        var isDownloadDirection = string.Equals(syncDirection, "download", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(syncDirection, "bidirectional", StringComparison.OrdinalIgnoreCase);
 
         // Esri sync protocol: the client echoes the server generation it actually
         // received (replicaServerGen, from the preceding extractChanges serverGen).
@@ -959,21 +1003,60 @@ internal static partial class FeatureServerEndpoints
 
         // The server generation cursor recorded for the replica. After an upload we record the
         // post-apply generation as both the last-sync and upload-base cursor so a subsequent download
-        // delta excludes the client's own just-applied edits. Download-only syncs advance the
-        // last-sync cursor to the generation the client acknowledged receiving (replicaServerGen,
-        // clamped to the live generation); only when the client supplies no acknowledgment do we
-        // fall back to the live current generation.
+        // delta excludes the client's own just-applied edits. Download/bidirectional syncs advance the
+        // last-sync cursor to the live current generation once the server-to-client delta below has been
+        // assembled, so the replica receives every change committed since its last sync exactly once.
         long currentGen;
-        if (didUpload)
+        if (didUpload && !isDownloadDirection)
         {
             currentGen = uploadServerGen;
         }
         else
         {
-            var liveGen = await changeTracker.GetCurrentGenerationAsync(cancellationToken);
-            currentGen = acknowledgedServerGen is { } acknowledged
-                ? Math.Min(acknowledged, liveGen)
-                : liveGen;
+            currentGen = await changeTracker.GetCurrentGenerationAsync(cancellationToken);
+        }
+
+        // Download / bidirectional sync: assemble the server-to-client delta and deliver it in the
+        // response. This is the core of the #1775 fix — previously the download direction returned
+        // success with no edits and never advanced the serverGen, so server-side changes committed after
+        // createReplica were never delivered. The delta is assembled with the same change-tracking engine
+        // extractChanges uses. The "since" cursor is the generation the client says it already holds
+        // (replicaServerGen, the serverGen from its preceding extractChanges/createReplica) when supplied,
+        // otherwise the replica's recorded last-sync generation; an upload in the same bidirectional call
+        // moves that baseline to the post-apply generation so the replica does not receive its own edits.
+        LayerChanges[]? downloadEdits = null;
+        ReplicaInfoLayerServerGeneration[]? downloadLayerServerGens = null;
+        if (isDownloadDirection)
+        {
+            var downloadSinceGen = didUpload
+                ? uploadServerGen
+                : acknowledgedServerGen is { } acknowledged
+                    ? Math.Min(acknowledged, currentGen)
+                    : replica.LastSyncGeneration;
+
+            var (assembledEdits, deltaError) = await BuildReplicaLayerChangesAsync(
+                context,
+                replicaId,
+                downloadSinceGen,
+                replicaLayers,
+                changeTracker,
+                cancellationToken);
+            if (deltaError is not null)
+            {
+                return deltaError;
+            }
+
+            downloadEdits = assembledEdits;
+            downloadLayerServerGens = replicaLayers
+                .Select(layer => layer.PublicLayerId)
+                .Distinct()
+                .Select(id => new ReplicaInfoLayerServerGeneration
+                {
+                    Id = id,
+                    ServerGen = currentGen,
+                    ServerSibGen = currentGen
+                })
+                .ToArray();
         }
 
         var updated = replica with
@@ -1005,6 +1088,8 @@ internal static partial class FeatureServerEndpoints
             ReplicaId = replicaId,
             SyncDirection = syncDirection,
             ServerGen = currentGen,
+            Edits = downloadEdits,
+            LayerServerGens = downloadLayerServerGens,
             AppliedAdds = appliedAdds,
             AppliedUpdates = appliedUpdates,
             AppliedDeletes = appliedDeletes,

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Models/ReplicationModels.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Models/ReplicationModels.cs
@@ -425,6 +425,22 @@ public sealed class SynchronizeReplicaResponse
     public long ServerGen { get; set; }
 
     /// <summary>
+    /// Server-to-client changes assembled for a download (or bidirectional) sync: the per-layer
+    /// adds/updates/deletes committed on the server since the replica's last sync generation. Omitted
+    /// (null) for upload-only syncs, which carry no download payload.
+    /// </summary>
+    [JsonPropertyName("edits")]
+    public LayerChanges[]? Edits { get; set; }
+
+    /// <summary>
+    /// Per-layer server generations advanced by this synchronization, encoded using the ArcGIS replicas
+    /// resource shape. Lets a per-layer replica record the generation it has now received for each layer.
+    /// Omitted (null) for upload-only syncs.
+    /// </summary>
+    [JsonPropertyName("layerServerGens")]
+    public ReplicaInfoLayerServerGeneration[]? LayerServerGens { get; set; }
+
+    /// <summary>
     /// Number of uploaded add operations applied during this synchronization. Omitted (null) for
     /// download-only syncs that carry no upload.
     /// </summary>

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/CachingReplicaStore.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/CachingReplicaStore.cs
@@ -119,6 +119,27 @@ internal sealed partial class CachingReplicaStore : IReplicaStore
         return state;
     }
 
+    public async Task<IReadOnlyList<ReplicaState>> ListByServiceAsync(string serviceId, CancellationToken cancellationToken = default)
+    {
+        // Serve the enumeration from the authoritative repository so /replicas reflects
+        // createReplica / unRegisterReplica immediately. Writes go through Postgres first
+        // (write-through), so the repository is the live registry; the distributed cache cannot
+        // enumerate keys and would otherwise lag (#1775).
+        var records = await _repository.ListByServiceAsync(serviceId, cancellationToken).ConfigureAwait(false);
+        if (records.Count == 0)
+        {
+            return [];
+        }
+
+        var states = new ReplicaState[records.Count];
+        for (var i = 0; i < records.Count; i++)
+        {
+            states[i] = ToState(records[i]);
+        }
+
+        return states;
+    }
+
     public async Task<bool> RemoveAsync(string replicaId, CancellationToken cancellationToken = default)
     {
         // Remove from both stores

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicaSyncTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicaSyncTests.cs
@@ -283,10 +283,138 @@ public sealed class FeatureServerReplicaSyncTests : IAsyncLifetime
         serverName.Should().Be("client-only");
     }
 
+    [IntegrationTest]
+    [Operation(Operations.SynchronizeReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/synchronizeReplica")]
+    public async Task SynchronizeReplica_Download_DeliversPostReplicaChangesAndAdvancesServerGen()
+    {
+        // Repro for the #1775 download no-op: createReplica at generation N, add a feature server-side,
+        // then synchronizeReplica(download) must deliver the added feature (in edits) and advance
+        // serverGen past N. Previously the download direction returned success with no edits and echoed
+        // the client serverGen, so the post-replica feature was never delivered.
+        var createRoot = await CreateReplicaWithResponseAsync("DownloadDelivery", "0");
+        var replicaId = createRoot.GetProperty("replicaID").GetString()!;
+        var baseServerGen = createRoot.GetProperty("serverGen").GetInt64();
+
+        // Server-side edit committed AFTER the replica was created.
+        var objectId = await AddFeatureAsync("post-replica-add");
+
+        // Download sync echoing the replica's serverGen (replicaServerGen=N), exactly as a client that has
+        // only the createReplica generation would send.
+        var downloadRoot = await SynchronizeDownloadWithResponseAsync(replicaId, baseServerGen);
+
+        downloadRoot.GetProperty("success").GetBoolean().Should().BeTrue();
+        downloadRoot.GetProperty("syncDirection").GetString().Should().Be("download");
+
+        // serverGen must advance past the client's generation so the cursor moves forward.
+        var newServerGen = downloadRoot.GetProperty("serverGen").GetInt64();
+        newServerGen.Should().BeGreaterThan(baseServerGen, "the download must advance the replica's serverGen past the post-replica edit");
+
+        // The post-replica feature must be delivered in the edits payload as an add on layer 0.
+        downloadRoot.TryGetProperty("edits", out var edits).Should().BeTrue("download syncs must carry an edits delta");
+        edits.ValueKind.Should().Be(JsonValueKind.Array);
+        var layer0 = edits.EnumerateArray().Single(layer => layer.GetProperty("id").GetInt32() == 0);
+        layer0.GetProperty("adds").GetInt32().Should().Be(1);
+        layer0.GetProperty("addFeatures")
+            .EnumerateArray()
+            .Should()
+            .Contain(feature =>
+                feature.GetProperty("attributes").GetProperty("objectid").GetInt64() == objectId);
+
+        // A subsequent download from the advanced cursor must be empty (the feature is delivered exactly once).
+        var secondDownload = await SynchronizeDownloadWithResponseAsync(replicaId, newServerGen);
+        secondDownload.GetProperty("serverGen").GetInt64().Should().Be(newServerGen);
+        if (secondDownload.TryGetProperty("edits", out var secondEdits) && secondEdits.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var layer in secondEdits.EnumerateArray())
+            {
+                layer.GetProperty("adds").GetInt32().Should().Be(0, "an already-delivered change must not be sent again");
+                layer.GetProperty("updates").GetInt32().Should().Be(0);
+                layer.GetProperty("deletes").GetInt32().Should().Be(0);
+            }
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ListReplicas)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/replicas")]
+    public async Task Replicas_AfterCreateAndUnregister_ReflectsLiveRegistryImmediately()
+    {
+        // #1775 minor bug: /replicas must reflect createReplica / unRegisterReplica immediately (served
+        // from the live registry), not lag behind a cached snapshot.
+        var replicaId = await CreateReplicaAsync("LiveRegistryReplica", "0");
+
+        // Immediately after createReplica the new replica must be visible.
+        var afterCreate = await ListReplicaIdsAsync();
+        afterCreate.Should().Contain(replicaId, "a just-created replica must appear in /replicas without lag");
+
+        // Immediately after unRegisterReplica the replica must be gone.
+        await UnregisterReplicaAsync(replicaId);
+        var afterUnregister = await ListReplicaIdsAsync();
+        afterUnregister.Should().NotContain(replicaId, "an unregistered replica must disappear from /replicas without lag");
+    }
+
     private static bool HasNoConflicts(JsonElement root)
         => !root.TryGetProperty("conflicts", out var conflicts)
            || conflicts.ValueKind == JsonValueKind.Null
            || conflicts.GetArrayLength() == 0;
+
+    private async Task<JsonElement> CreateReplicaWithResponseAsync(string name, string layers)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            replicaName = name,
+            layers,
+            syncModel = "perReplica",
+            f = "json"
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/createReplica",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement.Clone();
+    }
+
+    private async Task<JsonElement> SynchronizeDownloadWithResponseAsync(string replicaId, long replicaServerGen)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            replicaID = replicaId,
+            syncDirection = "download",
+            replicaServerGen,
+            f = "json"
+        });
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/synchronizeReplica",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement.Clone();
+    }
+
+    private async Task UnregisterReplicaAsync(string replicaId)
+    {
+        var payload = JsonSerializer.Serialize(new { replicaID = replicaId, f = "json" });
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/unRegisterReplica",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private async Task<List<string>> ListReplicaIdsAsync()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/replicas?f=json");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return doc.RootElement
+            .EnumerateArray()
+            .Select(replica => replica.GetProperty("replicaID").GetString()!)
+            .ToList();
+    }
 
     private async Task<string> CreateReplicaAsync(string name, string layers)
     {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicationTests.cs
@@ -711,6 +711,10 @@ public sealed class FeatureServerReplicationTests : IAsyncLifetime
         public Task<ReplicaState?> GetAsync(string replicaId, CancellationToken cancellationToken = default)
             => Task.FromResult<ReplicaState?>(null);
 
+        public Task<IReadOnlyList<ReplicaState>> ListByServiceAsync(string serviceId, CancellationToken cancellationToken = default)
+            => throw new ServiceUnavailableException(
+                "Distributed replica state is unavailable while attempting to list replica state.");
+
         public Task<bool> RemoveAsync(string replicaId, CancellationToken cancellationToken = default)
             => Task.FromResult(false);
     }

--- a/tests/dotnet/Honua.TestKit/TestWebApplicationFactory.cs
+++ b/tests/dotnet/Honua.TestKit/TestWebApplicationFactory.cs
@@ -282,6 +282,16 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
             return Task.FromResult(replica);
         }
 
+        public Task<IReadOnlyList<ReplicaState>> ListByServiceAsync(string serviceId, CancellationToken cancellationToken = default)
+        {
+            var matches = _replicas.Values
+                .Where(replica => string.Equals(replica.ServiceId, serviceId, StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(replica => replica.CreatedAt)
+                .ThenBy(replica => replica.ReplicaId, StringComparer.Ordinal)
+                .ToArray();
+            return Task.FromResult<IReadOnlyList<ReplicaState>>(matches);
+        }
+
         public Task<bool> RemoveAsync(string replicaId, CancellationToken cancellationToken = default)
             => Task.FromResult(_replicas.TryRemove(replicaId, out _));
     }


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to honua-io/honua-server#1775

## Summary
Fixes the FeatureServer offline-sync bugs reported in #1775. The headline (HIGH-severity) bug: the GeoServices `synchronizeReplica` **download** direction was a no-op. `createReplica` (serverGen=N) → add a feature server-side → `POST .../FeatureServer/synchronizeReplica` with `syncDirection=download&replicaServerGen=N` returned `{"success":true,"syncDirection":"download","serverGen":N}` with **no `edits`/`layerServerGens` payload**, and `serverGen` echoed the client value (never advanced) — so changes committed after the replica was created were never delivered. The change-tracking engine itself was fine (`extractChanges` and the **upload** direction both work correctly); only the download-assembly path was not wired to it.

This change assembles the download delta through the same change-tracking path `extractChanges` uses, returns it in new `edits`/`layerServerGens` response fields, and advances `serverGen` to the live current generation so each change is delivered exactly once. It also fixes the minor `/replicas` enumeration lag by serving the list from the live registry (`IReplicaStore`) instead of the lagging `IReplicaRepository` snapshot.

## Changes Made
- Extracted the `extractChanges` per-layer delta assembly into a shared `BuildReplicaLayerChangesAsync` helper (preserves the `LastSyncGeneration == 0` full-extract fallback and the per-layer record-limit guard), and made `extractChanges` call it.
- Wired the `synchronizeReplica` download/bidirectional direction to that helper: it now assembles the server-to-client delta since the replica's last-sync generation (or the client-supplied `replicaServerGen`, or the post-apply generation for bidirectional uploads), returns it in `edits`/`layerServerGens`, and advances `serverGen` to the live current generation.
- Added `edits` (`LayerChanges[]`) and `layerServerGens` (`ReplicaInfoLayerServerGeneration[]`) to `SynchronizeReplicaResponse` (both use already source-gen-registered types, so AOT JSON is covered).
- Added `IReplicaStore.ListByServiceAsync`; implemented it in `CachingReplicaStore` (delegates to the authoritative write-through repository) and `DistributedReplicaStore` (in-process fallback registry). `/replicas` (`HandleReplicas`) now reads from the live `IReplicaStore` so create/unregister are reflected immediately.
- Tests: added `SynchronizeReplica_Download_DeliversPostReplicaChangesAndAdvancesServerGen` (createReplica → server-side add → download delivers the feature + serverGen advances + second download is empty) and `Replicas_AfterCreateAndUnregister_ReflectsLiveRegistryImmediately`. Updated the `IReplicaStore` test doubles (`InMemoryReplicaStore`, `ThrowingReplicaStore`) for the new method.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. The new `synchronizeReplica` response fields (`edits`, `layerServerGens`) are additive and omitted when null; the `/replicas` source change is internal.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review


---
<!-- Body brought into PR-template conformance; no code changed. CI re-runs full validation. -->

Related to #1775
