### PR TITLE
feat(geoservices): VectorTileServer tilemap availability + catalog registration (#1781)

### DIFF
--- a/src/Honua.Protocols.GeoServices/Catalog/GeoservicesCatalogEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/Catalog/GeoservicesCatalogEndpoints.cs
@@ -22,6 +22,7 @@ internal static class GeoservicesCatalogEndpoints
     private const string FeatureServerProtocolName = "FeatureServer";
     private const string MapServerProtocolName = "MapServer";
     private const string ImageServerProtocolName = "ImageServer";
+    private const string VectorTileServerProtocolName = "VectorTileServer";
 
     /// <summary>
     /// Maps root catalog endpoints under /rest.
@@ -32,7 +33,7 @@ internal static class GeoservicesCatalogEndpoints
             .WithDisplayName("GeoServices Services Directory")
             .WithName("GeoServicesServicesDirectory")
             .WithSummary("List available GeoServices endpoints")
-            .WithDescription("Returns FeatureServer, MapServer, and ImageServer service directory entries.")
+            .WithDescription("Returns FeatureServer, MapServer, ImageServer, and VectorTileServer service directory entries.")
             .WithTags("GeoServices Catalog")
             .CacheOutput("ServiceDirectory")
             .Produces<ServicesDirectoryResponse>(StatusCodes.Status200OK, JsonContentType)
@@ -204,8 +205,9 @@ internal static class GeoservicesCatalogEndpoints
 
     /// <summary>
     /// Maps an Esri-family primary protocol to the directory-entry "type" string the
-    /// GeoServices REST catalog exposes. Returns false for non-Esri protocols
-    /// (OGC API Features, STAC, etc.) which are surfaced through other catalogs.
+    /// GeoServices REST catalog exposes (FeatureServer, MapServer, ImageServer,
+    /// VectorTileServer). Returns false for non-Esri protocols (OGC API Features, STAC, etc.)
+    /// which are surfaced through other catalogs.
     /// </summary>
     private static bool TryMapServiceType(string? primaryProtocol, out string directoryType)
     {
@@ -219,6 +221,9 @@ internal static class GeoservicesCatalogEndpoints
                 return true;
             case ImageServerProtocolName:
                 directoryType = "ImageServer";
+                return true;
+            case VectorTileServerProtocolName:
+                directoryType = "VectorTileServer";
                 return true;
             default:
                 directoryType = string.Empty;

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerJsonContext.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerJsonContext.cs
@@ -15,6 +15,8 @@ namespace Honua.Protocols.GeoServices.VectorTileServer.Models;
 [JsonSerializable(typeof(VectorTileLevelOfDetail))]
 [JsonSerializable(typeof(VectorTileLevelOfDetail[]))]
 [JsonSerializable(typeof(VectorTileExtent))]
+[JsonSerializable(typeof(VectorTileMapResponse))]
+[JsonSerializable(typeof(VectorTileMapLocation))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerResponses.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerResponses.cs
@@ -148,6 +148,54 @@ internal sealed class VectorTileLevelOfDetail
     public double Scale { get; init; }
 }
 
+/// <summary>
+/// Response for the VectorTileServer tileMap endpoint
+/// (<c>GET /rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dim}/{dim}</c>).
+/// The shape mirrors the Esri tileMap availability block: a <c>location</c> describing the
+/// requested tile window and a row-major <c>data</c> array of <c>1</c> (tile in range) / <c>0</c>
+/// (tile outside the LOD/coordinate bounds) flags.
+/// </summary>
+internal sealed class VectorTileMapResponse
+{
+    /// <summary>
+    /// Whether the returned <see cref="Location"/> was adjusted (clamped) from the requested
+    /// window. Honua returns the requested window verbatim, so this is always <see langword="false"/>.
+    /// </summary>
+    [JsonPropertyName("adjusted")]
+    public bool Adjusted { get; init; }
+
+    /// <summary>The tile window the availability block covers.</summary>
+    [JsonPropertyName("location")]
+    public required VectorTileMapLocation Location { get; init; }
+
+    /// <summary>
+    /// Row-major availability flags for the window (<c>Height * Width</c> entries): <c>1</c>
+    /// when the tile is inside the LOD/coordinate bounds, <c>0</c> otherwise.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public required int[] Data { get; init; }
+}
+
+/// <summary>Describes the tile window (top-left origin and size, in tiles) of a tileMap block.</summary>
+internal sealed class VectorTileMapLocation
+{
+    /// <summary>Column index (tile X) of the top-left tile in the window.</summary>
+    [JsonPropertyName("left")]
+    public required int Left { get; init; }
+
+    /// <summary>Row index (tile Y) of the top-left tile in the window.</summary>
+    [JsonPropertyName("top")]
+    public required int Top { get; init; }
+
+    /// <summary>Window width, in tiles.</summary>
+    [JsonPropertyName("width")]
+    public required int Width { get; init; }
+
+    /// <summary>Window height, in tiles.</summary>
+    [JsonPropertyName("height")]
+    public required int Height { get; init; }
+}
+
 /// <summary>Esri spatial extent for a VectorTileServer response.</summary>
 internal sealed class VectorTileExtent
 {

--- a/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.TileMap.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.TileMap.cs
@@ -1,20 +1,40 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 //
-// FOUNDATION STUB (#1777). The tileMap (sparse tile index) route is declared here and
-// stubbed as HTTP 501 so honua-server#1781 can implement the tileMap handler in this file
-// WITHOUT editing the shared VectorTileServerEndpoints.cs. Replace HandleGetTileMap's body
-// (and the route metadata as needed) when wiring the tileMap pipeline; do not move the
-// registration.
+// honua-server#1781: VectorTileServer tileMap (sparse tile-availability index). The service
+// descriptor advertises "tilemap" as its tileMap pointer; ArcGIS clients call this route to
+// learn which tiles in a block exist before requesting them. This file fills the foundation
+// 501 stub (#1777) WITHOUT editing the shared VectorTileServerEndpoints.cs; the route
+// registration stays here.
+
+using System.Diagnostics;
+using System.Globalization;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Tiles;
+using Honua.Core.Features.Validation.Abstractions;
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Models;
+using Honua.Protocols.GeoServices.VectorTileServer.Models;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Options;
+using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
 
 namespace Honua.Protocols.GeoServices.VectorTileServer;
 
 internal static partial class VectorTileServerEndpoints
 {
     /// <summary>
+    /// Largest tile-block edge (in tiles) a single tileMap request may ask for. ArcGIS
+    /// clients probe small blocks (typically 8x8); bound the request so an absurd dimension
+    /// cannot allocate an unbounded availability buffer.
+    /// </summary>
+    private const int MaxTileMapDimension = 32;
+
+    /// <summary>
     /// Maps the VectorTileServer tileMap routes (sparse tile-availability index). The service
-    /// descriptor advertises <c>tilemap</c> as its <c>tileMap</c> pointer. Stubbed as 501 in
-    /// the foundation; implemented by honua-server#1781.
+    /// descriptor advertises <c>tilemap</c> as its <c>tileMap</c> pointer. Implemented by
+    /// honua-server#1781: returns the Esri tileMap availability block computed from the
+    /// service tiling scheme (LOD range + WebMercatorQuad coordinate bounds).
     /// </summary>
     private static void MapTileMapEndpoints(IEndpointRouteBuilder endpoints)
     {
@@ -23,20 +43,172 @@ internal static partial class VectorTileServerEndpoints
             .WithDisplayName("Get Vector Tile Map")
             .WithName("GetVectorTileMap")
             .WithSummary("Get the VectorTileServer tile-availability map for a tile block")
-            .WithDescription("Returns the sparse tile-availability index for a block of tiles. Stubbed (501) until honua-server#1781 wires the tileMap pipeline.")
+            .WithDescription("Returns the Esri tile-availability index for a block of tiles: 1 for tiles inside the LOD/coordinate bounds, 0 for tiles outside them.")
             .WithTags("VectorTileServer")
             .AllowAnonymous()
-            .Produces(200, contentType: "application/json")
-            .Produces(404)
-            .Produces(501);
+            .Produces(200, contentType: JsonContentType)
+            .Produces(400)
+            .Produces(404);
+
+        // The tileMap root resource. ArcGIS clients sometimes GET the bare `tilemap` pointer
+        // advertised by the service descriptor before walking the {z}/{y}/{x}/{dim}/{dim}
+        // blocks; return the top-of-pyramid availability block so the resource resolves.
+        endpoints.MapGet("/rest/services/{serviceId}/VectorTileServer/tilemap",
+                static (HttpContext context, CancellationToken cancellationToken) => HandleGetTileMapRoot(context))
+            .WithDisplayName("Get Vector Tile Map Root")
+            .WithName("GetVectorTileMapRoot")
+            .WithSummary("Get the VectorTileServer root tile-availability map")
+            .WithDescription("Returns the Esri tile-availability index for the top of the tiling pyramid (level 0).")
+            .WithTags("VectorTileServer")
+            .AllowAnonymous()
+            .Produces(200, contentType: JsonContentType)
+            .Produces(404);
     }
 
     /// <summary>
-    /// Foundation placeholder for the tileMap route. honua-server#1781 replaces this body with
-    /// the real tile-availability handler.
+    /// Handles the tileMap root resource (<c>tilemap</c>) by returning the level-0
+    /// availability block (a single tile that always exists).
     /// </summary>
-    private static IResult HandleGetTileMap(HttpContext context)
-        => Results.Problem(
-            detail: "VectorTileServer tileMap is not yet implemented.",
-            statusCode: StatusCodes.Status501NotImplemented);
+    private static Task<IResult> HandleGetTileMapRoot(HttpContext context)
+        => HandleTileMapAsync(context, z: 0, y: 0, x: 0, height: 1, width: 1);
+
+    /// <summary>
+    /// Handles a tileMap block request (<c>tilemap/{z}/{y}/{x}/{dim}/{dim}</c>). The route
+    /// segments are <c>z</c> (LOD), <c>y</c>/<c>x</c> (top-left tile of the block), and two
+    /// dimensions (block height then width, in tiles, per the Esri tileMap convention).
+    /// </summary>
+    private static Task<IResult> HandleGetTileMap(HttpContext context)
+    {
+        var z = GetRouteInt(context, "z");
+        var y = GetRouteInt(context, "y");
+        var x = GetRouteInt(context, "x");
+        var height = GetRouteInt(context, "dimension");
+        var width = GetRouteInt(context, "dimension2");
+        return HandleTileMapAsync(context, z, y, x, height, width);
+    }
+
+    private static async Task<IResult> HandleTileMapAsync(HttpContext context, int z, int y, int x, int height, int width)
+    {
+        var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+
+        var serviceError = RouteValidationHelpers.ValidateServiceId(context, out var serviceId);
+        if (serviceError is not null)
+        {
+            return serviceError;
+        }
+
+        // Bound the block dimensions before touching the catalog so an absurd request is
+        // rejected cheaply. The top-left tile coordinates may legitimately be large at deep
+        // zooms, so they are range-checked against the LOD grid rather than rejected here.
+        if (height <= 0 || width <= 0 || height > MaxTileMapDimension || width > MaxTileMapDimension)
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                $"tileMap block dimensions must be between 1 and {MaxTileMapDimension} tiles per side.");
+        }
+
+        if (z < 0 || x < 0 || y < 0)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "tileMap tile coordinates must be non-negative.");
+        }
+
+        using var scope = HonuaTelemetryScope.StartFeature(
+            "tilemap",
+            HonuaTelemetry.Protocols.VectorTileServer,
+            "*");
+        scope.WithTag(HonuaTelemetry.Tags.ServiceId, serviceId)
+            .WithTag(HonuaTelemetry.Tags.Operation, "get-tilemap");
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
+            var serviceResult = await ServiceResourceValidationHelpers.ValidateServiceV2Async(
+                resourceValidator,
+                serviceId,
+                MetadataV2ServiceProtocols.VectorTileServer,
+                context,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (!serviceResult.IsValid)
+            {
+                return serviceResult.ErrorResult!;
+            }
+
+            var maxLod = context.RequestServices.GetRequiredService<IOptions<LimitsOptions>>().Value.Tiles.MaxTileZoom;
+
+            // A tileMap request whose LOD lies outside the service tiling scheme cannot be
+            // satisfied — Esri returns an error rather than an all-zero block. Reject it as a
+            // bad request so clients distinguish "level not served" from "tiles not present".
+            if (z > maxLod)
+            {
+                return StandardErrorHelpers.CreateBadRequest(
+                    context,
+                    $"Requested level {z} is outside the service tiling scheme (0..{maxLod}).");
+            }
+
+            var response = BuildTileMapResponse(z, y, x, height, width, maxLod);
+
+            stopwatch.Stop();
+            scope.SetSuccess(response.Data.Length);
+            scope.CategorizeLatency(stopwatch.Elapsed.TotalMilliseconds);
+
+            return Results.Json(response, VectorTileServerJsonContext.Default.VectorTileMapResponse, contentType: JsonContentType);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            scope.RecordException(ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Computes the dense tileMap availability block: <c>1</c> for every tile inside the
+    /// LOD/coordinate bounds of the WebMercatorQuad tiling scheme, <c>0</c> for tiles that
+    /// fall outside the level's coordinate grid. The block is row-major over
+    /// <paramref name="height"/> rows then <paramref name="width"/> columns, starting at the
+    /// top-left tile (<paramref name="x"/>, <paramref name="y"/>).
+    /// </summary>
+    private static VectorTileMapResponse BuildTileMapResponse(int z, int y, int x, int height, int width, int maxLod)
+    {
+        var data = new int[height * width];
+        var index = 0;
+        for (var row = 0; row < height; row++)
+        {
+            var tileY = y + row;
+            for (var col = 0; col < width; col++)
+            {
+                var tileX = x + col;
+                // In-range tiles within the served LOD range map to 1; tiles that overrun the
+                // level's grid (e.g. the right/bottom edge of the world at this zoom) map to 0.
+                var available = z <= maxLod && TileMath.ValidateTileCoordinates(tileX, tileY, z);
+                data[index++] = available ? 1 : 0;
+            }
+        }
+
+        return new VectorTileMapResponse
+        {
+            // The availability block is returned exactly as requested (no clamping), so the
+            // location mirrors the request and `adjusted` is false.
+            Adjusted = false,
+            Location = new VectorTileMapLocation
+            {
+                Left = x,
+                Top = y,
+                Width = width,
+                Height = height
+            },
+            Data = data
+        };
+    }
+
+    private static int GetRouteInt(HttpContext context, string key)
+        => context.Request.RouteValues.TryGetValue(key, out var value)
+           && value is not null
+           && int.TryParse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : -1;
 }

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -851,6 +851,7 @@ public static class EndpointRegistry
         new("GET", "/rest/services/{serviceId}/VectorTileServer/resources/styles"),
         new("GET", "/rest/services/{serviceId}/VectorTileServer/resources/styles/{**resourcePath}"),
         new("GET", "/rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}"),
+        new("GET", "/rest/services/{serviceId}/VectorTileServer/tilemap"),
 
         new("GET", "/rest/services/{id}/ImageServer"),
         new("POST", "/rest/services/{id}/ImageServer"),

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -34,6 +34,7 @@ using Honua.Server.Features.Styling;
 using Honua.Protocols.GeoServices.MapServer;
 using Honua.Protocols.GeoServices.NAServer;
 using Honua.Protocols.GeoServices.Sharing;
+using Honua.Protocols.GeoServices.VectorTileServer;
 using Honua.Protocols.GeoServices.VersionManagementServer;
 using Honua.Ai.Protocols.Mcp;
 using Honua.Ai.NlQuery;
@@ -200,6 +201,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapSharingRestEndpoints();
         endpoints.MapImageServerEndpoints();
         endpoints.MapMapServerEndpoints();
+        endpoints.MapVectorTileServerEndpoints();
         endpoints.MapOgcClassicEndpoints();
         endpoints.MapAttachmentEndpoints();
         endpoints.MapTileJsonEndpoints();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Catalog/GeoservicesCatalogEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Catalog/GeoservicesCatalogEndpointTests.cs
@@ -104,6 +104,33 @@ public sealed class GeoservicesCatalogEndpointTests : IClassFixture<WebAppFixtur
     [IntegrationTest]
     [Operation(Operations.GetMetadata)]
     [Endpoint("GET /rest/services")]
+    public async Task GetServicesDirectory_IncludesVectorTileServerEntry()
+    {
+        var response = await _fixture.Client.GetAsync("/rest/services?f=json");
+
+        response.Be200Ok();
+
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var vectorTileEntries = payload.RootElement
+            .GetProperty("services")
+            .EnumerateArray()
+            .Where(service =>
+                service.TryGetProperty("type", out var type) &&
+                string.Equals(type.GetString(), "VectorTileServer", StringComparison.Ordinal))
+            .ToArray();
+
+        // The default test graph seeds an EsriVectorTileLayer publication on the "test"
+        // service, so the catalog must advertise a VectorTileServer entry with a
+        // service-name-scoped URL, matching every other service type.
+        vectorTileEntries.Should().NotBeEmpty();
+        vectorTileEntries.Should().OnlyContain(service =>
+            service.GetProperty("url").GetString()!.EndsWith(
+                "/rest/services/test/VectorTileServer", StringComparison.Ordinal));
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services")]
     public async Task GetServicesDirectory_ImageServerEntriesUseServiceScopedUrls()
     {
         var rasterStore = Substitute.For<IRasterStore>();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
@@ -136,11 +136,100 @@ public sealed class VectorTileServerEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.GetTileMetadata)]
     [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}")]
-    public async Task VectorTileServer_TileMap_IsStubbedNotImplemented()
+    public async Task VectorTileServer_TileMap_FullyInRange_ReturnsAllAvailable()
     {
+        // Level 2 has a 4x4 grid (0..3 in both axes); a 4x4 block at (0,0) covers it exactly.
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tilemap/2/0/0/4/4");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        var tileMap = JsonSerializer.Deserialize(
+            content, VectorTileServerJsonContext.Default.VectorTileMapResponse);
+
+        tileMap.Should().NotBeNull();
+        tileMap!.Adjusted.Should().BeFalse();
+        tileMap.Location.Left.Should().Be(0);
+        tileMap.Location.Top.Should().Be(0);
+        tileMap.Location.Width.Should().Be(4);
+        tileMap.Location.Height.Should().Be(4);
+        tileMap.Data.Should().HaveCount(16);
+        tileMap.Data.Should().OnlyContain(value => value == 1);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}")]
+    public async Task VectorTileServer_TileMap_EdgeBlock_MarksOutOfRangeTilesZero()
+    {
+        // Level 2 grid is 0..3. A 2x2 block anchored at (3,3) covers tile (3,3) plus three
+        // tiles that overrun the grid edge, so only the top-left flag is 1.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tilemap/2/3/3/2/2");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        var tileMap = JsonSerializer.Deserialize(
+            content, VectorTileServerJsonContext.Default.VectorTileMapResponse);
+
+        tileMap.Should().NotBeNull();
+        tileMap!.Data.Should().HaveCount(4);
+        // Row-major: (3,3)=in-range, (4,3)=out, (3,4)=out, (4,4)=out.
+        tileMap.Data.Should().Equal(1, 0, 0, 0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tilemap")]
+    public async Task VectorTileServer_TileMapRoot_ReturnsTopOfPyramid()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tilemap");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        var tileMap = JsonSerializer.Deserialize(
+            content, VectorTileServerJsonContext.Default.VectorTileMapResponse);
+
+        tileMap.Should().NotBeNull();
+        tileMap!.Data.Should().ContainSingle().Which.Should().Be(1);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}")]
+    public async Task VectorTileServer_TileMap_LevelOutsideScheme_ReturnsBadRequest()
+    {
+        // Level 99 is well beyond the served LOD range; the tileMap pyramid cannot describe it.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tilemap/99/0/0/2/2");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}")]
+    public async Task VectorTileServer_TileMap_AbsurdDimension_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tilemap/2/0/0/4096/4096");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tilemap/{z}/{y}/{x}/{dimension}/{dimension2}")]
+    public async Task VectorTileServer_TileMap_UnknownService_ReturnsNotFound()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/rest/services/does-not-exist/VectorTileServer/tilemap/2/0/0/4/4");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 }


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes honua-io/honua-server#1781
Part of honua-io/honua-server#1776

