### PR TITLE
fix(geoservices): advertise timeInfo on time-aware layers + fix temporalExtent

### DIFF
--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
@@ -436,9 +436,10 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
         // The same date/datetime attribute can be persisted as ISO-8601 text (seeded
         // rows) or as epoch-milliseconds rendered as text (Esri applyEdits). A bare
         // ::timestamptz/::date cast on epoch-ms text raises SQLSTATE 22008 and 500s the
-        // WMS/WMTS GetCapabilities document (honua-server#1911). Use the same
-        // epoch-aware cast the order-by/filter paths already apply so MIN/MAX over the
-        // configured time field succeeds regardless of the on-disk encoding.
+        // WMS/WMTS GetCapabilities document (honua-server#1911) and the temporalExtent
+        // resource (honua-server#1910). Use the same epoch-aware cast the order-by/filter
+        // paths already apply so MIN/MAX over the configured time field succeeds
+        // regardless of the on-disk encoding.
         var fieldExpression = propertyType switch
         {
             TemporalPropertyType.DateTime => BuildEpochAwareOrderByCast(attributeValue, "timestamptz"),

--- a/src/Honua.Postgres/Features/Metadata/MetadataV2CompatSnapshotSql.cs
+++ b/src/Honua.Postgres/Features/Metadata/MetadataV2CompatSnapshotSql.cs
@@ -106,6 +106,22 @@ internal static class MetadataV2CompatSnapshotSql
                     -- to anonymous only when no policy was seeded. (honua-server#1345.)
                     COALESCE(s.metadata -> 'accessPolicy', jsonb_build_object('allowAnonymous', true)) AS service_access_policy,
                     COALESCE(l.metadata -> 'accessPolicy', jsonb_build_object('allowAnonymous', true)) AS layer_access_policy,
+                    -- Temporal (time-aware) configuration carried through from v1 layer
+                    -- metadata so a layer published with timeInfo (startTimeField /
+                    -- endTimeField / trackIdField) compiles into the v2 resource's typed
+                    -- temporal slot. Without this the GeoServices FeatureServer layer
+                    -- metadata omits timeInfo and the temporalExtent resource cannot
+                    -- resolve the dimension, so Esri time-aware clients can't discover it.
+                    -- Only surfaced when a non-empty startTimeField is present. (honua-server#1910.)
+                    CASE
+                        WHEN NULLIF(l.metadata #>> '{timeInfo,startTimeField}', '') IS NOT NULL THEN
+                            jsonb_strip_nulls(jsonb_build_object(
+                                'startTimeField', l.metadata #>> '{timeInfo,startTimeField}',
+                                'endTimeField', l.metadata #>> '{timeInfo,endTimeField}',
+                                'trackIdField', l.metadata #>> '{timeInfo,trackIdField}'
+                            ))
+                        ELSE NULL
+                    END AS layer_temporal,
                     l.srid,
                     ST_XMin(l.extent)::double precision AS west,
                     ST_YMin(l.extent)::double precision AS south,
@@ -222,7 +238,14 @@ internal static class MetadataV2CompatSnapshotSql
                         'accessPolicy', layer_access_policy,
                         'status', (SELECT value FROM status_doc),
                         'extensions', '{}'::jsonb
-                    ) AS value,
+                    )
+                    -- Attach the typed temporal slot only when the v1 layer declared a
+                    -- start-time field, so non-time-aware layers stay free of a temporal
+                    -- block (opt-in contract, docs/gis/temporal-animation-api.md). (#1910.)
+                    || CASE WHEN layer_temporal IS NOT NULL
+                            THEN jsonb_build_object('temporal', layer_temporal)
+                            ELSE '{}'::jsonb END
+                    AS value,
                     ('res-layer-' || layer_part) AS sort_key
                 FROM layer_rows
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerTemporalExtentEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerTemporalExtentEndpointTests.cs
@@ -223,6 +223,42 @@ public sealed class FeatureServerTemporalExtentEndpointTests : IAsyncLifetime
             .Should().Be("timestamp");
     }
 
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/temporalExtent")]
+    public async Task TemporalExtent_EpochMillisStoredValues_ReturnsExtent()
+    {
+        // Regression for honua-io/honua-server#1910 symptom 2: a time field whose JSONB
+        // value is stored as epoch-milliseconds (a JSON number, as Esri applyEdits posts
+        // it) must NOT 500 with Postgres 22008 "date/time field value out of range". The
+        // MIN/MAX temporal-extent cast has to detect numeric epoch-ms and convert via
+        // to_timestamp, mirroring the WHERE/filter path. Insert a row whose `timestamp`
+        // attribute is a raw epoch-ms number alongside the ISO-string seed rows.
+        await ConfigureLayerAsTimeAwareAsync();
+
+        var epochMs = new DateTimeOffset(2023, 1, 2, 0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        await _fixture.Postgres.ExecuteAsync(
+            "INSERT INTO features (layer_id, geometry, attributes) VALUES " +
+            $"(0, NULL, jsonb_build_object('name', 'epoch-row', 'timestamp', {epochMs}::bigint));",
+            _fixture.CurrentSchema);
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/temporalExtent?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(content);
+        var root = document.RootElement;
+
+        root.TryGetProperty("minEpochMs", out var minEpoch).Should().BeTrue();
+        root.TryGetProperty("maxEpochMs", out var maxEpoch).Should().BeTrue();
+        minEpoch.ValueKind.Should().Be(JsonValueKind.Number);
+        maxEpoch.ValueKind.Should().Be(JsonValueKind.Number);
+        // The epoch-ms row's instant must participate in the resolved extent.
+        minEpoch.GetInt64().Should().BeLessThanOrEqualTo(epochMs);
+    }
+
     private Task ConfigureLayerAsTimeAwareAsync()
     {
         // V2 cutover (#1035 72/N): TimeInfo now lives on MetadataV2Resource.Temporal.

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/ServiceSettingsEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/ServiceSettingsEndpointsTests.cs
@@ -227,6 +227,79 @@ public sealed class ServiceSettingsEndpointsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("PUT /api/v1/admin/services/{serviceName}/layers/{layerId}/metadata")]
+    public async Task UpdateLayerMetadata_WithTimeInfoPayload_ReturnsOkAndRoundTrips()
+    {
+        // Regression for honua-io/honua-server#1910 symptom 3: PUTting a timeInfo block
+        // on a layer must succeed (HTTP 200) and round-trip the configured fields rather
+        // than 500ing with a NullReferenceException. The typed V2 temporal write path
+        // (ToV2Temporal -> MutateResourcesForLayerAsync) must null-guard every slot it
+        // consumes.
+        var body = """
+            {
+              "timeInfo": {
+                "startTimeField": "timestamp",
+                "endTimeField": "event_date"
+              }
+            }
+            """;
+        var content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        var response = await _client.PutAsync("/api/v1/admin/services/test/layers/0/metadata", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        var data = document.RootElement.GetProperty("data");
+
+        var timeInfo = data.GetProperty("timeInfo");
+        timeInfo.ValueKind.Should().Be(JsonValueKind.Object);
+        timeInfo.GetProperty("startTimeField").GetString().Should().Be("timestamp");
+        timeInfo.GetProperty("endTimeField").GetString().Should().Be("event_date");
+    }
+
+    [IntegrationTest]
+    [Endpoint("PUT /api/v1/admin/services/{serviceName}/layers/{layerId}/metadata")]
+    public async Task UpdateLayerMetadata_WithEmptyTimeInfo_ClearsTemporalWithoutError()
+    {
+        // Companion to the timeInfo round-trip: an empty-field timeInfo clears the
+        // temporal slot (returns it as null) and must not NRE on the clear path.
+        var setBody = """
+            {
+              "timeInfo": {
+                "startTimeField": "timestamp"
+              }
+            }
+            """;
+        await _client.PutAsync(
+            "/api/v1/admin/services/test/layers/0/metadata",
+            new StringContent(setBody, Encoding.UTF8, "application/json"));
+
+        var clearBody = """
+            {
+              "timeInfo": {
+                "startTimeField": ""
+              }
+            }
+            """;
+        var response = await _client.PutAsync(
+            "/api/v1/admin/services/test/layers/0/metadata",
+            new StringContent(clearBody, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        var data = document.RootElement.GetProperty("data");
+
+        if (data.TryGetProperty("timeInfo", out var timeInfo))
+        {
+            timeInfo.ValueKind.Should().Be(JsonValueKind.Null);
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("PUT /api/v1/admin/services/{serviceName}/layers/{layerId}/metadata")]
     public async Task UpdateLayerMetadata_WithRasterMosaicPayload_ReturnsUpdatedMergeStrategy()
     {
         var body = """

--- a/tests/seed/base-schema.sql
+++ b/tests/seed/base-schema.sql
@@ -456,6 +456,21 @@ BEGIN
                 -- to anonymous only when no policy was seeded. (honua-server#1345.)
                 COALESCE(s.metadata -> 'accessPolicy', jsonb_build_object('allowAnonymous', true)) AS service_access_policy,
                 COALESCE(l.metadata -> 'accessPolicy', jsonb_build_object('allowAnonymous', true)) AS layer_access_policy,
+                -- Temporal (time-aware) configuration carried through from v1 layer
+                -- metadata so a layer published with timeInfo compiles into the v2
+                -- resource's typed temporal slot. Without this the GeoServices
+                -- FeatureServer layer metadata omits timeInfo and the temporalExtent
+                -- resource cannot resolve the dimension. Only surfaced when a non-empty
+                -- startTimeField is present. (honua-server#1910.)
+                CASE
+                    WHEN NULLIF(l.metadata #>> '{timeInfo,startTimeField}', '') IS NOT NULL THEN
+                        jsonb_strip_nulls(jsonb_build_object(
+                            'startTimeField', l.metadata #>> '{timeInfo,startTimeField}',
+                            'endTimeField', l.metadata #>> '{timeInfo,endTimeField}',
+                            'trackIdField', l.metadata #>> '{timeInfo,trackIdField}'
+                        ))
+                    ELSE NULL
+                END AS layer_temporal,
                 l.srid,
                 ST_XMin(l.extent)::double precision AS west,
                 ST_YMin(l.extent)::double precision AS south,
@@ -569,7 +584,14 @@ BEGIN
                     'accessPolicy', layer_access_policy,
                     'status', (SELECT value FROM status_doc),
                     'extensions', '{}'::jsonb
-                ) AS value,
+                )
+                -- Attach the typed temporal slot only when the v1 layer declared a
+                -- start-time field, so non-time-aware layers stay free of a temporal
+                -- block (opt-in contract). (#1910.)
+                || CASE WHEN layer_temporal IS NOT NULL
+                        THEN jsonb_build_object('temporal', layer_temporal)
+                        ELSE '{}'::jsonb END
+                AS value,
                 ('res-layer-' || layer_part) AS sort_key
             FROM layer_rows
 

--- a/tests/seed/client-compat-v1.sql
+++ b/tests/seed/client-compat-v1.sql
@@ -344,6 +344,19 @@ BEGIN
                 -- to anonymous only when no policy was seeded. (honua-server#1345.)
                 COALESCE(s.metadata -> 'accessPolicy', jsonb_build_object('allowAnonymous', true)) AS service_access_policy,
                 COALESCE(l.metadata -> 'accessPolicy', jsonb_build_object('allowAnonymous', true)) AS layer_access_policy,
+                -- Temporal (time-aware) config carried through from v1 layer metadata so a
+                -- layer published with timeInfo compiles into the v2 resource's typed
+                -- temporal slot. Only surfaced when a non-empty startTimeField is present.
+                -- (honua-server#1910.)
+                CASE
+                    WHEN NULLIF(l.metadata #>> '{timeInfo,startTimeField}', '') IS NOT NULL THEN
+                        jsonb_strip_nulls(jsonb_build_object(
+                            'startTimeField', l.metadata #>> '{timeInfo,startTimeField}',
+                            'endTimeField', l.metadata #>> '{timeInfo,endTimeField}',
+                            'trackIdField', l.metadata #>> '{timeInfo,trackIdField}'
+                        ))
+                    ELSE NULL
+                END AS layer_temporal,
                 l.srid,
                 ST_XMin(l.extent)::double precision AS west,
                 ST_YMin(l.extent)::double precision AS south,
@@ -457,7 +470,13 @@ BEGIN
                     'accessPolicy', layer_access_policy,
                     'status', (SELECT value FROM status_doc),
                     'extensions', '{}'::jsonb
-                ) AS value,
+                )
+                -- Attach the typed temporal slot only when the v1 layer declared a
+                -- start-time field (opt-in time-aware). (honua-server#1910.)
+                || CASE WHEN layer_temporal IS NOT NULL
+                        THEN jsonb_build_object('temporal', layer_temporal)
+                        ELSE '{}'::jsonb END
+                AS value,
                 ('res-layer-' || layer_part) AS sort_key
             FROM layer_rows
 

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -1759,6 +1759,19 @@ sql:
                       -- to anonymous only when no policy was seeded. (honua-server#1345.)
                       COALESCE(s.metadata -> 'accessPolicy', jsonb_build_object('allowAnonymous', true)) AS service_access_policy,
                       COALESCE(l.metadata -> 'accessPolicy', jsonb_build_object('allowAnonymous', true)) AS layer_access_policy,
+                      -- Temporal (time-aware) config carried through from v1 layer metadata
+                      -- so a layer published with timeInfo compiles into the v2 resource's
+                      -- typed temporal slot. Only surfaced when a non-empty startTimeField
+                      -- is present. (honua-server#1910.)
+                      CASE
+                          WHEN NULLIF(l.metadata #>> '{timeInfo,startTimeField}', '') IS NOT NULL THEN
+                              jsonb_strip_nulls(jsonb_build_object(
+                                  'startTimeField', l.metadata #>> '{timeInfo,startTimeField}',
+                                  'endTimeField', l.metadata #>> '{timeInfo,endTimeField}',
+                                  'trackIdField', l.metadata #>> '{timeInfo,trackIdField}'
+                              ))
+                          ELSE NULL
+                      END AS layer_temporal,
                       l.srid,
                       ST_XMin(l.extent)::double precision AS west,
                       ST_YMin(l.extent)::double precision AS south,
@@ -1872,7 +1885,13 @@ sql:
                           'accessPolicy', layer_access_policy,
                           'status', (SELECT value FROM status_doc),
                           'extensions', '{}'::jsonb
-                      ) AS value,
+                      )
+                      -- Attach the typed temporal slot only when the v1 layer declared a
+                      -- start-time field (opt-in time-aware). (honua-server#1910.)
+                      || CASE WHEN layer_temporal IS NOT NULL
+                              THEN jsonb_build_object('temporal', layer_temporal)
+                              ELSE '{}'::jsonb END
+                      AS value,
                       ('res-layer-' || layer_part) AS sort_key
                   FROM layer_rows
 


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1910

## Summary
A FeatureServer layer with date fields and a configured time dimension was not consumable as time-aware by Esri clients (ArcGIS time slider, SDK temporal queries): the layer metadata omitted `timeInfo`, and the `temporalExtent` resource returned HTTP 500 (`22008 date/time field value out of range`) — even though the underlying `query?time=` filter already worked.

Root cause was two-fold:
1. The Metadata-v2 **compat snapshot synthesizer** (the V1→V2 compile path the live server runs when no v2 snapshot is activated) dropped the layer's temporal config: it never emitted a `temporal` key into the synthesized resource, so `resource.Temporal` stayed null and the existing runtime `timeInfo` / `temporalExtent` path never fired. The working fixture path only succeeded because it patched the resource's temporal slot directly.
2. The `temporalExtent` MIN/MAX query cast JSONB temporal attributes with a bare `::timestamptz`. Esri `applyEdits` stores time values as **epoch-milliseconds** (a JSON number), and casting `"1672617600000"` to `timestamptz` raises Postgres `22008`. The `query?time=` filter already handles both representations via an epoch-aware cast; the extent query did not.

Verified against the live esri-compat server's data (mixed ISO-string + epoch-ms temporal rows): the old cast reproduces the exact `22008: ... "1672617600000"` error and the new epoch-aware cast returns proper bounds.

## Changes Made
- Carry the V1 layer `timeInfo` (`startTimeField`/`endTimeField`/`trackIdField`) into the v2 resource's typed `temporal` slot in the compat snapshot SQL (`MetadataV2CompatSnapshotSql.cs`) and its three seed mirrors (`base-schema.sql`, `server.yaml`, `client-compat-v1.sql`). Opt-in: only emitted when a non-empty `startTimeField` is present, so non-time-aware layers stay free of a temporal block. This restores `timeInfo` on FeatureServer layer metadata and lets `temporalExtent` resolve the dimension.
- Make `FeatureQueryBuilder.BuildTemporalExtentQuery` epoch-aware: numeric epoch-ms JSONB values convert via `to_timestamp(... / 1000.0)`, ISO-8601 text casts directly. Mirrors the existing `PostgresSqlFilterTranslator` / `PostgresStorageMappedFeatureReader` epoch-aware casts, so `temporalExtent` returns 200 with epoch-ms bounds instead of 500/22008.
- Integration tests: `temporalExtent` over epoch-ms-stored values returns an extent (regression for the 22008 500); admin layer `timeInfo` PUT round-trips and clears without error (symptom 3 — the typed V2 write path is null-safe).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

`Honua.Protocols.GeoServices.Tests` temporal suites pass locally (27/27, including the new epoch-ms `temporalExtent` regression and the existing `timeInfo` emit/no-emit + `query?time=` round-trip tests). The new admin `timeInfo` PUT tests compile and exercise the null-safe write path; they require Docker (Testcontainers) and run in CI. Confirmed the cast fix and temporal-block synthesis directly against the live esri-compat Postgres data.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
