### PR TITLE
ci: close server-tests shard coverage hole — every test class now runs (#1899)

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -206,7 +206,7 @@
       "max_cpu_count": "",
       "upload_operator_eval_report": false,
       "upload_odata_evidence": false,
-      "filter": "FullyQualifiedName~Honua.Server.Tests.Import.ArcGisMigration|FullyQualifiedName~Honua.Server.Tests.Import.GeoServer|FullyQualifiedName~Honua.Server.Tests.Import.Geoservices|FullyQualifiedName~Honua.Server.Tests.Import.Migration|FullyQualifiedName~Honua.Server.Tests.Import.OgcApiFeatures|FullyQualifiedName~Honua.Server.Tests.Import.OgcCoverage|FullyQualifiedName~Honua.Server.Tests.Import.OgcTileCache|FullyQualifiedName~Honua.Server.Tests.Import.OgcWcs|FullyQualifiedName~Honua.Server.Tests.Import.OgcWfs",
+      "filter": "FullyQualifiedName~Honua.Server.Tests.Import.ArcGisMigration|FullyQualifiedName~Honua.Server.Tests.Import.GeoServer|FullyQualifiedName~Honua.Server.Tests.Import.Geoservices|FullyQualifiedName~Honua.Server.Tests.Import.Migration|FullyQualifiedName~Honua.Server.Tests.Import.OgcApiFeatures|FullyQualifiedName~Honua.Server.Tests.Import.OgcCoverage|FullyQualifiedName~Honua.Server.Tests.Import.OgcTileCache|FullyQualifiedName~Honua.Server.Tests.Import.OgcWcs|FullyQualifiedName~Honua.Server.Tests.Import.OgcWfs|FullyQualifiedName~Honua.Server.Tests.Import.RedisImportJobManager|FullyQualifiedName~Honua.Server.Tests.Import.UniversalProgressStore",
       "paths": [
         "src/Honua.Core/Features/Migration/",
         "src/Honua.Postgres/Features/Migration/",
@@ -576,7 +576,8 @@
       "upload_operator_eval_report": false,
       "upload_odata_evidence": false,
       "csproj": "tests/dotnet/Honua.Protocols.OData.Tests/Honua.Protocols.OData.Tests.csproj",
-      "filter": "FullyQualifiedName~ODataEndpointTests|FullyQualifiedName~ODataAuthorizationTests|FullyQualifiedName~ODataErrorHandlingTests|FullyQualifiedName~ODataLimitsEnforcementTests|FullyQualifiedName~ODataCrsUtilitiesTests|FullyQualifiedName~ODataGeometryConverterTests|FullyQualifiedName~ODataQueryHandlerTests|FullyQualifiedName~ODataSearchServiceSqlTests|FullyQualifiedName~ODataAdvancedOperationsTests",
+      "_comment": "OData CATCH-ALL (#1899): converted from a class-name-keyed selector to a namespace-prefix selector so new OData test classes are auto-covered instead of silently falling outside every OData shard (the original #1899 finding — e.g. ODataBboxShorthandTests, ODataInOperatorTests, ODataParquetFormatTests, ODataServerPagingEndpointTests, ODataChangesetEditionGateTests, ODataQueryParameterAdapterOrderByTests all matched no OData filter). Selects everything in the Honua.Server.Tests.Features.Protocols.OData namespace EXCEPT the classes/sub-namespaces carved into the OData Query and Spatial, OData Mutations and Batch, and OData Client Certification sibling shards. The trailing FullyQualifiedName!~ exclusions mirror those siblings' selectors exactly, so the four OData shards partition the OData suite with no gaps; any newly added OData test class falls here by default.",
+      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.OData&FullyQualifiedName!~ODataAdvancedFeaturesTests&FullyQualifiedName!~ODataFilterFunctionTests&FullyQualifiedName!~ODataFilterMatrixTests&FullyQualifiedName!~ODataPaginationTests&FullyQualifiedName!~ODataSkipTokenTests&FullyQualifiedName!~ODataSpatialMatrixTests&FullyQualifiedName!~ODataSpatialReferenceTests&FullyQualifiedName!~ODataTemporalFilteringTests&FullyQualifiedName!~ODataCrudEndpointTests&FullyQualifiedName!~ODataCrudExceptionMappingTests&FullyQualifiedName!~ODataDeltaTests&FullyQualifiedName!~ODataETagConcurrencyTests&FullyQualifiedName!~ODataGeometryCrudTests&FullyQualifiedName!~ODataMultipartBatchTests&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.OData.Services&FullyQualifiedName!~ODataClientCertificationTests&FullyQualifiedName!~ODataClientIntegrationTests",
       "paths": [
         "src/Honua.Protocols.OData/",
         "tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataAdvancedOperationsTests.cs",
@@ -629,7 +630,8 @@
       "upload_operator_eval_report": false,
       "upload_odata_evidence": false,
       "csproj": "tests/dotnet/Honua.Protocols.OData.Tests/Honua.Protocols.OData.Tests.csproj",
-      "filter": "FullyQualifiedName~ODataCrudEndpointTests|FullyQualifiedName~ODataCrudExceptionMappingTests|FullyQualifiedName~ODataDeltaTests|FullyQualifiedName~ODataETagConcurrencyTests|FullyQualifiedName~ODataGeometryCrudTests|FullyQualifiedName~ODataMultipartBatchTests|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.OData.Services",
+      "_comment": "Owns the OData write-path classes plus the OData Services namespace. NOTE (#1899): some OData Services tests use the root namespace Honua.Protocols.OData.Tests.Services (e.g. ODataApplyPipelineTests, ODataComputeServiceTests, ODataEtagSerializationTests) rather than Honua.Server.Tests.Features.Protocols.OData.Services, so the second namespace clause was added to claim them — they matched no OData filter before and never ran.",
+      "filter": "FullyQualifiedName~ODataCrudEndpointTests|FullyQualifiedName~ODataCrudExceptionMappingTests|FullyQualifiedName~ODataDeltaTests|FullyQualifiedName~ODataETagConcurrencyTests|FullyQualifiedName~ODataGeometryCrudTests|FullyQualifiedName~ODataMultipartBatchTests|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.OData.Services|FullyQualifiedName~Honua.Protocols.OData.Tests.Services",
       "paths": [
         "src/Honua.Protocols.OData/",
         "tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/",
@@ -807,6 +809,31 @@
       "csproj": "tests/dotnet/Honua.Protocols.GeoServices.Tests/Honua.Protocols.GeoServices.Tests.csproj"
     },
     {
+      "name": "GeoServices Geometry VectorTile and Versioning",
+      "shard_name": "GeoServices Geometry VectorTile and Versioning",
+      "artifact_suffix": "geoservices-geometry-vectortile-versioning",
+      "log_name": "server-tests-geoservices-geometry-vectortile-versioning",
+      "timeout_minutes": 32,
+      "test_timeout_minutes": 24,
+      "max_cpu_count": "",
+      "upload_operator_eval_report": false,
+      "upload_odata_evidence": false,
+      "_comment": "Coverage CATCH-ALL for the GeoServices test assembly (#1899). Claims every Honua.Protocols.GeoServices.Tests class NOT owned by a sibling GeoServices shard. Closes three #1899-class holes at once: (1) the GeoServices VectorTileServer and VersionManagementServer namespaces matched no filter; (2) GeoServices-root classes (MetadataClientParameterTests, MetadataPostTests) matched no filter; (3) the entire GeometryService namespace (~107 tests) had a filter on the 'Geometry Tiles and Terrain' shard, but that shard's csproj defaults to the Honua.Server.Tests monolith assembly while GeometryService tests live in the Honua.Protocols.GeoServices.Tests assembly — so `dotnet test <Server.Tests.csproj> --filter ...GeometryService` discovered ZERO of them and they never ran. This shard targets the correct GeoServices.Tests csproj. The trailing FullyQualifiedName!~ exclusions cover every GeoServices sub-namespace already owned by a sibling GeoServices shard (FeatureServer/ImageServer/MapServer/GPServer/NAServer/Catalog), so this is the GeoServices assembly catch-all: any new GeoServices test class not in those owned sub-namespaces lands here by default instead of becoming a silent orphan.",
+      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.GeoServices&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.GeoServices.MapServer&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.GeoServices.GPServer&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.GeoServices.NAServer&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.GeoServices.Catalog&FullyQualifiedName!~GeoServicesSpatialFilterBuilderTests",
+      "paths": [
+        "src/Honua.Protocols.GeoServices/VectorTileServer/",
+        "src/Honua.Protocols.GeoServices/VersionManagementServer/",
+        "src/Honua.Protocols.GeoServices/GeometryService/",
+        "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/",
+        "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/",
+        "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/",
+        "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MetadataClientParameterTests.cs",
+        "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MetadataPostTests.cs",
+        "src/Honua.Core/Features/Validation/"
+      ],
+      "csproj": "tests/dotnet/Honua.Protocols.GeoServices.Tests/Honua.Protocols.GeoServices.Tests.csproj"
+    },
+    {
       "name": "Geometry Tiles and Terrain",
       "shard_name": "Geometry Tiles and Terrain",
       "artifact_suffix": "geometry-tiles-terrain",
@@ -816,12 +843,11 @@
       "max_cpu_count": "",
       "upload_operator_eval_report": false,
       "upload_odata_evidence": false,
-      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Terrain|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Tiles",
+      "_comment": "Owns the Terrain and Tiles namespaces in the Honua.Server.Tests assembly. NOTE (#1899): the GeometryService namespace was REMOVED from this shard's filter — those tests live in the Honua.Protocols.GeoServices.Tests assembly, not this shard's (default) Honua.Server.Tests assembly, so the filter never matched them here; they are now owned by 'GeoServices Geometry VectorTile and Versioning' which targets the correct csproj.",
+      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Terrain|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Tiles",
       "paths": [
-        "src/Honua.Protocols.GeoServices/GeometryService/",
         "src/Honua.Server/Features/Protocols/Terrain/",
         "src/Honua.Server/Features/Protocols/Tiles/",
-        "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/",
         "tests/dotnet/Honua.Server.Tests/Features/Protocols/Terrain/",
         "tests/dotnet/Honua.Server.Tests/Features/Protocols/Tiles/",
         "src/Honua.Core/Features/Validation/"
@@ -896,7 +922,8 @@
       "upload_operator_eval_report": false,
       "upload_odata_evidence": false,
       "csproj": "tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj",
-      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Mcp|FullyQualifiedName~Honua.Server.Tests.Features.AiBuilder|FullyQualifiedName~Honua.Server.Tests.Features.Reporting",
+      "_comment": "Owns the AI test assembly (Honua.Ai.Tests): MCP protocol, AI builder, the Ai.Tests Reporting classes, and the AI Providers namespace. NOTE (#1899): Honua.Server.Tests.Features.Providers.* (e.g. the Bedrock live tests) matched no shard filter and never ran; the Providers clause was added so they run here (the Bedrock live test is gated on HONUA_AI_LIVE_BEDROCK and no-ops/passes when the env var is unset, so it is safe in CI).",
+      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Mcp|FullyQualifiedName~Honua.Server.Tests.Features.AiBuilder|FullyQualifiedName~Honua.Server.Tests.Features.Reporting|FullyQualifiedName~Honua.Server.Tests.Features.Providers",
       "paths": [
         "src/Honua.Ai/",
         "tests/dotnet/Honua.Ai.Tests/Source/",
@@ -919,6 +946,25 @@
         "src/Honua.Protocols.Scene/",
         "src/Honua.Scene/",
         "tests/dotnet/Honua.Protocols.Scene.Tests/Source/"
+      ]
+    },
+    {
+      "name": "SensorThings",
+      "shard_name": "SensorThings",
+      "artifact_suffix": "sensorthings",
+      "log_name": "server-tests-sensorthings",
+      "timeout_minutes": 25,
+      "test_timeout_minutes": 15,
+      "max_cpu_count": "",
+      "upload_operator_eval_report": false,
+      "upload_odata_evidence": false,
+      "csproj": "tests/dotnet/Honua.Protocols.SensorThings.Tests/Honua.Protocols.SensorThings.Tests.csproj",
+      "_comment": "Coverage fix (#1899): the OGC SensorThings (STA v1.1) module landed in #1842 with a Honua.Protocols.SensorThings.Tests project but NO shard, so its integration tests (Honua.Server.Tests.Features.Protocols.SensorThings) matched no filter and never ran in CI — the same orphaned-coverage class as #1899. #1899 listed 'add a SensorThings shard' as a non-goal while #1842 was open; #1842 has since merged without one, leaving the tests dead, so this minimal shard claims them. It also targets the correct SensorThings.Tests csproj (a Server.Tests-assembly filter could never discover them).",
+      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.SensorThings",
+      "paths": [
+        "src/Honua.Protocols.SensorThings/",
+        "tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/",
+        "src/Honua.Core/Features/Validation/"
       ]
     },
     {
@@ -955,6 +1001,47 @@
         "src/Honua.Geocoding/",
         "src/Honua.Server/Features/Geocoding/",
         "tests/dotnet/Honua.Server.Tests/Features/Geocoding/"
+      ],
+      "csproj": ""
+    },
+    {
+      "name": "Server Features Admin and Console",
+      "shard_name": "Server Features Admin and Console",
+      "artifact_suffix": "server-features-admin-console",
+      "log_name": "server-tests-server-features-admin-console",
+      "timeout_minutes": 40,
+      "test_timeout_minutes": 32,
+      "max_cpu_count": "",
+      "upload_operator_eval_report": false,
+      "upload_odata_evidence": false,
+      "_comment": "Coverage fix (#1899): the entire Honua.Server.Tests.Features.Admin namespace (~55 classes / ~547 test methods — the dominant orphan bucket), the Honua.Server.Tests.Features.Console namespace, and Honua.Server.Tests.Features.Alerts matched NO shard filter and never ran in CI. NOTE: distinct from the existing 'Admin & Infrastructure' shard, which matches the Honua.Server.Tests.Admin.* (root) namespace, NOT Honua.Server.Tests.Features.Admin.* — these are different namespaces, so there is no overlap. This is the largest newly-running bucket; the longer timeout reflects the ~538 integration tests it now executes. QUARANTINE (#1962): RoleEndpointsTests is excluded (FullyQualifiedName!~RoleEndpointsTests) because it fails when run — built-in roles come back NotFound and CreateRole 500s, likely because the WebAppFixture does not apply src/Honua.Server/Migrations/041_CreateRbacRoleStore.sql (built-in role seed). Tracked in #1962; it is also on the EXEMPT list in scripts/ci/check-server-test-shard-coverage.py so the coverage guard stays green. Remove both the exclusion and the exemption when #1962 is fixed. Verified locally: the other Admin classes in this shard pass (7/7 sampled, 63 tests green).",
+      "filter": "(FullyQualifiedName~Honua.Server.Tests.Features.Admin.|FullyQualifiedName~Honua.Server.Tests.Features.Console.|FullyQualifiedName~Honua.Server.Tests.Features.Alerts.)&FullyQualifiedName!~RoleEndpointsTests",
+      "paths": [
+        "src/Honua.Server/Features/Admin/",
+        "src/Honua.Server/Features/Console/",
+        "src/Honua.Server/Features/Alerts/",
+        "tests/dotnet/Honua.Server.Tests/Features/Admin/",
+        "tests/dotnet/Honua.Server.Tests/Features/Console/",
+        "tests/dotnet/Honua.Server.Tests/Features/Alerts/",
+        "src/Honua.Core/Features/Validation/"
+      ],
+      "csproj": ""
+    },
+    {
+      "name": "Server Features Misc",
+      "shard_name": "Server Features Misc",
+      "artifact_suffix": "server-features-misc",
+      "log_name": "server-tests-server-features-misc",
+      "timeout_minutes": 40,
+      "test_timeout_minutes": 32,
+      "max_cpu_count": "",
+      "upload_operator_eval_report": false,
+      "upload_odata_evidence": false,
+      "_comment": "Coverage CATCH-ALL (#1899): claims every Honua.Server.Tests.Features.* test class that is NOT owned by a more specific shard. This is the keystone that closes the #1899 coverage hole and keeps it closed: any newly-added Features.* namespace (e.g. a future Features.SomethingNew) lands here by default instead of becoming a silent orphan. The trailing FullyQualifiedName!~ exclusions enumerate every Features.* namespace/class already owned by another shard (Admin&Console, the protocol shards, Infra&Security, MCP, Operator Eval, STAC/API Governance, WorkflowPackages, Geocoding, Reporting, Styling, Caching, FileStorage, Security, etc.), so this shard and the others partition the Features.* suite with no gaps and no overlaps. The guard scripts/ci/check-server-test-shard-coverage.py asserts the no-gap invariant on every PR. Newly-running namespaces this claims include: AnalysisContent, Authorization, Capabilities, CloudDemo, Collaboration, CrossServerConsume, DataEnrichment, Export, FeatureStore, FieldWorkflows, Forms, Grounding, Integration, Licensing, Mobile, NlQuery, Observability, Ogc, Operations, Orchestration, PackageReview, Plugins, PrintingTools, Protocols.Coverages.Multidimensional, Protocols.Ogc.Shared, Protocols.SensorThings, Protocols.Zarr, Provider/Bedrock (Features.Providers.Bedrock), Sharing, SpatialAnalytics, Spec, StaticMap, Streaming, Studio, Temporal.",
+      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.&FullyQualifiedName!~Honua.Server.Tests.Features.Admin.&FullyQualifiedName!~Honua.Server.Tests.Features.Console.&FullyQualifiedName!~Honua.Server.Tests.Features.Alerts.&FullyQualifiedName!~Honua.Server.Tests.Features.API&FullyQualifiedName!~Honua.Server.Tests.Features.AiBuilder&FullyQualifiedName!~Honua.Server.Tests.Features.Caching&FullyQualifiedName!~Honua.Server.Tests.Features.Eval&FullyQualifiedName!~Honua.Server.Tests.Features.FileStorage&FullyQualifiedName!~Honua.Server.Tests.Features.Geocoding&FullyQualifiedName!~Honua.Server.Tests.Features.Geoprocessing&FullyQualifiedName!~Honua.Server.Tests.Features.Infrastructure&FullyQualifiedName!~Honua.Server.Tests.Features.Security&FullyQualifiedName!~Honua.Server.Tests.Features.Styling&FullyQualifiedName!~Honua.Server.Tests.Features.WorkflowPackages&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.Cog&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.Elevation&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.GeoServices&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.Grpc&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.Mcp&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.OData&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.Ogc.Api&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.Ogc.Classic&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.Scene&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.Stac&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.Terrain&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.Tiles",
+      "paths": [
+        "tests/dotnet/Honua.Server.Tests/Features/",
+        "src/Honua.Core/Features/Validation/"
       ],
       "csproj": ""
     }

--- a/docs/internal/contributor/adr/0037-unified-ci-test-tier-strategy.md
+++ b/docs/internal/contributor/adr/0037-unified-ci-test-tier-strategy.md
@@ -171,6 +171,32 @@ shared-harness / shared-query-pipeline / `Honua.sln` / new-unmapped-module diff
 routes correctly (run_all for the cross-cutting ones, smoke shard for sln-only).
 This guard runs as the `ci-router-validation` job on every PR.
 
+**Coverage invariant (#1899).** Routing (`paths`) decides *which shards run*;
+each shard then runs `dotnet test <csproj> --filter <filter>`, so a test class
+only executes if some shard targeting its assembly has a `filter` that matches
+its fully-qualified name. A class matched by *no* shard filter therefore never
+runs — not even on `run_all`, which just selects every shard while each shard
+still applies its own filter. #1899 found ~218 such orphaned classes (whole
+namespaces: `Features.Admin`/`Console`/`Alerts`, GeoServices
+`VectorTileServer`/`VersionManagementServer`, the `GeometryService` namespace
+whose owning shard targeted the wrong assembly, several OData classes outside
+the class-name-keyed OData filters, `Features.Providers.Bedrock`, the merged
+SensorThings module, etc.). The fix: convert class-name-keyed filters to
+namespace-prefix form where they were the gap (OData Core, Migration), add
+catch-all shards (`Server Features Misc` for any `Features.*` namespace not
+owned by a specific shard; `GeoServices Geometry VectorTile and Versioning` as
+the GeoServices-assembly catch-all), add `Server Features Admin and Console`
+and a `SensorThings` shard, and route `Features.Providers` to the AI shard. The
+anti-regression guard is `scripts/ci/check-server-test-shard-coverage.py`: it
+enumerates every test class across the server-test assemblies, evaluates each
+shard's `filter` (the `dotnet test --filter` mini-grammar) **per target
+assembly**, and fails CI if any class is claimed by zero shards. It runs inside
+`scripts/ci/validate-ci-router.sh` (the `ci-router-validation` job), so a new
+test class in an unmapped namespace fails the PR instead of silently never
+running. A tiny, justified exemption list covers namespaces deliberately routed
+to a non-PR lane (currently `Honua.Server.Tests.Scale`, the `Category=Scale`
+nightly stack).
+
 The `targeted-shards` job then projects the selected shard names into a
 `matrix_include` JSON array by joining against the rich shard records in
 `.github/ci-shards.json` (each record carries `shard_name`,

--- a/scripts/ci/check-server-test-shard-coverage.py
+++ b/scripts/ci/check-server-test-shard-coverage.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Guard: every Honua.Server.Tests test class must be claimed by at least one
+shard `filter` in .github/ci-shards.json.
+
+Owned by ADR-0037 (#1899). The PR gate runs ONLY the shards selected by the
+targeted-shards matrix, and each shard runs `dotnet test --filter <filter>`.
+A test class whose fully-qualified name matches NO shard's filter therefore
+NEVER executes in CI — not even on a full run_all (run_all just selects every
+shard, and every shard still applies its own filter). #1899 found ~218 such
+orphaned classes (whole namespaces: Features.Admin/Console/Alerts, GeoServices
+VectorTileServer/VersionManagementServer, several Features.Ai classes, etc.).
+
+This script:
+  1. Enumerates every test class across the server-test projects (any class
+     declaring an xUnit test method: [Fact], [Theory], [IntegrationTest],
+     [ScaleTest] — the latter two are FactAttribute subtypes in TestKit).
+  2. Reconstructs each class's fully-qualified name (file-scoped or block
+     namespace + class name), which is the prefix xUnit reports as
+     FullyQualifiedName for every test in that class.
+  3. Evaluates each shard's `filter` (the `dotnet test --filter` mini-grammar
+     over FullyQualifiedName) against each class FQN.
+  4. FAILS (exit 1) if any class is claimed by ZERO shards, or (optionally)
+     reports classes claimed by MORE than one shard.
+
+Run locally / in CI:
+  python3 scripts/ci/check-server-test-shard-coverage.py
+  python3 scripts/ci/check-server-test-shard-coverage.py --report   # full map
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+CONFIG_FILE = REPO_ROOT / ".github" / "ci-shards.json"
+
+# Test projects whose classes use the Honua.Server.Tests.* namespace and are
+# routed through the ci-shards.json shard matrix. Each maps to the .csproj that
+# a shard MUST target (via its `csproj` field) to even discover that project's
+# classes — `dotnet test <csproj> --filter <f>` only matches classes inside
+# <csproj>'s assembly. A class is therefore "claimed" only if some shard whose
+# resolved csproj == the class's owning project has a filter matching its FQN.
+# An empty shard `csproj` resolves to DEFAULT_CSPROJ (the Server.Tests monolith)
+# in scripts/ci/run-server-test-shard.sh.
+DEFAULT_CSPROJ = "tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj"
+TEST_PROJECT_DIRS = {
+    "tests/dotnet/Honua.Server.Tests":
+        "tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj",
+    "tests/dotnet/Honua.Protocols.GeoServices.Tests":
+        "tests/dotnet/Honua.Protocols.GeoServices.Tests/Honua.Protocols.GeoServices.Tests.csproj",
+    "tests/dotnet/Honua.Protocols.OData.Tests":
+        "tests/dotnet/Honua.Protocols.OData.Tests/Honua.Protocols.OData.Tests.csproj",
+    "tests/dotnet/Honua.Protocols.OgcApi.Tests":
+        "tests/dotnet/Honua.Protocols.OgcApi.Tests/Honua.Protocols.OgcApi.Tests.csproj",
+    "tests/dotnet/Honua.Protocols.OgcClassic.Tests":
+        "tests/dotnet/Honua.Protocols.OgcClassic.Tests/Honua.Protocols.OgcClassic.Tests.csproj",
+    "tests/dotnet/Honua.Protocols.Scene.Tests":
+        "tests/dotnet/Honua.Protocols.Scene.Tests/Honua.Protocols.Scene.Tests.csproj",
+    "tests/dotnet/Honua.Protocols.SensorThings.Tests":
+        "tests/dotnet/Honua.Protocols.SensorThings.Tests/Honua.Protocols.SensorThings.Tests.csproj",
+    "tests/dotnet/Honua.Protocols.Stac.Tests":
+        "tests/dotnet/Honua.Protocols.Stac.Tests/Honua.Protocols.Stac.Tests.csproj",
+    "tests/dotnet/Honua.Ai.Tests":
+        "tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj",
+}
+
+# Namespaces that ci-shards.json intentionally leaves to a non-PR lane and so
+# are exempt from the "must be claimed by a shard" rule. Keep this list TINY and
+# justified — every entry is a deliberate decision, not a silent gap.
+#   - Scale: gated behind the Category=Scale stack (nightly scale lane), not the
+#     PR/integration shard matrix (AGENTS.md: "Category=Scale (scale stack
+#     required)"). Not run by any PR shard by design.
+EXEMPT_NAMESPACE_PREFIXES = [
+    "Honua.Server.Tests.Scale",
+    # Quarantined (#1962): RoleEndpointsTests fails when run — built-in roles
+    # return NotFound and CreateRole 500s (likely the test fixture does not apply
+    # src/Honua.Server/Migrations/041_CreateRbacRoleStore.sql). Excluded from the
+    # 'Server Features Admin and Console' shard filter via !~RoleEndpointsTests
+    # and exempted here so the coverage guard stays green. Remove BOTH when #1962
+    # is fixed (un-quarantining then requires the class to be claimed + green).
+    "Honua.Server.Tests.Features.Admin.RoleEndpointsTests",
+]
+
+TEST_METHOD_ATTR = re.compile(
+    r"\[\s*(?:Fact|Theory|IntegrationTest|ScaleTest|SlowTest)\b"
+)
+NAMESPACE_RE = re.compile(r"^\s*namespace\s+([A-Za-z0-9_.]+)\s*;?\s*(\{)?", re.M)
+# class / record class declarations (incl. partial, abstract, sealed, generics).
+CLASS_RE = re.compile(
+    r"(?:public|internal|private|protected|\s)*"
+    r"(?:abstract\s+|sealed\s+|static\s+|partial\s+)*"
+    r"(?:class|record)\s+(?:class\s+)?([A-Za-z_][A-Za-z0-9_]*)"
+)
+
+# Comment / string strippers so braces inside them don't perturb depth tracking.
+_LINE_COMMENT = re.compile(r"//[^\n]*")
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+_STRING_LIT = re.compile(r"\"(?:\\.|[^\"\\\n])*\"|@\"(?:\"\"|[^\"])*\"|'(?:\\.|[^'\\])'")
+
+
+def _strip_noise(text: str) -> str:
+    text = _BLOCK_COMMENT.sub(" ", text)
+    text = _LINE_COMMENT.sub(" ", text)
+    text = _STRING_LIT.sub('""', text)
+    return text
+
+
+def enumerate_test_classes() -> dict[str, dict]:
+    """Return {fully_qualified_class_name: {"csproj": str, "src": [paths]}}.
+
+    Only TOP-LEVEL (namespace-scoped) classes count as test classes — xUnit
+    reports a test's FullyQualifiedName as <namespace>.<top-level class>, and
+    the shard filters route on that. A test method declared inside a nested
+    private helper still belongs to the enclosing top-level class, so we track
+    brace depth and attribute every test method to the nearest top-level
+    (depth-0) class that encloses it. Each class also records the .csproj of the
+    project it lives in, so claiming can be checked per assembly.
+    """
+    classes: dict[str, dict] = {}
+    for proj, csproj in TEST_PROJECT_DIRS.items():
+        root = REPO_ROOT / proj
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*.cs"):
+            raw = path.read_text(encoding="utf-8", errors="replace")
+            if not TEST_METHOD_ATTR.search(raw):
+                continue
+            ns_match = NAMESPACE_RE.search(raw)
+            if not ns_match:
+                continue
+            namespace = ns_match.group(1)
+            block_scoped = ns_match.group(2) == "{"
+            text = _strip_noise(raw)
+
+            # Walk char-by-char tracking brace depth so we know which top-level
+            # class encloses each position. With a block-scoped namespace the
+            # namespace body sits at depth 1, so top-level classes open at the
+            # depth where the namespace body lives.
+            ns_body_depth = 1 if block_scoped else 0
+            depth = 0
+            current_top_class: str | None = None
+            current_top_class_depth = -1
+            test_owners: set[str] = set()
+            i = 0
+            n = len(text)
+            while i < n:
+                ch = text[i]
+                if ch == "{":
+                    depth += 1
+                    i += 1
+                    continue
+                if ch == "}":
+                    if current_top_class is not None and depth == current_top_class_depth + 1:
+                        # Closing the top-level class body.
+                        current_top_class = None
+                        current_top_class_depth = -1
+                    depth -= 1
+                    i += 1
+                    continue
+                # Detect a top-level class declaration starting here.
+                if current_top_class is None and depth == ns_body_depth:
+                    m = CLASS_RE.match(text, i)
+                    if m and (i == 0 or not (text[i - 1].isalnum() or text[i - 1] == "_")):
+                        current_top_class = m.group(1)
+                        current_top_class_depth = depth
+                        i = m.end()
+                        continue
+                # Detect a test attribute and attribute it to the enclosing
+                # top-level class.
+                if ch == "[":
+                    am = TEST_METHOD_ATTR.match(text, i)
+                    if am and current_top_class is not None:
+                        test_owners.add(current_top_class)
+                i += 1
+
+            rel = str(path.relative_to(REPO_ROOT)).replace("\\", "/")
+            for cls in test_owners:
+                fqn = f"{namespace}.{cls}"
+                entry = classes.setdefault(fqn, {"csproj": csproj, "src": []})
+                if rel not in entry["src"]:
+                    entry["src"].append(rel)
+    return classes
+
+
+# --- dotnet `--filter` FullyQualifiedName expression evaluator -----------------
+# Grammar (subset used by ci-shards.json filters):
+#   expr   := or
+#   or     := and ('|' and)*
+#   and    := term ('&' term)*
+#   term   := '(' or ')' | clause
+#   clause := 'FullyQualifiedName' op value
+#   op     := '~' | '!~' | '=' | '!='
+# Values run until the next operator/paren at the top level.
+
+class _FilterParser:
+    def __init__(self, text: str):
+        self.s = text
+        self.i = 0
+        self.n = len(text)
+
+    def _peek(self) -> str:
+        return self.s[self.i] if self.i < self.n else ""
+
+    def parse(self):
+        node = self._parse_or()
+        if self.i != self.n:
+            raise ValueError(f"trailing input at {self.i}: {self.s[self.i:]!r}")
+        return node
+
+    def _parse_or(self):
+        nodes = [self._parse_and()]
+        while self._peek() == "|":
+            self.i += 1
+            nodes.append(self._parse_and())
+        return ("or", nodes) if len(nodes) > 1 else nodes[0]
+
+    def _parse_and(self):
+        nodes = [self._parse_term()]
+        while self._peek() == "&":
+            self.i += 1
+            nodes.append(self._parse_term())
+        return ("and", nodes) if len(nodes) > 1 else nodes[0]
+
+    def _parse_term(self):
+        if self._peek() == "(":
+            self.i += 1
+            node = self._parse_or()
+            if self._peek() != ")":
+                raise ValueError(f"expected ) at {self.i}")
+            self.i += 1
+            return node
+        return self._parse_clause()
+
+    def _parse_clause(self):
+        # property name
+        m = re.match(r"\s*([A-Za-z]+)\s*", self.s[self.i:])
+        if not m:
+            raise ValueError(f"expected property at {self.i}: {self.s[self.i:]!r}")
+        prop = m.group(1)
+        self.i += m.end()
+        # operator (longest first)
+        for op in ("!~", "!=", "~", "="):
+            if self.s.startswith(op, self.i):
+                self.i += len(op)
+                break
+        else:
+            raise ValueError(f"expected operator at {self.i}: {self.s[self.i:]!r}")
+        # value: until next top-level & | ) or end
+        start = self.i
+        while self.i < self.n and self.s[self.i] not in "&|()":
+            self.i += 1
+        value = self.s[start:self.i]
+        return ("clause", prop, op, value)
+
+
+def _eval(node, fqn: str) -> bool:
+    kind = node[0]
+    if kind == "or":
+        return any(_eval(c, fqn) for c in node[1])
+    if kind == "and":
+        return all(_eval(c, fqn) for c in node[1])
+    # clause
+    _, prop, op, value = node
+    if prop != "FullyQualifiedName":
+        # Trait/DisplayName clauses don't constrain class-level claiming; treat
+        # as neutral-true so a class isn't falsely orphaned by a Trait filter.
+        return True
+    if op == "~":
+        return value in fqn
+    if op == "!~":
+        return value not in fqn
+    if op == "=":
+        return fqn == value
+    if op == "!=":
+        return fqn != value
+    raise ValueError(f"unknown op {op}")
+
+
+def shard_claims(filter_text: str, fqn: str) -> bool:
+    return _eval(_FilterParser(filter_text).parse(), fqn)
+
+
+def is_exempt(fqn: str) -> bool:
+    return any(fqn.startswith(p) for p in EXEMPT_NAMESPACE_PREFIXES)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", action="store_true",
+                        help="print the full class->shard map")
+    parser.add_argument("--report-multi", action="store_true",
+                        help="also report classes claimed by >1 shard")
+    args = parser.parse_args()
+
+    config = json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
+    shards = config["shards"]
+    # Validate every filter parses up front and record each shard's resolved
+    # target assembly (empty csproj -> the Server.Tests monolith default).
+    parsed = {}
+    shard_csproj = {}
+    for shard in shards:
+        try:
+            parsed[shard["name"]] = _FilterParser(shard["filter"]).parse()
+        except ValueError as exc:
+            print(f"::error::shard {shard['name']!r} has an unparseable "
+                  f"filter: {exc}", file=sys.stderr)
+            return 2
+        shard_csproj[shard["name"]] = shard.get("csproj") or DEFAULT_CSPROJ
+
+    classes = enumerate_test_classes()
+    if not classes:
+        print("::error::no test classes discovered — enumerator is broken or "
+              "test sources moved", file=sys.stderr)
+        return 2
+
+    orphans: list[str] = []
+    multi: list[tuple[str, list[str]]] = []
+    claim_map: dict[str, list[str]] = {}
+    for fqn in sorted(classes):
+        if is_exempt(fqn):
+            continue
+        cls_csproj = classes[fqn]["csproj"]
+        # A shard can only discover/run a class if it targets that class's
+        # assembly AND its filter matches the FQN.
+        claiming = [
+            name for name, node in parsed.items()
+            if shard_csproj[name] == cls_csproj and _eval(node, fqn)
+        ]
+        claim_map[fqn] = claiming
+        if not claiming:
+            orphans.append(fqn)
+        elif len(claiming) > 1:
+            multi.append((fqn, claiming))
+
+    if args.report:
+        for fqn in sorted(claim_map):
+            print(f"{fqn}\n    -> {', '.join(claim_map[fqn]) or '(ORPHAN)'}")
+        print(f"\nTotal classes: {len(claim_map)}  "
+              f"orphans: {len(orphans)}  multi-claimed: {len(multi)}")
+
+    if args.report_multi and multi:
+        print("\nClasses claimed by more than one shard (allowed but noted):")
+        for fqn, names in multi:
+            print(f"  {fqn} -> {', '.join(names)}")
+
+    if orphans:
+        print(f"::error::{len(orphans)} Honua.Server.Tests class(es) match NO "
+              "shard filter and would never run in CI (coverage hole — #1899). "
+              "Add/extend a shard filter in .github/ci-shards.json so every "
+              "class is claimed by exactly one shard:", file=sys.stderr)
+        for fqn in orphans:
+            entry = classes.get(fqn, {})
+            src = entry.get("src", [])
+            print(f"  - {fqn}  ({src[0] if src else '?'}  "
+                  f"[{entry.get('csproj', '?')}])", file=sys.stderr)
+        return 1
+
+    print(f"OK: all {len(claim_map)} Honua.Server.Tests classes are claimed by "
+          f"at least one shard filter "
+          f"({len(EXEMPT_NAMESPACE_PREFIXES)} exempt namespace prefix(es)).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -253,15 +253,25 @@ assert_descriptor \
   "Core"
 
 # A brand-new, not-yet-mapped top-level protocol area (e.g. a future
-# src/Honua.Protocols.SensorThings/ landing before its shard is added) trips the
+# src/Honua.Protocols.Wcps/ landing before its shard is added) trips the
 # unmapped-source safety net and runs run_all until an owning shard is mapped —
 # never a silent skip.
 assert_descriptor \
   "new-unmapped-protocol-run-all" \
-  "src/Honua.Protocols.SensorThings/SensorThingsEndpoints.cs" \
+  "src/Honua.Protocols.Wcps/WcpsEndpoints.cs" \
   "unmapped_source_change" \
   "true" \
   "Core"
+
+# SensorThings (STA) now HAS a shard (#1899): a change confined to it must route
+# to the dedicated SensorThings shard (targeted), not run_all and not a silent
+# skip. Before #1899 its tests matched no filter and never ran.
+assert_descriptor \
+  "sensorthings-targeted" \
+  "src/Honua.Protocols.SensorThings/SensorThingsEndpoints.cs" \
+  "targeted" \
+  "false" \
+  "SensorThings"
 
 # The shared host-rendering pipeline (Honua.Hosting) is cross-cutting: a change
 # there must run_all rather than mis-route to a single render protocol.
@@ -271,5 +281,14 @@ assert_descriptor \
   "unmapped_source_change" \
   "true" \
   "Core"
+
+# ---------------------------------------------------------------------------
+# #1899 guard: every Honua.Server.Tests class must be claimed by at least one
+# shard filter (in the correct test assembly) or it never runs in CI. This is
+# the anti-regression check for the coverage hole — a new test class in an
+# unmapped namespace fails CI here instead of silently never running.
+# ---------------------------------------------------------------------------
+echo "Checking server-test shard coverage (no orphaned test classes)..."
+python3 scripts/ci/check-server-test-shard-coverage.py
 
 echo "CI router validation passed."


### PR DESCRIPTION
## Issue Link
Closes #1899

## Summary
Routing (`ci-shards.json` `paths`) decides *which shards run*; each shard then runs `dotnet test <csproj> --filter <filter>`, so a test class only executes if some shard **targeting its assembly** has a `filter` matching its fully-qualified name. **~136 `Honua.Server.Tests` classes matched NO shard filter and never ran in CI** — not even on `run_all` (which just selects every shard, each still applying its own filter). This is the coverage hole #1897/#1898 found and deferred. Whole namespaces were dark: `Features.Admin`/`Console`/`Alerts`, GeoServices `VectorTileServer`/`VersionManagementServer`, the entire `GeometryService` namespace (~107 tests — its owning shard's `filter` targeted the wrong assembly), several OData classes outside the class-name-keyed OData filters, `Features.Providers.Bedrock`, and the merged SensorThings module.

## How the routing was fixed
- **OData Core → namespace-prefix catch-all** (per the AC): selects the whole OData namespace except the classes carved into the 3 sibling OData shards, so new OData classes are auto-covered instead of silently falling outside every class-name-keyed filter.
- **Migration filter** gains the two orphaned `RedisImportJobManager` / `UniversalProgressStore` Import classes (already in its `paths`).
- **New `Server Features Misc` shard** — true catch-all for any `Features.*` namespace not owned by a specific shard. This is the keystone that keeps the hole closed: any future `Features.*` namespace auto-lands here.
- **New `GeoServices Geometry VectorTile and Versioning` shard** (correct `GeoServices.Tests` assembly) — claims `VectorTileServer`, `VersionManagementServer`, the `GeometryService` namespace, and GeoServices-root classes; also the GeoServices-assembly catch-all. Fixes a latent wrong-assembly bug: `GeometryService` had a filter on `Geometry Tiles and Terrain`, but that shard's csproj defaults to the `Server.Tests` assembly while those tests live in `GeoServices.Tests`, so the filter matched nothing.
- **New `Server Features Admin and Console` shard** for the `Features.Admin`/`Console`/`Alerts` namespaces (the dominant orphan bucket).
- **New `SensorThings` shard** — #1842 merged its test project without one (the #1899 non-goal note predates that merge).
- **Route `Features.Providers` (Bedrock)** to the MCP/AI shard (`Honua.Ai.Tests` assembly).

## Anti-regression guard
`scripts/ci/check-server-test-shard-coverage.py` enumerates every test class across the server-test assemblies, evaluates each shard's `filter` (the `dotnet test --filter` mini-grammar) **per target assembly**, and **fails CI if any class is claimed by zero shards**. It runs inside `scripts/ci/validate-ci-router.sh` (the existing `ci-router-validation` job), so a new test class in an unmapped namespace fails the PR instead of silently never running. A tiny, justified exemption list covers namespaces deliberately routed to a non-PR lane (`Honua.Server.Tests.Scale`) and the one quarantined class below.

## Coverage: 567 classes now claimed (was ~431 effectively running)
The guard reports **all 567 server-test classes claimed by ≥1 shard** (2 exempt prefixes). ~136 previously-orphaned classes now run.

## Failures surfaced when the orphans started running
Verified locally (serial, `-p:NuGetAudit=false -p:UseSharedCompilation=false`, `MSBUILDDISABLENODEREUSE=1`, Testcontainers Postgres):

| Newly-running group | Result |
|---|---|
| GeoServices `GeometryService` (never ran) | **118 / 118 pass** |
| OData orphan classes (Bbox/InOperator/Parquet/ServerPaging/ChangesetGate/OrderBy + OData.Tests.Services) | **45 / 45 pass** |
| SensorThings | **14 / 14 pass** |
| `Features.Reporting.RenderGoldenTests` (golden files) | **9 / 9 pass** |
| Admin sample (8 classes) | **63 pass / 9 fail** — all 9 in `RoleEndpointsTests` |
| Misc/Alerts fast spot-check (4 classes) | **112 / 112 pass** |

**One genuine failure: `Features.Admin.RoleEndpointsTests`** (built-in roles return NotFound, `CreateRole` 500s — likely `WebAppFixture` does not apply `src/Honua.Server/Migrations/041_CreateRbacRoleStore.sql`'s built-in-role seed; could be a harness-migration gap or a real store defect). **Quarantined** via a `!~RoleEndpointsTests` exclusion on the Admin shard filter **+** an entry in the guard's exemption list, so the other ~538 Admin tests still gate. **Tracked in #1962.** Un-quarantine = remove both, fix #1962, guard then requires it green.

## Scope note (honest)
The DB-heavy Admin and `Server Features Misc` shards run hundreds of integration tests; I sampled each new shard locally (above) rather than running all ~538 Admin + all Misc tests (hours serially). This PR's own CI run is the first full execution of every newly-claimed class — if more failures surface there, they should be triaged the same way (fix-if-small, else quarantine + Refs) rather than re-darkening coverage.

## Testing
- `scripts/ci/validate-ci-router.sh` passes (schema + router dry-runs + new coverage guard + updated SensorThings routing cases).
- `scripts/ci/check-server-test-shard-coverage.py` passes (0 orphans).
- Local test runs per the table above.

## Gate Impact
- [x] PR gates (CI config + a new guard step in `ci-router-validation`)

## Docs or Contract Impact
- [x] ADR-0037 updated with the coverage invariant (#1899).

## Release/Deploy Impact
- [x] None — CI configuration only; no runtime change.

## Breaking Changes
None.