### PR TITLE
ci(merge-train): first-class instrumentation, dashboard, and metrics

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -95,9 +95,42 @@ jobs:
           GH_TOKEN: ${{ secrets.HONUA_MERGE_TOKEN || secrets.GITHUB_TOKEN }}
           TRAIN_APPLY: ${{ steps.mode.outputs.train_apply }}
           MAX_BATCH: ${{ steps.mode.outputs.max_batch }}
+          # Instrumentation: the run timestamp is injected here (not generated in
+          # the script) so the Step Summary, metrics JSON, and state-issue
+          # aggregate all agree on a single run instant.
+          TRAIN_RUN_TIMESTAMP: ${{ github.event.repository.updated_at }}
+          # Write the metrics artifact into the workspace for upload below. The
+          # train ALSO appends its dashboard to $GITHUB_STEP_SUMMARY directly, so
+          # the Summary tab is populated even when the train selects nothing.
+          TRAIN_METRICS_OUT: ${{ github.workspace }}/merge-train-metrics.json
         run: |
           set -euo pipefail
+          # Stamp a real ISO-8601 instant (the repository updated_at above is only
+          # a stable fallback; prefer a fresh UTC timestamp for this run).
+          export TRAIN_RUN_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           if [[ -z "${{ secrets.HONUA_MERGE_TOKEN }}" ]]; then
             echo "::warning::HONUA_MERGE_TOKEN not set; using GITHUB_TOKEN. A GITHUB_TOKEN push does not retrigger downstream workflows, so live batch-branch CI may not start. Set HONUA_MERGE_TOKEN before enabling live mode."
           fi
           scripts/ci/merge-train/train.sh
