### PR TITLE
fix(geoservices): catalog service-typing (raster→ImageServer/MapServer) + edit-capability advertisement guard

### DIFF
--- a/src/Honua.Protocols.GeoServices/Catalog/GeoservicesCatalogEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/Catalog/GeoservicesCatalogEndpoints.cs
@@ -80,7 +80,15 @@ internal static class GeoservicesCatalogEndpoints
 
         foreach (var service in snapshot.Graph.Services.OrderBy(static s => s.Metadata.Name, StringComparer.OrdinalIgnoreCase))
         {
-            if (!TryMapServiceType(service.PrimaryProtocol, out var directoryType))
+            // Derive the catalog "type" from every Esri-family protocol the service
+            // exposes, not just the primary one. A service reachable under multiple
+            // Esri types (e.g. both FeatureServer and MapServer, or a vector layer that
+            // is also rendered as a MapServer) is listed once per type, mirroring how a
+            // real ArcGIS Services Directory enumerates it (#1853). Raster/coverage
+            // services that expose ImageServer/MapServer therefore type as
+            // ImageServer/MapServer instead of being flattened to FeatureServer.
+            var directoryTypes = MapEsriDirectoryTypes(service);
+            if (directoryTypes.Count == 0)
             {
                 continue;
             }
@@ -110,13 +118,18 @@ internal static class GeoservicesCatalogEndpoints
                 continue;
             }
 
