### PR TITLE
feat(ci): event-driven AI merge-coordinator triage (#2021)

### DIFF
--- a/.github/workflows/auto-rerun-flaky.yml
+++ b/.github/workflows/auto-rerun-flaky.yml
@@ -24,12 +24,21 @@ jobs:
       github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      # Check out the DEFAULT branch's classifier — the single shared source of the
+      # leaf/aggregator + FLAKY/SOLID regex sets (scripts/ci/ci-failure-classifier.js),
+      # consumed by both this workflow and ci-failure-triage.yml (#2021) so they can
+      # never drift. Never the PR's copy — a PR must not rewrite its own flake rules.
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
       - uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.MERGE_TRAIN_TOKEN }}
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
             const run = context.payload.workflow_run;
+            const { classifyFailures } = require('./scripts/ci/ci-failure-classifier.js');
 
             const { data: jobsResp } = await github.rest.actions.listJobsForWorkflowRun({
               owner, repo, run_id: run.id, per_page: 100, filter: 'latest',
@@ -38,48 +47,15 @@ jobs:
               .filter(j => j.conclusion === 'failure')
               .map(j => j.name);
 
-            if (failed.length === 0) {
-              core.info('No failed jobs found (already rerun or transient list) — skipping.');
+            // Shared classifier: excludes aggregator roll-ups (CI Gate / Test Suite
+            // Summary), treats SOLID leaf gates (Build/Format/Analyze/AOT/...) as real,
+            // and only the known-flaky shards as rerun-eligible. Identical intent to
+            // the previous inline logic — now sourced from one module.
+            const { verdict, reason, flakyFailed } = classifyFailures(failed);
+            if (verdict !== 'flake-only') {
+              core.info(`No auto-rerun (${verdict}): ${reason}`);
               return;
             }
 
-            // Aggregator roll-ups, NOT independent signals: these fail whenever ANY
-            // downstream job fails, so they carry no information about real-vs-flake.
-            // They must be excluded before classification — otherwise a pure shard
-            // flake that trips `CI Gate` (which it always does) would look like a
-            // deterministic-gate failure and never get its retry. Classify only the
-            // LEAF jobs.
-            const AGGREGATORS = [/CI Gate/i, /Test Suite Summary/i];
-            const leafFailed = failed.filter(n => !AGGREGATORS.some(r => r.test(n)));
-
-            if (leafFailed.length === 0) {
-              core.info(`Only aggregator roll-ups failed (${failed.join(', ')}); no leaf job to rerun — skipping.`);
-              return;
-            }
-
-            // Deterministic gates — a failure in a LEAF gate is real, never auto-rerun.
-            // (CI Gate / Test Suite Summary are aggregators, handled above — not here.)
-            const SOLID = [
-              /Build & Format/i, /\bFormat\b/i, /Analyze/i, /CodeQL/i,
-              /PR Template/i, /Router/i, /Mergeability/i,
-              /AOT/i, /Package Compatibility/i, /Type Check/i,
-            ];
-            // Known-flaky integration/infra shards — transient, eligible for one retry.
-            const FLAKY = [
-              /Server Tests/i, /OGC API/i, /Postgres Compatibility/i,
-              /Docker Build/i, /Integration Tests/i, /Browser/i, /MCP/i,
-            ];
-
-            const anySolid = leafFailed.some(n => SOLID.some(r => r.test(n)));
-            if (anySolid) {
-              core.info(`Deterministic leaf gate failed (${leafFailed.join(', ')}) — not a flake, no rerun.`);
-              return;
-            }
-            const allFlaky = leafFailed.every(n => FLAKY.some(r => r.test(n)));
-            if (!allFlaky) {
-              core.info(`Leaf failures not all in the known-flaky set (${leafFailed.join(', ')}) — no auto-rerun.`);
-              return;
-            }
-
-            core.info(`Re-running failed flaky jobs once: ${failed.join(', ')}`);
+            core.info(`Re-running failed flaky jobs once: ${flakyFailed.join(', ')}`);
             await github.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: run.id });

--- a/.github/workflows/ci-failure-triage.yml
+++ b/.github/workflows/ci-failure-triage.yml
@@ -1,0 +1,225 @@
+name: CI failure triage
+
+# Event-driven AI merge-coordinator triage (#2021). AUGMENTS the existing
+# webhook coordinator — it does NOT replace it:
+#   * pr-merge-train.yml     merges the oldest CLEAN PR / freshens the oldest BEHIND one.
+#   * auto-rerun-flaky.yml   gives a PR's CI exactly ONE retry when only known-flaky
+#                            shards failed.
+# Both stay AS-IS. This workflow adds the missing piece that made session-side
+# polling necessary: AI triage of GENUINELY-real failures, so a human/Claude loop
+# no longer has to babysit the queue.
+#
+# It fires on CI completion, resolves the PR(s) from the run's head SHA, and runs
+# the SAME deterministic classifier auto-rerun uses (scripts/ci/ci-failure-classifier.js
+# — the single shared source of the leaf/aggregator + FLAKY/SOLID regex sets):
+#   * clean        → nothing to do (the train handles merge/freshen).
+#   * flake-only   → ensure exactly ONE rerun happened (guarded by run_attempt so a
+#                    run is never rerun more than once — no storms). auto-rerun owns
+#                    attempt 1; this is the backstop if auto-rerun missed it.
+#   * real-failure → gather the failing job's log tail, call Bedrock for a triage
+#                    verdict, post it as a PR comment, and label `ci-needs-triage`.
+# AI is used ONLY in the real-failure branch. Everything else is deterministic.
+#
+# Bedrock auth: the standard AWS credential chain via aws-actions/configure-aws-credentials.
+# If no Bedrock creds/role are configured in CI, the AI step DEGRADES GRACEFULLY —
+# it still labels the PR and posts a "triage skipped" notice instead of hard-failing.
+# See docs/internal/contributor/merge-coordination-runbook.md to enable it.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  actions: write          # gh run rerun
+  contents: read
+  pull-requests: write    # comment + label
+  id-token: write         # OIDC for configure-aws-credentials (no-op if no role configured)
+
+concurrency:
+  group: triage-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (for the shared classifier + triage scripts)
+        uses: actions/checkout@v5
+        with:
+          # Always check out the default branch's scripts, not the PR's — a PR
+          # must not be able to rewrite its own triage logic.
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      # Configure AWS credentials for Bedrock. This step is BEST-EFFORT: with no
+      # role/secret configured it produces no usable credentials, and the triage
+      # script then degrades gracefully (skips AI, still labels). continue-on-error
+      # keeps a missing/again-misconfigured role from failing the job.
+      - name: Configure AWS credentials (Bedrock) — best effort
+        id: aws
+        if: ${{ vars.BEDROCK_TRIAGE_ROLE_ARN != '' }}
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.BEDROCK_TRIAGE_ROLE_ARN }}
+          aws-region: ${{ vars.BEDROCK_TRIAGE_REGION || 'us-west-2' }}
+
+      - name: Install Bedrock SDK (only if a triage role is configured)
+        if: ${{ vars.BEDROCK_TRIAGE_ROLE_ARN != '' }}
+        continue-on-error: true
+        run: npm install --no-save @aws-sdk/client-bedrock-runtime@^3
+
+      - name: Classify, rerun-or-triage
+        uses: actions/github-script@v9
+        env:
+          AWS_REGION: ${{ vars.BEDROCK_TRIAGE_REGION || 'us-west-2' }}
+          BEDROCK_TRIAGE_MODEL: ${{ vars.BEDROCK_TRIAGE_MODEL }}
+        with:
+          # Workflow-scoped token so triage can comment / label PRs whose delta
+          # touches .github/workflows/** (GITHUB_TOKEN is forbidden from that),
+          # matching pr-merge-train.yml and auto-rerun-flaky.yml.
+          github-token: ${{ secrets.MERGE_TRAIN_TOKEN }}
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const run = context.payload.workflow_run;
+            const { classifyFailures } = require('./scripts/ci/ci-failure-classifier.js');
+            const { runTriage } = require('./scripts/ci/bedrock-triage.js');
+
+            const LABEL = 'ci-needs-triage';
+            const HOLD = 'hold';
+
+            // 1) Resolve the associated PR(s) from the run's head SHA.
+            //    workflow_run carries pull_requests only for same-repo PRs; fall
+            //    back to a head-SHA search so fork PRs resolve too.
+            let prs = run.pull_requests || [];
+            if (prs.length === 0) {
+              const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner, repo, commit_sha: run.head_sha,
+              });
+              prs = data.filter(p => p.state === 'open');
+            }
+            if (prs.length === 0) {
+              core.info(`No open PR associated with ${run.head_sha} — nothing to triage.`);
+              return;
+            }
+
+            // 2) Deterministic classify (shared logic) on the LATEST attempt's jobs.
+            const { data: jobsResp } = await github.rest.actions.listJobsForWorkflowRun({
+              owner, repo, run_id: run.id, per_page: 100, filter: 'latest',
+            });
+            const failedJobs = jobsResp.jobs.filter(j => j.conclusion === 'failure');
+            const { verdict, leafFailed, solidFailed, unknownFailed, flakyFailed, reason } =
+              classifyFailures(failedJobs.map(j => j.name));
+            core.info(`Verdict: ${verdict} — ${reason}`);
+
+            if (verdict === 'clean') {
+              core.info('Only aggregator roll-ups failed; the merge train handles the rest.');
+              return;
+            }
+
+            // 3) flake-only → ensure a rerun happened, AT MOST ONCE.
+            //    auto-rerun-flaky.yml owns the first retry (it fires on run_attempt == 1).
+            //    This is the backstop: only act on attempt 1 (so a run is never rerun
+            //    more than once — no storms), and only if auto-rerun didn't already.
+            if (verdict === 'flake-only') {
+              if (run.run_attempt > 1) {
+                core.info(`Run already on attempt ${run.run_attempt}; flake rerun budget spent — not rerunning.`);
+                return;
+              }
+              try {
+                await github.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: run.id });
+                core.info(`Backstop rerun of failed flaky jobs: ${flakyFailed.join(', ')}`);
+              } catch (e) {
+                // auto-rerun likely already triggered it (GitHub rejects a second
+                // rerun of the same attempt) — that's the desired "at most once".
+                core.info(`Rerun not issued (already rerun by auto-rerun, or in progress): ${e.message}`);
+              }
+              return;
+            }
+
+            // 4) real-failure → AI triage + label. Pick the most informative failing
+            //    leaf job (prefer a SOLID gate, else the first unknown leaf).
+            const failedNames = new Set([...solidFailed, ...unknownFailed]);
+            const targetJob = failedJobs.find(j => failedNames.has(j.name)) || failedJobs[0];
+
+            // Pull the failing job's log tail.
+            let logTail = '';
+            try {
+              const logResp = await github.request(
+                'GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs',
+                { owner, repo, job_id: targetJob.id }
+              );
+              logTail = typeof logResp.data === 'string'
+                ? logResp.data
+                : Buffer.from(logResp.data).toString('utf8');
+            } catch (e) {
+              logTail = `(could not fetch logs for job ${targetJob.name}: ${e.message})`;
+            }
+
+            const runUrl = `${run.html_url}`;
+            for (const pr of prs) {
+              // Skip held PRs — same escape hatch the merge train respects.
+              const { data: full } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
+              if (full.labels.some(l => l.name === HOLD)) {
+                core.info(`#${pr.number} is on hold — skipping triage.`);
+                continue;
+              }
+
+              // Ensure the label exists, then apply it.
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: LABEL });
+              } catch {
+                await github.rest.issues.createLabel({
+                  owner, repo, name: LABEL, color: 'B60205',
+                  description: 'CI failed on a real gate/shard; AI-triaged, needs a human or fix.',
+                }).catch(() => {});
+              }
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr.number, labels: [LABEL],
+              }).catch(e => core.warning(`Label add failed: ${e.message}`));
+
+              // AI triage (graceful-degrade if no creds/SDK).
+              let triage;
+              try {
+                triage = await runTriage({
+                  jobName: targetJob.name, prNumber: pr.number, logTail,
+                });
+              } catch (e) {
+                triage = { available: false, notice: `Bedrock triage errored (non-fatal): ${e.message}` };
+              }
+
+              let body;
+              if (triage.available) {
+                body = [
+                  `### CI triage — \`${targetJob.name}\` (real failure)`,
+                  '',
+                  `${reason}`,
+                  '',
+                  `**AI classification:** \`${triage.classification}\``,
+                  `**Root cause:** ${triage.rootCause || '_n/a_'}`,
+                  `**Suggested action:** ${triage.suggestedAction || '_n/a_'}`,
+                  '',
+                  `Run: ${runUrl} · model: \`${triage.model}\``,
+                  `<sub>Posted by ci-failure-triage (#2021). Deterministic classifier verdict: real-failure.</sub>`,
+                ].join('\n');
+              } else {
+                body = [
+                  `### CI triage — \`${targetJob.name}\` (real failure)`,
+                  '',
+                  `${reason}`,
+                  '',
+                  `> AI triage was skipped: ${triage.notice}`,
+                  '',
+                  `Run: ${runUrl}`,
+                  `<sub>Posted by ci-failure-triage (#2021). Labelled \`${LABEL}\`; resolve the gate and push, or add the \`hold\` label.</sub>`,
+                ].join('\n');
+              }
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: pr.number, body,
+              }).catch(e => core.warning(`Comment failed: ${e.message}`));
+              core.info(`Triaged #${pr.number} (AI ${triage.available ? 'ran' : 'skipped'}).`);
+            }

