### PR TITLE
fix(geoprocessing): honor DevGrantEdition in the startup Redis-entitlement gate (#1787)

### DIFF
--- a/src/Honua.Hosting/Features/Licensing/DevLicenseEntitlementService.cs
+++ b/src/Honua.Hosting/Features/Licensing/DevLicenseEntitlementService.cs
@@ -35,31 +35,7 @@ internal sealed partial class DevLicenseEntitlementService : ILicenseEntitlement
         HonuaEdition grantEdition,
         ILogger<DevLicenseEntitlementService>? logger = null)
     {
-        var activeKeys = FeatureCatalog.All
-            .Where(feature => feature.MinimumEdition <= grantEdition)
-            .Select(feature => feature.Key)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var entitlements = FeatureCatalog.All
-            .Select(feature => new Entitlement
-            {
-                Key = feature.Key,
-                Name = feature.DisplayName,
-                IsActive = activeKeys.Contains(feature.Key),
-            })
-            .ToArray();
-
-        _snapshot = new LicenseSnapshot(
-            grantEdition,
-            IsValid: true,
-            LicenseValidationState.Valid,
-            ExpiresAt: null,
-            LicensedTo: "Honua Dev Grant",
-            LicenseId: "dev-grant",
-            IssuedAt: null,
-            entitlements,
-            activeKeys,
-            SnapshotVersion: 1,
-            KeyId: null);
+        _snapshot = DevLicenseSnapshotFactory.Create(grantEdition);
 
         if (logger is not null)
         {

--- a/src/Honua.Hosting/Features/Licensing/DevLicenseSnapshotFactory.cs
+++ b/src/Honua.Hosting/Features/Licensing/DevLicenseSnapshotFactory.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Licensing.Domain;
+
+namespace Honua.Infrastructure.Licensing;
+
+/// <summary>
+/// Builds the in-memory <see cref="LicenseSnapshot"/> used by the test/dev-only
+/// <c>Licensing:DevGrantEdition</c> override. Centralising the snapshot construction keeps the
+/// runtime entitlement path (<see cref="DevLicenseEntitlementService"/>) and the bootstrap
+/// entitlement probe (<see cref="FileBackedLicenseService.LoadBootstrapSnapshotAsync"/>)
+/// consistent — both grant every catalog entitlement up to the configured edition, so a startup
+/// gate cannot disagree with a runtime gate (honua-server#1787).
+/// </summary>
+internal static class DevLicenseSnapshotFactory
+{
+    /// <summary>
+    /// Builds a dev-grant snapshot granting every catalog entitlement up to
+    /// <paramref name="grantEdition"/>.
+    /// </summary>
+    /// <param name="grantEdition">The highest edition whose entitlements are granted.</param>
+    /// <returns>An in-memory snapshot reflecting the dev grant.</returns>
+    public static LicenseSnapshot Create(HonuaEdition grantEdition)
+    {
+        var activeKeys = FeatureCatalog.All
+            .Where(feature => feature.MinimumEdition <= grantEdition)
+            .Select(feature => feature.Key)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var entitlements = FeatureCatalog.All
+            .Select(feature => new Entitlement
+            {
+                Key = feature.Key,
+                Name = feature.DisplayName,
+                IsActive = activeKeys.Contains(feature.Key),
+            })
+            .ToArray();
+
+        return new LicenseSnapshot(
+            grantEdition,
+            IsValid: true,
+            LicenseValidationState.Valid,
+            ExpiresAt: null,
+            LicensedTo: "Honua Dev Grant",
+            LicenseId: "dev-grant",
+            IssuedAt: null,
+            entitlements,
+            activeKeys,
+            SnapshotVersion: 1,
+            KeyId: null);
+    }
+
+    /// <summary>
+    /// Attempts to parse a configured <c>Licensing:DevGrantEdition</c> value into a
+    /// <see cref="HonuaEdition"/>.
+    /// </summary>
+    /// <param name="devGrantEdition">The raw configuration value (may be null/empty).</param>
+    /// <param name="edition">The parsed edition when the value is a valid edition name.</param>
+    /// <returns><see langword="true"/> when a non-empty value parsed to a known edition.</returns>
+    public static bool TryParseEdition(string? devGrantEdition, out HonuaEdition edition)
+    {
+        if (!string.IsNullOrWhiteSpace(devGrantEdition) &&
+            Enum.TryParse(devGrantEdition, ignoreCase: true, out edition))
+        {
+            return true;
+        }
+
+        edition = default;
+        return false;
+    }
+}

--- a/src/Honua.Hosting/Features/Licensing/FileBackedLicenseService.cs
+++ b/src/Honua.Hosting/Features/Licensing/FileBackedLicenseService.cs
@@ -94,9 +94,19 @@ internal sealed class FileBackedLicenseService :
             current.KeyId);
     }
 
