### PR TITLE
ci: publish moving `trunk`/`trunk-aot` image tags from nightly (#1770)

### DIFF
--- a/.github/workflows/nightly-container-build.yml
+++ b/.github/workflows/nightly-container-build.yml
@@ -121,6 +121,7 @@ jobs:
             type=raw,value=nightly-aot
             type=raw,value=nightly-aot-{{date 'YYYYMMDD'}}
             type=sha,prefix=nightly-aot-
+            type=raw,value=trunk-aot
           flavor: |
             suffix=-${{ matrix.arch }}
 
@@ -321,6 +322,7 @@ jobs:
             type=raw,value=nightly
             type=raw,value=nightly-{{date 'YYYYMMDD'}}
             type=sha,prefix=nightly-
+            type=raw,value=trunk
           flavor: |
             suffix=-${{ matrix.arch }}
 
@@ -384,6 +386,7 @@ jobs:
             type=raw,value=nightly-aot
             type=raw,value=nightly-aot-{{date 'YYYYMMDD'}}
             type=sha,prefix=nightly-aot-
+            type=raw,value=trunk-aot
 
       - name: Create and push multi-arch manifests
         env:
@@ -432,6 +435,7 @@ jobs:
             type=raw,value=nightly
             type=raw,value=nightly-{{date 'YYYYMMDD'}}
             type=sha,prefix=nightly-
+            type=raw,value=trunk
 
       - name: Create and push multi-arch manifests
         env:

--- a/docs/guides/deploy/cloud-deployments.md
+++ b/docs/guides/deploy/cloud-deployments.md
@@ -18,6 +18,20 @@ Infrastructure-as-code for all of these patterns ships as private Terraform modu
 
 Generic web images are published to Docker Hub (`honuaio/honua-server`) and GHCR (`ghcr.io/honua-io/honua-server`). Cloud-targeted tags (`*-ecs`, `*-lambda`, `*-functions`, each with `-aot` variants) are published by CI to ECR/ACR. Prefer the AOT tags — faster start, lower memory; keep JIT tags as a debug fallback.
 
+### Which tag to pull
+
+On the generic web image (Docker Hub + GHCR), tags have distinct contracts. Pick by whether you want the latest *release* or the latest *trunk* build:
+
+| Tag | Means | Moves when | Published by |
+|---|---|---|---|
+| `latest` / `latest-aot` | Latest stable **release** | A `v*` release tag is cut | `deploy.yml` |
+| `vX.Y.Z` / `vX.Y.Z-aot` | A specific pinned release | Never (immutable) | `deploy.yml` |
+| `trunk` / `trunk-aot` | Latest **trunk** build (HEAD of the default branch) | Every nightly build | `nightly-container-build.yml` |
+| `nightly` / `nightly-aot`, `nightly-YYYYMMDD`, `nightly-<sha>` | Same trunk build as `trunk`/`trunk-aot`, plus dated/sha-pinned variants | Every nightly build | `nightly-container-build.yml` |
+
+- **Production / demos**: pull `latest` (or a pinned `vX.Y.Z`). `latest` deliberately tracks the latest *release*, not trunk, so it never silently advances to an unreleased build.
+- **Trunk-following consumers** (certification harnesses, "test against current trunk" CI, bleeding-edge previews): pull `trunk` / `trunk-aot`. These are the documented, obviously-named moving tags for the head of the default branch and are refreshed by the nightly build. Do **not** reach for `latest` expecting trunk — it can lag a release cycle behind.
+
 ## Pattern by team size
 
 - **Dev/test (1–5 people)**: single host with [Docker Compose](docker-compose.md); no HA, local volumes.


### PR DESCRIPTION
## What

The generic-web `:latest` / `latest-aot` tags on Docker Hub + GHCR only move when a `v*` release tag is cut (`deploy.yml`). The nightly (`nightly-container-build.yml`) builds trunk every night but only under non-obvious names (`nightly`, `nightly-aot`, `nightly-<date>`, `nightly-<sha>`). Net result: consumers that pull `:latest` expecting "current trunk" silently get a release-cycle-stale image (~7 weeks at time of filing in #1770).

This adds first-class, obviously-named **moving trunk tags** published by the nightly server-image jobs:

| Job | New tag |
|---|---|
| `build-jit` / `manifest-jit` | `trunk` |
| `build-aot` / `manifest-aot` | `trunk-aot` |

They point at the same nightly build as `nightly` / `nightly-aot` — just under a name people actually reach for. The existing nightly tags are unchanged.

`:latest` / `latest-aot` are deliberately **left meaning "latest release"** (they are demo/prod-facing and must not silently advance to an unreleased build — see the ⚠️ in #1770). This is recommendation #1 from the ticket (new moving tag, low blast radius), not clobbering `:latest`.

The Lambda nightly jobs are intentionally untouched — they are a serverless runtime artifact, not a generic web image consumers pull as "trunk".

## Docs

`docs/guides/deploy/cloud-deployments.md` now has a **"Which tag to pull"** table documenting the contract of each tag (`latest` = latest release; `trunk`/`trunk-aot` = latest trunk build, moves nightly; `vX.Y.Z` = pinned) so it can't silently rot again.

## Acceptance criteria (#1770)

- [x] A documented, moving tag that means "latest trunk build" exists and is published by the nightly (`trunk` / `trunk-aot`).
- [x] `:latest`'s contract (latest release vs latest trunk) is documented.
- [ ] Trunk-following consumers (honua-esri-compat) repoint — that is the cross-repo consumer PR tracked separately in the ticket; the esri-compat harness can move to `trunk-aot` once these tags publish.

## Verification

- YAML parses cleanly (`yaml.safe_load`); all 7 jobs intact. actionlint/yamllint were not available in the dev environment.
- **CI-only**: the actual multi-arch build + push of the new `trunk`/`trunk-aot` manifests to GHCR + Docker Hub can only be exercised by the scheduled nightly run (or a `workflow_dispatch`) — not reproducible locally.

Closes #1770