### PR TITLE
fix(controlplane): resolve IAuditLog via scope factory so OperationGateway isn't a captive dependency

### DIFF
--- a/src/Honua.Server/Features/ControlPlane/OperationGateway.cs
+++ b/src/Honua.Server/Features/ControlPlane/OperationGateway.cs
@@ -6,6 +6,7 @@ using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Guardrails.Abstractions;
 using Honua.Core.Features.Guardrails.Domain;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.ControlPlane;
 
@@ -21,7 +22,7 @@ internal sealed partial class OperationGateway : IOperationGateway
     private readonly IGuardrailLadder _ladder;
     private readonly IOperationProposalStore _proposalStore;
     private readonly Dictionary<OperationClass, IOperationExecutor> _executors;
-    private readonly IAuditLog _auditLog;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly IProposalNotifier _notifier;
     private readonly ILogger<OperationGateway> _logger;
 
@@ -29,7 +30,7 @@ internal sealed partial class OperationGateway : IOperationGateway
         IGuardrailLadder ladder,
         IOperationProposalStore proposalStore,
         IEnumerable<IOperationExecutor> executors,
-        IAuditLog auditLog,
+        IServiceScopeFactory scopeFactory,
         IProposalNotifier notifier,
         ILogger<OperationGateway> logger)
     {
@@ -37,7 +38,7 @@ internal sealed partial class OperationGateway : IOperationGateway
         _ladder = ladder;
         _proposalStore = proposalStore;
         _executors = executors.ToDictionary(executor => executor.OperationClass);
-        _auditLog = auditLog;
+        _scopeFactory = scopeFactory;
         _notifier = notifier;
         _logger = logger;
     }
@@ -286,13 +287,21 @@ internal sealed partial class OperationGateway : IOperationGateway
         ExecutionPayload = proposal.Plan.ExecutionPayload,
     };
 