--- a/docs/internal/contributor/merge-coordination-runbook.md
+++ b/docs/internal/contributor/merge-coordination-runbook.md
@@ -1,0 +1,65 @@
+# Merge coordination runbook (webhook-driven)
+
+Merge-queue coordination on `honua-server` is **fully event-driven (webhook)**.
+Session-side polling — a Claude `/loop` heartbeat or a `gh`-polling Monitor babysitting
+the queue — is **no longer required to drain the queue**. Three workflows cooperate, all
+triggered by GitHub events, none needing a live session:
+
+| Workflow | Trigger | Job |
+|---|---|---|
+| `pr-merge-train.yml` | `push` to trunk, `check_suite` completed, 15-min backstop cron | Merges the oldest **CLEAN** PR (squash); else freshens every **BEHIND** PR. One mechanical action per trigger, re-triggers itself. |
+| `auto-rerun-flaky.yml` | `workflow_run` (CI) completed, `run_attempt == 1` | Gives a PR's CI exactly **one** retry when only known-flaky shards failed (40P01 deadlock, Testcontainers/Docker). Never reruns a real gate. |
+| `ci-failure-triage.yml` | `workflow_run` (CI) completed, `conclusion == failure` | The missing piece (#2021): **AI triage of genuinely-real failures** + autonomous rerun-orchestration backstop. Does *not* merge — that stays in the train. |
+
+## What `ci-failure-triage.yml` does
+
+1. Resolves the associated PR(s) from the CI run's head SHA (incl. fork PRs, via a head-SHA search).
+2. Runs the **shared deterministic classifier** (`scripts/ci/ci-failure-classifier.js`) — the
+   single source of the leaf/aggregator + FLAKY-shard/SOLID-gate regex sets, also consumed by
+   `auto-rerun-flaky.yml` so the two can never drift.
+3. Acts on the verdict:
+   - **clean** (only aggregator roll-ups failed) → nothing; the train handles merge/freshen.
+   - **flake-only** → ensures a rerun happened **at most once** (only on `run_attempt == 1`,
+     after `auto-rerun-flaky` owns the first attempt — this is the backstop; a second rerun of
+     the same attempt is rejected by GitHub, which is the desired "no storms" behavior).
+   - **real-failure** (a SOLID gate failed, or an unrecognized leaf) → gathers the failing
+     job's log tail, calls **Bedrock** for a triage verdict `{classification, rootCause,
+     suggestedAction}`, posts it as a PR comment, and applies the `ci-needs-triage` label
+     (created on first use). **AI is used only here.**
+4. Skips PRs carrying the `hold` label (same escape hatch the train respects). Concurrency is
+   serialized per head branch (`cancel-in-progress: false`). Uses `secrets.MERGE_TRAIN_TOKEN`
+   so it can comment/label PRs whose delta touches `.github/workflows/**`.
+
+## Bedrock auth in CI — and graceful degradation
+
+The triage AI step talks to Claude on **Amazon Bedrock** via the **Converse API** using the
+standard **AWS credential chain** — no API key. Today there is **no CI Bedrock credential path**
+(the only `aws-actions/configure-aws-credentials` usage in the repo is in `deploy.yml` /
+`deploy-platform-images.yml`, with static ECR push keys, not Bedrock). So the AI step
+**degrades gracefully**: when no creds are present it skips the model call, still labels the PR
+`ci-needs-triage`, and posts a "triage skipped" notice instead of hard-failing.
+
+To **enable** AI triage, add these repository (or environment) **variables** + an OIDC role:
+
+| Setting | Kind | Purpose |
+|---|---|---|
+| `BEDROCK_TRIAGE_ROLE_ARN` | repo variable | IAM role for GitHub OIDC to assume; needs `bedrock:InvokeModel` on the chosen model/profile. When set, the workflow runs `configure-aws-credentials` (OIDC, `id-token: write`) and installs `@aws-sdk/client-bedrock-runtime`. |
+| `BEDROCK_TRIAGE_REGION` | repo variable | Bedrock region (default `us-west-2`). |
+| `BEDROCK_TRIAGE_MODEL` | repo variable | Bedrock model id / cross-region inference profile (e.g. `us.anthropic.claude-sonnet-4-5-20250929-v1:0`). Defaults to that profile if unset. |
+
+The IAM trust policy must allow `token.actions.githubusercontent.com` for this repo. This mirrors
+how the AI studio flows authenticate to Bedrock (see `docs/guides/run-studio-ai-on-bedrock.md`):
+Converse API + IAM credential chain, model is a Bedrock id / inference profile.
+
+## Testing & validation
+
+- `scripts/ci/ci-failure-classifier.js` is unit-tested (`node --test scripts/ci/ci-failure-classifier.test.js`)
+  against flake-only / real-gate / mixed / unknown job-name sets — proving it matches
+  `auto-rerun-flaky`'s intent.
+- `scripts/ci/bedrock-triage.js` returns `available: false` with a notice when no AWS creds are
+  present (graceful skip), so the workflow is safe with Bedrock unconfigured.
+- `workflow_run`-triggered workflows only execute once on the default branch, so live validation
+  is **post-merge** (the same as `auto-rerun-flaky` when it landed). First-firing watch plan: on
+  the next red PR-CI, confirm (a) flake-only runs get at most one rerun, (b) a real gate failure
+  gets the `ci-needs-triage` label + a triage comment, and (c) with no Bedrock role set, the
+  comment is the graceful-skip notice (not a job failure).

--- a/scripts/ci/bedrock-triage.js
+++ b/scripts/ci/bedrock-triage.js
@@ -1,0 +1,121 @@
+// Bedrock AI triage for genuinely-real CI failures (#2021).
+//
+// Given a failing job's name + log tail, ask Claude on Amazon Bedrock (Converse API,
+// AWS credential chain) for a structured triage verdict:
+//   { classification: "flake" | "real", rootCause, suggestedAction }
+//
+// Auth: the standard AWS credential chain via @aws-sdk/client-bedrock-runtime
+// (env vars set by aws-actions/configure-aws-credentials, or an attached role).
+// NO API key. The model is a Bedrock model id / cross-region inference profile.
+//
+// GRACEFUL DEGRADATION: this module never throws to the caller for a missing-creds
+// or missing-SDK condition. `runTriage()` returns a result object with
+// `available: false` and a human-readable `notice` instead, so the workflow can
+// still label the PR and post a "triage skipped" comment rather than hard-failing.
+// It only surfaces a hard error for an unexpected Bedrock fault AFTER creds were
+// present (the caller decides whether to treat that as fatal — the workflow does not).
+
+'use strict';
+
+const DEFAULT_MODEL = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+const DEFAULT_REGION = 'us-west-2';
+const MAX_LOG_CHARS = 12000; // keep the prompt bounded; tail is the informative part
+
+function buildPrompt({ jobName, prNumber, logTail }) {
+  const tail = (logTail || '').slice(-MAX_LOG_CHARS);
+  return [
+    'You are a CI triage assistant for the honua-server repository.',
+    'A CI job failed AND it was NOT auto-classified as a known transient flake',
+    '(it is either a deterministic gate — Build/Format/Analyze/AOT/Package/CodeQL —',
+    'or an integration shard that failed across a rerun). Decide whether this is a',
+    'genuine code/logic break ("real") or still likely a transient infrastructure',
+    'flake ("flake") that escaped the deterministic classifier (e.g. a Postgres',
+    '40P01 deadlock, a Testcontainers/Docker startup hiccup, a runner OOM, a network',
+    'blip, or a cancelled job).',
+    '',
+    `PR: #${prNumber}`,
+    `Failing job: ${jobName}`,
+    '',
+    'Failing job log tail (most recent output):',
+    '```',
+    tail,
+    '```',
+    '',
+    'Respond with ONLY a JSON object, no prose, of the exact shape:',
+    '{"classification":"real"|"flake","rootCause":"<one or two sentences>",',
+    '"suggestedAction":"<one concrete next step: e.g. rerun the shard, fix X in file Y, bump timeout>"}',
+  ].join('\n');
+}
+
+function parseVerdict(text) {
+  // The model is asked for bare JSON, but be defensive: pull the first {...} block.
+  const match = (text || '').match(/\{[\s\S]*\}/);
+  if (!match) {
+    return { classification: 'unknown', rootCause: 'Model returned no parseable JSON.', suggestedAction: 'Inspect the failing job logs manually.', raw: text };
+  }
+  try {
+    const obj = JSON.parse(match[0]);
+    return {
+      classification: obj.classification === 'flake' ? 'flake' : (obj.classification === 'real' ? 'real' : 'unknown'),
+      rootCause: String(obj.rootCause || '').slice(0, 1000),
+      suggestedAction: String(obj.suggestedAction || '').slice(0, 1000),
+      raw: text,
+    };
+  } catch {
+    return { classification: 'unknown', rootCause: 'Model JSON failed to parse.', suggestedAction: 'Inspect the failing job logs manually.', raw: text };
+  }
+}
+
+/**
+ * @returns {Promise<{available: boolean, notice?: string, classification?: string,
+ *                    rootCause?: string, suggestedAction?: string, model?: string}>}
+ */
+async function runTriage({ jobName, prNumber, logTail, model, region }) {
+  const resolvedModel = model || process.env.BEDROCK_TRIAGE_MODEL || DEFAULT_MODEL;
+  const resolvedRegion = region || process.env.AWS_REGION || process.env.BEDROCK_TRIAGE_REGION || DEFAULT_REGION;
+
+  // Cheap pre-check: if no AWS credential signal is present at all, skip without
+  // touching the SDK. configure-aws-credentials exports AWS_ACCESS_KEY_ID (static)
+  // or AWS_ROLE_ARN/AWS_WEB_IDENTITY_TOKEN_FILE (OIDC) or container creds.
+  const hasCredSignal =
+    process.env.AWS_ACCESS_KEY_ID ||
+    process.env.AWS_ROLE_ARN ||
+    process.env.AWS_WEB_IDENTITY_TOKEN_FILE ||
+    process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI ||
+    process.env.AWS_PROFILE;
+  if (!hasCredSignal) {
+    return {
+      available: false,
+      notice: 'No AWS credentials available in CI (no BEDROCK OIDC role / keys configured) — AI triage skipped. See docs/internal/contributor/merge-coordination-runbook.md to enable.',
+      model: resolvedModel,
+    };
+  }
+
+  let BedrockRuntimeClient, ConverseCommand;
+  try {
+    ({ BedrockRuntimeClient, ConverseCommand } = require('@aws-sdk/client-bedrock-runtime'));
+  } catch {
+    return {
+      available: false,
+      notice: '@aws-sdk/client-bedrock-runtime is not installed on the runner — AI triage skipped (the PR is still labelled).',
+      model: resolvedModel,
+    };
+  }
+
+  const client = new BedrockRuntimeClient({ region: resolvedRegion });
+  const prompt = buildPrompt({ jobName, prNumber, logTail });
+
+  const resp = await client.send(new ConverseCommand({
+    modelId: resolvedModel,
+    messages: [{ role: 'user', content: [{ text: prompt }] }],
+    inferenceConfig: { maxTokens: 1024, temperature: 0 },
+  }));
+
+  const text = (resp.output && resp.output.message && resp.output.message.content || [])
+    .map(b => b.text || '')
+    .join('');
+  const verdict = parseVerdict(text);
+  return { available: true, model: resolvedModel, ...verdict };
+}
+
+module.exports = { runTriage, buildPrompt, parseVerdict, DEFAULT_MODEL, DEFAULT_REGION };

