### PR TITLE
fix(imageserver): computeHistograms/computeStatisticsHistograms succeed on multiband rasters

### DIFF
--- a/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
@@ -2492,7 +2492,10 @@ internal sealed class PostgresRasterStore : IRasterStore
                 SELECT unnest(@rasterIds) AS raster_id
             ),
             source AS (
-                SELECT {BuildClipExpression("raster", clipSrid)} AS rast
+                SELECT {BuildClipExpression("raster", clipSrid)} AS rast,
+                       id,
+                       created_at,
+                       COALESCE(acquisition_date, created_at) AS effective_acquisition
                 FROM {_rasterDataTable}
                 WHERE layer_id = @layerId AND id IN (SELECT raster_id FROM requested)
             )
@@ -2567,7 +2570,10 @@ internal sealed class PostgresRasterStore : IRasterStore
                 SELECT unnest(@rasterIds) AS raster_id
             ),
             source AS (
-                SELECT {BuildClipExpression("raster", clipSrid)} AS rast
+                SELECT {BuildClipExpression("raster", clipSrid)} AS rast,
+                       id,
+                       created_at,
+                       COALESCE(acquisition_date, created_at) AS effective_acquisition
                 FROM {_rasterDataTable}
                 WHERE layer_id = @layerId AND id IN (SELECT raster_id FROM requested)
             )

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterStoreStatisticsTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterStoreStatisticsTests.cs
@@ -163,6 +163,79 @@ public sealed class PostgresRasterStoreStatisticsTests(PostgresFixture fixture)
         }
     }
 
+    [IntegrationTest]
+    public async Task GetClippedMosaicStatisticsAsync_MultibandRasters_ReturnsPerBandStatisticsForClip()
+    {
+        // Regression for #1920: the clipped-mosaic compute path (computeStatisticsHistograms
+        // over multiple rasters with an AOI geometry) failed with Postgres 42703
+        // ("column effective_acquisition does not exist") because the clip `source` CTE did
+        // not project the columns the ST_Union ORDER BY references.
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreStatisticsTests));
+        try
+        {
+            await CreateRasterTablesAsync(schemaName);
+            var west = await InsertThreeBandRasterAsync(schemaName, "west", band1: 200, band2: 120, band3: 60, upperLeftX: 0);
+            var east = await InsertThreeBandRasterAsync(schemaName, "east", band1: 210, band2: 130, band3: 70, upperLeftX: 2);
+            var store = CreateStore(schemaName);
+
+            // AOI envelope falling strictly inside the west raster's footprint (one pixel),
+            // so the clipped mosaic resolves to west's constant per-band values only.
+            var clip = await MakeEnvelopeAsync(schemaName, 0, 0, 1, 1);
+
+            var statistics = await store.GetClippedMosaicStatisticsAsync(
+                LayerId,
+                [west, east],
+                RasterMergeStrategy.Newest,
+                clip,
+                clipSrid: 4326);
+
+            statistics.Should().HaveCount(3, "the clipped mosaic must report all three bands");
+            statistics[0].Band.Should().Be(1);
+            statistics[0].MeanValue.Should().Be(200);
+            statistics[1].Band.Should().Be(2);
+            statistics[1].MeanValue.Should().Be(120);
+            statistics[2].Band.Should().Be(3);
+            statistics[2].MeanValue.Should().Be(60);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task GetClippedMosaicHistogramsAsync_MultibandRasters_ReturnsPerBandHistogramsForClip()
+    {
+        // Regression for #1920: the clipped-mosaic histogram path threw the same 42703 error.
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreStatisticsTests));
+        try
+        {
+            await CreateRasterTablesAsync(schemaName);
+            var west = await InsertThreeBandRasterAsync(schemaName, "west", band1: 200, band2: 120, band3: 60, upperLeftX: 0);
+            var east = await InsertThreeBandRasterAsync(schemaName, "east", band1: 210, band2: 130, band3: 70, upperLeftX: 2);
+            var store = CreateStore(schemaName);
+
+            var clip = await MakeEnvelopeAsync(schemaName, 0, 0, 4, 2);
+
+            var histograms = await store.GetClippedMosaicHistogramsAsync(
+                LayerId,
+                [west, east],
+                RasterMergeStrategy.Newest,
+                clip,
+                clipSrid: 4326,
+                bands: null,
+                binCount: 16);
+
+            histograms.Should().HaveCount(3, "the clipped mosaic must report all three bands");
+            histograms.Select(h => h.Band).Should().Equal(1, 2, 3);
+            histograms.Should().OnlyContain(h => h.Counts.Sum() > 0);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
     private PostgresRasterStore CreateStore(string schemaName)
         => new(
             new FixtureConnectionProvider(fixture.DataSource),
@@ -256,6 +329,64 @@ public sealed class PostgresRasterStoreStatisticsTests(PostgresFixture fixture)
             """;
         command.Parameters.AddWithValue("layerId", LayerId);
         return (long)(await command.ExecuteScalarAsync())!;
+    }
+
+    private async Task<long> InsertThreeBandRasterAsync(
+        string schemaName,
+        string name,
+        double band1,
+        double band2,
+        double band3,
+        double upperLeftX)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO raster_data (layer_id, name, raster, acquisition_date, created_at)
+            SELECT @layerId,
+                   @name,
+                   ST_AddBand(
+                       ST_AddBand(
+                           ST_AddBand(
+                               ST_MakeEmptyRaster(2, 2, @upperLeftX, 2, 1, -1, 0, 0, 4326),
+                               '32BF'::text,
+                               @band1,
+                               NULL
+                           ),
+                           '32BF'::text,
+                           @band2,
+                           NULL
+                       ),
+                       '32BF'::text,
+                       @band3,
+                       NULL
+                   ),
+                   NOW(),
+                   NOW()
+            RETURNING id;
+            """;
+        command.Parameters.AddWithValue("layerId", LayerId);
+        command.Parameters.AddWithValue("name", name);
+        command.Parameters.AddWithValue("upperLeftX", upperLeftX);
+        command.Parameters.AddWithValue("band1", band1);
+        command.Parameters.AddWithValue("band2", band2);
+        command.Parameters.AddWithValue("band3", band3);
+        return (long)(await command.ExecuteScalarAsync())!;
+    }
+
+    // Produces a clip envelope as WKB so it round-trips through the store's
+    // ST_GeomFromWKB(@clipGeom, srid) parameter exactly as the handler supplies it.
+    // Built via PostGIS to avoid taking a direct NetTopologySuite dependency in this project.
+    private async Task<byte[]> MakeEnvelopeAsync(string schemaName, double xmin, double ymin, double xmax, double ymax)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schemaName);
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT ST_AsBinary(ST_MakeEnvelope(@xmin, @ymin, @xmax, @ymax, 4326))";
+        command.Parameters.AddWithValue("xmin", xmin);
+        command.Parameters.AddWithValue("ymin", ymin);
+        command.Parameters.AddWithValue("xmax", xmax);
+        command.Parameters.AddWithValue("ymax", ymax);
+        return (byte[])(await command.ExecuteScalarAsync())!;
     }
 
     private async Task<long> CountAsync(string schemaName, string sql)


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1920

