### PR TITLE
fix(ci): advisory shards conclude success so PRs stay CLEAN (restore merge-train auto-drain)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -782,13 +782,16 @@ jobs:
     needs: [build, changes, targeted-shards]
     timeout-minutes: ${{ matrix.timeout_minutes }}
     # Advisory shards (matrix.advisory == true in .github/ci-shards.json) RUN and
-    # publish results but do NOT gate the merge queue: continue-on-error makes the
-    # job conclusion `success` even when the test step fails, so CI Gate's
-    # contains(needs.*.result, 'failure') aggregation stays green. Used to keep a
-    # newly-running coverage shard visible while its rotted tests are repaired
-    # (the #1899/#1964 Features.* orphan buckets; tracked in #1965) instead of
-    # blocking unrelated PRs. Delete the shard's `advisory` field to re-block it.
-    continue-on-error: ${{ matrix.advisory == true }}
+    # publish results but do NOT gate the merge: continue-on-error is applied to the
+    # "Run server test shard" STEP (below), so an advisory test failure is swallowed
+    # there and the JOB CONCLUDES SUCCESS. That keeps CI Gate green (needs.*.result
+    # has no failure) AND keeps the job's check-run green — so the PR's
+    # mergeStateStatus stays CLEAN and the clean-only merge-train can auto-merge it.
+    # (A job-LEVEL continue-on-error kept CI Gate green but still published a FAILING
+    # check-run for the shard, forcing every PR to UNSTABLE and stalling auto-drain.)
+    # Used to keep a newly-running coverage shard visible while its rotted tests are
+    # repaired (the #1899/#1964 Features.* orphan buckets; tracked in #1965) instead
+    # of blocking unrelated PRs. Delete the shard's `advisory` field to re-block it.
     strategy:
       fail-fast: false
       matrix:
@@ -858,6 +861,11 @@ jobs:
             --configuration Release
 
       - name: Run server test shard
+        # Advisory shards (matrix.advisory==true) swallow their test failure HERE so
+        # the job concludes success and the PR stays CLEAN (see job comment above).
+        # Non-advisory shards (false) fail the job as normal. A build failure in an
+        # earlier step still fails the job regardless — only the test run is swallowed.
+        continue-on-error: ${{ matrix.advisory == true }}
         shell: bash
         env:
           HONUA_SERVER_TEST_SHARD_NAME: ${{ matrix.shard_name }}


### PR DESCRIPTION
## Summary
Advisory coverage shards were stalling the **entire** merge queue. They had a **job-level** `continue-on-error`, which kept `CI Gate` green (via `needs.*.result`) but still published a **failing check-run** — so every PR's `mergeStateStatus` was **UNSTABLE**, and the clean-only merge-train auto-merged nothing. The queue only drained by manual merges.

This moves `continue-on-error: ${{ matrix.advisory == true }}` from the **job** to the **"Run server test shard" step**, so an advisory test failure is swallowed there and the **job concludes success** → CI Gate green **and** check-run green → PR stays **CLEAN** → merge-train auto-drains.

## Changes Made
- Remove the job-level `continue-on-error` on the `Server Tests` matrix job.
- Add `continue-on-error: ${{ matrix.advisory == true }}` to the `Run server test shard` step.
- Update the explanatory comment block.

## Breaking Changes
None. Non-advisory shards still fail the job normally; a build failure in an earlier step still fails the job (only the test-run step is swallowed for advisory shards). The real fix for the rotted Features.* tests stays tracked in #1965.

## Gate Impact
- [x] CI/workflow change — restores auto-merge; does not weaken any required gate (CI Gate behavior unchanged).

## Testing
- [x] `ci.yml` validated as well-formed YAML; logic reasoned through (advisory → step swallow → job success → CLEAN). Verified live in CI on this PR.

Related to #1965
