### PR TITLE
feat(geoservices): Esri VectorTileServer adapter — metadata, tile, styles, tilemap, catalog (#1776)

### DIFF
--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -1456,6 +1456,50 @@
       ]
     },
     {
+      "surfaceId": "vector-tile-server",
+      "displayName": "GeoServices REST VectorTileServer",
+      "surfaceKind": "http-route-family",
+      "protocol": "GeoServices REST VectorTileServer",
+      "canonicalIdentifier": "/rest/services/{serviceId}/VectorTileServer",
+      "parentSurfaceId": null,
+      "endpointPrefixes": [],
+      "endpointExactMatches": [],
+      "endpointContains": [
+        "/VectorTileServer"
+      ],
+      "operationKeys": [],
+      "proofs": [
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "EndpointRegistry coverage and deployed-route drift checks for the VectorTileServer service-metadata adapter",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/EndpointRegistry.cs",
+            "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/API/EndpointRegistryDriftTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": null,
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "scenario-depth",
+          "proofMechanism": "Tile data, style/resources, and tileMap routes are declared and stubbed (HTTP 501) in the metadata foundation; the parallel wave fills the handlers under the VectorTileServer epic.",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Tile.cs",
+            "src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Resources.cs",
+            "src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.TileMap.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "bounded-child-ticket",
+          "linkedTicket": "#1776",
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
       "surfaceId": "map-server",
       "displayName": "GeoServices REST MapServer",
       "surfaceKind": "http-route-family",

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -1485,7 +1485,7 @@
         },
         {
           "proofClass": "scenario-depth",
-          "proofMechanism": "Tile data, style/resources, and tileMap routes are declared and stubbed (HTTP 501) in the metadata foundation; the parallel wave fills the handlers under the VectorTileServer epic.",
+          "proofMechanism": "Tile data (tile/{z}/{y}/{x}.pbf), style/resources (default styles + root.json, scoped-minimal sprites and glyph ranges), and tileMap routes are implemented as thin adapters over the shared vector-tile pipeline; sprite/glyphs are referenced from the composed style only when it has symbol layers.",
           "executionLane": "ci:test-all",
           "evidenceLocations": [
             "src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Tile.cs",
@@ -1493,8 +1493,8 @@
             "src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.TileMap.cs"
           ],
           "ownerRepo": "honua-server",
-          "status": "bounded-child-ticket",
-          "linkedTicket": "#1776",
+          "status": "implemented",
+          "linkedTicket": null,
           "versionCaptureRule": null
         }
       ]

--- a/docs/gis/vector-tile-server.md
+++ b/docs/gis/vector-tile-server.md
@@ -1,0 +1,56 @@
+# GeoServices REST — VectorTileServer
+
+Honua exposes an Esri-compatible **VectorTileServer** adapter under
+`/rest/services/{serviceId}/VectorTileServer`. It is a thin protocol adapter over the shared
+vector-tile, style, and metadata pipelines — it parses Esri-shaped requests, resolves the service
+by **name** against the Metadata v2 graph, and formats Esri/Mapbox-compatible responses. It does
+not reimplement tile rendering, style storage, or catalog logic.
+
+The service is read-only and anonymous by design (it inherits the service access policy; the
+canonical seed service is open). Clients hydrate service metadata with `GET` or with a
+`POST {"f":"json"}` (Esri clients use the latter).
+
+## Per-operation route matrix
+
+| Operation | Method | Route | Response | Notes |
+|---|---|---|---|---|
+| Service metadata | GET / POST | `/rest/services/{serviceId}/VectorTileServer` | `application/json` | Esri VectorTileServer descriptor: `tiles` template, `tileInfo` (512px WebMercatorQuad), `defaultStyles`, `tileMap`, `capabilities: TilesOnly`, `type: indexedVector`, min/max LOD, full/initial extent. |
+| Tile | GET | `/rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf` | `application/vnd.mapbox-vector-tile` (200), empty (204) | Mapbox Vector Tile for the service's primary tiled layer. Esri `{z}/{y}/{x}` maps directly onto the canonical `(tileCol=x, tileRow=y, zoom=z)` tuple (shared top-left WebMercatorQuad origin). Out-of-range zoom / bad coordinates → 400. |
+| Default styles | GET | `/rest/services/{serviceId}/VectorTileServer/resources/styles` | `application/json` | Mapbox GL v8 style (`root.json`) composed from the layer's stored style (or a deterministic geometry-aware default). The vector source is rewritten onto this service's tile route. |
+| Style resource | GET | `/rest/services/{serviceId}/VectorTileServer/resources/styles/{**resourcePath}` | `application/json` | Serves `root.json` (and the bare path). Any other style sub-resource → 404. |
+| Sprite resource | GET | `/rest/services/{serviceId}/VectorTileServer/resources/sprites/{spriteResource}` | `application/json` / `image/png` | Scoped-minimal: `sprite.json` / `sprite@2x.json` → empty sprite index (`{}`); `sprite.png` / `sprite@2x.png` → 1×1 transparent PNG. Unknown sprite resource → 404. |
+| Glyph range | GET | `/rest/services/{serviceId}/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf` | `application/x-protobuf` | Scoped-minimal: a single minimal Mapbox glyph stack for the default `0-255` range. Out-of-range range → 404. The fontstack is informational — any fontstack resolves to the same minimal stack. |
+| TileMap | GET | `/rest/services/{serviceId}/VectorTileServer/tilemap` | `application/json` | Top-of-pyramid availability descriptor (single `1`). |
+| TileMap (block) | GET | `/rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}` | `application/json` | Row-major availability flags for the requested `dimension × dimension2` block. Tiles overrunning the gridset edge are `0`. Levels outside the LOD scheme or absurd dimensions → 400. |
+
+All routes resolve the service by name and return **404** for an unknown service.
+
+## Design decisions
+
+These decisions were ratified under epic **#1776** (VectorTileServer) and its child tickets:
+
+- **512px WebMercatorQuad gridset.** `tileInfo` advertises a 512×512 pixel tiling scheme on the
+  WebMercatorQuad tile matrix set (`wkid 102100` / `latestWkid 3857`), top-left origin, `pbf`
+  format, with the standard LOD scale ladder (`559082264.0287178` at level 0, halved per level).
+- **Single primary source per service.** The composed style emits exactly one vector source
+  (id `esri`) whose `tiles[]` is this service's absolute tile template; the legacy TileJSON `url`
+  pointer is stripped so clients fetch tiles directly. The tile and style handlers resolve the
+  service's **primary** tiled publication (preferring the `EsriVectorTileLayer` publication, then
+  the lowest layer index).
+- **`EsriVectorTileLayer` publication type.** VectorTileServer services publish their tiled layer
+  under the `EsriVectorTileLayer` Metadata v2 publication type (wire value `esri-vector-tile-layer`),
+  which is the preferred publication type the adapter resolves.
+- **Sprites/glyphs scoped-minimal.** Honua does not author per-service sprite sheets or glyph
+  stacks. The `resources/sprites/*` and `resources/fonts/*` routes serve deterministic in-process
+  stubs (empty sprite index, 1×1 transparent PNG, one minimal glyph stack for the `0-255` range).
+  The composed `root.json` references `sprite`/`glyphs` **only when the style has at least one
+  `symbol` layer** (the only Mapbox GL layer type that consumes a sprite or glyph stack); otherwise
+  they are omitted so the served document never advertises a reference the client cannot use.
+
+## Implementation
+
+- Endpoints: `src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints*.cs`
+- Style composition: `src/Honua.Protocols.GeoServices/VectorTileServer/Services/VectorTileStyleComposer.cs`
+- Sprite/glyph stub assets: `src/Honua.Protocols.GeoServices/VectorTileServer/Services/VectorTileEmbeddedAssets.cs`
+- Route catalog: `src/Honua.Server/EndpointRegistry.cs`
+- Integration tests: `tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/`

--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2Enums.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataV2Enums.cs
@@ -376,6 +376,12 @@ public enum MetadataV2PublicationType
     EsriImageLayer,
 
     /// <summary>
+    /// An Esri vector tile layer publication (GeoServices VectorTileServer).
+    /// </summary>
+    [JsonStringEnumMemberName("esri-vector-tile-layer")]
+    EsriVectorTileLayer,
+
+    /// <summary>
     /// A STAC collection publication.
     /// </summary>
     [JsonStringEnumMemberName("stac-collection")]

--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/ServiceProtocols.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/ServiceProtocols.cs
@@ -20,6 +20,9 @@ public static class ServiceProtocols
     /// <summary>GeoServices GPServer protocol.</summary>
     public const string GPServer = "GPServer";
 
+    /// <summary>GeoServices VectorTileServer protocol.</summary>
+    public const string VectorTileServer = "VectorTileServer";
+
     /// <summary>OGC API Features protocol.</summary>
     public const string OgcFeatures = "OgcFeatures";
 
@@ -68,6 +71,7 @@ public static class ServiceProtocols
         MapServer,
         ImageServer,
         GPServer,
+        VectorTileServer,
         OgcFeatures,
         OgcApiMaps,
         OgcApiCoverages,
@@ -156,6 +160,11 @@ public static class ServiceProtocols
         if (string.Equals(protocol, ImageServer, StringComparison.OrdinalIgnoreCase))
         {
             return publicationType == MetadataV2PublicationType.EsriImageLayer;
+        }
+
+        if (string.Equals(protocol, VectorTileServer, StringComparison.OrdinalIgnoreCase))
+        {
+            return publicationType == MetadataV2PublicationType.EsriVectorTileLayer;
         }
 
         if (string.Equals(protocol, OData, StringComparison.OrdinalIgnoreCase))

--- a/src/Honua.Protocols.GeoServices/Catalog/GeoservicesCatalogEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/Catalog/GeoservicesCatalogEndpoints.cs
@@ -22,6 +22,7 @@ internal static class GeoservicesCatalogEndpoints
     private const string FeatureServerProtocolName = "FeatureServer";
     private const string MapServerProtocolName = "MapServer";
     private const string ImageServerProtocolName = "ImageServer";
+    private const string VectorTileServerProtocolName = "VectorTileServer";
 
     /// <summary>
     /// Maps root catalog endpoints under /rest.
@@ -32,7 +33,7 @@ internal static class GeoservicesCatalogEndpoints
             .WithDisplayName("GeoServices Services Directory")
             .WithName("GeoServicesServicesDirectory")
             .WithSummary("List available GeoServices endpoints")
-            .WithDescription("Returns FeatureServer, MapServer, and ImageServer service directory entries.")
+            .WithDescription("Returns FeatureServer, MapServer, ImageServer, and VectorTileServer service directory entries.")
             .WithTags("GeoServices Catalog")
             .CacheOutput("ServiceDirectory")
             .Produces<ServicesDirectoryResponse>(StatusCodes.Status200OK, JsonContentType)
@@ -204,8 +205,9 @@ internal static class GeoservicesCatalogEndpoints
 
     /// <summary>
     /// Maps an Esri-family primary protocol to the directory-entry "type" string the
