### PR TITLE
feat(mcp): publish-service tool + register promotion resources by default (#1951)

### DIFF
--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
@@ -56,6 +56,19 @@ internal static class McpServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, ExecutePlanTool>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, CancelJobTool>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, ProposeOperationTool>());
+
+        // honua_publish_service (#1951): the authoring/publishing tool. It routes
+        // through the canonical IOperationInvoker (operations toolset) →
+        // ServicePublishExecutor → ILayerPublishingService rather than
+        // reimplementing publish. Registered unconditionally and gated at
+        // invocation time: the operations toolset (AddOperationsToolset) is wired
+        // later in the server composition root than AddMcpOperatorSurface, so a
+        // descriptor-list check here would never see IOperationInvoker. Instead
+        // the tool resolves the invoker per-request and returns a structured
+        // "unavailable" handle when no operations toolset is composed — the same
+        // pattern ProposeOperationTool uses for the operation gateway.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, PublishServiceTool>());
+
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, PlanAnalysisTool>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, GroundCandidatesTool>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, ClarifyIntentTool>());

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
@@ -49,6 +49,8 @@ namespace Honua.Ai.Protocols.Mcp.Models;
 [JsonSerializable(typeof(McpCancelJobOutput))]
 [JsonSerializable(typeof(McpProposeOperationArgument))]
 [JsonSerializable(typeof(McpProposeOperationOutput))]
+[JsonSerializable(typeof(McpPublishServiceArgument))]
+[JsonSerializable(typeof(McpPublishServiceOutput))]
 [JsonSerializable(typeof(McpProposalResource))]
 [JsonSerializable(typeof(McpNotImplementedOutput))]
 [JsonSerializable(typeof(McpToolErrorOutput))]

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpToolModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpToolModels.cs
@@ -84,6 +84,95 @@ internal sealed class McpProposeOperationOutput
 }
 
 /// <summary>
