### PR TITLE
feat(conformance): wire ets-wms11 + WFS-transactional CITE + declare Features Part 2 CRS

### DIFF
--- a/.github/workflows/cite-evidence-report.yml
+++ b/.github/workflows/cite-evidence-report.yml
@@ -102,6 +102,15 @@ jobs:
           run_suite "WFS 1.0" ./scripts/conformance/cite/run-cite-wfs10-tests.sh basic
           run_suite "WFS 1.1" ./scripts/conformance/cite/run-cite-wfs11-tests.sh basic
           run_suite "WFS 2.0" ./scripts/conformance/cite/run-cite-wfs20-tests.sh basic
+          # WFS 2.0 transactional conformance classes (Transaction + LockFeature).
+          # Writes to its own results dir so it coexists with the basic leg in the
+          # evidence bundle instead of overwriting cite-wfs20-results. The env var
+          # is exported (not an inline prefix) because run_suite is a bash function
+          # and inline `VAR=x fn` does not export into a function's environment.
+          export HONUA_CITE_WFS20_RESULTS_DIR=cite-wfs20-transactional-results
+          run_suite "WFS 2.0 Transactional" ./scripts/conformance/cite/run-cite-wfs20-tests.sh transactional
+          unset HONUA_CITE_WFS20_RESULTS_DIR
+          run_suite "WMS 1.1.1" ./scripts/conformance/cite/run-cite-wms11-tests.sh default
           run_suite "WMS 1.3" ./scripts/conformance/cite/run-cite-wms-tests.sh default
           run_suite "WMTS 1.0" ./scripts/conformance/cite/run-cite-wmts-tests.sh default
           run_suite "WCS 2.0" ./scripts/conformance/cite/run-cite-wcs20-tests.sh core

--- a/.github/workflows/cite-wms11-conformance.yml
+++ b/.github/workflows/cite-wms11-conformance.yml
@@ -1,0 +1,41 @@
+name: OGC WMS 1.1.1 CITE Conformance Tests
+
+on:
+  # Tier: nightly — conformance suites are external and heavyweight.
+  # PR/push triggers removed in #485. See docs/internal/ci/gate-model.md.
+  schedule:
+    # Run weekly to track WMS 1.1.1 conformance drift
+    - cron: '0 6 * * 4'
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: 'CITE test profile'
+        required: false
+        default: 'default'
+        type: choice
+        options:
+          - default
+          - minimal
+          - full
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: cite-wms11-conformance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cite:
+    uses: ./.github/workflows/cite-conformance-common.yml
+    with:
+      suite: wms11
+      display-name: WMS 1.1.1
+      runner-script: ./scripts/conformance/cite/run-cite-wms11-tests.sh
+      results-dir: cite-wms11-results
+      summary-file: cite-wms11-summary.md
+      timeout-seconds: 2400
+      job-timeout-minutes: 45
+      cite-profile: ${{ inputs.profile || 'default' }}
+      extra-artifact-paths: docker/cite/wms11/config/

--- a/docker/cite/README.md
+++ b/docker/cite/README.md
@@ -6,7 +6,8 @@ This directory contains reproducible Docker inputs for OGC CITE and related conf
 
 - `ogc-api-features/` - OGC API Features CITE compose, config, and seed data.
 - `ogc-api-tiles/` - OGC API Tiles CITE compose, config, and seed data.
-- `wfs20/` - WFS 2.0 CITE compose and WFS-specific metadata config.
+- `wfs20/` - WFS 2.0 CITE compose and WFS-specific metadata config. Runs both the `basic` and `transactional` profiles (the transactional leg exercises the Transaction + LockFeature conformance classes).
+- `wms11/` - WMS 1.1.1 CITE compose and config (`ogccite/ets-wms11`).
 - `wms13/` - WMS 1.3 CITE compose and config.
 - `wcs20/` - WCS 2.0 CITE compose, config, and deterministic local raster seed data.
 - `wmts10/` - WMTS 1.0 CITE compose and config.

--- a/docker/cite/wfs20/compose.yml
+++ b/docker/cite/wfs20/compose.yml
@@ -93,7 +93,7 @@ services:
       - HOST_UID=${HOST_UID:-1000}
       - HOST_GID=${HOST_GID:-1000}
     volumes:
-      - ../../../cite-wfs20-results:/results
+      - ../../../${HONUA_CITE_WFS20_RESULTS_DIR:-cite-wfs20-results}:/results
       - ../shared/scripts:/scripts:ro
     networks:
       - cite-network