+
+      - name: Ensure Step Summary is never silent
+        if: always()
+        run: |
+          # Defensive: if the train crashed before writing any dashboard, leave a
+          # breadcrumb so a run is never an empty Summary tab.
+          if [[ ! -s "${GITHUB_STEP_SUMMARY:-/dev/null}" ]]; then
+            {
+              echo "## 🚂 Merge Train"
+              echo ""
+              echo "_The train produced no dashboard this run (it may have failed before reporting). Check the **Run train** step log above._"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload merge-train metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: merge-train-metrics
+          path: ${{ github.workspace }}/merge-train-metrics.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/internal/contributor/adr/0055-optimistic-batch-merge-train.md
+++ b/docs/internal/contributor/adr/0055-optimistic-batch-merge-train.md
@@ -93,7 +93,70 @@ Triggers `schedule` (*/15), `workflow_run:{workflows:[CI]}`, and
 contents/pull-requests/actions/issues write. Uses `secrets.HONUA_MERGE_TOKEN`
 if present, else `GITHUB_TOKEN` (a `GITHUB_TOKEN` push does NOT retrigger
 downstream workflows, so live batch-branch CI needs the PAT). No `matrix.*`
-appears in any job-level `if:`.
+appears in any job-level `if:`. After the train runs, `if: always()` steps
+guarantee the Step Summary is never empty and upload `merge-train-metrics.json`
+as the `merge-train-metrics` artifact.
+
+### Instrumentation / observability (first-class)
+
+Lack of visibility was half the prior CI nightmare, so the train makes every
+decision obvious at a glance. This is ADDITIVE — it reads only what the decision
+steps already produced and changes no decision logic; dry-run stays read-only.
+
+- **Structured, grouped run log.** Every step emits a greppable, leveled line via
+  one formatter: `[train][<step>][<LEVEL>] <msg>` where `<LEVEL>` is
+  `INFO`/`WARN`/`DECISION` (the founder greps `DECISION`). Each pipeline step
+  wraps its output in GitHub Actions `::group::`/`::endgroup::` (only when
+  `$GITHUB_ACTIONS`) so the workflow log is collapsible per step; off-Actions it
+  prints a plain banner so a local dry-run reads cleanly. Landings and
+  escalations also emit `::notice::`/`::warning::` so they surface in the run's
+  annotations.
+- **Step Summary dashboard (headline).** Each run appends a Markdown report to
+  `$GITHUB_STEP_SUMMARY` (mirrored to stdout for local dry-runs): run mode
+  (DRY-RUN vs LIVE), trunk SHA, batch branch, a **candidates table** (PR# |
+  author | CI-Gate | decision: included / skipped+reason / escalated), the
+  **batch** (branch + included/skipped PRs), the **smart-CI shard set**
+  (targeted shards + `run_all` reason), a **run-actions** counter table
+  (forward-fixes / flake reruns / attribution drops / escalated / landed), and
+  **per-phase timings**. `_dashboard` is rendered on EVERY exit path — including
+  "nothing selected" — so a run is never a silent Summary tab.
+- **Machine-readable metrics.** `merge-train-metrics.json`
+  (`schema: honua.merge-train.metrics/v1`) is written to `$TRAIN_METRICS_OUT`
+  and uploaded as the `merge-train-metrics` workflow artifact (`if: always()`).
+  The run timestamp is injected by the workflow (`TRAIN_RUN_TIMESTAMP`), not
+  generated mid-script, so the Summary, metrics, and aggregate agree on one
+  instant. Schema:
+
+  ```json
+  {
+    "schema": "honua.merge-train.metrics/v1",
+    "run_timestamp": "<ISO-8601>",
+    "mode": "DRY-RUN|LIVE",
+    "outcome": "nothing-ready|dry-run|landed|trunk-moved-reassemble|escalated-batch|all-dropped|land-error",
+    "trunk_sha": "<sha|''>",
+    "last_landed_sha": "<sha|null>",
+    "counts": {
+      "candidates": 0, "selected": 0,
+      "skipped_by_reason": { "select_ineligible": 0, "assemble_conflict": 0 },
+      "included": 0, "landed": 0, "escalated": 0,
+      "flake_reruns": 0, "forward_fixes": 0, "attribution_drops": 0
+    },
+    "smart_ci": { "shard_count": 0, "run_all": false },
+    "phase_durations_seconds": { "select": 0, "assemble": 0, "smart-ci": 0, "ci-gate": 0, "land": 0 }
+  }
+  ```
+
+- **Persistent over-time dashboard.** Aggregate metrics accumulate across LIVE
+  runs in a second fenced block (` ```json aggregate `,
+  `schema: honua.merge-train.aggregate/v1`) inside the SAME **Merge Train State**
+  issue, with a human-readable Markdown dashboard rendered above it — total
+  batches, PRs landed, runs, median time-to-land, flake-rerun rate (reruns per
+  batch), escalation count, current trunk SHA, last-landed SHA, and the live
+  flake-signature list. The state issue was chosen over a committed
+  `docs/ci/merge-train-status.md` because it needs no commit/push per run (lower
+  friction, and the train stays FF-CAS-clean about what it pushes to trunk). In
+  dry-run the aggregate dashboard renders to the Step Summary but is NOT
+  persisted to the issue.
 
 ### No bot attribution (runtime requirement)
 

--- a/scripts/ci/merge-train/lib.sh
+++ b/scripts/ci/merge-train/lib.sh
@@ -50,9 +50,92 @@ TRAIN_SHARDS_CONFIG="${TRAIN_SHARDS_CONFIG:-${TRAIN_REPO_ROOT}/.github/ci-shards
 TRAIN_TARGETED_SCRIPT="${TRAIN_TARGETED_SCRIPT:-${TRAIN_REPO_ROOT}/scripts/ci/honua-server-targeted-tests.sh}"
 
 # --- logging ------------------------------------------------------------------
-train_log()  { printf '[train] %s\n' "$*" >&2; }
-train_warn() { printf '[train][warn] %s\n' "$*" >&2; }
-train_err()  { printf '[train][error] %s\n' "$*" >&2; }
+# Visibility was half the prior CI nightmare, so every step emits a clear,
+# greppable, leveled line. The base helpers stay backward-compatible; the
+# component-aware helpers below add a [step] segment and a level so the run log
+# reads `[train][select][INFO] ...`, `[train][assemble][DECISION] ...`, etc.
+#
+# TRAIN_STEP is the active pipeline step (set by train_step_begin). Levels:
+#   INFO     — routine progress.
+#   WARN     — recoverable anomaly (skips, caps, re-assembles).
+#   DECISION — a choice the train made (included/skipped/escalated/landed).
+: "${TRAIN_STEP:=train}"
+
+train_log()  { _train_emit INFO "$*"; }
+train_warn() { _train_emit WARN "$*"; }
+train_err()  { _train_emit ERROR "$*"; }
+# train_decision: a first-class DECISION line — the thing the founder grep's for.
+train_decision() { _train_emit DECISION "$*"; }
+
+# _train_emit <level> <msg...>: the single formatter for every log line.
+# Format: [train][<step>][<level>] <msg> (the [<step>] segment is omitted when no
+# step group is active so generic lines read [train][INFO] ...). All go to stderr
+# so stdout stays the scripts' machine channel (batch branch name, JSON, etc.).
+_train_emit() {
+  local level="$1"; shift
+  if [[ -n "${TRAIN_STEP:-}" && "${TRAIN_STEP}" != "train" ]]; then
+    printf '[train][%s][%s] %s\n' "${TRAIN_STEP}" "${level}" "$*" >&2
+  else
+    printf '[train][%s] %s\n' "${level}" "$*" >&2
+  fi
+}
+
+# --- GitHub Actions grouping + annotations (no-op off-Actions) ----------------
+# Each pipeline step's output is wrapped in ::group::/::endgroup:: so the
+# workflow log is collapsible per step. Off Actions ($GITHUB_ACTIONS unset) these
+# print a plain banner to stderr so a local dry-run still reads cleanly.
+train_group() {
+  TRAIN_STEP="$1"
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    printf '::group::[train] %s — %s\n' "$1" "${2:-}" >&2
+  else
+    printf '\n----- [train] %s — %s -----\n' "$1" "${2:-}" >&2
+  fi
+}
+train_endgroup() {
+  [[ -n "${GITHUB_ACTIONS:-}" ]] && printf '::endgroup::\n' >&2 || true
+  TRAIN_STEP="train"
+}
+
+# train_notice / train_annotate_warn: surface landings + escalations in the run's
+# annotations (the Actions summary banner). No-op (but still logged) off Actions.
+train_notice() {
+  [[ -n "${GITHUB_ACTIONS:-}" ]] && printf '::notice::%s\n' "$*" >&2 || true
+  train_decision "$*"
+}
+train_annotate_warn() {
+  [[ -n "${GITHUB_ACTIONS:-}" ]] && printf '::warning::%s\n' "$*" >&2 || true
+  train_warn "$*"
+}
+
+# --- step timing --------------------------------------------------------------
+# train_step_begin <name> records a monotonic start; train_step_end <name> emits
+# the elapsed seconds and appends "<name>=<secs>" to TRAIN_TIMINGS_FILE (if set)
+# for the metrics JSON. Uses SECONDS-derived epoch math (portable, no bc).
+train_now() { date -u +%s; }
+declare -A _TRAIN_STEP_START 2>/dev/null || true
+train_step_begin() { _TRAIN_STEP_START["$1"]="$(train_now)"; }
+train_step_end() {
+  local name="$1" start now dur
+  start="${_TRAIN_STEP_START[$name]:-}"
+  [[ -z "${start}" ]] && return 0
+  now="$(train_now)"; dur=$(( now - start ))
+  train_log "phase '${name}' took ${dur}s"
+  [[ -n "${TRAIN_TIMINGS_FILE:-}" ]] && printf '%s=%s\n' "${name}" "${dur}" >>"${TRAIN_TIMINGS_FILE}"
+  printf '%s' "${dur}"
+}
+
+# --- Step Summary dashboard ---------------------------------------------------
+# train_summary <markdown-line...>: append a line to $GITHUB_STEP_SUMMARY (the
+# Actions Summary tab) AND mirror it to stdout so a local dry-run prints the same
+# dashboard. TRAIN_SUMMARY_FILE overrides the sink (tests / local capture).
+train_summary() {
+  local sink="${TRAIN_SUMMARY_FILE:-${GITHUB_STEP_SUMMARY:-}}"
+  if [[ -n "${sink}" ]]; then
+    printf '%s\n' "$*" >>"${sink}"
+  fi
+  printf '%s\n' "$*"
+}
 
 # train_side_effect: the single chokepoint for every state-mutating action.
 # In live mode (TRAIN_APPLY=1) it executes the command; otherwise it logs the
@@ -115,4 +198,95 @@ train_shard_paths() {
   local shard_name="$1" config="${2:-${TRAIN_SHARDS_CONFIG}}"
   jq -r --arg n "${shard_name}" \
     '.shards[] | select(.name == $n) | .paths[]' "${config}"
+}
+
+# --- machine-readable metrics (per-run counters) ------------------------------
+# A flat key=value counter store backed by TRAIN_METRICS_KV (a temp file). The
+# orchestrator bumps counters as decisions are made, then train_metrics_render
+# emits a single merge-train-metrics.json uploaded as a workflow artifact.
+#
+# Counter keys (documented in ADR-0055 "Instrumentation"):
+#   candidates selected included landed escalated
+#   skipped_conflict flake_reruns forward_fixes attribution_drops
+#   smartci_shard_count
+# Plus the run outcome (string) and per-phase durations (from TRAIN_TIMINGS_FILE).
+train_metric_set() {  # key value
+  [[ -z "${TRAIN_METRICS_KV:-}" ]] && return 0
+  printf '%s=%s\n' "$1" "$2" >>"${TRAIN_METRICS_KV}"
+}
+# train_metric_get <key> [default]: last-write-wins read of a counter.
+train_metric_get() {
+  local key="$1" def="${2:-0}" val
+  [[ -z "${TRAIN_METRICS_KV:-}" || ! -s "${TRAIN_METRICS_KV:-/dev/null}" ]] && { printf '%s' "${def}"; return 0; }
+  val="$(grep -E "^${key}=" "${TRAIN_METRICS_KV}" | tail -1 | cut -d= -f2-)"
+  printf '%s' "${val:-${def}}"
+}
+train_metric_inc() {  # key [by]
+  local key="$1" by="${2:-1}" cur
+  cur="$(train_metric_get "${key}" 0)"
+  train_metric_set "${key}" "$(( cur + by ))"
+}
+
+# train_timings_json: turn the "<phase>=<secs>" lines into a JSON object.
+train_timings_json() {
+  local f="${TRAIN_TIMINGS_FILE:-}"
+  if [[ -z "${f}" || ! -s "${f}" ]]; then echo '{}'; return 0; fi
+  # Last write wins per phase so a re-run phase (re-assemble) reports its latest.
+  awk -F= 'NF>=2 {t[$1]=$2} END {for (k in t) print k"="t[k]}' "${f}" \
+    | jq -R 'split("=") | {(.[0]): (.[1]|tonumber)}' | jq -s 'add // {}'
+}
+
+# train_metrics_render <run_timestamp> <mode> <trunk_sha> <last_landed_sha> <outcome> [shard_descriptor]
+#   Emit the full merge-train-metrics.json document on stdout.
+train_metrics_render() {
+  local ts="$1" mode="$2" trunk_sha="$3" last_landed="$4" outcome="$5" shard_desc="${6:-}"
+  local shard_count run_all
+  shard_count="$(train_metric_get smartci_shard_count 0)"
+  run_all="false"
+  if [[ -n "${shard_desc}" ]] && jq -e . >/dev/null 2>&1 <<<"${shard_desc}"; then
+    run_all="$(jq -r '.run_all // false' <<<"${shard_desc}")"
+  fi
+  [[ "${run_all}" != "true" && "${run_all}" != "false" ]] && run_all="false"
+  local last_json="null"; [[ -n "${last_landed}" && "${last_landed}" != "null" ]] && last_json="\"${last_landed}\""
+
+  jq -n \
+    --arg ts "${ts}" \
+    --arg mode "${mode}" \
+    --arg trunk "${trunk_sha}" \
+    --argjson last "${last_json}" \
+    --arg outcome "${outcome}" \
+    --argjson candidates "$(train_metric_get candidates 0)" \
+    --argjson selected "$(train_metric_get selected 0)" \
+    --argjson included "$(train_metric_get included 0)" \
+    --argjson landed "$(train_metric_get landed 0)" \
+    --argjson escalated "$(train_metric_get escalated 0)" \
+    --argjson skipped_conflict "$(train_metric_get skipped_conflict 0)" \
+    --argjson skipped_select "$(train_metric_get skipped_select 0)" \
+    --argjson flake_reruns "$(train_metric_get flake_reruns 0)" \
+    --argjson forward_fixes "$(train_metric_get forward_fixes 0)" \
+    --argjson attribution_drops "$(train_metric_get attribution_drops 0)" \
+    --argjson shard_count "${shard_count:-0}" \
+    --argjson run_all "${run_all:-false}" \
+    --argjson durations "$(train_timings_json)" \
+    '{
+      schema: "honua.merge-train.metrics/v1",
+      run_timestamp: $ts,
+      mode: $mode,
+      outcome: $outcome,
+      trunk_sha: $trunk,
+      last_landed_sha: $last,
+      counts: {
+        candidates: $candidates,
+        selected: $selected,
+        skipped_by_reason: { select_ineligible: $skipped_select, assemble_conflict: $skipped_conflict },
+        included: $included,
+        landed: $landed,
+        escalated: $escalated,
+        flake_reruns: $flake_reruns,
+        forward_fixes: $forward_fixes,
+        attribution_drops: $attribution_drops
+      },
+      smart_ci: { shard_count: $shard_count, run_all: $run_all },
+      phase_durations_seconds: $durations
+    }'
 }

--- a/scripts/ci/merge-train/select.sh
+++ b/scripts/ci/merge-train/select.sh
@@ -56,7 +56,7 @@ train_select() {
     pr_list="${TRAIN_PR_LIST_JSON}"
   else
     pr_list="$(gh pr list --base "${TRAIN_BASE_BRANCH}" --state open \
-      --json number,headRefOid,isDraft,mergeable,mergeStateStatus,labels,createdAt,files \
+      --json number,headRefOid,isDraft,mergeable,mergeStateStatus,labels,createdAt,files,author \
       --limit 100)"
   fi
 
@@ -106,7 +106,8 @@ train_select() {
            --arg oid "$(jq -r '.headRefOid' <<<"${line}")" \
            --arg created "$(jq -r '.createdAt' <<<"${line}")" \
            --arg gate "${gate}" \
-      '{number:$n, headRefOid:$oid, createdAt:$created, gate:$gate}'
+           --arg author "$(jq -r '.author.login // .author.name // "?"' <<<"${line}")" \
+      '{number:$n, headRefOid:$oid, createdAt:$created, gate:$gate, author:$author}'
 
     count=$((count + 1))
     if [[ "${count}" -ge "${MAX_BATCH}" ]]; then

--- a/scripts/ci/merge-train/state.sh
+++ b/scripts/ci/merge-train/state.sh
@@ -100,3 +100,139 @@ train_state_read() {
     inblk      { print }
   '
 }
+
+# --- persistent over-time dashboard (the founder's "dashboard") ---------------
+# Aggregate metrics accumulate across LIVE runs in a second fenced block
+# (```json aggregate```) inside the SAME Merge Train State issue, with a
+# human-readable Markdown dashboard rendered above it. We chose the issue over a
+# committed docs file because it needs no commit/push per run (lower friction,
+# and the train must stay FF-CAS-clean about what it pushes to trunk). In
+# dry-run the dashboard renders to the Step Summary but is NOT persisted.
+
+# train_aggregate_block: emit the parsed ```json aggregate``` block (or empty).
+train_aggregate_block() {
+  local body
+  if [[ -n "${TRAIN_AGG_BODY_OVERRIDE:-}" ]]; then
+    body="${TRAIN_AGG_BODY_OVERRIDE}"
+  else
+    local num; num="$(train_state_issue_number)"
+    [[ -z "${num}" ]] && return 0
+    body="$(gh issue view "${num}" --json body --jq '.body' 2>/dev/null || echo "")"
+  fi
+  printf '%s\n' "${body}" | awk '
+    /^```json aggregate/ { inblk=1; next }
+    /^```/               { if (inblk) { inblk=0 }; next }
+    inblk                { print }
+  '
+}
+
+# train_aggregate_merge <prev-json> : read this run's per-run counters
+# (TRAIN_METRICS_KV) plus a time-to-land sample, fold them into prev, emit the
+# new aggregate JSON. Pure-ish (reads metric counters + env); no I/O writes.
+train_aggregate_merge() {
+  local prev="${1:-}" ttl_sample="${2:-}"
+  [[ -z "${prev}" ]] && prev='{}'
+
+  local landed_now flake_now esc_now batches_inc
+  landed_now="$(train_metric_get landed 0)"
+  flake_now="$(train_metric_get flake_reruns 0)"
+  esc_now="$(train_metric_get escalated 0)"
+  # A "batch" counts when at least one PR landed this run.
+  batches_inc=0; [[ "${landed_now}" -gt 0 ]] && batches_inc=1
+
+  jq -n \
+    --argjson prev "${prev}" \
+    --argjson landed_now "${landed_now}" \
+    --argjson flake_now "${flake_now}" \
+    --argjson esc_now "${esc_now}" \
+    --argjson batches_inc "${batches_inc}" \
+    --arg ttl "${ttl_sample}" \
+    --arg now "${TRAIN_RUN_TIMESTAMP:-}" \
+    '
+    ($prev.totals // {}) as $t
+    | ($prev.ttl_samples // []) as $samp
+    | (if ($ttl|length) > 0 then ($samp + [($ttl|tonumber)]) else $samp end) as $samp2
+    | ($samp2 | sort) as $sorted
+    | (if ($sorted|length) > 0 then $sorted[ (($sorted|length)/2) | floor ] else null end) as $median
+    | {
+        schema: "honua.merge-train.aggregate/v1",
+        updated: $now,
+        totals: {
+          batches:         (($t.batches // 0) + $batches_inc),
+          prs_landed:      (($t.prs_landed // 0) + $landed_now),
+          flake_reruns:    (($t.flake_reruns // 0) + $flake_now),
+          escalations:     (($t.escalations // 0) + $esc_now),
+          runs:            (($t.runs // 0) + 1)
+        },
+        median_time_to_land_seconds: $median,
+        ttl_samples: ($samp2 | .[-50:])
+      }'
+}
+
+# train_aggregate_dashboard_md <agg-json> <trunk_sha> <last_landed> : render the
+# human Markdown dashboard for the state issue (and Step Summary).
+train_aggregate_dashboard_md() {
+  local agg="$1" trunk="$2" last="$3"
+  local batches prs flake esc runs median rate
+  batches="$(jq -r '.totals.batches // 0' <<<"${agg}")"
+  prs="$(jq -r '.totals.prs_landed // 0' <<<"${agg}")"
+  flake="$(jq -r '.totals.flake_reruns // 0' <<<"${agg}")"
+  esc="$(jq -r '.totals.escalations // 0' <<<"${agg}")"
+  runs="$(jq -r '.totals.runs // 0' <<<"${agg}")"
+  median="$(jq -r '.median_time_to_land_seconds // "—"' <<<"${agg}")"
+  # flake-rerun rate = flake reruns / batches (guard div-by-zero).
+  if [[ "${batches}" -gt 0 ]]; then
+    rate="$(jq -rn --argjson f "${flake}" --argjson b "${batches}" '($f/$b)|.*100|floor/100')"
+  else
+    rate="0"
+  fi
+
+  printf '## Merge Train — aggregate dashboard\n\n'
+  printf '| Metric | Value |\n|---|---|\n'
+  printf '| Total batches landed | %s |\n' "${batches}"
+  printf '| PRs landed | %s |\n' "${prs}"
+  printf '| Train runs | %s |\n' "${runs}"
+  printf '| Median time-to-land | %s |\n' "$([[ "${median}" == "—" || "${median}" == "null" ]] && echo "—" || echo "${median}s")"
+  printf '| Flake-rerun rate (reruns/batch) | %s |\n' "${rate}"
+  printf '| Escalations | %s |\n' "${esc}"
+  printf '| Current trunk SHA | `%s` |\n' "${trunk:-—}"
+  printf '| Last-landed SHA | `%s` |\n' "${last:-—}"
+  printf '| Live flake signatures | `%s` |\n' "${TRAIN_FLAKE_REGEX}"
+  printf '\n'
+}
+
+# train_aggregate_update <trunk_sha> <last_landed> [ttl_sample_seconds]:
+# fold this run into the persisted aggregate and write it (with the machine-state
+# block preserved) back to the state issue. Side-effecting (gated by TRAIN_APPLY
+# via train_state_write); in dry-run it renders to the Step Summary only.
+train_aggregate_update() {
+  local trunk="$1" last="$2" ttl="${3:-}"
+  local prev agg
+  prev="$(train_aggregate_block)"
+  agg="$(train_aggregate_merge "${prev}" "${ttl}")"
+
+  # Render the human dashboard (always emitted to the Step Summary for visibility).
+  local md; md="$(train_aggregate_dashboard_md "${agg}" "${trunk}" "${last}")"
+  if train_have train_summary; then
+    while IFS= read -r line; do train_summary "${line}"; done <<<"${md}"
+  fi
+
+  # Persist only in LIVE mode (dry-run never writes the issue).
+  if [[ "${TRAIN_APPLY}" != "1" ]]; then
+    train_log "dry-run: aggregate dashboard rendered (not persisted to state issue)"
+    return 0
+  fi
+
+  # Read the current machine-state block back so we re-emit a complete body.
+  local state_json; state_json="$(train_state_read)"
+  [[ -z "${state_json}" ]] && state_json='{}'
+
+  local body="${TRAIN_AGG_BODY_FILE:-$(mktemp)}"
+  {
+    printf 'Machine-managed state for the optimistic batch merge train. Do not edit by hand.\n\n'
+    printf '%s' "${md}"
+    printf '\n```json\n%s\n```\n' "${state_json}"
+    printf '\n```json aggregate\n%s\n```\n' "${agg}"
+  } >"${body}"
+  train_state_write "${body}"
+}

--- a/scripts/ci/merge-train/train.sh
+++ b/scripts/ci/merge-train/train.sh
@@ -45,31 +45,68 @@ trap 'rm -rf "${TRAIN_WORK}"' EXIT
 export TRAIN_INCLUDED_FILE="${TRAIN_WORK}/included.tsv"
 export TRAIN_SKIPPED_FILE="${TRAIN_WORK}/skipped.tsv"
 export TRAIN_RUN_ID_FILE="${TRAIN_WORK}/run_id"
+# Instrumentation sinks (additive observability — no decision logic reads these).
+export TRAIN_TIMINGS_FILE="${TRAIN_WORK}/timings.kv"
+export TRAIN_METRICS_KV="${TRAIN_WORK}/metrics.kv"
+: >"${TRAIN_TIMINGS_FILE}"; : >"${TRAIN_METRICS_KV}"
+# Where the machine-readable metrics doc is written (uploaded as an artifact).
+: "${TRAIN_METRICS_OUT:=${TRAIN_REPO_ROOT}/merge-train-metrics.json}"
+# Run timestamp: prefer one injected by the workflow; else generate.
+: "${TRAIN_RUN_TIMESTAMP:=$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+# _train_mode_label: human label for the run mode.
+_train_mode_label() { [[ "${TRAIN_APPLY}" == "1" ]] && echo LIVE || echo DRY-RUN; }
+
+# _emit_metrics <outcome> <trunk_sha> <last_landed> [shard_descriptor]: render the
+# machine-readable metrics JSON to TRAIN_METRICS_OUT (best-effort; never fatal).
+_emit_metrics() {
+  local outcome="$1" trunk_sha="$2" last_landed="$3" shard_desc="${4:-}"
+  train_metrics_render "${TRAIN_RUN_TIMESTAMP}" "$(_train_mode_label)" \
+    "${trunk_sha}" "${last_landed}" "${outcome}" "${shard_desc}" \
+    >"${TRAIN_METRICS_OUT}" 2>/dev/null \
+    && train_log "metrics written: ${TRAIN_METRICS_OUT} (outcome=${outcome})" \
+    || train_warn "could not write metrics JSON"
+}
 
 main() {
-  train_log "mode: $( [[ "${TRAIN_APPLY}" == "1" ]] && echo LIVE || echo DRY-RUN ) MAX_BATCH=${MAX_BATCH}"
+  train_log "mode: $(_train_mode_label) MAX_BATCH=${MAX_BATCH} run=${TRAIN_RUN_TIMESTAMP}"
 
   # --- select ----------------------------------------------------------------
+  train_group select "pick ready PRs (oldest-first, capped at ${MAX_BATCH})"
+  train_step_begin select
   local selected
   selected="$(train_select | jq -s '.')"
   local prs
   prs="$(jq -r '.[].number' <<<"${selected}")"
+  local n_selected; n_selected="$(jq 'length' <<<"${selected}")"
+  train_metric_set selected "${n_selected}"
+  # candidates = total open PRs the selector evaluated (selected ones surface in
+  # the batch; the rest were skipped at select for draft/hold/conflict/CI-gate).
+  # TRAIN_CANDIDATE_COUNT lets the caller inject the raw count; else fall back to
+  # the selected count so the metric is never larger than reality.
+  train_metric_set candidates "${TRAIN_CANDIDATE_COUNT:-${n_selected}}"
+  train_metric_set skipped_select "$(( ${TRAIN_CANDIDATE_COUNT:-${n_selected}} - n_selected ))"
+  train_step_end select >/dev/null
   if [[ -z "${prs}" ]]; then
-    train_log "no ready PRs; nothing to do"
-    echo
-    echo "=== MERGE TRAIN DECISION (dry-run=$([[ "${TRAIN_APPLY}" == "1" ]] && echo 0 || echo 1)) ==="
-    echo "selected batch: (none)"
+    train_decision "no ready PRs; nothing to do"
+    train_endgroup
+    _emit_metrics "nothing-ready" "" "" ""
+    _dashboard "" "${selected}" "" "" "no ready PRs — nothing to select"
     return 0
   fi
-  train_log "candidate batch (oldest-first, capped): $(tr '\n' ' ' <<<"${prs}")"
+  train_decision "candidate batch (oldest-first, capped): $(tr '\n' ' ' <<<"${prs}")"
+  train_endgroup
 
   # --- trunk base ------------------------------------------------------------
   git -C "${TRAIN_REPO_ROOT}" fetch --quiet "${TRAIN_REMOTE}" "${TRAIN_BASE_BRANCH}"
   local trunk_sha trunk_sha7
   trunk_sha="$(git -C "${TRAIN_REPO_ROOT}" rev-parse "${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}")"
   trunk_sha7="${trunk_sha:0:7}"
+  train_log "trunk base: ${trunk_sha} (${trunk_sha7})"
 
   # --- assemble (transactional detect-and-skip) ------------------------------
+  train_group assemble "merge PR heads onto a fresh branch off ${TRAIN_BASE_BRANCH}"
+  train_step_begin assemble
   # state: write BEFORE assembling (resumable at assemble phase).
   _write_state "" "${trunk_sha}" "" "assemble" "" 0 0
   local batch
@@ -80,12 +117,21 @@ main() {
   local included skipped
   included="$(cut -f1 "${TRAIN_INCLUDED_FILE}" | tr '\n' ',' | sed 's/,$//')"
   skipped="$(cut -f1 "${TRAIN_SKIPPED_FILE}" | tr '\n' ' ')"
-  train_log "INCLUDED: ${included:-<none>}"
-  [[ -n "${skipped// /}" ]] && train_log "SKIPPED_CONFLICT: ${skipped}"
+  train_metric_set included "$(grep -c . "${TRAIN_INCLUDED_FILE}" 2>/dev/null || echo 0)"
+  train_metric_set skipped_conflict "$(grep -c . "${TRAIN_SKIPPED_FILE}" 2>/dev/null || echo 0)"
+  for pr in $(tr ',' ' ' <<<"${included}"); do
+    [[ -n "${pr}" ]] && train_decision "INCLUDE #${pr} (assembled clean)"
+  done
+  for pr in ${skipped}; do
+    [[ -n "${pr}" ]] && train_decision "SKIP #${pr} (conflict; aborted clean)"
+  done
+  train_step_end assemble >/dev/null
+  train_endgroup
 
   if [[ -z "${included}" ]]; then
-    train_warn "no PRs assembled cleanly; nothing to land"
-    _decision_report "${batch}" "${selected}" "${trunk_sha}" "" "(all skipped)"
+    train_annotate_warn "no PRs assembled cleanly; nothing to land"
+    _emit_metrics "nothing-ready" "${trunk_sha}" "" ""
+    _dashboard "${batch}" "${selected}" "${trunk_sha}" "" "all candidates skipped on conflict — nothing to land"
     return 0
   fi
 
@@ -97,20 +143,29 @@ main() {
   done
 
   # --- smart-ci + forward-fix + flake + attribute loop -----------------------
+  train_group smart-ci "compute shard subset for the batch's cumulative diff"
+  train_step_begin smart-ci
   local shard_descriptor
   shard_descriptor="$(train_smart_ci_shards "${batch}")"
-  train_log "smart-CI shard subset: ${shard_descriptor}"
+  train_metric_set smartci_shard_count "$(jq -r '(.shards // []) | length' <<<"${shard_descriptor}" 2>/dev/null || echo 0)"
+  train_decision "smart-CI shard subset: ${shard_descriptor}"
 
   local gate fwdfix=0 flake_reruns=0
   gate="$(train_smart_ci_run "${batch}")"
+  train_step_end smart-ci >/dev/null
+  train_endgroup
 
   if [[ "${TRAIN_APPLY}" != "1" ]]; then
     train_log "dry-run: stopping before CI gate evaluation/land (no pushes happened)"
-    _decision_report "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" ""
+    _emit_metrics "dry-run" "${trunk_sha}" "" "${shard_descriptor}"
+    _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
+      "dry-run: stopped before CI gate/land (no pushes happened)"
     return 0
   fi
 
   # Live-mode gate handling (forward-fix -> flake -> attribute -> land).
+  train_group ci-gate "evaluate CI Gate; forward-fix / classify-flake / attribute"
+  train_step_begin ci-gate
   while [[ "${gate}" != "SUCCESS" ]]; do
     local run_id; run_id="$(cat "${TRAIN_RUN_ID_FILE}" 2>/dev/null || echo "")"
     local failing; failing="$(train_failing_jobs "${run_id}")"
@@ -120,6 +175,8 @@ main() {
       _write_state "${batch}" "${trunk_sha}" "${included}" "forward-fix" "${run_id}" "${fwdfix}" "${flake_reruns}"
       if train_forward_fix "${batch}" "${fwdfix}"; then
         fwdfix=$((fwdfix + 1))
+        train_metric_set forward_fixes "${fwdfix}"
+        train_decision "forward-fix #${fwdfix} applied (dotnet format); re-running CI"
         gate="$(train_smart_ci_run "${batch}")"
         continue
       fi
@@ -129,6 +186,8 @@ main() {
     _write_state "${batch}" "${trunk_sha}" "${included}" "classify-flake" "${run_id}" "${fwdfix}" "${flake_reruns}"
     if train_classify_flake "${run_id}" "${flake_reruns}"; then
       flake_reruns=$((flake_reruns + 1))
+      train_metric_set flake_reruns "${flake_reruns}"
+      train_decision "flake signature matched; rerun #${flake_reruns} of failed jobs"
       # Re-poll the same run after rerun.
       while :; do
         local st; st="$(gh run view "${run_id}" --json status --jq '.status' 2>/dev/null || echo "")"
@@ -143,20 +202,32 @@ main() {
     _write_state "${batch}" "${trunk_sha}" "${included}" "attribute" "${run_id}" "${fwdfix}" "${flake_reruns}"
     local culprits; culprits="$(train_attribute "${failing}" "${TRAIN_INCLUDED_FILE}")"
     if [[ "${culprits}" == "ESCALATE_BATCH" ]]; then
-      train_warn "escalating entire batch; manual triage required"
+      train_metric_inc escalated "$(grep -c . "${TRAIN_INCLUDED_FILE}" 2>/dev/null || echo 0)"
+      train_annotate_warn "escalating entire batch; manual triage required"
       for pr in $(tr ',' ' ' <<<"${included}"); do
         train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_LANDING}"
       done
+      train_step_end ci-gate >/dev/null; train_endgroup
+      _emit_metrics "escalated-batch" "${trunk_sha}" "" "${shard_descriptor}"
+      _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
+        "ESCALATED whole batch: CI failure not attributable to a member diff"
       return 0
     fi
     # Drop culprits, rebuild minus them, re-CI.
     local remaining="${included}"
     for pr in ${culprits}; do
       train_drop_pr "${pr}" "real CI failure attributed to its diff"
+      train_metric_inc attribution_drops
+      train_metric_inc escalated
+      train_notice "DROP #${pr}: real CI failure attributed to its diff; rebuilding batch without it"
       remaining="$(tr ',' '\n' <<<"${remaining}" | grep -vx "${pr}" | tr '\n' ',' | sed 's/,$//')"
     done
     if [[ -z "${remaining}" ]]; then
-      train_warn "all members dropped; batch empty"
+      train_annotate_warn "all members dropped; batch empty"
+      train_step_end ci-gate >/dev/null; train_endgroup
+      _emit_metrics "all-dropped" "${trunk_sha}" "" "${shard_descriptor}"
+      _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
+        "all batch members dropped on attribution — batch empty"
       return 0
     fi
     included="${remaining}"
@@ -166,20 +237,43 @@ main() {
     included="$(cut -f1 "${TRAIN_INCLUDED_FILE}" | tr '\n' ',' | sed 's/,$//')"
     gate="$(train_smart_ci_run "${batch}")"
   done
+  train_step_end ci-gate >/dev/null
+  train_endgroup
 
   # --- land (FF-only CAS) ----------------------------------------------------
+  train_group land "fast-forward-only CAS push of the CI-green batch onto ${TRAIN_BASE_BRANCH}"
+  train_step_begin land
   _write_state "${batch}" "${trunk_sha}" "${included}" "land" "$(cat "${TRAIN_RUN_ID_FILE}" 2>/dev/null)" "${fwdfix}" "${flake_reruns}"
   local rc=0
   train_land "${batch}" "${trunk_sha}" "${TRAIN_INCLUDED_FILE}" || rc=$?
   if [[ "${rc}" == "10" ]]; then
-    train_warn "land deferred: trunk moved; the next scheduled run re-assembles"
+    train_annotate_warn "land deferred: trunk moved; the next scheduled run re-assembles"
+    train_step_end land >/dev/null; train_endgroup
+    _emit_metrics "trunk-moved-reassemble" "${trunk_sha}" "" "${shard_descriptor}"
+    _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
+      "land deferred: trunk moved (FF-CAS) — next run re-assembles"
     return 0
   fi
-  [[ "${rc}" != "0" ]] && { train_err "land failed (rc=${rc})"; return "${rc}"; }
+  if [[ "${rc}" != "0" ]]; then
+    train_err "land failed (rc=${rc})"
+    train_step_end land >/dev/null; train_endgroup
+    _emit_metrics "land-error" "${trunk_sha}" "" "${shard_descriptor}"
+    _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
+      "land FAILED (rc=${rc})"
+    return "${rc}"
+  fi
 
   local new_trunk; new_trunk="$(git -C "${TRAIN_REPO_ROOT}" rev-parse "${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}")"
+  train_metric_set landed "$(grep -c . "${TRAIN_INCLUDED_FILE}" 2>/dev/null || echo 0)"
   _write_state "" "${new_trunk}" "" "done" "" 0 0 "${batch_landed:-${new_trunk}}"
-  train_log "landed batch ${batch}; trunk now ${new_trunk:0:7}"
+  train_notice "LANDED batch ${batch} ($(tr ',' ' ' <<<"${included}")); trunk now ${new_trunk:0:7}"
+  train_step_end land >/dev/null
+  train_endgroup
+  _emit_metrics "landed" "${new_trunk}" "${new_trunk}" "${shard_descriptor}"
+  _dashboard "${batch}" "${selected}" "${new_trunk}" "${shard_descriptor}" \
+    "LANDED ${included} via FF-CAS; trunk now ${new_trunk:0:7}"
+  # Persistent over-time dashboard (state issue): aggregate after a successful land.
+  train_aggregate_update "${new_trunk}" "${new_trunk}"
 }
 
 # _write_state branch trunk_base included-csv phase run_id fwdfix flake [last_landed]
@@ -189,35 +283,118 @@ _write_state() {
   train_state_write "${body}"
 }
 
-# _decision_report: human-readable dry-run summary (the shadow-run output).
-_decision_report() {
+# _pr_decision <pr>: classify a candidate PR's outcome for the dashboard table.
+# Reads the included/skipped scratch files (decision logic already ran). Returns
+# "included" / "skipped (conflict)" / "escalated".
+_pr_decision() {
+  local pr="$1"
+  if grep -qE "^${pr}	" "${TRAIN_INCLUDED_FILE}" 2>/dev/null; then
+    echo "✅ included"
+  elif grep -qE "^${pr}	" "${TRAIN_SKIPPED_FILE}" 2>/dev/null; then
+    echo "⏭️ skipped — assemble conflict (aborted clean)"
+  else
+    echo "⏹️ not in batch"
+  fi
+}
+
+# _dashboard <batch> <selected-json> <trunk_sha> <shard_descriptor> <outcome-note>
+# The headline deliverable: a Markdown report appended to $GITHUB_STEP_SUMMARY
+# (and mirrored to stdout for local dry-runs). Reads only the scratch files /
+# metrics the decision logic already produced — it makes NO decisions.
+_dashboard() {
   local batch="$1" selected="$2" trunk_sha="$3" shard_descriptor="$4" note="$5"
-  echo
-  echo "=== MERGE TRAIN DECISION (dry-run) ==="
-  echo "trunk base:        ${trunk_sha} (${trunk_sha:0:7})"
-  echo "batch branch:      ${batch}"
-  echo
-  echo "candidate PRs (oldest-first, capped at MAX_BATCH=${MAX_BATCH}):"
-  jq -r '.[] | "  #\(.number)  created=\(.createdAt)  ci-gate=\(.gate)"' <<<"${selected}"
-  echo
-  echo "WOULD INCLUDE (assembled clean):"
-  if [[ -s "${TRAIN_INCLUDED_FILE}" ]]; then
-    while IFS=$'\t' read -r pr sha; do echo "  #${pr}  head=${sha:0:7}"; done <"${TRAIN_INCLUDED_FILE}"
+  local mode; mode="$(_train_mode_label)"
+
+  train_summary "## 🚂 Merge Train — ${mode} run"
+  train_summary ""
+  train_summary "| | |"
+  train_summary "|---|---|"
+  train_summary "| **Mode** | ${mode} ($([[ "${TRAIN_APPLY}" == "1" ]] && echo 'writes ACT' || echo 'no pushes/merges/comments')) |"
+  train_summary "| **Run timestamp** | ${TRAIN_RUN_TIMESTAMP} |"
+  train_summary "| **Trunk base** | \`${trunk_sha:-<none>}\` ${trunk_sha:+(${trunk_sha:0:7})} |"
+  train_summary "| **Batch branch** | \`${batch:-<none>}\` |"
+  train_summary "| **MAX_BATCH** | ${MAX_BATCH} |"
+  train_summary "| **Outcome** | ${note:-—} |"
+  train_summary ""
+
+  # --- candidates table ------------------------------------------------------
+  train_summary "### Candidates"
+  train_summary ""
+  if [[ "$(jq 'length' <<<"${selected}")" -gt 0 ]]; then
+    train_summary "| PR | Author | CI-Gate | Decision |"
+    train_summary "|---|---|---|---|"
+    local rows; rows="$(jq -r '.[] | "\(.number)\t\(.author // "?")\t\(.gate)"' <<<"${selected}")"
+    local num author gate decision
+    while IFS=$'\t' read -r num author gate; do
+      [[ -z "${num}" ]] && continue
+      decision="$(_pr_decision "${num}")"
+      train_summary "| #${num} | ${author} | ${gate} | ${decision} |"
+    done <<<"${rows}"
   else
-    echo "  (none)"
+    train_summary "_No PRs were eligible for selection this run._"
   fi
-  echo
-  echo "WOULD SKIP (conflict, aborted clean — zero residue):"
+  train_summary ""
+
+  # --- batch -----------------------------------------------------------------
+  local included_csv=""
+  [[ -s "${TRAIN_INCLUDED_FILE}" ]] && included_csv="$(cut -f1 "${TRAIN_INCLUDED_FILE}" 2>/dev/null | sed 's/^/#/' | tr '\n' ' ')"
+  train_summary "### Batch"
+  train_summary ""
+  train_summary "- **Branch:** \`${batch:-<none>}\`"
+  train_summary "- **Included PRs:** ${included_csv:-_(none)_}"
   if [[ -s "${TRAIN_SKIPPED_FILE}" ]]; then
-    while IFS=$'\t' read -r pr why; do echo "  #${pr}  ${why}"; done <"${TRAIN_SKIPPED_FILE}"
-  else
-    echo "  (none)"
+    local skipped_csv; skipped_csv="$(cut -f1 "${TRAIN_SKIPPED_FILE}" | sed 's/^/#/' | tr '\n' ' ')"
+    train_summary "- **Skipped (conflict):** ${skipped_csv}"
   fi
-  echo
-  echo "COMPUTED SMART-CI SHARD SUBSET (run on the cumulative batch diff):"
-  echo "  ${shard_descriptor:-<none>}"
-  [[ -n "${note}" ]] && { echo; echo "note: ${note}"; }
-  echo "======================================"
+  train_summary ""
+
+  # --- smart-CI shard set ----------------------------------------------------
+  train_summary "### Smart-CI shard set"
+  train_summary ""
+  if [[ -n "${shard_descriptor}" ]] && jq -e . >/dev/null 2>&1 <<<"${shard_descriptor}"; then
+    local run_all reason shards
+    run_all="$(jq -r '.run_all' <<<"${shard_descriptor}")"
+    reason="$(jq -r '.reason // ""' <<<"${shard_descriptor}")"
+    shards="$(jq -r '(.shards // []) | join(", ")' <<<"${shard_descriptor}")"
+    if [[ "${run_all}" == "true" ]]; then
+      train_summary "- **run_all:** \`true\` — ${reason:-full matrix}"
+    else
+      local shard_n; shard_n="$(jq -r '(.shards // []) | length' <<<"${shard_descriptor}")"
+      train_summary "- **Targeted (run_all=false), ${shard_n} shards:** ${shards:-_(none)_}"
+      [[ -n "${reason}" ]] && train_summary "- **Reason:** ${reason}"
+    fi
+  else
+    train_summary "_(not computed — no batch reached smart-CI)_"
+  fi
+  train_summary ""
+
+  # --- gate / heals / land ---------------------------------------------------
+  train_summary "### Run actions"
+  train_summary ""
+  train_summary "| Metric | Count |"
+  train_summary "|---|---|"
+  train_summary "| Candidates selected | $(train_metric_get selected 0) |"
+  train_summary "| Included | $(train_metric_get included 0) |"
+  train_summary "| Skipped (conflict) | $(train_metric_get skipped_conflict 0) |"
+  train_summary "| Forward-fixes applied | $(train_metric_get forward_fixes 0) |"
+  train_summary "| Flake reruns | $(train_metric_get flake_reruns 0) |"
+  train_summary "| Attribution drops | $(train_metric_get attribution_drops 0) |"
+  train_summary "| Escalated | $(train_metric_get escalated 0) |"
+  train_summary "| Landed | $(train_metric_get landed 0) |"
+  train_summary ""
+
+  # --- per-phase timings -----------------------------------------------------
+  if [[ -s "${TRAIN_TIMINGS_FILE:-/dev/null}" ]]; then
+    train_summary "### Per-phase timings"
+    train_summary ""
+    train_summary "| Phase | Seconds |"
+    train_summary "|---|---|"
+    awk -F= 'NF>=2 {t[$1]=$2} END {for (k in t) print k"\t"t[k]}' "${TRAIN_TIMINGS_FILE}" \
+      | while IFS=$'\t' read -r ph secs; do train_summary "| ${ph} | ${secs} |"; done
+    train_summary ""
+  fi
+
+  train_summary "_Machine-readable metrics: \`merge-train-metrics.json\` (workflow artifact). Aggregate over-time dashboard: the **Merge Train State** issue._"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Adds first-class instrumentation/logging to the optimistic batch merge train
(ADR-0055). Follow-up to #2039 (already merged): lack of visibility was half the
prior CI nightmare, so this makes every train decision obvious at a glance.

This is ADDITIVE observability only — no decision logic changed, dry-run stays
read-only, and the offline fixture suite is unchanged at 39/39.

## Changes Made

- `lib.sh`: leveled/grouped logging (`[train][step][LEVEL]`, INFO/WARN/DECISION),
  GitHub Actions `::group::`/`::notice::`/`::warning::` wrappers, per-phase
  timing, a `$GITHUB_STEP_SUMMARY` helper, per-run metric counters, and the
  `merge-train-metrics.json` renderer (`schema: honua.merge-train.metrics/v1`).
- `train.sh`: wrap each phase in groups + timings, increment metrics on every
  decision, route reporting into a Markdown Step Summary dashboard rendered on
  EVERY exit path (including nothing-selected, so a run is never silent), and
  emit the metrics JSON per outcome.
- `select.sh`: carry PR `author` through for the candidates table.
- `state.sh`: persistent over-time aggregate dashboard in the Merge Train State
  issue (batches, PRs landed, median time-to-land, flake-rerun rate,
  escalations, current/last-landed trunk SHA, live flake signatures). Dry-run
  renders to the Step Summary but does not persist to the issue.
- `merge-train.yml`: inject the run timestamp, add a never-silent Step Summary
  guard, and upload `merge-train-metrics.json` as a workflow artifact
  (`if: always()`). No `matrix.*` added to any job-level `if:`.
- `ADR-0055`: instrumentation section + metrics/aggregate schemas.

## Breaking Changes

None.

## Gate Impact

- [x] No gate impact (additive logging/reporting only; no decision logic changed)

## Testing

- [x] Ran scripts/ci/merge-train/fixtures/validate-merge-train.sh and all checks passed (39/39)
- [x] Dry-run (`TRAIN_APPLY=0`) against the real open PRs: rendered the Step
      Summary dashboard + a valid `merge-train-metrics.json`; `bash -n` all
      scripts; YAML parse of the workflow; `jq` validity of the metrics JSON.

Related to #2039