+/// Arguments for <c>honua_publish_service</c>: publish a source table as a
+/// hosted layer/service through the canonical <c>service.publish</c> operation
+/// (#1951). Field names mirror the <c>service.publish</c> operation parameters
+/// the <c>ServicePublishExecutor</c> maps onto a <c>LayerPublishRequest</c>.
+/// </summary>
+internal sealed class McpPublishServiceArgument
+{
+    [JsonPropertyName("connectionId")]
+    public string? ConnectionId { get; set; }
+
+    [JsonPropertyName("schema")]
+    public string? Schema { get; set; }
+
+    [JsonPropertyName("table")]
+    public string? Table { get; set; }
+
+    [JsonPropertyName("layerName")]
+    public string? LayerName { get; set; }
+
+    [JsonPropertyName("serviceName")]
+    public string? ServiceName { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("geometryColumn")]
+    public string? GeometryColumn { get; set; }
+
+    [JsonPropertyName("geometryType")]
+    public string? GeometryType { get; set; }
+
+    [JsonPropertyName("srid")]
+    public int? Srid { get; set; }
+
+    [JsonPropertyName("primaryKey")]
+    public string? PrimaryKey { get; set; }
+
+    [JsonPropertyName("fields")]
+    public IReadOnlyList<string>? Fields { get; set; }
+}
+
+/// <summary>
+/// Output for <c>honua_publish_service</c>. Projects the canonical
+/// <c>OperationHandle</c> returned by the operations dispatcher: a
+/// <c>Completed</c> publish carries the resulting service URI, layer id, and
+/// metadata revision; a <c>RequiresApproval</c> outcome carries the approval
+/// lane the agent must wait on; a <c>Queued</c> outcome carries the durable job
+/// id (#1951).
+/// </summary>
+internal sealed class McpPublishServiceOutput
+{
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+
+    [JsonPropertyName("requiresApproval")]
+    public bool RequiresApproval { get; set; }
+
+    [JsonPropertyName("operationId")]
+    public string OperationId { get; set; } = string.Empty;
+
+    [JsonPropertyName("handleId")]
+    public string HandleId { get; set; } = string.Empty;
+
+    [JsonPropertyName("serviceUri")]
+    public string? ServiceUri { get; set; }
+
+    [JsonPropertyName("layerId")]
+    public string? LayerId { get; set; }
+
+    [JsonPropertyName("serviceName")]
+    public string? ServiceName { get; set; }
+
+    [JsonPropertyName("metadataRevision")]
+    public long? MetadataRevision { get; set; }
+
+    [JsonPropertyName("jobId")]
+    public string? JobId { get; set; }
+
+    [JsonPropertyName("approvalLane")]
+    public string? ApprovalLane { get; set; }
+
+    [JsonPropertyName("summary")]
+    public string? Summary { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+}
+
+/// <summary>
 /// Canonical-object plan wire shape consumed by MCP plan tools.
 /// Maps directly to <see cref="Honua.Core.Features.Geoprocessing.Domain.AnalysisPlan"/>.
 /// </summary>

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
@@ -123,6 +123,51 @@ internal static class McpToolOutputSchemas
         """);
 
     /// <summary>
+    /// Schema for <see cref="Models.McpPublishServiceOutput"/>. Projects the
+    /// canonical <c>OperationHandle</c>: <c>status</c> is the
+    /// <c>OperationHandleStatus</c> (Completed | Queued | RequiresApproval |
+    /// Running | Failed); a completed publish carries <c>serviceUri</c>,
+    /// <c>layerId</c>, and <c>metadataRevision</c>; a requires-approval outcome
+    /// carries <c>approvalLane</c>; a queued outcome carries <c>jobId</c>.
+    /// </summary>
+    public static readonly JsonElement PublishServiceOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["status", "requiresApproval", "operationId", "handleId"],
+          "properties": {
+            "status": {
+              "type": "string",
+              "description": "Operation handle status: Completed, Queued, Running, RequiresApproval, or Failed."
+            },
+            "requiresApproval": { "type": "boolean" },
+            "operationId": { "type": "string" },
+            "handleId": { "type": "string" },
+            "serviceUri": {
+              "type": ["string", "null"],
+              "description": "honua://published-services/{serviceName} URI of the published service when the publish completed."
+            },
+            "layerId": { "type": ["string", "null"] },
+            "serviceName": { "type": ["string", "null"] },
+            "metadataRevision": {
+              "type": ["integer", "null"],
+              "description": "Metadata v2 graph revision produced by the publish."
+            },
+            "jobId": {
+              "type": ["string", "null"],
+              "description": "Durable job id when the operation was queued."
+            },
+            "approvalLane": {
+              "type": ["string", "null"],
+              "description": "Approval lane to wait on when the publish requires human approval."
+            },
+            "summary": { "type": ["string", "null"] },
+            "message": { "type": ["string", "null"] }
+          }
+        }
+        """);
+
+    /// <summary>
     /// Schema for <see cref="Models.McpPlanAnalysisOutput"/>. The compiled plan,
     /// spec draft, clarification, and estimate are deep nested shapes; the schema
     /// pins the top-level envelope and leaves those sub-objects open so the

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolSchemas.cs
@@ -75,6 +75,63 @@ internal static class McpToolSchemas
         }
         """;
 
+    private const string PublishServiceArgumentSchemaJson = """
+        {
+          "type": "object",
+          "required": ["connectionId", "schema", "table", "layerName"],
+          "properties": {
+            "connectionId": {
+              "type": "string",
+              "description": "Secure-connection identifier whose table is published. Required: the canonical service.publish operation resolves the target database connection from it."
+            },
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Source schema containing the table to publish."
+            },
+            "table": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Source table to publish as a layer."
+            },
+            "layerName": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Display name for the published layer."
+            },
+            "serviceName": {
+              "type": "string",
+              "description": "Target service name. Defaults to the canonical default service when omitted."
+            },
+            "description": {
+              "type": "string",
+              "description": "Optional layer description."
+            },
+            "geometryColumn": {
+              "type": "string",
+              "description": "Geometry column to publish when the table has more than one."
+            },
+            "geometryType": {
+              "type": "string",
+              "description": "Geometry type override (for example Point, Polygon) when it cannot be inferred."
+            },
+            "srid": {
+              "type": "integer",
+              "description": "Spatial reference identifier for the published layer."
+            },
+            "primaryKey": {
+              "type": "string",
+              "description": "Primary key column when the table has no detectable key."
+            },
+            "fields": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Subset of attribute columns to publish. All columns are published when omitted."
+            }
+          }
+        }
+        """;
+
     private const string PlanAnalysisArgumentSchemaJson = """
         {
           "type": "object",
@@ -177,6 +234,16 @@ internal static class McpToolSchemas
     /// Schema for <see cref="Models.McpProposeOperationArgument"/>.
     /// </summary>
     public static readonly JsonElement ProposeOperationArgumentSchema = Parse(ProposeOperationArgumentSchemaJson);
+
+    /// <summary>
+    /// Schema for <see cref="Models.McpPublishServiceArgument"/>. <c>connectionId</c>,
+    /// <c>schema</c>, <c>table</c>, and <c>layerName</c> are marked required to
+    /// match the <c>service.publish</c> executor, which throws on a missing
+    /// connection id or required publish parameter at submit time — so a
+    /// schema-driven client should never send a payload the operation always
+    /// refuses.
+    /// </summary>
+    public static readonly JsonElement PublishServiceArgumentSchema = Parse(PublishServiceArgumentSchemaJson);
 
     /// <summary>
     /// Schema used by stub tools that accept no arguments.

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishServiceTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishServiceTool.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+using Honua.Ai.Protocols.Mcp.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Ai.Protocols.Mcp.Tools;
+
+/// <summary>
+/// MCP tool that publishes a source table as a hosted layer/service through the
+/// canonical <c>service.publish</c> operation (#1951). It does NOT reimplement
+/// publishing: it adapts the tool arguments onto an
+/// <see cref="OperationRequest"/> and routes them through the shared
+/// <see cref="IOperationInvoker"/>, which runs the operator-gate policy decision
+/// point before reaching <c>ServicePublishExecutor</c> →
+/// <c>ILayerPublishingService.PublishLayerAsync</c>. The returned
+/// <see cref="OperationHandle"/> is projected into a structured result so the
+/// agent can branch on Completed (service URI + metadata revision available),
+/// Queued (poll the job), or RequiresApproval (wait on the approval lane).
+/// </summary>
+internal sealed class PublishServiceTool : IMcpTool
+{
+    public const string ToolName = "honua_publish_service";
+
+    /// <summary>
+    /// Canonical operations-toolset operation id this tool routes through. Mirrors
+    /// <c>Honua.Server.Features.Operations.ServicePublishOperation.OperationId</c>;
+    /// duplicated as a literal here because <c>Honua.Ai</c> cannot reference the
+    /// server assembly (dependency direction).
+    /// </summary>
+    public const string PublishOperationId = "service.publish";
+
+    private readonly ILogger<PublishServiceTool> _logger;
+
+    public PublishServiceTool(ILogger<PublishServiceTool> logger)
+    {
+        _logger = logger;
+    }
+
+    public string Name => ToolName;
+
+    public string WorkflowFamily => McpTelemetry.WorkflowFamily.Lifecycle;
+
+    public McpToolDescriptor Describe() => new()
+    {
+        Name = ToolName,
+        Title = "Publish service",
+        Description = "Publish a source table as a hosted layer/service through the canonical service.publish operation and its operator-approval gate. "
+            + "Returns a structured operation handle: Completed carries the published service URI, layer id, and metadata revision; "
+            + "RequiresApproval carries the approval lane to wait on; Queued carries the durable job id.",
+        InputSchema = McpToolSchemas.PublishServiceArgumentSchema,
+        OutputSchema = McpToolOutputSchemas.PublishServiceOutputSchema,
+        // Write tool: it mutates the catalog by creating a new published layer.
+        // Not destructive (it creates rather than destroys state). Not idempotent:
+        // service.publish does not honor an idempotency key, so a replay publishes
+        // a second layer.
+        Annotations = McpToolAnnotationSets.Write("Publish service", destructive: false, idempotent: false)
+    };
+
+    public async Task<McpToolsCallResult> InvokeAsync(
+        HttpContext httpContext,
+        JsonElement? arguments,
+        CancellationToken cancellationToken)
+    {
+        McpTelemetry.EnrichActivity("PublishService");
+        McpLog.ToolInvoked(_logger, ToolName, WorkflowFamily);
+
+        var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
+        var argument = McpToolHelpers.ParseArguments(arguments, McpJsonContext.Default.McpPublishServiceArgument);
+
+        var invoker = httpContext.RequestServices.GetService<IOperationInvoker>();
+        if (invoker is null)
+        {
+            return McpToolHelpers.SuccessResult(
+                new McpPublishServiceOutput
+                {
+                    Status = OperationHandleStatus.Failed.ToString(),
+                    RequiresApproval = false,
+                    OperationId = PublishOperationId,
+                    Message = "The operations toolset is unavailable (no IOperationInvoker is registered in this composition)."
+                },
+                McpJsonContext.Default.McpPublishServiceOutput);
+        }
+
+        var request = BuildRequest(argument);
+        var context = new OperationPolicyContext
+        {
+            PrincipalId = principal.Identity?.Name
+        };
+
+        var handle = await invoker.SubmitAsync(request, context, cancellationToken).ConfigureAwait(false);
+
+        return McpToolHelpers.SuccessResult(Project(handle), McpJsonContext.Default.McpPublishServiceOutput);
+    }
+
+    private static OperationRequest BuildRequest(McpPublishServiceArgument argument)
+    {
+        var parameters = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["schema"] = argument.Schema,
+            ["table"] = argument.Table,
+            ["layerName"] = argument.LayerName,
+            ["description"] = argument.Description,
+            ["geometryColumn"] = argument.GeometryColumn,
+            ["geometryType"] = argument.GeometryType,
+            ["primaryKey"] = argument.PrimaryKey,
+        };
+
+        if (argument.Srid is { } srid)
+        {
+            parameters["srid"] = srid.ToString(CultureInfo.InvariantCulture);
+        }
+
+        return new OperationRequest
+        {
+            OperationId = PublishOperationId,
+            ConnectionId = argument.ConnectionId,
+            ServiceName = argument.ServiceName,
+            Fields = argument.Fields ?? [],
+            Parameters = parameters,
+        };
+    }
+
+    private static McpPublishServiceOutput Project(OperationHandle handle)
+    {
+        var output = new McpPublishServiceOutput
+        {
+            Status = handle.Status.ToString(),
+            RequiresApproval = handle.Status == OperationHandleStatus.RequiresApproval,
+            OperationId = handle.OperationId,
+            HandleId = handle.HandleId,
+            JobId = handle.JobId,
+            ApprovalLane = handle.ApprovalLane,
+            MetadataRevision = handle.MetadataRevision,
+            Summary = handle.Result?.Summary,
+            Message = handle.Reason,
+        };
+
+        if (handle.Result is { } result)
+        {
+            if (result.Details.TryGetValue("layerId", out var layerId))
+            {
+                output.LayerId = layerId;
+            }
+
+            if (result.Details.TryGetValue("serviceName", out var serviceName))
+            {
+                output.ServiceName = serviceName;
+                output.ServiceUri = McpResourceUris.PublishedServiceUri(serviceName);
+            }
+        }
+
+        return output;
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -195,6 +195,24 @@ internal static class FeatureRegistrationExtensions
         services.AddOrchestration();
         services.AddPMTilesProxy();
 
+        // Hosted-promotion MCP surface (#1951): advertise
+        // honua://published-services|deployments|map-packages|app-packages on the
+        // deployed server, but ONLY when canonical promotion persistence is wired.
+        // The promotion resource handlers depend on IPublishedServiceStore /
+        // IDeploymentStore; advertising them without a backing store would surface
+        // an always-empty surface and break the honesty invariant the MCP
+        // tools/list contract relies on. AddMcpPromotionSurface deliberately wires
+        // no fallback stores, so this gate is the single place the default
+        // composition opts in once a provider has registered the canonical stores
+        // earlier in the composition root (for example AddPostgreSqlServices). On a
+        // store-less profile this is a no-op and the resources stay off — the same
+        // gating contract the operator-surface tools use.
+        if (services.Any(d => d.ServiceType == typeof(Honua.Core.Features.Publishing.Abstractions.IPublishedServiceStore))
+            && services.Any(d => d.ServiceType == typeof(Honua.Core.Features.Deployment.Abstractions.IDeploymentStore)))
+        {
+            services.AddMcpPromotionSurface();
+        }
+
         return services;
     }
 

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpServiceCollectionExtensionsTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpServiceCollectionExtensionsTests.cs
@@ -60,6 +60,18 @@ public sealed class McpServiceCollectionExtensionsTests
     }
 
     [UnitTest]
