### PR TITLE
fix(geoservices): validateSQL accepts canonical esriSQLType* enum

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
@@ -1084,11 +1084,17 @@ internal static partial class FeatureServerEndpoints
         }
 
         // Esri's service-level sqlType is one of where|orderBy|expression. It defaults to
-        // `where` when omitted, matching the most common ArcGIS client usage.
+        // `where` when omitted, matching the most common ArcGIS client usage. Real ArcGIS
+        // clients send the canonical enum (esriSQLTypeWhere/OrderBy/Expression), so map those
+        // to the short forms while still accepting the short forms directly (#1858).
         var sqlType = GetValueString(values, "sqlType");
         if (string.IsNullOrWhiteSpace(sqlType))
         {
             sqlType = "where";
+        }
+        else
+        {
+            sqlType = NormalizeServiceSqlType(sqlType);
         }
 
         if (!IsSupportedServiceSqlType(sqlType))
@@ -1118,6 +1124,33 @@ internal static partial class FeatureServerEndpoints
         => string.Equals(sqlType, "where", StringComparison.OrdinalIgnoreCase)
            || string.Equals(sqlType, "orderBy", StringComparison.OrdinalIgnoreCase)
            || string.Equals(sqlType, "expression", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Maps the canonical Esri <c>sqlType</c> enum values
+    /// (<c>esriSQLTypeWhere</c>/<c>esriSQLTypeOrderBy</c>/<c>esriSQLTypeExpression</c>) that real
+    /// ArcGIS clients send to the short forms (<c>where</c>/<c>orderBy</c>/<c>expression</c>) the
+    /// rest of the pipeline uses. Short forms and any unrecognized value pass through unchanged so
+    /// the caller still validates them (#1858).
+    /// </summary>
+    private static string NormalizeServiceSqlType(string sqlType)
+    {
+        if (string.Equals(sqlType, "esriSQLTypeWhere", StringComparison.OrdinalIgnoreCase))
+        {
+            return "where";
+        }
+
+        if (string.Equals(sqlType, "esriSQLTypeOrderBy", StringComparison.OrdinalIgnoreCase))
+        {
+            return "orderBy";
+        }
+
+        if (string.Equals(sqlType, "esriSQLTypeExpression", StringComparison.OrdinalIgnoreCase))
+        {
+            return "expression";
+        }
+
+        return sqlType;
+    }
 
     /// <summary>
     /// Validates a SQL string for the given Esri <c>sqlType</c> against a layer schema.

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerMaintenanceTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerMaintenanceTests.cs
@@ -465,6 +465,56 @@ public sealed class FeatureServerMaintenanceTests : IAsyncLifetime
         document.RootElement.GetProperty("isValidSQL").GetBoolean().Should().BeTrue();
     }
 
+    // #1858: Real Esri clients send the canonical sqlType enum
+    // (esriSQLTypeWhere / esriSQLTypeOrderBy / esriSQLTypeExpression). These must be
+    // accepted in addition to the short forms.
+    [IntegrationTest]
+    [Operation(Operations.ValidateSql)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/validateSQL")]
+    public async Task ServiceValidateSql_EsriSqlTypeWhereEnum_ReturnsIsValid()
+    {
+        var content = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("sql", "objectid > 0"),
+            new KeyValuePair<string, string>("sqlType", "esriSQLTypeWhere"),
+            new KeyValuePair<string, string>("f", "json"),
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/validateSQL",
+            content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("isValidSQL").GetBoolean().Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ValidateSql)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/validateSQL")]
+    public async Task ServiceValidateSql_EsriSqlTypeOrderByEnum_ReturnsIsValid()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/validateSQL?sql={Uri.EscapeDataString("objectid DESC")}&sqlType=esriSQLTypeOrderBy&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("isValidSQL").GetBoolean().Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ValidateSql)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/validateSQL")]
+    public async Task ServiceValidateSql_EsriSqlTypeExpressionEnum_ReturnsIsValid()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/validateSQL?sql={Uri.EscapeDataString("objectid = 1")}&sqlType=esriSQLTypeExpression&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("isValidSQL").GetBoolean().Should().BeTrue();
+    }
+
     [IntegrationTest]
     [Operation(Operations.ValidateSql)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/validateSQL")]


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1858

## Summary
Service-level FeatureServer `validateSQL` rejected the canonical Esri `sqlType` enum values that real ArcGIS clients send (`esriSQLTypeWhere` / `esriSQLTypeOrderBy` / `esriSQLTypeExpression`), returning HTTP 400 "sqlType must be 'where', 'orderBy', or 'expression'." Only the short forms were accepted, so `validateSQL` was unusable from any genuine Esri client (FS-OP-VALIDATE-SQL). This maps the canonical enum to the short forms before validation while keeping the short forms working and still returning 400 on a genuinely invalid `sqlType`.

## Changes Made
- Added `NormalizeServiceSqlType` in `FeatureServerRequestHandlers.Maintenance.cs` mapping `esriSQLTypeWhere->where`, `esriSQLTypeOrderBy->orderBy`, `esriSQLTypeExpression->expression` (case-insensitive, unknown values pass through unchanged so they still 400).
- Applied the normalizer in `HandleServiceValidateSql` after the omitted-`sqlType` default, before `IsSupportedServiceSqlType`.
- Added integration tests for all three `esriSQLType*` enum values (200 + `isValidSQL: true`); existing tests cover short forms and the garbage-400 path.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
