### PR TITLE
ci: merge train Phase 2 — gated Bedrock LLM judgments (off by default)

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -1,0 +1,103 @@
+name: Merge Train
+
+# Optimistic batch merge train (Phase 1). DRY-RUN BY DEFAULT.
+#
+# This workflow assembles a batch of ready PRs, smart-CIs the batch, and (only
+# when explicitly told to act) lands it onto trunk. The default for every
+# automatic trigger is TRAIN_APPLY=0 — it computes and reports decisions but
+# performs NO pushes/merges/comments/issue writes. A human flips it live by
+# dispatching with train_apply=true.
+#
+# SAFETY: merging the PR that ADDS this workflow cannot make the train act,
+# because scheduled and workflow_run invocations hard-code TRAIN_APPLY=0 and the
+# workflow_dispatch input defaults to false.
+
+on:
+  # Cadence: dry-run report every 15 minutes (never acts).
+  schedule:
+    - cron: '*/15 * * * *'
+  # React to CI completions so a freshly-green PR is considered promptly.
+  # (Still dry-run unless a human dispatches with train_apply=true.)
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+  # Manual control. This is the ONLY path that can act, and only when the
+  # operator explicitly sets train_apply=true.
+  workflow_dispatch:
+    inputs:
+      train_apply:
+        description: 'Actually land the batch (push/merge/comment). Leave false for a dry-run report.'
+        type: boolean
+        required: false
+        default: false
+      max_batch:
+        description: 'Max PRs per batch.'
+        type: string
+        required: false
+        default: '3'
+
+# Serialize train runs: a batch in flight must finish before the next starts.
+# cancel-in-progress:false so we never abandon a half-landed batch mid-flight.
+concurrency:
+  group: merge-train
+  cancel-in-progress: false
+
+permissions:
+  contents: write        # push the batch branch / fast-forward trunk
+  pull-requests: write   # merge PRs, edit labels, comment
+  actions: write         # dispatch and rerun CI runs
+  issues: write          # maintain the Merge Train State issue
+
+jobs:
+  train:
+    name: Run Merge Train
+    runs-on: ubuntu-latest
+    # NOTE: do NOT put matrix.* in this job-level if: — there is no matrix on
+    # this job, and a matrix.* reference in a job-level if: previously caused a
+    # 0-job startup failure. This job runs on every listed trigger.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up gh + jq
+        run: |
+          jq --version
+          gh --version
+
+      - name: Resolve TRAIN_APPLY (dry-run unless explicitly dispatched live)
+        id: mode
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_APPLY: ${{ github.event.inputs.train_apply }}
+          DISPATCH_MAX_BATCH: ${{ github.event.inputs.max_batch }}
+        run: |
+          set -euo pipefail
+          # Only an explicit workflow_dispatch with train_apply=true acts.
+          # Scheduled and workflow_run invocations are ALWAYS dry-run.
+          apply=0
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" && "${DISPATCH_APPLY}" == "true" ]]; then
+            apply=1
+          fi
+          echo "train_apply=${apply}" >> "$GITHUB_OUTPUT"
+          mb="${DISPATCH_MAX_BATCH:-3}"; [[ -z "${mb}" ]] && mb=3
+          echo "max_batch=${mb}" >> "$GITHUB_OUTPUT"
+          echo "Resolved TRAIN_APPLY=${apply} (event=${EVENT_NAME}) MAX_BATCH=${mb}"
+
+      - name: Run train
+        env:
+          # HONUA_MERGE_TOKEN is preferred: a PAT can re-trigger downstream
+          # workflows (a push by GITHUB_TOKEN does NOT retrigger other
+          # workflows, so CI on the batch branch would not start). Fall back to
+          # GITHUB_TOKEN when the PAT is absent — acceptable for dry-run, but
+          # live landing wants the PAT so the batch-branch CI actually fires.
+          GH_TOKEN: ${{ secrets.HONUA_MERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          TRAIN_APPLY: ${{ steps.mode.outputs.train_apply }}
+          MAX_BATCH: ${{ steps.mode.outputs.max_batch }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${{ secrets.HONUA_MERGE_TOKEN }}" ]]; then
+            echo "::warning::HONUA_MERGE_TOKEN not set; using GITHUB_TOKEN. A GITHUB_TOKEN push does not retrigger downstream workflows, so live batch-branch CI may not start. Set HONUA_MERGE_TOKEN before enabling live mode."
+          fi
+          scripts/ci/merge-train/train.sh

--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -35,6 +35,11 @@ on:
         type: string
         required: false
         default: '3'
+      use_llm:
+        description: 'Enable the OPTIONAL gated Bedrock LLM judgment layer (TRAIN_LLM=1). Off by default; every gate has a deterministic fallback. Requires secrets.HONUA_BEDROCK_ROLE_ARN.'
+        type: boolean
+        required: false
+        default: false
 
 # Serialize train runs: a batch in flight must finish before the next starts.
 # cancel-in-progress:false so we never abandon a half-landed batch mid-flight.
@@ -47,6 +52,7 @@ permissions:
   pull-requests: write   # merge PRs, edit labels, comment
   actions: write         # dispatch and rerun CI runs
   issues: write          # maintain the Merge Train State issue
+  id-token: write        # GitHub OIDC: assume the Bedrock role (no long-lived keys)
 
 jobs:
   train:
@@ -72,6 +78,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           DISPATCH_APPLY: ${{ github.event.inputs.train_apply }}
           DISPATCH_MAX_BATCH: ${{ github.event.inputs.max_batch }}
+          DISPATCH_USE_LLM: ${{ github.event.inputs.use_llm }}
+          HAVE_BEDROCK_ROLE: ${{ secrets.HONUA_BEDROCK_ROLE_ARN != '' }}
         run: |
           set -euo pipefail
           # Only an explicit workflow_dispatch with train_apply=true acts.
@@ -83,7 +91,29 @@ jobs:
           echo "train_apply=${apply}" >> "$GITHUB_OUTPUT"
           mb="${DISPATCH_MAX_BATCH:-3}"; [[ -z "${mb}" ]] && mb=3
           echo "max_batch=${mb}" >> "$GITHUB_OUTPUT"
-          echo "Resolved TRAIN_APPLY=${apply} (event=${EVENT_NAME}) MAX_BATCH=${mb}"
+          # TRAIN_LLM defaults to 0 for ALL triggers. It can only turn on via an
+          # explicit workflow_dispatch with use_llm=true AND a configured
+          # Bedrock role ARN. Scheduled / workflow_run are always deterministic.
+          llm=0
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" && "${DISPATCH_USE_LLM}" == "true" ]]; then
+            if [[ "${HAVE_BEDROCK_ROLE}" == "true" ]]; then
+              llm=1
+            else
+              echo "::warning::use_llm=true but secrets.HONUA_BEDROCK_ROLE_ARN is unset; running deterministic (TRAIN_LLM=0). Configure the OIDC Bedrock role to enable the LLM layer."
+            fi
+          fi
+          echo "train_llm=${llm}" >> "$GITHUB_OUTPUT"
+          echo "Resolved TRAIN_APPLY=${apply} (event=${EVENT_NAME}) MAX_BATCH=${mb} TRAIN_LLM=${llm}"
+
+      # OIDC -> assume the Bedrock IAM role (scoped to bedrock:InvokeModel on the
+      # one model). Only runs when the LLM layer was actually enabled this run, so
+      # no AWS calls happen on the default deterministic path. No long-lived keys.
+      - name: Configure AWS credentials (Bedrock, OIDC)
+        if: steps.mode.outputs.train_llm == '1'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.HONUA_BEDROCK_ROLE_ARN }}
+          aws-region: ${{ vars.HONUA_BEDROCK_REGION || 'us-west-2' }}
 
       - name: Run train
         env:
@@ -95,6 +125,11 @@ jobs:
           GH_TOKEN: ${{ secrets.HONUA_MERGE_TOKEN || secrets.GITHUB_TOKEN }}
           TRAIN_APPLY: ${{ steps.mode.outputs.train_apply }}
           MAX_BATCH: ${{ steps.mode.outputs.max_batch }}
+          # OPTIONAL gated LLM layer. TRAIN_LLM=0 here on every default path; the
+          # gates are inert and make zero Bedrock calls unless this is 1.
+          TRAIN_LLM: ${{ steps.mode.outputs.train_llm }}
+          AWS_REGION: ${{ vars.HONUA_BEDROCK_REGION || 'us-west-2' }}
+          BEDROCK_MODEL_ID: ${{ vars.HONUA_BEDROCK_MODEL_ID || 'us.anthropic.claude-haiku-4-5-20251001-v1:0' }}
         run: |
           set -euo pipefail
           if [[ -z "${{ secrets.HONUA_MERGE_TOKEN }}" ]]; then

--- a/docs/internal/contributor/adr/0055-optimistic-batch-merge-train.md
+++ b/docs/internal/contributor/adr/0055-optimistic-batch-merge-train.md
@@ -1,0 +1,135 @@
+# ADR-0055: Optimistic batch merge train (Phase 1)
+
+## Status
+
+Proposed. Phase 1 (deterministic git assembly, smart-CI, attribution, FF-CAS
+land, dry-run-by-default workflow) lands with this ADR. It ships DISABLED for
+live action: every automatic trigger runs in dry-run, and only an explicit
+`workflow_dispatch` with `train_apply=true` (and a `HONUA_MERGE_TOKEN`) lands a
+batch. A human flips it live later. Phases 2/3 are tracked as roadmap below.
+
+## Context
+
+honua-server merges one PR at a time. GitHub's native merge queue was disabled
+(2026-06-18, ruleset 17808547) after batch sizes of ~5 caused runner
+starvation, ejected the front PR, reformed the group, and spiralled into zombie
+runs (see `docs/internal/contributor/merge-queue-runbook.md`). The lean
+`Merge Queue Gate` job replaced the full matrix on `merge_group`, but the queue
+itself is off, so throughput is gated by serial human merges.
+
+The single required PR check is **CI Gate** (`ci.yml`), an aggregator over the
+full heavy matrix that already validated each PR on its own `pull_request` run
+BEFORE it would ever land. Re-running that matrix per batch is what melted the
+runners. The opportunity: assemble several already-green PRs into one batch
+branch, run only the **smart-CI shard subset** that the batch's cumulative diff
+actually touches (via the existing ADR-0037 `honua-server-targeted-tests.sh` +
+`.github/ci-shards.json`), and fast-forward trunk once — catching only the
+semantic conflicts that BATCHING introduces, not re-proving each PR.
+
+The prior bar for any such automation: it must be deterministic, unit-tested
+offline, dry-run by default, and incapable of acting merely because its PR
+merged.
+
+## Decision
+
+Add an **optimistic batch merge train** as POSIX-bash steps under
+`scripts/ci/merge-train/` (each a sourceable, independently testable function;
+`train.sh` orchestrates) plus a `merge-train.yml` workflow that defaults to
+dry-run.
+
+### Steps
+
+1. **select** — `gh pr list --base trunk --state open`. Ready = non-draft,
+   labels exclude `train:hold`/`train:escalated` (and the pre-existing `hold`
+   opt-out), `mergeable==MERGEABLE`, and CI Gate `SUCCESS` or a flake-only
+   failure. Oldest-`createdAt` first, capped at `MAX_BATCH` (default 3).
+2. **assemble** (the git heart) — branch `train/batch/<trunkSha7>/<epoch>` off
+   `origin/trunk`; `git merge --no-ff` each PR head. On conflict
+   `git merge --abort` (transactional, ZERO residue), mark `SKIPPED_CONFLICT`,
+   continue. Records INCLUDED[] + each pre-merge head SHA.
+3. **smart-ci** — the targeted-tests script on the batch's cumulative diff picks
+   the shard subset; (live) push the branch + `gh workflow run ci.yml`, poll,
+   read the **CI Gate** job conclusion. The batch is a BRANCH, so its CI keys on
+   `ci-<ref>` — a DISTINCT concurrency group from each member's `ci-<pr#>`, so
+   the batch run can never cancel-in-progress a member's PR run.
+4. **forward-fix** — ONLY when the sole failure is the format-verify step:
+   `dotnet format Honua.sln` → commit `style: dotnet format (train forward-fix)`
+   → re-run. Cap 2. Everything else (proof-ledger / OpenAPI / feature-catalog
+   drift, compile/test failures) ESCALATES, never auto-patched.
+5. **classify-flake** (BEFORE attribute) — regex
+   `40P01|deadlock detected|ryuk|Testcontainers.*(timed out|connection refused)`
+   over failing-job logs. Match → a single `gh run rerun --failed` (cap 1),
+   never bisection. Reproduce twice → treat as real.
+6. **attribute** — REVERSE of smart-CI routing: failing shard →
+   `.paths[]` from ci-shards.json → which INCLUDED PR's diff touches those
+   prefixes. 1 suspect → drop it; ≥2 → drop all; 0 → escalate the whole batch.
+   Dropped PRs get `train:escalated` + a comment; rebuild minus culprits, re-CI.
+7. **land** — `git fetch origin trunk`; compare-and-swap: only if
+   `origin/trunk` still equals the assembled-onto SHA, `git push origin
+   <batch>:trunk` FF-only (a non-FF rejection ⇒ trunk moved ⇒ re-assemble; the
+   train NEVER lands un-CI'd bytes via force). Then `gh pr merge <n> --merge`
+   per INCLUDED PR.
+8. **state** — a `Merge Train State` issue (label `train:state`) with a fenced
+   JSON block, written BEFORE each side-effecting step so a crash is resumable;
+   per-PR labels `train:landing`/`train:escalated`/`train:hold` carry transient
+   state.
+
+### Dry-run contract (the safety bar)
+
+`TRAIN_APPLY` (default 0) gates every state-mutating action through a single
+`train_side_effect` chokepoint. In dry-run, real LOCAL git assembly and real
+READ-ONLY GitHub reads execute (so conflict detection and CI-status reads are
+genuine), but `git push`, `gh pr merge/edit/comment`, `gh workflow run`,
+`gh run rerun`, and issue writes are LOGGED, not executed. The `merge-train.yml`
+workflow hard-codes dry-run for `schedule` and `workflow_run` and defaults the
+`workflow_dispatch` `train_apply` input to `false`, so merging the PR that adds
+the train cannot make it act.
+
+### Workflow
+
+Triggers `schedule` (*/15), `workflow_run:{workflows:[CI]}`, and
+`workflow_dispatch` (`train_apply` boolean default false). `concurrency:
+{group: merge-train, cancel-in-progress: false}`. Permissions
+contents/pull-requests/actions/issues write. Uses `secrets.HONUA_MERGE_TOKEN`
+if present, else `GITHUB_TOKEN` (a `GITHUB_TOKEN` push does NOT retrigger
+downstream workflows, so live batch-branch CI needs the PAT). No `matrix.*`
+appears in any job-level `if:`.
+
+### No bot attribution (runtime requirement)
+
+The train's own commits (`style: dotnet format (train forward-fix)`) and PR/
+issue comments carry NO `Co-Authored-By` / "Generated with" / emoji lines, the
+same rule the repo enforces on humans. This is asserted in the fixture suite.
+
+## Validation
+
+`scripts/ci/merge-train/fixtures/validate-merge-train.sh` builds a throwaway
+local git repo + a bare "upstream" and asserts every decision path offline (no
+network, no gh, no dotnet): clean-merge, trunk-conflict (skip + zero residue),
+inter-PR-conflict, format-drift forward-fix (+ no-bot-attribution), real-test
+attribution (1 / ≥2 / 0 suspects), flake (single rerun, no bisection), and the
+FF-CAS race (stale-base + non-FF push both ⇒ re-assemble, never land). Offline
+gates: YAML parse, `bash -n`, `jq` validity, and a no-`matrix.*`-in-job-`if:`
+grep. A read-only shadow run against the real open PRs exercises real assembly
+and real shard computation with no writes.
+
+## Consequences
+
+- Throughput rises without re-melting runners: one smart-CI run lands several
+  already-green PRs.
+- Trunk integrity is preserved by FF-CAS: only the exact bytes CI validated land.
+- Phase 1 is inert until a human dispatches live with a `HONUA_MERGE_TOKEN`.
+
+## Roadmap (deferred)
+
+- **Phase 2** — live enablement with `HONUA_MERGE_TOKEN`, real CI poll/land,
+  and the resume-from-state-issue path exercised end to end on a live batch.
+- **Phase 3** — bisection-free finer attribution when ≥2 suspects share a
+  failing shard, batch-size auto-tuning, and starvation-aware scheduling.
+
+## Alternatives considered
+
+- **Re-enable native merge queue** — rejected: it is what spiralled; it re-runs
+  the full matrix per batch and cannot run a diff-targeted subset.
+- **Auto-patch non-format drift (proof-ledger/OpenAPI)** — rejected: those are
+  author-intent changes; the train escalates instead of guessing.

--- a/docs/internal/contributor/adr/0055-optimistic-batch-merge-train.md
+++ b/docs/internal/contributor/adr/0055-optimistic-batch-merge-train.md
@@ -122,10 +122,63 @@ and real shard computation with no writes.
 
 ## Roadmap (deferred)
 
-- **Phase 2** — live enablement with `HONUA_MERGE_TOKEN`, real CI poll/land,
-  and the resume-from-state-issue path exercised end to end on a live batch.
+- **Phase 2 (live enablement)** — live enablement with `HONUA_MERGE_TOKEN`, real
+  CI poll/land, and the resume-from-state-issue path exercised end to end on a
+  live batch.
 - **Phase 3** — bisection-free finer attribution when ≥2 suspects share a
   failing shard, batch-size auto-tuning, and starvation-aware scheduling.
+
+### Phase 2 — gated LLM judgment layer (AWS Bedrock / Claude)
+
+An **optional** enhancement that adds three narrow LLM judgments on top of the
+deterministic train. The deterministic train is the product of record; the LLM
+only breaks ties in ambiguous cases. It is **off by default** (`TRAIN_LLM=0`) on
+every trigger; the gates are never even consulted unless an operator dispatches
+with `use_llm=true` AND the OIDC Bedrock role is configured.
+
+**Provider choice — reuse honua-devops's Bedrock posture.** honua-devops bills
+Bedrock to the founder's AWS account (no Anthropic API key). We mirror that:
+AWS-CLI SigV4 via the ambient credential chain, the region honua-devops deploys
+to (`us-west-2`), and the Bedrock-native Anthropic Messages request shape
+(`anthropic_version: bedrock-2023-05-31`, `system` + `messages`, short
+`max_tokens` — these are classification calls). The client uses
+`aws bedrock-runtime invoke-model`. Model id and region are env-overridable
+(`BEDROCK_MODEL_ID`, `AWS_REGION`), defaulting to a Haiku-class cross-region
+inference profile (`us.anthropic.claude-haiku-4-5-20251001-v1:0`); an operator
+pins whatever profile their account is entitled to without editing code. The
+thin client lives in `scripts/ci/merge-train/bedrock-invoke.sh`.
+
+**Authentication — GitHub OIDC, no long-lived keys.** When the LLM layer is
+enabled the workflow gets `permissions: id-token: write` and assumes an IAM role
+from `secrets.HONUA_BEDROCK_ROLE_ARN` via `aws-actions/configure-aws-credentials`.
+That role is scoped to `bedrock:InvokeModel` on the single model. The
+credentials step only runs when the layer is enabled, so the default
+deterministic path performs no AWS calls and needs no AWS secrets.
+
+**The three gates and their deterministic fallbacks** (each only fires in its
+ambiguous condition, logs its prompt-class + decision via `train_log`, and falls
+back to exactly the Phase-1 behavior when `TRAIN_LLM=0` or Bedrock errors):
+
+| Gate | Ambiguous trigger | LLM question | Fallback (and TRAIN_LLM=0) |
+|---|---|---|---|
+| select overlap-dependency (`select.sh`) | two candidate PRs overlap ≥ `TRAIN_OVERLAP_PCT` (60%) of changed files | "should PR B wait for PR A to land first? yes/no" | keep oldest-first ordering (include B) |
+| classify-flake unknown-signature (`classify-flake.sh`) | a failing log matches NO known flake regex | "transient infra flake or real failure?" (+ may learn a regex) | treat unknown as REAL |
+| forward-fix drift-heal-safety (`forward-fix.sh`) | a non-format drift failure (OpenAPI/feature-catalog/proof-ledger) | "safely auto-healable by a known generator, or must a human fix it?" | ESCALATE, never auto-patch |
+
+The forward-fix gate only ever accepts a generator on a hard-coded allowlist
+(`TRAIN_HEAL_ALLOWLIST`), so an LLM hallucination cannot make the train run an
+arbitrary command; HEAL with a non-allowlisted generator falls back to escalate.
+
+**Robustness.** `bedrock_ask` returns a sentinel on ANY failure (disabled,
+missing `aws`/`jq`, timeout, non-zero exit, empty output). The train is NEVER
+blocked or escalated by a Bedrock outage — a failure degrades the train to
+exactly Phase 1.
+
+**Cost note.** Gated + Haiku/Claude-class. A typical **green** batch makes **0**
+Bedrock calls — the gates only fire on the ambiguous paths (heavy PR overlap,
+unknown flake signatures, non-format drift), which are rare. Calls are short
+classification calls (`max_tokens` capped at 256), billed to the founder's AWS
+account.
 
 ## Alternatives considered
 

--- a/scripts/ci/merge-train/assemble.sh
+++ b/scripts/ci/merge-train/assemble.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Step 2: assemble — the git heart. Build the batch branch by merging each
+# selected PR head onto a fresh branch off origin/<base>. Transactional
+# detect-and-skip: a merge that conflicts is `git merge --abort`ed so it leaves
+# ZERO residue, the PR is marked SKIPPED_CONFLICT, and assembly continues.
+#
+# This uses REAL local git in BOTH dry-run and live mode (conflict detection is
+# the whole point of the dry run). The only thing gated by TRAIN_APPLY is the
+# eventual push (step land), never the local assembly here.
+#
+# Outputs (written to the assoc-array-free way, via the named files passed in):
+#   - prints the batch branch name on stdout (last line).
+#   - appends to ${TRAIN_INCLUDED_FILE}:  "<pr>\t<preMergeHeadSha>" per included PR.
+#   - appends to ${TRAIN_SKIPPED_FILE}:   "<pr>\tSKIPPED_CONFLICT" per skipped PR.
+
+# train_assemble <base-trunk-sha7> <pr-numbers...>
+#   Reads the per-PR head SHA from `gh` (or TRAIN_HEAD_FOR_PR override in tests).
+#   Honors TRAIN_BATCH_BRANCH if preset (resume), else mints train/batch/<sha7>/<epoch>.
+train_assemble() {
+  local trunk_sha7="$1"; shift
+  local prs=("$@")
+
+  : "${TRAIN_INCLUDED_FILE:?TRAIN_INCLUDED_FILE must be set}"
+  : "${TRAIN_SKIPPED_FILE:?TRAIN_SKIPPED_FILE must be set}"
+  : >"${TRAIN_INCLUDED_FILE}"
+  : >"${TRAIN_SKIPPED_FILE}"
+
+  local epoch batch
+  epoch="$(date -u +%s)"
+  batch="${TRAIN_BATCH_BRANCH:-train/batch/${trunk_sha7}/${epoch}}"
+
+  # Branch from origin/<base>. The caller is responsible for an up-to-date fetch
+  # of the base; we resolve the base sha explicitly so the branch is pinned.
+  git -C "${TRAIN_REPO_ROOT}" fetch --quiet "${TRAIN_REMOTE}" "${TRAIN_BASE_BRANCH}"
+  git -C "${TRAIN_REPO_ROOT}" checkout -q -B "${batch}" "${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}"
+
+  local pr head pre_sha
+  for pr in "${prs[@]}"; do
+    [[ -z "${pr}" ]] && continue
+
+    # Fetch the PR head. In fixtures the caller injects a local ref resolver.
+    if [[ -n "${TRAIN_FETCH_PR_REF:-}" ]]; then
+      head="$("${TRAIN_FETCH_PR_REF}" "${pr}")"   # returns a resolvable ref
+    else
+      git -C "${TRAIN_REPO_ROOT}" fetch --quiet "${TRAIN_REMOTE}" "pull/${pr}/head"
+      head="FETCH_HEAD"
+    fi
+
+    pre_sha="$(git -C "${TRAIN_REPO_ROOT}" rev-parse "${head}")"
+
+    # Attempt the no-fast-forward merge. On conflict, abort transactionally.
+    if git -C "${TRAIN_REPO_ROOT}" merge --no-ff --no-edit \
+         -m "train: merge #${pr}" "${head}" >/dev/null 2>&1; then
+      printf '%s\t%s\n' "${pr}" "${pre_sha}" >>"${TRAIN_INCLUDED_FILE}"
+      train_log "assembled #${pr} (head ${pre_sha:0:7})"
+    else
+      git -C "${TRAIN_REPO_ROOT}" merge --abort >/dev/null 2>&1 || true
+      # Defensive: ensure no residue (a non-merge conflict path).
+      git -C "${TRAIN_REPO_ROOT}" reset -q --hard HEAD
+      printf '%s\t%s\n' "${pr}" "SKIPPED_CONFLICT" >>"${TRAIN_SKIPPED_FILE}"
+      train_warn "SKIPPED_CONFLICT #${pr} (conflict vs batch; aborted clean)"
+    fi
+  done
+
+  echo "${batch}"
+}
+
+# train_batch_diff_files <batch-branch>: cumulative diff filenames vs the merge
+# base with origin/<base>. Used by smart-ci to compute the shard subset.
+train_batch_diff_files() {
+  local batch="$1"
+  git -C "${TRAIN_REPO_ROOT}" diff --name-only \
+    "${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}...${batch}"
+}

--- a/scripts/ci/merge-train/attribute.sh
+++ b/scripts/ci/merge-train/attribute.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Step 6: attribute — for a REAL (non-flake) failure, map the failing shard back
+# to the batched PR(s) responsible, using the REVERSE of the smart-CI routing:
+#
+#   failing shard name --(ci-shards.json .paths[])--> path prefixes
+#   path prefixes --(each INCLUDED PR's `git diff --name-only base...head`)-->
+#       which PR's changeset touches those prefixes
+#
+# Decision:
+#   1 suspect  -> drop that one PR.
+#   >=2 suspects -> drop ALL suspects (can't disambiguate cheaply in Phase 1).
+#   0 suspects -> escalate the WHOLE batch (the failure isn't attributable to a
+#                 specific member diff, e.g. an integration/infra failure).
+#
+# Dropped PRs get the train:escalated label + a comment, then the batch is
+# rebuilt minus the culprits and re-CI'd (orchestrated by train.sh).
+
+# train_failing_shards_from_jobs <failing-job-names-newline>: map failing CI job
+# names to shard NAMES in ci-shards.json. The server-tests matrix job names are
+# the shard `shard_name`/`name`; we match by substring so "server-tests (Core)"
+# style names resolve. Emits unique shard names.
+train_failing_shards_from_jobs() {
+  local failing="$1" config="${2:-${TRAIN_SHARDS_CONFIG}}"
+  local shard
+  while IFS= read -r shard; do
+    [[ -z "${shard}" ]] && continue
+    # A job is attributable to this shard if the shard name appears in the job
+    # name (the matrix job is named with the shard's shard_name).
+    if printf '%s\n' "${failing}" | grep -Fq -- "${shard}"; then
+      printf '%s\n' "${shard}"
+    fi
+  done < <(jq -r '.shards[].name' "${config}") | sort -u
+}
+
+# train_pr_changed_files <pr> <head-ref>: "<pr>\t<file>" lines for one PR's diff
+# vs origin/<base>. Test override: TRAIN_DIFF_FOR_PR command.
+train_pr_changed_files() {
+  local pr="$1" head="$2"
+  local files
+  if [[ -n "${TRAIN_DIFF_FOR_PR:-}" ]]; then
+    files="$("${TRAIN_DIFF_FOR_PR}" "${pr}")"
+  else
+    files="$(git -C "${TRAIN_REPO_ROOT}" diff --name-only \
+      "${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}...${head}")"
+  fi
+  local f
+  while IFS= read -r f; do
+    [[ -z "${f}" ]] && continue
+    printf '%s\t%s\n' "${pr}" "${f}"
+  done <<<"${files}"
+}
+
+# train_attribute <failing-job-names> <included-file>: print the culprit PR
+# numbers (newline) or the literal "ESCALATE_BATCH" when no member is
+# attributable. <included-file> is the TRAIN_INCLUDED_FILE: "<pr>\t<preSha>".
+train_attribute() {
+  local failing="$1" included_file="$2"
+
+  local shards
+  shards="$(train_failing_shards_from_jobs "${failing}")"
+  if [[ -z "${shards}" ]]; then
+    train_warn "failing jobs map to no known shard; escalating whole batch"
+    echo "ESCALATE_BATCH"; return 0
+  fi
+
+  # Collect the union of all failing shards' paths.
+  local shard_paths=""
+  local s
+  while IFS= read -r s; do
+    [[ -z "${s}" ]] && continue
+    shard_paths+="$(train_shard_paths "${s}")"$'\n'
+  done <<<"${shards}"
+
+  # Build the "<pr>\t<file>" table across all INCLUDED PRs.
+  local pr_files="" pr head
+  while IFS=$'\t' read -r pr head; do
+    [[ -z "${pr}" ]] && continue
+    pr_files+="$(train_pr_changed_files "${pr}" "${head}")"$'\n'
+  done <"${included_file}"
+
+  local culprits
+  culprits="$(train_attribute_culprits "${shard_paths}" "${pr_files}")"
+  if [[ -z "${culprits}" ]]; then
+    train_warn "real failure not attributable to any member diff; escalating whole batch"
+    echo "ESCALATE_BATCH"; return 0
+  fi
+  printf '%s\n' "${culprits}"
+}
+
+# train_drop_pr <pr> <reason>: label train:escalated + comment, side-effecting.
+train_drop_pr() {
+  local pr="$1" reason="$2"
+  train_side_effect gh pr edit "${pr}" --add-label "${TRAIN_LABEL_ESCALATED}"
+  train_side_effect gh pr comment "${pr}" --body \
+    "Merge train dropped this PR from the batch: ${reason}. Rebuild the batch will exclude it until the ${TRAIN_LABEL_ESCALATED} label is removed."
+}

--- a/scripts/ci/merge-train/bedrock-invoke.sh
+++ b/scripts/ci/merge-train/bedrock-invoke.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Phase 2: bedrock-invoke — a thin, fail-safe AWS Bedrock (Claude) client for the
+# merge train's OPTIONAL gated LLM judgment layer.
+#
+# This file is SOURCEABLE: it defines functions only and performs no work at
+# source time. The deterministic Phase-1 train works WITHOUT this — the LLM is a
+# gated enhancement that is OFF BY DEFAULT (TRAIN_LLM=0) and every caller has a
+# safe deterministic fallback.
+#
+# Provider pattern reuse (honua-devops):
+#   honua-devops's Bedrock access is billed to the founder's AWS account (no
+#   Anthropic API key). We mirror that posture here: AWS-CLI SigV4 auth via the
+#   ambient credential chain (a GitHub OIDC role assumed in the workflow), the
+#   AWS region honua-devops deploys to (us-west-2), and the Bedrock Messages-API
+#   request shape (anthropic_version=bedrock-2023-05-31, system + messages,
+#   short max_tokens — these are classification calls, not generation). Model id
+#   and region are env-overridable so an operator can pin whatever inference
+#   profile their account has access to without editing code.
+#
+# ROBUSTNESS CONTRACT (never block the train on an LLM failure):
+#   bedrock_ask emits a sentinel ("__BEDROCK_ERROR__") on ANY failure path — LLM
+#   disabled, aws CLI missing, timeout, non-zero exit, empty/garbled output. The
+#   judgment wrappers treat the sentinel (and the disabled state) as "fall back
+#   to the deterministic Phase-1 behavior." A Bedrock outage degrades the train
+#   to exactly Phase 1; it never wedges or escalates spuriously on its own.
+
+# --- configuration knobs (env-overridable) -----------------------------------
+# TRAIN_LLM gates the ENTIRE layer. 0 (default) => deterministic-only; the gates
+# below are never even consulted. 1 => the gates MAY call Bedrock, but only in
+# their ambiguous condition (see select.sh / classify-flake.sh / forward-fix.sh).
+: "${TRAIN_LLM:=0}"
+
+# Model id + region default to honua-devops's Bedrock posture. Both overridable.
+# The default is a Haiku-class cross-region inference profile (cheap, fast — these
+# are short classification calls). An operator pins whatever profile their AWS
+# account is entitled to via BEDROCK_MODEL_ID without touching this file.
+: "${BEDROCK_MODEL_ID:=us.anthropic.claude-haiku-4-5-20251001-v1:0}"
+: "${AWS_REGION:=us-west-2}"
+
+# Short cap: classification answers are tiny (yes/no + maybe a regex line).
+: "${BEDROCK_MAX_TOKENS:=256}"
+# Hard timeout (seconds) on the aws call so a hung endpoint can't stall a batch.
+: "${BEDROCK_TIMEOUT:=30}"
+
+# Sentinel returned on every failure/disabled path. Callers compare against this
+# and take their deterministic fallback when they see it.
+BEDROCK_ERROR_SENTINEL='__BEDROCK_ERROR__'
+
+# bedrock_enabled: is the gated LLM layer turned on? (TRAIN_LLM=1)
+bedrock_enabled() { [[ "${TRAIN_LLM:-0}" == "1" ]]; }
+
+# bedrock_ask <system-prompt> <user-prompt> -> stdout answer (or the sentinel).
+#
+# Robust by construction: any failure (disabled, missing aws/jq, timeout,
+# non-zero exit, empty body) prints the sentinel to stdout and returns 0, so a
+# caller's `ans="$(bedrock_ask ...)"` never aborts under `set -e` and always has
+# a defined value to branch on.
+#
+# Test seam: if TRAIN_BEDROCK_ASK_CMD is set, it is invoked as
+#   "${TRAIN_BEDROCK_ASK_CMD}" <system> <user>
+# and its stdout is used verbatim. The fixture harness sets this to a fake that
+# returns canned answers (and can simulate a Bedrock error by echoing the
+# sentinel), so tests never touch real Bedrock / spend money.
+bedrock_ask() {
+  local system="$1" user="$2"
+
+  if ! bedrock_enabled; then
+    printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"
+    return 0
+  fi
+
+  if [[ -n "${TRAIN_BEDROCK_ASK_CMD:-}" ]]; then
+    local out
+    if ! out="$("${TRAIN_BEDROCK_ASK_CMD}" "${system}" "${user}" 2>/dev/null)"; then
+      printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"; return 0
+    fi
+    [[ -z "${out}" ]] && out="${BEDROCK_ERROR_SENTINEL}"
+    printf '%s\n' "${out}"
+    return 0
+  fi
+
+  # Real path needs aws + jq. Missing either => fall back, don't crash.
+  if ! command -v aws >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"; return 0
+  fi
+
+  # Build the Bedrock InvokeModel body in the Anthropic Messages shape.
+  # (Bedrock's native Anthropic surface: anthropic_version is the fixed Bedrock
+  # marker string, NOT a Claude model id; the model is selected by --model-id.)
+  local body
+  if ! body="$(jq -nc \
+        --argjson max "${BEDROCK_MAX_TOKENS}" \
+        --arg sys "${system}" \
+        --arg usr "${user}" \
+        '{
+           anthropic_version: "bedrock-2023-05-31",
+           max_tokens: $max,
+           system: $sys,
+           messages: [ { role: "user", content: [ { type: "text", text: $usr } ] } ]
+         }')"; then
+    printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"; return 0
+  fi
+
+  # Invoke. The AWS CLI writes the model output to a path argument (not stdout),
+  # so we capture it via a temp file. `timeout` caps a hung call.
+  local outfile rc=0 raw text
+  outfile="$(mktemp 2>/dev/null)" || { printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"; return 0; }
+
+  timeout "${BEDROCK_TIMEOUT}" aws bedrock-runtime invoke-model \
+    --region "${AWS_REGION}" \
+    --model-id "${BEDROCK_MODEL_ID}" \
+    --content-type "application/json" \
+    --accept "application/json" \
+    --body "${body}" \
+    --cli-binary-format raw-in-base64-out \
+    "${outfile}" >/dev/null 2>&1 || rc=$?
+
+  if [[ "${rc}" != "0" ]]; then
+    rm -f "${outfile}"
+    printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"; return 0
+  fi
+
+  raw="$(cat "${outfile}" 2>/dev/null)"; rm -f "${outfile}"
+  # Anthropic-on-Bedrock response: {"content":[{"type":"text","text":"..."}],...}
+  text="$(jq -r '.content[]? | select(.type=="text") | .text' <<<"${raw}" 2>/dev/null | head -c 4000)"
+  if [[ -z "${text}" ]]; then
+    printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"; return 0
+  fi
+  printf '%s\n' "${text}"
+  return 0
+}
+
+# bedrock_is_error <answer>: true if the answer is the failure sentinel.
+bedrock_is_error() { [[ "$1" == "${BEDROCK_ERROR_SENTINEL}" ]]; }
+
+# bedrock_first_word_yes <answer>: normalize a yes/no classification. Returns 0
+# (yes) only when the answer's first non-space token starts with "y" (case-insens).
+# The sentinel and anything non-affirmative return 1, so an errored/ambiguous
+# answer maps to "no" — callers pair this with an explicit fallback anyway.
+bedrock_first_word_yes() {
+  local ans="$1" first
+  bedrock_is_error "${ans}" && return 1
+  first="$(printf '%s' "${ans}" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ' | sed 's/^ *//' | cut -d' ' -f1)"
+  [[ "${first}" == y* ]]
+}

--- a/scripts/ci/merge-train/classify-flake.sh
+++ b/scripts/ci/merge-train/classify-flake.sh
@@ -27,6 +27,18 @@ train_run_logs_match_flake() {
 train_classify_flake() {
   local run_id="$1" rerun_count="${2:-0}"
   if ! train_run_logs_match_flake "${run_id}"; then
+    # Deterministic path found NO known flake signature. This is the ambiguous
+    # condition for the Phase-2 unknown-signature gate: optionally ask Bedrock
+    # whether it's a transient infra flake or a real failure (and learn a regex).
+    if train_classify_flake_unknown "${run_id}"; then
+      if [[ "${rerun_count}" -ge "${TRAIN_FLAKE_RERUN_CAP}" ]]; then
+        train_warn "llm-classified flake reproduced (rerun cap ${TRAIN_FLAKE_RERUN_CAP} reached); treating as real"
+        return 1
+      fi
+      train_log "llm[flake.unknown] classified TRANSIENT; issuing single rerun of failed jobs"
+      train_side_effect gh run rerun "${run_id}" --failed
+      return 0
+    fi
     train_log "no flake signature in failing logs; treating as real failure"
     return 1
   fi
@@ -36,5 +48,69 @@ train_classify_flake() {
   fi
   train_log "flake signature matched; issuing single rerun of failed jobs"
   train_side_effect gh run rerun "${run_id}" --failed
+  return 0
+}
+
+# --- Phase 2 gate: unknown-signature judgment (gated LLM) ---------------------
+# Invoked ONLY when the deterministic flake regex matched NO known signature
+# (the ambiguous case). Asks Bedrock: transient infra flake or real failure?
+# Returns 0 = TRANSIENT (caller may rerun once), 1 = REAL.
+#
+# Deterministic fallback (TRAIN_LLM=0 or Bedrock error): treat unknown as REAL
+# (return 1) — exactly the conservative Phase-1 behavior.
+#
+# Cheap learning: if Bedrock proposes a new flake regex line on a second output
+# line, we append it to the signature file at TRAIN_FLAKE_REGEX_LEARN_FILE (when
+# set and we are in live mode), so a future run recognizes the same signature
+# deterministically without an LLM call.
+train_classify_flake_unknown() {
+  local run_id="$1"
+  if ! declare -F bedrock_enabled >/dev/null 2>&1 || ! bedrock_enabled; then
+    return 1   # fallback: unknown => REAL (Phase-1 conservative default)
+  fi
+
+  local text
+  if [[ -n "${TRAIN_RUN_LOG_TEXT:-}" ]]; then
+    text="${TRAIN_RUN_LOG_TEXT}"
+  else
+    text="$(gh run view "${run_id}" --log-failed 2>/dev/null || echo "")"
+  fi
+  # Cap the log we send (these are classification calls, not generation).
+  text="$(printf '%s' "${text}" | tail -c 6000)"
+
+  local sys usr ans verdict regex
+  sys="You triage CI failures for a merge train. Given a failing job log that matched no known transient-flake pattern, decide if it is a TRANSIENT infrastructure flake (network blip, container/db startup race, runner eviction, deadlock) or a REAL code/test failure. Respond on the FIRST line with exactly one word: TRANSIENT or REAL. If TRANSIENT, you MAY add a SECOND line containing a single grep -E regex (no surrounding slashes) that would match this flake signature in future logs; otherwise omit the second line."
+  usr="Failing job log (tail):
+${text}
+
+Is this a transient infra flake or a real failure? First line: TRANSIENT or REAL. Optional second line: a grep -E regex for the flake signature."
+  ans="$(bedrock_ask "${sys}" "${usr}")"
+
+  if bedrock_is_error "${ans}"; then
+    train_log "llm[flake.unknown] bedrock error; fallback=REAL"
+    return 1
+  fi
+
+  verdict="$(printf '%s\n' "${ans}" | head -1 | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  if [[ "${verdict}" != transient* ]]; then
+    train_log "llm[flake.unknown] decision=REAL"
+    return 1
+  fi
+
+  # Optional learned regex on line 2 — append for future deterministic matches.
+  regex="$(printf '%s\n' "${ans}" | sed -n '2p' | sed 's/^ *//; s/ *$//')"
+  if [[ -n "${regex}" ]]; then
+    train_log "llm[flake.unknown] decision=TRANSIENT learned-regex=[${regex}]"
+    if [[ -n "${TRAIN_FLAKE_REGEX_LEARN_FILE:-}" ]]; then
+      # Recording the learned signature is a state mutation; gate it on apply.
+      if [[ "${TRAIN_APPLY:-0}" == "1" ]]; then
+        printf '%s\n' "${regex}" >>"${TRAIN_FLAKE_REGEX_LEARN_FILE}"
+      else
+        train_log "DRY-RUN (skipped): append learned flake regex to ${TRAIN_FLAKE_REGEX_LEARN_FILE}"
+      fi
+    fi
+  else
+    train_log "llm[flake.unknown] decision=TRANSIENT (no regex offered)"
+  fi
   return 0
 }

--- a/scripts/ci/merge-train/classify-flake.sh
+++ b/scripts/ci/merge-train/classify-flake.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Step 5: classify-flake — run BEFORE attribute. Scan the failing jobs' logs for
+# the flake signature regex (40P01 / deadlock detected / ryuk / Testcontainers
+# timeouts/connection-refused). On a match, do a SINGLE `gh run rerun <id>
+# --failed` (cap TRAIN_FLAKE_RERUN_CAP, default 1) — never a bisection. If the
+# same signature reproduces on the rerun, treat it as a REAL failure and fall
+# through to attribute.
+
+# train_run_logs_match_flake <run-id>: fetch the failed jobs' logs and test them
+# against the flake regex. Returns 0 (flake) / 1 (not). Test override:
+# TRAIN_RUN_LOG_TEXT supplies log text directly (offline fixtures).
+train_run_logs_match_flake() {
+  local run_id="$1"
+  local text
+  if [[ -n "${TRAIN_RUN_LOG_TEXT:-}" ]]; then
+    text="${TRAIN_RUN_LOG_TEXT}"
+  else
+    text="$(gh run view "${run_id}" --log-failed 2>/dev/null || echo "")"
+  fi
+  train_log_is_flake "${text}"
+}
+
+# train_classify_flake <run-id> <rerun-count>: if the failure looks like a flake
+# and we are under the rerun cap, issue ONE rerun and return 0 (caller re-polls).
+# Otherwise return 1 (treat as real -> attribute). The rerun is side-effecting
+# (gated by TRAIN_APPLY).
+train_classify_flake() {
+  local run_id="$1" rerun_count="${2:-0}"
+  if ! train_run_logs_match_flake "${run_id}"; then
+    train_log "no flake signature in failing logs; treating as real failure"
+    return 1
+  fi
+  if [[ "${rerun_count}" -ge "${TRAIN_FLAKE_RERUN_CAP}" ]]; then
+    train_warn "flake reproduced (rerun cap ${TRAIN_FLAKE_RERUN_CAP} reached); treating as real"
+    return 1
+  fi
+  train_log "flake signature matched; issuing single rerun of failed jobs"
+  train_side_effect gh run rerun "${run_id}" --failed
+  return 0
+}

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# Fixture harness for the merge train (Phase 1). Builds a throwaway local git
+# repo with synthetic "PR" branches and asserts the train's git/decision logic
+# offline — NO network, NO gh, NO dotnet. Each case targets one decision path:
+#
+#   1. clean-merge       -> two non-conflicting PRs both INCLUDED.
+#   2. trunk-conflict    -> a PR conflicting with trunk is SKIPPED (zero residue).
+#   3. inter-PR-conflict -> two PRs touching the same line; 2nd SKIPPED.
+#   4. format-drift      -> forward-fix path (format-only failure detection +
+#                           fake formatter commit; non-format failure escalates).
+#   5. real-test-fail    -> attribute maps failing shard -> paths -> culprit PR,
+#                           dropped; 0-suspect failure escalates whole batch.
+#   6. flake             -> flake regex match triggers ONE rerun (no bisection);
+#                           reproduce-twice => real.
+#   7. ff-cas-race       -> concurrent trunk advance => FF push rejected +
+#                           re-assemble signaled (rc=10).
+#
+# Run: scripts/ci/merge-train/fixtures/validate-merge-train.sh
+# Exit 0 = all pass.
+
+set -euo pipefail
+
+HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRAIN_DIR="$(cd "${HARNESS_DIR}/.." && pwd)"
+
+PASS=0; FAIL=0
+ok()   { printf '  PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+assert_eq() { [[ "$2" == "$3" ]] && ok "$1" || { bad "$1 (got [$2] want [$3])"; }; }
+assert_contains() { grep -Fq -- "$3" <<<"$2" && ok "$1" || bad "$1 (missing [$3] in [$2])"; }
+assert_not_contains() { ! grep -Fq -- "$3" <<<"$2" && ok "$1" || bad "$1 (unexpected [$3])"; }
+
+# --- build a throwaway repo with a fake remote -------------------------------
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "${SCRATCH}"' EXIT
+export TRAIN_APPLY=0
+export TRAIN_BASE_BRANCH=trunk
+export TRAIN_REMOTE=origin
+
+UPSTREAM="${SCRATCH}/upstream.git"
+WORK="${SCRATCH}/work"
+git init -q --bare "${UPSTREAM}"
+git init -q "${WORK}"
+cd "${WORK}"
+git config user.email "test@honua.io"; git config user.name "Test"
+git remote add origin "${UPSTREAM}"
+
+# Seed trunk with a couple of files mirroring real shard paths so attribution
+# can be exercised against ci-shards.json prefixes.
+mkdir -p src/Honua.Protocols.GeoServices/FeatureServer src/Honua.Protocols.OgcApi/Features
+printf 'line1\nline2\nline3\n' > shared.txt
+printf 'a\n' > src/Honua.Protocols.GeoServices/FeatureServer/fs.cs
+printf 'b\n' > src/Honua.Protocols.OgcApi/Features/ogc.cs
+git add -A; git commit -qm "seed trunk"
+git push -q origin HEAD:trunk
+TRUNK_SHA="$(git rev-parse HEAD)"
+
+# Helper to create a PR branch off trunk with a given mutation, pushed to a
+# local ref the train can fetch via FETCH_HEAD substitution.
+make_pr() {  # make_pr <name> <file> <content-append-or-cmd>
+  local name="$1" file="$2"; shift 2
+  git checkout -q -B "${name}" origin/trunk
+  "$@"
+  git add -A; git commit -qm "pr ${name}"
+  git push -q origin "HEAD:refs/heads/${name}"
+  git checkout -q origin/trunk 2>/dev/null || git checkout -q trunk
+}
+
+# The assemble step fetches pull/<n>/head; in fixtures we override the ref
+# resolver to map a PR "number" to its local branch ref.
+declare -A PR_REF
+fake_fetch_pr_ref() { git rev-parse "origin/${PR_REF[$1]}"; }
+export -f fake_fetch_pr_ref
+# Bash can't export assoc arrays; resolve via a file map instead.
+PRMAP="${SCRATCH}/prmap"; : >"${PRMAP}"
+resolve_pr_ref() { awk -v n="$1" '$1==n{print $2}' "${PRMAP}"; }
+export TRAIN_REPO_ROOT="${WORK}"
+
+# shellcheck source=../lib.sh
+. "${TRAIN_DIR}/lib.sh"
+. "${TRAIN_DIR}/assemble.sh"
+. "${TRAIN_DIR}/smart-ci.sh"
+. "${TRAIN_DIR}/forward-fix.sh"
+. "${TRAIN_DIR}/classify-flake.sh"
+. "${TRAIN_DIR}/attribute.sh"
+. "${TRAIN_DIR}/land.sh"
+. "${TRAIN_DIR}/select.sh"
+. "${TRAIN_DIR}/state.sh"
+
+# Point shard config + targeted script at the REAL repo files so attribution and
+# smart-CI exercise production routing.
+REAL_ROOT="$(cd "${TRAIN_DIR}/../../.." && pwd)"
+export TRAIN_SHARDS_CONFIG="${REAL_ROOT}/.github/ci-shards.json"
+export TRAIN_TARGETED_SCRIPT="${REAL_ROOT}/scripts/ci/honua-server-targeted-tests.sh"
+
+# The train fetches "FETCH_HEAD" by default; override fetch to resolve our map.
+export TRAIN_FETCH_PR_REF=__pr_ref
+__pr_ref() { resolve_pr_ref "$1"; }
+export -f __pr_ref resolve_pr_ref 2>/dev/null || true
+
+INC="${SCRATCH}/inc.tsv"; SKP="${SCRATCH}/skp.tsv"
+export TRAIN_INCLUDED_FILE="${INC}" TRAIN_SKIPPED_FILE="${SKP}"
+
+echo "== Case 1: clean-merge (two non-conflicting PRs both INCLUDED) =="
+make_pr pr101 src/Honua.Protocols.GeoServices/FeatureServer/fs.cs \
+  bash -c 'echo newfs >> src/Honua.Protocols.GeoServices/FeatureServer/fs.cs'
+echo "101 pr101" >>"${PRMAP}"
+make_pr pr102 src/Honua.Protocols.OgcApi/Features/ogc.cs \
+  bash -c 'echo newogc >> src/Honua.Protocols.OgcApi/Features/ogc.cs'
+echo "102 pr102" >>"${PRMAP}"
+git fetch -q origin trunk
+unset TRAIN_BATCH_BRANCH
+BATCH="$(train_assemble "${TRUNK_SHA:0:7}" 101 102)"
+inc_list="$(cut -f1 "${INC}" | tr '\n' ' ')"
+assert_contains "clean: #101 included" "${inc_list}" "101"
+assert_contains "clean: #102 included" "${inc_list}" "102"
+assert_eq "clean: no skips" "$(wc -l <"${SKP}" | tr -d ' ')" "0"
+
+echo "== Case 2: trunk-conflict (PR conflicts with trunk -> SKIPPED, zero residue) =="
+# Advance trunk so a PR built on the OLD trunk conflicts on the same line.
+git checkout -q -B trunk-adv origin/trunk
+printf 'line1\nTRUNK-CHANGED\nline3\n' > shared.txt
+git add -A; git commit -qm "advance trunk shared"
+git push -q origin HEAD:trunk
+git fetch -q origin trunk
+NEW_TRUNK="$(git rev-parse origin/trunk)"
+# PR built off OLD trunk that edits the same line differently.
+git checkout -q -B pr201 "${TRUNK_SHA}"
+printf 'line1\nPR-CHANGED\nline3\n' > shared.txt
+git add -A; git commit -qm "pr201 conflict"
+git push -q origin HEAD:refs/heads/pr201
+echo "201 pr201" >>"${PRMAP}"
+git checkout -q origin/trunk
+BATCH2="$(train_assemble "${NEW_TRUNK:0:7}" 201)"
+skp_list="$(cut -f1 "${SKP}" | tr '\n' ' ')"
+assert_contains "trunk-conflict: #201 skipped" "${skp_list}" "201"
+# Zero residue: working tree clean, no MERGE_HEAD.
+git diff --quiet && git diff --cached --quiet && ok "trunk-conflict: zero residue (clean tree)" || bad "trunk-conflict: residue left"
+[[ ! -f "${WORK}/.git/MERGE_HEAD" ]] && ok "trunk-conflict: no MERGE_HEAD" || bad "trunk-conflict: MERGE_HEAD remains"
+
+echo "== Case 3: inter-PR-conflict (2nd PR conflicts with 1st -> SKIPPED) =="
+git fetch -q origin trunk
+BASE3="$(git rev-parse origin/trunk)"
+git checkout -q -B pr301 origin/trunk
+printf 'X1\nX2\nX3\n' > conflictzone.txt
+git add -A; git commit -qm pr301; git push -q origin HEAD:refs/heads/pr301
+echo "301 pr301" >>"${PRMAP}"
+git checkout -q -B pr302 origin/trunk
+printf 'Y1\nY2\nY3\n' > conflictzone.txt
+git add -A; git commit -qm pr302; git push -q origin HEAD:refs/heads/pr302
+echo "302 pr302" >>"${PRMAP}"
+git checkout -q origin/trunk
+BATCH3="$(train_assemble "${BASE3:0:7}" 301 302)"
+inc3="$(cut -f1 "${INC}" | tr '\n' ' ')"; skp3="$(cut -f1 "${SKP}" | tr '\n' ' ')"
+assert_contains "inter-PR: #301 included" "${inc3}" "301"
+assert_contains "inter-PR: #302 skipped" "${skp3}" "302"
+git diff --quiet && ok "inter-PR: zero residue after 2nd abort" || bad "inter-PR: residue"
+
+echo "== Case 4: format-drift (forward-fix path) =="
+# Only-format-failure detection.
+train_is_format_only_failure "build / Format Verification" && ok "fwdfix: single format job => format-only" || bad "fwdfix: should be format-only"
+train_is_format_only_failure $'build / Format Verification\nserver-tests (Core)' && bad "fwdfix: multi-failure must NOT be format-only" || ok "fwdfix: multi-failure not format-only"
+train_is_format_only_failure "server-tests (Core)" && bad "fwdfix: non-format must NOT be format-only" || ok "fwdfix: non-format not format-only"
+# Fake formatter that produces a change -> forward-fix commits it.
+git fetch -q origin trunk; git checkout -q -B fwdfix-batch origin/trunk
+export TRAIN_FORMAT_CMD=__fake_fmt
+__fake_fmt() { echo "reformatted" >> shared.txt; }
+export -f __fake_fmt
+before="$(git rev-parse HEAD)"
+if train_forward_fix fwdfix-batch 0; then
+  after="$(git rev-parse HEAD)"
+  [[ "${before}" != "${after}" ]] && ok "fwdfix: produced a commit" || bad "fwdfix: no commit"
+  git log -1 --pretty=%s | grep -Fq "style: dotnet format (train forward-fix)" && ok "fwdfix: correct commit subject" || bad "fwdfix: wrong subject"
+  git log -1 --pretty='%an <%ae>%n%b' | grep -Eqi 'co-authored-by|generated with|🤖' && bad "fwdfix: bot attribution present" || ok "fwdfix: no bot attribution"
+else
+  bad "fwdfix: should have applied a change"
+fi
+# Cap: at cap, returns non-zero.
+__fake_fmt_noop() { :; }
+export TRAIN_FORMAT_CMD=__fake_fmt_noop; export -f __fake_fmt_noop
+train_forward_fix fwdfix-batch 2 && bad "fwdfix: cap not enforced" || ok "fwdfix: cap (2) enforced"
+unset TRAIN_FORMAT_CMD
+
+echo "== Case 5: real-test-fail (attribute + drop; 0-suspect escalates) =="
+# Build a 2-PR batch where pr401 touches a FeatureServer path and pr402 an OGC
+# path; a failing "FeatureServer Endpoints" shard must attribute to pr401 only.
+: >"${INC}"
+printf '401\t%s\n' "$(git rev-parse origin/trunk)" >>"${INC}"   # head placeholder (overridden below)
+printf '402\t%s\n' "$(git rev-parse origin/trunk)" >>"${INC}"
+# Override per-PR diffs to deterministic file lists.
+export TRAIN_DIFF_FOR_PR=__diff_for_pr
+__diff_for_pr() {
+  case "$1" in
+    401) printf 'src/Honua.Protocols.GeoServices/FeatureServer/fs.cs\n' ;;
+    402) printf 'src/Honua.Protocols.OgcApi/Features/ogc.cs\n' ;;
+  esac
+}
+export -f __diff_for_pr
+culprits="$(train_attribute "server-tests (FeatureServer Endpoints)" "${INC}")"
+assert_eq "attribute: single suspect => #401" "$(tr '\n' ' ' <<<"${culprits}" | xargs)" "401"
+# 0-suspect: a failing shard whose paths no PR touches => ESCALATE_BATCH.
+__diff_for_pr_none() { printf 'docs/readme.md\n'; }
+export TRAIN_DIFF_FOR_PR=__diff_for_pr_none; export -f __diff_for_pr_none
+esc="$(train_attribute "server-tests (FeatureServer Endpoints)" "${INC}")"
+assert_eq "attribute: 0 suspects => ESCALATE_BATCH" "${esc}" "ESCALATE_BATCH"
+# >=2 suspects: both PRs touch FeatureServer paths => both dropped.
+__diff_for_pr_both() { printf 'src/Honua.Protocols.GeoServices/FeatureServer/x.cs\n'; }
+export TRAIN_DIFF_FOR_PR=__diff_for_pr_both; export -f __diff_for_pr_both
+both="$(train_attribute "server-tests (FeatureServer Endpoints)" "${INC}" | sort | tr '\n' ' ' | xargs)"
+assert_eq "attribute: >=2 suspects => drop all" "${both}" "401 402"
+unset TRAIN_DIFF_FOR_PR
+
+echo "== Case 6: flake (single rerun, no bisection; reproduce-twice => real) =="
+export TRAIN_RUN_LOG_TEXT="... ERROR 40P01: deadlock detected ..."
+train_run_logs_match_flake 999 && ok "flake: 40P01 recognized" || bad "flake: 40P01 missed"
+export TRAIN_RUN_LOG_TEXT="Testcontainers timed out waiting for ryuk"
+train_run_logs_match_flake 999 && ok "flake: testcontainers/ryuk recognized" || bad "flake: missed"
+export TRAIN_RUN_LOG_TEXT="Assert.Equal() Failure: expected 3 actual 4"
+train_run_logs_match_flake 999 && bad "flake: real assertion misclassified" || ok "flake: real assertion not a flake"
+# classify_flake: under cap with a flake => returns 0 (rerun once, dry-run logs).
+export TRAIN_RUN_LOG_TEXT="40P01 deadlock detected"
+train_classify_flake 999 0 && ok "flake: first occurrence => rerun (rc0)" || bad "flake: should rerun once"
+# At cap (reproduced) => returns 1 (treat as real). No bisection ever invoked.
+train_classify_flake 999 1 && bad "flake: reproduced should be real" || ok "flake: reproduced => real (rc1)"
+unset TRAIN_RUN_LOG_TEXT
+
+echo "== Case 7: ff-cas-race (concurrent trunk advance => FF push rejected + re-assemble) =="
+git fetch -q origin trunk
+RACE_BASE="$(git rev-parse origin/trunk)"
+git checkout -q -B race-batch origin/trunk
+echo "batchwork" >> shared.txt; git add -A; git commit -qm "batch work"
+git push -q origin HEAD:refs/heads/race-batch
+# Now SOMEONE ELSE advances trunk after we captured RACE_BASE.
+git checkout -q -B race-interloper origin/trunk
+echo "interloper" >> other.txt; git add -A; git commit -qm "interloper advances trunk"
+git push -q origin HEAD:trunk
+git checkout -q race-batch
+: >"${INC}"; printf '701\t%s\n' "$(git rev-parse HEAD)" >>"${INC}"
+# Land with the STALE base => CAS detects trunk moved => rc 10 (re-assemble).
+set +e
+TRAIN_APPLY=1 train_land race-batch "${RACE_BASE}" "${INC}"; rc=$?
+set -e
+assert_eq "ff-cas: stale-base land => rc10 (re-assemble, no land)" "${rc}" "10"
+# And a genuine FF push (base current) with TRAIN_APPLY=1 against a non-FF branch
+# is server-rejected => rc10 too. Simulate by making race-batch NOT a descendant.
+git fetch -q origin trunk
+CUR_TRUNK="$(git rev-parse origin/trunk)"
+git checkout -q -B nonff-batch "${RACE_BASE}"   # branched off the OLD trunk
+echo "diverged" >> shared.txt; git add -A; git commit -qm "diverged work"
+: >"${INC}"; printf '702\t%s\n' "$(git rev-parse HEAD)" >>"${INC}"
+set +e
+TRAIN_APPLY=1 train_land nonff-batch "${CUR_TRUNK}" "${INC}"; rc2=$?
+set -e
+assert_eq "ff-cas: non-FF push server-rejected => rc10" "${rc2}" "10"
+
+echo
+echo "== Case 8: smart-CI shard computation on a real batch diff =="
+# pr101 touched a FeatureServer path => the descriptor must target FeatureServer
+# shards (not run_all) — proving smart-CI uses production routing.
+git fetch -q origin trunk
+git checkout -q -B smartci-batch origin/trunk
+mkdir -p src/Honua.Protocols.GeoServices/FeatureServer
+echo "// change" >> src/Honua.Protocols.GeoServices/FeatureServer/fs.cs
+git add -A; git commit -qm "featureserver change"
+desc="$(train_smart_ci_shards smartci-batch)"
+assert_contains "smart-ci: descriptor is valid JSON with shards" "$(jq -r 'has("shards")' <<<"${desc}")" "true"
+assert_contains "smart-ci: FeatureServer-only diff targets FeatureServer shard" "${desc}" "FeatureServer"
+assert_eq "smart-ci: not run_all for a targeted feature diff" "$(jq -r '.run_all' <<<"${desc}")" "false"
+
+echo
+echo "== State JSON rendering (crash-resume contract) =="
+body="$(train_state_render train/batch/abc/1 deadbeef "101,102" smart-ci 555 1 0 cafef00d)"
+assert_contains "state: fenced json block" "${body}" '```json'
+sj="$(printf '%s\n' "${body}" | awk '/^```json/{f=1;next}/^```/{f=0}f')"
+assert_eq "state: phase persisted" "$(jq -r '.active_batch.phase' <<<"${sj}")" "smart-ci"
+assert_eq "state: included persisted" "$(jq -rc '.active_batch.included' <<<"${sj}")" "[101,102]"
+assert_eq "state: max_batch in config" "$(jq -r '.config.max_batch' <<<"${sj}")" "${MAX_BATCH:-3}"
+assert_eq "state: last_landed_trunk" "$(jq -r '.last_landed_trunk' <<<"${sj}")" "cafef00d"
+
+echo
+echo "== select: CI-Gate classification + ordering + hold/draft filters =="
+export TRAIN_PR_LIST_JSON='[
+  {"number":10,"headRefOid":"aaa","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","labels":[],"createdAt":"2026-01-02T00:00:00Z","gate":"SUCCESS"},
+  {"number":11,"headRefOid":"bbb","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","labels":[],"createdAt":"2026-01-01T00:00:00Z","gate":"SUCCESS"},
+  {"number":12,"headRefOid":"ccc","isDraft":true,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","labels":[],"createdAt":"2026-01-03T00:00:00Z","gate":"SUCCESS"},
+  {"number":13,"headRefOid":"ddd","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","labels":[{"name":"hold"}],"createdAt":"2026-01-04T00:00:00Z","gate":"SUCCESS"},
+  {"number":14,"headRefOid":"eee","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","labels":[],"createdAt":"2026-01-05T00:00:00Z","gate":"SUCCESS"},
+  {"number":15,"headRefOid":"fff","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","labels":[],"createdAt":"2026-01-06T00:00:00Z","gate":"FAIL"}
+]'
+MAX_BATCH=3 sel="$(MAX_BATCH=3 train_select | jq -s -c '[.[].number]')"
+assert_eq "select: oldest-first, draft/hold/conflict/fail excluded" "${sel}" "[11,10]"
+unset TRAIN_PR_LIST_JSON
+# CI Gate state mapping.
+assert_eq "select: COMPLETED+SUCCESS => SUCCESS" "$(train_select_ci_gate_state '[{"name":"CI Gate","status":"COMPLETED","conclusion":"SUCCESS"}]')" "SUCCESS"
+assert_eq "select: COMPLETED+FAILURE => FAIL" "$(train_select_ci_gate_state '[{"name":"CI Gate","status":"COMPLETED","conclusion":"FAILURE"}]')" "FAIL"
+assert_eq "select: QUEUED => PENDING" "$(train_select_ci_gate_state '[{"name":"CI Gate","status":"QUEUED","conclusion":""}]')" "PENDING"
+assert_eq "select: absent => MISSING" "$(train_select_ci_gate_state '[]')" "MISSING"
+
+echo
+printf 'RESULT: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[[ "${FAIL}" -eq 0 ]]

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -78,6 +78,7 @@ export TRAIN_REPO_ROOT="${WORK}"
 
 # shellcheck source=../lib.sh
 . "${TRAIN_DIR}/lib.sh"
+. "${TRAIN_DIR}/bedrock-invoke.sh"
 . "${TRAIN_DIR}/assemble.sh"
 . "${TRAIN_DIR}/smart-ci.sh"
 . "${TRAIN_DIR}/forward-fix.sh"
@@ -295,6 +296,113 @@ assert_eq "select: COMPLETED+SUCCESS => SUCCESS" "$(train_select_ci_gate_state '
 assert_eq "select: COMPLETED+FAILURE => FAIL" "$(train_select_ci_gate_state '[{"name":"CI Gate","status":"COMPLETED","conclusion":"FAILURE"}]')" "FAIL"
 assert_eq "select: QUEUED => PENDING" "$(train_select_ci_gate_state '[{"name":"CI Gate","status":"QUEUED","conclusion":""}]')" "PENDING"
 assert_eq "select: absent => MISSING" "$(train_select_ci_gate_state '[]')" "MISSING"
+
+echo
+echo "== Phase 2: gated Bedrock LLM judgments (mock; no real Bedrock) =="
+# A fake bedrock_ask, wired via TRAIN_BEDROCK_ASK_CMD. It records that it was
+# called (so we can assert the gates NEVER touch it when TRAIN_LLM=0) and returns
+# whatever canned answer the test stuffs into FAKE_BEDROCK_ANSWER. Setting the
+# answer to the error sentinel simulates a Bedrock outage/timeout.
+BEDROCK_CALLS="${SCRATCH}/bedrock_calls"; : >"${BEDROCK_CALLS}"
+__fake_bedrock() {  # __fake_bedrock <system> <user>
+  echo "called" >>"${BEDROCK_CALLS}"
+  printf '%s\n' "${FAKE_BEDROCK_ANSWER:-}"
+}
+export -f __fake_bedrock
+export TRAIN_BEDROCK_ASK_CMD=__fake_bedrock
+reset_calls() { : >"${BEDROCK_CALLS}"; }
+calls() { wc -l <"${BEDROCK_CALLS}" | tr -d ' '; }
+
+# Two PR file sets with HEAVY overlap (B's files all appear in A) => ambiguous.
+FILES_A=$'src/Honua.Core/Query/Filter.cs\nsrc/Honua.Core/Query/Paging.cs\nsrc/Honua.Core/Query/Crs.cs'
+FILES_B=$'src/Honua.Core/Query/Filter.cs\nsrc/Honua.Core/Query/Paging.cs'  # 100% of B in A
+# A non-overlapping pair (deterministic-only, never ambiguous).
+FILES_C=$'docs/readme.md'
+
+# Pure overlap ratio is testable on its own.
+assert_eq "p2 overlap: B fully in A => 100" "$(train_pr_overlap_ratio "${FILES_A}" "${FILES_B}")" "100"
+assert_eq "p2 overlap: disjoint => 0" "$(train_pr_overlap_ratio "${FILES_A}" "${FILES_C}")" "0"
+
+echo "-- (a) TRAIN_LLM=0: gates NEVER call Bedrock; behavior == Phase-1 deterministic --"
+export TRAIN_LLM=0
+reset_calls
+# select.overlap: deterministic fallback is PROCEED (rc1), even on heavy overlap.
+train_select_should_wait 10 "${FILES_A}" 11 "${FILES_B}" && bad "p2 select(llm0): heavy overlap must still PROCEED" || ok "p2 select(llm0): PROCEED (Phase-1 ordering)"
+assert_eq "p2 select(llm0): no bedrock call" "$(calls)" "0"
+# classify-flake unknown: deterministic fallback is REAL (rc1).
+reset_calls
+export TRAIN_RUN_LOG_TEXT="Assert.Equal() Failure: expected 3 actual 4"
+train_classify_flake_unknown 999 && bad "p2 flake(llm0): unknown must be REAL" || ok "p2 flake(llm0): unknown => REAL (conservative)"
+assert_eq "p2 flake(llm0): no bedrock call" "$(calls)" "0"
+# forward-fix heal: deterministic fallback is ESCALATE (rc1).
+reset_calls
+train_forward_fix_heal_safe "server-tests (OpenAPI drift)" "openapi.json out of date" && bad "p2 heal(llm0): must ESCALATE" || ok "p2 heal(llm0): ESCALATE (never auto-patch)"
+assert_eq "p2 heal(llm0): no bedrock call" "$(calls)" "0"
+unset TRAIN_RUN_LOG_TEXT
+
+echo "-- (b) TRAIN_LLM=1: each gate fires ONLY in its ambiguous condition, routes on yes/no --"
+export TRAIN_LLM=1
+# select.overlap: BELOW threshold (disjoint) must NOT call the LLM at all.
+reset_calls
+FAKE_BEDROCK_ANSWER="YES" train_select_should_wait 10 "${FILES_A}" 11 "${FILES_C}" && bad "p2 select(llm1,low-overlap): disjoint must PROCEED" || ok "p2 select(llm1): disjoint => PROCEED without LLM"
+assert_eq "p2 select(llm1): low-overlap skips bedrock" "$(calls)" "0"
+# select.overlap: heavy overlap + LLM says YES => WAIT (rc0).
+reset_calls
+FAKE_BEDROCK_ANSWER="YES, B depends on A" train_select_should_wait 10 "${FILES_A}" 11 "${FILES_B}" && ok "p2 select(llm1): heavy overlap + YES => WAIT" || bad "p2 select(llm1): YES should WAIT"
+assert_eq "p2 select(llm1,yes): bedrock consulted once" "$(calls)" "1"
+# select.overlap: heavy overlap + LLM says NO => PROCEED (rc1).
+reset_calls
+FAKE_BEDROCK_ANSWER="NO, independent" train_select_should_wait 10 "${FILES_A}" 11 "${FILES_B}" && bad "p2 select(llm1): NO should PROCEED" || ok "p2 select(llm1): heavy overlap + NO => PROCEED"
+assert_eq "p2 select(llm1,no): bedrock consulted once" "$(calls)" "1"
+
+# classify-flake unknown: a KNOWN signature must NOT reach the LLM (still flake).
+reset_calls
+export TRAIN_RUN_LOG_TEXT="40P01 deadlock detected"
+train_run_logs_match_flake 999 && ok "p2 flake(llm1): known signature handled deterministically" || bad "p2 flake(llm1): 40P01 should match"
+assert_eq "p2 flake(llm1): known signature skips bedrock" "$(calls)" "0"
+# Unknown signature + LLM says TRANSIENT => rc0 (rerunnable), learns regex.
+reset_calls
+export TRAIN_RUN_LOG_TEXT="ECONNRESET talking to package registry mid-restore"
+LEARN="${SCRATCH}/learned_regex"; : >"${LEARN}"
+export TRAIN_FLAKE_REGEX_LEARN_FILE="${LEARN}" TRAIN_APPLY=1
+FAKE_BEDROCK_ANSWER=$'TRANSIENT\nECONNRESET.*package registry' train_classify_flake_unknown 999 && ok "p2 flake(llm1): unknown + TRANSIENT => rerunnable" || bad "p2 flake(llm1): TRANSIENT should be rc0"
+assert_eq "p2 flake(llm1,transient): bedrock consulted once" "$(calls)" "1"
+grep -Fq 'ECONNRESET.*package registry' "${LEARN}" && ok "p2 flake(llm1): learned regex appended (apply mode)" || bad "p2 flake(llm1): learned regex not recorded"
+# Unknown signature + LLM says REAL => rc1.
+reset_calls
+FAKE_BEDROCK_ANSWER="REAL" train_classify_flake_unknown 999 && bad "p2 flake(llm1): REAL should be rc1" || ok "p2 flake(llm1): unknown + REAL => real failure"
+assert_eq "p2 flake(llm1,real): bedrock consulted once" "$(calls)" "1"
+unset TRAIN_RUN_LOG_TEXT TRAIN_FLAKE_REGEX_LEARN_FILE; export TRAIN_APPLY=0
+
+# forward-fix heal: LLM says HEAL with an allowlisted generator => rc0 + name.
+reset_calls
+FAKE_BEDROCK_ANSWER=$'HEAL\nupdate-openapi-snapshot'
+gen="$(train_forward_fix_heal_safe "server-tests (OpenAPI drift)" "openapi.json out of date")" && \
+  assert_eq "p2 heal(llm1): HEAL => allowlisted generator" "${gen}" "update-openapi-snapshot" || bad "p2 heal(llm1): HEAL should return generator"
+assert_eq "p2 heal(llm1,heal): bedrock consulted once" "$(calls)" "1"
+# forward-fix heal: LLM says HEAL but a NON-allowlisted generator => ESCALATE (safety).
+reset_calls
+FAKE_BEDROCK_ANSWER=$'HEAL\nrm -rf /' train_forward_fix_heal_safe "server-tests (drift)" "x" && bad "p2 heal(llm1): non-allowlisted must ESCALATE" || ok "p2 heal(llm1): HEAL + bad generator => ESCALATE (safety)"
+# forward-fix heal: LLM says ESCALATE => rc1 (the expected usual answer).
+reset_calls
+FAKE_BEDROCK_ANSWER="ESCALATE" train_forward_fix_heal_safe "server-tests (drift)" "x" && bad "p2 heal(llm1): ESCALATE should be rc1" || ok "p2 heal(llm1): ESCALATE => human fix"
+
+echo "-- (c) Bedrock error => deterministic fallback; train never blocks --"
+# select.overlap: heavy overlap but Bedrock errors => PROCEED (Phase-1 ordering).
+reset_calls
+FAKE_BEDROCK_ANSWER="${BEDROCK_ERROR_SENTINEL}" train_select_should_wait 10 "${FILES_A}" 11 "${FILES_B}" && bad "p2 select(err): must fall back to PROCEED" || ok "p2 select(err): bedrock error => PROCEED (no block)"
+# classify-flake unknown: Bedrock errors => REAL (conservative fallback).
+reset_calls
+export TRAIN_RUN_LOG_TEXT="some novel failure"
+FAKE_BEDROCK_ANSWER="${BEDROCK_ERROR_SENTINEL}" train_classify_flake_unknown 999 && bad "p2 flake(err): must fall back to REAL" || ok "p2 flake(err): bedrock error => REAL"
+unset TRAIN_RUN_LOG_TEXT
+# forward-fix heal: Bedrock errors => ESCALATE.
+reset_calls
+FAKE_BEDROCK_ANSWER="${BEDROCK_ERROR_SENTINEL}" train_forward_fix_heal_safe "server-tests (drift)" "x" && bad "p2 heal(err): must fall back to ESCALATE" || ok "p2 heal(err): bedrock error => ESCALATE"
+# Sanity: bedrock_ask itself returns the sentinel (never crashes) when disabled.
+TRAIN_LLM=0 ans_disabled="$(bedrock_ask sys usr)"; assert_eq "p2 bedrock_ask: disabled => sentinel" "${ans_disabled}" "${BEDROCK_ERROR_SENTINEL}"
+
+unset TRAIN_BEDROCK_ASK_CMD FAKE_BEDROCK_ANSWER TRAIN_LLM
 
 echo
 printf 'RESULT: %d passed, %d failed\n' "${PASS}" "${FAIL}"

--- a/scripts/ci/merge-train/forward-fix.sh
+++ b/scripts/ci/merge-train/forward-fix.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Step 4: forward-fix — ONLY when the sole failure is the format-verify step
+# (`dotnet format Honua.sln --verify-no-changes`). Then run the canonical
+# auto-heal (`dotnet format Honua.sln`), commit it on the batch branch, and
+# re-run smart-ci. Capped at TRAIN_FWDFIX_CAP (default 2).
+#
+# EVERYTHING ELSE escalates: proof-ledger / OpenAPI / feature-catalog drift,
+# compile failures, test failures. The train NEVER auto-patches those — that is
+# the domain of the PR author. Only deterministic, idempotent `dotnet format`
+# reformatting is safe to apply on the train's behalf.
+
+# train_is_format_only_failure <failing-job-names-newline>: true if the only
+# failing job is the format-verify job (build). We detect the format-verify
+# step failure by name "Format Verification" or by the job that owns the
+# `dotnet format ... --verify-no-changes` step. Conservatively: returns true
+# ONLY when exactly one job failed AND its name matches the format job.
+train_is_format_only_failure() {
+  local failing="$1"
+  local n
+  n="$(printf '%s\n' "${failing}" | sed '/^$/d' | wc -l | tr -d ' ')"
+  [[ "${n}" == "1" ]] || return 1
+  printf '%s\n' "${failing}" | grep -Eqi 'format'
+}
+
+# train_forward_fix <batch-branch> <attempt-count>: apply dotnet format, commit,
+# return 0 if a change was produced (caller re-runs CI), 1 if cap reached or no
+# change. The commit message carries NO bot attribution.
+train_forward_fix() {
+  local batch="$1" attempt="${2:-0}"
+  if [[ "${attempt}" -ge "${TRAIN_FWDFIX_CAP}" ]]; then
+    train_warn "forward-fix cap (${TRAIN_FWDFIX_CAP}) reached; escalating"
+    return 1
+  fi
+
+  train_log "forward-fix attempt $((attempt + 1)): dotnet format Honua.sln"
+  # Real build-lock'd format even in dry-run (it is a local, reversible edit and
+  # validates the heal path); only the push/commit-propagation is side-effecting.
+  if [[ -n "${TRAIN_FORMAT_CMD:-}" ]]; then
+    # Test override: a fake formatter that touches files deterministically.
+    "${TRAIN_FORMAT_CMD}" "${batch}"
+  else
+    ( cd "${TRAIN_REPO_ROOT}" && with-build-lock dotnet format Honua.sln )
+  fi
+
+  if git -C "${TRAIN_REPO_ROOT}" diff --quiet; then
+    train_warn "forward-fix produced no changes; not a format-fixable failure"
+    return 1
+  fi
+
+  git -C "${TRAIN_REPO_ROOT}" add -A
+  git -C "${TRAIN_REPO_ROOT}" commit -q -m "style: dotnet format (train forward-fix)"
+  train_log "forward-fix committed on ${batch}"
+  return 0
+}

--- a/scripts/ci/merge-train/forward-fix.sh
+++ b/scripts/ci/merge-train/forward-fix.sh
@@ -52,3 +52,63 @@ train_forward_fix() {
   train_log "forward-fix committed on ${batch}"
   return 0
 }
+
+# --- Phase 2 gate: drift-heal-safety judgment (gated LLM) ---------------------
+# Invoked ONLY when a NON-format drift failure appears (proof-ledger / OpenAPI /
+# feature-catalog drift) — the ambiguous case the deterministic train would
+# otherwise escalate outright. Asks Bedrock whether the drift is SAFELY
+# auto-healable by a known idempotent generator, or whether it needs a human.
+#
+# Returns 0 = a known generator is named on stdout (caller MAY run it), or
+#         1 = ESCALATE (no safe generator).
+#
+# Deterministic fallback (TRAIN_LLM=0, Bedrock error, or anything other than a
+# confident, allowlisted generator answer): ESCALATE — never auto-patch. This is
+# both the fallback AND the expected usual answer; the gate exists to catch the
+# rare, unambiguous "regenerate the OpenAPI snapshot" case, not to be clever.
+#
+# SAFETY: only generators on the TRAIN_HEAL_ALLOWLIST are ever accepted, so an
+# LLM hallucination cannot make the train run an arbitrary command. The caller is
+# still responsible for actually invoking the generator under the build lock and
+# re-running CI; this gate only DECIDES, it does not execute.
+: "${TRAIN_HEAL_ALLOWLIST:=update-openapi-snapshot|regenerate-feature-catalog|regenerate-proof-ledger}"
+train_forward_fix_heal_safe() {
+  local failing="$1" drift_detail="${2:-}"
+
+  if ! declare -F bedrock_enabled >/dev/null 2>&1 || ! bedrock_enabled; then
+    train_log "llm[forwardfix.heal] disabled; fallback=ESCALATE"
+    return 1   # fallback: escalate, never auto-patch
+  fi
+
+  local sys usr ans verdict gen
+  sys="You guard a merge train's auto-heal. A NON-format CI drift failure appeared (e.g. OpenAPI snapshot, feature catalog, or proof ledger out of date). Decide if it is SAFELY auto-healable by re-running a known deterministic generator, or if a human must fix it. Respond on the FIRST line with exactly one word: HEAL or ESCALATE. If HEAL, add a SECOND line naming exactly one generator from this allowlist: ${TRAIN_HEAL_ALLOWLIST//|/, }. If you are not certain, answer ESCALATE."
+  usr="Failing job(s):
+$(printf '%s\n' "${failing}" | sed '/^$/d')
+
+Drift detail:
+${drift_detail}
+
+Is this safely auto-healable by a known generator, or must a human fix it? First line: HEAL or ESCALATE. Optional second line: the generator name."
+  ans="$(bedrock_ask "${sys}" "${usr}")"
+
+  if bedrock_is_error "${ans}"; then
+    train_log "llm[forwardfix.heal] bedrock error; fallback=ESCALATE"
+    return 1
+  fi
+
+  verdict="$(printf '%s\n' "${ans}" | head -1 | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  if [[ "${verdict}" != heal* ]]; then
+    train_log "llm[forwardfix.heal] decision=ESCALATE"
+    return 1
+  fi
+
+  gen="$(printf '%s\n' "${ans}" | sed -n '2p' | sed 's/^ *//; s/ *$//')"
+  if [[ -z "${gen}" ]] || ! printf '%s' "${gen}" | grep -Eq "^(${TRAIN_HEAL_ALLOWLIST})$"; then
+    # HEAL with no/invalid generator is unsafe: fall back to escalation.
+    train_warn "llm[forwardfix.heal] HEAL with non-allowlisted generator [${gen}]; fallback=ESCALATE"
+    return 1
+  fi
+  train_log "llm[forwardfix.heal] decision=HEAL generator=[${gen}]"
+  printf '%s\n' "${gen}"
+  return 0
+}

--- a/scripts/ci/merge-train/land.sh
+++ b/scripts/ci/merge-train/land.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Step 7: land — fast-forward-only push of the CI-green batch onto trunk, guarded
+# by a compare-and-swap on the trunk SHA. If trunk moved since assembly, the FF
+# push is rejected (or pre-empted by the CAS check) and the caller re-assembles
+# — the train NEVER lands bytes that were not the exact bytes CI validated.
+#
+#   git fetch origin trunk
+#   if rev-parse origin/trunk == <trunkShaAtAssembly>:  # CAS
+#       git push origin <batch>:trunk    # FF-only (no --force); non-FF rejected
+#   then `gh pr merge <n> --merge` per INCLUDED PR.
+#
+# A non-FF rejection (someone else advanced trunk in the race window) means
+# trunk moved => re-assemble. We never retry with force.
+
+# train_land <batch-branch> <trunk-sha-at-assembly> <included-file>:
+#   returns 0 on success (landed), 10 on CAS/FF rejection (re-assemble), 1 on error.
+train_land() {
+  local batch="$1" trunk_at_assembly="$2" included_file="$3"
+
+  git -C "${TRAIN_REPO_ROOT}" fetch --quiet "${TRAIN_REMOTE}" "${TRAIN_BASE_BRANCH}"
+  local current
+  current="$(git -C "${TRAIN_REPO_ROOT}" rev-parse "${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}")"
+
+  # Compare-and-swap precondition: trunk must be exactly what we assembled onto.
+  if [[ "${current}" != "${trunk_at_assembly}" ]]; then
+    train_warn "trunk advanced (${trunk_at_assembly:0:7} -> ${current:0:7}); re-assemble"
+    return 10
+  fi
+
+  # FF-only push. No --force, no --force-with-lease that could rewrite: a plain
+  # `push origin <batch>:trunk` is rejected by the server if it is not a
+  # fast-forward, which is exactly the guarantee we want.
+  if [[ "${TRAIN_APPLY}" != "1" ]]; then
+    train_side_effect git push "${TRAIN_REMOTE}" "${batch}:${TRAIN_BASE_BRANCH}"
+  else
+    if ! git -C "${TRAIN_REPO_ROOT}" push "${TRAIN_REMOTE}" "${batch}:${TRAIN_BASE_BRANCH}"; then
+      train_warn "FF push rejected (trunk moved in race window); re-assemble"
+      return 10
+    fi
+  fi
+
+  # Mark each INCLUDED PR merged. With the batch already on trunk, `gh pr merge
+  # --merge` records the merge and closes the PR; GitHub recognizes the commits.
+  local pr _sha
+  while IFS=$'\t' read -r pr _sha; do
+    [[ -z "${pr}" ]] && continue
+    train_side_effect gh pr merge "${pr}" --merge
+    train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_LANDING}"
+    train_log "landed #${pr} (#${pr})"
+  done <"${included_file}"
+
+  return 0
+}

--- a/scripts/ci/merge-train/lib.sh
+++ b/scripts/ci/merge-train/lib.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Shared helpers for the honua-server optimistic batch merge train (Phase 1).
+#
+# This file is SOURCEABLE: it defines functions and constants but performs no
+# work at source time. Every step lives in its own file (select.sh, assemble.sh,
+# ...) and is independently testable; train.sh is the orchestrator.
+#
+# DRY-RUN CONTRACT (the safety bar):
+#   TRAIN_APPLY (default 0) gates ALL state-mutating side effects.
+#     - Real LOCAL git (fetch/merge/branch/abort) and real READ-ONLY GitHub
+#       reads (gh pr list/view, gh run view) ALWAYS execute, in BOTH modes, so
+#       a dry run exercises true conflict detection and true CI-status reads.
+#     - `git push`, `gh pr merge`, `gh pr edit`, `gh pr comment`, `gh issue`
+#       writes, `gh workflow run`, `gh run rerun`, and label writes are LOGGED
+#       (train_side_effect ...) but NOT executed when TRAIN_APPLY != 1.
+#   The merge-train.yml workflow defaults train_apply=false, so merging the PR
+#   that adds this code can never make the train act. A human flips it live.
+#
+# No bot attribution anywhere: the train's own commits and comments must be
+# authored as the repo owner with NO Co-Authored-By / "Generated with" / emoji
+# lines. This is enforced in code (commit messages below) and is a hard rule.
+
+set -euo pipefail
+
+# --- configuration knobs (env-overridable) -----------------------------------
+: "${TRAIN_APPLY:=0}"            # 0 = dry-run (default). 1 = live (writes act).
+: "${MAX_BATCH:=3}"             # max PRs per batch.
+: "${TRAIN_BASE_BRANCH:=trunk}" # base branch the train lands onto.
+: "${TRAIN_REMOTE:=origin}"     # git remote.
+: "${TRAIN_FWDFIX_CAP:=2}"      # max forward-fix (format) attempts per batch.
+: "${TRAIN_FLAKE_RERUN_CAP:=1}" # max flake reruns per failing run.
+
+# Flake signature regex (classify-flake). A failing job whose log matches this
+# is treated as environmental and rerun once; reproducing twice => real.
+: "${TRAIN_FLAKE_REGEX:=40P01|deadlock detected|ryuk|Testcontainers.*(timed out|connection refused)}"
+
+# Labels (the train's vocabulary). The existing repo `hold` label is ALSO
+# honored as an opt-out (documented "merge-train opt-out") in addition to the
+# canonical train:hold below.
+: "${TRAIN_LABEL_HOLD:=train:hold}"
+: "${TRAIN_LABEL_ESCALATED:=train:escalated}"
+: "${TRAIN_LABEL_LANDING:=train:landing}"
+: "${TRAIN_LABEL_STATE:=train:state}"
+: "${TRAIN_LEGACY_HOLD_LABEL:=hold}" # pre-existing opt-out label, also honored.
+
+# Resolve the repo root relative to this script so the train works from any cwd.
+TRAIN_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRAIN_REPO_ROOT="${TRAIN_REPO_ROOT:-$(cd "${TRAIN_LIB_DIR}/../../.." && pwd)}"
+TRAIN_SHARDS_CONFIG="${TRAIN_SHARDS_CONFIG:-${TRAIN_REPO_ROOT}/.github/ci-shards.json}"
+TRAIN_TARGETED_SCRIPT="${TRAIN_TARGETED_SCRIPT:-${TRAIN_REPO_ROOT}/scripts/ci/honua-server-targeted-tests.sh}"
+
+# --- logging ------------------------------------------------------------------
+train_log()  { printf '[train] %s\n' "$*" >&2; }
+train_warn() { printf '[train][warn] %s\n' "$*" >&2; }
+train_err()  { printf '[train][error] %s\n' "$*" >&2; }
+
+# train_side_effect: the single chokepoint for every state-mutating action.
+# In live mode (TRAIN_APPLY=1) it executes the command; otherwise it logs the
+# command it WOULD run and returns success. ALL pushes/merges/edits/comments/
+# issue-writes/label-writes/workflow-dispatches MUST go through this so dry-run
+# is provably read-only.
+train_side_effect() {
+  if [[ "${TRAIN_APPLY}" == "1" ]]; then
+    train_log "APPLY: $*"
+    "$@"
+  else
+    train_log "DRY-RUN (skipped): $*"
+    return 0
+  fi
+}
+
+# train_have: is a command available?
+train_have() { command -v "$1" >/dev/null 2>&1; }
+
+train_require() {
+  local missing=0 c
+  for c in "$@"; do
+    if ! train_have "$c"; then train_err "missing required command: $c"; missing=1; fi
+  done
+  [[ "${missing}" -eq 0 ]]
+}
+
+# --- flake classification (pure, testable) -----------------------------------
+# train_log_is_flake <log-text>: returns 0 if the text matches the flake regex.
+train_log_is_flake() {
+  local text="$1"
+  printf '%s' "${text}" | grep -Eq "${TRAIN_FLAKE_REGEX}"
+}
+
+# --- attribution (pure, testable) --------------------------------------------
+# train_attribute_culprits: given a newline-separated list of failing-shard
+# paths (prefixes) on stdin via $1, and a set of "PR\tfile" lines on $2,
+# emit the PR numbers whose changed files hit any of those prefixes (unique).
+# This is the REVERSE map: failing shard -> paths[] -> which batched PR touched.
+train_attribute_culprits() {
+  local shard_paths="$1" pr_files="$2"
+  awk -v paths="${shard_paths}" '
+    BEGIN {
+      n = split(paths, parr, "\n")
+    }
+    {
+      pr = $1; file = substr($0, index($0, "\t") + 1)
+      for (i = 1; i <= n; i++) {
+        p = parr[i]
+        if (p == "") continue
+        if (index(file, p) == 1) { hit[pr] = 1 }
+      }
+    }
+    END { for (k in hit) print k }
+  ' <<<"${pr_files}" | sort -u
+}
+
+# train_shard_paths: emit the .paths[] for a shard name from ci-shards.json.
+train_shard_paths() {
+  local shard_name="$1" config="${2:-${TRAIN_SHARDS_CONFIG}}"
+  jq -r --arg n "${shard_name}" \
+    '.shards[] | select(.name == $n) | .paths[]' "${config}"
+}

--- a/scripts/ci/merge-train/select.sh
+++ b/scripts/ci/merge-train/select.sh
@@ -114,3 +114,67 @@ train_select() {
     fi
   done <<<"${ordered}"
 }
+
+# --- Phase 2 gate: overlap-dependency judgment (gated LLM) --------------------
+# When two candidate PRs heavily overlap in the files they change, landing the
+# newer one first can silently strand a logical dependency. The deterministic
+# Phase-1 behavior keeps strict oldest-first ordering; Phase 2 OPTIONALLY asks
+# Bedrock, only in the ambiguous (heavy-overlap) case, whether the later PR (B)
+# should wait for the earlier PR (A) to land first.
+#
+# train_pr_overlap_ratio <filesA-newline> <filesB-newline>: emit an integer
+# percentage (0-100) of B's files that also appear in A (|A∩B|/|B|). Pure +
+# testable; no network.
+train_pr_overlap_ratio() {
+  local files_a="$1" files_b="$2"
+  awk -v a="${files_a}" '
+    BEGIN { n = split(a, arr, "\n"); for (i=1;i<=n;i++) if (arr[i]!="") inA[arr[i]]=1 }
+    { if ($0 != "") { tot++; if ($0 in inA) hit++ } }
+    END { if (tot == 0) { print 0 } else { printf "%d\n", (hit*100)/tot } }
+  ' <<<"${files_b}"
+}
+
+# train_select_should_wait <prA> <filesA-newline> <prB> <filesB-newline>:
+# Decide whether candidate PR B should WAIT for PR A (B is the later/newer one).
+# Returns 0 = WAIT (skip B this batch), 1 = proceed (include B).
+#
+# Deterministic fallback (TRAIN_LLM=0, Bedrock error, or below-threshold
+# overlap): NEVER wait — keep oldest-first ordering, i.e. exactly Phase 1.
+# The LLM is consulted ONLY when overlap >= TRAIN_OVERLAP_PCT (default 60),
+# which is the "ambiguous" condition. Logs prompt-class + decision via train_log.
+: "${TRAIN_OVERLAP_PCT:=60}"
+train_select_should_wait() {
+  local pr_a="$1" files_a="$2" pr_b="$3" files_b="$4"
+
+  # Deterministic guard first: only an ambiguous heavy overlap consults the LLM.
+  local ratio; ratio="$(train_pr_overlap_ratio "${files_a}" "${files_b}")"
+  if [[ "${ratio}" -lt "${TRAIN_OVERLAP_PCT}" ]]; then
+    return 1   # not ambiguous: proceed (Phase-1 ordering)
+  fi
+  if ! declare -F bedrock_enabled >/dev/null 2>&1 || ! bedrock_enabled; then
+    train_log "llm[select.overlap] disabled; fallback=PROCEED (#${pr_b} not held; overlap ${ratio}%)"
+    return 1   # fallback: keep oldest-first, include B
+  fi
+
+  local sys usr ans
+  sys="You order code-review pull requests for a merge train. Two PRs change a heavily overlapping set of files. Answer with exactly one word: YES if PR B should wait for PR A to land first (e.g. B builds on A or would conflict/strand A), or NO if they are independent and B can land now. Output only YES or NO."
+  usr="PR A (#${pr_a}) changed files:
+$(printf '%s\n' "${files_a}" | sed '/^$/d')
+
+PR B (#${pr_b}) changed files:
+$(printf '%s\n' "${files_b}" | sed '/^$/d')
+
+File overlap of B onto A: ${ratio}%. Should PR B wait for PR A to land first? Answer YES or NO."
+  ans="$(bedrock_ask "${sys}" "${usr}")"
+
+  if bedrock_is_error "${ans}"; then
+    train_log "llm[select.overlap] bedrock error; fallback=PROCEED (#${pr_b} not held)"
+    return 1   # fallback on any LLM failure
+  fi
+  if bedrock_first_word_yes "${ans}"; then
+    train_log "llm[select.overlap] decision=WAIT (#${pr_b} waits for #${pr_a}; overlap ${ratio}%)"
+    return 0   # hold B this batch
+  fi
+  train_log "llm[select.overlap] decision=PROCEED (#${pr_b} independent of #${pr_a}; overlap ${ratio}%)"
+  return 1
+}

--- a/scripts/ci/merge-train/select.sh
+++ b/scripts/ci/merge-train/select.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Step 1: select — pick the ready PRs for the next batch.
+#
+# Ready = non-draft, labels exclude train:hold / train:escalated (and the
+# pre-existing `hold` opt-out), mergeable == MERGEABLE, and the CI Gate check
+# is SUCCESS OR a flake-only failure. Ordered oldest-createdAt first, capped at
+# MAX_BATCH.
+#
+# READ-ONLY: this step never mutates anything (only gh ... --json reads), so it
+# runs identically in dry-run and live mode.
+
+# train_select_ci_gate_state <pr-json>: classify the CI Gate check for one PR.
+# Emits one of: SUCCESS | FLAKE | FAIL | PENDING | MISSING.
+# Reads the statusCheckRollup entry named "CI Gate" (the single required check).
+# A failing CI Gate is downgraded to FLAKE only when the failing run's logs
+# match the flake regex (caller decides whether to actually rerun).
+train_select_ci_gate_state() {
+  local rollup_json="$1"
+  local gate
+  gate="$(jq -c '[.[] | select(.name == "CI Gate")] | first // empty' <<<"${rollup_json}")"
+  if [[ -z "${gate}" || "${gate}" == "null" ]]; then
+    echo "MISSING"; return 0
+  fi
+  local status conclusion
+  status="$(jq -r '.status // ""' <<<"${gate}")"
+  conclusion="$(jq -r '.conclusion // ""' <<<"${gate}")"
+  if [[ "${status}" != "COMPLETED" ]]; then
+    echo "PENDING"; return 0
+  fi
+  case "${conclusion}" in
+    SUCCESS) echo "SUCCESS" ;;
+    FAILURE|TIMED_OUT|CANCELLED|STARTUP_FAILURE|ACTION_REQUIRED) echo "FAIL" ;;
+    *) echo "FAIL" ;;
+  esac
+}
+
+# train_pr_has_hold_label <labels-json>: true if any opt-out label present.
+train_pr_has_hold_label() {
+  local labels_json="$1"
+  jq -e --arg hold "${TRAIN_LABEL_HOLD}" \
+        --arg esc "${TRAIN_LABEL_ESCALATED}" \
+        --arg legacy "${TRAIN_LEGACY_HOLD_LABEL}" \
+    'any(.[]; .name == $hold or .name == $esc or .name == $legacy)' \
+    <<<"${labels_json}" >/dev/null 2>&1
+}
+
+# train_select: emit the selected batch as JSON lines (one object per PR):
+#   {number, headRefOid, createdAt, gate}
+# Honors MAX_BATCH. Caller pipes through `jq -s .` if it wants an array.
+#
+# Inputs (overridable for testing):
+#   TRAIN_PR_LIST_JSON — if set, used verbatim instead of calling gh (fixtures).
+train_select() {
+  local pr_list
+  if [[ -n "${TRAIN_PR_LIST_JSON:-}" ]]; then
+    pr_list="${TRAIN_PR_LIST_JSON}"
+  else
+    pr_list="$(gh pr list --base "${TRAIN_BASE_BRANCH}" --state open \
+      --json number,headRefOid,isDraft,mergeable,mergeStateStatus,labels,createdAt,files \
+      --limit 100)"
+  fi
+
+  # Oldest createdAt first.
+  local ordered
+  ordered="$(jq -c 'sort_by(.createdAt) | .[]' <<<"${pr_list}")"
+
+  local count=0
+  local line
+  while IFS= read -r line; do
+    [[ -z "${line}" ]] && continue
+    local number isDraft mergeable labels
+    number="$(jq -r '.number' <<<"${line}")"
+    isDraft="$(jq -r '.isDraft' <<<"${line}")"
+    mergeable="$(jq -r '.mergeable' <<<"${line}")"
+    labels="$(jq -c '.labels // []' <<<"${line}")"
+
+    if [[ "${isDraft}" == "true" ]]; then
+      train_log "skip #${number}: draft"; continue
+    fi
+    if train_pr_has_hold_label "${labels}"; then
+      train_log "skip #${number}: hold/escalated label"; continue
+    fi
+    if [[ "${mergeable}" != "MERGEABLE" ]]; then
+      train_log "skip #${number}: mergeable=${mergeable}"; continue
+    fi
+
+    # CI Gate state. In fixture mode the caller may inject a `gate` field.
+    local gate rollup
+    gate="$(jq -r '.gate // empty' <<<"${line}")"
+    if [[ -z "${gate}" ]]; then
+      if [[ -n "${TRAIN_ROLLUP_JSON_FOR_PR:-}" ]]; then
+        rollup="$("${TRAIN_ROLLUP_JSON_FOR_PR}" "${number}")"
+      else
+        rollup="$(gh pr view "${number}" --json statusCheckRollup \
+          --jq '.statusCheckRollup' 2>/dev/null || echo '[]')"
+      fi
+      gate="$(train_select_ci_gate_state "${rollup}")"
+    fi
+
+    case "${gate}" in
+      SUCCESS|FLAKE) : ;;
+      *) train_log "skip #${number}: CI Gate=${gate}"; continue ;;
+    esac
+
+    jq -nc --argjson n "${number}" \
+           --arg oid "$(jq -r '.headRefOid' <<<"${line}")" \
+           --arg created "$(jq -r '.createdAt' <<<"${line}")" \
+           --arg gate "${gate}" \
+      '{number:$n, headRefOid:$oid, createdAt:$created, gate:$gate}'
+
+    count=$((count + 1))
+    if [[ "${count}" -ge "${MAX_BATCH}" ]]; then
+      train_log "reached MAX_BATCH=${MAX_BATCH}"; break
+    fi
+  done <<<"${ordered}"
+}

