### PR TITLE
feat(mcp): tool annotations + output schemas for every tool (#1953)

### DIFF
--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/ListLayersTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/ListLayersTool.cs
@@ -40,8 +40,11 @@ internal sealed class ListLayersTool : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = ToolName,
+        Title = "List layers",
         Description = "List the published services and layers available to query or render, with geometry type, extent, and a short description. Use the returned serviceId/layerId with honua_query_features and honua_render_map.",
-        InputSchema = MapToolSchemas.ListLayersArgumentSchema
+        InputSchema = MapToolSchemas.ListLayersArgumentSchema,
+        OutputSchema = McpToolOutputSchemas.ListLayersOutputSchema,
+        Annotations = McpToolAnnotationSets.ReadOnly("List layers")
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/QueryFeaturesTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/QueryFeaturesTool.cs
@@ -47,8 +47,11 @@ internal sealed class QueryFeaturesTool : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = ToolName,
+        Title = "Query features",
         Description = "Query features from a published layer (by serviceId/layerId) with an optional attribute WHERE clause, bbox, outFields, and result limit. Returns a GeoJSON FeatureCollection.",
-        InputSchema = MapToolSchemas.QueryFeaturesArgumentSchema
+        InputSchema = MapToolSchemas.QueryFeaturesArgumentSchema,
+        OutputSchema = McpToolOutputSchemas.QueryFeaturesOutputSchema,
+        Annotations = McpToolAnnotationSets.ReadOnly("Query features")
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/RenderMapTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/RenderMapTool.cs
@@ -42,8 +42,13 @@ internal sealed class RenderMapTool : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = ToolName,
+        Title = "Render map",
         Description = "Render a map image (PNG) for one or more published layers over a bbox and return it as an inline image. Layers draw bottom-to-top. Width/height are capped at 1024 px.",
-        InputSchema = MapToolSchemas.RenderMapArgumentSchema
+        InputSchema = MapToolSchemas.RenderMapArgumentSchema,
+        // Read-only render. No OutputSchema: this tool returns an image content
+        // block, not a structuredContent payload, so there is no structured
+        // result shape to describe.
+        Annotations = McpToolAnnotationSets.ReadOnly("Render map")
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
@@ -27,6 +27,7 @@ namespace Honua.Ai.Protocols.Mcp.Models;
 [JsonSerializable(typeof(McpServerInfo))]
 [JsonSerializable(typeof(McpToolsListResult))]
 [JsonSerializable(typeof(McpToolDescriptor))]
+[JsonSerializable(typeof(McpToolAnnotations))]
 [JsonSerializable(typeof(McpToolsCallParams))]
 [JsonSerializable(typeof(McpToolsCallResult))]
 [JsonSerializable(typeof(McpContentBlock))]

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpWireModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpWireModels.cs
@@ -190,11 +190,92 @@ internal sealed class McpToolDescriptor
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Human-readable display title for the tool. Per the MCP 2025-03-26 tool
+    /// annotations shape this is surfaced both as a top-level <c>title</c> and on
+    /// <see cref="Annotations"/>; a client may prefer either. Null tools omit it.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
     [JsonPropertyName("description")]
     public string Description { get; set; } = string.Empty;
 
     [JsonPropertyName("inputSchema")]
     public JsonElement InputSchema { get; set; }
+
+    /// <summary>
+    /// JSON-schema document describing the tool's structured result. The MCP
+    /// revision this server advertises (2025-03-26) predates the standard
+    /// <c>outputSchema</c> field (added in 2025-06-18), so the schema is
+    /// published here under the Honua extension key
+    /// <c>structuredContentSchema</c> rather than <c>outputSchema</c>. It
+    /// describes the same <see cref="McpToolsCallResult.StructuredContent"/>
+    /// payload <c>outputSchema</c> would: when the negotiated revision is bumped
+    /// to 2025-06-18+ (honua-server#1954) this moves to the standard
+    /// <c>outputSchema</c> key. Null for tools whose result carries no structured
+    /// content (e.g. image-only renders).
+    /// </summary>
+    [JsonPropertyName("structuredContentSchema")]
+    public JsonElement? OutputSchema { get; set; }
+
+    /// <summary>
+    /// MCP 2025-03-26 tool behavior hints. Lets a client LLM distinguish
+    /// read-only planning/grounding tools from write tools and reason about
+    /// destructiveness/idempotency before invoking. Hints are advisory and must
+    /// not be trusted for security; the server still enforces authorization.
+    /// </summary>
+    [JsonPropertyName("annotations")]
+    public McpToolAnnotations? Annotations { get; set; }
+}
+
+/// <summary>
+/// MCP 2025-03-26 tool annotation hints
+/// (<c>annotations: { title, readOnlyHint, destructiveHint, idempotentHint,
+/// openWorldHint }</c>). Each hint is advisory metadata describing the tool's
+/// behavior so a client LLM can plan tool use; the server does not rely on them
+/// for authorization. See
+/// https://modelcontextprotocol.io/specification/2025-03-26/server/tools#tool-annotations.
+/// </summary>
+internal sealed class McpToolAnnotations
+{
+    /// <summary>Human-readable display title for the tool.</summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// <c>true</c> when the tool does not modify its environment (planning,
+    /// grounding, validation, preview, read queries). When true,
+    /// <see cref="DestructiveHint"/> and <see cref="IdempotentHint"/> carry no
+    /// meaning and are omitted.
+    /// </summary>
+    [JsonPropertyName("readOnlyHint")]
+    public bool? ReadOnlyHint { get; set; }
+
+    /// <summary>
+    /// <c>true</c> when a write tool may perform destructive updates (e.g.
+    /// cancelling an in-flight job). Only meaningful when
+    /// <see cref="ReadOnlyHint"/> is false; omitted for read-only tools.
+    /// </summary>
+    [JsonPropertyName("destructiveHint")]
+    public bool? DestructiveHint { get; set; }
+
+    /// <summary>
+    /// <c>true</c> when repeated calls with the same arguments have no
+    /// additional effect (e.g. execute honors an idempotency key; cancel is a
+    /// no-op once requested). Only meaningful when <see cref="ReadOnlyHint"/> is
+    /// false; omitted for read-only tools.
+    /// </summary>
+    [JsonPropertyName("idempotentHint")]
+    public bool? IdempotentHint { get; set; }
+
+    /// <summary>
+    /// <c>true</c> when the tool interacts with an open world of external
+    /// entities (e.g. third-party geocoding/routing providers). Omitted when the
+    /// tool operates only over the server's closed catalog.
+    /// </summary>
+    [JsonPropertyName("openWorldHint")]
+    public bool? OpenWorldHint { get; set; }
 }
 
 /// <summary>

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/CancelJobTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/CancelJobTool.cs
@@ -32,8 +32,13 @@ internal sealed class CancelJobTool : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = ToolName,
+        Title = "Cancel job",
         Description = "Request cancellation of an in-flight geoprocessing job by identifier.",
