### PR TITLE
fix(geoservices): accept POST on service-level query/queryDomains; cap resultRecordCount; ImageServer slices

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEndpoints.cs
@@ -108,9 +108,25 @@ internal static partial class FeatureServerEndpoints
             .WithDisplayName("Query FeatureServer Service (GET)")
             .WithName("QueryFeatureServiceGet")
             .WithSummary("Query features from a FeatureServer service using GET")
-            .WithDescription("GET-only service-level query endpoint that returns per-layer results for the selected accessible layers")
+            .WithDescription("Service-level query endpoint that returns per-layer results for the selected accessible layers")
             .WithTags("FeatureServer")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<ServiceQueryResponse>(200, "application/json")
+            .Produces(400)
+            .Produces(404);
+
+        // Esri services accept BOTH GET and POST for the service-level query operation;
+        // clients POST large layerDefs/layers arrays that exceed URL limits
+        // (honua-server#1825). The POST companion shares the read-only handler and is
+        // anonymous by design (per-layer access is enforced by the handler).
+        var serviceQueryPost = endpoints.MapPost("/rest/services/{serviceId}/FeatureServer/query", HandleServiceQueryFeaturesPost)
+            .WithDisplayName("Query FeatureServer Service (POST)")
+            .WithName("QueryFeatureServicePost")
+            .WithSummary("Query features from a FeatureServer service using POST")
+            .WithDescription("Service-level query endpoint that returns per-layer results for the selected accessible layers")
+            .WithTags("FeatureServer")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
+            .AllowAnonymous()
             .Produces<ServiceQueryResponse>(200, "application/json")
             .Produces(400)
             .Produces(404);
@@ -431,6 +447,21 @@ internal static partial class FeatureServerEndpoints
             .WithSummary("Query coded-value domains for the service")
             .WithDescription("Returns schema-defined domains for accessible service layers")
             .WithTags("FeatureServer")
