### PR TITLE
fix(geoservices): track service-level query POST routes and scope resultRecordCount clamp

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureQueryValidator.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureQueryValidator.cs
@@ -26,6 +26,14 @@ internal sealed class FeatureQueryValidator : IFeatureQueryValidator
             ClampLimitToMaximum = true
         };
 
+    // queryRelatedRecords keeps the stricter contract: an over-maximum resultRecordCount
+    // is rejected with a 400 ("Query parameters exceed configured limits") rather than
+    // silently clamped. The clamp above is intentionally scoped to the primary feature
+    // query operation (honua-server#1825); the related-records executor does not emit
+    // exceededTransferLimit paging, so a silent cap there would hide truncation.
+    private static readonly PaginationValidationOptions _relatedRecordsPagination =
+        new(MinOffset: 0, MinLimit: 1, OffsetParameterName: "resultOffset", LimitParameterName: "resultRecordCount");
+
     public FeatureQueryValidator(ICommonQueryValidator commonQueryValidator)
     {
         _commonQueryValidator = commonQueryValidator ?? throw new ArgumentNullException(nameof(commonQueryValidator));
@@ -109,7 +117,7 @@ internal sealed class FeatureQueryValidator : IFeatureQueryValidator
         var paginationResult = _commonQueryValidator.ValidateAndNormalizePagination(
             queryParams.ResultOffset,
             queryParams.ResultRecordCount,
-            _featureQueryPagination);
+            _relatedRecordsPagination);
         if (!paginationResult.IsValid)
         {
             return RelatedRecordsValidationResult.Invalid(paginationResult.ErrorMessage ?? "Invalid record count.");

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -658,6 +658,9 @@ public static class EndpointRegistry
         new("GET", "/rest/services/{serviceId}/FeatureServer/{layerId}/query"),
         new("POST", "/rest/services/{serviceId}/FeatureServer/{layerId}/query"),
         new("GET", "/rest/services/{serviceId}/FeatureServer/query"),
+        // Esri clients POST large layerDefs/layers arrays that exceed URL limits, so the
+        // service-level query operation accepts both GET and POST (#1825).
+        new("POST", "/rest/services/{serviceId}/FeatureServer/query"),
         new("POST", "/rest/services/{serviceId}/FeatureServer/applyEdits"),
         new("POST", "/rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits"),
         new("POST", "/rest/services/{serviceId}/FeatureServer/{layerId}/addFeatures"),
@@ -693,6 +696,8 @@ public static class EndpointRegistry
         new("GET", "/rest/services/{serviceId}/FeatureServer/{layerId}/calculate"),
         new("POST", "/rest/services/{serviceId}/FeatureServer/{layerId}/calculate"),
         new("GET", "/rest/services/{serviceId}/FeatureServer/queryDomains"),
+        // queryDomains also accepts POST so clients can submit large layers arrays (#1825).
+        new("POST", "/rest/services/{serviceId}/FeatureServer/queryDomains"),
         new("GET", "/rest/services/{serviceId}/FeatureServer/relationships"),
         new("GET", "/rest/services/{serviceId}/FeatureServer/validateSQL"),
         new("POST", "/rest/services/{serviceId}/FeatureServer/validateSQL"),
@@ -837,6 +842,8 @@ public static class EndpointRegistry
         new("GET", "/rest/services/{serviceId}/MapServer/allLayersAndTables"),
         new("GET", "/rest/services/{serviceId}/MapServer/layers"),
         new("GET", "/rest/services/{serviceId}/MapServer/queryDomains"),
+        // queryDomains also accepts POST so clients can submit large layers arrays (#1825).
+        new("POST", "/rest/services/{serviceId}/MapServer/queryDomains"),
         new("GET", "/rest/services/{serviceId}/MapServer/dynamicLayer"),
         new("GET", "/rest/services/{serviceId}/MapServer/generateRenderer"),
         new("POST", "/rest/services/{serviceId}/MapServer/generateRenderer"),

--- a/tests/dotnet/Honua.Server.Tests/LimitsEnforcementTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/LimitsEnforcementTests.cs
@@ -97,45 +97,41 @@ public sealed class LimitsEnforcementTests : IAsyncLifetime
 
     #region Query Limits Enforcement
 
+    // honua-server#1825: a resultRecordCount above maxRecordCount is silently capped to
+    // maxRecordCount (the page is returned with exceededTransferLimit:true) rather than
+    // rejected with a 400, matching ArcGIS. Under/at the limit return the page normally;
+    // over the limit clamps. Offsets are still hard-rejected (see QueryGet_OffsetLimit).
     [Theory]
     [Operation(Operations.Query)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
-    [InlineData(99, true)]   // Under limit
-    [InlineData(100, true)]  // At limit
-    [InlineData(101, false)] // Over limit
-    public async Task QueryGet_RecordCountLimit_EnforcedCorrectly(int requestedCount, bool shouldSucceed)
+    [InlineData(99)]   // Under limit
+    [InlineData(100)]  // At limit
+    [InlineData(101)]  // Over limit — clamped to maxRecordCount
+    public async Task QueryGet_RecordCountLimit_EnforcedCorrectly(int requestedCount)
     {
         // Act
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?resultRecordCount={requestedCount}&f=json");
 
         // Assert
-        if (shouldSucceed)
-        {
-            response.Be200Ok();
-            var content = await response.Content.ReadAsStringAsync();
-            content.Should().NotBeNullOrEmpty();
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().NotBeNullOrEmpty();
 
-            var queryResponse = JsonSerializer.Deserialize<QueryResponse>(
-                content, FeatureServerJsonContext.Default.QueryResponse);
-            queryResponse.Should().NotBeNull();
-        }
-        else
-        {
-            response.Be400BadRequest();
-            var content = await response.Content.ReadAsStringAsync();
-            content.Should().Contain("exceed configured limits");
-            content.Should().Contain("Maximum record count: 100");
-        }
+        var queryResponse = JsonSerializer.Deserialize<QueryResponse>(
+            content, FeatureServerJsonContext.Default.QueryResponse);
+        queryResponse.Should().NotBeNull();
     }
 
+    // honua-server#1825: as with GET, an over-maximum resultRecordCount on POST query is
+    // clamped to maxRecordCount and the page returned, not rejected with a 400.
     [Theory]
     [Operation(Operations.Query)]
     [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
-    [InlineData(99, true)]   // Under limit
-    [InlineData(100, true)]  // At limit
-    [InlineData(101, false)] // Over limit
-    public async Task QueryPost_RecordCountLimit_EnforcedCorrectly(int requestedCount, bool shouldSucceed)
+    [InlineData(99)]   // Under limit
+    [InlineData(100)]  // At limit
+    [InlineData(101)]  // Over limit — clamped to maxRecordCount
+    public async Task QueryPost_RecordCountLimit_EnforcedCorrectly(int requestedCount)
     {
         // Arrange
         var queryParams = new QueryParameters
@@ -153,23 +149,13 @@ public sealed class LimitsEnforcementTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query", content);
 
         // Assert
-        if (shouldSucceed)
-        {
-            response.Be200Ok();
-            var responseContent = await response.Content.ReadAsStringAsync();
-            responseContent.Should().NotBeNullOrEmpty();
+        response.Be200Ok();
+        var responseContent = await response.Content.ReadAsStringAsync();
+        responseContent.Should().NotBeNullOrEmpty();
 
-            var queryResponse = JsonSerializer.Deserialize<QueryResponse>(
-                responseContent, FeatureServerJsonContext.Default.QueryResponse);
-            queryResponse.Should().NotBeNull();
-        }
-        else
-        {
-            response.Be400BadRequest();
-            var responseContent = await response.Content.ReadAsStringAsync();
-            responseContent.Should().Contain("exceed configured limits");
-            responseContent.Should().Contain("Maximum record count: 100");
-        }
+        var queryResponse = JsonSerializer.Deserialize<QueryResponse>(
+            responseContent, FeatureServerJsonContext.Default.QueryResponse);
+        queryResponse.Should().NotBeNull();
     }
 
     [Theory]


### PR DESCRIPTION
## Related Issue

Related to #1825 (follow-up regressions from #1847)

## Summary

PR #1847 (#1825) added POST handlers for the service-level `FeatureServer/query`, `FeatureServer/queryDomains`, and `MapServer/queryDomains` routes and switched the primary feature-query path to **clamp** an over-maximum `resultRecordCount` to `maxRecordCount` (returning the page with `exceededTransferLimit:true`) instead of rejecting it with a 400. It left three regressions that fail the PR gate on every branch rebased past it (observed on #1842, #1843, and #1819's lineage):

- `EndpointRegistryDriftTests.AllDeployedEndpoints_AreTrackedInRegistry` (STAC and API Governance shard) failed on `POST /rest/services/{serviceId}/FeatureServer/query` — the new POST routes were deployed but never added to `EndpointRegistry.All`.
- `QueryRelatedRecordsEndpointTests.QueryRelatedRecords_WithExcessiveResultRecordCount_Returns400` (Core shard) failed — the clamp was applied through a shared `PaginationValidationOptions` instance that `queryRelatedRecords` also consumes, silently changing its contract.
- `LimitsEnforcementTests.QueryGet/QueryPost_RecordCountLimit_EnforcedCorrectly` (Core shard) failed — they still asserted the old 400 behavior for the primary query path.

## Changes Made

- Register `POST /rest/services/{serviceId}/FeatureServer/query`, `POST /rest/services/{serviceId}/FeatureServer/queryDomains`, and `POST /rest/services/{serviceId}/MapServer/queryDomains` in `EndpointRegistry.All` (their HTTP-backing integration tests already exist).
- Give `queryRelatedRecords` its own non-clamping `PaginationValidationOptions` so an over-maximum `resultRecordCount` is still rejected with 400; keep the clamp scoped to the primary feature-query path.
- Update `LimitsEnforcementTests` over-maximum `resultRecordCount` cases to expect the intended clamp-to-maximum behavior, matching `Query_WithResultRecordCountAboveMaxRecordCount_ClampsInsteadOfBadRequest`.

## Breaking Changes

None.

## Gate Impact

- [x] No gate-tier change (fixes a regression so the existing gate passes)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Verified locally with Docker (Testcontainers + PostGIS) on a clean `origin/trunk` worktree:
- `EndpointRegistryDriftTests` + `QueryRelatedRecordsEndpointTests`: 39/39 passed.
- `LimitsEnforcementTests`: 17/17 passed.