--- a/scripts/ci/ci-failure-classifier.js
+++ b/scripts/ci/ci-failure-classifier.js
@@ -1,0 +1,105 @@
+// Shared CI-failure classifier — single source of truth for the leaf-vs-aggregator
+// and FLAKY-shard-vs-SOLID-gate distinction used by BOTH the auto-rerun-flaky
+// workflow and the event-driven ci-failure-triage workflow (#2021).
+//
+// Why this exists: auto-rerun-flaky.yml (#1967) and ci-failure-triage.yml must
+// agree, byte-for-byte, on what counts as a "real" failure vs a known flake. If
+// the two carried independent copies of these regex sets they would drift, and a
+// shard reclassified in one place but not the other would either get auto-rerun
+// forever (storm) or get AI-triaged when it is a known flake (noise). Keeping the
+// regexes here — consumed by both — makes that class of bug impossible.
+//
+// Pure, dependency-free CommonJS so it loads inside actions/github-script (which
+// can `require()` a workspace file after actions/checkout) and runs under plain
+// `node` in unit tests with no install step (honoring the build-lock rules: no
+// npm install needed).
+
+'use strict';
+
+// Aggregator roll-ups, NOT independent signals: these fail whenever ANY
+// downstream job fails, so they carry no information about real-vs-flake.
+// They must be excluded before classification — otherwise a pure shard flake
+// that trips `CI Gate` (which it always does) would look like a deterministic-
+// gate failure and never get its retry. Classify only the LEAF jobs.
+const AGGREGATORS = [/CI Gate/i, /Test Suite Summary/i];
+
+// Deterministic gates — a failure in a LEAF gate is real, never auto-rerun.
+// (CI Gate / Test Suite Summary are aggregators, handled above — not here.)
+const SOLID = [
+  /Build & Format/i, /\bFormat\b/i, /Analyze/i, /CodeQL/i,
+  /PR Template/i, /Router/i, /Mergeability/i,
+  /AOT/i, /Package Compatibility/i, /Type Check/i,
+];
+
+// Known-flaky integration/infra shards — transient (Postgres 40P01 deadlock,
+// Testcontainers/Docker hiccups), eligible for ONE retry.
+const FLAKY = [
+  /Server Tests/i, /OGC API/i, /Postgres Compatibility/i,
+  /Docker Build/i, /Integration Tests/i, /Browser/i, /MCP/i,
+];
+
+/**
+ * Classify a CI run's failed job names into a coordination verdict.
+ *
+ * @param {string[]} failedJobNames - names of jobs whose conclusion === 'failure'.
+ * @returns {{
+ *   verdict: 'clean' | 'flake-only' | 'real-failure',
+ *   leafFailed: string[],
+ *   solidFailed: string[],
+ *   flakyFailed: string[],
+ *   unknownFailed: string[],
+ *   reason: string,
+ * }}
+ *
+ * Verdicts:
+ *   'clean'        — no failed leaf jobs (only aggregator roll-ups, or nothing).
+ *   'flake-only'   — every failed leaf is in the known-flaky set; safe to rerun once.
+ *   'real-failure' — a SOLID gate failed, OR a leaf failed that is not in the
+ *                    known-flaky set (unknown). Either way: do NOT silently rerun;
+ *                    hand to AI triage.
+ */
+function classifyFailures(failedJobNames) {
+  const failed = (failedJobNames || []).filter(n => typeof n === 'string' && n.length > 0);
+
+  const leafFailed = failed.filter(n => !AGGREGATORS.some(r => r.test(n)));
+  if (leafFailed.length === 0) {
+    return {
+      verdict: 'clean',
+      leafFailed: [],
+      solidFailed: [],
+      flakyFailed: [],
+      unknownFailed: [],
+      reason: failed.length === 0
+        ? 'No failed jobs.'
+        : `Only aggregator roll-ups failed (${failed.join(', ')}); no leaf job.`,
+    };
+  }
+
+  const solidFailed = leafFailed.filter(n => SOLID.some(r => r.test(n)));
+  const flakyFailed = leafFailed.filter(n => FLAKY.some(r => r.test(n)) && !SOLID.some(r => r.test(n)));
+  const unknownFailed = leafFailed.filter(
+    n => !SOLID.some(r => r.test(n)) && !FLAKY.some(r => r.test(n)),
+  );
+
+  if (solidFailed.length > 0) {
+    return {
+      verdict: 'real-failure',
+      leafFailed, solidFailed, flakyFailed, unknownFailed,
+      reason: `Deterministic leaf gate failed (${solidFailed.join(', ')}).`,
+    };
+  }
+  if (unknownFailed.length > 0) {
+    return {
+      verdict: 'real-failure',
+      leafFailed, solidFailed, flakyFailed, unknownFailed,
+      reason: `Leaf failure(s) not in the known-flaky set (${unknownFailed.join(', ')}).`,
+    };
+  }
+  return {
+    verdict: 'flake-only',
+    leafFailed, solidFailed, flakyFailed, unknownFailed,
+    reason: `All leaf failures are known-flaky shards (${flakyFailed.join(', ')}).`,
+  };
+}
+
+module.exports = { classifyFailures, AGGREGATORS, SOLID, FLAKY };

