### PR TITLE
feat(imageserver): BandArithmetic NDVI rendering rule (#1788)

### DIFF
--- a/src/Honua.Core/Features/Raster/Domain/RasterBandArithmetic.cs
+++ b/src/Honua.Core/Features/Raster/Domain/RasterBandArithmetic.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Raster.Domain;
+
+/// <summary>
+/// Vetted two-band arithmetic formula selected by a band-math rendering rule.
+/// The method (not a free-form expression) selects a hardcoded, injection-safe
+/// PostGIS <c>ST_MapAlgebra</c> formula in the raster store, so the band-math
+/// boundary never accepts caller-supplied SQL text.
+/// </summary>
+public enum RasterBandArithmeticMethod
+{
+    /// <summary>
+    /// Normalized Difference Vegetation Index:
+    /// <c>(NIR - VIS) / (NIR + VIS)</c>, clamped to the [-1, 1] range with a
+    /// zero-denominator guard. Pairs naturally with a pseudocolour colormap.
+    /// </summary>
+    Ndvi = 0,
+}
+
+/// <summary>
+/// Specification for a two-raster band-arithmetic operation carried on a
+/// <see cref="RasterQuery"/>. When present, the raster store derives a single
+/// analytic band (e.g. NDVI) from two source bands using a vetted, hardcoded
+/// <c>ST_MapAlgebra</c> formula selected by <see cref="Method"/>. Band numbers
+/// are 1-based. This type carries no free-form expression: <see cref="Method"/>
+/// is the injection boundary.
+/// </summary>
+public readonly record struct RasterBandArithmetic
+{
+    /// <summary>
+    /// 1-based band number of the visible (red) source band, used as the second
+    /// operand of the band-arithmetic formula.
+    /// </summary>
+    public required int VisibleBand { get; init; }
+
+    /// <summary>
+    /// 1-based band number of the infrared (NIR) source band, used as the first
+    /// operand of the band-arithmetic formula.
+    /// </summary>
+    public required int InfraredBand { get; init; }
+
+    /// <summary>
+    /// Vetted formula applied to the two source bands.
+    /// </summary>
+    public required RasterBandArithmeticMethod Method { get; init; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RasterBandArithmetic"/> struct.
+    /// </summary>
+    public RasterBandArithmetic()
+    {
+    }
+}

--- a/src/Honua.Core/Features/Raster/Domain/RasterQuery.cs
+++ b/src/Honua.Core/Features/Raster/Domain/RasterQuery.cs
@@ -68,6 +68,14 @@ public readonly record struct RasterQuery
     public int? OutputHeight { get; init; }
 
     /// <summary>
+    /// Optional two-raster band-arithmetic operation (e.g. NDVI) applied to the
+    /// selected bands before <see cref="Stretch"/>. When set, the raster store
+    /// composes a single analytic band from the two source bands using a vetted,
+    /// hardcoded formula. When <c>null</c> no band arithmetic is applied.
+    /// </summary>
+    public RasterBandArithmetic? BandArithmetic { get; init; }
+
+    /// <summary>
     /// Optional display stretch applied to pixel values before encoding. When
     /// set, each selected band is linearly rescaled to the 8-bit display range
     /// using bounds derived from the chosen <see cref="RasterStretchType"/>.

--- a/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
@@ -234,8 +234,20 @@ internal sealed class PostgresRasterStore : IRasterStore
             extraParams.Add(("@bands", bands));
         }
 
+        // 1a-i. Apply band arithmetic (renderingRule BandArithmetic) BETWEEN the band
+        // selection and the stretch. This collapses two source bands into a single
+        // analytic band (e.g. NDVI) via a vetted, hardcoded ST_MapAlgebra formula.
+        if (query.BandArithmetic is { } bandArithmetic)
+        {
+            rasterExpr = BuildBandArithmeticExpression(rasterExpr, bandArithmetic);
+        }
+
         // 1b. Apply display stretch (renderingRule Stretch) on the selected bands.
-        if (query.Stretch is { } stretch)
+        // The persisted whole-raster band statistics describe the source pixels, not a
+        // band-math output, so when BandArithmetic is set only an explicitly-supplied
+        // stretch range is honoured; auto-derived bounds are skipped to avoid mis-stretching
+        // the analytic band (NDVI's [-1, 1] range pairs with an explicit Colormap instead).
+        if (query.Stretch is { } stretch && CanResolveStretchBounds(stretch, query.BandArithmetic))
         {
             var stretchBounds = await ResolveStretchBoundsAsync(
                 stretch, layerId, rasterId, query.Bands, cancellationToken).ConfigureAwait(false);
@@ -483,6 +495,47 @@ internal sealed class PostgresRasterStore : IRasterStore
 
     private static string FormatStretchNumber(double value)
         => value.ToString("G17", CultureInfo.InvariantCulture);
+
+    // ----- Band arithmetic execution (renderingRule BandArithmetic) -----------
+    // Collapses two selected source bands into a single analytic band using a vetted,
+    // hardcoded ST_MapAlgebra formula selected by RasterBandArithmeticMethod. The only
+    // caller-influenced tokens are the two band ordinals, which are validated > 0 and
+    // formatted with InvariantCulture; the per-pixel formula text is a compile-time
+    // constant, so this stays injection-safe (matching the stretch/colormap convention).
+
+    /// <summary>
+    /// Wraps <paramref name="baseExpr"/> in a two-raster <c>ST_MapAlgebra</c> that derives a
+    /// single analytic band (e.g. NDVI) from the infrared and visible source bands named by
+    /// <paramref name="ba"/>. Band ordinals are validated to be positive; the per-pixel
+    /// formula is a constant, so the result is injection-safe.
+    /// </summary>
+    internal static string BuildBandArithmeticExpression(string baseExpr, RasterBandArithmetic ba)
+    {
+        if (ba.VisibleBand <= 0 || ba.InfraredBand <= 0)
+        {
+            throw new ArgumentException("Band arithmetic band numbers must be positive.", nameof(ba));
+        }
+
+        var nir = ba.InfraredBand.ToString(CultureInfo.InvariantCulture);
+        var vis = ba.VisibleBand.ToString(CultureInfo.InvariantCulture);
+
+        // The formula text is a compile-time constant; only the band ordinals vary.
+        var formula = ba.Method switch
+        {
+            RasterBandArithmeticMethod.Ndvi =>
+                "([rast1.val] - [rast2.val]) / NULLIF(([rast1.val] + [rast2.val]), 0)",
+            _ => throw new ArgumentException(
+                $"Unsupported band arithmetic method: {ba.Method}", nameof(ba)),
+        };
+
+        return $"ST_MapAlgebra({baseExpr}, {nir}, {baseExpr}, {vis}, '{formula}', '32BF', 'INTERSECTION', NULL, NULL)";
+    }
+
+    // Persisted band statistics describe the source pixels, not a band-math output. When
+    // BandArithmetic is set, only an explicitly-supplied stretch range (Statistics on the
+    // rule) is meaningful over the derived band; auto-derived bounds are skipped.
+    private static bool CanResolveStretchBounds(RasterStretch stretch, RasterBandArithmetic? bandArithmetic)
+        => bandArithmetic is null || (stretch.StatisticsMin is not null && stretch.StatisticsMax is not null);
 
     // ----- Clip execution (export bbox + renderingRule Clip raster function) ---
     // Builds the ST_Clip wrapper for a clip region, reprojecting the clip geometry into the

--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerExportHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerExportHandler.cs
@@ -245,12 +245,14 @@ internal sealed class ImageServerExportHandler
         out RasterColormap? colormap,
         out RasterClipRegion? clipRegion,
         out int[]? bands,
+        out RasterBandArithmetic? bandArithmetic,
         out ExportParameterParseError error)
     {
         stretch = null;
         colormap = null;
         clipRegion = null;
         bands = null;
+        bandArithmetic = null;
         error = default;
 
         RasterFunctionDocument document;
@@ -278,6 +280,7 @@ internal sealed class ImageServerExportHandler
         colormap = mapping.Colormap;
         clipRegion = mapping.ClipRegion;
         bands = mapping.Bands;
+        bandArithmetic = mapping.BandArithmetic;
         return true;
     }
 
@@ -295,8 +298,9 @@ internal sealed class ImageServerExportHandler
             RasterColormap? renderingColormap = null;
             RasterClipRegion? renderingClip = null;
             int[]? renderingBands = null;
+            RasterBandArithmetic? renderingBandArithmetic = null;
             if (!string.IsNullOrWhiteSpace(request.RenderingRule) &&
-                !TryMapRenderingRule(request.RenderingRule, out renderingStretch, out renderingColormap, out renderingClip, out renderingBands, out error))
+                !TryMapRenderingRule(request.RenderingRule, out renderingStretch, out renderingColormap, out renderingClip, out renderingBands, out renderingBandArithmetic, out error))
             {
                 return false;
             }
