### PR TITLE
fix(testkit): eliminate residual 40P01 + leader-election CI flakes (#1568 followup)

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningAsyncReconcileTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningAsyncReconcileTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Immutable;
 using System.Reflection;
-using DbUp;
 using FluentAssertions;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
@@ -18,7 +17,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.ObjectPool;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
-using Npgsql;
 
 namespace Honua.Server.Tests.Features.FeatureStore;
 
@@ -52,17 +50,13 @@ public sealed class BranchVersioningAsyncReconcileTests : IAsyncLifetime
     {
         await _fixture.ExecuteAsync($"CREATE SCHEMA {_schema}");
 
-        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
-        {
-            SearchPath = $"{_schema},public"
-        };
-        var upgrader = DeployChanges.To
-            .PostgresqlDatabase(connectionStringBuilder.ToString(), _schema)
-            .JournalToPostgresqlTable(_schema, "schema_versions")
-            .WithScriptsEmbeddedInAssembly(Assembly.GetAssembly(typeof(Program))!)
-            .WithTransaction()
-            .Build();
-        var result = upgrader.PerformUpgrade();
+        // honua-server#1568 follow-up: serialize the embedded migration set (it mutates the literal,
+        // process-global honua schema, which per-test search_path isolation does NOT scope) under the
+        // shared seed advisory lock so this upgrade does not race locked seeders on the shared catalog
+        // and deadlock (40P01) the parallel [Collection("Database")] run.
+        var result = await _fixture.RunEmbeddedMigrationsUnderLockAsync(
+            _schema,
+            Assembly.GetAssembly(typeof(Program))!);
         result.Successful.Should().BeTrue(result.Error?.ToString());
 
         await _fixture.ExecuteAsync($"""

--- a/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningIntegrationTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Immutable;
 using System.Reflection;
-using DbUp;
 using FluentAssertions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Postgres.Features.FeatureStore;
@@ -51,17 +50,16 @@ public sealed class BranchVersioningIntegrationTests : IAsyncLifetime
         // Apply the full embedded migration set into the isolated schema so features + the honua.*
         // versioning tables (gdb_versions, version_edits, feature_changes, sync_generation) and their
         // triggers all exist exactly as production runs them.
-        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
-        {
-            SearchPath = $"{_schema},public"
-        };
-        var upgrader = DeployChanges.To
-            .PostgresqlDatabase(connectionStringBuilder.ToString(), _schema)
-            .JournalToPostgresqlTable(_schema, "schema_versions")
-            .WithScriptsEmbeddedInAssembly(Assembly.GetAssembly(typeof(Program))!)
-            .WithTransaction()
-            .Build();
-        var result = upgrader.PerformUpgrade();
+        //
+        // honua-server#1568 follow-up: 001_CreateHonuaSchema.sql mutates the literal, process-global
+        // honua schema (CREATE SCHEMA IF NOT EXISTS honua; CREATE TABLE honua.services/layers ...),
+        // which per-test search_path isolation does NOT scope. Running this upgrade unlocked made it a
+        // non-participant that raced every locked seeder's ACCESS EXCLUSIVE catalog locks on the same
+        // global honua.* objects and deadlocked the parallel [Collection("Database")] run (40P01).
+        // Route it through the shared seed advisory lock like the seeders.
+        var result = await _fixture.RunEmbeddedMigrationsUnderLockAsync(
+            _schema,
+            Assembly.GetAssembly(typeof(Program))!);
         result.Successful.Should().BeTrue(result.Error?.ToString());
 
         // Register the test layer so the feature store resolves its SRID (4326) and stamps written

--- a/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningOverlayReadScaleTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningOverlayReadScaleTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Reflection;
-using DbUp;
 using FluentAssertions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Postgres.Features.FeatureStore;
@@ -85,17 +84,13 @@ public sealed class BranchVersioningOverlayReadScaleTests : IAsyncLifetime
     {
         await _fixture.ExecuteAsync($"CREATE SCHEMA {_schema}");
 
-        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
-        {
-            SearchPath = $"{_schema},public"
-        };
-        var upgrader = DeployChanges.To
-            .PostgresqlDatabase(connectionStringBuilder.ToString(), _schema)
-            .JournalToPostgresqlTable(_schema, "schema_versions")
-            .WithScriptsEmbeddedInAssembly(Assembly.GetAssembly(typeof(Program))!)
-            .WithTransaction()
-            .Build();
-        var result = upgrader.PerformUpgrade();
+        // honua-server#1568 follow-up: serialize the embedded migration set (it mutates the literal,
+        // process-global honua schema, which per-test search_path isolation does NOT scope) under the
+        // shared seed advisory lock so this upgrade does not race locked seeders on the shared catalog
+        // and deadlock (40P01) the parallel [Collection("Database")] run.
+        var result = await _fixture.RunEmbeddedMigrationsUnderLockAsync(
+            _schema,
+            Assembly.GetAssembly(typeof(Program))!);
         result.Successful.Should().BeTrue(result.Error?.ToString());
 
         await _fixture.ExecuteAsync($"""

--- a/tests/dotnet/Honua.Server.Tests/Import/RedisImportJobManagerIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/RedisImportJobManagerIntegrationTests.cs
@@ -126,7 +126,11 @@ public sealed class RedisImportJobManagerIntegrationTests
             (await electionA.TryAcquireLeadershipAsync()).Should().BeTrue();
             (await electionB.TryAcquireLeadershipAsync()).Should().BeFalse();
 
-            electionA.Dispose();
+            // Await the deterministic release path (DisposeAsync) rather than the synchronous
+            // Dispose(): the latter schedules the Redis LockRelease as a fire-and-forget Task.Run,
+            // so the lock can still be held when B polls immediately after, intermittently failing
+            // this test. DisposeAsync awaits the release before returning, removing that race.
+            await electionA.DisposeAsync();
             disposedA = true;
 
             (await electionB.TryAcquireLeadershipAsync()).Should().BeTrue(
@@ -136,10 +140,10 @@ public sealed class RedisImportJobManagerIntegrationTests
         {
             if (!disposedA)
             {
-                electionA.Dispose();
+                await electionA.DisposeAsync();
             }
 
-            electionB.Dispose();
+            await electionB.DisposeAsync();
         }
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/DatabaseFixtureAdapter.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/DatabaseFixtureAdapter.cs
@@ -55,4 +55,14 @@ public sealed class DatabaseFixtureAdapter : IDatabaseFixture
     {
         await _postgresFixture.ApplyGlobalSeedSqlAsync(sql, schemaName);
     }
+
+    public Task<DbUp.Engine.DatabaseUpgradeResult> RunEmbeddedMigrationsUnderLockAsync(
+        string schemaName,
+        System.Reflection.Assembly migrationsAssembly)
+    {
+        return _postgresFixture.RunEmbeddedMigrationsUnderLockAsync(
+            schemaName,
+            ConnectionString,
+            migrationsAssembly);
+    }
 }

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/IDatabaseFixture.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/IDatabaseFixture.cs
@@ -46,4 +46,20 @@ public interface IDatabaseFixture : IAsyncLifetime
     /// <param name="sql">The raw seed/setup SQL to apply.</param>
     /// <param name="schemaName">Optional schema to set on <c>search_path</c> before applying the SQL.</param>
     Task ApplyGlobalSeedSqlAsync(string sql, string? schemaName = null);
+
+    /// <summary>
+    /// Runs the full embedded DbUp migration set into <paramref name="schemaName"/> while holding the
+    /// shared seed advisory lock (honua-server#1568 follow-up). The migration set includes
+    /// <c>001_CreateHonuaSchema.sql</c>, which mutates the literal, process-global <c>honua</c> schema
+    /// that per-test <c>search_path</c> isolation does NOT scope; routing it through the lock keeps
+    /// parallel <c>[Collection("Database")]</c> upgrades from racing the shared catalog and deadlocking
+    /// (40P01) against locked seeders. Use this instead of a bare
+    /// <c>DeployChanges...PerformUpgrade()</c>.
+    /// </summary>
+    /// <param name="schemaName">Isolated schema to deploy into.</param>
+    /// <param name="migrationsAssembly">Assembly whose embedded migration scripts are deployed.</param>
+    /// <returns>The DbUp upgrade result.</returns>
+    Task<DbUp.Engine.DatabaseUpgradeResult> RunEmbeddedMigrationsUnderLockAsync(
+        string schemaName,
+        System.Reflection.Assembly migrationsAssembly);
 }

--- a/tests/dotnet/Honua.TestKit/Honua.TestKit.csproj
+++ b/tests/dotnet/Honua.TestKit/Honua.TestKit.csproj
@@ -12,6 +12,9 @@
 
     <!-- PostgreSQL/PostGIS -->
     <PackageReference Include="BouncyCastle.Cryptography" />
+    <!-- DbUp: TestKit serializes the embedded migration set under the shared seed advisory lock
+         (RunEmbeddedMigrationsUnderLockAsync) so global-honua DDL stays off the 40P01 path (#1568). -->
+    <PackageReference Include="dbup-postgresql" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="FluentAssertions.Json" />
     <PackageReference Include="FsCheck.Xunit" />

--- a/tests/dotnet/Honua.TestKit/PostgresFixture.cs
+++ b/tests/dotnet/Honua.TestKit/PostgresFixture.cs
@@ -291,6 +291,60 @@ public sealed class PostgresFixture : IAsyncLifetime
             cancellationToken);
     }
 
+    /// <summary>
+    /// Runs the full embedded DbUp migration set against <paramref name="schemaName"/> while holding
+    /// the shared <see cref="Seeding.SeedRunner.SeedApplicationLockKey"/> advisory lock, retrying on a
+    /// transient <c>40P01</c>/<c>40001</c>.
+    /// </summary>
+    /// <remarks>
+    /// honua-server#1568 follow-up: <c>001_CreateHonuaSchema.sql</c> runs <c>CREATE SCHEMA IF NOT
+    /// EXISTS honua; CREATE TABLE honua.services/layers ...</c> against the literal, process-global
+    /// <c>honua</c> schema, which the per-test <c>search_path</c> isolation does NOT scope. Tests that
+    /// run the embedded migration set directly via <c>DeployChanges...PerformUpgrade()</c> must take
+    /// this same advisory lock; otherwise they are non-participants that race every locked seeder's
+    /// <c>ACCESS EXCLUSIVE</c> catalog/table locks on the same global <c>honua.*</c> objects and
+    /// deadlock the parallel <c>[Collection("Database")]</c> run. The original #1568 fix routed
+    /// <c>DatabaseMigrationTests</c> and the raw <c>.sql</c> seeds through the lock but left the
+    /// <c>BranchVersioning*</c> upgrades unguarded — this helper closes that gap.
+    /// </remarks>
+    /// <param name="schemaName">Isolated schema to deploy into (also the journal/search-path schema).</param>
+    /// <param name="connectionString">Base connection string; its <c>SearchPath</c> is set to the schema.</param>
+    /// <param name="migrationsAssembly">Assembly whose embedded <c>.sql</c> scripts are deployed.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The DbUp upgrade result.</returns>
+    public async Task<DbUp.Engine.DatabaseUpgradeResult> RunEmbeddedMigrationsUnderLockAsync(
+        string schemaName,
+        string connectionString,
+        System.Reflection.Assembly migrationsAssembly,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(schemaName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        ArgumentNullException.ThrowIfNull(migrationsAssembly);
+
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(connectionString)
+        {
+            SearchPath = $"{schemaName},public",
+        };
+
+        DbUp.Engine.DatabaseUpgradeResult result = null!;
+        await RunUnderSchemaMutationLockAsync(
+            () =>
+            {
+                var upgrader = DbUp.DeployChanges.To
+                    .PostgresqlDatabase(connectionStringBuilder.ToString(), schemaName)
+                    .JournalToPostgresqlTable(schemaName, "schema_versions")
+                    .WithScriptsEmbeddedInAssembly(migrationsAssembly)
+                    .WithTransaction()
+                    .Build();
+                result = upgrader.PerformUpgrade();
+                return Task.CompletedTask;
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        return result;
+    }
+
     private static async Task ExecuteAdvisoryLockCommandAsync(NpgsqlConnection connection, string sql, CancellationToken cancellationToken)
     {
         await using var cmd = connection.CreateCommand();


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1568

## Summary
Root-causes and fixes (not retries) the residual `40P01: deadlock detected` integration flakes and the `LeaderElection_Dispose` race that the affected shards relied on auto-retry for.

**The gap #1568 / PR #1914 missed:** #1914 routed `DatabaseMigrationTests` and the raw `.sql` seeds through the `SeedRunner.SeedApplicationLockKey` advisory lock, but it left three sibling tests running the **full embedded DbUp migration set** directly via `DeployChanges...PerformUpgrade()` with **no lock**:

- `BranchVersioningIntegrationTests`
- `BranchVersioningAsyncReconcileTests`
- `BranchVersioningOverlayReadScaleTests`

`001_CreateHonuaSchema.sql` runs `CREATE SCHEMA IF NOT EXISTS honua; CREATE TABLE honua.services/layers ...` against the **literal, process-global `honua` schema**, which the per-test `search_path` isolation does NOT scope. An unlocked upgrade is a **non-participant** in the advisory lock — it bypasses the lock entirely and races every *locked* seeder's `ACCESS EXCLUSIVE` catalog/table locks on the same global `honua.*` objects in interleaved order, deadlocking the parallel `[Collection("Database")]` run. That unguarded concurrent-DDL source is exactly why `DbUpMigrations.MobileOfflineDemoSeed` and the `OGC API Maps and Tiles` shards (both of which seed `server.yaml`'s global-`honua` DDL *under* the lock) still hit `40P01` after #1914 — they were correctly locked, but kept colliding with the unlocked Branch-Versioning upgrades.

## Root cause per flake
- **`DbUpMigrations_MobileOfflineDemoSeed_*` (Server Tests Core) & `OGC API Maps and Tiles` — `40P01`:** their own DDL/seed paths were already locked; they deadlocked against the three unlocked `BranchVersioning*` `PerformUpgrade()` calls racing the shared `honua` catalog. Same root cause, one fix.
- **`LeaderElection_Dispose_ReleasesLeadershipForNextInstance` (Server Tests Migration) — Redis disposal race (not Postgres):** the synchronous `RedisLeaderElection.Dispose()` schedules the Redis `LockRelease` as a **fire-and-forget `Task.Run`**. The test calls `electionA.Dispose()` then *immediately* polls `electionB.TryAcquireLeadershipAsync()`; when B's `LockTake` runs before the background release, A still holds the lease → B fails. The class already exposes a deterministic `DisposeAsync()` that **awaits** the release.

## Changes Made
- Add `PostgresFixture.RunEmbeddedMigrationsUnderLockAsync(schema, conn, asm)` — runs the embedded DbUp migration set under the shared `SeedApplicationLockKey` advisory lock with bounded `40P01`/`40001` retry; surfaced through `IDatabaseFixture` + `DatabaseFixtureAdapter`. (Adds the `dbup-postgresql` package ref to `Honua.TestKit`.)
- Route all three `BranchVersioning*` upgrades through it, so every real-DB global-`honua` DDL path now serializes on one lock. (`DbUpMigrations_WithInvalidConnectionString` uses an invalid connection and never reaches the DB, so it stays unguarded by design.)
- `LeaderElection_Dispose_*`: await the existing deterministic `DisposeAsync()` instead of fire-and-forget `Dispose()` (test-only change; no production code touched).

## Stress evidence
External PostGIS `18-3.6` / Redis `7`, `maxParallelThreads=-1`, fresh-DB reset per run to mirror CI Testcontainers:
- Migration + BranchVersioning combined filter: **15/15 green, zero `40P01`**.
- `LeaderElection_Dispose`: **20/20 green** — baseline (sync `Dispose()`) reproduced **0/20** (20/20 fail) against the same Redis, conclusively isolating the race.
- `dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true` → **0 warn / 0 err**; `dotnet format Honua.sln --verify-no-changes` → **clean**.

Residual-risk note: the cross-collection `40P01` itself only fires under heavy concurrent host load (per the known-flake note), so it was not reproducible from a narrowed filter on an idle box; the fix is verified by removing the unguarded DDL source (every remaining real-DB `PerformUpgrade` is now lock-guarded) plus the green stress runs. Docker CLI was unavailable in-distro; reproduction used the Windows daemon via `docker.exe` + `HONUA_TEST_DB_URL`/`HONUA_TEST_REDIS_URL`.

## Testing
- [x] Integration tests added/updated
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