--- a/scripts/ci/ci-failure-classifier.test.js
+++ b/scripts/ci/ci-failure-classifier.test.js
@@ -1,0 +1,84 @@
+// Unit tests for the shared CI-failure classifier (#2021).
+// Run with no install step:  node --test scripts/ci/ci-failure-classifier.test.js
+//
+// These prove the classifier matches the intent baked into auto-rerun-flaky.yml:
+// aggregators are excluded, SOLID gates are real, the known-flaky shards are
+// rerun-eligible, and anything unrecognized is treated as real (fail safe).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { classifyFailures } = require('./ci-failure-classifier.js');
+
+test('no failures → clean', () => {
+  const r = classifyFailures([]);
+  assert.equal(r.verdict, 'clean');
+});
+
+test('only aggregator roll-ups failed → clean (no leaf to act on)', () => {
+  const r = classifyFailures(['CI Gate', 'Test Suite Summary']);
+  assert.equal(r.verdict, 'clean');
+  assert.deepEqual(r.leafFailed, []);
+});
+
+test('flake-only: a single known-flaky shard → flake-only', () => {
+  const r = classifyFailures(['Server Tests (shard 3)', 'CI Gate']);
+  assert.equal(r.verdict, 'flake-only');
+  assert.deepEqual(r.flakyFailed, ['Server Tests (shard 3)']);
+});
+
+test('flake-only: multiple known-flaky shards + aggregator → flake-only', () => {
+  const r = classifyFailures([
+    'OGC API Maps and Tiles',
+    'Postgres Compatibility',
+    'Integration Tests',
+    'CI Gate',
+  ]);
+  assert.equal(r.verdict, 'flake-only');
+  assert.equal(r.flakyFailed.length, 3);
+});
+
+test('real-failure: a SOLID gate (Build & Format) failed → real-failure', () => {
+  const r = classifyFailures(['Build & Format', 'CI Gate']);
+  assert.equal(r.verdict, 'real-failure');
+  assert.deepEqual(r.solidFailed, ['Build & Format']);
+});
+
+test('real-failure: AOT gate failed → real-failure', () => {
+  const r = classifyFailures(['AOT Compatibility Verify']);
+  assert.equal(r.verdict, 'real-failure');
+});
+
+test('mixed SOLID + FLAKY → real-failure (the SOLID gate wins; no free rerun)', () => {
+  const r = classifyFailures(['Analyze', 'Server Tests (shard 1)', 'CI Gate']);
+  assert.equal(r.verdict, 'real-failure');
+  assert.deepEqual(r.solidFailed, ['Analyze']);
+  assert.equal(r.flakyFailed.length, 1);
+});
+
+test('unknown leaf job (not SOLID, not FLAKY) → real-failure (fail safe)', () => {
+  const r = classifyFailures(['Some New Job Nobody Mapped', 'CI Gate']);
+  assert.equal(r.verdict, 'real-failure');
+  assert.deepEqual(r.unknownFailed, ['Some New Job Nobody Mapped']);
+});
+
+test('Format aggregator-vs-leaf: PR Template is SOLID, not a flake', () => {
+  const r = classifyFailures(['Validate PR Template Compliance']);
+  assert.equal(r.verdict, 'real-failure');
+});
+
+test('CodeQL is a SOLID gate', () => {
+  const r = classifyFailures(['CodeQL']);
+  assert.equal(r.verdict, 'real-failure');
+});
+
+test('Docker Build shard is flaky-eligible', () => {
+  const r = classifyFailures(['Docker Build']);
+  assert.equal(r.verdict, 'flake-only');
+});
+
+test('garbage/empty entries are ignored', () => {
+  const r = classifyFailures(['', null, undefined, 'CI Gate']);
+  assert.equal(r.verdict, 'clean');
+});