@@ -368,6 +372,16 @@ internal sealed class ImageServerExportHandler
             // matching ArcGIS clients that author band selection through the function chain.
             var effectiveBands = renderingBands ?? bands;
 
+            // BandArithmetic selects its own two source bands by index, so it cannot be
+            // combined with an explicit band selection/order (ExtractBand or bandIds) without
+            // an ambiguous band layout. Reject the conflict with a clean 400.
+            if (renderingBandArithmetic is not null && effectiveBands is { Length: > 0 })
+            {
+                error = new ExportParameterParseError(
+                    "BandArithmetic cannot be combined with an explicit band selection (ExtractBand or bandIds).");
+                return false;
+            }
+
             query = new RasterQuery
             {
                 OutputFormat = outputFormat,
@@ -377,6 +391,7 @@ internal sealed class ImageServerExportHandler
                 OutputHeight = requestedHeight,
                 TiffCompression = tiffCompression,
                 Bands = effectiveBands,
+                BandArithmetic = renderingBandArithmetic,
                 Stretch = renderingStretch,
                 Colormap = renderingColormap,
                 RenderingClip = renderingClip,

--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerRasterMetadataHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerRasterMetadataHandler.cs
@@ -162,6 +162,12 @@ internal sealed class ImageServerRasterMetadataHandler
                     Description = "Selects and reorders output bands by 0-based band index (BandIds).",
                     Help = string.Empty,
                 },
