### PR TITLE
fix(geoservices): MapServer find returns findResults instead of 500

### DIFF
--- a/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Find.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Find.cs
@@ -16,6 +16,7 @@ using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Helpers;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Services;
+using Honua.Protocols.GeoServices.FeatureServer;
 using Honua.Protocols.GeoServices.MapServer.Models;
 using Honua.ServiceDefaults;
 using Microsoft.Extensions.Options;
@@ -222,6 +223,10 @@ internal static partial class MapServerEndpoints
 
                 var objectIdField = GeoServicesObjectIdFieldResolver.ResolveObjectIdFieldName(layer.Resource);
                 var displayField = ResolveDisplayField(layer.Resource, objectIdField);
+                // esriFieldTypeDate attributes must serialize as epoch-ms integers uniformly,
+                // matching the MapServer identify and FeatureServer query paths (a date field
+                // searched via searchFields would otherwise leak its raw stored shape).
+                var dateFieldNames = GeoServicesFieldConventions.ResolveDateFieldNames(layer.Resource);
 
                 SqlFragment? layerSqlFilter = null;
                 if (!string.IsNullOrWhiteSpace(layerDef) &&
@@ -288,6 +293,8 @@ internal static partial class MapServerEndpoints
 
                             attributes[kvp.Key] = FeatureAttributeValueNormalizer.Normalize(kvp.Value);
                         }
+
+                        GeoServicesFieldConventions.CoerceDateAttributes(attributes, dateFieldNames);
 
                         object? geometryResult = null;
                         if (returnGeometry && feature.Geometry != null)

--- a/src/Honua.Protocols.GeoServices/MapServer/Models/MapServerJsonContext.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/Models/MapServerJsonContext.cs
@@ -59,7 +59,17 @@ namespace Honua.Protocols.GeoServices.MapServer.Models;
 [JsonSerializable(typeof(int))]
 [JsonSerializable(typeof(long))]
 [JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(float))]
+// decimal is produced by JsonElementConverter.ConvertToScalar for high-precision PostGIS
+// numeric columns and lands in the object-typed Attributes/Geometry slots. The published
+// image runs with JsonSerializerIsReflectionEnabledByDefault=false, so a missing
+// JsonTypeInfo throws NotSupportedException (HTTP 500) instead of falling back to
+// reflection — see honua-server#1771 (MapServer find 500 on the AOT image).
+[JsonSerializable(typeof(decimal))]
 [JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(Guid))]