--- a/docker/cite/wms11/compose.yml
+++ b/docker/cite/wms11/compose.yml
@@ -1,0 +1,162 @@
+services:
+  honua-server:
+    image: honua-server:latest
+    build:
+      context: ../../..
+      dockerfile: Dockerfile
+    ports:
+      - "${HONUA_CITE_WMS11_SERVER_PORT:-8098}:8080"
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Test
+      - ASPNETCORE_URLS=http://+:8080
+      - PUBLIC_BASE_URL=http://honua-server:8080
+      - HONUA_DEV_AUTH=true
+      - HONUA_REGISTER_TEST_INFRASTRUCTURE=true
+      - Cache__Enabled=false
+      - DataSource__Provider=postgres
+      - HostValidation__Enabled=false
+      - HostValidation__AllowedHosts__0=honua-server
+      - HostValidation__AllowedHosts__1=localhost
+      - HONUA_ADMIN_PASSWORD=CiteAdminPassword123!
+      - ConnectionStrings__DefaultConnection=Server=postgres;Port=5432;Database=honua_cite_wms11;User Id=postgres;Password=cite_password;
+      - ConnectionStrings__honua=Server=postgres;Port=5432;Database=honua_cite_wms11;User Id=postgres;Password=cite_password;
+      - ConnectionStrings__Redis=redis:6379
+      - Security__ConnectionEncryption__MasterKey=test-master-key-that-is-at-least-32-characters-long-for-security
+      - Security__ConnectionEncryption__Salt=dGVzdC1zYWx0LWZvci1lbmNyeXB0aW9uLXRlc3RpbmctcHVycG9zZXM=
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - cite-wms11-network
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "-T", "5", "-O", "/dev/null", "http://localhost:8080/healthz/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  postgres:
+    image: postgis/postgis:16-3.4
+    environment:
+      - POSTGRES_DB=honua_cite_wms11
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=cite_password
+      - POSTGRES_INITDB_ARGS=--encoding=UTF-8 --lc-collate=C --lc-ctype=C
+    ports:
+      - "5436:5432"
+    networks:
+      - cite-wms11-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7.4-alpine
+    command: redis-server --appendonly no
+    networks:
+      - cite-wms11-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  cite-engine:
+    image: ogccite/ets-wms11:1.23-teamengine-6.0.0-RC2
+    ports:
+      - "8085:8080"
+    environment:
+      - JAVA_OPTS=-Xmx2g -DTE_BASE=/root/te_base
+      - TEAMENGINE_BASE_URL=http://cite-engine:8080/teamengine
+    volumes:
+      - cite-wms11-logs:/root/te_base/users/cite/logs
+      - ./config:/cite-config:ro
+    networks:
+      - cite-wms11-network
+    depends_on:
+      honua-server:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/teamengine"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+
+  cite-runner:
+    image: ogccite/ets-wms11:1.23-teamengine-6.0.0-RC2
+    environment:
+      - WMS_CAPABILITIES_URL
+      - WMS_UPDATESEQUENCE
+      - WMS_HIGH_UPDATESEQUENCE
+      - WMS_LOW_UPDATESEQUENCE
+      - WMS_PROFILE
+      - WMS_RECOMMENDED
+      - WMS_GETFEATUREINFO
+      - WMS_FEESCONSTRAINTS
+      - WMS_BBOXCONSTRAINTS
+    command:
+      - bash
+      - -lc
+      - |
+          set -euo pipefail
+          WMS_CAPABILITIES_URL="$${WMS_CAPABILITIES_URL:-http://honua-server:8080/rest/services/cite/MapServer/WMS?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1}"
+          WMS_UPDATESEQUENCE="$${WMS_UPDATESEQUENCE:-auto}"
+          WMS_HIGH_UPDATESEQUENCE="$${WMS_HIGH_UPDATESEQUENCE:-}"
+          WMS_LOW_UPDATESEQUENCE="$${WMS_LOW_UPDATESEQUENCE:-}"
+          WMS_PROFILE="$${WMS_PROFILE:-queryable}"
+          WMS_RECOMMENDED="$${WMS_RECOMMENDED:-true}"
+          WMS_GETFEATUREINFO="$${WMS_GETFEATUREINFO:-true}"
+          WMS_FEESCONSTRAINTS="$${WMS_FEESCONSTRAINTS:-false}"
+          WMS_BBOXCONSTRAINTS="$${WMS_BBOXCONSTRAINTS:-either}"
+          echo 'Waiting for services to be ready...'
+          sleep 30
+          echo 'Preparing TeamEngine console...'
+          curl -sS --fail --retry 5 --retry-delay 2 --retry-all-errors -L -o /tmp/teamengine-console-6.0.0-RC2-bin.zip https://repo1.maven.org/maven2/org/opengis/cite/teamengine/teamengine-console/6.0.0-RC2/teamengine-console-6.0.0-RC2-bin.zip
+          unzip -q /tmp/teamengine-console-6.0.0-RC2-bin.zip -d /tmp/te-console
+          mkdir -p /root/te_base/resources/lib /root/te_base/scripts
+          mkdir -p /root/te_base/users/cite/logs
+          rm -rf /root/te_base/scripts/wms11
+          unzip -qo -j /root/ets-wms11-*-deps.zip -d /root/te_base/resources/lib || true
+          unzip -qo /root/ets-wms11-*-ctl.zip -d /root/te_base/scripts || true
+          export TE_BASE=/root/te_base
+          echo 'Starting WMS 1.1.1 CITE conformance tests...'
+          /tmp/te-console/bin/unix/test.sh \
+            -source=/root/te_base/scripts/wms11/1.1.1/ctl/main-auto.xml \
+            -test=wms:main_wms_auto \
+            "@capabilities-url=$${WMS_CAPABILITIES_URL}" \
+            "@updatesequence=$${WMS_UPDATESEQUENCE}" \
+            "@high-updatesequence=$${WMS_HIGH_UPDATESEQUENCE}" \
+            "@low-updatesequence=$${WMS_LOW_UPDATESEQUENCE}" \
+            "@profile=$${WMS_PROFILE}" \
+            "@recommended=$${WMS_RECOMMENDED}" \
+            "@getfeatureinfo=$${WMS_GETFEATUREINFO}" \
+            "@feesconstraints=$${WMS_FEESCONSTRAINTS}" \
+            "@bboxconstraints=$${WMS_BBOXCONSTRAINTS}" \
+            -logdir=users/cite/logs \
+            -session=cite-wms11-session-$(date +%Y%m%d-%H%M%S)
+          echo 'CITE tests completed. Check results in logdir.'
+    volumes:
+      - cite-wms11-results:/root/te_base/users/cite/logs
+      - ./config:/cite-config:ro
+    networks:
+      - cite-wms11-network
+    depends_on:
+      cite-engine:
+        condition: service_healthy
+    profiles:
+      - test
+
+volumes:
+  cite-wms11-logs:
+    driver: local
+  cite-wms11-results:
+    driver: local
+
+networks:
+  cite-wms11-network:
+    driver: bridge

--- a/docker/cite/wms11/config/test-params.xml
+++ b/docker/cite/wms11/config/test-params.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<values xmlns:parsers="http://www.occamlab.com/te/parsers">
+  <parsers:session>
+    <parsers:test>ets-wms11</parsers:test>
+    <parsers:profile>queryable</parsers:profile>
+  </parsers:session>
+  <value key="capabilities-url">http://honua-server:8080/rest/services/cite/MapServer/WMS?SERVICE=WMS&amp;REQUEST=GetCapabilities&amp;VERSION=1.1.1</value>
+  <value key="updatesequence">auto</value>
+  <value key="high-updatesequence"></value>
+  <value key="low-updatesequence"></value>
+  <value key="profile">queryable</value>
+  <value key="recommended">true</value>
+  <value key="getfeatureinfo">true</value>
+  <value key="feesconstraints">false</value>
+  <value key="bboxconstraints">either</value>
+</values>

