### PR TITLE
ci(router): target registration-plumbing & shared-feature changes instead of run_all

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -46,6 +46,66 @@
   "default_shards_when_no_match": [
     "Core"
   ],
+  "_targeted_override_prefixes_comment": "Narrows over-broad run_all triggers (ADR-0037 targeting follow-up). A changed file under one of these prefixes is CLAIMED by the listed shard subset instead of escalating to run_all: it is excluded from the infrastructure_paths short-circuit and the unmapped_source_run_all_prefixes net, and the listed shards are unioned into the targeted result. Evaluated AFTER the empty-diff guard and BEFORE the infrastructure_paths check. Two over-broad triggers are narrowed: (1) endpoint-registration PLUMBING — src/Honua.Server/EndpointRegistry.cs, src/Honua.Server/Program.cs, and src/Honua.Server/Startup/JsonContextRegistration.cs — which almost every feature PR touches; these route to a representative SMOKE subset spanning the main protocol families (FeatureServer, OGC API Features, one classic OGC = WMS, OData, MCP) plus the always-on API/governance and admin-infrastructure shards, NOT all 45. The architecture/governance guards that run on EVERY PR (EndpointRegistry/OperationRegistry drift + coverage, proof-ledger, in Honua.Architecture.Tests on the build job) are the safety net that catches a registration mistake regardless of which server-test shards run, which is what makes a smoke subset safe here. (2) shared FEATURE-AREA dirs under src/Honua.Hosting/ — Authentication/ and Security/ — route to the auth/security-relevant shards (Infra and Security, Admin & Infrastructure, OData Core which carries ODataAuthorizationTests), NOT all 45. IMPORTANT: keep these prefixes SPECIFIC. They MUST be narrower than the genuinely cross-cutting paths that must stay run_all: do NOT add Honua.Core abstractions, DI/host bootstrap (Honua.Hosting.csproj, Startup/InfrastructureCompositionRoot.cs), the rest of src/Honua.Hosting/Features/ (Rendering/Caching/etc. stay run_all via the unmapped net), Directory.Build.props/Directory.Packages.props, .github/workflows/**, ci-shards.json, the router scripts, or *.sln here. A registration override prefix must point at a SPECIFIC plumbing file, not a whole shared directory.",
+  "targeted_override_prefixes": [
+    {
+      "prefix": "src/Honua.Server/EndpointRegistry.cs",
+      "reason": "endpoint_registration_plumbing",
+      "shards": [
+        "FeatureServer Endpoints",
+        "OGC API Features",
+        "OGC Classic Maps",
+        "OData Core",
+        "MCP",
+        "STAC and API Governance",
+        "Admin & Infrastructure"
+      ]
+    },
+    {
+      "prefix": "src/Honua.Server/Program.cs",
+      "reason": "endpoint_registration_plumbing",
+      "shards": [
+        "FeatureServer Endpoints",
+        "OGC API Features",
+        "OGC Classic Maps",
+        "OData Core",
+        "MCP",
+        "STAC and API Governance",
+        "Admin & Infrastructure"
+      ]
+    },
+    {
+      "prefix": "src/Honua.Server/Startup/JsonContextRegistration.cs",
+      "reason": "endpoint_registration_plumbing",
+      "shards": [
+        "FeatureServer Endpoints",
+        "OGC API Features",
+        "OGC Classic Maps",
+        "OData Core",
+        "MCP",
+        "STAC and API Governance",
+        "Admin & Infrastructure"
+      ]
+    },
+    {
+      "prefix": "src/Honua.Hosting/Features/Authentication/",
+      "reason": "shared_auth_feature_area",
+      "shards": [
+        "Infra and Security",
+        "Admin & Infrastructure",
+        "OData Core"
+      ]
+    },
+    {
+      "prefix": "src/Honua.Hosting/Features/Security/",
+      "reason": "shared_security_feature_area",
+      "shards": [
+        "Infra and Security",
+        "Admin & Infrastructure",
+        "OData Core"
+      ]
+    }
+  ],
   "shards": [
     {
       "name": "Core Endpoints",

--- a/docs/internal/contributor/adr/0037-unified-ci-test-tier-strategy.md
+++ b/docs/internal/contributor/adr/0037-unified-ci-test-tier-strategy.md
@@ -99,6 +99,43 @@ test script and the workflow matrix do not drift.
 changed source path to one or more shards via `.github/ci-shards.json`, and
 emits a JSON descriptor consumed by the `server-tests` matrix:
 
+- **Registration-plumbing & shared-feature-area overrides
+  (`targeted_override_prefixes`).** Evaluated first (after the empty-diff guard,
+  before `infrastructure_paths`). A changed file under one of these prefixes is
+  *claimed* by an explicit shard subset instead of escalating to `run_all`: it is
+  removed from the `infrastructure_paths` short-circuit and the
+  `unmapped_source_run_all_prefixes` net, and the entry's shards are unioned into
+  the targeted result. This narrows two over-broad `run_all` triggers that almost
+  every feature PR tripped:
+  - **Endpoint-registration plumbing** —
+    `src/Honua.Server/EndpointRegistry.cs`, `src/Honua.Server/Program.cs`, and
+    `src/Honua.Server/Startup/JsonContextRegistration.cs` — routes to a
+    representative **smoke subset** (FeatureServer Endpoints, OGC API Features,
+    OGC Classic Maps, OData Core, MCP, STAC and API Governance, Admin &
+    Infrastructure), not all 45 shards. An endpoint-*adding* PR that also touches
+    a feature dir under a shard's `paths` runs the smoke subset **plus** that
+    feature's owning shard(s).
+  - **Shared auth/security feature areas** —
+    `src/Honua.Hosting/Features/Authentication/` and
+    `src/Honua.Hosting/Features/Security/` — route to the auth/security shards
+    (Infra and Security, Admin & Infrastructure, OData Core), not all 45.
+
+  Safety rests on the **always-on architecture/governance guards**: the `build`
+  job runs `Honua.Architecture.Tests` on every PR, which includes the
+  `EndpointRegistry`/`OperationRegistry` drift + coverage tests and the
+  proof-ledger tests. A registration mistake (an endpoint added to `Program.cs`
+  but missing from `EndpointRegistry`, an operation with no test, an
+  uncovered public surface) fails there **regardless of which server-test shards
+  run** — `run_all` was never what caught those. Keep these prefixes SPECIFIC:
+  they must point at individual plumbing files or narrowly-bounded feature dirs,
+  never at `Honua.Core` abstractions, DI/host bootstrap
+  (`Startup/InfrastructureCompositionRoot.cs`, `Honua.Hosting.csproj`), the rest
+  of `src/Honua.Hosting/Features/` (Rendering/Caching/… stay `run_all` via the
+  unmapped net), `Directory.Build.props`/`Directory.Packages.props`,
+  `.github/workflows/**`, `ci-shards.json`, the router scripts, or `*.sln` —
+  those stay `run_all`. `scripts/ci/validate-ci-router.sh` asserts every override
+  shard name is a real shard and locks in the narrowed routing against
+  regression.
 - If the diff touches **shared infrastructure**
   (`infrastructure_paths` in `ci-shards.json` —
   `tests/dotnet/Honua.TestKit/` (the `PostgresFixture`/`SeedRunner` harness),

--- a/scripts/ci/honua-server-targeted-tests.sh
+++ b/scripts/ci/honua-server-targeted-tests.sh
@@ -7,25 +7,39 @@
 #   1. When no files changed (empty diff), emit
 #      {"run_all": true, "reason": "no_changed_files"} so a manual replay still
 #      exercises the full matrix.
-#   2. When the diff touches a path under `infrastructure_paths` in
+#   2. Compute the `targeted_override_prefixes` set: changed files under one of
+#      those prefixes are "claimed" by an explicit smoke/feature-area shard
+#      subset instead of escalating to run_all. This narrows the over-broad
+#      run_all triggers for endpoint-registration PLUMBING
+#      (EndpointRegistry.cs, Program.cs registration, Startup/JsonContextRegistration.cs)
+#      and for shared FEATURE-AREA dirs (e.g. Honua.Hosting/Features/Authentication/,
+#      .../Security/). Files matched here are removed from the infrastructure_paths
+#      escalation (step 3) and the unmapped-source net (step 5), and the override's
+#      shard list is unioned into the targeted result. The always-on architecture/
+#      governance guards (EndpointRegistry/OperationRegistry drift + coverage,
+#      proof-ledger) run on every PR regardless and catch registration mistakes,
+#      which is what makes targeting these plumbing paths safe rather than run_all.
+#   3. When the diff touches a path under `infrastructure_paths` in
 #      ci-shards.json (TestKit, Core/Postgres project and shared
 #      infrastructure paths, Honua.ServiceDefaults,
-#      src/Honua.Server/Features/Infrastructure/, Honua.sln), emit
+#      src/Honua.Server/Features/Infrastructure/, src/Honua.Server/Startup/) that
+#      is NOT already claimed by a `targeted_override_prefixes` entry, emit
 #      {"run_all": true, "reason": "infrastructure_change"}.
-#   3. Otherwise, walk every changed file, match it against shard `paths`
+#   4. Otherwise, walk every changed file, match it against shard `paths`
 #      prefixes, and union the shard names that claim it.
-#   4. When the diff touches a path under `unmapped_source_run_all_prefixes`
+#   5. When the diff touches a path under `unmapped_source_run_all_prefixes`
 #      (src/Honua.Server/, src/Honua.DuckDB/, tests/dotnet/Honua.Server.Tests/)
-#      that no shard's `paths` claims, emit
+#      that no shard's `paths` claims AND that is not claimed by a
+#      `targeted_override_prefixes` entry, emit
 #      {"run_all": true, "reason": "unmapped_source_change"} so a new feature
 #      directory does not silently fall back to the Core shard whose filter
 #      excludes Honua.Server.Tests.Features.*.
-#   5. When the union from step 3 is empty (e.g. doc-only or CI-only diffs
-#      that did not trigger steps 2 or 4), fall back to
+#   6. When the union from steps 4 + 2 is empty (e.g. doc-only or CI-only diffs
+#      that did not trigger steps 3 or 5), fall back to
 #      `default_shards_when_no_match` (currently ["Core"]) with reason
 #      "no_path_match" so the smoke shard still runs.
-#   6. Otherwise emit {"run_all": false, "shards": [...], "reason": "targeted"}
-#      with the matched shard set.
+#   7. Otherwise emit {"run_all": false, "shards": [...], "reason": "targeted"}
+#      with the matched + override shard set.
 #
 # Usage:
 #   honua-server-targeted-tests.sh                    # auto-detect base ref
@@ -131,15 +145,44 @@ if [[ -z "${CHANGED_FILES}" ]]; then
   exit 0
 fi
 
-# Detect whether any shared-infrastructure path was touched.
+# Compute the targeted-override contribution: the union of shard names declared
+# by every `targeted_override_prefixes` entry whose prefix matches a changed
+# file. These prefixes deliberately route endpoint-registration PLUMBING and
+# shared FEATURE-AREA dirs to a small representative subset instead of run_all.
+# A file under such a prefix is "override-claimed" — it must NOT escalate the
+# infrastructure_paths short-circuit (step 3) nor trip the unmapped-source net
+# (step 5). The shards collected here are unioned into the targeted result.
+OVERRIDE_SHARDS_JSON="$(
+  printf '%s\n' "${CHANGED_FILES}" \
+    | jq -Rsc --slurpfile cfg "${CONFIG_FILE}" '
+        split("\n")
+        | map(select(length > 0)) as $files
+        | ($cfg[0].targeted_override_prefixes // [])
+        | map(
+            . as $entry
+            | select($files | any(. as $f | $f | startswith($entry.prefix)))
+            | $entry.shards[]
+          )
+        | unique
+      '
+)"
+
+# Detect whether any shared-infrastructure path was touched. A file that is also
+# claimed by a targeted-override prefix is excluded so registration plumbing
+# (e.g. src/Honua.Server/Startup/JsonContextRegistration.cs, which sits under the
+# infrastructure_paths prefix src/Honua.Server/Startup/) routes to the override's
+# smoke subset instead of forcing run_all. Non-override infrastructure files
+# (the TestKit harness, the Core/Postgres canonical pipeline, etc.) still
+# escalate as before.
 INFRA_HIT="$(
   printf '%s\n' "${CHANGED_FILES}" \
     | jq -Rsc --slurpfile cfg "${CONFIG_FILE}" '
         split("\n")
-        | map(select(length > 0))
-        | . as $files
+        | map(select(length > 0)) as $files
+        | ($cfg[0].targeted_override_prefixes // []) as $overrides
+        | ($files | map(select(. as $f | ($overrides | any(. as $o | $f | startswith($o.prefix))) | not))) as $unclaimed
         | $cfg[0].infrastructure_paths
-        | any(. as $prefix | $files | any(startswith($prefix)))
+        | any(. as $prefix | $unclaimed | any(startswith($prefix)))
       '
 )"
 
@@ -179,11 +222,13 @@ UNMAPPED_SOURCE_HIT="$(
         | map(select(length > 0)) as $files
         | ($cfg[0].unmapped_source_run_all_prefixes // []) as $watched
         | ($cfg[0].shards | map(.paths) | flatten) as $known_paths
+        | ($cfg[0].targeted_override_prefixes // []) as $overrides
         | $files
         | any(
             . as $f
             | ($watched | any(. as $p | $f | startswith($p)))
               and (($known_paths | any(. as $p | $f | startswith($p))) | not)
+              and (($overrides | any(. as $o | $f | startswith($o.prefix))) | not)
           )
       '
 )"
@@ -194,9 +239,20 @@ if [[ "${UNMAPPED_SOURCE_HIT}" == "true" ]]; then
   exit 0
 fi
 
+# Union the targeted-override shards (step 2) into the matched set. An
+# endpoint-adding PR that touches both a registration-plumbing override prefix
+# AND a feature dir under a shard's `paths` thus runs the override smoke subset
+# PLUS that feature's owning shard(s).
+TARGETED_SHARDS_JSON="$(
+  jq -nc \
+    --argjson matched "${TARGETED_SHARDS_JSON}" \
+    --argjson overrides "${OVERRIDE_SHARDS_JSON}" \
+    '($matched + $overrides) | unique'
+)"
+
 # Apply default-when-no-match. Only reached when no source under a watched
-# prefix was touched (e.g. docs- or workflow-only diffs that did not already
-# trigger the infrastructure_paths short-circuit).
+# prefix was touched AND no override prefix matched (e.g. docs- or workflow-only
+# diffs that did not already trigger the infrastructure_paths short-circuit).
 SHARDS_LEN="$(printf '%s' "${TARGETED_SHARDS_JSON}" | jq 'length')"
 if [[ "${SHARDS_LEN}" == "0" ]]; then
   TARGETED_SHARDS_JSON="$(jq -c '.default_shards_when_no_match' "${CONFIG_FILE}")"

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -45,7 +45,29 @@ jq -e '
   and (([.shards[].name] | length) == ([.shards[].name] | unique | length))
   and (([.shards[].artifact_suffix] | length) == ([.shards[].artifact_suffix] | unique | length))
   and (([.shards[].log_name] | length) == ([.shards[].log_name] | unique | length))
+  and (
+    # targeted_override_prefixes (optional) must be well-formed: each entry has a
+    # non-empty prefix, a reason, and a non-empty shard list whose names ALL
+    # reference real shards (a typo would silently route to no shard).
+    (.targeted_override_prefixes // []) | (
+      type == "array"
+      and ([
+        .[]
+        | (.prefix | type == "string" and length > 0)
+          and (.reason | type == "string" and length > 0)
+          and (.shards | type == "array" and length > 0)
+      ] | all)
+    )
+  )
 ' .github/ci-shards.json >/dev/null
+
+echo "Validating targeted_override_prefixes reference real shards..."
+jq -e '
+  ([.shards[].name]) as $names
+  | (.targeted_override_prefixes // [])
+  | all(.shards[] | . as $s | $names | index($s) != null)
+' .github/ci-shards.json >/dev/null \
+  || { echo "::error::a targeted_override_prefixes entry references an unknown shard name" >&2; exit 1; }
 
 echo "Checking shell script syntax..."
 bash -n scripts/ci/*.sh
@@ -279,6 +301,117 @@ assert_descriptor \
   "hosting-rendering-run-all" \
   "src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs" \
   "unmapped_source_change" \
+  "true" \
+  "Core"
+
+# ---------------------------------------------------------------------------
+# targeted_override_prefixes guard (ADR-0037 targeting follow-up): endpoint-
+# registration PLUMBING and shared Honua.Hosting FEATURE-AREA dirs route to a
+# representative SMOKE / auth subset instead of run_all. The always-on
+# architecture/governance guards (EndpointRegistry/OperationRegistry drift +
+# coverage, proof-ledger; Honua.Architecture.Tests on the build job) run on
+# every PR regardless and catch a registration mistake, so a smoke subset here
+# is safe. These lock in the narrowed triggers against regression.
+# ---------------------------------------------------------------------------
+
+# EndpointRegistry.cs alone: registration plumbing -> smoke subset, NOT run_all,
+# and NOT a silent skip. Includes the API/governance shard.
+assert_descriptor \
+  "endpoint-registry-plumbing-smoke" \
+  "src/Honua.Server/EndpointRegistry.cs" \
+  "targeted" \
+  "false" \
+  "STAC and API Governance"
+assert_excludes_shard \
+  "endpoint-registry-excludes-wfs-endpoints" \
+  "src/Honua.Server/EndpointRegistry.cs" \
+  "WFS Endpoints"
+
+# Program.cs (route registration) -> same smoke subset, NOT run_all.
+assert_descriptor \
+  "program-registration-smoke" \
+  "src/Honua.Server/Program.cs" \
+  "targeted" \
+  "false" \
+  "FeatureServer Endpoints"
+
+# Startup/JsonContextRegistration.cs sits under the infrastructure_paths prefix
+# src/Honua.Server/Startup/ but the override must WIN so a JSON-context tweak
+# routes to the smoke subset instead of forcing run_all.
+assert_descriptor \
+  "jsoncontext-registration-smoke" \
+  "src/Honua.Server/Startup/JsonContextRegistration.cs" \
+  "targeted" \
+  "false" \
+  "OData Core"
+
+# An endpoint-ADDING feature PR touches the registration plumbing AND a feature
+# dir under a shard's paths: it runs the smoke subset PLUS that feature's owning
+# shard (here GeoServices ImageServer), and is targeted, not run_all.
+assert_descriptor \
+  "endpoint-adding-feature-includes-feature-shard" \
+  "$(printf '%s\n%s\n%s' \
+      'src/Honua.Server/EndpointRegistry.cs' \
+      'src/Honua.Server/Program.cs' \
+      'src/Honua.Protocols.GeoServices/ImageServer/ImageServerEndpoints.cs')" \
+  "targeted" \
+  "false" \
+  "GeoServices ImageServer"
+assert_descriptor \
+  "endpoint-adding-feature-includes-smoke" \
+  "$(printf '%s\n%s' \
+      'src/Honua.Server/EndpointRegistry.cs' \
+      'src/Honua.Protocols.GeoServices/ImageServer/ImageServerEndpoints.cs')" \
+  "targeted" \
+  "false" \
+  "MCP"
+
+# A Honua.Hosting/Features/Authentication/ change -> auth/security shards, NOT
+# run_all and NOT a silent skip.
+assert_descriptor \
+  "hosting-authentication-auth-shards" \
+  "src/Honua.Hosting/Features/Authentication/JwtBearerSupport.cs" \
+  "targeted" \
+  "false" \
+  "Infra and Security"
+assert_excludes_shard \
+  "hosting-authentication-excludes-featureserver" \
+  "src/Honua.Hosting/Features/Authentication/JwtBearerSupport.cs" \
+  "FeatureServer Endpoints"
+
+# A Honua.Hosting/Features/Security/ change -> same auth/security shards.
+assert_descriptor \
+  "hosting-security-auth-shards" \
+  "src/Honua.Hosting/Features/Security/SecretReferenceResolver.cs" \
+  "targeted" \
+  "false" \
+  "Infra and Security"
+
+# Conservatism guards: the override must NOT widen run_all coverage. A NON-override
+# Startup file (DI/host bootstrap core) must STILL run_all, and a generic unmapped
+# Honua.Server source file must STILL run_all.
+assert_descriptor \
+  "startup-bootstrap-core-still-run-all" \
+  "src/Honua.Server/Startup/InfrastructureCompositionRoot.cs" \
+  "infrastructure_change" \
+  "true" \
+  "Core"
+assert_descriptor \
+  "non-override-hosting-feature-still-run-all" \
+  "src/Honua.Hosting/Features/Caching/HostResponseCache.cs" \
+  "unmapped_source_change" \
+  "true" \
+  "Core"
+
+# A registration override mixed with a genuinely cross-cutting Core change still
+# escalates to run_all (the Core file is not override-claimed): override must not
+# mask a real infrastructure change.
+assert_descriptor \
+  "override-plus-core-still-run-all" \
+  "$(printf '%s\n%s' \
+      'src/Honua.Server/Startup/JsonContextRegistration.cs' \
+      'src/Honua.Core/Queries/FeatureQuery.cs')" \
+  "infrastructure_change" \
   "true" \
   "Core"
 


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1897

## Summary
Almost every feature PR touches endpoint-registration plumbing (`EndpointRegistry.cs`, `Program.cs` route registration, `Startup/JsonContextRegistration.cs`) or a shared `Honua.Hosting` feature area, all of which currently force the ADR-0037 targeted-shards router to `run_all` — all 45 server-test shards. With ~20 concurrent PRs each fanning out to 45 shards, the free-tier runner pool saturates and the merge queue crawls. Measured: #1963 ran 45 shards because it changed `src/Honua.Hosting/Features/Authentication/*`; a correctly-targeted PR (#1959, STAC-only) ran just 2.

This adds a `targeted_override_prefixes` map to `.github/ci-shards.json`: a changed file under one of these *specific* prefixes is **claimed** by an explicit shard subset instead of escalating to `run_all`. It is excluded from the `infrastructure_paths` short-circuit and the `unmapped_source_run_all_prefixes` net, and its shards are unioned into the targeted result. No shard `filter` is touched, so the #1899 coverage invariant is fully preserved (all 570 test classes still claimed by a shard, 0 orphans).

**Why a smoke subset is safe (not a coverage regression):** the `build` job runs `Honua.Architecture.Tests` on *every* PR — `EndpointRegistry`/`OperationRegistry` drift + coverage tests and the proof-ledger tests. A registration mistake (endpoint added to `Program.cs` but missing from `EndpointRegistry`, an operation with no test, an uncovered public surface) fails there regardless of which server-test shards run. `run_all` was never what caught those.

## Changes Made
- Add `targeted_override_prefixes` to `.github/ci-shards.json` mapping over-broad `run_all` triggers to targeted shard subsets:
  - Registration plumbing (`src/Honua.Server/EndpointRegistry.cs`, `src/Honua.Server/Program.cs`, `src/Honua.Server/Startup/JsonContextRegistration.cs`) → smoke subset: **FeatureServer Endpoints, OGC API Features, OGC Classic Maps, OData Core, MCP, STAC and API Governance, Admin & Infrastructure** (7 shards, not 45).
  - `src/Honua.Hosting/Features/Authentication/` and `.../Security/` → **Infra and Security, Admin & Infrastructure, OData Core** (3 shards, not 45).
- Rework `scripts/ci/honua-server-targeted-tests.sh`: evaluate overrides first (after the empty-diff guard, before `infrastructure_paths`); exclude override-claimed files from both run_all nets; union override shards into the targeted result so an endpoint-*adding* PR runs the smoke subset **plus** the new feature's owning shard(s).
- Extend `scripts/ci/validate-ci-router.sh`: validate every override shard name references a real shard, and add 13 routing assertions (registration-plumbing smoke; endpoint-adding-feature unions feature shard; Hosting auth/security shards; and conservatism guards proving DI-bootstrap `Startup/InfrastructureCompositionRoot.cs`, the rest of `Honua.Hosting/Features/`, and override+Core mixes all still `run_all`).
- Document the mechanism and its safety basis in ADR-0037.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

`scripts/ci/validate-ci-router.sh` passes (all existing + 13 new cases); `check-server-test-shard-coverage.py` → all 570 classes claimed, 0 orphans; `ci-shards.json` JSON-valid; `ci.yml` YAML-valid; bash syntax clean. Before/after shard counts:

| Scenario | Before | After |
|---|---|---|
| `EndpointRegistry.cs` + `Program.cs` + a `Features/<X>/` dir | 45 | 8 (smoke + `<X>` shard) |
| `Honua.Hosting/Features/Authentication/*` (cf. #1963) | 45 | 3 |
| `Honua.Core/Queries/*` abstraction | 45 | 45 (unchanged) |
| STAC-only leaf (cf. #1959) | 2 | 2 (unchanged) |
| `Startup/InfrastructureCompositionRoot.cs`, `Honua.Hosting/Features/Rendering/*` | 45 | 45 (unchanged) |
| `ci-shards.json` / `.github/workflows/**` | router smoke / no integration | unchanged |

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] Documentation updated
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. CI-only change; no runtime, build, or format impact.

**Reviewable tradeoff:** registration-plumbing and Hosting auth/security PRs now run a representative subset of server-test shards instead of all 45. The architecture/governance guards (always-on) catch registration drift/coverage gaps regardless, and no shard filter changed so no test is orphaned — but a *protocol-specific* runtime regression introduced *solely* via a plumbing-file edit and exercised only by a non-smoke shard would not be caught at PR time (it would surface on the nightly full-matrix run). The smoke subset spans every protocol family to keep this window small.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