## Summary
Implements the GeoServices VectorTileServer `tilemap` availability route and registers VectorTileServer services in the `/rest/services` catalog (epic #1776), filling the foundation 501 stub from #1777.

The `tilemap` route returns the Esri tile-availability index for a block of tiles, computed from the service tiling scheme using `Honua.Core.Features.Tiles.TileMath`: `1` for tiles inside the LOD/coordinate bounds of the WebMercatorQuad scheme, `0` for tiles that overrun the level's grid. The catalog now emits VectorTileServer directory entries with the correct `type`/`url`, matching the access-denied/empty behaviour of the other Esri service types.

While verifying the foundation's catalog wiring, I found the #1777 VectorTileServer endpoints were never reachable in the running host: routes are mapped through the explicit `MapServerFeatureEndpoints` list (the `IHonuaProtocolModule` discovery path is dormant and never invoked), and that list omitted `MapVectorTileServerEndpoints()`. Every VectorTileServer route (metadata, tile, resources, tilemap) returned 404, including the foundation's own metadata tests. This PR wires the registration in so all VectorTileServer routes resolve.

## Changes Made
- Implemented `VectorTileServerEndpoints.TileMap.cs`: `GET .../VectorTileServer/tilemap/{z}/{y}/{x}/{dim}/{dim}` plus the `/tilemap` root, returning Esri tilemap JSON (`adjusted`, `location`, `data[]`) as a dense availability block computed with `TileMath`; bounds `dim` (1..32) and the LOD against the service tiling scheme, rejecting absurd dimensions and out-of-scheme levels with 400.
- Added `VectorTileMapResponse` / `VectorTileMapLocation` DTOs and registered them in the source-generated `VectorTileServerJsonContext`.
- Registered VectorTileServer in `GeoservicesCatalogEndpoints.TryMapServiceType` so `/rest/services` lists `type:"VectorTileServer"` entries with `url:{base}/rest/services/{name}/VectorTileServer`.
- Wired `MapVectorTileServerEndpoints()` into the live host registration (`FeatureRegistrationExtensions.MapServerFeatureEndpoints`) alongside MapServer/ImageServer; the foundation's module-discovery path is dormant, so the routes were otherwise unreachable.
- Registered the new `/tilemap` root route in `EndpointRegistry` for the API-surface coverage gate.
- Added integration tests: tilemap full/edge/root/out-of-range/absurd-dimension/unknown-service, and a catalog VectorTileServer-listing test.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