+    /// <summary>
+    /// Computes the bootstrap license snapshot consulted by early startup gates (e.g. the
+    /// Redis-cache entitlement probe) before DI is built. When <paramref name="honorDevGrant"/>
+    /// is <see langword="true"/> and <c>Licensing:DevGrantEdition</c> is set to a valid edition,
+    /// the returned snapshot reflects that dev grant — keeping the startup gate consistent with
+    /// the runtime <see cref="DevLicenseEntitlementService"/> entitlement path (honua-server#1787).
+    /// Callers must pass <c>honorDevGrant: false</c> in Production so the override never relaxes a
+    /// startup gate without a signed license (the host-level guard fails the process closed there).
+    /// </summary>
     internal static async Task<LicenseSnapshot> LoadBootstrapSnapshotAsync(
         IConfiguration configuration,
         ILoggerFactory loggerFactory,
+        bool honorDevGrant = false,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(configuration);
@@ -104,6 +114,12 @@ internal sealed class FileBackedLicenseService :
 
         var options = new LicenseOptions();
         configuration.GetSection(LicenseOptions.SectionName).Bind(options);
+
+        if (honorDevGrant &&
+            DevLicenseSnapshotFactory.TryParseEdition(options.DevGrantEdition, out var grantEdition))
+        {
+            return DevLicenseSnapshotFactory.Create(grantEdition);
+        }
 
         var service = new FileBackedLicenseService(
             Options.Create(options),

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -139,7 +139,9 @@ builder.Services.AddDataProtection();
 var useAspire = builder.Configuration.GetSection("Aspire").Exists();
 var redisConnectionString = builder.Configuration.GetConnectionString("redis")
     ?? builder.Configuration["Aspire:StackExchange:Redis:ConnectionString"];
-var redisCacheEntitled = await StartupConfigurationHelpers.IsRedisCacheEntitledAsync(builder.Configuration);
+var redisCacheEntitled = await StartupConfigurationHelpers.IsRedisCacheEntitledAsync(
+    builder.Configuration,
+    builder.Environment);
 var redisCacheConnectionString = redisCacheEntitled ? redisConnectionString : null;
 var redisInfrastructureConnectionString = RedisConnectionSelector.SelectInfrastructureConnectionString(
     redisConnectionString,

--- a/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
+++ b/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
@@ -78,7 +78,18 @@ internal static class StartupConfigurationHelpers
     /// Inspect a bootstrap license snapshot to determine whether the running host is
     /// entitled to use Redis as the distributed cache backend.
     /// </summary>
-    public static async Task<bool> IsRedisCacheEntitledAsync(IConfiguration configuration)
+    /// <remarks>
+    /// Outside Production the snapshot honors the test/dev-only <c>Licensing:DevGrantEdition</c>
+    /// override, identically to the runtime <c>DevLicenseEntitlementService</c> entitlement path.
+    /// Without this, a Development + <c>DevGrantEdition=Pro</c> stack with Redis reachable would
+    /// fail the gate, the <c>IConnectionMultiplexer</c> would never be wired, and the durable job
+    /// store would not register — so authenticated GPServer <c>/execute</c> and <c>/submitJob</c>
+    /// returned 503 despite the dev grant entitling Redis (honua-server#1787). DevGrant is never
+    /// honored in Production (the host-level guard fails the process closed there).
+    /// </remarks>
+    public static async Task<bool> IsRedisCacheEntitledAsync(
+        IConfiguration configuration,
+        IHostEnvironment environment)
     {
         var redisConnectionString = configuration.GetConnectionString("redis")
             ?? configuration["Aspire:StackExchange:Redis:ConnectionString"];
@@ -89,7 +100,7 @@ internal static class StartupConfigurationHelpers
 
         using var loggerFactory = LoggerFactory.Create(static builder => builder.AddConsole());
         var snapshot = await FileBackedLicenseService
-            .LoadBootstrapSnapshotAsync(configuration, loggerFactory)
+            .LoadBootstrapSnapshotAsync(configuration, loggerFactory, honorDevGrant: !environment.IsProduction())
             .ConfigureAwait(false);
         return snapshot.HasEntitlement("caching.redis");
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Licensing/RedisCacheEntitlementGateTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Licensing/RedisCacheEntitlementGateTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Server.Startup;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+
+namespace Honua.Server.Tests.Features.Licensing;
+
+/// <summary>
+/// Guards the startup Redis-cache entitlement gate
+/// (<see cref="StartupConfigurationHelpers.IsRedisCacheEntitledAsync"/>). The gate decides
+/// whether the host wires the <c>IConnectionMultiplexer</c> that the durable job store depends
+/// on. Before honua-server#1787 it read a bootstrap license snapshot that ignored
+/// <c>Licensing:DevGrantEdition</c>, so a Development + <c>DevGrantEdition=Pro</c> stack with
+/// Redis reachable still had no store and GPServer <c>/execute</c>/<c>/submitJob</c> returned 503.
+/// </summary>
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.LicenseManagement)]
+public sealed class RedisCacheEntitlementGateTests
+{
+    private const string RedisConnectionString = "localhost:6379";
+
+    [UnitTest]
+    public async Task IsRedisCacheEntitled_DevGrantPro_InDevelopment_EntitlesRedis()
+    {
+        // Reproduces honua-server#1787: no signed license, only Licensing:DevGrantEdition=Pro.
+        var configuration = BuildConfiguration(
+            redisConnectionString: RedisConnectionString,
+            devGrantEdition: "Pro");
+        var environment = new TestHostEnvironment { EnvironmentName = Environments.Development };
+
+        var entitled = await StartupConfigurationHelpers.IsRedisCacheEntitledAsync(configuration, environment);
+
+        entitled.Should().BeTrue(
+            "DevGrantEdition=Pro grants caching.redis at runtime, so the startup gate must agree " +
+            "and wire the durable job store the GPServer needs");
+    }
+
+    [UnitTest]
+    public async Task IsRedisCacheEntitled_NoLicenseNoDevGrant_DoesNotEntitleRedis()
+    {
+        var configuration = BuildConfiguration(
+            redisConnectionString: RedisConnectionString,
+            devGrantEdition: null);
+        var environment = new TestHostEnvironment { EnvironmentName = Environments.Development };
+
+        var entitled = await StartupConfigurationHelpers.IsRedisCacheEntitledAsync(configuration, environment);
+
+        entitled.Should().BeFalse(
+            "without a signed license or a dev grant the Community snapshot does not include caching.redis");
+    }
+
+    [UnitTest]
+    public async Task IsRedisCacheEntitled_DevGrantPro_InProduction_DoesNotEntitleRedis()
+    {
+        // Fail-closed: the dev-only override must never relax a startup gate in Production.
+        var configuration = BuildConfiguration(
+            redisConnectionString: RedisConnectionString,
+            devGrantEdition: "Pro");
+        var environment = new TestHostEnvironment { EnvironmentName = Environments.Production };
+
+        var entitled = await StartupConfigurationHelpers.IsRedisCacheEntitledAsync(configuration, environment);
+
+        entitled.Should().BeFalse(
+            "DevGrantEdition is a test/dev-only override and must be ignored by the gate in Production");
+    }
+
+    [UnitTest]
+    public async Task IsRedisCacheEntitled_DevGrantCommunity_DoesNotEntitleRedis()
+    {
+        // caching.redis is a Pro entitlement; a Community dev grant must not unlock it.
+        var configuration = BuildConfiguration(
+            redisConnectionString: RedisConnectionString,
+            devGrantEdition: "Community");
+        var environment = new TestHostEnvironment { EnvironmentName = Environments.Development };
+
+        var entitled = await StartupConfigurationHelpers.IsRedisCacheEntitledAsync(configuration, environment);
+
+        entitled.Should().BeFalse(
+            "caching.redis requires Pro; a Community dev grant does not reach that edition");
+    }
+
+    [UnitTest]
+    public async Task IsRedisCacheEntitled_NoRedisConnectionString_ReturnsFalse()
+    {
+        var configuration = BuildConfiguration(
+            redisConnectionString: null,
+            devGrantEdition: "Pro");
+        var environment = new TestHostEnvironment { EnvironmentName = Environments.Development };
+
+        var entitled = await StartupConfigurationHelpers.IsRedisCacheEntitledAsync(configuration, environment);
+
+        entitled.Should().BeFalse("there is nothing to connect to without a Redis connection string");
+    }
+
+    private static IConfiguration BuildConfiguration(string? redisConnectionString, string? devGrantEdition)
+    {
+        var settings = new Dictionary<string, string?>();
+        if (!string.IsNullOrWhiteSpace(redisConnectionString))
+        {
+            settings["ConnectionStrings:redis"] = redisConnectionString;
+        }
+
+        if (!string.IsNullOrWhiteSpace(devGrantEdition))
+        {
+            settings["Licensing:DevGrantEdition"] = devGrantEdition;
+        }
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Development;
+        public string ApplicationName { get; set; } = "Honua.Server.Tests";
+        public string ContentRootPath { get; set; } = "/";
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes honua-io/honua-server#1787

## Summary
Authenticated GPServer `/execute` and `/submitJob` cleared auth and plan validation but then returned `503 "Job operations require Redis-backed durable storage"` on a Development stack configured with `Licensing:DevGrantEdition=Pro` and a reachable Redis.

Root cause: `GeoprocessingJobService` resolves `IExecutionJobStore` (`RedisExecutionJobStore`), which is registered only when an `IConnectionMultiplexer` is in DI. That multiplexer is wired at startup only when the Redis-cache entitlement gate (`StartupConfigurationHelpers.IsRedisCacheEntitledAsync`) returns true. The gate reads a **bootstrap license snapshot that ignored `Licensing:DevGrantEdition`** — so even though `DevGrantEdition=Pro` grants `caching.redis` at runtime (via `DevLicenseEntitlementService`), the startup gate disagreed, the multiplexer was never created, and the durable job store never registered. `DevGrant` granted runtime entitlements but not the startup wiring.

This change makes the startup gate honor `DevGrantEdition` the same way the runtime entitlement path does, so a Development + `DevGrantEdition=Pro` stack with Redis reachable wires the multiplexer, registers the durable store, and runs GP jobs.

## Changes Made
- Added `DevLicenseSnapshotFactory` — a single source of truth that builds the dev-grant `LicenseSnapshot` (every catalog entitlement up to the configured edition) and parses `DevGrantEdition`. Both the runtime and bootstrap paths now use it so they cannot drift.
- Refactored `DevLicenseEntitlementService` to build its snapshot via the factory (behavior unchanged).
- `FileBackedLicenseService.LoadBootstrapSnapshotAsync` now accepts a `honorDevGrant` flag; when set and `DevGrantEdition` parses to a valid edition, it returns the dev-grant snapshot instead of the file/Community snapshot.
- `StartupConfigurationHelpers.IsRedisCacheEntitledAsync` now takes `IHostEnvironment` and passes `honorDevGrant: !environment.IsProduction()`, so the gate honors the dev grant everywhere except Production (fail-closed; the host-level guard in `LicensingRegistration` still throws if `DevGrantEdition` is set in Production).
- Updated the `Program.cs` call site to pass `builder.Environment`.
- Added `RedisCacheEntitlementGateTests` proving the gate is true for `DevGrantEdition=Pro` in Development and false for: no grant, Community grant (Redis is a Pro entitlement), Production (fail-closed), and a missing Redis connection string.

### Sync `/execute` (secondary concern — assessed, no change)
The brief asked whether sync `/execute` should return inline without the durable store. It should not. `HandleExecute` deliberately routes through `IGeoprocessingJobService.SubmitJobAsync` + poll-until-terminal — the canonical process/job runtime mandated by the adapter rules in `AGENTS.md` ("GPServer ... must adapt to the canonical process/job runtime and not create protocol-local job lifecycle semantics"). Adding a store-free inline engine would fork that runtime and violate the protocol-adapter architecture. The DevGrant gate fix is the correct, sufficient remedy: with it, a Development stack with Redis reachable now has the store, so sync execute works there too.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Targeted build/test (affected projects only, per the brief):
- `dotnet build src/Honua.Server/Honua.Server.csproj -c Release /p:TreatWarningsAsErrors=true` — succeeded, 0 warnings.
- `dotnet test Honua.Server.Tests --filter "RedisCacheEntitlementGateTests|FileBackedLicenseServiceTests"` — 16/16 passed (5 new gate tests + 11 existing license tests confirm the factory refactor is non-regressing).
- `dotnet format` over the touched files — no changes.
- The single failing architecture test (`PublicInterfaceProofLedgerTests.SdkCompatibilityWorkflow_ShouldConvertSmokeTimeoutsIntoCellEvidence`) inspects an unrelated SDK-compatibility GitHub workflow YAML and fails on a clean trunk checkout; it is unaffected by and unrelated to this change.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