+    public void AddMcpOperatorSurface_RegistersPublishServiceTool()
+    {
+        var services = BuildBaseServices();
+        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+
+        RegisteredToolHandlers(services)
+            .Should().Contain(typeof(PublishServiceTool),
+                "honua_publish_service is the default authoring/publishing tool (#1951); it gates "
+                + "on IOperationInvoker at invocation time, so it is always advertised.");
+    }
+
+    [UnitTest]
     public void AddMcpOperatorSurface_DoesNotRegisterFallbackPromotionStores()
     {
         var services = BuildBaseServices();
@@ -136,16 +148,15 @@ public sealed class McpServiceCollectionExtensionsTests
     }
 
     /// <summary>
-    /// Tripwire for the default real-host composition
-    /// (<see cref="FeatureRegistrationExtensions.AddServerFeatures"/>): the
-    /// promotion surface must remain gated off until canonical publishing and
-    /// deployment persistence register earlier in the composition root. When
-    /// that lands, this assertion flips and forces a deliberate update to call
-    /// <see cref="McpServiceCollectionExtensions.AddMcpPromotionSurface"/> in
-    /// the default composition.
+    /// The default real-host composition
+    /// (<see cref="FeatureRegistrationExtensions.AddServerFeatures"/>) gates the
+    /// promotion surface on canonical publishing + deployment persistence
+    /// (#1951). With no provider registering those stores, the gate stays closed
+    /// and the promotion resources are NOT advertised — the same honesty
+    /// invariant that keeps tools/list from advertising an always-empty surface.
     /// </summary>
     [UnitTest]
