### PR TITLE
fix: back the multidim-coverages jobs endpoint in the API-governance suite

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Coverages/Multidimensional/MultidimensionalCoverageEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Coverages/Multidimensional/MultidimensionalCoverageEndpointTests.cs
@@ -275,7 +275,11 @@ public class MultidimensionalCoverageEndpointTests : IAsyncLifetime
     [Endpoint("GET /api/v1/admin/multidim-coverages/jobs/{jobId}")]
     public async Task ScanJobStatus_WithNonexistentJob_Returns404()
     {
-        var response = await _client.GetAsync($"{Route}/jobs/covscan-does-not-exist");
+        // Use the full literal route here (not the $"{Route}/..." indirection used
+        // elsewhere in this file) so the EndpointRegistry drift scanner, which matches
+        // route templates against literal request strings in test source, recognizes
+        // this GET as backing "GET /api/v1/admin/multidim-coverages/jobs/{jobId}".
+        var response = await _client.GetAsync("/api/v1/admin/multidim-coverages/jobs/covscan-does-not-exist");
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1800

## Summary
A trunk regression was failing CI for every open PR: the architecture/governance test
`EndpointRegistryDriftTests.AllEndpointRegistryEntries_AreBackedByHttpRequests` reported
`GET /api/v1/admin/multidim-coverages/jobs/{jobId}` (added by #1800) as not backed by any
HTTP request in the integration suite.

The governance test source-scans `[IntegrationTest]` method bodies and matches each
`EndpointRegistry` route template against literal request strings. The multidim-coverages
job-status tests issued their `GET` via `$"{Route}/jobs/{jobId}"`, hiding the
`/api/v1/admin/multidim-coverages` literal behind the `Route` constant, so the scanner
never saw a backing `GET` for that route template. (The sibling `GET /{id}` entry passes
because its test uses the full literal path.)

The fix mirrors the sibling test: issue the job-status `GET` against the full literal route.

## Changes Made
- Changed `ScanJobStatus_WithNonexistentJob_Returns404` to call the full literal route `/api/v1/admin/multidim-coverages/jobs/covscan-does-not-exist` instead of `$"{Route}/jobs/..."`, so the EndpointRegistry drift scanner recognizes the backing `GET`.
- Added an explanatory comment noting why the literal route (not the `Route` indirection) is required here.

## Testing
- [x] Integration tests added/updated
- [x] Architecture tests pass

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
