### PR TITLE
fix(mapserver): surface relationships + hasAttachments on sublayer metadata

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
@@ -665,7 +665,7 @@ internal static partial class FeatureServerEndpoints
     /// no publication exists on this service for the related resource, the relationship is
     /// skipped (clients can't address it as an integer layer id anyway).
     /// </summary>
-    private static LayerRelationshipInfo[] BuildRelationshipResponseV2(
+    internal static LayerRelationshipInfo[] BuildRelationshipResponseV2(
         MetadataV2Resource resource,
         MetadataV2GraphSnapshot snapshot)
     {
@@ -893,7 +893,7 @@ internal static partial class FeatureServerEndpoints
     /// canonical resource shape; the resource opts in via <c>resource.Metadata.Annotations</c>
     /// (<c>honua.io/attachments=true</c>) or the legacy <c>"supportsAttachments"</c> annotation.
     /// </summary>
-    private static bool ResourceSupportsAttachmentsV2(MetadataV2Resource resource)
+    internal static bool ResourceSupportsAttachmentsV2(MetadataV2Resource resource)
     {
         // Canonical annotation key. Keep the legacy spelling alongside so resources migrated
         // verbatim from v1 still resolve.

--- a/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Metadata.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Metadata.cs
@@ -382,7 +382,12 @@ internal static partial class MapServerEndpoints
             ],
             Capabilities = layerCapabilities,
             SupportsAdvancedQueries = true,
-            HasAttachments = resource.Editing?.SupportsAttachments ?? false,
+            // Mirror hasAttachments + relationships from the same source the FeatureServer
+            // layer metadata uses (annotation-driven attachments + the canonical resource
+            // relationships) so a MapServer sublayer advertises the related records and
+            // attachments the equivalent FeatureServer layer does (#1923).
+            HasAttachments = FeatureServerEndpoints.ResourceSupportsAttachmentsV2(resource),
+            Relationships = FeatureServerEndpoints.BuildRelationshipResponseV2(resource, snapshot),
             MinScale = resource.Display?.MinScale ?? 0,
             MaxScale = resource.Display?.MaxScale ?? 0,
             DefaultVisibility = resource.Display?.DefaultVisibility ?? true,

--- a/src/Honua.Protocols.GeoServices/MapServer/Models/MapServerJsonContext.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/Models/MapServerJsonContext.cs
@@ -18,6 +18,8 @@ namespace Honua.Protocols.GeoServices.MapServer.Models;
 [JsonSerializable(typeof(MapServerLayerResponse))]
 [JsonSerializable(typeof(MapServerFieldInfo))]
 [JsonSerializable(typeof(MapServerFieldInfo[]))]
+[JsonSerializable(typeof(FeatureServer.Models.LayerRelationshipInfo))]
+[JsonSerializable(typeof(FeatureServer.Models.LayerRelationshipInfo[]))]
 [JsonSerializable(typeof(IdentifyResponse))]
 [JsonSerializable(typeof(IdentifyResult))]
 [JsonSerializable(typeof(IdentifyResult[]))]

--- a/src/Honua.Protocols.GeoServices/MapServer/Models/MapServerResponses.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/Models/MapServerResponses.cs
@@ -587,6 +587,13 @@ internal sealed class MapServerLayerResponse
     public bool HasAttachments { get; init; }
 
     /// <summary>
+    /// Layer-to-layer relationship metadata, mirrored from the underlying layer so the
+    /// MapServer sublayer surfaces the same relationships the FeatureServer layer advertises.
+    /// </summary>
+    [JsonPropertyName("relationships")]
+    public FeatureServer.Models.LayerRelationshipInfo[] Relationships { get; init; } = [];
+
+    /// <summary>
     /// Min scale visibility threshold.
     /// </summary>
     [JsonPropertyName("minScale")]

--- a/tests/dotnet/Honua.Server.Tests/MapServerSublayerRelationshipMetadataTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/MapServerSublayerRelationshipMetadataTests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+
+namespace Honua.Server.Tests;
+
+/// <summary>
+/// Regression tests for #1923: a MapServer sublayer's metadata must surface the same
+/// <c>relationships</c> and <c>hasAttachments</c> that the equivalent FeatureServer layer
+/// advertises, so ArcGIS clients consuming the MapServer can discover related records and
+/// attachments. The seeded test layer 0 declares a relationship class and opts into
+/// attachments, so both protocol surfaces are expected to report them.
+/// </summary>
+[Protocol(TestProtocols.MapServer)]
+[Collection("Database.CoreFeatureStore")]
+public sealed class MapServerSublayerRelationshipMetadataTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+    private const string TestServiceId = "test";
+    private const int TestLayerId = 0;
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task FeatureServerLayerMetadata_SurfacesRelationshipsAndHasAttachments()
+    {
+        using var document = await GetLayerMetadataAsync("FeatureServer");
+        var root = document.RootElement;
+
+        AssertRelationshipsPresent(root);
+        root.GetProperty("hasAttachments").GetBoolean().Should().BeTrue(
+            "the seeded test layer opts into attachments");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/{layerId}")]
+    public async Task MapServerSublayerMetadata_SurfacesRelationshipsAndHasAttachments()
+    {
+        // The core of #1923: the MapServer sublayer previously emitted relationships:[] and
+        // hasAttachments:false even though the same layer's FeatureServer metadata advertised
+        // both. Assert the MapServer sublayer now mirrors the underlying layer.
+        using var document = await GetLayerMetadataAsync("MapServer");
+        var root = document.RootElement;
+
+        AssertRelationshipsPresent(root);
+        root.GetProperty("hasAttachments").GetBoolean().Should().BeTrue(
+            "the MapServer sublayer must mirror the FeatureServer layer's hasAttachments (#1923)");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/{layerId}")]
+    public async Task MapServerSublayerMetadata_MatchesFeatureServerRelationshipsAndAttachments()
+    {
+        // Both protocol surfaces must agree on the relationship ids and attachment support so
+        // a client consuming either surface sees a consistent layer description.
+        using var featureServer = await GetLayerMetadataAsync("FeatureServer");
+        using var mapServer = await GetLayerMetadataAsync("MapServer");
+
+        var featureRelationshipIds = ReadRelationshipIds(featureServer.RootElement);
+        var mapRelationshipIds = ReadRelationshipIds(mapServer.RootElement);
+
+        mapRelationshipIds.Should().BeEquivalentTo(featureRelationshipIds,
+            "the MapServer sublayer relationships must mirror the FeatureServer layer relationships");
+
+        mapServer.RootElement.GetProperty("hasAttachments").GetBoolean()
+            .Should().Be(featureServer.RootElement.GetProperty("hasAttachments").GetBoolean());
+    }
+
+    private static void AssertRelationshipsPresent(JsonElement root)
+    {
+        root.TryGetProperty("relationships", out var relationships).Should().BeTrue(
+            "layer metadata must include a relationships array");
+        relationships.ValueKind.Should().Be(JsonValueKind.Array);
+        relationships.GetArrayLength().Should().BeGreaterThan(0,
+            "the seeded test layer declares at least one relationship");
+
+        foreach (var relationship in relationships.EnumerateArray())
+        {
+            relationship.GetProperty("id").ValueKind.Should().Be(JsonValueKind.Number);
+            relationship.GetProperty("relatedTableId").ValueKind.Should().Be(JsonValueKind.Number);
+            relationship.GetProperty("name").ValueKind.Should().Be(JsonValueKind.String);
+        }
+    }
+
+    private static List<int> ReadRelationshipIds(JsonElement root)
+    {
+        var ids = new List<int>();
+        if (root.TryGetProperty("relationships", out var relationships)
+            && relationships.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var relationship in relationships.EnumerateArray())
+            {
+                ids.Add(relationship.GetProperty("id").GetInt32());
+            }
+        }
+
+        ids.Sort();
+        return ids;
+    }
+
+    private async Task<JsonDocument> GetLayerMetadataAsync(string serviceType)
+    {
+        using var client = _fixture.CreateClient();
+        var response = await client.GetAsync(
+            $"/rest/services/{TestServiceId}/{serviceType}/{TestLayerId}?f=json");
+        response.Be200Ok();
+
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonDocument.Parse(content);
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Mixins/WebAppFixtureMetadataV2Mixin.cs
+++ b/tests/dotnet/Honua.TestKit/Mixins/WebAppFixtureMetadataV2Mixin.cs
@@ -244,6 +244,15 @@ internal static class WebAppFixtureMetadataV2Mixin
                     .Append("style-layer-0-esri")
                     .Distinct(StringComparer.Ordinal)
                     .ToArray(),
+                // Opt the canonical test layer into attachments so both the FeatureServer
+                // and MapServer layer metadata advertise hasAttachments:true (#1923).
+                Metadata = resources[i].Metadata with
+                {
+                    Annotations = new Dictionary<string, string>(resources[i].Metadata.Annotations, StringComparer.Ordinal)
+                    {
+                        ["honua.io/attachments"] = "true",
+                    },
+                },
                 Relationships =
                 [
                     new MetadataV2Relationship


### PR DESCRIPTION
## Issue Link
Closes #1923

## Summary
A MapServer sublayer's metadata omitted the `relationships` and `hasAttachments` that the **same** FeatureServer layer advertises, so ArcGIS clients consuming the MapServer could not discover related records or attachments on it.

`GET /rest/services/test/FeatureServer/0?f=json` reported `relationships:[1]`, `hasAttachments:true`, while `GET /rest/services/test/MapServer/0?f=json` reported `relationships:[]`, `hasAttachments:false`.

Root cause: the MapServer layer-metadata builder (`MapLayerToMapServerLayerResponse`) never emitted `relationships`, and resolved `hasAttachments` from a different source (`resource.Editing?.SupportsAttachments`) than the FeatureServer layer-metadata builder, which mirrors them from the canonical resource (`BuildRelationshipResponseV2` + the annotation-driven `ResourceSupportsAttachmentsV2`). This fix makes the MapServer sublayer reuse the exact same FeatureServer source for both fields.

## Changes Made
- `MapServerLayerResponse`: added a `relationships` property (reusing the FeatureServer `LayerRelationshipInfo` wire shape) defaulting to `[]`.
- `MapServerJsonContext`: registered `LayerRelationshipInfo` / `LayerRelationshipInfo[]` for AOT serialization.
- `MapLayerToMapServerLayerResponse`: set `Relationships = FeatureServerEndpoints.BuildRelationshipResponseV2(resource, snapshot)` and `HasAttachments = FeatureServerEndpoints.ResourceSupportsAttachmentsV2(resource)` — the same source the FeatureServer layer metadata uses (no duplicated logic; the two FeatureServer helpers were promoted from `private` to `internal`).
- Test fixture: opted the canonical seeded test layer 0 into attachments (`honua.io/attachments=true`) so both protocol surfaces advertise `hasAttachments:true`.
- Added `MapServerSublayerRelationshipMetadataTests` (Testcontainers + PostGIS): asserts BOTH `FeatureServer/{id}` and `MapServer/{id}` metadata surface non-empty `relationships` and `hasAttachments:true`, and that the MapServer sublayer mirrors the FeatureServer relationship ids + attachment flag.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
