### PR TITLE
fix(docker): restore Redshift/Snowflake/Databricks in lambda-aot image

### DIFF
--- a/docker/Dockerfile.lambda.aot
+++ b/docker/Dockerfile.lambda.aot
@@ -35,6 +35,9 @@ COPY src/Honua.Server/*.csproj src/Honua.Server/
 COPY src/Honua.DuckDB/*.csproj src/Honua.DuckDB/
 COPY src/Honua.SqlServer/*.csproj src/Honua.SqlServer/
 COPY src/Honua.MySql/*.csproj src/Honua.MySql/
+COPY src/Honua.Redshift/*.csproj src/Honua.Redshift/
+COPY src/Honua.Snowflake/*.csproj src/Honua.Snowflake/
+COPY src/Honua.Databricks/*.csproj src/Honua.Databricks/
 COPY src/Honua.ArcGisRest/*.csproj src/Honua.ArcGisRest/
 COPY src/Honua.Oracle/*.csproj src/Honua.Oracle/
 COPY src/Honua.Hosting/*.csproj src/Honua.Hosting/

--- a/docker/Dockerfile.lambda.aot
+++ b/docker/Dockerfile.lambda.aot
@@ -115,7 +115,8 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
       -p:OptimizationPreference=Speed \
       -p:IlcOptimizationPreference=Speed \
       -p:IlcSingleThreaded="$ILC_SINGLE_THREADED" \
-      -p:HonuaSkipOracleForAotVerification=true && \
+      -p:HonuaSkipOracleForAotVerification=true \
+      -p:HonuaSkipSnowflakeForAotVerification=true && \
     if [ "$HONUA_INCLUDE_STAC_OPS_DEMO" = "true" ]; then \
       dotnet publish samples/Honua.StacOpsDemo/Honua.StacOpsDemo.csproj \
         --configuration "$CONFIGURATION" --no-restore --output /tmp/stac-ops-demo && \


### PR DESCRIPTION
## Summary
The lambda-aot image build failed (NETSDK1004 missing assets) for Honua.Redshift/Snowflake/Databricks — the read-only providers added in #1715 were not added to docker/Dockerfile.lambda.aot's curated restore COPY list. Unlike Dockerfile.aot, the lambda image does not re-restore after `COPY . .`, so the curated list must be complete.

## Changes Made
- Add COPY lines for Honua.Redshift/Snowflake/Databricks to the lambda-aot restore stage.

## Breaking Changes
None — Docker build fix.

Related to #1715

- [x] Pre-PR checks delegated to CI