--- a/docs/cite-status.md
+++ b/docs/cite-status.md
@@ -44,7 +44,19 @@ failed, 0 skipped, 0 CantTell.
 | WMTS 1.0 | `default` | 60 / 60 | 100% | 2026-05-17 |
 
 The WFS 2.0 explicit transactional slice is tracked separately and passes
-25 / 25 with 0 failed and 0 skipped as of the same run.
+25 / 25 with 0 failed and 0 skipped as of the same run. It is now promoted into
+the weekly `CITE Evidence Report` as a dedicated leg
+(`cite-wfs20-transactional-results`) alongside the `basic` leg, so the
+Transaction + LockFeature conformance classes are measured every run.
+
+**Newly wired (pending first evidence run):** WMS 1.1.1 (`ets-wms11`,
+`default` profile) is now wired end-to-end — `docker/cite/wms11/`,
+`scripts/conformance/cite/run-cite-wms11-tests.sh`, the weekly
+`cite-wms11-conformance.yml` dispatcher, and the `CITE Evidence Report` master
+list. The first scheduled run will populate its row here. Honua already serves
+and version-negotiates WMS 1.1.1 (1.1.1 axis order, `WMT_MS_Capabilities`,
+`application/vnd.ogc.se_xml` exceptions, `X`/`Y` GetFeatureInfo, and — added
+with this wiring — `application/vnd.ogc.gml` GML FeatureInfo).
 
 ### Common Re-Grading Mistakes To Avoid
 

