### PR TITLE
feat(tiles): config-driven custom TileMatrixSet registry (#1791)

### DIFF
--- a/src/Honua.Core/Features/Tiles/GridGeometry.cs
+++ b/src/Honua.Core/Features/Tiles/GridGeometry.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+
+namespace Honua.Core.Features.Tiles;
+
+/// <summary>
+/// A small, protocol-neutral description of a tile matrix set (gridset): the spatial
+/// reference, tile origin, tile pixel dimensions, and the per-level matrix dimensions and
+/// scale denominators. Both the OGC API Tiles and classic WMTS adapters consume this so the
+/// "which gridsets exist and what is their geometry" decision lives in one place
+/// (<see cref="ITileMatrixSetRegistry"/>) instead of being hardcoded per protocol.
+/// </summary>
+/// <remarks>
+/// <para>This is intentionally a small value type defined in <c>Honua.Core</c> so it can be
+/// shared across the protocol assemblies and the rendering pipeline without introducing a
+/// cross-assembly project-reference cycle (the rendering layer's <c>TileGridKind</c> enum
+/// cannot represent operator-defined gridsets).</para>
+/// <para>The two built-in gridsets (WebMercatorQuad, WorldCRS84Quad) are seeded from the same
+/// constants and formulas the protocol adapters already use, so their advertised metadata and
+/// capabilities XML remain byte-identical (the OGC CITE guard).</para>
+/// </remarks>
+public sealed record GridGeometry
+{
+    /// <summary>The tile matrix set identifier (e.g. <c>WebMercatorQuad</c>).</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The numeric spatial reference identifier (SRID) of the gridset CRS.</summary>
+    public required int Srid { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> when the gridset CRS is geographic (degrees, e.g. CRS84) rather
+    /// than projected (meters, e.g. Web Mercator). Drives the tile-envelope filter SRID and the
+    /// axis interpretation of <see cref="TopLeftX"/>/<see cref="TopLeftY"/>.
+    /// </summary>
+    public required bool IsGeographic { get; init; }
+
+    /// <summary>
+    /// The X (easting / longitude) coordinate of the grid's top-left corner (point of origin),
+    /// expressed in the gridset CRS.
+    /// </summary>
+    public required double TopLeftX { get; init; }
+
+    /// <summary>
+    /// The Y (northing / latitude) coordinate of the grid's top-left corner (point of origin),
+    /// expressed in the gridset CRS.
+    /// </summary>
+    public required double TopLeftY { get; init; }
+
+    /// <summary>Tile width in pixels (default 256).</summary>
+    public required int TileWidth { get; init; }
+
+    /// <summary>Tile height in pixels (default 256).</summary>
+    public required int TileHeight { get; init; }
+
+    /// <summary>The per-level tile matrices, ordered by ascending level identifier.</summary>
+    public required ImmutableArray<GridLevel> Levels { get; init; }
+
+    /// <summary>
+    /// Returns the tile matrix for the given level identifier, or <see langword="null"/> when no
+    /// level with that identifier exists in the gridset.
+    /// </summary>
+    /// <param name="level">The tile matrix (zoom) level identifier.</param>
+    public GridLevel? FindLevel(int level)
+    {
+        foreach (var candidate in Levels)
+        {
+            if (candidate.Level == level)
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Computes the bounding box of a tile in the gridset CRS from the grid origin and the
+    /// requested level's matrix dimensions. Returns <see langword="null"/> when the level is
+    /// not part of the gridset.
+    /// </summary>
+    /// <param name="x">Tile column index.</param>
+    /// <param name="y">Tile row index.</param>
+    /// <param name="level">Tile matrix (zoom) level identifier.</param>
+    public TileBounds? GetTileBounds(int x, int y, int level)
+    {
+        if (FindLevel(level) is not { } gridLevel)
+        {
+            return null;
+        }
+
+        // The full grid spans (MatrixWidth * tile-extent) horizontally from the top-left
+        // origin. The per-tile extent in CRS units is derived from the cell size and tile
+        // pixel dimensions: cellSize is CRS-units per pixel, so a tile is cellSize * tileSize.
+        var tileSpanX = gridLevel.CellSize * TileWidth;
+        var tileSpanY = gridLevel.CellSize * TileHeight;
+
+        var xMin = TopLeftX + (x * tileSpanX);
+        var yMax = TopLeftY - (y * tileSpanY);
+        var xMax = xMin + tileSpanX;
+        var yMin = yMax - tileSpanY;
+
+        return new TileBounds(xMin, yMin, xMax, yMax);
+    }
+}
+
+/// <summary>
+/// A single tile matrix (zoom level) within a <see cref="GridGeometry"/>: its scale
+/// denominator, cell size, and matrix dimensions (columns × rows).
+/// </summary>
+/// <param name="Level">The tile matrix (zoom) level identifier.</param>
+/// <param name="ScaleDenominator">The OGC scale denominator at this level.</param>
+/// <param name="CellSize">The cell size (CRS units per pixel) at this level.</param>
+/// <param name="MatrixWidth">The number of tile columns at this level.</param>
+/// <param name="MatrixHeight">The number of tile rows at this level.</param>
+public readonly record struct GridLevel(
+    int Level,
+    double ScaleDenominator,
+    double CellSize,
+    long MatrixWidth,
+    long MatrixHeight);

--- a/src/Honua.Core/Features/Tiles/ITileMatrixSetRegistry.cs
+++ b/src/Honua.Core/Features/Tiles/ITileMatrixSetRegistry.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Honua.Core.Features.Tiles;
+
+/// <summary>
+/// The single source of truth for the tile matrix sets (gridsets) the server advertises: the two
+/// built-in gridsets (WebMercatorQuad, WorldCRS84Quad) merged with any operator-defined custom
+/// gridsets bound from configuration. Both the OGC API Tiles and classic WMTS adapters resolve
+/// supported gridsets and their <see cref="GridGeometry"/> through this registry instead of
+/// hardcoding the supported set per protocol.
+/// </summary>
+public interface ITileMatrixSetRegistry
+{
+    /// <summary>
+    /// All registered tile matrix sets (built-in first, then operator-defined in configured
+    /// order), as metadata-only entries.
+    /// </summary>
+    IReadOnlyList<TileMatrixSetEntry> All { get; }
+
+    /// <summary>
+    /// Determines whether a tile matrix set with the given identifier is registered
+    /// (case-insensitive).
+    /// </summary>
+    /// <param name="tileMatrixSetId">The tile matrix set identifier.</param>
+    bool IsSupported(string tileMatrixSetId);
+
+    /// <summary>
+    /// Looks up a tile matrix set metadata entry by identifier (case-insensitive).
+    /// </summary>
+    /// <param name="tileMatrixSetId">The tile matrix set identifier.</param>
+    /// <param name="entry">The resolved entry when found.</param>
+    /// <returns><see langword="true"/> when an entry was found.</returns>
+    bool TryGet(string tileMatrixSetId, [NotNullWhen(true)] out TileMatrixSetEntry? entry);
+
+    /// <summary>
+    /// Resolves the full <see cref="GridGeometry"/> (per-level matrices) for a tile matrix set.
+    /// For the built-in gridsets the levels are generated for <c>0..maxLevel</c> using the
+    /// canonical OGC formulas so output stays byte-identical; for custom gridsets the configured
+    /// levels are returned (a <paramref name="maxLevel"/> argument is ignored).
+    /// </summary>
+    /// <param name="tileMatrixSetId">The tile matrix set identifier.</param>
+    /// <param name="maxLevel">The maximum level to generate for built-in (formula-driven) gridsets.</param>
+    /// <param name="geometry">The resolved grid geometry when found.</param>
+    /// <returns><see langword="true"/> when the gridset is registered.</returns>
+    bool TryGetGeometry(string tileMatrixSetId, int maxLevel, [NotNullWhen(true)] out GridGeometry? geometry);
+}
+
+/// <summary>
+/// Metadata describing a registered tile matrix set (gridset) without the per-level matrices.
+/// </summary>
+public sealed record TileMatrixSetEntry
+{
+    /// <summary>The tile matrix set identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The human-readable title.</summary>
+    public required string Title { get; init; }
+
+    /// <summary>The tile matrix set URI.</summary>
+    public required string Uri { get; init; }
+
+    /// <summary>The CRS URI advertised for this gridset.</summary>
+    public required string Crs { get; init; }
+
+    /// <summary>The numeric SRID of the gridset CRS.</summary>
+    public required int Srid { get; init; }
+
+    /// <summary><see langword="true"/> when the gridset CRS is geographic (degrees) rather than projected.</summary>
+    public required bool IsGeographic { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> for the two reserved built-in gridsets, <see langword="false"/>
+    /// for operator-defined custom gridsets.
+    /// </summary>
+    public required bool IsBuiltIn { get; init; }
+}

--- a/src/Honua.Core/Features/Tiles/TileMath.cs
+++ b/src/Honua.Core/Features/Tiles/TileMath.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System;
 using Honua.Core.Features.Shared.Models;
 
 namespace Honua.Core.Features.Tiles;
@@ -33,6 +34,24 @@ public static class TileMath
         var yMin = yMax - tileSize;
 
         return new TileBounds(xMin, yMin, xMax, yMax);
+    }
+
+    /// <summary>
+    /// Gets the bounding box for a tile using an explicit <see cref="GridGeometry"/> (the grid
+    /// origin, tile pixel size, and per-level cell size). This is the gridset-aware generalization
+    /// of <see cref="GetTileBounds(int, int, int)"/> / <see cref="GetTileBoundsGeographic(int, int, int)"/>
+    /// used by operator-defined custom tile matrix sets. Returns <see langword="null"/> when the
+    /// requested level is not part of the gridset.
+    /// </summary>
+    /// <param name="geometry">The grid geometry.</param>
+    /// <param name="x">Tile X (column) coordinate.</param>
+    /// <param name="y">Tile Y (row) coordinate.</param>
+    /// <param name="z">Tile matrix (zoom) level.</param>
+    /// <returns>Bounding box as (xmin, ymin, xmax, ymax) in the gridset CRS, or <see langword="null"/>.</returns>
+    public static TileBounds? GetTileBounds(GridGeometry geometry, int x, int y, int z)
+    {
+        ArgumentNullException.ThrowIfNull(geometry);
+        return geometry.GetTileBounds(x, y, z);
     }
 
     /// <summary>

--- a/src/Honua.Core/Features/Tiles/TileMatrixSetDefinitionOptions.cs
+++ b/src/Honua.Core/Features/Tiles/TileMatrixSetDefinitionOptions.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+
+namespace Honua.Core.Features.Tiles;
+
+/// <summary>
+/// Bound configuration for operator-defined custom tile matrix sets (gridsets). Operators add
+/// entries under the <c>TileMatrixSets</c> configuration section; each entry is merged with the
+/// two built-in gridsets (WebMercatorQuad, WorldCRS84Quad) by <see cref="ITileMatrixSetRegistry"/>
+/// and advertised through the OGC API Tiles and classic WMTS metadata surfaces.
+/// </summary>
+public sealed class TileMatrixSetDefinitionOptions
+{
+    /// <summary>
+    /// The configuration section name that binds to these options.
+    /// </summary>
+    public const string SectionName = "TileMatrixSets";
+
+    /// <summary>
+    /// The operator-defined custom tile matrix sets. The two built-in gridsets are always
+    /// available and must not be redefined here (the validator rejects collisions).
+    /// </summary>
+    public IList<CustomTileMatrixSet> Custom { get; set; } = new List<CustomTileMatrixSet>();
+}
+
+/// <summary>
+/// One operator-defined custom tile matrix set (gridset). Mirrors the OGC tile matrix set model:
+/// an identifier, CRS, origin, tile pixel size, and an ordered list of zoom levels.
+/// </summary>
+public sealed class CustomTileMatrixSet
+{
+    /// <summary>
+    /// The tile matrix set identifier (used in URLs and capabilities). Must be unique and must
+    /// not collide with the reserved built-in identifiers.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The CRS URI advertised for this gridset (e.g.
+    /// <c>http://www.opengis.net/def/crs/EPSG/0/3857</c>).
+    /// </summary>
+    public string Crs { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional tile matrix set URI. When omitted, adapters fall back to the identifier.
+    /// </summary>
+    public string? Uri { get; set; }
+
+    /// <summary>
+    /// Optional human-readable title. When omitted, adapters fall back to the identifier.
+    /// </summary>
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// The numeric spatial reference identifier (SRID) for the gridset CRS. Used by the render
+    /// pipeline to build the tile envelope filter and reproject from the storage CRS.
+    /// </summary>
+    public int Srid { get; set; }
+
+    /// <summary>
+    /// The grid origin (top-left corner) as <c>[x, y]</c> in the gridset CRS. For geographic
+    /// CRSes the values are longitude/latitude in CRS storage order; adapters apply the
+    /// protocol-specific axis order when emitting metadata.
+    /// </summary>
+    public double[] TopLeftCorner { get; set; } = [];
+
+    /// <summary>
+    /// Tile width in pixels.
+    /// </summary>
+    public int TileWidth { get; set; } = 256;
+
+    /// <summary>
+    /// Tile height in pixels.
+    /// </summary>
+    public int TileHeight { get; set; } = 256;
+
+    /// <summary>
+    /// The ordered list of zoom levels (tile matrices) for this gridset.
+    /// </summary>
+    public IList<TileMatrixLevel> Levels { get; set; } = new List<TileMatrixLevel>();
+}
+
+/// <summary>
+/// One zoom level (tile matrix) within a <see cref="CustomTileMatrixSet"/>.
+/// </summary>
+public sealed class TileMatrixLevel
+{
+    /// <summary>
+    /// The tile matrix (zoom) level identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The OGC scale denominator at this level.
+    /// </summary>
+    public double ScaleDenominator { get; set; }
+
+    /// <summary>
+    /// The cell size (CRS units per pixel) at this level.
+    /// </summary>
+    public double CellSize { get; set; }
+
+    /// <summary>
+    /// The number of tile columns at this level.
+    /// </summary>
+    public long MatrixWidth { get; set; }
+
+    /// <summary>
+    /// The number of tile rows at this level.
+    /// </summary>
+    public long MatrixHeight { get; set; }
+}

--- a/src/Honua.Core/Features/Tiles/TileMatrixSetOptionsValidator.cs
+++ b/src/Honua.Core/Features/Tiles/TileMatrixSetOptionsValidator.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using Honua.Core.Configuration;
+
+namespace Honua.Core.Features.Tiles;
+
+/// <summary>
+/// Validates operator-defined custom tile matrix sets at startup. Rejects duplicate or
+/// reserved-id collisions, non-monotonic scale denominators, non-positive matrix dimensions,
+/// invalid SRIDs, and malformed top-left corners so a misconfigured gridset fails fast instead
+/// of producing inconsistent capabilities.
+/// </summary>
+public sealed class TileMatrixSetOptionsValidator : OptionsValidator<TileMatrixSetDefinitionOptions>
+{
+    /// <inheritdoc />
+    protected override void ValidateOptions(TileMatrixSetDefinitionOptions options, List<string> failures)
+    {
+        if (options.Custom is null || options.Custom.Count == 0)
+        {
+            return;
+        }
+
+        var seenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        for (var index = 0; index < options.Custom.Count; index++)
+        {
+            var entry = options.Custom[index];
+            var label = string.IsNullOrWhiteSpace(entry.Id)
+                ? $"TileMatrixSets:Custom[{index}]"
+                : $"TileMatrixSets:Custom '{entry.Id}'";
+
+            if (string.IsNullOrWhiteSpace(entry.Id))
+            {
+                failures.Add($"{label} must have a non-empty Id.");
+            }
+            else
+            {
+                foreach (var reserved in TileMatrixSetRegistry.ReservedIds)
+                {
+                    if (string.Equals(reserved, entry.Id, StringComparison.OrdinalIgnoreCase))
+                    {
+                        failures.Add($"{label} collides with the reserved built-in tile matrix set '{reserved}'.");
+                    }
+                }
+
+                if (!seenIds.Add(entry.Id))
+                {
+                    failures.Add($"{label} is a duplicate tile matrix set identifier.");
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(entry.Crs))
+            {
+                failures.Add($"{label} must specify a Crs.");
+            }
+
+            if (entry.Srid <= 0)
+            {
+                failures.Add($"{label} must specify a positive Srid.");
+            }
+
+            if (entry.TileWidth <= 0 || entry.TileHeight <= 0)
+            {
+                failures.Add($"{label} must have positive TileWidth and TileHeight.");
+            }
+
+            if (entry.TopLeftCorner is null || entry.TopLeftCorner.Length != 2)
+            {
+                failures.Add($"{label} must specify a TopLeftCorner with exactly two values [x, y].");
+            }
+
+            ValidateLevels(entry, label, failures);
+        }
+    }
+
+    private static void ValidateLevels(CustomTileMatrixSet entry, string label, List<string> failures)
+    {
+        if (entry.Levels is null || entry.Levels.Count == 0)
+        {
+            failures.Add($"{label} must define at least one level.");
+            return;
+        }
+
+        var seenLevelIds = new HashSet<int>();
+        double? previousScaleDenominator = null;
+        var sortedLevels = new List<TileMatrixLevel>(entry.Levels);
+        sortedLevels.Sort(static (a, b) => a.Id.CompareTo(b.Id));
+
+        foreach (var level in sortedLevels)
+        {
+            if (!seenLevelIds.Add(level.Id))
+            {
+                failures.Add($"{label} has a duplicate level id {level.Id}.");
+            }
+
+            if (level.ScaleDenominator <= 0)
+            {
+                failures.Add($"{label} level {level.Id} must have a positive ScaleDenominator.");
+            }
+
+            if (level.CellSize <= 0)
+            {
+                failures.Add($"{label} level {level.Id} must have a positive CellSize.");
+            }
+
+            if (level.MatrixWidth <= 0 || level.MatrixHeight <= 0)
+            {
+                failures.Add($"{label} level {level.Id} must have positive MatrixWidth and MatrixHeight.");
+            }
+
+            // Scale denominators must strictly decrease as the level (zoom) increases — each
+            // level halves the cell size of the previous one. A non-monotonic set is a
+            // misconfiguration that would corrupt zoom selection.
+            if (previousScaleDenominator is { } previous && level.ScaleDenominator >= previous)
+            {
+                failures.Add(
+                    $"{label} level {level.Id} ScaleDenominator must be strictly smaller than the previous level (scale denominators must decrease as level increases).");
+            }
+
+            if (level.ScaleDenominator > 0)
+            {
+                previousScaleDenominator = level.ScaleDenominator;
+            }
+        }
+    }
+}

--- a/src/Honua.Core/Features/Tiles/TileMatrixSetRegistry.cs
+++ b/src/Honua.Core/Features/Tiles/TileMatrixSetRegistry.cs
@@ -1,0 +1,248 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Honua.Core.Features.Shared.Models;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Core.Features.Tiles;
+
+/// <summary>
+/// Default <see cref="ITileMatrixSetRegistry"/> implementation. Seeds the two reserved built-in
+/// gridsets (WebMercatorQuad, WorldCRS84Quad) from the canonical OGC constants and formulas so
+/// their advertised geometry is byte-identical to the previous hardcoded paths, then merges any
+/// operator-defined custom gridsets bound from the <c>TileMatrixSets</c> configuration section.
+/// </summary>
+public sealed class TileMatrixSetRegistry : ITileMatrixSetRegistry
+{
+    /// <summary>WebMercatorQuad reserved built-in identifier.</summary>
+    public const string WebMercatorQuadId = "WebMercatorQuad";
+
+    /// <summary>WorldCRS84Quad reserved built-in identifier.</summary>
+    public const string WorldCrs84QuadId = "WorldCRS84Quad";
+
+    private const string WebMercatorQuadUri = "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad";
+    private const string WebMercatorCrs = "http://www.opengis.net/def/crs/EPSG/0/3857";
+    private const string WebMercatorTitle = "Web Mercator Quad";
+
+    private const string WorldCrs84QuadUri = "http://www.opengis.net/def/tilematrixset/OGC/1.0/WorldCRS84Quad";
+    private const string Crs84 = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
+    private const string WorldCrs84Title = "World CRS84 Quad";
+
+    private const double WebMercatorExtent = SpatialConstants.WebMercatorExtent;
+    private const double PixelSizeMeters = SpatialConstants.PixelSizeMeters;
+    private const double DegreesPerPixel = SpatialConstants.DegreesPerPixel;
+    private const int DefaultTileSize = 256;
+
+    /// <summary>
+    /// The reserved built-in identifiers that operators may not redefine. Exposed so the
+    /// configuration validator can reject collisions with the same source of truth.
+    /// </summary>
+    public static readonly ImmutableArray<string> ReservedIds =
+        [WebMercatorQuadId, WorldCrs84QuadId];
+
+    private readonly ImmutableArray<TileMatrixSetEntry> _entries;
+    private readonly Dictionary<string, TileMatrixSetEntry> _entriesById;
+    private readonly Dictionary<string, CustomTileMatrixSet> _customById;
+
+    /// <summary>
+    /// Creates a registry from the bound <see cref="TileMatrixSetDefinitionOptions"/>.
+    /// </summary>
+    /// <param name="options">The bound custom tile matrix set options.</param>
+    public TileMatrixSetRegistry(IOptions<TileMatrixSetDefinitionOptions> options)
+        : this(options?.Value ?? new TileMatrixSetDefinitionOptions())
+    {
+    }
+
+    /// <summary>
+    /// Creates a registry from the supplied options instance (used directly by tests).
+    /// </summary>
+    /// <param name="options">The custom tile matrix set options.</param>
+    public TileMatrixSetRegistry(TileMatrixSetDefinitionOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var entries = ImmutableArray.CreateBuilder<TileMatrixSetEntry>();
+        entries.Add(new TileMatrixSetEntry
+        {
+            Id = WebMercatorQuadId,
+            Title = WebMercatorTitle,
+            Uri = WebMercatorQuadUri,
+            Crs = WebMercatorCrs,
+            Srid = 3857,
+            IsGeographic = false,
+            IsBuiltIn = true
+        });
+        entries.Add(new TileMatrixSetEntry
+        {
+            Id = WorldCrs84QuadId,
+            Title = WorldCrs84Title,
+            Uri = WorldCrs84QuadUri,
+            Crs = Crs84,
+            Srid = 4326,
+            IsGeographic = true,
+            IsBuiltIn = true
+        });
+
+        _customById = new Dictionary<string, CustomTileMatrixSet>(StringComparer.OrdinalIgnoreCase);
+        foreach (var custom in options.Custom ?? new List<CustomTileMatrixSet>())
+        {
+            if (custom is null || string.IsNullOrWhiteSpace(custom.Id))
+            {
+                continue;
+            }
+
+            // Defensive: a misconfigured duplicate or reserved-id collision should have been
+            // rejected at startup by TileMatrixSetOptionsValidator. Skip silently here so the
+            // registry never throws while serving requests.
+            if (_customById.ContainsKey(custom.Id) ||
+                ReservedIds.Any(reserved => string.Equals(reserved, custom.Id, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            _customById[custom.Id] = custom;
+            entries.Add(new TileMatrixSetEntry
+            {
+                Id = custom.Id,
+                Title = string.IsNullOrWhiteSpace(custom.Title) ? custom.Id : custom.Title!,
+                Uri = string.IsNullOrWhiteSpace(custom.Uri) ? custom.Id : custom.Uri!,
+                Crs = custom.Crs,
+                Srid = custom.Srid,
+                IsGeographic = IsGeographicSrid(custom.Srid),
+                IsBuiltIn = false
+            });
+        }
+
+        _entries = entries.ToImmutable();
+        _entriesById = _entries.ToDictionary(entry => entry.Id, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<TileMatrixSetEntry> All => _entries;
+
+    /// <inheritdoc />
+    public bool IsSupported(string tileMatrixSetId)
+        => !string.IsNullOrWhiteSpace(tileMatrixSetId) && _entriesById.ContainsKey(tileMatrixSetId);
+
+    /// <inheritdoc />
+    public bool TryGet(string tileMatrixSetId, [NotNullWhen(true)] out TileMatrixSetEntry? entry)
+    {
+        if (!string.IsNullOrWhiteSpace(tileMatrixSetId) &&
+            _entriesById.TryGetValue(tileMatrixSetId, out var found))
+        {
+            entry = found;
+            return true;
+        }
+
+        entry = null;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetGeometry(string tileMatrixSetId, int maxLevel, [NotNullWhen(true)] out GridGeometry? geometry)
+    {
+        if (string.IsNullOrWhiteSpace(tileMatrixSetId) || !_entriesById.TryGetValue(tileMatrixSetId, out var entry))
+        {
+            geometry = null;
+            return false;
+        }
+
+        if (entry.IsBuiltIn)
+        {
+            geometry = string.Equals(entry.Id, WorldCrs84QuadId, StringComparison.OrdinalIgnoreCase)
+                ? BuildWorldCrs84QuadGeometry(maxLevel)
+                : BuildWebMercatorQuadGeometry(maxLevel);
+            return true;
+        }
+
+        geometry = BuildCustomGeometry(entry, _customById[entry.Id]);
+        return true;
+    }
+
+    private static GridGeometry BuildWebMercatorQuadGeometry(int maxLevel)
+    {
+        var levels = ImmutableArray.CreateBuilder<GridLevel>();
+        for (var z = 0; z <= Math.Max(0, maxLevel); z++)
+        {
+            var matrixSize = 1L << z;
+            var cellSize = (2.0 * WebMercatorExtent) / ((double)DefaultTileSize * matrixSize);
+            var scaleDenominator = cellSize / PixelSizeMeters;
+            levels.Add(new GridLevel(z, scaleDenominator, cellSize, matrixSize, matrixSize));
+        }
+
+        return new GridGeometry
+        {
+            Id = WebMercatorQuadId,
+            Srid = 3857,
+            IsGeographic = false,
+            TopLeftX = -WebMercatorExtent,
+            TopLeftY = WebMercatorExtent,
+            TileWidth = DefaultTileSize,
+            TileHeight = DefaultTileSize,
+            Levels = levels.ToImmutable()
+        };
+    }
+
+    private static GridGeometry BuildWorldCrs84QuadGeometry(int maxLevel)
+    {
+        var levels = ImmutableArray.CreateBuilder<GridLevel>();
+        for (var z = 0; z <= Math.Max(0, maxLevel); z++)
+        {
+            // WorldCRS84Quad: at zoom 0, 2 cols x 1 row covering the full globe.
+            var numRows = 1L << z;
+            var numCols = numRows * 2;
+            var cellSize = 180.0 / ((double)DefaultTileSize * numRows);
+            var scaleDenominator = cellSize / DegreesPerPixel;
+            levels.Add(new GridLevel(z, scaleDenominator, cellSize, numCols, numRows));
+        }
+
+        return new GridGeometry
+        {
+            Id = WorldCrs84QuadId,
+            Srid = 4326,
+            IsGeographic = true,
+            TopLeftX = -180.0,
+            TopLeftY = 90.0,
+            TileWidth = DefaultTileSize,
+            TileHeight = DefaultTileSize,
+            Levels = levels.ToImmutable()
+        };
+    }
+
+    private static GridGeometry BuildCustomGeometry(TileMatrixSetEntry entry, CustomTileMatrixSet custom)
+    {
+        var levels = ImmutableArray.CreateBuilder<GridLevel>(custom.Levels.Count);
+        foreach (var level in custom.Levels.OrderBy(candidate => candidate.Id))
+        {
+            levels.Add(new GridLevel(
+                level.Id,
+                level.ScaleDenominator,
+                level.CellSize,
+                level.MatrixWidth,
+                level.MatrixHeight));
+        }
+
+        var topLeftX = custom.TopLeftCorner.Length > 0 ? custom.TopLeftCorner[0] : 0.0;
+        var topLeftY = custom.TopLeftCorner.Length > 1 ? custom.TopLeftCorner[1] : 0.0;
+
+        return new GridGeometry
+        {
+            Id = entry.Id,
+            Srid = custom.Srid,
+            IsGeographic = entry.IsGeographic,
+            TopLeftX = topLeftX,
+            TopLeftY = topLeftY,
+            TileWidth = custom.TileWidth,
+            TileHeight = custom.TileHeight,
+            Levels = levels.ToImmutable()
+        };
+    }
+
+    private static bool IsGeographicSrid(int srid)
+        => Array.IndexOf(SpatialConstants.GeographicSrids, srid) >= 0;
+}

--- a/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs
+++ b/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs
@@ -152,9 +152,9 @@ internal static class RasterMapRenderingPipeline
             context,
             serviceSrid,
             renderLayers,
-            z, y, x,
+            TileSrid,
+            TileMath.GetTileBounds(x, y, z),
             maxFeatures,
-            TileGridKind.WebMercatorQuad,
             cancellationToken,
             layerTemporalFilters);
 
@@ -177,18 +177,32 @@ internal static class RasterMapRenderingPipeline
         TileGridKind grid,
         CancellationToken cancellationToken,
         IReadOnlyList<TemporalFilter?>? layerTemporalFilters = null)
-        => RenderRasterTileCoreAsync(
+    {
+        var isGeographicGrid = grid == TileGridKind.WorldCrs84Quad;
+        var tileSrid = isGeographicGrid ? GeographicTileSrid : TileSrid;
+        var tileBounds = isGeographicGrid
+            ? TileMath.GetTileBoundsGeographic(x, y, z)
+            : TileMath.GetTileBounds(x, y, z);
+        return RenderRasterTileCoreAsync(
             context,
             serviceSrid,
             renderLayers,
-            z, y, x,
+            tileSrid,
+            tileBounds,
             maxFeatures,
-            grid,
             cancellationToken,
             layerTemporalFilters);
+    }
 
-#pragma warning disable CA1068 // legacy callers/tests pass cancellation before optional temporal filters
-    private static async Task<RasterTileRenderResult> RenderRasterTileCoreAsync(
+    /// <summary>
+    /// Renders a raster tile for an operator-defined custom tile matrix set described by a
+    /// <see cref="GridGeometry"/>. The tile envelope is computed from the grid origin / cell size
+    /// (in the gridset CRS) and the canonical query pipeline reprojects from the storage CRS as
+    /// needed. The two built-in gridsets continue to flow through the <see cref="TileGridKind"/>
+    /// overload so their output stays byte-identical; this overload exists because the enum cannot
+    /// represent operator-defined gridsets.
+    /// </summary>
+    internal static Task<RasterTileRenderResult> RenderRasterTileForGridAsync(
         HttpContext context,
         int serviceSrid,
         IReadOnlyList<RenderLayerDescriptor> renderLayers,
@@ -196,16 +210,36 @@ internal static class RasterMapRenderingPipeline
         int y,
         int x,
         int maxFeatures,
-        TileGridKind grid,
+        GridGeometry gridGeometry,
+        CancellationToken cancellationToken,
+        IReadOnlyList<TemporalFilter?>? layerTemporalFilters = null)
+    {
+        ArgumentNullException.ThrowIfNull(gridGeometry);
+        var tileBounds = gridGeometry.GetTileBounds(x, y, z)
+            ?? throw new ArgumentOutOfRangeException(nameof(z), "Requested level is not part of the tile matrix set.");
+        return RenderRasterTileCoreAsync(
+            context,
+            serviceSrid,
+            renderLayers,
+            gridGeometry.Srid,
+            tileBounds,
+            maxFeatures,
+            cancellationToken,
+            layerTemporalFilters);
+    }
+
+#pragma warning disable CA1068 // legacy callers/tests pass cancellation before optional temporal filters
+    private static async Task<RasterTileRenderResult> RenderRasterTileCoreAsync(
+        HttpContext context,
+        int serviceSrid,
+        IReadOnlyList<RenderLayerDescriptor> renderLayers,
+        int tileSrid,
+        TileBounds tileBounds,
+        int maxFeatures,
         CancellationToken cancellationToken,
         IReadOnlyList<TemporalFilter?>? layerTemporalFilters)
 #pragma warning restore CA1068
     {
-        var isGeographicGrid = grid == TileGridKind.WorldCrs84Quad;
-        var tileSrid = isGeographicGrid ? GeographicTileSrid : TileSrid;
-        var tileBounds = isGeographicGrid
-            ? TileMath.GetTileBoundsGeographic(x, y, z)
-            : TileMath.GetTileBounds(x, y, z);
         var renderExtent = new SkiaMapRenderer.RenderExtent(
             tileBounds.XMin,
             tileBounds.YMin,

--- a/src/Honua.Protocols.OgcApi/Tiles/OgcTilesUtilities.cs
+++ b/src/Honua.Protocols.OgcApi/Tiles/OgcTilesUtilities.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Shared.Models;
+using Honua.Core.Features.Tiles;
 using Honua.Infrastructure.Helpers;
 using Honua.Protocols.Ogc.Common;
 using Honua.Protocols.Ogc.Api.Tiles.Models;
@@ -120,17 +121,118 @@ internal static class OgcTilesUtilities
     private const double DegreesPerPixel = SpatialConstants.DegreesPerPixel;
 
     /// <summary>
-    /// Determines whether the given tile matrix set identifier is supported.
-    /// </summary>
-    public static bool IsSupportedTileMatrixSet(string tileMatrixSetId)
-        => string.Equals(tileMatrixSetId, WebMercatorQuadId, StringComparison.OrdinalIgnoreCase)
-           || string.Equals(tileMatrixSetId, WorldCrs84QuadId, StringComparison.OrdinalIgnoreCase);
-
-    /// <summary>
     /// Returns true when the tile matrix set identifier is WorldCRS84Quad.
     /// </summary>
     public static bool IsWorldCrs84Quad(string tileMatrixSetId)
         => string.Equals(tileMatrixSetId, WorldCrs84QuadId, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Resolves the well-known scale set URI advertised for a registered tile matrix set. The two
+    /// built-ins keep their canonical OGC well-known scale sets; operator-defined custom gridsets
+    /// advertise none.
+    /// </summary>
+    public static string? GetWellKnownScaleSet(TileMatrixSetEntry entry)
+    {
+        if (!entry.IsBuiltIn)
+        {
+            return null;
+        }
+
+        return string.Equals(entry.Id, WorldCrs84QuadId, StringComparison.OrdinalIgnoreCase)
+            ? WorldCrs84ScaleSet
+            : WebMercatorScaleSet;
+    }
+
+    /// <summary>
+    /// Builds a tile matrix set summary item from a registry entry.
+    /// </summary>
+    public static TileMatrixSetItem BuildTileMatrixSetItem(TileMatrixSetEntry entry, string baseUrl)
+    {
+        var selfHref = $"{baseUrl}/ogc/tiles/tileMatrixSets/{entry.Id}";
+        return new TileMatrixSetItem
+        {
+            Id = entry.Id,
+            Title = entry.Title,
+            Uri = entry.Uri,
+            Crs = entry.Crs,
+            Links = ImmutableArray.Create(Link.Create(
+                href: selfHref,
+                rel: RelationTypes.Self,
+                type: MediaTypes.Json,
+                title: "Tile matrix set definition"))
+        };
+    }
+
+    /// <summary>
+    /// Builds the full tile matrix set definition from a registry entry and its grid geometry.
+    /// For the two built-ins this reproduces the exact byte-identical output of the legacy
+    /// <c>BuildWebMercatorQuadDefinition</c>/<c>BuildWorldCrs84QuadDefinition</c> paths because the
+    /// registry seeds them from the same constants and formulas.
+    /// </summary>
+    public static TileMatrixSetDefinition BuildTileMatrixSetDefinition(
+        TileMatrixSetEntry entry,
+        GridGeometry geometry,
+        int minLevel = 0)
+    {
+        var tileMatrices = ImmutableArray.CreateBuilder<TileMatrix>(geometry.Levels.Length);
+        foreach (var level in geometry.Levels)
+        {
+            if (level.Level < minLevel)
+            {
+                continue;
+            }
+
+            tileMatrices.Add(new TileMatrix
+            {
+                Id = level.Level.ToString(CultureInfo.InvariantCulture),
+                ScaleDenominator = level.ScaleDenominator,
+                CellSize = level.CellSize,
+                PointOfOrigin = ImmutableArray.Create(geometry.TopLeftX, geometry.TopLeftY),
+                TileWidth = geometry.TileWidth,
+                TileHeight = geometry.TileHeight,
+                MatrixWidth = checked((int)level.MatrixWidth),
+                MatrixHeight = checked((int)level.MatrixHeight),
+                CornerOfOrigin = "topLeft"
+            });
+        }
+
+        return new TileMatrixSetDefinition
+        {
+            Id = entry.Id,
+            Title = entry.Title,
+            Uri = entry.Uri,
+            Crs = entry.Crs,
+            WellKnownScaleSet = GetWellKnownScaleSet(entry),
+            TileMatrices = tileMatrices.ToImmutable()
+        };
+    }
+
+    /// <summary>
+    /// Builds tile matrix set limits (full coverage) from a grid geometry. Each level exposes the
+    /// full matrix-width × matrix-height extent.
+    /// </summary>
+    public static ImmutableArray<TileMatrixSetLimit> BuildTileMatrixSetLimits(GridGeometry geometry, int minLevel = 0)
+    {
+        var matrixLimits = ImmutableArray.CreateBuilder<TileMatrixSetLimit>(geometry.Levels.Length);
+        foreach (var level in geometry.Levels)
+        {
+            if (level.Level < minLevel)
+            {
+                continue;
+            }
+
+            matrixLimits.Add(new TileMatrixSetLimit
+            {
+                TileMatrix = level.Level.ToString(CultureInfo.InvariantCulture),
+                MinTileRow = 0,
+                MaxTileRow = checked((int)(level.MatrixHeight - 1)),
+                MinTileCol = 0,
+                MaxTileCol = checked((int)(level.MatrixWidth - 1))
+            });
+        }
+
+        return matrixLimits.ToImmutable();
+    }
 
     public static TileMatrixSetItem BuildWebMercatorQuadItem(string baseUrl)
     {

--- a/src/Honua.Protocols.OgcApi/Tiles/TileMatrixSetEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Tiles/TileMatrixSetEndpoints.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using Honua.Core.Configuration;
+using Honua.Core.Features.Tiles;
 using Honua.Infrastructure.Helpers;
 using Honua.Infrastructure.Models;
 using Honua.Protocols.Ogc.Common;
@@ -40,7 +41,10 @@ internal static class TileMatrixSetEndpoints
         return endpoints;
     }
 
-    private static IResult HandleGetTileMatrixSets(HttpContext context, string? f)
+    private static IResult HandleGetTileMatrixSets(
+        HttpContext context,
+        string? f,
+        [FromServices] ITileMatrixSetRegistry registry)
     {
         var validationError = OgcCommonUtilities.ValidateQueryParameters(context.Request, OgcTilesUtilities.AllowedQueryParameters.Metadata);
         if (validationError is not null)
@@ -55,9 +59,13 @@ internal static class TileMatrixSetEndpoints
 
         var request = context.Request;
         var baseUrl = BaseUrlResolver.GetBaseUrl(context);
-        var items = ImmutableArray.Create(
-            OgcTilesUtilities.BuildWebMercatorQuadItem(baseUrl),
-            OgcTilesUtilities.BuildWorldCrs84QuadItem(baseUrl));
+        var itemsBuilder = ImmutableArray.CreateBuilder<TileMatrixSetItem>(registry.All.Count);
+        foreach (var entry in registry.All)
+        {
+            itemsBuilder.Add(OgcTilesUtilities.BuildTileMatrixSetItem(entry, baseUrl));
+        }
+
+        var items = itemsBuilder.ToImmutable();
 
         var links = OgcCommonUtilities.BuildFormatLinks(
                 request,
@@ -86,7 +94,8 @@ internal static class TileMatrixSetEndpoints
         string tileMatrixSetId,
         HttpContext context,
         string? f,
-        [FromServices] IOptions<LimitsOptions> limitsOptions)
+        [FromServices] IOptions<LimitsOptions> limitsOptions,
+        [FromServices] ITileMatrixSetRegistry registry)
     {
         var validationError = OgcCommonUtilities.ValidateQueryParameters(context.Request, OgcTilesUtilities.AllowedQueryParameters.Metadata);
         if (validationError is not null)
@@ -99,14 +108,21 @@ internal static class TileMatrixSetEndpoints
             return OgcCommonUtilities.CreateFormatError(context, formatError);
         }
 
-        if (!OgcTilesUtilities.IsSupportedTileMatrixSet(tileMatrixSetId))
+        if (!registry.TryGet(tileMatrixSetId, out var entry))
         {
             return StandardErrorHelpers.CreateNotFound(context, $"Tile matrix set '{tileMatrixSetId}' not found.");
         }
 
-        var definition = OgcTilesUtilities.IsWorldCrs84Quad(tileMatrixSetId)
-            ? OgcTilesUtilities.BuildWorldCrs84QuadDefinition(limitsOptions.Value.Tiles)
-            : OgcTilesUtilities.BuildWebMercatorQuadDefinition(limitsOptions.Value.Tiles);
+        // Built-in gridsets generate levels for the configured zoom range; custom gridsets carry
+        // their own explicit levels (the maxLevel argument is ignored for those).
+        var maxLevel = Math.Max(0, limitsOptions.Value.Tiles.MaxTileZoom);
+        if (!registry.TryGetGeometry(entry.Id, maxLevel, out var geometry))
+        {
+            return StandardErrorHelpers.CreateNotFound(context, $"Tile matrix set '{tileMatrixSetId}' not found.");
+        }
+
+        var minLevel = entry.IsBuiltIn ? Math.Max(0, limitsOptions.Value.Tiles.MinTileZoom) : 0;
+        var definition = OgcTilesUtilities.BuildTileMatrixSetDefinition(entry, geometry, minLevel);
         return OgcCommonUtilities.FormatMetadataResponse(definition, OgcTilesJsonContext.Default.TileMatrixSetDefinition, outputFormat, "Tile matrix set");
     }
 }

--- a/src/Honua.Protocols.OgcApi/Tiles/TilesEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Tiles/TilesEndpoints.cs
@@ -163,7 +163,11 @@ internal static partial class TilesEndpoints
             return CreateFormatError(context, f);
         }
 
-        if (!OgcTilesUtilities.IsSupportedTileMatrixSet(tileMatrixSetId))
+        // The dataset/collection tileset-metadata documents advertise vector + PNG tiles for the
+        // two built-in gridsets only (the MVT tile provider understands those pyramids). Custom
+        // gridsets are advertised through /ogc/tiles/tileMatrixSets and served via GetTile (PNG);
+        // their per-dataset tileset documents are a deferred follow-up.
+        if (!OgcTileMatrixSetDescriptors.TryGet(tileMatrixSetId, out _))
         {
             return StandardErrorHelpers.CreateNotFound(context, $"Tile matrix set '{tileMatrixSetId}' not found.");
         }
@@ -215,7 +219,8 @@ internal static partial class TilesEndpoints
         [FromServices] IMetadataV2GraphProvider graphProvider,
         [FromServices] ITileProvider tileProvider,
         [FromServices] IOptions<TileOptions> tileOptions,
-        [FromServices] IOptions<LimitsOptions> limitsOptions)
+        [FromServices] IOptions<LimitsOptions> limitsOptions,
+        [FromServices] ITileMatrixSetRegistry tileMatrixSetRegistry)
     {
         if (!TryRequireTenantContext(context, out var tenantError))
         {
@@ -245,7 +250,8 @@ internal static partial class TilesEndpoints
             cancellationToken => ResolveDatasetLayersAsync(collections, graphProvider, context, cancellationToken),
             tileProvider,
             tileOptions,
-            limitsOptions);
+            limitsOptions,
+            tileMatrixSetRegistry);
     }
 
     private static async Task<IResult> HandleGetCollectionTilesets(
@@ -312,7 +318,11 @@ internal static partial class TilesEndpoints
             return CreateFormatError(context, f);
         }
 
-        if (!OgcTilesUtilities.IsSupportedTileMatrixSet(tileMatrixSetId))
+        // The dataset/collection tileset-metadata documents advertise vector + PNG tiles for the
+        // two built-in gridsets only (the MVT tile provider understands those pyramids). Custom
+        // gridsets are advertised through /ogc/tiles/tileMatrixSets and served via GetTile (PNG);
+        // their per-dataset tileset documents are a deferred follow-up.
+        if (!OgcTileMatrixSetDescriptors.TryGet(tileMatrixSetId, out _))
         {
             return StandardErrorHelpers.CreateNotFound(context, $"Tile matrix set '{tileMatrixSetId}' not found.");
         }
@@ -356,7 +366,8 @@ internal static partial class TilesEndpoints
         [FromServices] IMetadataV2GraphProvider graphProvider,
         [FromServices] ITileProvider tileProvider,
         [FromServices] IOptions<TileOptions> tileOptions,
-        [FromServices] IOptions<LimitsOptions> limitsOptions)
+        [FromServices] IOptions<LimitsOptions> limitsOptions,
+        [FromServices] ITileMatrixSetRegistry tileMatrixSetRegistry)
     {
         if (!TryRequireTenantContext(context, out var tenantError))
         {
@@ -395,7 +406,8 @@ internal static partial class TilesEndpoints
             },
             tileProvider,
             tileOptions,
-            limitsOptions);
+            limitsOptions,
+            tileMatrixSetRegistry);
     }
 
     private static async Task<IResult> HandleTileRequestAsync(
@@ -413,7 +425,8 @@ internal static partial class TilesEndpoints
         Func<CancellationToken, Task<(TileRequestLayer[] Layers, IResult? Error)>> resolveLayersAsync,
         ITileProvider tileProvider,
         IOptions<TileOptions> tileOptions,
-        IOptions<LimitsOptions> limitsOptions)
+        IOptions<LimitsOptions> limitsOptions,
+        ITileMatrixSetRegistry tileMatrixSetRegistry)
     {
         var request = context.Request;
         var validationError = OgcCommonUtilities.ValidateQueryParameters(request, allowedQueryParameters);
@@ -439,12 +452,12 @@ internal static partial class TilesEndpoints
             }
         }
 
-        if (!OgcTilesUtilities.IsSupportedTileMatrixSet(tileMatrixSetId))
+        if (!tileMatrixSetRegistry.TryGet(tileMatrixSetId, out var tileMatrixSetEntry))
         {
             return StandardErrorHelpers.CreateNotFound(context, $"Tile matrix set '{tileMatrixSetId}' not found.");
         }
 
-        var isGeographic = OgcTilesUtilities.IsWorldCrs84Quad(tileMatrixSetId);
+        var isGeographic = tileMatrixSetEntry.IsGeographic;
 
         if (!int.TryParse(tileMatrix, NumberStyles.Integer, CultureInfo.InvariantCulture, out var zoomLevel))
         {
@@ -453,14 +466,37 @@ internal static partial class TilesEndpoints
 
         var tileOptionsValue = tileOptions.Value;
         var tileLimits = limitsOptions.Value.Tiles;
-        if (zoomLevel < tileLimits.MinTileZoom || zoomLevel > tileLimits.MaxTileZoom)
+
+        // Resolve the grid geometry. Built-in gridsets generate levels for the configured zoom
+        // range and are still subject to the server-wide tile-zoom limits; custom gridsets are
+        // validated against their own configured level set.
+        if (!tileMatrixSetRegistry.TryGetGeometry(tileMatrixSetEntry.Id, Math.Max(0, tileLimits.MaxTileZoom), out var gridGeometry))
         {
-            return StandardErrorHelpers.CreateBadRequest(context, $"Tile matrix '{tileMatrix}' is outside supported range.");
+            return StandardErrorHelpers.CreateNotFound(context, $"Tile matrix set '{tileMatrixSetId}' not found.");
         }
 
-        var validCoords = isGeographic
-            ? TileMath.ValidateTileCoordinatesGeographic(tileCol, tileRow, zoomLevel)
-            : TileMath.ValidateTileCoordinates(tileCol, tileRow, zoomLevel);
+        bool validCoords;
+        if (tileMatrixSetEntry.IsBuiltIn)
+        {
+            if (zoomLevel < tileLimits.MinTileZoom || zoomLevel > tileLimits.MaxTileZoom)
+            {
+                return StandardErrorHelpers.CreateBadRequest(context, $"Tile matrix '{tileMatrix}' is outside supported range.");
+            }
+
+            validCoords = isGeographic
+                ? TileMath.ValidateTileCoordinatesGeographic(tileCol, tileRow, zoomLevel)
+                : TileMath.ValidateTileCoordinates(tileCol, tileRow, zoomLevel);
+        }
+        else
+        {
+            if (gridGeometry.FindLevel(zoomLevel) is not { } customLevel)
+            {
+                return StandardErrorHelpers.CreateBadRequest(context, $"Tile matrix '{tileMatrix}' is outside supported range.");
+            }
+
+            validCoords = tileCol >= 0 && tileRow >= 0 &&
+                tileCol < customLevel.MatrixWidth && tileRow < customLevel.MatrixHeight;
+        }
 
         if (!validCoords)
         {
@@ -528,6 +564,18 @@ internal static partial class TilesEndpoints
             // datacube render is the deferred Shape B follow-up (after #1790). Direct endpoint
             // tests cover this record-but-don't-render behavior.
 
+            // Tile envelope in the gridset CRS. For the two built-ins this is byte-identical to
+            // the legacy TileMath.GetTileBounds / GetTileBoundsGeographic output (the registry
+            // seeds those geometries from the same formulas); for custom gridsets the envelope is
+            // derived from the configured origin / cell size.
+            var tileBounds = gridGeometry.GetTileBounds(tileCol, tileRow, zoomLevel);
+            if (tileBounds is null)
+            {
+                return StandardErrorHelpers.CreateBadRequest(context, $"Invalid tile coordinates: row={tileRow}, col={tileCol}, matrix={tileMatrix}.");
+            }
+
+            var filterSrid = gridGeometry.Srid;
+
             // Raster (PNG) tile path
             if (isRaster)
             {
@@ -535,10 +583,8 @@ internal static partial class TilesEndpoints
                     ? await HandleRasterTileAsync(
                         context,
                         layer,
-                        tileCol,
-                        tileRow,
-                        zoomLevel,
-                        isGeographic,
+                        tileBounds,
+                        filterSrid,
                         GetTemporalFilterForLayer(layer, temporalFilters),
                         GetVerticalSelectionForLayer(layer, verticalSelections),
                         tileLimits,
@@ -548,15 +594,25 @@ internal static partial class TilesEndpoints
                     : await HandleDatasetRasterTileAsync(
                         context,
                         layers,
-                        tileCol,
-                        tileRow,
-                        zoomLevel,
-                        isGeographic,
+                        tileBounds,
+                        filterSrid,
                         temporalFilters,
                         tileLimits,
                         tileOptionsValue,
                         activity,
                         cancellationToken);
+            }
+
+            // Vector tiles flow through the shared MVT tile provider, which generates tiles against
+            // the standard WebMercatorQuad / WorldCRS84Quad pyramids only. Operator-defined custom
+            // gridsets are advertised + served as PNG (raster) tiles; vector tiles for a custom
+            // gridset are not supported (request PNG with f=png). This keeps the MVT pipeline from
+            // silently emitting tiles in the wrong grid.
+            if (!tileMatrixSetEntry.IsBuiltIn)
+            {
+                return StandardErrorHelpers.CreateNotAcceptable(
+                    context,
+                    $"Vector tiles are not available for tile matrix set '{tileMatrixSetId}'. Request PNG tiles (f=png).");
             }
 
             // Vector tile path. Record-but-don't-render the vertical selection (see the
@@ -623,10 +679,8 @@ internal static partial class TilesEndpoints
     private static async Task<IResult> HandleRasterTileAsync(
         HttpContext context,
         TileRequestLayer layer,
-        int tileCol,
-        int tileRow,
-        int zoomLevel,
-        bool isGeographic,
+        TileBounds bounds,
+        int filterSrid,
         TemporalFilter? temporalFilter,
         VerticalSelection? verticalSelection,
         TileLimits tileLimits,
@@ -643,11 +697,6 @@ internal static partial class TilesEndpoints
             activity?.SetTag("honua.tile.vertical_selection", selection.RawValue);
         }
 
-        var bounds = isGeographic
-            ? TileMath.GetTileBoundsGeographic(tileCol, tileRow, zoomLevel)
-            : TileMath.GetTileBounds(tileCol, tileRow, zoomLevel);
-
-        var filterSrid = isGeographic ? 4326 : 3857;
         var spatialFilter = CreateBboxSpatialFilter(bounds, filterSrid);
 
         var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
@@ -732,21 +781,14 @@ internal static partial class TilesEndpoints
     private static async Task<IResult> HandleDatasetRasterTileAsync(
         HttpContext context,
         TileRequestLayer[] layers,
-        int tileCol,
-        int tileRow,
-        int zoomLevel,
-        bool isGeographic,
+        TileBounds bounds,
+        int filterSrid,
         IReadOnlyDictionary<int, TemporalFilter?> temporalFilters,
         TileLimits tileLimits,
         TileOptions tileOptionsValue,
         Activity? activity,
         CancellationToken cancellationToken)
     {
-        var bounds = isGeographic
-            ? TileMath.GetTileBoundsGeographic(tileCol, tileRow, zoomLevel)
-            : TileMath.GetTileBounds(tileCol, tileRow, zoomLevel);
-
-        var filterSrid = isGeographic ? 4326 : 3857;
         var spatialFilter = CreateBboxSpatialFilter(bounds, filterSrid);
         var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
         var renderedLayers = new List<TileRenderer.TileRenderLayer>(layers.Length);

--- a/src/Honua.Protocols.OgcClassic/Wmts/WmtsRequestHandlers.cs
+++ b/src/Honua.Protocols.OgcClassic/Wmts/WmtsRequestHandlers.cs
@@ -330,6 +330,7 @@ internal static class WmtsRequestHandlers
             var baseUrl = BaseUrlResolver.GetBaseUrl(context);
             var coordinateTransformService = context.RequestServices.GetService<ICoordinateTransformService>();
             var capabilitiesFeatureReader = context.RequestServices.GetService<IFeatureReader>();
+            var tileMatrixSetRegistry = context.RequestServices.GetService<ITileMatrixSetRegistry>();
             // Capabilities only advertises resources that (a) carry geometry and (b) the caller
             // is allowed to read. V2 carries geometry on Spatial.GeometryType OR via a
             // Geometry/Geography schema field (matches the resolution used by the renderer).
@@ -345,6 +346,7 @@ internal static class WmtsRequestHandlers
                 wmtsMaxZoom,
                 coordinateTransformService,
                 capabilitiesFeatureReader,
+                tileMatrixSetRegistry,
                 cancellationToken).ConfigureAwait(false);
             return Results.Content(xml, responseMimeType);
         }
@@ -585,9 +587,21 @@ internal static class WmtsRequestHandlers
             return CreateWmtsExceptionReport(context, "MissingParameterValue", "TileMatrixSet", "TILEMATRIXSET parameter is required.");
         }
 
-        if (!TryResolveWmtsTileGrid(tileMatrixSet, out var tileGrid))
+        var tileMatrixSetRegistry = context.RequestServices.GetService<ITileMatrixSetRegistry>();
+        var isBuiltInGrid = TryResolveWmtsTileGrid(tileMatrixSet, out var tileGrid);
+        GridGeometry? customGridGeometry = null;
+        if (!isBuiltInGrid)
         {
-            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "TileMatrixSet", "Supported TILEMATRIXSET values are WebMercatorQuad and WorldCRS84Quad.");
+            // Operator-defined custom gridset (advertised in GetCapabilities). The custom grid's
+            // own levels bound the valid TILEMATRIX/TILEROW/TILECOL ranges (the global wmtsMaxZoom
+            // applies only to the built-in pyramids).
+            if (tileMatrixSetRegistry is null ||
+                !tileMatrixSetRegistry.TryGet(tileMatrixSet!, out var customEntry) ||
+                customEntry.IsBuiltIn ||
+                !tileMatrixSetRegistry.TryGetGeometry(customEntry.Id, wmtsMaxZoom, out customGridGeometry))
+            {
+                return CreateWmtsExceptionReport(context, "InvalidParameterValue", "TileMatrixSet", "Supported TILEMATRIXSET values are WebMercatorQuad and WorldCRS84Quad.");
+            }
         }
 
         if (!TryGetRequiredQueryValue(query, "TILEMATRIX", out var tileMatrixValue))
@@ -597,9 +611,19 @@ internal static class WmtsRequestHandlers
 
         if (!int.TryParse(tileMatrixValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var tileMatrix) ||
             tileMatrix < 0 ||
-            tileMatrix > wmtsMaxZoom)
+            (isBuiltInGrid && tileMatrix > wmtsMaxZoom))
         {
             return CreateWmtsExceptionReport(context, "InvalidParameterValue", "TileMatrix", "Invalid TILEMATRIX parameter.");
+        }
+
+        GridLevel? customLevel = null;
+        if (!isBuiltInGrid)
+        {
+            customLevel = customGridGeometry!.FindLevel(tileMatrix);
+            if (customLevel is null)
+            {
+                return CreateWmtsExceptionReport(context, "InvalidParameterValue", "TileMatrix", "Invalid TILEMATRIX parameter.");
+            }
         }
 
         if (!TryGetRequiredQueryValue(query, "TILEROW", out var tileRowValue))
@@ -622,8 +646,12 @@ internal static class WmtsRequestHandlers
             return CreateWmtsExceptionReport(context, "InvalidParameterValue", "TileCol", "Invalid TILECOL parameter.");
         }
 
-        var maxRowIndex = GetWmtsMaxTileRowIndex(tileMatrix);
-        var maxColIndex = GetWmtsMaxTileColIndex(tileGrid, tileMatrix);
+        var maxRowIndex = isBuiltInGrid
+            ? GetWmtsMaxTileRowIndex(tileMatrix)
+            : (int)(customLevel!.Value.MatrixHeight - 1);
+        var maxColIndex = isBuiltInGrid
+            ? GetWmtsMaxTileColIndex(tileGrid, tileMatrix)
+            : (int)(customLevel!.Value.MatrixWidth - 1);
         if (tileRow > maxRowIndex)
         {
             return CreateWmtsExceptionReport(context, "TileOutOfRange", "TileRow", "TILEROW is outside the valid range for TILEMATRIX.");
@@ -645,17 +673,29 @@ internal static class WmtsRequestHandlers
             BuildRenderDescriptor(layer, verticalSelection)
         };
 
-        var renderResult = await RenderRasterTileForGridAsync(
-            context,
-            serviceSrid,
-            renderDescriptors,
-            tileMatrix,
-            tileRow,
-            tileCol,
-            MaxFeaturesPerLayer,
-            tileGrid,
-            tileTemporalCancellationToken,
-            tileTemporalFilter is null ? null : [tileTemporalFilter]).ConfigureAwait(false);
+        var renderResult = isBuiltInGrid
+            ? await RenderRasterTileForGridAsync(
+                context,
+                serviceSrid,
+                renderDescriptors,
+                tileMatrix,
+                tileRow,
+                tileCol,
+                MaxFeaturesPerLayer,
+                tileGrid,
+                tileTemporalCancellationToken,
+                tileTemporalFilter is null ? null : [tileTemporalFilter]).ConfigureAwait(false)
+            : await RenderRasterTileForGridAsync(
+                context,
+                serviceSrid,
+                renderDescriptors,
+                tileMatrix,
+                tileRow,
+                tileCol,
+                MaxFeaturesPerLayer,
+                customGridGeometry!,
+                tileTemporalCancellationToken,
+                tileTemporalFilter is null ? null : [tileTemporalFilter]).ConfigureAwait(false);
 
         return renderResult.IsSuccess
             ? Results.Bytes(renderResult.ImageBytes, PngMimeType)
@@ -1263,6 +1303,7 @@ internal static class WmtsRequestHandlers
         int wmtsMaxZoom,
         ICoordinateTransformService? coordinateTransformService,
         IFeatureReader? featureReader,
+        ITileMatrixSetRegistry? tileMatrixSetRegistry,
         CancellationToken cancellationToken)
     {
         var sb = new StringBuilder(4096);
@@ -1447,6 +1488,7 @@ internal static class WmtsRequestHandlers
                 AppendWmtsDimensionElements(sb, dimensions);
                 AppendWmtsTileMatrixSetLink(sb, TileGridKind.WebMercatorQuad, wmtsMaxZoom);
                 AppendWmtsTileMatrixSetLink(sb, TileGridKind.WorldCrs84Quad, wmtsMaxZoom);
+                AppendWmtsCustomTileMatrixSetLinks(sb, tileMatrixSetRegistry, wmtsMaxZoom);
                 sb.Append("      <ResourceURL format=\"image/png\" resourceType=\"tile\" template=\"")
                     .Append(EscapeXml(tileTemplate))
                     .AppendLine("\" />");
@@ -1465,6 +1507,7 @@ internal static class WmtsRequestHandlers
 
             AppendWmtsWebMercatorTileMatrixSet(sb, wmtsMaxZoom);
             AppendWmtsWorldCrs84QuadTileMatrixSet(sb, wmtsMaxZoom);
+            AppendWmtsCustomTileMatrixSets(sb, tileMatrixSetRegistry, wmtsMaxZoom);
             sb.AppendLine("  </Contents>");
         }
 
