### PR TITLE
fix: cap GDAL base64 decode allocation before MaxArtifactBytes check

### DIFF
--- a/src/Honua.Worker.Gdal/Execution/GdalJobInputReader.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalJobInputReader.cs
@@ -120,11 +120,50 @@ internal static class GdalJobInputReader
         out byte[] bytes,
         out string error)
     {
-        if (!TryGetBase64Input(parameters, name, out bytes, out error))
+        bytes = [];
+        error = "";
+
+        if (!TryGetInput(parameters, name, out var raw))
         {
+            error = $"missing required input '{name}'";
             return false;
         }
 
+        // Reject oversized payloads BEFORE decoding so the MaxArtifactBytes
+        // ceiling caps the decode-time allocation rather than letting an
+        // attacker materialize ~0.75x the (unbounded) base64 length first.
+        // Base64 packs 4 encoded chars into 3 decoded bytes, so the decoded
+        // size is at most (raw.Length / 4) * 3. Any whitespace/newlines the
+        // encoder may have inserted only make the real decoded size smaller,
+        // so this remains a valid (conservative) upper bound on the payload.
+        // Use long arithmetic to avoid int overflow on huge inputs.
+        if ((long)raw.Length / 4 * 3 > maxBytes)
+        {
+            error = $"input '{name}' size exceeds configured MaxArtifactBytes={maxBytes}";
+            return false;
+        }
+
+        try
+        {
+            bytes = Convert.FromBase64String(raw);
+        }
+        catch (FormatException)
+        {
+            error = $"input '{name}' is not valid base64";
+            return false;
+        }
+
+        if (bytes.Length == 0)
+        {
+            error = $"input '{name}' decoded to zero bytes";
+            bytes = [];
+            return false;
+        }
+
+        // Belt-and-suspenders exact check: the upper-bound pre-check above can
+        // admit a payload slightly over the cap when '=' padding shrinks the
+        // real decoded length below the conservative bound. Cheap now that the
+        // input is bounded.
         if (bytes.Length > maxBytes)
         {
             error = $"input '{name}' size {bytes.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}";

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalJobInputReaderTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalJobInputReaderTests.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Unit coverage for <see cref="GdalJobInputReader"/>'s base64 decode path,
+/// pinning that the <c>MaxArtifactBytes</c> ceiling is enforced BEFORE the
+/// payload is materialized so an oversized input cannot drive a large
+/// decode-time allocation before rejection.
+/// </summary>
+public sealed class GdalJobInputReaderTests
+{
+    private static Dictionary<string, string> Param(string name, string value)
+        => new(StringComparer.Ordinal)
+        {
+            [GdalWorkerParameterKeys.StepInputPrefix + name] = value,
+        };
+
+    [UnitTest]
+    public void TryGetBase64Input_OversizedPayload_RejectedByPreDecodeUpperBound()
+    {
+        // Encoded length whose conservative decoded upper bound ((len / 4) * 3)
+        // exceeds the tiny cap, proving the PRE-DECODE guard fires on the
+        // encoded length before Convert.FromBase64String is ever called: a
+        // 48-byte payload encodes to 64 base64 chars, whose upper bound
+        // (64 / 4) * 3 == 48 bytes exceeds the 16-byte cap and is rejected.
+        const long maxBytes = 16;
+        var raw = Convert.ToBase64String(Encoding.UTF8.GetBytes(new string('x', 48)));
+
+        var ok = GdalJobInputReader.TryGetBase64Input(
+            Param("source", raw),
+            "source",
+            maxBytes,
+            out var bytes,
+            out var error);
+
+        ok.Should().BeFalse();
+        bytes.Should().BeEmpty();
+        error.Should().Contain("MaxArtifactBytes=16");
+        error.Should().Contain("source");
+    }
+
+    [UnitTest]
+    public void TryGetBase64Input_InBoundsPayload_DecodesSuccessfully()
+    {
+        var payload = Encoding.UTF8.GetBytes("a-modest-in-bounds-raster-payload");
+        var raw = Convert.ToBase64String(payload);
+
+        var ok = GdalJobInputReader.TryGetBase64Input(
+            Param("source", raw),
+            "source",
+            maxBytes: 1024,
+            out var bytes,
+            out var error);
+
+        ok.Should().BeTrue();
+        error.Should().BeEmpty();
+        bytes.Should().Equal(payload);
+    }
+
+    [UnitTest]
+    public void TryGetBase64Input_ExactlyAtCap_DecodesSuccessfully()
+    {
+        // 24 bytes encodes to 32 base64 chars with no padding; upper bound
+        // (32 / 4) * 3 == 24 == cap, so it must pass both the pre-check and
+        // the exact post-decode check.
+        var payload = Encoding.UTF8.GetBytes(new string('z', 24));
+        var raw = Convert.ToBase64String(payload);
+
+        var ok = GdalJobInputReader.TryGetBase64Input(
+            Param("source", raw),
+            "source",
+            maxBytes: 24,
+            out var bytes,
+            out var error);
+
+        ok.Should().BeTrue();
+        error.Should().BeEmpty();
+        bytes.Should().HaveCount(24);
+    }
+
+    [UnitTest]
+    public void TryGetBase64Input_MissingInput_ReportsMissing()
+    {
+        var ok = GdalJobInputReader.TryGetBase64Input(
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            "source",
+            maxBytes: 1024,
+            out var bytes,
+            out var error);
+
+        ok.Should().BeFalse();
+        bytes.Should().BeEmpty();
+        error.Should().Contain("missing required input 'source'");
+    }
+
+    [UnitTest]
+    public void TryGetBase64Input_InvalidBase64_ReportsFormatError()
+    {
+        var ok = GdalJobInputReader.TryGetBase64Input(
+            Param("source", "not valid base64!!!"),
+            "source",
+            maxBytes: 1024,
+            out var bytes,
+            out var error);
+
+        ok.Should().BeFalse();
+        bytes.Should().BeEmpty();
+        error.Should().Contain("not valid base64");
+    }
+
+    [UnitTest]
+    public void TryGetBase64Input_EmptyDecode_ReportsZeroBytes()
+    {
+        var ok = GdalJobInputReader.TryGetBase64Input(
+            Param("source", ""),
+            "source",
+            maxBytes: 1024,
+            out var bytes,
+            out var error);
+
+        ok.Should().BeFalse();
+        bytes.Should().BeEmpty();
+        error.Should().Contain("zero bytes");
+    }
+}


### PR DESCRIPTION
Closes #2009

## Summary

The GDAL worker's `TryGetBase64Input(maxBytes)` overload fully materialized the decoded byte array with `Convert.FromBase64String` *before* comparing its length against `MaxArtifactBytes`. An oversized input therefore allocated roughly 0.75x its base64 length before being rejected, so the documented `MaxArtifactBytes` ceiling did not actually bound decode-time memory — it was bounded only by inbound parameter size.

This adds a pre-decode guard that rejects the input based on its conservative decoded upper bound before any decode allocation occurs, while keeping the exact post-decode check as a backstop.

## Changes Made

- `GdalJobInputReader.TryGetBase64Input(maxBytes)` now estimates the decoded size from the encoded length (`(raw.Length / 4) * 3`) and rejects oversized inputs before calling `Convert.FromBase64String`. Whitespace and `=` padding only shrink the real decoded size, so the bound stays conservative.
- Retained the exact post-decode `bytes.Length > maxBytes` check as a belt-and-suspenders backstop for inputs admitted by the upper-bound estimate.
- Added `GdalJobInputReaderTests` covering: pre-decode rejection of oversized payloads, in-bounds decode, exactly-at-cap decode, missing input, invalid base64, and zero-byte decode.

## Breaking Changes

None.

## Gate Impact

- [x] No gate impact (bug fix; no API/conformance surface change)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Built `tests/dotnet/Honua.Worker.Gdal.Tests` (Release, `TreatWarningsAsErrors=true`) and ran the `GdalJobInputReader` filter: 6/6 passing. `dotnet format --verify-no-changes` clean on the changed files.
