### PR TITLE
fix(geoservices): FeatureServer format/content-negotiation conformance

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerQueryHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerQueryHandler.cs
@@ -465,6 +465,23 @@ internal sealed partial class FeatureServerQueryHandler(
                     ["GeoJSON output does not support returnM=true."]);
             }
 
+            // f=pjson is byte-identical to f=json except for indentation. TryValidateOutputFormat
+            // collapses pjson to json, so recover the pretty flag from the raw requested format
+            // and indent the serialized JSON payload below (#1824).
+            var prettyJson = string.Equals(requestedFormat?.Trim(), "pjson", StringComparison.OrdinalIgnoreCase);
+
+            // returnCountOnly/returnIdsOnly/returnExtentOnly produce scalar/structural results,
+            // not a GeoJSON FeatureCollection. The format validator allow-lists geojson for the
+            // query operation, but these secondary modes cannot honor it — return a clean 400
+            // rather than silently downgrading to an Esri-JSON 200 (#1824).
+            if (string.Equals(format, "geojson", StringComparison.OrdinalIgnoreCase) &&
+                (validatedParams.ReturnCountOnly || validatedParams.ReturnIdsOnly || validatedParams.ReturnExtentOnly))
+            {
+                return StandardErrorHelpers.CreateBadRequest(context,
+                    "Invalid query parameters",
+                    ["f=geojson is not supported for returnCountOnly, returnIdsOnly, or returnExtentOnly queries."]);
+            }
+
             var canCache = !ShouldBypassQueryResponseCache(validatedParams) &&
                            ResponseCacheUtilities.ShouldCache(context, _cacheOptions);
             var cacheTtl = canCache ? _cacheOptions.GetQueryTtlWithJitter() : TimeSpan.Zero;