-    /// GeoServices REST catalog exposes. Returns false for non-Esri protocols
-    /// (OGC API Features, STAC, etc.) which are surfaced through other catalogs.
+    /// GeoServices REST catalog exposes (FeatureServer, MapServer, ImageServer,
+    /// VectorTileServer). Returns false for non-Esri protocols (OGC API Features, STAC, etc.)
+    /// which are surfaced through other catalogs.
     /// </summary>
     private static bool TryMapServiceType(string? primaryProtocol, out string directoryType)
     {
@@ -219,6 +221,9 @@ internal static class GeoservicesCatalogEndpoints
                 return true;
             case ImageServerProtocolName:
                 directoryType = "ImageServer";
+                return true;
+            case VectorTileServerProtocolName:
+                directoryType = "VectorTileServer";
                 return true;
             default:
                 directoryType = string.Empty;

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerJsonContext.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerJsonContext.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Protocols.GeoServices.VectorTileServer.Models;
+
+/// <summary>
+/// AOT-compatible source-generated JSON serialization context for VectorTileServer models.
+/// </summary>
+[JsonSerializable(typeof(VectorTileServerMetadataResponse))]
+[JsonSerializable(typeof(VectorTileInfo))]
+[JsonSerializable(typeof(VectorTileOrigin))]
+[JsonSerializable(typeof(VectorTileSpatialReference))]
+[JsonSerializable(typeof(VectorTileLevelOfDetail))]
+[JsonSerializable(typeof(VectorTileLevelOfDetail[]))]
+[JsonSerializable(typeof(VectorTileExtent))]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+internal sealed partial class VectorTileServerJsonContext : JsonSerializerContext;

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerJsonContext.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerJsonContext.cs
@@ -15,6 +15,8 @@ namespace Honua.Protocols.GeoServices.VectorTileServer.Models;
 [JsonSerializable(typeof(VectorTileLevelOfDetail))]
 [JsonSerializable(typeof(VectorTileLevelOfDetail[]))]
 [JsonSerializable(typeof(VectorTileExtent))]
+[JsonSerializable(typeof(VectorTileMapResponse))]
+[JsonSerializable(typeof(VectorTileMapLocation))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerResponses.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerResponses.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Protocols.GeoServices.VectorTileServer.Models;
+
+/// <summary>
+/// Response for the GeoServices VectorTileServer service metadata endpoint
+/// (<c>GET/POST /rest/services/{serviceId}/VectorTileServer</c>). The shape mirrors the
+/// Esri VectorTileServer service descriptor that ArcGIS clients hydrate when adding a
+/// hosted vector tile layer: a <c>tiles</c> template, a WebMercatorQuad <see cref="VectorTileInfo"/>
+/// descriptor, and the tileMap / styles / capabilities resource pointers. This is a thin
+/// metadata adapter — Honua does not host an Esri-format vector tile cache, so the tile,
+/// resources, and tileMap routes are stubbed in the foundation and filled in by follow-up
+/// tickets (#1778 / #1779 / #1781).
+/// </summary>
+internal sealed class VectorTileServerMetadataResponse
+{
+    /// <summary>ArcGIS service version number.</summary>
+    [JsonPropertyName("currentVersion")]
+    public double CurrentVersion { get; init; } = 10.81;
+
+    /// <summary>Service name (the GeoServices service identifier the route resolves).</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    /// <summary>Capabilities advertised by the service. Tile-only for the metadata foundation.</summary>
+    [JsonPropertyName("capabilities")]
+    public string Capabilities { get; init; } = "TilesOnly";
+
+    /// <summary>
+    /// Vector-tile content type. ArcGIS uses <c>indexedVector</c> for hosted vector tile layers.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "indexedVector";
+
+    /// <summary>Tile URL templates relative to the service root.</summary>
+    [JsonPropertyName("tiles")]
+    public string[] Tiles { get; init; } = ["tile/{z}/{y}/{x}.pbf"];
+
+    /// <summary>Exported tiles are not supported by the metadata foundation.</summary>
+    [JsonPropertyName("exportTilesAllowed")]
+    public bool ExportTilesAllowed { get; init; }
+
+    /// <summary>Lowest level of detail served by the tiling scheme.</summary>
+    [JsonPropertyName("minLOD")]
+    public int MinLod { get; init; }
+
+    /// <summary>Highest level of detail served by the tiling scheme.</summary>
+    [JsonPropertyName("maxLOD")]
+    public int MaxLod { get; init; }
+
+    /// <summary>Relative path of the default vector tile styles resource.</summary>
+    [JsonPropertyName("defaultStyles")]
+    public string DefaultStyles { get; init; } = "resources/styles";
+
+    /// <summary>Relative path of the tile map (sparse tile index) resource.</summary>
+    [JsonPropertyName("tileMap")]
+    public string TileMap { get; init; } = "tilemap";
+
+    /// <summary>WebMercatorQuad tiling-scheme descriptor.</summary>
+    [JsonPropertyName("tileInfo")]
+    public VectorTileInfo? TileInfo { get; init; }
+
+    /// <summary>The full spatial extent of the service.</summary>
+    [JsonPropertyName("fullExtent")]
+    public VectorTileExtent? FullExtent { get; init; }
+
+    /// <summary>The initial display extent of the service.</summary>
+    [JsonPropertyName("initialExtent")]
+    public VectorTileExtent? InitialExtent { get; init; }
+}
+
+/// <summary>
+/// WebMercatorQuad tiling-scheme descriptor for a VectorTileServer service. Vector tiles use
+/// 512-pixel rows/cols and the <c>pbf</c> (Mapbox Vector Tile) format, unlike the 256-pixel
+/// PNG raster tiling scheme advertised by MapServer / ImageServer.
+/// </summary>
+internal sealed class VectorTileInfo
+{
+    /// <summary>Number of logical rows per tile (512 for the vector tiling scheme).</summary>
+    [JsonPropertyName("rows")]
+    public int Rows { get; init; } = 512;
+
+    /// <summary>Number of logical columns per tile (512 for the vector tiling scheme).</summary>
+    [JsonPropertyName("cols")]
+    public int Cols { get; init; } = 512;
+
+    /// <summary>Logical DPI advertised for the tiling scheme.</summary>
+    [JsonPropertyName("dpi")]
+    public int Dpi { get; init; } = 96;
+
+    /// <summary>Tile payload format. Vector tiles are protobuf-encoded MVT.</summary>
+    [JsonPropertyName("format")]
+    public string Format { get; init; } = "pbf";
+
+    /// <summary>Tile origin point (top-left of the world extent) in map coordinates.</summary>
+    [JsonPropertyName("origin")]
+    public VectorTileOrigin? Origin { get; init; }
+
+    /// <summary>Spatial reference of the tiling scheme.</summary>
+    [JsonPropertyName("spatialReference")]
+    public VectorTileSpatialReference? SpatialReference { get; init; }
+
+    /// <summary>Levels of detail (zoom levels) available in the tiling scheme.</summary>
+    [JsonPropertyName("lods")]
+    public VectorTileLevelOfDetail[]? Lods { get; init; }
+}
+
+/// <summary>Tile origin point coordinates for a vector tiling scheme.</summary>
+internal sealed class VectorTileOrigin
+{
+    /// <summary>X coordinate of the tile origin.</summary>
+    [JsonPropertyName("x")]
+    public double X { get; init; }
+
+    /// <summary>Y coordinate of the tile origin.</summary>
+    [JsonPropertyName("y")]
+    public double Y { get; init; }
+}
+
+/// <summary>Spatial reference information for a VectorTileServer response.</summary>
+internal sealed class VectorTileSpatialReference
+{
+    /// <summary>Well-Known ID (EPSG code) of the spatial reference.</summary>
+    [JsonPropertyName("wkid")]
+    public required int Wkid { get; init; }
+
+    /// <summary>Latest Well-Known ID (for newer EPSG codes).</summary>
+    [JsonPropertyName("latestWkid")]
+    public int? LatestWkid { get; init; }
+}
+
+/// <summary>Describes a single level of detail (zoom level) in the vector tiling scheme.</summary>
+internal sealed class VectorTileLevelOfDetail
+{
+    /// <summary>Zoom level number.</summary>
+    [JsonPropertyName("level")]
+    public int Level { get; init; }
+
+    /// <summary>Map resolution in units per pixel at this zoom level.</summary>
+    [JsonPropertyName("resolution")]
+    public double Resolution { get; init; }
+
+    /// <summary>Scale denominator at this zoom level.</summary>
+    [JsonPropertyName("scale")]
+    public double Scale { get; init; }
+}
+
+/// <summary>Esri spatial extent for a VectorTileServer response.</summary>
+internal sealed class VectorTileExtent
+{
+    /// <summary>Minimum X coordinate.</summary>
+    [JsonPropertyName("xmin")]
+    public required double Xmin { get; init; }
+
+    /// <summary>Minimum Y coordinate.</summary>
+    [JsonPropertyName("ymin")]
+    public required double Ymin { get; init; }
+
+    /// <summary>Maximum X coordinate.</summary>
+    [JsonPropertyName("xmax")]
+    public required double Xmax { get; init; }
+
+    /// <summary>Maximum Y coordinate.</summary>
+    [JsonPropertyName("ymax")]
+    public required double Ymax { get; init; }
+
+    /// <summary>Spatial reference of the extent.</summary>
+    [JsonPropertyName("spatialReference")]
+    public required VectorTileSpatialReference SpatialReference { get; init; }
+}

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerResponses.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerResponses.cs
@@ -148,6 +148,54 @@ internal sealed class VectorTileLevelOfDetail
     public double Scale { get; init; }
 }
 
+/// <summary>
+/// Response for the VectorTileServer tileMap endpoint
+/// (<c>GET /rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dim}/{dim}</c>).
+/// The shape mirrors the Esri tileMap availability block: a <c>location</c> describing the
+/// requested tile window and a row-major <c>data</c> array of <c>1</c> (tile in range) / <c>0</c>
+/// (tile outside the LOD/coordinate bounds) flags.
+/// </summary>
+internal sealed class VectorTileMapResponse
+{
+    /// <summary>
+    /// Whether the returned <see cref="Location"/> was adjusted (clamped) from the requested
+    /// window. Honua returns the requested window verbatim, so this is always <see langword="false"/>.
+    /// </summary>
+    [JsonPropertyName("adjusted")]
+    public bool Adjusted { get; init; }
+
+    /// <summary>The tile window the availability block covers.</summary>
+    [JsonPropertyName("location")]
+    public required VectorTileMapLocation Location { get; init; }
+
+    /// <summary>
+    /// Row-major availability flags for the window (<c>Height * Width</c> entries): <c>1</c>
+    /// when the tile is inside the LOD/coordinate bounds, <c>0</c> otherwise.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public required int[] Data { get; init; }
+}
+
+/// <summary>Describes the tile window (top-left origin and size, in tiles) of a tileMap block.</summary>
+internal sealed class VectorTileMapLocation
+{
+    /// <summary>Column index (tile X) of the top-left tile in the window.</summary>
+    [JsonPropertyName("left")]
+    public required int Left { get; init; }
+
+    /// <summary>Row index (tile Y) of the top-left tile in the window.</summary>
+    [JsonPropertyName("top")]
+    public required int Top { get; init; }
+
+    /// <summary>Window width, in tiles.</summary>
+    [JsonPropertyName("width")]
+    public required int Width { get; init; }
+
+    /// <summary>Window height, in tiles.</summary>
+    [JsonPropertyName("height")]
+    public required int Height { get; init; }
+}
+
 /// <summary>Esri spatial extent for a VectorTileServer response.</summary>
 internal sealed class VectorTileExtent
 {

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/Services/VectorTileEmbeddedAssets.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/Services/VectorTileEmbeddedAssets.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+//
+// Minimal embedded sprite/glyph assets served by the GeoServices VectorTileServer
+// resources surface (honua-server#1780, epic #1776). Per the epic decision the sprite/glyph
+// pipeline is scoped-minimal: Honua does not author per-service sprite sheets or glyph stacks,
+// so symbol layers in a composed style resolve against these deterministic stubs rather than
+// 404ing the client. The bytes are produced in-process (no embedded resource files) so the
+// assembly stays AOT/trim-safe and the surface has no content-pipeline wiring.
+
+namespace Honua.Protocols.GeoServices.VectorTileServer.Services;
+
+/// <summary>
+/// Deterministic, in-process sprite/glyph stub assets served by the VectorTileServer
+/// <c>resources/sprites/*</c> and <c>resources/fonts/*</c> routes. The sprite index is an
+/// empty JSON object and the sprite image is a 1×1 fully transparent PNG; the glyph stack is a
+/// single minimal Mapbox glyph PBF whose lone fontstack carries the default name and range with
+/// zero embedded glyphs.
+/// </summary>
+internal static class VectorTileEmbeddedAssets
+{
+    /// <summary>
+    /// The fontstack name reported by the embedded glyph PBF. Composed styles that reference
+    /// glyphs use the <c>{fontstack}</c>/<c>{range}</c> template, so the served fontstack name
+    /// is informational; any requested fontstack resolves to this same minimal stack.
+    /// </summary>
+    internal const string DefaultFontStackName = "Honua Default";
+
+    /// <summary>
+    /// The single glyph range the minimal stack advertises (the canonical first 256-codepoint
+    /// window). Out-of-range requests 404.
+    /// </summary>
+    internal const string DefaultGlyphRange = "0-255";
+
+    /// <summary>Content type for the sprite index JSON document.</summary>
+    internal const string SpriteJsonContentType = "application/json";
+
+    /// <summary>Content type for the sprite PNG image.</summary>
+    internal const string SpritePngContentType = "image/png";
+
+    /// <summary>Content type for the glyph protobuf payload (Mapbox glyphs encoding).</summary>
+    internal const string GlyphPbfContentType = "application/x-protobuf";
+
+    /// <summary>
+    /// The empty sprite index document. An empty object is a valid Mapbox sprite index that
+    /// declares zero icons, so a client that requested a sprite still parses a well-formed
+    /// response.
+    /// </summary>
+    internal const string SpriteIndexJson = "{}";
+
+    // 1x1 fully transparent 8-bit RGBA PNG (sig + IHDR + IDAT + IEND).
+    private static readonly byte[] TransparentPngBytes =
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+        0x89, 0x00, 0x00, 0x00, 0x0B, 0x49, 0x44, 0x41,
+        0x54, 0x78, 0xDA, 0x63, 0x60, 0x00, 0x02, 0x00,
+        0x00, 0x05, 0x00, 0x01, 0xE9, 0xFA, 0xDC, 0xD8,
+        0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44,
+        0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    // Minimal Mapbox glyph PBF: a `glyphs` message holding one `fontstack` with name and range
+    // (field 1 = "Honua Default", field 2 = "0-255") and zero embedded glyphs.
+    private static readonly byte[] GlyphStackBytes =
+    [
+        0x0A, 0x16, 0x0A, 0x0D, 0x48, 0x6F, 0x6E, 0x75,
+        0x61, 0x20, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6C,
+        0x74, 0x12, 0x05, 0x30, 0x2D, 0x32, 0x35, 0x35,
+    ];
+
+    /// <summary>Returns the 1×1 transparent sprite PNG bytes.</summary>
+    internal static byte[] GetSpritePng() => (byte[])TransparentPngBytes.Clone();
+
+    /// <summary>Returns the minimal glyph stack PBF bytes.</summary>
+    internal static byte[] GetGlyphPbf() => (byte[])GlyphStackBytes.Clone();
+
+    /// <summary>
+    /// Determines whether the requested glyph <paramref name="range"/> is the canonical
+    /// 256-codepoint window the minimal stack serves. Only <c>0-255</c> is served; every other
+    /// range 404s, matching the scoped-minimal decision.
+    /// </summary>
+    internal static bool IsServedRange(string range)
+        => string.Equals(range, DefaultGlyphRange, StringComparison.Ordinal);
+}

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/Services/VectorTileServerTileInfoBuilder.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/Services/VectorTileServerTileInfoBuilder.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Protocols.GeoServices.VectorTileServer.Models;
+using SpatialConstants = Honua.Core.Features.Shared.Models.SpatialConstants;
+
+namespace Honua.Protocols.GeoServices.VectorTileServer.Services;
+
+/// <summary>
+/// Builds the static WebMercatorQuad <c>tileInfo</c> descriptor advertised by VectorTileServer
+/// service metadata. The level-of-detail table is fixed for the Web Mercator (EPSG:3857)
+/// vector tiling scheme. This mirrors <c>ImageServerTileInfoBuilder</c> but for the vector
+/// tiling scheme: 512-pixel logical tiles serving the <c>pbf</c> (Mapbox Vector Tile) format,
+/// where the level-0 scale denominator follows the OGC WebMercatorQuad standard
+/// (<c>559082264.0287178</c>) and halves every level. This is pure metadata assembly — the
+/// metadata foundation does not host an Esri-format vector tile cache (#1777).
+/// </summary>
+internal static class VectorTileServerTileInfoBuilder
+{
+    /// <summary>Logical tile dimension, in pixels, for the vector WebMercatorQuad scheme.</summary>
+    private const int TileSize = 512;
+
+    /// <summary>Esri advertises a logical 96 DPI for WebMercator caches.</summary>
+    private const int Dpi = 96;
+
+    /// <summary>
+    /// Ground resolution (meters per pixel) at zoom level 0 for a 512-pixel
+    /// WebMercatorQuad tile: <c>(2 * WebMercatorExtent) / 512</c>.
+    /// </summary>
+    private const double Resolution0 = (2.0 * SpatialConstants.WebMercatorExtent) / TileSize;
+
+    /// <summary>
+    /// Scale denominator at zoom level 0 for the WebMercatorQuad tile matrix set. This is the
+    /// OGC-standardized value Esri vector tile caches advertise; each subsequent level halves it.
+    /// </summary>
+    private const double ScaleDenominator0 = 559082264.0287178;
+
+    /// <summary>WebMercator spatial reference well-known id used by Esri tile caches.</summary>
+    private const int WebMercatorWkid = 102100;
+
+    /// <summary>The EPSG-aligned latest well-known id for WebMercator (3857).</summary>
+    private const int WebMercatorLatestWkid = 3857;
+
+    /// <summary>Maximum zoom level the WebMercatorQuad scheme supports.</summary>
+    internal const int MaxLevel = 24;
+
+    /// <summary>
+    /// Builds the fixed WebMercatorQuad <see cref="VectorTileInfo"/> descriptor covering
+    /// levels <c>0..maxLevel</c> inclusive.
+    /// </summary>
+    /// <param name="maxLevel">
+    /// Highest zoom level to include in the LOD array (clamped to the Web Mercator range
+    /// 0–24 that the WebMercatorQuad scheme accepts).
+    /// </param>
+    /// <returns>A populated <see cref="VectorTileInfo"/> descriptor.</returns>
+    public static VectorTileInfo Build(int maxLevel)
+    {
+        var clampedMax = Math.Clamp(maxLevel, 0, MaxLevel);
+        var lods = new VectorTileLevelOfDetail[clampedMax + 1];
+        for (var level = 0; level <= clampedMax; level++)
+        {
+            var factor = (double)(1L << level);
+            lods[level] = new VectorTileLevelOfDetail
+            {
+                Level = level,
+                Resolution = Resolution0 / factor,
+                Scale = ScaleDenominator0 / factor
+            };
+        }
+
+        return new VectorTileInfo
+        {
+            Rows = TileSize,
+            Cols = TileSize,
+            Dpi = Dpi,
+            Format = "pbf",
+            // WebMercatorQuad tiles originate at the top-left of the world extent.
+            Origin = new VectorTileOrigin
+            {
+                X = -SpatialConstants.WebMercatorExtent,
+                Y = SpatialConstants.WebMercatorExtent
+            },
+            SpatialReference = new VectorTileSpatialReference
+            {
+                Wkid = WebMercatorWkid,
+                LatestWkid = WebMercatorLatestWkid
+            },
+            Lods = lods
+        };
+    }
+}

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/Services/VectorTileStyleComposer.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/Services/VectorTileStyleComposer.cs
@@ -1,0 +1,278 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+//
+// Composes the Mapbox GL v8 style document served by the GeoServices VectorTileServer
+// resources/styles/root.json endpoint (honua-server#1779, epic #1776). Given the canonical
+// MapLibre/Mapbox style stored for the service's primary layer (or none), it produces a
+// GL v8 document whose vector source's tile template resolves to this service's
+// tile/{z}/{y}/{x}.pbf route.
+//
+// Per the epic decision, sprite and glyphs references are OMITTED: Honua has no sprite/glyph
+// pipeline yet (honua-server#1780 adds it), so emitting those refs would 404 in clients. Any
+// sprite/glyphs already present in a stored style are stripped here so the served document
+// stays self-consistent.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Protocols.GeoServices.VectorTileServer.Services;
+
+/// <summary>
+/// Rewrites a stored MapLibre/Mapbox style (or synthesizes a deterministic default) into the
+/// Mapbox GL v8 style document served by the VectorTileServer <c>resources/styles/root.json</c>
+/// endpoint. The sole vector source is pointed at this service's tile template; sprite/glyphs
+/// references are omitted until the sprite/glyph pipeline lands (honua-server#1780).
+/// </summary>
+internal static class VectorTileStyleComposer
+{
+    /// <summary>
+    /// Source layer name emitted in the default style and used to bind layers to the vector
+    /// source. Matches the canonical Honua tile source-layer name.
+    /// </summary>
+    internal const string DefaultSourceLayerName = "layer";
+
+    private const string DefaultPointColor = "#2D69A5";
+    private const string DefaultLineColor = "#2D69A5";
+    private const string DefaultFillColor = "#2D69A5";
+    private const string DefaultOutlineColor = "#1A4D80";
+    private const string DefaultStrokeColor = "#FFFFFF";
+
+    /// <summary>
+    /// Composes the GL v8 style JSON for a service.
+    /// </summary>
+    /// <param name="storedMapLibreJson">
+    /// The canonical MapLibre/Mapbox style stored for the service's primary layer, or
+    /// <see langword="null"/>/whitespace when the layer has no stored style.
+    /// </param>
+    /// <param name="serviceName">The GeoServices service name (used for the style <c>name</c>).</param>
+    /// <param name="sourceId">The vector source identifier to emit (for example <c>esri</c>).</param>
+    /// <param name="tileUrl">
+    /// The absolute tile template, for example
+    /// <c>https://host/rest/services/{id}/VectorTileServer/tile/{z}/{y}/{x}.pbf</c>.
+    /// </param>
+    /// <param name="geometryType">
+    /// The primary layer's geometry type, used to pick deterministic default paint when no
+    /// style is stored.
+    /// </param>
+    /// <returns>A serialized Mapbox GL v8 style document.</returns>
+    public static string Compose(
+        string? storedMapLibreJson,
+        string serviceName,
+        string sourceId,
+        string tileUrl,
+        MetadataV2GeometryType geometryType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tileUrl);
+
+        var root = TryParseStoredStyle(storedMapLibreJson)
+            ?? BuildDefaultStyle(serviceName, sourceId, tileUrl, geometryType);
+
+        RewriteSources(root, sourceId, tileUrl);
+        StripSpriteAndGlyphs(root);
+        EnsureVersionAndName(root, serviceName);
+
+        return root.ToJsonString(SerializerOptions);
+    }
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = false
+    };
+
+    private static JsonObject? TryParseStoredStyle(string? storedMapLibreJson)
+    {
+        if (string.IsNullOrWhiteSpace(storedMapLibreJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonNode.Parse(storedMapLibreJson) as JsonObject;
+        }
+        catch (JsonException)
+        {
+            // A stored style that no longer parses should not fail the endpoint; fall back
+            // to the deterministic default instead of surfacing a 500.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Rewrites every <c>sources.&lt;id&gt;</c> entry so the served document only advertises
+    /// the local vector tile route. The configured <paramref name="sourceId"/> is guaranteed to
+    /// exist as a vector source whose <c>tiles[]</c> is the absolute service tile template; the
+    /// legacy <c>url</c> (TileJSON pointer) is removed so clients fetch tiles directly.
+    /// </summary>
+    private static void RewriteSources(JsonObject root, string sourceId, string tileUrl)
+    {
+        if (root["sources"] is not JsonObject sources)
+        {
+            sources = new JsonObject();
+            root["sources"] = sources;
+        }
+
+        // Rewrite any existing vector source in place so layer source-bindings stay valid.
+        foreach (var entry in sources.ToArray())
+        {
+            if (entry.Value is JsonObject source)
+            {
+                RewriteVectorSource(source, tileUrl);
+            }
+        }
+
+        if (sources[sourceId] is not JsonObject configured)
+        {
+            configured = new JsonObject();
+            sources[sourceId] = configured;
+        }
+
+        RewriteVectorSource(configured, tileUrl);
+    }
+
+    private static void RewriteVectorSource(JsonObject source, string tileUrl)
+    {
+        source["type"] = "vector";
+        // Direct tile template wins; drop the TileJSON pointer so we never emit a URL the
+        // VectorTileServer surface does not serve.
+        source.Remove("url");
+        source["tiles"] = new JsonArray(tileUrl);
+    }
+
+    private static void StripSpriteAndGlyphs(JsonObject root)
+    {
+        root.Remove("sprite");
+        root.Remove("glyphs");
+    }
+
+    private static void EnsureVersionAndName(JsonObject root, string serviceName)
+    {
+        root["version"] = 8;
+        if (root["name"] is null)
+        {
+            root["name"] = serviceName;
+        }
+    }
+
+    /// <summary>
+    /// Builds a deterministic, geometry-aware default GL v8 style for a layer with no stored
+    /// style. The paint defaults mirror the canonical Honua per-layer defaults so the
+    /// VectorTileServer surface renders identically to the rest of the server.
+    /// </summary>
+    private static JsonObject BuildDefaultStyle(
+        string serviceName,
+        string sourceId,
+        string tileUrl,
+        MetadataV2GeometryType geometryType)
+    {
+        var layers = BuildDefaultLayers(sourceId, geometryType);
+
+        return new JsonObject
+        {
+            ["version"] = 8,
+            ["name"] = serviceName,
+            ["sources"] = new JsonObject
+            {
+                [sourceId] = new JsonObject
+                {
+                    ["type"] = "vector",
+                    ["tiles"] = new JsonArray(tileUrl)
+                }
+            },
+            ["layers"] = layers
+        };
+    }
+
+    private static JsonArray BuildDefaultLayers(string sourceId, MetadataV2GeometryType geometryType)
+    {
+        var layers = new JsonArray();
+
+        switch (geometryType)
+        {
+            case MetadataV2GeometryType.Point:
+            case MetadataV2GeometryType.MultiPoint:
+                layers.Add(CircleLayer(sourceId));
+                break;
+
+            case MetadataV2GeometryType.LineString:
+            case MetadataV2GeometryType.MultiLineString:
+                layers.Add(LineLayer(sourceId));
+                break;
+
+            case MetadataV2GeometryType.Polygon:
+            case MetadataV2GeometryType.MultiPolygon:
+                layers.Add(FillLayer(sourceId));
+                layers.Add(FillOutlineLayer(sourceId));
+                break;
+
+            default:
+                // Unknown / mixed / non-geometric: emit a superset so any geometry renders.
+                layers.Add(FillLayer(sourceId));
+                layers.Add(LineLayer(sourceId));
+                layers.Add(CircleLayer(sourceId));
+                break;
+        }
+
+        return layers;
+    }
+
+    private static JsonObject CircleLayer(string sourceId) => new()
+    {
+        ["id"] = $"{sourceId}-circle",
+        ["type"] = "circle",
+        ["source"] = sourceId,
+        ["source-layer"] = DefaultSourceLayerName,
+        ["paint"] = new JsonObject
+        {
+            ["circle-color"] = DefaultPointColor,
+            ["circle-radius"] = 4,
+            ["circle-opacity"] = 0.85,
+            ["circle-stroke-color"] = DefaultStrokeColor,
+            ["circle-stroke-width"] = 1
+        }
+    };
+
+    private static JsonObject LineLayer(string sourceId) => new()
+    {
+        ["id"] = $"{sourceId}-line",
+        ["type"] = "line",
+        ["source"] = sourceId,
+        ["source-layer"] = DefaultSourceLayerName,
+        ["paint"] = new JsonObject
+        {
+            ["line-color"] = DefaultLineColor,
+            ["line-width"] = 2,
+            ["line-opacity"] = 0.9
+        }
+    };
+
+    private static JsonObject FillLayer(string sourceId) => new()
+    {
+        ["id"] = $"{sourceId}-fill",
+        ["type"] = "fill",
+        ["source"] = sourceId,
+        ["source-layer"] = DefaultSourceLayerName,
+        ["paint"] = new JsonObject
+        {
+            ["fill-color"] = DefaultFillColor,
+            ["fill-opacity"] = 0.4
+        }
+    };
+
+    private static JsonObject FillOutlineLayer(string sourceId) => new()
+    {
+        ["id"] = $"{sourceId}-fill-outline",
+        ["type"] = "line",
+        ["source"] = sourceId,
+        ["source-layer"] = DefaultSourceLayerName,
+        ["paint"] = new JsonObject
+        {
+            ["line-color"] = DefaultOutlineColor,
+            ["line-width"] = 0.75,
+            ["line-opacity"] = 0.8
+        }
+    };
+}

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/Services/VectorTileStyleComposer.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/Services/VectorTileStyleComposer.cs
@@ -7,10 +7,13 @@
 // GL v8 document whose vector source's tile template resolves to this service's
 // tile/{z}/{y}/{x}.pbf route.
 //
-// Per the epic decision, sprite and glyphs references are OMITTED: Honua has no sprite/glyph
-// pipeline yet (honua-server#1780 adds it), so emitting those refs would 404 in clients. Any
-// sprite/glyphs already present in a stored style are stripped here so the served document
-// stays self-consistent.
+// Sprite/glyphs references are scoped-minimal (honua-server#1780, epic decision): Honua serves
+// only a stub sprite sheet and a stub glyph stack, so emitting sprite/glyphs is useful ONLY for
+// styles that actually consume them — i.e. styles with at least one `symbol` layer. When the
+// composed style has a symbol layer, the composer points sprite/glyphs at THIS service's
+// resources routes (absolute); otherwise it omits them. Any stale sprite/glyphs already present
+// in a stored style are always replaced (when symbol layers exist) or stripped (when they don't)
+// so the served document stays self-consistent.
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -22,7 +25,8 @@ namespace Honua.Protocols.GeoServices.VectorTileServer.Services;
 /// Rewrites a stored MapLibre/Mapbox style (or synthesizes a deterministic default) into the
 /// Mapbox GL v8 style document served by the VectorTileServer <c>resources/styles/root.json</c>
 /// endpoint. The sole vector source is pointed at this service's tile template; sprite/glyphs
-/// references are omitted until the sprite/glyph pipeline lands (honua-server#1780).
+/// references are emitted (pointed at this service's scoped-minimal sprite/glyph routes) only
+/// when the composed style has at least one <c>symbol</c> layer (honua-server#1780).
 /// </summary>
 internal static class VectorTileStyleComposer
 {
@@ -55,13 +59,26 @@ internal static class VectorTileStyleComposer
     /// The primary layer's geometry type, used to pick deterministic default paint when no
     /// style is stored.
     /// </param>
+    /// <param name="spriteUrl">
+    /// The absolute sprite base reference for this service (for example
+    /// <c>https://host/rest/services/{id}/VectorTileServer/resources/sprites/sprite</c>), emitted
+    /// only when the composed style has a symbol layer. Pass <see langword="null"/> to always omit.
+    /// </param>
+    /// <param name="glyphsUrl">
+    /// The absolute glyphs template for this service (for example
+    /// <c>https://host/rest/services/{id}/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf</c>),
+    /// emitted only when the composed style has a symbol layer. Pass <see langword="null"/> to
+    /// always omit.
+    /// </param>
     /// <returns>A serialized Mapbox GL v8 style document.</returns>
     public static string Compose(
         string? storedMapLibreJson,
         string serviceName,
         string sourceId,
         string tileUrl,
-        MetadataV2GeometryType geometryType)
+        MetadataV2GeometryType geometryType,
+        string? spriteUrl = null,
+        string? glyphsUrl = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
         ArgumentException.ThrowIfNullOrWhiteSpace(sourceId);
@@ -71,7 +88,7 @@ internal static class VectorTileStyleComposer
             ?? BuildDefaultStyle(serviceName, sourceId, tileUrl, geometryType);
 
         RewriteSources(root, sourceId, tileUrl);
-        StripSpriteAndGlyphs(root);
+        ApplySpriteAndGlyphs(root, spriteUrl, glyphsUrl);
         EnsureVersionAndName(root, serviceName);
 
         return root.ToJsonString(SerializerOptions);
@@ -142,10 +159,50 @@ internal static class VectorTileStyleComposer
         source["tiles"] = new JsonArray(tileUrl);
     }
 
-    private static void StripSpriteAndGlyphs(JsonObject root)
+    /// <summary>
+    /// Applies the scoped-minimal sprite/glyphs rule: when the composed style has at least one
+    /// <c>symbol</c> layer and absolute references are supplied, point <c>sprite</c>/<c>glyphs</c>
+    /// at this service's resources routes; otherwise strip them so the served document never
+    /// advertises a sprite/glyph reference the client would fail to use.
+    /// </summary>
+    private static void ApplySpriteAndGlyphs(JsonObject root, string? spriteUrl, string? glyphsUrl)
     {
+        if (HasSymbolLayer(root)
+            && !string.IsNullOrWhiteSpace(spriteUrl)
+            && !string.IsNullOrWhiteSpace(glyphsUrl))
+        {
+            root["sprite"] = spriteUrl;
+            root["glyphs"] = glyphsUrl;
+            return;
+        }
+
         root.Remove("sprite");
         root.Remove("glyphs");
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when any layer in the style has <c>type == "symbol"</c>,
+    /// the only Mapbox GL layer type that consumes a sprite sheet (icons) or glyph stack (text).
+    /// </summary>
+    private static bool HasSymbolLayer(JsonObject root)
+    {
+        if (root["layers"] is not JsonArray layers)
+        {
+            return false;
+        }
+
+        foreach (var layer in layers)
+        {
+            if (layer is JsonObject layerObject
+                && layerObject["type"] is JsonValue typeValue
+                && typeValue.TryGetValue(out string? type)
+                && string.Equals(type, "symbol", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static void EnsureVersionAndName(JsonObject root, string serviceName)

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Resources.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Resources.cs
@@ -1,19 +1,38 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 //
-// FOUNDATION STUB (#1777). The vector tile style / resources routes are declared here and
-// stubbed as HTTP 501 so honua-server#1779 can implement the resource handlers in this file
-// WITHOUT editing the shared VectorTileServerEndpoints.cs. Replace the handler bodies (and
-// the route metadata as needed) when wiring the styles pipeline; do not move the registration.
+// VectorTileServer resources/styles surface (honua-server#1779, epic #1776). Implements the
+// Esri-compatible default-style document (root.json) by composing the canonical MapLibre style
+// stored for the service's primary layer into a Mapbox GL v8 document whose vector source is
+// pointed at this service's tile/{z}/{y}/{x}.pbf route (VectorTileStyleComposer). Per the epic
+// decision, sprite and glyphs references are OMITTED until the sprite/glyph pipeline lands
+// (honua-server#1780); style sub-resources other than root.json return 404.
+
+using System.Diagnostics;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Styling.Abstractions;
+using Honua.Core.Features.Validation.Abstractions;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Models;
+using Honua.Protocols.GeoServices.VectorTileServer.Services;
+using Honua.ServiceDefaults;
+using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
 
 namespace Honua.Protocols.GeoServices.VectorTileServer;
 
 internal static partial class VectorTileServerEndpoints
 {
+    // The single vector source id emitted in the composed style. Esri vector tile styles
+    // conventionally use "esri"; clients bind layers to this source.
+    private const string StyleSourceId = "esri";
+
     /// <summary>
     /// Maps the VectorTileServer resources routes (default styles, sprites, glyphs). The
     /// service descriptor advertises <c>resources/styles</c> as <c>defaultStyles</c>.
-    /// Stubbed as 501 in the foundation; implemented by honua-server#1779.
+    /// Implemented by honua-server#1779; <c>resources/styles</c> and
+    /// <c>resources/styles/root.json</c> return the composed GL style, other sub-resources 404.
     /// </summary>
     private static void MapResourcesEndpoints(IEndpointRouteBuilder endpoints)
     {
@@ -22,40 +41,216 @@ internal static partial class VectorTileServerEndpoints
             .WithDisplayName("Get Vector Tile Default Styles")
             .WithName("GetVectorTileDefaultStyles")
             .WithSummary("Get the default vector tile style document (root.json)")
-            .WithDescription("Returns the Mapbox GL style JSON for the service. Stubbed (501) until honua-server#1779 wires the styles pipeline.")
+            .WithDescription("Returns the Mapbox GL v8 style JSON for the service, with the vector source pointed at this service's tile template.")
             .WithTags("VectorTileServer")
             .AllowAnonymous()
-            .Produces(200, contentType: "application/json")
-            .Produces(404)
-            .Produces(501);
+            .Produces(200, contentType: JsonContentType)
+            .Produces(404);
 
         endpoints.MapGet("/rest/services/{serviceId}/VectorTileServer/resources/styles/{**resourcePath}",
-                static (HttpContext context, CancellationToken cancellationToken) => HandleGetStyleResource(context))
+                static (HttpContext context, string resourcePath, CancellationToken cancellationToken)
+                    => HandleGetStyleResource(context, resourcePath))
             .WithDisplayName("Get Vector Tile Style Resource")
             .WithName("GetVectorTileStyleResource")
-            .WithSummary("Get a vector tile style sub-resource (sprites, glyphs, root.json)")
-            .WithDescription("Returns a style sub-resource. Stubbed (501) until honua-server#1779 wires the styles pipeline.")
+            .WithSummary("Get a vector tile style sub-resource (root.json)")
+            .WithDescription("Returns the root.json style document. Sprite and glyph sub-resources are not served yet (honua-server#1780) and return 404.")
             .WithTags("VectorTileServer")
             .AllowAnonymous()
-            .Produces(404)
-            .Produces(501);
+            .Produces(200, contentType: JsonContentType)
+            .Produces(404);
     }
 
     /// <summary>
-    /// Foundation placeholder for the default styles resource. honua-server#1779 replaces this
-    /// body with the real style document handler.
+    /// Serves the default style document at <c>resources/styles</c>.
     /// </summary>
-    private static IResult HandleGetDefaultStyles(HttpContext context)
-        => Results.Problem(
-            detail: "VectorTileServer default styles are not yet implemented.",
-            statusCode: StatusCodes.Status501NotImplemented);
+    private static Task<IResult> HandleGetDefaultStyles(HttpContext context)
+        => ComposeRootStyleAsync(context);
 
     /// <summary>
-    /// Foundation placeholder for style sub-resources. honua-server#1779 replaces this body
-    /// with the real style sub-resource handler.
+    /// Serves style sub-resources. Only <c>root.json</c> (and the bare path) is served; sprite
+    /// and glyph sub-resources are not produced yet (honua-server#1780) and return 404.
     /// </summary>
-    private static IResult HandleGetStyleResource(HttpContext context)
-        => Results.Problem(
-            detail: "VectorTileServer style resources are not yet implemented.",
-            statusCode: StatusCodes.Status501NotImplemented);
+    private static Task<IResult> HandleGetStyleResource(HttpContext context, string resourcePath)
+    {
+        var normalized = (resourcePath ?? string.Empty).Trim('/');
+        if (normalized.Length == 0
+            || string.Equals(normalized, "root.json", StringComparison.OrdinalIgnoreCase))
+        {
+            return ComposeRootStyleAsync(context);
+        }
+
+        return Task.FromResult(StandardErrorHelpers.CreateNotFound(
+            context,
+            $"Style resource '{resourcePath}' is not available."));
+    }
+
+    /// <summary>
+    /// Resolves the service and its primary vector tile publication, composes the Mapbox GL v8
+    /// style document (canonical MapLibre style rewritten onto this service's tile route, or a
+    /// deterministic default when the layer has no stored style), and returns it as JSON.
+    /// </summary>
+    private static async Task<IResult> ComposeRootStyleAsync(HttpContext context)
+    {
+        var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+
+        var serviceError = RouteValidationHelpers.ValidateServiceId(context, out var serviceId);
+        if (serviceError is not null)
+        {
+            return serviceError;
+        }
+
+        using var scope = HonuaTelemetryScope.StartFeature(
+            "metadata",
+            HonuaTelemetry.Protocols.VectorTileServer,
+            "*");
+        scope.WithTag(HonuaTelemetry.Tags.ServiceId, serviceId)
+            .WithTag(HonuaTelemetry.Tags.Operation, "get-default-styles");
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
+            var serviceResult = await ServiceResourceValidationHelpers.ValidateServiceV2Async(
+                resourceValidator,
+                serviceId,
+                MetadataV2ServiceProtocols.VectorTileServer,
+                context,
+                cancellationToken: cancellationToken);
+            if (!serviceResult.IsValid)
+            {
+                return serviceResult.ErrorResult!;
+            }
+
+            var service = serviceResult.Service!;
+            var graphProvider = context.RequestServices.GetRequiredService<IMetadataV2GraphProvider>();
+            var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+
+            var primary = ResolvePrimaryStylePublication(snapshot, service, context);
+            if (primary is null)
+            {
+                return StandardErrorHelpers.CreateNotFound(
+                    context,
+                    "The VectorTileServer service has no accessible vector tile layer.");
+            }
+
+            var (_, resource) = primary.Value;
+            var styleId = resource.Metadata.Name;
+            var geometryType = resource.ReadGeometryType();
+
+            var storedMapLibreJson = await ResolveStoredMapLibreStyleAsync(
+                context,
+                styleId,
+                cancellationToken).ConfigureAwait(false);
+
+            var tileUrl = BuildTileTemplateUrl(context, service.Metadata.Name);
+            var styleJson = VectorTileStyleComposer.Compose(
+                storedMapLibreJson,
+                service.Metadata.Name,
+                StyleSourceId,
+                tileUrl,
+                geometryType);
+
+            stopwatch.Stop();
+            scope.SetSuccess(1);
+            scope.CategorizeLatency(stopwatch.Elapsed.TotalMilliseconds);
+
+            return Results.Content(styleJson, JsonContentType);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            scope.RecordException(ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the primary, access-permitted vector tile publication for the service (preferring
+    /// the publication flagged <see cref="MetadataV2Publication.IsPrimary"/>, then the lowest
+    /// layer index) together with its backing resource.
+    /// </summary>
+    private static (MetadataV2Publication Publication, MetadataV2Resource Resource)? ResolvePrimaryStylePublication(
+        MetadataV2GraphSnapshot snapshot,
+        MetadataV2Service service,
+        HttpContext context)
+    {
+        (MetadataV2Publication Publication, MetadataV2Resource Resource)? best = null;
+        foreach (var publication in snapshot.Index.PublicationsByService[service.Metadata.Id])
+        {
+            var resource = snapshot.ResolveResource(publication);
+            if (resource is null)
+            {
+                continue;
+            }
+
+            if (!AccessPolicyHelpers.IsResourceAccessible(context, resource, service))
+            {
+                continue;
+            }
+
+            if (best is null
+                || IsPreferredPublication(publication, best.Value.Publication))
+            {
+                best = (publication, resource);
+            }
+        }
+
+        return best;
+    }
+
+    private static bool IsPreferredPublication(
+        MetadataV2Publication candidate,
+        MetadataV2Publication current)
+    {
+        if (candidate.IsPrimary != current.IsPrimary)
+        {
+            return candidate.IsPrimary;
+        }
+
+        var candidateIndex = candidate.LayerIndex ?? int.MaxValue;
+        var currentIndex = current.LayerIndex ?? int.MaxValue;
+        return candidateIndex < currentIndex;
+    }
+
+    /// <summary>
+    /// Reads the canonical MapLibre style stored for the service's primary layer via the shared
+    /// OGC style projection. Returns <see langword="null"/> when no style is stored so the
+    /// composer falls back to a deterministic default.
+    /// </summary>
+    private static async Task<string?> ResolveStoredMapLibreStyleAsync(
+        HttpContext context,
+        string styleId,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(styleId))
+        {
+            return null;
+        }
+
+        var projection = context.RequestServices.GetService<IOgcStyleProjection>();
+        if (projection is null)
+        {
+            return null;
+        }
+
+        var stylesheet = await projection
+            .GetStylesheetAsync(styleId, OgcStyleEncoding.MapboxStyle, cancellationToken)
+            .ConfigureAwait(false);
+
+        return stylesheet?.Content;
+    }
+
+    /// <summary>
+    /// Builds the absolute tile template for the service, for example
+    /// <c>https://host/rest/services/{name}/VectorTileServer/tile/{z}/{y}/{x}.pbf</c>.
+    /// </summary>
+    private static string BuildTileTemplateUrl(HttpContext context, string serviceName)
+    {
+        var baseUrl = BaseUrlResolver.GetBaseUrl(context).TrimEnd('/');
+        var encodedService = Uri.EscapeDataString(serviceName);
+        return $"{baseUrl}/rest/services/{encodedService}/VectorTileServer/tile/{{z}}/{{y}}/{{x}}.pbf";
+    }
 }

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Resources.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Resources.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+//
+// FOUNDATION STUB (#1777). The vector tile style / resources routes are declared here and
+// stubbed as HTTP 501 so honua-server#1779 can implement the resource handlers in this file
+// WITHOUT editing the shared VectorTileServerEndpoints.cs. Replace the handler bodies (and
+// the route metadata as needed) when wiring the styles pipeline; do not move the registration.
+
+namespace Honua.Protocols.GeoServices.VectorTileServer;
+
+internal static partial class VectorTileServerEndpoints
+{
+    /// <summary>
+    /// Maps the VectorTileServer resources routes (default styles, sprites, glyphs). The
+    /// service descriptor advertises <c>resources/styles</c> as <c>defaultStyles</c>.
+    /// Stubbed as 501 in the foundation; implemented by honua-server#1779.
+    /// </summary>
+    private static void MapResourcesEndpoints(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/rest/services/{serviceId}/VectorTileServer/resources/styles",
+                static (HttpContext context, CancellationToken cancellationToken) => HandleGetDefaultStyles(context))
+            .WithDisplayName("Get Vector Tile Default Styles")
+            .WithName("GetVectorTileDefaultStyles")
+            .WithSummary("Get the default vector tile style document (root.json)")
+            .WithDescription("Returns the Mapbox GL style JSON for the service. Stubbed (501) until honua-server#1779 wires the styles pipeline.")
+            .WithTags("VectorTileServer")
+            .AllowAnonymous()
+            .Produces(200, contentType: "application/json")
+            .Produces(404)
+            .Produces(501);
+
+        endpoints.MapGet("/rest/services/{serviceId}/VectorTileServer/resources/styles/{**resourcePath}",
+                static (HttpContext context, CancellationToken cancellationToken) => HandleGetStyleResource(context))
+            .WithDisplayName("Get Vector Tile Style Resource")
+            .WithName("GetVectorTileStyleResource")
+            .WithSummary("Get a vector tile style sub-resource (sprites, glyphs, root.json)")
+            .WithDescription("Returns a style sub-resource. Stubbed (501) until honua-server#1779 wires the styles pipeline.")
+            .WithTags("VectorTileServer")
+            .AllowAnonymous()
+            .Produces(404)
+            .Produces(501);
+    }
+
+    /// <summary>
+    /// Foundation placeholder for the default styles resource. honua-server#1779 replaces this
+    /// body with the real style document handler.
+    /// </summary>
+    private static IResult HandleGetDefaultStyles(HttpContext context)
+        => Results.Problem(
+            detail: "VectorTileServer default styles are not yet implemented.",
+            statusCode: StatusCodes.Status501NotImplemented);
+
+    /// <summary>
+    /// Foundation placeholder for style sub-resources. honua-server#1779 replaces this body
+    /// with the real style sub-resource handler.
+    /// </summary>
+    private static IResult HandleGetStyleResource(HttpContext context)
+        => Results.Problem(
+            detail: "VectorTileServer style resources are not yet implemented.",
+            statusCode: StatusCodes.Status501NotImplemented);
+}

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Resources.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Resources.cs
@@ -1,12 +1,18 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 //
-// VectorTileServer resources/styles surface (honua-server#1779, epic #1776). Implements the
-// Esri-compatible default-style document (root.json) by composing the canonical MapLibre style
-// stored for the service's primary layer into a Mapbox GL v8 document whose vector source is
-// pointed at this service's tile/{z}/{y}/{x}.pbf route (VectorTileStyleComposer). Per the epic
-// decision, sprite and glyphs references are OMITTED until the sprite/glyph pipeline lands
-// (honua-server#1780); style sub-resources other than root.json return 404.
+// VectorTileServer resources surface (honua-server#1779 styles + honua-server#1780 sprites/glyphs,
+// epic #1776). Implements the Esri-compatible default-style document (root.json) by composing the
+// canonical MapLibre style stored for the service's primary layer into a Mapbox GL v8 document
+// whose vector source is pointed at this service's tile/{z}/{y}/{x}.pbf route
+// (VectorTileStyleComposer). The composed style references sprite/glyphs (pointed at the
+// scoped-minimal resources/sprites and resources/fonts routes below) ONLY when it has symbol
+// layers; otherwise they stay omitted. style sub-resources other than root.json return 404.
+//
+// Sprites/glyphs are scoped-minimal (honua-server#1780): resources/sprites/sprite[.json|.png|
+// @2x.json|@2x.png] serve an empty sprite index / 1x1 transparent PNG, and
+// resources/fonts/{fontstack}/{range}.pbf serves a single minimal glyph stack for the default
+// 0-255 range (other ranges 404). These are deterministic in-process stubs (VectorTileEmbeddedAssets).
 
 using System.Diagnostics;
 using Honua.Core.Features.Metadata.Abstractions;
@@ -53,10 +59,35 @@ internal static partial class VectorTileServerEndpoints
             .WithDisplayName("Get Vector Tile Style Resource")
             .WithName("GetVectorTileStyleResource")
             .WithSummary("Get a vector tile style sub-resource (root.json)")
-            .WithDescription("Returns the root.json style document. Sprite and glyph sub-resources are not served yet (honua-server#1780) and return 404.")
+            .WithDescription("Returns the root.json style document. Sprite and glyph sub-resources are served under resources/sprites and resources/fonts.")
             .WithTags("VectorTileServer")
             .AllowAnonymous()
             .Produces(200, contentType: JsonContentType)
+            .Produces(404);
+
+        endpoints.MapGet("/rest/services/{serviceId}/VectorTileServer/resources/sprites/{spriteResource}",
+                static (HttpContext context, string spriteResource, CancellationToken cancellationToken)
+                    => HandleGetSpriteResource(context, spriteResource))
+            .WithDisplayName("Get Vector Tile Sprite Resource")
+            .WithName("GetVectorTileSpriteResource")
+            .WithSummary("Get a vector tile sprite resource (sprite.json / sprite.png / @2x variants)")
+            .WithDescription("Returns the scoped-minimal sprite index (empty JSON object) or sprite image (1x1 transparent PNG). Unknown sprite resources return 404.")
+            .WithTags("VectorTileServer")
+            .AllowAnonymous()
+            .Produces(200, contentType: VectorTileEmbeddedAssets.SpriteJsonContentType)
+            .Produces(200, contentType: VectorTileEmbeddedAssets.SpritePngContentType)
+            .Produces(404);
+
+        endpoints.MapGet("/rest/services/{serviceId}/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf",
+                static (HttpContext context, string fontstack, string range, CancellationToken cancellationToken)
+                    => HandleGetGlyphRange(context, fontstack, range))
+            .WithDisplayName("Get Vector Tile Glyph Range")
+            .WithName("GetVectorTileGlyphRange")
+            .WithSummary("Get a vector tile glyph range PBF for a fontstack")
+            .WithDescription("Returns the scoped-minimal Mapbox glyph PBF for the default 0-255 range. Out-of-range or unknown ranges return 404.")
+            .WithTags("VectorTileServer")
+            .AllowAnonymous()
+            .Produces(200, contentType: VectorTileEmbeddedAssets.GlyphPbfContentType)
             .Produces(404);
     }
 
@@ -143,12 +174,16 @@ internal static partial class VectorTileServerEndpoints
                 cancellationToken).ConfigureAwait(false);
 
             var tileUrl = BuildTileTemplateUrl(context, service.Metadata.Name);
+            var spriteUrl = BuildSpriteBaseUrl(context, service.Metadata.Name);
+            var glyphsUrl = BuildGlyphsTemplateUrl(context, service.Metadata.Name);
             var styleJson = VectorTileStyleComposer.Compose(
                 storedMapLibreJson,
                 service.Metadata.Name,
                 StyleSourceId,
                 tileUrl,
-                geometryType);
+                geometryType,
+                spriteUrl,
+                glyphsUrl);
 
             stopwatch.Stop();
             scope.SetSuccess(1);
@@ -252,5 +287,115 @@ internal static partial class VectorTileServerEndpoints
         var baseUrl = BaseUrlResolver.GetBaseUrl(context).TrimEnd('/');
         var encodedService = Uri.EscapeDataString(serviceName);
         return $"{baseUrl}/rest/services/{encodedService}/VectorTileServer/tile/{{z}}/{{y}}/{{x}}.pbf";
+    }
+
+    /// <summary>
+    /// Builds the absolute sprite base reference for the service (no extension), for example
+    /// <c>https://host/rest/services/{name}/VectorTileServer/resources/sprites/sprite</c>. Clients
+    /// append <c>.json</c>/<c>.png</c>/<c>@2x.*</c> as needed.
+    /// </summary>
+    private static string BuildSpriteBaseUrl(HttpContext context, string serviceName)
+    {
+        var baseUrl = BaseUrlResolver.GetBaseUrl(context).TrimEnd('/');
+        var encodedService = Uri.EscapeDataString(serviceName);
+        return $"{baseUrl}/rest/services/{encodedService}/VectorTileServer/resources/sprites/sprite";
+    }
+
+    /// <summary>
+    /// Builds the absolute glyphs template for the service, for example
+    /// <c>https://host/rest/services/{name}/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf</c>.
+    /// </summary>
+    private static string BuildGlyphsTemplateUrl(HttpContext context, string serviceName)
+    {
+        var baseUrl = BaseUrlResolver.GetBaseUrl(context).TrimEnd('/');
+        var encodedService = Uri.EscapeDataString(serviceName);
+        return $"{baseUrl}/rest/services/{encodedService}/VectorTileServer/resources/fonts/{{fontstack}}/{{range}}.pbf";
+    }
+
+    /// <summary>
+    /// Serves the scoped-minimal sprite resources. Resolves the service (404 for unknown
+    /// services) then returns the empty sprite index (<c>sprite.json</c> / <c>sprite@2x.json</c>)
+    /// or 1×1 transparent PNG (<c>sprite.png</c> / <c>sprite@2x.png</c>). Any other resource 404s.
+    /// </summary>
+    private static async Task<IResult> HandleGetSpriteResource(HttpContext context, string spriteResource)
+    {
+        var serviceError = await ValidateVectorTileServiceAsync(context);
+        if (serviceError is not null)
+        {
+            return serviceError;
+        }
+
+        switch (spriteResource)
+        {
+            case "sprite.json":
+            case "sprite@2x.json":
+                return Results.Content(
+                    VectorTileEmbeddedAssets.SpriteIndexJson,
+                    VectorTileEmbeddedAssets.SpriteJsonContentType);
+
+            case "sprite.png":
+            case "sprite@2x.png":
+                return Results.Bytes(
+                    VectorTileEmbeddedAssets.GetSpritePng(),
+                    VectorTileEmbeddedAssets.SpritePngContentType);
+
+            default:
+                return StandardErrorHelpers.CreateNotFound(
+                    context,
+                    $"Sprite resource '{spriteResource}' is not available.");
+        }
+    }
+
+    /// <summary>
+    /// Serves the scoped-minimal glyph range PBF. Resolves the service (404 for unknown
+    /// services) then returns the minimal glyph stack for the default <c>0-255</c> range; any
+    /// other range 404s. The fontstack is informational — any fontstack resolves to the same
+    /// minimal stack.
+    /// </summary>
+    private static async Task<IResult> HandleGetGlyphRange(HttpContext context, string fontstack, string range)
+    {
+        var serviceError = await ValidateVectorTileServiceAsync(context);
+        if (serviceError is not null)
+        {
+            return serviceError;
+        }
+
+        if (string.IsNullOrWhiteSpace(fontstack) || !VectorTileEmbeddedAssets.IsServedRange(range))
+        {
+            return StandardErrorHelpers.CreateNotFound(
+                context,
+                $"Glyph range '{range}' is not available for fontstack '{fontstack}'.");
+        }
+
+        return Results.Bytes(
+            VectorTileEmbeddedAssets.GetGlyphPbf(),
+            VectorTileEmbeddedAssets.GlyphPbfContentType);
+    }
+
+    /// <summary>
+    /// Validates that the route's service id resolves to an accessible VectorTileServer service.
+    /// Returns the error <see cref="IResult"/> (400/404) when validation fails, or
+    /// <see langword="null"/> when the service exists. Static sprite/glyph payloads do not depend
+    /// on layer state, so this only gates on service existence — mirroring the other resource routes.
+    /// </summary>
+    private static async Task<IResult?> ValidateVectorTileServiceAsync(HttpContext context)
+    {
+        var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+
+        var serviceError = RouteValidationHelpers.ValidateServiceId(context, out var serviceId);
+        if (serviceError is not null)
+        {
+            return serviceError;
+        }
+
+        var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
+        var serviceResult = await ServiceResourceValidationHelpers.ValidateServiceV2Async(
+            resourceValidator,
+            serviceId,
+            MetadataV2ServiceProtocols.VectorTileServer,
+            context,
+            cancellationToken: cancellationToken);
+
+        return serviceResult.IsValid ? null : serviceResult.ErrorResult;
     }
 }

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Tile.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Tile.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+//
+// FOUNDATION STUB (#1777). The vector tile data route is declared here and stubbed as
+// HTTP 501 so honua-server#1778 can implement the tile handler in this file WITHOUT
+// editing the shared VectorTileServerEndpoints.cs. Replace HandleGetTile's body (and the
+// route metadata as needed) when wiring the tile pipeline; do not move the registration.
+
+namespace Honua.Protocols.GeoServices.VectorTileServer;
+
+internal static partial class VectorTileServerEndpoints
+{
+    /// <summary>
+    /// Maps the VectorTileServer vector tile data route (<c>tile/{z}/{y}/{x}.pbf</c>).
+    /// Stubbed as 501 in the foundation; implemented by honua-server#1778.
+    /// </summary>
+    private static void MapTileEndpoints(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/rest/services/{serviceId}/VectorTileServer/tile/{z:int}/{y:int}/{x:int}.pbf",
+                static (HttpContext context, CancellationToken cancellationToken) => HandleGetTile(context))
+            .WithDisplayName("Get Vector Tile")
+            .WithName("GetVectorTile")
+            .WithSummary("Get a Mapbox Vector Tile (.pbf) from a VectorTileServer service")
+            .WithDescription("Returns a protobuf-encoded vector tile. Stubbed (501) until honua-server#1778 wires the tile pipeline.")
+            .WithTags("VectorTileServer")
+            .AllowAnonymous()
+            .Produces(200, contentType: "application/vnd.mapbox-vector-tile")
+            .Produces(404)
+            .Produces(501);
+    }
+
+    /// <summary>
+    /// Foundation placeholder for the vector tile data route. honua-server#1778 replaces this
+    /// body with the real tile handler.
+    /// </summary>
+    private static IResult HandleGetTile(HttpContext context)
+        => Results.Problem(
+            detail: "VectorTileServer tile retrieval is not yet implemented.",
+            statusCode: StatusCodes.Status501NotImplemented);
+}

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Tile.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Tile.cs
@@ -1,40 +1,207 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 //
-// FOUNDATION STUB (#1777). The vector tile data route is declared here and stubbed as
-// HTTP 501 so honua-server#1778 can implement the tile handler in this file WITHOUT
-// editing the shared VectorTileServerEndpoints.cs. Replace HandleGetTile's body (and the
-// route metadata as needed) when wiring the tile pipeline; do not move the registration.
+// VectorTileServer vector tile data route (honua-server#1778). Implemented WITHOUT editing
+// the shared VectorTileServerEndpoints.cs: the route is declared here in this partial file.
+//
+// The handler is a thin protocol adapter over the shared vector-tile pipeline. It resolves
+// the GeoServices service by NAME (ValidateServiceV2Async, mirroring the foundation metadata
+// handler), resolves the service's primary tiled publication -> storage layer id, then
+// delegates to Honua.Infrastructure.Rendering.VectorTileExecution / ITileProvider.GetMvtTileAsync
+// (the same canonical path FeatureServer's /tiles/{layerId}/{z}/{x}/{y}.mvt uses). No new
+// data-access path is introduced.
+//
+// Esri addresses tiles as {z}/{y}/{x} over the WebMercatorQuad matrix set (top-left origin),
+// which is the same origin as the canonical (x, y, z) tuple, so the mapping is direct
+// (z -> zoomLevel, x -> tileCol, y -> tileRow).
+
+using System.Diagnostics;
+using Honua.Core.Configuration;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Shared.Models;
+using Honua.Core.Features.Tiles;
+using Honua.Core.Features.Validation.Abstractions;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Models;
+using Honua.Infrastructure.Rendering;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Options;
+using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
 
 namespace Honua.Protocols.GeoServices.VectorTileServer;
 
 internal static partial class VectorTileServerEndpoints
 {
+    private const string VectorTileServerProtocolName = "VectorTileServer";
+    private const string MvtContentType = "application/vnd.mapbox-vector-tile";
+
     /// <summary>
     /// Maps the VectorTileServer vector tile data route (<c>tile/{z}/{y}/{x}.pbf</c>).
-    /// Stubbed as 501 in the foundation; implemented by honua-server#1778.
     /// </summary>
     private static void MapTileEndpoints(IEndpointRouteBuilder endpoints)
     {
         endpoints.MapGet("/rest/services/{serviceId}/VectorTileServer/tile/{z:int}/{y:int}/{x:int}.pbf",
-                static (HttpContext context, CancellationToken cancellationToken) => HandleGetTile(context))
+                static (HttpContext context, int z, int y, int x, CancellationToken cancellationToken)
+                    => HandleGetTile(context, z, y, x, cancellationToken))
             .WithDisplayName("Get Vector Tile")
             .WithName("GetVectorTile")
             .WithSummary("Get a Mapbox Vector Tile (.pbf) from a VectorTileServer service")
-            .WithDescription("Returns a protobuf-encoded vector tile. Stubbed (501) until honua-server#1778 wires the tile pipeline.")
+            .WithDescription("Returns a protobuf-encoded Mapbox Vector Tile for the service's primary tiled layer over the WebMercatorQuad tile matrix set.")
             .WithTags("VectorTileServer")
             .AllowAnonymous()
-            .Produces(200, contentType: "application/vnd.mapbox-vector-tile")
-            .Produces(404)
-            .Produces(501);
+            .CacheOutput("MvtTile")
+            .Produces(200, contentType: MvtContentType)
+            .Produces(204)
+            .Produces(400)
+            .Produces(404);
     }
 
     /// <summary>
-    /// Foundation placeholder for the vector tile data route. honua-server#1778 replaces this
-    /// body with the real tile handler.
+    /// Handle a VectorTileServer tile request. Resolves the service by name, resolves its
+    /// primary tiled publication to a storage layer id, and renders the tile through the
+    /// shared vector-tile execution path. Esri <c>{z}/{y}/{x}</c> maps directly onto the
+    /// canonical <c>(x, y, z)</c> tuple (shared top-left WebMercatorQuad origin).
     /// </summary>
-    private static IResult HandleGetTile(HttpContext context)
-        => Results.Problem(
-            detail: "VectorTileServer tile retrieval is not yet implemented.",
-            statusCode: StatusCodes.Status501NotImplemented);
+    private static async Task<IResult> HandleGetTile(HttpContext context, int z, int y, int x, CancellationToken cancellationToken)
+    {
+        var serviceError = RouteValidationHelpers.ValidateServiceId(context, out var serviceId);
+        if (serviceError is not null)
+        {
+            return serviceError;
+        }
+
+        var tileOptions = context.RequestServices.GetRequiredService<IOptions<TileOptions>>().Value;
+        var tileLimits = context.RequestServices.GetRequiredService<IOptions<LimitsOptions>>().Value.Tiles;
+
+        // Out-of-range zoom (LimitsOptions.Tiles) and bad coordinates -> 400, before any
+        // metadata/data resolution, mirroring FeatureServer's HandleLayerTile.
+        if (z < tileLimits.MinTileZoom || z > tileLimits.MaxTileZoom)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                $"Zoom level {z} is outside supported range",
+                [$"Supported zoom range is {tileLimits.MinTileZoom}-{tileLimits.MaxTileZoom}"]);
+        }
+
+        if (!TileMath.ValidateTileCoordinates(x, y, z))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                $"Invalid tile coordinates: x={x}, y={y}, z={z}");
+        }
+
+        using var scope = HonuaTelemetryScope.StartFeature(
+            "tile",
+            HonuaTelemetry.Protocols.VectorTileServer,
+            "*");
+        scope.WithTag(HonuaTelemetry.Tags.ServiceId, serviceId)
+            .WithTag(HonuaTelemetry.Tags.Operation, "get-tile");
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
+            var serviceResult = await ServiceResourceValidationHelpers.ValidateServiceV2Async(
+                resourceValidator,
+                serviceId,
+                MetadataV2ServiceProtocols.VectorTileServer,
+                context,
+                cancellationToken: cancellationToken);
+            if (!serviceResult.IsValid)
+            {
+                return serviceResult.ErrorResult!;
+            }
+
+            var service = serviceResult.Service!;
+            var graphProvider = context.RequestServices.GetRequiredService<IMetadataV2GraphProvider>();
+            var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+
+            var primary = ResolvePrimaryTiledPublication(snapshot, service);
+            if (primary is null)
+            {
+                return StandardErrorHelpers.CreateNotFound(context,
+                    $"Service '{service.Metadata.Name}' has no tiled layer to render.");
+            }
+
+            var (publication, resource) = primary.Value;
+
+            var accessError = AccessPolicyHelpers.RequireAnyResourceAccess(context, [resource], service);
+            if (accessError != null)
+            {
+                return accessError;
+            }
+
+            // Mirror the V2 metadata builders' resolution order: integer storage handle is
+            // publication.LayerIndex when the graph carries no explicit storage binding.
+            var storageLayerId = publication.LayerIndex ?? snapshot.ResolveStorageLayerId(publication);
+            if (storageLayerId is null)
+            {
+                return StandardErrorHelpers.CreateNotFound(context,
+                    $"Layer '{resource.Metadata.Name}' is not bound to a storage layer.");
+            }
+
+            var query = VectorTileExecution.CreateQuery(
+                resource.ReadSrid() ?? SpatialReference.WGS84.Wkid);
+
+            var tileProvider = context.RequestServices.GetRequiredService<ITileProvider>();
+
+            // Esri tile/{z}/{y}/{x} -> canonical (tileCol=x, tileRow=y, zoom=z); same top-left origin.
+            var result = await VectorTileExecution.ExecuteAsync(
+                context,
+                tileProvider,
+                storageLayerId.Value,
+                x,
+                y,
+                z,
+                query,
+                tileOptions,
+                tileLimits,
+                cancellationToken);
+
+            stopwatch.Stop();
+            scope.SetSuccess();
+            scope.CategorizeLatency(stopwatch.Elapsed.TotalMilliseconds);
+            return result;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            scope.RecordException(ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the service's primary tiled publication. Prefers an
+    /// <see cref="MetadataV2PublicationType.EsriVectorTileLayer"/> publication (the type the
+    /// VectorTileServer adapter advertises); falls back to the first resolvable publication so
+    /// services that publish their tiled layer under a different publication type still render.
+    /// </summary>
+    private static (MetadataV2Publication Publication, MetadataV2Resource Resource)? ResolvePrimaryTiledPublication(
+        MetadataV2GraphSnapshot snapshot,
+        MetadataV2Service service)
+    {
+        (MetadataV2Publication Publication, MetadataV2Resource Resource)? fallback = null;
+        foreach (var publication in snapshot.Index.PublicationsByService[service.Metadata.Id])
+        {
+            var resource = snapshot.ResolveResource(publication);
+            if (resource is null)
+            {
+                continue;
+            }
+
+            if (publication.PublicationType == MetadataV2PublicationType.EsriVectorTileLayer)
+            {
+                return (publication, resource);
+            }
+
+            fallback ??= (publication, resource);
+        }
+
+        return fallback;
+    }
 }

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.TileMap.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.TileMap.cs
@@ -1,20 +1,40 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 //
-// FOUNDATION STUB (#1777). The tileMap (sparse tile index) route is declared here and
-// stubbed as HTTP 501 so honua-server#1781 can implement the tileMap handler in this file
-// WITHOUT editing the shared VectorTileServerEndpoints.cs. Replace HandleGetTileMap's body
-// (and the route metadata as needed) when wiring the tileMap pipeline; do not move the
-// registration.
+// honua-server#1781: VectorTileServer tileMap (sparse tile-availability index). The service
+// descriptor advertises "tilemap" as its tileMap pointer; ArcGIS clients call this route to
+// learn which tiles in a block exist before requesting them. This file fills the foundation
+// 501 stub (#1777) WITHOUT editing the shared VectorTileServerEndpoints.cs; the route
+// registration stays here.
+
+using System.Diagnostics;
+using System.Globalization;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Tiles;
+using Honua.Core.Features.Validation.Abstractions;
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Models;
+using Honua.Protocols.GeoServices.VectorTileServer.Models;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Options;
+using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
 
 namespace Honua.Protocols.GeoServices.VectorTileServer;
 
 internal static partial class VectorTileServerEndpoints
 {
     /// <summary>
+    /// Largest tile-block edge (in tiles) a single tileMap request may ask for. ArcGIS
+    /// clients probe small blocks (typically 8x8); bound the request so an absurd dimension
+    /// cannot allocate an unbounded availability buffer.
+    /// </summary>
+    private const int MaxTileMapDimension = 32;
+
+    /// <summary>
     /// Maps the VectorTileServer tileMap routes (sparse tile-availability index). The service
-    /// descriptor advertises <c>tilemap</c> as its <c>tileMap</c> pointer. Stubbed as 501 in
-    /// the foundation; implemented by honua-server#1781.
+    /// descriptor advertises <c>tilemap</c> as its <c>tileMap</c> pointer. Implemented by
+    /// honua-server#1781: returns the Esri tileMap availability block computed from the
+    /// service tiling scheme (LOD range + WebMercatorQuad coordinate bounds).
     /// </summary>
     private static void MapTileMapEndpoints(IEndpointRouteBuilder endpoints)
     {
@@ -23,20 +43,172 @@ internal static partial class VectorTileServerEndpoints
             .WithDisplayName("Get Vector Tile Map")
             .WithName("GetVectorTileMap")
             .WithSummary("Get the VectorTileServer tile-availability map for a tile block")
-            .WithDescription("Returns the sparse tile-availability index for a block of tiles. Stubbed (501) until honua-server#1781 wires the tileMap pipeline.")
+            .WithDescription("Returns the Esri tile-availability index for a block of tiles: 1 for tiles inside the LOD/coordinate bounds, 0 for tiles outside them.")
             .WithTags("VectorTileServer")
             .AllowAnonymous()
-            .Produces(200, contentType: "application/json")
-            .Produces(404)
-            .Produces(501);
+            .Produces(200, contentType: JsonContentType)
+            .Produces(400)
+            .Produces(404);
+
+        // The tileMap root resource. ArcGIS clients sometimes GET the bare `tilemap` pointer
+        // advertised by the service descriptor before walking the {z}/{y}/{x}/{dim}/{dim}
+        // blocks; return the top-of-pyramid availability block so the resource resolves.
+        endpoints.MapGet("/rest/services/{serviceId}/VectorTileServer/tilemap",
+                static (HttpContext context, CancellationToken cancellationToken) => HandleGetTileMapRoot(context))
+            .WithDisplayName("Get Vector Tile Map Root")
+            .WithName("GetVectorTileMapRoot")
+            .WithSummary("Get the VectorTileServer root tile-availability map")
+            .WithDescription("Returns the Esri tile-availability index for the top of the tiling pyramid (level 0).")
+            .WithTags("VectorTileServer")
+            .AllowAnonymous()
+            .Produces(200, contentType: JsonContentType)
+            .Produces(404);
     }
 
     /// <summary>
-    /// Foundation placeholder for the tileMap route. honua-server#1781 replaces this body with
-    /// the real tile-availability handler.
+    /// Handles the tileMap root resource (<c>tilemap</c>) by returning the level-0
+    /// availability block (a single tile that always exists).
     /// </summary>
-    private static IResult HandleGetTileMap(HttpContext context)
-        => Results.Problem(
-            detail: "VectorTileServer tileMap is not yet implemented.",
-            statusCode: StatusCodes.Status501NotImplemented);
+    private static Task<IResult> HandleGetTileMapRoot(HttpContext context)
+        => HandleTileMapAsync(context, z: 0, y: 0, x: 0, height: 1, width: 1);
+
+    /// <summary>
+    /// Handles a tileMap block request (<c>tilemap/{z}/{y}/{x}/{dim}/{dim}</c>). The route
+    /// segments are <c>z</c> (LOD), <c>y</c>/<c>x</c> (top-left tile of the block), and two
+    /// dimensions (block height then width, in tiles, per the Esri tileMap convention).
+    /// </summary>
+    private static Task<IResult> HandleGetTileMap(HttpContext context)
+    {
+        var z = GetRouteInt(context, "z");
+        var y = GetRouteInt(context, "y");
+        var x = GetRouteInt(context, "x");
+        var height = GetRouteInt(context, "dimension");
+        var width = GetRouteInt(context, "dimension2");
+        return HandleTileMapAsync(context, z, y, x, height, width);
+    }
+
+    private static async Task<IResult> HandleTileMapAsync(HttpContext context, int z, int y, int x, int height, int width)
+    {
+        var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+
+        var serviceError = RouteValidationHelpers.ValidateServiceId(context, out var serviceId);
+        if (serviceError is not null)
+        {
+            return serviceError;
+        }
+
+        // Bound the block dimensions before touching the catalog so an absurd request is
+        // rejected cheaply. The top-left tile coordinates may legitimately be large at deep
+        // zooms, so they are range-checked against the LOD grid rather than rejected here.
+        if (height <= 0 || width <= 0 || height > MaxTileMapDimension || width > MaxTileMapDimension)
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                $"tileMap block dimensions must be between 1 and {MaxTileMapDimension} tiles per side.");
+        }
+
+        if (z < 0 || x < 0 || y < 0)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "tileMap tile coordinates must be non-negative.");
+        }
+
+        using var scope = HonuaTelemetryScope.StartFeature(
+            "tilemap",
+            HonuaTelemetry.Protocols.VectorTileServer,
+            "*");
+        scope.WithTag(HonuaTelemetry.Tags.ServiceId, serviceId)
+            .WithTag(HonuaTelemetry.Tags.Operation, "get-tilemap");
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
+            var serviceResult = await ServiceResourceValidationHelpers.ValidateServiceV2Async(
+                resourceValidator,
+                serviceId,
+                MetadataV2ServiceProtocols.VectorTileServer,
+                context,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (!serviceResult.IsValid)
+            {
+                return serviceResult.ErrorResult!;
+            }
+
+            var maxLod = context.RequestServices.GetRequiredService<IOptions<LimitsOptions>>().Value.Tiles.MaxTileZoom;
+
+            // A tileMap request whose LOD lies outside the service tiling scheme cannot be
+            // satisfied — Esri returns an error rather than an all-zero block. Reject it as a
+            // bad request so clients distinguish "level not served" from "tiles not present".
+            if (z > maxLod)
+            {
+                return StandardErrorHelpers.CreateBadRequest(
+                    context,
+                    $"Requested level {z} is outside the service tiling scheme (0..{maxLod}).");
+            }
+
+            var response = BuildTileMapResponse(z, y, x, height, width, maxLod);
+
+            stopwatch.Stop();
+            scope.SetSuccess(response.Data.Length);
+            scope.CategorizeLatency(stopwatch.Elapsed.TotalMilliseconds);
+
+            return Results.Json(response, VectorTileServerJsonContext.Default.VectorTileMapResponse, contentType: JsonContentType);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            scope.RecordException(ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Computes the dense tileMap availability block: <c>1</c> for every tile inside the
+    /// LOD/coordinate bounds of the WebMercatorQuad tiling scheme, <c>0</c> for tiles that
+    /// fall outside the level's coordinate grid. The block is row-major over
+    /// <paramref name="height"/> rows then <paramref name="width"/> columns, starting at the
+    /// top-left tile (<paramref name="x"/>, <paramref name="y"/>).
+    /// </summary>
+    private static VectorTileMapResponse BuildTileMapResponse(int z, int y, int x, int height, int width, int maxLod)
+    {
+        var data = new int[height * width];
+        var index = 0;
+        for (var row = 0; row < height; row++)
+        {
+            var tileY = y + row;
+            for (var col = 0; col < width; col++)
+            {
+                var tileX = x + col;
+                // In-range tiles within the served LOD range map to 1; tiles that overrun the
+                // level's grid (e.g. the right/bottom edge of the world at this zoom) map to 0.
+                var available = z <= maxLod && TileMath.ValidateTileCoordinates(tileX, tileY, z);
+                data[index++] = available ? 1 : 0;
+            }
+        }
+
+        return new VectorTileMapResponse
+        {
+            // The availability block is returned exactly as requested (no clamping), so the
+            // location mirrors the request and `adjusted` is false.
+            Adjusted = false,
+            Location = new VectorTileMapLocation
+            {
+                Left = x,
+                Top = y,
+                Width = width,
+                Height = height
+            },
+            Data = data
+        };
+    }
+
+    private static int GetRouteInt(HttpContext context, string key)
+        => context.Request.RouteValues.TryGetValue(key, out var value)
+           && value is not null
+           && int.TryParse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : -1;
 }

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.TileMap.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.TileMap.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+//
+// FOUNDATION STUB (#1777). The tileMap (sparse tile index) route is declared here and
+// stubbed as HTTP 501 so honua-server#1781 can implement the tileMap handler in this file
+// WITHOUT editing the shared VectorTileServerEndpoints.cs. Replace HandleGetTileMap's body
+// (and the route metadata as needed) when wiring the tileMap pipeline; do not move the
+// registration.
+
+namespace Honua.Protocols.GeoServices.VectorTileServer;
+
+internal static partial class VectorTileServerEndpoints
+{
+    /// <summary>
+    /// Maps the VectorTileServer tileMap routes (sparse tile-availability index). The service
+    /// descriptor advertises <c>tilemap</c> as its <c>tileMap</c> pointer. Stubbed as 501 in
+    /// the foundation; implemented by honua-server#1781.
+    /// </summary>
+    private static void MapTileMapEndpoints(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/rest/services/{serviceId}/VectorTileServer/tilemap/{z:int}/{y:int}/{x:int}/{dimension:int}/{dimension2:int}",
+                static (HttpContext context, CancellationToken cancellationToken) => HandleGetTileMap(context))
+            .WithDisplayName("Get Vector Tile Map")
+            .WithName("GetVectorTileMap")
+            .WithSummary("Get the VectorTileServer tile-availability map for a tile block")
+            .WithDescription("Returns the sparse tile-availability index for a block of tiles. Stubbed (501) until honua-server#1781 wires the tileMap pipeline.")
+            .WithTags("VectorTileServer")
+            .AllowAnonymous()
+            .Produces(200, contentType: "application/json")
+            .Produces(404)
+            .Produces(501);
+    }
+
+    /// <summary>
+    /// Foundation placeholder for the tileMap route. honua-server#1781 replaces this body with
+    /// the real tile-availability handler.
+    /// </summary>
+    private static IResult HandleGetTileMap(HttpContext context)
+        => Results.Problem(
+            detail: "VectorTileServer tileMap is not yet implemented.",
+            statusCode: StatusCodes.Status501NotImplemented);
+}

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.cs
@@ -1,0 +1,279 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+//
+// Read-only Esri-compatible VectorTileServer surface; anonymous by design. The
+// service-name route resolves the GeoServices service by NAME (not a numeric layer
+// id) via ValidateServiceV2Async, mirroring MapServer. GET + POST share the metadata
+// handler because Esri clients hydrate service metadata by POSTing {"f":"json"}.
+//
+// This is the metadata FOUNDATION (#1777): the tile / resources / tileMap routes are
+// declared here but their handlers live in partial files (*.Tile.cs / *.Resources.cs /
+// *.TileMap.cs) so the parallel wave (#1778 / #1779 / #1781) can fill them in WITHOUT
+// editing this file. The foundation stubs them as HTTP 501.
+
+using System.Diagnostics;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Validation.Abstractions;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Models;
+using Honua.Protocols.GeoServices.VectorTileServer.Models;
+using Honua.Protocols.GeoServices.VectorTileServer.Services;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Options;
+using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
+
+namespace Honua.Protocols.GeoServices.VectorTileServer;
+
+/// <summary>
+/// Maps GeoServices VectorTileServer REST API endpoints (Esri vector tile service adapter).
+/// </summary>
+internal static partial class VectorTileServerEndpoints
+{
+    private const string JsonContentType = "application/json";
+
+    /// <summary>
+    /// Maps VectorTileServer REST API endpoints using AOT-compatible routing. The
+    /// service identifier in the route is the GeoServices service NAME, resolved through
+    /// the shared <c>ValidateServiceV2Async</c> helper against the
+    /// <see cref="MetadataV2ServiceProtocols.VectorTileServer"/> protocol.
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder to register routes on.</param>
+    /// <returns>The same <paramref name="endpoints"/> instance for chaining.</returns>
+    public static IEndpointRouteBuilder MapVectorTileServerEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        endpoints.MapGet("/rest/services/{serviceId}/VectorTileServer",
+                static (HttpContext context, CancellationToken cancellationToken) => HandleGetServiceMetadata(context))
+            .WithDisplayName("Get VectorTileServer Service Metadata")
+            .WithName("GetVectorTileServerMetadata")
+            .WithSummary("Get VectorTileServer service metadata")
+            .WithDescription("Returns Esri-compatible VectorTileServer service metadata including the WebMercatorQuad tileInfo descriptor")
+            .WithTags("VectorTileServer")
+            .AllowAnonymous()
+            .CacheOutput("ServiceMetadata");
+
+        // Esri clients hydrate metadata by POSTing {"f":"json"}; mirror the GET form so
+        // discovery succeeds. Anonymous by design and without the CacheOutput companion,
+        // matching the MapServer metadata POST variant.
+        endpoints.MapPost("/rest/services/{serviceId}/VectorTileServer",
+                static (HttpContext context, CancellationToken cancellationToken) => HandleGetServiceMetadata(context))
+            .WithDisplayName("Get VectorTileServer Service Metadata (POST)")
+            .WithName("GetVectorTileServerMetadataPost")
+            .WithSummary("Get VectorTileServer service metadata using POST")
+            .WithDescription("Returns Esri-compatible VectorTileServer service metadata including the WebMercatorQuad tileInfo descriptor")
+            .WithTags("VectorTileServer")
+            .AllowAnonymous();
+
+        MapTileEndpoints(endpoints);
+        MapResourcesEndpoints(endpoints);
+        MapTileMapEndpoints(endpoints);
+
+        return endpoints;
+    }
+
+    /// <summary>
+    /// Handle VectorTileServer service metadata requests. Resolves the service by name and
+    /// emits the Esri VectorTileServer descriptor (tiles template, WebMercatorQuad tileInfo,
+    /// styles / tileMap pointers, and the service extent resolved like MapServer).
+    /// </summary>
+    private static async Task<IResult> HandleGetServiceMetadata(HttpContext context)
+    {
+        var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+        if (!TryValidateMetadataFormat(context.Request.Query, out var formatError))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, formatError ?? "Output format is not supported.");
+        }
+
+        var serviceError = RouteValidationHelpers.ValidateServiceId(context, out var serviceId);
+        if (serviceError is not null)
+        {
+            return serviceError;
+        }
+
+        using var scope = HonuaTelemetryScope.StartFeature(
+            "metadata",
+            HonuaTelemetry.Protocols.VectorTileServer,
+            "*");
+        scope.WithTag(HonuaTelemetry.Tags.ServiceId, serviceId)
+            .WithTag(HonuaTelemetry.Tags.Operation, "get-service-metadata");
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
+            var serviceResult = await ServiceResourceValidationHelpers.ValidateServiceV2Async(
+                resourceValidator,
+                serviceId,
+                MetadataV2ServiceProtocols.VectorTileServer,
+                context,
+                cancellationToken: cancellationToken);
+            if (!serviceResult.IsValid)
+            {
+                return serviceResult.ErrorResult!;
+            }
+
+            var service = serviceResult.Service!;
+            var graphProvider = context.RequestServices.GetRequiredService<IMetadataV2GraphProvider>();
+            var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+
+            var publications = ResolveVectorTilePublications(snapshot, service);
+
+            var accessError = AccessPolicyHelpers.RequireAnyResourceAccess(
+                context,
+                publications.Select(static publication => publication.Resource),
+                service);
+            if (accessError != null)
+            {
+                return accessError;
+            }
+
+            var visiblePublications = publications
+                .Where(publication => AccessPolicyHelpers.IsResourceAccessible(context, publication.Resource, service))
+                .ToArray();
+
+            var limitsOptions = context.RequestServices.GetRequiredService<IOptions<LimitsOptions>>().Value;
+            var response = BuildMetadataResponse(service, visiblePublications, limitsOptions.Tiles.MaxTileZoom);
+
+            stopwatch.Stop();
+            scope.SetSuccess(visiblePublications.Length);
+            scope.CategorizeLatency(stopwatch.Elapsed.TotalMilliseconds);
+
+            return Results.Json(response, VectorTileServerJsonContext.Default.VectorTileServerMetadataResponse, contentType: JsonContentType);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            scope.RecordException(ex);
+            throw;
+        }
+    }
+
+    private sealed record VectorTilePublicationDescriptor(
+        MetadataV2Publication Publication,
+        MetadataV2Resource Resource);
+
+    private static VectorTilePublicationDescriptor[] ResolveVectorTilePublications(
+        MetadataV2GraphSnapshot snapshot,
+        MetadataV2Service service)
+    {
+        var descriptors = new List<VectorTilePublicationDescriptor>();
+        foreach (var publication in snapshot.Index.PublicationsByService[service.Metadata.Id])
+        {
+            var resource = snapshot.ResolveResource(publication);
+            if (resource is null)
+            {
+                continue;
+            }
+
+            descriptors.Add(new VectorTilePublicationDescriptor(publication, resource));
+        }
+
+        return [.. descriptors];
+    }
+
+    private static VectorTileServerMetadataResponse BuildMetadataResponse(
+        MetadataV2Service service,
+        IReadOnlyList<VectorTilePublicationDescriptor> publications,
+        int maxTileZoom)
+    {
+        var tileInfo = VectorTileServerTileInfoBuilder.Build(maxTileZoom);
+        var minLod = tileInfo.Lods is { Length: > 0 } lods ? lods[0].Level : 0;
+        var maxLod = tileInfo.Lods is { Length: > 0 } maxLods ? maxLods[^1].Level : 0;
+
+        var spatialReference = ResolveServiceSpatialReference(service, publications);
+        var extent = ResolveServiceExtent(publications, spatialReference);
+
+        return new VectorTileServerMetadataResponse
+        {
+            Name = service.Metadata.Name,
+            TileInfo = tileInfo,
+            MinLod = minLod,
+            MaxLod = maxLod,
+            FullExtent = extent,
+            InitialExtent = extent
+        };
+    }
+
+    private static MetadataV2SpatialReference ResolveServiceSpatialReference(
+        MetadataV2Service service,
+        IReadOnlyList<VectorTilePublicationDescriptor> publications)
+        => service.SpatialReference
+           ?? publications.Select(static publication => publication.Resource.Spatial?.SpatialReference)
+               .FirstOrDefault(static spatialReference => spatialReference is not null)
+           ?? MetadataV2SpatialReference.Wgs84;
+
+    private static VectorTileExtent? ResolveServiceExtent(
+        IReadOnlyList<VectorTilePublicationDescriptor> publications,
+        MetadataV2SpatialReference spatialReference)
+    {
+        double? west = null;
+        double? south = null;
+        double? east = null;
+        double? north = null;
+
+        foreach (var publication in publications)
+        {
+            var bbox = publication.Resource.ReadBbox();
+            if (bbox is null)
+            {
+                continue;
+            }
+
+            west = west.HasValue ? Math.Min(west.Value, bbox.West) : bbox.West;
+            south = south.HasValue ? Math.Min(south.Value, bbox.South) : bbox.South;
+            east = east.HasValue ? Math.Max(east.Value, bbox.East) : bbox.East;
+            north = north.HasValue ? Math.Max(north.Value, bbox.North) : bbox.North;
+        }
+
+        if (!(west.HasValue && south.HasValue && east.HasValue && north.HasValue))
+        {
+            return null;
+        }
+
+        return new VectorTileExtent
+        {
+            Xmin = west.Value,
+            Ymin = south.Value,
+            Xmax = east.Value,
+            Ymax = north.Value,
+            SpatialReference = ToVectorTileSpatialReference(spatialReference)
+        };
+    }
+
+    private static VectorTileSpatialReference ToVectorTileSpatialReference(MetadataV2SpatialReference spatialReference)
+    {
+        var wkid = spatialReference.ResolveSrid() ?? 4326;
+        return new VectorTileSpatialReference { Wkid = wkid, LatestWkid = wkid };
+    }
+
+    private static bool TryValidateMetadataFormat(IQueryCollection query, out string? error)
+    {
+        error = null;
+        if (!query.TryGetValue("f", out var formatValues))
+        {
+            return true;
+        }
+
+        var format = formatValues.ToString();
+        if (string.IsNullOrWhiteSpace(format))
+        {
+            return true;
+        }
+
+        if (string.Equals(format, "json", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(format, "pjson", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        error = $"Output format '{format}' is not supported.";
+        return false;
+    }
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -850,6 +850,8 @@ public static class EndpointRegistry
         new("GET", "/rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf"),
         new("GET", "/rest/services/{serviceId}/VectorTileServer/resources/styles"),
         new("GET", "/rest/services/{serviceId}/VectorTileServer/resources/styles/{**resourcePath}"),
+        new("GET", "/rest/services/{serviceId}/VectorTileServer/resources/sprites/{spriteResource}"),
+        new("GET", "/rest/services/{serviceId}/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf"),
         new("GET", "/rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}"),
         new("GET", "/rest/services/{serviceId}/VectorTileServer/tilemap"),
 

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -845,6 +845,13 @@ public static class EndpointRegistry
         new("GET", "/ogc/services/{serviceId}/wms"),
         new("GET", "/ogc/services/{serviceId}/wcs"),
 
+        new("GET", "/rest/services/{serviceId}/VectorTileServer"),
+        new("POST", "/rest/services/{serviceId}/VectorTileServer"),
+        new("GET", "/rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf"),
+        new("GET", "/rest/services/{serviceId}/VectorTileServer/resources/styles"),
+        new("GET", "/rest/services/{serviceId}/VectorTileServer/resources/styles/{**resourcePath}"),
+        new("GET", "/rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}"),
+
         new("GET", "/rest/services/{id}/ImageServer"),
         new("POST", "/rest/services/{id}/ImageServer"),
         new("GET", "/rest/services/{id}/ImageServer/conf.json"),

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -851,6 +851,7 @@ public static class EndpointRegistry
         new("GET", "/rest/services/{serviceId}/VectorTileServer/resources/styles"),
         new("GET", "/rest/services/{serviceId}/VectorTileServer/resources/styles/{**resourcePath}"),
         new("GET", "/rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}"),
+        new("GET", "/rest/services/{serviceId}/VectorTileServer/tilemap"),
 
         new("GET", "/rest/services/{id}/ImageServer"),
         new("POST", "/rest/services/{id}/ImageServer"),

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
@@ -788,6 +788,7 @@ internal sealed class CapabilityManifestService(
             MetadataV2PublicationType.EsriFeatureLayer => "esri-feature-layer",
             MetadataV2PublicationType.EsriMapLayer => "esri-map-layer",
             MetadataV2PublicationType.EsriImageLayer => "esri-image-layer",
+            MetadataV2PublicationType.EsriVectorTileLayer => "esri-vector-tile-layer",
             MetadataV2PublicationType.StacCollection => "stac-collection",
             MetadataV2PublicationType.DcatDistribution => "dcat-distribution",
             MetadataV2PublicationType.OgcRecord => "ogc-record",

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -34,6 +34,7 @@ using Honua.Server.Features.Styling;
 using Honua.Protocols.GeoServices.MapServer;
 using Honua.Protocols.GeoServices.NAServer;
 using Honua.Protocols.GeoServices.Sharing;
+using Honua.Protocols.GeoServices.VectorTileServer;
 using Honua.Protocols.GeoServices.VersionManagementServer;
 using Honua.Ai.Protocols.Mcp;
 using Honua.Ai.NlQuery;
@@ -200,6 +201,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapSharingRestEndpoints();
         endpoints.MapImageServerEndpoints();
         endpoints.MapMapServerEndpoints();
+        endpoints.MapVectorTileServerEndpoints();
         endpoints.MapOgcClassicEndpoints();
         endpoints.MapAttachmentEndpoints();
         endpoints.MapTileJsonEndpoints();

--- a/src/Honua.Server/Features/Infrastructure/Hosting/Modules/GeoServicesProtocolModule.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/Modules/GeoServicesProtocolModule.cs
@@ -5,6 +5,7 @@ using Honua.Protocols.GeoServices.FeatureServer;
 using Honua.Protocols.GeoServices.ImageServer;
 using Honua.Protocols.GeoServices.MapServer;
 using Honua.Protocols.GeoServices.Sharing;
+using Honua.Protocols.GeoServices.VectorTileServer;
 using Honua.Protocols.GeoServices.VersionManagementServer;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
@@ -44,6 +45,7 @@ public sealed class GeoServicesProtocolModule : IHonuaProtocolModule
         endpoints.MapFeatureServerEndpoints();
         endpoints.MapMapServerEndpoints();
         endpoints.MapImageServerEndpoints();
+        endpoints.MapVectorTileServerEndpoints();
         endpoints.MapSharingRestEndpoints();
         endpoints.MapVersionManagementServerEndpoints();
     }

--- a/src/Honua.ServiceDefaults/HonuaTelemetry.cs
+++ b/src/Honua.ServiceDefaults/HonuaTelemetry.cs
@@ -285,6 +285,9 @@ public static class HonuaTelemetry
         /// <summary>GeoServices Image Server REST API.</summary>
         public const string ImageServer = "ImageServer";
 
+        /// <summary>GeoServices VectorTileServer REST API.</summary>
+        public const string VectorTileServer = "VectorTileServer";
+
         /// <summary>OData v4 protocol.</summary>
         public const string OData = "OData";
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Catalog/GeoservicesCatalogEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Catalog/GeoservicesCatalogEndpointTests.cs
@@ -104,6 +104,33 @@ public sealed class GeoservicesCatalogEndpointTests : IClassFixture<WebAppFixtur
     [IntegrationTest]
     [Operation(Operations.GetMetadata)]
     [Endpoint("GET /rest/services")]
+    public async Task GetServicesDirectory_IncludesVectorTileServerEntry()
+    {
+        var response = await _fixture.Client.GetAsync("/rest/services?f=json");
+
+        response.Be200Ok();
+
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var vectorTileEntries = payload.RootElement
+            .GetProperty("services")
+            .EnumerateArray()
+            .Where(service =>
+                service.TryGetProperty("type", out var type) &&
+                string.Equals(type.GetString(), "VectorTileServer", StringComparison.Ordinal))
+            .ToArray();
+
+        // The default test graph seeds an EsriVectorTileLayer publication on the "test"
+        // service, so the catalog must advertise a VectorTileServer entry with a
+        // service-name-scoped URL, matching every other service type.
+        vectorTileEntries.Should().NotBeEmpty();
+        vectorTileEntries.Should().OnlyContain(service =>
+            service.GetProperty("url").GetString()!.EndsWith(
+                "/rest/services/test/VectorTileServer", StringComparison.Ordinal));
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services")]
     public async Task GetServicesDirectory_ImageServerEntriesUseServiceScopedUrls()
     {
         var rasterStore = Substitute.For<IRasterStore>();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
@@ -114,23 +114,92 @@ public sealed class VectorTileServerEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.GetTileMetadata)]
     [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/resources/styles")]
-    public async Task VectorTileServer_DefaultStyles_IsStubbedNotImplemented()
+    public async Task VectorTileServer_DefaultStyles_ReturnsGlStyleWithRewrittenTileSource()
     {
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/resources/styles");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
+
+        using var document = JsonDocument.Parse(content);
+        var root = document.RootElement;
+
+        // Valid Mapbox GL style v8.
+        root.GetProperty("version").GetInt32().Should().Be(8);
+
+        // sprite/glyphs are omitted until the sprite/glyph pipeline lands (honua-server#1780).
+        root.TryGetProperty("sprite", out _).Should().BeFalse();
+        root.TryGetProperty("glyphs", out _).Should().BeFalse();
+
+        // A vector source whose tile template resolves to THIS service's tile route.
+        var sources = root.GetProperty("sources");
+        sources.EnumerateObject().Should().NotBeEmpty();
+
+        var sawVectorTileTemplate = false;
+        foreach (var source in sources.EnumerateObject())
+        {
+            source.Value.GetProperty("type").GetString().Should().Be("vector");
+
+            // The TileJSON pointer must not be emitted (we serve tiles directly).
+            source.Value.TryGetProperty("url", out _).Should().BeFalse();
+
+            var tiles = source.Value.GetProperty("tiles");
+            tiles.GetArrayLength().Should().BeGreaterThan(0);
+            foreach (var tile in tiles.EnumerateArray())
+            {
+                var template = tile.GetString();
+                template.Should().NotBeNullOrEmpty();
+                template.Should().Contain(
+                    $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/{{z}}/{{y}}/{{x}}.pbf");
+                template.Should().StartWith("http");
+                sawVectorTileTemplate = true;
+            }
+        }
+
+        sawVectorTileTemplate.Should().BeTrue();
+
+        // The layer with no stored style still yields a deterministic, non-empty default style.
+        root.GetProperty("layers").GetArrayLength().Should().BeGreaterThan(0);
     }
 
     [IntegrationTest]
     [Operation(Operations.GetTileMetadata)]
     [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/resources/styles/{**resourcePath}")]
-    public async Task VectorTileServer_StyleResource_IsStubbedNotImplemented()
+    public async Task VectorTileServer_StyleResource_RootJson_ReturnsGlStyle()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/resources/styles/root.json");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        using var document = JsonDocument.Parse(content);
+        document.RootElement.GetProperty("version").GetInt32().Should().Be(8);
+        document.RootElement.GetProperty("sources").EnumerateObject().Should().NotBeEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/resources/styles/{**resourcePath}")]
+    public async Task VectorTileServer_StyleResource_SpriteOrGlyph_ReturnsNotFound()
     {
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/resources/styles/sprites/sprite.json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/resources/styles")]
+    public async Task VectorTileServer_DefaultStyles_UnknownService_ReturnsNotFound()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/rest/services/does-not-exist/VectorTileServer/resources/styles");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
@@ -371,4 +371,105 @@ public sealed class VectorTileServerEndpointTests : IAsyncLifetime
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/resources/sprites/{spriteResource}")]
+    public async Task VectorTileServer_SpriteJson_ReturnsEmptyJsonObject()
+    {
+        foreach (var name in new[] { "sprite.json", "sprite@2x.json" })
+        {
+            var response = await _fixture.Client.GetAsync(
+                $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/resources/sprites/{name}");
+
+            var content = await response.Content.ReadAsStringAsync();
+            response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+            response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
+
+            using var document = JsonDocument.Parse(content);
+            document.RootElement.ValueKind.Should().Be(JsonValueKind.Object);
+            document.RootElement.EnumerateObject().Should().BeEmpty($"{name} is an empty sprite index");
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/resources/sprites/{spriteResource}")]
+    public async Task VectorTileServer_SpritePng_ReturnsTransparentPng()
+    {
+        foreach (var name in new[] { "sprite.png", "sprite@2x.png" })
+        {
+            var response = await _fixture.Client.GetAsync(
+                $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/resources/sprites/{name}");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Content.Headers.ContentType!.MediaType.Should().Be("image/png");
+
+            var bytes = await response.Content.ReadAsByteArrayAsync();
+            bytes.Should().NotBeEmpty();
+            // PNG signature.
+            bytes.Take(8).Should().Equal(0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/resources/sprites/{spriteResource}")]
+    public async Task VectorTileServer_Sprite_UnknownResource_ReturnsNotFound()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/resources/sprites/sprite@3x.png");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/resources/sprites/{spriteResource}")]
+    public async Task VectorTileServer_Sprite_UnknownService_ReturnsNotFound()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/rest/services/does-not-exist/VectorTileServer/resources/sprites/sprite.json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf")]
+    public async Task VectorTileServer_GlyphRange_ReturnsGlyphPbf()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/resources/fonts/Honua%20Default/0-255.pbf");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/x-protobuf");
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        bytes.Should().NotBeEmpty("a valid glyph PBF carries the fontstack message");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf")]
+    public async Task VectorTileServer_Glyph_OutOfRange_ReturnsNotFound()
+    {
+        // Ranges must be the canonical 256-codepoint windows (0-255, 256-511, …); an
+        // arbitrary range is not served by the minimal embedded glyph stack.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/resources/fonts/Honua%20Default/99-1234.pbf");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf")]
+    public async Task VectorTileServer_Glyph_UnknownService_ReturnsNotFound()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/rest/services/does-not-exist/VectorTileServer/resources/fonts/Honua%20Default/0-255.pbf");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
@@ -136,11 +136,100 @@ public sealed class VectorTileServerEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.GetTileMetadata)]
     [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}")]
-    public async Task VectorTileServer_TileMap_IsStubbedNotImplemented()
+    public async Task VectorTileServer_TileMap_FullyInRange_ReturnsAllAvailable()
     {
+        // Level 2 has a 4x4 grid (0..3 in both axes); a 4x4 block at (0,0) covers it exactly.
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tilemap/2/0/0/4/4");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        var tileMap = JsonSerializer.Deserialize(
+            content, VectorTileServerJsonContext.Default.VectorTileMapResponse);
+
+        tileMap.Should().NotBeNull();
+        tileMap!.Adjusted.Should().BeFalse();
+        tileMap.Location.Left.Should().Be(0);
+        tileMap.Location.Top.Should().Be(0);
+        tileMap.Location.Width.Should().Be(4);
+        tileMap.Location.Height.Should().Be(4);
+        tileMap.Data.Should().HaveCount(16);
+        tileMap.Data.Should().OnlyContain(value => value == 1);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}")]
+    public async Task VectorTileServer_TileMap_EdgeBlock_MarksOutOfRangeTilesZero()
+    {
+        // Level 2 grid is 0..3. A 2x2 block anchored at (3,3) covers tile (3,3) plus three
+        // tiles that overrun the grid edge, so only the top-left flag is 1.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tilemap/2/3/3/2/2");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        var tileMap = JsonSerializer.Deserialize(
+            content, VectorTileServerJsonContext.Default.VectorTileMapResponse);
+
+        tileMap.Should().NotBeNull();
+        tileMap!.Data.Should().HaveCount(4);
+        // Row-major: (3,3)=in-range, (4,3)=out, (3,4)=out, (4,4)=out.
+        tileMap.Data.Should().Equal(1, 0, 0, 0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tilemap")]
+    public async Task VectorTileServer_TileMapRoot_ReturnsTopOfPyramid()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tilemap");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        var tileMap = JsonSerializer.Deserialize(
+            content, VectorTileServerJsonContext.Default.VectorTileMapResponse);
+
+        tileMap.Should().NotBeNull();
+        tileMap!.Data.Should().ContainSingle().Which.Should().Be(1);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}")]
+    public async Task VectorTileServer_TileMap_LevelOutsideScheme_ReturnsBadRequest()
+    {
+        // Level 99 is well beyond the served LOD range; the tileMap pyramid cannot describe it.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tilemap/99/0/0/2/2");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}")]
+    public async Task VectorTileServer_TileMap_AbsurdDimension_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tilemap/2/0/0/4096/4096");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}")]
+    public async Task VectorTileServer_TileMap_UnknownService_ReturnsNotFound()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/rest/services/does-not-exist/VectorTileServer/tilemap/2/0/0/4/4");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Protocols.GeoServices.VectorTileServer.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.VectorTileServer;
+
+/// <summary>
+/// Integration tests for the GeoServices VectorTileServer service-metadata foundation
+/// (honua-server#1777). The service is resolved by NAME against an EsriVectorTileLayer
+/// publication seeded into the default Metadata v2 test graph. The tile / resources /
+/// tileMap routes are stubbed (501) in the foundation and asserted here so the API-surface
+/// coverage gate is satisfied before the parallel wave fills them in.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.VectorTileServer)]
+public sealed class VectorTileServerEndpointTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer")]
+    public async Task VectorTileServer_Metadata_ReturnsServiceDescriptor()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer?f=json");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        var metadata = JsonSerializer.Deserialize(
+            content, VectorTileServerJsonContext.Default.VectorTileServerMetadataResponse);
+
+        metadata.Should().NotBeNull();
+        metadata!.Name.Should().Be(WebAppFixture.TestServiceId);
+        metadata.CurrentVersion.Should().BeGreaterThan(0);
+        metadata.Capabilities.Should().Be("TilesOnly");
+        metadata.Type.Should().Be("indexedVector");
+        metadata.ExportTilesAllowed.Should().BeFalse();
+        metadata.Tiles.Should().ContainSingle().Which.Should().Be("tile/{z}/{y}/{x}.pbf");
+        metadata.DefaultStyles.Should().Be("resources/styles");
+        metadata.TileMap.Should().Be("tilemap");
+
+        metadata.TileInfo.Should().NotBeNull();
+        metadata.TileInfo!.Rows.Should().Be(512);
+        metadata.TileInfo.Cols.Should().Be(512);
+        metadata.TileInfo.Format.Should().Be("pbf");
+        metadata.TileInfo.Origin.Should().NotBeNull();
+        metadata.TileInfo.SpatialReference.Should().NotBeNull();
+        metadata.TileInfo.SpatialReference!.Wkid.Should().Be(102100);
+        metadata.TileInfo.SpatialReference.LatestWkid.Should().Be(3857);
+        metadata.TileInfo.Lods.Should().NotBeNullOrEmpty();
+        metadata.TileInfo.Lods![0].Level.Should().Be(0);
+        metadata.TileInfo.Lods[0].Scale.Should().BeApproximately(559082264.0287178, 1e-3);
+        metadata.TileInfo.Lods[1].Scale.Should().BeApproximately(559082264.0287178 / 2.0, 1e-3);
+
+        metadata.MinLod.Should().Be(0);
+        metadata.MaxLod.Should().Be(metadata.TileInfo.Lods[^1].Level);
+        metadata.FullExtent.Should().NotBeNull();
+        metadata.InitialExtent.Should().NotBeNull();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("POST /rest/services/{serviceId}/VectorTileServer")]
+    public async Task VectorTileServer_Metadata_Post_ReturnsServiceDescriptor()
+    {
+        using var body = new StringContent("f=json", Encoding.UTF8, "application/x-www-form-urlencoded");
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer", body);
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        var metadata = JsonSerializer.Deserialize(
+            content, VectorTileServerJsonContext.Default.VectorTileServerMetadataResponse);
+        metadata.Should().NotBeNull();
+        metadata!.Name.Should().Be(WebAppFixture.TestServiceId);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer")]
+    public async Task VectorTileServer_Metadata_UnknownService_ReturnsNotFound()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/rest/services/does-not-exist/VectorTileServer?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf")]
+    public async Task VectorTileServer_Tile_IsStubbedNotImplemented()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/0/0/0.pbf");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/resources/styles")]
+    public async Task VectorTileServer_DefaultStyles_IsStubbedNotImplemented()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/resources/styles");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/resources/styles/{**resourcePath}")]
+    public async Task VectorTileServer_StyleResource_IsStubbedNotImplemented()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/resources/styles/sprites/sprite.json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}")]
+    public async Task VectorTileServer_TileMap_IsStubbedNotImplemented()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tilemap/2/0/0/4/4");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+    }
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
@@ -103,12 +103,82 @@ public sealed class VectorTileServerEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.GetTile)]
     [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf")]
-    public async Task VectorTileServer_Tile_IsStubbedNotImplemented()
+    public async Task VectorTileServer_Tile_InRange_ReturnsMvtBytesWithCacheHeader()
+    {
+        // Zoom 1, tile (0,0) covers a quadrant of the world; the seeded "test" service
+        // resolves its EsriVectorTileLayer publication -> storage layer 0 and renders MVT.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/1/0/0.pbf");
+
+        // The seeded geometry may or may not intersect this specific tile, so accept either
+        // rendered bytes or an empty (204) tile; both are valid pipeline outcomes.
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NoContent);
+
+        // Cache-Control (max-age from TileOptions.CacheMaxAge) is set on both OK and 204.
+        response.Headers.Should().ContainKey("Cache-Control");
+        response.Headers.CacheControl!.MaxAge.Should().BeGreaterThan(TimeSpan.Zero);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.mapbox-vector-tile");
+            var bytes = await response.Content.ReadAsByteArrayAsync();
+            bytes.Should().NotBeEmpty();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf")]
+    public async Task VectorTileServer_Tile_EmptyTile_ReturnsNoContent()
+    {
+        // A high-zoom tile far from the seeded extent yields no features -> 204 No Content.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/15/0/0.pbf");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        response.Headers.Should().ContainKey("Cache-Control");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf")]
+    public async Task VectorTileServer_Tile_BadCoordinates_ReturnsBadRequest()
+    {
+        // x/y out of range for the zoom level (z=1 -> max index 1) -> 400 Bad Request.
+        var badCoordinates = new[]
+        {
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/1/2/0.pbf", // y >= 2^z
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/1/0/2.pbf"  // x >= 2^z
+        };
+
+        foreach (var url in badCoordinates)
+        {
+            var response = await _fixture.Client.GetAsync(url);
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest, $"{url} is out of range");
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf")]
+    public async Task VectorTileServer_Tile_OutOfRangeZoom_ReturnsBadRequest()
+    {
+        // Zoom above LimitsOptions.Tiles.MaxTileZoom -> 400 Bad Request.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/30/0/0.pbf");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf")]
+    public async Task VectorTileServer_Tile_UnknownService_ReturnsNotFound()
     {
         var response = await _fixture.Client.GetAsync(
-            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/0/0/0.pbf");
+            "/rest/services/does-not-exist/VectorTileServer/tile/1/0/0.pbf");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileStyleComposerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileStyleComposerTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Protocols.GeoServices.VectorTileServer.Services;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.VectorTileServer;
+
+/// <summary>
+/// Unit tests for <see cref="VectorTileStyleComposer"/> covering the sprite/glyphs scoping
+/// rule introduced for honua-server#1780: sprite and glyphs references are emitted into the
+/// composed Mapbox GL style ONLY when the style contains at least one <c>symbol</c> layer
+/// (which is what consumes a sprite/glyph stack); otherwise they stay omitted.
+/// </summary>
+public sealed class VectorTileStyleComposerTests
+{
+    private const string ServiceName = "test";
+    private const string SourceId = "esri";
+    private const string TileUrl = "https://host/rest/services/test/VectorTileServer/tile/{z}/{y}/{x}.pbf";
+    private const string SpriteUrl = "https://host/rest/services/test/VectorTileServer/resources/sprites/sprite";
+    private const string GlyphsUrl = "https://host/rest/services/test/VectorTileServer/resources/fonts/{fontstack}/{range}.pbf";
+
+    [Fact]
+    public void Compose_DefaultPointStyle_OmitsSpriteAndGlyphs()
+    {
+        var json = VectorTileStyleComposer.Compose(
+            storedMapLibreJson: null,
+            ServiceName,
+            SourceId,
+            TileUrl,
+            MetadataV2GeometryType.Point,
+            SpriteUrl,
+            GlyphsUrl);
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        root.GetProperty("version").GetInt32().Should().Be(8);
+        root.TryGetProperty("sprite", out _).Should().BeFalse("the default point style has no symbol layers");
+        root.TryGetProperty("glyphs", out _).Should().BeFalse("the default point style has no symbol layers");
+    }
+
+    [Fact]
+    public void Compose_StoredStyleWithSymbolLayer_EmitsAbsoluteSpriteAndGlyphs()
+    {
+        const string storedStyle = """
+            {
+              "version": 8,
+              "sources": {
+                "esri": { "type": "vector", "tiles": ["https://old/tiles/{z}/{y}/{x}.pbf"] }
+              },
+              "layers": [
+                {
+                  "id": "labels",
+                  "type": "symbol",
+                  "source": "esri",
+                  "source-layer": "layer",
+                  "layout": { "text-field": "{name}", "text-font": ["Honua Default"] }
+                }
+              ]
+            }
+            """;
+
+        var json = VectorTileStyleComposer.Compose(
+            storedStyle,
+            ServiceName,
+            SourceId,
+            TileUrl,
+            MetadataV2GeometryType.Point,
+            SpriteUrl,
+            GlyphsUrl);
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        root.GetProperty("sprite").GetString().Should().Be(SpriteUrl);
+        root.GetProperty("glyphs").GetString().Should().Be(GlyphsUrl);
+
+        // The vector source must still be rewritten onto this service's tile route.
+        var tile = root.GetProperty("sources").GetProperty("esri")
+            .GetProperty("tiles")[0].GetString();
+        tile.Should().Be(TileUrl);
+    }
+
+    [Fact]
+    public void Compose_StoredStyleWithSymbolLayer_StripsStaleStoredSpriteAndGlyphs()
+    {
+        // A stored style may carry sprite/glyphs pointers that do not resolve on this server;
+        // the composer must replace them with this service's absolute references, never echo
+        // the stale ones.
+        const string storedStyle = """
+            {
+              "version": 8,
+              "sprite": "https://stale/sprite",
+              "glyphs": "https://stale/fonts/{fontstack}/{range}.pbf",
+              "sources": { "esri": { "type": "vector", "url": "https://old/tilejson" } },
+              "layers": [
+                { "id": "labels", "type": "symbol", "source": "esri", "source-layer": "layer" }
+              ]
+            }
+            """;
+
+        var json = VectorTileStyleComposer.Compose(
+            storedStyle,
+            ServiceName,
+            SourceId,
+            TileUrl,
+            MetadataV2GeometryType.Point,
+            SpriteUrl,
+            GlyphsUrl);
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        root.GetProperty("sprite").GetString().Should().Be(SpriteUrl);
+        root.GetProperty("glyphs").GetString().Should().Be(GlyphsUrl);
+    }
+
+    [Fact]
+    public void Compose_StoredStyleWithoutSymbolLayer_OmitsSpriteAndGlyphs()
+    {
+        const string storedStyle = """
+            {
+              "version": 8,
+              "sources": { "esri": { "type": "vector", "tiles": ["https://old/{z}/{y}/{x}.pbf"] } },
+              "layers": [
+                { "id": "fill", "type": "fill", "source": "esri", "source-layer": "layer" }
+              ]
+            }
+            """;
+
+        var json = VectorTileStyleComposer.Compose(
+            storedStyle,
+            ServiceName,
+            SourceId,
+            TileUrl,
+            MetadataV2GeometryType.Polygon,
+            SpriteUrl,
+            GlyphsUrl);
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        root.TryGetProperty("sprite", out _).Should().BeFalse();
+        root.TryGetProperty("glyphs", out _).Should().BeFalse();
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Constants/ProtocolNames.cs
+++ b/tests/dotnet/Honua.TestKit/Constants/ProtocolNames.cs
@@ -130,6 +130,11 @@ public static class ProtocolNames
     public const string ImageServer = "ImageServer";
 
     /// <summary>
+    /// GeoServices VectorTileServer REST API.
+    /// </summary>
+    public const string VectorTileServer = "VectorTileServer";
+
+    /// <summary>
     /// OGC API - Maps (Part 1: Core).
     /// </summary>
     public const string OgcApiMaps = "OGC-API-Maps";

--- a/tests/dotnet/Honua.TestKit/Mixins/WebAppFixtureMetadataV2Mixin.cs
+++ b/tests/dotnet/Honua.TestKit/Mixins/WebAppFixtureMetadataV2Mixin.cs
@@ -161,6 +161,20 @@ internal static class WebAppFixtureMetadataV2Mixin
                 serviceLocalId: "test-layer",
                 publicationType: MetadataV2PublicationType.EsriImageLayer);
 
+        // VectorTileServer publication for the canonical "test" service. The
+        // GeoServices VectorTileServer adapter resolves the service by NAME against
+        // an EsriVectorTileLayer publication (honua-server#1777). Publish layer 0 so
+        // /rest/services/test/VectorTileServer resolves and inherits the seeded bbox.
+        builder
+            .AddService("svc-test-vectortile", "test", protocols: [MetadataV2ServiceProtocols.VectorTileServer])
+            .AddPublication(
+                id: "pub-vectortile-0",
+                serviceId: "svc-test-vectortile",
+                resourceId: "res-layer-0",
+                layerIndex: 0,
+                serviceLocalId: "0",
+                publicationType: MetadataV2PublicationType.EsriVectorTileLayer);
+
         // FeatureServer and MapServer publications for the canonical "test" service.
         // The GeoServices REST catalog endpoint enumerates these directly from the V2
         // graph, so the directory only emits FeatureServer/MapServer entries when matching


### PR DESCRIPTION
## Summary
Adds the Esri GeoServices **VectorTileServer** REST surface as a thin adapter over honua's existing MVT pipeline (`VectorTileExecution`/`ITileProvider`), Esri TileInfo/LOD builder, and MapLibre GL style projection — **no new tiler or style engine**. Consolidates the epic #1776 foundation + wave into one PR (your fewer-PRs preference): metadata, tile, root.json styles, tilemap, catalog registration.

Closes #1777, #1778, #1779, #1780, #1781, #1782. Part of #1776.

## Endpoints (service-name keyed, WebMercatorQuad, 512px, top-left/XYZ origin)
- `GET /rest/services/{id}/VectorTileServer?f=json` (+POST) — metadata: `tiles`, `tileInfo`/LODs, `tileMap`, `defaultStyles`, `capabilities:"TilesOnly"`, `type:"indexedVector"`.
- `GET …/tile/{z}/{y}/{x}.pbf` — MVT via the shared `VectorTileExecution.ExecuteAsync` (200/204, Cache-Control; 400 bad coords/zoom; 404 unknown service).
- `GET …/resources/styles/root.json` — Mapbox GL v8 from `IOgcStyleProjection` with tile URLs rewritten absolute (`VectorTileStyleComposer`); deterministic geometry-aware default when no style stored; sprite/glyphs omitted (scoped to a later ticket).
- `GET …/tilemap/{z}/{y}/{x}/{dim}/{dim}` — dense availability via `TileMath` (dim 1..32; out-of-range/absurd → 400).
- `/rest/services` lists `type:"VectorTileServer"`.

## Key changes
- New slice `src/Honua.Protocols.GeoServices/VectorTileServer/` (endpoints + `VectorTileServerTileInfoBuilder` + `VectorTileStyleComposer` + DTOs/JSON context).
- New `ServiceProtocols.VectorTileServer` + `MetadataV2PublicationType.EsriVectorTileLayer` (no DbUp migration — `publication_type` is plain TEXT, round-trips via the JSON enum converter).
- **Live route registration**: `MapVectorTileServerEndpoints()` wired into `FeatureRegistrationExtensions.MapServerFeatureEndpoints` (the host's actual route path; the `IHonuaProtocolModule` discovery path is dormant — without this every VTS route 404s).
- Catalog `TryMapServiceType` + `EndpointRegistry` + telemetry/proof-ledger wiring.

## Testing
- [x] Integration tests (Testcontainers + PostGIS, ADR-0011): metadata GET/POST, tile (200/204/400/404), root.json (GL v8 shape + rewritten URLs + default), tilemap (full/edge/out-of-range/absurd-dim), catalog listing.
- [x] Architecture tests (EndpointRegistry / ApiSurfaceCoverage / proof-ledger) green; targeted Release builds (GeoServices + Server) 0 warnings/0 errors with `TreatWarningsAsErrors=true`.

## Gate Impact
- [x] Adds a new public API surface (VectorTileServer routes) — covered by integration + architecture tests.

## Breaking Changes
None (additive new service type).

## Release/Deploy
No migration. New service type is denormalized TEXT in the metadata-v2 graph; accepted automatically.

- [x] Ran the targeted equivalent of scripts/ci/pre-pr-check.sh (Release build, dotnet format --verify-no-changes, affected tests) — all green.


---
<!-- Body brought into PR-template conformance; no code changed. CI re-runs full validation. -->

## Changes Made
- See the change description above.

