### PR TITLE
feat(geoservices): VectorTileServer tile/{z}/{y}/{x}.pbf (#1778)

### DIFF
--- a/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Tile.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Tile.cs
@@ -1,40 +1,207 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 //
-// FOUNDATION STUB (#1777). The vector tile data route is declared here and stubbed as
-// HTTP 501 so honua-server#1778 can implement the tile handler in this file WITHOUT
-// editing the shared VectorTileServerEndpoints.cs. Replace HandleGetTile's body (and the
-// route metadata as needed) when wiring the tile pipeline; do not move the registration.
+// VectorTileServer vector tile data route (honua-server#1778). Implemented WITHOUT editing
+// the shared VectorTileServerEndpoints.cs: the route is declared here in this partial file.
+//
+// The handler is a thin protocol adapter over the shared vector-tile pipeline. It resolves
+// the GeoServices service by NAME (ValidateServiceV2Async, mirroring the foundation metadata
+// handler), resolves the service's primary tiled publication -> storage layer id, then
+// delegates to Honua.Infrastructure.Rendering.VectorTileExecution / ITileProvider.GetMvtTileAsync
+// (the same canonical path FeatureServer's /tiles/{layerId}/{z}/{x}/{y}.mvt uses). No new
+// data-access path is introduced.
+//
+// Esri addresses tiles as {z}/{y}/{x} over the WebMercatorQuad matrix set (top-left origin),
+// which is the same origin as the canonical (x, y, z) tuple, so the mapping is direct
+// (z -> zoomLevel, x -> tileCol, y -> tileRow).
+
+using System.Diagnostics;
+using Honua.Core.Configuration;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Shared.Models;
+using Honua.Core.Features.Tiles;
+using Honua.Core.Features.Validation.Abstractions;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Models;
+using Honua.Infrastructure.Rendering;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Options;
+using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
 
 namespace Honua.Protocols.GeoServices.VectorTileServer;
 
 internal static partial class VectorTileServerEndpoints
 {
+    private const string VectorTileServerProtocolName = "VectorTileServer";
+    private const string MvtContentType = "application/vnd.mapbox-vector-tile";
+
     /// <summary>
     /// Maps the VectorTileServer vector tile data route (<c>tile/{z}/{y}/{x}.pbf</c>).
-    /// Stubbed as 501 in the foundation; implemented by honua-server#1778.
     /// </summary>
     private static void MapTileEndpoints(IEndpointRouteBuilder endpoints)
     {
         endpoints.MapGet("/rest/services/{serviceId}/VectorTileServer/tile/{z:int}/{y:int}/{x:int}.pbf",
-                static (HttpContext context, CancellationToken cancellationToken) => HandleGetTile(context))
+                static (HttpContext context, int z, int y, int x, CancellationToken cancellationToken)
+                    => HandleGetTile(context, z, y, x, cancellationToken))
             .WithDisplayName("Get Vector Tile")
             .WithName("GetVectorTile")
             .WithSummary("Get a Mapbox Vector Tile (.pbf) from a VectorTileServer service")
-            .WithDescription("Returns a protobuf-encoded vector tile. Stubbed (501) until honua-server#1778 wires the tile pipeline.")
+            .WithDescription("Returns a protobuf-encoded Mapbox Vector Tile for the service's primary tiled layer over the WebMercatorQuad tile matrix set.")
             .WithTags("VectorTileServer")
             .AllowAnonymous()
-            .Produces(200, contentType: "application/vnd.mapbox-vector-tile")
-            .Produces(404)
-            .Produces(501);
+            .CacheOutput("MvtTile")
+            .Produces(200, contentType: MvtContentType)
+            .Produces(204)
+            .Produces(400)
+            .Produces(404);
     }
 
     /// <summary>
-    /// Foundation placeholder for the vector tile data route. honua-server#1778 replaces this
-    /// body with the real tile handler.
+    /// Handle a VectorTileServer tile request. Resolves the service by name, resolves its
+    /// primary tiled publication to a storage layer id, and renders the tile through the
+    /// shared vector-tile execution path. Esri <c>{z}/{y}/{x}</c> maps directly onto the
+    /// canonical <c>(x, y, z)</c> tuple (shared top-left WebMercatorQuad origin).
     /// </summary>
-    private static IResult HandleGetTile(HttpContext context)
-        => Results.Problem(
-            detail: "VectorTileServer tile retrieval is not yet implemented.",
-            statusCode: StatusCodes.Status501NotImplemented);
+    private static async Task<IResult> HandleGetTile(HttpContext context, int z, int y, int x, CancellationToken cancellationToken)
+    {
+        var serviceError = RouteValidationHelpers.ValidateServiceId(context, out var serviceId);
+        if (serviceError is not null)
+        {
+            return serviceError;
+        }
+
+        var tileOptions = context.RequestServices.GetRequiredService<IOptions<TileOptions>>().Value;
+        var tileLimits = context.RequestServices.GetRequiredService<IOptions<LimitsOptions>>().Value.Tiles;
+
+        // Out-of-range zoom (LimitsOptions.Tiles) and bad coordinates -> 400, before any
+        // metadata/data resolution, mirroring FeatureServer's HandleLayerTile.
+        if (z < tileLimits.MinTileZoom || z > tileLimits.MaxTileZoom)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                $"Zoom level {z} is outside supported range",
+                [$"Supported zoom range is {tileLimits.MinTileZoom}-{tileLimits.MaxTileZoom}"]);
+        }
+
+        if (!TileMath.ValidateTileCoordinates(x, y, z))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                $"Invalid tile coordinates: x={x}, y={y}, z={z}");
+        }
+
+        using var scope = HonuaTelemetryScope.StartFeature(
+            "tile",
+            HonuaTelemetry.Protocols.VectorTileServer,
+            "*");
+        scope.WithTag(HonuaTelemetry.Tags.ServiceId, serviceId)
+            .WithTag(HonuaTelemetry.Tags.Operation, "get-tile");
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
+            var serviceResult = await ServiceResourceValidationHelpers.ValidateServiceV2Async(
+                resourceValidator,
+                serviceId,
+                MetadataV2ServiceProtocols.VectorTileServer,
+                context,
+                cancellationToken: cancellationToken);
+            if (!serviceResult.IsValid)
+            {
+                return serviceResult.ErrorResult!;
+            }
+
+            var service = serviceResult.Service!;
+            var graphProvider = context.RequestServices.GetRequiredService<IMetadataV2GraphProvider>();
+            var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+
+            var primary = ResolvePrimaryTiledPublication(snapshot, service);
+            if (primary is null)
+            {
+                return StandardErrorHelpers.CreateNotFound(context,
+                    $"Service '{service.Metadata.Name}' has no tiled layer to render.");
+            }
+
+            var (publication, resource) = primary.Value;
+
+            var accessError = AccessPolicyHelpers.RequireAnyResourceAccess(context, [resource], service);
+            if (accessError != null)
+            {
+                return accessError;
+            }
+
+            // Mirror the V2 metadata builders' resolution order: integer storage handle is
+            // publication.LayerIndex when the graph carries no explicit storage binding.
+            var storageLayerId = publication.LayerIndex ?? snapshot.ResolveStorageLayerId(publication);
+            if (storageLayerId is null)
+            {
+                return StandardErrorHelpers.CreateNotFound(context,
+                    $"Layer '{resource.Metadata.Name}' is not bound to a storage layer.");
+            }
+
+            var query = VectorTileExecution.CreateQuery(
+                resource.ReadSrid() ?? SpatialReference.WGS84.Wkid);
+
+            var tileProvider = context.RequestServices.GetRequiredService<ITileProvider>();
+
+            // Esri tile/{z}/{y}/{x} -> canonical (tileCol=x, tileRow=y, zoom=z); same top-left origin.
+            var result = await VectorTileExecution.ExecuteAsync(
+                context,
+                tileProvider,
+                storageLayerId.Value,
+                x,
+                y,
+                z,
+                query,
+                tileOptions,
+                tileLimits,
+                cancellationToken);
+
+            stopwatch.Stop();
+            scope.SetSuccess();
+            scope.CategorizeLatency(stopwatch.Elapsed.TotalMilliseconds);
+            return result;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            scope.RecordException(ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the service's primary tiled publication. Prefers an
+    /// <see cref="MetadataV2PublicationType.EsriVectorTileLayer"/> publication (the type the
+    /// VectorTileServer adapter advertises); falls back to the first resolvable publication so
+    /// services that publish their tiled layer under a different publication type still render.
+    /// </summary>
+    private static (MetadataV2Publication Publication, MetadataV2Resource Resource)? ResolvePrimaryTiledPublication(
+        MetadataV2GraphSnapshot snapshot,
+        MetadataV2Service service)
+    {
+        (MetadataV2Publication Publication, MetadataV2Resource Resource)? fallback = null;
+        foreach (var publication in snapshot.Index.PublicationsByService[service.Metadata.Id])
+        {
+            var resource = snapshot.ResolveResource(publication);
+            if (resource is null)
+            {
+                continue;
+            }
+
+            if (publication.PublicationType == MetadataV2PublicationType.EsriVectorTileLayer)
+            {
+                return (publication, resource);
+            }
+
+            fallback ??= (publication, resource);
+        }
+
+        return fallback;
+    }
 }

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -34,6 +34,7 @@ using Honua.Server.Features.Styling;
 using Honua.Protocols.GeoServices.MapServer;
 using Honua.Protocols.GeoServices.NAServer;
 using Honua.Protocols.GeoServices.Sharing;
