### PR TITLE
feat(mcp): add catalog, feature-query, and map-render MCP tools

### DIFF
--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/ListLayersTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/ListLayersTool.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Geoprocessing;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Tools;
+
+namespace Honua.Ai.Protocols.Mcp.MapTools;
+
+/// <summary>
+/// MCP tool that lists the published services and layers an AI client can act
+/// on. Thin adapter over the canonical
+/// <see cref="IMetadataV2GraphProvider"/> graph — the same metadata snapshot
+/// that backs the GeoServices <c>/rest/services</c> directory and FeatureServer
+/// layer metadata — so the discovery surface never grows its own catalog model.
+/// Discovery is free (no Pro entitlement); the caller still authenticates and
+/// passes the operator read grant.
+/// </summary>
+internal sealed class ListLayersTool : IMcpTool
+{
+    public const string ToolName = "honua_list_layers";
+
+    private readonly IGeoprocessingJobService _jobService;
+    private readonly ILogger<ListLayersTool> _logger;
+
+    public ListLayersTool(IGeoprocessingJobService jobService, ILogger<ListLayersTool> logger)
+    {
+        _jobService = jobService;
+        _logger = logger;
+    }
+
+    public string Name => ToolName;
+
+    public string WorkflowFamily => McpTelemetry.WorkflowFamily.Results;
+
+    public McpToolDescriptor Describe() => new()
+    {
+        Name = ToolName,
+        Description = "List the published services and layers available to query or render, with geometry type, extent, and a short description. Use the returned serviceId/layerId with honua_query_features and honua_render_map.",
+        InputSchema = MapToolSchemas.ListLayersArgumentSchema
+    };
+
+    public async Task<McpToolsCallResult> InvokeAsync(
+        HttpContext httpContext,
+        JsonElement? arguments,
+        CancellationToken cancellationToken)
+    {
+        McpTelemetry.EnrichActivity("ListLayers");
+        McpLog.ToolInvoked(_logger, ToolName, WorkflowFamily);
+
+        var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
+        await _jobService
+            .EnsureCallerAuthorizedAsync(principal, OperatorResourceType.Process, OperatorOperation.Read, cancellationToken)
+            .ConfigureAwait(false);
+
+        string? filter = null;
+        if (arguments is { ValueKind: not JsonValueKind.Null and not JsonValueKind.Undefined })
+        {
+            var argument = McpToolHelpers.ParseArguments(arguments, MapToolJsonContext.Default.McpListLayersArgument);
+            filter = string.IsNullOrWhiteSpace(argument.Filter) ? null : argument.Filter.Trim();
+        }
+
+        var graphProvider = httpContext.RequestServices.GetRequiredService<IMetadataV2GraphProvider>();
+        var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+
+        var layers = new List<McpLayerSummary>();
+        foreach (var service in snapshot.Graph.Services)
+        {
+            var publications = snapshot.PublicationsForService(service.Metadata.Id);
+            foreach (var publication in publications)
+            {
+                var resource = snapshot.ResolveResource(publication);
+                if (resource is null || publication.LayerIndex is not { } layerIndex)
+                {
+                    continue;
+                }
+
+                var summary = ToSummary(service, publication, resource, layerIndex);
+                if (filter is null || Matches(summary, service, filter))
+                {
+                    layers.Add(summary);
+                }
+            }
+        }
+
+        layers.Sort(static (a, b) =>
+        {
+            var byService = string.CompareOrdinal(a.ServiceName, b.ServiceName);
+            return byService != 0 ? byService : a.LayerId.CompareTo(b.LayerId);
+        });
+
+        var output = new McpListLayersOutput
+        {
+            LayerCount = layers.Count,
+            Layers = layers
+        };
+
+        return McpToolHelpers.SuccessResult(output, MapToolJsonContext.Default.McpListLayersOutput);
+    }
+
+    private static McpLayerSummary ToSummary(
+        MetadataV2Service service,
+        MetadataV2Publication publication,
+        MetadataV2Resource resource,
+        int layerIndex)
+    {
+        var spatial = resource.Spatial;
+        var bbox = spatial?.Bbox;
+        var name = !string.IsNullOrWhiteSpace(publication.TitleOverride)
+            ? publication.TitleOverride!
+            : (!string.IsNullOrWhiteSpace(resource.Metadata.Title)
+                ? resource.Metadata.Title!
+                : resource.Metadata.Name);
+
+        return new McpLayerSummary
+        {
+            ServiceId = service.Metadata.Id,
+            ServiceName = service.Metadata.Name,
+            LayerId = layerIndex,
+            Name = name,
+            Type = resource.Type.ToString(),
+            GeometryType = (spatial?.GeometryType ?? MetadataV2GeometryType.None).ToString(),
+            Srid = spatial?.SpatialReference?.ResolveSrid(),
+            Extent = bbox is null
+                ? null
+                : new McpExtent
+                {
+                    MinX = bbox.West,
+                    MinY = bbox.South,
+                    MaxX = bbox.East,
+                    MaxY = bbox.North
+                },
+            Description = resource.Metadata.Description
+        };
+    }
+
+    private static bool Matches(McpLayerSummary summary, MetadataV2Service service, string filter)
+        => summary.Name.Contains(filter, StringComparison.OrdinalIgnoreCase)
+            || summary.ServiceName.Contains(filter, StringComparison.OrdinalIgnoreCase)
+            || service.Metadata.Id.Contains(filter, StringComparison.OrdinalIgnoreCase)
+            || (summary.Description?.Contains(filter, StringComparison.OrdinalIgnoreCase) ?? false);
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolJsonContext.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolJsonContext.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Honua.Ai.Protocols.Mcp.MapTools;
+
+/// <summary>
+/// AOT-compatible source-generated JSON context for the catalog / feature-query
+/// / map-render MCP DTOs. Kept separate from the core MCP JSON context so the
+/// map-tools feature slice owns its own serializer surface — mirrors the
+/// location slice's <c>LocationJsonContext</c>.
+/// </summary>
+[JsonSerializable(typeof(McpListLayersArgument))]
+[JsonSerializable(typeof(McpListLayersOutput))]
+[JsonSerializable(typeof(McpLayerSummary))]
+[JsonSerializable(typeof(McpExtent))]
+[JsonSerializable(typeof(McpQueryFeaturesArgument))]
+[JsonSerializable(typeof(McpQueryFeaturesOutput))]
+[JsonSerializable(typeof(McpGeoJsonFeatureCollection))]
+[JsonSerializable(typeof(McpRenderMapArgument))]
+[JsonSerializable(typeof(McpRenderLayerRef))]
+[JsonSerializable(typeof(JsonNode))]
+[JsonSerializable(typeof(JsonElement))]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+internal sealed partial class MapToolJsonContext : JsonSerializerContext;

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolLayerResolver.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolLayerResolver.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Geoprocessing;
+
+namespace Honua.Ai.Protocols.Mcp.MapTools;
+
+/// <summary>
+/// Resolves a published <c>(serviceId, layerId)</c> tuple to the canonical
+/// Metadata v2 publication/resource and the integer storage-layer handle that
+/// <see cref="Honua.Core.Features.FeatureStore.Abstractions.IFeatureReader"/>
+/// and <see cref="Honua.Core.Features.Raster.Abstractions.IRasterMapRenderer"/>
+/// consume. The same snapshot extensions back the GeoServices FeatureServer and
+/// MapServer adapters, so the MCP tools resolve layers identically rather than
+/// growing their own catalog lookup.
+/// </summary>
+internal readonly record struct MapToolLayerContext(
+    MetadataV2Service Service,
+    MetadataV2Publication Publication,
+    MetadataV2Resource Resource,
+    int StorageLayerId);
+
+internal static class MapToolLayerResolver
+{
+    /// <summary>
+    /// Resolves the layer addressing tuple against the supplied metadata
+    /// snapshot. The service is matched by id first, then by name (mirroring the
+    /// GeoServices catalog which accepts either). Failures surface as
+    /// <see cref="GeoprocessingNotFoundException"/> /
+    /// <see cref="GeoprocessingValidationException"/> so they flow through the
+    /// shared MCP error mapper.
+    /// </summary>
+    public static MapToolLayerContext Resolve(
+        MetadataV2GraphSnapshot snapshot,
+        string? serviceId,
+        int? layerId)
+    {
+        if (string.IsNullOrWhiteSpace(serviceId))
+        {
+            throw new GeoprocessingValidationException("'serviceId' is required.");
+        }
+
+        if (layerId is not { } resolvedLayerId || resolvedLayerId < 0)
+        {
+            throw new GeoprocessingValidationException("'layerId' is required and must be a non-negative integer.");
+        }
+
+        var service = ResolveService(snapshot, serviceId.Trim());
+        if (service is null)
+        {
+            throw new GeoprocessingNotFoundException($"Service '{serviceId}' was not found in the published catalog.");
+        }
+
+        var publication = snapshot.FindPublicationByLayerIndex(service.Metadata.Id, resolvedLayerId);
+        if (publication is null)
+        {
+            throw new GeoprocessingNotFoundException(
+                $"Layer {resolvedLayerId} was not found on service '{service.Metadata.Name}'.");
+        }
+
+        var resource = snapshot.ResolveResource(publication);
+        if (resource is null)
+        {
+            throw new GeoprocessingNotFoundException(
+                $"Layer {resolvedLayerId} on service '{service.Metadata.Name}' has no backing resource.");
+        }
+
+        var storageLayerId = snapshot.ResolveStorageLayerId(publication)
+            ?? snapshot.ResolveStorageLayerId(resource);
+        if (storageLayerId is not { } resolvedStorageLayerId)
+        {
+            throw new GeoprocessingNotFoundException(
+                $"Layer {resolvedLayerId} on service '{service.Metadata.Name}' is not backed by queryable storage.");
+        }
+
+        return new MapToolLayerContext(service, publication, resource, resolvedStorageLayerId);
+    }
+
+    private static MetadataV2Service? ResolveService(MetadataV2GraphSnapshot snapshot, string serviceId)
+    {
+        foreach (var candidate in snapshot.Graph.Services)
+        {
+            if (string.Equals(candidate.Metadata.Id, serviceId, StringComparison.OrdinalIgnoreCase))
+            {
+                return candidate;
+            }
+        }
+
+        return snapshot.FindService(serviceId);
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolModels.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Ai.Protocols.Mcp.MapTools;
+
+// -----------------------------------------------------------------------
+// honua_list_layers
+// -----------------------------------------------------------------------
+
+/// <summary>
+/// Arguments for <c>honua_list_layers</c>. The optional <see cref="Filter"/>
+/// substring narrows the published catalog by service or layer name/title.
+/// </summary>
+internal sealed class McpListLayersArgument
+{
+    [JsonPropertyName("filter")]
+    public string? Filter { get; set; }
+}
+
+/// <summary>
+/// Output for <c>honua_list_layers</c>: the published services and the layers
+/// they expose, projected from the canonical Metadata v2 graph.
+/// </summary>
+internal sealed class McpListLayersOutput
+{
+    [JsonPropertyName("layerCount")]
+    public int LayerCount { get; set; }
+
+    [JsonPropertyName("layers")]
+    public IReadOnlyList<McpLayerSummary> Layers { get; set; } = [];
+}
+
+/// <summary>
+/// One published layer entry. <see cref="ServiceId"/> + <see cref="LayerId"/>
+/// are the addressing tuple consumed by <c>honua_query_features</c> and
+/// <c>honua_render_map</c>.
+/// </summary>
+internal sealed class McpLayerSummary
+{
+    [JsonPropertyName("serviceId")]
+    public string ServiceId { get; set; } = string.Empty;
+
+    [JsonPropertyName("serviceName")]
+    public string ServiceName { get; set; } = string.Empty;
+
+    [JsonPropertyName("layerId")]
+    public int LayerId { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("geometryType")]
+    public string GeometryType { get; set; } = string.Empty;
+
+    [JsonPropertyName("srid")]
+    public int? Srid { get; set; }
+
+    [JsonPropertyName("extent")]
+    public McpExtent? Extent { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+}
+
+/// <summary>
+/// Axis-aligned bounding box in the order GeoJSON/OGC expect:
+/// <c>[minX, minY, maxX, maxY]</c>.
+/// </summary>
+internal sealed class McpExtent
+{
+    [JsonPropertyName("minX")]
+    public double MinX { get; set; }
+
+    [JsonPropertyName("minY")]
+    public double MinY { get; set; }
+
+    [JsonPropertyName("maxX")]
+    public double MaxX { get; set; }
+
+    [JsonPropertyName("maxY")]
+    public double MaxY { get; set; }
+}
+
+// -----------------------------------------------------------------------
+// honua_query_features
+// -----------------------------------------------------------------------
+
+/// <summary>
+/// Arguments for <c>honua_query_features</c>.
+/// </summary>
+internal sealed class McpQueryFeaturesArgument
+{
+    [JsonPropertyName("serviceId")]
+    public string? ServiceId { get; set; }
+
+    [JsonPropertyName("layerId")]
+    public int? LayerId { get; set; }
+
+    [JsonPropertyName("where")]
+    public string? Where { get; set; }
+
+    /// <summary>Bounding box filter as <c>[minX, minY, maxX, maxY]</c>.</summary>
+    [JsonPropertyName("bbox")]
+    public IReadOnlyList<double>? Bbox { get; set; }
+
+    [JsonPropertyName("bboxSrid")]
+    public int? BboxSrid { get; set; }
+
+    [JsonPropertyName("outFields")]
+    public IReadOnlyList<string>? OutFields { get; set; }
+
+    [JsonPropertyName("limit")]
+    public int? Limit { get; set; }
+
+    [JsonPropertyName("outSrid")]
+    public int? OutSrid { get; set; }
+}
+
+/// <summary>
+/// Output for <c>honua_query_features</c>: a compact summary plus the GeoJSON
+/// <c>FeatureCollection</c> emitted by the canonical feature-query pipeline.
+/// </summary>
+internal sealed class McpQueryFeaturesOutput
+{
+    [JsonPropertyName("serviceId")]
+    public string ServiceId { get; set; } = string.Empty;
+
+    [JsonPropertyName("layerId")]
+    public int LayerId { get; set; }
+
+    [JsonPropertyName("returnedCount")]
+    public int ReturnedCount { get; set; }
+
+    [JsonPropertyName("limit")]
+    public int Limit { get; set; }
+
+    [JsonPropertyName("exceededTransferLimit")]
+    public bool ExceededTransferLimit { get; set; }
+
+    /// <summary>RFC 7946 GeoJSON <c>FeatureCollection</c> for the returned features.</summary>
+    [JsonPropertyName("geojson")]
+    public McpGeoJsonFeatureCollection GeoJson { get; set; } = new();
+}
+
+/// <summary>
+/// Minimal GeoJSON <c>FeatureCollection</c> wrapper. Feature geometries and
+/// attribute values are carried as raw JSON nodes so the source-generated
+/// serializer can emit them without reflecting over arbitrary attribute types.
+/// </summary>
+internal sealed class McpGeoJsonFeatureCollection
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "FeatureCollection";
+
+    [JsonPropertyName("features")]
+    public IReadOnlyList<System.Text.Json.Nodes.JsonNode> Features { get; set; } = [];
+}
+
+// -----------------------------------------------------------------------
+// honua_render_map
+// -----------------------------------------------------------------------
+
+/// <summary>
+/// Arguments for <c>honua_render_map</c>.
+/// </summary>
+internal sealed class McpRenderMapArgument
+{
+    /// <summary>
+    /// Ordered layers to render, bottom-to-top. Each entry addresses a published
+    /// layer by <c>serviceId</c> + <c>layerId</c>.
+    /// </summary>
+    [JsonPropertyName("layers")]
+    public IReadOnlyList<McpRenderLayerRef>? Layers { get; set; }
+
+    /// <summary>Map extent as <c>[minX, minY, maxX, maxY]</c>.</summary>
+    [JsonPropertyName("bbox")]
+    public IReadOnlyList<double>? Bbox { get; set; }
+
+    [JsonPropertyName("bboxSrid")]
+    public int? BboxSrid { get; set; }
+
+    [JsonPropertyName("width")]
+    public int? Width { get; set; }
+
+    [JsonPropertyName("height")]
+    public int? Height { get; set; }
+
+    [JsonPropertyName("transparent")]
+    public bool? Transparent { get; set; }
+}
+
+/// <summary>
+/// A single layer reference inside a <c>honua_render_map</c> request.
+/// </summary>
+internal sealed class McpRenderLayerRef
+{
+    [JsonPropertyName("serviceId")]
+    public string? ServiceId { get; set; }
+
+    [JsonPropertyName("layerId")]
+    public int? LayerId { get; set; }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolSchemas.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Ai.Protocols.Mcp.MapTools;
+
+/// <summary>
+/// JSON-schema documents advertised in <c>tools/list</c> for the catalog,
+/// feature-query, and map-render tools. Schemas are immutable
+/// <see cref="JsonElement"/> values parsed at type-load time to keep the MCP
+/// surface AOT-safe (no runtime schema reflection). Mirrors
+/// <see cref="Honua.Ai.Protocols.Mcp.Location.LocationToolSchemas"/>.
+/// </summary>
+internal static class MapToolSchemas
+{
+    /// <summary>Default feature count returned by <c>honua_query_features</c>.</summary>
+    public const int DefaultFeatureLimit = 100;
+
+    /// <summary>Hard ceiling on features returned by <c>honua_query_features</c>.</summary>
+    public const int MaxFeatureLimit = 1000;
+
+    /// <summary>Default render width/height when omitted.</summary>
+    public const int DefaultRenderSize = 512;
+
+    /// <summary>Maximum render width/height per side (caps cost and payload).</summary>
+    public const int MaxRenderSize = 1024;
+
+    private const string ListLayersArgumentSchemaJson = """
+        {
+          "type": "object",
+          "properties": {
+            "filter": {
+              "type": "string",
+              "description": "Optional case-insensitive substring to match against service and layer name/title. When omitted, all published layers are returned."
+            }
+          }
+        }
+        """;
+
+    private const string QueryFeaturesArgumentSchemaJson = """
+        {
+          "type": "object",
+          "required": ["serviceId", "layerId"],
+          "properties": {
+            "serviceId": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Published service identifier or name (from honua_list_layers.serviceId)."
+            },
+            "layerId": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Service-local layer index (from honua_list_layers.layerId)."
+            },
+            "where": {
+              "type": "string",
+              "description": "Optional attribute filter expressed as an ArcGIS/SQL WHERE clause (e.g. \"population > 10000\")."
+            },
+            "bbox": {
+              "type": "array",
+              "minItems": 4,
+              "maxItems": 4,
+              "items": { "type": "number" },
+              "description": "Optional spatial filter envelope as [minX, minY, maxX, maxY]."
+            },
+            "bboxSrid": {
+              "type": "integer",
+              "default": 4326,
+              "description": "Spatial reference (SRID/WKID) of the bbox ordinates."
+            },
+            "outFields": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Optional attribute fields to return; omit for all fields."
+            },
+            "limit": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 100,
+              "description": "Maximum number of features to return (capped at 1000)."
+            },
+            "outSrid": {
+              "type": "integer",
+              "default": 4326,
+              "description": "Output spatial reference (SRID/WKID) for returned geometries."
+            }
+          }
+        }
+        """;
+
+    private const string RenderMapArgumentSchemaJson = """
+        {
+          "type": "object",
+          "required": ["layers", "bbox"],
+          "properties": {
+            "layers": {
+              "type": "array",
+              "minItems": 1,
+              "description": "Ordered layers to draw, bottom-to-top.",
+              "items": {
+                "type": "object",
+                "required": ["serviceId", "layerId"],
+                "properties": {
+                  "serviceId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Published service identifier or name (from honua_list_layers.serviceId)."
+                  },
+                  "layerId": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Service-local layer index (from honua_list_layers.layerId)."
+                  }
+                }
+              }
+            },
+            "bbox": {
+              "type": "array",
+              "minItems": 4,
+              "maxItems": 4,
+              "items": { "type": "number" },
+              "description": "Map extent as [minX, minY, maxX, maxY]."
+            },
+            "bboxSrid": {
+              "type": "integer",
+              "default": 4326,
+              "description": "Spatial reference (SRID/WKID) of the bbox and output image."
+            },
+            "width": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1024,
+              "default": 512,
+              "description": "Output image width in pixels (capped at 1024)."
+            },
+            "height": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1024,
+              "default": 512,
+              "description": "Output image height in pixels (capped at 1024)."
+            },
+            "transparent": {
+              "type": "boolean",
+              "default": false,
+              "description": "Render a transparent background instead of an opaque one."
+            }
+          }
+        }
+        """;
+
+    /// <summary>Schema for <see cref="McpListLayersArgument"/>.</summary>
+    public static readonly JsonElement ListLayersArgumentSchema = Parse(ListLayersArgumentSchemaJson);
+
+    /// <summary>Schema for <see cref="McpQueryFeaturesArgument"/>.</summary>
+    public static readonly JsonElement QueryFeaturesArgumentSchema = Parse(QueryFeaturesArgumentSchemaJson);
+
+    /// <summary>Schema for <see cref="McpRenderMapArgument"/>.</summary>
+    public static readonly JsonElement RenderMapArgumentSchema = Parse(RenderMapArgumentSchemaJson);
+
+    private static JsonElement Parse(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/QueryFeaturesTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/QueryFeaturesTool.cs
@@ -1,0 +1,256 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Geometry.Abstractions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Queries.Filters;
+using Honua.Geoprocessing;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Tools;
+
+namespace Honua.Ai.Protocols.Mcp.MapTools;
+
+/// <summary>
+/// MCP tool that queries features from a published layer and returns GeoJSON.
+/// Thin adapter over the canonical feature-query pipeline: it resolves the
+/// layer through the same Metadata v2 snapshot the FeatureServer uses, parses
+/// the optional attribute filter through the shared
+/// <see cref="IFilterExpressionService"/> (FeatureServer's <c>where</c> path),
+/// executes through <see cref="IFeatureReader"/>, and serializes geometry via
+/// the shared <see cref="IGeometryService"/> WKB→GeoJSON converter. No query,
+/// filter, or geometry logic is reimplemented here.
+/// </summary>
+internal sealed class QueryFeaturesTool : IMcpTool
+{
+    public const string ToolName = "honua_query_features";
+
+    private readonly IGeoprocessingJobService _jobService;
+    private readonly ILogger<QueryFeaturesTool> _logger;
+
+    public QueryFeaturesTool(IGeoprocessingJobService jobService, ILogger<QueryFeaturesTool> logger)
+    {
+        _jobService = jobService;
+        _logger = logger;
+    }
+
+    public string Name => ToolName;
+
+    public string WorkflowFamily => McpTelemetry.WorkflowFamily.Results;
+
+    public McpToolDescriptor Describe() => new()
+    {
+        Name = ToolName,
+        Description = "Query features from a published layer (by serviceId/layerId) with an optional attribute WHERE clause, bbox, outFields, and result limit. Returns a GeoJSON FeatureCollection.",
+        InputSchema = MapToolSchemas.QueryFeaturesArgumentSchema
+    };
+
+    public async Task<McpToolsCallResult> InvokeAsync(
+        HttpContext httpContext,
+        JsonElement? arguments,
+        CancellationToken cancellationToken)
+    {
+        McpTelemetry.EnrichActivity("QueryFeatures");
+        McpLog.ToolInvoked(_logger, ToolName, WorkflowFamily);
+
+        var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
+        await _jobService
+            .EnsureCallerAuthorizedAsync(principal, OperatorResourceType.Process, OperatorOperation.Read, cancellationToken)
+            .ConfigureAwait(false);
+
+        var argument = McpToolHelpers.ParseArguments(arguments, MapToolJsonContext.Default.McpQueryFeaturesArgument);
+
+        var graphProvider = httpContext.RequestServices.GetRequiredService<IMetadataV2GraphProvider>();
+        var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        var layer = MapToolLayerResolver.Resolve(snapshot, argument.ServiceId, argument.LayerId);
+
+        var limit = ResolveLimit(argument.Limit);
+        var outSrid = argument.OutSrid ?? 4326;
+        if (outSrid <= 0)
+        {
+            throw new GeoprocessingValidationException("'outSrid' must be a positive SRID/WKID.");
+        }
+
+        var geometryService = httpContext.RequestServices.GetRequiredService<IGeometryService>();
+        var filterService = httpContext.RequestServices.GetRequiredService<IFilterExpressionService>();
+
+        var query = new FeatureQuery
+        {
+            OutFields = ToOutFields(argument.OutFields),
+            Limit = limit,
+            OutputSrid = outSrid,
+            SqlFilter = BuildAttributeFilter(filterService, argument.Where, layer),
+            SpatialFilter = BuildBboxFilter(geometryService, argument.Bbox, argument.BboxSrid)
+        };
+
+        var reader = httpContext.RequestServices.GetRequiredService<IFeatureReader>();
+        var result = await reader.QueryAsync(layer.StorageLayerId, query, cancellationToken).ConfigureAwait(false);
+
+        var features = new List<JsonNode>(result.Items.Length);
+        foreach (var feature in result.Items)
+        {
+            features.Add(ToGeoJsonFeature(feature, geometryService));
+        }
+
+        var output = new McpQueryFeaturesOutput
+        {
+            ServiceId = layer.Service.Metadata.Id,
+            LayerId = argument.LayerId!.Value,
+            ReturnedCount = features.Count,
+            Limit = limit,
+            ExceededTransferLimit = result.HasMoreResults,
+            GeoJson = new McpGeoJsonFeatureCollection { Features = features }
+        };
+
+        return McpToolHelpers.SuccessResult(output, MapToolJsonContext.Default.McpQueryFeaturesOutput);
+    }
+
+    private static int ResolveLimit(int? requested)
+    {
+        var limit = requested ?? MapToolSchemas.DefaultFeatureLimit;
+        if (limit < 1)
+        {
+            throw new GeoprocessingValidationException("'limit' must be a positive integer.");
+        }
+
+        return Math.Min(limit, MapToolSchemas.MaxFeatureLimit);
+    }
+
+    private static ImmutableArray<string>? ToOutFields(IReadOnlyList<string>? outFields)
+    {
+        if (outFields is null || outFields.Count == 0)
+        {
+            return null;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<string>(outFields.Count);
+        foreach (var field in outFields)
+        {
+            if (!string.IsNullOrWhiteSpace(field))
+            {
+                builder.Add(field.Trim());
+            }
+        }
+
+        return builder.Count == 0 ? null : builder.ToImmutable();
+    }
+
+    private static SqlFragment? BuildAttributeFilter(
+        IFilterExpressionService filterService,
+        string? where,
+        in MapToolLayerContext layer)
+    {
+        if (string.IsNullOrWhiteSpace(where))
+        {
+            return null;
+        }
+
+        var parse = filterService.Parse(FilterLanguage.ArcGisSql, where);
+        if (!parse.IsSuccess)
+        {
+            throw new GeoprocessingValidationException(
+                $"Invalid 'where' clause: {parse.ErrorMessage ?? "could not be parsed."}");
+        }
+
+        var translation = filterService.Translate(parse.Expression, layer.Resource);
+        if (!translation.IsSuccess)
+        {
+            throw new GeoprocessingValidationException(
+                $"Invalid 'where' clause: {translation.ErrorMessage ?? "could not be translated."}");
+        }
+
+        return translation.SqlFilter;
+    }
+
+    private static SpatialFilter? BuildBboxFilter(
+        IGeometryService geometryService,
+        IReadOnlyList<double>? bbox,
+        int? bboxSrid)
+    {
+        if (bbox is null)
+        {
+            return null;
+        }
+
+        if (bbox.Count != 4)
+        {
+            throw new GeoprocessingValidationException("'bbox' must contain exactly four numbers: [minX, minY, maxX, maxY].");
+        }
+
+        var minX = bbox[0];
+        var minY = bbox[1];
+        var maxX = bbox[2];
+        var maxY = bbox[3];
+        if (maxX < minX || maxY < minY)
+        {
+            throw new GeoprocessingValidationException("'bbox' max ordinates must be greater than or equal to the min ordinates.");
+        }
+
+        var srid = bboxSrid ?? 4326;
+        var wkt = string.Format(
+            CultureInfo.InvariantCulture,
+            "POLYGON(({0} {1},{2} {1},{2} {3},{0} {3},{0} {1}))",
+            minX,
+            minY,
+            maxX,
+            maxY);
+
+        var wkb = geometryService.ConvertWktToWkb(wkt, srid)
+            ?? throw new GeoprocessingValidationException("'bbox' could not be converted to a geometry envelope.");
+
+        return SpatialFilter.Create(
+            wkb,
+            SpatialRelationship.EnvelopeIntersects,
+            srid: srid,
+            isSimpleEnvelope: true,
+            allowEnvelopeOnly: true,
+            envelopeMinX: minX,
+            envelopeMinY: minY,
+            envelopeMaxX: maxX,
+            envelopeMaxY: maxY);
+    }
+
+    private static JsonObject ToGeoJsonFeature(Feature feature, IGeometryService geometryService)
+    {
+        var geometryJson = geometryService.ConvertWkbToGeoJson(feature.Geometry);
+        JsonNode? geometryNode = geometryJson is null ? null : JsonNode.Parse(geometryJson);
+
+        var properties = new JsonObject();
+        foreach (var pair in feature.Attributes)
+        {
+            properties[pair.Key] = ToJsonValue(pair.Value);
+        }
+
+        return new JsonObject
+        {
+            ["type"] = "Feature",
+            ["id"] = feature.Id,
+            ["geometry"] = geometryNode,
+            ["properties"] = properties
+        };
+    }
+
+    private static JsonValue? ToJsonValue(object? value) => value switch
+    {
+        null => null,
+        string s => JsonValue.Create(s),
+        bool b => JsonValue.Create(b),
+        int i => JsonValue.Create(i),
+        long l => JsonValue.Create(l),
+        short sh => JsonValue.Create(sh),
+        byte bt => JsonValue.Create(bt),
+        double d => JsonValue.Create(d),
+        float f => JsonValue.Create(f),
+        decimal m => JsonValue.Create(m),
+        DateTime dt => JsonValue.Create(dt.ToString("O", CultureInfo.InvariantCulture)),
+        DateTimeOffset dto => JsonValue.Create(dto.ToString("O", CultureInfo.InvariantCulture)),
+        Guid g => JsonValue.Create(g.ToString()),
+        _ => JsonValue.Create(value.ToString())
+    };
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/RenderMapTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/RenderMapTool.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Geoprocessing;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Tools;
+
+namespace Honua.Ai.Protocols.Mcp.MapTools;
+
+/// <summary>
+/// MCP tool that renders a map image for one or more published layers and
+/// returns it as an MCP <c>image</c> content block (base64 PNG) so the client
+/// can display it inline. Thin adapter over the canonical
+/// <see cref="IRasterMapRenderer"/> pipeline — the same renderer the OGC API
+/// Maps / MapServer export / WMS GetMap surfaces drive — so no rasterization or
+/// styling logic is reimplemented here. Layers are resolved through the same
+/// Metadata v2 snapshot the GeoServices surfaces use and passed bottom-to-top.
+/// </summary>
+internal sealed class RenderMapTool : IMcpTool
+{
+    public const string ToolName = "honua_render_map";
+
+    private readonly IGeoprocessingJobService _jobService;
+    private readonly ILogger<RenderMapTool> _logger;
+
+    public RenderMapTool(IGeoprocessingJobService jobService, ILogger<RenderMapTool> logger)
+    {
+        _jobService = jobService;
+        _logger = logger;
+    }
+
+    public string Name => ToolName;
+
+    public string WorkflowFamily => McpTelemetry.WorkflowFamily.Results;
+
+    public McpToolDescriptor Describe() => new()
+    {
+        Name = ToolName,
+        Description = "Render a map image (PNG) for one or more published layers over a bbox and return it as an inline image. Layers draw bottom-to-top. Width/height are capped at 1024 px.",
+        InputSchema = MapToolSchemas.RenderMapArgumentSchema
+    };
+
+    public async Task<McpToolsCallResult> InvokeAsync(
+        HttpContext httpContext,
+        JsonElement? arguments,
+        CancellationToken cancellationToken)
+    {
+        McpTelemetry.EnrichActivity("RenderMap");
+        McpLog.ToolInvoked(_logger, ToolName, WorkflowFamily);
+
+        var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
+        await _jobService
+            .EnsureCallerAuthorizedAsync(principal, OperatorResourceType.Process, OperatorOperation.Read, cancellationToken)
+            .ConfigureAwait(false);
+
+        var argument = McpToolHelpers.ParseArguments(arguments, MapToolJsonContext.Default.McpRenderMapArgument);
+
+        if (argument.Layers is not { Count: > 0 })
+        {
+            throw new GeoprocessingValidationException("'layers' is required and must contain at least one layer.");
+        }
+
+        var bbox = ResolveBbox(argument.Bbox);
+        var bboxSrid = argument.BboxSrid ?? 4326;
+        if (bboxSrid <= 0)
+        {
+            throw new GeoprocessingValidationException("'bboxSrid' must be a positive SRID/WKID.");
+        }
+
+        var width = ResolveSize(argument.Width, "width");
+        var height = ResolveSize(argument.Height, "height");
+
+        var graphProvider = httpContext.RequestServices.GetRequiredService<IMetadataV2GraphProvider>();
+        var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+
+        var storageLayerIds = new int[argument.Layers.Count];
+        for (var i = 0; i < argument.Layers.Count; i++)
+        {
+            var layerRef = argument.Layers[i];
+            var resolved = MapToolLayerResolver.Resolve(snapshot, layerRef.ServiceId, layerRef.LayerId);
+            storageLayerIds[i] = resolved.StorageLayerId;
+        }
+
+        var request = new MapRenderRequest
+        {
+            BoundingBox = bbox,
+            Width = width,
+            Height = height,
+            BoundingBoxCrs = bboxSrid,
+            Crs = bboxSrid,
+            Format = RasterFormat.PNG,
+            Transparent = argument.Transparent ?? false
+        };
+
+        var renderer = httpContext.RequestServices.GetRequiredService<IRasterMapRenderer>();
+        var result = await renderer
+            .RenderDatasetMapAsync(storageLayerIds, request, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (result.Data.Length == 0)
+        {
+            throw new GeoprocessingStoreUnavailableException("Map rendering produced an empty image.");
+        }
+
+        var base64 = Convert.ToBase64String(result.Data);
+        var caption = string.Format(
+            CultureInfo.InvariantCulture,
+            "Rendered {0} layer{1} at {2}x{3} px over bbox [{4}, {5}, {6}, {7}] (SRID {8}).",
+            storageLayerIds.Length,
+            storageLayerIds.Length == 1 ? string.Empty : "s",
+            result.Width,
+            result.Height,
+            bbox[0],
+            bbox[1],
+            bbox[2],
+            bbox[3],
+            bboxSrid);
+
+        return new McpToolsCallResult
+        {
+            IsError = false,
+            Content =
+            [
+                new McpContentBlock { Type = "text", Text = caption },
+                new McpContentBlock
+                {
+                    Type = "image",
+                    Data = base64,
+                    MimeType = result.ContentType
+                }
+            ]
+        };
+    }
+
+    private static double[] ResolveBbox(IReadOnlyList<double>? bbox)
+    {
+        if (bbox is null || bbox.Count != 4)
+        {
+            throw new GeoprocessingValidationException("'bbox' must contain exactly four numbers: [minX, minY, maxX, maxY].");
+        }
+
+        var minX = bbox[0];
+        var minY = bbox[1];
+        var maxX = bbox[2];
+        var maxY = bbox[3];
+        if (maxX <= minX || maxY <= minY)
+        {
+            throw new GeoprocessingValidationException("'bbox' max ordinates must be greater than the min ordinates.");
+        }
+
+        return [minX, minY, maxX, maxY];
+    }
+
+    private static int ResolveSize(int? requested, string field)
+    {
+        var size = requested ?? MapToolSchemas.DefaultRenderSize;
+        if (size < 1)
+        {
+            throw new GeoprocessingValidationException($"'{field}' must be a positive integer.");
+        }
+
+        return Math.Min(size, MapToolSchemas.MaxRenderSize);
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
@@ -75,6 +75,30 @@ internal static class McpServiceCollectionExtensions
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, RouteTool>());
         }
 
+        // Catalog-discovery and feature-query tools (#1xxx) are thin adapters
+        // over the canonical Metadata v2 graph and the shared feature-query
+        // pipeline. They are only advertised when the host composition has wired
+        // IMetadataV2GraphProvider (the same provider that backs /rest/services
+        // and FeatureServer query). Gating keeps tools/list honest in tests that
+        // call AddMcpOperatorSurface in isolation without a data provider.
+        if (services.Any(d => d.ServiceType == typeof(Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphProvider)))
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, MapTools.ListLayersTool>());
+
+            if (services.Any(d => d.ServiceType == typeof(Honua.Core.Features.FeatureStore.Abstractions.IFeatureReader)))
+            {
+                services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, MapTools.QueryFeaturesTool>());
+            }
+
+            // The map-render tool additionally needs the canonical raster
+            // renderer (the same IRasterMapRenderer the OGC API Maps / MapServer
+            // export / WMS GetMap surfaces drive).
+            if (services.Any(d => d.ServiceType == typeof(Honua.Core.Features.Raster.Abstractions.IRasterMapRenderer)))
+            {
+                services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, MapTools.RenderMapTool>());
+            }
+        }
+
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpResource, JobStatusResource>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpResource, JobResultsResource>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpResource, ProposalStatusResource>());

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpWireModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpWireModels.cs
@@ -231,6 +231,24 @@ internal sealed class McpContentBlock
 
     [JsonPropertyName("text")]
     public string? Text { get; set; }
+
+    /// <summary>
+    /// Base64-encoded binary payload for an <c>image</c> content block. Per the
+    /// MCP 2025-03-26 content-block schema an image block carries
+    /// <c>{ "type": "image", "data": "&lt;base64&gt;", "mimeType": "image/png" }</c>.
+    /// Null for text blocks (omitted from the wire by the
+    /// <c>WhenWritingNull</c> serializer policy) so existing text tools are
+    /// unaffected.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public string? Data { get; set; }
+
+    /// <summary>
+    /// MIME type for an <c>image</c> content block (e.g. <c>image/png</c>). Null
+    /// for text blocks.
+    /// </summary>
+    [JsonPropertyName("mimeType")]
+    public string? MimeType { get; set; }
 }
 
 /// <summary>

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpMapToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpMapToolTests.cs
@@ -1,0 +1,273 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Geometry.Abstractions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Queries.Filters;
+using Honua.Geoprocessing;
+using Honua.Ai.Protocols.Mcp;
+using Honua.Ai.Protocols.Mcp.MapTools;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Focused coverage for the catalog-discovery, feature-query, and map-render MCP
+/// tools. These run through the JSON-RPC dispatcher while substituting the
+/// canonical metadata / feature-query / raster-render services, so they validate
+/// the MCP adapter behavior without a database or renderer dependency.
+/// </summary>
+[Protocol(TestProtocols.Mcp)]
+public sealed class McpMapToolTests
+{
+    private const string ServiceId = "svc-parcels";
+    private const string ServiceName = "Parcels";
+    private const string ResourceId = "res-parcels";
+    private const int LayerIndex = 0;
+    private const int StorageLayerId = 42;
+
+    private readonly IGeoprocessingJobService _jobService = Substitute.For<IGeoprocessingJobService>();
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/list")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/list")]
+    public async Task ToolsList_IncludesCatalogQueryAndRenderTools()
+    {
+        var surface = BuildSurface();
+
+        var response = await surface.DispatchAsync(
+            AuthenticatedContext(BuildServices()),
+            ListToolsRequest("list-1"),
+            CancellationToken.None);
+
+        response.Should().NotBeNull();
+        response!.Error.Should().BeNull();
+        var names = response.Result!.Value.GetProperty("tools")
+            .EnumerateArray()
+            .Select(t => t.GetProperty("name").GetString())
+            .ToArray();
+
+        names.Should().Contain([
+            ListLayersTool.ToolName,
+            QueryFeaturesTool.ToolName,
+            RenderMapTool.ToolName
+        ]);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_list_layers")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_ListLayers_ReturnsPublishedLayers()
+    {
+        var surface = BuildSurface();
+
+        var response = await surface.DispatchAsync(
+            AuthenticatedContext(BuildServices()),
+            ToolCall("layers-1", ListLayersTool.ToolName, "{}"),
+            CancellationToken.None);
+
+        response!.Error.Should().BeNull();
+        var result = response.Result!.Value;
+        result.GetProperty("isError").GetBoolean().Should().BeFalse();
+        var structured = result.GetProperty("structuredContent");
+        structured.GetProperty("layerCount").GetInt32().Should().Be(1);
+        var layer = structured.GetProperty("layers")[0];
+        layer.GetProperty("serviceId").GetString().Should().Be(ServiceId);
+        layer.GetProperty("layerId").GetInt32().Should().Be(LayerIndex);
+        layer.GetProperty("geometryType").GetString().Should().Be(nameof(MetadataV2GeometryType.Polygon));
+        layer.GetProperty("extent").GetProperty("minX").GetDouble().Should().Be(-10);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_query_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_QueryFeatures_ReturnsGeoJson()
+    {
+        var reader = Substitute.For<IFeatureReader>();
+        reader.QueryAsync(StorageLayerId, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new QueryResult<Feature>
+            {
+                TotalCount = 1,
+                HasMoreResults = false,
+                Items =
+                [
+                    new Feature
+                    {
+                        Id = 7,
+                        Geometry = [0x01],
+                        Attributes = ImmutableDictionary<string, object?>.Empty.Add("name", "Lot 7")
+                    }
+                ]
+            });
+
+        var geometryService = Substitute.For<IGeometryService>();
+        geometryService.ConvertWkbToGeoJson(Arg.Any<byte[]?>())
+            .Returns("""{"type":"Point","coordinates":[1,2]}""");
+
+        var surface = BuildSurface();
+        var response = await surface.DispatchAsync(
+            AuthenticatedContext(BuildServices(reader: reader, geometryService: geometryService)),
+            ToolCall("query-1", QueryFeaturesTool.ToolName, $$"""
+                {"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}},"limit":10}
+                """),
+            CancellationToken.None);
+
+        response!.Error.Should().BeNull();
+        var result = response.Result!.Value;
+        result.GetProperty("isError").GetBoolean().Should().BeFalse();
+        var structured = result.GetProperty("structuredContent");
+        structured.GetProperty("returnedCount").GetInt32().Should().Be(1);
+        var feature = structured.GetProperty("geojson").GetProperty("features")[0];
+        feature.GetProperty("type").GetString().Should().Be("Feature");
+        feature.GetProperty("id").GetInt64().Should().Be(7);
+        feature.GetProperty("geometry").GetProperty("type").GetString().Should().Be("Point");
+        feature.GetProperty("properties").GetProperty("name").GetString().Should().Be("Lot 7");
+
+        await reader.Received(1).QueryAsync(StorageLayerId, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_render_map")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_RenderMap_ReturnsImageContentBlock()
+    {
+        var pngBytes = Encoding.ASCII.GetBytes("PNGDATA");
+        var renderer = Substitute.For<IRasterMapRenderer>();
+        renderer.RenderDatasetMapAsync(
+                Arg.Is<int[]>(ids => ids.Length == 1 && ids[0] == StorageLayerId),
+                Arg.Any<MapRenderRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new RasterResult
+            {
+                Data = pngBytes,
+                ContentType = "image/png",
+                Width = 256,
+                Height = 256
+            });
+
+        var surface = BuildSurface();
+        var response = await surface.DispatchAsync(
+            AuthenticatedContext(BuildServices(renderer: renderer)),
+            ToolCall("render-1", RenderMapTool.ToolName, $$"""
+                {
+                  "layers":[{"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}}}],
+                  "bbox":[-10,-10,10,10],
+                  "width":256,
+                  "height":256
+                }
+                """),
+            CancellationToken.None);
+
+        response!.Error.Should().BeNull();
+        var result = response.Result!.Value;
+        result.GetProperty("isError").GetBoolean().Should().BeFalse();
+
+        var content = result.GetProperty("content").EnumerateArray().ToArray();
+        content.Should().Contain(block => block.GetProperty("type").GetString() == "text");
+
+        var imageBlock = content.Single(block => block.GetProperty("type").GetString() == "image");
+        imageBlock.GetProperty("mimeType").GetString().Should().Be("image/png");
+        var data = imageBlock.GetProperty("data").GetString();
+        data.Should().NotBeNullOrEmpty();
+        Convert.FromBase64String(data!).Should().Equal(pngBytes);
+
+        await renderer.Received(1).RenderDatasetMapAsync(
+            Arg.Any<int[]>(), Arg.Any<MapRenderRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    private McpOperatorSurface BuildSurface() => new(
+        [
+            new ListLayersTool(_jobService, NullLogger<ListLayersTool>.Instance),
+            new QueryFeaturesTool(_jobService, NullLogger<QueryFeaturesTool>.Instance),
+            new RenderMapTool(_jobService, NullLogger<RenderMapTool>.Instance)
+        ],
+        [],
+        NullLogger<McpOperatorSurface>.Instance);
+
+    private static TestMetadataV2GraphProvider BuildGraphProvider()
+    {
+        var spatial = new MetadataV2ResourceSpatial
+        {
+            GeometryType = MetadataV2GeometryType.Polygon,
+            SpatialReference = new MetadataV2SpatialReference { Srid = 4326 },
+            Bbox = new MetadataV2Bbox { West = -10, South = -10, East = 10, North = 10 }
+        };
+
+        return new TestMetadataV2GraphBuilder()
+            .AddResource(ResourceId, "Parcels Dataset", spatial: spatial)
+            .AddStorageBinding("bind-parcels", ResourceId, "public.parcels", storageLayerId: StorageLayerId)
+            .AddService(ServiceId, ServiceName)
+            .AddPublication("pub-parcels", ServiceId, ResourceId, layerIndex: LayerIndex, storageBindingId: "bind-parcels")
+            .BuildProvider();
+    }
+
+    private static ServiceProvider BuildServices(
+        IFeatureReader? reader = null,
+        IGeometryService? geometryService = null,
+        IRasterMapRenderer? renderer = null)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IMetadataV2GraphProvider>(BuildGraphProvider());
+        services.AddSingleton(reader ?? Substitute.For<IFeatureReader>());
+        services.AddSingleton(geometryService ?? Substitute.For<IGeometryService>());
+        services.AddSingleton(renderer ?? Substitute.For<IRasterMapRenderer>());
+        services.AddSingleton(Substitute.For<IFilterExpressionService>());
+        return services.BuildServiceProvider();
+    }
+
+    private static DefaultHttpContext AuthenticatedContext(IServiceProvider services)
+    {
+        var context = McpTestFactory.AuthenticatedHttpContext();
+        context.RequestServices = services;
+        return context;
+    }
+
+    private static McpJsonRpcRequest ListToolsRequest(string id) => new()
+    {
+        JsonRpc = "2.0",
+        Id = JsonString(id),
+        Method = "tools/list"
+    };
+
+    private static McpJsonRpcRequest ToolCall(string id, string toolName, string argumentsJson) => new()
+    {
+        JsonRpc = "2.0",
+        Id = JsonString(id),
+        Method = "tools/call",
+        Params = Json($$"""
+            {"name":"{{toolName}}","arguments":{{argumentsJson}}}
+            """)
+    };
+
+    private static JsonElement JsonString(string value)
+    {
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(value));
+        return document.RootElement.Clone();
+    }
+
+    private static JsonElement Json(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
@@ -38,7 +38,10 @@ public sealed class McpTaxonomyAlignmentTests
         "honua_ground_candidates",
         "honua_clarify_intent",
         "honua_geocode_address",
-        "honua_solve_route"
+        "honua_solve_route",
+        "honua_list_layers",
+        "honua_query_features",
+        "honua_render_map"
     };
 
     private static readonly string[] TaxonomyResourceUris =
@@ -344,7 +347,13 @@ public sealed class McpTaxonomyAlignmentTests
             new GroundCandidatesTool(groundingService, jobService, NullLogger<GroundCandidatesTool>.Instance),
             new ClarifyIntentTool(groundingService, jobService, NullLogger<ClarifyIntentTool>.Instance),
             new GeocodeTool(jobService, NullLogger<GeocodeTool>.Instance),
-            new RouteTool(jobService, NullLogger<RouteTool>.Instance)
+            new RouteTool(jobService, NullLogger<RouteTool>.Instance),
+            new Honua.Ai.Protocols.Mcp.MapTools.ListLayersTool(
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.ListLayersTool>.Instance),
+            new Honua.Ai.Protocols.Mcp.MapTools.QueryFeaturesTool(
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.QueryFeaturesTool>.Instance),
+            new Honua.Ai.Protocols.Mcp.MapTools.RenderMapTool(
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.RenderMapTool>.Instance)
         ];
     }
 


### PR DESCRIPTION
## Issue Link
Related to the "point your AI at our MCP and get maps" capability (operator MCP catalog/query/render tools). No tracking issue number.

## Summary
Adds three tools to the operator MCP surface (`honua.operator.mcp` at `/mcp`) so an AI client can discover layers, query feature data, and get a rendered map image back inline:

- **`honua_list_layers`** — catalog discovery. Projects the published services/layers (name, type, geometry type, extent, SRID, description) from the canonical Metadata v2 graph (`IMetadataV2GraphProvider`) — the same snapshot that backs `/rest/services` and FeatureServer layer metadata. Optional substring `filter`.
- **`honua_query_features`** — queries a layer by `serviceId`/`layerId` with optional `where` (ArcGIS/SQL), `bbox`, `outFields`, `limit`, `outSrid`. Reuses the canonical feature-query pipeline (`IFeatureReader` + shared `IFilterExpressionService` for the WHERE clause + `IGeometryService` for WKB→GeoJSON). Returns a GeoJSON `FeatureCollection` plus a compact summary, with a default limit of 100 and a hard cap of 1000.
- **`honua_render_map`** — renders a PNG for one or more ordered layers (bottom-to-top) over a bbox via the canonical `IRasterMapRenderer.RenderDatasetMapAsync` (the same renderer driven by OGC API Maps / MapServer export / WMS GetMap). Returns an MCP **image content block** (`{"type":"image","data":"<base64>","mimeType":"image/png"}`) plus a text caption. Width/height capped at 1024 px.

Each tool is a thin adapter resolved from the request scope (mirroring the existing geocode/route tools); none reimplements catalog, query, or render logic. Tools are advertised in `tools/list` only when their backing canonical service is wired (metadata graph / feature reader / raster renderer), matching the existing capability-gating pattern.

To carry the rendered image, `McpContentBlock` is extended with optional `data`/`mimeType`. This is additive — text blocks are unchanged because the new fields are omitted by the `WhenWritingNull` serializer policy.

A demo redeploy is required to make these live (out of scope here — this PR only lands the code).

## Changes Made
- Add `MapTools/` slice in `Honua.Ai`: `ListLayersTool`, `QueryFeaturesTool`, `RenderMapTool`, shared `MapToolLayerResolver`, DTO models, JSON-schema definitions, and an AOT source-generated `MapToolJsonContext`.
- Register the three tools in `AddMcpOperatorSurface`, gated on `IMetadataV2GraphProvider` (list), `+IFeatureReader` (query), and `+IRasterMapRenderer` (render).
- Extend `McpContentBlock` with optional `data`/`mimeType` for MCP image content blocks.
- Add `McpMapToolTests` (tools/list advertises the 3 tools; each tool's `tools/call` path; render returns a non-empty base64 image block); update the taxonomy roster and `BuildTools` list.

## Testing
- [x] Unit tests added/updated
- [x] Architecture tests pass

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — three new additive MCP tools and an additive, backward-compatible `McpContentBlock` extension.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