--- a/scripts/conformance/cite/build-cite-evidence.sh
+++ b/scripts/conformance/cite/build-cite-evidence.sh
@@ -75,6 +75,8 @@ SUITES=(
     "wfs10|WFS 1.0|cite-wfs10-results|cite-wfs10-summary.md"
     "wfs11|WFS 1.1|cite-wfs11-results|cite-wfs11-summary.md"
     "wfs20|WFS 2.0|cite-wfs20-results|cite-summary.md"
+    "wfs20-transactional|WFS 2.0 Transactional|cite-wfs20-transactional-results|cite-summary.md"
+    "wms11|WMS 1.1.1|cite-wms11-results|cite-wms11-summary.md"
     "wms13|WMS 1.3|cite-wms-results|cite-wms-summary.md"
     "wmts10|WMTS 1.0|cite-wmts-results|cite-wmts-summary.md"
     "wcs20|WCS 2.0|cite-wcs20-results|cite-wcs20-summary.md"

--- a/scripts/conformance/cite/run-cite-wfs20-tests.sh
+++ b/scripts/conformance/cite/run-cite-wfs20-tests.sh
@@ -14,7 +14,13 @@ NC='\033[0m' # No Color
 
 # Configuration
 CITE_COMPOSE_FILE="docker/cite/wfs20/compose.yml"
-CITE_RESULTS_DIR="cite-wfs20-results"
+# Results dir is overridable so the transactional evidence leg can write to its
+# own directory (cite-wfs20-transactional-results) without clobbering the basic
+# run that shares this same runner. The compose `cite-runner` /results mount
+# reads the same HONUA_CITE_WFS20_RESULTS_DIR env so host + container agree.
+CITE_RESULTS_DIR="${HONUA_CITE_WFS20_RESULTS_DIR:-cite-wfs20-results}"
+HONUA_CITE_WFS20_RESULTS_DIR="$CITE_RESULTS_DIR"
+export HONUA_CITE_WFS20_RESULTS_DIR
 CITE_TIMEOUT=1800  # 30 minutes timeout
 HEALTHCHECK_TIMEOUT=300  # 5 minutes
 HONUA_CITE_WFS20_SERVER_PORT="${HONUA_CITE_WFS20_SERVER_PORT:-8090}"

--- a/scripts/conformance/cite/run-cite-wms11-tests.sh
+++ b/scripts/conformance/cite/run-cite-wms11-tests.sh
@@ -1,0 +1,423 @@
+#!/bin/bash
+
+# WMS 1.1.1 CITE conformance testing script for Honua Server.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+CITE_COMPOSE_FILE="docker/cite/wms11/compose.yml"
+CITE_RESULTS_DIR="cite-wms11-results"
+CITE_RESULTS_CONTAINER_DIR="/root/te_base/users/cite/logs"
+CITE_TIMEOUT=1800
+HONUA_HEALTHCHECK_TIMEOUT=300
+POSTGRES_HEALTHCHECK_TIMEOUT=120
+HONUA_CITE_WMS11_SERVER_PORT="${HONUA_CITE_WMS11_SERVER_PORT:-8098}"
+export HONUA_CITE_WMS11_SERVER_PORT
+PASSED_TESTS=0
+FAILED_TESTS=0
+SKIPPED_TESTS=0
+CANTTELL_TESTS=0
+TOTAL_TESTS=0
+
+CLEANUP=true
+INTERACTIVE=false
+VERBOSE=false
+PROFILE="default"
+SKIP_BUILD="${HONUA_CITE_SKIP_BUILD:-false}"
+WMS_PROFILE="queryable"
+WMS_RECOMMENDED="true"
+WMS_GETFEATUREINFO="true"
+WMS_FEESCONSTRAINTS="false"
+WMS_BBOXCONSTRAINTS="either"
+
+set_profile_options() {
+    local profile="$1"
+    WMS_PROFILE="no"
+    WMS_RECOMMENDED="false"
+    WMS_GETFEATUREINFO="false"
+    WMS_FEESCONSTRAINTS="false"
+    WMS_BBOXCONSTRAINTS="either"
+
+    case "$profile" in
+        minimal)
+            WMS_PROFILE="basic"
+            WMS_RECOMMENDED="false"
+            WMS_GETFEATUREINFO="false"
+            ;;
+        default)
+            WMS_PROFILE="queryable"
+            WMS_RECOMMENDED="true"
+            WMS_GETFEATUREINFO="true"
+            ;;
+        full)
+            WMS_PROFILE="queryable"
+            WMS_RECOMMENDED="true"
+            WMS_GETFEATUREINFO="true"
+            WMS_BBOXCONSTRAINTS="either"
+            ;;
+        *)
+            echo -e "${RED}Unknown profile: $profile${NC}"
+            exit 1
+            ;;
+    esac
+}
+
+echo -e "${BLUE}WMS 1.1.1 CITE Conformance Tests${NC}"
+echo "================================"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-cleanup)
+            CLEANUP=false
+            shift
+            ;;
+        --interactive)
+            INTERACTIVE=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --profile)
+            PROFILE="$2"
+            shift 2
+            ;;
+        --skip-build)
+            SKIP_BUILD=true
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --no-cleanup      Don't cleanup containers after tests"
+            echo "  --interactive     Run in interactive mode (keep containers running)"
+            echo "  --verbose         Enable verbose logging"
+            echo "  --profile PROF    Use specific CITE profile (minimal|default|full)"
+            echo "  --skip-build      Reuse existing honua-server:latest image"
+            echo "  --help, -h        Show this help"
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            exit 1
+            ;;
+    esac
+done
+
+echo -e "${YELLOW}Checking prerequisites...${NC}"
+
+if ! command -v docker &> /dev/null; then
+    echo -e "${RED}Docker not found. Please install Docker${NC}"
+    exit 1
+fi
+
+if ! command -v docker-compose &> /dev/null && ! command -v docker compose &> /dev/null; then
+    echo -e "${RED}Docker Compose not found. Please install Docker Compose${NC}"
+    exit 1
+fi
+
+if command -v docker-compose &> /dev/null; then
+    COMPOSE_CMD="docker-compose"
+else
+    COMPOSE_CMD="docker compose"
+fi
+
+if [[ "$SKIP_BUILD" == "true" ]]; then
+    echo -e "${YELLOW}Skipping Honua Server Docker image build; using existing honua-server:latest${NC}"
+else
+    echo -e "${YELLOW}Building Honua Server Docker image...${NC}"
+    if ! scripts/docker/build-with-github-packages.sh -t honua-server:latest .; then
+        echo -e "${RED}Failed to build Honua Server Docker image${NC}"
+        exit 1
+    fi
+
+    echo -e "${GREEN}Honua Server image built successfully${NC}"
+fi
+
+cleanup() {
+    if [[ "$CLEANUP" == "true" && "$INTERACTIVE" == "false" ]]; then
+        echo -e "\n${YELLOW}Cleaning up containers and networks...${NC}"
+        $COMPOSE_CMD -f "$CITE_COMPOSE_FILE" down --remove-orphans --volumes 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT
+
+echo -e "${YELLOW}Starting CITE WMS 1.1.1 test environment...${NC}"
+$COMPOSE_CMD -f "$CITE_COMPOSE_FILE" down --remove-orphans --volumes 2>/dev/null || true
+$COMPOSE_CMD -f "$CITE_COMPOSE_FILE" up -d postgres
+
+echo -e "${YELLOW}Waiting for Postgres to be ready...${NC}"
+start_time=$(date +%s)
+while true; do
+    current_time=$(date +%s)
+    elapsed=$((current_time - start_time))
+
+    if [[ $elapsed -gt $POSTGRES_HEALTHCHECK_TIMEOUT ]]; then
+        echo -e "${RED}Timeout waiting for Postgres to become healthy${NC}"
+        echo "Check logs with: $COMPOSE_CMD -f $CITE_COMPOSE_FILE logs postgres"
+        exit 1
+    fi
+
+    if $COMPOSE_CMD -f "$CITE_COMPOSE_FILE" ps postgres | grep -q "healthy"; then
+        break
+    fi
+
+    echo "Waiting for Postgres... (${elapsed}s elapsed)"
+    sleep 5
+done
+
+echo -e "${GREEN}Postgres is healthy${NC}"
+
+$COMPOSE_CMD -f "$CITE_COMPOSE_FILE" up -d honua-server
+
+echo -e "${YELLOW}Waiting for Honua Server to be ready (migrations)...${NC}"
+start_time=$(date +%s)
+while true; do
+    current_time=$(date +%s)
+    elapsed=$((current_time - start_time))
+
+    if [[ $elapsed -gt $HONUA_HEALTHCHECK_TIMEOUT ]]; then
+        echo -e "${RED}Timeout waiting for Honua Server to become healthy${NC}"
+        echo "Check logs with: $COMPOSE_CMD -f $CITE_COMPOSE_FILE logs honua-server"
+        exit 1
+    fi
+
+    if $COMPOSE_CMD -f "$CITE_COMPOSE_FILE" ps honua-server | grep -q "healthy"; then
+        break
+    fi
+
+    echo "Waiting for Honua Server... (${elapsed}s elapsed)"
+    sleep 5
+done
+
+echo -e "${GREEN}Honua Server is healthy${NC}"
+
+echo -e "${YELLOW}Stopping Honua Server to seed data...${NC}"
+$COMPOSE_CMD -f "$CITE_COMPOSE_FILE" stop honua-server
+
+echo -e "${YELLOW}Seeding CITE WMS 1.1.1 database...${NC}"
+POSTGRES_CONTAINER=$($COMPOSE_CMD -f "$CITE_COMPOSE_FILE" ps -q postgres)
+if [[ -z "$POSTGRES_CONTAINER" ]]; then
+    echo -e "${RED}Postgres container not found${NC}"
+    exit 1
+fi
+
+docker cp docker/cite/shared/seed/mapserver.sql "$POSTGRES_CONTAINER":/tmp/cite-mapserver-seed.sql
+docker exec -i "$POSTGRES_CONTAINER" psql -v ON_ERROR_STOP=1 -U postgres -d honua_cite_wms11 -f /tmp/cite-mapserver-seed.sql >/dev/null
+echo -e "${GREEN}CITE WMS 1.1.1 database seeded${NC}"
+
+$COMPOSE_CMD -f "$CITE_COMPOSE_FILE" up -d honua-server cite-engine
+
+echo -e "${YELLOW}Waiting for Honua Server to be ready...${NC}"
+start_time=$(date +%s)
+while true; do
+    current_time=$(date +%s)
+    elapsed=$((current_time - start_time))
+
+    if [[ $elapsed -gt $HONUA_HEALTHCHECK_TIMEOUT ]]; then
+        echo -e "${RED}Timeout waiting for Honua Server to become healthy${NC}"
+        echo "Check logs with: $COMPOSE_CMD -f $CITE_COMPOSE_FILE logs honua-server"
+        exit 1
+    fi
+
+    if $COMPOSE_CMD -f "$CITE_COMPOSE_FILE" ps honua-server | grep -q "healthy"; then
+        break
+    fi
+
+    echo "Waiting for Honua Server... (${elapsed}s elapsed)"
+    sleep 5
+done
+
+echo -e "${GREEN}Honua Server is healthy${NC}"
+
+echo -e "${YELLOW}Verifying WMS 1.1.1 endpoints...${NC}"
+HONUA_BASE_URL="http://localhost:${HONUA_CITE_WMS11_SERVER_PORT}"
+CAPS_URL_HOST="${HONUA_BASE_URL}/rest/services/cite/MapServer/WMS?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1"
+CAPS_URL_CONTAINER="http://honua-server:8080/rest/services/cite/MapServer/WMS?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1"
+CAPS_URL="$CAPS_URL_HOST"
+GETMAP_URL="${HONUA_BASE_URL}/rest/services/cite/MapServer/WMS?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.1&BBOX=-180,-90,180,90&SRS=EPSG:4326&WIDTH=256&HEIGHT=256&LAYERS=0&FORMAT=image/png&STYLES="
+
+if ! curl -s -f "$CAPS_URL_HOST" > /dev/null; then
+    echo -e "${RED}WMS 1.1.1 GetCapabilities endpoint not accessible${NC}"
+    exit 1
+fi
+
+if ! curl -s -f "$GETMAP_URL" > /dev/null; then
+    echo -e "${YELLOW}WMS 1.1.1 GetMap preflight failed; continuing to CITE execution for full diagnostics${NC}"
+fi
+
+echo -e "${GREEN}WMS 1.1.1 endpoints are accessible${NC}"
+
+if [[ "$INTERACTIVE" == "true" ]]; then
+    echo -e "${BLUE}Interactive mode enabled${NC}"
+    echo "Services are running at:"
+    echo "  Honua Server:     $HONUA_BASE_URL"
+    echo "  CITE Team Engine: http://localhost:8085/teamengine"
+    echo "  PostgreSQL:       localhost:5436"
+    echo ""
+    echo "Press Ctrl+C to stop all services"
+    tail -f /dev/null
+fi
+
+mkdir -p "$CITE_RESULTS_DIR"
+rm -rf "$CITE_RESULTS_DIR"/*
+
+echo -e "${YELLOW}Capturing WMS 1.1.1 capabilities...${NC}"
+if ! curl -s -f "$CAPS_URL_HOST" > "$CITE_RESULTS_DIR/capabilities.xml"; then
+    echo -e "${RED}Failed to capture WMS 1.1.1 capabilities${NC}"
+    exit 1
+fi
+
+set_profile_options "$PROFILE"
+
+echo -e "${YELLOW}Running WMS 1.1.1 CITE conformance tests (profile: $PROFILE)...${NC}"
+$COMPOSE_CMD -f "$CITE_COMPOSE_FILE" rm -f -s cite-runner >/dev/null 2>&1 || true
+WMS_CAPABILITIES_URL="$CAPS_URL_CONTAINER" \
+WMS_UPDATESEQUENCE="auto" \
+WMS_HIGH_UPDATESEQUENCE="" \
+WMS_LOW_UPDATESEQUENCE="" \
+WMS_PROFILE="$WMS_PROFILE" \
+WMS_RECOMMENDED="$WMS_RECOMMENDED" \
+WMS_GETFEATUREINFO="$WMS_GETFEATUREINFO" \
+WMS_FEESCONSTRAINTS="$WMS_FEESCONSTRAINTS" \
+WMS_BBOXCONSTRAINTS="$WMS_BBOXCONSTRAINTS" \
+    $COMPOSE_CMD -f "$CITE_COMPOSE_FILE" --profile test up --force-recreate cite-runner
+
+echo -e "${YELLOW}Waiting for CITE tests to complete...${NC}"
+start_time=$(date +%s)
+while true; do
+    current_time=$(date +%s)
+    elapsed=$((current_time - start_time))
+
+    if [[ $elapsed -gt $CITE_TIMEOUT ]]; then
+        echo -e "${RED}CITE tests timed out after ${CITE_TIMEOUT} seconds${NC}"
+        break
+    fi
+
+    if ! $COMPOSE_CMD -f "$CITE_COMPOSE_FILE" ps cite-runner | grep -q "Up"; then
+        break
+    fi
+
+    if [[ $((elapsed % 30)) -eq 0 ]]; then
+        echo "CITE tests running... (${elapsed}s elapsed)"
+    fi
+
+    sleep 5
+done
+
+echo -e "${YELLOW}Extracting CITE test results...${NC}"
+CITE_RUNNER_CONTAINER=$($COMPOSE_CMD -f "$CITE_COMPOSE_FILE" ps -aq cite-runner 2>/dev/null | tail -n 1 || echo "")
+if [[ -n "$CITE_RUNNER_CONTAINER" ]]; then
+    docker cp "$CITE_RUNNER_CONTAINER":"$CITE_RESULTS_CONTAINER_DIR"/. "$CITE_RESULTS_DIR/" 2>/dev/null || true
+fi
+
+echo -e "\n${BLUE}CITE Test Results Analysis${NC}"
+echo "==============================="
+
+RESULTS_FOUND=false
+if [[ -d "$CITE_RESULTS_DIR" && $(ls -A "$CITE_RESULTS_DIR" 2>/dev/null) ]]; then
+    RESULTS_FOUND=true
+    echo "Results saved to: $CITE_RESULTS_DIR/"
+
+    RESULTS_XML=$(find "$CITE_RESULTS_DIR" -type f -name "testng-results.xml" | sort | tail -n 1)
+    if [[ -n "$RESULTS_XML" && -f "$RESULTS_XML" ]]; then
+        echo -e "${GREEN}Test result files found${NC}"
+        TOTAL_TESTS=$(sed -n 's/.*total="\([0-9]\+\)".*/\1/p' "$RESULTS_XML" | head -n 1)
+        PASSED_TESTS=$(sed -n 's/.*passed="\([0-9]\+\)".*/\1/p' "$RESULTS_XML" | head -n 1)
+        FAILED_TESTS=$(sed -n 's/.*failed="\([0-9]\+\)".*/\1/p' "$RESULTS_XML" | head -n 1)
+        SKIPPED_TESTS=$(sed -n 's/.*skipped="\([0-9]\+\)".*/\1/p' "$RESULTS_XML" | head -n 1)
+        CANTTELL_TESTS=0
+    else
+        SESSION_DIR=$(find "$CITE_RESULTS_DIR" -maxdepth 1 -type d -name "cite-wms11-session-*" | sort | tail -n 1)
+        RESULT_CODE_LINES=""
+        if [[ -n "$SESSION_DIR" && -d "$SESSION_DIR" ]]; then
+            RESULT_CODE_LINES=$(grep -Rho 'endtest result="[0-9]\+"' "$SESSION_DIR" 2>/dev/null || true)
+        fi
+
+        if [[ -n "$RESULT_CODE_LINES" ]]; then
+            TOTAL_TESTS=$(printf '%s\n' "$RESULT_CODE_LINES" | wc -l | tr -d ' ')
+            PASSED_TESTS=$(printf '%s\n' "$RESULT_CODE_LINES" | grep -c 'result="1"' || true)
+            SKIPPED_TESTS=$(printf '%s\n' "$RESULT_CODE_LINES" | grep -c 'result="3"' || true)
+            CANTTELL_TESTS=$(printf '%s\n' "$RESULT_CODE_LINES" | grep -c 'result="4"' || true)
+            FAILED_TESTS=$((TOTAL_TESTS - PASSED_TESTS - SKIPPED_TESTS - CANTTELL_TESTS))
+        fi
+    fi
+
+    TOTAL_TESTS=${TOTAL_TESTS:-0}
+    PASSED_TESTS=${PASSED_TESTS:-0}
+    FAILED_TESTS=${FAILED_TESTS:-0}
+    SKIPPED_TESTS=${SKIPPED_TESTS:-0}
+    CANTTELL_TESTS=${CANTTELL_TESTS:-0}
+
+    echo "Total tests executed: $TOTAL_TESTS"
+    echo "Tests passed: $PASSED_TESTS"
+    echo "Tests failed: $FAILED_TESTS"
+    echo "Tests skipped: $SKIPPED_TESTS"
+    echo "Tests canttell: $CANTTELL_TESTS"
+else
+    echo -e "${RED}No test results found${NC}"
+fi
+
+if [[ "$VERBOSE" == "true" || $FAILED_TESTS -gt 0 ]]; then
+    echo -e "\n${BLUE}Service Logs${NC}"
+    echo "==============="
+    echo -e "${YELLOW}Honua Server logs:${NC}"
+    $COMPOSE_CMD -f "$CITE_COMPOSE_FILE" logs --tail=50 honua-server || true
+
+    echo -e "\n${YELLOW}CITE Runner logs:${NC}"
+    $COMPOSE_CMD -f "$CITE_COMPOSE_FILE" logs cite-runner || true
+fi
+
+SUCCESS_RATE=0
+if [[ ${TOTAL_TESTS:-0} -gt 0 ]]; then
+    SUCCESS_RATE=$((PASSED_TESTS * 100 / TOTAL_TESTS))
+fi
+
+cat > "$CITE_RESULTS_DIR/cite-wms11-summary.md" << EOF_SUMMARY
+# WMS 1.1.1 CITE Conformance Test Results
+
+## Summary
+
+- **Total Tests**: $TOTAL_TESTS
+- **Passed**: $PASSED_TESTS
+- **Failed**: $FAILED_TESTS
+- **Skipped**: $SKIPPED_TESTS
+- **CantTell**: $CANTTELL_TESTS
+- **Success Rate**: ${SUCCESS_RATE}%
+
+## Environment
+
+- **Profile**: $PROFILE
+- **CITE Suite**: ets-wms11
+- **Capabilities URL**: $CAPS_URL
+
+## Artifacts
+
+- capabilities.xml: captured WMS 1.1.1 capabilities document
+- testng-results.xml: raw TeamEngine result summary (when available)
+
+EOF_SUMMARY
+
+echo -e "${GREEN}Summary report saved to: $CITE_RESULTS_DIR/cite-wms11-summary.md${NC}"
+
+if [[ "$RESULTS_FOUND" != "true" ]]; then
+    echo -e "${RED}CITE testing failed to execute properly.${NC}"
+    exit 2
+elif [[ $FAILED_TESTS -gt 0 || $SKIPPED_TESTS -gt 0 || $CANTTELL_TESTS -gt 0 ]]; then
+    echo -e "${YELLOW}CITE testing completed with failures, skips, or CantTell results. Review results.${NC}"
+    exit 1
+elif [[ $TOTAL_TESTS -eq 0 ]]; then
+    echo -e "${RED}CITE testing produced no executable tests.${NC}"
+    exit 2
+else
+    echo -e "${GREEN}CITE conformance testing completed successfully!${NC}"
+    exit 0
+fi

--- a/src/Honua.Protocols.OgcClassic/OgcClassicRequestHelpers.cs
+++ b/src/Honua.Protocols.OgcClassic/OgcClassicRequestHelpers.cs
@@ -13,6 +13,11 @@ internal static class OgcClassicRequestHelpers
     internal const string PngMimeType = "image/png";
     internal const string PlainTextMimeType = "text/plain";
     internal const string JsonMimeType = "application/json";
+
+    // WMS GetFeatureInfo GML output. WMS 1.1.1 (OGC 01-068r3) requires the
+    // application/vnd.ogc.gml INFO_FORMAT to be advertised and served for the
+    // GML FeatureInfo conformance class (ets-wms11 wms:wms-getfeatureinfo).
+    internal const string GmlFeatureInfoMimeType = "application/vnd.ogc.gml";
     internal const string CiteServiceName = "cite";
     internal const string CiteTerrainLayerTitle = "cite:Terrain";
 
@@ -72,6 +77,12 @@ internal static class OgcClassicRequestHelpers
         if (string.Equals(format, JsonMimeType, StringComparison.OrdinalIgnoreCase))
         {
             normalizedFormat = JsonMimeType;
+            return true;
+        }
+
+        if (string.Equals(format, GmlFeatureInfoMimeType, StringComparison.OrdinalIgnoreCase))
+        {
+            normalizedFormat = GmlFeatureInfoMimeType;
             return true;
         }
 

--- a/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetCapabilities.cs
+++ b/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetCapabilities.cs
@@ -403,6 +403,7 @@ internal static partial class WmsRequestHandlers
 
         sb.AppendLine("      <GetFeatureInfo>");
         sb.AppendLine("        <Format>text/plain</Format>");
+        sb.AppendLine("        <Format>application/vnd.ogc.gml</Format>");
         sb.AppendLine("        <Format>application/json</Format>");
         sb.AppendLine("        <DCPType>");
         sb.AppendLine("          <HTTP>");

--- a/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetFeatureInfo.cs
+++ b/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetFeatureInfo.cs
@@ -307,10 +307,8 @@ internal static partial class WmsRequestHandlers
         sb.Append("<msGMLOutput xmlns:gml=\"http://www.opengis.net/gml\" ")
             .AppendLine("xmlns:xlink=\"http://www.w3.org/1999/xlink\">");
 
-        var featureIndex = 0;
         foreach (var feature in features)
         {
-            featureIndex++;
             var layerElement = ToGmlElementName(feature.Layer);
             sb.Append("  <").Append(layerElement).Append("_layer>").AppendLine();
             sb.Append("    <").Append(layerElement).Append("_feature>").AppendLine();

--- a/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetFeatureInfo.cs
+++ b/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetFeatureInfo.cs
@@ -129,7 +129,7 @@ internal static partial class WmsRequestHandlers
 
         if (!TryNormalizeFeatureInfoFormat(GetQueryValue(query, "INFO_FORMAT"), out var infoFormat))
         {
-            return CreateWmsServiceException(context, "InvalidFormat", "Unsupported INFO_FORMAT. Supported values are text/plain and application/json.");
+            return CreateWmsServiceException(context, "InvalidFormat", "Unsupported INFO_FORMAT. Supported values are text/plain, application/vnd.ogc.gml, and application/json.");
         }
 
         var filterResult = TryParseWmsLayerFilters(context, query, mapLayers);
@@ -172,6 +172,7 @@ internal static partial class WmsRequestHandlers
 
         var plainText = new StringBuilder();
         var jsonFeatures = new List<WmsFeatureInfoFeature>();
+        var gmlFeatures = new List<WmsFeatureInfoFeature>();
 
         foreach (var layer in queryLayers)
         {
@@ -245,6 +246,16 @@ internal static partial class WmsRequestHandlers
                     continue;
                 }
 
+                if (string.Equals(infoFormat, GmlFeatureInfoMimeType, StringComparison.OrdinalIgnoreCase))
+                {
+                    gmlFeatures.Add(new WmsFeatureInfoFeature
+                    {
+                        Layer = layerName,
+                        Attributes = attributes
+                    });
+                    continue;
+                }
+
                 plainText.Append("Layer=").Append(layerName).AppendLine();
                 foreach (var attribute in attributes.OrderBy(pair => pair.Key, StringComparer.OrdinalIgnoreCase))
                 {
@@ -268,9 +279,98 @@ internal static partial class WmsRequestHandlers
             return Results.Json(payload, OgcClassicJsonContext.Default.WmsFeatureInfoResponse, contentType: JsonMimeType);
         }
 
+        if (string.Equals(infoFormat, GmlFeatureInfoMimeType, StringComparison.OrdinalIgnoreCase))
+        {
+            var gml = BuildWmsGmlFeatureInfo(gmlFeatures);
+            return Results.Content(gml, GmlFeatureInfoMimeType, Encoding.UTF8, StatusCodes.Status200OK);
+        }
+
         var body = plainText.Length > 0
             ? plainText.ToString().TrimEnd()
             : "No features found.";
         return Results.Content(body, PlainTextMimeType, Encoding.UTF8, StatusCodes.Status200OK);
+    }
+
+    /// <summary>
+    /// Builds a WMS GetFeatureInfo GML response (INFO_FORMAT
+    /// <c>application/vnd.ogc.gml</c>). Emits an OGC FeatureInfoResponse wrapping
+    /// one element per identified feature with its visible attributes as child
+    /// elements. This mirrors the MapServer/GeoServer <c>msGMLOutput</c> shape the
+    /// WMS 1.1.1 GML FeatureInfo conformance class (ets-wms11
+    /// <c>wms:wms-getfeatureinfo</c>) expects: a well-formed XML document whose
+    /// content type matches the advertised GML format.
+    /// </summary>
+    private static string BuildWmsGmlFeatureInfo(IReadOnlyList<WmsFeatureInfoFeature> features)
+    {
+        var sb = new StringBuilder(512);
+        sb.AppendLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        sb.Append("<msGMLOutput xmlns:gml=\"http://www.opengis.net/gml\" ")
+            .AppendLine("xmlns:xlink=\"http://www.w3.org/1999/xlink\">");
+
+        var featureIndex = 0;
+        foreach (var feature in features)
+        {
+            featureIndex++;
+            var layerElement = ToGmlElementName(feature.Layer);
+            sb.Append("  <").Append(layerElement).Append("_layer>").AppendLine();
+            sb.Append("    <").Append(layerElement).Append("_feature>").AppendLine();
+            sb.Append("      <gml:name>")
+                .Append(EscapeXml(feature.Layer))
+                .AppendLine("</gml:name>");
+
+            foreach (var attribute in feature.Attributes.OrderBy(pair => pair.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                var element = ToGmlElementName(attribute.Key);
+                sb.Append("      <")
+                    .Append(element)
+                    .Append('>')
+                    .Append(EscapeXml(FormatFeatureInfoValue(attribute.Value)))
+                    .Append("</")
+                    .Append(element)
+                    .AppendLine(">");
+            }
+
+            sb.Append("    </").Append(layerElement).Append("_feature>").AppendLine();
+            sb.Append("  </").Append(layerElement).Append("_layer>").AppendLine();
+        }
+
+        sb.AppendLine("</msGMLOutput>");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Normalizes an arbitrary layer/attribute name into a safe XML element
+    /// NCName: strips a namespace prefix, replaces non name-char runs with '_',
+    /// and prefixes a leading non-letter so the result is always a valid element
+    /// name. Falls back to <c>field</c> when nothing usable remains.
+    /// </summary>
+    private static string ToGmlElementName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return "field";
+        }
+
+        var colon = name.LastIndexOf(':');
+        var local = colon >= 0 && colon < name.Length - 1 ? name[(colon + 1)..] : name;
+
+        var sb = new StringBuilder(local.Length);
+        foreach (var ch in local)
+        {
+            sb.Append(char.IsLetterOrDigit(ch) || ch == '_' || ch == '-' || ch == '.' ? ch : '_');
+        }
+
+        var candidate = sb.ToString().Trim('_');
+        if (candidate.Length == 0)
+        {
+            return "field";
+        }
+
+        if (!char.IsLetter(candidate[0]) && candidate[0] != '_')
+        {
+            candidate = "_" + candidate;
+        }
+
+        return candidate;
     }
 }

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wms/OgcClassicWmsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wms/OgcClassicWmsTests.cs
@@ -42,6 +42,9 @@ public sealed class OgcClassicWmsTests : IAsyncLifetime
         content.Should().Contain("EPSG:4326");
         content.Should().Contain("<GetMap>");
         content.Should().Contain("<GetFeatureInfo>");