+using Honua.Protocols.GeoServices.VectorTileServer;
 using Honua.Protocols.GeoServices.VersionManagementServer;
 using Honua.Ai.Protocols.Mcp;
 using Honua.Ai.NlQuery;
@@ -200,6 +201,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapSharingRestEndpoints();
         endpoints.MapImageServerEndpoints();
         endpoints.MapMapServerEndpoints();
+        endpoints.MapVectorTileServerEndpoints();
         endpoints.MapOgcClassicEndpoints();
         endpoints.MapAttachmentEndpoints();
         endpoints.MapTileJsonEndpoints();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
@@ -103,12 +103,82 @@ public sealed class VectorTileServerEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.GetTile)]
     [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf")]
-    public async Task VectorTileServer_Tile_IsStubbedNotImplemented()
+    public async Task VectorTileServer_Tile_InRange_ReturnsMvtBytesWithCacheHeader()
+    {
+        // Zoom 1, tile (0,0) covers a quadrant of the world; the seeded "test" service
+        // resolves its EsriVectorTileLayer publication -> storage layer 0 and renders MVT.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/1/0/0.pbf");
+
+        // The seeded geometry may or may not intersect this specific tile, so accept either
+        // rendered bytes or an empty (204) tile; both are valid pipeline outcomes.
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NoContent);
+
+        // Cache-Control (max-age from TileOptions.CacheMaxAge) is set on both OK and 204.
+        response.Headers.Should().ContainKey("Cache-Control");
+        response.Headers.CacheControl!.MaxAge.Should().BeGreaterThan(TimeSpan.Zero);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.mapbox-vector-tile");
+            var bytes = await response.Content.ReadAsByteArrayAsync();
+            bytes.Should().NotBeEmpty();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf")]
+    public async Task VectorTileServer_Tile_EmptyTile_ReturnsNoContent()
+    {
+        // A high-zoom tile far from the seeded extent yields no features -> 204 No Content.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/15/0/0.pbf");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        response.Headers.Should().ContainKey("Cache-Control");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf")]
+    public async Task VectorTileServer_Tile_BadCoordinates_ReturnsBadRequest()
+    {
+        // x/y out of range for the zoom level (z=1 -> max index 1) -> 400 Bad Request.
+        var badCoordinates = new[]
+        {
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/1/2/0.pbf", // y >= 2^z
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/1/0/2.pbf"  // x >= 2^z
+        };
+
+        foreach (var url in badCoordinates)
+        {
+            var response = await _fixture.Client.GetAsync(url);
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest, $"{url} is out of range");
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf")]
+    public async Task VectorTileServer_Tile_OutOfRangeZoom_ReturnsBadRequest()
+    {
+        // Zoom above LimitsOptions.Tiles.MaxTileZoom -> 400 Bad Request.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/30/0/0.pbf");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf")]
+    public async Task VectorTileServer_Tile_UnknownService_ReturnsNotFound()
     {
         var response = await _fixture.Client.GetAsync(
-            $"/rest/services/{WebAppFixture.TestServiceId}/VectorTileServer/tile/0/0/0.pbf");
+            "/rest/services/does-not-exist/VectorTileServer/tile/1/0/0.pbf");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [IntegrationTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes honua-io/honua-server#1778
Part of honua-io/honua-server#1776

## Summary
Implements the GeoServices **VectorTileServer** vector-tile data route
`GET /rest/services/{serviceId}/VectorTileServer/tile/{z}/{y}/{x}.pbf`, filling the HTTP 501
foundation stub (#1777). The handler is a thin protocol adapter: it resolves the service by
name (`ValidateServiceV2Async`), resolves the service's primary tiled publication to a storage
layer id, and renders the tile through the shared `VectorTileExecution.ExecuteAsync` /
`ITileProvider.GetMvtTileAsync` pipeline — the same canonical path FeatureServer's
`/tiles/{layerId}/{z}/{x}/{y}.mvt` uses. No new data-access path is introduced. Esri's
`{z}/{y}/{x}` addressing maps directly onto the canonical `(x, y, z)` tuple (shared top-left
WebMercatorQuad origin).

While wiring the handler I found the #1777 foundation registered the VectorTileServer routes
**only** on the dormant `GeoServicesProtocolModule` path; the server maps endpoints through the
direct `MapServerFeatureEndpoints` list (and never calls `MapDiscoveredProtocolModules`), so
the entire VectorTileServer surface — including the foundation's own metadata/styles/tileMap
routes — was absent from the route table and returned an unmatched-route 404. This PR adds the
single missing registration call so the surface is reachable.

## Changes Made
- Filled `VectorTileServerEndpoints.Tile.cs` `HandleGetTile`: resolve service by name, resolve the primary tiled publication → storage layer id, delegate to the shared `VectorTileExecution` pipeline; returns `application/vnd.mapbox-vector-tile` bytes (200) for non-empty tiles, 204 for empty tiles, with `Cache-Control: public, max-age=<TileOptions.CacheMaxAge>` on both.
- Added zoom-range validation against `LimitsOptions.Tiles` and coordinate validation via `TileMath.ValidateTileCoordinates` → 400 on out-of-range zoom / bad coords; unknown service → 404 (both before any data access). Updated the route's `Produces` metadata (200 MVT / 204 / 400 / 404) and `CacheOutput("MvtTile")`; left the shared `VectorTileServerEndpoints.cs` untouched.
- Fixed VectorTileServer endpoint registration: added `endpoints.MapVectorTileServerEndpoints()` (and its `using`) to `MapServerFeatureEndpoints` in `FeatureRegistrationExtensions.cs`, alongside MapServer/ImageServer. Without this the foundation route group never registered (every VectorTileServer route 404'd).
- Replaced the foundation 501 stub test with real integration tests in `VectorTileServerEndpointTests`: in-range tile (200 MVT or 204, with Cache-Control), empty tile → 204, bad coordinates → 400, out-of-range zoom → 400, unknown service → 404. The foundation metadata/styles/tileMap tests now also pass (routes are reachable).

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

All 11 VectorTileServer integration tests pass (Testcontainers + PostGIS):
`dotnet test tests/dotnet/Honua.Protocols.GeoServices.Tests --filter FullyQualifiedName~VectorTileServer` → Passed 11, Failed 0.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