## Summary
On-the-fly `computeHistograms` and `computeStatisticsHistograms` returned **HTTP 500** ("An error occurred while computing statistics and histograms.") on the multiband `test/ImageServer` for both GET and POST when an AOI `geometry` was supplied, even though the precomputed `/statistics` and `/histograms` child resources served valid per-band data. The handler swallowed the real cause into a generic 500.

The inner exception captured from server logs was:

```
Npgsql.PostgresException 42703: column "effective_acquisition" does not exist
```

Root cause: when the request selects more than one raster (the mosaic branch) plus an AOI envelope, the handler calls `GetClippedMosaicStatisticsAsync` / `GetClippedMosaicHistogramsAsync`. Both build a `source` CTE that projected only `rast`, then aggregate with `CreateMosaicAggregateExpression`, whose default `ST_Union` carries `ORDER BY effective_acquisition ASC, created_at ASC, id ASC`. Because the clipped `source` CTE did not project those ordering columns (unlike every non-clipped mosaic pipeline, which does), Postgres rejected the aggregate with `42703` and the handler turned it into the generic 500. The single-raster clipped path does not use the mosaic aggregate, so it was unaffected; the precomputed/stored paths read persisted rows and never hit this SQL, which is why they worked.

Fix: project `id`, `created_at`, and `COALESCE(acquisition_date, created_at) AS effective_acquisition` in both clipped-mosaic `source` CTEs, matching the existing non-clipped mosaic pipelines.

## Changes Made
- `src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs`: project `id`, `created_at`, and `effective_acquisition` in the clipped-mosaic `source` CTEs of `GetClippedMosaicStatisticsAsync` and `GetClippedMosaicHistogramsAsync`, so the `ST_Union(... ORDER BY effective_acquisition, created_at, id)` aggregate resolves its ordering columns.
- `tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterStoreStatisticsTests.cs`: add Testcontainers+PostGIS regression tests that seed two 3-band rasters and assert `GetClippedMosaicStatisticsAsync` / `GetClippedMosaicHistogramsAsync` return well-formed per-band statistics/histograms for an AOI clip. Both reproduce the `42703` failure before the fix and pass after.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Reproduced the live 500 against the running multiband `test/ImageServer` and captured the `42703` inner exception from `honua-esri-compat-honua-1` logs. Verified the corrected SQL against PostGIS directly (3-band per-band stats). New integration tests fail-first with `42703: column "effective_acquisition" does not exist` and pass after the fix.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
