### PR TITLE
feat(coverages): datetime temporal subsetting for Zarr coverages (#1790)

### DIFF
--- a/src/Honua.Core/Features/Raster/Domain/ZarrModels.cs
+++ b/src/Honua.Core/Features/Raster/Domain/ZarrModels.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.Infrastructure.Domain;
+using Honua.Core.Features.Raster.Multidimensional.Domain;
 
 namespace Honua.Core.Features.Raster.Domain;
 
@@ -49,6 +50,16 @@ public sealed record ZarrArrayMetadata(
 /// <summary>
 /// Parsed Zarr store metadata covering one or more arrays.
 /// </summary>
+/// <param name="ZarrFormat">Detected Zarr format version.</param>
+/// <param name="Srid">CRS as an EPSG SRID; 0 when not georeferenced.</param>
+/// <param name="Extent">Spatial extent in the declared CRS.</param>
+/// <param name="Arrays">Discovered arrays (variables).</param>
+/// <param name="PrimaryVariable">Default variable name, or null.</param>
+/// <param name="SpatialXDimension">Declared X dimension name, or null.</param>
+/// <param name="SpatialYDimension">Declared Y dimension name, or null.</param>
+/// <param name="TemporalDimension">Declared time dimension name, or null.</param>
+/// <param name="Temporal">Temporal extent of the time axis, or null when the
+/// store declares no resolvable time axis.</param>
 public sealed record ZarrStoreMetadata(
     ZarrFormatVersion ZarrFormat,
     int Srid,
@@ -57,7 +68,8 @@ public sealed record ZarrStoreMetadata(
     string? PrimaryVariable,
     string? SpatialXDimension,
     string? SpatialYDimension,
-    string? TemporalDimension);
+    string? TemporalDimension,
+    TemporalExtent? Temporal = null);
 
 /// <summary>
 /// Persisted catalog entry for a registered Zarr store.

--- a/src/Honua.Core/Features/Raster/ZarrParser/CfTimeAxisIndexer.cs
+++ b/src/Honua.Core/Features/Raster/ZarrParser/CfTimeAxisIndexer.cs
@@ -1,0 +1,208 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+
+namespace Honua.Core.Features.Raster.ZarrParser;
+
+/// <summary>
+/// Maps OGC API <c>datetime</c> requests onto integer indices of an evenly
+/// spaced CF time axis. Pure and AOT-safe: no allocation beyond the optional
+/// error string and no dependency on the read pipeline. The axis is described
+/// by its first and last sample instants plus the number of samples
+/// (<c>stepCount</c>); the per-step spacing is derived as
+/// <c>(end - start) / (stepCount - 1)</c> for <c>stepCount &gt; 1</c>.
+/// Irregular or unknown spacing is rejected with a client-safe error.
+/// </summary>
+public static class CfTimeAxisIndexer
+{
+    /// <summary>
+    /// Resolves the inclusive index range on an evenly spaced time axis that an
+    /// OGC <c>datetime</c> request selects.
+    /// </summary>
+    /// <param name="start">First sample instant of the axis.</param>
+    /// <param name="end">Last sample instant of the axis.</param>
+    /// <param name="stepCount">Number of samples along the axis.</param>
+    /// <param name="reqStart">Requested interval start, or null for an open-ended (<c>../t1</c>) request.</param>
+    /// <param name="reqEnd">Requested interval end, or null for an open-ended (<c>t0/..</c>) request.</param>
+    /// <param name="lowInclusive">Resolved inclusive low index when the method returns true.</param>
+    /// <param name="highInclusive">Resolved inclusive high index when the method returns true.</param>
+    /// <param name="error">Client-safe error when the method returns false.</param>
+    /// <returns>True when the request resolves to a non-empty in-range index range.</returns>
+    /// <remarks>
+    /// An instant request (<paramref name="reqStart"/> == <paramref name="reqEnd"/>) rounds to the
+    /// nearest index and is rejected when it falls outside <c>[start - step/2, end + step/2]</c>.
+    /// An interval request takes <c>low = ceil((t0 - start) / step)</c> and
+    /// <c>high = floor((t1 - start) / step)</c>, each clamped to the axis, and is rejected when the
+    /// clamped range is empty. The axis must declare at least one sample and (for
+    /// <c>stepCount &gt; 1</c>) a positive spacing; both are otherwise rejected as irregular/unknown.
+    /// </remarks>
+    public static bool TryResolveTimeIndexRange(
+        DateTimeOffset start,
+        DateTimeOffset end,
+        long stepCount,
+        DateTimeOffset? reqStart,
+        DateTimeOffset? reqEnd,
+        out int lowInclusive,
+        out int highInclusive,
+        out string? error)
+    {
+        lowInclusive = 0;
+        highInclusive = 0;
+        error = null;
+
+        if (stepCount < 1)
+        {
+            error = "The coverage time axis declares no samples; temporal subsetting is unavailable.";
+            return false;
+        }
+
+        if (stepCount > int.MaxValue)
+        {
+            error = "The coverage time axis is too large for temporal subsetting.";
+            return false;
+        }
+
+        var lastIndex = (int)(stepCount - 1);
+
+        // Single-sample axis: the only addressable index is 0, located at `start`.
+        if (stepCount == 1)
+        {
+            return ResolveSingleSampleAxis(start, reqStart, reqEnd, out lowInclusive, out highInclusive, out error);
+        }
+
+        var stepTicks = (end - start).Ticks / (stepCount - 1);
+        if (stepTicks <= 0)
+        {
+            error = "The coverage time axis is not evenly spaced or has unknown spacing; temporal subsetting is unavailable.";
+            return false;
+        }
+
+        var step = TimeSpan.FromTicks(stepTicks);
+
+        // Instant request: round to the nearest index.
+        if (reqStart is { } instantStart && reqEnd is { } instantEnd && instantStart == instantEnd)
+        {
+            return ResolveInstant(start, end, lastIndex, step, instantStart, out lowInclusive, out highInclusive, out error);
+        }
+
+        // Interval request (possibly open-ended on either side). Compute the
+        // unclamped index bounds first so a request that lies entirely outside
+        // the axis is rejected rather than silently clamped to an endpoint.
+        var low = 0;
+        if (reqStart is { } t0)
+        {
+            low = CeilDiv(t0 - start, step);
+        }
+
+        var high = lastIndex;
+        if (reqEnd is { } t1)
+        {
+            high = FloorDiv(t1 - start, step);
+        }
+
+        if (high < 0 || low > lastIndex || high < low)
+        {
+            error = "The requested datetime interval does not intersect the coverage time axis.";
+            return false;
+        }
+
+        lowInclusive = Math.Clamp(low, 0, lastIndex);
+        highInclusive = Math.Clamp(high, 0, lastIndex);
+        return true;
+    }
+
+    private static bool ResolveSingleSampleAxis(
+        DateTimeOffset start,
+        DateTimeOffset? reqStart,
+        DateTimeOffset? reqEnd,
+        out int lowInclusive,
+        out int highInclusive,
+        out string? error)
+    {
+        lowInclusive = 0;
+        highInclusive = 0;
+        error = null;
+
+        // Open on both sides, or an interval/instant that brackets the only sample.
+        var lowerOk = reqStart is not { } t0 || t0 <= start;
+        var upperOk = reqEnd is not { } t1 || t1 >= start;
+        if (lowerOk && upperOk)
+        {
+            return true;
+        }
+
+        error = "The requested datetime does not intersect the coverage time axis.";
+        return false;
+    }
+
+    private static bool ResolveInstant(
+        DateTimeOffset start,
+        DateTimeOffset end,
+        int lastIndex,
+        TimeSpan step,
+        DateTimeOffset instant,
+        out int lowInclusive,
+        out int highInclusive,
+        out string? error)
+    {
+        lowInclusive = 0;
+        highInclusive = 0;
+        error = null;
+
+        var halfStep = TimeSpan.FromTicks(step.Ticks / 2);
+        if (instant < start - halfStep || instant > end + halfStep)
+        {
+            error = string.Create(
+                CultureInfo.InvariantCulture,
+                $"The requested datetime is outside the coverage time axis [{start:O}, {end:O}].");
+            return false;
+        }
+
+        var index = RoundDiv(instant - start, step);
+        index = Math.Clamp(index, 0, lastIndex);
+        lowInclusive = index;
+        highInclusive = index;
+        return true;
+    }
+
+    private static int CeilDiv(TimeSpan offset, TimeSpan step)
+    {
+        var ticks = offset.Ticks;
+        var stepTicks = step.Ticks;
+        if (ticks <= 0)
+        {
+            // Floor division toward negative infinity keeps below-axis requests at/under index 0.
+            return (int)Math.Max(long.MinValue + 1, FloorDivTicks(ticks, stepTicks));
+        }
+        return (int)Math.Min(int.MaxValue, (ticks + stepTicks - 1) / stepTicks);
+    }
+
+    private static int FloorDiv(TimeSpan offset, TimeSpan step)
+    {
+        var value = FloorDivTicks(offset.Ticks, step.Ticks);
+        return (int)Math.Clamp(value, int.MinValue, int.MaxValue);
+    }
+
+    private static int RoundDiv(TimeSpan offset, TimeSpan step)
+    {
+        var ticks = offset.Ticks;
+        var stepTicks = step.Ticks;
+        // Round half away from zero on the positive side; below-axis instants floor to 0 via clamp.
+        if (ticks <= 0)
+        {
+            return (int)Math.Clamp(FloorDivTicks(ticks + (stepTicks / 2), stepTicks), int.MinValue, int.MaxValue);
+        }
+        return (int)Math.Min(int.MaxValue, (ticks + (stepTicks / 2)) / stepTicks);
+    }
+
+    private static long FloorDivTicks(long value, long divisor)
+    {
+        var quotient = value / divisor;
+        if ((value % divisor != 0) && ((value < 0) != (divisor < 0)))
+        {
+            quotient--;
+        }
+        return quotient;
+    }
+}

--- a/src/Honua.Core/Features/Raster/ZarrParser/ZarrMetadataExtractor.cs
+++ b/src/Honua.Core/Features/Raster/ZarrParser/ZarrMetadataExtractor.cs
@@ -9,6 +9,7 @@ using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Raster.Multidimensional.Domain;
 
 namespace Honua.Core.Features.Raster.ZarrParser;
 
@@ -72,7 +73,7 @@ public sealed class ZarrMetadataExtractor : IZarrMetadataReader
             throw new InvalidDataException("Zarr store contains no arrays.");
         }
 
-        var (srid, extent, primary, xDim, yDim, tDim) = ResolveStoreGeoreferencing(attrsDoc, arrays);
+        var (srid, extent, primary, xDim, yDim, tDim, temporal) = ResolveStoreGeoreferencing(attrsDoc, arrays);
 
         return new ZarrStoreMetadata(
             ZarrFormat: arrays[0].ZarrFormat,
@@ -82,7 +83,8 @@ public sealed class ZarrMetadataExtractor : IZarrMetadataReader
             PrimaryVariable: primary,
             SpatialXDimension: xDim,
             SpatialYDimension: yDim,
-            TemporalDimension: tDim);
+            TemporalDimension: tDim,
+            Temporal: temporal);
     }
 
     private static string NormalizeRootPath(string rootPath)
