### PR TITLE
ci: PR merge train + flaky auto-rerun (stop hand-babysitting PRs)

### DIFF
--- a/.github/workflows/auto-rerun-flaky.yml
+++ b/.github/workflows/auto-rerun-flaky.yml
@@ -1,0 +1,69 @@
+name: Auto-rerun flaky CI
+
+# Gives a PR's CI exactly ONE automatic retry when the only failures are in the
+# known-flaky integration/infra shards (transient Postgres `40P01 deadlock`,
+# Testcontainers/Docker hiccups) and NOT in any deterministic gate (build, format,
+# analyze, CodeQL, template, router, mergeability). A real code/logic failure in a
+# deterministic job is never given a free pass; a genuinely-broken integration test
+# costs at most one extra run before it fails again and sticks.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  rerun:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt == 1 &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const run = context.payload.workflow_run;
+
+            const { data: jobsResp } = await github.rest.actions.listJobsForWorkflowRun({
+              owner, repo, run_id: run.id, per_page: 100, filter: 'latest',
+            });
+            const failed = jobsResp.jobs
+              .filter(j => j.conclusion === 'failure')
+              .map(j => j.name);
+
+            if (failed.length === 0) {
+              core.info('No failed jobs found (already rerun or transient list) — skipping.');
+              return;
+            }
+
+            // Deterministic gates — a failure here is real, never auto-rerun.
+            const SOLID = [
+              /Build & Format/i, /\bFormat\b/i, /Analyze/i, /CodeQL/i,
+              /PR Template/i, /Router/i, /Mergeability/i, /CI Gate/i,
+              /AOT/i, /Package Compatibility/i, /Type Check/i,
+            ];
+            // Known-flaky integration/infra shards — transient, eligible for one retry.
+            const FLAKY = [
+              /Server Tests/i, /OGC API/i, /Postgres Compatibility/i,
+              /Docker Build/i, /Integration Tests/i, /Browser/i, /MCP/i,
+            ];
+
+            const anySolid = failed.some(n => SOLID.some(r => r.test(n)));
+            if (anySolid) {
+              core.info(`Deterministic gate failed (${failed.join(', ')}) — not a flake, no rerun.`);
+              return;
+            }
+            const allFlaky = failed.every(n => FLAKY.some(r => r.test(n)));
+            if (!allFlaky) {
+              core.info(`Failures not all in the known-flaky set (${failed.join(', ')}) — no auto-rerun.`);
+              return;
+            }
+
+            core.info(`Re-running failed flaky jobs once: ${failed.join(', ')}`);
+            await github.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: run.id });

--- a/.github/workflows/pr-merge-train.yml
+++ b/.github/workflows/pr-merge-train.yml
@@ -1,0 +1,90 @@
+name: PR merge train
+
+# Keeps open PRs flowing to trunk without a human babysitting "update the branch"
+# or clicking merge. With strict (up-to-date-before-merge) branch protection, every
+# PR goes stale each time another merges; this train does ONE action per trigger —
+# merge the oldest green + up-to-date PR, or if none is ready, freshen the next
+# green-but-behind PR — so it drains serially (no runner storm) and re-triggers
+# itself (a merge pushes trunk; an update completes a check_suite).
+#
+# Safety: it only ever merges a PR GitHub reports as `clean` (all required checks
+# green AND up to date), and only updates PRs that are `behind` but otherwise
+# mergeable. Red/draft/conflicting PRs are never touched.
+
+on:
+  push:
+    branches: [trunk]
+  check_suite:
+    types: [completed]
+  schedule:
+    - cron: '*/15 * * * *'   # backstop in case an event is missed
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+concurrency:
+  group: pr-merge-train
+  cancel-in-progress: false
+
+jobs:
+  train:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+            // mergeable_state is computed async; poll past 'unknown'.
+            async function fullState(number) {
+              for (let i = 0; i < 5; i++) {
+                const { data } = await github.rest.pulls.get({ owner, repo, pull_number: number });
+                if (data.mergeable_state !== 'unknown') return data;
+                await sleep(2500);
+              }
+              return (await github.rest.pulls.get({ owner, repo, pull_number: number })).data;
+            }
+
+            const { data: list } = await github.rest.pulls.list({
+              owner, repo, state: 'open', base: 'trunk', per_page: 100,
+            });
+            const open = list.filter(p => !p.draft)
+                             .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+
+            // 1) Merge the first CLEAN PR (green + up to date). One per run — the
+            //    resulting trunk push re-triggers the train for the next.
+            for (const pr of open) {
+              const full = await fullState(pr.number);
+              if (full.mergeable_state === 'clean') {
+                try {
+                  await github.rest.pulls.merge({
+                    owner, repo, pull_number: pr.number, merge_method: 'squash',
+                  });
+                  core.info(`Merged #${pr.number} — ${pr.title}`);
+                  return;
+                } catch (e) {
+                  core.warning(`Merge #${pr.number} failed: ${e.message}`);
+                }
+              }
+            }
+
+            // 2) Nothing clean — freshen the oldest green-but-behind PR to tee up
+            //    the next merge (its CI completion re-triggers the train).
+            for (const pr of open) {
+              const full = await fullState(pr.number);
+              if (full.mergeable_state === 'behind') {
+                try {
+                  await github.rest.pulls.updateBranch({ owner, repo, pull_number: pr.number });
+                  core.info(`Updated #${pr.number} to trunk — ${pr.title}`);
+                  return;
+                } catch (e) {
+                  core.warning(`Update #${pr.number} failed: ${e.message}`);
+                }
+              }
+            }
+
+            core.info('Merge train idle: nothing clean to merge or behind to update.');


### PR DESCRIPTION
## Summary
Removes the human from the mechanical PR-remediation loop — "update the branch", "rerun the flake", "click merge" — that strict (up-to-date-before-merge) branch protection otherwise makes constant.

## Changes Made
- **`pr-merge-train.yml`** — on trunk push / check_suite completion / 15-min backstop, does exactly ONE action: squash-merge the oldest PR GitHub reports as `clean` (green + up to date), or if none is ready, `update-branch` the oldest green-but-behind PR. Serial by construction (one action per trigger, self-retriggering) so there's no runner storm and it plays nice with strict protection. Never touches red, draft, or conflicting PRs.
- **`auto-rerun-flaky.yml`** — gives a PR's CI one automatic retry when the *only* failures are in known-flaky integration/infra shards (transient `40P01 deadlock`, Docker/Testcontainers) and never when a deterministic gate (build/format/analyze/template/CI Gate/AOT) fails.

## Breaking Changes
None. Additive CI automation; both workflows only act on PRs that already satisfy branch protection.

Related to #1758

- [x] Pre-PR checks delegated to CI (scripts/ci/pre-pr-check.sh re-runs in-pipeline)