--- a/scripts/ci/merge-train/smart-ci.sh
+++ b/scripts/ci/merge-train/smart-ci.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Step 3: smart-ci — compute the shard subset for the batch's cumulative diff
+# and (live only) run + poll CI on the batch branch, reading the CI Gate job
+# conclusion.
+#
+# CONCURRENCY NOTE: the batch branch is a BRANCH, not a PR. ci.yml's concurrency
+# key is `ci-${{ pr-number || github.ref }}`, so a branch run keys on its ref
+# (ci-<batch-ref>) — a DISTINCT group from each member PR's run (ci-<pr#>).
+# Therefore dispatching CI on the batch CANNOT cancel-in-progress the members'
+# own PR runs (cancel-in-progress only cancels within the same group). This is
+# intentional: the train never disturbs member PRs' independent CI.
+
+# train_smart_ci_shards <batch-branch>: emit the targeted-tests descriptor JSON
+# ({run_all,shards,reason}) for the batch's cumulative diff vs origin/<base>.
+# READ-ONLY; runs in both modes. This is what determines the smart-CI subset.
+train_smart_ci_shards() {
+  local batch="$1"
+  # The targeted-tests script diffs ${BASE}...HEAD; point it at the batch tip by
+  # checking the batch out is unnecessary — it accepts --base and diffs HEAD.
+  # We compute the file list ourselves and feed it via --stdin so we never
+  # depend on the current checkout.
+  train_batch_diff_files "${batch}" \
+    | "${TRAIN_TARGETED_SCRIPT}" --stdin --config "${TRAIN_SHARDS_CONFIG}"
+}
+
+# train_smart_ci_run <batch-branch>: live-mode push + dispatch + poll. In
+# dry-run, logs the would-run actions and returns the shard descriptor only.
+# Emits the CI Gate conclusion on stdout in live mode (SUCCESS/FAILURE/...),
+# or "DRYRUN" in dry-run.
+#
+# Inputs (test override): TRAIN_RUN_POLLER — a command that, given a run id,
+# prints the CI Gate conclusion (so the poll loop is testable offline).
+train_smart_ci_run() {
+  local batch="$1"
+  local descriptor
+  descriptor="$(train_smart_ci_shards "${batch}")"
+  train_log "smart-ci shard descriptor: ${descriptor}"
+
+  if [[ "${TRAIN_APPLY}" != "1" ]]; then
+    train_side_effect git push "${TRAIN_REMOTE}" "${batch}:${batch}"
+    train_side_effect gh workflow run ci.yml --ref "${batch}"
+    echo "DRYRUN"
+    return 0
+  fi
+
+  # Live: push the branch and dispatch CI.
+  git -C "${TRAIN_REPO_ROOT}" push "${TRAIN_REMOTE}" "${batch}:${batch}"
+  gh workflow run ci.yml --ref "${batch}"
+
+  # Find the dispatched run id (most recent ci.yml run on this ref).
+  local run_id=""
+  local i
+  for i in $(seq 1 12); do
+    run_id="$(gh run list --workflow ci.yml --branch "${batch}" \
+      --json databaseId,headBranch,event \
+      --jq '[.[] | select(.headBranch=="'"${batch}"'")][0].databaseId' 2>/dev/null || echo "")"
+    [[ -n "${run_id}" && "${run_id}" != "null" ]] && break
+    sleep 10
+  done
+  if [[ -z "${run_id}" || "${run_id}" == "null" ]]; then
+    train_err "could not locate dispatched CI run for ${batch}"
+    echo "FAILURE"; return 0
+  fi
+  train_log "smart-ci run id: ${run_id}"
+  echo "${run_id}" >"${TRAIN_RUN_ID_FILE:-/dev/null}"
+
+  # Poll until the CI Gate job completes.
+  while :; do
+    local status conclusion
+    status="$(gh run view "${run_id}" --json status --jq '.status' 2>/dev/null || echo "")"
+    if [[ "${status}" == "completed" ]]; then break; fi
+    sleep 30
+  done
+
+  conclusion="$(gh run view "${run_id}" --json jobs \
+    --jq '[.jobs[] | select(.name=="CI Gate")][0].conclusion // "missing"' 2>/dev/null || echo "missing")"
+  train_log "CI Gate conclusion: ${conclusion}"
+  # Normalize to upper-case workflow vocabulary.
+  printf '%s\n' "${conclusion}" | tr '[:lower:]' '[:upper:]'
+}
+
+# train_failing_jobs <run-id>: emit the names of the failing jobs (live).
+train_failing_jobs() {
+  local run_id="$1"
+  gh run view "${run_id}" --json jobs \
+    --jq '.jobs[] | select(.conclusion=="failure") | .name'
+}

