### PR TITLE
ci: run merge train + flaky-rerun under a workflow-scoped token (#1855)

### DIFF
--- a/.github/workflows/auto-rerun-flaky.yml
+++ b/.github/workflows/auto-rerun-flaky.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - uses: actions/github-script@v9
         with:
+          github-token: ${{ secrets.MERGE_TRAIN_TOKEN }}
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
             const run = context.payload.workflow_run;

--- a/.github/workflows/pr-merge-train.yml
+++ b/.github/workflows/pr-merge-train.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
       - uses: actions/github-script@v9
         with:
+          # Workflow-scoped token so the train can update-branch / merge PRs whose
+          # delta touches .github/workflows/** (GITHUB_TOKEN is forbidden from that).
+          github-token: ${{ secrets.MERGE_TRAIN_TOKEN }}
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
             const sleep = ms => new Promise(r => setTimeout(r, ms));


### PR DESCRIPTION
## Summary
Pass `MERGE_TRAIN_TOKEN` (a workflow-scoped token, already stored as a repo secret) to the `actions/github-script` steps in `pr-merge-train.yml` and `auto-rerun-flaky.yml`, so the train can update-branch/merge PRs that touch `.github/workflows/**` — which the built-in GITHUB_TOKEN is forbidden from doing. This removes the recurring stall where a merged workflow PR left every open PR behind-by-a-workflow-commit until a human swept them.

## Changes Made
- `pr-merge-train.yml` + `auto-rerun-flaky.yml`: `github-token: ${{ secrets.MERGE_TRAIN_TOKEN }}` on the github-script step.

## Breaking Changes
None — CI automation. The token is repo-scoped via the secret.

Closes #1855

- [x] Pre-PR checks delegated to CI