### PR TITLE
fix(ogc): WMS/WMTS GetCapabilities robust to raster/related/time layers

### DIFF
--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
@@ -433,10 +433,16 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
         parameters.Add(fieldName);
 
         var attributeValue = DatabaseSchema.BuildJsonPathParameter(fieldParamIndex);
+        // The same date/datetime attribute can be persisted as ISO-8601 text (seeded
+        // rows) or as epoch-milliseconds rendered as text (Esri applyEdits). A bare
+        // ::timestamptz/::date cast on epoch-ms text raises SQLSTATE 22008 and 500s the
+        // WMS/WMTS GetCapabilities document (honua-server#1911). Use the same
+        // epoch-aware cast the order-by/filter paths already apply so MIN/MAX over the
+        // configured time field succeeds regardless of the on-disk encoding.
         var fieldExpression = propertyType switch
         {
-            TemporalPropertyType.DateTime => $"NULLIF({attributeValue}, '')::timestamptz",
-            TemporalPropertyType.Date => $"NULLIF({attributeValue}, '')::date",
+            TemporalPropertyType.DateTime => BuildEpochAwareOrderByCast(attributeValue, "timestamptz"),
+            TemporalPropertyType.Date => BuildEpochAwareOrderByCast(attributeValue, "date"),
             _ => attributeValue
         };
 

--- a/src/Honua.Protocols.OgcClassic/OgcClassicLog.cs
+++ b/src/Honua.Protocols.OgcClassic/OgcClassicLog.cs
@@ -23,6 +23,12 @@ internal static partial class OgcClassicLog
     public static partial void WmsFailed(ILogger logger, string serviceId, string errorMessage, Exception? exception = null);
 
     [LoggerMessage(
+        EventId = 5644,
+        Level = LogLevel.Warning,
+        Message = "OGC capabilities: skipping time dimension for layer {LayerId} ({LayerName}); temporal extent resolution failed and the layer will be advertised without a TIME dimension")]
+    public static partial void TemporalExtentSkipped(ILogger logger, int layerId, string layerName, Exception? exception = null);
+
+    [LoggerMessage(
         EventId = 5642,
         Level = LogLevel.Information,
         Message = "OGC WMTS {RequestType} requested: {ServiceId}")]

--- a/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetCapabilities.cs
+++ b/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetCapabilities.cs
@@ -13,6 +13,7 @@ using Honua.Infrastructure.Services;
 using Honua.Protocols.Ogc.Common;
 using Honua.Protocols.Ogc.Classic;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using static Honua.Infrastructure.Rendering.RasterMapRenderingPipeline;
 using static Honua.Protocols.Ogc.Classic.OgcClassicRequestHelpers;
 
@@ -132,13 +133,17 @@ internal static partial class WmsRequestHandlers
             return [];
         }
 
+        var logger = context.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Honua.Protocols.Ogc.Classic.Wms.WmsRequestHandlers");
+
         // Fan out DB aggregate queries concurrently; each is a MIN/MAX scan on one table.
+        // Resolve each layer defensively: a single layer whose temporal column cannot be
+        // aggregated (e.g. data stored in an encoding the cast cannot parse) must not 500
+        // the whole GetCapabilities document — skip its TIME dimension and keep the rest
+        // (honua-server#1911).
         var tasks = temporalLayers.Select(layer =>
-            TemporalExtentHelpers.TryResolveTemporalRangeV2Async(
-                layer.Resource,
-                layer.StorageLayerId,
-                featureReader,
-                cancellationToken));
+            ResolveTemporalRangeSafeAsync(layer, featureReader, logger, cancellationToken));
 
         var results = await Task.WhenAll(tasks).ConfigureAwait(false);
 
@@ -152,6 +157,42 @@ internal static partial class WmsRequestHandlers
         }
 
         return dict;
+    }
+
+    /// <summary>
+    /// Resolves a single layer's temporal range, degrading gracefully when the
+    /// underlying aggregate query fails (e.g. the configured time column holds
+    /// values the temporal cast cannot parse). A per-layer failure logs a warning
+    /// and yields <c>null</c> so the layer is advertised without a TIME dimension
+    /// rather than failing the whole capabilities document (honua-server#1911).
+    /// </summary>
+    private static async Task<MetadataV2TemporalRange?> ResolveTemporalRangeSafeAsync(
+        WmsLayer layer,
+        IFeatureReader featureReader,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await TemporalExtentHelpers.TryResolveTemporalRangeV2Async(
+                layer.Resource,
+                layer.StorageLayerId,
+                featureReader,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            OgcClassicLog.TemporalExtentSkipped(
+                logger,
+                layer.StorageLayerId,
+                GetWmsLayerDisplayName(layer),
+                ex);
+            return null;
+        }
     }
 
     private static void AppendWmsTemporalDimension(

--- a/src/Honua.Protocols.OgcClassic/Wmts/WmtsRequestHandlers.cs
+++ b/src/Honua.Protocols.OgcClassic/Wmts/WmtsRequestHandlers.cs
@@ -347,6 +347,7 @@ internal static class WmtsRequestHandlers
                 coordinateTransformService,
                 capabilitiesFeatureReader,
                 tileMatrixSetRegistry,
+                logger,
                 cancellationToken).ConfigureAwait(false);
             return Results.Content(xml, responseMimeType);
         }
