### PR TITLE
ci: gate merge train on opt-in auto-merge label

### DIFF
--- a/.github/workflows/pr-merge-train.yml
+++ b/.github/workflows/pr-merge-train.yml
@@ -1,11 +1,13 @@
 name: PR merge train
 
-# Keeps open PRs flowing to trunk without a human babysitting "update the branch"
-# or clicking merge. With strict (up-to-date-before-merge) branch protection, every
-# PR goes stale each time another merges; this train does ONE action per trigger —
-# merge the oldest green + up-to-date PR, or if none is ready, freshen the next
-# green-but-behind PR — so it drains serially (no runner storm) and re-triggers
-# itself (a merge pushes trunk; an update completes a check_suite).
+# Keeps opted-in PRs flowing to trunk without a human babysitting "update the branch"
+# or clicking merge. A PR opts in by carrying the `auto-merge` label; everything else
+# (drafts, WIP, other agents' in-flight branches) is left untouched. With strict
+# (up-to-date-before-merge) branch protection, every PR goes stale each time another
+# merges; this train does ONE action per trigger — merge the oldest labeled green +
+# up-to-date PR, or if none is ready, freshen the next labeled green-but-behind PR —
+# so it drains serially (no runner storm) and re-triggers itself (a merge pushes
+# trunk; an update completes a check_suite).
 #
 # Safety: it only ever merges a PR GitHub reports as `clean` (all required checks
 # green AND up to date), and only updates PRs that are `behind` but otherwise
@@ -49,10 +51,14 @@ jobs:
               return (await github.rest.pulls.get({ owner, repo, pull_number: number })).data;
             }
 
+            // Opt-in: the train only ever touches PRs explicitly marked ready with the
+            // `auto-merge` label. WIP / drafts / someone else's in-flight branches are
+            // left strictly alone until their owner adds the label.
+            const LABEL = 'auto-merge';
             const { data: list } = await github.rest.pulls.list({
               owner, repo, state: 'open', base: 'trunk', per_page: 100,
             });
-            const open = list.filter(p => !p.draft)
+            const open = list.filter(p => !p.draft && p.labels.some(l => l.name === LABEL))
                              .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
 
             // 1) Merge the first CLEAN PR (green + up to date). One per run — the


### PR DESCRIPTION
## Summary
Make the PR merge train opt-in: it only merges/updates PRs carrying the `auto-merge` label, so in-flight work (drafts, other agents' feature branches) is never merged out from under its author.

## Changes Made
- `pr-merge-train.yml`: filter candidate PRs to non-draft + `auto-merge`-labeled on both the merge and update paths.

## Breaking Changes
None — tightens the train's scope.

Related to #1816

- [x] Pre-PR checks delegated to CI (scripts/ci/pre-pr-check.sh re-runs in-pipeline)