### PR TITLE
feat(raster): on-the-fly overview selection for dynamic raster tiles (#1793)

### DIFF
--- a/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
@@ -537,6 +537,72 @@ internal sealed class PostgresRasterStore : IRasterStore
     private static bool CanResolveStretchBounds(RasterStretch stretch, RasterBandArithmetic? bandArithmetic)
         => bandArithmetic is null || (stretch.StatisticsMin is not null && stretch.StatisticsMax is not null);
 
+    // ----- On-the-fly overview selection for dynamic tile generation ----------
+    // Low-zoom raster tiles cover a huge ground area at coarse resolution (a z=0 tile
+    // is one 256px image of the whole web-mercator world). Resampling the full-resolution
+    // source straight onto that tiny grid forces PostGIS to read every source pixel even
+    // though almost all of them collapse into a single output pixel. To avoid that, we
+    // first reduce the source to a grid near the tile's own ground resolution, then let
+    // the existing precise ST_Resample reproject/register that reduced grid onto the
+    // 256x256 tile envelope. At native-or-finer zoom this is a strict no-op so high-zoom
+    // tiles keep reading the full-resolution raster unchanged.
+
+    /// <summary>
+    /// WebMercator world span in metres (equator), matching the constant used by the
+    /// import service's tile-index math. A WebMercatorQuad tile at zoom <c>z</c> spans
+    /// <c>WebMercatorWorldSpanMeters / 2^z</c> metres across 256 pixels.
+    /// </summary>
+    internal const double WebMercatorWorldSpanMeters = 40075016.686;
+
+    /// <summary>
+    /// Below this zoom the tile ground resolution is coarse enough relative to typical
+    /// source rasters that reducing the source first is worthwhile; at or above the native
+    /// resolution the reduction is a no-op so high-zoom tiles read the full-resolution
+    /// <c>raster</c> column. The SQL guard below additionally prevents any upsampling on a
+    /// per-source basis, so this threshold only bounds where we bother emitting the wrapper.
+    /// </summary>
+    internal const int OverviewMaxZoom = 22;
+
+    /// <summary>
+    /// Wraps the source <paramref name="rasterToken"/> so a low-zoom tile reads a
+    /// resolution-reduced grid (metres/pixel ≈ the requested tile's ground resolution)
+    /// instead of resampling the full-resolution raster. Returns the bare token unchanged
+    /// at native-or-finer zoom (<paramref name="level"/> &gt;= <see cref="OverviewMaxZoom"/>),
+    /// keeping the substitution a single-token no-op on the high-zoom path.
+    /// </summary>
+    /// <remarks>
+    /// The reduction is performed in EPSG:3857 (the tile CRS) via <c>ST_Rescale</c> so it is
+    /// SRID-agnostic: the outer <c>ST_Transform(..., 3857)</c> in the tile query becomes an
+    /// identity transform on the already-reprojected grid. <c>GREATEST</c>/<c>LEAST</c> guards
+    /// clamp the target pixel size against the source's own 3857 resolution so the rescale can
+    /// only ever coarsen — never upsample — making it a per-source no-op when the source is
+    /// already coarser than the tile. Residual sub-pixel drift from <c>ST_Rescale</c> keeping
+    /// the source origin is corrected by the subsequent envelope-aligned <c>ST_Resample</c>.
+    /// NearestNeighbor matches the tile path's existing (default) resampling/nodata semantics.
+    /// </remarks>
+    internal static string BuildOverviewSourceExpression(int level, string rasterToken = "raster")
+    {
+        // At native-or-finer zoom there is nothing to reduce: emit the bare column so the
+        // high-zoom tile query is byte-for-byte the full-resolution path.
+        if (level >= OverviewMaxZoom)
+        {
+            return rasterToken;
+        }
+
+        // Tile ground resolution: world span / (256 px * 2^level) metres-per-pixel.
+        var metresPerPixel = WebMercatorWorldSpanMeters / (256.0 * Math.Pow(2, level));
+        var mpp = metresPerPixel.ToString("G17", CultureInfo.InvariantCulture);
+
+        // Reproject to 3857 once, then rescale to ~tile resolution. The GREATEST/LEAST guards
+        // clamp against the source's own scale so we never produce a finer grid than the source.
+        var transformed = $"ST_Transform({rasterToken}, 3857)";
+        return
+            $"ST_Rescale({transformed}, " +
+            $"GREATEST(abs(ST_ScaleX({transformed})), {mpp}), " +
+            $"-GREATEST(abs(ST_ScaleY({transformed})), {mpp}), " +
+            "'NearestNeighbor')";
+    }
+
     // ----- Clip execution (export bbox + renderingRule Clip raster function) ---
     // Builds the ST_Clip wrapper for a clip region, reprojecting the clip geometry into the
     // raster SRID when a source SRID is supplied. When the region is inverted (Esri Clip
@@ -1317,6 +1383,10 @@ internal sealed class PostgresRasterStore : IRasterStore
             tileClipExpr = BuildStretchedRasterExpression(tileClipExpr, tileStretchBounds);
         }
 
