### PR TITLE
feat(scene): LAS/LAZ/COPC point-cloud ingest → 3D Tiles (#1201)

### DIFF
--- a/docs/reference/protocols/3d-tiles-and-scenes.md
+++ b/docs/reference/protocols/3d-tiles-and-scenes.md
@@ -51,6 +51,34 @@ curl -X POST "https://server.example.com/api/v1/admin/scenes" \
   -d '{"id":"downtown","name":"Downtown massing model","assetRoot":"/data/scenes/downtown","isPublic":true}'
 ```
 
+## Scene ingest (admin, Enterprise)
+
+Ingest endpoints convert a source document into a deterministic 3D Tiles tileset, register it in the scene dataset registry, and return the servable tileset URL. All routes require admin authorization, are gated by an Enterprise entitlement (a `402` upgrade response otherwise), and accept `multipart/form-data` with a `file` field. Conversion is pure-managed (no native PDAL/py3dtiles dependency); the tileset is materialised inline and promoted atomically to its asset root.
+
+| Method | Path | Source → output | Entitlement |
+| --- | --- | --- | --- |
+| POST | `/api/v1/admin/scenes/ingest/citygml` | CityGML building model → Building Scene Layer (`.glb`) tileset | `scene.bim-ingest` |
+| POST | `/api/v1/admin/scenes/ingest/pointcloud` | LAS point cloud → 3D Tiles point (`.pnts`) quadtree | `scene.pointcloud-ingest` |
+
+Common form fields: `file` (required), `sceneId` (optional URL slug; derived when omitted), `displayName`, `description`, `editionGate`, `cacheMaxAgeSeconds`, `requiresAuth`.
+
+### Point cloud (`/pointcloud`)
+
+Decodes a LAS point cloud into a quadtree of `.pnts` tiles plus `tileset.json`, preserving per-point **classification**, **intensity**, and **RGB**. Output is byte-stable for identical input.
+
+- **Supported formats:** uncompressed ASPRS **LAS** 1.1–1.4, point data record formats 0, 1, 2, 3, 6, 7, 8. Compressed **LAZ** and **COPC** are detected and rejected with a `400` problem-detail (decompression is a tracked follow-up; reproject/decompress to LAS before ingest).
+- **CRS:** geographic source coordinates only (EPSG:4326 / 4979 / OGC CRS84). Axis order is selected by the optional `sourceCrsAxisOrder` field (`lonlat` default, or `latlon`). Projected source CRS are rejected with a `400`; reproject to geographic before ingest.
+- **Limits:** upload capped at 256 MiB; total point count capped (default 250 M) to bound worst-case memory. Per-tile point budget and LOD depth follow the shared `SceneGeneration` tiling options.
+
+```bash
+curl -X POST "https://server.example.com/api/v1/admin/scenes/ingest/pointcloud" \
+  -H "X-API-Key: $ADMIN_KEY" \
+  -F "file=@cloud.las" -F "sceneId=lidar-survey" -F "sourceCrsAxisOrder=lonlat"
+# → 201 { "sceneId": "lidar-survey", "tilesetUrl": ".../scenes/lidar-survey/tileset.json", ... }
+```
+
+The registered tileset serves through the standard [hosted serving](#hosted-3d-tiles-serving) routes and loads in CesiumJS like any other point tileset.
+
 ## gRPC scene access
 
 `SceneService`, `TileService`, and `ElevationService` expose the same scene/tile/elevation reads over gRPC — see [gRPC](grpc.md).

--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -192,6 +192,16 @@ public static class FeatureCatalog
     public const string SceneBimIngestKey = "scene.bim-ingest";
 
     /// <summary>
+    /// Entitlement key for LAS/LAZ/COPC point-cloud ingest into a servable 3D
+    /// Tiles point tileset (#1201). Enterprise-only: gates the admin
+    /// <c>POST /api/v1/admin/scenes/ingest/pointcloud</c> surface that decodes a
+    /// LAS point cloud and publishes a deterministic <c>.pnts</c> quadtree
+    /// tileset preserving per-point classification, intensity, and RGB.
+    /// Postgres-only (registration-backed).
+    /// </summary>
+    public const string ScenePointCloudIngestKey = "scene.pointcloud-ingest";
+
+    /// <summary>
     /// All edition-gated features in the platform.
     /// </summary>
     public static IReadOnlyList<FeatureDefinition> All { get; } =
@@ -366,6 +376,8 @@ public static class FeatureCatalog
         // Scene — Enterprise (CityGML/BIM ingest + Building Scene Layer publishing)
         new(SceneBimIngestKey, "CityGML/BIM Scene Ingest", Categories.Scene,
             HonuaEdition.Enterprise, "Ingest CityGML building models into a servable Building Scene Layer 3D Tiles tileset with per-feature discipline / sub-layer semantics."),
+        new(ScenePointCloudIngestKey, "Point Cloud Scene Ingest", Categories.Scene,
+            HonuaEdition.Enterprise, "Ingest LAS point clouds into a servable 3D Tiles point tileset preserving per-point classification, intensity, and RGB."),
 
         // Extensibility — Enterprise (plugin/extension SDK)
         new(PluginSdkKey, "Plugin/Extension SDK", Categories.Extensibility,

--- a/src/Honua.Scene/Publishing/PointCloudScenePublishExecutor.cs
+++ b/src/Honua.Scene/Publishing/PointCloudScenePublishExecutor.cs
@@ -1,0 +1,492 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Globalization;
+using Honua.Core.Exceptions;
+using Honua.Core.Features.Scene;
+using Honua.Core.Features.Scene.Abstractions;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Core.Features.Scene.PointCloud;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.Scene;
+
+/// <summary>
+/// Publishing executor that converts an uploaded LAS point cloud into a
+/// deterministic 3D Tiles point tileset (a quadtree of <c>.pnts</c> tiles plus a
+/// <c>tileset.json</c>) and registers it with the hosted scene registry (#1201).
+/// This is the wired ingest path on top of the
+/// <see cref="LasPointCloudReader"/> + <see cref="PointCloudTilesetBuilder"/>
+/// vertical slice: it stages the generated tileset, registers the dataset (the
+/// canonical collision authority), then atomically promotes the staged bytes to
+/// the final scene asset root so the standard scene serving path can stream them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The executor reuses <see cref="SceneTilesetStaging"/> for the stage → register
+/// → promote → compensate mechanics so its durability semantics match the
+/// feature-layer and CityGML/BIM ingest paths. The heavy LAS → 3D Tiles
+/// conversion is pure-managed (no native PDAL/py3dtiles dependency), so the
+/// server materialises the tileset inline; the async-job / out-of-tree-worker
+/// surface used by NetCDF coverage refresh is unnecessary here.
+/// </para>
+/// <para>
+/// CRS handling is intentionally conservative for v1, mirroring the CityGML
+/// ingest path: a geographic source CRS (EPSG:4326/4979 or OGC CRS84, in either
+/// axis order) passes through to the ellipsoid; LAZ/COPC compressed inputs are
+/// rejected by <see cref="LasPointCloudReader"/> and projected source CRS are
+/// rejected here with <see cref="SceneGenerationErrorCodes.LayerCrsUnknown"/> —
+/// both documented follow-ups. Classification, intensity, and RGB are preserved
+/// per point by the builder/PNTS writer.
+/// </para>
+/// </remarks>
+internal sealed partial class PointCloudScenePublishExecutor
+{
+    private readonly IHostEnvironment _environment;
+    private readonly IOptions<SceneGenerationServerOptions> _options;
+    private readonly ILogger<PointCloudScenePublishExecutor> _logger;
+    private readonly ISceneRegistrationService? _registration;
+
+    public PointCloudScenePublishExecutor(
+        IHostEnvironment environment,
+        IOptions<SceneGenerationServerOptions> options,
+        ILogger<PointCloudScenePublishExecutor> logger,
+        ISceneRegistrationService? registration = null)
+    {
+        _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _registration = registration;
+    }
+
+    /// <summary>Default scene cache <c>max-age</c> when the request omits one.</summary>
+    private const int DefaultCacheMaxAgeSeconds = 3600;
+
+    /// <summary>
+    /// Parses, tiles, registers, and promotes a LAS point cloud into a servable
+    /// 3D Tiles point scene.
+    /// </summary>
+    /// <param name="request">The ingest request carrying the LAS bytes and target metadata.</param>
+    /// <param name="cancellationToken">Cancels the ingest before promotion.</param>
+    /// <returns>The ingest outcome with the resolved scene id, asset root, and tileset summary.</returns>
+    /// <exception cref="LasFormatException">The buffer is malformed or uses an unsupported (LAZ/COPC) format.</exception>
+    /// <exception cref="ValidationException">An option is invalid, the source CRS is unsupported, or the scene id/name collides with an existing dataset.</exception>
+    public async Task<PointCloudSceneIngestOutcome> IngestAsync(
+        PointCloudSceneIngestRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Source);
+
+        var serverOptions = _options.Value;
+        var intentId = Guid.NewGuid().ToString("N");
+
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity(
+            HonuaTelemetry.Activities.TileGeneration,
+            ActivityKind.Internal);
+        activity?.SetTag("honua.scene.intent_id", intentId);
+        activity?.SetTag("honua.scene.source_kind", "pointcloud");
+
+        PointCloudIngestLog.Started(_logger, intentId, request.Source.Length);
+        var stopwatch = Stopwatch.StartNew();
+
+        // 1. Decode + tile before any I/O so a malformed buffer, an unsupported
+        //    (LAZ/COPC) format, or an unsupported CRS fails fast without ever
+        //    creating a staging directory. The reader throws LasFormatException
+        //    for compressed/unsupported inputs; the transform throws a
+        //    ValidationException for projected/unknown CRS.
+        var header = LasPointCloudReader.ReadHeader(request.Source);
+        var transform = BuildGeoTransform(request.SourceCrs);
+        var points = LasPointCloudReader.ReadPoints(request.Source, header).ToList();
+        if (points.Count == 0)
+        {
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.OptionsInvalid}: LAS point cloud contains no points to ingest.");
+        }
+
+        PointCloudTilesetResult tileset;
+        try
+        {
+            tileset = PointCloudTilesetBuilder.Build(
+                points,
+                transform,
+                BuildTilingOptions(serverOptions),
+                serverOptions.GeneratorTag);
+        }
+        catch (LasFormatException)
+        {
+            // The builder enforces the same stable scene-error contract as the
+            // reader (e.g. the total-point cap); surface it unchanged so the
+            // endpoint maps it to a problem-detail.
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.OptionsInvalid}: LAS point cloud produced no renderable points.",
+                ex);
+        }
+
+        // 2. Resolve + validate the registry-bound identifiers and options.
+        var sceneId = ResolveSceneId(request.SceneId, intentId);
+        var displayName = ResolveDisplayName(request.DisplayName, sceneId);
+        ValidateOptions(displayName, request.EditionGate, request.CacheMaxAgeSeconds);
+        var cacheMaxAge = request.CacheMaxAgeSeconds ?? DefaultCacheMaxAgeSeconds;
+
+        await PreflightSceneRegistrationConflictAsync(sceneId, cancellationToken).ConfigureAwait(false);
+
+        // 3. Stage → register → promote, reusing the shared durability mechanics.
+        var outputDirectory = SceneTilesetStaging.ResolveOutputDirectory(
+            _environment.ContentRootPath, serverOptions.OutputRoot, sceneId);
+        var stagingDirectory = SceneTilesetStaging.ResolveStagingDirectory(
+            _environment.ContentRootPath, serverOptions.OutputRoot, intentId);
+        string? stagingToCleanup = stagingDirectory;
+        try
+        {
+            Directory.CreateDirectory(stagingDirectory);
+            await File.WriteAllBytesAsync(
+                Path.Combine(stagingDirectory, "tileset.json"),
+                tileset.TilesetJsonBytes,
+                cancellationToken).ConfigureAwait(false);
+            foreach (var (uri, bytes) in tileset.Tiles)
+            {
+                await File.WriteAllBytesAsync(
+                    Path.Combine(stagingDirectory, uri),
+                    bytes,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            var registeredDatasetId = await TryRegisterSceneAsync(
+                sceneId,
+                displayName,
+                request.Description,
+                outputDirectory,
+                tileset.BoundsDegrees,
+                cacheMaxAge,
+                request.EditionGate,
+                request.RequiresAuth,
+                request.CreatedBy ?? "publisher",
+                cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                SceneTilesetStaging.PromoteStagingToFinal(
+                    stagingDirectory,
+                    outputDirectory,
+                    stale => PointCloudIngestLog.PromotionOverwroteStaleFinalDir(_logger, stale));
+            }
+            catch
+            {
+                if (registeredDatasetId is { } datasetId)
+                {
+                    await CompensateRegistrationAsync(datasetId, sceneId).ConfigureAwait(false);
+                }
+                throw;
+            }
+            stagingToCleanup = null;
+
+            stopwatch.Stop();
+            activity?.SetTag("honua.scene.id", sceneId);
+            activity?.SetTag("honua.scene.point_count", tileset.PointCount);
+            activity?.SetTag("honua.scene.tile_count", tileset.TileCount);
+            PointCloudIngestLog.Completed(
+                _logger, intentId, sceneId, tileset.PointCount, tileset.TileCount, stopwatch.ElapsedMilliseconds);
+
+            return new PointCloudSceneIngestOutcome(
+                sceneId,
+                outputDirectory,
+                tileset.BoundsDegrees,
+                tileset.PointCount,
+                tileset.TileCount,
+                header.HasColor);
+        }
+        finally
+        {
+            if (stagingToCleanup is not null)
+            {
+                SceneTilesetStaging.TryDeleteStaging(
+                    stagingToCleanup,
+                    ex => PointCloudIngestLog.StagingCleanupFailed(_logger, stagingToCleanup, ex));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Maps the configured scene generation LOD knobs onto the point-cloud
+    /// tiling options so the operator-tunable feature-tiling thresholds drive the
+    /// point quadtree as well, keeping a single source of truth for LOD depth.
+    /// </summary>
+    private static PointCloudTilingOptions BuildTilingOptions(SceneGenerationServerOptions serverOptions)
+        => new()
+        {
+            MaxPointsPerTile = serverOptions.MaxFeaturesPerTile,
+            MaxDepth = serverOptions.MaxLodDepth,
+            InteriorSampleCount = serverOptions.InteriorSampleCount
+        };
+
+    /// <summary>
+    /// Builds the geographic projection delegate for the source point cloud. v1
+    /// supports a geographic source CRS only (EPSG:4326/4979 or OGC CRS84); axis
+    /// order is taken from the request hint. A projected/unknown CRS is rejected
+    /// as a documented limitation, mirroring the CityGML ingest path.
+    /// </summary>
+    private static PointCloudGeoTransform BuildGeoTransform(PointCloudSourceCrs sourceCrs)
+    {
+        // Geographic pass-through: keep height (ellipsoidal meters) untouched and
+        // swap the horizontal ordinates when the request declares latitude-first
+        // axis order so the builder always receives (longitude, latitude, height).
+        return sourceCrs switch
+        {
+            PointCloudSourceCrs.GeographicLonLat => static (x, y, z) => (x, y, z),
+            PointCloudSourceCrs.GeographicLatLon => static (x, y, z) => (y, x, z),
+            _ => throw new ValidationException(
+                $"{SceneGenerationErrorCodes.LayerCrsUnknown}: point-cloud source CRS '{sourceCrs}' is " +
+                "projected or unsupported. v1 point-cloud ingest supports geographic coordinates only " +
+                "(EPSG:4326, EPSG:4979, or OGC CRS84). Reproject the LAS to geographic coordinates before ingest."),
+        };
+    }
+
+    private static string ResolveSceneId(string? explicitId, string intentId)
+    {
+        if (!string.IsNullOrEmpty(explicitId))
+        {
+            var normalized = explicitId.ToLowerInvariant();
+            if (!SceneDatasetValidator.TryValidateSceneId(normalized, out var error))
+            {
+                throw new ValidationException(
+                    $"{SceneGenerationErrorCodes.OptionsInvalid}: sceneId is invalid: {error}");
+            }
+            return normalized;
+        }
+
+        var suffix = intentId.Length >= 8 ? intentId[..8] : intentId;
+        var candidate = $"pointcloud-{suffix}".ToLowerInvariant();
+        if (!SceneDatasetValidator.TryValidateSceneId(candidate, out var autoError))
+        {
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.OptionsInvalid}: derived sceneId '{candidate}' is invalid: {autoError}. Supply an explicit sceneId.");
+        }
+        return candidate;
+    }
+
+    private static string ResolveDisplayName(string? explicitName, string sceneId)
+    {
+        if (!string.IsNullOrEmpty(explicitName))
+        {
+            return explicitName;
+        }
+
+        // Suffix with the resolved sceneId so the default name is unique by
+        // construction (the registry enforces name uniqueness), mirroring the
+        // feature-layer and CityGML generation defaults.
+        const string baseName = "Point Cloud";
+        var suffix = $" ({sceneId})";
+        var available = SceneDatasetValidator.MaxSceneNameLength - suffix.Length;
+        if (available <= 0)
+        {
+            return sceneId;
+        }
+        var trimmed = baseName.Length > available ? baseName[..available] : baseName;
+        return trimmed + suffix;
+    }
+
+    private static void ValidateOptions(string displayName, string? editionGate, int? cacheMaxAgeSeconds)
+    {
+        if (!SceneDatasetValidator.TryValidateName(displayName, out var nameError))
+        {
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.OptionsInvalid}: displayName is invalid: {nameError}");
+        }
+
+        if (!SceneDatasetValidator.TryValidateEditionGate(editionGate, out var editionError))
+        {
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.OptionsInvalid}: editionGate is invalid: {editionError}");
+        }
+
+        if (cacheMaxAgeSeconds is { } cache)
+        {
+            var policy = new SceneCachePolicy(cache, NoStore: false);
+            if (!SceneDatasetValidator.TryValidateCachePolicy(policy, out var cacheError))
+            {
+                throw new ValidationException(
+                    $"{SceneGenerationErrorCodes.OptionsInvalid}: cacheMaxAgeSeconds is invalid: {cacheError}");
+            }
+        }
+    }
+
+    private async Task PreflightSceneRegistrationConflictAsync(string sceneId, CancellationToken cancellationToken)
+    {
+        if (_registration is null)
+        {
+            return;
+        }
+        var existing = await _registration.GetBySceneIdAsync(sceneId, cancellationToken).ConfigureAwait(false);
+        if (existing is not null)
+        {
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.SceneRegistrationConflict}: A scene dataset with id '{sceneId}' already exists.");
+        }
+    }
+
+    private async Task<Guid?> TryRegisterSceneAsync(
+        string sceneId,
+        string displayName,
+        string? description,
+        string outputDirectory,
+        double[] bounds,
+        int cacheMaxAgeSeconds,
+        string? editionGate,
+        bool requiresAuth,
+        string createdBy,
+        CancellationToken cancellationToken)
+    {
+        if (_registration is null)
+        {
+            return null;
+        }
+
+        var record = new SceneDatasetRecord
+        {
+            DatasetId = Guid.NewGuid(),
+            Id = sceneId,
+            Name = displayName,
+            Description = description,
+            AssetRoot = outputDirectory,
+            TilesetFileName = "tileset.json",
+            DatasetType = SceneDatasetType.HostedTiles,
+            Extent = new SceneExtent(bounds[0], bounds[1], bounds[2], bounds[3]),
+            // Point-cloud positions are placed on the WGS-84 ellipsoid with
+            // ellipsoidal height in meters, so the registered CRS is 4979.
+            Crs = "EPSG:4979",
+            CachePolicy = new SceneCachePolicy(cacheMaxAgeSeconds, NoStore: false),
+            EditionGate = editionGate,
+            RequiresAuth = requiresAuth,
+            IsPublic = !requiresAuth,
+            AllowedRoles = null,
+            Status = SceneDatasetStatus.Active,
+            ValidationMessage = null,
+            Revision = 1,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBy = createdBy,
+            UpdatedAt = null
+        };
+
+        try
+        {
+            var saved = await _registration.RegisterAsync(record, cancellationToken).ConfigureAwait(false);
+            return saved?.DatasetId is { } id && id != Guid.Empty ? id : record.DatasetId;
+        }
+        catch (SceneDatasetAlreadyExistsException ex)
+        {
+            throw new ValidationException(
+                $"{SceneGenerationErrorCodes.SceneRegistrationConflict}: A scene dataset with id '{sceneId}' or name '{displayName}' already exists.",
+                ex);
+        }
+    }
+
+    private async Task CompensateRegistrationAsync(Guid datasetId, string sceneId)
+    {
+        if (_registration is null)
+        {
+            return;
+        }
+        try
+        {
+            var deactivated = await _registration.DeactivateAsync(datasetId, CancellationToken.None).ConfigureAwait(false);
+            PointCloudIngestLog.RegistrationCompensated(_logger, sceneId, datasetId, deactivated);
+        }
+        catch (Exception ex)
+        {
+            PointCloudIngestLog.RegistrationCompensationFailed(_logger, sceneId, datasetId, ex);
+        }
+    }
+
+    internal static partial class PointCloudIngestLog
+    {
+        [LoggerMessage(EventId = 8470, Level = LogLevel.Information,
+            Message = "Point-cloud scene ingest started: intent {IntentId}, document {ByteCount} bytes")]
+        public static partial void Started(ILogger logger, string intentId, int byteCount);
+
+        [LoggerMessage(EventId = 8471, Level = LogLevel.Information,
+            Message = "Point-cloud scene ingest completed: intent {IntentId}, scene {SceneId}, points {PointCount}, tiles {TileCount}, elapsed {ElapsedMs}ms")]
+        public static partial void Completed(ILogger logger, string intentId, string sceneId, int pointCount, int tileCount, long elapsedMs);
+
+        [LoggerMessage(EventId = 8472, Level = LogLevel.Warning,
+            Message = "Point-cloud scene ingest overwrote stale final directory {FinalDirectory} during staging promotion; the registry record now points at the new bytes.")]
+        public static partial void PromotionOverwroteStaleFinalDir(ILogger logger, string finalDirectory);
+
+        [LoggerMessage(EventId = 8473, Level = LogLevel.Warning,
+            Message = "Point-cloud scene ingest could not delete staging directory {StagingDirectory}; subsequent ingests are unaffected but the directory may need a manual sweep.")]
+        public static partial void StagingCleanupFailed(ILogger logger, string stagingDirectory, Exception exception);
+
+        [LoggerMessage(EventId = 8474, Level = LogLevel.Warning,
+            Message = "Point-cloud scene ingest deactivated registry record for scene {SceneId} ({DatasetId}) after staging promotion failed; deactivated={Deactivated}.")]
+        public static partial void RegistrationCompensated(ILogger logger, string sceneId, Guid datasetId, bool deactivated);
+
+        [LoggerMessage(EventId = 8475, Level = LogLevel.Error,
+            Message = "Point-cloud scene ingest could not deactivate registry record for scene {SceneId} ({DatasetId}) after staging promotion failed; record remains Active and must be cleaned up via the admin scene CRUD path.")]
+        public static partial void RegistrationCompensationFailed(ILogger logger, string sceneId, Guid datasetId, Exception exception);
+    }
+}
+
+/// <summary>
+/// Horizontal source-CRS interpretation for a point-cloud ingest request
+/// (#1201). v1 supports geographic coordinates only; the value selects axis
+/// order. LAS files do not carry a reliable inline EPSG field (the CRS lives in
+/// VLR/WKT records), so the caller declares the interpretation explicitly.
+/// </summary>
+internal enum PointCloudSourceCrs
+{
+    /// <summary>LAS X is longitude (degrees), Y is latitude (degrees). Default.</summary>
+    GeographicLonLat = 0,
+
+    /// <summary>LAS X is latitude (degrees), Y is longitude (degrees).</summary>
+    GeographicLatLon = 1,
+}
+
+/// <summary>
+/// Request to ingest a LAS point cloud into a servable 3D Tiles point scene
+/// (#1201).
+/// </summary>
+/// <param name="Source">The uncompressed LAS buffer bytes.</param>
+/// <param name="SourceCrs">Geographic axis-order interpretation of the LAS X/Y ordinates.</param>
+/// <param name="SceneId">Optional explicit scene slug; derived from the intent id when omitted.</param>
+/// <param name="DisplayName">Optional display name; derived from the scene id when omitted.</param>
+/// <param name="Description">Optional human-readable description.</param>
+/// <param name="EditionGate">Optional edition gate slug recorded on the dataset.</param>
+/// <param name="CacheMaxAgeSeconds">Optional cache <c>max-age</c>; defaults to 3600 when omitted.</param>
+/// <param name="RequiresAuth">When true, the registered scene requires authentication instead of being public.</param>
+/// <param name="CreatedBy">Optional audit identity for the registration record.</param>
+internal sealed record PointCloudSceneIngestRequest(
+    byte[] Source,
+    PointCloudSourceCrs SourceCrs = PointCloudSourceCrs.GeographicLonLat,
+    string? SceneId = null,
+    string? DisplayName = null,
+    string? Description = null,
+    string? EditionGate = null,
+    int? CacheMaxAgeSeconds = null,
+    bool RequiresAuth = false,
+    string? CreatedBy = null);
+
+/// <summary>
+/// Outcome of a point-cloud scene ingest: the resolved scene id, on-disk asset
+/// root, and the point tileset summary surfaced to the admin response (#1201).
+/// </summary>
+/// <param name="SceneId">Resolved scene slug used in the tileset URL.</param>
+/// <param name="AssetRoot">Final on-disk directory holding the promoted tileset.</param>
+/// <param name="BoundsDegrees">Dataset envelope [west, south, east, north] in degrees.</param>
+/// <param name="PointCount">Number of points ingested.</param>
+/// <param name="TileCount">Number of <c>.pnts</c> tile content files written.</param>
+/// <param name="HasColor">True when the source LAS carried per-point RGB preserved in the tiles.</param>
+internal sealed record PointCloudSceneIngestOutcome(
+    string SceneId,
+    string AssetRoot,
+    double[] BoundsDegrees,
+    int PointCount,
+    int TileCount,
+    bool HasColor);

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -777,6 +777,9 @@ public static class EndpointRegistry
         // CityGML/BIM scene ingest admin endpoint (#1207).
         new("POST", "/api/v1/admin/scenes/ingest/citygml"),
 
+        // LAS/LAZ/COPC point-cloud scene ingest admin endpoint (#1201).
+        new("POST", "/api/v1/admin/scenes/ingest/pointcloud"),
+
         new("GET", "/elevation/{datasetId}/value"),
         new("GET", "/elevation/{datasetId}/profile"),
 

--- a/src/Honua.Server/Features/Admin/Models/ScenePointCloudIngestJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/ScenePointCloudIngestJsonContext.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Source-generated JSON context for the LAS/LAZ/COPC point-cloud scene ingest
+/// admin API response (#1201). The request is multipart/form-data, so only the
+/// response model needs source-generated serialization.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(PointCloudIngestResponse))]
+internal sealed partial class ScenePointCloudIngestJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Admin/Models/ScenePointCloudIngestModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/ScenePointCloudIngestModels.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Response payload returned by POST /api/v1/admin/scenes/ingest/pointcloud (#1201).
+/// </summary>
+public sealed class PointCloudIngestResponse
+{
+    /// <summary>Stable identifier used in the resulting scene URL.</summary>
+    public string SceneId { get; set; } = string.Empty;
+
+    /// <summary>Routable URL for the generated point tileset's root document.</summary>
+    public string TilesetUrl { get; set; } = string.Empty;
+
+    /// <summary>Number of points ingested from the LAS point cloud.</summary>
+    public int PointCount { get; set; }
+
+    /// <summary>Number of <c>.pnts</c> tile content files written under the scene asset root.</summary>
+    public int TileCount { get; set; }
+
+    /// <summary>True when the source LAS carried per-point RGB preserved in the output tiles.</summary>
+    public bool HasColor { get; set; }
+
+    /// <summary>Bounding region of the dataset in WGS-84 degrees [west, south, east, north].</summary>
+    public double[] BoundingRegionDegrees { get; set; } = [0, 0, 0, 0];
+}

--- a/src/Honua.Server/Features/Admin/ScenePointCloudIngestEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/ScenePointCloudIngestEndpoints.cs
@@ -1,0 +1,324 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Exceptions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Core.Features.Scene.PointCloud;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Caching;
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Licensing;
+using Honua.Infrastructure.Models;
+using Honua.Infrastructure.Scene;
+using Honua.Server.Features.Admin.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Admin endpoint for LAS/LAZ/COPC point-cloud scene ingest (#1201). Decodes an
+/// uploaded LAS point cloud into a deterministic 3D Tiles point tileset (a
+/// quadtree of <c>.pnts</c> tiles + <c>tileset.json</c>), registers it, and
+/// returns the servable tileset URL. Enterprise-gated.
+/// </summary>
+/// <remarks>
+/// The endpoint is mapped only when the point-cloud ingest executor is
+/// registered (Postgres profiles), mirroring the CityGML/BIM and feature-layer
+/// scene generation surfaces. Admin authentication is enforced by the group
+/// policy; the Enterprise entitlement is enforced inside the handler so an
+/// authenticated non-Enterprise operator receives a 402 with an upgrade message
+/// rather than a silent 404. The heavy LAS → 3D Tiles conversion is pure-managed
+/// (no native PDAL/py3dtiles dependency), so the tileset is materialised inline;
+/// compressed LAZ and Cloud-Optimized Point Cloud (COPC) inputs are rejected with
+/// a 400 problem-detail and are a documented follow-up.
+/// </remarks>
+internal static partial class ScenePointCloudIngestEndpoints
+{
+    private const string TagAdmin = "Admin";
+    private const string TagScenes = "Scene Ingest";
+
+    /// <summary>Upper bound on the uploaded LAS document size (256 MiB) for the admin surface.</summary>
+    private const long MaxUploadBytes = 256L * 1024 * 1024;
+
+    /// <summary>
+    /// Maps the admin point-cloud ingest endpoint. No-op when the executor is not
+    /// registered (non-Postgres profiles).
+    /// </summary>
+    public static IEndpointRouteBuilder MapScenePointCloudIngestEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var inspector = endpoints.ServiceProvider.GetService<IServiceProviderIsService>();
+        if (inspector is not null && !inspector.IsService(typeof(PointCloudScenePublishExecutor)))
+        {
+            return endpoints;
+        }
+
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/scenes/ingest")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags(TagAdmin, TagScenes)
+            .RequireAdminAuthorization();
+
+        _ = group.MapPost("/pointcloud", HandleIngestPointCloud)
+            .WithName("IngestPointCloudScene")
+            .WithSummary("Ingest a LAS point cloud into a servable 3D Tiles point tileset (Enterprise).")
+            .Accepts<IFormFile>("multipart/form-data")
+            .Produces<PointCloudIngestResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status402PaymentRequired)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .DisableAntiforgery();
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleIngestPointCloud(
+        HttpContext context,
+        CancellationToken cancellationToken)
+    {
+        var logger = context.RequestServices.GetRequiredService<ILogger<ScenePointCloudIngestEndpointsLogCategory>>();
+
+        // Enterprise gate first: an authenticated non-Enterprise operator gets a
+        // 402 with an upgrade message before any document is read.
+        var gateError = LicenseGate.RequireEntitlement(
+            context, FeatureCatalog.ScenePointCloudIngestKey, "Point Cloud Scene Ingest", logger);
+        if (gateError is not null)
+        {
+            return gateError;
+        }
+
+        if (!context.Request.HasFormContentType)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest,
+                "Request must be multipart/form-data with a 'file' field carrying the LAS point cloud.");
+        }
+
+        var form = await context.Request.ReadFormAsync(cancellationToken).ConfigureAwait(false);
+        var file = form.Files["file"] ?? (form.Files.Count > 0 ? form.Files[0] : null);
+        if (file is null || file.Length == 0)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest,
+                "A non-empty 'file' field carrying the LAS point cloud is required.");
+        }
+        if (file.Length > MaxUploadBytes)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest,
+                $"LAS point cloud exceeds the {MaxUploadBytes}-byte upload limit.");
+        }
+
+        if (!TryParseOptionalInt(form, "cacheMaxAgeSeconds", out var cacheMaxAge, out var cacheError))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, cacheError!);
+        }
+        if (!TryParseOptionalBool(form, "requiresAuth", out var requiresAuth, out var authError))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, authError!);
+        }
+        if (!TryParseSourceCrs(form, out var sourceCrs, out var crsError))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, crsError!);
+        }
+
+        byte[] document;
+        await using (var stream = file.OpenReadStream())
+        {
+            using var buffer = new MemoryStream(file.Length > 0 ? (int)file.Length : 0);
+            await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+            document = buffer.ToArray();
+        }
+
+        var request = new PointCloudSceneIngestRequest(
+            Source: document,
+            SourceCrs: sourceCrs,
+            SceneId: NullIfBlank(form["sceneId"]),
+            DisplayName: NullIfBlank(form["displayName"]),
+            Description: NullIfBlank(form["description"]),
+            EditionGate: NullIfBlank(form["editionGate"]),
+            CacheMaxAgeSeconds: cacheMaxAge,
+            RequiresAuth: requiresAuth ?? false,
+            CreatedBy: context.User.Identity?.Name);
+
+        var executor = context.RequestServices.GetRequiredService<PointCloudScenePublishExecutor>();
+
+        try
+        {
+            var outcome = await executor.IngestAsync(request, cancellationToken).ConfigureAwait(false);
+            await InvalidateSceneCacheAsync(context, outcome.SceneId, logger, cancellationToken).ConfigureAwait(false);
+
+            var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+            var tilesetUrl = string.Concat(
+                baseUrl.AsSpan().TrimEnd('/'),
+                "/scenes/".AsSpan(),
+                outcome.SceneId.AsSpan(),
+                "/tileset.json".AsSpan());
+
+            var response = new PointCloudIngestResponse
+            {
+                SceneId = outcome.SceneId,
+                TilesetUrl = tilesetUrl,
+                PointCount = outcome.PointCount,
+                TileCount = outcome.TileCount,
+                HasColor = outcome.HasColor,
+                BoundingRegionDegrees = outcome.BoundsDegrees
+            };
+
+            ScenePointCloudIngestLog.IngestCompleted(
+                logger, outcome.SceneId, outcome.PointCount, outcome.TileCount);
+
+            return Results.Json(
+                response,
+                ScenePointCloudIngestJsonContext.Default.PointCloudIngestResponse,
+                statusCode: StatusCodes.Status201Created);
+        }
+        catch (LasFormatException fex)
+        {
+            ScenePointCloudIngestLog.IngestRejected(logger, fex.Code, fex.Message);
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest,
+                $"{fex.Code}: {fex.Message}");
+        }
+        catch (ValidationException vex)
+        {
+            ScenePointCloudIngestLog.IngestRejected(logger, "VALIDATION", vex.Message);
+            var (status, detail) = ClassifyValidationError(vex.Message);
+            return ProblemDetailsHelpers.CreateAdminProblem(context, status, detail);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return Results.StatusCode(StatusCodes.Status499ClientClosedRequest);
+        }
+        catch (Exception ex)
+        {
+            ScenePointCloudIngestLog.IngestFailed(logger, ex);
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status500InternalServerError,
+                "Failed to ingest LAS point cloud.");
+        }
+    }
+
+    private static (int Status, string Detail) ClassifyValidationError(string message)
+    {
+        if (message.StartsWith($"{SceneGenerationErrorCodes.SceneRegistrationConflict}:", StringComparison.Ordinal))
+        {
+            return (StatusCodes.Status409Conflict, message);
+        }
+        return (StatusCodes.Status400BadRequest, message);
+    }
+
+    private static bool TryParseSourceCrs(IFormCollection form, out PointCloudSourceCrs value, out string? error)
+    {
+        // Default to longitude/latitude axis order when unspecified, matching the
+        // request record default. The accepted values mirror the geographic axis
+        // orders the v1 executor supports.
+        value = PointCloudSourceCrs.GeographicLonLat;
+        error = null;
+        var raw = form["sourceCrsAxisOrder"];
+        if (raw.Count == 0 || string.IsNullOrWhiteSpace(raw[0]))
+        {
+            return true;
+        }
+        switch (raw[0]!.Trim().ToLowerInvariant())
+        {
+            case "lonlat":
+            case "longlat":
+            case "xy":
+                value = PointCloudSourceCrs.GeographicLonLat;
+                return true;
+            case "latlon":
+            case "latlong":
+            case "yx":
+                value = PointCloudSourceCrs.GeographicLatLon;
+                return true;
+            default:
+                error = "sourceCrsAxisOrder must be 'lonlat' or 'latlon'.";
+                return false;
+        }
+    }
+
+    private static bool TryParseOptionalInt(
+        IFormCollection form, string key, out int? value, out string? error)
+    {
+        value = null;
+        error = null;
+        var raw = form[key];
+        if (raw.Count == 0 || string.IsNullOrWhiteSpace(raw[0]))
+        {
+            return true;
+        }
+        if (!int.TryParse(raw[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            error = $"{key} must be an integer.";
+            return false;
+        }
+        value = parsed;
+        return true;
+    }
+
+    private static bool TryParseOptionalBool(
+        IFormCollection form, string key, out bool? value, out string? error)
+    {
+        value = null;
+        error = null;
+        var raw = form[key];
+        if (raw.Count == 0 || string.IsNullOrWhiteSpace(raw[0]))
+        {
+            return true;
+        }
+        if (!bool.TryParse(raw[0], out var parsed))
+        {
+            error = $"{key} must be 'true' or 'false'.";
+            return false;
+        }
+        value = parsed;
+        return true;
+    }
+
+    private static string? NullIfBlank(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private static async Task InvalidateSceneCacheAsync(
+        HttpContext context,
+        string sceneId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var invalidator = context.RequestServices.GetService<OutputCacheInvalidationService>();
+        if (invalidator is null)
+        {
+            return;
+        }
+        try
+        {
+            await invalidator.InvalidateSceneAsync(sceneId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            ScenePointCloudIngestLog.CacheInvalidationFailed(logger, sceneId, ex);
+        }
+    }
+
+    /// <summary>
+    /// Log category marker used by <see cref="ILogger{TCategoryName}"/> bindings.
+    /// </summary>
+    internal sealed class ScenePointCloudIngestEndpointsLogCategory;
+
+    internal static partial class ScenePointCloudIngestLog
+    {
+        [LoggerMessage(EventId = 8480, Level = LogLevel.Information,
+            Message = "Point-cloud ingest request completed: scene {SceneId}, points {PointCount}, tiles {TileCount}")]
+        public static partial void IngestCompleted(ILogger logger, string sceneId, int pointCount, int tileCount);
+
+        [LoggerMessage(EventId = 8481, Level = LogLevel.Warning,
+            Message = "Point-cloud ingest request rejected: code {Code}, reason {Reason}")]
+        public static partial void IngestRejected(ILogger logger, string code, string reason);
+
+        [LoggerMessage(EventId = 8482, Level = LogLevel.Error,
+            Message = "Point-cloud ingest request failed unexpectedly.")]
+        public static partial void IngestFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(EventId = 8483, Level = LogLevel.Warning,
+            Message = "Point-cloud ingest scene cache invalidation failed for scene {SceneId}; subsequent reads may serve stale content until cache expires.")]
+        public static partial void CacheInvalidationFailed(ILogger logger, string sceneId, Exception exception);
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -224,6 +224,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapVisibilityAnalysisEndpoints();
         endpoints.MapSceneGenerationEndpoints();
         endpoints.MapSceneBimIngestEndpoints();
+        endpoints.MapScenePointCloudIngestEndpoints();
         endpoints.MapPMTilesProxyEndpoints();
         endpoints.MapStyleEndpoints();
         endpoints.MapOgcCoveragesEndpoints();

--- a/src/Honua.Server/Features/Infrastructure/Scene/SceneGenerationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Scene/SceneGenerationServiceCollectionExtensions.cs
@@ -48,6 +48,11 @@ internal static class SceneGenerationServiceCollectionExtensions
         // executor so the Enterprise-gated admin ingest endpoint can resolve it.
         services.TryAddScoped<CityGmlScenePublishExecutor>();
 
+        // LAS/LAZ/COPC point-cloud ingest path (#1201): registered alongside the
+        // other scene executors so the Enterprise-gated admin point-cloud ingest
+        // endpoint can resolve it.
+        services.TryAddScoped<PointCloudScenePublishExecutor>();
+
         return services;
     }
 

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -784,6 +784,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Admin.Models.SceneDatasetJsonContext.Default,
         Honua.Server.Features.Admin.Models.SceneGenerationJsonContext.Default,
         Honua.Server.Features.Admin.Models.SceneBimIngestJsonContext.Default,
+        Honua.Server.Features.Admin.Models.ScenePointCloudIngestJsonContext.Default,
         Honua.Protocols.Scene.Models.PublicSceneDiscoveryJsonContext.Default,
         Honua.Server.Features.Admin.Models.RateLimitJsonContext.Default,
         Honua.Server.Features.Admin.Models.TableDiscoveryJsonContext.Default,

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/ScenePointCloudIngestEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/ScenePointCloudIngestEndpointsTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Tests.Features.Infrastructure.Scene;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+/// <summary>
+/// Integration tests for the Enterprise-gated LAS/LAZ/COPC point-cloud scene
+/// ingest endpoint (#1201). Covers the HTTP-surface contract — admin
+/// authentication, the Enterprise entitlement gate, malformed/compressed-upload
+/// rejection — and the end-to-end happy path that ingests a synthetic LAS
+/// fixture and serves the resulting 3D Tiles point tileset.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Configuration)]
+public class ScenePointCloudIngestEndpointsTests : IAsyncLifetime
+{
+    private const string AdminPassword = "scene-pcloud-ingest-admin-key";
+    private const string IngestUrl = "/api/v1/admin/scenes/ingest/pointcloud";
+
+    private readonly WebAppFixture _fixture;
+    private readonly string _outputRoot;
+    private HttpClient _client = null!;
+
+    public ScenePointCloudIngestEndpointsTests()
+    {
+        // Generated tilesets must land in a temp directory rather than the
+        // server's default content-root-relative "scenes-generated" folder, so
+        // an end-to-end ingest never leaks artifacts into the source tree.
+        _outputRoot = Path.Combine(Path.GetTempPath(), $"honua-pcloud-it-{Guid.NewGuid():N}");
+        _fixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .WithTestLicense(HonuaEdition.Enterprise)
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+                builder.UseSetting("SceneGeneration:OutputRoot", _outputRoot);
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+        if (Directory.Exists(_outputRoot))
+        {
+            Directory.Delete(_outputRoot, recursive: true);
+        }
+    }
+
+    private static MultipartFormDataContent BuildUpload(byte[] document, params (string Key, string Value)[] fields)
+    {
+        var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(document);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        content.Add(fileContent, "file", "cloud.las");
+        foreach (var (key, value) in fields)
+        {
+            content.Add(new StringContent(value, Encoding.UTF8), key);
+        }
+        return content;
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/pointcloud")]
+    public async Task Ingest_Unauthenticated_Returns401()
+    {
+        using var unauth = _fixture.CreateClient();
+        using var upload = BuildUpload(PointCloudSceneFixtures.ColoredGridGeographic());
+
+        var response = await unauth.PostAsync(IngestUrl, upload);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/pointcloud")]
+    public async Task Ingest_EmptyFile_Returns400()
+    {
+        using var upload = BuildUpload(Array.Empty<byte>());
+
+        var response = await _client.PostAsync(IngestUrl, upload);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/pointcloud")]
+    public async Task Ingest_MalformedDocument_Returns400()
+    {
+        using var upload = BuildUpload(Encoding.UTF8.GetBytes("this is not a LAS point cloud"));
+
+        var response = await _client.PostAsync(IngestUrl, upload);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/pointcloud")]
+    public async Task Ingest_LazCompressed_Returns400()
+    {
+        using var upload = BuildUpload(
+            PointCloudSceneFixtures.MarkCompressed(PointCloudSceneFixtures.ColoredGridGeographic()),
+            ("sceneId", "pcloud-laz-rejected"));
+
+        var response = await _client.PostAsync(IngestUrl, upload);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/pointcloud")]
+    public async Task Ingest_ValidLas_Returns201AndServesTileset()
+    {
+        using var upload = BuildUpload(
+            PointCloudSceneFixtures.ColoredGridGeographic(),
+            ("sceneId", "pcloud-ingest-it"),
+            ("displayName", "Point Cloud Ingest IT"),
+            ("editionGate", "enterprise"));
+
+        var response = await _client.PostAsync(IngestUrl, upload);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<PointCloudIngestResponse>();
+        Assert.NotNull(body);
+        Assert.Equal("pcloud-ingest-it", body!.SceneId);
+        Assert.Equal(256, body.PointCount);
+        Assert.True(body.TileCount >= 1);
+        Assert.True(body.HasColor);
+        Assert.EndsWith("/scenes/pcloud-ingest-it/tileset.json", body.TilesetUrl);
+
+        // The registered tileset must be servable through the standard scene path.
+        var tileset = await _client.GetAsync("/scenes/pcloud-ingest-it/tileset.json");
+        Assert.Equal(HttpStatusCode.OK, tileset.StatusCode);
+        var tilesetBody = await tileset.Content.ReadAsStringAsync();
+        Assert.Contains("geometricError", tilesetBody);
+
+        // A referenced .pnts tile must resolve through the asset-path serving route.
+        var tile = await _client.GetAsync("/scenes/pcloud-ingest-it/points_0000.pnts");
+        Assert.Equal(HttpStatusCode.OK, tile.StatusCode);
+        var tileBytes = await tile.Content.ReadAsByteArrayAsync();
+        // "pnts" magic in little-endian leading bytes.
+        Assert.True(tileBytes.Length >= 4);
+        Assert.Equal((byte)'p', tileBytes[0]);
+        Assert.Equal((byte)'n', tileBytes[1]);
+        Assert.Equal((byte)'t', tileBytes[2]);
+        Assert.Equal((byte)'s', tileBytes[3]);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/pointcloud")]
+    public async Task Ingest_LiteralRoute_AcceptsValidUpload()
+    {
+        // Issues the POST against the literal route string so the API-surface
+        // drift scanner (EndpointRegistryDriftTests) can match this method body
+        // to the "POST /api/v1/admin/scenes/ingest/pointcloud" registry entry; the
+        // other tests in this class reach the route through the IngestUrl
+        // constant, which the source scanner cannot resolve.
+        using var upload = BuildUpload(
+            PointCloudSceneFixtures.ColoredGridGeographic(),
+            ("sceneId", "pcloud-ingest-literal"),
+            ("editionGate", "enterprise"));
+
+        var response = await _client.PostAsync("/api/v1/admin/scenes/ingest/pointcloud", upload);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/pointcloud")]
+    public async Task Ingest_NonEnterpriseEdition_Returns402()
+    {
+        // A fresh fixture without the Enterprise entitlement: the admin operator
+        // is authenticated but the entitlement gate must deny the ingest.
+        var proFixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .WithTestLicense(HonuaEdition.Pro)
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+            });
+        await proFixture.InitializeAsync();
+        try
+        {
+            using var proClient = proFixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
+            using var upload = BuildUpload(PointCloudSceneFixtures.SinglePointGeographic(), ("sceneId", "pro-denied"));
+
+            var response = await proClient.PostAsync(IngestUrl, upload);
+
+            Assert.Equal(HttpStatusCode.PaymentRequired, response.StatusCode);
+        }
+        finally
+        {
+            await proFixture.DisposeAsync();
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/PointCloudSceneFixtures.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/PointCloudSceneFixtures.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Scene;
+
+/// <summary>
+/// Synthesizes minimal, valid uncompressed LAS 1.2 buffers in memory for the
+/// point-cloud ingest tests (#1201). Avoids committing a binary fixture while
+/// exercising the real header/point-record byte layout the reader parses. The
+/// emitted coordinates are treated as geographic (lon/lat degrees) by the
+/// executor's geographic-pass-through transform.
+/// </summary>
+internal static class PointCloudSceneFixtures
+{
+    private const int HeaderSize = 227;          // LAS 1.2 public header block.
+    private const int RecordLengthFormat3 = 34;  // base 28 + RGB 6.
+
+    /// <summary>
+    /// Builds a LAS 1.2, point data record format 3 (XYZ + GPS time + RGB)
+    /// buffer holding a small geographic grid of coloured points around the
+    /// supplied origin. The grid is dense enough to subdivide into multiple
+    /// quadtree tiles under a small per-tile cap.
+    /// </summary>
+    public static byte[] ColoredGridGeographic(
+        int columns = 16,
+        int rows = 16,
+        double originLon = -122.5,
+        double originLat = 37.5,
+        double step = 0.0005)
+    {
+        var points = new List<(double X, double Y, double Z, ushort Intensity, byte Classification, ushort R, ushort G, ushort B)>(columns * rows);
+        for (var r = 0; r < rows; r++)
+        {
+            for (var c = 0; c < columns; c++)
+            {
+                var lon = originLon + c * step;
+                var lat = originLat + r * step;
+                var z = 10.0 + ((c + r) % 5);
+                // 8-bit-in-16-bit colour (the common producer quirk) so the
+                // ingest preserves a recognisable RGB ramp.
+                var red = (ushort)((c * 255) / Math.Max(1, columns - 1));
+                var green = (ushort)((r * 255) / Math.Max(1, rows - 1));
+                var blue = (ushort)128;
+                var classification = (byte)(2 + ((c + r) % 3)); // ground / low-veg / building.
+                var intensity = (ushort)(c * 17 + r * 31);
+                points.Add((lon, lat, z, intensity, classification, red, green, blue));
+            }
+        }
+
+        return BuildFormat3(points);
+    }
+
+    /// <summary>Builds a single-point geographic LAS buffer (smallest valid cloud).</summary>
+    public static byte[] SinglePointGeographic(double lon = -122.5, double lat = 37.5, double height = 12.0)
+        => BuildFormat3([(lon, lat, height, Intensity: (ushort)100, Classification: (byte)2, R: (ushort)10, G: (ushort)20, B: (ushort)30)]);
+
+    /// <summary>Marks a format-3 buffer as LAZ-compressed (sets bit 7 of the format byte).</summary>
+    public static byte[] MarkCompressed(byte[] lasBuffer)
+    {
+        var copy = (byte[])lasBuffer.Clone();
+        copy[104] = (byte)(copy[104] | 0x80);
+        return copy;
+    }
+
+    private static byte[] BuildFormat3(
+        List<(double X, double Y, double Z, ushort Intensity, byte Classification, ushort R, ushort G, ushort B)> points)
+    {
+        // A fine scale keeps the descaled geographic coordinates within int range
+        // when divided through, matching the reader's scale/offset model.
+        const double scale = 1e-7;
+        const double offsetX = 0.0;
+        const double offsetY = 0.0;
+        const double offsetZ = 0.0;
+
+        var pointDataOffset = HeaderSize;
+        var total = pointDataOffset + points.Count * RecordLengthFormat3;
+        var buffer = new byte[total];
+        var span = buffer.AsSpan();
+
+        span[0] = (byte)'L';
+        span[1] = (byte)'A';
+        span[2] = (byte)'S';
+        span[3] = (byte)'F';
+        span[24] = 1; // version major
+        span[25] = 2; // version minor
+
+        BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(94, 2), HeaderSize);
+        BinaryPrimitives.WriteUInt32LittleEndian(span.Slice(96, 4), (uint)pointDataOffset);
+        span[104] = 3; // point data record format 3
+        BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(105, 2), RecordLengthFormat3);
+        BinaryPrimitives.WriteUInt32LittleEndian(span.Slice(107, 4), (uint)points.Count);
+
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(131, 8), scale);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(139, 8), scale);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(147, 8), scale);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(155, 8), offsetX);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(163, 8), offsetY);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(171, 8), offsetZ);
+
+        double minX = double.PositiveInfinity, minY = double.PositiveInfinity, minZ = double.PositiveInfinity;
+        double maxX = double.NegativeInfinity, maxY = double.NegativeInfinity, maxZ = double.NegativeInfinity;
+
+        var offset = pointDataOffset;
+        foreach (var p in points)
+        {
+            var xi = (int)Math.Round((p.X - offsetX) / scale);
+            var yi = (int)Math.Round((p.Y - offsetY) / scale);
+            var zi = (int)Math.Round((p.Z - offsetZ) / scale);
+
+            BinaryPrimitives.WriteInt32LittleEndian(span.Slice(offset, 4), xi);
+            BinaryPrimitives.WriteInt32LittleEndian(span.Slice(offset + 4, 4), yi);
+            BinaryPrimitives.WriteInt32LittleEndian(span.Slice(offset + 8, 4), zi);
+            BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(offset + 12, 2), p.Intensity);
+            span[offset + 15] = p.Classification;
+            BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(offset + 28, 2), p.R);
+            BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(offset + 30, 2), p.G);
+            BinaryPrimitives.WriteUInt16LittleEndian(span.Slice(offset + 32, 2), p.B);
+
+            if (p.X < minX) minX = p.X;
+            if (p.Y < minY) minY = p.Y;
+            if (p.Z < minZ) minZ = p.Z;
+            if (p.X > maxX) maxX = p.X;
+            if (p.Y > maxY) maxY = p.Y;
+            if (p.Z > maxZ) maxZ = p.Z;
+
+            offset += RecordLengthFormat3;
+        }
+
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(179, 8), maxX);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(187, 8), minX);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(195, 8), maxY);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(203, 8), minY);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(211, 8), maxZ);
+        BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(219, 8), minZ);
+
+        return buffer;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/PointCloudScenePublishExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/PointCloudScenePublishExecutorTests.cs
@@ -1,0 +1,255 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Exceptions;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Core.Features.Scene.PointCloud;
+using Honua.Infrastructure.Scene;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Scene;
+
+/// <summary>
+/// Hermetic unit tests for the wired LAS point-cloud ingest executor (#1201).
+/// They exercise the full decode → tile → register → promote pipeline against a
+/// temp output root and an in-memory registration stub, proving the produced
+/// <c>.pnts</c> tileset is written to a servable asset root with point-cloud
+/// dataset semantics without standing up Postgres or an HTTP host.
+/// </summary>
+public sealed class PointCloudScenePublishExecutorTests : IDisposable
+{
+    private readonly string _outputRoot;
+    private readonly StubRegistrationService _registration;
+    private readonly PointCloudScenePublishExecutor _executor;
+
+    public PointCloudScenePublishExecutorTests()
+    {
+        _outputRoot = Path.Combine(Path.GetTempPath(), $"honua-pcloud-{Guid.NewGuid():N}");
+        _registration = new StubRegistrationService();
+
+        var options = Options.Create(new SceneGenerationServerOptions
+        {
+            OutputRoot = _outputRoot,
+            GeneratorTag = "honua-test-generator/1.0",
+            // A small per-tile cap so the synthetic grid subdivides into a
+            // multi-tile quadtree exercising the LOD path.
+            MaxFeaturesPerTile = 32,
+            MaxLodDepth = 8,
+            InteriorSampleCount = 16
+        });
+
+        _executor = new PointCloudScenePublishExecutor(
+            new TestHostEnvironment(),
+            options,
+            NullLogger<PointCloudScenePublishExecutor>.Instance,
+            _registration);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_outputRoot))
+        {
+            Directory.Delete(_outputRoot, recursive: true);
+        }
+    }
+
+    [UnitTest]
+    public async Task Ingest_ColoredGrid_WritesServableTilesetAndRegistersDataset()
+    {
+        var outcome = await _executor.IngestAsync(
+            new PointCloudSceneIngestRequest(
+                PointCloudSceneFixtures.ColoredGridGeographic(),
+                SceneId: "pcloud-grid",
+                DisplayName: "Point Cloud Grid",
+                EditionGate: "enterprise"),
+            CancellationToken.None);
+
+        outcome.SceneId.Should().Be("pcloud-grid");
+        outcome.PointCount.Should().Be(256);
+        outcome.TileCount.Should().BeGreaterThan(1, "the grid must subdivide under the small per-tile cap.");
+        outcome.HasColor.Should().BeTrue("format-3 LAS carries RGB.");
+
+        // The tileset.json plus every referenced .pnts tile must exist under the
+        // promoted asset root so the standard scene serving path can stream them.
+        var tilesetPath = Path.Combine(outcome.AssetRoot, "tileset.json");
+        File.Exists(tilesetPath).Should().BeTrue();
+
+        using var json = JsonDocument.Parse(await File.ReadAllBytesAsync(tilesetPath));
+        json.RootElement.GetProperty("asset").GetProperty("version").GetString().Should().Be("1.1");
+        var uris = new List<string>();
+        CollectContentUris(json.RootElement.GetProperty("root"), uris);
+        uris.Should().NotBeEmpty();
+        foreach (var uri in uris)
+        {
+            File.Exists(Path.Combine(outcome.AssetRoot, uri)).Should().BeTrue($"tile '{uri}' must be on disk.");
+            uri.Should().EndWith(".pnts");
+        }
+
+        // No staging directory should survive a successful promotion.
+        Directory.GetDirectories(_outputRoot, ".staging-*").Should().BeEmpty();
+
+        _registration.Records.Should().ContainSingle();
+        var record = _registration.Records[0];
+        record.Id.Should().Be("pcloud-grid");
+        record.Name.Should().Be("Point Cloud Grid");
+        record.AssetRoot.Should().Be(outcome.AssetRoot);
+        record.TilesetFileName.Should().Be("tileset.json");
+        record.DatasetType.Should().Be(SceneDatasetType.HostedTiles);
+        record.Crs.Should().Be("EPSG:4979");
+        record.EditionGate.Should().Be("enterprise");
+        record.IsPublic.Should().BeTrue();
+        record.RequiresAuth.Should().BeFalse();
+        record.Status.Should().Be(SceneDatasetStatus.Active);
+    }
+
+    [UnitTest]
+    public async Task Ingest_PreservesClassificationIntensityAndRgb()
+    {
+        var outcome = await _executor.IngestAsync(
+            new PointCloudSceneIngestRequest(
+                PointCloudSceneFixtures.SinglePointGeographic(),
+                SceneId: "pcloud-attrs"),
+            CancellationToken.None);
+
+        // A single point produces exactly one .pnts leaf; decode it and assert
+        // the PNTS feature/batch tables carry the preserved attributes.
+        var pnts = await File.ReadAllBytesAsync(Path.Combine(outcome.AssetRoot, FindFirstPnts(outcome.AssetRoot)));
+
+        var featureJson = ReadPntsFeatureTableJson(pnts);
+        featureJson.RootElement.GetProperty("POINTS_LENGTH").GetInt32().Should().Be(1);
+        featureJson.RootElement.TryGetProperty("RGB", out _).Should().BeTrue("coloured cloud must emit the RGB semantic.");
+
+        var batchJson = ReadPntsBatchTableJson(pnts);
+        batchJson.RootElement.TryGetProperty("INTENSITY", out _).Should().BeTrue();
+        batchJson.RootElement.TryGetProperty("CLASSIFICATION", out _).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public async Task Ingest_SameSourceTwice_ProducesByteIdenticalTileset()
+    {
+        var las = PointCloudSceneFixtures.ColoredGridGeographic();
+        var first = await _executor.IngestAsync(
+            new PointCloudSceneIngestRequest(las, SceneId: "det-a"), CancellationToken.None);
+        var second = await _executor.IngestAsync(
+            new PointCloudSceneIngestRequest(las, SceneId: "det-b"), CancellationToken.None);
+
+        var tileset1 = await File.ReadAllBytesAsync(Path.Combine(first.AssetRoot, "tileset.json"));
+        var tileset2 = await File.ReadAllBytesAsync(Path.Combine(second.AssetRoot, "tileset.json"));
+        tileset1.Should().Equal(tileset2, "identical LAS input must produce byte-identical tileset.json output.");
+
+        var tile1 = await File.ReadAllBytesAsync(Path.Combine(first.AssetRoot, "points_0000.pnts"));
+        var tile2 = await File.ReadAllBytesAsync(Path.Combine(second.AssetRoot, "points_0000.pnts"));
+        tile1.Should().Equal(tile2, "identical LAS input must produce byte-identical .pnts output.");
+    }
+
+    [UnitTest]
+    public async Task Ingest_RequiresAuth_RegistersProtectedScene()
+    {
+        var outcome = await _executor.IngestAsync(
+            new PointCloudSceneIngestRequest(
+                PointCloudSceneFixtures.SinglePointGeographic(),
+                SceneId: "protected-pcloud",
+                RequiresAuth: true),
+            CancellationToken.None);
+
+        outcome.SceneId.Should().Be("protected-pcloud");
+        var record = _registration.Records.Single();
+        record.RequiresAuth.Should().BeTrue();
+        record.IsPublic.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task Ingest_DuplicateSceneId_ThrowsRegistrationConflict()
+    {
+        await _executor.IngestAsync(
+            new PointCloudSceneIngestRequest(PointCloudSceneFixtures.SinglePointGeographic(), SceneId: "dup"),
+            CancellationToken.None);
+
+        var act = async () => await _executor.IngestAsync(
+            new PointCloudSceneIngestRequest(PointCloudSceneFixtures.SinglePointGeographic(), SceneId: "dup"),
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationException>();
+        ex.Which.Message.Should().StartWith(SceneGenerationErrorCodes.SceneRegistrationConflict);
+    }
+
+    [UnitTest]
+    public async Task Ingest_LazCompressed_ThrowsLasFormatExceptionAndLeavesNothing()
+    {
+        var laz = PointCloudSceneFixtures.MarkCompressed(PointCloudSceneFixtures.ColoredGridGeographic());
+
+        var act = async () => await _executor.IngestAsync(
+            new PointCloudSceneIngestRequest(laz, SceneId: "laz-rejected"),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<LasFormatException>();
+
+        // A rejected ingest must not leave any registration or output behind.
+        _registration.Records.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public async Task Ingest_GarbageBytes_ThrowsLasFormatException()
+    {
+        var act = async () => await _executor.IngestAsync(
+            new PointCloudSceneIngestRequest(Encoding.UTF8.GetBytes("this is not a LAS point cloud")),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<LasFormatException>();
+        _registration.Records.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public async Task Ingest_InvalidCacheMaxAge_ThrowsOptionsInvalid()
+    {
+        var act = async () => await _executor.IngestAsync(
+            new PointCloudSceneIngestRequest(
+                PointCloudSceneFixtures.SinglePointGeographic(),
+                SceneId: "bad-cache",
+                CacheMaxAgeSeconds: -1),
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationException>();
+        ex.Which.Message.Should().StartWith(SceneGenerationErrorCodes.OptionsInvalid);
+    }
+
+    private static string FindFirstPnts(string assetRoot)
+        => Path.GetFileName(Directory.GetFiles(assetRoot, "*.pnts").OrderBy(p => p, StringComparer.Ordinal).First());
+
+    private static void CollectContentUris(JsonElement node, List<string> sink)
+    {
+        if (node.TryGetProperty("content", out var content)
+            && content.TryGetProperty("uri", out var uri)
+            && uri.GetString() is { } value)
+        {
+            sink.Add(value);
+        }
+        if (node.TryGetProperty("children", out var children))
+        {
+            foreach (var child in children.EnumerateArray())
+            {
+                CollectContentUris(child, sink);
+            }
+        }
+    }
+
+    private static JsonDocument ReadPntsFeatureTableJson(byte[] pnts)
+    {
+        var featureJsonLength = BitConverter.ToInt32(pnts, 12);
+        return JsonDocument.Parse(Encoding.UTF8.GetString(pnts, 28, featureJsonLength));
+    }
+
+    private static JsonDocument ReadPntsBatchTableJson(byte[] pnts)
+    {
+        var featureJsonLength = BitConverter.ToInt32(pnts, 12);
+        var featureBinaryLength = BitConverter.ToInt32(pnts, 16);
+        var batchJsonLength = BitConverter.ToInt32(pnts, 20);
+        var batchJsonOffset = 28 + featureJsonLength + featureBinaryLength;
+        return JsonDocument.Parse(Encoding.UTF8.GetString(pnts, batchJsonOffset, batchJsonLength));
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1201

## Summary
Finishes the point-cloud ingest slice on top of the existing Scene point-cloud vertical (#1200/#1201 already shipped the pure-managed LAS reader, PNTS writer, and deterministic quadtree tileset builder). A new `PointCloudScenePublishExecutor` decodes a LAS point cloud, builds the `.pnts` quadtree + `tileset.json`, registers the dataset (the canonical collision authority), and atomically promotes the staged bytes to the scene asset root so the **existing** SceneServer/3D-Tiles serving path streams them — mirroring the CityGML/BIM ingest executor (#1207) precedent exactly. Classification, intensity, and RGB are preserved per point; output is byte-stable.

The heavy LAS → 3D Tiles conversion is **pure-managed** (no native PDAL/py3dtiles dependency), so the tileset is materialised inline rather than dispatched to an out-of-tree worker (the NetCDF/GDAL async-job pattern is unnecessary here). Compressed **LAZ** and **COPC** inputs are detected and rejected with a `400` problem-detail (native decompression is a tracked follow-up); projected source CRS are likewise rejected — both mirror the conservative v1 CityGML path. v1 supports uncompressed LAS 1.1–1.4 (point formats 0,1,2,3,6,7,8) with geographic source coordinates.

## Changes Made
- New `PointCloudScenePublishExecutor` (decode → tile → register → promote → compensate) reusing `SceneTilesetStaging` and the existing `PointCloudTilesetBuilder`/`PntsTileWriter`/`LasPointCloudReader`.
- New Enterprise-gated admin endpoint `POST /api/v1/admin/scenes/ingest/pointcloud` (entitlement `scene.pointcloud-ingest`), with response model, source-generated JSON context, DI registration, host wiring, `EndpointRegistry` entry, and `FeatureCatalog` key.
- Hermetic executor unit tests (8) + endpoint integration tests (7), incl. the end-to-end ingest serving `tileset.json` and a `.pnts` tile through the scene route, plus the literal-path backing test required by `EndpointRegistry` governance.
- Docs: supported point-cloud formats + limits in the 3D Tiles & scenes reference.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