+[JsonSerializable(typeof(byte[]))]
+[JsonSerializable(typeof(DateOnly))]
 [JsonSerializable(typeof(DateTime))]
 [JsonSerializable(typeof(DateTimeOffset))]
 [JsonSourceGenerationOptions(

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
@@ -2190,4 +2190,81 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
                }
              }
              """;
+
+    [IntegrationTest]
+    [Operation(Operations.Find)]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/find")]
+    public async Task MapServer_Find_ReturnsFindResults()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/find?searchText=Test&layers=0&returnGeometry=true&f=json");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        var find = JsonSerializer.Deserialize(content, MapServerJsonContext.Default.FindResponse);
+        find.Should().NotBeNull();
+        find!.Results.Should().NotBeNullOrEmpty();
+
+        var hit = find.Results!.First();
+        hit.LayerId.Should().Be(0);
+        hit.LayerName.Should().NotBeNullOrWhiteSpace();
+        hit.FoundFieldName.Should().NotBeNullOrWhiteSpace();
+        hit.Value.Should().NotBeNullOrWhiteSpace();
+        hit.Attributes.Should().NotBeNullOrEmpty();
+        hit.Geometry.Should().NotBeNull();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Find)]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/find")]
+    public async Task MapServer_Find_WithEmptySearchFields_ReturnsFindResults()
+    {
+        // Esri clients (ArcGIS API for Python) send searchFields= empty, which is the
+        // original honua-server#1771 repro that 500'd.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/find?searchText=a&layers=0&searchFields=&returnGeometry=true&f=json");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        var find = JsonSerializer.Deserialize(content, MapServerJsonContext.Default.FindResponse);
+        find.Should().NotBeNull();
+        find!.Results.Should().NotBeNull();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Find)]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/find")]
+    public async Task MapServer_Find_WithContainsFalse_UsesExactMatch()
+    {
+        // contains=false => exact (case-insensitive) match. 'Test Feature' is an exact
+        // value in the seed; 'Test' alone must not match under exact semantics.
+        var exact = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/find" +
+            $"?searchText={Uri.EscapeDataString("Test Feature")}&layers=0&searchFields=name&contains=false&f=json");
+        var exactContent = await exact.Content.ReadAsStringAsync();
+        exact.StatusCode.Should().Be(HttpStatusCode.OK, exactContent);
+        var exactFind = JsonSerializer.Deserialize(exactContent, MapServerJsonContext.Default.FindResponse);
+        exactFind!.Results.Should().NotBeNullOrEmpty();
+        exactFind.Results!.Should().OnlyContain(r => r.FoundFieldName == "name");
+
+        var partial = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/find" +
+            $"?searchText=Test&layers=0&searchFields=name&contains=false&f=json");
+        var partialContent = await partial.Content.ReadAsStringAsync();
+        partial.StatusCode.Should().Be(HttpStatusCode.OK, partialContent);
+        var partialFind = JsonSerializer.Deserialize(partialContent, MapServerJsonContext.Default.FindResponse);
+        partialFind!.Results.Should().BeNullOrEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Find)]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/find")]
+    public async Task MapServer_Find_WithoutLayers_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/find?searchText=Test&f=json");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerFindSerializationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerFindSerializationTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Protocols.GeoServices.MapServer.Models;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.MapServer;
+
+/// <summary>
+/// Reproduces honua-server#1771 at the serialization layer: the published/AOT image
+/// sets <c>JsonSerializerIsReflectionEnabledByDefault=false</c>, so the source-generated
+/// <see cref="MapServerJsonContext"/> must contain a <c>JsonTypeInfo</c> for every runtime
+/// CLR type that can land in a <see cref="FindResult.Attributes"/> <c>object</c> slot. The
+/// integration tests run with reflection enabled (test default), which masks a missing
+/// registration; these tests force source-generated-only metadata so the gap surfaces as a
+/// failing test instead of a runtime 500 on the AOT image.
+/// </summary>
+public sealed class MapServerFindSerializationTests
+{
+    // Mirrors the published image: only source-generated metadata, no reflection fallback.
+    private static readonly JsonSerializerOptions AotOptions = new()
+    {
+        TypeInfoResolver = MapServerJsonContext.Default,
+    };
+
+    [Fact]
+    public void FindResponse_WithDecimalAttribute_SerializesWithoutReflectionFallback()
+    {
+        // A high-precision PostGIS numeric column materializes as System.Decimal
+        // (JsonElementConverter.ConvertToScalar -> GetDecimal()).
+        var response = BuildResponse(new Dictionary<string, object?>
+        {
+            ["objectid"] = 1,
+            ["measure"] = 12.3456789012345678901234567890m,
+        });
+
+        var act = () => JsonSerializer.Serialize(response, MapServerJsonContext.Default.FindResponse);
+        act.Should().NotThrow("decimal attribute values must be serializable on the AOT image");
+    }
+
+    [Fact]
+    public void FindResponse_WithNestedJsonElementAttribute_SerializesWithoutReflectionFallback()
+    {
+        // A JSONB object/array attribute survives as a raw JsonElement.
+        using var doc = JsonDocument.Parse("""{"nested":{"a":1},"list":[1,2,3]}""");
+        var response = BuildResponse(new Dictionary<string, object?>
+        {
+            ["objectid"] = 1,
+            ["payload"] = doc.RootElement.Clone(),
+        });
+
+        var act = () => JsonSerializer.Serialize(response, MapServerJsonContext.Default.FindResponse);
+        act.Should().NotThrow("JsonElement attribute values must be serializable on the AOT image");
+    }
+
+    [Fact]
+    public void FindResponse_WithScalarAttributes_RoundTrips()
+    {
+        var response = BuildResponse(new Dictionary<string, object?>
+        {
+            ["objectid"] = 1L,
+            ["name"] = "Test Feature",
+            ["ratio"] = 1.5d,
+            ["flag"] = 1,
+        });
+
+        var json = JsonSerializer.Serialize(response, AotOptions.GetTypeInfo(typeof(FindResponse)));
+        json.Should().Contain("Test Feature");
+        json.Should().Contain("results");
+    }
+
+    private static FindResponse BuildResponse(Dictionary<string, object?> attributes) => new()
+    {
+        Results =
+        [
+            new FindResult
+            {
+                LayerId = 0,
+                LayerName = "Layer",
+                DisplayFieldName = "name",
+                FoundFieldName = "name",
+                Value = "Test Feature",
+                Attributes = attributes,
+                GeometryType = "esriGeometryPoint",
+                Geometry = null,
+            },
+        ],
+    };
+}

--- a/tests/dotnet/Honua.TestKit/Constants/Operations.cs
+++ b/tests/dotnet/Honua.TestKit/Constants/Operations.cs
@@ -116,6 +116,7 @@ public static class Operations
     public const string Export = "Export";
     public const string Print = "Print";
     public const string Identify = "Identify";
+    public const string Find = "Find";
     public const string Render = "Render";
     public const string Tile = "Tile";
     public const string Wms = "WMS";


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1771

## Summary
`GET/POST /rest/services/{svc}/MapServer/find` returned **HTTP 500** on the published/AOT image (reproduced by ArcGIS API for Python `MapServer.find` and ArcGIS Maps SDK for JS), even though the handler is fully implemented and returns a valid `findResults` payload under JIT.

Root cause: the published image sets `JsonSerializerIsReflectionEnabledByDefault=false`, so the source-generated `MapServerJsonContext` must contain a `JsonTypeInfo` for **every** runtime CLR type that can land in the `object`-typed `FindResult.Attributes` / `Geometry` slots. A high-precision PostGIS numeric column materializes as `System.Decimal` (via `JsonElementConverter.ConvertToScalar` → `GetDecimal()`), and `decimal` was **not** registered in `MapServerJsonContext`. Serializing that polymorphic `object` slot therefore threw `NotSupportedException` → unhandled 500. The integration test harness runs with reflection enabled (the test default), which masked the gap, so existing find tests were green while the AOT image 500'd.

`find` was uniquely affected (vs. the working `identify`/`query`/`export`) only as a function of which attribute value types each request happened to serialize — the same latent gap exists for any GeoServices MapServer object-slot value of an unregistered type.

## Changes Made
- Registered `decimal`, `float`, `Guid`, `byte[]`, and `DateOnly` in `MapServerJsonContext` so polymorphic `object` attribute/geometry values serialize under `JsonSerializerIsReflectionEnabledByDefault=false` instead of throwing `NotSupportedException`.
- Coerced `esriFieldTypeDate` attributes to epoch-ms integers on the find path (`GeoServicesFieldConventions.CoerceDateAttributes`), matching the existing MapServer `identify` and FeatureServer `query` behavior so a searched date field serializes uniformly rather than leaking its raw stored shape.
- Added `MapServerFindSerializationTests` — source-generated-only (reflection-disabled) serialization tests that reproduce the #1771 500 (decimal attribute) and lock in the fix, plus nested-`JsonElement` and scalar round-trip coverage. These would have caught the regression that integration tests masked.
- Added find integration tests to `MapServerEndpointTests`: happy-path `findResults` shape + match hit, the original `searchText=a&layers=0&searchFields=` repro now returning 200, `contains=false` exact-match semantics, and missing-`layers` → 400.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