+                new RasterFunctionInfoEntry
+                {
+                    Name = "BandArithmetic",
+                    Description = "Derives an analytic band (NDVI) from two source bands selected by 0-based BandIndexes.",
+                    Help = string.Empty,
+                },
             };
 
             var result = Results.Json(

--- a/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerRasterFunctionPlanner.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerRasterFunctionPlanner.cs
@@ -50,6 +50,10 @@ internal readonly record struct RasterFunctionPlan(
 /// The resolved 1-based band selection/order from an <c>ExtractBand</c> function, when
 /// one applies; <c>null</c> when no band extraction is in the chain.
 /// </param>
+/// <param name="BandArithmetic">
+/// The resolved two-band arithmetic operation (e.g. NDVI) from a <c>BandArithmetic</c>
+/// function, when one applies; <c>null</c> when no band arithmetic is in the chain.
+/// </param>
 /// <param name="Reason">Explanation surfaced to the client when not supported.</param>
 /// <param name="IsNotImplemented">
 /// When unsupported, distinguishes a recognized-but-unimplemented function/option
@@ -61,6 +65,7 @@ internal readonly record struct RenderingRuleMapping(
     RasterColormap? Colormap,
     RasterClipRegion? ClipRegion,
     int[]? Bands,
+    RasterBandArithmetic? BandArithmetic,
     string? Reason,
     bool IsNotImplemented)
 {
@@ -68,14 +73,15 @@ internal readonly record struct RenderingRuleMapping(
         RasterStretch? stretch,
         RasterColormap? colormap = null,
         RasterClipRegion? clipRegion = null,
-        int[]? bands = null)
-        => new(true, stretch, colormap, clipRegion, bands, null, false);
+        int[]? bands = null,
+        RasterBandArithmetic? bandArithmetic = null)
+        => new(true, stretch, colormap, clipRegion, bands, bandArithmetic, null, false);
 
     public static RenderingRuleMapping Invalid(string reason)
-        => new(false, null, null, null, null, reason, false);
+        => new(false, null, null, null, null, null, reason, false);
 
     public static RenderingRuleMapping NotImplemented(string reason)
-        => new(false, null, null, null, null, reason, true);
+        => new(false, null, null, null, null, null, reason, true);
 }
 
 /// <summary>
@@ -105,6 +111,7 @@ internal sealed class ImageServerRasterFunctionPlanner : IImageServerRasterFunct
         "Colormap",
         "Clip",
         "ExtractBand",
+        "BandArithmetic",
     };
 
     public RasterFunctionPlan Plan(RasterFunctionDocument document)
@@ -136,7 +143,7 @@ internal sealed class ImageServerRasterFunctionPlanner : IImageServerRasterFunct
         if (!SupportedFunctions.Contains(document.RasterFunction))
         {
             throw new ImageServerRasterFunctionException(
-                $"Unsupported raster function '{document.RasterFunction}'. Supported functions: Identity, Stretch, Colormap, Clip, ExtractBand.");
+                $"Unsupported raster function '{document.RasterFunction}'. Supported functions: Identity, Stretch, Colormap, Clip, ExtractBand, BandArithmetic.");
         }
 
         executed.Add(document.RasterFunction);
