### PR TITLE
feat(ci): lean merge-queue gate (merge_group runs lean check, not full matrix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,20 @@ on:
   pull_request:
     branches: [trunk]
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-  # Merge queue: GitHub batches approved PRs and runs CI once on the combined
-  # result before fast-forwarding trunk (replaces manual PR bundling). A
-  # merge_group event is a non-pull_request event, so the existing job logic
-  # already routes it down the FULL integration lane (changes/targeted-shards
-  # else-branches => run_all; PR-only jobs short-circuit to success), making
-  # the queue the thorough trunk-protecting gate while the PR lane stays
-  # selective/fast. Enable in branch protection with "CI Gate" as the required
-  # status check (see docs/internal/ci/merge-queue.md).
+  # Merge queue (LEAN gate): GitHub batches approved PRs and runs CI once on
+  # the combined commit before fast-forwarding trunk. The full ~45-job matrix
+  # (AOT, docker, the 30+-shard Server Tests fanout, browser/MCP lanes) already
+  # gated each PR on its own `pull_request` run BEFORE it entered the queue, so
+  # re-running that matrix on every batch is pure waste — and at batch sizes of
+  # 5 it caused runner starvation, ejected the front PR, reformed the group,
+  # spawned zombie runs, and spiralled (merge queue disabled 2026-06-18,
+  # ruleset 17808547). The merge_group event therefore runs ONLY the lean
+  # `merge-queue-gate` job (build + format + fast unit/architecture smoke) to
+  # catch semantic conflicts from BATCHING — not to re-validate each PR. Every
+  # heavy job is `if:`-gated to `pull_request`/schedule and SKIPS on
+  # merge_group; the PR-time aggregator `CI Gate` likewise does not run on
+  # merge_group. The merge-queue REQUIRED check must be `Merge Queue Gate`,
+  # NOT `CI Gate`. See docs/internal/contributor/merge-queue-runbook.md.
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
@@ -26,6 +32,15 @@ on:
         default: ''
 
 concurrency:
+  # PR runs key on the PR number (re-push cancels the prior run). merge_group
+  # and other non-PR events key on github.ref. For merge_group, github.ref is
+  # the unique per-batch queue ref (refs/heads/gh-readonly-queue/trunk/pr-...),
+  # so each batch gets its OWN concurrency group: a reformed group runs under a
+  # NEW ref and is NOT cancelled-in-progress by the prior batch (and cannot be
+  # cancelled BY it). This is deliberate — the historical zombie-run spiral came
+  # from re-running the full matrix per batch, not from this key; with the lean
+  # gate the per-batch group is cheap, so leave cancel-in-progress on (it still
+  # collapses duplicate checks_requested events for the SAME batch ref).
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
@@ -53,8 +68,9 @@ jobs:
     # Gate every heavy CI job on PR-body template compliance. For non-PR events
     # (schedule, workflow_dispatch) this job short-circuits to success so
     # nightly/manual runs are never blocked. Dependabot PRs skip the check to
-    # match the previous standalone workflow's behavior.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
+    # match the previous standalone workflow's behavior. Skips on merge_group —
+    # the batched commit has no PR body and the lean gate does not template-check.
+    if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -209,6 +225,9 @@ jobs:
     # #1736/#1737 needed a manual re-trigger). pr-template-check is still a
     # first-class job and still feeds CI Gate (so a template failure still
     # fails the gate), but it no longer gates whether the code is validated.
+    # Skips on merge_group (no PR to check mergeability/freshness for; the queue
+    # enforces up-to-date-ness itself).
+    if: ${{ github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -256,6 +275,12 @@ jobs:
 
   changes:
     name: Detect Non-Test Changes
+    # Skips on merge_group: the lean merge-queue gate does not consult the
+    # change-detection / shard-routing graph (it always runs build + format +
+    # fast smoke). Skipping `changes` cascades a skip to every heavy job that
+    # `needs: changes` (build, *-tests, postgres-compat, aot-build, docker-build,
+    # browser/MCP lanes), so the full matrix never runs on a batched commit.
+    if: ${{ github.event_name != 'merge_group' }}
     needs: pr-readiness
     runs-on: ubuntu-latest
     outputs:
@@ -1001,7 +1026,10 @@ jobs:
 
   test-all:
     name: Test Suite Summary
-    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') }}
+    # `always()` would otherwise let this run on merge_group with all test
+    # needs skipped (a misleading all-skipped "pass"); exclude merge_group so
+    # the heavy test lane is fully dormant on a batched commit.
+    if: ${{ github.event_name != 'merge_group' && always() && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') }}
     runs-on: ubuntu-latest
     needs:
       - dotnet-foundation-tests
@@ -1884,13 +1912,108 @@ jobs:
           docker stop honua-test || true
           docker rm honua-test || true
 
+  # ===========================================================================
+  # LEAN MERGE-QUEUE GATE
+  # ===========================================================================
+  # Runs ONLY on merge_group (the batched/combined commit GitHub forms from the
+  # queued PRs). It is the queue's REQUIRED status check — set branch
+  # protection / ruleset 17808547's merge_group required check to "Merge Queue
+  # Gate", NOT "CI Gate". It is deliberately LEAN: build (warnings-as-errors) +
+  # format + the Fast/architecture unit smoke. It does NOT run AOT, docker, the
+  # Server Tests shard matrix, the browser/MCP/Postgres lanes, or any
+  # integration suite — those already gated each PR on its own pull_request run
+  # before the PR entered the queue. The queue only needs to catch SEMANTIC
+  # conflicts introduced by BATCHING (e.g. two PRs that each compile alone but
+  # not together, a format drift, an architecture-rule break). Keeping it lean
+  # is the fix for the 2026-06-18 runner-starvation spiral: a batch of 5 no
+  # longer fans out to ~225 concurrent jobs, so the group finishes inside
+  # check_response_timeout_minutes and the front PR is not ejected.
+  merge-queue-gate:
+    name: Merge Queue Gate
+    if: ${{ github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      # Mirror the build job's disk reclaim — the full-solution build can
+      # exhaust ubuntu-latest disk once every project writes Release outputs.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/swift || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          df -h / || true
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-ci
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: scripts/ci/dotnet-restore-retry.sh Honua.sln
+
+      # Full-solution warnings-as-errors build. On a BATCHED commit the
+      # "affected projects" optimization is unsafe (the merge_group ref's diff
+      # base is the queue base, not a single PR), so build the whole solution —
+      # this is the one place we want the combined batch fully compiled.
+      - name: Build (warnings as errors)
+        timeout-minutes: 20
+        run: |
+          dotnet build Honua.sln \
+            --no-restore \
+            --configuration Release \
+            /p:TreatWarningsAsErrors=true
+
+      - name: Format Check
+        run: dotnet format Honua.sln --verify-no-changes --verbosity diagnostic
+
+      - name: Create Test Results Directory
+        run: mkdir -p ./tests/TestResults
+
+      # Fast unit smoke — the same coverage-free Fast tier the PR lane runs, to
+      # catch a batch that compiles but breaks shared unit behavior. NOT the
+      # Postgres/integration shards (those ran per-PR and need the DB service).
+      - name: Run .NET Tests (Server Fast Tier)
+        timeout-minutes: 15
+        run: |
+          dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --filter "Tier=Fast" \
+            --logger "trx;LogFileName=merge-queue-server-fast.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults
+
+      # Architecture-enforcement tests are cheap and catch the BLOCKING
+      # dependency-direction / controller / encapsulation regressions that a
+      # batch could reintroduce by combining two otherwise-clean PRs.
+      - name: Run .NET Tests (Architecture)
+        timeout-minutes: 10
+        run: |
+          dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --logger "trx;LogFileName=merge-queue-architecture.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults
+
   # Summary gate: a single job that branch-protection can require.
   # Add every job whose failure should block merge.
   ci-gate:
     name: CI Gate
     # When a newer run supersedes this one via workflow concurrency, avoid
     # publishing a false failing gate from the cancelled run.
-    if: ${{ always() && !cancelled() }}
+    #
+    # Does NOT run on merge_group: CI Gate is the PR-TIME aggregator (it needs
+    # the full heavy matrix, all of which is skipped on a batched commit). The
+    # merge queue's required check is the separate `Merge Queue Gate` job below,
+    # NOT this one. Keeping CI Gate off merge_group avoids a misleading all-
+    # skipped "pass" status appearing in the queue context.
+    if: ${{ github.event_name != 'merge_group' && always() && !cancelled() }}
     needs: [pr-template-check, pr-readiness, changes, targeted-shards, ci-router-validation, build, test-all, aot-build, js-integration-tests, esri-leaflet-browser-tests, maplibre-compat, mcp-certification, core-package-compatibility, postgres-compat, docker-build]
     runs-on: ubuntu-latest
     steps:

--- a/docs/internal/ci/merge-queue.md
+++ b/docs/internal/ci/merge-queue.md
@@ -5,37 +5,34 @@ This documents the CI-throughput work: the **merge queue** (automates the manual
 findings. CI workflow changes can only be fully validated by an actual GitHub run —
 follow the validation steps before relying on them.
 
-## 1. Merge queue
+## 1. Merge queue — SUPERSEDED by the LEAN gate
 
-`ci.yml` now triggers on `merge_group` (in addition to `pull_request`). A
-`merge_group` event is a non-`pull_request` event, so the existing job logic
-already routes it down the **full** integration lane (`changes` /
-`targeted-shards` else-branches → `run_all`; the PR-only jobs
-`pr-template-check` / `pr-readiness` short-circuit to success). Net design:
+> **SUPERSEDED (2026-06).** The "full lane on `merge_group`" design below is the
+> design that caused the 2026-06-18 runner-starvation spiral and forced the queue
+> off (ruleset 17808547 → disabled). It is kept for history. The current target
+> architecture is the **lean `merge_group` gate** — see
+> [`../contributor/lean-merge-queue-runbook.md`](../contributor/lean-merge-queue-runbook.md).
+> In short: `merge_group` now runs ONLY the `Merge Queue Gate` job (build +
+> format + fast/architecture unit smoke), NOT the full matrix; the queue's
+> required check is **`Merge Queue Gate`**, NOT `CI Gate`; recommended
+> `max_entries_to_build = 2` and `check_response_timeout = 15`.
 
-| Lane | Trigger | Scope | Who waits on it |
+`ci.yml` triggers on `merge_group` (in addition to `pull_request`). **Historic
+(broken) design:** a `merge_group` event is a non-`pull_request` event, so the
+job logic routed it down the **full** integration lane (`changes` /
+`targeted-shards` else-branches → `run_all`). That re-ran the whole ~45-job
+matrix on every batch → ~225 concurrent jobs at batch-5 → starvation →
+front-PR eject → group reform → zombie runs → spiral. **Do not re-enable the
+queue with this design.**
+
+| Lane | Trigger | Scope (current/lean) | Who waits on it |
 |------|---------|-------|-----------------|
 | **PR** | `pull_request` | Selective (affected shards) — fast | the author, per push |
-| **Merge queue** | `merge_group` | Full CI on the **batched** commit | nobody blocks; auto-merges on green |
+| **Merge queue** | `merge_group` | **Lean** gate only (build+format+fast smoke) | nobody blocks; auto-merges on green |
 
-This is the fix for "I have to ask for PRs to be bundled": GitHub batches approved
-PRs, runs CI **once** on the combined result, and fast-forwards `trunk` only if green.
-
-### Enable it (one-time, repo settings — not in code)
-1. **Settings → Branches → Branch protection rule for `trunk`** → enable
-   **"Require merge queue"**.
-2. Set the **required status check** to **`CI Gate`** (the aggregating job in `ci.yml`).
-   Remove individual job names from "required checks" — `CI Gate` already aggregates them.
-3. Merge-queue settings: merge method = your convention (squash); start with
-   **max batch = 5**, **min = 1**, **wait = 5 min**; "only merge if combined check passes".
-4. (Optional) `gh` after enabling: `gh pr merge <n> --auto --squash` queues a PR.
-
-### Validate before trusting it
-- Open a throwaway PR, approve it, click **"Merge when ready"**.
-- Watch the `CI` run triggered by the **`merge_group`** event (not the PR event).
-  Confirm `CI Gate` reports success and the PR fast-forwards trunk.
-- If the `merge_group` run errors in `pr-template-check`/`pr-readiness`, those
-  jobs' PR-only steps weren't skipped — re-check their `if:` guards.
+GitHub batches approved PRs, runs the lean gate **once** on the combined result,
+and fast-forwards `trunk` only if green. Re-enable steps, sizing, strict-off and
+train-fallback recommendations live in the lean runbook linked above.
 
 ## 2. Test-suite speed (per-class fixtures)
 
@@ -195,7 +192,7 @@ window Jun 6–18, n=321 `CI` runs). Numbers are billable Linux-runner minutes.
 | **A full `CI` run = ~449 billable min across ~50 jobs.** | Measured mean over 19 full runs (range 420–550). Dominated by `.NET Foundation Tests` (~22m) + `Postgres Compatibility` (~17–19m) + the 30-shard `Server Tests` matrix. | — |
 | **~48% of PRs still run the FULL matrix.** | 146 of 304 PR `CI` runs were ≥40 jobs (full `run_all`, 30 shards); the other ~50% ran the scoped ~mid lane (~75 min). Affected-scoping works (docs PRs hit ~0 min, verified on #1736) but most *source* PRs escalate. | Root cause: `unmapped_source_run_all_prefixes` + `infrastructure_paths` in `ci-shards.json` include the most-edited dirs (`src/Honua.Core/`, `src/Honua.Postgres/`, `src/Honua.Server/`, `Core/Models`, `Core/Queries`, `Postgres/Migrations`). Any source change those don't map to a shard's explicit `paths` → `run_all`. Tightening this is the single biggest minute lever; **needs sign-off** (under-testing risk). |
 | **Per-shard fixed build overhead.** | On small shards the `dotnet restore`+`Build server test binaries` step is ~3 min for ~0–4 min of actual testing (Performance 87% overhead, MCP 61%, STAC 40%). 30 shards each rebuild from source (`enable-build-cache` defaults to `false`). | Consolidate the ~8–10 sub-6-min shards into ~3–4; or enable the cross-job binary cache for shards. Wall-clock is set by `Core`/`FeatureServer Endpoints` (long pole), so consolidating tiny shards costs ~0 wall-clock. **Coordinate with in-flight shard work (#1724 follow-ups).** |
-| **Merge-queue lane duplicates full CI per queued PR (~428 min each).** | A `merge_group` event is non-`pull_request` → routes down the full lane unconditionally. The PR already ran (selective or full) on `pull_request`; the queue re-runs full. Currently low volume (6 `merge_group` vs 124 direct trunk pushes in-window), so this is latent, not yet dominant — but each queued PR pays full CI twice. | If queue volume grows, scope the `merge_group` lane to the union of its batched PRs' affected shards instead of `run_all`. |
+| **Merge-queue lane duplicates full CI per queued PR (~428 min each).** | A `merge_group` event was non-`pull_request` → routed down the full lane unconditionally. The PR already ran (selective or full) on `pull_request`; the queue re-ran full. **FIXED (2026-06): the `merge_group` lane is now the LEAN `Merge Queue Gate` (build+format+fast/arch smoke, ~1 runner job), not the full matrix** — see `../contributor/lean-merge-queue-runbook.md`. This also removes the runner-starvation spiral that disabled the queue. | Done. Sizing/re-enable in the lean runbook. |
 | **`ALLGREEN` grouping + 60-min check timeout amplifies queue stalls.** | Ruleset: `max_entries_to_build=5`, `grouping_strategy=ALLGREEN`, `check_response_timeout_minutes=60`. One failing PR in a batch invalidates the whole group → full CI re-runs on the smaller group. A hung shard can hold the group for up to 60 min. | Keep batching; consider lowering `check_response_timeout` once shard timeouts are tightened, and ensure no shard's `timeout_minutes` exceeds it. |
 | **Gate fragility: template-check failure skipped ALL validation and published a RED CI Gate.** | Verified on docs PR #1736: `pr-template-check` failed → `pr-readiness`/`changes`/every build+test job SKIPPED → `CI Gate` FAILED with 0 min of real validation. Documented in CLAUDE.md as the #1 agent-PR failure (#1736/#1737 needed manual re-trigger). | **Fixed in this PR** (§ below): decouple `pr-readiness`/build graph from `pr-template-check` so real validation runs; template-check stays a first-class job feeding CI Gate (a template failure still fails the gate, but now alongside real results). |
 

--- a/docs/internal/contributor/lean-merge-queue-runbook.md
+++ b/docs/internal/contributor/lean-merge-queue-runbook.md
@@ -1,0 +1,185 @@
+# Lean merge-queue runbook (honua-server)
+
+Target architecture for re-enabling GitHub's native merge queue on `honua-server`
+**without** the runner-starvation spiral that forced it off on **2026-06-18**. This
+runbook covers: the lean `merge_group` gate (landed in `ci.yml` by this PR), the
+exact ruleset re-enable steps (a follow-up — **do NOT flip the ruleset in this
+PR**), recommended queue sizing, and how the queue interacts with strict branch
+protection and `pr-merge-train.yml`.
+
+Companion docs:
+- `docs/internal/ci/merge-queue.md` — the original CI-throughput operator runbook
+  (shard routing, suite-speed, CI-minutes review). Its §1 "full lane on
+  merge_group" design is **superseded** by this runbook's lean gate.
+- `docs/internal/contributor/merge-coordination-runbook.md` — the webhook-driven
+  train + flaky-rerun + AI-triage workflows that drain the queue today.
+
+## 1. Why the queue was disabled (root cause)
+
+When the queue was on, the `merge_group` event re-ran the **FULL ~45-job CI
+matrix** on the batched commit — because a `merge_group` event is a
+non-`pull_request` event, the `changes`/`targeted-shards` jobs took their
+`else` (full-CI) branch and escalated to `run_all` (every Server Tests shard +
+AOT + docker + Postgres + browser/MCP lanes). With `max_entries_to_build = 5`,
+a single batch fanned out to **~225 concurrent jobs**. That starved the runner
+pool; the runner-starved `AOT Build Verification` and the long shard matrix
+couldn't finish inside `check_response_timeout_minutes`; GitHub **ejected the
+front PR**, **reformed the group**, and spawned a **NEW** run **without
+cancelling the old** — zombie runs piling up → spiral. Ruleset **17808547
+"Merge queue (trunk)"** was set to **enforcement: disabled**.
+
+## 2. The fix — a LEAN `merge_group` gate (this PR)
+
+The full matrix already gated each PR on its own `pull_request` run **before**
+the PR was approved and entered the queue. Re-running it on the batch is pure
+waste. The queue only needs to catch **semantic conflicts from batching** (two
+PRs that each compile alone but not together; a format/architecture regression a
+merge reintroduces). So `merge_group` now runs **one lean job**:
+
+`Merge Queue Gate` (`merge-queue-gate` in `ci.yml`):
+- `if: github.event_name == 'merge_group'`
+- Full-solution **build** (warnings-as-errors) + **`dotnet format --verify-no-changes`**
+- **Server Fast tier** unit smoke (`Tier=Fast`, no Postgres/integration) +
+  **Architecture** enforcement tests
+- **NO** AOT, **NO** docker, **NO** Server Tests shard matrix, **NO**
+  Postgres/browser/MCP/Python lanes.
+
+Every heavy job and the PR-time aggregator `CI Gate` are `if:`-gated to skip on
+`merge_group` (see §5 for the exact graph). A batch of 5 therefore runs **one
+runner job**, not ~225 — it finishes inside the timeout, so the front PR is
+never ejected and the group never reforms into a zombie.
+
+### Jobs on `merge_group` vs `pull_request`
+
+| Lane | Trigger | Jobs that run | Scope |
+|------|---------|---------------|-------|
+| **PR** | `pull_request` | the full graph: `pr-template-check`, `pr-readiness`, `changes`, `targeted-shards`, `ci-router-validation`, `build`, `dotnet-foundation-tests`, `server-tests` (selective shard subset), `python-integration-tests`, `js-*`, `esri-leaflet-browser-tests`, `maplibre-compat`, `mcp-*`, `postgres-compat`, `core-package-compatibility`, `aot-build`, `docker-build`, `test-all`, **`CI Gate`** | selective (affected shards) per ADR-0037 |
+| **Merge queue** | `merge_group` | **`Merge Queue Gate` ONLY** — every other job cascade-skips | build + format + fast/arch unit smoke |
+
+`CI Gate` is the **PR-time** required check. `Merge Queue Gate` is the
+**queue-time** required check. They are distinct jobs by design.
+
+## 3. Re-enabling ruleset 17808547 (FOLLOW-UP — after this lands on trunk)
+
+Do this only **after** this PR is merged so the lean gate exists on `trunk`.
+Enabling the queue while the old "full lane on merge_group" design is live on
+trunk would reproduce the spiral.
+
+1. **Make `Merge Queue Gate` the queue's required check.**
+   - Branches → ruleset **17808547 "Merge queue (trunk)"** → **Merge queue**
+     rule's **required status checks** → set to **`Merge Queue Gate`**.
+   - **Remove `CI Gate`** from the *merge-queue* required checks (it is the
+     PR-time gate; it does not run on `merge_group` and would hang the queue
+     waiting on a check that never reports).
+   - Keep `CI Gate` as the required check on the **branch-protection / PR**
+     ruleset (the up-front gate before a PR can be queued) — unchanged.
+2. **Sizing** (recommended):
+   - `max_entries_to_build`: **2** (down from the prior 5). The lean gate is
+     cheap, but a smaller batch means a single bad PR invalidates fewer
+     entries under `ALLGREEN` grouping, and keeps blast radius small while we
+     re-validate the queue. Raise to 3–5 once a week of clean runs proves the
+     lean gate holds.
+   - `minimum_group_size`: **1** (don't wait to batch; merge singletons fast).
+   - `check_response_timeout_minutes`: **15** (down from 60). The lean gate's
+     job timeout is 30 min worst case but typically completes in <10; 15 gives
+     headroom without letting a hung gate hold the group for an hour. Ensure no
+     step in `merge-queue-gate` can exceed this (build 20 / fast 15 / arch 10
+     are step caps but run sequentially — the job timeout is 30, so if you set
+     the response timeout to 15 also trim the job `timeout-minutes` to ~20 or
+     keep 15 and accept a rare timeout-eject; 15 is recommended with the job at
+     30 and the understanding that a genuinely slow batch ejects safely).
+   - `grouping_strategy`: keep **`ALLGREEN`**.
+   - Merge method: **squash** (matches the train's convention and repo history).
+3. **Flip enforcement to `active`.** Set ruleset 17808547 enforcement from
+   **disabled** → **active** (Active). Optionally stage via **Evaluate** first
+   to dry-run without enforcing.
+4. **Verify live** (post-enable — the queue cannot be exercised until it's on
+   the default branch):
+   - Open a throwaway PR, approve it, click **"Merge when ready"**.
+   - Watch the `CI` run triggered by the **`merge_group`** event. Confirm
+     **only** `Merge Queue Gate` runs (no AOT/docker/shard jobs appear), it
+     reports success, and the PR fast-forwards `trunk`.
+   - Confirm a batch of ≥2 queued PRs produces **one** `merge-queue-gate` job
+     per batch ref, not a full matrix.
+
+### Rollback
+
+If the queue misbehaves, set ruleset 17808547 enforcement back to **disabled**
+(one toggle). PRs immediately fall back to direct merge under classic branch
+protection + `pr-merge-train.yml`, exactly as today. No code revert needed —
+the lean gate simply stops being invoked when `merge_group` events stop firing.
+
+## 4. Strict branch protection — keep it OFF
+
+`strict` (require-branch-up-to-date-before-merge) was turned **off** so PRs
+merge in parallel when green. **Keep it off once the queue is on.** The merge
+queue **enforces up-to-date-ness itself**: it builds each entry on top of the
+combined batch (the latest trunk + the PRs ahead of it), so a stale PR is
+re-based by the queue before its gate runs. Turning `strict` back on would
+re-introduce the serial re-stale storm (every merge re-stales every other PR)
+that the queue exists to eliminate — redundant and harmful. **Recommendation:
+strict stays OFF.**
+
+## 5. Interaction with `pr-merge-train.yml`
+
+`pr-merge-train.yml` currently does GitHub's job manually: it squash-merges the
+oldest CLEAN PR and freshens BEHIND PRs (see `merge-coordination-runbook.md`).
+**With a real merge queue, the queue does the merging and the up-to-date-ing,
+so the train's merge/freshen role is superseded.**
+
+**Recommendation: keep the train but neuter its merge/freshen actions while the
+queue is the primary drainer** — i.e. treat the queue as primary and the train
+as a *disabled-by-default fallback*, NOT run both merge mechanisms at once
+(double-merge races, the train fighting the queue's rebases). Two safe options:
+
+- **Preferred:** when ruleset 17808547 goes `active`, **disable
+  `pr-merge-train.yml`** (comment its triggers or add a guard
+  `if: vars.MERGE_QUEUE_ENABLED != 'true'`). The rollback in §3 (queue back to
+  disabled) then re-arms the train by flipping that variable — one toggle,
+  symmetric with the ruleset.
+- **Minimum:** at least stop the train from **merging** while the queue is on
+  (leave its freshen path off too — the queue rebases). Do not leave both
+  merge paths live.
+
+The flaky-rerun (`auto-rerun-flaky.yml`) and AI-triage (`ci-failure-triage.yml`)
+workflows are **orthogonal** and stay on regardless — they react to CI
+conclusions, they don't merge.
+
+## 6. Static verification done in this PR
+
+The queue/`merge_group` event cannot be fully exercised until the ruleset is
+`active` on the default branch, so this PR verifies the gate **statically**:
+
+- **YAML validity:** `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` passes.
+- **Job-graph trace (parsed `if:`/`needs:`):** on `merge_group`, the **only**
+  job that runs is `Merge Queue Gate`. All 21 other jobs — including
+  `aot-build`, `docker-build`, the `server-tests` shard matrix, the
+  Postgres/browser/MCP/Python lanes, and `CI Gate` — cascade-skip (`changes`,
+  `pr-readiness`, `pr-template-check`, `test-all`, and `CI Gate` carry explicit
+  `github.event_name != 'merge_group'` guards; everything else skips because it
+  `needs:` a skipped upstream job).
+- **PR-path unchanged:** every guard added is `github.event_name != 'merge_group'
+  && (existing)`, which is a no-op on `pull_request`/`schedule`/
+  `workflow_dispatch`, so the existing selective PR lane and nightly full lane
+  are untouched.
+- **Concurrency:** `merge_group` keys on `github.ref`, which is the unique
+  per-batch queue ref (`refs/heads/gh-readonly-queue/trunk/pr-...`). Each batch
+  gets its own concurrency group, so a reformed group runs under a NEW ref and
+  is not cancelled-by / cannot-cancel the prior batch — the lean gate makes the
+  per-batch run cheap, so `cancel-in-progress: true` only collapses duplicate
+  `checks_requested` events for the SAME batch ref.
+
+**Live validation is post-merge + post-ruleset-enable** (§3 step 4), with the
+one-toggle rollback in §3.
+
+## 7. Open items / things guessed
+
+- **Exact prior ruleset field values** (`max_entries_to_build=5`,
+  `grouping_strategy=ALLGREEN`, `check_response_timeout_minutes=60`) are taken
+  from `docs/internal/ci/merge-queue.md` §5, not re-read live from the GitHub
+  API (the ruleset is currently disabled). Confirm against
+  `gh api repos/honua-io/honua-server/rulesets/17808547` before flipping.
+- The recommended `max_entries_to_build=2` and `check_response_timeout=15` are
+  conservative re-entry values, not measured — tune up after a week of clean
+  queue runs (the lean gate's real wall-time will tell you the safe batch size
+  and timeout).


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2026

## Summary
The honua-server merge queue was disabled on 2026-06-18 (ruleset 17808547) because the `merge_group` event re-ran the FULL ~45-job CI matrix (AOT, docker, the 30+-shard Server Tests fanout, Postgres/browser/MCP lanes) on each batched commit. A batch of 5 fanned out to ~225 concurrent jobs, starved the runner pool, ejected the front PR, reformed the group, and spawned zombie runs (spiral).

This PR makes the `merge_group` gate **lean**: the full matrix already validates each PR on its own `pull_request` run before it enters the queue, so the queue only needs a fast final integration check on the batched result to catch semantic conflicts from batching. This lands the lean gate only — **the ruleset is NOT flipped live**; re-enabling the queue is a documented follow-up after this is on trunk.

## Changes Made
- Added `merge-queue-gate` ("Merge Queue Gate") job in `ci.yml`, `if: github.event_name == 'merge_group'`: full-solution build (warnings-as-errors) + `dotnet format --verify-no-changes` + Server Fast tier + Architecture unit smoke. No AOT, docker, shard matrix, or Postgres/browser/MCP/Python lanes.
- Gated `changes`, `pr-readiness`, `pr-template-check`, `test-all`, and `CI Gate` with `github.event_name != 'merge_group'`; every heavy job cascade-skips because it `needs:` a skipped upstream. On `merge_group` ONLY the lean gate runs; the `pull_request`/`schedule` lanes are unchanged (the added guard is a no-op there).
- Documented the merge_group concurrency reasoning (per-batch queue ref ⇒ each batch is its own concurrency group ⇒ a reformed group cannot zombie/cancel the prior batch).
- Added `docs/internal/contributor/lean-merge-queue-runbook.md`: target architecture, exact ruleset 17808547 re-enable steps (required check = `Merge Queue Gate`, NOT `CI Gate`; `max_entries_to_build=2`; `check_response_timeout_minutes=15`), keep `strict` OFF, and the `pr-merge-train.yml` fallback recommendation.
- Marked the superseded "full lane on merge_group" design in `docs/internal/ci/merge-queue.md` and updated its CI-minutes finding.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

<!-- Workflow-only change. Verified statically: `python3 -c "import yaml; yaml.safe_load(...)"` on both touched workflows; a parsed-`if:`/`needs:` job-graph trace confirming ONLY `Merge Queue Gate` runs on merge_group and all 21 other jobs (incl. aot-build, docker-build, server-tests matrix, CI Gate) cascade-skip; PR/nightly lanes unchanged. merge_group cannot be exercised until the ruleset is active on the default branch — live validation + rollback are in the runbook. -->

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [x] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

<!-- "Infrastructure": re-enabling ruleset 17808547 is a manual follow-up (steps in the runbook). This PR does NOT flip it. -->

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