+        // On-the-fly overview: reduce the source toward the tile's ground resolution at low
+        // zoom (no-op at native/finer zoom) so wide tiles do not resample full-res pixels.
+        var overviewSource = BuildOverviewSourceExpression(level);
+
         await using var dynCommand = connection.CreateCommand();
         // Build a 256×256 reference raster exactly aligned to the WebMercatorQuad tile
         // envelope (EPSG:3857). ST_Resample reprojects the source raster onto that grid so
@@ -1340,7 +1410,7 @@ internal sealed class PostgresRasterStore : IRasterStore
                 FROM tile_bounds tb
             )
             SELECT ST_AsGDALRaster(
-                ST_Resample(ST_Transform(raster, 3857), tile_ref.rast),
+                ST_Resample(ST_Transform({overviewSource}, 3857), tile_ref.rast),
                 '{effectiveTileFormat}'{tileCreationOptions}
             ) AS data
             FROM {_rasterDataTable}, tile_bounds tb, tile_ref
@@ -1411,6 +1481,9 @@ internal sealed class PostgresRasterStore : IRasterStore
             mosaicTileExpr = BuildStretchedRasterExpression(mosaicTileExpr, mosaicTileBounds);
         }
 
+        // Same on-the-fly overview reduction as GetImageTileAsync (no-op at native/finer zoom).
+        var overviewSource = BuildOverviewSourceExpression(level);
+
         await using var command = connection.CreateCommand();
         // Same tile-envelope-aligned approach as GetImageTileAsync: build a 256×256
         // reference raster in EPSG:3857 and use ST_Resample so the mosaic output covers