@@ -381,7 +383,7 @@ public sealed class ZarrMetadataExtractor : IZarrMetadataReader
         return fallback;
     }
 
-    private static (int Srid, RasterExtent Extent, string? PrimaryVariable, string? XDim, string? YDim, string? TDim)
+    private static (int Srid, RasterExtent Extent, string? PrimaryVariable, string? XDim, string? YDim, string? TDim, TemporalExtent? Temporal)
         ResolveStoreGeoreferencing(JsonDocument? attrsDoc, List<ZarrArrayMetadata> arrays)
     {
         var srid = 0;
@@ -391,6 +393,7 @@ public sealed class ZarrMetadataExtractor : IZarrMetadataReader
         string? xDim = null;
         string? yDim = null;
         string? tDim = null;
+        TemporalExtent? temporal = null;
 
         if (attrsDoc is not null && attrsDoc.RootElement.ValueKind == JsonValueKind.Object)
         {
@@ -431,6 +434,7 @@ public sealed class ZarrMetadataExtractor : IZarrMetadataReader
             xDim = ReadOptionalString(root, "x_dimension");
             yDim = ReadOptionalString(root, "y_dimension");
             tDim = ReadOptionalString(root, "t_dimension");
+            temporal = ResolveTemporalExtent(root, tDim, arrays);
         }
 
         if (string.IsNullOrEmpty(primary) && arrays.Count > 0)
@@ -447,7 +451,105 @@ public sealed class ZarrMetadataExtractor : IZarrMetadataReader
             Srid = srid
         };
 