+        // WMS GML FeatureInfo conformance class (ets-wms11 wms:wms-getfeatureinfo)
+        // requires the application/vnd.ogc.gml GetFeatureInfo format to be advertised.
+        content.Should().Contain("<Format>application/vnd.ogc.gml</Format>");
         content.Should().Contain("schemaLocation");
     }
 
@@ -561,6 +564,30 @@ public sealed class OgcClassicWmsTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.OK, content);
         response.Content.Headers.ContentType?.MediaType.Should().Be("text/plain");
         content.Should().Contain("Layer=");
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.Wms111)]
+    [Operation(Operations.Wms)]
+    [InterfaceOperation(TestProtocols.Wms111, "GetFeatureInfo")]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/WMS")]
+    public async Task Wms111_GetFeatureInfo_WithGmlFormat_ReturnsGml()
+    {
+        // WMS 1.1.1 GML FeatureInfo conformance class (ets-wms11
+        // wms:wms-getfeatureinfo): the advertised application/vnd.ogc.gml
+        // INFO_FORMAT must be served as a well-formed GML document whose
+        // Content-Type echoes the requested format (not a service exception).
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/WMS?SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.1.1&BBOX=-180,-90,180,90&SRS=EPSG:4326&WIDTH=256&HEIGHT=256&LAYERS={WebAppFixture.TestLayerId}&QUERY_LAYERS={WebAppFixture.TestLayerId}&INFO_FORMAT=application/vnd.ogc.gml&X=41&Y=74");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.ogc.gml");
+        content.Should().Contain("<?xml");
+        content.Should().Contain("msGMLOutput");
+        // Document must be well-formed XML.
+        var act = () => System.Xml.Linq.XDocument.Parse(content);
+        act.Should().NotThrow();
     }
 
     [IntegrationTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1776

## Summary
Closes the three named OGC CITE coverage gaps by wiring official TeamEngine ETS suites/profiles that already exist, using the `ets-wms13` wiring as the template. Each gap and result:

1. **WMS 1.1.1 (`ets-wms11`) — suite added + 1 real conformance bug fixed.** honua already serves and version-negotiates WMS 1.1.1, but ran no 1.1.1 suite. Cloned the wms13 pattern end-to-end. Running `ogccite/ets-wms11` against the live server surfaced **5 failing assertions, all from a single root cause**: honua did not support the `application/vnd.ogc.gml` GetFeatureInfo format that the WMS 1.1.1 GML FeatureInfo conformance class (`wms:wms-getfeatureinfo`, `wmsops-getcapabilities-response-capability_metadata-2`, `wmsops-getfeatureinfo-params-query_layers-1..4`) requires. **Fixed in `src/Honua.Protocols.OgcClassic`**: advertise `application/vnd.ogc.gml` in GetFeatureInfo capabilities and serve a well-formed `msGMLOutput` GML document with the matching Content-Type. All other ets-wms11 assertions (capabilities structure, GetMap, recommended/dimension, updatesequence, exceptions, axis order, SRS) already passed.

2. **WFS 2.0 transactional — promoted into the weekly/evidence bundle.** The transactional profile + `generate_transactional_suite` already existed but was not measured in the evidence bundle. Promoted it as a dedicated leg writing to its own results dir (`cite-wfs20-transactional-results`, overridable via `HONUA_CITE_WFS20_RESULTS_DIR`) so Transaction + LockFeature conformance classes are measured every run without clobbering the `basic` leg.

3. **OGC API Features Part 2 (CRS) — verified already declared; no code change.** honua already declares `ogcapi-features-2/1.0/conf/crs` unconditionally in `/ogc/features/conformance`, advertises the per-collection `crs` list (EPSG:4326/3857 + CRS84) and `storageCrs`, honors the `crs` query parameter, and emits the `Content-Crs` response header. The existing `ets-ogcapi-features10` `full` profile already auto-derives and exercises the CRS class from that declaration (it is part of the 137/137 Features pass count). Confirmed live; no change required.

## Changes Made
- Add `docker/cite/wms11/` (compose + `config/test-params.xml`) targeting `ogccite/ets-wms11:1.23-teamengine-6.0.0-RC2`, cloned from `wms13`.
- Add `scripts/conformance/cite/run-cite-wms11-tests.sh` (seeds the shared `cite` MapServer service, runs `wms:main_wms_auto`, zero-tolerance gate on fail/skip/CantTell).
- Add `.github/workflows/cite-wms11-conformance.yml` weekly dispatcher (reuses `cite-conformance-common.yml`).
- Register WMS 1.1.1 + the WFS 2.0 transactional leg in `.github/workflows/cite-evidence-report.yml` and the `build-cite-evidence.sh` suite inventory.
- Make the WFS 2.0 runner + compose results dir overridable (`HONUA_CITE_WFS20_RESULTS_DIR`) so the transactional leg coexists with basic.
- Fix WMS GML GetFeatureInfo: accept/advertise/serve `application/vnd.ogc.gml` (`OgcClassicRequestHelpers.cs`, `WmsRequestHandlers.GetCapabilities.cs`, `WmsRequestHandlers.GetFeatureInfo.cs`).
- Add integration tests: 1.1.1 GML GetFeatureInfo returns well-formed `msGMLOutput`; capabilities advertises the GML format.
- Update `docs/cite-status.md` and `docker/cite/README.md`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] Nightly gates (conformance, performance, security)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