@@ -1304,6 +1305,7 @@ internal static class WmtsRequestHandlers
         ICoordinateTransformService? coordinateTransformService,
         IFeatureReader? featureReader,
         ITileMatrixSetRegistry? tileMatrixSetRegistry,
+        ILogger logger,
         CancellationToken cancellationToken)
     {
         var sb = new StringBuilder(4096);
@@ -1440,7 +1442,7 @@ internal static class WmtsRequestHandlers
             // Pre-fetch temporal extent ranges for all time-aware layers concurrently so
             // the capabilities layer loop does not issue a sequential DB round-trip per layer.
             var wmtsTemporalRanges = await PrefetchWmtsTemporalRangesAsync(
-                visibleLayers, featureReader, cancellationToken).ConfigureAwait(false);
+                visibleLayers, featureReader, logger, cancellationToken).ConfigureAwait(false);
 
             foreach (var layer in visibleLayers)
             {
@@ -1738,6 +1740,7 @@ internal static class WmtsRequestHandlers
     private static async Task<Dictionary<int, MetadataV2TemporalRange>> PrefetchWmtsTemporalRangesAsync(
         IReadOnlyList<WmtsLayer> layers,
         IFeatureReader? featureReader,
+        ILogger logger,
         CancellationToken cancellationToken)
     {
         if (featureReader is null)
@@ -1754,12 +1757,11 @@ internal static class WmtsRequestHandlers
             return [];
         }
 
+        // A single layer whose temporal column cannot be aggregated must not 500 the
+        // whole GetCapabilities document — skip its TIME dimension and keep the rest
+        // (honua-server#1911).
         var tasks = temporalLayers.Select(layer =>
-            TemporalExtentHelpers.TryResolveTemporalRangeV2Async(
-                layer.Resource,
-                layer.StorageLayerId,
-                featureReader,
-                cancellationToken));
+            ResolveWmtsTemporalRangeSafeAsync(layer, featureReader, logger, cancellationToken));
 
         var results = await Task.WhenAll(tasks).ConfigureAwait(false);
 
@@ -1773,6 +1775,38 @@ internal static class WmtsRequestHandlers
         }
 
         return dict;
