### PR TITLE
fix(ogc): make type-only geometry serialization reflection-free (#1647)

### DIFF
--- a/src/Honua.Protocols.OgcApi/Features/Services/OgcResponseFormatter.cs
+++ b/src/Honua.Protocols.OgcApi/Features/Services/OgcResponseFormatter.cs
@@ -956,10 +956,18 @@ internal static class OgcResponseFormatter
 
         if (string.IsNullOrWhiteSpace(geometry.CoordinatesJson))
         {
-            return JsonSerializer.Serialize(new Dictionary<string, string>
+            // Written through Utf8JsonWriter rather than a reflection-based
+            // JsonSerializer.Serialize overload: the published image disables
+            // reflection-based serialization (honua-server#1647).
+            using var typeOnlyStream = new MemoryStream();
+            using (var typeOnlyWriter = new Utf8JsonWriter(typeOnlyStream))
             {
-                ["type"] = geometry.Type
-            });
+                typeOnlyWriter.WriteStartObject();
+                typeOnlyWriter.WriteString("type", geometry.Type);
+                typeOnlyWriter.WriteEndObject();
+            }
+
+            return Encoding.UTF8.GetString(typeOnlyStream.ToArray());
         }
 
         try


### PR DESCRIPTION
## What

`OgcResponseFormatter` serialized the no-coordinates geometry stub (`{ "type": ... }`) using the reflection-based `JsonSerializer.Serialize(object)` overload. The published server image runs with `JsonSerializerIsReflectionEnabledByDefault=false` (`PublishAot=true`), so that overload throws *"Reflection-based serialization has been disabled"* at runtime and 500s the affected OGC API Features responses (honua-server#1647).

This rewrites that one call to emit the stub directly through `Utf8JsonWriter`, matching the reflection-free pattern already used by the OData ETag (`ODataUtilityService.SerializeForEtag`) and feature serialization lanes.

## Why this PR

This was the last residual reflection-based `JsonSerializer.Serialize(...)` call left in the OGC formatter after the #1647 sweep landed elsewhere on trunk. The OData side of #1647 is already fixed on trunk; this closes the matching OGC gap.

## Scope

- One file: `src/Honua.Protocols.OgcApi/Features/Services/OgcResponseFormatter.cs` (+11/-3).
- No behavior change to the emitted JSON (`{"type":"<geomType>"}`), only the serialization path.

## Verification

`dotnet build src/Honua.Protocols.OgcApi -c Release` — succeeds, 0 warnings, 0 errors.