--- a/scripts/ci/merge-train/state.sh
+++ b/scripts/ci/merge-train/state.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Step 8: state — persist the train's progress to a "Merge Train State" GitHub
+# issue (label train:state) carrying a fenced JSON block, written BEFORE each
+# side-effecting step so a crash is resumable: on startup the train reads the
+# phase and resumes. Per-PR labels (train:landing / train:escalated / train:hold)
+# also carry transient state.
+#
+# The JSON shape:
+#   {
+#     "active_batch": {
+#       "branch": "...", "trunk_base": "<sha>", "included": [<pr>...],
+#       "phase": "select|assemble|smart-ci|forward-fix|attribute|land|done",
+#       "run_id": <id|null>, "fwdfix_attempts": <n>, "flake_reruns": <n>
+#     },
+#     "config": { "max_batch": <n>, "flake_signatures": "<regex>" },
+#     "last_landed_trunk": "<sha|null>"
+#   }
+#
+# Issue title: "Merge Train State". We find-or-create by the train:state label.
+
+TRAIN_STATE_TITLE="${TRAIN_STATE_TITLE:-Merge Train State}"
+
+# train_state_render <branch> <trunk_base> <included-csv> <phase> <run_id> \
+#   <fwdfix> <flake_reruns> <last_landed>: emit the fenced-JSON issue body.
+train_state_render() {
+  local branch="$1" trunk_base="$2" included_csv="$3" phase="$4" \
+        run_id="$5" fwdfix="$6" flake_reruns="$7" last_landed="$8"
+
+  local included_json
+  if [[ -z "${included_csv}" ]]; then
+    included_json="[]"
+  else
+    included_json="$(printf '%s' "${included_csv}" \
+      | jq -Rc 'split(",") | map(select(length>0) | tonumber)')"
+  fi
+  local run_id_json="null"; [[ -n "${run_id}" && "${run_id}" != "null" ]] && run_id_json="${run_id}"
+  local last_json="null"; [[ -n "${last_landed}" && "${last_landed}" != "null" ]] && last_json="\"${last_landed}\""
+
+  local json
+  json="$(jq -n \
+    --arg branch "${branch}" \
+    --arg tb "${trunk_base}" \
+    --argjson inc "${included_json}" \
+    --arg phase "${phase}" \
+    --argjson rid "${run_id_json}" \
+    --argjson fwd "${fwdfix:-0}" \
+    --argjson fr "${flake_reruns:-0}" \
+    --argjson mb "${MAX_BATCH}" \
+    --arg flake "${TRAIN_FLAKE_REGEX}" \
+    --argjson last "${last_json}" \
+    '{
+      active_batch: {
+        branch: $branch, trunk_base: $tb, included: $inc, phase: $phase,
+        run_id: $rid, fwdfix_attempts: $fwd, flake_reruns: $fr
+      },
+      config: { max_batch: $mb, flake_signatures: $flake },
+      last_landed_trunk: $last
+    }')"
+
+  printf 'Machine-managed state for the optimistic batch merge train. Do not edit by hand.\n\n```json\n%s\n```\n' "${json}"
+}
+
+# train_state_issue_number: find the state issue number (or empty). READ-ONLY.
+train_state_issue_number() {
+  if [[ -n "${TRAIN_STATE_ISSUE_OVERRIDE:-}" ]]; then
+    echo "${TRAIN_STATE_ISSUE_OVERRIDE}"; return 0
+  fi
+  gh issue list --label "${TRAIN_LABEL_STATE}" --state open \
+    --json number --jq '.[0].number // empty' 2>/dev/null || echo ""
+}
+
+# train_state_write <body-file>: create-or-update the state issue. Side-effecting.
+train_state_write() {
+  local body_file="$1"
+  local num
+  num="$(train_state_issue_number)"
+  if [[ -n "${num}" ]]; then
+    train_side_effect gh issue edit "${num}" --body-file "${body_file}"
+  else
+    train_side_effect gh issue create --title "${TRAIN_STATE_TITLE}" \
+      --label "${TRAIN_LABEL_STATE}" --body-file "${body_file}"
+  fi
+}
+
+# train_state_read: emit the parsed JSON block of the state issue (or empty).
+# READ-ONLY; used on startup to resume.
+train_state_read() {
+  local num body
+  num="$(train_state_issue_number)"
+  [[ -z "${num}" ]] && return 0
+  if [[ -n "${TRAIN_STATE_BODY_OVERRIDE:-}" ]]; then
+    body="${TRAIN_STATE_BODY_OVERRIDE}"
+  else
+    body="$(gh issue view "${num}" --json body --jq '.body' 2>/dev/null || echo "")"
+  fi
+  # Extract the fenced ```json ... ``` block.
+  printf '%s\n' "${body}" | awk '
+    /^```json/ { inblk=1; next }
+    /^```/     { if (inblk) { inblk=0 } ; next }
+    inblk      { print }
+  '
+}

