### PR TITLE
feat(ai/mcp): live Bedrock-backed plan_analysis/execute over MCP, fixtures as fallback (#1884)

### DIFF
--- a/src/Honua.Ai/Features/AiBuilder/AiBuilderServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/AiBuilder/AiBuilderServiceCollectionExtensions.cs
@@ -3,6 +3,9 @@
 
 using Honua.Ai.AiBuilder.Fixtures;
 using Honua.Ai.AiBuilder.Planning;
+using Honua.Core.Features.WorkflowPackages.Generation;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Honua.Ai.AiBuilder;
@@ -25,16 +28,79 @@ internal static class AiBuilderServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Registers the default fixture-backed planner for AI-builder plan analysis.
-    /// Hosts can replace <see cref="IPlanAnalysisService"/> after calling this
-    /// method to wire a live planner implementation.
+    /// Registers the planner backing the <c>honua_plan_analysis</c> MCP tool.
+    /// Provider selection is config-driven and mirrors the
+    /// <c>WorkflowGeneration</c> provider-selection pattern: when AI workflow
+    /// generation is enabled (<c>WorkflowGeneration:Enabled=true</c>) with a live
+    /// (non-deterministic) default provider — for example AWS Bedrock — the live
+    /// <see cref="LivePlanAnalysisService"/> compiles arbitrary intents into
+    /// executable plans through the shared Bedrock seam. Otherwise the
+    /// deterministic <see cref="FixturePlanAnalysisService"/> remains in place so
+    /// CI and replay stay AI-credit-free. The fixture catalog is always
+    /// registered so the fallback path is available regardless.
     /// </summary>
-    public static IServiceCollection AddAiBuilderPlanAnalysis(this IServiceCollection services)
+    /// <remarks>
+    /// The live planner depends on the WorkflowGeneration services
+    /// (<c>IWorkflowGenerationService</c> / <c>IWorkflowNodeRegistry</c>); the
+    /// server composition registers those via <c>AddWorkflowGeneration</c>. Hosts
+    /// can still call <c>services.Replace(...)</c> after this method to force a
+    /// specific implementation.
+    /// </remarks>
+    public static IServiceCollection AddAiBuilderPlanAnalysis(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddAiBuilderFixtures();
+
+        if (ShouldUseLivePlanner(configuration))
+        {
+            services.TryAddSingleton<IPlanAnalysisService, LivePlanAnalysisService>();
+        }
+        else
+        {
+            services.TryAddSingleton<IPlanAnalysisService, FixturePlanAnalysisService>();
+        }
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the deterministic fixture-backed planner unconditionally. Kept
+    /// for tests and hosts that have no AI provider plumbing wired.
+    /// </summary>
+    public static IServiceCollection AddAiBuilderFixturePlanAnalysis(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddAiBuilderFixtures();
         services.TryAddSingleton<IPlanAnalysisService, FixturePlanAnalysisService>();
         return services;
+    }
+
+    /// <summary>
+    /// True when an AI workflow-generation provider is configured such that the
+    /// live plan lane should run instead of fixture replay: the feature is
+    /// enabled and the default provider id is a live provider (anything other
+    /// than the deterministic fixture provider).
+    /// </summary>
+    internal static bool ShouldUseLivePlanner(IConfiguration configuration)
+    {
+        var section = configuration.GetSection(WorkflowGenerationConfiguration.SectionName);
+        if (!section.GetValue<bool>("Enabled"))
+        {
+            return false;
+        }
+
+        var defaultProvider = (section.GetValue<string>("DefaultProvider")
+            ?? WorkflowGenerationConfiguration.LocalProviderId).Trim();
+
+        return defaultProvider.Length > 0
+            && !string.Equals(
+                defaultProvider,
+                WorkflowGenerationConfiguration.DeterministicProviderId,
+                StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Honua.Ai/Features/AiBuilder/Planning/LivePlanAnalysisLog.cs
+++ b/src/Honua.Ai/Features/AiBuilder/Planning/LivePlanAnalysisLog.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Ai.AiBuilder.Planning;
+
+/// <summary>
+/// Structured logging for the live (provider-backed) AI-builder plan analysis
+/// service. Event ID range: 6660-6669. Telemetry activities use the
+/// <c>honua.planner.*</c> shape.
+/// </summary>
+internal static partial class LivePlanAnalysisLog
+{
+    [LoggerMessage(
+        EventId = 6660,
+        Level = LogLevel.Information,
+        Message = "Live plan analysis compiled an executable plan (provider={Provider}, steps={StepCount})")]
+    public static partial void Planned(ILogger logger, string provider, int stepCount);
+}

--- a/src/Honua.Ai/Features/AiBuilder/Planning/LivePlanAnalysisService.cs
+++ b/src/Honua.Ai/Features/AiBuilder/Planning/LivePlanAnalysisService.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.WorkflowPackages.Abstractions;
+using Honua.Core.Features.WorkflowPackages.Domain;
+using Honua.Core.Features.WorkflowPackages.Generation.Abstractions;
+using Honua.Core.Features.WorkflowPackages.Generation.Domain;
+using Honua.ServiceDefaults;
+using Honua.Ai.Protocols.Mcp.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Ai.AiBuilder.Planning;
+
+/// <summary>
+/// Live implementation of <see cref="IPlanAnalysisService"/> backed by the
+/// <c>WorkflowGeneration</c> seam (<see cref="IWorkflowGenerationService"/> →
+/// the configured <see cref="IWorkflowGenerationProvider"/>, e.g. AWS Bedrock).
+/// Turns an arbitrary natural-language GIS intent into an executable analysis
+/// plan rather than matching a fixture, then hands the canonical
+/// <see cref="McpAnalysisPlanOutput"/> back to the MCP <c>honua_plan_analysis</c>
+/// tool so <c>validate_plan</c>/<c>dry_run_plan</c>/<c>execute_plan</c> operate on
+/// it unchanged downstream.
+/// </summary>
+/// <remarks>
+/// This service reuses the WorkflowGeneration orchestration wholesale: the
+/// node-registry grounding, the config-driven provider selection
+/// (<c>WorkflowGeneration:DefaultProvider</c>), and the hard validation gate all
+/// run inside <see cref="IWorkflowGenerationService.GenerateAsync"/>. The only
+/// new behaviour here is adapting the validated <see cref="WorkflowGraph"/> into
+/// the geoprocessing analysis-plan shape via <see cref="WorkflowGraphPlanMapper"/>
+/// and projecting the non-success turns (clarification / unsupported / refused)
+/// onto the plan-analysis envelope. Auth and the operation policy/approval gates
+/// are unchanged — they remain enforced by the MCP tool surface and the plan
+/// executor.
+/// </remarks>
+internal sealed class LivePlanAnalysisService : IPlanAnalysisService
+{
+    private readonly IWorkflowGenerationService _generationService;
+    private readonly IWorkflowNodeRegistry _nodeRegistry;
+    private readonly ILogger<LivePlanAnalysisService> _logger;
+
+    public LivePlanAnalysisService(
+        IWorkflowGenerationService generationService,
+        IWorkflowNodeRegistry nodeRegistry,
+        ILogger<LivePlanAnalysisService> logger)
+    {
+        _generationService = generationService;
+        _nodeRegistry = nodeRegistry;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<McpPlanAnalysisOutput> PlanAsync(
+        string intent,
+        JsonElement? context,
+        CancellationToken cancellationToken)
+    {
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("honua.planner.live");
+
+        var result = await _generationService
+            .GenerateAsync(new WorkflowGenerationRequest { Prompt = intent }, cancellationToken)
+            .ConfigureAwait(false);
+
+        activity?.SetTag("planner.provider", result.Provider);
+        activity?.SetTag("planner.status", result.Status.ToString());
+
+        var output = await ProjectAsync(intent, result, cancellationToken).ConfigureAwait(false);
+        output.Context = context;
+        return output;
+    }
+
+    private async Task<McpPlanAnalysisOutput> ProjectAsync(
+        string intent,
+        WorkflowGenerationResult result,
+        CancellationToken cancellationToken)
+    {
+        switch (result.Status)
+        {
+            case WorkflowGenerationStatus.Generated when result.Graph is not null:
+                {
+                    var nodeDefinitions = await BuildNodeIndexAsync(result.Graph, cancellationToken)
+                        .ConfigureAwait(false);
+                    var intentId = "intent-" + Math.Abs(intent.GetHashCode(StringComparison.Ordinal))
+                        .ToString(System.Globalization.CultureInfo.InvariantCulture);
+                    var planId = "plan-" + (result.RegistryVersion ?? "live");
+
+                    var plan = WorkflowGraphPlanMapper.ToAnalysisPlan(
+                        result.Graph, planId, intentId, nodeDefinitions);
+
+                    LivePlanAnalysisLog.Planned(_logger, result.Provider ?? "unknown", plan.Steps.Count);
+
+                    return new McpPlanAnalysisOutput
+                    {
+                        Status = "planned",
+                        Plan = plan,
+                        ContractVersion = result.RegistryVersion is null
+                            ? null
+                            : "honua.workflow_generation." + result.RegistryVersion
+                    };
+                }
+
+            case WorkflowGenerationStatus.NeedsClarification:
+                return new McpPlanAnalysisOutput
+                {
+                    Status = "clarification_required",
+                    Reason = result.Rationale ?? "The intent is ambiguous; clarification is required.",
+                    Clarification = MapClarification(result.Clarifications)
+                };
+
+            case WorkflowGenerationStatus.Unsupported:
+                return new McpPlanAnalysisOutput
+                {
+                    Status = "unsupported",
+                    Reason = result.Rationale ?? "The requested capability is not supported on this server.",
+                    CapabilityState = MapCapabilityState(result.CapabilityState)
+                };
+
+            default:
+                // Refused or Error: surface as a rejection with the provider rationale.
+                return new McpPlanAnalysisOutput
+                {
+                    Status = "rejected",
+                    Reason = result.Rationale ?? "The planner could not compile the intent into a plan."
+                };
+        }
+    }
+
+    private async Task<Dictionary<string, WorkflowNodeDefinition>> BuildNodeIndexAsync(
+        WorkflowGraph graph,
+        CancellationToken cancellationToken)
+    {
+        var index = new Dictionary<string, WorkflowNodeDefinition>(StringComparer.Ordinal);
+        foreach (var node in graph.Nodes)
+        {
+            if (index.ContainsKey(node.NodeTypeId))
+            {
+                continue;
+            }
+
+            var definition = await _nodeRegistry
+                .GetNodeAsync(node.NodeTypeId, cancellationToken)
+                .ConfigureAwait(false);
+            if (definition is not null)
+            {
+                index[node.NodeTypeId] = definition;
+            }
+        }
+
+        return index;
+    }
+
+    private static McpPlanAnalysisClarification MapClarification(
+        IReadOnlyList<WorkflowGenerationClarification> clarifications)
+    {
+        var candidates = new List<McpPlanAnalysisClarificationCandidate>(clarifications.Count);
+        foreach (var clarification in clarifications)
+        {
+            candidates.Add(new McpPlanAnalysisClarificationCandidate
+            {
+                Kind = clarification.Kind,
+                Field = clarification.Id,
+                Reason = clarification.Reason ?? clarification.Prompt,
+                Options = clarification.Choices.Select(choice => choice.Id).ToArray()
+            });
+        }
+
+        return new McpPlanAnalysisClarification { Candidates = candidates };
+    }
+
+    private static McpPlanAnalysisCapabilityState? MapCapabilityState(
+        WorkflowGenerationCapabilityState? capabilityState)
+    {
+        if (capabilityState is null)
+        {
+            return null;
+        }
+
+        return new McpPlanAnalysisCapabilityState
+        {
+            Name = capabilityState.Name,
+            State = capabilityState.State,
+            Reason = capabilityState.Reason
+        };
+    }
+}

--- a/src/Honua.Ai/Features/AiBuilder/Planning/WorkflowGraphPlanMapper.cs
+++ b/src/Honua.Ai/Features/AiBuilder/Planning/WorkflowGraphPlanMapper.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.WorkflowPackages.Domain;
+using Honua.Ai.Protocols.Mcp.Models;
+
+namespace Honua.Ai.AiBuilder.Planning;
+
+/// <summary>
+/// Pure mapping helpers that adapt a validated
+/// <see cref="WorkflowGraph"/> (the output of the
+/// <c>WorkflowGeneration</c> Bedrock seam) into the canonical
+/// <see cref="McpAnalysisPlanOutput"/> shape the MCP plan lane returns.
+/// Kept in one place so the live planner and unit tests pin the same contract
+/// translation, mirroring <see cref="AiBuilderScenarioMapper"/> for fixtures.
+/// </summary>
+/// <remarks>
+/// The two subsystems carry different plan models: the workflow-generation
+/// provider emits a node/edge graph keyed by registry <c>NodeTypeId</c>; the
+/// MCP <c>validate_plan</c>/<c>dry_run_plan</c>/<c>execute_plan</c> lane consumes
+/// an <see cref="Honua.Core.Features.Geoprocessing.Domain.AnalysisPlan"/> with
+/// steps keyed by <see cref="Honua.Core.Features.Geoprocessing.Domain.AnalysisPlanStepKind"/>.
+/// The bridge is that a registry node carries the canonical
+/// <see cref="WorkflowNodeDefinition.ProcessId"/> and a
+/// <see cref="WorkflowNodeRuntimeKind"/>, so each graph node maps deterministically
+/// to one analysis-plan step without re-prompting the model.
+/// </remarks>
+internal static class WorkflowGraphPlanMapper
+{
+    /// <summary>
+    /// Adapts a validated graph into the wire-format analysis plan. Edges feed
+    /// each step's <c>dependsOn</c>; node parameters become step inputs; the
+    /// node definition (when resolvable in <paramref name="nodeDefinitions"/>)
+    /// supplies the canonical process id and step kind.
+    /// </summary>
+    public static McpAnalysisPlanOutput ToAnalysisPlan(
+        WorkflowGraph graph,
+        string planId,
+        string intentId,
+        IReadOnlyDictionary<string, WorkflowNodeDefinition> nodeDefinitions)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        ArgumentNullException.ThrowIfNull(nodeDefinitions);
+
+        var dependsOn = BuildDependencyIndex(graph.Edges);
+
+        var steps = new List<McpAnalysisPlanStepOutput>(graph.Nodes.Count);
+        foreach (var node in graph.Nodes)
+        {
+            nodeDefinitions.TryGetValue(node.NodeTypeId, out var definition);
+
+            steps.Add(new McpAnalysisPlanStepOutput
+            {
+                StepId = node.NodeId,
+                Kind = MapStepKind(definition, node.NodeTypeId),
+                ProcessId = ResolveProcessId(definition, node.NodeTypeId),
+                DependsOn = dependsOn.TryGetValue(node.NodeId, out var deps)
+                    ? deps
+                    : [],
+                Inputs = node.Parameters.Count == 0
+                    ? new Dictionary<string, string>(StringComparer.Ordinal)
+                    : new Dictionary<string, string>(node.Parameters, StringComparer.Ordinal)
+            });
+        }
+
+        return new McpAnalysisPlanOutput
+        {
+            PlanId = planId,
+            IntentId = intentId,
+            Steps = steps,
+            Outputs = [],
+            Warnings = []
+        };
+    }
+
+    /// <summary>
+    /// Maps a node's runtime kind (and, when present, the canonical process id
+    /// it adapts) to the canonical <c>AnalysisPlanStepKind</c> string accepted
+    /// by <c>McpToolHelpers.ToDomainPlan</c>. Unknown or non-geoprocessing
+    /// runtime families fall through to <c>Geoprocess</c> so the wire output
+    /// never carries an invalid step kind.
+    /// </summary>
+    private static string MapStepKind(WorkflowNodeDefinition? definition, string nodeTypeId)
+    {
+        var runtimeKind = definition?.RuntimeKind ?? WorkflowNodeRuntimeKind.Geoprocessing;
+
+        return runtimeKind switch
+        {
+            WorkflowNodeRuntimeKind.Geoprocessing => MapGeoprocessingKind(definition, nodeTypeId),
+            // ETL and workflow-utility nodes adapt to the canonical Geoprocess
+            // step (the executor treats them as process invocations); query/
+            // render/export specialisations are derived from the node id below.
+            _ => MapGeoprocessingKind(definition, nodeTypeId)
+        };
+    }
+
+    // Derives the most specific analysis step kind from the node's category and
+    // type id. The workflow node registry uses dotted ids such as
+    // process:feature.query, process:geometry.buffer, process:map.render,
+    // process:export.geojson; we key off those stems so the plan executor
+    // schedules each step against the right runtime family.
+    private static string MapGeoprocessingKind(WorkflowNodeDefinition? definition, string nodeTypeId)
+    {
+        var probe = (nodeTypeId + " " + (definition?.Category ?? string.Empty)).ToLowerInvariant();
+
+        if (probe.Contains("query", StringComparison.Ordinal)
+            || probe.Contains("select", StringComparison.Ordinal)
+            || probe.Contains("filter", StringComparison.Ordinal))
+        {
+            return "QueryFeatures";
+        }
+
+        if (probe.Contains("aggregate", StringComparison.Ordinal)
+            || probe.Contains("summar", StringComparison.Ordinal)
+            || probe.Contains("statistic", StringComparison.Ordinal))
+        {
+            return "Aggregate";
+        }
+
+        if (probe.Contains("render", StringComparison.Ordinal)
+            || probe.Contains("map", StringComparison.Ordinal))
+        {
+            return "RenderMap";
+        }
+
+        if (probe.Contains("export", StringComparison.Ordinal)
+            || probe.Contains("package", StringComparison.Ordinal)
+            || probe.Contains("artifact", StringComparison.Ordinal))
+        {
+            return "Export";
+        }
+
+        return "Geoprocess";
+    }
+
+    private static string? ResolveProcessId(WorkflowNodeDefinition? definition, string nodeTypeId)
+    {
+        if (!string.IsNullOrWhiteSpace(definition?.ProcessId))
+        {
+            return definition!.ProcessId;
+        }
+
+        // The id convention is "<provider>:<process-id>"; when the node adapts a
+        // geoprocessing process but did not surface ProcessId explicitly, the
+        // suffix is the canonical process id the executor resolves.
+        var separator = nodeTypeId.IndexOf(':', StringComparison.Ordinal);
+        return separator >= 0 && separator < nodeTypeId.Length - 1
+            ? nodeTypeId[(separator + 1)..]
+            : null;
+    }
+
+    // Builds a TargetNodeId -> [SourceNodeId, ...] index so each step lists the
+    // upstream nodes it depends on, deduplicated and in graph edge order.
+    private static Dictionary<string, IReadOnlyList<string>> BuildDependencyIndex(
+        IReadOnlyList<WorkflowEdge> edges)
+    {
+        var pending = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var edge in edges)
+        {
+            if (string.IsNullOrEmpty(edge.TargetNodeId) || string.IsNullOrEmpty(edge.SourceNodeId))
+            {
+                continue;
+            }
+
+            if (!pending.TryGetValue(edge.TargetNodeId, out var sources))
+            {
+                sources = [];
+                pending[edge.TargetNodeId] = sources;
+            }
+
+            if (!sources.Contains(edge.SourceNodeId, StringComparer.Ordinal))
+            {
+                sources.Add(edge.SourceNodeId);
+            }
+        }
+
+        var index = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+        foreach (var (target, sources) in pending)
+        {
+            index[target] = sources;
+        }
+
+        return index;
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
@@ -40,12 +40,14 @@ internal static class McpServiceCollectionExtensions
 
         services.AddGroundingServices(configuration);
 
-        // PlanAnalysisTool uses the fixture-replay implementation of
-        // IPlanAnalysisService by default. Hosts wiring a live planner should
-        // call services.Replace(...) after AddMcpOperatorSurface to swap in
-        // their implementation; the catalog itself is harmless to keep around
-        // either way because it lazily loads embedded fixtures.
-        services.AddAiBuilderPlanAnalysis();
+        // PlanAnalysisTool resolves its IPlanAnalysisService config-driven:
+        // the live (Bedrock-backed) planner when WorkflowGeneration is enabled
+        // with a live default provider, otherwise the deterministic fixture
+        // replay. The fixture catalog is always registered as the fallback, so
+        // CI (no provider configured) stays AI-credit-free. Hosts can still call
+        // services.Replace(...) after AddMcpOperatorSurface to force a specific
+        // implementation.
+        services.AddAiBuilderPlanAnalysis(configuration);
 
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, ValidatePlanTool>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, DryRunPlanTool>());

--- a/tests/dotnet/Honua.Ai.Tests/Source/LivePlanAnalysisServiceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/LivePlanAnalysisServiceTests.cs
@@ -1,0 +1,335 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.WorkflowPackages.Abstractions;
+using Honua.Core.Features.WorkflowPackages.Domain;
+using Honua.Core.Features.WorkflowPackages.Generation;
+using Honua.Core.Features.WorkflowPackages.Generation.Abstractions;
+using Honua.Core.Features.WorkflowPackages.Generation.Domain;
+using Honua.Ai.AiBuilder;
+using Honua.Ai.AiBuilder.Planning;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.Ai.WorkflowGeneration;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Exercises the live (provider-backed) AI-builder plan lane that compiles an
+/// arbitrary natural-language intent into an executable analysis plan through the
+/// shared <c>WorkflowGeneration</c> Bedrock seam. The provider here is a FAKE
+/// <see cref="IWorkflowGenerationProvider"/> returning a canned graph — no live
+/// Bedrock/AI calls — so the live code path is proven deterministically in CI.
+/// </summary>
+[Protocol(TestProtocols.Mcp)]
+public sealed class LivePlanAnalysisServiceTests
+{
+    private const string BufferIntent =
+        "Buffer the Maui flood-hazard layer by 500 m and select intersecting parcels.";
+
+    [UnitTest]
+    public async Task PlanAsync_ArbitraryIntentNotInAnyFixture_ReturnsExecutablePlanViaLiveProvider()
+    {
+        var service = CreateLiveService(FakeProvider.Generated(CannedGraph()));
+
+        var output = await service.PlanAsync(BufferIntent, context: null, CancellationToken.None);
+
+        output.Status.Should().Be("planned");
+        output.Plan.Should().NotBeNull();
+        output.FixtureCase.Should().BeNullOrEmpty("the live path is not a fixture replay");
+
+        var stepIds = output.Plan!.Steps.Select(step => step.StepId).ToArray();
+        stepIds.Should().BeEquivalentTo(["buffer-flood", "select-parcels"]);
+
+        // The downstream MCP validate/dry-run/execute lane consumes the plan via
+        // McpToolHelpers.ToDomainPlan; proving that conversion succeeds proves the
+        // adapted graph is a real executable plan, not just a wire blob.
+        var domainPlan = ToDomainPlan(output.Plan!);
+        domainPlan.Steps.Should().HaveCount(2);
+        domainPlan.Steps[0].Kind.Should().Be(AnalysisPlanStepKind.Geoprocess);
+        domainPlan.Steps[0].ProcessId.Should().Be("geometry.buffer");
+        domainPlan.Steps[1].Kind.Should().Be(AnalysisPlanStepKind.QueryFeatures);
+        domainPlan.Steps[1].DependsOn.Should().Contain("buffer-flood");
+    }
+
+    [UnitTest]
+    public async Task PlanAsync_ProviderNeedsClarification_ReturnsClarificationRequired()
+    {
+        var clarifications = new[]
+        {
+            new WorkflowGenerationClarification
+            {
+                Id = "source",
+                Kind = "source",
+                Prompt = "Which flood-hazard layer?",
+                Choices =
+                [
+                    new WorkflowGenerationClarificationChoice { Id = "maui", Label = "Maui flood hazard" }
+                ]
+            }
+        };
+        var service = CreateLiveService(FakeProvider.Clarification(clarifications));
+
+        var output = await service.PlanAsync(BufferIntent, context: null, CancellationToken.None);
+
+        output.Status.Should().Be("clarification_required");
+        output.Plan.Should().BeNull();
+        output.Clarification!.Candidates.Select(c => c.Kind).Should().Contain("source");
+    }
+
+    [UnitTest]
+    public async Task PlanAsync_ProviderUnsupported_ReturnsUnsupportedWithCapabilityState()
+    {
+        var service = CreateLiveService(FakeProvider.Unsupported("spatialJoin"));
+
+        var output = await service.PlanAsync(BufferIntent, context: null, CancellationToken.None);
+
+        output.Status.Should().Be("unsupported");
+        output.Plan.Should().BeNull();
+        output.CapabilityState!.Name.Should().Be("spatialJoin");
+    }
+
+    [UnitTest]
+    public async Task PlanAsync_EchoesContextBackUnchanged()
+    {
+        var service = CreateLiveService(FakeProvider.Generated(CannedGraph()));
+        var context = McpTestFactory.ParseJson("""{"correlationId":"abc-123"}""");
+
+        var output = await service.PlanAsync(BufferIntent, context, CancellationToken.None);
+
+        output.Context.Should().NotBeNull();
+        output.Context!.Value.GetProperty("correlationId").GetString().Should().Be("abc-123");
+    }
+
+    [UnitTest]
+    public void ShouldUseLivePlanner_NoProviderConfigured_IsFalse()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        AiBuilderServiceCollectionExtensions.ShouldUseLivePlanner(configuration).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void ShouldUseLivePlanner_DisabledWithBedrockDefault_IsFalse()
+    {
+        var configuration = BuildConfiguration(enabled: false, defaultProvider: "bedrock");
+
+        AiBuilderServiceCollectionExtensions.ShouldUseLivePlanner(configuration).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void ShouldUseLivePlanner_EnabledWithDeterministicDefault_IsFalse()
+    {
+        var configuration = BuildConfiguration(enabled: true, defaultProvider: "deterministic");
+
+        AiBuilderServiceCollectionExtensions.ShouldUseLivePlanner(configuration).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void ShouldUseLivePlanner_EnabledWithBedrockDefault_IsTrue()
+    {
+        var configuration = BuildConfiguration(enabled: true, defaultProvider: "bedrock");
+
+        AiBuilderServiceCollectionExtensions.ShouldUseLivePlanner(configuration).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void AddAiBuilderPlanAnalysis_NoProvider_ResolvesFixturePlanner()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAiBuilderPlanAnalysis(new ConfigurationBuilder().Build());
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IPlanAnalysisService>()
+            .Should().BeOfType<FixturePlanAnalysisService>();
+    }
+
+    [UnitTest]
+    public void AddAiBuilderPlanAnalysis_BedrockConfigured_ResolvesLivePlanner()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Live planner dependencies (normally registered by AddWorkflowGeneration /
+        // AddWorkflowPackages in the server composition).
+        services.AddSingleton(Substitute.For<IWorkflowGenerationService>());
+        services.AddSingleton(Substitute.For<IWorkflowNodeRegistry>());
+
+        services.AddAiBuilderPlanAnalysis(BuildConfiguration(enabled: true, defaultProvider: "bedrock"));
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IPlanAnalysisService>()
+            .Should().BeOfType<LivePlanAnalysisService>();
+    }
+
+    // Builds the live service over the REAL WorkflowGenerationService so the test
+    // exercises the full seam (provider selection + node-registry grounding + the
+    // hard validation gate), with only the provider faked.
+    private static LivePlanAnalysisService CreateLiveService(IWorkflowGenerationProvider fakeProvider)
+    {
+        var registry = Substitute.For<IWorkflowNodeRegistry>();
+        registry.GetSnapshotAsync(Arg.Any<CancellationToken>()).Returns(Snapshot());
+        foreach (var node in Snapshot().Nodes)
+        {
+            registry.GetNodeAsync(node.NodeTypeId, Arg.Any<CancellationToken>()).Returns(node);
+        }
+
+        var generationService = new WorkflowGenerationService(
+            new[] { fakeProvider },
+            registry,
+            Options.Create(new WorkflowGenerationConfiguration
+            {
+                Enabled = true,
+                DefaultProvider = "bedrock"
+            }),
+            NullLogger<WorkflowGenerationService>.Instance);
+
+        return new LivePlanAnalysisService(
+            generationService,
+            registry,
+            NullLogger<LivePlanAnalysisService>.Instance);
+    }
+
+    private static WorkflowGraph CannedGraph() => new()
+    {
+        Nodes =
+        [
+            new WorkflowNode
+            {
+                NodeId = "buffer-flood",
+                NodeTypeId = "process:geometry.buffer",
+                Parameters = new Dictionary<string, string> { ["distance"] = "500", ["unit"] = "meters" }
+            },
+            new WorkflowNode
+            {
+                NodeId = "select-parcels",
+                NodeTypeId = "process:feature.query"
+            }
+        ],
+        Edges =
+        [
+            new WorkflowEdge { SourceNodeId = "buffer-flood", TargetNodeId = "select-parcels" }
+        ]
+    };
+
+    // Registry snapshot carrying the canned graph's node types so the graph passes
+    // the validation gate; the buffer node surfaces a canonical ProcessId.
+    private static WorkflowNodeRegistrySnapshot Snapshot() => new()
+    {
+        RegistryVersion = "test-registry-live",
+        GeneratedAt = DateTimeOffset.UnixEpoch,
+        Providers = [],
+        Nodes =
+        [
+            Node("process:geometry.buffer", "geometry.buffer", WorkflowNodeRuntimeKind.Geoprocessing, "transform"),
+            Node("process:feature.query", processId: null, WorkflowNodeRuntimeKind.Geoprocessing, "query")
+        ]
+    };
+
+    private static WorkflowNodeDefinition Node(
+        string nodeTypeId,
+        string? processId,
+        WorkflowNodeRuntimeKind runtimeKind,
+        string category) => new()
+        {
+            NodeTypeId = nodeTypeId,
+            ProviderId = "test",
+            RuntimeKind = runtimeKind,
+            Title = nodeTypeId,
+            Description = nodeTypeId,
+            Category = category,
+            ParameterSchemas = [],
+            CapabilityFlags = new WorkflowNodeCapabilityFlags { Executable = true },
+            RuntimeHints = new WorkflowNodeRuntimeHints(),
+            ProcessId = processId
+        };
+
+    private static IConfiguration BuildConfiguration(bool enabled, string defaultProvider) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["WorkflowGeneration:Enabled"] = enabled ? "true" : "false",
+                ["WorkflowGeneration:DefaultProvider"] = defaultProvider
+            })
+            .Build();
+
+    private static AnalysisPlan ToDomainPlan(McpAnalysisPlanOutput plan)
+    {
+        var input = new McpPlanInput
+        {
+            PlanId = plan.PlanId,
+            IntentId = plan.IntentId,
+            Steps = plan.Steps.Select(step => new McpPlanStepInput
+            {
+                StepId = step.StepId,
+                Kind = step.Kind,
+                ProcessId = step.ProcessId,
+                DependsOn = step.DependsOn.ToList(),
+                Inputs = new Dictionary<string, string>(step.Inputs)
+            }).ToList(),
+            Outputs = [],
+            Warnings = plan.Warnings.ToList()
+        };
+
+        return McpToolHelpers.ToDomainPlan(input);
+    }
+
+    /// <summary>
+    /// Fake provider that returns a canned proposal — stands in for the Bedrock
+    /// provider so the live path runs without any AI call.
+    /// </summary>
+    private sealed class FakeProvider : IWorkflowGenerationProvider
+    {
+        private readonly WorkflowGenerationProposal _proposal;
+
+        private FakeProvider(WorkflowGenerationProposal proposal) => _proposal = proposal;
+
+        public string ProviderId => "bedrock";
+
+        public bool IsConfigured => true;
+
+        public Task<WorkflowGenerationProposal> GenerateAsync(
+            WorkflowGenerationProviderRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(_proposal);
+
+        public static FakeProvider Generated(WorkflowGraph graph) => new(new WorkflowGenerationProposal
+        {
+            Status = WorkflowGenerationStatus.Generated,
+            Graph = graph,
+            ProviderId = "bedrock",
+            Model = "fake-model"
+        });
+
+        public static FakeProvider Clarification(IReadOnlyList<WorkflowGenerationClarification> clarifications)
+            => new(new WorkflowGenerationProposal
+            {
+                Status = WorkflowGenerationStatus.NeedsClarification,
+                Clarifications = clarifications,
+                ProviderId = "bedrock"
+            });
+
+        public static FakeProvider Unsupported(string capability) => new(new WorkflowGenerationProposal
+        {
+            Status = WorkflowGenerationStatus.Unsupported,
+            CapabilityState = new WorkflowGenerationCapabilityState
+            {
+                Name = capability,
+                State = "unsupported"
+            },
+            UnmappedRequests = [capability],
+            ProviderId = "bedrock"
+        });
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1884

## Summary
Wires the MCP `honua_plan_analysis` / `honua_execute_plan` (AiBuilder) lane to the live AI provider so an AI client over MCP can compile and run a real GIS analysis from an **arbitrary** natural-language intent. Today the lane runs on the fixture-based `FixturePlanAnalysisService`, which rejects anything without an embedded fixture (`"No AI-builder fixture matches the supplied intent."`). This reuses the existing `WorkflowGeneration` Bedrock seam (already validated on Demo A) for the MCP plan lane, while keeping the fixtures as the deterministic CI/replay fallback.

The two subsystems carry different plan models — the WorkflowGeneration provider emits a node/edge `WorkflowGraph` keyed by registry `NodeTypeId`; the MCP plan lane consumes a geoprocessing `AnalysisPlan` keyed by `AnalysisPlanStepKind`. The seam reused is the **provider/orchestration** (`IWorkflowGenerationService` → `IWorkflowGenerationProvider` Bedrock), and a small pure adapter (`WorkflowGraphPlanMapper`) bridges the validated graph into the analysis-plan shape. A registry node already carries the canonical `ProcessId` and a `RuntimeKind`, so each graph node maps deterministically to one analysis-plan step without a second AI client or a parallel plan model.

## Changes Made
- Add `LivePlanAnalysisService` (`IPlanAnalysisService`) backed by `IWorkflowGenerationService.GenerateAsync` — reuses the node-registry grounding, config-driven provider selection, and the hard validation gate; adapts the validated graph to `McpAnalysisPlanOutput` and projects non-success provider turns (`needs-clarification`→`clarification_required`, `unsupported`→`unsupported`, refused/error→`rejected`).
- Add `WorkflowGraphPlanMapper`: pure graph→plan adapter (`NodeId`→`StepId`, `NodeTypeId`/`ProcessId` + `RuntimeKind`→`AnalysisPlanStepKind`, `Parameters`→`Inputs`, incoming `Edges`→`DependsOn`). The plan/validate/dry-run/execute contract is unchanged downstream (`McpToolHelpers.ToDomainPlan` consumes it as-is).
- Config-driven selection in `AddAiBuilderPlanAnalysis(IConfiguration)`: live planner when `WorkflowGeneration:Enabled=true` with a live (non-`deterministic`) `DefaultProvider`; otherwise the fixture planner. Mirrors the WorkflowGeneration provider-selection pattern. Fixtures are never removed (`AddAiBuilderFixturePlanAnalysis` kept for tests/hosts without AI plumbing).
- `PlanAnalysisTool` and `ExecutePlanTool` are untouched — they keep resolving `IPlanAnalysisService`, so auth + the operation policy/approval gates are preserved (no bypass of `propose_operation`/approval semantics).
- Tests in `Honua.Ai.Tests` using a **FAKE** `IWorkflowGenerationProvider` (no real Bedrock in CI): live path compiles an unfixtured intent into an executable plan (and that plan round-trips through `ToDomainPlan`); clarification/unsupported projection; config-selection (`ShouldUseLivePlanner`) and DI-resolution (fixture vs live) coverage.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires environment variable or secret changes

**Config to light up the live lane on the demo** (additive — defaults keep fixtures):
- `WorkflowGeneration__Enabled=true`
- `WorkflowGeneration__DefaultProvider=bedrock`
- `WorkflowGeneration__Providers__bedrock__Model=<bedrock model id>` (e.g. an Anthropic Claude model id on Bedrock)
- `WorkflowGeneration__Providers__bedrock__Region=us-west-2` (optional; defaults to `us-west-2`)

The demo Lambda already sets `WorkflowGeneration__Enabled=true` / `WorkflowGeneration__DefaultProvider=bedrock`, so the MCP plan lane inherits the live builder on redeploy. With no provider configured (CI default), the lane stays on `FixturePlanAnalysisService` and makes **no** Bedrock calls.

## Breaking Changes
None — additive. Fixture behavior is preserved as the default/fallback when no live AI provider is configured.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

> Note: `Honua.Ai` build (Release, warnings-as-errors) is 0/0; new + existing AiBuilder/WorkflowGeneration/MCP tests pass; `dotnet format` clean on the changed set. The only red in the Architecture suite is a **pre-existing trunk drift** unrelated to this PR — `POST /rest/services/{serviceId}/FeatureServer/query` (GeoServices, added by #1847/#1885) is missing from `EndpointRegistry.All`; this PR adds no new HTTP endpoints.