-        return (srid, extent, primary, xDim, yDim, tDim);
+        return (srid, extent, primary, xDim, yDim, tDim, temporal);
+    }
+
+    /// <summary>
+    /// Builds the store temporal extent from optional <c>.zattrs</c> keys
+    /// <c>t_start</c>, <c>t_end</c>, and a step expressed as either
+    /// <c>t_step</c> (ISO-8601 duration / RFC3339-parseable timespan) or
+    /// <c>t_step_seconds</c> (numeric seconds). Step count is taken from the
+    /// time dimension's length on any array that declares it. Returns null when
+    /// the required attributes are absent or unresolvable.
+    /// </summary>
+    private static TemporalExtent? ResolveTemporalExtent(JsonElement root, string? tDim, List<ZarrArrayMetadata> arrays)
+    {
+        if (string.IsNullOrEmpty(tDim))
+        {
+            return null;
+        }
+
+        if (!TryReadDateTimeOffset(root, "t_start", out var start) ||
+            !TryReadDateTimeOffset(root, "t_end", out var end))
+        {
+            return null;
+        }
+
+        var stepCount = ResolveTemporalStepCount(tDim, arrays);
+        if (stepCount <= 0)
+        {
+            return null;
+        }
+
+        // The step attributes are validated for consistency but the indexer
+        // derives spacing from (start, end, stepCount); we only require that a
+        // step source is present so irregular axes opt out explicitly.
+        if (!TryReadStepSeconds(root, out _))
+        {
+            return null;
+        }
+
+        return new TemporalExtent(start, end, stepCount);
+    }
+
+    private static long ResolveTemporalStepCount(string tDim, List<ZarrArrayMetadata> arrays)
+    {
+        foreach (var array in arrays)
+        {
+            for (var i = 0; i < array.DimensionNames.Length; i++)
+            {
+                if (string.Equals(array.DimensionNames[i], tDim, StringComparison.OrdinalIgnoreCase))
+                {
+                    return array.Shape[i];
+                }
+            }
+        }
+        return 0;
+    }
+
+    private static bool TryReadDateTimeOffset(JsonElement root, string property, out DateTimeOffset value)
+    {
+        value = default;
+        if (!root.TryGetProperty(property, out var el) || el.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+        return DateTimeOffset.TryParse(
+            el.GetString(),
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out value);
+    }
+
+    private static bool TryReadStepSeconds(JsonElement root, out double seconds)
+    {
+        seconds = 0;
+        if (root.TryGetProperty("t_step_seconds", out var secEl) &&
+            secEl.ValueKind == JsonValueKind.Number &&
+            secEl.TryGetDouble(out var parsedSeconds) &&
+            parsedSeconds > 0)
+        {
+            seconds = parsedSeconds;
+            return true;
+        }
+
+        if (root.TryGetProperty("t_step", out var stepEl))
+        {
+            if (stepEl.ValueKind == JsonValueKind.Number && stepEl.TryGetDouble(out var numericStep) && numericStep > 0)
+            {
+                seconds = numericStep;
+                return true;
+            }
+            if (stepEl.ValueKind == JsonValueKind.String &&
+                TimeSpan.TryParse(stepEl.GetString(), CultureInfo.InvariantCulture, out var span) &&
+                span.Ticks > 0)
+            {
+                seconds = span.TotalSeconds;
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string? ReadOptionalString(JsonElement root, string property)

--- a/src/Honua.Protocols.OgcApi/Coverages/Handlers/OgcCoveragesHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Coverages/Handlers/OgcCoveragesHandler.cs
@@ -918,7 +918,7 @@ internal sealed class OgcCoveragesHandler
 
         if (context.Request.Query.ContainsKey("datetime"))
         {
-            return "The datetime parameter is not supported by this OGC API Coverages implementation.";
+            return "The datetime parameter is not applicable to a single-raster coverage. Temporal subsetting is supported only for multidimensional (Zarr) coverages with a time axis.";
         }
 
         if (context.Request.Query.ContainsKey("subset"))

--- a/src/Honua.Protocols.OgcApi/Coverages/Services/ZarrCoverageService.cs
+++ b/src/Honua.Protocols.OgcApi/Coverages/Services/ZarrCoverageService.cs
@@ -38,7 +38,7 @@ internal sealed class ZarrCoverageService
     private const long MaxCoverageOutputBytes = 16L * 1024L * 1024L;
 
     private static readonly ImmutableHashSet<string> SupportedQueryParameters =
-        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "f", "subset", "properties");
+        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "f", "subset", "properties", "datetime");
 
     private static readonly string[] AcceptableMediaTypes = [CoverageJsonContentType, MediaTypes.Json];
 
@@ -217,6 +217,11 @@ internal sealed class ZarrCoverageService
         if (!TryParseSubsets(context.Request.Query["subset"], out var subsets, out var subsetError))
         {
             return StandardErrorHelpers.CreateBadRequest(context, subsetError!);
+        }
+
+        if (!TryApplyTemporalSubset(context, metadata, subsets, out var temporalError))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, temporalError!);
         }
 
         if (!ZarrCoverageSubsetPlanner.TryPlan(metadata, variable, subsets, MaxCoverageOutputBytes, out var plan, out var planError))