-        InputSchema = McpToolSchemas.CancelJobArgumentSchema
+        InputSchema = McpToolSchemas.CancelJobArgumentSchema,
+        OutputSchema = McpToolOutputSchemas.CancelJobOutputSchema,
+        // Write tool: destructive because it tears down in-flight execution;
+        // idempotent because cancelling an already-cancelled job is a no-op.
+        Annotations = McpToolAnnotationSets.Write("Cancel job", destructive: true, idempotent: true)
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ClarifyIntentTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ClarifyIntentTool.cs
@@ -44,8 +44,11 @@ internal sealed class ClarifyIntentTool : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = ToolName,
+        Title = "Clarify intent",
         Description = "Continue a grounding pass with operator clarification answers; returns an updated draft intent and (if ambiguity remains) another clarification envelope.",
-        InputSchema = InputSchemaElement
+        InputSchema = InputSchemaElement,
+        OutputSchema = McpToolOutputSchemas.GroundingOutputSchema,
+        Annotations = McpToolAnnotationSets.ReadOnly("Clarify intent")
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/DryRunPlanTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/DryRunPlanTool.cs
@@ -34,8 +34,11 @@ internal sealed class DryRunPlanTool : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = ToolName,
+        Title = "Dry-run plan",
         Description = "Estimate duration, artifact kinds, and side effects for a plan without executing it.",
-        InputSchema = McpToolSchemas.PlanArgumentSchema
+        InputSchema = McpToolSchemas.PlanArgumentSchema,
+        OutputSchema = McpToolOutputSchemas.DryRunOutputSchema,
+        Annotations = McpToolAnnotationSets.ReadOnly("Dry-run plan")
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ExecutePlanTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ExecutePlanTool.cs
@@ -52,8 +52,14 @@ internal sealed class ExecutePlanTool : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = ToolName,
+        Title = "Execute plan",
         Description = "Submit an analysis plan for asynchronous execution and return the job identifier and resource URI.",
-        InputSchema = McpToolSchemas.ExecutePlanArgumentSchema
+        InputSchema = McpToolSchemas.ExecutePlanArgumentSchema,
+        OutputSchema = McpToolOutputSchemas.ExecuteOutputSchema,
+        // Write tool: it submits server-side work. Idempotent because it honors
+        // the optional idempotencyKey (replays return the same job record);
+        // non-destructive because it creates a new job rather than destroying state.
+        Annotations = McpToolAnnotationSets.Write("Execute plan", destructive: false, idempotent: true)
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/GeocodeTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/GeocodeTool.cs
@@ -55,8 +55,13 @@ internal sealed class GeocodeTool : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = ToolName,
+        Title = "Geocode address",
         Description = "Forward-geocode a freeform address and return ranked candidate locations with coordinates and match scores. Requires the Pro 'geocoding.forward' entitlement.",
-        InputSchema = LocationToolSchemas.GeocodeArgumentSchema
+        InputSchema = LocationToolSchemas.GeocodeArgumentSchema,
+        OutputSchema = McpToolOutputSchemas.GeocodeOutputSchema,
+        // Read-only lookup; open-world because resolution can route to external
+        // geocoding providers rather than the server's closed catalog.
+        Annotations = McpToolAnnotationSets.ReadOnlyOpenWorld("Geocode address")
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/GroundCandidatesTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/GroundCandidatesTool.cs
@@ -43,8 +43,11 @@ internal sealed class GroundCandidatesTool : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = ToolName,
+        Title = "Ground candidates",
         Description = "Ground a natural-language goal to a workflow family, ranked catalog candidates, a draft intent, and an optional clarification envelope.",
