### PR TITLE
ci(shards): add Geocoding shard so geocoding PRs target one shard, not run_all

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -938,6 +938,25 @@
         "tests/dotnet/Honua.Protocols.Stac.Tests/Source/",
         "src/Honua.Core/Features/Validation/"
       ]
+    },
+    {
+      "name": "Geocoding",
+      "shard_name": "Geocoding",
+      "artifact_suffix": "geocoding",
+      "log_name": "server-tests-geocoding",
+      "timeout_minutes": 25,
+      "test_timeout_minutes": 15,
+      "max_cpu_count": "",
+      "upload_operator_eval_report": false,
+      "upload_odata_evidence": false,
+      "_comment": "ADR-0037: GeocodeServer feature tests (Honua.Server.Tests.Features.Geocoding) were claimed by NO shard filter, so they only ran under run_all (orphaned — same class as #1899). This shard claims those tests and the geocoding source dirs (including the standalone Honua.Geocoding project) so a geocoding-only change targets one shard instead of falling through the unmapped-source net to run_all.",
+      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Geocoding",
+      "paths": [
+        "src/Honua.Geocoding/",
+        "src/Honua.Server/Features/Geocoding/",
+        "tests/dotnet/Honua.Server.Tests/Features/Geocoding/"
+      ],
+      "csproj": ""
     }
   ]
 }

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -219,6 +219,22 @@ assert_excludes_shard \
   "src/Honua.Protocols.Scene/SceneServerEndpoints.cs" \
   "FeatureServer Endpoints"
 
+# A Geocoding (GeocodeServer) change targets the dedicated Geocoding shard and
+# excludes unrelated shards. Before this shard existed, geocoding source lived
+# under the unmapped-source net AND its tests matched no shard filter, so any
+# geocoding-only PR escalated to run_all while never running geocoding tests in
+# a targeted run. This locks in that a geocoding change is now targeted.
+assert_descriptor \
+  "geocoding-targeted" \
+  "src/Honua.Geocoding/Features/Geocoding/Domain/GeocodeMagicKey.cs" \
+  "targeted" \
+  "false" \
+  "Geocoding"
+assert_excludes_shard \
+  "geocoding-excludes-imageserver" \
+  "src/Honua.Server/Features/Geocoding/GeocodingHandler.cs" \
+  "GeoServices ImageServer"
+
 # Cross-cutting safety preserved: the shared test harness (TestKit /
 # PostgresFixture / SeedRunner) and the shared canonical query pipeline in
 # Honua.Core/Queries still escalate to run_all.


### PR DESCRIPTION
## Summary

Geocoding (GeocodeServer) PRs were running the full 40-shard server-test matrix (`run_all`) on every change, while the geocoding tests themselves were **orphaned** — `Honua.Server.Tests.Features.Geocoding` matched no shard `filter`, so those 3 test classes only ever ran under `run_all` and never in a targeted run. This is the same orphaned-test-class class as #1899.

Two root causes, both fixed by adding one dedicated shard:
- Geocoding source (`src/Honua.Geocoding/`, `src/Honua.Server/Features/Geocoding/`) fell through the `unmapped_source_run_all_prefixes` net → `run_all`.
- Geocoding tests were claimed by no shard `filter` → never targeted.

Verified live on the current backlog: `#1893` (geocoding) routed `run_all` (40 shards). With this change a geocoding-only diff routes `targeted → ["Geocoding"]` (1 shard).

## Changes Made

- Add a dedicated **Geocoding** shard to `.github/ci-shards.json` (`filter: Honua.Server.Tests.Features.Geocoding`, default `Honua.Server.Tests` project) that claims the geocoding source dirs and test dir via `paths`.
- Add two guard cases to `scripts/ci/validate-ci-router.sh`: a geocoding source change must route `targeted` selecting `Geocoding`, and must exclude unrelated shards. Cross-cutting Core/TestKit changes still escalate to `run_all` (existing guards unchanged).

## Breaking Changes

None. CI-routing config only; no runtime/test code changed. The new shard runs the same geocoding tests that previously only ran under `run_all`, so coverage strictly increases for targeted runs.

## Gate Impact

- [x] CI/infrastructure only (test routing); no product behavior change

## Testing

- [x] Ran `scripts/ci/validate-ci-router.sh` and all checks passed — `geocoding-targeted` → `{"run_all":false,"shards":["Geocoding"]}`, `geocoding-excludes-imageserver` → `["Geocoding"]`, all pre-existing cases still green.

Related to #1899