### PR DESCRIPTION
## Issue Link
Closes #2021

## Summary
Adds an event-driven AI merge-coordinator that retires session-side polling. Merge-queue coordination was already webhook-driven via `pr-merge-train.yml` (merge/freshen) and `auto-rerun-flaky.yml` (one flake retry); the missing piece was autonomous handling of *genuinely-real* failures, which a human/Claude `/loop` had to babysit. This adds a new `workflow_run`-triggered `ci-failure-triage.yml` that classifies failures deterministically, reruns flake-only at most once, and AI-triages real failures via Bedrock — so polling is no longer required to drain the queue. The existing two workflows are augmented, not replaced.

## Changes Made
- Add `.github/workflows/ci-failure-triage.yml` (`workflow_run` on CI completed): resolve PR(s) from head SHA → classify → flake-only rerun (guarded to at most once) → real-failure AI triage (Bedrock) posting a PR comment + `ci-needs-triage` label. Concurrency serialized per head branch; skips `hold`-labelled PRs; uses `MERGE_TRAIN_TOKEN`.
- Add `scripts/ci/ci-failure-classifier.js` — the single shared source of the leaf/aggregator + FLAKY-shard/SOLID-gate regex sets, with `scripts/ci/ci-failure-classifier.test.js` (12 cases, `node --test`).
- Refactor `auto-rerun-flaky.yml` to consume the shared classifier instead of its duplicated inline regex sets (one-retry behavior and `run_attempt == 1` guard unchanged).
- Add `scripts/ci/bedrock-triage.js` — Converse API via the AWS credential chain, with graceful degradation (skip AI + still label) when no CI creds are configured.
- Add `docs/internal/contributor/merge-coordination-runbook.md` documenting the webhook model and the Bedrock role/variables to enable AI triage.
- `pr-merge-train.yml` left as-is.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