@@ -418,6 +423,71 @@ internal sealed class ZarrCoverageService
         }
 
         variable = tokens[0];
+        return true;
+    }
+
+    /// <summary>
+    /// Translates an OGC <c>datetime</c> query parameter into a synthetic
+    /// grid-index subset over the store's time dimension and appends it to
+    /// <paramref name="subsets"/>. No-ops when <c>datetime</c> is absent. Requires
+    /// the store to declare a resolvable time axis, and rejects a request that
+    /// also subsets the time dimension explicitly via <c>subset=</c>.
+    /// </summary>
+    private static bool TryApplyTemporalSubset(
+        HttpContext context,
+        ZarrStoreMetadata metadata,
+        List<ZarrCoverageDimensionSubset> subsets,
+        out string? error)
+    {
+        error = null;
+        var datetime = OgcCommonUtilities.GetQueryValue(context.Request, "datetime");
+        if (string.IsNullOrWhiteSpace(datetime))
+        {
+            return true;
+        }
+
+        if (metadata.TemporalDimension is not { } timeDimension || metadata.Temporal is not { } temporal)
+        {
+            error = "The datetime parameter is not supported for this coverage collection because it does not declare a time axis.";
+            return false;
+        }
+
+        foreach (var subset in subsets)
+        {
+            if (string.Equals(subset.Dimension, timeDimension, StringComparison.OrdinalIgnoreCase))
+            {
+                error = $"Specify the time dimension '{timeDimension}' with either datetime or subset, not both.";
+                return false;
+            }
+        }
+
+        if (!OgcTemporalFilterParser.TryParseRange(datetime, out var reqStart, out var reqEnd, out var parseError))
+        {
+            error = parseError ?? "Invalid datetime parameter.";
+            return false;
+        }
+
+        if (reqStart is null && reqEnd is null)
+        {
+            return true;
+        }
+
+        if (!CfTimeAxisIndexer.TryResolveTimeIndexRange(
+                temporal.Start,
+                temporal.End,
+                temporal.StepCount,
+                reqStart,
+                reqEnd,
+                out var low,
+                out var high,
+                out var indexError))
+        {
+            error = indexError ?? "The requested datetime could not be resolved against the coverage time axis.";
+            return false;
+        }
+
+        // OGC subset bounds are closed intervals; the planner expects an exclusive stop.
+        subsets.Add(new ZarrCoverageDimensionSubset(timeDimension, low, high + 1));
         return true;
     }
 