-    private Task WriteAuditAsync(
+    // The gateway is a singleton but IAuditLog is scoped (PostgresAuditLog needs a
+    // per-operation DB connection), so resolve it from a fresh scope per audit write
+    // rather than capturing it as a constructor dependency. Capturing the scoped
+    // service would be a captive dependency and fails DI scope validation at startup
+    // under the durable control-plane path (honua-server#1908).
+    private async Task WriteAuditAsync(
         OperationProposal proposal,
         string action,
         string actor,
         AuditOutcome outcome,
         CancellationToken cancellationToken)
-        => _auditLog.RecordAsync(
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var auditLog = scope.ServiceProvider.GetRequiredService<IAuditLog>();
+        await auditLog.RecordAsync(
             new AuditEvent
             {
                 Timestamp = DateTimeOffset.UtcNow,
@@ -306,7 +315,8 @@ internal sealed partial class OperationGateway : IOperationGateway
                 CorrelationId = proposal.Audit.CorrelationId ?? proposal.ProposalId,
                 Details = $"{{\"kind\":\"{proposal.Kind}\",\"status\":\"{proposal.Status}\"}}",
             },
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
+    }
 
     private static partial class Log
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/OperationGatewayCompositionRootTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/OperationGatewayCompositionRootTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.AuditLog;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.Guardrails.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Regression coverage for honua-server#1908: the durable control-plane gateway
+/// graph must build under DI scope validation without a captive-dependency error.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>OperationGateway</c> is registered as a <b>singleton</b> (the production
+/// composition root in <c>Program.cs</c> wires it that way on the Pro+Redis durable
+/// path), but it writes audit events through
+/// <see cref="IAuditLog"/>, which the production registration
+/// (<c>AddHonuaAuditLog</c>) wires as <b>scoped</b> — the Postgres sink needs a
+/// per-operation DB connection. A singleton that takes a scoped service as a
+/// constructor dependency is a captive dependency: ASP.NET Core's
+/// <c>ServiceProviderOptions.ValidateScopes</c>/<c>ValidateOnBuild</c> (both ON in
+/// Development) reject it at <c>Build()</c>, so the server crash-loops on startup
+/// (container exit 139).
+/// </para>
+/// <para>
+/// This only surfaced on the durable control-plane path because the singleton
+/// gateway is registered only when the Pro dev grant + a Redis connection are present
+/// (the #1841 GP-job topology); the Community/no-Redis composition never registers
+/// the gateway, so scope validation never saw the captive dependency.
+/// </para>
+/// <para>
+/// This test reproduces the crash in isolation, mirroring
+/// <c>MetadataReleaseLifecycleFixTests</c> (the established pattern in this folder for
+/// the same class of scoped-from-singleton bug): it registers the <b>real</b>
+/// <c>OperationGateway</c> as a singleton with <see cref="IAuditLog"/> registered
+/// <b>scoped</b> exactly as production does, then builds the provider with scope
+/// validation ON. Before the fix (gateway captures <c>IAuditLog</c> in its
+/// constructor) <c>BuildServiceProvider</c> throws; after the fix (gateway resolves
+/// <c>IAuditLog</c> per-operation via <see cref="IServiceScopeFactory"/>) it builds
+/// and the singleton resolves cleanly.
+/// </para>
+/// </remarks>
+public sealed class OperationGatewayCompositionRootTests
+{
+    [Fact]
+    public void OperationGateway_RegisteredSingletonWithScopedAuditLogUnderScopeValidation_BuildsWithoutCaptiveDependency()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // IAuditLog is scoped in production (AddHonuaAuditLog -> TryAddScoped). This is
+        // the scoped service that a captive singleton would illegally capture.
+        services.AddScoped<IAuditLog>(_ => NullAuditLog.Instance);
+
+        // The gateway's other collaborators are singleton-safe in production; their
+        // behaviour is irrelevant to the captive-dependency check, only their presence
+        // and lifetime in the constructor graph that ValidateOnBuild walks.
+        services.AddSingleton(Substitute.For<IGuardrailLadder>());
+        services.AddSingleton(Substitute.For<IOperationProposalStore>());
+        services.AddSingleton(Substitute.For<IProposalNotifier>());
+
+        // The real production registration: OperationGateway as a singleton (mirrors
+        // Program.cs AddSingleton<IOperationGateway, OperationGateway>()).
+        services.AddSingleton<IOperationGateway, OperationGateway>();
+
+        // ValidateScopes + ValidateOnBuild reproduce the Development/production default
+        // that surfaced #1908: the provider walks every singleton's constructor graph at
+        // build time and fails closed if a singleton consumes a scoped service.
+        var build = () => services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true,
+        });
+
+        using var provider = build.Should().NotThrow(
+            "the singleton OperationGateway must not capture the scoped IAuditLog; it " +
+            "resolves IAuditLog per-operation via IServiceScopeFactory (honua-server#1908)")
+            .Subject;
+
+        // The singleton must resolve from the ROOT provider (as the production host does)
+        // without a scope, proving no scoped service is captured in its constructor.
+        provider.GetRequiredService<IOperationGateway>().Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1908

## Summary
`Honua.ControlPlane.OperationGateway` is registered as a **singleton** on the durable control-plane path (Pro edition + Redis — the GP-job topology wired by #1841), but it took a constructor dependency on `IAuditLog`, which the production registration (`AddHonuaAuditLog` → `TryAddScoped`) wires as **scoped** because the Postgres audit sink needs a per-operation DB connection. A singleton that captures a scoped service is a captive dependency: ASP.NET Core's `ServiceProviderOptions.ValidateScopes`/`ValidateOnBuild` (both ON in Development) reject it at `Build()`, so the server crash-loops on startup (container exit 139). This only surfaced under Pro+Redis because the Community/no-Redis composition never registers the singleton gateway, so scope validation never saw the captive dependency.

This change resolves `IAuditLog` per audit write through `IServiceScopeFactory` instead of capturing it, mirroring the existing pattern in `PluginBackgroundServiceHost` (and the sibling fix in `MetadataReleasePreflightGate`). The graph now builds cleanly under scope validation.

## Changes Made
- `OperationGateway`: replace the captured `IAuditLog` constructor dependency with `IServiceScopeFactory`; `WriteAuditAsync` now creates a scope per audit write and resolves `IAuditLog` from it (`await using var scope = _scopeFactory.CreateAsyncScope()`), so the scoped service is never captured by the singleton.
- Add `OperationGatewayCompositionRootTests`: registers the real `OperationGateway` as a singleton with `IAuditLog` scoped (exactly as production wires them) and asserts `BuildServiceProvider` with `ValidateScopes`/`ValidateOnBuild` does not throw. This test fails before the fix with the exact `Cannot consume scoped service 'IAuditLog' from singleton 'IOperationGateway'` error and passes after.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review