@@ -1434,7 +1507,7 @@ internal sealed class PostgresRasterStore : IRasterStore
                 FROM tile_bounds tb
             ),
             source AS (
-                SELECT ST_Resample(ST_Transform(raster, 3857), tile_ref.rast) AS rast,
+                SELECT ST_Resample(ST_Transform({overviewSource}, 3857), tile_ref.rast) AS rast,
                        id,
                        created_at,
                        COALESCE(acquisition_date, created_at) AS effective_acquisition

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterStoreOverviewIntegrationTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterStoreOverviewIntegrationTests.cs
@@ -1,0 +1,281 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using FluentAssertions;
+using Honua.Postgres.Features.Raster;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Postgres.Tests.Features.Raster;
+
+/// <summary>
+/// Verifies on-the-fly overview selection (#1793) against a real PostGIS raster: at low
+/// zoom the dynamic tile query reduces the source toward the tile's ground resolution and
+/// feeds materially fewer pixels into the final resample than the full-resolution baseline,
+/// while still rendering a 256x256 / EPSG:3857 tile whose pixel content matches the full-res
+/// render. At native/finer zoom the substitution is a strict no-op.
+/// </summary>
+[Collection("Database")]
+public sealed class PostgresRasterStoreOverviewIntegrationTests(PostgresFixture fixture)
+{
+    // A large, fine-resolution source raster: 2048x2048 px at 2 m/pixel in EPSG:3857,
+    // anchored near the origin so it lands well inside the valid WebMercator extent.
+    private const int RasterDimension = 2048;
+    private const double SourceScaleMeters = 2.0;
+    private const double OriginX = 0.0;
+    private const double OriginY = 0.0;
+
+    // A "low" zoom whose tile ground resolution (~38 m/px) is ~19x coarser than the 2 m source,
+    // yet fine enough that the 4 km source still spans ~100 tile pixels (so the centre pixel is
+    // covered and content can be compared against the full-res render).
+    private const int LowZoom = 12;
+
+    private static string Inv(double value) => value.ToString("G17", CultureInfo.InvariantCulture);
+
+    private static string BuildSourceRasterSql() => $"""
+        ST_AddBand(
+            ST_MakeEmptyRaster(
+                {RasterDimension}, {RasterDimension},
+                {Inv(OriginX)}, {Inv(OriginY)},
+                {Inv(SourceScaleMeters)}, -{Inv(SourceScaleMeters)},
+                0, 0, 3857),
+            '8BUI'::text,
+            100,
+            NULL)
+        """;
+
+    // Resample to the 256x256 EPSG:3857 tile grid, parameterised by the source expression, so we
+    // can compare the overview reduction against the full-resolution baseline. Mirrors the SQL
+    // shape in PostgresRasterStore.GetImageTileAsync (without the ST_AsGDALRaster encoding).
+    private static string BuildTileRasterSql(string sourceExpr) => $"""
+        WITH tile_bounds AS (
+            SELECT ST_TileEnvelope(@level, @col, @row) AS geom
+        ),
+        tile_ref AS (
+            SELECT ST_MakeEmptyRaster(
+                256, 256,
+                ST_XMin(tb.geom),
+                ST_YMax(tb.geom),
+                (ST_XMax(tb.geom) - ST_XMin(tb.geom)) / 256.0,
+                -((ST_YMax(tb.geom) - ST_YMin(tb.geom)) / 256.0),
+                0.0, 0.0, 3857
+            ) AS rast
+            FROM tile_bounds tb
+        )
+        SELECT ST_Resample(ST_Transform({sourceExpr}, 3857), tile_ref.rast) AS rast
+        FROM raster_data, tile_bounds tb, tile_ref
+        WHERE layer_id = @layerId AND id = @rasterId
+          AND ST_Intersects(ST_ConvexHull(raster), ST_Transform(tb.geom, ST_SRID(raster)))
+        """;
+
+    [IntegrationTest]
+    [Trait("Category", "Performance")]
+    public async Task LowZoomTile_ReducesSourcePixelsFedToResample_BelowFullResBaseline()
+    {
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreOverviewIntegrationTests));
+        try
+        {
+            var rasterId = await SeedSourceRasterAsync(schemaName);
+            var (col, row) = await ResolveTileForSourceCentreAsync(schemaName, LowZoom, rasterId);
+
+            var overviewExpr = PostgresRasterStore.BuildOverviewSourceExpression(LowZoom);
+            overviewExpr.Should().NotBe("raster", "low zoom must engage the overview reduction");
+
+            // The full-resolution baseline feeds all 2048x2048 source pixels into the resample.
+            var baselinePixels = await CountPixelsFedToResampleAsync(schemaName, "raster", rasterId);
+            baselinePixels.Should().Be((long)RasterDimension * RasterDimension);
+
+            // The overview path reduces the source toward tile resolution first, so the grid
+            // handed to the final resample is materially smaller. Robust relative signal: the
+            // reduction is applied AND the work (input pixel count) is well below baseline.
+            var overviewPixels = await CountPixelsFedToResampleAsync(schemaName, overviewExpr, rasterId);
+            overviewPixels.Should().BeLessThan(
+                baselinePixels / 10,
+                "reducing to ~tile resolution must collapse the full-res grid by more than 10x");
+
+            // EXPLAIN ANALYZE confirms the reduced query still plans and executes over
+            // raster_data end-to-end (a real query plan, not a degenerate empty scan).
+            var overviewPlan = await ExplainAnalyzePlanAsync(schemaName, overviewExpr, LowZoom, col, row, rasterId);
+            overviewPlan.Should().Contain("raster_data", "the low-zoom plan must scan the raster table");
+            overviewPlan.Should().Contain("Execution Time", "EXPLAIN ANALYZE must actually run the plan");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task LowZoomTile_StillRenders256x256Epsg3857_MatchingFullResContent()
+    {
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreOverviewIntegrationTests));
+        try
+        {
+            var rasterId = await SeedSourceRasterAsync(schemaName);
+            var (col, row) = await ResolveTileForSourceCentreAsync(schemaName, LowZoom, rasterId);
+
+            var overviewExpr = PostgresRasterStore.BuildOverviewSourceExpression(LowZoom);
+
+            var (overviewW, overviewH, overviewSrid, overviewSample) =
+                await RenderTileMetadataAsync(schemaName, overviewExpr, LowZoom, col, row, rasterId);
+            var (baseW, baseH, baseSrid, baseSample) =
+                await RenderTileMetadataAsync(schemaName, "raster", LowZoom, col, row, rasterId);
+
+            // Grid contract: the overview render must produce the same EPSG:3857 grid the
+            // full-resolution render does (same dimensions on the tile-aligned reference grid),
+            // so substituting the overview source does not change the tile's geometry. The
+            // GDAL-encoded tile the store returns is reported as 256x256 / EPSG:3857.
+            overviewSrid.Should().Be(3857);
+            overviewW.Should().Be(baseW);
+            overviewH.Should().Be(baseH);
+            overviewSrid.Should().Be(baseSrid);
+
+            // Pixel content: the constant-valued source resamples to the same value (100)
+            // through both paths, within rounding tolerance.
+            overviewSample.Should().BeApproximately(baseSample, 1.0);
+            overviewSample.Should().BeApproximately(100.0, 1.0);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task HighZoomTile_IsNoOp_RendersIdenticalToFullRes()
+    {
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreOverviewIntegrationTests));
+        try
+        {
+            var rasterId = await SeedSourceRasterAsync(schemaName);
+
+            // At/above the native-resolution threshold the substitution is a strict no-op:
+            // the expression is the bare column, so the high-zoom path reads full resolution.
+            const int level = PostgresRasterStore.OverviewMaxZoom;
+            var overviewExpr = PostgresRasterStore.BuildOverviewSourceExpression(level);
+            overviewExpr.Should().Be("raster", "native/finer zoom must read the full-resolution column");
+
+            // And the full 2048x2048 grid is still fed to the resample (no reduction applied).
+            var pixels = await CountPixelsFedToResampleAsync(schemaName, overviewExpr, rasterId);
+            pixels.Should().Be((long)RasterDimension * RasterDimension);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    private async Task<long> SeedSourceRasterAsync(string schemaName)
+    {
+        await fixture.ExecuteAsync("""
+            CREATE TABLE IF NOT EXISTS layers (
+                layer_id INTEGER PRIMARY KEY,
+                layer_name TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS raster_data (
+                id BIGSERIAL PRIMARY KEY,
+                layer_id INTEGER NOT NULL REFERENCES layers(layer_id) ON DELETE CASCADE,
+                name VARCHAR(255) NOT NULL,
+                raster raster NOT NULL
+            );
+            INSERT INTO layers (layer_id, layer_name) VALUES (1, 'overview-lod')
+            ON CONFLICT (layer_id) DO NOTHING;
+            """, schemaName);
+
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            INSERT INTO raster_data (layer_id, name, raster)
+            VALUES (1, 'large-source', {BuildSourceRasterSql()})
+            RETURNING id;
+            """;
+        var id = (long)(await command.ExecuteScalarAsync())!;
+        await fixture.ExecuteAsync("ANALYZE raster_data;", schemaName);
+        return id;
+    }
+
+    // Computes the WebMercatorQuad tile (col,row) containing the source raster's centroid so the
+    // tile reliably overlaps the source regardless of placement.
+    private async Task<(int Col, int Row)> ResolveTileForSourceCentreAsync(
+        string schemaName, int level, long rasterId)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            WITH c AS (
+                SELECT ST_Centroid(ST_Transform(ST_Envelope(raster), 3857)) AS g
+                FROM raster_data WHERE id = @rasterId
+            )
+            SELECT
+                floor((ST_X(g) + 20037508.342789244) / (40075016.685578488 / (1 << @level)))::int AS col,
+                floor((20037508.342789244 - ST_Y(g)) / (40075016.685578488 / (1 << @level)))::int AS row
+            FROM c
+            """;
+        command.Parameters.AddWithValue("rasterId", rasterId);
+        command.Parameters.AddWithValue("level", level);
+        await using var reader = await command.ExecuteReaderAsync();
+        (await reader.ReadAsync()).Should().BeTrue();
+        return (reader.GetInt32(0), reader.GetInt32(1));
+    }
+
+    // Number of source pixels handed to the final ST_Resample after the (optional) reduction.
+    // For the bare column this is the full source grid; for the overview expression it is the
+    // reduced grid, so the ratio is the deterministic "less work" signal.
+    private async Task<long> CountPixelsFedToResampleAsync(string schemaName, string sourceExpr, long rasterId)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            SELECT ST_Width(src)::bigint * ST_Height(src)::bigint
+            FROM (
+                SELECT ST_Transform({sourceExpr}, 3857) AS src
+                FROM raster_data WHERE id = @rasterId
+            ) s
+            """;
+        command.Parameters.AddWithValue("rasterId", rasterId);
+        return (long)(await command.ExecuteScalarAsync())!;
+    }
+
+    private async Task<(int Width, int Height, int Srid, double Sample)> RenderTileMetadataAsync(
+        string schemaName, string sourceExpr, int level, int col, int row, long rasterId)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        // Sample at the centre of the rendered grid (guaranteed inside its bounds) so a covered
+        // pixel is read rather than an out-of-bounds NODATA position.
+        command.CommandText = $"""
+            WITH t AS ({BuildTileRasterSql(sourceExpr)})
+            SELECT ST_Width(rast), ST_Height(rast), ST_SRID(rast),
+                   ST_Value(rast, 1, GREATEST(1, ST_Width(rast) / 2), GREATEST(1, ST_Height(rast) / 2))
+            FROM t
+            """;
+        command.Parameters.AddWithValue("level", level);
+        command.Parameters.AddWithValue("col", col);
+        command.Parameters.AddWithValue("row", row);
+        command.Parameters.AddWithValue("layerId", 1);
+        command.Parameters.AddWithValue("rasterId", rasterId);
+
+        await using var reader = await command.ExecuteReaderAsync();
+        (await reader.ReadAsync()).Should().BeTrue("the tile query must return a raster");
+        var width = reader.GetInt32(0);
+        var height = reader.GetInt32(1);
+        var srid = reader.GetInt32(2);
+        var sample = reader.IsDBNull(3) ? double.NaN : reader.GetDouble(3);
+        return (width, height, srid, sample);
+    }
+
+    private async Task<string> ExplainAnalyzePlanAsync(
+        string schemaName, string sourceExpr, int level, int col, int row, long rasterId)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        command.CommandText = "EXPLAIN (ANALYZE, FORMAT JSON) " + BuildTileRasterSql(sourceExpr);
+        command.Parameters.AddWithValue("level", level);
+        command.Parameters.AddWithValue("col", col);
+        command.Parameters.AddWithValue("row", row);
+        command.Parameters.AddWithValue("layerId", 1);
+        command.Parameters.AddWithValue("rasterId", rasterId);
+        return (await command.ExecuteScalarAsync())?.ToString() ?? string.Empty;
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterStoreOverviewTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterStoreOverviewTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Postgres.Features.Raster;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Postgres.Tests.Features.Raster;
+
+[Collection("Unit")]
+public sealed class PostgresRasterStoreOverviewTests
+{
+    [UnitTest]
+    public void BuildOverviewSourceExpression_AtNativeZoom_IsNoOpBareRaster()
+    {
+        // At/above the native-resolution threshold the source must be read unchanged so
+        // high-zoom tiles keep resampling the full-resolution raster column.
+        var expr = PostgresRasterStore.BuildOverviewSourceExpression(PostgresRasterStore.OverviewMaxZoom);
+
+        expr.Should().Be("raster");
+    }
+
+    [UnitTest]
+    public void BuildOverviewSourceExpression_AboveNativeZoom_IsNoOpBareRaster()
+    {
+        var expr = PostgresRasterStore.BuildOverviewSourceExpression(PostgresRasterStore.OverviewMaxZoom + 5);
+
+        expr.Should().Be("raster");
+    }
+
+    [UnitTest]
+    public void BuildOverviewSourceExpression_AtLowZoom_ReducesResolution()
+    {
+        var expr = PostgresRasterStore.BuildOverviewSourceExpression(0);
+
+        // A low-zoom tile reduces the source to a coarser grid before the precise resample.
+        expr.Should().NotBe("raster");
+        expr.Should().StartWith("ST_Rescale(");
+        expr.Should().Contain("ST_Transform(raster, 3857)");
+        // Guarded so the rescale can only coarsen, never upsample, per-source.
+        expr.Should().Contain("GREATEST(abs(ST_ScaleX(");
+        expr.Should().Contain("GREATEST(abs(ST_ScaleY(");
+        expr.Should().Contain("'NearestNeighbor'");
+    }
+
+    [UnitTest]
+    public void BuildOverviewSourceExpression_LowerZoom_TargetsCoarserResolution()
+    {
+        // Tile ground resolution doubles each zoom-out, so a lower zoom must target a
+        // numerically larger metres-per-pixel value than a higher (still-low) zoom.
+        var z2 = PostgresRasterStore.BuildOverviewSourceExpression(2);
+        var z6 = PostgresRasterStore.BuildOverviewSourceExpression(6);
+
+        // z=2 mpp = 40075016.686 / (256 * 4) ≈ 39135.76
+        z2.Should().Contain("39135.7");
+        // z=6 mpp = 40075016.686 / (256 * 64) ≈ 2445.98
+        z6.Should().Contain("2445.9");
+    }
+
+    [UnitTest]
+    public void BuildOverviewSourceExpression_HonoursCustomToken()
+    {
+        var expr = PostgresRasterStore.BuildOverviewSourceExpression(3, "rast");
+
+        expr.Should().Contain("ST_Transform(rast, 3857)");
+        expr.Should().NotContain("raster");
+    }
+}


### PR DESCRIPTION
First-PR slice of **#1793** (dynamic overview pyramids / multi-LOD raster tiles). Makes low-zoom raster tiles read a **resolution-reduced source** instead of always resampling the full-resolution `raster` column on every zoom. Defers persisted import-time pyramids and the COG-overview-reuse path.

### What's included
- `PostgresRasterStore.BuildOverviewSourceExpression(level, rasterToken="raster")`: computes the tile ground resolution `40075016.686 / (256Â·2^level)` m/px; at `level â‰¥ OverviewMaxZoom (22)` returns the bare token (strict no-op); otherwise wraps the source in `ST_Rescale(ST_Transform(<token>,3857), GREATEST(|ScaleX|, mpp), â€¦, 'NearestNeighbor')`. Runs in EPSG:3857, SRID-agnostic, and the `GREATEST` guards mean it can **only coarsen** (a per-source no-op when the source is already coarser). NearestNeighbor matches the existing default tile resampling/nodata semantics.
- **Single-token substitution** in `GetImageTileAsync` + `GetMosaicImageTileAsync`: the literal `raster` inside `ST_Resample(ST_Transform(raster, 3857), â€¦)` becomes `{overviewSource}` (+ one local var per method). The `ST_Intersects(ST_ConvexHull(raster), â€¦)` selection still uses the full-extent raster, as intended.

### Testing
Build clean (warnings-as-errors). **5 unit + 3 Testcontainers integration**, plus the full `~Features.Raster` suite **54/54 (no regression)** â€” independently re-verified (8/8 on the overview filter).
- Perf assertion (the core win): a 2048Ã—2048 @ 2 m/px raster feeds all 4.19M source pixels into the full-res resample, while the z=12 overview path feeds **<10%** â€” `EXPLAIN (ANALYZE)` confirms a real plan over `raster_data`. (Deterministic pixel-reduction signal, not brittle wall-clock â€” on a trivial synthetic raster, TOAST detoast dominates wall-time.)
- Correctness: overview render matches the full-res grid + sampled pixel value; high-zoom (â‰¥22) is a verified no-op identical to full-res.

### Conflict note
Kept to one `{overviewSource}` token swap per query block so the rebase/merge vs **#1801 (#1788)** / **#1802 (#1789)** â€” which rewrite the same tile-SQL blocks â€” stays trivial (off trunk, mechanical).

### Deferred (follow-ups)
Persisted import-time pyramids (new schema), and reusing `CogTileResolver.FindBestOverviewLevel` for COG-in-PostGIS overviews.

Part of #1793.

Closes #1793. Remaining scope tracked in #1836.