### PR TITLE
test(mcp): validate /mcp vocabulary against published geospatial-mcp JSON schemas (#1957)

### DIFF
--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/README.md
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/README.md
@@ -1,0 +1,22 @@
+# Vendored geospatial-mcp JSON Schemas
+
+This directory is a **vendored copy** of the published JSON Schemas from the
+[`geospatial-mcp`](https://github.com/honua-io/geospatial-mcp) standard
+(`spec/schemas/`). It exists so `McpTaxonomyAlignmentTests` can assert that
+Honua's live `/mcp` advertised tool input schemas and resource payload shapes
+**conform to the open standard Honua champions** — Honua is the reference
+implementation.
+
+- Source: `geospatial-mcp` `spec/schemas/` (branch `feat/json-schemas-conformance`,
+  PR honua-io/geospatial-mcp#21).
+- Do not hand-edit. Re-vendor when the upstream schemas change.
+- Files are copied to the test output directory (`CopyToOutputDirectory`) and
+  loaded at test time.
+
+The conformance tests validate representative valid argument/payload instances
+against both Honua's live schema and the vendored standard schema, and assert
+structural alignment (required fields, enum values) for the tools Honua
+implements today. Standard tools Honua does not yet implement as discrete MCP
+tools (the map/app composition and publish families) are tracked as
+**known-gaps**: their absence does not fail the suite; only NON-CONFORMANCE of
+an implemented tool fails.

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/artifact/artifact.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/artifact/artifact.json
@@ -1,0 +1,19 @@
+{
+  "id": "artifact.feature_layer_workspace_view",
+  "schemaRef": "resources/artifact.schema.json",
+  "validates": "inputs",
+  "uri": "honua://workspaces/ws_91/artifacts/artifact_exposed_facilities",
+  "inputs": {
+    "artifactId": "artifact_exposed_facilities",
+    "kind": "FeatureLayer",
+    "label": "Exposed facilities",
+    "uri": "honua://workspaces/ws_91/layers/exposed_facilities",
+    "contentType": "application/geo+json",
+    "metadata": { "count": "23" },
+    "lifecycleState": "Available",
+    "promotionSourceReady": true,
+    "sourceWorkspaceKind": "TempLayer"
+  },
+  "expected": "resource_projection",
+  "canonicalRefs": ["ArtifactRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/provenance/provenance.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/provenance/provenance.json
@@ -1,0 +1,20 @@
+{
+  "id": "provenance.full",
+  "schemaRef": "resources/provenance.schema.json",
+  "validates": "inputs",
+  "uri": "honua://results/result_3f21/provenance",
+  "inputs": {
+    "sources": [
+      { "datasetId": "critical_facilities", "version": "2026.05", "description": "County critical facilities registry." },
+      { "datasetId": "fema_100yr_floodplain", "version": "2024", "description": "FEMA 100-year floodplain." }
+    ],
+    "processDefinitions": ["intersect"],
+    "assumptions": ["Used FEMA 2024 100-year floodplain layer."],
+    "clarificationsAsked": ["q_hazard_layer"],
+    "clarificationsAnswered": ["q_hazard_layer"],
+    "executedAt": "2026-06-21T14:02:11Z",
+    "generatedArtifactIds": ["artifact_exposed_facilities"]
+  },
+  "expected": "resource_projection",
+  "canonicalRefs": ["ProvenanceRecord"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/result-package/result-package.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/result-package/result-package.json
@@ -1,0 +1,32 @@
+{
+  "id": "result-package.completed",
+  "schemaRef": "resources/result-package.schema.json",
+  "validates": "inputs",
+  "uri": "honua://results/result_3f21",
+  "inputs": {
+    "resultPackageId": "result_3f21",
+    "status": "Completed",
+    "summary": {
+      "title": "Flood exposure of critical facilities",
+      "description": "23 of 412 critical facilities fall within the FEMA 100-year floodplain."
+    },
+    "assumptions": ["Used FEMA 2024 100-year floodplain layer."],
+    "artifacts": [
+      {
+        "artifactId": "artifact_exposed_facilities",
+        "kind": "FeatureLayer",
+        "label": "Exposed facilities",
+        "uri": "honua://workspaces/ws_91/layers/exposed_facilities",
+        "contentType": "application/geo+json",
+        "metadata": { "count": "23" }
+      }
+    ],
+    "provenance": {
+      "processDefinitions": ["intersect"],
+      "executedAt": "2026-06-21T14:02:11Z",
+      "generatedArtifactIds": ["artifact_exposed_facilities"]
+    }
+  },
+  "expected": "resource_projection",
+  "canonicalRefs": ["AnalysisResultPackage", "ArtifactRef", "ProvenanceRecord"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/workspace/workspace.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/workspace/workspace.json
@@ -1,0 +1,17 @@
+{
+  "id": "workspace.active_temp",
+  "schemaRef": "resources/workspace.schema.json",
+  "validates": "inputs",
+  "uri": "honua://workspaces/ws_91",
+  "inputs": {
+    "workspaceId": "ws_91",
+    "kind": "temp_layer",
+    "label": "Flood analysis scratch",
+    "uri": "honua://workspaces/ws_91",
+    "expiresAt": "2026-06-28T00:00:00Z",
+    "status": "active",
+    "resultsUri": "honua://jobs/job_7f3a/results"
+  },
+  "expected": "resource_projection",
+  "canonicalRefs": ["WorkspaceRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/cancel_job/cancel_job.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/cancel_job/cancel_job.json
@@ -1,0 +1,8 @@
+{
+  "id": "cancel_job.basic",
+  "schemaRef": "tools/cancel_job.schema.json",
+  "validates": "inputs",
+  "inputs": { "jobId": "job_7f3a" },
+  "expected": "tool_result",
+  "canonicalRefs": ["ExecutionJob"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/clarify_intent/clarify_intent.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/clarify_intent/clarify_intent.json
@@ -1,0 +1,18 @@
+{
+  "id": "clarify_intent.answers",
+  "schemaRef": "tools/clarify_intent.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "goal": "Assess flood exposure for critical facilities in the county.",
+    "intentId": "intent_8c21",
+    "assumptionPolicy": "AskWhenMaterial",
+    "response": {
+      "answers": {
+        "q_buffer_distance": ["500"],
+        "q_hazard_layer": ["dataset:fema_100yr_floodplain"]
+      }
+    }
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["ClarificationResponse", "AnalysisIntent"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/execute_plan/execute_plan.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/execute_plan/execute_plan.json
@@ -1,0 +1,19 @@
+{
+  "id": "execute_plan.executable",
+  "schemaRef": "tools/execute_plan.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "plan": {
+      "planId": "plan_a1",
+      "intentId": "intent_8c21",
+      "steps": [
+        { "stepId": "s1", "kind": "QueryFeatures", "inputs": { "datasetId": "critical_facilities" } },
+        { "stepId": "s2", "kind": "Geoprocess", "processId": "buffer", "inputs": { "distance": "500" }, "dependsOn": ["s1"] }
+      ],
+      "outputs": ["FeatureLayer"]
+    },
+    "idempotencyKey": "exec-2026-06-21-001"
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["AnalysisPlan", "ExecutionJob"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/geocode_address/geocode_address.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/geocode_address/geocode_address.json
@@ -1,0 +1,13 @@
+{
+  "id": "geocode_address.basic",
+  "schemaRef": "tools/geocode_address.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "address": "1100 Congress Ave, Austin, TX 78701",
+    "maxResults": 3,
+    "countryCodes": "us",
+    "outSrid": 4326
+  },
+  "expected": "tool_result",
+  "canonicalRefs": []
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/ground_candidates/ground_candidates.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/ground_candidates/ground_candidates.json
@@ -1,0 +1,17 @@
+{
+  "id": "ground_candidates.initial",
+  "schemaRef": "tools/ground_candidates.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "goal": "Assess flood exposure for critical facilities in the county.",
+    "assumptionPolicy": "AskWhenMaterial",
+    "explicitInputs": ["dataset:critical_facilities"],
+    "constraints": {
+      "areaOfInterest": "named:Travis County",
+      "spatialReferenceId": 4326,
+      "units": "meters"
+    }
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["CapabilityCatalog", "AnalysisIntent", "ClarificationRequest"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/list_layers/list_layers.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/list_layers/list_layers.json
@@ -1,0 +1,8 @@
+{
+  "id": "list_layers.filter",
+  "schemaRef": "tools/list_layers.schema.json",
+  "validates": "inputs",
+  "inputs": { "filter": "parcels" },
+  "expected": "tool_result",
+  "canonicalRefs": ["CapabilityCatalog", "LayerRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/plan_analysis/plan_analysis.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/plan_analysis/plan_analysis.json
@@ -1,0 +1,11 @@
+{
+  "id": "plan_analysis.basic",
+  "schemaRef": "tools/plan_analysis.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "intent": "Find parcels within 500 meters of the proposed transit corridor and summarize total acreage by zoning class.",
+    "context": { "fixtureScenarioId": "site_selection" }
+  },
+  "expected": "emit_plan",
+  "canonicalRefs": ["AnalysisIntent", "AnalysisPlan"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/propose_operation/propose_operation.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/propose_operation/propose_operation.json
@@ -1,0 +1,12 @@
+{
+  "id": "propose_operation.metadata_release",
+  "schemaRef": "tools/propose_operation.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "kind": "MetadataRelease",
+    "reason": "Promote v2 metadata snapshot after analyst review.",
+    "idempotencyKey": "mr-2026-06-21"
+  },
+  "expected": "tool_result",
+  "canonicalRefs": []
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/query_features/query_features.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/query_features/query_features.json
@@ -1,0 +1,17 @@
+{
+  "id": "query_features.where_and_bbox",
+  "schemaRef": "tools/query_features.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "serviceId": "county_parcels",
+    "layerId": 0,
+    "where": "zoning = 'R1'",
+    "bbox": [-97.95, 30.15, -97.55, 30.55],
+    "bboxSrid": 4326,
+    "outFields": ["parcel_id", "zoning", "acreage"],
+    "limit": 250,
+    "outSrid": 4326
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["LayerRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/render_map/render_map.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/render_map/render_map.json
@@ -1,0 +1,18 @@
+{
+  "id": "render_map.two_layers",
+  "schemaRef": "tools/render_map.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "layers": [
+      { "serviceId": "basemap", "layerId": 0 },
+      { "serviceId": "county_parcels", "layerId": 0 }
+    ],
+    "bbox": [-97.95, 30.15, -97.55, 30.55],
+    "bboxSrid": 4326,
+    "width": 800,
+    "height": 600,
+    "transparent": false
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["LayerRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/solve_route/solve_route.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/solve_route/solve_route.json
@@ -1,0 +1,16 @@
+{
+  "id": "solve_route.three_stops",
+  "schemaRef": "tools/solve_route.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "stops": [
+      { "lon": -97.7431, "lat": 30.2672 },
+      { "lon": -97.7341, "lat": 30.2849 },
+      { "lon": -97.7011, "lat": 30.3079 }
+    ],
+    "travelProfile": "driving",
+    "outSrid": 4326
+  },
+  "expected": "tool_result",
+  "canonicalRefs": []
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/validate_plan/validate_plan.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/validate_plan/validate_plan.json
@@ -1,0 +1,19 @@
+{
+  "id": "validate_plan.partial",
+  "schemaRef": "tools/validate_plan.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "plan": {
+      "planId": "plan_a1",
+      "intentId": "intent_8c21",
+      "steps": [
+        { "stepId": "s1", "kind": "QueryFeatures", "inputs": { "datasetId": "critical_facilities" } },
+        { "stepId": "s2", "kind": "Geoprocess", "processId": "buffer", "inputs": { "distance": "500" }, "dependsOn": ["s1"] },
+        { "stepId": "s3", "kind": "Aggregate", "dependsOn": ["s2"] }
+      ],
+      "outputs": ["FeatureLayer", "Report"]
+    }
+  },
+  "expected": "plan_validation",
+  "canonicalRefs": ["AnalysisPlan", "PlanValidationResult"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/validate_plan/validate_plan_empty.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/validate_plan/validate_plan_empty.json
@@ -1,0 +1,11 @@
+{
+  "id": "validate_plan.empty_reports_violations",
+  "schemaRef": "tools/validate_plan.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "plan": {}
+  },
+  "expected": "plan_validation",
+  "canonicalRefs": ["AnalysisPlan", "PlanValidationResult"],
+  "notes": "validate_plan accepts a partial/empty plan so the validator can report EMPTY_PLAN_ID / EMPTY_STEPS as structured violations rather than rejecting at ingest. The empty plan is a VALID input."
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/common/geoprocessing-error.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/common/geoprocessing-error.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/common/geoprocessing-error.schema.json",
+  "title": "GeoprocessingError",
+  "description": "Canonical error envelope reused verbatim by every MCP tool and resource failure path. See spec/resources.md §Error Model. No parallel MCP-local error taxonomy is permitted.",
+  "type": "object",
+  "required": ["kind", "message"],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "description": "GeoprocessingErrorKind value.",
+      "enum": [
+        "ValidationFailed",
+        "AuthorizationDenied",
+        "UnknownDataset",
+        "UnknownProcess",
+        "ExecutionFailed",
+        "Timeout",
+        "Cancelled",
+        "OutputBindingFailed"
+      ]
+    },
+    "message": {
+      "type": "string",
+      "description": "Human-readable summary."
+    },
+    "stepId": {
+      "type": "string",
+      "description": "Plan step identifier when applicable."
+    },
+    "violations": {
+      "type": "array",
+      "description": "Structured validation failures.",
+      "items": {
+        "type": "object",
+        "required": ["code", "message"],
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" },
+          "fieldPath": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "geospatial-mcp JSON Schema index",
+  "description": "Machine-readable map from standard MCP tool names and resource family URIs to their JSON Schema (draft 2020-12) files. 'standardName' is the bare taxonomy.md tool name; 'referenceToolName' is the name the reference implementation (Honua /mcp) advertises. 'implementationStatus' records whether the reference implementation ships the tool today (implemented) or whether it is a standard family not yet implemented as a discrete tool (known-gap).",
+  "date": "2026-06-21",
+  "dialect": "https://json-schema.org/draft/2020-12/schema",
+  "tools": [
+    {
+      "standardName": "plan_analysis",
+      "referenceToolName": "honua_plan_analysis",
+      "family": "Intent and planning",
+      "schema": "tools/plan_analysis.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "ground_candidates",
+      "referenceToolName": "honua_ground_candidates",
+      "family": "Intent and planning",
+      "schema": "tools/ground_candidates.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "clarify_intent",
+      "referenceToolName": "honua_clarify_intent",
+      "family": "Intent and planning",
+      "schema": "tools/clarify_intent.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "validate_plan",
+      "referenceToolName": "honua_validate_plan",
+      "family": "Intent and planning",
+      "schema": "tools/validate_plan.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Reference also advertises honua_dry_run_plan with the same partial-plan input schema."
+    },
+    {
+      "standardName": "execute_plan",
+      "referenceToolName": "honua_execute_plan",
+      "family": "Execution",
+      "schema": "tools/execute_plan.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "create_map_package",
+      "referenceToolName": null,
+      "family": "Map composition",
+      "schema": "tools/create_map_package.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "refine_map_package",
+      "referenceToolName": null,
+      "family": "Map composition",
+      "schema": "tools/refine_map_package.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "apply_style_preset",
+      "referenceToolName": null,
+      "family": "Map composition",
+      "schema": "tools/apply_style_preset.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "compose_mixed_protocol_map",
+      "referenceToolName": null,
+      "family": "Map composition",
+      "schema": "tools/compose_mixed_protocol_map.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "preview_map_package",
+      "referenceToolName": null,
+      "family": "Map composition",
+      "schema": "tools/preview_map_package.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "create_app_package",
+      "referenceToolName": null,
+      "family": "App composition",
+      "schema": "tools/create_app_package.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "preview_app_package",
+      "referenceToolName": null,
+      "family": "App composition",
+      "schema": "tools/preview_app_package.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "publish_result",
+      "referenceToolName": null,
+      "family": "Publishing",
+      "schema": "tools/publish_result.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "list_layers",
+      "referenceToolName": "honua_list_layers",
+      "family": "Discovery and query (reference shape)",
+      "schema": "tools/list_layers.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Reference-implementation discovery tool over the open-core data-access surface; the bare taxonomy models discovery as a CapabilityCatalog read."
+    },
+    {
+      "standardName": "query_features",
+      "referenceToolName": "honua_query_features",
+      "family": "Discovery and query (reference shape)",
+      "schema": "tools/query_features.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "render_map",
+      "referenceToolName": "honua_render_map",
+      "family": "Discovery and query (reference shape)",
+      "schema": "tools/render_map.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "geocode_address",
+      "referenceToolName": "honua_geocode_address",
+      "family": "Analysis and geoprocessing (reference shape)",
+      "schema": "tools/geocode_address.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "solve_route",
+      "referenceToolName": "honua_solve_route",
+      "family": "Analysis and geoprocessing (reference shape)",
+      "schema": "tools/solve_route.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "cancel_job",
+      "referenceToolName": "honua_cancel_job",
+      "family": "Execution (reference shape)",
+      "schema": "tools/cancel_job.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "propose_operation",
+      "referenceToolName": "honua_propose_operation",
+      "family": "Control-plane proposal (reference shape)",
+      "schema": "tools/propose_operation.schema.json",
+      "implementationStatus": "implemented"
+    }
+  ],
+  "resources": [
+    {
+      "family": "Result package",
+      "uriForm": "honua://results/{result_package_id}",
+      "schema": "resources/result-package.schema.json",
+      "shapeFidelity": "concrete"
+    },
+    {
+      "family": "Result artifact",
+      "uriForm": "honua://results/{result_package_id}/artifacts/{artifact_id}",
+      "schema": "resources/artifact.schema.json",
+      "shapeFidelity": "concrete"
+    },
+    {
+      "family": "Result provenance",
+      "uriForm": "honua://results/{result_package_id}/provenance",
+      "schema": "resources/provenance.schema.json",
+      "shapeFidelity": "concrete"
+    },
+    {
+      "family": "Workspace",
+      "uriForm": "honua://workspaces/{workspace_id}",
+      "schema": "resources/workspace.schema.json",
+      "shapeFidelity": "concrete-reference"
+    },
+    {
+      "family": "Workspace artifact",
+      "uriForm": "honua://workspaces/{workspace_id}/artifacts/{artifact_id}",
+      "schema": "resources/artifact.schema.json",
+      "shapeFidelity": "concrete"
+    },
+    {
+      "family": "Map package",
+      "uriForm": "honua://maps/{map_package_id}",
+      "schema": "resources/map-package.schema.json",
+      "shapeFidelity": "responsibility-level"
+    },
+    {
+      "family": "App package",
+      "uriForm": "honua://apps/{app_package_id}",
+      "schema": "resources/app-package.schema.json",
+      "shapeFidelity": "responsibility-level"
+    },
+    {
+      "family": "Style",
+      "uriForm": "honua://styles/{style_id}",
+      "schema": "resources/style.schema.json",
+      "shapeFidelity": "responsibility-level"
+    },
+    {
+      "family": "Theme",
+      "uriForm": "honua://themes/{theme_id}",
+      "schema": "resources/theme.schema.json",
+      "shapeFidelity": "responsibility-level"
+    },
+    {
+      "family": "Map template",
+      "uriForm": "honua://templates/maps/{map_template_id}",
+      "schema": "resources/map-template.schema.json",
+      "shapeFidelity": "responsibility-level"
+    },
+    {
+      "family": "Published service",
+      "uriForm": "honua://services/{published_service_id}",
+      "schema": "resources/published-service.schema.json",
+      "shapeFidelity": "responsibility-level"
+    },
+    {
+      "family": "Deployment",
+      "uriForm": "honua://deployments/{deployment_id}",
+      "schema": "resources/deployment.schema.json",
+      "shapeFidelity": "responsibility-level"
+    }
+  ],
+  "common": [
+    {
+      "name": "GeoprocessingError",
+      "schema": "common/geoprocessing-error.schema.json",
+      "role": "Canonical error envelope reused by all tool/resource failure paths."
+    }
+  ]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/app-package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/app-package.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/app-package.schema.json",
+  "title": "App package resource payload",
+  "description": "Responsibility-level projection of an AppPackage at honua://apps/{app_package_id}. Concrete field spellings finalize upstream (honua-server#731); only the stable appPackageId is pinned. Responsibilities: target SDK declaration, template binding, package format/manifest, bundle artifact, delivery asset manifest, map binding, runtime config schema, hosting/route hints, bound data artifacts. See resources.md §honua://apps/{app_package_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["appPackageId"],
+  "properties": {
+    "appPackageId": {
+      "type": "string",
+      "description": "Stable identifier (app_…)."
+    },
+    "templateId": { "type": "string" },
+    "targetSdk": { "type": "string" },
+    "mapPackageId": { "type": "string" },
+    "bundleArtifactId": { "type": "string" },
+    "boundArtifactIds": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/artifact.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/artifact.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/artifact.schema.json",
+  "title": "Artifact resource payload",
+  "description": "Read-only projection of an ArtifactRef, addressable as honua://results/{rpid}/artifacts/{aid} (outcome view) or honua://workspaces/{wsid}/artifacts/{aid} (lifecycle view). lifecycleState is an MCP-layer projection, not a field of ArtifactRef. See resources.md §honua://results/{result_package_id}/artifacts/{artifact_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["artifactId", "kind"],
+  "properties": {
+    "artifactId": {
+      "type": "string",
+      "description": "Stable identifier (artifact_…)."
+    },
+    "kind": {
+      "type": "string",
+      "description": "ArtifactKind.",
+      "enum": ["Scalar", "FeatureLayer", "Table", "Raster", "File", "Report", "Map", "AppBundle"]
+    },
+    "label": { "type": "string", "description": "Human-readable label." },
+    "uri": {
+      "type": "string",
+      "description": "Canonical content locator (workspace-scoped). NOT the inspection URI."
+    },
+    "contentType": { "type": "string", "description": "MIME type." },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Canonical metadata map."
+    },
+    "lifecycleState": {
+      "type": "string",
+      "description": "ArtifactLifecycleState (MCP-layer projection from the workspace lifecycle service).",
+      "enum": ["Pending", "Available", "Promoted", "Expired", "Deleted"]
+    },
+    "promotionSourceReady": {
+      "type": "boolean",
+      "description": "Workspace-rooted reads only: source-side promotion preconditions met. Result-rooted reads do not resolve promotion readiness."
+    },
+    "sourceWorkspaceKind": {
+      "type": "string",
+      "enum": ["Scratch", "Persistent", "TempLayer", "SavedLayer", "ResultCollection"]
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/deployment.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/deployment.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/deployment.schema.json",
+  "title": "Deployment resource payload",
+  "description": "Responsibility-level projection of a Deployment at honua://deployments/{deployment_id}. Concrete field spellings finalize upstream (honua-server#732); only the stable deploymentId is pinned. Responsibilities: deployment kind, target binding (targetRef → AppPackage|MapPackage|PublishedService|opaque Process/Pipeline), hosting mode, route configuration, revision id, runtime profile, delivery artifact refs, runtime config, visibility scope, auth/approval policy refs, publication lifecycle state. Read-only — no control paths. See resources.md §honua://deployments/{deployment_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["deploymentId"],
+  "properties": {
+    "deploymentId": {
+      "type": "string",
+      "description": "Stable identifier (dep_…)."
+    },
+    "kind": {
+      "type": "string",
+      "description": "Package class.",
+      "enum": ["app_package", "published_service", "process", "pipeline"]
+    },
+    "targetRef": {
+      "type": "string",
+      "description": "Resolves to AppPackage | MapPackage | PublishedService; Process/Pipeline targets are opaque identifiers."
+    },
+    "hostingMode": { "type": "string" },
+    "revisionId": { "type": "string", "description": "Revision identifier (rev_…)." },
+    "publicationState": { "type": "string", "description": "Read-only publication lifecycle projection." }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/map-package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/map-package.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/map-package.schema.json",
+  "title": "Map package resource payload",
+  "description": "Responsibility-level projection of a MapPackage at honua://maps/{map_package_id}. Concrete field spellings finalize upstream (honua-server#731); only the stable mapPackageId is pinned and additional properties are permitted. Responsibilities: package format/template binding, source bindings, styling composition, map-spec document, initial view, legend/popup/label composition, artifact bindings. See resources.md §honua://maps/{map_package_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["mapPackageId"],
+  "properties": {
+    "mapPackageId": {
+      "type": "string",
+      "description": "Stable identifier (map_…)."
+    },
+    "templateId": { "type": "string", "description": "Bound MapTemplate." },
+    "sourceBindings": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "styleId": { "type": "string" },
+    "themeId": { "type": "string" },
+    "initialView": { "type": "object", "additionalProperties": true },
+    "previewArtifactId": { "type": "string" }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/map-template.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/map-template.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/map-template.schema.json",
+  "title": "Map template resource payload",
+  "description": "Responsibility-level projection of a MapTemplate at honua://templates/maps/{map_template_id}. The identifier is registry-defined (e.g. analysis_default); concrete field spellings are upstream-owned. Responsibilities: cartographic composition class, named SourceBinding slots, default style/theme composition, layout/view presets. See resources.md §honua://templates/maps/{map_template_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["mapTemplateId"],
+  "properties": {
+    "mapTemplateId": {
+      "type": "string",
+      "description": "Registry-defined map-template identifier (e.g. analysis_default)."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/provenance.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/provenance.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/provenance.schema.json",
+  "title": "Provenance resource payload",
+  "description": "Read-only projection of a ProvenanceRecord, addressable as honua://results/{result_package_id}/provenance. See resources.md §honua://results/{result_package_id}/provenance.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "sources": {
+      "type": "array",
+      "description": "Dataset sources with version and description.",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "datasetId": { "type": "string" },
+          "version": { "type": "string" },
+          "description": { "type": "string" }
+        }
+      }
+    },
+    "processDefinitions": {
+      "type": "array",
+      "description": "Process identifiers used.",
+      "items": { "type": "string" }
+    },
+    "assumptions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "clarificationsAsked": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "clarificationsAnswered": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "executedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Execution timestamp."
+    },
+    "generatedArtifactIds": {
+      "type": "array",
+      "description": "Artifacts produced by this execution.",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/published-service.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/published-service.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/published-service.schema.json",
+  "title": "Published service resource payload",
+  "description": "Responsibility-level projection of a PublishedService at honua://services/{published_service_id}. Concrete field spellings finalize upstream (honua-server#730); only the stable serviceId is pinned. Responsibilities: protocol surface enumeration, styling composition, source-to-service lineage summary, refresh state (read-only). Read-only — no control paths. See resources.md §honua://services/{published_service_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["serviceId"],
+  "properties": {
+    "serviceId": {
+      "type": "string",
+      "description": "Upstream serviceId (no MCP-local prefix convention)."
+    },
+    "protocols": {
+      "type": "array",
+      "description": "Protocol surface enumeration (e.g. GeoServices, OGC API Features, WMS, WFS, OData, tiles).",
+      "items": { "type": "string" }
+    },
+    "refreshState": { "type": "string", "description": "Read-only refresh lifecycle signal." }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/result-package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/result-package.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/result-package.schema.json",
+  "title": "Result package resource payload",
+  "description": "Read-only projection returned for honua://results/{result_package_id} (AnalysisResultPackage). See resources.md §Result Package Resources.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["resultPackageId", "status"],
+  "properties": {
+    "resultPackageId": {
+      "type": "string",
+      "description": "Stable identifier (result_…)."
+    },
+    "status": {
+      "type": "string",
+      "description": "GeoprocessingWorkflowStatus (read-only).",
+      "enum": [
+        "Draft",
+        "AwaitingClarification",
+        "Validated",
+        "AwaitingApproval",
+        "AwaitingExecution",
+        "Running",
+        "Completed",
+        "Failed",
+        "Cancelled"
+      ]
+    },
+    "summary": {
+      "type": "object",
+      "description": "Title and description.",
+      "additionalProperties": true,
+      "properties": {
+        "title": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "assumptions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": { "$ref": "artifact.schema.json" }
+    },
+    "workspaceRefs": {
+      "type": "array",
+      "items": { "$ref": "workspace.schema.json" }
+    },
+    "mapPackageId": {
+      "type": "string",
+      "description": "Deferred reference to a MapPackage (map_…)."
+    },
+    "appPackageId": {
+      "type": "string",
+      "description": "Deferred reference to an AppPackage (app_…)."
+    },
+    "provenance": { "$ref": "provenance.schema.json" },
+    "errors": {
+      "type": "array",
+      "items": { "$ref": "../common/geoprocessing-error.schema.json" }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/style.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/style.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/style.schema.json",
+  "title": "Style resource payload",
+  "description": "Responsibility-level projection of a StyleRef at honua://styles/{style_id}. Concrete field spellings are upstream-owned; only the stable styleId is pinned. Responsibilities: thematic renderer selection, style preset reuse/composition, label/popup bindings, legend-generation inputs. See resources.md §honua://styles/{style_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["styleId"],
+  "properties": {
+    "styleId": { "type": "string", "description": "Stable identifier (style_…)." }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/theme.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/theme.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/theme.schema.json",
+  "title": "Theme resource payload",
+  "description": "Responsibility-level projection of a ThemeSpec at honua://themes/{theme_id}. Concrete field spellings are upstream-owned; only the stable themeId is pinned. Responsibilities: color-ramp tokens, typography tokens, spacing/panel chrome, semantic status colors. See resources.md §honua://themes/{theme_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["themeId"],
+  "properties": {
+    "themeId": { "type": "string", "description": "Stable identifier (theme_…)." }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/workspace.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/workspace.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/workspace.schema.json",
+  "title": "Workspace resource payload",
+  "description": "Read-only projection of a WorkspaceRef, addressable as honua://workspaces/{workspace_id}. The canonical kind values are Scratch/Persistent/TempLayer/SavedLayer/ResultCollection; the reference implementation projects lower_snake_case wire spellings (x-honua-reference-shape). lifecycleState is an MCP-layer projection. See resources.md §honua://workspaces/{workspace_id}.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["workspaceId"],
+  "properties": {
+    "workspaceId": {
+      "type": "string",
+      "description": "Stable identifier (ws_…)."
+    },
+    "kind": {
+      "type": "string",
+      "description": "WorkspaceKind. Canonical enum names are Scratch/Persistent/TempLayer/SavedLayer/ResultCollection; the reference implementation emits the lower_snake_case wire spelling.",
+      "enum": [
+        "scratch",
+        "persistent",
+        "temp_layer",
+        "saved_layer",
+        "result_collection",
+        "Scratch",
+        "Persistent",
+        "TempLayer",
+        "SavedLayer",
+        "ResultCollection",
+        ""
+      ]
+    },
+    "label": { "type": "string", "description": "Human-readable label." },
+    "uri": { "type": "string", "description": "Canonical URI." },
+    "expiresAt": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "Expiration timestamp when applicable."
+    },
+    "status": {
+      "type": "string",
+      "description": "WorkspaceLifecycleState projection. Reference wire spellings: active, cleanup_pending, sealed, not_found, degraded.",
+      "enum": ["active", "cleanup_pending", "sealed", "not_found", "degraded"]
+    },
+    "cleanupScheduledAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "resultsUri": { "type": ["string", "null"] },
+    "notImplementedReason": { "type": "string" }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/apply_style_preset.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/apply_style_preset.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/apply_style_preset.schema.json",
+  "title": "apply_style_preset inputSchema",
+  "description": "Argument shape for apply_style_preset (Analyze, Build App; returns the updated MapPackage). Applies a reusable StyleRef preset to a map package, optionally scoped to a binding. Responsibility-level; concrete styling field set finalizes upstream. See taxonomy.md §Map composition and resources.md §honua://styles/{style_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["mapPackageId", "styleId"],
+  "properties": {
+    "mapPackageId": {
+      "type": "string",
+      "description": "Identifier (map_…) of the MapPackage to style."
+    },
+    "styleId": {
+      "type": "string",
+      "description": "StyleRef preset identifier (style_…) to apply."
+    },
+    "targetBindingId": {
+      "type": "string",
+      "description": "Optional SourceBinding the preset is scoped to; applies map-wide when omitted."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/cancel_job.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/cancel_job.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/cancel_job.schema.json",
+  "title": "cancel_job inputSchema",
+  "description": "Argument shape for the execution-lifecycle cancel tool (advertised name honua_cancel_job). Requests cancellation of a submitted ExecutionJob. x-honua-reference-shape: lifecycle control over the execution handoff; tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["jobId"],
+  "properties": {
+    "jobId": {
+      "type": "string",
+      "description": "Execution job identifier to request cancellation for."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/clarify_intent.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/clarify_intent.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/clarify_intent.schema.json",
+  "title": "clarify_intent inputSchema",
+  "description": "Argument shape for the clarify_intent tool (Analyze, Publish Data, Build App). Reference advertised name: honua_clarify_intent. Re-runs grounding with the operator's answers merged in. Extends ground_candidates with required intentId and a response carrying answers keyed by questionId. See planning.md §2.",
+  "type": "object",
+  "required": ["goal", "intentId", "response"],
+  "properties": {
+    "goal": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Freeform natural-language description of the operator's goal."
+    },
+    "intentId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Intent identifier being clarified. Required on a clarification turn."
+    },
+    "workflowFamilyHint": {
+      "type": "string",
+      "enum": ["Analyze", "PublishData", "BuildApp", "AutomateDeploy"]
+    },
+    "assumptionPolicy": {
+      "type": "string",
+      "enum": ["AskAlways", "AskWhenMaterial", "UseDefaults"]
+    },
+    "explicitInputs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "areaOfInterest": { "type": "string" },
+        "spatialReferenceId": { "type": "integer" },
+        "timeWindowStart": { "type": "string", "format": "date-time" },
+        "timeWindowEnd": { "type": "string", "format": "date-time" },
+        "units": { "type": "string" }
+      }
+    },
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "workspaceId": { "type": "string" },
+        "priorIntentId": { "type": "string" },
+        "promotionScope": { "type": "string" }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["answers"],
+      "description": "ClarificationResponse: answers keyed by questionId.",
+      "properties": {
+        "answers": {
+          "type": "object",
+          "minProperties": 1,
+          "description": "Answers keyed by question identifier. Each answer is a non-empty list of values to support multi-select questions.",
+          "additionalProperties": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/compose_mixed_protocol_map.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/compose_mixed_protocol_map.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/compose_mixed_protocol_map.schema.json",
+  "title": "compose_mixed_protocol_map inputSchema",
+  "description": "Argument shape for compose_mixed_protocol_map (Analyze, Build App; returns a MapPackage). Composes a single map from layers bound across multiple protocols (GeoServices, OGC API, WMS/WFS, tiles) at the semantic level — protocol adaptation happens below the contract layer (taxonomy.md §Non-Goals 4). Responsibility-level; concrete binding field set finalizes upstream.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["sourceBindings"],
+  "properties": {
+    "templateId": { "type": "string" },
+    "sourceBindings": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Canonical SourceBinding entries, each protocol-aware. The tool does not expose protocol-specific operations.",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "styleId": { "type": "string" },
+    "themeId": { "type": "string" },
+    "initialView": { "type": "object", "additionalProperties": true }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/create_app_package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/create_app_package.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/create_app_package.schema.json",
+  "title": "create_app_package inputSchema",
+  "description": "Argument shape for create_app_package (Build App; returns an AppPackage). Composes an SDK-native application from a map package, artifacts, and an app template. V1 targets honua-sdk-js with MapLibre GL JS. Responsibility-level: the AppPackage authoring field set finalizes upstream (honua-server#731). See taxonomy.md §App composition and resources.md §honua://apps/{app_package_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "templateId": {
+      "type": "string",
+      "description": "App-template registry identifier (surfaced through AppPackage.templateId)."
+    },
+    "targetSdk": {
+      "type": "string",
+      "description": "Target SDK declaration. V1 default is honua-sdk-js.",
+      "default": "honua-sdk-js"
+    },
+    "mapPackageId": {
+      "type": "string",
+      "description": "MapPackage (map_…) bound into the application."
+    },
+    "boundArtifactIds": {
+      "type": "array",
+      "description": "ArtifactRef identifiers (artifact_…) required at runtime.",
+      "items": { "type": "string" }
+    },
+    "runtimeConfig": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Runtime configuration values projected into the generated app."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/create_map_package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/create_map_package.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/create_map_package.schema.json",
+  "title": "create_map_package inputSchema",
+  "description": "Argument shape for create_map_package (Analyze, Build App map-composition family; returns a MapPackage). Responsibility-level: the concrete MapPackage authoring field set is finalizing upstream (honua-server#731), so this schema pins the stable composition inputs (source bindings, style/theme selection, template, initial view) and permits additional properties. See taxonomy.md §Map composition and resources.md §honua://maps/{map_package_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "templateId": {
+      "type": "string",
+      "description": "Registry-defined MapTemplate identifier seeding the composition (e.g. analysis_default)."
+    },
+    "sourceBindings": {
+      "type": "array",
+      "description": "Protocol-aware bindings of map layers to data sources (canonical SourceBinding entries).",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "styleId": {
+      "type": "string",
+      "description": "StyleRef selection (style_… ) applied to the composition."
+    },
+    "themeId": {
+      "type": "string",
+      "description": "ThemeSpec selection (theme_… ) applied to the composition."
+    },
+    "initialView": {
+      "type": "object",
+      "description": "Initial view geometry: bounding box and CRS.",
+      "additionalProperties": true,
+      "properties": {
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": { "type": "number" }
+        },
+        "crs": { "type": ["string", "integer"] }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/execute_plan.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/execute_plan.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/execute_plan.schema.json",
+  "title": "execute_plan inputSchema",
+  "description": "Argument shape for the execute_plan tool (Analyze, Publish Data; handoff returns an ExecutionJob reference for Analyze). Reference advertised name: honua_execute_plan. Submission rejects a missing planId or empty steps, so the executable plan REQUIRES planId and at least one step (contrast validate_plan). See planning.md §5.2.",
+  "type": "object",
+  "required": ["plan"],
+  "properties": {
+    "plan": { "$ref": "#/$defs/executablePlan" },
+    "idempotencyKey": {
+      "type": "string",
+      "description": "Optional deduplication key. Replays with the same key return the same job record."
+    }
+  },
+  "$defs": {
+    "executablePlan": {
+      "type": "object",
+      "description": "Canonical AnalysisPlan in executable form. planId and a non-empty steps array are mandatory.",
+      "required": ["planId", "steps"],
+      "properties": {
+        "planId": { "type": "string", "minLength": 1 },
+        "intentId": { "type": "string" },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/planStep" }
+        },
+        "outputs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/artifactKind" }
+        },
+        "warnings": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "planStep": {
+      "type": "object",
+      "required": ["stepId", "kind"],
+      "properties": {
+        "stepId": { "type": "string" },
+        "kind": { "$ref": "#/$defs/planStepKind" },
+        "processId": { "type": "string" },
+        "inputs": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "planStepKind": {
+      "type": "string",
+      "enum": ["QueryFeatures", "Geoprocess", "Aggregate", "RenderMap", "Export"]
+    },
+    "artifactKind": {
+      "type": "string",
+      "enum": ["Scalar", "FeatureLayer", "Table", "Raster", "File", "Report", "Map", "AppBundle"]
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/geocode_address.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/geocode_address.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/geocode_address.schema.json",
+  "title": "geocode_address inputSchema",
+  "description": "Argument shape for the analysis/geoprocessing geocode tool (advertised name honua_geocode_address). Resolves a freeform address to ranked candidates. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["address"],
+  "properties": {
+    "address": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Freeform single-line address text to geocode."
+    },
+    "maxResults": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 50,
+      "default": 5,
+      "description": "Maximum number of candidates to return."
+    },
+    "countryCodes": {
+      "type": "string",
+      "description": "Optional comma-separated ISO 3166 country codes to restrict the search."
+    },
+    "outSrid": {
+      "type": "integer",
+      "default": 4326,
+      "description": "Spatial reference (SRID/WKID) for returned candidate coordinates."
+    },
+    "provider": {
+      "type": "string",
+      "description": "Optional preferred geocoding provider name."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/ground_candidates.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/ground_candidates.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/ground_candidates.schema.json",
+  "title": "ground_candidates inputSchema",
+  "description": "Argument shape for the ground_candidates tool (Analyze, Publish Data). Reference advertised name: honua_ground_candidates. Grounds a natural-language goal to a workflow family, ranked candidates, a draft intent, and an optional clarification envelope. See taxonomy.md §Intent and planning and planning.md §2.",
+  "type": "object",
+  "required": ["goal"],
+  "properties": {
+    "goal": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Freeform natural-language description of the operator's goal."
+    },
+    "intentId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Intent identifier. Optional on the initial grounding call (server allocates one); required on a clarification turn."
+    },
+    "workflowFamilyHint": {
+      "type": "string",
+      "description": "Optional workflow-family override (one of the canonical WorkflowFamily names).",
+      "enum": ["Analyze", "PublishData", "BuildApp", "AutomateDeploy"]
+    },
+    "assumptionPolicy": {
+      "type": "string",
+      "description": "Policy controlling when inferred assumptions trigger a clarification. See planning.md §2.3.",
+      "enum": ["AskAlways", "AskWhenMaterial", "UseDefaults"]
+    },
+    "explicitInputs": {
+      "type": "array",
+      "description": "Dataset, layer, or artifact identifiers the caller has already pinned.",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional analysis constraints.",
+      "properties": {
+        "areaOfInterest": {
+          "type": "string",
+          "description": "AOI as WKT, bounding-box string, or named area."
+        },
+        "spatialReferenceId": {
+          "type": "integer",
+          "description": "EPSG SRID for the AOI (defaults to 4326)."
+        },
+        "timeWindowStart": { "type": "string", "format": "date-time" },
+        "timeWindowEnd": { "type": "string", "format": "date-time" },
+        "units": {
+          "type": "string",
+          "description": "Preferred unit system (e.g. 'meters', 'feet')."
+        }
+      }
+    },
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional workflow context.",
+      "properties": {
+        "workspaceId": { "type": "string" },
+        "priorIntentId": { "type": "string" },
+        "promotionScope": { "type": "string" }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/list_layers.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/list_layers.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/list_layers.schema.json",
+  "title": "list_layers inputSchema",
+  "description": "Argument shape for the discovery/query layer-listing tool. The bare standard taxonomy models discovery as a CapabilityCatalog read; the reference implementation exposes it as a tool (advertised name honua_list_layers) over the open-core data-access surface. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "properties": {
+    "filter": {
+      "type": "string",
+      "description": "Optional case-insensitive substring to match against service and layer name/title. When omitted, all published layers are returned."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/plan_analysis.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/plan_analysis.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/plan_analysis.schema.json",
+  "title": "plan_analysis inputSchema",
+  "description": "Argument shape for the plan_analysis tool (Analyze family; emits an AnalysisPlan). Reference advertised name: honua_plan_analysis. Compiles a natural-language intent into an analysis plan / canonical spec draft. See taxonomy.md §Intent and planning.",
+  "type": "object",
+  "required": ["intent"],
+  "properties": {
+    "intent": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Natural-language intent to compile into an analysis plan or canonical spec draft."
+    },
+    "context": {
+      "type": "object",
+      "description": "Optional caller context. Echoed back unchanged by the reference implementation."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/preview_app_package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/preview_app_package.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/preview_app_package.schema.json",
+  "title": "preview_app_package inputSchema",
+  "description": "Argument shape for preview_app_package (Build App; returns a preview ArtifactRef). Produces a read-only preview artifact for an existing app package. Responsibility-level. See taxonomy.md §App composition.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["appPackageId"],
+  "properties": {
+    "appPackageId": {
+      "type": "string",
+      "description": "Identifier (app_…) of the AppPackage to preview."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/preview_map_package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/preview_map_package.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/preview_map_package.schema.json",
+  "title": "preview_map_package inputSchema",
+  "description": "Argument shape for preview_map_package (Analyze, Build App; returns a preview ArtifactRef). Produces a read-only preview artifact for an existing map package. Responsibility-level. See taxonomy.md §Map composition.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["mapPackageId"],
+  "properties": {
+    "mapPackageId": {
+      "type": "string",
+      "description": "Identifier (map_…) of the MapPackage to preview."
+    },
+    "width": { "type": "integer", "minimum": 1 },
+    "height": { "type": "integer", "minimum": 1 }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/propose_operation.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/propose_operation.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/propose_operation.schema.json",
+  "title": "propose_operation inputSchema",
+  "description": "Argument shape for the control-plane proposal tool (advertised name honua_propose_operation). Proposes an in-scope mutating control-plane operation for human approval (never autonomously executed), consistent with the ADR-0028 no-direct-AI-mutation boundary in taxonomy.md §Non-Goals. x-honua-reference-shape: tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["kind"],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "description": "In-scope mutating control-plane operation class to propose.",
+      "enum": ["AdminConfigChange", "Deploy", "MetadataRelease", "Seed"]
+    },
+    "reason": {
+      "type": "string",
+      "description": "Operator-facing reason or change note for the proposal."
+    },
+    "executionPayload": {
+      "type": "string",
+      "description": "Opaque, class-specific JSON execution payload replayed when the proposal is approved."
+    },
+    "idempotencyKey": {
+      "type": "string",
+      "description": "Stable idempotency key for the underlying operation."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/publish_result.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/publish_result.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/publish_result.schema.json",
+  "title": "publish_result inputSchema",
+  "description": "Argument shape for publish_result (Analyze, Publish Data, Build App). Promotes a result/package to a canonical promotion-surface target: PublishedService for Publish Data, Deployment for Analyze and Build App (resources.md §Promotion-Surface Resources). Publish/PolicyBoundary clarifications fire before handoff (planning.md). Responsibility-level: concrete promotion field set finalizes upstream (honua-server#730/#732).",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["sourceId"],
+  "properties": {
+    "sourceId": {
+      "type": "string",
+      "description": "Identifier of the package or result being promoted (result_…, map_…, app_…)."
+    },
+    "targetKind": {
+      "type": "string",
+      "description": "Promotion-surface target family. Published_service for Publish Data; deployment for Analyze and Build App.",
+      "enum": ["published_service", "deployment"]
+    },
+    "visibility": {
+      "type": "string",
+      "description": "Promotion visibility scope.",
+      "enum": ["workspace_shared", "public"]
+    },
+    "routePrefix": {
+      "type": "string",
+      "description": "Optional route prefix for a deployment target."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/query_features.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/query_features.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/query_features.schema.json",
+  "title": "query_features inputSchema",
+  "description": "Argument shape for the discovery/query feature-query tool (advertised name honua_query_features). Reads features from a published layer with an optional attribute and spatial filter. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["serviceId", "layerId"],
+  "properties": {
+    "serviceId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Published service identifier or name (from list_layers.serviceId)."
+    },
+    "layerId": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Service-local layer index (from list_layers.layerId)."
+    },
+    "where": {
+      "type": "string",
+      "description": "Optional attribute filter expressed as an ArcGIS/SQL WHERE clause."
+    },
+    "bbox": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "items": { "type": "number" },
+      "description": "Optional spatial filter envelope as [minX, minY, maxX, maxY]."
+    },
+    "bboxSrid": {
+      "type": "integer",
+      "default": 4326,
+      "description": "Spatial reference (SRID/WKID) of the bbox ordinates."
+    },
+    "outFields": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional attribute fields to return; omit for all fields."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 1000,
+      "default": 100,
+      "description": "Maximum number of features to return (capped at 1000)."
+    },
+    "outSrid": {
+      "type": "integer",
+      "default": 4326,
+      "description": "Output spatial reference (SRID/WKID) for returned geometries."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/refine_map_package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/refine_map_package.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/refine_map_package.schema.json",
+  "title": "refine_map_package inputSchema",
+  "description": "Argument shape for refine_map_package (Analyze, Build App; returns the updated MapPackage). Refines an existing map package's composition. Responsibility-level: targets a mapPackageId and carries a refinement delta whose concrete field set finalizes upstream (honua-server#731). See taxonomy.md §Map composition.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["mapPackageId"],
+  "properties": {
+    "mapPackageId": {
+      "type": "string",
+      "description": "Identifier (map_…) of the MapPackage to refine."
+    },
+    "styleId": { "type": "string" },
+    "themeId": { "type": "string" },
+    "sourceBindings": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "initialView": { "type": "object", "additionalProperties": true }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/render_map.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/render_map.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/render_map.schema.json",
+  "title": "render_map inputSchema",
+  "description": "Argument shape for the map-render tool (advertised name honua_render_map). Renders an image of ordered layers over an extent. This is the reference implementation's read-only map preview surface, distinct from the semantic map-composition family (create_map_package, etc.). x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["layers", "bbox"],
+  "properties": {
+    "layers": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Ordered layers to draw, bottom-to-top.",
+      "items": {
+        "type": "object",
+        "required": ["serviceId", "layerId"],
+        "properties": {
+          "serviceId": { "type": "string", "minLength": 1 },
+          "layerId": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "bbox": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "items": { "type": "number" },
+      "description": "Map extent as [minX, minY, maxX, maxY]."
+    },
+    "bboxSrid": {
+      "type": "integer",
+      "default": 4326,
+      "description": "Spatial reference (SRID/WKID) of the bbox and output image."
+    },
+    "width": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 1024,
+      "default": 512,
+      "description": "Output image width in pixels (capped at 1024)."
+    },
+    "height": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 1024,
+      "default": 512,
+      "description": "Output image height in pixels (capped at 1024)."
+    },
+    "transparent": {
+      "type": "boolean",
+      "default": false,
+      "description": "Render a transparent background instead of an opaque one."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/solve_route.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/solve_route.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/solve_route.schema.json",
+  "title": "solve_route inputSchema",
+  "description": "Argument shape for the analysis/geoprocessing routing tool (advertised name honua_solve_route). Solves an ordered route through a sequence of stops. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["stops"],
+  "properties": {
+    "stops": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 25,
+      "description": "Ordered stops to route through, in visit order.",
+      "items": {
+        "type": "object",
+        "required": ["lon", "lat"],
+        "properties": {
+          "lon": { "type": "number", "description": "Longitude (X) ordinate." },
+          "lat": { "type": "number", "description": "Latitude (Y) ordinate." }
+        }
+      }
+    },
+    "travelProfile": {
+      "type": "string",
+      "default": "driving",
+      "description": "Travel profile / cost-model selector (e.g. \"driving\", \"walking\")."
+    },
+    "outSrid": {
+      "type": "integer",
+      "default": 4326,
+      "description": "Output spatial reference (SRID/WKID) for the returned route geometry."
+    },
+    "inSrid": {
+      "type": "integer",
+      "description": "Spatial reference of the input stop ordinates; defaults to outSrid."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/validate_plan.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/validate_plan.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/validate_plan.schema.json",
+  "title": "validate_plan inputSchema",
+  "description": "Argument shape for the validate_plan tool (Analyze, Publish Data, Build App; also shared by the dry_run_plan preview tool in the reference implementation). Reference advertised name: honua_validate_plan. Accepts a partial AnalysisPlan so the validator can report EMPTY_PLAN_ID / EMPTY_STEPS as structured violations rather than rejecting at ingest — planId and steps are therefore NOT required here (contrast execute_plan). See planning.md §5.1.",
+  "type": "object",
+  "required": ["plan"],
+  "properties": {
+    "plan": { "$ref": "#/$defs/analysisPlan" }
+  },
+  "$defs": {
+    "analysisPlan": {
+      "type": "object",
+      "description": "Canonical AnalysisPlan expressed as MCP plan input. Partial plans are permitted at validate time.",
+      "required": [],
+      "properties": {
+        "planId": { "type": "string" },
+        "intentId": { "type": "string" },
+        "steps": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/planStep" }
+        },
+        "outputs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/artifactKind" }
+        },
+        "warnings": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "planStep": {
+      "type": "object",
+      "required": ["stepId", "kind"],
+      "properties": {
+        "stepId": { "type": "string" },
+        "kind": { "$ref": "#/$defs/planStepKind" },
+        "processId": { "type": "string" },
+        "inputs": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "planStepKind": {
+      "type": "string",
+      "description": "Canonical AnalysisPlanStepKind value. Server parsing is case-insensitive but clients should send the canonical PascalCase spelling.",
+      "enum": ["QueryFeatures", "Geoprocess", "Aggregate", "RenderMap", "Export"]
+    },
+    "artifactKind": {
+      "type": "string",
+      "description": "Canonical ArtifactKind value.",
+      "enum": ["Scalar", "FeatureLayer", "Table", "Raster", "File", "Report", "Map", "AppBundle"]
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj
+++ b/tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj
@@ -22,6 +22,18 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Newtonsoft.Json.Schema" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      Vendored copy of the published geospatial-mcp JSON Schemas + conformance
+      fixtures (geospatial-mcp spec/schemas/). McpTaxonomyAlignmentTests
+      validates Honua's live /mcp advertised tool input schemas and resource
+      shapes against these so Honua provably conforms to the standard it
+      champions. See ConformanceSchemas/README.md.
+    -->
+    <Content Include="ConformanceSchemas\**\*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
@@ -232,7 +232,7 @@ public sealed partial class McpTaxonomyAlignmentTests
 
         // properties.plan -> $defs.analysisPlan -> properties.steps.items
         //   -> $defs.planStep -> properties.kind -> $defs.planStepKind.enum
-        var analysisPlan = ResolveRef(root, root, "properties", "plan");
+        var analysisPlan = ResolveRef(root, root.GetProperty("properties"), "plan");
         var steps = analysisPlan.GetProperty("properties").GetProperty("steps");
         var planStep = ResolveRef(root, steps, "items");
         var kind = ResolveRef(root, planStep.GetProperty("properties"), "kind");

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
@@ -1,0 +1,423 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.TestKit.Attributes;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Schema;
+using StandardSchema = Newtonsoft.Json.Schema.JSchema;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Conformance tests that assert Honua's live <c>/mcp</c> advertised tool input
+/// schemas and resource payload shapes conform to the published
+/// <c>geospatial-mcp</c> JSON Schemas (draft 2020-12). Honua is the reference
+/// implementation of the open standard, so these tests pin Honua to the standard
+/// it champions.
+///
+/// <para>
+/// The vendored standard schemas live under
+/// <c>ConformanceSchemas/geospatial-mcp/</c> and the standard's own conformance
+/// fixtures under <c>ConformanceSchemas/fixtures/</c> (see the directory README).
+/// </para>
+///
+/// <para>
+/// Strategy: for every tool Honua implements, the standard's fixture example
+/// inputs (representative valid arguments) MUST validate against BOTH Honua's
+/// live advertised <c>inputSchema</c> and the vendored standard schema — i.e.
+/// the two contracts agree on what a valid call looks like. Standard tools Honua
+/// does not yet implement as discrete MCP tools (the map/app composition and
+/// publish families) are tracked as known-gaps: their absence does not fail the
+/// suite. Only NON-CONFORMANCE of an IMPLEMENTED tool fails.
+/// </para>
+/// </summary>
+public sealed partial class McpTaxonomyAlignmentTests
+{
+    /// <summary>
+    /// Maps Honua's advertised tool name to the bare standard tool name (and its
+    /// vendored schema file). Tools Honua implements today.
+    /// </summary>
+    private static readonly Dictionary<string, string> ImplementedToolStandardNames =
+        new(StringComparer.Ordinal)
+        {
+            ["honua_plan_analysis"] = "plan_analysis",
+            ["honua_ground_candidates"] = "ground_candidates",
+            ["honua_clarify_intent"] = "clarify_intent",
+            ["honua_validate_plan"] = "validate_plan",
+            ["honua_dry_run_plan"] = "validate_plan",
+            ["honua_execute_plan"] = "execute_plan",
+            ["honua_cancel_job"] = "cancel_job",
+            ["honua_propose_operation"] = "propose_operation",
+            ["honua_geocode_address"] = "geocode_address",
+            ["honua_solve_route"] = "solve_route",
+            ["honua_list_layers"] = "list_layers",
+            ["honua_query_features"] = "query_features",
+            ["honua_render_map"] = "render_map",
+        };
+
+    /// <summary>
+    /// Standard tool families enumerated in the geospatial-mcp taxonomy that
+    /// Honua does not yet advertise as discrete MCP tools. These are known-gaps:
+    /// they are recorded so coverage stays honest, but their absence must not
+    /// fail the conformance suite.
+    /// </summary>
+    private static readonly string[] KnownGapStandardTools =
+    {
+        "create_map_package",
+        "refine_map_package",
+        "apply_style_preset",
+        "compose_mixed_protocol_map",
+        "preview_map_package",
+        "create_app_package",
+        "preview_app_package",
+        "publish_result",
+    };
+
+    private static string SchemaRoot =>
+        Path.Combine(AppContext.BaseDirectory, "ConformanceSchemas", "geospatial-mcp");
+
+    private static string FixtureRoot =>
+        Path.Combine(AppContext.BaseDirectory, "ConformanceSchemas", "fixtures");
+
+    [UnitTest]
+    public void VendoredStandardSchemas_AreDraft2020_12AndLoad()
+    {
+        Directory.Exists(SchemaRoot).Should().BeTrue(
+            $"vendored geospatial-mcp schemas must be present at '{SchemaRoot}'");
+
+        var schemaFiles = Directory
+            .EnumerateFiles(SchemaRoot, "*.schema.json", SearchOption.AllDirectories)
+            .ToArray();
+
+        schemaFiles.Should().NotBeEmpty("vendored standard schemas must be copied to the test output");
+
+        foreach (var file in schemaFiles)
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(file));
+            doc.RootElement.TryGetProperty("$schema", out var dialect).Should().BeTrue(
+                $"'{file}' must declare a $schema dialect");
+            dialect.GetString().Should().Be(
+                "https://json-schema.org/draft/2020-12/schema",
+                $"'{file}' must be draft 2020-12");
+
+            // The schema must compile under a JSON-schema engine.
+            var act = () => LoadSchema(file);
+            act.Should().NotThrow($"'{file}' must be a loadable JSON schema");
+        }
+    }
+
+    [UnitTest]
+    public void EveryImplementedTool_IsMappedToAStandardSchema_OrIsADeliberatePackageReviewTool()
+    {
+        // Guard: a NEW tool added to BuildTools() that has no standard mapping
+        // and is not a deliberately-excluded reference tool fails here, forcing
+        // the author to either map it to a standard schema or document the gap.
+        var liveToolNames = BuildTools().Select(t => t.Name).ToHashSet(StringComparer.Ordinal);
+
+        var unmapped = liveToolNames
+            .Where(n => !ImplementedToolStandardNames.ContainsKey(n))
+            .ToArray();
+
+        unmapped.Should().BeEmpty(
+            "every advertised /mcp tool must map to a published geospatial-mcp tool schema "
+            + "(add a mapping in ImplementedToolStandardNames or record a known-gap)");
+    }
+
+    [UnitTest]
+    public void ImplementedTools_AdvertiseInputSchemasConformantWithTheStandard()
+    {
+        var tools = BuildTools();
+
+        foreach (var tool in tools)
+        {
+            ImplementedToolStandardNames.TryGetValue(tool.Name, out var standardName)
+                .Should().BeTrue($"tool '{tool.Name}' must map to a standard tool schema");
+
+            var standardSchemaPath = Path.Combine(SchemaRoot, "tools", standardName + ".schema.json");
+            File.Exists(standardSchemaPath).Should().BeTrue(
+                $"vendored standard schema for '{standardName}' must exist");
+
+            var liveSchema = LoadSchemaFromJson(SerializeLive(tool.Describe().InputSchema));
+            var standardSchema = LoadSchema(standardSchemaPath);
+
+            // Both schemas must be object schemas describing an argument bag.
+            liveSchema.Type.Should().HaveFlag(JSchemaType.Object,
+                $"Honua '{tool.Name}' inputSchema must be an object schema");
+            standardSchema.Type.Should().HaveFlag(JSchemaType.Object,
+                $"standard '{standardName}' schema must be an object schema");
+
+            // The standard MUST NOT require a field Honua's live schema does not
+            // require, otherwise a schema-driven client following the standard
+            // could send a call Honua rejects (or omit a field Honua needs).
+            // For implemented tools the two required sets must agree.
+            var liveRequired = liveSchema.Required.OrderBy(x => x, StringComparer.Ordinal);
+            var standardRequired = standardSchema.Required.OrderBy(x => x, StringComparer.Ordinal);
+            standardRequired.Should().BeEquivalentTo(liveRequired,
+                $"required top-level fields for '{tool.Name}' must match the standard '{standardName}'");
+        }
+    }
+
+    [UnitTest]
+    public void ImplementedTools_StandardFixtureInputs_ValidateAgainstBothLiveAndStandardSchemas()
+    {
+        // The strongest conformance assertion: the standard's own example inputs
+        // (representative VALID calls) must be accepted by BOTH Honua's live
+        // advertised inputSchema AND the published standard schema. If Honua's
+        // schema rejected a standard-valid call, Honua would not conform.
+        var tools = BuildTools().ToDictionary(t => t.Name, StringComparer.Ordinal);
+        var asserted = 0;
+
+        foreach (var (liveName, standardName) in ImplementedToolStandardNames)
+        {
+            if (!tools.TryGetValue(liveName, out var tool))
+            {
+                // honua_dry_run_plan maps to the same standard schema as
+                // honua_validate_plan; both are present, but skip silently if a
+                // mapping entry has no live tool (covered by the mapping guard).
+                continue;
+            }
+
+            var fixtureDir = Path.Combine(FixtureRoot, "tools", standardName);
+            if (!Directory.Exists(fixtureDir))
+            {
+                continue;
+            }
+
+            var liveSchema = LoadSchemaFromJson(SerializeLive(tool.Describe().InputSchema));
+            var standardSchema = LoadSchema(
+                Path.Combine(SchemaRoot, "tools", standardName + ".schema.json"));
+
+            foreach (var fixtureFile in Directory.EnumerateFiles(fixtureDir, "*.json"))
+            {
+                var inputs = ReadFixtureInputs(fixtureFile);
+                if (inputs is null)
+                {
+                    continue;
+                }
+
+                inputs.IsValid(standardSchema, out IList<string> standardErrors);
+                standardErrors.Should().BeEmpty(
+                    $"standard fixture '{Path.GetFileName(fixtureFile)}' must validate "
+                    + $"against the standard '{standardName}' schema");
+
+                inputs.IsValid(liveSchema, out IList<string> liveErrors);
+                liveErrors.Should().BeEmpty(
+                    $"standard fixture '{Path.GetFileName(fixtureFile)}' (a standard-valid "
+                    + $"call) must be accepted by Honua's live '{liveName}' inputSchema — "
+                    + "otherwise Honua does not conform to the standard");
+
+                asserted++;
+            }
+        }
+
+        asserted.Should().BeGreaterThan(0, "at least one tool fixture must be asserted");
+    }
+
+    [UnitTest]
+    public void PlanTools_StepKindAndArtifactEnums_MatchTheStandard()
+    {
+        // The standard pins AnalysisPlanStepKind and ArtifactKind enum values.
+        // Honua's live plan schemas source the same enums; assert the live enum
+        // is a SUBSET of (i.e. not broader than) what the standard advertises so
+        // a standard-conformant client never sees an undocumented step kind.
+        // The vendored validate_plan schema expresses the plan via $defs/$ref;
+        // resolve the enums against the raw JSON so the assertion does not depend
+        // on a JSON-schema engine's $ref representation.
+        using var doc = JsonDocument.Parse(
+            File.ReadAllText(Path.Combine(SchemaRoot, "tools", "validate_plan.schema.json")));
+        var root = doc.RootElement;
+
+        // properties.plan -> $defs.analysisPlan -> properties.steps.items
+        //   -> $defs.planStep -> properties.kind -> $defs.planStepKind.enum
+        var analysisPlan = ResolveRef(root, root, "properties", "plan");
+        var steps = analysisPlan.GetProperty("properties").GetProperty("steps");
+        var planStep = ResolveRef(root, steps, "items");
+        var kind = ResolveRef(root, planStep.GetProperty("properties"), "kind");
+        var standardStepKinds = EnumStrings(kind);
+
+        var outputs = analysisPlan.GetProperty("properties").GetProperty("outputs");
+        var artifactKind = ResolveRef(root, outputs, "items");
+        var standardArtifactKinds = EnumStrings(artifactKind);
+
+        var liveStepKinds = McpToolSchemas.PlanStepKindNames;
+        var liveArtifactKinds = McpToolSchemas.ArtifactKindNames;
+
+        liveStepKinds.Should().BeSubsetOf(standardStepKinds,
+            "every live AnalysisPlanStepKind must be advertised by the standard");
+        liveArtifactKinds.Should().BeSubsetOf(standardArtifactKinds,
+            "every live ArtifactKind must be advertised by the standard");
+    }
+
+    [UnitTest]
+    public void KnownGapStandardTools_AreDocumented_AndDoNotFailOnAbsence()
+    {
+        // Records the standard tools Honua has NOT yet implemented as discrete
+        // MCP tools. The test asserts they are genuinely absent from the live
+        // roster (so an accidental implementation flips them out of the gap list)
+        // and that the standard ships a schema for each (so the gap is real and
+        // closeable), WITHOUT failing on the absence itself.
+        var liveToolNames = BuildTools().Select(t => t.Name).ToHashSet(StringComparer.Ordinal);
+
+        foreach (var gap in KnownGapStandardTools)
+        {
+            liveToolNames.Should().NotContain("honua_" + gap,
+                $"'{gap}' is recorded as a known-gap; if Honua now implements it, "
+                + "map it in ImplementedToolStandardNames and remove it from the gap list");
+
+            File.Exists(Path.Combine(SchemaRoot, "tools", gap + ".schema.json"))
+                .Should().BeTrue($"the standard must publish a schema for the gap tool '{gap}'");
+        }
+    }
+
+    [UnitTest]
+    public void ResourcePayloads_StandardFixtures_ConformToTheVendoredResourceSchemas()
+    {
+        // Resource families Honua projects today, with concrete shapes the
+        // standard enumerates. The standard's resource fixtures must validate
+        // against the vendored resource schemas (the inspection-projection
+        // contract Honua's resource surfaces emit).
+        var resourceFamilies = new[]
+        {
+            ("result-package", "result-package.schema.json"),
+            ("artifact", "artifact.schema.json"),
+            ("provenance", "provenance.schema.json"),
+            ("workspace", "workspace.schema.json"),
+        };
+
+        var asserted = 0;
+        foreach (var (family, schemaFile) in resourceFamilies)
+        {
+            var schema = LoadSchema(Path.Combine(SchemaRoot, "resources", schemaFile));
+            var fixtureDir = Path.Combine(FixtureRoot, "resources", family);
+            Directory.Exists(fixtureDir).Should().BeTrue(
+                $"resource fixtures for '{family}' must be vendored");
+
+            foreach (var fixtureFile in Directory.EnumerateFiles(fixtureDir, "*.json"))
+            {
+                var inputs = ReadFixtureInputs(fixtureFile);
+                if (inputs is null)
+                {
+                    continue;
+                }
+
+                inputs.IsValid(schema, out IList<string> errors);
+                errors.Should().BeEmpty(
+                    $"resource fixture '{Path.GetFileName(fixtureFile)}' must conform to "
+                    + $"the '{family}' payload schema");
+                asserted++;
+            }
+        }
+
+        asserted.Should().BeGreaterThan(0, "at least one resource fixture must be asserted");
+    }
+
+    [UnitTest]
+    public void HonuaResourceFamilies_AreCoveredByTheStandardResourceSchemas()
+    {
+        // Every resource family Honua advertises that the standard defines a
+        // payload schema for must have a vendored schema present, so the
+        // conformance surface stays complete as new resources are added.
+        var standardResourceFamilies = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "result-package", "artifact", "provenance", "workspace",
+            "map-package", "app-package", "style", "theme",
+            "map-template", "published-service", "deployment",
+        };
+
+        foreach (var family in standardResourceFamilies)
+        {
+            File.Exists(Path.Combine(SchemaRoot, "resources", family + ".schema.json"))
+                .Should().BeTrue($"vendored standard resource schema for '{family}' must exist");
+        }
+
+        // Honua advertises at least the workspace + result/job + promotion-surface
+        // families; assert the roster is non-trivial so the wiring is real.
+        BuildResources().Should().NotBeEmpty();
+    }
+
+    // -------------------------------------------------------------------
+    // JSON-schema loading + fixture helpers
+    // -------------------------------------------------------------------
+
+    private static string SerializeLive(JsonElement schema) => schema.GetRawText();
+
+    private static StandardSchema LoadSchema(string path)
+    {
+        var resolver = new JSchemaPreloadedResolver();
+        PreloadVendoredSchemas(resolver);
+        using var reader = new Newtonsoft.Json.JsonTextReader(new StringReader(File.ReadAllText(path)));
+        return StandardSchema.Load(reader, new JSchemaReaderSettings { Resolver = resolver });
+    }
+
+    private static StandardSchema LoadSchemaFromJson(string json)
+    {
+        var resolver = new JSchemaPreloadedResolver();
+        PreloadVendoredSchemas(resolver);
+        using var reader = new Newtonsoft.Json.JsonTextReader(new StringReader(json));
+        return StandardSchema.Load(reader, new JSchemaReaderSettings { Resolver = resolver });
+    }
+
+    private static void PreloadVendoredSchemas(JSchemaPreloadedResolver resolver)
+    {
+        // Register every vendored schema by both its $id and relative file paths
+        // so cross-file $ref (e.g. result-package -> artifact.schema.json,
+        // ../common/geoprocessing-error.schema.json) resolves offline.
+        foreach (var file in Directory.EnumerateFiles(SchemaRoot, "*.json", SearchOption.AllDirectories))
+        {
+            var content = File.ReadAllText(file);
+            using var doc = JsonDocument.Parse(content);
+            if (doc.RootElement.TryGetProperty("$id", out var id) && id.GetString() is { } idValue)
+            {
+                resolver.Add(new Uri(idValue), content);
+            }
+
+            // Relative-path forms used by $ref within the resources/ directory.
+            var fileName = Path.GetFileName(file);
+            resolver.Add(new Uri(fileName, UriKind.Relative), content);
+            var relFromResources = Path.GetRelativePath(Path.Combine(SchemaRoot, "resources"), file)
+                .Replace(Path.DirectorySeparatorChar, '/');
+            resolver.Add(new Uri(relFromResources, UriKind.Relative), content);
+        }
+    }
+
+    private static JToken? ReadFixtureInputs(string fixtureFile)
+    {
+        var root = JObject.Parse(File.ReadAllText(fixtureFile));
+        return root.TryGetValue("inputs", out var inputs) ? inputs : null;
+    }
+
+    /// <summary>
+    /// Reads <paramref name="property"/> from <paramref name="parent"/> and, if it is a
+    /// draft 2020-12 <c>$ref</c> into local <c>$defs</c>, resolves the referenced
+    /// schema against <paramref name="root"/>. Only the local
+    /// <c>#/$defs/&lt;name&gt;</c> form used by the vendored schemas is supported.
+    /// </summary>
+    private static JsonElement ResolveRef(JsonElement root, JsonElement parent, string property)
+    {
+        parent.TryGetProperty(property, out var value).Should().BeTrue(
+            $"schema must expose property '{property}'");
+
+        if (value.TryGetProperty("$ref", out var refElement)
+            && refElement.GetString() is { } reference
+            && reference.StartsWith("#/$defs/", StringComparison.Ordinal))
+        {
+            var defName = reference["#/$defs/".Length..];
+            root.GetProperty("$defs").TryGetProperty(defName, out var resolved).Should().BeTrue(
+                $"schema must define $defs/{defName}");
+            return resolved;
+        }
+
+        return value;
+    }
+
+    private static string[] EnumStrings(JsonElement schema)
+    {
+        schema.TryGetProperty("enum", out var enumElement).Should().BeTrue(
+            "schema node must declare an enum");
+        enumElement.ValueKind.Should().Be(JsonValueKind.Array);
+        return enumElement.EnumerateArray().Select(e => e.GetString()!).ToArray();
+    }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
@@ -25,7 +25,7 @@ namespace Honua.Server.Tests.Features.Protocols.Mcp;
 /// Contract Families</c>. A rename on either side trips this test.
 /// </summary>
 [Protocol(TestProtocols.Mcp)]
-public sealed class McpTaxonomyAlignmentTests
+public sealed partial class McpTaxonomyAlignmentTests
 {
     private static readonly string[] TaxonomyToolNames =
     {


### PR DESCRIPTION
## Summary
Wire Honua's `/mcp` as the reference implementation of the `geospatial-mcp` standard: vendor the standard's newly-published JSON Schemas (geospatial-mcp #21) and assert Honua's advertised tool input schemas + resource shapes conform to them.

## Changes Made
- Add `tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/` (vendored geospatial-mcp JSON Schemas) as test content.
- Add `McpGeospatialMcpSchemaConformanceTests` validating Honua's `/mcp` tool/resource vocabulary against those schemas; not-yet-implemented standard tools are known-gaps (fail on non-conformance of implemented tools, not on absence).
- Extend `McpTaxonomyAlignmentTests` accordingly.

## Breaking Changes
None. Test-only.

## Gate Impact
- [x] Test/CI only — no product code changed.

## Testing
- [x] Build-clean + formatted locally (agent reached the test phase); CI runs the new conformance test. Pairs with geospatial-mcp #21.

Related to #1957
