### PR TITLE
fix(geocoding): align batch results, scope failover budget, stop mutating injected HttpClient

### DIFF
--- a/src/Honua.Geocoding/Features/Geocoding/Abstractions/BaseGeocodeProvider.cs
+++ b/src/Honua.Geocoding/Features/Geocoding/Abstractions/BaseGeocodeProvider.cs
@@ -111,20 +111,21 @@ internal abstract class BaseGeocodeProvider : IGeocodeProvider
     /// </summary>
     /// <remarks>
     /// The default implementation fans the batch out to <see cref="ForwardGeocodeAsync"/>,
-    /// returning exactly one candidate slot for every input address in request order. Inputs
-    /// that are blank or that the forward geocoder cannot match still occupy a slot, emitted as
-    /// an explicit "no match" candidate (see <see cref="GeocodeCandidate.CreateNoMatch"/>), so
-    /// the returned list stays 1:1 with <see cref="BatchGeocodeRequest.Queries"/> and positional
-    /// alignment is preserved end-to-end. Each emitted candidate also carries a stable
-    /// <see cref="GeocodeCandidate.ResultIdAttribute"/> entry equal to its zero-based input index,
-    /// matching the Esri <c>geocodeAddresses</c> contract where every location reports a
-    /// <c>ResultID</c> that correlates it back to the submitted record. Providers with a native
-    /// batch endpoint should override this for efficiency, but must preserve the same 1:1 ordering
-    /// and <c>ResultID</c> guarantees.
+    /// requesting up to <see cref="BatchGeocodeRequest.MaxResultsPerQuery"/> candidates per input
+    /// address and emitting every returned candidate in request order. An input that the forward
+    /// geocoder cannot match (or that is blank) still occupies exactly one explicit "no match"
+    /// candidate (see <see cref="GeocodeCandidate.CreateNoMatch"/>), so the returned list never
+    /// drops below one slot per input and ordering is preserved end-to-end. Every emitted candidate
+    /// carries a stable <see cref="GeocodeCandidate.ResultIdAttribute"/> entry equal to its
+    /// zero-based input index, matching the Esri <c>geocodeAddresses</c> contract where every
+    /// location reports a <c>ResultID</c> that correlates it back to the submitted record; when
+    /// <see cref="BatchGeocodeRequest.MaxResultsPerQuery"/> exceeds one, multiple candidates may
+    /// share the same <c>ResultID</c>. Providers with a native batch endpoint should override this
+    /// for efficiency, but must preserve the same ordering and <c>ResultID</c> guarantees.
     /// </remarks>
     /// <param name="request">Batch geocoding request</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>List of geocoding candidates, one per input address in request order</returns>
+    /// <returns>List of geocoding candidates in request order, at least one slot per input address</returns>
     protected virtual async Task<IReadOnlyList<GeocodeCandidate>> BatchGeocodeCoreAsync(
         BatchGeocodeRequest request,
         CancellationToken cancellationToken = default)
@@ -145,6 +146,11 @@ internal abstract class BaseGeocodeProvider : IGeocodeProvider
                 continue;
             }
 
+            // Request up to MaxResultsPerQuery candidates for this input and stamp every emitted
+            // candidate with the input's zero-based index (ResultID) so callers can correlate each
+            // result back to its submitted record even when an input yields several candidates. An
+            // input that yields zero candidates still occupies exactly one explicit "no match" slot,
+            // so the result list never drops below one entry per input and stays in request order.
             var forwardRequest = new ForwardGeocodeRequest(
                 Query: query,
                 MaxResults: Math.Max(1, request.MaxResultsPerQuery),
@@ -152,9 +158,16 @@ internal abstract class BaseGeocodeProvider : IGeocodeProvider
                 CountryCodes: request.CountryCodes);
 
             var candidates = await ForwardGeocodeAsync(forwardRequest, cancellationToken).ConfigureAwait(false);
-            results.Add(candidates.Count > 0
-                ? candidates[0].WithResultId(index)
-                : GeocodeCandidate.CreateNoMatch(index, request.SpatialReferenceWkid));
+            if (candidates.Count == 0)
+            {
+                results.Add(GeocodeCandidate.CreateNoMatch(index, request.SpatialReferenceWkid));
+                continue;
+            }
+
+            foreach (var candidate in candidates)
+            {
+                results.Add(candidate.WithResultId(index));
+            }
         }
 
         return results;

--- a/src/Honua.Geocoding/Features/Geocoding/Domain/GeocodeModels.cs
+++ b/src/Honua.Geocoding/Features/Geocoding/Domain/GeocodeModels.cs
@@ -84,8 +84,16 @@ public sealed record BatchGeocodeRequest(
     string? CountryCodes = null)
 {
     /// <summary>
-    /// Maximum number of results per query
+    /// Maximum number of candidate results requested per query.
     /// </summary>
+    /// <remarks>
+    /// The default batch path requests up to this many candidates per input record and returns
+    /// them in request order, stamping each candidate with the originating input's
+    /// <see cref="GeocodeCandidate.ResultIdAttribute"/> (matching the Esri <c>geocodeAddresses</c>
+    /// contract where every location reports a <c>ResultID</c>). When this value exceeds one,
+    /// several candidates may share the same <c>ResultID</c>. An input that yields no candidates
+    /// still occupies exactly one explicit "no match" slot, so alignment is always preserved.
+    /// </remarks>
     public int MaxResultsPerQuery { get; init; } = 1;
 }
 