-    public void AddServerFeatures_DefaultComposition_DoesNotAdvertisePromotionResources()
+    public void AddServerFeatures_DefaultComposition_WithoutCanonicalStores_DoesNotAdvertisePromotionResources()
     {
         var services = BuildBaseServices();
         services.AddServerFeatures(new ConfigurationBuilder().Build());
@@ -164,6 +175,34 @@ public sealed class McpServiceCollectionExtensionsTests
             .Should().BeFalse("no canonical IPublishedServiceStore persistence is wired into AddServerFeatures yet");
         services.Any(d => d.ServiceType == typeof(IDeploymentStore))
             .Should().BeFalse("no canonical IDeploymentStore persistence is wired into AddServerFeatures yet");
+    }
+
+    /// <summary>
+    /// Positive branch of the #1951 gate: when canonical
+    /// <see cref="IPublishedServiceStore"/> and <see cref="IDeploymentStore"/>
+    /// persistence is registered before the default composition runs (as a
+    /// durable provider does), <see cref="FeatureRegistrationExtensions.AddServerFeatures"/>
+    /// opts the promotion surface in automatically, so a deployed server
+    /// advertises honua://published-services|deployments|map-packages|app-packages.
+    /// </summary>
+    [UnitTest]
+    public void AddServerFeatures_WithCanonicalStores_AdvertisesPromotionResourcesByDefault()
+    {
+        var services = BuildBaseServices();
+        services.AddSingleton(Substitute.For<IPublishedServiceStore>());
+        services.AddSingleton(Substitute.For<IDeploymentStore>());
+
+        services.AddServerFeatures(new ConfigurationBuilder().Build());
+
+        RegisteredResourceHandlers(services)
+            .Should().Contain(new[]
+            {
+                typeof(PublishedServiceResource),
+                typeof(DeploymentResource),
+                typeof(MapPackageResource),
+                typeof(AppPackageResource),
+                typeof(PromotionSurfaceIndexResource)
+            }, "the default composition opts the promotion surface in once canonical publishing + deployment persistence is present (#1951)");
     }
 
     private static IEnumerable<Type?> RegisteredToolHandlers(IServiceCollection services)

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
@@ -34,6 +34,7 @@ public sealed class McpTaxonomyAlignmentTests
         "honua_dry_run_plan",
         "honua_cancel_job",
         "honua_propose_operation",