`node --test scripts/ci/ci-failure-classifier.test.js` → 12/12 pass (flake-only / real-gate / mixed / unknown-leaf / aggregator-only). Proved the Bedrock graceful-skip path (`available: false` + notice) and the JSON-verdict parser locally. All three workflows pass `@action-validator/cli` schema validation and `python3 yaml.safe_load`. `workflow_run` workflows can't fully execute until merged to the default branch, so **live validation is post-merge** (as with `auto-rerun-flaky` when it landed) — first-firing watch: confirm one rerun for flake-only, a `ci-needs-triage` label + triage comment for a real gate failure, and the graceful-skip notice when no Bedrock role is set.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

To enable AI triage (optional; degrades gracefully without it): add repo variables `BEDROCK_TRIAGE_ROLE_ARN` (GitHub-OIDC IAM role with `bedrock:InvokeModel`), `BEDROCK_TRIAGE_REGION`, `BEDROCK_TRIAGE_MODEL`. No CI Bedrock path exists today; until configured, the workflow labels + posts a skip notice. `MERGE_TRAIN_TOKEN` is already in use by the existing coordinator workflows.

## Breaking Changes
None. The new workflow only triages/reruns; mechanical merge/freshen stays in `pr-merge-train.yml`. `auto-rerun-flaky` keeps identical behavior (now sourced from the shared classifier).

---

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