-            if (string.Equals(directoryType, "ImageServer", StringComparison.Ordinal))
+            var escapedName = Uri.EscapeDataString(service.Metadata.Name);
+            foreach (var directoryType in directoryTypes)
             {
-                imageServerServices.Add(service);
-            }
-            else
-            {
-                var escapedName = Uri.EscapeDataString(service.Metadata.Name);
+                // ImageServer availability additionally depends on a raster-store probe,
+                // so those entries are collected and probed concurrently below rather
+                // than emitted unconditionally here.
+                if (string.Equals(directoryType, ImageServerProtocolName, StringComparison.Ordinal))
+                {
+                    imageServerServices.Add(service);
+                    continue;
+                }
+
                 entries.Add(new ServiceDirectoryEntry
                 {
                     Name = service.Metadata.Name,
@@ -225,7 +238,31 @@ internal static class GeoservicesCatalogEndpoints
     }
 
     /// <summary>
-    /// Maps an Esri-family primary protocol to the directory-entry "type" string the
+    /// Maps every Esri-family protocol a service exposes to the directory-entry "type"
+    /// strings the GeoServices REST catalog advertises (FeatureServer, MapServer,
+    /// ImageServer, VectorTileServer, SceneServer), preserving the service's declared
+    /// protocol order and de-duplicating. A service reachable under several Esri types
+    /// is listed once per type, matching ArcGIS Services Directory semantics (#1853).
+    /// Non-Esri protocols (OGC API Features, STAC, OData, etc.) are skipped because they
+    /// are surfaced through their own catalogs.
+    /// </summary>
+    private static List<string> MapEsriDirectoryTypes(MetadataV2Service service)
+    {
+        var types = new List<string>();
+        foreach (var protocol in service.Protocols)
+        {
+            if (TryMapServiceType(protocol, out var directoryType) &&
+                !types.Contains(directoryType, StringComparer.Ordinal))
+            {
+                types.Add(directoryType);
+            }
+        }
+
+        return types;
+    }
+
+    /// <summary>
+    /// Maps an Esri-family protocol to the directory-entry "type" string the
     /// GeoServices REST catalog exposes (FeatureServer, MapServer, ImageServer,
     /// VectorTileServer). Returns false for non-Esri protocols (OGC API Features, STAC, etc.)
     /// which are surfaced through other catalogs.

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Catalog/GeoservicesCatalogServiceTypingTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Catalog/GeoservicesCatalogServiceTypingTests.cs
@@ -1,0 +1,196 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+using Honua.TestKit.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.Catalog;
+
+/// <summary>
+/// Regression tests for honua-server#1853 — the Esri REST Services Directory
+/// (<c>GET /rest/services</c>) must type each service from the Esri protocols it
+/// actually exposes: vector feature services as <c>FeatureServer</c>, raster/coverage
+/// services as <c>ImageServer</c> (or <c>MapServer</c> for rendered-map services), and
+/// a service reachable under multiple Esri types once per type — instead of flattening
+/// everything to <c>FeatureServer</c>.
+/// </summary>
+[Collection("Database.GeoServicesCatalog")]
+[Protocol(TestProtocols.GeoservicesCatalog)]
+public sealed class GeoservicesCatalogServiceTypingTests
+{
+    private const string VectorServiceName = "typing-vector";
+    private const string RasterServiceName = "typing-raster";
+    private const string MultiTypeServiceName = "typing-multi";
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services")]
+    public async Task GetServicesDirectory_RasterService_TypedAsImageServerNotFeatureServer()
+    {
+        var rasterStore = BuildRasterStoreWithRasters();
+
+        await using var fixture = await CreateFixtureAsync(rasterStore);
+
+        var services = await GetServicesByNameAsync(fixture, RasterServiceName);
+
+        // The raster service exposes only the ImageServer protocol, so it must NOT
+        // appear as a FeatureServer in the catalog (the #1853 mis-typing).
+        services.Should().NotBeEmpty();
+        services.Should().Contain(type => type == "ImageServer");
+        services.Should().NotContain(type => type == "FeatureServer");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services")]
+    public async Task GetServicesDirectory_VectorService_TypedAsFeatureServer()
+    {
+        var rasterStore = BuildRasterStoreWithRasters();
+
+        await using var fixture = await CreateFixtureAsync(rasterStore);
+
+        var services = await GetServicesByNameAsync(fixture, VectorServiceName);
+
+        services.Should().ContainSingle();
+        services.Should().Contain(type => type == "FeatureServer");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services")]
+    public async Task GetServicesDirectory_MultiProtocolService_ListedOncePerEsriType()
+    {
+        var rasterStore = BuildRasterStoreWithRasters();
+
+        await using var fixture = await CreateFixtureAsync(rasterStore);
+
+        var services = await GetServicesByNameAsync(fixture, MultiTypeServiceName);
+
+        // A service reachable as both FeatureServer and MapServer is listed once per
+        // type (Esri Services Directory semantics), not collapsed to its primary
+        // protocol only.
+        services.Should().Contain(type => type == "FeatureServer");
+        services.Should().Contain(type => type == "MapServer");
+    }
+
+    private static async Task<string[]> GetServicesByNameAsync(WebAppFixture fixture, string serviceName)
+    {
+        var response = await fixture.Client.GetAsync("/rest/services?f=json");
+        response.Be200Ok();
+
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return payload.RootElement
+            .GetProperty("services")
+            .EnumerateArray()
+            .Where(service =>
+                service.TryGetProperty("name", out var name) &&
+                string.Equals(name.GetString(), serviceName, StringComparison.Ordinal))
+            .Select(service => service.GetProperty("type").GetString()!)
+            .ToArray();
+    }
+
+    private static IRasterStore BuildRasterStoreWithRasters()
+    {
+        var rasterStore = Substitute.For<IRasterStore>();
+        rasterStore.ListRastersAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => Task.FromResult(new[]
+            {
+                new RasterInfo
+                {
+                    Id = 1,
+                    LayerId = callInfo.ArgAt<int>(0),
+                    Name = "typing-raster-tile",
+                    Width = 256,
+                    Height = 256,
+                    BandCount = 3,
+                    PixelType = "8BUI",
+                    Srid = 4326,
+                    CreatedAt = DateTimeOffset.UtcNow
+                }
+            }));
+        return rasterStore;
+    }
+
+    private static async Task<WebAppFixture> CreateFixtureAsync(IRasterStore rasterStore)
+    {
+        var provider = new TestMetadataV2GraphProvider(BuildTypingGraph());
+
+        var fixture = new WebAppFixture()
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IMetadataV2GraphProvider>();
+                services.RemoveAll<IMetadataV2GraphStore>();
+                services.AddSingleton(provider);
+                services.AddSingleton<IMetadataV2GraphProvider>(provider);
+                services.AddSingleton<IMetadataV2GraphStore>(provider);
+                services.AddSingleton(rasterStore);
+            });
+
+        await fixture.InitializeAsync();
+        return fixture;
+    }
+
+    private static MetadataV2Graph BuildTypingGraph()
+    {
+        var anonymous = new AccessPolicy { AllowAnonymous = true };
+        var builder = new TestMetadataV2GraphBuilder();
+
+        // Vector feature service -> FeatureServer.
+        builder
+            .AddResource("res-typing-vector", "Vector Layer", MetadataV2ResourceType.FeatureDataset,
+                spatial: PointSpatial(), accessPolicy: anonymous)
+            .AddService("svc-typing-vector", VectorServiceName,
+                protocols: [ServiceProtocols.FeatureServer], accessPolicy: anonymous)
+            .AddPublication("pub-typing-vector", "svc-typing-vector", "res-typing-vector",
+                layerIndex: 700, serviceLocalId: "700",
+                publicationType: MetadataV2PublicationType.EsriFeatureLayer);
+
+        // Raster/coverage service -> ImageServer (must not flatten to FeatureServer).
+        builder
+            .AddResource("res-typing-raster", "Raster Layer", MetadataV2ResourceType.RasterDataset,
+                accessPolicy: anonymous)
+            .AddService("svc-typing-raster", RasterServiceName,
+                protocols: [ServiceProtocols.ImageServer], accessPolicy: anonymous)
+            .AddPublication("pub-typing-raster", "svc-typing-raster", "res-typing-raster",
+                layerIndex: 701, serviceLocalId: "701",
+                publicationType: MetadataV2PublicationType.EsriImageLayer);
+
+        // Service reachable under multiple Esri types -> one entry per type.
+        builder
+            .AddResource("res-typing-multi", "Multi Layer", MetadataV2ResourceType.FeatureDataset,
+                spatial: PointSpatial(), accessPolicy: anonymous)
+            .AddService("svc-typing-multi", MultiTypeServiceName,
+                protocols: [ServiceProtocols.FeatureServer, ServiceProtocols.MapServer],
+                accessPolicy: anonymous)
+            .AddPublication("pub-typing-multi", "svc-typing-multi", "res-typing-multi",
+                layerIndex: 702, serviceLocalId: "702",
+                publicationType: MetadataV2PublicationType.EsriFeatureLayer);
+
+        return builder.Build();
+    }
+
+    private static MetadataV2ResourceSpatial PointSpatial()
+        => new()
+        {
+            GeometryType = MetadataV2GeometryType.Point,
+            SpatialReference = new MetadataV2SpatialReference
+            {
+                Srid = 4326,
+                Crs = "EPSG:4326",
+                IsGeographic = true
+            },
+            PrimaryGeometryField = "shape"
+        };
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerEditCapabilityAdvertisementTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerEditCapabilityAdvertisementTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+using Honua.TestKit.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
+
+/// <summary>
+/// Regression tests for honua-server#1852 — a FeatureServer published as editable must
+/// advertise <c>Create,Update,Delete</c> (plus <c>Editing</c>) in its <c>capabilities</c>
+/// string so Esri clients (ArcGIS Pro / JS API) surface their edit tools; a read-only
+/// service still advertises <c>Query</c> only. The advertised capabilities are driven by
+/// the publish-time service metadata (<c>service.Options["capabilities"]</c>), not a
+/// hardcoded value.
+/// </summary>
+[Protocol(TestProtocols.FeatureServer)]
+[Collection("Database")]
+public sealed class FeatureServerEditCapabilityAdvertisementTests
+{
+    private const string EditableServiceName = "editcaps-editable";
+    private const string ReadOnlyServiceName = "editcaps-readonly";
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer")]
+    public async Task GetServiceMetadata_EditableService_AdvertisesCreateUpdateDelete()
+    {
+        await using var fixture = await CreateFixtureAsync();
+
+        var capabilities = await GetServiceCapabilitiesAsync(fixture, EditableServiceName);
+
+        capabilities.Should().Contain("Query");
+        capabilities.Should().Contain("Create");
+        capabilities.Should().Contain("Update");
+        capabilities.Should().Contain("Delete");
+        capabilities.Should().Contain("Editing");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task GetLayerMetadata_EditableService_AdvertisesCreateUpdateDelete()
+    {
+        await using var fixture = await CreateFixtureAsync();
+
+        var capabilities = await GetLayerCapabilitiesAsync(fixture, EditableServiceName, layerId: 800);
+
+        capabilities.Should().Contain("Create");
+        capabilities.Should().Contain("Update");
+        capabilities.Should().Contain("Delete");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer")]
+    public async Task GetServiceMetadata_ReadOnlyService_AdvertisesQueryOnly()
+    {
+        await using var fixture = await CreateFixtureAsync();
+
+        var capabilities = await GetServiceCapabilitiesAsync(fixture, ReadOnlyServiceName);
+
+        capabilities.Should().Contain("Query");
+        capabilities.Should().NotContain("Create");
+        capabilities.Should().NotContain("Update");
+        capabilities.Should().NotContain("Delete");
+        capabilities.Should().NotContain("Editing");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task GetLayerMetadata_ReadOnlyService_AdvertisesQueryOnly()
+    {
+        await using var fixture = await CreateFixtureAsync();
+
+        var capabilities = await GetLayerCapabilitiesAsync(fixture, ReadOnlyServiceName, layerId: 801);
+
+        capabilities.Should().Contain("Query");
+        capabilities.Should().NotContain("Create");
+        capabilities.Should().NotContain("Update");
+        capabilities.Should().NotContain("Delete");
+    }
+
+    private static async Task<string[]> GetServiceCapabilitiesAsync(WebAppFixture fixture, string serviceName)
+    {
+        var response = await fixture.Client.GetAsync($"/rest/services/{serviceName}/FeatureServer?f=json");
+        var content = await response.Content.ReadAsStringAsync();
+        response.Be200Ok();
+
+        using var document = JsonDocument.Parse(content);
+        return ParseCapabilities(document.RootElement);
+    }
+
+    private static async Task<string[]> GetLayerCapabilitiesAsync(WebAppFixture fixture, string serviceName, int layerId)
+    {
+        var response = await fixture.Client.GetAsync($"/rest/services/{serviceName}/FeatureServer/{layerId}?f=json");
+        var content = await response.Content.ReadAsStringAsync();
+        response.Be200Ok();
+
+        using var document = JsonDocument.Parse(content);
+        return ParseCapabilities(document.RootElement);
+    }
+
+    private static string[] ParseCapabilities(JsonElement root)
+    {
+        root.TryGetProperty("capabilities", out var capabilities).Should().BeTrue();
+        return capabilities.GetString()!
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private static async Task<WebAppFixture> CreateFixtureAsync()
+    {
+        var provider = new TestMetadataV2GraphProvider(BuildGraph());
+
+        var fixture = new WebAppFixture()
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IMetadataV2GraphProvider>();
+                services.RemoveAll<IMetadataV2GraphStore>();
+                services.AddSingleton(provider);
+                services.AddSingleton<IMetadataV2GraphProvider>(provider);
+                services.AddSingleton<IMetadataV2GraphStore>(provider);
+            });
+
+        await fixture.InitializeAsync();
+        return fixture;
+    }
+
+    private static MetadataV2Graph BuildGraph()
+    {
+        var anonymous = new AccessPolicy { AllowAnonymous = true };
+        var builder = new TestMetadataV2GraphBuilder();
+
+        AddFeatureService(builder, "editable", EditableServiceName, layerId: 800, anonymous,
+            capabilities: ["Query", "Create", "Update", "Delete"]);
+        AddFeatureService(builder, "readonly", ReadOnlyServiceName, layerId: 801, anonymous,
+            capabilities: null);
+
+        return builder.Build();
+    }
+
+    private static void AddFeatureService(
+        TestMetadataV2GraphBuilder builder,
+        string key,
+        string serviceName,
+        int layerId,
+        AccessPolicy accessPolicy,
+        string[]? capabilities)
+    {
+        var resourceId = $"res-{key}";
+        var serviceId = $"svc-{key}";
+        var bindingId = $"binding-{key}";
+
+        builder
+            .AddResource(resourceId, $"{key} Layer", MetadataV2ResourceType.FeatureDataset,
+                fields:
+                [
+                    new MetadataV2Field { Name = "objectid", Type = MetadataV2FieldType.Integer, Nullable = false },
+                    new MetadataV2Field { Name = "name", Type = MetadataV2FieldType.String, Nullable = true, Length = 255 },
+                    new MetadataV2Field { Name = "shape", Type = MetadataV2FieldType.Geometry, Nullable = false }
+                ],
+                accessPolicy: accessPolicy,
+                spatial: new MetadataV2ResourceSpatial
+                {
+                    GeometryType = MetadataV2GeometryType.Point,
+                    SpatialReference = new MetadataV2SpatialReference
+                    {
+                        Srid = 4326,
+                        Crs = "EPSG:4326",
+                        IsGeographic = true
+                    },
+                    PrimaryGeometryField = "shape"
+                })
+            .AddStorageBinding(bindingId, resourceId, $"test.layers.{layerId}", storageLayerId: layerId)
+            .AddService(serviceId, serviceName,
+                protocols: [ServiceProtocols.FeatureServer],
+                accessPolicy: accessPolicy,
+                options: BuildServiceOptions(capabilities))
+            .AddPublication($"pub-{key}", serviceId, resourceId,
+                layerIndex: layerId, serviceLocalId: layerId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                storageBindingId: bindingId,
+                publicationType: MetadataV2PublicationType.EsriFeatureLayer);
+    }
+
+    private static Dictionary<string, JsonElement>? BuildServiceOptions(string[]? capabilities)
+    {
+        if (capabilities is null)
+        {
+            // No declared capabilities -> the builder defaults to Query (read-only),
+            // matching a service published without edit capability.
+            return null;
+        }
+
+        return new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+        {
+            ["capabilities"] = JsonSerializer.SerializeToElement(capabilities)
+        };
+    }
+}


### PR DESCRIPTION
## Summary
Two Esri-compat catalog/metadata fixes for the GeoServices REST surface.

## Changes Made
- **#1853 (catalog typing):** the GeoServices Services Directory now derives each service's `type` from every Esri-family protocol it exposes (`MapEsriDirectoryTypes`), listing the service once per type — raster/coverage services type as `ImageServer`/`MapServer` instead of being flattened to `FeatureServer`, and a service reachable under multiple Esri types appears once per type, mirroring a real ArcGIS Services Directory. Added literal-path integration tests for vector→FeatureServer, raster→ImageServer, and multi-protocol once-per-type.
- **#1852 (edit-capability advertisement):** the FeatureServer `capabilities` string is derived from publish-time service metadata (`service.Options["capabilities"]`) — an editable service advertises `Create,Update,Delete,Editing` (service- and layer-level), a read-only service advertises `Query` only, never a hardcoded value. Added literal-path integration tests pinning both the editable and read-only contracts at the service and layer metadata endpoints.

## Breaking Changes
None — Esri clients (ArcGIS Pro / JS API) now see correct service types in the catalog and, when a service is published as editable, the advertised edit tools.

> #1852 deploy note: the demo's `maui-parcels` showing `capabilities:"Query"` despite working `applyEdits` is a publish-config artifact (the service was published without editing capabilities) — it is resolved by re-publishing the layer as editable, which now flows through to the advertised capabilities correctly.

Related to #1852
Closes #1853

- [x] Pre-PR checks: Release build warnings-as-errors 0/0, `dotnet format --verify-no-changes` clean, new + existing catalog/capability + EndpointRegistry governance tests pass.