--- a/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/CfTimeAxisIndexerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/CfTimeAxisIndexerTests.cs
@@ -1,0 +1,201 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Globalization;
+using FluentAssertions;
+using Honua.Core.Features.Raster.ZarrParser;
+using Xunit;
+
+namespace Honua.Core.Tests.Raster.ZarrParser;
+
+public class CfTimeAxisIndexerTests
+{
+    // Axis: 5 daily samples, 2026-01-01 .. 2026-01-05 (step = 1 day).
+    private static readonly DateTimeOffset AxisStart = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset AxisEnd = new(2026, 1, 5, 0, 0, 0, TimeSpan.Zero);
+    private const long FiveSamples = 5;
+
+    [Theory]
+    [InlineData("2026-01-01T00:00:00Z", 0)]
+    [InlineData("2026-01-03T00:00:00Z", 2)]
+    [InlineData("2026-01-05T00:00:00Z", 4)]
+    [InlineData("2026-01-02T10:00:00Z", 1)] // rounds down to nearest (10h < 12h)
+    [InlineData("2026-01-02T14:00:00Z", 2)] // rounds up to nearest (14h > 12h)
+    public void Instant_RoundsToNearestIndex(string instant, int expectedIndex)
+    {
+        var t = DateTimeOffset.Parse(instant, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
+
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisEnd, FiveSamples, t, t, out var low, out var high, out var error);
+
+        ok.Should().BeTrue(error);
+        low.Should().Be(expectedIndex);
+        high.Should().Be(expectedIndex);
+    }
+
+    [Fact]
+    public void Interval_UsesCeilForLowAndFloorForHigh()
+    {
+        // [2026-01-01T12:00Z, 2026-01-04T12:00Z] -> low=ceil(0.5)=1, high=floor(3.5)=3
+        var t0 = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var t1 = new DateTimeOffset(2026, 1, 4, 12, 0, 0, TimeSpan.Zero);
+
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisEnd, FiveSamples, t0, t1, out var low, out var high, out var error);
+
+        ok.Should().BeTrue(error);
+        low.Should().Be(1);
+        high.Should().Be(3);
+    }
+
+    [Fact]
+    public void Interval_ExactBoundsSelectFullRange()
+    {
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisEnd, FiveSamples, AxisStart, AxisEnd, out var low, out var high, out var error);
+
+        ok.Should().BeTrue(error);
+        low.Should().Be(0);
+        high.Should().Be(4);
+    }
+
+    [Fact]
+    public void OpenEndedStart_SelectsFromIndexZero()
+    {
+        // ../2026-01-03 -> low=0, high=floor(2)=2
+        var t1 = new DateTimeOffset(2026, 1, 3, 0, 0, 0, TimeSpan.Zero);
+
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisEnd, FiveSamples, null, t1, out var low, out var high, out var error);
+
+        ok.Should().BeTrue(error);
+        low.Should().Be(0);
+        high.Should().Be(2);
+    }
+
+    [Fact]
+    public void OpenEndedEnd_SelectsToLastIndex()
+    {
+        // 2026-01-03/.. -> low=2, high=lastIndex=4
+        var t0 = new DateTimeOffset(2026, 1, 3, 0, 0, 0, TimeSpan.Zero);
+
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisEnd, FiveSamples, t0, null, out var low, out var high, out var error);
+
+        ok.Should().BeTrue(error);
+        low.Should().Be(2);
+        high.Should().Be(4);
+    }
+
+    [Fact]
+    public void Instant_OutOfRange_ReturnsError()
+    {
+        var t = new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisEnd, FiveSamples, t, t, out _, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Interval_BeforeAxis_ReturnsError()
+    {
+        var t0 = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var t1 = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisEnd, FiveSamples, t0, t1, out _, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Interval_AfterAxis_ReturnsError()
+    {
+        var t0 = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var t1 = new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisEnd, FiveSamples, t0, t1, out _, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Interval_SpanningAxis_ClampsToFullRange()
+    {
+        var t0 = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var t1 = new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisEnd, FiveSamples, t0, t1, out var low, out var high, out var error);
+
+        ok.Should().BeTrue(error);
+        low.Should().Be(0);
+        high.Should().Be(4);
+    }
+
+    [Fact]
+    public void SingleSample_BracketingRequest_SelectsIndexZero()
+    {
+        var t0 = new DateTimeOffset(2025, 12, 1, 0, 0, 0, TimeSpan.Zero);
+        var t1 = new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisStart, stepCount: 1, t0, t1, out var low, out var high, out var error);
+
+        ok.Should().BeTrue(error);
+        low.Should().Be(0);
+        high.Should().Be(0);
+    }
+
+    [Fact]
+    public void SingleSample_ExactInstant_SelectsIndexZero()
+    {
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisStart, stepCount: 1, AxisStart, AxisStart, out var low, out var high, out var error);
+
+        ok.Should().BeTrue(error);
+        low.Should().Be(0);
+        high.Should().Be(0);
+    }
+
+    [Fact]
+    public void SingleSample_NonIntersectingInterval_ReturnsError()
+    {
+        var t0 = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var t1 = new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisStart, stepCount: 1, t0, t1, out _, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ZeroStepCount_ReturnsError()
+    {
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisEnd, stepCount: 0, AxisStart, AxisEnd, out _, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void NonPositiveSpacing_ReturnsError()
+    {
+        // start == end with more than one declared sample -> spacing is zero/unknown.
+        var ok = CfTimeAxisIndexer.TryResolveTimeIndexRange(
+            AxisStart, AxisStart, stepCount: 5, AxisStart, AxisStart, out _, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().NotBeNull();
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrFixtureBuilder.cs
+++ b/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrFixtureBuilder.cs
@@ -88,6 +88,55 @@ internal static class ZarrFixtureBuilder
         return objects;
     }
 
+    /// <summary>
+    /// Builds a grouped store with a 3D (time, y, x) variable and optional
+    /// temporal <c>.zattrs</c> keys. When <paramref name="includeTemporalAttrs"/>
+    /// is false the time-axis attributes are omitted so the extractor reports a
+    /// null temporal extent. Chunk payloads are not written (metadata-only fixture).
+    /// </summary>
+    public static Dictionary<string, byte[]> BuildGroupedWithTime(
+        string root,
+        int timeSteps,
+        int rows,
+        int cols,
+        bool includeTemporalAttrs)
+    {
+        var objects = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        objects[root + "/.zgroup"] = Encoding.UTF8.GetBytes("{\"zarr_format\":2}");
+
+        var attrs = new StringBuilder();
+        attrs.Append('{')
+            .Append("\"variables\":[\"temperature\"],")
+            .Append("\"primary_variable\":\"temperature\",")
+            .Append("\"crs_wkid\":4326,")
+            .Append("\"extent\":[-180,-90,180,90],")
+            .Append("\"x_dimension\":\"x\",")
+            .Append("\"y_dimension\":\"y\",")
+            .Append("\"t_dimension\":\"time\"");
+        if (includeTemporalAttrs)
+        {
+            attrs.Append(",\"t_start\":\"2026-01-01T00:00:00Z\"")
+                .Append(",\"t_end\":\"2026-01-05T00:00:00Z\"")
+                .Append(",\"t_step_seconds\":86400");
+        }
+        attrs.Append('}');
+        objects[root + "/.zattrs"] = Encoding.UTF8.GetBytes(attrs.ToString());
+
+        var arrayRoot = root + "/temperature";
+        var zarray = "{"
+            + "\"chunks\":[" + timeSteps + "," + rows + "," + cols + "],"
+            + "\"compressor\":null,"
+            + "\"dtype\":\"<f4\","
+            + "\"fill_value\":0,"
+            + "\"filters\":null,"
+            + "\"order\":\"C\","
+            + "\"shape\":[" + timeSteps + "," + rows + "," + cols + "],"
+            + "\"zarr_format\":2}";
+        objects[arrayRoot + "/.zarray"] = Encoding.UTF8.GetBytes(zarray);
+        objects[arrayRoot + "/.zattrs"] = Encoding.UTF8.GetBytes("{\"_ARRAY_DIMENSIONS\":[\"time\",\"y\",\"x\"]}");
+        return objects;
+    }
+
     public static Dictionary<string, byte[]> BuildInvalidJson(string root)
     {
         var objects = new Dictionary<string, byte[]>(StringComparer.Ordinal);

--- a/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrMetadataExtractorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrMetadataExtractorTests.cs
@@ -70,6 +70,45 @@ public class ZarrMetadataExtractorTests
     }
 
     [Fact]
+    public async Task ReadMetadataAsync_TemporalAttrsPresent_PopulatesTemporalExtent()
+    {
+        var objects = ZarrFixtureBuilder.BuildGroupedWithTime(
+            root: "stores/timeseries",
+            timeSteps: 5,
+            rows: 8,
+            cols: 8,
+            includeTemporalAttrs: true);
+        var reader = new InMemoryZarrRangeReader(objects);
+        var extractor = new ZarrMetadataExtractor();
+
+        var metadata = await extractor.ReadMetadataAsync(reader, "bucket", "stores/timeseries");
+
+        metadata.TemporalDimension.Should().Be("time");
+        metadata.Temporal.Should().NotBeNull();
+        metadata.Temporal!.Start.Should().Be(new System.DateTimeOffset(2026, 1, 1, 0, 0, 0, System.TimeSpan.Zero));
+        metadata.Temporal.End.Should().Be(new System.DateTimeOffset(2026, 1, 5, 0, 0, 0, System.TimeSpan.Zero));
+        metadata.Temporal.StepCount.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task ReadMetadataAsync_TemporalAttrsAbsent_TemporalExtentNull()
+    {
+        var objects = ZarrFixtureBuilder.BuildGroupedWithTime(
+            root: "stores/timeseries-notime",
+            timeSteps: 5,
+            rows: 8,
+            cols: 8,
+            includeTemporalAttrs: false);
+        var reader = new InMemoryZarrRangeReader(objects);
+        var extractor = new ZarrMetadataExtractor();
+
+        var metadata = await extractor.ReadMetadataAsync(reader, "bucket", "stores/timeseries-notime");
+
+        metadata.TemporalDimension.Should().Be("time");
+        metadata.Temporal.Should().BeNull();
+    }
+
+    [Fact]
     public async Task ReadMetadataAsync_InvalidJson_ThrowsInvalidData()
     {
         var objects = ZarrFixtureBuilder.BuildInvalidJson("stores/broken");

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Coverages/OgcCoveragesEndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Coverages/OgcCoveragesEndpointsTests.cs
@@ -211,7 +211,7 @@ public sealed class OgcCoveragesEndpointsTests : IAsyncLifetime
     {
         var invalidRequests = new[]
         {
-            ("datetime=2026-04-29T00:00:00Z", "datetime"),
+            ("datetime=2026-04-29T00:00:00Z", "not applicable to a single-raster coverage"),
             ("subset=x(1,2)", "subset"),
             ("scale-axes=x(64)", "scale-axes"),
             ("f=netcdf", "NetCDF"),


### PR DESCRIPTION
First-PR slice of **#1790** (OGC API Coverages + WCS read parity). Adds `datetime` temporal subsetting on `GET /ogc/coverages/collections/{id}/coverage` for Zarr/multidimensional coverages â€” the datacube time-series unlock that pairs with the #1756 cluster and EDR (#1757).

### What's included
- **`CfTimeAxisIndexer`** (Core, pure/AOT-safe): maps a `datetime` instant or interval to a time-axis index range on an evenly-spaced CF axis (`step = (endâˆ’start)/(stepCountâˆ’1)`). Instant â†’ nearest index with `[startâˆ’step/2, end+step/2]` range rejection; interval â†’ ceil(low)/floor(high) on the *unclamped* bounds (out-of-axis intervals are rejected, not silently clamped); open-ended `../t1` and `t0/..`; `stepCount==1` single-sample; irregular/unknown axis (`stepCount<1` or `stepâ‰¤0`) â†’ clean error.
- **`ZarrStoreMetadata.Temporal`** (optional `TemporalExtent`) populated by `ZarrMetadataExtractor` from `.zattrs` (`t_start`/`t_end` + `t_step`/`t_step_seconds`); null when absent (irregular axes opt out explicitly).
- **`ZarrCoverageService`**: `datetime` added to supported params; parsed via the shared `OgcTemporalFilterParser.TryParseRange`; requires a discovered time axis (else `400`); emits a synthetic time-dimension `subset` consumed by the existing planner/reader; rejects conflict when an explicit `subset=` also targets the time dim.
- **`OgcCoveragesHandler`**: the blanket single-raster `datetime` rejection replaced with an accurate message.

### Testing
Build clean (warnings-as-errors). 26 Core unit (indexer + extractor) + 7 OGC Coverages endpoint tests â€” independently re-verified. The end-to-end Zarr temporal *pixel* read needs a servable Zarr fixture + cloud range reader (cloud-only, same as #1756); the indexer math, metadata extraction, parameter acceptance, and 400/conflict branches are all locally verified.

### Scope / non-goals (deferred to #1790 follow-ups)
- **WCS 2.0 untouched** â€” `RasterQuery`/`ExportImageAsync`/WCS handlers not modified, so WCS 2.0 CITE stays 82/82.
- Deferred: WCS temporal subsetting, interpolation/resampling selection, CoverageJSON-from-WCS, and raster temporal-mosaic selection on the coverage path.

Part of #1790.

Closes #1790. Remaining scope tracked in #1834.