@@ -507,10 +524,25 @@ internal sealed partial class FeatureServerQueryHandler(
                 var currentCacheKey = GetCacheKey();
                 if (currentCacheKey is null)
                 {
+                    // f=pjson is JSON with indentation; re-indent the serialized payload rather
+                    // than returning the compact Results.Json so pjson is not byte-identical to
+                    // json (#1824).
+                    if (prettyJson)
+                    {
+                        var prettyPayload = JsonReindenter.ToIndentedUtf8Bytes(
+                            JsonSerializer.SerializeToUtf8Bytes(response, typeInfo));
+                        return Results.Bytes(prettyPayload, contentType);
+                    }
+
                     return Results.Json(response, typeInfo, contentType: contentType);
                 }
 
                 var payload = JsonSerializer.SerializeToUtf8Bytes(response, typeInfo);
+                if (prettyJson)
+                {
+                    payload = JsonReindenter.ToIndentedUtf8Bytes(payload);
+                }
+
                 var cachedResponse = ResponseCacheUtilities.CreateCachedResponse(payload, contentType, _etagService);
                 await _responseCache.SetAsync(currentCacheKey, cachedResponse, cacheTtl, cancellationToken);
                 return ResponseCacheUtilities.CreateResultFromCachedResponse(context, cachedResponse, _etagService);
@@ -731,9 +763,26 @@ internal sealed partial class FeatureServerQueryHandler(
                 FeatureServerLog.QueryExecuted(_logger, "extent", serviceId, layerId, stopwatch.Elapsed.TotalMilliseconds);
                 extent ??= await ResolveExtentFallbackAsync(context, validatedParams, queryLayer.Resource, outputSrid, cancellationToken);
                 HonuaTelemetry.SetSuccess(featureActivity, (int)Math.Min(extentCount, int.MaxValue));
+                var extentInfo = extent.HasValue ? extent.Value.ToExtentInfo() : null;
+
+                // f=pbf must return the ExtentCountResult arm of the FeatureCollectionPBuffer
+                // QueryResult oneof (application/x-protobuf), mirroring the count path; otherwise
+                // the extent branch silently degrades to JSON (#1824).
+                if (string.Equals(format, "pbf", StringComparison.OrdinalIgnoreCase) && extentInfo is not null)
+                {
+                    var (extentPayload, extentContentType) = PbfQueryFormatter.FormatExtentAsPbf(
+                        extentInfo.Xmin,
+                        extentInfo.Ymin,
+                        extentInfo.Xmax,
+                        extentInfo.Ymax,
+                        extentInfo.SpatialReference.Wkid,
+                        extentCount);
+                    return await CreateCachedBytesResultAsync(extentPayload, extentContentType);
+                }
+
                 var response = new QueryResponse
                 {
-                    Extent = extent.HasValue ? extent.Value.ToExtentInfo() : null,
+                    Extent = extentInfo,
                     Count = extentCount,
                     Features = null
                 };
@@ -743,8 +792,13 @@ internal sealed partial class FeatureServerQueryHandler(
 
             if (validatedParams.ReturnIdsOnly)
             {
+                // f=pbf must return the ObjectIdsResult arm of the FeatureCollectionPBuffer
+                // QueryResult oneof (application/x-protobuf), mirroring the count path; the
+                // JSON streaming writer cannot emit protobuf, so force materialization for pbf
+                // and never take the streaming branch (#1824).
+                var idsIsPbf = string.Equals(format, "pbf", StringComparison.OrdinalIgnoreCase);
                 var idsEffectiveLimit = query.Limit ?? validatedParams.ObjectIds?.Length ?? queryLimits.DefaultRecordCount;
-                var idsUseStreaming = !query.Limit.HasValue || idsEffectiveLimit > StreamingThreshold;
+                var idsUseStreaming = !idsIsPbf && (!query.Limit.HasValue || idsEffectiveLimit > StreamingThreshold);
                 if (idsUseStreaming)
                 {
                     await _queryExecutor.StreamIdsAsync(
@@ -780,6 +834,12 @@ internal sealed partial class FeatureServerQueryHandler(
                     .Select(feature => GeoServicesObjectIdFieldResolver.ResolveObjectIdValue(feature, objectIdFieldName))
                     .ToArray();
                 HonuaTelemetry.SetSuccess(featureActivity, objectIds.Length);
+
+                if (idsIsPbf)
+                {
+                    var (idsPayload, idsContentType) = PbfQueryFormatter.FormatIdsAsPbf(objectIdFieldName, objectIds);
+                    return await CreateCachedBytesResultAsync(idsPayload, idsContentType);
+                }
 
                 var response = new QueryResponse
                 {
@@ -941,7 +1001,11 @@ internal sealed partial class FeatureServerQueryHandler(
                     outFields = parsed.Length == 0 ? null : parsed;
                 }
                 var shouldApplyDistinct = validatedParams.ReturnDistinctValues && outFields is { Length: > 0 };
+                // The raw point fast path emits a pre-serialized compact JSON payload; f=pjson
+                // needs indentation, so skip the fast path and fall through to the materialized
+                // formatter where the pretty flag is honored (#1824).
                 if (quantizationTransform is null &&
+                    !prettyJson &&
                     CanUseRawGeoServicesPointFastPath(queryLayer.Resource, validatedParams, query, outputSrid, format) &&
                     await _queryExecutor.SupportsRawGeoServicesPointOutputAsync(
                         queryLayer.Service,

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.TopFeatures.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.TopFeatures.cs
@@ -82,12 +82,15 @@ internal static partial class FeatureServerEndpoints
         activity?.SetTag(HonuaTelemetry.Tags.LayerId, layerId);
 
         var requestedFormat = GetValueString(values, "f");
-        if (!TryValidateOutputFormat(requestedFormat, JsonOnlyFormats, out _, out var formatError))
+        if (!TryValidateOutputFormat(requestedFormat, TopFeaturesFormats, out var topFeaturesFormat, out var formatError))
         {
             return StandardErrorHelpers.CreateBadRequest(context,
                 "Invalid query parameters",
                 [formatError ?? "Output format is not supported."]);
         }
+
+        var topFeaturesIsPbf = string.Equals(topFeaturesFormat, "pbf", StringComparison.OrdinalIgnoreCase);
+        var topFeaturesIsPretty = string.Equals(requestedFormat?.Trim(), "pjson", StringComparison.OrdinalIgnoreCase);
 
         var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
         var cancellationToken = GetTimeoutAwareCancellationToken(context);
@@ -169,10 +172,36 @@ internal static partial class FeatureServerEndpoints
         // SDK with a null total and a TypeError in its paginator.
         if (returnCountOnly)
         {
-            return Results.Json(
+            if (topFeaturesIsPbf)
+            {
+                var (countPayload, countContentType) = PbfQueryFormatter.FormatCountAsPbf(result.Items.Length);
+                return Results.Bytes(countPayload, countContentType);
+            }
+
+            return CreateTopFeaturesJsonResult(
                 new QueryResponse { Count = result.Items.Length, Features = null },
-                FeatureServerJsonContext.Default.QueryResponse,
-                contentType: "application/json");
+                topFeaturesIsPretty);
+        }
+
+        // f=pbf returns the FeatureResult arm of the FeatureCollectionPBuffer; ArcGIS
+        // queryTopFeatures supports pbf, so emit protobuf rather than rejecting it (#1824).
+        if (topFeaturesIsPbf)
+        {
+            var pbfFormatter = context.RequestServices.GetRequiredService<PbfQueryFormatter>();
+            var topSrid = resource.ReadSrid();
+            var (pbfPayload, pbfContentType) = pbfFormatter.FormatAsPbf(
+                result,
+                resource,
+                returnGeometry: true,
+                outputSrid: topSrid,
+                returnZ: false,
+                returnM: false,
+                geometryPrecision: null,
+                maxAllowableOffset: null,
+                outFields: query.OutFields.HasValue && !query.OutFields.Value.IsDefaultOrEmpty
+                    ? [.. query.OutFields.Value]
+                    : null);
+            return Results.Bytes(pbfPayload, pbfContentType);
         }
 
         var responseFeatures = result.Items.Select(feature => new GeoServicesFeature
@@ -200,7 +229,23 @@ internal static partial class FeatureServerEndpoints
             ExceededTransferLimit = result.HasMoreResults
         };
 
-        return Results.Json(response, FeatureServerJsonContext.Default.QueryResponse, contentType: "application/json");
+        return CreateTopFeaturesJsonResult(response, topFeaturesIsPretty);
+    }
+
+    /// <summary>
+    /// Serializes a queryTopFeatures JSON response, emitting indented JSON for
+    /// <c>f=pjson</c> and compact JSON otherwise (#1824).
+    /// </summary>
+    private static IResult CreateTopFeaturesJsonResult(QueryResponse response, bool pretty)
+    {
+        if (!pretty)
+        {
+            return Results.Json(response, FeatureServerJsonContext.Default.QueryResponse, contentType: "application/json");
+        }
+
+        var prettyPayload = JsonReindenter.ToIndentedUtf8Bytes(
+            System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(response, FeatureServerJsonContext.Default.QueryResponse));
+        return Results.Bytes(prettyPayload, "application/json");
     }
 
     private static bool TryParseTopFilter(string json, out TopFilter topFilter, out string? error)

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.cs
@@ -241,6 +241,7 @@ internal static partial class FeatureServerEndpoints
     internal static FrozenSet<string> FeatureServerServiceQueryAllowedParameters => AllowedQueryParameters.ServiceQuery;
     internal static FrozenSet<string> FeatureServerQueryFormats => SupportedFormats.Query;
     internal static FrozenSet<string> JsonOnlyFormats => SupportedFormats.JsonOnly;
+    internal static FrozenSet<string> TopFeaturesFormats => SupportedFormats.TopFeatures;
 
     private static class SupportedFormats
     {
@@ -249,6 +250,11 @@ internal static partial class FeatureServerEndpoints
 
         public static readonly FrozenSet<string> JsonOnly =
             new[] { "json", "pjson" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+        // queryTopFeatures supports pbf (mirroring ArcGIS), unlike queryRelatedRecords
+        // which stays json/pjson-only (#1824).
+        public static readonly FrozenSet<string> TopFeatures =
+            new[] { "json", "pjson", "pbf" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/JsonReindenter.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/JsonReindenter.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers;
+using System.Text.Json;
+
+namespace Honua.Protocols.GeoServices.FeatureServer.Services;
+
+/// <summary>
+/// Transcodes a compact UTF-8 JSON payload into an indented (pretty-printed) UTF-8 JSON
+/// payload. Used to honor the GeoServices <c>f=pjson</c> format, which is JSON with
+/// indentation, without maintaining a parallel indented source-generated serializer
+/// context (the transform is type-agnostic and AOT-safe — it reads tokens and re-emits
+/// them with <see cref="JsonWriterOptions.Indented"/> set).
+/// </summary>
+internal static class JsonReindenter
+{
+    /// <summary>
+    /// Re-emits <paramref name="compactUtf8Json"/> with indentation. The input must be a
+    /// single well-formed JSON document (which it always is here — it was just produced by
+    /// the source-generated serializer).
+    /// </summary>
+    public static byte[] ToIndentedUtf8Bytes(ReadOnlySpan<byte> compactUtf8Json)
+    {
+        var buffer = new ArrayBufferWriter<byte>(compactUtf8Json.Length + (compactUtf8Json.Length / 2) + 16);
+        using (var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = true }))
+        {
+            var reader = new Utf8JsonReader(compactUtf8Json);
+            while (reader.Read())
+            {
+                WriteToken(ref reader, writer);
+            }
+        }
+
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static void WriteToken(ref Utf8JsonReader reader, Utf8JsonWriter writer)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.StartObject:
+                writer.WriteStartObject();
+                break;
+            case JsonTokenType.EndObject:
+                writer.WriteEndObject();
+                break;
+            case JsonTokenType.StartArray:
+                writer.WriteStartArray();
+                break;
+            case JsonTokenType.EndArray:
+                writer.WriteEndArray();
+                break;
+            case JsonTokenType.PropertyName:
+                writer.WritePropertyName(reader.GetString()!);
+                break;
+            case JsonTokenType.String:
+                writer.WriteStringValue(reader.GetString());
+                break;
+            case JsonTokenType.Number:
+                // Preserve the exact numeric token text (no float round-tripping).
+                writer.WriteRawValue(reader.ValueSpan, skipInputValidation: true);
+                break;
+            case JsonTokenType.True:
+                writer.WriteBooleanValue(true);
+                break;
+            case JsonTokenType.False:
+                writer.WriteBooleanValue(false);
+                break;
+            case JsonTokenType.Null:
+                writer.WriteNullValue();
+                break;
+        }
+    }
+}

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/PbfQueryFormatter.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/PbfQueryFormatter.cs
@@ -92,6 +92,136 @@ internal sealed class PbfQueryFormatter
         }
     }
 
+    /// <summary>
+    /// Formats a <c>returnIdsOnly=true</c> result as an Esri-compatible PBF response
+    /// (<c>FeatureCollectionPBuffer</c> with the <c>idsResult</c> arm of the
+    /// <c>QueryResult</c> oneof), mirroring how the count path emits protobuf so that
+    /// <c>f=pbf</c> on the ids-only path returns <c>application/x-protobuf</c> rather than
+    /// silently degrading to JSON (#1824).
+    /// </summary>
+    public static (byte[] response, string contentType) FormatIdsAsPbf(
+        string objectIdFieldName,
+        IReadOnlyList<long> objectIds)
+    {
+        // Schema (github.com/Esri/arcgis-pbf FeatureCollection.proto):
+        //   QueryResult { oneof Results { ... ObjectIdsResult idsResult = 3; ... } }
+        //   ObjectIdsResult { string objectIdFieldName = 1; ServerGens serverGens = 2;
+        //                     repeated uint64 objectIds = 3 [packed = true]; }
+        var packedIds = new ulong[objectIds.Count];
+        for (int i = 0; i < objectIds.Count; i++)
+        {
+            packedIds[i] = (ulong)objectIds[i];
+        }
+
+        var idsMsg = new ProtobufWriter(objectIds.Count * 4 + 32);
+        try
+        {
+            idsMsg.WriteString(1, objectIdFieldName);
+            idsMsg.WritePackedUInt64(3, packedIds);
+
+            var queryResult = new ProtobufWriter(idsMsg.Position + 8);
+            try
+            {
+                queryResult.WriteMessage(3, ref idsMsg);
+
+                var outer = new ProtobufWriter(queryResult.Position + 16);
+                try
+                {
+                    outer.WriteString(1, PbfVersion);
+                    outer.WriteMessage(2, ref queryResult);
+                    return (outer.ToArrayAndDispose(), "application/x-protobuf");
+                }
+                catch
+                {
+                    outer.Dispose();
+                    throw;
+                }
+            }
+            finally
+            {
+                queryResult.Dispose();
+            }
+        }
+        finally
+        {
+            idsMsg.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Formats a <c>returnExtentOnly=true</c> result as an Esri-compatible PBF response
+    /// (<c>FeatureCollectionPBuffer</c> with the <c>extentCountResult</c> arm of the
+    /// <c>QueryResult</c> oneof), mirroring how the count path emits protobuf so that
+    /// <c>f=pbf</c> on the extent-only path returns <c>application/x-protobuf</c> rather
+    /// than silently degrading to JSON (#1824).
+    /// </summary>
+    public static (byte[] response, string contentType) FormatExtentAsPbf(
+        double xmin,
+        double ymin,
+        double xmax,
+        double ymax,
+        int wkid,
+        long count)
+    {
+        // Schema (github.com/Esri/arcgis-pbf FeatureCollection.proto):
+        //   QueryResult { oneof Results { ... ExtentCountResult extentCountResult = 4; } }
+        //   ExtentCountResult { Envelope extent = 1; optional uint64 count = 2; }
+        //   Envelope { double XMin = 1; double YMin = 2; double XMax = 3; double YMax = 4;
+        //              SpatialReference SpatialReference = 5; }
+        var envelope = new ProtobufWriter(64);
+        try
+        {
+            envelope.WriteDoubleAlways(1, xmin);
+            envelope.WriteDoubleAlways(2, ymin);
+            envelope.WriteDoubleAlways(3, xmax);
+            envelope.WriteDoubleAlways(4, ymax);
+
+            var sr = new ProtobufWriter(16);
+            sr.WriteUInt32(1, (uint)wkid);
+            sr.WriteUInt32(2, (uint)wkid);
+            envelope.WriteMessage(5, ref sr);
+            sr.Dispose();
+
+            var extentMsg = new ProtobufWriter(envelope.Position + 16);
+            try
+            {
+                extentMsg.WriteMessage(1, ref envelope);
+                extentMsg.WriteUInt64Always(2, (ulong)Math.Max(count, 0));
+
+                var queryResult = new ProtobufWriter(extentMsg.Position + 8);
+                try
+                {
+                    queryResult.WriteMessage(4, ref extentMsg);
+
+                    var outer = new ProtobufWriter(queryResult.Position + 16);
+                    try
+                    {
+                        outer.WriteString(1, PbfVersion);
+                        outer.WriteMessage(2, ref queryResult);
+                        return (outer.ToArrayAndDispose(), "application/x-protobuf");
+                    }
+                    catch
+                    {
+                        outer.Dispose();
+                        throw;
+                    }
+                }
+                finally
+                {
+                    queryResult.Dispose();
+                }
+            }
+            finally
+            {
+                extentMsg.Dispose();
+            }
+        }
+        finally
+        {
+            envelope.Dispose();
+        }
+    }
+
     public (byte[] response, string contentType) FormatAsPbf(
         QueryResult<Feature> result,
         MetadataV2Resource resource,

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/ProtobufWriter.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/ProtobufWriter.cs
@@ -313,6 +313,24 @@ internal ref struct ProtobufWriter
         inner.Dispose();
     }
 
+    /// <summary>Writes a packed repeated uint64 field.</summary>
+    public void WritePackedUInt64(int fieldNumber, ReadOnlySpan<ulong> values)
+    {
+        if (values.IsEmpty)
+            return;
+
+        var inner = new ProtobufWriter(values.Length * 10);
+        foreach (ulong v in values)
+            inner.WriteRawVarint(v);
+
+        WriteTag(fieldNumber, 2);
+        WriteRawVarint((uint)inner.Position);
+        EnsureCapacity(inner.Position);
+        inner.WrittenMemory.Span.CopyTo(_buffer.AsSpan(_position));
+        _position += inner.Position;
+        inner.Dispose();
+    }
+
     /// <summary>Writes a packed repeated sint64 field.</summary>
     public void WritePackedSInt64(int fieldNumber, ReadOnlySpan<long> values)
     {

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/QueryFormatters.cs
@@ -751,10 +751,25 @@ internal sealed class QueryFormatter : IQueryFormatter
         return ConvertGeometryToGeoJsonGeometry(geometry);
     }
 
-    private static GeoJsonGeometry ConvertGeometryToGeoJsonGeometry(Geometry geometry)
+    internal static GeoJsonGeometry ConvertGeometryToGeoJsonGeometry(Geometry geometry)
     {
-        if (geometry is GeometryCollection collection)
+        // A multipart Esri geometry surfaces here as an NTS GeometryCollection whose
+        // members are all the same single-part type. RFC 7946 §3.1.4–3.1.7 requires a
+        // homogeneous multipart geometry to be tagged MultiPoint / MultiLineString /
+        // MultiPolygon, not GeometryCollection — strict consumers (QGIS, ogr2ogr) switch
+        // on the geometry `type` and mishandle the GeometryCollection form (#1824). Only a
+        // genuinely mixed-type collection stays a GeometryCollection.
+        if (geometry is GeometryCollection collection && geometry is not (MultiPoint or MultiLineString or MultiPolygon))
         {
+            if (TryCollapseHomogeneousCollection(collection, out var multi))
+            {
+                return new GeoJsonGeometry
+                {
+                    Type = MapGeoJsonType(multi),
+                    Coordinates = BuildGeoJsonCoordinates(multi)
+                };
+            }
+
             return new GeoJsonGeometry
             {
                 Type = "GeometryCollection",
@@ -768,6 +783,43 @@ internal sealed class QueryFormatter : IQueryFormatter
             Type = MapGeoJsonType(geometry),
             Coordinates = BuildGeoJsonCoordinates(geometry)
         };
+    }
+
+    /// <summary>
+    /// Collapses an NTS <see cref="GeometryCollection"/> whose members are all the same
+    /// single-part geometry type into the corresponding RFC 7946 <c>Multi*</c> geometry,
+    /// so a multipart feature serializes as <c>MultiPoint</c>/<c>MultiLineString</c>/
+    /// <c>MultiPolygon</c> rather than a <c>GeometryCollection</c> of single parts (#1824).
+    /// Returns false for empty or mixed-type collections, which remain a GeometryCollection.
+    /// </summary>
+    private static bool TryCollapseHomogeneousCollection(GeometryCollection collection, out Geometry multi)
+    {
+        multi = collection;
+        if (collection.NumGeometries == 0)
+        {
+            return false;
+        }
+
+        var factory = collection.Factory;
+        if (collection.Geometries.All(static g => g is Point))
+        {
+            multi = factory.CreateMultiPoint(collection.Geometries.Cast<Point>().ToArray());
+            return true;
+        }
+
+        if (collection.Geometries.All(static g => g is LineString))
+        {
+            multi = factory.CreateMultiLineString(collection.Geometries.Cast<LineString>().ToArray());
+            return true;
+        }
+
+        if (collection.Geometries.All(static g => g is Polygon))
+        {
+            multi = factory.CreateMultiPolygon(collection.Geometries.Cast<Polygon>().ToArray());
+            return true;
+        }
+
+        return false;
     }
 
     private static string MapGeoJsonType(Geometry geometry)

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryParameterTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryParameterTests.cs
@@ -390,15 +390,63 @@ public sealed class FeatureServerQueryParameterTests : IClassFixture<WebAppFixtu
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
-    public async Task Query_WithPjsonFormat_ReturnsCompactJson()
+    public async Task Query_WithPjsonFormat_ReturnsPrettyPrintedJson()
     {
+        // f=pjson must emit indented JSON, not the byte-identical compact f=json payload (#1824).
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?f=pjson");
 
         var content = await response.Content.ReadAsStringAsync();
         response.StatusCode.Should().Be(HttpStatusCode.OK, content);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
-        content.Should().NotContain("\n");
+        content.Should().Contain("\n", "pjson is pretty-printed (indented) JSON");
+
+        // Still valid, semantically-identical JSON.
+        var queryResponse = JsonSerializer.Deserialize(content, FeatureServerJsonContext.Default.QueryResponse);
+        queryResponse.Should().NotBeNull();
+        queryResponse!.Features.Should().NotBeNull();
+
+        // And distinct from the compact f=json byte payload.
+        var compact = await _fixture.Client.GetStringAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?f=json");
+        compact.Should().NotContain("\n");
+        content.Should().NotBe(compact);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithoutFormatAndWildcardAccept_DefaultsToJson()
+    {
+        // Esri REST defaults f to json; a no-f request (even with a wildcard Accept that a
+        // browser/curl sends) must not silently return binary protobuf (#1824).
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?where=1%3D1");
+        request.Headers.TryAddWithoutValidation("Accept", "*/*");
+
+        var response = await _fixture.Client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithoutFormatAndBrowserAccept_DefaultsToJson()
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?where=1%3D1");
+        request.Headers.TryAddWithoutValidation(
+            "Accept",
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8");
+
+        var response = await _fixture.Client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryTopFeaturesTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryTopFeaturesTests.cs
@@ -89,6 +89,30 @@ public sealed class FeatureServerQueryTopFeaturesTests : IClassFixture<WebAppFix
     [IntegrationTest]
     [Operation(Operations.QueryTopFeatures)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryTopFeatures")]
+    public async Task QueryTopFeatures_WithPbf_ReturnsProtobuf()
+    {
+        // Regression (#1824): queryTopFeatures rejected f=pbf ("Supported formats: json,
+        // pjson"). ArcGIS supports pbf here, so it must return application/x-protobuf.
+        var topFilter = JsonSerializer.Serialize(new
+        {
+            groupByFields = "category",
+            topCount = 2,
+            orderByFields = "objectid desc"
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryTopFeatures?topFilter={Uri.EscapeDataString(topFilter)}&f=pbf");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/x-protobuf");
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        bytes.Should().NotBeEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryTopFeatures)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryTopFeatures")]
     public async Task QueryTopFeatures_MissingTopFilter_ReturnsBadRequest()
     {
         var response = await _fixture.Client.GetAsync(

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/QueryFormatterTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/QueryFormatterTests.cs
@@ -548,6 +548,119 @@ public sealed class QueryFormatterTests
         queryResponse.Features[0].Attributes.Should().Contain("distance", 12.5);
     }
 
+    [Fact]
+    public async Task FormatQueryResultAsync_GeoJson_MultipartPolygon_EmitsMultiPolygonNotGeometryCollection()
+    {
+        // Regression (#1824): a multipart Esri geometry surfaces as an NTS GeometryCollection
+        // of single-part polygons; RFC 7946 requires the homogeneous form to be tagged
+        // MultiPolygon, not GeometryCollection.
+        var geoJson = await FormatGeoJsonGeometryAsync(
+            CreateGeometryCollectionWkb(CreatePolygon(0, 0), CreatePolygon(10, 10)),
+            CreatePolygonLayer());
+
+        geoJson.Features.Should().HaveCount(1);
+        geoJson.Features[0].Geometry!.Type.Should().Be("MultiPolygon");
+        geoJson.Features[0].Geometry!.Geometries.Should().BeNull("a Multi* geometry has coordinates, not nested geometries");
+    }
+
+    [Fact]
+    public async Task FormatQueryResultAsync_GeoJson_MultipartPolyline_EmitsMultiLineString()
+    {
+        var geoJson = await FormatGeoJsonGeometryAsync(
+            CreateGeometryCollectionWkb(CreateLine(0, 0), CreateLine(5, 5)),
+            CreateResource("polyline-layer", MetadataV2GeometryType.LineString,
+                new MetadataV2Field { Name = FieldNames.ObjectId, Type = MetadataV2FieldType.Integer, Nullable = false }));
+
+        geoJson.Features[0].Geometry!.Type.Should().Be("MultiLineString");
+    }
+
+    [Fact]
+    public async Task FormatQueryResultAsync_GeoJson_MultipartPoint_EmitsMultiPoint()
+    {
+        var geoJson = await FormatGeoJsonGeometryAsync(
+            CreateGeometryCollectionWkb(new Point(0, 0), new Point(3, 4)),
+            CreateResource("multipoint-layer", MetadataV2GeometryType.MultiPoint,
+                new MetadataV2Field { Name = FieldNames.ObjectId, Type = MetadataV2FieldType.Integer, Nullable = false }));
+
+        geoJson.Features[0].Geometry!.Type.Should().Be("MultiPoint");
+    }
+
+    [Fact]
+    public async Task FormatQueryResultAsync_GeoJson_SinglePartHoledPolygon_StaysPolygon()
+    {
+        // A single-part holed polygon must remain a Polygon (no false-positive Multi*).
+        var shell = new LinearRing([
+            new Coordinate(0, 0), new Coordinate(10, 0), new Coordinate(10, 10),
+            new Coordinate(0, 10), new Coordinate(0, 0)
+        ]);
+        var hole = new LinearRing([
+            new Coordinate(3, 3), new Coordinate(3, 6), new Coordinate(6, 6),
+            new Coordinate(6, 3), new Coordinate(3, 3)
+        ]);
+        var holed = new Polygon(shell, [hole]) { SRID = 4326 };
+
+        var geoJson = await FormatGeoJsonGeometryAsync(new WKBWriter().Write(holed), CreatePolygonLayer());
+
+        geoJson.Features[0].Geometry!.Type.Should().Be("Polygon");
+    }
+
+    private async Task<GeoJsonFeatureSet> FormatGeoJsonGeometryAsync(byte[] wkb, MetadataV2Resource resource)
+    {
+        var limitsOptions = Options.Create(new LimitsOptions());
+        var formatter = new QueryFormatter(
+            limitsOptions,
+            new PbfQueryFormatter(limitsOptions),
+            NullLogger<QueryFormatter>.Instance);
+
+        var feature = Feature.Create(
+            1,
+            wkb,
+            ImmutableDictionary<string, object?>.Empty.Add("objectid", 1L));
+
+        var (response, _) = await formatter.FormatQueryResultAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            resource,
+            format: "geojson",
+            returnGeometry: true,
+            outputSrid: null,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        return response.Should().BeOfType<GeoJsonFeatureSet>().Subject;
+    }
+
+    private static Polygon CreatePolygon(double originX, double originY)
+    {
+        var ring = new LinearRing(
+        [
+            new Coordinate(originX, originY),
+            new Coordinate(originX + 1, originY),
+            new Coordinate(originX + 1, originY + 1),
+            new Coordinate(originX, originY + 1),
+            new Coordinate(originX, originY)
+        ]);
+        return new Polygon(ring) { SRID = 4326 };
+    }
+
+    private static LineString CreateLine(double originX, double originY)
+    {
+        var coordinates = new[]
+        {
+            new Coordinate(originX, originY),
+            new Coordinate(originX + 1, originY + 1),
+            new Coordinate(originX + 2, originY)
+        };
+        return new LineString(coordinates) { SRID = 4326 };
+    }
+
+    private static byte[] CreateGeometryCollectionWkb(params Geometry[] parts)
+    {
+        var collection = new GeometryCollection(parts) { SRID = 4326 };
+        return new WKBWriter().Write(collection);
+    }
+
     private static MetadataV2Resource CreatePointLayer()
         => CreatePointResource(
             "test-layer",

--- a/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -1039,6 +1039,80 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
             ?? throw new Xunit.Sdk.XunitException("countResult.count (field 1) was not present");
     }
 
+    // Decodes the FeatureCollectionPBuffer ids-only response (#1824):
+    //   QueryResult { ObjectIdsResult idsResult = 3; }
+    //   ObjectIdsResult { string objectIdFieldName = 1; repeated uint64 objectIds = 3 [packed]; }
+    private static (string? FieldName, List<ulong> Ids) DecodePbfIds(byte[] bytes)
+    {
+        var queryResult = ReadMessageField(bytes, 2);
+        queryResult.Should().NotBeNull("the outer message must carry queryResult (field 2)");
+        var idsResult = ReadMessageField(queryResult!, 3);
+        idsResult.Should().NotBeNull("queryResult must carry the idsResult arm (field 3)");
+
+        string? fieldName = ReadStringField(idsResult!, 1);
+        var packed = ReadMessageField(idsResult!, 3); // packed repeated uint64 is length-delimited
+        var ids = new List<ulong>();
+        if (packed != null)
+        {
+            int pos = 0;
+            while (pos < packed.Length)
+            {
+                ids.Add(ReadVarint(packed, ref pos));
+            }
+        }
+
+        return (fieldName, ids);
+    }
+
+    // Decodes the FeatureCollectionPBuffer extent-only response (#1824):
+    //   QueryResult { ExtentCountResult extentCountResult = 4; }
+    //   ExtentCountResult { Envelope extent = 1; uint64 count = 2; }
+    //   Envelope { double XMin=1; YMin=2; XMax=3; YMax=4; SpatialReference SpatialReference=5; }
+    private static (double Xmin, double Ymin, double Xmax, double Ymax, uint Wkid, ulong Count) DecodePbfExtent(byte[] bytes)
+    {
+        var queryResult = ReadMessageField(bytes, 2);
+        queryResult.Should().NotBeNull("the outer message must carry queryResult (field 2)");
+        var extentCount = ReadMessageField(queryResult!, 4);
+        extentCount.Should().NotBeNull("queryResult must carry the extentCountResult arm (field 4)");
+        var envelope = ReadMessageField(extentCount!, 1);
+        envelope.Should().NotBeNull("extentCountResult must carry the envelope (field 1)");
+
+        var xmin = ReadDoubleField(envelope!, 1) ?? throw new Xunit.Sdk.XunitException("envelope.XMin missing");
+        var ymin = ReadDoubleField(envelope!, 2) ?? throw new Xunit.Sdk.XunitException("envelope.YMin missing");
+        var xmax = ReadDoubleField(envelope!, 3) ?? throw new Xunit.Sdk.XunitException("envelope.XMax missing");
+        var ymax = ReadDoubleField(envelope!, 4) ?? throw new Xunit.Sdk.XunitException("envelope.YMax missing");
+        var sr = ReadMessageField(envelope!, 5);
+        uint wkid = sr != null ? (uint)(ReadVarintField(sr, 1) ?? 0) : 0;
+        ulong count = ReadVarintField(extentCount!, 2) ?? 0;
+        return (xmin, ymin, xmax, ymax, wkid, count);
+    }
+
+    private static string? ReadStringField(byte[] data, int fieldNumber)
+    {
+        var raw = ReadMessageField(data, fieldNumber);
+        return raw == null ? null : Encoding.UTF8.GetString(raw);
+    }
+
+    private static double? ReadDoubleField(byte[] data, int fieldNumber)
+    {
+        int pos = 0;
+        while (pos < data.Length)
+        {
+            ulong tag = ReadVarint(data, ref pos);
+            int field = (int)(tag >> 3);
+            int wireType = (int)(tag & 0x7);
+            if (wireType == 1 && field == fieldNumber)
+            {
+                double value = BitConverter.ToDouble(data, pos);
+                return value;
+            }
+
+            SkipField(data, ref pos, wireType);
+        }
+
+        return null;
+    }
+
     private static byte[]? ReadMessageField(byte[] data, int fieldNumber)
     {
         int pos = 0;
@@ -1124,6 +1198,85 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         }
 
         return result;
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query?returnIdsOnly=true&f=pbf")]
+    public async Task QueryFeatures_WithReturnIdsOnlyAndPbf_ReturnsProtobufIds()
+    {
+        // Regression (#1824): returnIdsOnly ignored f=pbf and returned JSON. It must emit the
+        // ObjectIdsResult arm of the FeatureCollectionPBuffer QueryResult oneof with
+        // Content-Type application/x-protobuf, mirroring the count-pbf path (#1784).
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=1%3D1&returnIdsOnly=true&f=pbf");
+
+        response.Be200Ok();
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/x-protobuf");
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        bytes.Should().NotBeEmpty();
+        var (fieldName, ids) = DecodePbfIds(bytes);
+        fieldName.Should().NotBeNullOrEmpty();
+        ids.Should().HaveCount(5);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query?returnExtentOnly=true&f=pbf")]
+    public async Task QueryFeatures_WithReturnExtentOnlyAndPbf_ReturnsProtobufExtent()
+    {
+        // Regression (#1824): returnExtentOnly ignored f=pbf and returned JSON. It must emit the
+        // ExtentCountResult arm of the FeatureCollectionPBuffer QueryResult oneof with
+        // Content-Type application/x-protobuf.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=1%3D1&returnExtentOnly=true&f=pbf");
+
+        response.Be200Ok();
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/x-protobuf");
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        bytes.Should().NotBeEmpty();
+        var (xmin, ymin, xmax, ymax, wkid, count) = DecodePbfExtent(bytes);
+        xmin.Should().BeLessThanOrEqualTo(xmax);
+        ymin.Should().BeLessThanOrEqualTo(ymax);
+        wkid.Should().BeGreaterThan(0u);
+        count.Should().Be(5);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query?returnCountOnly=true&f=geojson")]
+    public async Task QueryFeatures_WithReturnCountOnlyAndGeoJson_ReturnsBadRequest()
+    {
+        // Regression (#1824): geojson on the secondary modes was silently downgraded to an
+        // Esri-JSON 200; it must be a clean 400 instead.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=1%3D1&returnCountOnly=true&f=geojson");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query?returnIdsOnly=true&f=geojson")]
+    public async Task QueryFeatures_WithReturnIdsOnlyAndGeoJson_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=1%3D1&returnIdsOnly=true&f=geojson");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query?returnExtentOnly=true&f=geojson")]
+    public async Task QueryFeatures_WithReturnExtentOnlyAndGeoJson_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=1%3D1&returnExtentOnly=true&f=geojson");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [IntegrationTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1824

## Summary
FeatureServer `query` had a family of format / content-negotiation gaps (an
incomplete follow-on to #1784, which only fixed `returnCountOnly + f=pbf`).
This PR completes the protobuf parity for the secondary query modes, stops the
silent geojson downgrade, makes `f=pjson` actually pretty-print, adds `pbf`
support to `queryTopFeatures`, and fixes the GeoJSON writer so multipart
geometries emit RFC 7946 `Multi*` instead of a `GeometryCollection`.

## Changes Made
- `returnIdsOnly + f=pbf` now emits the `ObjectIdsResult` arm of the Esri
  `FeatureCollectionPBuffer` (`application/x-protobuf`) instead of JSON; the pbf
  path forces materialization so it never takes the JSON streaming writer.
- `returnExtentOnly + f=pbf` now emits the `ExtentCountResult` arm
  (`application/x-protobuf`) instead of JSON.
- `f=geojson` on `returnCountOnly`/`returnIdsOnly`/`returnExtentOnly` now returns
  a clean `400` ("not supported for this query mode") rather than silently
  downgrading to an Esri-JSON `200`.
- `f=pjson` now returns indented JSON (via a type-agnostic, AOT-safe
  `JsonReindenter`) instead of being byte-identical to `f=json`; the raw
  point fast path is skipped for pjson so indentation is honored.
- `queryTopFeatures` now accepts `f=pbf` (added to a dedicated `TopFeatures`
  format allow-list and the serializer); `queryRelatedRecords` stays json/pjson.
- GeoJSON writer: a homogeneous multipart geometry (NTS `GeometryCollection` of
  same-typed single parts) now serializes as `MultiPoint`/`MultiLineString`/
  `MultiPolygon` (RFC 7946 §3.1); single-part holed polygons stay `Polygon`,
  and genuinely mixed collections stay `GeometryCollection`.
- New `PbfQueryFormatter.FormatIdsAsPbf` / `FormatExtentAsPbf` and a
  `ProtobufWriter.WritePackedUInt64` helper, matching the `github.com/Esri/arcgis-pbf`
  schema.
- Added regression tests for every fix (pbf ids/extent decode, geojson-400,
  pjson pretty-print, no-f default-to-json, queryTopFeatures pbf, multipart
  Multi* geometry, single-part holed polygon stays Polygon).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — these are conformance fixes. Clients that relied on the prior (incorrect)
behavior (binary/JSON mismatches, GeometryCollection multipart) get the
spec-correct response; existing `f=json`/`f=pbf` feature paths are unchanged.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