+    }
+
+    /// <summary>
+    /// Resolves a single WMTS layer's temporal range, degrading gracefully when the
+    /// underlying aggregate query fails (e.g. the configured time column holds values
+    /// the temporal cast cannot parse). A per-layer failure logs a warning and yields
+    /// <c>null</c> so the layer is advertised without a TIME dimension rather than
+    /// failing the whole capabilities document (honua-server#1911).
+    /// </summary>
+    private static async Task<MetadataV2TemporalRange?> ResolveWmtsTemporalRangeSafeAsync(
+        WmtsLayer layer,
+        IFeatureReader featureReader,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await TemporalExtentHelpers.TryResolveTemporalRangeV2Async(
+                layer.Resource,
+                layer.StorageLayerId,
+                featureReader,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            OgcClassicLog.TemporalExtentSkipped(logger, layer.StorageLayerId, layer.Identifier, ex);
+            return null;
+        }
     }
 
     private static string BuildWmtsDimensionTemplateSuffix(

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wms/OgcClassicWmsCapabilitiesRobustnessTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wms/OgcClassicWmsCapabilitiesRobustnessTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Npgsql;
+
+namespace Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms;
+
+/// <summary>
+/// Regression coverage for honua-server#1911: WMS/WMTS GetCapabilities returned
+/// HTTP 500 (a <c>ServiceExceptionReport</c> with <c>NoApplicableCode</c>) on
+/// services whose time-configured layer stored temporal values as
+/// epoch-milliseconds text (e.g. <c>1672617600000</c>, the encoding Esri
+/// <c>applyEdits</c> writes) rather than ISO-8601. The capabilities builder
+/// pre-fetches each time-aware layer's temporal extent with a MIN/MAX aggregate
+/// whose <c>::timestamptz</c>/<c>::date</c> cast raised PostgreSQL SQLSTATE 22008
+/// (<c>date/time field value out of range</c>) on the numeric text, failing the
+/// whole document. These tests configure the shared test layer as time-aware,
+/// write an epoch-ms value into its temporal column, and assert that both
+/// GetCapabilities surfaces return 200 with a well-formed capabilities document.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Wms13)]
+public sealed class OgcClassicWmsCapabilitiesRobustnessTests : IAsyncLifetime
+{
+    // 2023-01-02T00:00:00Z expressed as epoch-milliseconds — the on-disk form
+    // that raised SQLSTATE 22008 on a bare ::timestamptz cast in the issue.
+    private const string EpochMillisTimestamp = "1672617600000";
+
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Wms)]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/WMS")]
+    public async Task Wms_GetCapabilities_TimeLayerWithEpochMillisValues_Returns200()
+    {
+        await ConfigureLayerAsTimeAwareAsync();
+        await SetTemporalAttributeToEpochMillisAsync();
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/WMS?SERVICE=WMS&REQUEST=GetCapabilities");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        content.Should().NotContain("ServiceExceptionReport");
+        content.Should().Contain("<WMS_Capabilities");
+        // The capabilities document still advertises the time-aware layer with a
+        // resolved continuous time dimension (epoch-ms parsed as a real instant).
+        content.Should().Contain("<Dimension name=\"time\" units=\"ISO8601\"");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Wmts)]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/WMTS")]
+    public async Task Wmts_GetCapabilities_TimeLayerWithEpochMillisValues_Returns200()
+    {
+        await ConfigureLayerAsTimeAwareAsync();
+        await SetTemporalAttributeToEpochMillisAsync();
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/WMTS?SERVICE=WMTS&REQUEST=GetCapabilities");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        content.Should().NotContain("ExceptionReport");
+        content.Should().Contain("<Capabilities");
+        content.Should().Contain("<ows:Identifier>time</ows:Identifier>");
+    }
+
+    private Task ConfigureLayerAsTimeAwareAsync()
+    {
+        // Opt-in temporal config on the seeded "timestamp" DateTime field, mirroring
+        // OgcClassicWmsTemporalTests; the resolver only advertises an extent when the
+        // field resolves to a real Date/DateTime attribute.
+        _fixture.UpdateV2ResourceMetadata(
+            WebAppFixture.TestLayerId,
+            temporal: new MetadataV2ResourceTemporal { StartTimeField = "timestamp" });
+        return Task.CompletedTask;
+    }
+
+    private async Task SetTemporalAttributeToEpochMillisAsync()
+    {
+        // Overwrite the seeded ISO-8601 "timestamp" attribute with an epoch-ms text
+        // value to reproduce the Esri applyEdits on-disk encoding that 500'd the
+        // capabilities builder.
+        await using var connection = await _fixture.Postgres.GetConnectionAsync(_fixture.CurrentSchema!);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            UPDATE features
+            SET attributes = COALESCE(attributes, '{}'::jsonb)
+                || jsonb_build_object('timestamp', @value::text)
+            WHERE layer_id = @layerId;
+            """;
+        command.Parameters.Add(new NpgsqlParameter { ParameterName = "value", Value = EpochMillisTimestamp });
+        command.Parameters.Add(new NpgsqlParameter { ParameterName = "layerId", Value = WebAppFixture.TestLayerId });
+        await command.ExecuteNonQueryAsync();
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1911

## Summary
WMS/WMTS `GetCapabilities` returned HTTP 500 (an OGC `ServiceExceptionReport` with `NoApplicableCode` / "WMS request failed") on services whose time-configured layer stored temporal values as epoch-milliseconds text (the encoding Esri `applyEdits` writes, e.g. `1672617600000`) rather than ISO-8601.

Root cause: the capabilities builder pre-fetches each time-aware layer's temporal extent with a `MIN`/`MAX` aggregate over the configured time column. `BuildTemporalExtentQuery` cast that column with a bare `::timestamptz`/`::date`, so on epoch-ms text PostgreSQL raised `SQLSTATE 22008` (*date/time field value out of range*). The exception propagated out of the per-layer prefetch's `Task.WhenAll` and failed the entire capabilities document. (The raster/relationship layers in the `test` service were red herrings — they don't go through this path; the time-configured layer did.)

The extent builder was the one temporal SQL site that still used a bare cast — the order-by path (`BuildEpochAwareOrderByCast`), the source-mapped reader (`WrapEpochAwareTimestamp`), and the CQL2 filter translator (`BuildEpochAwareTemporalCast`) already guard this exact hazard.

## Changes Made
- `FeatureQueryBuilder.BuildTemporalExtentQuery` now uses the existing epoch-aware cast (`BuildEpochAwareOrderByCast`) for `DateTime`/`Date` fields, so `MIN`/`MAX` over the time column succeeds whether values are ISO-8601 or epoch-ms; the layer is advertised with a correct continuous TIME dimension instead of 500ing.
- Hardened the WMS and WMTS capabilities temporal prefetch (`PrefetchTemporalRangesAsync` / `PrefetchWmtsTemporalRangesAsync`) to resolve each layer's range independently: a per-layer failure now logs a warning (`OgcClassicLog.TemporalExtentSkipped`, event 5644) and the layer is advertised without a TIME dimension rather than failing the whole document (defense in depth; `OperationCanceledException` still propagates).
- Added integration tests (`OgcClassicWmsCapabilitiesRobustnessTests`) that configure the test layer as time-aware, write an epoch-ms value into its temporal column, and assert both `MapServer/WMS` and `MapServer/WMTS` `GetCapabilities` return 200 with a well-formed capabilities document (not a `ServiceException`).

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Failing-first verified: with the fix stashed, both new tests reproduce the exact issue (HTTP 500 / `NoApplicableCode`). With the fix applied, all 31 OgcClassic WMS/WMTS temporal tests pass (2 new + 29 existing, no regression). Live repro confirmed against the running esri-compat stack and root cause captured from container logs (`SQLSTATE 22008`).

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