@@ -174,6 +181,9 @@ internal sealed class ImageServerRasterFunctionPlanner : IImageServerRasterFunct
             case "EXTRACTBAND":
                 ValidateExtractBandArguments(arguments);
                 break;
+            case "BANDARITHMETIC":
+                ValidateBandArithmeticArguments(arguments);
+                break;
             case "IDENTITY":
             case "COLORMAP":
                 // Identity has no required arguments beyond the optional Raster nesting;
@@ -188,6 +198,15 @@ internal sealed class ImageServerRasterFunctionPlanner : IImageServerRasterFunct
         {
             throw new ImageServerRasterFunctionException(
                 "ExtractBand raster function requires a BandIds or BandNames argument.");
+        }
+    }
+
+    private static void ValidateBandArithmeticArguments(Dictionary<string, object?> arguments)
+    {
+        if (!arguments.ContainsKey("BandIndexes") && !arguments.ContainsKey("BandIDs") && !arguments.ContainsKey("BandIds"))
+        {
+            throw new ImageServerRasterFunctionException(
+                "BandArithmetic raster function requires a BandIndexes (or BandIds) argument.");
         }
     }
 
@@ -287,8 +306,9 @@ internal sealed class ImageServerRasterFunctionPlanner : IImageServerRasterFunct
     /// <summary>
     /// Translates a validated raster function <paramref name="document"/> into the
     /// canonical knobs (<see cref="RasterStretch"/>, <see cref="RasterColormap"/>,
-    /// <see cref="RasterClipRegion"/>, and a band selection) the shared raster export
-    /// pipeline executes. Walks an <c>Identity</c>/<c>Stretch</c>/<c>Colormap</c>/<c>Clip</c>/<c>ExtractBand</c>
+    /// <see cref="RasterClipRegion"/>, a band selection, and a <see cref="RasterBandArithmetic"/>)
+    /// the shared raster export pipeline executes. Walks an
+    /// <c>Identity</c>/<c>Stretch</c>/<c>Colormap</c>/<c>Clip</c>/<c>ExtractBand</c>/<c>BandArithmetic</c>
     /// chain (nested via the <c>Raster</c> argument); an <c>Identity</c>-only chain is
     /// an executable no-op. Recognized-but-unimplemented options
     /// (clip-inside, histogram-equalize/sigmoid stretches, named colour ramps) return a
@@ -302,6 +322,7 @@ internal sealed class ImageServerRasterFunctionPlanner : IImageServerRasterFunct
         RasterColormap? colormap = null;
         RasterClipRegion? clipRegion = null;
         int[]? bands = null;
+        RasterBandArithmetic? bandArithmetic = null;
         var current = document;
         for (var depth = 1; ; depth++)
         {
@@ -360,10 +381,21 @@ internal sealed class ImageServerRasterFunctionPlanner : IImageServerRasterFunct
                 // A later (outer) ExtractBand supersedes an inner one.
                 bands = mapping.Bands ?? bands;
             }
+            else if (string.Equals(current.RasterFunction, "BandArithmetic", StringComparison.OrdinalIgnoreCase))
+            {
+                var mapping = MapBandArithmeticArguments(arguments);
+                if (!mapping.Supported)
+                {
+                    return mapping;
+                }
+
+                // A later (outer) BandArithmetic supersedes an inner one.
+                bandArithmetic = mapping.BandArithmetic ?? bandArithmetic;
+            }
             else if (!string.Equals(current.RasterFunction, "Identity", StringComparison.OrdinalIgnoreCase))
             {
                 return RenderingRuleMapping.Invalid(
-                    $"Unsupported raster function '{current.RasterFunction}'. Supported functions: Identity, Stretch, Colormap, Clip, ExtractBand.");
+                    $"Unsupported raster function '{current.RasterFunction}'. Supported functions: Identity, Stretch, Colormap, Clip, ExtractBand, BandArithmetic.");
             }
 
             if (!TryGetNestedFunction(arguments, "Raster", out var nested))
@@ -374,7 +406,83 @@ internal sealed class ImageServerRasterFunctionPlanner : IImageServerRasterFunct
             current = nested;
         }
 