@@ -2414,6 +2457,95 @@ internal static class WmtsRequestHandlers
         }
 
         sb.AppendLine("    </TileMatrixSet>");
+    }
+
+    /// <summary>
+    /// Emits a per-layer <c>TileMatrixSetLink</c> (with explicit limits) for every operator-defined
+    /// custom gridset in the registry. Built-in links are emitted separately so their XML stays
+    /// byte-identical; this only adds the custom entries.
+    /// </summary>
+    internal static void AppendWmtsCustomTileMatrixSetLinks(
+        StringBuilder sb,
+        ITileMatrixSetRegistry? registry,
+        int wmtsMaxZoom)
+    {
+        if (registry is null)
+        {
+            return;
+        }
+
+        foreach (var entry in registry.All)
+        {
+            if (entry.IsBuiltIn || !registry.TryGetGeometry(entry.Id, wmtsMaxZoom, out var geometry))
+            {
+                continue;
+            }
+
+            sb.AppendLine("      <TileMatrixSetLink>");
+            sb.Append("        <TileMatrixSet>").Append(EscapeXml(entry.Id)).AppendLine("</TileMatrixSet>");
+            sb.AppendLine("        <TileMatrixSetLimits>");
+            foreach (var level in geometry.Levels)
+            {
+                sb.AppendLine("          <TileMatrixLimits>");
+                sb.Append("            <TileMatrix>").Append(level.Level.ToString(CultureInfo.InvariantCulture)).AppendLine("</TileMatrix>");
+                sb.AppendLine("            <MinTileRow>0</MinTileRow>");
+                sb.Append("            <MaxTileRow>").Append((level.MatrixHeight - 1).ToString(CultureInfo.InvariantCulture)).AppendLine("</MaxTileRow>");
+                sb.AppendLine("            <MinTileCol>0</MinTileCol>");
+                sb.Append("            <MaxTileCol>").Append((level.MatrixWidth - 1).ToString(CultureInfo.InvariantCulture)).AppendLine("</MaxTileCol>");
+                sb.AppendLine("          </TileMatrixLimits>");
+            }
+
+            sb.AppendLine("        </TileMatrixSetLimits>");
+            sb.AppendLine("      </TileMatrixSetLink>");
+        }
+    }
+
+    /// <summary>
+    /// Emits the <c>TileMatrixSet</c> definition for every operator-defined custom gridset in the
+    /// registry. The geographic-CRS axis order in <c>TopLeftCorner</c> matches the built-in CRS84
+    /// path (latitude then longitude); projected CRSes use easting then northing.
+    /// </summary>
+    internal static void AppendWmtsCustomTileMatrixSets(
+        StringBuilder sb,
+        ITileMatrixSetRegistry? registry,
+        int wmtsMaxZoom)
+    {
+        if (registry is null)
+        {
+            return;
+        }
+
+        foreach (var entry in registry.All)
+        {
+            if (entry.IsBuiltIn || !registry.TryGetGeometry(entry.Id, wmtsMaxZoom, out var geometry))
+            {
+                continue;
+            }
+
+            sb.AppendLine("    <TileMatrixSet>");
+            sb.Append("      <ows:Identifier>").Append(EscapeXml(entry.Id)).AppendLine("</ows:Identifier>");
+            sb.Append("      <ows:SupportedCRS>").Append(EscapeXml(entry.Crs)).AppendLine("</ows:SupportedCRS>");
+
+            foreach (var level in geometry.Levels)
+            {
+                // WMTS TopLeftCorner axis order follows the CRS: latitude/longitude for geographic
+                // CRSes (matching the built-in CRS84 grid), easting/northing for projected CRSes.
+                var firstAxis = geometry.IsGeographic ? geometry.TopLeftY : geometry.TopLeftX;
+                var secondAxis = geometry.IsGeographic ? geometry.TopLeftX : geometry.TopLeftY;
+
+                sb.AppendLine("      <TileMatrix>");
+                sb.Append("        <ows:Identifier>").Append(level.Level.ToString(CultureInfo.InvariantCulture)).AppendLine("</ows:Identifier>");
+                sb.Append("        <ScaleDenominator>").Append(FormatWmtsScaleDenominator(level.ScaleDenominator)).AppendLine("</ScaleDenominator>");
+                sb.Append("        <TopLeftCorner>").Append(firstAxis.ToString("F6", CultureInfo.InvariantCulture)).Append(' ').Append(secondAxis.ToString("F6", CultureInfo.InvariantCulture)).AppendLine("</TopLeftCorner>");
+                sb.Append("        <TileWidth>").Append(geometry.TileWidth.ToString(CultureInfo.InvariantCulture)).AppendLine("</TileWidth>");
+                sb.Append("        <TileHeight>").Append(geometry.TileHeight.ToString(CultureInfo.InvariantCulture)).AppendLine("</TileHeight>");
+                sb.Append("        <MatrixWidth>").Append(level.MatrixWidth.ToString(CultureInfo.InvariantCulture)).AppendLine("</MatrixWidth>");
+                sb.Append("        <MatrixHeight>").Append(level.MatrixHeight.ToString(CultureInfo.InvariantCulture)).AppendLine("</MatrixHeight>");
+                sb.AppendLine("      </TileMatrix>");
+            }
+
+            sb.AppendLine("    </TileMatrixSet>");
+        }
     }
 
     private static async Task AppendWmtsWgs84BoundingBoxAsync(

--- a/src/Honua.Server/Startup/InfrastructureCompositionRoot.cs
+++ b/src/Honua.Server/Startup/InfrastructureCompositionRoot.cs
@@ -175,6 +175,15 @@ internal static class InfrastructureCompositionRoot
         {
             configuration.GetSection(Honua.Core.Features.Tiles.TileOptions.SectionName).Bind(options);
         });