--- a/src/Honua.Geocoding/Features/Geocoding/Providers/AzureMapsGeocodeProvider.cs
+++ b/src/Honua.Geocoding/Features/Geocoding/Providers/AzureMapsGeocodeProvider.cs
@@ -45,15 +45,10 @@ internal sealed class AzureMapsGeocodeProvider : BaseGeocodeProvider
             };
         }
 
-        // Configure HTTP client
-        _httpClient.Timeout = TimeSpan.FromSeconds(configuration.TimeoutSeconds);
-
-        // Send the subscription key as a request header so it is not emitted in the
-        // URL (and therefore not captured by default HttpClient request-logging or
-        // outbound proxy access logs).  Azure Maps accepts `subscription-key` as
-        // either a query-string parameter or an HTTP header; the header form is
-        // preferred for secrets.
-        _httpClient.DefaultRequestHeaders.Add("subscription-key", configuration.SubscriptionKey);
+        // The injected HttpClient may be a shared/pooled typed client. Mutating its Timeout or
+        // DefaultRequestHeaders here would throw once a request has started and would bleed the
+        // subscription key across scopes, so the subscription-key header and request timeout are
+        // applied on each outbound request instead (see SendGetAsync).
     }
 
     /// <inheritdoc />
@@ -102,7 +97,7 @@ internal sealed class AzureMapsGeocodeProvider : BaseGeocodeProvider
         try
         {
             var url = BuildSearchUrl(request);
-            using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            using var response = await SendGetAsync(url, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -164,7 +159,7 @@ internal sealed class AzureMapsGeocodeProvider : BaseGeocodeProvider
         try
         {
             var url = BuildReverseUrl(request);
-            using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            using var response = await SendGetAsync(url, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -223,7 +218,7 @@ internal sealed class AzureMapsGeocodeProvider : BaseGeocodeProvider
         try
         {
             var url = BuildSuggestUrl(request);
-            using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            using var response = await SendGetAsync(url, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -278,7 +273,7 @@ internal sealed class AzureMapsGeocodeProvider : BaseGeocodeProvider
                       "&query=1%20Microsoft%20Way%2C%20Redmond%2C%20WA" +
                       "&limit=1";
 
-            using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            using var response = await SendGetAsync(url, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -302,6 +297,25 @@ internal sealed class AzureMapsGeocodeProvider : BaseGeocodeProvider
                 ErrorCode = GeocodeErrorCodes.NetworkTimeout
             };
         }
+    }
+
+    /// <summary>
+    /// Issues a GET against the injected (potentially shared) HttpClient, applying the Azure Maps
+    /// subscription-key header and request timeout per request rather than mutating the shared
+    /// client. The key is sent as a header so it is not captured by URL request-logging. The
+    /// caller owns disposal of the returned response.
+    /// </summary>
+    private async Task<HttpResponseMessage> SendGetAsync(string url, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("subscription-key", _configuration.SubscriptionKey);
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(_configuration.TimeoutSeconds));
+
+        return await _httpClient
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeoutCts.Token)
+            .ConfigureAwait(false);
     }
 
     private async Task EnsureSafeBaseUrlAsync(CancellationToken cancellationToken)

--- a/src/Honua.Geocoding/Features/Geocoding/Providers/NominatimGeocodeProvider.cs
+++ b/src/Honua.Geocoding/Features/Geocoding/Providers/NominatimGeocodeProvider.cs
@@ -36,15 +36,10 @@ internal sealed class NominatimGeocodeProvider : BaseGeocodeProvider
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
 
-        // Configure HTTP client
-        _httpClient.Timeout = TimeSpan.FromSeconds(configuration.TimeoutSeconds);
-        _httpClient.DefaultRequestHeaders.UserAgent.Clear();
-        _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(configuration.UserAgent);
-
-        if (!string.IsNullOrWhiteSpace(configuration.Email))
-        {
-            _httpClient.DefaultRequestHeaders.Add("X-Contact-Email", configuration.Email);
-        }
+        // The injected HttpClient may be a shared/pooled typed client. Mutating its Timeout or
+        // DefaultRequestHeaders here would throw once a request has started and would bleed
+        // configuration across scopes, so per-request User-Agent/contact headers and timeout are
+        // applied on each outbound request instead (see SendAsync).
     }
 
     /// <inheritdoc />
@@ -96,7 +91,7 @@ internal sealed class NominatimGeocodeProvider : BaseGeocodeProvider
         try
         {
             var url = BuildSearchUrl(request);
-            using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            using var response = await SendGetAsync(url, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -154,7 +149,7 @@ internal sealed class NominatimGeocodeProvider : BaseGeocodeProvider
         try
         {
             var url = BuildReverseUrl(request);
-            using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            using var response = await SendGetAsync(url, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -229,7 +224,7 @@ internal sealed class NominatimGeocodeProvider : BaseGeocodeProvider
         try
         {
             var url = $"{_configuration.BaseUrl.TrimEnd('/')}/status.php?format=json";
-            using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            using var response = await SendGetAsync(url, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -248,6 +243,30 @@ internal sealed class NominatimGeocodeProvider : BaseGeocodeProvider
                 ErrorCode = GeocodeErrorCodes.NetworkTimeout
             };
         }
+    }
+
+    /// <summary>
+    /// Issues a GET against the injected (potentially shared) HttpClient, applying the configured
+    /// User-Agent, optional contact email header, and request timeout per request rather than
+    /// mutating the shared client. The caller owns disposal of the returned response.
+    /// </summary>
+    private async Task<HttpResponseMessage> SendGetAsync(string url, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.UserAgent.Clear();
+        request.Headers.UserAgent.ParseAdd(_configuration.UserAgent);
+
+        if (!string.IsNullOrWhiteSpace(_configuration.Email))
+        {
+            request.Headers.Add("X-Contact-Email", _configuration.Email);
+        }
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(_configuration.TimeoutSeconds));
+
+        return await _httpClient
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeoutCts.Token)
+            .ConfigureAwait(false);
     }
 
     private async Task EnsureSafeBaseUrlAsync(CancellationToken cancellationToken)

--- a/src/Honua.Geocoding/Features/Geocoding/Services/GeocodeCoordinatorService.cs
+++ b/src/Honua.Geocoding/Features/Geocoding/Services/GeocodeCoordinatorService.cs
@@ -45,17 +45,27 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
 
         foreach (var provider in providers)
         {
+            // A provider that cannot perform the operation is skipped before it counts against
+            // the failover budget, so capability-incompatible providers never exhaust the
+            // MaxFailoverAttempts allowance for a working provider later in the list.
+            if (!provider.Capabilities.SupportsForwardGeocode)
+            {
+                GeocodeCoordinatorLog.CapabilityNotSupported(_logger, provider.Name, "forward geocoding");
+                continue;
+            }
+
+            // Stop once the configured number of real attempts is reached. Capability skips above
+            // are free and never consume this budget.
+            if (!HasFailoverBudget(attemptedProviders.Count))
+            {
+                break;
+            }
+
             attemptedProviders.Add(provider.Name);
             var stopwatch = Stopwatch.StartNew();
 
             try
             {
-                if (!provider.Capabilities.SupportsForwardGeocode)
-                {
-                    GeocodeCoordinatorLog.CapabilityNotSupported(_logger, provider.Name, "forward geocoding");
-                    continue;
-                }
-
                 var results = await provider.ForwardGeocodeAsync(request, cancellationToken).ConfigureAwait(false);
                 stopwatch.Stop();
 
@@ -95,7 +105,7 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
             }
         }
 
-        var errorMessage = BuildFailureMessage(lastException, "forward geocoding");
+        var errorMessage = BuildFailureMessage(lastException, "forward geocoding", attemptedProviders);
         var failedProviderName = attemptedProviders.LastOrDefault() ?? "unknown";
 
         GeocodeCoordinatorLog.AllAttemptsFailed(
@@ -129,17 +139,26 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
 
         foreach (var provider in providers)
         {
+            // Capability-incompatible providers are skipped before counting against the failover
+            // budget so they cannot exhaust MaxFailoverAttempts ahead of a capable provider.
+            if (!provider.Capabilities.SupportsReverseGeocode)
+            {
+                GeocodeCoordinatorLog.CapabilityNotSupported(_logger, provider.Name, "reverse geocoding");
+                continue;
+            }
+
+            // Stop once the configured number of real attempts is reached. Capability skips above
+            // are free and never consume this budget.
+            if (!HasFailoverBudget(attemptedProviders.Count))
+            {
+                break;
+            }
+
             attemptedProviders.Add(provider.Name);
             var stopwatch = Stopwatch.StartNew();
 
             try
             {
-                if (!provider.Capabilities.SupportsReverseGeocode)
-                {
-                    GeocodeCoordinatorLog.CapabilityNotSupported(_logger, provider.Name, "reverse geocoding");
-                    continue;
-                }
-
                 var result = await provider.ReverseGeocodeAsync(request, cancellationToken).ConfigureAwait(false);
                 stopwatch.Stop();
 
@@ -179,7 +198,7 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
             }
         }
 
-        var errorMessage = BuildFailureMessage(lastException, "reverse geocoding");
+        var errorMessage = BuildFailureMessage(lastException, "reverse geocoding", attemptedProviders);
         var failedProviderName = attemptedProviders.LastOrDefault() ?? "unknown";
 
         GeocodeCoordinatorLog.AllAttemptsFailed(
@@ -209,17 +228,26 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
 
         foreach (var provider in providers)
         {
+            // Capability-incompatible providers are skipped before counting against the failover
+            // budget so they cannot exhaust MaxFailoverAttempts ahead of a capable provider.
+            if (!provider.Capabilities.SupportsSuggest)
+            {
+                GeocodeCoordinatorLog.CapabilityNotSupported(_logger, provider.Name, "suggest");
+                continue;
+            }
+
+            // Stop once the configured number of real attempts is reached. Capability skips above
+            // are free and never consume this budget.
+            if (!HasFailoverBudget(attemptedProviders.Count))
+            {
+                break;
+            }
+
             attemptedProviders.Add(provider.Name);
             var stopwatch = Stopwatch.StartNew();
 
             try
             {
-                if (!provider.Capabilities.SupportsSuggest)
-                {
-                    GeocodeCoordinatorLog.CapabilityNotSupported(_logger, provider.Name, "suggest");
-                    continue;
-                }
-
                 var results = await provider.SuggestAsync(request, cancellationToken).ConfigureAwait(false);
                 stopwatch.Stop();
 
@@ -256,7 +284,7 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
             }
         }
 
-        var errorMessage = BuildFailureMessage(lastException, "suggestions");
+        var errorMessage = BuildFailureMessage(lastException, "suggestions", attemptedProviders);
         var failedProviderName = attemptedProviders.LastOrDefault() ?? "unknown";
 
         GeocodeCoordinatorLog.AllAttemptsFailed(
@@ -282,17 +310,26 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
 
         foreach (var provider in providers)
         {
+            // Capability-incompatible providers are skipped before counting against the failover
+            // budget so they cannot exhaust MaxFailoverAttempts ahead of a capable provider.
+            if (!provider.Capabilities.SupportsBatch)
+            {
+                GeocodeCoordinatorLog.CapabilityNotSupported(_logger, provider.Name, "batch geocoding");
+                continue;
+            }
+
+            // Stop once the configured number of real attempts is reached. Capability skips above
+            // are free and never consume this budget.
+            if (!HasFailoverBudget(attemptedProviders.Count))
+            {
+                break;
+            }
+
             attemptedProviders.Add(provider.Name);
             var stopwatch = Stopwatch.StartNew();
 
             try
             {
-                if (!provider.Capabilities.SupportsBatch)
-                {
-                    GeocodeCoordinatorLog.CapabilityNotSupported(_logger, provider.Name, "batch geocoding");
-                    continue;
-                }
-
                 var results = await provider.BatchGeocodeAsync(request, cancellationToken).ConfigureAwait(false);
                 stopwatch.Stop();
 
@@ -329,7 +366,7 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
             }
         }
 
-        var errorMessage = BuildFailureMessage(lastException, "batch geocoding");
+        var errorMessage = BuildFailureMessage(lastException, "batch geocoding", attemptedProviders);
         var failedProviderName = attemptedProviders.LastOrDefault() ?? "unknown";
 
         GeocodeCoordinatorLog.AllAttemptsFailed(
@@ -342,18 +379,31 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
             errorMessage, failedProviderName, attemptedProviders: attemptedProviders);
     }
 
+    // Returns true while there is remaining failover budget to initiate another real attempt.
+    // Capability-skipped providers do not count toward attemptedProviders, so they never consume
+    // this budget; only providers that actually attempt the operation do.
+    private bool HasFailoverBudget(int attemptedCount)
+    {
+        if (attemptedCount == 0)
+        {
+            return true;
+        }
+
+        return _configuration.EnableFailover && attemptedCount < Math.Max(1, _configuration.MaxFailoverAttempts);
+    }
+
     private List<IGeocodeProvider> GetProvidersToTry(string? preferredProviderName)
     {
         var providers = new List<IGeocodeProvider>();
 
-        // The total number of providers attempted is capped at MaxFailoverAttempts. The preferred
-        // provider is always tried first; the default provider and any additional failover providers
-        // are only added while there is remaining budget, so the overall attempt count never exceeds
-        // the configured cap (MaxFailoverAttempts is validated to be greater than zero, so the
-        // preferred provider always fits).
-        var maxProviders = Math.Max(1, _configuration.MaxFailoverAttempts);
+        // This returns the full ordered candidate set; it is intentionally NOT truncated to
+        // MaxFailoverAttempts. The MaxFailoverAttempts cap bounds the number of providers that
+        // actually *attempt* the operation, which the calling loop enforces (see
+        // HasFailoverBudget). Truncating here would let providers that the loop skips because
+        // they lack the requested capability crowd a capable provider out of the candidate list
+        // entirely, defeating failover.
 
-        // Add preferred provider first if specified and available
+        // Add preferred provider first if specified and available.
         if (!string.IsNullOrWhiteSpace(preferredProviderName))
         {
             var preferredProvider = _providerRegistry.GetProvider(preferredProviderName);
@@ -367,11 +417,8 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
             }
         }
 
-        // Add default provider if not already added and there is remaining budget. This addition
-        // counts against MaxFailoverAttempts so a distinct preferred + default pair cannot push the
-        // total beyond the cap.
-        if (providers.Count < maxProviders &&
-            (providers.Count == 0 || !providers.Any(p => p.Name.Equals(_configuration.DefaultProvider, StringComparison.OrdinalIgnoreCase))))
+        // Add default provider next if not already added.
+        if (providers.Count == 0 || !providers.Any(p => p.Name.Equals(_configuration.DefaultProvider, StringComparison.OrdinalIgnoreCase)))
         {
             var defaultProvider = _providerRegistry.GetProvider(_configuration.DefaultProvider);
             if (defaultProvider != null)
@@ -380,13 +427,12 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
             }
         }
 
-        // Add other providers for failover if enabled
-        if (_configuration.EnableFailover && providers.Count < maxProviders)
+        // Add the remaining registered providers as failover candidates when enabled.
+        if (_configuration.EnableFailover)
         {
             var allProviders = _providerRegistry.GetAllProviders();
             var additionalProviders = allProviders
-                .Where(p => !providers.Any(existing => existing.Name.Equals(p.Name, StringComparison.OrdinalIgnoreCase)))
-                .Take(maxProviders - providers.Count);
+                .Where(p => !providers.Any(existing => existing.Name.Equals(p.Name, StringComparison.OrdinalIgnoreCase)));
 
             providers.AddRange(additionalProviders);
         }
@@ -394,11 +440,18 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
         return providers;
     }
 
-    private static string BuildFailureMessage(Exception? exception, string operation)
+    private static string BuildFailureMessage(
+        Exception? exception,
+        string operation,
+        List<string> attemptedProviders)
     {
         if (exception is null)
         {
-            return $"No providers available for {operation}.";
+            // No provider actually attempted the operation. Either none were registered/available,
+            // or every candidate provider was skipped because it does not support this capability.
+            return attemptedProviders.Count == 0
+                ? $"No provider supports {operation}."
+                : $"No providers available for {operation}.";
         }
 
         return exception switch

--- a/tests/dotnet/Honua.Core.Tests/Features/Geocoding/BaseGeocodeProviderBatchTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Geocoding/BaseGeocodeProviderBatchTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Geocoding.Features.Geocoding.Abstractions;
+using Honua.Geocoding.Features.Geocoding.Domain;
+
+namespace Honua.Core.Tests.Features.Geocoding;
+
+public sealed class BaseGeocodeProviderBatchTests
+{
+    [Fact]
+    public async Task BatchGeocodeAsync_ReturnsOneSlotPerInput_PreservingPositionalAlignment()
+    {
+        var provider = new RecordingBatchProvider();
+
+        var results = await provider.BatchGeocodeAsync(
+            new BatchGeocodeRequest(["10 Downing St", "   ", "350 Fifth Ave"], 4326),
+            CancellationToken.None);
+
+        Assert.Equal(3, results.Count);
+
+        // Index 0 matched; index 1 is blank (no match); index 2 matched.
+        Assert.True(results[0].IsMatch);
+        Assert.Equal("0", results[0].Attributes[GeocodeCandidate.ResultIdAttribute]);
+
+        Assert.False(results[1].IsMatch);
+        Assert.Equal("1", results[1].Attributes[GeocodeCandidate.ResultIdAttribute]);
+
+        Assert.True(results[2].IsMatch);
+        Assert.Equal("2", results[2].Attributes[GeocodeCandidate.ResultIdAttribute]);
+
+        // Blank inputs do not call the forward geocoder.
+        Assert.Equal(2, provider.ForwardCalls.Count);
+    }
+
+    [Fact]
+    public async Task BatchGeocodeAsync_FanOutHonorsMaxResultsPerQuery()
+    {
+        var provider = new RecordingBatchProvider();
+
+        // MaxResultsPerQuery must flow through to each forward request so it is no longer a silent
+        // no-op (issue #2005).
+        await provider.BatchGeocodeAsync(
+            new BatchGeocodeRequest(["10 Downing St", "350 Fifth Ave"], 4326)
+            {
+                MaxResultsPerQuery = 5
+            },
+            CancellationToken.None);
+
+        Assert.Equal(2, provider.ForwardCalls.Count);
+        Assert.All(provider.ForwardCalls, forward => Assert.Equal(5, forward.MaxResults));
+    }
+
+    [Fact]
+    public async Task BatchGeocodeAsync_EmitsEveryCandidatePerInput_SharingResultId()
+    {
+        // Each input returns two candidates; the batch path must emit both, in order, each stamped
+        // with the originating input index so a multi-candidate input stays correlated (issue #2005).
+        var provider = new RecordingBatchProvider { CandidatesPerInput = 2 };
+
+        var results = await provider.BatchGeocodeAsync(
+            new BatchGeocodeRequest(["10 Downing St", "350 Fifth Ave"], 4326)
+            {
+                MaxResultsPerQuery = 2
+            },
+            CancellationToken.None);
+
+        Assert.Equal(4, results.Count);
+        Assert.Equal("0", results[0].Attributes[GeocodeCandidate.ResultIdAttribute]);
+        Assert.Equal("0", results[1].Attributes[GeocodeCandidate.ResultIdAttribute]);
+        Assert.Equal("1", results[2].Attributes[GeocodeCandidate.ResultIdAttribute]);
+        Assert.Equal("1", results[3].Attributes[GeocodeCandidate.ResultIdAttribute]);
+        Assert.All(results, candidate => Assert.True(candidate.IsMatch));
+    }
+
+    private sealed class RecordingBatchProvider : BaseGeocodeProvider
+    {
+        public List<ForwardGeocodeRequest> ForwardCalls { get; } = [];
+
+        public int CandidatesPerInput { get; init; } = 1;
+
+        public override string Name => "recording";
+
+        public override GeocodeProviderCapabilities Capabilities => new(
+            SupportsForwardGeocode: true,
+            SupportsBatch: true);
+
+        public override Task<IReadOnlyList<GeocodeCandidate>> ForwardGeocodeAsync(
+            ForwardGeocodeRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            ForwardCalls.Add(request);
+
+            var candidates = new List<GeocodeCandidate>(CandidatesPerInput);
+            for (var i = 0; i < CandidatesPerInput; i++)
+            {
+                candidates.Add(new GeocodeCandidate(request.Query, 1.0, 2.0, 90.0 - i, new Dictionary<string, string?>()));
+            }
+
+            return Task.FromResult<IReadOnlyList<GeocodeCandidate>>(candidates);
+        }
+
+        public override Task<ReverseGeocodeMatch?> ReverseGeocodeAsync(
+            ReverseGeocodeRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<ReverseGeocodeMatch?>(null);
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Geocoding/GeocodeCoordinatorFailoverTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Geocoding/GeocodeCoordinatorFailoverTests.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Geocoding.Features.Geocoding.Abstractions;
+using Honua.Geocoding.Features.Geocoding.Domain;
+using Honua.Geocoding.Features.Geocoding.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Core.Tests.Features.Geocoding;
+
+public sealed class GeocodeCoordinatorFailoverTests
+{
+    [Fact]
+    public async Task ForwardGeocodeAsync_CapabilityIncompatibleFirstProvider_DoesNotConsumeFailoverBudget()
+    {
+        // The first (default) provider cannot forward-geocode; a later provider can. The
+        // capability skip must not consume the MaxFailoverAttempts budget, so the capable
+        // provider is still attempted and succeeds.
+        var incapable = new FakeGeocodeProvider(
+            "incapable",
+            new GeocodeProviderCapabilities(SupportsForwardGeocode: false));
+
+        var capable = new FakeGeocodeProvider(
+            "capable",
+            new GeocodeProviderCapabilities(SupportsForwardGeocode: true))
+        {
+            ForwardResult =
+            [
+                new GeocodeCandidate("1 Test St", 1.0, 2.0, 99.0, new Dictionary<string, string?>())
+            ]
+        };
+
+        var coordinator = CreateCoordinator(
+            providers: [incapable, capable],
+            defaultProvider: "incapable",
+            maxFailoverAttempts: 1);
+
+        var result = await coordinator.ForwardGeocodeAsync(
+            new ForwardGeocodeRequest("1 Test St", 1, 4326, null),
+            providerName: null,
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("capable", result.ProviderName);
+        Assert.Single(result.Data);
+        Assert.Equal(1, capable.ForwardCallCount);
+        Assert.Equal(0, incapable.ForwardCallCount);
+    }
+
+    [Fact]
+    public async Task ForwardGeocodeAsync_AllProvidersLackCapability_FailsWithNoProviderSupportsMessage()
+    {
+        var incapableA = new FakeGeocodeProvider(
+            "a",
+            new GeocodeProviderCapabilities(SupportsForwardGeocode: false));
+        var incapableB = new FakeGeocodeProvider(
+            "b",
+            new GeocodeProviderCapabilities(SupportsForwardGeocode: false));
+
+        var coordinator = CreateCoordinator(
+            providers: [incapableA, incapableB],
+            defaultProvider: "a",
+            maxFailoverAttempts: 3);
+
+        var result = await coordinator.ForwardGeocodeAsync(
+            new ForwardGeocodeRequest("1 Test St", 1, 4326, null),
+            providerName: null,
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.NotNull(result.ErrorMessage);
+        Assert.Contains("No provider supports", result.ErrorMessage);
+        Assert.Empty(result.AttemptedProviders ?? []);
+    }
+
+    [Fact]
+    public async Task ReverseGeocodeAsync_CapabilityIncompatibleFirstProvider_FailsOverToCapableProvider()
+    {
+        var incapable = new FakeGeocodeProvider(
+            "incapable",
+            new GeocodeProviderCapabilities(SupportsReverseGeocode: false));
+
+        var capable = new FakeGeocodeProvider(
+            "capable",
+            new GeocodeProviderCapabilities(SupportsReverseGeocode: true))
+        {
+            ReverseResult = new ReverseGeocodeMatch("1 Test St", 1.0, 2.0, new Dictionary<string, string?>())
+        };
+
+        var coordinator = CreateCoordinator(
+            providers: [incapable, capable],
+            defaultProvider: "incapable",
+            maxFailoverAttempts: 1);
+
+        var result = await coordinator.ReverseGeocodeAsync(
+            new ReverseGeocodeRequest(1.0, 2.0, 4326),
+            providerName: null,
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("capable", result.ProviderName);
+        Assert.NotNull(result.Data);
+        Assert.Equal(1, capable.ReverseCallCount);
+    }
+
+    [Fact]
+    public async Task ForwardGeocodeAsync_FailoverBudgetCapsRealAttempts()
+    {
+        // Two erroring providers with a budget of one: only the first should actually attempt.
+        var first = new FakeGeocodeProvider(
+            "first",
+            new GeocodeProviderCapabilities(SupportsForwardGeocode: true))
+        {
+            ForwardException = new GeocodeProviderException("first failed")
+        };
+        var second = new FakeGeocodeProvider(
+            "second",
+            new GeocodeProviderCapabilities(SupportsForwardGeocode: true))
+        {
+            ForwardException = new GeocodeProviderException("second failed")
+        };
+
+        var coordinator = CreateCoordinator(
+            providers: [first, second],
+            defaultProvider: "first",
+            maxFailoverAttempts: 1);
+
+        var result = await coordinator.ForwardGeocodeAsync(
+            new ForwardGeocodeRequest("1 Test St", 1, 4326, null),
+            providerName: null,
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(1, first.ForwardCallCount);
+        Assert.Equal(0, second.ForwardCallCount);
+    }
+
+    private static GeocodeCoordinatorService CreateCoordinator(
+        IReadOnlyList<IGeocodeProvider> providers,
+        string defaultProvider,
+        int maxFailoverAttempts)
+    {
+        var configuration = new GeocodingConfiguration
+        {
+            DefaultProvider = defaultProvider,
+            EnableFailover = true,
+            MaxFailoverAttempts = maxFailoverAttempts
+        };
+
+        var registry = new GeocodeProviderRegistry(
+            new EmptyServiceProvider(),
+            providers,
+            Options.Create(configuration));
+
+        return new GeocodeCoordinatorService(
+            registry,
+            Options.Create(configuration),
+            NullLogger<GeocodeCoordinatorService>.Instance);
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class FakeGeocodeProvider : IGeocodeProvider
+    {
+        public FakeGeocodeProvider(string name, GeocodeProviderCapabilities capabilities)
+        {
+            Name = name;
+            Capabilities = capabilities;
+        }
+
+        public string Name { get; }
+
+        public GeocodeProviderCapabilities Capabilities { get; }
+
+        public IReadOnlyList<GeocodeCandidate> ForwardResult { get; init; } = [];
+
+        public ReverseGeocodeMatch? ReverseResult { get; init; }
+
+        public Exception? ForwardException { get; init; }
+
+        public int ForwardCallCount { get; private set; }
+
+        public int ReverseCallCount { get; private set; }
+
+        public Task<IReadOnlyList<GeocodeCandidate>> ForwardGeocodeAsync(
+            ForwardGeocodeRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            ForwardCallCount++;
+
+            if (ForwardException is not null)
+            {
+                throw ForwardException;
+            }
+
+            return Task.FromResult(ForwardResult);
+        }
+
+        public Task<ReverseGeocodeMatch?> ReverseGeocodeAsync(
+            ReverseGeocodeRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            ReverseCallCount++;
+            return Task.FromResult(ReverseResult);
+        }
+
+        public Task<IReadOnlyList<GeocodeSuggestion>> SuggestAsync(
+            SuggestGeocodeRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<GeocodeSuggestion>>([]);
+
+        public Task<IReadOnlyList<GeocodeCandidate>> BatchGeocodeAsync(
+            BatchGeocodeRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<GeocodeCandidate>>([]);
+
+        public Task<GeocodeProviderHealth> CheckHealthAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new GeocodeProviderHealth(Name, true, LastChecked: DateTime.UtcNow));
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Geocoding/Providers/NominatimGeocodeProviderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Geocoding/Providers/NominatimGeocodeProviderTests.cs
@@ -226,6 +226,82 @@ public sealed class NominatimGeocodeProviderTests
         Assert.All(results, candidate => Assert.Equal("10 Downing St, London", candidate.Address));
     }
 
+    [Fact]
+    public void Constructor_DoesNotMutateInjectedHttpClient_AllowsSharingAcrossProviders()
+    {
+        // A shared/pooled typed client whose headers are already set (simulating a prior request)
+        // must not be mutated by the constructor; constructing a second provider over the same
+        // client must not throw (DefaultRequestHeaders becomes read-only once a request starts).
+        using var sharedClient = new HttpClient(new StubHttpMessageHandler())
+        {
+            BaseAddress = new Uri("https://example.com/", UriKind.Absolute)
+        };
+        sharedClient.DefaultRequestHeaders.UserAgent.ParseAdd("Existing/1.0");
+
+        var configuration = new NominatimProviderConfiguration
+        {
+            BaseUrl = "https://example.com",
+            UserAgent = "Honua.Tests/1.0",
+            Email = "ops@example.com"
+        };
+
+        var first = new NominatimGeocodeProvider(configuration, sharedClient);
+        var second = new NominatimGeocodeProvider(configuration, sharedClient);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        // The injected client's headers are untouched by construction.
+        Assert.Equal("Existing/1.0", sharedClient.DefaultRequestHeaders.UserAgent.ToString());
+    }
+
+    [Fact]
+    public async Task ForwardGeocodeAsync_AppliesUserAgentAndContactHeaderPerRequest()
+    {
+        var handler = new HeaderCapturingHandler();
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://example.com/", UriKind.Absolute)
+        };
+
+        var provider = new NominatimGeocodeProvider(
+            new NominatimProviderConfiguration
+            {
+                BaseUrl = "https://example.com",
+                UserAgent = "Honua.Tests/1.0",
+                Email = "ops@example.com"
+            },
+            httpClient);
+
+        await provider.ForwardGeocodeAsync(
+            new ForwardGeocodeRequest("10 Downing St", 5, 4326, null),
+            CancellationToken.None);
+
+        Assert.Equal("Honua.Tests/1.0", handler.CapturedUserAgent);
+        Assert.Equal("ops@example.com", handler.CapturedContactEmail);
+    }
+
+    private sealed class HeaderCapturingHandler : HttpMessageHandler
+    {
+        public string? CapturedUserAgent { get; private set; }
+
+        public string? CapturedContactEmail { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CapturedUserAgent = request.Headers.UserAgent.ToString();
+            CapturedContactEmail = request.Headers.TryGetValues("X-Contact-Email", out var values)
+                ? values.FirstOrDefault()
+                : null;
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]", Encoding.UTF8, "application/json")
+            };
+
+            return Task.FromResult(response);
+        }
+    }
+
     private sealed class StubHttpMessageHandler : HttpMessageHandler
     {
         public int SendCount { get; private set; }


### PR DESCRIPTION
## Related Issue

Closes #2005
Closes #2006
Closes #2007

## Summary

Fixes three defects in the `Honua.Geocoding` provider/coordinator stack: batch results losing per-input alignment and ignoring `MaxResultsPerQuery`, the failover budget being consumed by capability-incompatible providers, and the Nominatim/Azure Maps providers mutating the injected (pooled) `HttpClient` in their constructors.

## Changes Made

- Rewrote `BaseGeocodeProvider.BatchGeocodeCoreAsync` to emit at least one result slot per input in request order, stamp every candidate with its zero-based input index (`ResultID`), and write an explicit "no match" slot (NaN coordinates) for blank or zero-candidate inputs, restoring Esri `geocodeAddresses` `ResultID` alignment.
- Honored `BatchGeocodeRequest.MaxResultsPerQuery` on the forward fan-out (no longer a silent no-op); when it exceeds one, multiple candidates may share the same `ResultID`. Updated the model and method XML docs accordingly.
- Changed `GeocodeCoordinatorService` (forward/reverse/suggest/batch) to skip capability-incompatible providers before they count against the failover budget, so they can no longer exhaust `MaxFailoverAttempts` ahead of a capable provider. `GetProvidersToTry` now returns the full ordered candidate set and the calling loop enforces the cap via a new `HasFailoverBudget` helper.
- Stopped `NominatimGeocodeProvider` and `AzureMapsGeocodeProvider` constructors from mutating the injected `HttpClient`. User-Agent, contact email, subscription-key header, and request timeout are now applied per request on the `HttpRequestMessage`.
- Added unit tests for batch alignment / `MaxResultsPerQuery`, capability-aware failover budgeting, and per-request header application.

## Breaking Changes

None. Public behavior changes are bug fixes; the batch result contract is unchanged for single-result-per-query callers.

## Gate Impact

- [x] No gate impact (internal geocoding behavior fix, no new endpoints or conformance surface)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Built `src/Honua.Geocoding` (Release, `TreatWarningsAsErrors=true`) clean. Ran `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --filter "FullyQualifiedName~Geocoding"`: 46 passed, 0 failed. `dotnet format --verify-no-changes` clean on changed files.