-        InputSchema = InputSchemaElement
+        InputSchema = InputSchemaElement,
+        OutputSchema = McpToolOutputSchemas.GroundingOutputSchema,
+        Annotations = McpToolAnnotationSets.ReadOnly("Ground candidates")
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolAnnotationSets.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolAnnotationSets.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Ai.Protocols.Mcp.Models;
+
+namespace Honua.Ai.Protocols.Mcp.Tools;
+
+/// <summary>
+/// Canonical <see cref="McpToolAnnotations"/> factories shared by every MCP tool
+/// descriptor. Centralizing the read/write classification here keeps the hint
+/// set consistent across tools and gives the taxonomy tests a single source of
+/// truth: planning/grounding/validation/preview/query tools are
+/// <c>readOnlyHint: true, destructiveHint: false</c>; write tools set
+/// <c>readOnlyHint: false</c> and carry idempotency/destructiveness hints.
+/// </summary>
+internal static class McpToolAnnotationSets
+{
+    /// <summary>
+    /// Read-only tool that operates only over the server's closed catalog
+    /// (planning, grounding, validation, preview, layer/feature reads). Marks
+    /// <c>readOnlyHint: true</c> and <c>destructiveHint: false</c>.
+    /// </summary>
+    public static McpToolAnnotations ReadOnly(string title) => new()
+    {
+        Title = title,
+        ReadOnlyHint = true,
+        DestructiveHint = false,
+    };
+
+    /// <summary>
+    /// Read-only tool that reaches an open world of external entities (e.g.
+    /// third-party geocoding/routing providers). Adds <c>openWorldHint: true</c>
+    /// on top of the read-only hints.
+    /// </summary>
+    public static McpToolAnnotations ReadOnlyOpenWorld(string title) => new()
+    {
+        Title = title,
+        ReadOnlyHint = true,
+        DestructiveHint = false,
+        OpenWorldHint = true,
+    };
+
+    /// <summary>
+    /// Write tool. <paramref name="destructive"/> flags whether the write may
+    /// destroy existing state; <paramref name="idempotent"/> flags whether
+    /// replays with the same arguments have no additional effect.
+    /// </summary>
+    public static McpToolAnnotations Write(string title, bool destructive, bool idempotent) => new()
+    {
+        Title = title,
+        ReadOnlyHint = false,
+        DestructiveHint = destructive,
+        IdempotentHint = idempotent,
+    };
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
@@ -1,0 +1,342 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.Ai.Protocols.Mcp.Tools;
+
+/// <summary>
+/// JSON-schema documents describing the structured result of each MCP tool.
+/// Mirrors <see cref="McpToolSchemas"/> (input schemas): schemas are immutable
+/// <see cref="JsonElement"/> values parsed at type-load time so the MCP surface
+/// stays AOT-safe, and the artifact-kind enum is sourced from the canonical
+/// <see cref="ArtifactKind"/> so the published contract cannot drift from the
+/// domain types the tools serialize.
+/// </summary>
+/// <remarks>
+/// The MCP revision this server advertises (2025-03-26) predates the standard
+/// <c>outputSchema</c> tool field (added in 2025-06-18). Each schema here is
+/// published on the descriptor under the Honua extension key
+/// <c>structuredContentSchema</c> and describes the same
+/// <c>result.structuredContent</c> payload <c>outputSchema</c> would. The
+/// revision bump that lets these move to the standard <c>outputSchema</c> key is
+/// tracked in honua-server#1954.
+/// </remarks>
+internal static class McpToolOutputSchemas
+{
+    private const string ValidationViolationDef = """
+        {
+          "type": "object",
+          "required": ["code", "message"],
+          "properties": {
+            "code": { "type": "string" },
+            "message": { "type": "string" },
+            "fieldPath": { "type": ["string", "null"] }
+          }
+        }
+        """;
+
+    /// <summary>Schema for <see cref="Models.McpValidatePlanOutput"/>.</summary>
+    public static readonly JsonElement ValidatePlanOutputSchema = Parse(
+        $$"""
+        {
+          "type": "object",
+          "required": ["isExecutable", "requiresApproval", "violations", "warnings"],
+          "properties": {
+            "isExecutable": { "type": "boolean" },
+            "requiresApproval": { "type": "boolean" },
+            "violations": { "type": "array", "items": {{ValidationViolationDef}} },
+            "warnings": { "type": "array", "items": { "type": "string" } }
+          }
+        }
+        """);
+
+    /// <summary>Schema for <see cref="Models.McpDryRunOutput"/>.</summary>
+    public static readonly JsonElement DryRunOutputSchema = Parse(
+        $$"""
+        {
+          "type": "object",
+          "required": ["estimatedDurationSeconds", "estimatedArtifacts", "sideEffects"],
+          "properties": {
+            "estimatedDurationSeconds": { "type": "number" },
+            "estimatedArtifacts": {
+              "type": "array",
+              "items": { "type": "string", "enum": {{ArtifactKindEnum}} }
+            },
+            "sideEffects": { "type": "array", "items": { "type": "string" } }
+          }
+        }
+        """);
+
+    /// <summary>Schema for <see cref="Models.McpExecuteOutput"/>.</summary>
+    public static readonly JsonElement ExecuteOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["jobId", "status", "createdAt", "resourceUri"],
+          "properties": {
+            "jobId": { "type": "string" },
+            "status": { "type": "string" },
+            "createdAt": { "type": "string", "format": "date-time" },
+            "resourceUri": {
+              "type": "string",
+              "description": "honua://jobs/{jobId} resource URI for polling lifecycle state via resources/read."
+            }
+          }
+        }
+        """);
+
+    /// <summary>Schema for <see cref="Models.McpCancelJobOutput"/>.</summary>
+    public static readonly JsonElement CancelJobOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["jobId", "status", "cancellationRequested"],
+          "properties": {
+            "jobId": { "type": "string" },
+            "status": { "type": "string" },
+            "cancellationRequested": { "type": "boolean" }
+          }
+        }
+        """);
+
+    /// <summary>Schema for <see cref="Models.McpProposeOperationOutput"/>.</summary>
+    public static readonly JsonElement ProposeOperationOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["outcome", "requiresApproval"],
+          "properties": {
+            "outcome": { "type": "string" },
+            "requiresApproval": { "type": "boolean" },
+            "proposalId": { "type": ["string", "null"] },
+            "resourceUri": {
+              "type": ["string", "null"],
+              "description": "honua://proposals/{proposalId} resource URI to poll when human approval is required."
+            },
+            "executionOperationId": { "type": ["string", "null"] },
+            "message": { "type": ["string", "null"] }
+          }
+        }
+        """);
+
+    /// <summary>
+    /// Schema for <see cref="Models.McpPlanAnalysisOutput"/>. The compiled plan,
+    /// spec draft, clarification, and estimate are deep nested shapes; the schema
+    /// pins the top-level envelope and leaves those sub-objects open so the
+    /// published contract stays stable as the planning engine evolves.
+    /// </summary>
+    public static readonly JsonElement PlanAnalysisOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["status"],
+          "properties": {
+            "status": { "type": "string" },
+            "plan": { "type": ["object", "null"] },
+            "specDraft": { "type": ["object", "null"] },
+            "warnings": { "type": "array", "items": { "type": "object" } },
+            "cache": { "type": ["object", "null"] },
+            "capabilityState": { "type": ["object", "null"] },
+            "clarification": { "type": ["object", "null"] },
+            "estimate": { "type": ["object", "null"] },
+            "fixtureCase": { "type": ["string", "null"] }
+          }
+        }
+        """);
+
+    /// <summary>
+    /// Schema for <c>McpGroundingOutput</c> (shared by honua_ground_candidates
+    /// and honua_clarify_intent). The classification, draft intent, candidate
+    /// ranking, and optional clarification envelope are deep nested shapes; the
+    /// schema pins the top-level envelope and leaves those sub-objects open.
+    /// </summary>
+    public static readonly JsonElement GroundingOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["workflowFamily", "draftIntent", "candidates", "engine"],
+          "properties": {
+            "workflowFamily": { "type": "object" },
+            "draftIntent": { "type": "object" },
+            "candidates": { "type": "object" },
+            "clarification": { "type": ["object", "null"] },
+            "engine": { "type": "string" }
+          }
+        }
+        """);
+
+    /// <summary>
+    /// Schema for <c>PackageReviewResponse</c> (shared by honua_validate_package
+    /// and honua_preview_package). The findings, requirements, estimate, and
+    /// optional preview plan are deep nested shapes; the schema pins the
+    /// top-level envelope and leaves those sub-objects open.
+    /// </summary>
+    public static readonly JsonElement PackageReviewOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "properties": {
+            "contractVersion": { "type": ["string", "null"] },
+            "packageFamily": { "type": ["string", "null"] },
+            "packageId": { "type": ["string", "null"] },
+            "decision": { "type": ["string", "null"] },
+            "findings": { "type": "array", "items": { "type": "object" } },
+            "previewPlan": { "type": ["object", "null"] },
+            "estimate": { "type": ["object", "null"] }
+          }
+        }
+        """);
+
+    /// <summary>Schema for <c>McpGeocodeOutput</c>.</summary>
+    public static readonly JsonElement GeocodeOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["provider", "candidates"],
+          "properties": {
+            "provider": { "type": "string" },
+            "candidates": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "address": { "type": ["string", "null"] },
+                  "x": { "type": "number" },
+                  "y": { "type": "number" },
+                  "score": { "type": "number" },
+                  "srid": { "type": "integer" },
+                  "matchLevel": { "type": ["string", "null"] },
+                  "addressType": { "type": ["string", "null"] }
+                }
+              }
+            }
+          }
+        }
+        """);
+
+    /// <summary>Schema for <c>McpRouteOutput</c>.</summary>
+    public static readonly JsonElement RouteOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["provider", "solved", "totalLengthMeters", "totalTimeMinutes", "directions"],
+          "properties": {
+            "provider": { "type": "string" },
+            "solved": { "type": "boolean" },
+            "routeGeometryGeoJson": { "type": ["string", "null"] },
+            "totalLengthMeters": { "type": "number" },
+            "totalTimeMinutes": { "type": "number" },
+            "directions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": { "type": "string" },
+                  "lengthMeters": { "type": "number" },
+                  "timeMinutes": { "type": "number" },
+                  "maneuverType": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+        """);
+
+    /// <summary>Schema for <c>McpListLayersOutput</c>.</summary>
+    public static readonly JsonElement ListLayersOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["layerCount", "layers"],
+          "properties": {
+            "layerCount": { "type": "integer" },
+            "layers": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "serviceId": { "type": "string" },
+                  "serviceName": { "type": "string" },
+                  "layerId": { "type": "integer" },
+                  "name": { "type": "string" },
+                  "type": { "type": "string" },
+                  "geometryType": { "type": "string" },
+                  "srid": { "type": ["integer", "null"] },
+                  "extent": { "type": ["object", "null"] },
+                  "description": { "type": ["string", "null"] }
+                }
+              }
+            }
+          }
+        }
+        """);
+
+    /// <summary>Schema for <c>McpQueryFeaturesOutput</c>.</summary>
+    public static readonly JsonElement QueryFeaturesOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["serviceId", "layerId", "returnedCount", "limit", "exceededTransferLimit", "geojson"],
+          "properties": {
+            "serviceId": { "type": "string" },
+            "layerId": { "type": "integer" },
+            "returnedCount": { "type": "integer" },
+            "limit": { "type": "integer" },
+            "exceededTransferLimit": { "type": "boolean" },
+            "geojson": {
+              "type": "object",
+              "description": "RFC 7946 GeoJSON FeatureCollection.",
+              "properties": {
+                "type": { "type": "string", "const": "FeatureCollection" },
+                "features": { "type": "array", "items": { "type": "object" } }
+              }
+            }
+          }
+        }
+        """);
+
+    /// <summary>Schema for <see cref="Models.McpNotImplementedOutput"/>.</summary>
+    public static readonly JsonElement NotImplementedOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["status", "tool", "blockedBy", "contract", "nextSteps"],
+          "properties": {
+            "status": { "type": "string", "const": "not_implemented" },
+            "tool": { "type": "string" },
+            "blockedBy": { "type": "string" },
+            "contract": { "type": "string" },
+            "nextSteps": { "type": "array", "items": { "type": "string" } }
+          }
+        }
+        """);
+
+    private static string ArtifactKindEnum => JsonStringArray(Enum.GetNames<ArtifactKind>());
+
+    private static string JsonStringArray(string[] values)
+    {
+        var builder = new StringBuilder(2 + values.Length * 16);
+        builder.Append('[');
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(", ");
+            }
+
+            builder.Append('"').Append(values[i]).Append('"');
+        }
+
+        builder.Append(']');
+        return builder.ToString();
+    }
+
+    private static JsonElement Parse(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/NotImplementedToolBase.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/NotImplementedToolBase.cs
@@ -41,6 +41,9 @@ internal abstract class NotImplementedToolBase : IMcpTool, IStubMcpTool
     /// </summary>
     protected abstract OperatorOperation AuthorizedOperation { get; }
 
+    /// <summary>Human-readable display title advertised in the tool annotations.</summary>
+    protected abstract string Title { get; }
+
     protected abstract string Description { get; }
 
     protected abstract string BlockedBy { get; }
@@ -52,8 +55,14 @@ internal abstract class NotImplementedToolBase : IMcpTool, IStubMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = Name,
+        Title = Title,
         Description = Description,
-        InputSchema = McpToolSchemas.EmptyObjectSchema
+        InputSchema = McpToolSchemas.EmptyObjectSchema,
+        // Contract-first stubs do not yet perform any side effect, so they are
+        // advertised read-only until the backing service ships. The structured
+        // result is the not_implemented envelope.
+        OutputSchema = McpToolOutputSchemas.NotImplementedOutputSchema,
+        Annotations = McpToolAnnotationSets.ReadOnly(Title)
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PackageReviewTools.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PackageReviewTools.cs
@@ -33,6 +33,8 @@ internal abstract class PackageReviewToolBase : IMcpTool
 
     protected abstract bool IncludePreviewPlan { get; }
 
+    protected abstract string Title { get; }
+
     protected abstract string Description { get; }
 
     public string WorkflowFamily => McpTelemetry.WorkflowFamily.Planning;
@@ -40,8 +42,13 @@ internal abstract class PackageReviewToolBase : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = Name,
+        Title = Title,
         Description = Description,
-        InputSchema = McpToolSchemas.PackageReviewArgumentSchema
+        InputSchema = McpToolSchemas.PackageReviewArgumentSchema,
+        OutputSchema = McpToolOutputSchemas.PackageReviewOutputSchema,
+        // Validate/preview only inspect a package and (for preview) compute a
+        // read-only preview plan; neither mutates server state.
+        Annotations = McpToolAnnotationSets.ReadOnly(Title)
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(
@@ -86,6 +93,8 @@ internal sealed class ValidatePackageTool : PackageReviewToolBase
 
     protected override bool IncludePreviewPlan => false;
 
+    protected override string Title => "Validate package";
+
     protected override string Description => "Validate any supported Honua package using the canonical package-review response shape.";
 }
 
@@ -106,6 +115,8 @@ internal sealed class PreviewPackageTool : PackageReviewToolBase
     protected override string OperationName => "PreviewPackage";
 
     protected override bool IncludePreviewPlan => true;
+
+    protected override string Title => "Preview package";
 
     protected override string Description => "Validate a package and return a read-only preview plan using the canonical package-review response shape.";
 }

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PlanAnalysisTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PlanAnalysisTool.cs
@@ -43,8 +43,11 @@ internal sealed class PlanAnalysisTool : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = ToolName,
+        Title = "Plan analysis",
         Description = "Compile a natural-language intent into an executable analysis plan or canonical spec draft.",
-        InputSchema = InputSchemaElement
+        InputSchema = InputSchemaElement,
+        OutputSchema = McpToolOutputSchemas.PlanAnalysisOutputSchema,
+        Annotations = McpToolAnnotationSets.ReadOnly("Plan analysis")
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ProposeOperationTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ProposeOperationTool.cs
@@ -36,9 +36,16 @@ internal sealed class ProposeOperationTool : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = ToolName,
+        Title = "Propose operation",
         Description = "Propose an in-scope mutating control-plane operation (admin config change, deploy, metadata release, or seed). "
             + "Returns the execution result directly when the edition permits, or a proposalId plus honua://proposals/{id} resource URI when human approval is required.",
-        InputSchema = McpToolSchemas.ProposeOperationArgumentSchema
+        InputSchema = McpToolSchemas.ProposeOperationArgumentSchema,
+        OutputSchema = McpToolOutputSchemas.ProposeOperationOutputSchema,
+        // Write tool: it routes a mutating control-plane operation through the
+        // approval gateway. Idempotent because it honors the optional
+        // idempotencyKey; not flagged destructive at the propose layer (the
+        // underlying operation class governs its own destructiveness).
+        Annotations = McpToolAnnotationSets.Write("Propose operation", destructive: false, idempotent: true)
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/RouteTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/RouteTool.cs
@@ -55,8 +55,13 @@ internal sealed class RouteTool : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = ToolName,
+        Title = "Solve route",
         Description = "Solve a multi-stop route through ordered stops and return the route geometry, length, travel time, and turn-by-turn directions. Requires the Pro 'routing.solve' entitlement.",
-        InputSchema = LocationToolSchemas.RouteArgumentSchema
+        InputSchema = LocationToolSchemas.RouteArgumentSchema,
+        OutputSchema = McpToolOutputSchemas.RouteOutputSchema,
+        // Read-only computation; open-world because solving can route to external
+        // routing providers rather than the server's closed catalog.
+        Annotations = McpToolAnnotationSets.ReadOnlyOpenWorld("Solve route")
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ValidatePlanTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ValidatePlanTool.cs
@@ -35,8 +35,11 @@ internal sealed class ValidatePlanTool : IMcpTool
     public McpToolDescriptor Describe() => new()
     {
         Name = ToolName,
+        Title = "Validate plan",
         Description = "Validate an analysis plan for executability, policy gates, and approvals.",
-        InputSchema = InputSchemaElement
+        InputSchema = InputSchemaElement,
+        OutputSchema = McpToolOutputSchemas.ValidatePlanOutputSchema,
+        Annotations = McpToolAnnotationSets.ReadOnly("Validate plan")
     };
 
     public async Task<McpToolsCallResult> InvokeAsync(

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
@@ -187,6 +187,214 @@ public sealed class McpTaxonomyAlignmentTests
         }
     }
 
+    // -------------------------------------------------------------------
+    // Tool annotations (#1953): every tool must advertise read/write hints
+    // -------------------------------------------------------------------
+
+    /// <summary>
+    /// Read-only tools per the geospatial-mcp taxonomy: planning, grounding,
+    /// validation, and map read tools never mutate server state. (The
+    /// package-review tools are read-only too but are constructed separately in
+    /// <c>PackageReviewTools_AreReadOnly_WithOutputSchemas</c> because they take
+    /// extra service dependencies that <see cref="BuildTools"/> does not wire.)
+    /// </summary>
+    private static readonly HashSet<string> ReadOnlyToolNames = new(StringComparer.Ordinal)
+    {
+        "honua_validate_plan",
+        "honua_dry_run_plan",
+        "honua_plan_analysis",
+        "honua_ground_candidates",
+        "honua_clarify_intent",
+        "honua_geocode_address",
+        "honua_solve_route",
+        "honua_list_layers",
+        "honua_query_features",
+        "honua_render_map",
+    };
+
+    /// <summary>
+    /// Write tools and their expected destructive/idempotent classification.
+    /// </summary>
+    private static readonly Dictionary<string, (bool Destructive, bool Idempotent)> WriteToolExpectations =
+        new(StringComparer.Ordinal)
+        {
+            ["honua_execute_plan"] = (Destructive: false, Idempotent: true),
+            ["honua_cancel_job"] = (Destructive: true, Idempotent: true),
+            ["honua_propose_operation"] = (Destructive: false, Idempotent: true),
+        };
+
+    [UnitTest]
+    public void EveryTool_AdvertisesAnnotations_WithTitle()
+    {
+        // Guard test: a NEW tool added without annotations (or without a title)
+        // fails here, forcing the author to classify it read-only vs write.
+        var tools = BuildTools();
+
+        foreach (var tool in tools)
+        {
+            var descriptor = tool.Describe();
+            descriptor.Annotations.Should().NotBeNull(
+                $"tool '{tool.Name}' must advertise MCP tool annotations (#1953)");
+            descriptor.Annotations!.ReadOnlyHint.Should().NotBeNull(
+                $"tool '{tool.Name}' must classify itself read-only vs write");
+            descriptor.Annotations.Title.Should().NotBeNullOrWhiteSpace(
+                $"tool '{tool.Name}' must carry a human-readable annotation title");
+            descriptor.Title.Should().NotBeNullOrWhiteSpace(
+                $"tool '{tool.Name}' must carry a top-level display title");
+        }
+    }
+
+    [UnitTest]
+    public void EveryTool_IsClassifiedInTheExpectedRosters()
+    {
+        // The read-only roster and write roster together must cover every tool;
+        // a tool missing from both rosters fails here so the test stays a
+        // complete guard against an unclassified new tool.
+        var toolNames = BuildTools().Select(t => t.Name).ToHashSet(StringComparer.Ordinal);
+        var classified = new HashSet<string>(ReadOnlyToolNames, StringComparer.Ordinal);
+        classified.UnionWith(WriteToolExpectations.Keys);
+
+        toolNames.Should().BeEquivalentTo(classified,
+            "every tool must appear in exactly one of the read-only or write rosters");
+    }
+
+    [UnitTest]
+    public void ReadOnlyTools_FlagReadOnlyAndNonDestructive()
+    {
+        var tools = BuildTools().Where(t => ReadOnlyToolNames.Contains(t.Name));
+
+        foreach (var tool in tools)
+        {
+            var annotations = tool.Describe().Annotations!;
+            annotations.ReadOnlyHint.Should().BeTrue($"'{tool.Name}' is a read-only tool");
+            annotations.DestructiveHint.Should().BeFalse($"'{tool.Name}' must not be flagged destructive");
+        }
+    }
+
+    [UnitTest]
+    public void WriteTools_AreFlaggedWrite_WithCorrectDestructiveAndIdempotentHints()
+    {
+        var tools = BuildTools().Where(t => WriteToolExpectations.ContainsKey(t.Name));
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var tool in tools)
+        {
+            var annotations = tool.Describe().Annotations!;
+            var (destructive, idempotent) = WriteToolExpectations[tool.Name];
+
+            annotations.ReadOnlyHint.Should().BeFalse($"'{tool.Name}' is a write tool");
+            annotations.DestructiveHint.Should().Be(destructive, $"'{tool.Name}' destructiveHint");
+            annotations.IdempotentHint.Should().Be(idempotent, $"'{tool.Name}' idempotentHint");
+            seen.Add(tool.Name);
+        }
+
+        seen.Should().BeEquivalentTo(WriteToolExpectations.Keys,
+            "every classified write tool must be present in the roster");
+    }
+
+    [UnitTest]
+    public void ExecutePlan_IsFlaggedWriteIdempotentNonDestructive()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        var annotations = new ExecutePlanTool(jobService, NullLogger<ExecutePlanTool>.Instance)
+            .Describe().Annotations!;
+
+        annotations.ReadOnlyHint.Should().BeFalse();
+        annotations.IdempotentHint.Should().BeTrue("execute honors the idempotencyKey");
+        annotations.DestructiveHint.Should().BeFalse("execute creates a new job rather than destroying state");
+    }
+
+    [UnitTest]
+    public void CancelJob_IsFlaggedWriteIdempotentDestructive()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        var annotations = new CancelJobTool(jobService, NullLogger<CancelJobTool>.Instance)
+            .Describe().Annotations!;
+
+        annotations.ReadOnlyHint.Should().BeFalse();
+        annotations.IdempotentHint.Should().BeTrue("cancelling an already-cancelled job is a no-op");
+        annotations.DestructiveHint.Should().BeTrue("cancel tears down in-flight execution");
+    }
+
+    [UnitTest]
+    public void PackageReviewTools_AreReadOnly_WithOutputSchemas()
+    {
+        // validate_package / preview_package only inspect a package (preview also
+        // computes a read-only preview plan); neither mutates server state.
+        var reviewService = Substitute.For<Honua.Core.Features.PackageReview.Abstractions.IPackageReviewService>();
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+
+        IMcpTool[] packageTools =
+        [
+            new ValidatePackageTool(reviewService, jobService, NullLogger<ValidatePackageTool>.Instance),
+            new PreviewPackageTool(reviewService, jobService, NullLogger<PreviewPackageTool>.Instance),
+        ];
+
+        foreach (var tool in packageTools)
+        {
+            var descriptor = tool.Describe();
+            descriptor.Title.Should().NotBeNullOrWhiteSpace();
+            descriptor.Annotations.Should().NotBeNull();
+            descriptor.Annotations!.ReadOnlyHint.Should().BeTrue($"'{tool.Name}' is read-only");
+            descriptor.Annotations.DestructiveHint.Should().BeFalse();
+            descriptor.OutputSchema.Should().NotBeNull($"'{tool.Name}' must publish an output schema");
+            descriptor.OutputSchema!.Value.GetProperty("type").GetString().Should().Be("object");
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Output schemas (#1953): structuredContent schema per tool result
+    // -------------------------------------------------------------------
+
+    [UnitTest]
+    public void StructuredTools_AdvertiseWellFormedOutputSchemas()
+    {
+        // honua_render_map returns an image content block, not structuredContent,
+        // so it legitimately carries no output schema; every other tool must.
+        var tools = BuildTools().Where(t => t.Name != "honua_render_map");
+
+        foreach (var tool in tools)
+        {
+            var descriptor = tool.Describe();
+            descriptor.OutputSchema.Should().NotBeNull(
+                $"tool '{tool.Name}' must publish a structuredContent output schema (#1953)");
+
+            var schema = descriptor.OutputSchema!.Value;
+            schema.ValueKind.Should().Be(JsonValueKind.Object,
+                $"'{tool.Name}' output schema must be a JSON-schema object");
+            schema.GetProperty("type").GetString().Should().Be("object",
+                $"'{tool.Name}' output schema root must be of type object");
+            schema.TryGetProperty("properties", out var properties).Should().BeTrue(
+                $"'{tool.Name}' output schema must declare properties");
+            properties.ValueKind.Should().Be(JsonValueKind.Object);
+            properties.EnumerateObject().Should().NotBeEmpty(
+                $"'{tool.Name}' output schema must describe at least one property");
+        }
+    }
+
+    [UnitTest]
+    public void RenderMap_HasNoOutputSchema_BecauseItReturnsAnImageBlock()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        var descriptor = new Honua.Ai.Protocols.Mcp.MapTools.RenderMapTool(
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.RenderMapTool>.Instance)
+            .Describe();
+
+        descriptor.OutputSchema.Should().BeNull();
+        descriptor.Annotations!.ReadOnlyHint.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void DryRunOutputSchema_ArtifactEnum_MatchesArtifactKind()
+    {
+        // Like the input schemas, the dry-run output schema sources its artifact
+        // enum from the canonical ArtifactKind so the contract cannot drift.
+        var enumValues = ExtractEnumValues(McpToolOutputSchemas.DryRunOutputSchema,
+            "properties", "estimatedArtifacts", "items", "enum");
+
+        enumValues.Should().BeEquivalentTo(Enum.GetNames<ArtifactKind>());
+    }
+
     [UnitTest]
     public void PlanSchema_StepKindEnum_MatchesAnalysisPlanStepKind()
     {


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1953

## Summary
Slice 1 of MCP tool ergonomics & safety (#1953): every MCP tool descriptor now advertises MCP 2025-03-26 tool **annotations** (`title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) and a **structured output schema**, so any client LLM can tell read-only planning/grounding tools from write tools and validate tool responses before/after a call. Scope is annotations + output schemas only; pagination and prompts are deferred to follow-ups.

## Changes Made
- Extended `McpToolDescriptor` with optional `Title`, `Annotations` (new `McpToolAnnotations` hint set), and `OutputSchema`; registered `McpToolAnnotations` in the source-gen `McpJsonContext` (AOT-safe). `tools/list` already serializes the descriptor, so the new fields flow automatically.
- Added `McpToolAnnotationSets` (canonical read-only / read-only-open-world / write annotation factories) and `McpToolOutputSchemas` (immutable `JsonElement` output schemas mirroring `McpToolSchemas`, with the artifact enum sourced from the canonical `ArtifactKind`).
- Populated annotations + output schema on every tool: planning/grounding/validate/preview/map-read → `readOnlyHint: true, destructiveHint: false`; `honua_execute_plan` → write (`idempotentHint: true`, non-destructive); `honua_cancel_job` → write (`idempotentHint: true`, `destructiveHint: true`); `honua_propose_operation` → write (`idempotentHint: true`); geocode/route → read-only `openWorldHint: true`. `honua_render_map` is read-only with no output schema (it returns an image content block, not structuredContent).
- Output schemas published under the Honua extension key `structuredContentSchema` (the advertised 2025-03-26 revision predates the standard `outputSchema` field added in 2025-06-18); documented the revision-bump follow-up to move to `outputSchema` under #1954.
- Extended `McpTaxonomyAlignmentTests` with annotation/output-schema assertions, including a guard test that fails when a NEW tool is added without annotations.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — descriptor fields are additive and omitted when null; existing `tools/list` clients are unaffected.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