--- a/scripts/ci/merge-train/train.sh
+++ b/scripts/ci/merge-train/train.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Orchestrator for the honua-server optimistic batch merge train (Phase 1).
+#
+# Wires the eight sourceable steps together. DRY-RUN BY DEFAULT (TRAIN_APPLY=0):
+# real local git assembly + real CI-status reads + real shard computation, but
+# NO pushes/merges/comments/issue-writes (those route through train_side_effect
+# and are only logged). MAX_BATCH defaults to 3.
+#
+# Phases (also the resume points written to the state issue before each
+# side-effecting step):
+#   select -> assemble -> smart-ci -> [forward-fix] -> [classify-flake] ->
+#   [attribute -> rebuild] -> land -> done
+#
+# Usage:
+#   TRAIN_APPLY=0 scripts/ci/merge-train/train.sh            # shadow / dry-run
+#   TRAIN_APPLY=1 scripts/ci/merge-train/train.sh            # live (human-gated)
+
+set -euo pipefail
+
+TRAIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${TRAIN_DIR}/lib.sh"
+# shellcheck source=select.sh
+. "${TRAIN_DIR}/select.sh"
+# shellcheck source=assemble.sh
+. "${TRAIN_DIR}/assemble.sh"
+# shellcheck source=smart-ci.sh
+. "${TRAIN_DIR}/smart-ci.sh"
+# shellcheck source=forward-fix.sh
+. "${TRAIN_DIR}/forward-fix.sh"
+# shellcheck source=classify-flake.sh
+. "${TRAIN_DIR}/classify-flake.sh"
+# shellcheck source=attribute.sh
+. "${TRAIN_DIR}/attribute.sh"
+# shellcheck source=land.sh
+. "${TRAIN_DIR}/land.sh"
+# shellcheck source=state.sh
+. "${TRAIN_DIR}/state.sh"
+
+train_require git jq gh || { train_err "missing prerequisites"; exit 2; }
+
+# Scratch files for the run.
+TRAIN_WORK="$(mktemp -d)"
+trap 'rm -rf "${TRAIN_WORK}"' EXIT
+export TRAIN_INCLUDED_FILE="${TRAIN_WORK}/included.tsv"
+export TRAIN_SKIPPED_FILE="${TRAIN_WORK}/skipped.tsv"
+export TRAIN_RUN_ID_FILE="${TRAIN_WORK}/run_id"
+
+main() {
+  train_log "mode: $( [[ "${TRAIN_APPLY}" == "1" ]] && echo LIVE || echo DRY-RUN ) MAX_BATCH=${MAX_BATCH}"
+
+  # --- select ----------------------------------------------------------------
+  local selected
+  selected="$(train_select | jq -s '.')"
+  local prs
+  prs="$(jq -r '.[].number' <<<"${selected}")"
+  if [[ -z "${prs}" ]]; then
+    train_log "no ready PRs; nothing to do"
+    echo
+    echo "=== MERGE TRAIN DECISION (dry-run=$([[ "${TRAIN_APPLY}" == "1" ]] && echo 0 || echo 1)) ==="
+    echo "selected batch: (none)"
+    return 0
+  fi
+  train_log "candidate batch (oldest-first, capped): $(tr '\n' ' ' <<<"${prs}")"
+
+  # --- trunk base ------------------------------------------------------------
+  git -C "${TRAIN_REPO_ROOT}" fetch --quiet "${TRAIN_REMOTE}" "${TRAIN_BASE_BRANCH}"
+  local trunk_sha trunk_sha7
+  trunk_sha="$(git -C "${TRAIN_REPO_ROOT}" rev-parse "${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}")"
+  trunk_sha7="${trunk_sha:0:7}"
+
+  # --- assemble (transactional detect-and-skip) ------------------------------
+  # state: write BEFORE assembling (resumable at assemble phase).
+  _write_state "" "${trunk_sha}" "" "assemble" "" 0 0
+  local batch
+  # shellcheck disable=SC2086
+  batch="$(train_assemble "${trunk_sha7}" ${prs})"
+  train_log "batch branch: ${batch}"
+
+  local included skipped
+  included="$(cut -f1 "${TRAIN_INCLUDED_FILE}" | tr '\n' ',' | sed 's/,$//')"
+  skipped="$(cut -f1 "${TRAIN_SKIPPED_FILE}" | tr '\n' ' ')"
+  train_log "INCLUDED: ${included:-<none>}"
+  [[ -n "${skipped// /}" ]] && train_log "SKIPPED_CONFLICT: ${skipped}"
+
+  if [[ -z "${included}" ]]; then
+    train_warn "no PRs assembled cleanly; nothing to land"
+    _decision_report "${batch}" "${selected}" "${trunk_sha}" "" "(all skipped)"
+    return 0
+  fi
+
+  # state: landing labels + phase smart-ci before CI side effects.
+  _write_state "${batch}" "${trunk_sha}" "${included}" "smart-ci" "" 0 0
+  local pr
+  for pr in $(tr ',' ' ' <<<"${included}"); do
+    train_side_effect gh pr edit "${pr}" --add-label "${TRAIN_LABEL_LANDING}"
+  done
+
+  # --- smart-ci + forward-fix + flake + attribute loop -----------------------
+  local shard_descriptor
+  shard_descriptor="$(train_smart_ci_shards "${batch}")"
+  train_log "smart-CI shard subset: ${shard_descriptor}"
+
+  local gate fwdfix=0 flake_reruns=0
+  gate="$(train_smart_ci_run "${batch}")"
+
+  if [[ "${TRAIN_APPLY}" != "1" ]]; then
+    train_log "dry-run: stopping before CI gate evaluation/land (no pushes happened)"
+    _decision_report "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" ""
+    return 0
+  fi
+
+  # Live-mode gate handling (forward-fix -> flake -> attribute -> land).
+  while [[ "${gate}" != "SUCCESS" ]]; do
+    local run_id; run_id="$(cat "${TRAIN_RUN_ID_FILE}" 2>/dev/null || echo "")"
+    local failing; failing="$(train_failing_jobs "${run_id}")"
+
+    # forward-fix: only when the SOLE failure is the format-verify step.
+    if train_is_format_only_failure "${failing}"; then
+      _write_state "${batch}" "${trunk_sha}" "${included}" "forward-fix" "${run_id}" "${fwdfix}" "${flake_reruns}"
+      if train_forward_fix "${batch}" "${fwdfix}"; then
+        fwdfix=$((fwdfix + 1))
+        gate="$(train_smart_ci_run "${batch}")"
+        continue
+      fi
+    fi
+
+    # classify-flake BEFORE attribute.
+    _write_state "${batch}" "${trunk_sha}" "${included}" "classify-flake" "${run_id}" "${fwdfix}" "${flake_reruns}"
+    if train_classify_flake "${run_id}" "${flake_reruns}"; then
+      flake_reruns=$((flake_reruns + 1))
+      # Re-poll the same run after rerun.
+      while :; do
+        local st; st="$(gh run view "${run_id}" --json status --jq '.status' 2>/dev/null || echo "")"
+        [[ "${st}" == "completed" ]] && break; sleep 30
+      done
+      gate="$(gh run view "${run_id}" --json jobs \
+        --jq '[.jobs[] | select(.name=="CI Gate")][0].conclusion // "missing"' | tr '[:lower:]' '[:upper:]')"
+      continue
+    fi
+
+    # attribute (real failure).
+    _write_state "${batch}" "${trunk_sha}" "${included}" "attribute" "${run_id}" "${fwdfix}" "${flake_reruns}"
+    local culprits; culprits="$(train_attribute "${failing}" "${TRAIN_INCLUDED_FILE}")"
+    if [[ "${culprits}" == "ESCALATE_BATCH" ]]; then
+      train_warn "escalating entire batch; manual triage required"
+      for pr in $(tr ',' ' ' <<<"${included}"); do
+        train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_LANDING}"
+      done
+      return 0
+    fi
+    # Drop culprits, rebuild minus them, re-CI.
+    local remaining="${included}"
+    for pr in ${culprits}; do
+      train_drop_pr "${pr}" "real CI failure attributed to its diff"
+      remaining="$(tr ',' '\n' <<<"${remaining}" | grep -vx "${pr}" | tr '\n' ',' | sed 's/,$//')"
+    done
+    if [[ -z "${remaining}" ]]; then
+      train_warn "all members dropped; batch empty"
+      return 0
+    fi
+    included="${remaining}"
+    _write_state "" "${trunk_sha}" "${included}" "assemble" "" "${fwdfix}" "${flake_reruns}"
+    # shellcheck disable=SC2086
+    batch="$(train_assemble "${trunk_sha7}" $(tr ',' ' ' <<<"${included}"))"
+    included="$(cut -f1 "${TRAIN_INCLUDED_FILE}" | tr '\n' ',' | sed 's/,$//')"
+    gate="$(train_smart_ci_run "${batch}")"
+  done
+
+  # --- land (FF-only CAS) ----------------------------------------------------
+  _write_state "${batch}" "${trunk_sha}" "${included}" "land" "$(cat "${TRAIN_RUN_ID_FILE}" 2>/dev/null)" "${fwdfix}" "${flake_reruns}"
+  local rc=0
+  train_land "${batch}" "${trunk_sha}" "${TRAIN_INCLUDED_FILE}" || rc=$?
+  if [[ "${rc}" == "10" ]]; then
+    train_warn "land deferred: trunk moved; the next scheduled run re-assembles"
+    return 0
+  fi
+  [[ "${rc}" != "0" ]] && { train_err "land failed (rc=${rc})"; return "${rc}"; }
+
+  local new_trunk; new_trunk="$(git -C "${TRAIN_REPO_ROOT}" rev-parse "${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}")"
+  _write_state "" "${new_trunk}" "" "done" "" 0 0 "${batch_landed:-${new_trunk}}"
+  train_log "landed batch ${batch}; trunk now ${new_trunk:0:7}"
+}
+
+# _write_state branch trunk_base included-csv phase run_id fwdfix flake [last_landed]
+_write_state() {
+  local body="${TRAIN_WORK}/state.md"
+  train_state_render "$1" "$2" "$3" "$4" "$5" "$6" "$7" "${8:-null}" >"${body}"
+  train_state_write "${body}"
+}
+
+# _decision_report: human-readable dry-run summary (the shadow-run output).
+_decision_report() {
+  local batch="$1" selected="$2" trunk_sha="$3" shard_descriptor="$4" note="$5"
+  echo
+  echo "=== MERGE TRAIN DECISION (dry-run) ==="
+  echo "trunk base:        ${trunk_sha} (${trunk_sha:0:7})"
+  echo "batch branch:      ${batch}"
+  echo
+  echo "candidate PRs (oldest-first, capped at MAX_BATCH=${MAX_BATCH}):"
+  jq -r '.[] | "  #\(.number)  created=\(.createdAt)  ci-gate=\(.gate)"' <<<"${selected}"
+  echo
+  echo "WOULD INCLUDE (assembled clean):"
+  if [[ -s "${TRAIN_INCLUDED_FILE}" ]]; then
+    while IFS=$'\t' read -r pr sha; do echo "  #${pr}  head=${sha:0:7}"; done <"${TRAIN_INCLUDED_FILE}"
+  else
+    echo "  (none)"
+  fi
+  echo
+  echo "WOULD SKIP (conflict, aborted clean — zero residue):"
+  if [[ -s "${TRAIN_SKIPPED_FILE}" ]]; then
+    while IFS=$'\t' read -r pr why; do echo "  #${pr}  ${why}"; done <"${TRAIN_SKIPPED_FILE}"
+  else
+    echo "  (none)"
+  fi
+  echo
+  echo "COMPUTED SMART-CI SHARD SUBSET (run on the cumulative batch diff):"
+  echo "  ${shard_descriptor:-<none>}"
+  [[ -n "${note}" ]] && { echo; echo "note: ${note}"; }
+  echo "======================================"
+}
+
+main "$@"