+            .Produces<QueryDomainsResponse>(200, "application/json")
+            .Produces(400)
+            .Produces(404);
+
+        // Esri services accept BOTH GET and POST for queryDomains; clients POST large
+        // layers arrays that exceed URL limits (honua-server#1825). The POST companion
+        // shares the read-only handler and is anonymous by design (per-layer access is
+        // enforced by the handler).
+        endpoints.MapPost("/rest/services/{serviceId}/FeatureServer/queryDomains", HandleQueryDomains)
+            .WithDisplayName("Query Domains (POST)")
+            .WithName("QueryDomainsPost")
+            .WithSummary("Query coded-value domains for the service using POST")
+            .WithDescription("Returns schema-defined domains for accessible service layers")
+            .WithTags("FeatureServer")
+            .AllowAnonymous()
             .Produces<QueryDomainsResponse>(200, "application/json")
             .Produces(400)
             .Produces(404);

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
@@ -500,16 +500,41 @@ internal static partial class FeatureServerEndpoints
         HttpContext context,
         [FromServices] ICommonQueryValidator queryValidator)
     {
-        if (!TryValidateAllowedParameters(context.Request.Query, queryValidator, AllowedQueryParameters.QueryDomains, out var error))
+        var cancellationToken = GetTimeoutAwareCancellationToken(context);
+
+        // Esri services accept BOTH GET and POST for queryDomains; clients POST large
+        // layers arrays that exceed URL limits (honua-server#1825). Merge the form body
+        // over the query string so both methods share this read-only handler.
+        var values = ToCaseInsensitiveDictionary(context.Request.Query);
+        if (HttpMethods.IsPost(context.Request.Method))
+        {
+            var (bodyValues, bodyReadError) = await TryReadRequestValuesAsync(context.Request, cancellationToken);
+            if (bodyValues == null)
+            {
+                if (TryGetUnsupportedMediaType(bodyReadError, out var receivedContentType))
+                {
+                    return CreateUnsupportedRequestContentTypeResult(context, receivedContentType);
+                }
+
+                return StandardErrorHelpers.CreateBadRequest(context,
+                    "Invalid query parameters",
+                    [bodyReadError ?? "Invalid request body."]);
+            }
+
+            foreach (var pair in bodyValues)
+            {
+                values[pair.Key] = pair.Value;
+            }
+        }
+
+        if (!TryValidateAllowedParameters(values, queryValidator, AllowedQueryParameters.QueryDomains, out var error))
         {
             return StandardErrorHelpers.CreateBadRequest(context,
                 "Invalid query parameters",
                 [error ?? "Invalid query parameter."]);
         }
 
-        var requestedFormat = context.Request.Query.TryGetValue("f", out var formatValue)
-            ? formatValue.ToString()
-            : null;
+        var requestedFormat = GetValueString(values, "f");
         if (!TryValidateOutputFormat(requestedFormat, JsonOnlyFormats, out _, out var formatError))
         {
             return StandardErrorHelpers.CreateBadRequest(context,
@@ -525,7 +550,6 @@ internal static partial class FeatureServerEndpoints
         scope.WithTag(HonuaTelemetry.Tags.ServiceId, serviceId);
 
         var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
-        var cancellationToken = GetTimeoutAwareCancellationToken(context);
         var serviceValidationResult = await FeatureServerResourceValidationHelpers.ValidateServiceV2Async(
             resourceValidator,
             serviceId,
@@ -541,7 +565,6 @@ internal static partial class FeatureServerEndpoints
         var snapshotProvider = context.RequestServices.GetRequiredService<IMetadataV2GraphProvider>();
         var snapshot = await snapshotProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
 
-        var values = ToCaseInsensitiveDictionary(context.Request.Query);
         if (!TryResolveRequestedServiceLayersV2(service, snapshot, values, out var selectedLayers, out _, out var selectionError))
         {
             return StandardErrorHelpers.CreateBadRequest(context,

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Query.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Query.cs
@@ -104,14 +104,57 @@ internal static partial class FeatureServerEndpoints
             cancellationToken);
     }
 
-    private static async Task<IResult> HandleServiceQueryFeaturesGet(
+    private static Task<IResult> HandleServiceQueryFeaturesGet(
         string serviceId,
         HttpContext context,
         [FromServices] FeatureServerQueryHandler queryHandler,
         [FromServices] ICommonQueryValidator queryValidator)
+        => HandleServiceQueryFeaturesAsync(serviceId, context, queryHandler, queryValidator);
+
+    // Esri Map/Feature services accept BOTH GET and POST for the service-level query
+    // operation; clients POST large layerDefs/layers arrays that exceed URL limits
+    // (honua-server#1825). The POST companion merges the form body over the query string
+    // and shares this handler; it is AllowAnonymous because the per-layer access policy is
+    // enforced below via RequireAnyResourceAccess/FilterAccessibleLayersV2.
+    private static Task<IResult> HandleServiceQueryFeaturesPost(
+        string serviceId,
+        HttpContext context,
+        [FromServices] FeatureServerQueryHandler queryHandler,
+        [FromServices] ICommonQueryValidator queryValidator)
+        => HandleServiceQueryFeaturesAsync(serviceId, context, queryHandler, queryValidator);
+
+    private static async Task<IResult> HandleServiceQueryFeaturesAsync(
+        string serviceId,
+        HttpContext context,
+        FeatureServerQueryHandler queryHandler,
+        ICommonQueryValidator queryValidator)
     {
+        var cancellationToken = GetTimeoutAwareCancellationToken(context);
+
+        var values = ToCaseInsensitiveDictionary(context.Request.Query);
+        if (HttpMethods.IsPost(context.Request.Method))
+        {
+            var (bodyValues, bodyReadError) = await TryReadRequestValuesAsync(context.Request, cancellationToken);
+            if (bodyValues == null)
+            {
+                if (TryGetUnsupportedMediaType(bodyReadError, out var receivedContentType))
+                {
+                    return CreateUnsupportedRequestContentTypeResult(context, receivedContentType);
+                }
+
+                return StandardErrorHelpers.CreateBadRequest(context,
+                    "Invalid query parameters",
+                    [bodyReadError ?? "Invalid request body."]);
+            }
+
+            foreach (var pair in bodyValues)
+            {
+                values[pair.Key] = pair.Value;
+            }
+        }
+
         if (!TryValidateAllowedParameters(
-                context.Request.Query,
+                values,
                 queryValidator,
                 FeatureServerServiceQueryAllowedParameters,
                 out var error))
@@ -121,7 +164,6 @@ internal static partial class FeatureServerEndpoints
                 [error ?? "Invalid query parameter."]);
         }
 
-        var values = ToCaseInsensitiveDictionary(context.Request.Query);
         var requestedFormat = GetValueString(values, "f");
 
         using var scope = HonuaTelemetryScope.StartFeature(
@@ -131,7 +173,6 @@ internal static partial class FeatureServerEndpoints
             context.TraceIdentifier);
         scope.WithTag(HonuaTelemetry.Tags.ServiceId, serviceId);
 
-        var cancellationToken = GetTimeoutAwareCancellationToken(context);
         var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
         var serviceValidationResult = await FeatureServerResourceValidationHelpers.ValidateServiceV2Async(
             resourceValidator,

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureQueryValidator.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureQueryValidator.cs
@@ -13,8 +13,18 @@ namespace Honua.Protocols.GeoServices.FeatureServer.Services;
 internal sealed class FeatureQueryValidator : IFeatureQueryValidator
 {
     private readonly ICommonQueryValidator _commonQueryValidator;
+
+    // ArcGIS silently caps an over-maximum resultRecordCount to maxRecordCount and
+    // returns the capped page with exceededTransferLimit:true rather than rejecting the
+    // request with a 400 (honua-server#1825). Clients commonly pass a large "give me
+    // everything" resultRecordCount, so clamp to the limit instead of failing. The
+    // executor still detects the overflow (it probes one extra row) and emits
+    // exceededTransferLimit:true, so the response stays spec-correct.
     private static readonly PaginationValidationOptions _featureQueryPagination =
-        new(MinOffset: 0, MinLimit: 1, OffsetParameterName: "resultOffset", LimitParameterName: "resultRecordCount");
+        new(MinOffset: 0, MinLimit: 1, OffsetParameterName: "resultOffset", LimitParameterName: "resultRecordCount")
+        {
+            ClampLimitToMaximum = true
+        };
 
     public FeatureQueryValidator(ICommonQueryValidator commonQueryValidator)
     {

--- a/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerMultidimensionalInfoBuilder.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerMultidimensionalInfoBuilder.cs
@@ -101,29 +101,36 @@ internal sealed class ImageServerMultidimensionalInfoBuilder(
     {
         if (TimeDimensionNames.Contains(dimension.Name) && metadata.Temporal is { } temporal)
         {
+            var min = (double)temporal.Start.ToUnixTimeMilliseconds();
+            var max = (double)temporal.End.ToUnixTimeMilliseconds();
+            var size = temporal.StepCount > 0 ? temporal.StepCount : dimension.Size;
+            var values = EnumerateRegularValues(min, max, size);
             return new ImageServerMultidimensionalDimension
             {
                 Name = StdTimeDimension,
                 Unit = "ISO8601",
-                Extent =
-                [
-                    temporal.Start.ToUnixTimeMilliseconds(),
-                    temporal.End.ToUnixTimeMilliseconds()
-                ],
-                HasRegularIntervals = false,
-                DimensionSize = temporal.StepCount > 0 ? temporal.StepCount : dimension.Size
+                Extent = [min, max],
+                // A regular axis whose coordinate values we can enumerate; surfacing the
+                // values lets the slices operation enumerate one slice per coordinate
+                // (honua-server#1825). Irregular/extent-only axes leave Values null.
+                Values = values,
+                HasRegularIntervals = values is not null,
+                DimensionSize = size
             };
         }
 
         if (VerticalDimensionNames.Contains(dimension.Name) && metadata.Vertical is { } vertical)
         {
+            var size = vertical.StepCount > 0 ? vertical.StepCount : dimension.Size;
+            var values = EnumerateRegularValues(vertical.Min, vertical.Max, size);
             return new ImageServerMultidimensionalDimension
             {
                 Name = StdZDimension,
                 Unit = string.IsNullOrWhiteSpace(vertical.Units) ? null : vertical.Units,
                 Extent = [vertical.Min, vertical.Max],
-                HasRegularIntervals = false,
-                DimensionSize = vertical.StepCount > 0 ? vertical.StepCount : dimension.Size
+                Values = values,
+                HasRegularIntervals = values is not null,
+                DimensionSize = size
             };
         }
 
@@ -134,5 +141,50 @@ internal sealed class ImageServerMultidimensionalInfoBuilder(
             HasRegularIntervals = false,
             DimensionSize = dimension.Size
         };
+    }
+
+    /// <summary>
+    /// Synthesizes the evenly-spaced coordinate values for a regular dimension whose
+    /// inclusive [<paramref name="min"/>, <paramref name="max"/>] extent and step count
+    /// (<paramref name="size"/>) are known. ArcGIS enumerates one slice per coordinate,
+    /// so a coverage that advertises <c>dimensionSize:N</c> must surface N values for the
+    /// slices operation to enumerate (honua-server#1825). Returns <see langword="null"/>
+    /// when the axis is not safely enumerable (non-positive size, non-finite bounds, or an
+    /// implausibly large size that would balloon the document) so the dimension falls back
+    /// to extent-only and contributes no slices.
+    /// </summary>
+    private static double[]? EnumerateRegularValues(double min, double max, long size)
+    {
+        const long MaxEnumerableSize = 10_000;
+
+        if (size <= 0 || size > MaxEnumerableSize)
+        {
+            return null;
+        }
+
+        if (!double.IsFinite(min) || !double.IsFinite(max))
+        {
+            return null;
+        }
+
+        var count = (int)size;
+        var values = new double[count];
+        if (count == 1)
+        {
+            // A single-coordinate axis pins to its lower bound (== upper bound for a
+            // degenerate extent).
+            values[0] = min;
+            return values;
+        }
+
+        var step = (max - min) / (count - 1);
+        for (var i = 0; i < count; i++)
+        {
+            // Anchor the final value exactly on max to avoid floating-point drift at the
+            // inclusive upper bound.
+            values[i] = i == count - 1 ? max : min + (step * i);
+        }
+
+        return values;
     }
 }

--- a/src/Honua.Protocols.GeoServices/MapServer/MapServerEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/MapServerEndpoints.cs
@@ -257,6 +257,19 @@ internal static partial class MapServerEndpoints
             .WithTags("MapServer")
             .CacheOutput("LayerMetadata");
 
+        // Esri services accept BOTH GET and POST for queryDomains; clients POST large
+        // layers arrays that exceed URL limits (honua-server#1825). The POST companion
+        // shares the read-only handler (no CacheOutput, matching the other MapServer POST
+        // companions).
+        endpoints.MapPost("/rest/services/{serviceId}/MapServer/queryDomains",
+                static (HttpContext context, CancellationToken cancellationToken) => HandleQueryDomains(context))
+            .WithDisplayName("Query MapServer Domains (POST)")
+            .WithName("MapServerQueryDomainsPost")
+            .WithSummary("Query coded-value and range domains using POST")
+            .WithDescription("Returns the domains referenced by the requested layers")
+            .WithTags("MapServer")
+            .AllowAnonymous();
+
         endpoints.MapGet("/rest/services/{serviceId}/MapServer/dynamicLayer",
                 static (HttpContext context, CancellationToken cancellationToken) => HandleDynamicLayerResource(context))
             .WithDisplayName("Get MapServer Dynamic Layer")

--- a/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Metadata.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Metadata.cs
@@ -17,6 +17,7 @@ using Honua.Protocols.GeoServices.FeatureServer;
 using Honua.Protocols.GeoServices.MapServer.Models;
 using Honua.ServiceDefaults;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 
 namespace Honua.Protocols.GeoServices.MapServer;
 
@@ -200,14 +201,14 @@ internal static partial class MapServerEndpoints
     }
 
     private static bool TryValidateMetadataFormat(IQueryCollection query, out string? error)
+        => TryValidateMetadataFormat(query.TryGetValue("f", out var formatValues) ? formatValues.ToString() : null, out error);
+
+    private static bool TryValidateMetadataFormat(Dictionary<string, StringValues> values, out string? error)
+        => TryValidateMetadataFormat(values.TryGetValue("f", out var formatValues) ? formatValues.ToString() : null, out error);
+
+    private static bool TryValidateMetadataFormat(string? format, out string? error)
     {
         error = null;
-        if (!query.TryGetValue("f", out var formatValues))
-        {
-            return true;
-        }
-
-        var format = formatValues.ToString();
         if (string.IsNullOrWhiteSpace(format))
         {
             return true;

--- a/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Resources.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Resources.cs
@@ -136,7 +136,17 @@ internal static partial class MapServerEndpoints
     private static async Task<IResult> HandleQueryDomains(HttpContext context)
     {
         var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
-        if (!TryValidateMetadataFormat(context.Request.Query, out var formatError))
+
+        // Esri services accept BOTH GET and POST for queryDomains; clients POST large
+        // layers arrays that exceed URL limits (honua-server#1825). Merge the form body
+        // over the query string so both methods share this read-only handler.
+        var (values, readError) = await TryReadMapServerRequestValuesAsync(context);
+        if (values is null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, readError ?? "Invalid request body.");
+        }
+
+        if (!TryValidateMetadataFormat(values, out var formatError))
         {
             return StandardErrorHelpers.CreateBadRequest(context, formatError ?? "Output format is not supported.");
         }
@@ -173,7 +183,7 @@ internal static partial class MapServerEndpoints
             var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
             var publishedLayers = ResolveMapServerMetadataLayers(snapshot, service);
 
-            if (!TryResolveQueryDomainsLayers(context.Request.Query, publishedLayers, out var selectedLayers, out var selectionError))
+            if (!TryResolveQueryDomainsLayers(values, publishedLayers, out var selectedLayers, out var selectionError))
             {
                 return StandardErrorHelpers.CreateBadRequest(context, selectionError ?? "Invalid layers parameter.");
             }
@@ -308,7 +318,7 @@ internal static partial class MapServerEndpoints
     }
 
     private static bool TryResolveQueryDomainsLayers(
-        IQueryCollection query,
+        Dictionary<string, StringValues> values,
         IReadOnlyList<MapServerMetadataLayerDescriptor> allLayers,
         out MapServerMetadataLayerDescriptor[] selected,
         out string? error)
@@ -316,7 +326,7 @@ internal static partial class MapServerEndpoints
         error = null;
         selected = [.. allLayers];
 
-        if (!query.TryGetValue("layers", out var layersRaw) || StringValues.IsNullOrEmpty(layersRaw))
+        if (!values.TryGetValue("layers", out var layersRaw) || StringValues.IsNullOrEmpty(layersRaw))
         {
             return true;
         }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryParameterTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryParameterTests.cs
@@ -74,6 +74,23 @@ public sealed class FeatureServerQueryParameterTests : IClassFixture<WebAppFixtu
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    // honua-server#1825: a resultRecordCount above maxRecordCount must be silently capped
+    // to maxRecordCount (and the page returned) rather than rejected with a 400 — this is
+    // what ArcGIS does, and clients routinely pass a large "give me everything" count. The
+    // default maxRecordCount in the test host is 10000, so 100000 is over the limit.
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithResultRecordCountAboveMaxRecordCount_ClampsInsteadOfBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?where=1%3D1&resultRecordCount=100000&f=json");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        content.Should().NotContain("cannot exceed");
+    }
+
     // BUG C regression: an unknown geometryType must be rejected, not coerced to an envelope.
     [IntegrationTest]
     [Operation(Operations.Query)]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerServiceQueryTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerServiceQueryTests.cs
@@ -70,4 +70,81 @@ public sealed class FeatureServerServiceQueryTests : IClassFixture<WebAppFixture
         targetLayer.GetProperty("features").GetArrayLength().Should().Be(0);
     }
 
+    // honua-server#1825: Esri services accept BOTH GET and POST for the service-level
+    // query op; clients POST large layerDefs/layers arrays. Previously POST returned 405.
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/query")]
+    public async Task ServiceQuery_Post_ReturnsPerLayerResults()
+    {
+        var form = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("where", "1=1"),
+            new KeyValuePair<string, string>("f", "json")
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/query", form);
+        var content = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "response body was {0}", content);
+
+        using var document = JsonDocument.Parse(content);
+        document.RootElement.TryGetProperty("layers", out var layers).Should().BeTrue();
+        layers.ValueKind.Should().Be(JsonValueKind.Array);
+        layers.EnumerateArray()
+            .Select(layer => layer.GetProperty("id").GetInt32())
+            .Should()
+            .Contain(WebAppFixture.TestLayerId);
+    }
+
+    // honua-server#1825: POST layerDefs (which can exceed URL limits) must apply per-layer.
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/query")]
+    public async Task ServiceQuery_Post_WithLayerDefs_AppliesPerLayerWhere()
+    {
+        var form = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("where", "1=1"),
+            new KeyValuePair<string, string>("f", "json"),
+            new KeyValuePair<string, string>("layerDefs", $"{{\"{WebAppFixture.TestLayerId}\":\"1=0\"}}")
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/query", form);
+        var content = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "response body was {0}", content);
+
+        using var document = JsonDocument.Parse(content);
+        var targetLayer = document.RootElement
+            .GetProperty("layers")
+            .EnumerateArray()
+            .Single(layer => layer.GetProperty("id").GetInt32() == WebAppFixture.TestLayerId);
+
+        targetLayer.GetProperty("features").GetArrayLength().Should().Be(0);
+    }
+
+    // honua-server#1825: service-level queryDomains must accept POST (FeatureServer).
+    [IntegrationTest]
+    [Operation(Operations.QueryDomains)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/queryDomains")]
+    public async Task ServiceQueryDomains_Post_ReturnsDomains()
+    {
+        var form = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("f", "json")
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/queryDomains", form);
+        var content = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "response body was {0}", content);
+
+        using var document = JsonDocument.Parse(content);
+        document.RootElement.TryGetProperty("domains", out var domains).Should().BeTrue();
+        domains.ValueKind.Should().Be(JsonValueKind.Array);
+    }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMultidimensionalInfoHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMultidimensionalInfoHandlerTests.cs
@@ -112,10 +112,22 @@ public class ImageServerMultidimensionalInfoHandlerTests
         timeDimension.Unit.Should().Be("ISO8601");
         timeDimension.DimensionSize.Should().Be(2);
         timeDimension.Extent.Should().HaveCount(2);
+        // A regular axis whose dimensionSize is known surfaces one coordinate value per
+        // slice so the slices operation can enumerate it (honua-server#1825).
+        timeDimension.HasRegularIntervals.Should().BeTrue();
+        timeDimension.Values.Should().NotBeNull();
+        timeDimension.Values!.Should().HaveCount(2)
+            .And.Equal(
+                DateTimeOffset.UnixEpoch.ToUnixTimeMilliseconds(),
+                DateTimeOffset.UnixEpoch.AddDays(1).ToUnixTimeMilliseconds());
 
         var verticalDimension = variable.Dimensions.Should().ContainSingle(d => d.Name == "StdZ").Subject;
         verticalDimension.Unit.Should().Be("Pa");
         verticalDimension.Extent.Should().Equal(1000.0, 50000.0);
+        verticalDimension.DimensionSize.Should().Be(5);
+        verticalDimension.HasRegularIntervals.Should().BeTrue();
+        // 5 evenly-spaced levels between 1000 and 50000 inclusive.
+        verticalDimension.Values!.Should().Equal(1000.0, 13250.0, 25500.0, 37750.0, 50000.0);
 
         // The horizontal axis stays under its source name with size only.
         variable.Dimensions.Should().ContainSingle(d => d.Name == "x")
@@ -291,5 +303,77 @@ public class ImageServerSlicesBuilderTests
         slices[1].MultidimensionalDefinition.Should()
             .ContainSingle(d => d.DimensionName == "StdTime")
             .Which.Values.Should().Equal(86_400_000);
+    }
+
+    /// <summary>
+    /// Regression for honua-server#1825: a multidimensional coverage that advertises
+    /// <c>hasMultidimensions:true</c> with a temporal dimension of <c>dimensionSize:4</c>
+    /// must enumerate one slice per temporal coordinate, not return an empty document.
+    /// </summary>
+    [UnitTest]
+    [Operation(Operations.GetServiceInfo)]
+    public async Task BuiltInfo_RegularTimeDimension_EnumeratesOneSlicePerStep()
+    {
+        var store = Substitute.For<IMultidimensionalCoverageStore>();
+        store.ListByLayerAsync(1, Arg.Any<CancellationToken>())
+            .Returns([CreateRegistration(metadata: CreateFourStepTemporalMetadata())]);
+
+        var info = await new ImageServerMultidimensionalInfoBuilder(store).BuildAsync(1, CancellationToken.None);
+        info.Should().NotBeNull();
+
+        var slices = ImageServerSlicesBuilder.Build(info!);
+
+        // dimensionSize:4 on the single temporal dimension => four slices, each pinning
+        // one StdTime coordinate.
+        slices.Should().HaveCount(4);
+        slices.Select(s => s.SliceId).Should().Equal(0, 1, 2, 3);
+        slices.Should().OnlyContain(s =>
+            s.MultidimensionalDefinition.Length == 1 &&
+            s.MultidimensionalDefinition[0].DimensionName == "StdTime" &&
+            s.MultidimensionalDefinition[0].VariableName == "temperature" &&
+            s.MultidimensionalDefinition[0].Values.Length == 1);
+    }
+
+    private static MultidimensionalCoverageMetadata CreateFourStepTemporalMetadata() => new()
+    {
+        Format = MultidimensionalCoverageFormat.NetCdf4,
+        Srid = 4326,
+        Extent = new RasterExtent { XMin = -180, YMin = -90, XMax = 180, YMax = 90, Srid = 4326 },
+        Resolution = (1.0, 1.0),
+        Temporal = new TemporalExtent(
+            DateTimeOffset.UnixEpoch,
+            DateTimeOffset.UnixEpoch.AddDays(3),
+            StepCount: 4),
+        Variables =
+        [
+            new MultidimensionalCoverageVariable(
+                Name: "temperature",
+                DataType: "float32",
+                Dimensions: [new MultidimensionalCoverageDimension("time", 4)],
+                ChunkLayout: null,
+                Units: "K",
+                LongName: "Air Temperature",
+                StandardName: "air_temperature",
+                NoData: -9999)
+        ]
+    };
+
+    private static MultidimensionalCoverageRegistration CreateRegistration(
+        MultidimensionalCoverageMetadata? metadata)
+    {
+        return new MultidimensionalCoverageRegistration
+        {
+            Id = 7,
+            LayerId = 1,
+            Name = "cube",
+            Format = MultidimensionalCoverageFormat.NetCdf4,
+            Provider = CloudStorageProvider.AwsS3,
+            Bucket = "bucket",
+            ObjectKey = "cube.nc",
+            Variables = Array.Empty<string>(),
+            Metadata = metadata,
+            MetadataScannedAt = metadata is null ? null : DateTimeOffset.UtcNow,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
     }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
@@ -1696,6 +1696,25 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
         domains.ValueKind.Should().Be(JsonValueKind.Array);
     }
 
+    // honua-server#1825: Esri services accept BOTH GET and POST for queryDomains; clients
+    // POST large layers arrays that exceed URL limits. Previously POST returned 405.
+    [IntegrationTest]
+    [Operation(Operations.QueryDomains)]
+    [Endpoint("POST /rest/services/{serviceId}/MapServer/queryDomains")]
+    public async Task MapServer_QueryDomains_Post_ReturnsDomainsArray()
+    {
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/queryDomains",
+            new FormUrlEncodedContent([new KeyValuePair<string, string>("f", "json")]));
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        using var document = JsonDocument.Parse(content);
+        document.RootElement.TryGetProperty("domains", out var domains).Should().BeTrue();
+        domains.ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
     [IntegrationTest]
     [Operation(Operations.QueryDomains)]
     [Endpoint("GET /rest/services/{serviceId}/MapServer/queryDomains")]


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to honua-io/honua-server#1825

<!-- Closes the service-POST, resultRecordCount, and ImageServer-slices items of #1825.
     The TIMESTAMP where-literal item (and the WHERE nesting-depth item) are owned by a
     separate PR, so this links with `Related to` and leaves #1825 open until that PR lands. -->

## Summary
Fixes three GeoServices conformance gaps from #1825 that break real ArcGIS SDK/clients.
Service-level `query`/`queryDomains` now accept POST (Esri accepts both GET and POST, and
clients POST large `layerDefs`/`layers` arrays that exceed URL limits); an over-maximum
`resultRecordCount` is now silently clamped (as ArcGIS does) instead of returning 400; and
ImageServer `slices` now enumerates one slice per coordinate on a regular multidimensional
axis instead of returning an empty document.

The TIMESTAMP where-literal item from #1825 is intentionally **out of scope** here — it is
owned by a separate PR.

## Changes Made
- Register POST companions for the service-level `query` operation (`FeatureServer/query`)
  and `queryDomains` on **both** FeatureServer and MapServer. Each POST companion shares
  the existing read-only handler, merges the form body over the query string, and enforces
  per-layer access via the layer access policy (so the POST routes are `AllowAnonymous` to
  match the existing query/identify POST companions).
- Clamp `resultRecordCount` to `maxRecordCount` instead of rejecting with 400, by enabling
  `ClampLimitToMaximum` on the GeoServices feature-query pagination options. The executor
  still detects the overflow and emits `exceededTransferLimit:true`, so the response stays
  spec-correct. Negative `resultRecordCount` is still rejected.
- Enumerate ImageServer slices by synthesizing the evenly-spaced coordinate values for a
  regular temporal/vertical dimension from its `[min,max]` extent + `dimensionSize`, so a
  coverage that advertises `hasMultidimensions:true` with `dimensionSize:N` yields N slices
  (irregular/extent-only axes still fall back to extent-only and contribute no slices).
- Tests: new integration tests for FeatureServer/MapServer service `query` and
  `queryDomains` POST, the `resultRecordCount` clamp, and unit tests proving the
  multidimensional-info builder now surfaces coordinate values and the slices builder
  enumerates one slice per step.

**Scoped out (noted for #1825):** the date `outStatistics` min/max encoding inconsistency
(item 4, MED-LOW). It lives in the FeatureServer statistics-result format serializers, which
a sibling PR is actively touching; deferring it avoids a merge collision. The
TIMESTAMP where-literal item is owned by another PR.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Targeted `Honua.Protocols.GeoServices.Tests` runs (Testcontainers + PostGIS), all green:
ImageServer slices/multidim unit (8/8), FeatureServer service query incl. new POST (5/5),
resultRecordCount clamp + MapServer queryDomains (5/5), FeatureServer query-param +
maintenance regression (72/72), MapServer endpoint regression incl. new POST (109/109).

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