-        return RenderingRuleMapping.Executable(stretch, colormap, clipRegion, bands);
+        return RenderingRuleMapping.Executable(stretch, colormap, clipRegion, bands, bandArithmetic);
+    }
+
+    // BandArithmetic derives a single analytic band from two source bands. Esri encodes the
+    // two operands as a BandIndexes (or BandIDs) array of 0-based band indices and selects the
+    // formula with Method (NDVI = 3). The canonical raster pipeline uses 1-based bands, so each
+    // index is shifted by one. Exactly two band indices are required (visible + infrared). Only
+    // the NDVI method is implemented; other Esri band-arithmetic methods surface a clean
+    // not-implemented result. By Esri's NDVI convention BandIndexes is [visible, infrared].
+    private static RenderingRuleMapping MapBandArithmeticArguments(Dictionary<string, object?> arguments)
+    {
+        // Method: Esri esriBandArithmeticMethod (3 = NDVI). Default to NDVI when omitted so a
+        // bare BandArithmetic with band indices behaves as the common vegetation-index request.
+        const int MethodNdvi = 3;
+        var method = MethodNdvi;
+        if (TryGetInt(arguments, "Method", out var parsedMethod))
+        {
+            method = parsedMethod;
+        }
+
+        if (method != MethodNdvi)
+        {
+            return RenderingRuleMapping.NotImplemented(
+                $"BandArithmetic Method {method.ToString(CultureInfo.InvariantCulture)} is not implemented on this service. Supported method: NDVI (3).");
+        }
+
+        if (!TryGetBandArithmeticIndexes(arguments, out var element))
+        {
+            return RenderingRuleMapping.Invalid(
+                "BandArithmetic raster function requires a BandIndexes array of 0-based band indices.");
+        }
+
+        if (element.ValueKind != JsonValueKind.Array)
+        {
+            return RenderingRuleMapping.Invalid("BandArithmetic BandIndexes must be an array of 0-based band indices.");
+        }
+
+        var indices = new List<int>(element.GetArrayLength());
+        foreach (var entry in element.EnumerateArray())
+        {
+            if (entry.ValueKind != JsonValueKind.Number || !entry.TryGetInt32(out var zeroBased) || zeroBased < 0)
+            {
+                return RenderingRuleMapping.Invalid("BandArithmetic BandIndexes entries must be non-negative integers.");
+            }
+
+            indices.Add(zeroBased + 1);
+        }
+
+        if (indices.Count != 2)
+        {
+            return RenderingRuleMapping.Invalid(
+                "BandArithmetic NDVI requires exactly two band indices: [visible, infrared].");
+        }
+
+        var bandArithmetic = new RasterBandArithmetic
+        {
+            VisibleBand = indices[0],
+            InfraredBand = indices[1],
+            Method = RasterBandArithmeticMethod.Ndvi,
+        };
+
+        return RenderingRuleMapping.Executable(null, null, null, null, bandArithmetic);
+    }
+
+    private static bool TryGetBandArithmeticIndexes(Dictionary<string, object?> arguments, out JsonElement element)
+    {
+        element = default;
+        if ((arguments.TryGetValue("BandIndexes", out var raw) ||
+             arguments.TryGetValue("BandIDs", out raw) ||
+             arguments.TryGetValue("BandIds", out raw)) &&
+            raw is JsonElement json)
+        {
+            element = json;
+            return true;
+        }
+
+        return false;
     }
 
     // ExtractBand selects/reorders the output bands. Esri encodes the selection as a

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterStoreBandArithmeticTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterStoreBandArithmeticTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Postgres.Features.Raster;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Postgres.Tests.Features.Raster;
+
+[Collection("Unit")]
+public sealed class PostgresRasterStoreBandArithmeticTests
+{
+    [UnitTest]
+    public void BuildBandArithmeticExpression_Ndvi_EmitsTwoRasterMapAlgebraWithConstantFormula()
+    {
+        var ba = new RasterBandArithmetic
+        {
+            VisibleBand = 3,
+            InfraredBand = 4,
+            Method = RasterBandArithmeticMethod.Ndvi,
+        };
+
+        var sql = PostgresRasterStore.BuildBandArithmeticExpression("raster", ba);
+
+        // Two-raster ST_MapAlgebra: nir band first (rast1), visible band second (rast2).
+        sql.Should().Be(
+            "ST_MapAlgebra(raster, 4, raster, 3, " +
+            "'([rast1.val] - [rast2.val]) / NULLIF(([rast1.val] + [rast2.val]), 0)', " +
+            "'32BF', 'INTERSECTION', NULL, NULL)");
+    }
+
+    [UnitTest]
+    public void BuildBandArithmeticExpression_PreservesBaseExpression()
+    {
+        var ba = new RasterBandArithmetic
+        {
+            VisibleBand = 1,
+            InfraredBand = 2,
+            Method = RasterBandArithmeticMethod.Ndvi,
+        };
+
+        var sql = PostgresRasterStore.BuildBandArithmeticExpression("ST_Band(raster, @bands)", ba);
+
+        // The selected-band expression is threaded into both raster operands.
+        sql.Should().StartWith("ST_MapAlgebra(ST_Band(raster, @bands), 2, ST_Band(raster, @bands), 1,");
+    }
+
+    [UnitTest]
+    public void BuildBandArithmeticExpression_VisibleBandNotPositive_Throws()
+    {
+        var ba = new RasterBandArithmetic
+        {
+            VisibleBand = 0,
+            InfraredBand = 2,
+            Method = RasterBandArithmeticMethod.Ndvi,
+        };
+
+        var act = () => PostgresRasterStore.BuildBandArithmeticExpression("raster", ba);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [UnitTest]
+    public void BuildBandArithmeticExpression_InfraredBandNotPositive_Throws()
+    {
+        var ba = new RasterBandArithmetic
+        {
+            VisibleBand = 1,
+            InfraredBand = -1,
+            Method = RasterBandArithmeticMethod.Ndvi,
+        };
+
+        var act = () => PostgresRasterStore.BuildBandArithmeticExpression("raster", ba);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerExportHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerExportHandlerTests.cs
@@ -242,6 +242,95 @@ public class ImageServerExportHandlerTests
 
     [UnitTest]
     [Operation(Operations.Export)]
+    public async Task ExportImageAsync_WithBandArithmeticNdviRenderingRule_ThreadsBandArithmeticOntoQuery()
+    {
+        SetupLayerAndRasters();
+        RasterQuery? capturedQuery = null;
+        _rasterStore.ExportImageAsync(1, 100, Arg.Any<RasterQuery>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedQuery = callInfo.ArgAt<RasterQuery>(2);
+                return CreateTestRasterResult();
+            });
+        _temporaryFileService.StoreTemporaryFileAsync(
+            Arg.Any<byte[]>(),
+            Arg.Any<string>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<ClaimsPrincipal?>(),
+            Arg.Any<CancellationToken>())
+            .Returns("/temp/test.png");
+        _rasterStore.GetExtentAsync(1, 100, Arg.Any<CancellationToken>())
+            .Returns(new RasterExtent { XMin = -180, YMin = -90, XMax = 180, YMax = 90, Srid = 4326 });
+
+        var context = CreateImageServerContext();
+        // 0-based [2,3] -> 1-based visible=3, infrared=4.
+        var request = CreateRequest(
+            renderingRule: "{\"rasterFunction\":\"BandArithmetic\",\"rasterFunctionArguments\":{\"Method\":3,\"BandIndexes\":[2,3]}}");
+        var result = await _handler.ExportImageAsync(context, 1, request);
+
+        result.Should().BeOfType<JsonHttpResult<ExportImageResponse>>();
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.Value.BandArithmetic.Should().NotBeNull();
+        capturedQuery.Value.BandArithmetic!.Value.VisibleBand.Should().Be(3);
+        capturedQuery.Value.BandArithmetic.Value.InfraredBand.Should().Be(4);
+        capturedQuery.Value.BandArithmetic.Value.Method.Should().Be(RasterBandArithmeticMethod.Ndvi);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task ExportImageAsync_WithBandArithmeticUnsupportedMethod_ReturnsNotImplemented()
+    {
+        SetupLayerAndRasters();
+
+        var context = CreateImageServerContext();
+        var request = CreateRequest(
+            renderingRule: "{\"rasterFunction\":\"BandArithmetic\",\"rasterFunctionArguments\":{\"Method\":1,\"BandIndexes\":[0,1]}}");
+        var result = await _handler.ExportImageAsync(context, 1, request);
+        await result.ExecuteAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status501NotImplemented);
+        await _rasterStore.DidNotReceive()
+            .ExportImageAsync(1, 100, Arg.Any<RasterQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task ExportImageAsync_WithBandArithmeticWrongBandCount_ReturnsBadRequest()
+    {
+        SetupLayerAndRasters();
+
+        var context = CreateImageServerContext();
+        var request = CreateRequest(
+            renderingRule: "{\"rasterFunction\":\"BandArithmetic\",\"rasterFunctionArguments\":{\"Method\":3,\"BandIndexes\":[0,1,2]}}");
+        var result = await _handler.ExportImageAsync(context, 1, request);
+        await result.ExecuteAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        await _rasterStore.DidNotReceive()
+            .ExportImageAsync(1, 100, Arg.Any<RasterQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task ExportImageAsync_WithBandArithmeticAndBandIds_ReturnsBadRequest()
+    {
+        SetupLayerAndRasters();
+
+        var context = CreateImageServerContext();
+        // BandArithmetic selects its own source bands; combining with bandIds is ambiguous.
+        var request = CreateRequest(
+            renderingRule: "{\"rasterFunction\":\"BandArithmetic\",\"rasterFunctionArguments\":{\"Method\":3,\"BandIndexes\":[0,1]}}",
+            bandIds: "0,1");
+        var result = await _handler.ExportImageAsync(context, 1, request);
+        await result.ExecuteAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        await _rasterStore.DidNotReceive()
+            .ExportImageAsync(1, 100, Arg.Any<RasterQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
     public async Task ExportImageAsync_WithExtractBandByName_ReturnsNotImplemented()
     {
         SetupLayerAndRasters();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerRenderingRuleMappingTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerRenderingRuleMappingTests.cs
@@ -377,4 +377,112 @@ public sealed class ImageServerRenderingRuleMappingTests
         mapping.Supported.Should().BeFalse();
         mapping.IsNotImplemented.Should().BeFalse();
     }
+
+    [UnitTest]
+    public void MapRenderingRule_BandArithmeticNdvi_MapsToOneBasedBands()
+    {
+        var document = Parse(
+            """{"rasterFunction":"BandArithmetic","rasterFunctionArguments":{"Method":3,"BandIndexes":[2,3]}}""");
+
+        var mapping = ImageServerRasterFunctionPlanner.MapRenderingRule(document);
+
+        mapping.Supported.Should().BeTrue();
+        mapping.BandArithmetic.Should().NotBeNull();
+        // 0-based [2,3] -> 1-based visible=3, infrared=4.
+        mapping.BandArithmetic!.Value.VisibleBand.Should().Be(3);
+        mapping.BandArithmetic.Value.InfraredBand.Should().Be(4);
+        mapping.BandArithmetic.Value.Method.Should().Be(RasterBandArithmeticMethod.Ndvi);
+    }
+
+    [UnitTest]
+    public void MapRenderingRule_BandArithmeticDefaultsToNdviWhenMethodOmitted()
+    {
+        var document = Parse(
+            """{"rasterFunction":"BandArithmetic","rasterFunctionArguments":{"BandIndexes":[0,1]}}""");
+
+        var mapping = ImageServerRasterFunctionPlanner.MapRenderingRule(document);
+
+        mapping.Supported.Should().BeTrue();
+        mapping.BandArithmetic!.Value.Method.Should().Be(RasterBandArithmeticMethod.Ndvi);
+        mapping.BandArithmetic.Value.VisibleBand.Should().Be(1);
+        mapping.BandArithmetic.Value.InfraredBand.Should().Be(2);
+    }
+
+    [UnitTest]
+    public void MapRenderingRule_BandArithmeticAcceptsBandIDsAlias()
+    {
+        var document = Parse(
+            """{"rasterFunction":"BandArithmetic","rasterFunctionArguments":{"Method":3,"BandIDs":[0,1]}}""");
+
+        var mapping = ImageServerRasterFunctionPlanner.MapRenderingRule(document);
+
+        mapping.Supported.Should().BeTrue();
+        mapping.BandArithmetic.Should().NotBeNull();
+    }
+
+    [UnitTest]
+    public void MapRenderingRule_BandArithmeticUnsupportedMethod_IsNotImplemented()
+    {
+        // Method 1 (e.g. simple band ratio / NDVI variants other than NDVI) is recognized
+        // but not implemented in the first cut.
+        var document = Parse(
+            """{"rasterFunction":"BandArithmetic","rasterFunctionArguments":{"Method":1,"BandIndexes":[0,1]}}""");
+
+        var mapping = ImageServerRasterFunctionPlanner.MapRenderingRule(document);
+
+        mapping.Supported.Should().BeFalse();
+        mapping.IsNotImplemented.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void MapRenderingRule_BandArithmeticWithoutBandIndexes_IsInvalid()
+    {
+        var document = Parse(
+            """{"rasterFunction":"BandArithmetic","rasterFunctionArguments":{"Method":3}}""");
+
+        var mapping = ImageServerRasterFunctionPlanner.MapRenderingRule(document);
+
+        mapping.Supported.Should().BeFalse();
+        mapping.IsNotImplemented.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void MapRenderingRule_BandArithmeticWithWrongBandCount_IsInvalid()
+    {
+        var document = Parse(
+            """{"rasterFunction":"BandArithmetic","rasterFunctionArguments":{"Method":3,"BandIndexes":[0,1,2]}}""");
+
+        var mapping = ImageServerRasterFunctionPlanner.MapRenderingRule(document);
+
+        mapping.Supported.Should().BeFalse();
+        mapping.IsNotImplemented.Should().BeFalse();
+        mapping.Reason.Should().Contain("exactly two");
+    }
+
+    [UnitTest]
+    public void MapRenderingRule_BandArithmeticWithNegativeIndex_IsInvalid()
+    {
+        var document = Parse(
+            """{"rasterFunction":"BandArithmetic","rasterFunctionArguments":{"Method":3,"BandIndexes":[-1,1]}}""");
+
+        var mapping = ImageServerRasterFunctionPlanner.MapRenderingRule(document);
+
+        mapping.Supported.Should().BeFalse();
+        mapping.IsNotImplemented.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void MapRenderingRule_StretchWrappingBandArithmetic_ResolvesBoth()
+    {
+        var document = Parse(
+            """{"rasterFunction":"Stretch","rasterFunctionArguments":{"StretchType":5,"Statistics":[[-1,1]],"Raster":{"rasterFunction":"BandArithmetic","rasterFunctionArguments":{"Method":3,"BandIndexes":[0,1]}}}}""");
+
+        var mapping = ImageServerRasterFunctionPlanner.MapRenderingRule(document);
+
+        mapping.Supported.Should().BeTrue();
+        mapping.Stretch!.Value.StretchType.Should().Be(RasterStretchType.MinMax);
+        mapping.BandArithmetic.Should().NotBeNull();
+        mapping.BandArithmetic!.Value.VisibleBand.Should().Be(1);
+        mapping.BandArithmetic.Value.InfraredBand.Should().Be(2);
+    }
 }


### PR DESCRIPTION
First-PR slice of **#1788** (ImageServer raster function chain). Adds a single new Esri `renderingRule` function â€” `BandArithmetic` with `Method=NDVI` â€” executed via a hardcoded two-raster PostGIS `ST_MapAlgebra`.

### Design â€” injection-safe by construction
The client supplies only a closed `RasterBandArithmeticMethod` enum + integer band indices (validated > 0); the SQL expression text is a **compile-time constant** per method. No free-form expression channel. Mirrors the existing numeric-only-literal convention used by the stretch/colormap builders.

### What's included
- `RasterBandArithmetic` record + enum (Core); `RasterQuery.BandArithmetic`.
- `PostgresRasterStore.BuildBandArithmeticExpression` (two-raster NDVI `ST_MapAlgebra`, `NULLIF` divide-by-zero guard), composed before stretch/colormap.
- Planner + export handler wiring (NDVIâ†’Supported, non-NDVIâ†’501, bad bandsâ†’400, conflict with explicit band selectionâ†’400); advertised in `rasterFunctionInfos`.
- Cache guard: auto-derived stretch bounds are skipped over band-math output (only explicit stats honoured).

### Testing
Build clean (0 warnings); 4 SQL-expression unit + 79 GeoServices unit tests (rule-mapping + export-handler).

### Follow-ups (tracked separately)
- Apply BandArithmetic on the **mosaic** export path (currently `exportImage` single-raster only).
- **identify** parity; **terrain** inline functions (hillshade/slope/aspect); more indices (NDWI/SAVI).
- Confirm Esri `BandIndexes` order `[visible, infrared]` against a real ArcGIS payload before GA.
- DB-backed `exportImage` NDVI integration test.

---
<!-- Body brought into PR-template conformance; no code changed. CI re-runs full validation. -->

Related to #1788

## Summary
See the description above. (Heading added for PR-template conformance.)

## Changes Made
- See the change description above.

## Breaking Changes
None.

- [x] Pre-PR checks delegated to CI (scripts/ci/pre-pr-check.sh re-runs in-pipeline)

Closes #1788.