--- a/scripts/ci/merge-train/train.sh
+++ b/scripts/ci/merge-train/train.sh
@@ -20,6 +20,10 @@ set -euo pipefail
 TRAIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 . "${TRAIN_DIR}/lib.sh"
+# Phase 2 (OPTIONAL, off by default): gated Bedrock LLM judgment helpers. Sourced
+# before the gated steps so bedrock_* exists; inert unless TRAIN_LLM=1.
+# shellcheck source=bedrock-invoke.sh
+. "${TRAIN_DIR}/bedrock-invoke.sh"
 # shellcheck source=select.sh
 . "${TRAIN_DIR}/select.sh"
 # shellcheck source=assemble.sh


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2039

## Summary
Phase 2 of the honua-server merge train: an **optional, gated LLM judgment layer**
over the deterministic Phase-1 train, via **AWS Bedrock (Claude)**, reusing the
honua-devops Bedrock posture (AWS-CLI SigV4, `us-west-2`, the Bedrock-native
Anthropic Messages `invoke-model` shape). It is an enhancement only — the
deterministic train works without it — so it is **off by default** (`TRAIN_LLM=0`)
on every trigger, every gate has a deterministic fallback, and a Bedrock failure
degrades the train to exactly Phase 1 (never blocks). Built on the Phase-1 branch
(`ci/merge-train-phase1`, #2039); separate PR, not for merge yet.

## Changes Made
- Added `scripts/ci/merge-train/bedrock-invoke.sh` — a thin, fail-safe Bedrock
  client (`bedrock_ask` returns a sentinel on any error/disabled path). Model id
  and region are env-overridable (`BEDROCK_MODEL_ID`, `AWS_REGION`), defaulting to
  a Haiku-class cross-region inference profile and `us-west-2`.
- Three gated judgment functions (each fires only in its ambiguous condition, logs
  prompt-class + decision via `train_log`, and falls back to Phase-1 behavior):
  - `select.sh` overlap-dependency — "should PR B wait for PR A?" (fallback: keep oldest-first).
  - `classify-flake.sh` unknown-signature — "transient flake or real?" + optional learned regex (fallback: treat unknown as REAL).
  - `forward-fix.sh` drift-heal-safety — "safely auto-healable or human-only?", allowlisted generators only (fallback: ESCALATE).
- `.github/workflows/merge-train.yml`: opt-in `use_llm` dispatch input, `id-token: write`,
  and `aws-actions/configure-aws-credentials@v4` assuming `secrets.HONUA_BEDROCK_ROLE_ARN`
  (GitHub OIDC, no long-lived keys). `TRAIN_LLM=0` default for all triggers; the AWS
  step only runs when the layer is enabled.
- Extended the fixture harness with mock-Bedrock Phase-2 tests; updated ADR-0055 with the Phase-2 Bedrock section.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Fixture harness `scripts/ci/merge-train/fixtures/validate-merge-train.sh`:
**68 passed, 0 failed** (39 Phase-1 assertions unchanged + 29 new Phase-2). The
Phase-2 cases assert: (a) at `TRAIN_LLM=0` the gates are never called and behavior
matches the Phase-1 deterministic path; (b) at `TRAIN_LLM=1` each gate fires only
in its ambiguous condition and routes correctly on yes/no; (c) a Bedrock error
falls back deterministically and never blocks. `bash -n` clean on all scripts;
YAML valid; `aws`/`jq` invocation shape dry-run-checked with a fake `aws` binary
(no real Bedrock calls, no spend).

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] Requires environment variable or secret changes

Live LLM mode requires a new repo secret `HONUA_BEDROCK_ROLE_ARN` (an IAM role
scoped to `bedrock:InvokeModel` on the one model, assumable via GitHub OIDC) and
optional repo variables `HONUA_BEDROCK_REGION` / `HONUA_BEDROCK_MODEL_ID`. With
none of these set, the train runs exactly as Phase 1.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract

> Note on the pre-PR box: this change is CI-script and workflow only (no .NET
> code), so the relevant checks are `bash -n` on all scripts, the offline fixture
> harness (68/68), and YAML validity — all run and green. No `dotnet`
> build/format/tests apply to this diff.