+
+        // Bind operator-defined custom tile matrix sets and expose the merged built-in +
+        // custom gridset registry consumed by the OGC API Tiles and classic WMTS adapters.
+        // ValidateOnStart drives the registered IValidateOptions<TileMatrixSetDefinitionOptions>
+        // (TileMatrixSetOptionsValidator) so a misconfigured gridset fails the host fast.
+        services.AddOptions<Honua.Core.Features.Tiles.TileMatrixSetDefinitionOptions>()
+            .Bind(configuration.GetSection(Honua.Core.Features.Tiles.TileMatrixSetDefinitionOptions.SectionName))
+            .ValidateOnStart();
+        services.AddSingleton<Honua.Core.Features.Tiles.ITileMatrixSetRegistry, Honua.Core.Features.Tiles.TileMatrixSetRegistry>();
     }
 
     /// <summary>

--- a/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
+++ b/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
@@ -163,6 +163,8 @@ internal static class StartupConfigurationHelpers
     public static void RegisterConfigurationValidators(IServiceCollection services)
     {
         services.AddSingleton<IValidateOptions<LimitsOptions>>(new LimitsOptionsValidator());
+        services.AddSingleton<IValidateOptions<Honua.Core.Features.Tiles.TileMatrixSetDefinitionOptions>>(
+            new Honua.Core.Features.Tiles.TileMatrixSetOptionsValidator());
         services.AddSingleton<IValidateOptions<CacheOptions>>(new CacheOptionsValidator());
         services.AddSingleton<IValidateOptions<CloudStorageOptions>>(new CloudStorageOptionsValidator());
         services.AddSingleton<IValidateOptions<OidcAuthenticationOptions>>(new OidcAuthenticationOptionsValidator());

--- a/tests/dotnet/Honua.Core.Tests/Features/Tiles/TileMatrixSetOptionsValidatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Tiles/TileMatrixSetOptionsValidatorTests.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Tiles;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Core.Tests.Features.Tiles;
+
+public class TileMatrixSetOptionsValidatorTests
+{
+    private static readonly TileMatrixSetOptionsValidator Validator = new();
+
+    private static CustomTileMatrixSet Valid(string id = "Custom1")
+        => new()
+        {
+            Id = id,
+            Crs = "http://www.opengis.net/def/crs/EPSG/0/3857",
+            Srid = 3857,
+            TopLeftCorner = [-20037508.34, 20037508.34],
+            TileWidth = 256,
+            TileHeight = 256,
+            Levels =
+            [
+                new TileMatrixLevel { Id = 0, ScaleDenominator = 500_000_000, CellSize = 140_000, MatrixWidth = 1, MatrixHeight = 1 },
+                new TileMatrixLevel { Id = 1, ScaleDenominator = 250_000_000, CellSize = 70_000, MatrixWidth = 2, MatrixHeight = 2 }
+            ]
+        };
+
+    private static ValidateOptionsResult Validate(params CustomTileMatrixSet[] custom)
+    {
+        var options = new TileMatrixSetDefinitionOptions();
+        foreach (var entry in custom)
+        {
+            options.Custom.Add(entry);
+        }
+
+        return Validator.Validate(Options.DefaultName, options);
+    }
+
+    [Fact]
+    public void Validate_NoCustom_Succeeds()
+    {
+        Validate().Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ValidCustom_Succeeds()
+    {
+        Validate(Valid()).Succeeded.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("WebMercatorQuad")]
+    [InlineData("worldcrs84quad")]
+    public void Validate_ReservedIdCollision_Fails(string reservedId)
+    {
+        var result = Validate(Valid(reservedId));
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(f => f.Contains("reserved built-in"));
+    }
+
+    [Fact]
+    public void Validate_DuplicateId_Fails()
+    {
+        var result = Validate(Valid("Dup"), Valid("Dup"));
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(f => f.Contains("duplicate"));
+    }
+
+    [Fact]
+    public void Validate_NonMonotonicScaleDenominators_Fails()
+    {
+        var custom = Valid();
+        // Level 1 scale denominator must be strictly smaller than level 0; make it larger.
+        custom.Levels[1].ScaleDenominator = 600_000_000;
+
+        var result = Validate(custom);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(f => f.Contains("ScaleDenominator must be strictly smaller"));
+    }
+
+    [Fact]
+    public void Validate_NonPositiveMatrixDimensions_Fails()
+    {
+        var custom = Valid();
+        custom.Levels[0].MatrixWidth = 0;
+
+        var result = Validate(custom);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(f => f.Contains("MatrixWidth and MatrixHeight"));
+    }
+
+    [Fact]
+    public void Validate_InvalidSrid_Fails()
+    {
+        var custom = Valid();
+        custom.Srid = 0;
+
+        var result = Validate(custom);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(f => f.Contains("positive Srid"));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(3)]
+    public void Validate_TopLeftCornerWrongArity_Fails(int arity)
+    {
+        var custom = Valid();
+        custom.TopLeftCorner = new double[arity];
+
+        var result = Validate(custom);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(f => f.Contains("TopLeftCorner"));
+    }
+
+    [Fact]
+    public void Validate_NoLevels_Fails()
+    {
+        var custom = Valid();
+        custom.Levels.Clear();
+
+        var result = Validate(custom);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(f => f.Contains("at least one level"));
+    }
+
+    [Fact]
+    public void Validate_EmptyId_Fails()
+    {
+        var custom = Valid();
+        custom.Id = "  ";
+
+        var result = Validate(custom);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(f => f.Contains("non-empty Id"));
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Tiles/TileMatrixSetRegistryTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Tiles/TileMatrixSetRegistryTests.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Linq;
+using FluentAssertions;
+using Honua.Core.Features.Tiles;
+
+namespace Honua.Core.Tests.Features.Tiles;
+
+public class TileMatrixSetRegistryTests
+{
+    private static CustomTileMatrixSet SampleCustom(string id = "HawaiiAlbers")
+        => new()
+        {
+            Id = id,
+            Crs = "http://www.opengis.net/def/crs/EPSG/0/102007",
+            Uri = "https://example.com/tms/HawaiiAlbers",
+            Title = "Hawaii Albers",
+            Srid = 102007,
+            TopLeftCorner = [-200000.0, 2400000.0],
+            TileWidth = 256,
+            TileHeight = 256,
+            Levels =
+            [
+                new TileMatrixLevel { Id = 0, ScaleDenominator = 4000000, CellSize = 1120, MatrixWidth = 1, MatrixHeight = 1 },
+                new TileMatrixLevel { Id = 1, ScaleDenominator = 2000000, CellSize = 560, MatrixWidth = 2, MatrixHeight = 2 }
+            ]
+        };
+
+    [Fact]
+    public void All_WithNoCustom_ReturnsTwoBuiltIns()
+    {
+        var registry = new TileMatrixSetRegistry(new TileMatrixSetDefinitionOptions());
+
+        registry.All.Should().HaveCount(2);
+        registry.All.Select(e => e.Id).Should().Equal("WebMercatorQuad", "WorldCRS84Quad");
+        registry.All.Should().OnlyContain(e => e.IsBuiltIn);
+    }
+
+    [Fact]
+    public void All_WithCustom_AppendsCustomAfterBuiltIns()
+    {
+        var options = new TileMatrixSetDefinitionOptions { Custom = { SampleCustom() } };
+        var registry = new TileMatrixSetRegistry(options);
+
+        registry.All.Should().HaveCount(3);
+        registry.All.Select(e => e.Id).Should().Equal("WebMercatorQuad", "WorldCRS84Quad", "HawaiiAlbers");
+        registry.All[2].IsBuiltIn.Should().BeFalse();
+        registry.All[2].Title.Should().Be("Hawaii Albers");
+    }
+
+    [Fact]
+    public void IsSupported_BuiltInsAndCustom_AreCaseInsensitive()
+    {
+        var registry = new TileMatrixSetRegistry(new TileMatrixSetDefinitionOptions { Custom = { SampleCustom() } });
+
+        registry.IsSupported("webmercatorquad").Should().BeTrue();
+        registry.IsSupported("WORLDCRS84QUAD").Should().BeTrue();
+        registry.IsSupported("hawaiialbers").Should().BeTrue();
+        registry.IsSupported("Nope").Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryGet_WebMercatorQuad_HasProjectedMetadata()
+    {
+        var registry = new TileMatrixSetRegistry(new TileMatrixSetDefinitionOptions());
+
+        registry.TryGet("WebMercatorQuad", out var entry).Should().BeTrue();
+        entry!.Crs.Should().Be("http://www.opengis.net/def/crs/EPSG/0/3857");
+        entry.Srid.Should().Be(3857);
+        entry.IsGeographic.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryGet_WorldCrs84Quad_IsGeographic()
+    {
+        var registry = new TileMatrixSetRegistry(new TileMatrixSetDefinitionOptions());
+
+        registry.TryGet("WorldCRS84Quad", out var entry).Should().BeTrue();
+        entry!.IsGeographic.Should().BeTrue();
+        entry.Srid.Should().Be(4326);
+    }
+
+    [Fact]
+    public void TryGetGeometry_WebMercatorQuad_MatchesCanonicalGrid()
+    {
+        var registry = new TileMatrixSetRegistry(new TileMatrixSetDefinitionOptions());
+
+        registry.TryGetGeometry("WebMercatorQuad", maxLevel: 3, out var geometry).Should().BeTrue();
+        geometry!.Levels.Should().HaveCount(4);
+        geometry.TopLeftX.Should().Be(-20037508.342789244);
+        geometry.TopLeftY.Should().Be(20037508.342789244);
+
+        // Level 0 is a single 256px tile spanning the whole Web Mercator extent.
+        var level0 = geometry.Levels[0];
+        level0.MatrixWidth.Should().Be(1);
+        level0.MatrixHeight.Should().Be(1);
+        level0.ScaleDenominator.Should().BeApproximately(559082264.0287178, 1e-6);
+
+        var bounds = geometry.GetTileBounds(0, 0, 0);
+        bounds.Should().NotBeNull();
+        bounds!.XMin.Should().BeApproximately(-20037508.342789244, 1e-3);
+        bounds.YMax.Should().BeApproximately(20037508.342789244, 1e-3);
+    }
+
+    [Fact]
+    public void TryGetGeometry_WorldCrs84Quad_IsTwoTilesWideAtZoomZero()
+    {
+        var registry = new TileMatrixSetRegistry(new TileMatrixSetDefinitionOptions());
+
+        registry.TryGetGeometry("WorldCRS84Quad", maxLevel: 2, out var geometry).Should().BeTrue();
+        geometry!.Levels[0].MatrixWidth.Should().Be(2);
+        geometry.Levels[0].MatrixHeight.Should().Be(1);
+        geometry.TopLeftX.Should().Be(-180.0);
+        geometry.TopLeftY.Should().Be(90.0);
+    }
+
+    [Fact]
+    public void TryGetGeometry_Custom_ReturnsConfiguredLevels()
+    {
+        var registry = new TileMatrixSetRegistry(new TileMatrixSetDefinitionOptions { Custom = { SampleCustom() } });
+
+        registry.TryGetGeometry("HawaiiAlbers", maxLevel: 99, out var geometry).Should().BeTrue();
+        geometry!.Srid.Should().Be(102007);
+        geometry.Levels.Should().HaveCount(2);
+        geometry.Levels[0].ScaleDenominator.Should().Be(4000000);
+        geometry.TopLeftX.Should().Be(-200000.0);
+        geometry.TopLeftY.Should().Be(2400000.0);
+    }
+
+    [Fact]
+    public void Constructor_ReservedIdCollision_IsIgnoredDefensively()
+    {
+        // The validator rejects this at startup; the registry must still not throw or
+        // shadow the built-in if a collision slips through.
+        var options = new TileMatrixSetDefinitionOptions
+        {
+            Custom = { SampleCustom("WebMercatorQuad") }
+        };
+        var registry = new TileMatrixSetRegistry(options);
+
+        registry.All.Should().HaveCount(2);
+        registry.TryGet("WebMercatorQuad", out var entry).Should().BeTrue();
+        entry!.IsBuiltIn.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GridGeometry_FindLevel_MissingLevel_ReturnsNull()
+    {
+        var registry = new TileMatrixSetRegistry(new TileMatrixSetDefinitionOptions { Custom = { SampleCustom() } });
+        registry.TryGetGeometry("HawaiiAlbers", 0, out var geometry).Should().BeTrue();
+
+        geometry!.FindLevel(0).Should().NotBeNull();
+        geometry.FindLevel(9).Should().BeNull();
+        geometry.GetTileBounds(0, 0, 9).Should().BeNull();
+    }
+}

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Tiles/TileMatrixSetDefinitionSnapshotTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Tiles/TileMatrixSetDefinitionSnapshotTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Linq;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Tiles;
+using Honua.Protocols.Ogc.Api.Tiles;
+using Honua.Protocols.Ogc.Api.Tiles.Models;
+
+namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Tiles;
+
+/// <summary>
+/// CITE byte-identical guard: the new registry/geometry-driven
+/// <see cref="OgcTilesUtilities.BuildTileMatrixSetDefinition"/> must produce output identical to
+/// the legacy hardcoded <c>BuildWebMercatorQuadDefinition</c> / <c>BuildWorldCrs84QuadDefinition</c>
+/// paths so OGC API Tiles 16/16 conformance does not regress. A drift here means the gridset
+/// generalization changed advertised metadata and the WMTS/Tiles CITE suites must be re-checked.
+/// </summary>
+public class TileMatrixSetDefinitionSnapshotTests
+{
+    private static readonly TileLimits Limits = new() { MinTileZoom = 0, MaxTileZoom = 18 };
+    private static readonly TileMatrixSetRegistry Registry = new(new TileMatrixSetDefinitionOptions());
+
+    private static string Serialize(TileMatrixSetDefinition definition)
+        => JsonSerializer.Serialize(definition, OgcTilesJsonContext.Default.TileMatrixSetDefinition);
+
+    private static TileMatrixSetDefinition RegistryDefinition(string id)
+    {
+        Registry.TryGet(id, out var entry).Should().BeTrue();
+        Registry.TryGetGeometry(id, Limits.MaxTileZoom, out var geometry).Should().BeTrue();
+        return OgcTilesUtilities.BuildTileMatrixSetDefinition(entry!, geometry!, Limits.MinTileZoom);
+    }
+
+    [Fact]
+    public void BuildWebMercatorQuadDefinition_RegistryDriven_MatchesLegacy()
+    {
+        var legacy = OgcTilesUtilities.BuildWebMercatorQuadDefinition(Limits);
+        var fromRegistry = RegistryDefinition("WebMercatorQuad");
+
+        fromRegistry.Should().BeEquivalentTo(legacy, options => options.WithStrictOrdering());
+        Serialize(fromRegistry).Should().Be(Serialize(legacy));
+    }
+
+    [Fact]
+    public void BuildWorldCrs84QuadDefinition_RegistryDriven_MatchesLegacy()
+    {
+        var legacy = OgcTilesUtilities.BuildWorldCrs84QuadDefinition(Limits);
+        var fromRegistry = RegistryDefinition("WorldCRS84Quad");
+
+        fromRegistry.Should().BeEquivalentTo(legacy, options => options.WithStrictOrdering());
+        Serialize(fromRegistry).Should().Be(Serialize(legacy));
+    }
+
+    [Fact]
+    public void BuildWebMercatorQuadDefinition_RespectsMinZoom()
+    {
+        var limits = new TileLimits { MinTileZoom = 3, MaxTileZoom = 6 };
+        var legacy = OgcTilesUtilities.BuildWebMercatorQuadDefinition(limits);
+
+        Registry.TryGet("WebMercatorQuad", out var entry).Should().BeTrue();
+        Registry.TryGetGeometry("WebMercatorQuad", limits.MaxTileZoom, out var geometry).Should().BeTrue();
+        var fromRegistry = OgcTilesUtilities.BuildTileMatrixSetDefinition(entry!, geometry!, limits.MinTileZoom);
+
+        fromRegistry.TileMatrices.Select(m => m.Id).Should().Equal("3", "4", "5", "6");
+        fromRegistry.Should().BeEquivalentTo(legacy, options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void BuildTileMatrixSetDefinition_CustomGrid_EmitsConfiguredMatricesAndNoWellKnownScaleSet()
+    {
+        var options = new TileMatrixSetDefinitionOptions
+        {
+            Custom =
+            {
+                new CustomTileMatrixSet
+                {
+                    Id = "DemoGrid",
+                    Crs = "http://www.opengis.net/def/crs/EPSG/0/3857",
+                    Uri = "https://example.com/tms/DemoGrid",
+                    Title = "Demo Grid",
+                    Srid = 3857,
+                    TopLeftCorner = [-20037508.342789244, 20037508.342789244],
+                    TileWidth = 512,
+                    TileHeight = 512,
+                    Levels =
+                    [
+                        new TileMatrixLevel { Id = 0, ScaleDenominator = 559082264.0287178, CellSize = 156543.03392804097, MatrixWidth = 1, MatrixHeight = 1 },
+                        new TileMatrixLevel { Id = 1, ScaleDenominator = 279541132.0143589, CellSize = 78271.51696402048, MatrixWidth = 2, MatrixHeight = 2 }
+                    ]
+                }
+            }
+        };
+        var registry = new TileMatrixSetRegistry(options);
+
+        registry.TryGet("DemoGrid", out var entry).Should().BeTrue();
+        registry.TryGetGeometry("DemoGrid", 99, out var geometry).Should().BeTrue();
+        var definition = OgcTilesUtilities.BuildTileMatrixSetDefinition(entry!, geometry!);
+
+        definition.Id.Should().Be("DemoGrid");
+        definition.Title.Should().Be("Demo Grid");
+        definition.Uri.Should().Be("https://example.com/tms/DemoGrid");
+        definition.WellKnownScaleSet.Should().BeNull();
+        definition.TileMatrices.Should().HaveCount(2);
+        definition.TileMatrices[0].TileWidth.Should().Be(512);
+        definition.TileMatrices[0].MatrixWidth.Should().Be(1);
+        definition.TileMatrices[1].MatrixWidth.Should().Be(2);
+        definition.TileMatrices.Select(m => m.Id).Should().Equal("0", "1");
+    }
+}

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wmts/WmtsCustomTileMatrixSetXmlTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wmts/WmtsCustomTileMatrixSetXmlTests.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.Tiles;
+using Honua.Protocols.Ogc.Classic.Wmts;
+
+namespace Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wmts;
+
+/// <summary>
+/// Unit coverage for the operator-defined custom tile matrix set emission in WMTS
+/// GetCapabilities. The built-in WebMercatorQuad / WorldCRS84Quad XML is emitted by separate,
+/// untouched methods so it stays byte-identical (the CITE WMTS 60/60 guard); these tests pin the
+/// shape of the additive custom-grid XML, including the geographic-CRS lat/lon TopLeftCorner axis
+/// order.
+/// </summary>
+public class WmtsCustomTileMatrixSetXmlTests
+{
+    private static TileMatrixSetRegistry RegistryWith(CustomTileMatrixSet custom)
+        => new(new TileMatrixSetDefinitionOptions { Custom = { custom } });
+
+    private static CustomTileMatrixSet ProjectedGrid() => new()
+    {
+        Id = "DemoProjected",
+        Crs = "urn:ogc:def:crs:EPSG:6.18:3:3857",
+        Srid = 3857,
+        TopLeftCorner = [-20037508.342789244, 20037508.342789244],
+        TileWidth = 256,
+        TileHeight = 256,
+        Levels =
+        [
+            new TileMatrixLevel { Id = 0, ScaleDenominator = 559082264.0287178, CellSize = 156543.03392804097, MatrixWidth = 1, MatrixHeight = 1 }
+        ]
+    };
+
+    private static CustomTileMatrixSet GeographicGrid() => new()
+    {
+        Id = "DemoGeographic",
+        Crs = "urn:ogc:def:crs:OGC:1.3:CRS84",
+        Srid = 4326,
+        TopLeftCorner = [-180.0, 90.0],
+        TileWidth = 256,
+        TileHeight = 256,
+        Levels =
+        [
+            new TileMatrixLevel { Id = 0, ScaleDenominator = 279541132.0143589, CellSize = 0.703125, MatrixWidth = 2, MatrixHeight = 1 }
+        ]
+    };
+
+    [Fact]
+    public void AppendCustomTileMatrixSets_NullRegistry_EmitsNothing()
+    {
+        var sb = new StringBuilder();
+        WmtsRequestHandlers.AppendWmtsCustomTileMatrixSets(sb, null, 18);
+        sb.ToString().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AppendCustomTileMatrixSets_OnlyBuiltIns_EmitsNothing()
+    {
+        var sb = new StringBuilder();
+        WmtsRequestHandlers.AppendWmtsCustomTileMatrixSets(sb, new TileMatrixSetRegistry(new TileMatrixSetDefinitionOptions()), 18);
+        sb.ToString().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AppendCustomTileMatrixSets_ProjectedGrid_EmitsXyTopLeftCorner()
+    {
+        var sb = new StringBuilder();
+        WmtsRequestHandlers.AppendWmtsCustomTileMatrixSets(sb, RegistryWith(ProjectedGrid()), 18);
+        var xml = sb.ToString();
+
+        xml.Should().Contain("<ows:Identifier>DemoProjected</ows:Identifier>");
+        xml.Should().Contain("<ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.18:3:3857</ows:SupportedCRS>");
+        // Projected: easting then northing.
+        xml.Should().Contain("<TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>");
+        xml.Should().Contain("<MatrixWidth>1</MatrixWidth>");
+    }
+
+    [Fact]
+    public void AppendCustomTileMatrixSets_GeographicGrid_EmitsLatLonTopLeftCorner()
+    {
+        var sb = new StringBuilder();
+        WmtsRequestHandlers.AppendWmtsCustomTileMatrixSets(sb, RegistryWith(GeographicGrid()), 18);
+        var xml = sb.ToString();
+
+        xml.Should().Contain("<ows:Identifier>DemoGeographic</ows:Identifier>");
+        // Geographic CRS: latitude (90) then longitude (-180), matching the built-in CRS84 grid.
+        xml.Should().Contain("<TopLeftCorner>90.000000 -180.000000</TopLeftCorner>");
+        xml.Should().Contain("<MatrixWidth>2</MatrixWidth>");
+        xml.Should().Contain("<MatrixHeight>1</MatrixHeight>");
+    }
+
+    [Fact]
+    public void AppendCustomTileMatrixSetLinks_EmitsLimitsForEachLevel()
+    {
+        var sb = new StringBuilder();
+        WmtsRequestHandlers.AppendWmtsCustomTileMatrixSetLinks(sb, RegistryWith(GeographicGrid()), 18);
+        var xml = sb.ToString();
+
+        xml.Should().Contain("<TileMatrixSet>DemoGeographic</TileMatrixSet>");
+        xml.Should().Contain("<MaxTileCol>1</MaxTileCol>");
+        xml.Should().Contain("<MaxTileRow>0</MaxTileRow>");
+    }
+}


### PR DESCRIPTION
First-PR slice of **#1791** (operator-defined custom TileMatrixSets) â€” the **config-driven TMS registry** (define + advertise + GetTile). Request-CRS reprojection is a deferred fast-follow (the `ST_Transform`/`OutputSrid` machinery already exists; axis-order is the hazard).

> **Stacked on #1792 (PR #1820)** â€” it builds on #1792's tiles changes (preserved, not reverted). Base this PR on `feat/tiles-elevation-dim-1792`; merges cleanly after #1820.

### What's included
- New (`Honua.Core/Features/Tiles`): `GridGeometry`/`GridLevel` value types, `TileMatrixSetDefinitionOptions` (`CustomTileMatrixSet`/`TileMatrixLevel`, section `"TileMatrixSets"`), `ITileMatrixSetRegistry` + `TileMatrixSetRegistry` (merges the two built-ins, seeded from existing constants, with operator entries), and `TileMatrixSetOptionsValidator` (fail-fast `ValidateOnStart`).
- Routed the three hardcoded sites through the registry/geometry: `TileMath.GetTileBounds(GridGeometry,â€¦)`, `OgcTilesUtilities` (geometry-driven `Build*`, replacing the `IsWorldCrs84Quad` fork), `TileMatrixSetEndpoints` + `TilesEndpoints` (registry-driven list/define/GetTile), `RasterMapRenderingPipeline` (new `GridGeometry` render overload), `WmtsRequestHandlers` (capabilities + GetTile for custom grids). DI wiring in the composition root.

### CITE byte-identical guard â€” passing
4 OGC snapshot tests assert the registry/geometry-driven definition for **WebMercatorQuad + WorldCRS84Quad is byte-identical** (record + serialized JSON) to the legacy builders, incl. the MinTileZoom case. Built-in **WMTS XML emitters are untouched** (byte-identical by construction); custom-grid emitters are additive, after the built-ins. CRS84's `WellKnownScaleSet` omission + lat/lon TopLeftCorner axis order preserved.

### Testing
Build clean (warnings-as-errors). **36 tests re-verified**: 27 Core (registry + GridGeometry + validator: duplicate/reserved-id, non-monotonic scale, non-positive dims, bad SRID, TopLeftCorner arity), 4 OGC snapshot, 5 WMTS custom-XML; full Core Tiles suite 93 (no regression). **CITE OGC API Tiles 16/16 + WMTS 60/60 must be re-run in CI.**

### Deferred / scoped
- Request-CRS reprojection (`crs`/`subset-crs`) â†’ fast-follow.
- Custom gridsets serve **PNG only** (the MVT provider only knows the two standard pyramids; vector requests on a custom grid â†’ 406 â†’ `f=png`). Built-in vector tiles unchanged.
- Per-collection tileset listing docs (`/ogc/tiles/.../tiles`) still list the two built-ins (byte-identical); custom grids are advertised via `/tileMatrixSets` + the definition endpoint + WMTS capabilities and served via GetTile.

Part of #1791.

Closes #1791. Remaining scope tracked in #1839.