+        "honua_publish_service",
         "honua_plan_analysis",
         "honua_ground_candidates",
         "honua_clarify_intent",
@@ -222,6 +223,7 @@ public sealed class McpTaxonomyAlignmentTests
             ["honua_execute_plan"] = (Destructive: false, Idempotent: true),
             ["honua_cancel_job"] = (Destructive: true, Idempotent: true),
             ["honua_propose_operation"] = (Destructive: false, Idempotent: true),
+            ["honua_publish_service"] = (Destructive: false, Idempotent: false),
         };
 
     [UnitTest]
@@ -549,6 +551,7 @@ public sealed class McpTaxonomyAlignmentTests
             new ExecutePlanTool(jobService, NullLogger<ExecutePlanTool>.Instance),
             new CancelJobTool(jobService, NullLogger<CancelJobTool>.Instance),
             new ProposeOperationTool(NullLogger<ProposeOperationTool>.Instance),
+            new PublishServiceTool(NullLogger<PublishServiceTool>.Instance),
             new PlanAnalysisTool(
                 Substitute.For<Honua.Ai.AiBuilder.Planning.IPlanAnalysisService>(),
                 jobService,

--- a/tests/dotnet/Honua.Ai.Tests/Source/PublishServiceToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/PublishServiceToolTests.cs
@@ -1,0 +1,198 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Verifies the MCP <c>honua_publish_service</c> tool (#1951): it advertises the
+/// correct write annotations and output schema, routes <c>tools/call</c> through
+/// the canonical <see cref="IOperationInvoker"/> (operations toolset /
+/// service.publish), and projects the resulting <see cref="OperationHandle"/>
+/// into a structured Completed / RequiresApproval / unavailable result.
+/// </summary>
+[Protocol(TestProtocols.Mcp)]
+public sealed class PublishServiceToolTests
+{
+    private static DefaultHttpContext ContextWithInvoker(IOperationInvoker? invoker)
+    {
+        var services = new ServiceCollection();
+        if (invoker is not null)
+        {
+            services.AddSingleton(invoker);
+        }
+
+        return new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+            User = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "agent-x")], "Test"))
+        };
+    }
+
+    private static PublishServiceTool CreateTool()
+        => new(NullLogger<PublishServiceTool>.Instance);
+
+    private static System.Text.Json.JsonElement Arguments(McpPublishServiceArgument argument)
+        => McpTestFactory.ToArguments(argument, McpJsonContext.Default.McpPublishServiceArgument);
+
+    [UnitTest]
+    public void Describe_AdvertisesWriteAnnotationsAndOutputSchema()
+    {
+        var descriptor = CreateTool().Describe();
+
+        descriptor.Name.Should().Be("honua_publish_service");
+        descriptor.Title.Should().NotBeNullOrWhiteSpace();
+        descriptor.Annotations.Should().NotBeNull();
+        descriptor.Annotations!.ReadOnlyHint.Should().BeFalse("publishing mutates the catalog");
+        descriptor.Annotations.DestructiveHint.Should().BeFalse("publish creates a layer rather than destroying state");
+        descriptor.Annotations.IdempotentHint.Should().BeFalse("service.publish does not honor an idempotency key");
+
+        descriptor.OutputSchema.Should().NotBeNull();
+        var schema = descriptor.OutputSchema!.Value;
+        schema.GetProperty("type").GetString().Should().Be("object");
+        schema.GetProperty("properties").TryGetProperty("status", out _).Should().BeTrue();
+        schema.GetProperty("properties").TryGetProperty("serviceUri", out _).Should().BeTrue();
+        schema.GetProperty("properties").TryGetProperty("metadataRevision", out _).Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Operation(Operations.StudioLifecycle)]
+    [Endpoint("POST /mcp tools/call honua_publish_service")]
+    public async Task PublishService_WhenCompleted_RoutesToInvoker_AndReturnsServiceUriAndRevision()
+    {
+        OperationRequest? captured = null;
+        var invoker = new FakeInvoker((request, _) =>
+        {
+            captured = request;
+            return new OperationHandle
+            {
+                OperationId = PublishServiceTool.PublishOperationId,
+                HandleId = "op-abc",
+                Status = OperationHandleStatus.Completed,
+                MetadataRevision = 42,
+                Result = new OperationResultSummary
+                {
+                    Summary = "Published layer 'Parcels' (id 7) to service 'cadastre'.",
+                    Details = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["layerId"] = "7",
+                        ["serviceName"] = "cadastre",
+                    }
+                }
+            };
+        });
+
+        var tool = CreateTool();
+        var arguments = Arguments(new McpPublishServiceArgument
+        {
+            ConnectionId = "11111111-1111-1111-1111-111111111111",
+            Schema = "public",
+            Table = "parcels",
+            LayerName = "Parcels",
+            ServiceName = "cadastre",
+            Srid = 4326,
+            Fields = ["objectid", "owner"]
+        });
+
+        var result = await tool.InvokeAsync(ContextWithInvoker(invoker), arguments, CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        var content = result.StructuredContent!.Value;
+        content.GetProperty("status").GetString().Should().Be("Completed");
+        content.GetProperty("requiresApproval").GetBoolean().Should().BeFalse();
+        content.GetProperty("serviceUri").GetString().Should().Be("honua://published-services/cadastre");
+        content.GetProperty("layerId").GetString().Should().Be("7");
+        content.GetProperty("metadataRevision").GetInt64().Should().Be(42);
+
+        // The tool adapts onto the canonical service.publish operation rather than
+        // reimplementing publishing.
+        captured.Should().NotBeNull();
+        captured!.OperationId.Should().Be("service.publish");
+        captured.ConnectionId.Should().Be("11111111-1111-1111-1111-111111111111");
+        captured.ServiceName.Should().Be("cadastre");
+        captured.Parameters["schema"].Should().Be("public");
+        captured.Parameters["table"].Should().Be("parcels");
+        captured.Parameters["layerName"].Should().Be("Parcels");
+        captured.Parameters["srid"].Should().Be("4326");
+        captured.Fields.Should().BeEquivalentTo("objectid", "owner");
+    }
+
+    [UnitTest]
+    [Operation(Operations.StudioLifecycle)]
+    [Endpoint("POST /mcp tools/call honua_publish_service")]
+    public async Task PublishService_WhenRequiresApproval_ReturnsApprovalLane()
+    {
+        var invoker = new FakeInvoker((_, _) => new OperationHandle
+        {
+            OperationId = PublishServiceTool.PublishOperationId,
+            HandleId = "op-pending",
+            Status = OperationHandleStatus.RequiresApproval,
+            ApprovalLane = "operator-gate",
+            Reason = "Publishing requires operator approval on this tier."
+        });
+
+        var tool = CreateTool();
+        var arguments = Arguments(new McpPublishServiceArgument
+        {
+            ConnectionId = "conn-1",
+            Schema = "public",
+            Table = "parcels",
+            LayerName = "Parcels"
+        });
+
+        var result = await tool.InvokeAsync(ContextWithInvoker(invoker), arguments, CancellationToken.None);
+
+        var content = result.StructuredContent!.Value;
+        content.GetProperty("status").GetString().Should().Be("RequiresApproval");
+        content.GetProperty("requiresApproval").GetBoolean().Should().BeTrue();
+        content.GetProperty("approvalLane").GetString().Should().Be("operator-gate");
+        content.GetProperty("message").GetString().Should().Be("Publishing requires operator approval on this tier.");
+    }
+
+    [UnitTest]
+    [Operation(Operations.StudioLifecycle)]
+    [Endpoint("POST /mcp tools/call honua_publish_service")]
+    public async Task PublishService_WhenInvokerUnavailable_ReturnsFailedWithoutThrowing()
+    {
+        var tool = CreateTool();
+        var arguments = Arguments(new McpPublishServiceArgument
+        {
+            ConnectionId = "conn-1",
+            Schema = "public",
+            Table = "parcels",
+            LayerName = "Parcels"
+        });
+
+        var result = await tool.InvokeAsync(ContextWithInvoker(invoker: null), arguments, CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        var content = result.StructuredContent!.Value;
+        content.GetProperty("status").GetString().Should().Be("Failed");
+        content.GetProperty("requiresApproval").GetBoolean().Should().BeFalse();
+        content.GetProperty("message").GetString().Should().Contain("operations toolset is unavailable");
+    }
+
+    private sealed class FakeInvoker(Func<OperationRequest, OperationPolicyContext, OperationHandle> handler)
+        : IOperationInvoker
+    {
+        public Task<OperationValidation> ValidateAsync(OperationRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new OperationValidation { IsValid = true, Status = "valid" });
+
+        public Task<OperationHandle> SubmitAsync(
+            OperationRequest request,
+            OperationPolicyContext context,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(handler(request, context));
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1951

## Summary
Lands the MCP authoring/publishing slice of workstream #1951 (epic #1948) so a chat can build AND ship, not just plan. Adds a `honua_publish_service` MCP tool that publishes a source table as a hosted layer/service through the existing canonical publish + operator-approval path, and wires the hosted-promotion MCP resources into the default server composition (gated on canonical persistence) so `honua://published-services|deployments|map-packages|app-packages` actually appear on a deployed server once a durable store provider registers them.

No HTTP routes are added — MCP tools/resources are not HTTP routes — so EndpointRegistry/proof-ledger governance is unaffected (Architecture.Tests stay green).

## Changes Made
- Add `honua_publish_service` MCP tool (`PublishServiceTool`): a thin adapter onto the canonical `service.publish` operation via `IOperationInvoker` (operations toolset → `ServicePublishExecutor` → `ILayerPublishingService.PublishLayerAsync`). It does NOT reimplement publishing. It projects the canonical `OperationHandle` into a structured result — `Completed` carries the published service URI + layer id + metadata revision, `RequiresApproval` carries the operator-gate approval lane, `Queued` carries the durable job id. Write annotations (`readOnlyHint:false`, `destructiveHint:false`, `idempotentHint:false` — `service.publish` honors no idempotency key) plus a `structuredContent` output schema, matching the #1953 annotation pattern. Registered in `AddMcpOperatorSurface`; the invoker is resolved per-request and a structured "unavailable" handle is returned when no operations toolset is composed (mirrors `ProposeOperationTool`'s gateway handling — the operations toolset composes later than the operator surface, so a descriptor-list check would never see it).
- Wire `AddMcpPromotionSurface()` into the default composition (`FeatureRegistrationExtensions.AddServerFeatures`), gated on canonical `IPublishedServiceStore` + `IDeploymentStore` persistence being present. Today no provider registers those stores, so the gate stays closed and the resources stay off (they cannot honestly advertise an always-empty surface); when a durable provider registers them, the promotion surface opts in automatically.
- Add `McpPublishServiceArgument` / `McpPublishServiceOutput` models + input/output JSON schemas + JSON source-gen context registration.
- Tests: publish tool advertises correct write annotations + output schema; `tools/call` routes through a fake `IOperationInvoker` and projects Completed / RequiresApproval / unavailable; the default-composition gate is proven in both branches (off without stores, on with both stores); taxonomy roster + write-tool expectations updated for the new tool.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

<sub>Verification: `dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true` → 0/0; `dotnet format Honua.sln --verify-no-changes` → clean; `Honua.Ai.Tests` (Category!=Integration) → 256/256; `Honua.Architecture.Tests` → 116/116. The 34 Ai.Tests integration failures in this environment are Testcontainers/Docker-daemon-absent, not a regression.</sub>
