### PR TITLE
ci: merge train — instrumentation + Phase 2 Bedrock (key auth), reconciled

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -35,6 +35,11 @@ on:
         type: string
         required: false
         default: '3'
+      use_llm:
+        description: 'Enable the OPTIONAL gated Bedrock LLM judgment layer (TRAIN_LLM=1). Off by default; every gate has a deterministic fallback. Requires secrets.BEDROCK_AWS_ACCESS_KEY_ID / secrets.BEDROCK_AWS_SECRET_ACCESS_KEY.'
+        type: boolean
+        required: false
+        default: false
 
 # Serialize train runs: a batch in flight must finish before the next starts.
 # cancel-in-progress:false so we never abandon a half-landed batch mid-flight.
@@ -72,6 +77,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           DISPATCH_APPLY: ${{ github.event.inputs.train_apply }}
           DISPATCH_MAX_BATCH: ${{ github.event.inputs.max_batch }}
+          DISPATCH_USE_LLM: ${{ github.event.inputs.use_llm }}
+          HAVE_BEDROCK_KEYS: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID != '' && secrets.BEDROCK_AWS_SECRET_ACCESS_KEY != '' }}
         run: |
           set -euo pipefail
           # Only an explicit workflow_dispatch with train_apply=true acts.
@@ -83,16 +90,28 @@ jobs:
           echo "train_apply=${apply}" >> "$GITHUB_OUTPUT"
           mb="${DISPATCH_MAX_BATCH:-3}"; [[ -z "${mb}" ]] && mb=3
           echo "max_batch=${mb}" >> "$GITHUB_OUTPUT"
-          echo "Resolved TRAIN_APPLY=${apply} (event=${EVENT_NAME}) MAX_BATCH=${mb}"
+          # TRAIN_LLM defaults to 0 for ALL triggers. It can only turn on via an
+          # explicit workflow_dispatch with use_llm=true AND configured Bedrock
+          # access-key secrets. Scheduled / workflow_run are always deterministic.
+          llm=0
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" && "${DISPATCH_USE_LLM}" == "true" ]]; then
+            if [[ "${HAVE_BEDROCK_KEYS}" == "true" ]]; then
+              llm=1
+            else
+              echo "::warning::use_llm=true but secrets.BEDROCK_AWS_ACCESS_KEY_ID / BEDROCK_AWS_SECRET_ACCESS_KEY are unset; running deterministic (TRAIN_LLM=0). Configure the dedicated Bedrock access-key secrets to enable the LLM layer."
+            fi
+          fi
+          echo "train_llm=${llm}" >> "$GITHUB_OUTPUT"
+          echo "Resolved TRAIN_APPLY=${apply} (event=${EVENT_NAME}) MAX_BATCH=${mb} TRAIN_LLM=${llm}"
 
       - name: Run train
         env:
-          # HONUA_MERGE_TOKEN is preferred: a PAT can re-trigger downstream
+          # MERGE_TRAIN_TOKEN is preferred: a PAT can re-trigger downstream
           # workflows (a push by GITHUB_TOKEN does NOT retrigger other
           # workflows, so CI on the batch branch would not start). Fall back to
           # GITHUB_TOKEN when the PAT is absent — acceptable for dry-run, but
           # live landing wants the PAT so the batch-branch CI actually fires.
-          GH_TOKEN: ${{ secrets.HONUA_MERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.MERGE_TRAIN_TOKEN || secrets.GITHUB_TOKEN }}
           TRAIN_APPLY: ${{ steps.mode.outputs.train_apply }}
           MAX_BATCH: ${{ steps.mode.outputs.max_batch }}
           # Instrumentation: the run timestamp is injected here (not generated in
@@ -103,13 +122,26 @@ jobs:
           # train ALSO appends its dashboard to $GITHUB_STEP_SUMMARY directly, so
           # the Summary tab is populated even when the train selects nothing.
           TRAIN_METRICS_OUT: ${{ github.workspace }}/merge-train-metrics.json
+          # OPTIONAL gated LLM layer. TRAIN_LLM=0 here on every default path; the
+          # gates are inert and make zero Bedrock calls unless this is 1.
+          TRAIN_LLM: ${{ steps.mode.outputs.train_llm }}
+          # Bedrock auth via the dedicated least-privilege IAM user
+          # (honua-merge-train-bedrock) access-key secrets. These are only
+          # consumed by bedrock-invoke.sh when TRAIN_LLM=1; on every default
+          # (deterministic) path no AWS call is made and the keys go unused.
+          # bedrock-invoke.sh reads the standard AWS_* env, so exporting the
+          # secrets here is all that is needed.
+          AWS_ACCESS_KEY_ID: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ vars.HONUA_BEDROCK_REGION || 'us-west-2' }}
+          BEDROCK_MODEL_ID: ${{ vars.HONUA_BEDROCK_MODEL_ID || 'us.anthropic.claude-haiku-4-5-20251001-v1:0' }}
         run: |
           set -euo pipefail
           # Stamp a real ISO-8601 instant (the repository updated_at above is only
           # a stable fallback; prefer a fresh UTC timestamp for this run).
           export TRAIN_RUN_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          if [[ -z "${{ secrets.HONUA_MERGE_TOKEN }}" ]]; then
-            echo "::warning::HONUA_MERGE_TOKEN not set; using GITHUB_TOKEN. A GITHUB_TOKEN push does not retrigger downstream workflows, so live batch-branch CI may not start. Set HONUA_MERGE_TOKEN before enabling live mode."
+          if [[ -z "${{ secrets.MERGE_TRAIN_TOKEN }}" ]]; then
+            echo "::warning::MERGE_TRAIN_TOKEN not set; using GITHUB_TOKEN. A GITHUB_TOKEN push does not retrigger downstream workflows, so live batch-branch CI may not start. Set MERGE_TRAIN_TOKEN before enabling live mode."
           fi
           scripts/ci/merge-train/train.sh
 

--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -95,9 +95,42 @@ jobs:
           GH_TOKEN: ${{ secrets.HONUA_MERGE_TOKEN || secrets.GITHUB_TOKEN }}
           TRAIN_APPLY: ${{ steps.mode.outputs.train_apply }}
           MAX_BATCH: ${{ steps.mode.outputs.max_batch }}
+          # Instrumentation: the run timestamp is injected here (not generated in
+          # the script) so the Step Summary, metrics JSON, and state-issue
+          # aggregate all agree on a single run instant.
+          TRAIN_RUN_TIMESTAMP: ${{ github.event.repository.updated_at }}
+          # Write the metrics artifact into the workspace for upload below. The
+          # train ALSO appends its dashboard to $GITHUB_STEP_SUMMARY directly, so
+          # the Summary tab is populated even when the train selects nothing.
+          TRAIN_METRICS_OUT: ${{ github.workspace }}/merge-train-metrics.json
         run: |
           set -euo pipefail
+          # Stamp a real ISO-8601 instant (the repository updated_at above is only
+          # a stable fallback; prefer a fresh UTC timestamp for this run).
+          export TRAIN_RUN_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           if [[ -z "${{ secrets.HONUA_MERGE_TOKEN }}" ]]; then
             echo "::warning::HONUA_MERGE_TOKEN not set; using GITHUB_TOKEN. A GITHUB_TOKEN push does not retrigger downstream workflows, so live batch-branch CI may not start. Set HONUA_MERGE_TOKEN before enabling live mode."
           fi
           scripts/ci/merge-train/train.sh
+
+      - name: Ensure Step Summary is never silent
+        if: always()
+        run: |
+          # Defensive: if the train crashed before writing any dashboard, leave a
+          # breadcrumb so a run is never an empty Summary tab.
+          if [[ ! -s "${GITHUB_STEP_SUMMARY:-/dev/null}" ]]; then
+            {
+              echo "## 🚂 Merge Train"
+              echo ""
+              echo "_The train produced no dashboard this run (it may have failed before reporting). Check the **Run train** step log above._"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload merge-train metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: merge-train-metrics
+          path: ${{ github.workspace }}/merge-train-metrics.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/internal/contributor/adr/0055-optimistic-batch-merge-train.md
+++ b/docs/internal/contributor/adr/0055-optimistic-batch-merge-train.md
@@ -5,7 +5,7 @@
 Proposed. Phase 1 (deterministic git assembly, smart-CI, attribution, FF-CAS
 land, dry-run-by-default workflow) lands with this ADR. It ships DISABLED for
 live action: every automatic trigger runs in dry-run, and only an explicit
-`workflow_dispatch` with `train_apply=true` (and a `HONUA_MERGE_TOKEN`) lands a
+`workflow_dispatch` with `train_apply=true` (and a `MERGE_TRAIN_TOKEN`) lands a
 batch. A human flips it live later. Phases 2/3 are tracked as roadmap below.
 
 ## Context
@@ -90,7 +90,7 @@ the train cannot make it act.
 Triggers `schedule` (*/15), `workflow_run:{workflows:[CI]}`, and
 `workflow_dispatch` (`train_apply` boolean default false). `concurrency:
 {group: merge-train, cancel-in-progress: false}`. Permissions
-contents/pull-requests/actions/issues write. Uses `secrets.HONUA_MERGE_TOKEN`
+contents/pull-requests/actions/issues write. Uses `secrets.MERGE_TRAIN_TOKEN`
 if present, else `GITHUB_TOKEN` (a `GITHUB_TOKEN` push does NOT retrigger
 downstream workflows, so live batch-branch CI needs the PAT). No `matrix.*`
 appears in any job-level `if:`. After the train runs, `if: always()` steps
@@ -181,14 +181,74 @@ and real shard computation with no writes.
 - Throughput rises without re-melting runners: one smart-CI run lands several
   already-green PRs.
 - Trunk integrity is preserved by FF-CAS: only the exact bytes CI validated land.
-- Phase 1 is inert until a human dispatches live with a `HONUA_MERGE_TOKEN`.
+- Phase 1 is inert until a human dispatches live with a `MERGE_TRAIN_TOKEN`.
 
 ## Roadmap (deferred)
 
-- **Phase 2** — live enablement with `HONUA_MERGE_TOKEN`, real CI poll/land,
-  and the resume-from-state-issue path exercised end to end on a live batch.
+- **Phase 2 (live enablement)** — live enablement with `MERGE_TRAIN_TOKEN`, real
+  CI poll/land, and the resume-from-state-issue path exercised end to end on a
+  live batch.
 - **Phase 3** — bisection-free finer attribution when ≥2 suspects share a
   failing shard, batch-size auto-tuning, and starvation-aware scheduling.
+
+### Phase 2 — gated LLM judgment layer (AWS Bedrock / Claude)
+
+An **optional** enhancement that adds three narrow LLM judgments on top of the
+deterministic train. The deterministic train is the product of record; the LLM
+only breaks ties in ambiguous cases. It is **off by default** (`TRAIN_LLM=0`) on
+every trigger; the gates are never even consulted unless an operator dispatches
+with `use_llm=true` AND the dedicated Bedrock access-key secrets are configured.
+
+**Provider choice — reuse honua-devops's Bedrock posture.** honua-devops bills
+Bedrock to the founder's AWS account (no Anthropic API key). We mirror that:
+AWS-CLI SigV4 via the standard AWS credential chain, the region honua-devops
+deploys to (`us-west-2`), and the Bedrock-native Anthropic Messages request shape
+(`anthropic_version: bedrock-2023-05-31`, `system` + `messages`, short
+`max_tokens` — these are classification calls). The client uses
+`aws bedrock-runtime invoke-model`. Model id and region are env-overridable
+(`BEDROCK_MODEL_ID`, `AWS_REGION`), defaulting to the verified-ACTIVE Haiku-class
+cross-region inference profile (`us.anthropic.claude-haiku-4-5-20251001-v1:0`) in
+`us-west-2`; an operator pins whatever profile their account is entitled to
+without editing code. The thin client lives in
+`scripts/ci/merge-train/bedrock-invoke.sh`.
+
+**Authentication — dedicated least-privilege IAM access keys.** When the LLM
+layer is enabled the workflow exports the standard AWS env
+(`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) on the train step
+from the dedicated secrets `secrets.BEDROCK_AWS_ACCESS_KEY_ID` /
+`secrets.BEDROCK_AWS_SECRET_ACCESS_KEY`. These belong to a dedicated
+least-privilege IAM user, `honua-merge-train-bedrock`, scoped to
+`bedrock:InvokeModel` on the single model. `bedrock-invoke.sh` reads creds from
+that standard AWS env, so exporting the secrets is all that is required (no
+OIDC, no role assumption). The keys are only consulted when `TRAIN_LLM=1`, so
+the default deterministic path performs no AWS calls and uses no AWS
+credentials. Landing still uses `secrets.MERGE_TRAIN_TOKEN` (falling back to
+`GITHUB_TOKEN`). `TRAIN_LLM` is off by default on every trigger.
+
+**The three gates and their deterministic fallbacks** (each only fires in its
+ambiguous condition, logs its prompt-class + decision via `train_log`, and falls
+back to exactly the Phase-1 behavior when `TRAIN_LLM=0` or Bedrock errors):
+
+| Gate | Ambiguous trigger | LLM question | Fallback (and TRAIN_LLM=0) |
+|---|---|---|---|
+| select overlap-dependency (`select.sh`) | two candidate PRs overlap ≥ `TRAIN_OVERLAP_PCT` (60%) of changed files | "should PR B wait for PR A to land first? yes/no" | keep oldest-first ordering (include B) |
+| classify-flake unknown-signature (`classify-flake.sh`) | a failing log matches NO known flake regex | "transient infra flake or real failure?" (+ may learn a regex) | treat unknown as REAL |
+| forward-fix drift-heal-safety (`forward-fix.sh`) | a non-format drift failure (OpenAPI/feature-catalog/proof-ledger) | "safely auto-healable by a known generator, or must a human fix it?" | ESCALATE, never auto-patch |
+
+The forward-fix gate only ever accepts a generator on a hard-coded allowlist
+(`TRAIN_HEAL_ALLOWLIST`), so an LLM hallucination cannot make the train run an
+arbitrary command; HEAL with a non-allowlisted generator falls back to escalate.
+
+**Robustness.** `bedrock_ask` returns a sentinel on ANY failure (disabled,
+missing `aws`/`jq`, timeout, non-zero exit, empty output). The train is NEVER
+blocked or escalated by a Bedrock outage — a failure degrades the train to
+exactly Phase 1.
+
+**Cost note.** Gated + Haiku/Claude-class. A typical **green** batch makes **0**
+Bedrock calls — the gates only fire on the ambiguous paths (heavy PR overlap,
+unknown flake signatures, non-format drift), which are rare. Calls are short
+classification calls (`max_tokens` capped at 256), billed to the founder's AWS
+account.
 
 ## Alternatives considered
 

--- a/docs/internal/contributor/adr/0055-optimistic-batch-merge-train.md
+++ b/docs/internal/contributor/adr/0055-optimistic-batch-merge-train.md
@@ -93,7 +93,70 @@ Triggers `schedule` (*/15), `workflow_run:{workflows:[CI]}`, and
 contents/pull-requests/actions/issues write. Uses `secrets.HONUA_MERGE_TOKEN`
 if present, else `GITHUB_TOKEN` (a `GITHUB_TOKEN` push does NOT retrigger
 downstream workflows, so live batch-branch CI needs the PAT). No `matrix.*`
-appears in any job-level `if:`.
+appears in any job-level `if:`. After the train runs, `if: always()` steps
+guarantee the Step Summary is never empty and upload `merge-train-metrics.json`
+as the `merge-train-metrics` artifact.
+
+### Instrumentation / observability (first-class)
+
+Lack of visibility was half the prior CI nightmare, so the train makes every
+decision obvious at a glance. This is ADDITIVE — it reads only what the decision
+steps already produced and changes no decision logic; dry-run stays read-only.
+
+- **Structured, grouped run log.** Every step emits a greppable, leveled line via
+  one formatter: `[train][<step>][<LEVEL>] <msg>` where `<LEVEL>` is
+  `INFO`/`WARN`/`DECISION` (the founder greps `DECISION`). Each pipeline step
+  wraps its output in GitHub Actions `::group::`/`::endgroup::` (only when
+  `$GITHUB_ACTIONS`) so the workflow log is collapsible per step; off-Actions it
+  prints a plain banner so a local dry-run reads cleanly. Landings and
+  escalations also emit `::notice::`/`::warning::` so they surface in the run's
+  annotations.
+- **Step Summary dashboard (headline).** Each run appends a Markdown report to
+  `$GITHUB_STEP_SUMMARY` (mirrored to stdout for local dry-runs): run mode
+  (DRY-RUN vs LIVE), trunk SHA, batch branch, a **candidates table** (PR# |
+  author | CI-Gate | decision: included / skipped+reason / escalated), the
+  **batch** (branch + included/skipped PRs), the **smart-CI shard set**
+  (targeted shards + `run_all` reason), a **run-actions** counter table
+  (forward-fixes / flake reruns / attribution drops / escalated / landed), and
+  **per-phase timings**. `_dashboard` is rendered on EVERY exit path — including
+  "nothing selected" — so a run is never a silent Summary tab.
+- **Machine-readable metrics.** `merge-train-metrics.json`
+  (`schema: honua.merge-train.metrics/v1`) is written to `$TRAIN_METRICS_OUT`
+  and uploaded as the `merge-train-metrics` workflow artifact (`if: always()`).
+  The run timestamp is injected by the workflow (`TRAIN_RUN_TIMESTAMP`), not
+  generated mid-script, so the Summary, metrics, and aggregate agree on one
+  instant. Schema:
+
+  ```json
+  {
+    "schema": "honua.merge-train.metrics/v1",
+    "run_timestamp": "<ISO-8601>",
+    "mode": "DRY-RUN|LIVE",
+    "outcome": "nothing-ready|dry-run|landed|trunk-moved-reassemble|escalated-batch|all-dropped|land-error",
+    "trunk_sha": "<sha|''>",
+    "last_landed_sha": "<sha|null>",
+    "counts": {
+      "candidates": 0, "selected": 0,
+      "skipped_by_reason": { "select_ineligible": 0, "assemble_conflict": 0 },
+      "included": 0, "landed": 0, "escalated": 0,
+      "flake_reruns": 0, "forward_fixes": 0, "attribution_drops": 0
+    },
+    "smart_ci": { "shard_count": 0, "run_all": false },
+    "phase_durations_seconds": { "select": 0, "assemble": 0, "smart-ci": 0, "ci-gate": 0, "land": 0 }
+  }
+  ```
+
+- **Persistent over-time dashboard.** Aggregate metrics accumulate across LIVE
+  runs in a second fenced block (` ```json aggregate `,
+  `schema: honua.merge-train.aggregate/v1`) inside the SAME **Merge Train State**
+  issue, with a human-readable Markdown dashboard rendered above it — total
+  batches, PRs landed, runs, median time-to-land, flake-rerun rate (reruns per
+  batch), escalation count, current trunk SHA, last-landed SHA, and the live
+  flake-signature list. The state issue was chosen over a committed
+  `docs/ci/merge-train-status.md` because it needs no commit/push per run (lower
+  friction, and the train stays FF-CAS-clean about what it pushes to trunk). In
+  dry-run the aggregate dashboard renders to the Step Summary but is NOT
+  persisted to the issue.
 
 ### No bot attribution (runtime requirement)
 

--- a/scripts/ci/merge-train/bedrock-invoke.sh
+++ b/scripts/ci/merge-train/bedrock-invoke.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Phase 2: bedrock-invoke — a thin, fail-safe AWS Bedrock (Claude) client for the
+# merge train's OPTIONAL gated LLM judgment layer.
+#
+# This file is SOURCEABLE: it defines functions only and performs no work at
+# source time. The deterministic Phase-1 train works WITHOUT this — the LLM is a
+# gated enhancement that is OFF BY DEFAULT (TRAIN_LLM=0) and every caller has a
+# safe deterministic fallback.
+#
+# Provider pattern reuse (honua-devops):
+#   honua-devops's Bedrock access is billed to the founder's AWS account (no
+#   Anthropic API key). We mirror that posture here: AWS-CLI SigV4 auth via the
+#   ambient credential chain (a GitHub OIDC role assumed in the workflow), the
+#   AWS region honua-devops deploys to (us-west-2), and the Bedrock Messages-API
+#   request shape (anthropic_version=bedrock-2023-05-31, system + messages,
+#   short max_tokens — these are classification calls, not generation). Model id
+#   and region are env-overridable so an operator can pin whatever inference
+#   profile their account has access to without editing code.
+#
+# ROBUSTNESS CONTRACT (never block the train on an LLM failure):
+#   bedrock_ask emits a sentinel ("__BEDROCK_ERROR__") on ANY failure path — LLM
+#   disabled, aws CLI missing, timeout, non-zero exit, empty/garbled output. The
+#   judgment wrappers treat the sentinel (and the disabled state) as "fall back
+#   to the deterministic Phase-1 behavior." A Bedrock outage degrades the train
+#   to exactly Phase 1; it never wedges or escalates spuriously on its own.
+
+# --- configuration knobs (env-overridable) -----------------------------------
+# TRAIN_LLM gates the ENTIRE layer. 0 (default) => deterministic-only; the gates
+# below are never even consulted. 1 => the gates MAY call Bedrock, but only in
+# their ambiguous condition (see select.sh / classify-flake.sh / forward-fix.sh).
+: "${TRAIN_LLM:=0}"
+
+# Model id + region default to honua-devops's Bedrock posture. Both overridable.
+# The default is a Haiku-class cross-region inference profile (cheap, fast — these
+# are short classification calls). An operator pins whatever profile their AWS
+# account is entitled to via BEDROCK_MODEL_ID without touching this file.
+: "${BEDROCK_MODEL_ID:=us.anthropic.claude-haiku-4-5-20251001-v1:0}"
+: "${AWS_REGION:=us-west-2}"
+
+# Short cap: classification answers are tiny (yes/no + maybe a regex line).
+: "${BEDROCK_MAX_TOKENS:=256}"
+# Hard timeout (seconds) on the aws call so a hung endpoint can't stall a batch.
+: "${BEDROCK_TIMEOUT:=30}"
+
+# Sentinel returned on every failure/disabled path. Callers compare against this
+# and take their deterministic fallback when they see it.
+BEDROCK_ERROR_SENTINEL='__BEDROCK_ERROR__'
+
+# bedrock_enabled: is the gated LLM layer turned on? (TRAIN_LLM=1)
+bedrock_enabled() { [[ "${TRAIN_LLM:-0}" == "1" ]]; }
+
+# bedrock_ask <system-prompt> <user-prompt> -> stdout answer (or the sentinel).
+#
+# Robust by construction: any failure (disabled, missing aws/jq, timeout,
+# non-zero exit, empty body) prints the sentinel to stdout and returns 0, so a
+# caller's `ans="$(bedrock_ask ...)"` never aborts under `set -e` and always has
+# a defined value to branch on.
+#
+# Test seam: if TRAIN_BEDROCK_ASK_CMD is set, it is invoked as
+#   "${TRAIN_BEDROCK_ASK_CMD}" <system> <user>
+# and its stdout is used verbatim. The fixture harness sets this to a fake that
+# returns canned answers (and can simulate a Bedrock error by echoing the
+# sentinel), so tests never touch real Bedrock / spend money.
+bedrock_ask() {
+  local system="$1" user="$2"
+
+  if ! bedrock_enabled; then
+    printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"
+    return 0
+  fi
+
+  if [[ -n "${TRAIN_BEDROCK_ASK_CMD:-}" ]]; then
+    local out
+    if ! out="$("${TRAIN_BEDROCK_ASK_CMD}" "${system}" "${user}" 2>/dev/null)"; then
+      printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"; return 0
+    fi
+    [[ -z "${out}" ]] && out="${BEDROCK_ERROR_SENTINEL}"
+    printf '%s\n' "${out}"
+    return 0
+  fi
+
+  # Real path needs aws + jq. Missing either => fall back, don't crash.
+  if ! command -v aws >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"; return 0
+  fi
+
+  # Build the Bedrock InvokeModel body in the Anthropic Messages shape.
+  # (Bedrock's native Anthropic surface: anthropic_version is the fixed Bedrock
+  # marker string, NOT a Claude model id; the model is selected by --model-id.)
+  local body
+  if ! body="$(jq -nc \
+        --argjson max "${BEDROCK_MAX_TOKENS}" \
+        --arg sys "${system}" \
+        --arg usr "${user}" \
+        '{
+           anthropic_version: "bedrock-2023-05-31",
+           max_tokens: $max,
+           system: $sys,
+           messages: [ { role: "user", content: [ { type: "text", text: $usr } ] } ]
+         }')"; then
+    printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"; return 0
+  fi
+
+  # Invoke. The AWS CLI writes the model output to a path argument (not stdout),
+  # so we capture it via a temp file. `timeout` caps a hung call.
+  local outfile rc=0 raw text
+  outfile="$(mktemp 2>/dev/null)" || { printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"; return 0; }
+
+  timeout "${BEDROCK_TIMEOUT}" aws bedrock-runtime invoke-model \
+    --region "${AWS_REGION}" \
+    --model-id "${BEDROCK_MODEL_ID}" \
+    --content-type "application/json" \
+    --accept "application/json" \
+    --body "${body}" \
+    --cli-binary-format raw-in-base64-out \
+    "${outfile}" >/dev/null 2>&1 || rc=$?
+
+  if [[ "${rc}" != "0" ]]; then
+    rm -f "${outfile}"
+    printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"; return 0
+  fi
+
+  raw="$(cat "${outfile}" 2>/dev/null)"; rm -f "${outfile}"
+  # Anthropic-on-Bedrock response: {"content":[{"type":"text","text":"..."}],...}
+  text="$(jq -r '.content[]? | select(.type=="text") | .text' <<<"${raw}" 2>/dev/null | head -c 4000)"
+  if [[ -z "${text}" ]]; then
+    printf '%s\n' "${BEDROCK_ERROR_SENTINEL}"; return 0
+  fi
+  printf '%s\n' "${text}"
+  return 0
+}
+
+# bedrock_is_error <answer>: true if the answer is the failure sentinel.
+bedrock_is_error() { [[ "$1" == "${BEDROCK_ERROR_SENTINEL}" ]]; }
+
+# bedrock_first_word_yes <answer>: normalize a yes/no classification. Returns 0
+# (yes) only when the answer's first non-space token starts with "y" (case-insens).
+# The sentinel and anything non-affirmative return 1, so an errored/ambiguous
+# answer maps to "no" — callers pair this with an explicit fallback anyway.
+bedrock_first_word_yes() {
+  local ans="$1" first
+  bedrock_is_error "${ans}" && return 1
+  first="$(printf '%s' "${ans}" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ' | sed 's/^ *//' | cut -d' ' -f1)"
+  [[ "${first}" == y* ]]
+}

--- a/scripts/ci/merge-train/classify-flake.sh
+++ b/scripts/ci/merge-train/classify-flake.sh
@@ -27,6 +27,18 @@ train_run_logs_match_flake() {
 train_classify_flake() {
   local run_id="$1" rerun_count="${2:-0}"
   if ! train_run_logs_match_flake "${run_id}"; then
+    # Deterministic path found NO known flake signature. This is the ambiguous
+    # condition for the Phase-2 unknown-signature gate: optionally ask Bedrock
+    # whether it's a transient infra flake or a real failure (and learn a regex).
+    if train_classify_flake_unknown "${run_id}"; then
+      if [[ "${rerun_count}" -ge "${TRAIN_FLAKE_RERUN_CAP}" ]]; then
+        train_warn "llm-classified flake reproduced (rerun cap ${TRAIN_FLAKE_RERUN_CAP} reached); treating as real"
+        return 1
+      fi
+      train_log "llm[flake.unknown] classified TRANSIENT; issuing single rerun of failed jobs"
+      train_side_effect gh run rerun "${run_id}" --failed
+      return 0
+    fi
     train_log "no flake signature in failing logs; treating as real failure"
     return 1
   fi
@@ -36,5 +48,69 @@ train_classify_flake() {
   fi
   train_log "flake signature matched; issuing single rerun of failed jobs"
   train_side_effect gh run rerun "${run_id}" --failed
+  return 0
+}
+
+# --- Phase 2 gate: unknown-signature judgment (gated LLM) ---------------------
+# Invoked ONLY when the deterministic flake regex matched NO known signature
+# (the ambiguous case). Asks Bedrock: transient infra flake or real failure?
+# Returns 0 = TRANSIENT (caller may rerun once), 1 = REAL.
+#
+# Deterministic fallback (TRAIN_LLM=0 or Bedrock error): treat unknown as REAL
+# (return 1) — exactly the conservative Phase-1 behavior.
+#
+# Cheap learning: if Bedrock proposes a new flake regex line on a second output
+# line, we append it to the signature file at TRAIN_FLAKE_REGEX_LEARN_FILE (when
+# set and we are in live mode), so a future run recognizes the same signature
+# deterministically without an LLM call.
+train_classify_flake_unknown() {
+  local run_id="$1"
+  if ! declare -F bedrock_enabled >/dev/null 2>&1 || ! bedrock_enabled; then
+    return 1   # fallback: unknown => REAL (Phase-1 conservative default)
+  fi
+
+  local text
+  if [[ -n "${TRAIN_RUN_LOG_TEXT:-}" ]]; then
+    text="${TRAIN_RUN_LOG_TEXT}"
+  else
+    text="$(gh run view "${run_id}" --log-failed 2>/dev/null || echo "")"
+  fi
+  # Cap the log we send (these are classification calls, not generation).
+  text="$(printf '%s' "${text}" | tail -c 6000)"
+
+  local sys usr ans verdict regex
+  sys="You triage CI failures for a merge train. Given a failing job log that matched no known transient-flake pattern, decide if it is a TRANSIENT infrastructure flake (network blip, container/db startup race, runner eviction, deadlock) or a REAL code/test failure. Respond on the FIRST line with exactly one word: TRANSIENT or REAL. If TRANSIENT, you MAY add a SECOND line containing a single grep -E regex (no surrounding slashes) that would match this flake signature in future logs; otherwise omit the second line."
+  usr="Failing job log (tail):
+${text}
+
+Is this a transient infra flake or a real failure? First line: TRANSIENT or REAL. Optional second line: a grep -E regex for the flake signature."
+  ans="$(bedrock_ask "${sys}" "${usr}")"
+
+  if bedrock_is_error "${ans}"; then
+    train_log "llm[flake.unknown] bedrock error; fallback=REAL"
+    return 1
+  fi
+
+  verdict="$(printf '%s\n' "${ans}" | head -1 | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  if [[ "${verdict}" != transient* ]]; then
+    train_log "llm[flake.unknown] decision=REAL"
+    return 1
+  fi
+
+  # Optional learned regex on line 2 — append for future deterministic matches.
+  regex="$(printf '%s\n' "${ans}" | sed -n '2p' | sed 's/^ *//; s/ *$//')"
+  if [[ -n "${regex}" ]]; then
+    train_log "llm[flake.unknown] decision=TRANSIENT learned-regex=[${regex}]"
+    if [[ -n "${TRAIN_FLAKE_REGEX_LEARN_FILE:-}" ]]; then
+      # Recording the learned signature is a state mutation; gate it on apply.
+      if [[ "${TRAIN_APPLY:-0}" == "1" ]]; then
+        printf '%s\n' "${regex}" >>"${TRAIN_FLAKE_REGEX_LEARN_FILE}"
+      else
+        train_log "DRY-RUN (skipped): append learned flake regex to ${TRAIN_FLAKE_REGEX_LEARN_FILE}"
+      fi
+    fi
+  else
+    train_log "llm[flake.unknown] decision=TRANSIENT (no regex offered)"
+  fi
   return 0
 }

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -78,6 +78,7 @@ export TRAIN_REPO_ROOT="${WORK}"
 
 # shellcheck source=../lib.sh
 . "${TRAIN_DIR}/lib.sh"
+. "${TRAIN_DIR}/bedrock-invoke.sh"
 . "${TRAIN_DIR}/assemble.sh"
 . "${TRAIN_DIR}/smart-ci.sh"
 . "${TRAIN_DIR}/forward-fix.sh"
@@ -295,6 +296,113 @@ assert_eq "select: COMPLETED+SUCCESS => SUCCESS" "$(train_select_ci_gate_state '
 assert_eq "select: COMPLETED+FAILURE => FAIL" "$(train_select_ci_gate_state '[{"name":"CI Gate","status":"COMPLETED","conclusion":"FAILURE"}]')" "FAIL"
 assert_eq "select: QUEUED => PENDING" "$(train_select_ci_gate_state '[{"name":"CI Gate","status":"QUEUED","conclusion":""}]')" "PENDING"
 assert_eq "select: absent => MISSING" "$(train_select_ci_gate_state '[]')" "MISSING"
+
+echo
+echo "== Phase 2: gated Bedrock LLM judgments (mock; no real Bedrock) =="
+# A fake bedrock_ask, wired via TRAIN_BEDROCK_ASK_CMD. It records that it was
+# called (so we can assert the gates NEVER touch it when TRAIN_LLM=0) and returns
+# whatever canned answer the test stuffs into FAKE_BEDROCK_ANSWER. Setting the
+# answer to the error sentinel simulates a Bedrock outage/timeout.
+BEDROCK_CALLS="${SCRATCH}/bedrock_calls"; : >"${BEDROCK_CALLS}"
+__fake_bedrock() {  # __fake_bedrock <system> <user>
+  echo "called" >>"${BEDROCK_CALLS}"
+  printf '%s\n' "${FAKE_BEDROCK_ANSWER:-}"
+}
+export -f __fake_bedrock
+export TRAIN_BEDROCK_ASK_CMD=__fake_bedrock
+reset_calls() { : >"${BEDROCK_CALLS}"; }
+calls() { wc -l <"${BEDROCK_CALLS}" | tr -d ' '; }
+
+# Two PR file sets with HEAVY overlap (B's files all appear in A) => ambiguous.
+FILES_A=$'src/Honua.Core/Query/Filter.cs\nsrc/Honua.Core/Query/Paging.cs\nsrc/Honua.Core/Query/Crs.cs'
+FILES_B=$'src/Honua.Core/Query/Filter.cs\nsrc/Honua.Core/Query/Paging.cs'  # 100% of B in A
+# A non-overlapping pair (deterministic-only, never ambiguous).
+FILES_C=$'docs/readme.md'
+
+# Pure overlap ratio is testable on its own.
+assert_eq "p2 overlap: B fully in A => 100" "$(train_pr_overlap_ratio "${FILES_A}" "${FILES_B}")" "100"
+assert_eq "p2 overlap: disjoint => 0" "$(train_pr_overlap_ratio "${FILES_A}" "${FILES_C}")" "0"
+
+echo "-- (a) TRAIN_LLM=0: gates NEVER call Bedrock; behavior == Phase-1 deterministic --"
+export TRAIN_LLM=0
+reset_calls
+# select.overlap: deterministic fallback is PROCEED (rc1), even on heavy overlap.
+train_select_should_wait 10 "${FILES_A}" 11 "${FILES_B}" && bad "p2 select(llm0): heavy overlap must still PROCEED" || ok "p2 select(llm0): PROCEED (Phase-1 ordering)"
+assert_eq "p2 select(llm0): no bedrock call" "$(calls)" "0"
+# classify-flake unknown: deterministic fallback is REAL (rc1).
+reset_calls
+export TRAIN_RUN_LOG_TEXT="Assert.Equal() Failure: expected 3 actual 4"
+train_classify_flake_unknown 999 && bad "p2 flake(llm0): unknown must be REAL" || ok "p2 flake(llm0): unknown => REAL (conservative)"
+assert_eq "p2 flake(llm0): no bedrock call" "$(calls)" "0"
+# forward-fix heal: deterministic fallback is ESCALATE (rc1).
+reset_calls
+train_forward_fix_heal_safe "server-tests (OpenAPI drift)" "openapi.json out of date" && bad "p2 heal(llm0): must ESCALATE" || ok "p2 heal(llm0): ESCALATE (never auto-patch)"
+assert_eq "p2 heal(llm0): no bedrock call" "$(calls)" "0"
+unset TRAIN_RUN_LOG_TEXT
+
+echo "-- (b) TRAIN_LLM=1: each gate fires ONLY in its ambiguous condition, routes on yes/no --"
+export TRAIN_LLM=1
+# select.overlap: BELOW threshold (disjoint) must NOT call the LLM at all.
+reset_calls
+FAKE_BEDROCK_ANSWER="YES" train_select_should_wait 10 "${FILES_A}" 11 "${FILES_C}" && bad "p2 select(llm1,low-overlap): disjoint must PROCEED" || ok "p2 select(llm1): disjoint => PROCEED without LLM"
+assert_eq "p2 select(llm1): low-overlap skips bedrock" "$(calls)" "0"
+# select.overlap: heavy overlap + LLM says YES => WAIT (rc0).
+reset_calls
+FAKE_BEDROCK_ANSWER="YES, B depends on A" train_select_should_wait 10 "${FILES_A}" 11 "${FILES_B}" && ok "p2 select(llm1): heavy overlap + YES => WAIT" || bad "p2 select(llm1): YES should WAIT"
+assert_eq "p2 select(llm1,yes): bedrock consulted once" "$(calls)" "1"
+# select.overlap: heavy overlap + LLM says NO => PROCEED (rc1).
+reset_calls
+FAKE_BEDROCK_ANSWER="NO, independent" train_select_should_wait 10 "${FILES_A}" 11 "${FILES_B}" && bad "p2 select(llm1): NO should PROCEED" || ok "p2 select(llm1): heavy overlap + NO => PROCEED"
+assert_eq "p2 select(llm1,no): bedrock consulted once" "$(calls)" "1"
+
+# classify-flake unknown: a KNOWN signature must NOT reach the LLM (still flake).
+reset_calls
+export TRAIN_RUN_LOG_TEXT="40P01 deadlock detected"
+train_run_logs_match_flake 999 && ok "p2 flake(llm1): known signature handled deterministically" || bad "p2 flake(llm1): 40P01 should match"
+assert_eq "p2 flake(llm1): known signature skips bedrock" "$(calls)" "0"
+# Unknown signature + LLM says TRANSIENT => rc0 (rerunnable), learns regex.
+reset_calls
+export TRAIN_RUN_LOG_TEXT="ECONNRESET talking to package registry mid-restore"
+LEARN="${SCRATCH}/learned_regex"; : >"${LEARN}"
+export TRAIN_FLAKE_REGEX_LEARN_FILE="${LEARN}" TRAIN_APPLY=1
+FAKE_BEDROCK_ANSWER=$'TRANSIENT\nECONNRESET.*package registry' train_classify_flake_unknown 999 && ok "p2 flake(llm1): unknown + TRANSIENT => rerunnable" || bad "p2 flake(llm1): TRANSIENT should be rc0"
+assert_eq "p2 flake(llm1,transient): bedrock consulted once" "$(calls)" "1"
+grep -Fq 'ECONNRESET.*package registry' "${LEARN}" && ok "p2 flake(llm1): learned regex appended (apply mode)" || bad "p2 flake(llm1): learned regex not recorded"
+# Unknown signature + LLM says REAL => rc1.
+reset_calls
+FAKE_BEDROCK_ANSWER="REAL" train_classify_flake_unknown 999 && bad "p2 flake(llm1): REAL should be rc1" || ok "p2 flake(llm1): unknown + REAL => real failure"
+assert_eq "p2 flake(llm1,real): bedrock consulted once" "$(calls)" "1"
+unset TRAIN_RUN_LOG_TEXT TRAIN_FLAKE_REGEX_LEARN_FILE; export TRAIN_APPLY=0
+
+# forward-fix heal: LLM says HEAL with an allowlisted generator => rc0 + name.
+reset_calls
+FAKE_BEDROCK_ANSWER=$'HEAL\nupdate-openapi-snapshot'
+gen="$(train_forward_fix_heal_safe "server-tests (OpenAPI drift)" "openapi.json out of date")" && \
+  assert_eq "p2 heal(llm1): HEAL => allowlisted generator" "${gen}" "update-openapi-snapshot" || bad "p2 heal(llm1): HEAL should return generator"
+assert_eq "p2 heal(llm1,heal): bedrock consulted once" "$(calls)" "1"
+# forward-fix heal: LLM says HEAL but a NON-allowlisted generator => ESCALATE (safety).
+reset_calls
+FAKE_BEDROCK_ANSWER=$'HEAL\nrm -rf /' train_forward_fix_heal_safe "server-tests (drift)" "x" && bad "p2 heal(llm1): non-allowlisted must ESCALATE" || ok "p2 heal(llm1): HEAL + bad generator => ESCALATE (safety)"
+# forward-fix heal: LLM says ESCALATE => rc1 (the expected usual answer).
+reset_calls
+FAKE_BEDROCK_ANSWER="ESCALATE" train_forward_fix_heal_safe "server-tests (drift)" "x" && bad "p2 heal(llm1): ESCALATE should be rc1" || ok "p2 heal(llm1): ESCALATE => human fix"
+
+echo "-- (c) Bedrock error => deterministic fallback; train never blocks --"
+# select.overlap: heavy overlap but Bedrock errors => PROCEED (Phase-1 ordering).
+reset_calls
+FAKE_BEDROCK_ANSWER="${BEDROCK_ERROR_SENTINEL}" train_select_should_wait 10 "${FILES_A}" 11 "${FILES_B}" && bad "p2 select(err): must fall back to PROCEED" || ok "p2 select(err): bedrock error => PROCEED (no block)"
+# classify-flake unknown: Bedrock errors => REAL (conservative fallback).
+reset_calls
+export TRAIN_RUN_LOG_TEXT="some novel failure"
+FAKE_BEDROCK_ANSWER="${BEDROCK_ERROR_SENTINEL}" train_classify_flake_unknown 999 && bad "p2 flake(err): must fall back to REAL" || ok "p2 flake(err): bedrock error => REAL"
+unset TRAIN_RUN_LOG_TEXT
+# forward-fix heal: Bedrock errors => ESCALATE.
+reset_calls
+FAKE_BEDROCK_ANSWER="${BEDROCK_ERROR_SENTINEL}" train_forward_fix_heal_safe "server-tests (drift)" "x" && bad "p2 heal(err): must fall back to ESCALATE" || ok "p2 heal(err): bedrock error => ESCALATE"
+# Sanity: bedrock_ask itself returns the sentinel (never crashes) when disabled.
+TRAIN_LLM=0 ans_disabled="$(bedrock_ask sys usr)"; assert_eq "p2 bedrock_ask: disabled => sentinel" "${ans_disabled}" "${BEDROCK_ERROR_SENTINEL}"
+
+unset TRAIN_BEDROCK_ASK_CMD FAKE_BEDROCK_ANSWER TRAIN_LLM
 
 echo
 printf 'RESULT: %d passed, %d failed\n' "${PASS}" "${FAIL}"

--- a/scripts/ci/merge-train/forward-fix.sh
+++ b/scripts/ci/merge-train/forward-fix.sh
@@ -52,3 +52,63 @@ train_forward_fix() {
   train_log "forward-fix committed on ${batch}"
   return 0
 }
+
+# --- Phase 2 gate: drift-heal-safety judgment (gated LLM) ---------------------
+# Invoked ONLY when a NON-format drift failure appears (proof-ledger / OpenAPI /
+# feature-catalog drift) — the ambiguous case the deterministic train would
+# otherwise escalate outright. Asks Bedrock whether the drift is SAFELY
+# auto-healable by a known idempotent generator, or whether it needs a human.
+#
+# Returns 0 = a known generator is named on stdout (caller MAY run it), or
+#         1 = ESCALATE (no safe generator).
+#
+# Deterministic fallback (TRAIN_LLM=0, Bedrock error, or anything other than a
+# confident, allowlisted generator answer): ESCALATE — never auto-patch. This is
+# both the fallback AND the expected usual answer; the gate exists to catch the
+# rare, unambiguous "regenerate the OpenAPI snapshot" case, not to be clever.
+#
+# SAFETY: only generators on the TRAIN_HEAL_ALLOWLIST are ever accepted, so an
+# LLM hallucination cannot make the train run an arbitrary command. The caller is
+# still responsible for actually invoking the generator under the build lock and
+# re-running CI; this gate only DECIDES, it does not execute.
+: "${TRAIN_HEAL_ALLOWLIST:=update-openapi-snapshot|regenerate-feature-catalog|regenerate-proof-ledger}"
+train_forward_fix_heal_safe() {
+  local failing="$1" drift_detail="${2:-}"
+
+  if ! declare -F bedrock_enabled >/dev/null 2>&1 || ! bedrock_enabled; then
+    train_log "llm[forwardfix.heal] disabled; fallback=ESCALATE"
+    return 1   # fallback: escalate, never auto-patch
+  fi
+
+  local sys usr ans verdict gen
+  sys="You guard a merge train's auto-heal. A NON-format CI drift failure appeared (e.g. OpenAPI snapshot, feature catalog, or proof ledger out of date). Decide if it is SAFELY auto-healable by re-running a known deterministic generator, or if a human must fix it. Respond on the FIRST line with exactly one word: HEAL or ESCALATE. If HEAL, add a SECOND line naming exactly one generator from this allowlist: ${TRAIN_HEAL_ALLOWLIST//|/, }. If you are not certain, answer ESCALATE."
+  usr="Failing job(s):
+$(printf '%s\n' "${failing}" | sed '/^$/d')
+
+Drift detail:
+${drift_detail}
+
+Is this safely auto-healable by a known generator, or must a human fix it? First line: HEAL or ESCALATE. Optional second line: the generator name."
+  ans="$(bedrock_ask "${sys}" "${usr}")"
+
+  if bedrock_is_error "${ans}"; then
+    train_log "llm[forwardfix.heal] bedrock error; fallback=ESCALATE"
+    return 1
+  fi
+
+  verdict="$(printf '%s\n' "${ans}" | head -1 | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  if [[ "${verdict}" != heal* ]]; then
+    train_log "llm[forwardfix.heal] decision=ESCALATE"
+    return 1
+  fi
+
+  gen="$(printf '%s\n' "${ans}" | sed -n '2p' | sed 's/^ *//; s/ *$//')"
+  if [[ -z "${gen}" ]] || ! printf '%s' "${gen}" | grep -Eq "^(${TRAIN_HEAL_ALLOWLIST})$"; then
+    # HEAL with no/invalid generator is unsafe: fall back to escalation.
+    train_warn "llm[forwardfix.heal] HEAL with non-allowlisted generator [${gen}]; fallback=ESCALATE"
+    return 1
+  fi
+  train_log "llm[forwardfix.heal] decision=HEAL generator=[${gen}]"
+  printf '%s\n' "${gen}"
+  return 0
+}

--- a/scripts/ci/merge-train/lib.sh
+++ b/scripts/ci/merge-train/lib.sh
@@ -50,9 +50,92 @@ TRAIN_SHARDS_CONFIG="${TRAIN_SHARDS_CONFIG:-${TRAIN_REPO_ROOT}/.github/ci-shards
 TRAIN_TARGETED_SCRIPT="${TRAIN_TARGETED_SCRIPT:-${TRAIN_REPO_ROOT}/scripts/ci/honua-server-targeted-tests.sh}"
 
 # --- logging ------------------------------------------------------------------
-train_log()  { printf '[train] %s\n' "$*" >&2; }
-train_warn() { printf '[train][warn] %s\n' "$*" >&2; }
-train_err()  { printf '[train][error] %s\n' "$*" >&2; }
+# Visibility was half the prior CI nightmare, so every step emits a clear,
+# greppable, leveled line. The base helpers stay backward-compatible; the
+# component-aware helpers below add a [step] segment and a level so the run log
+# reads `[train][select][INFO] ...`, `[train][assemble][DECISION] ...`, etc.
+#
+# TRAIN_STEP is the active pipeline step (set by train_step_begin). Levels:
+#   INFO     — routine progress.
+#   WARN     — recoverable anomaly (skips, caps, re-assembles).
+#   DECISION — a choice the train made (included/skipped/escalated/landed).
+: "${TRAIN_STEP:=train}"
+
+train_log()  { _train_emit INFO "$*"; }
+train_warn() { _train_emit WARN "$*"; }
+train_err()  { _train_emit ERROR "$*"; }
+# train_decision: a first-class DECISION line — the thing the founder grep's for.
+train_decision() { _train_emit DECISION "$*"; }
+
+# _train_emit <level> <msg...>: the single formatter for every log line.
+# Format: [train][<step>][<level>] <msg> (the [<step>] segment is omitted when no
+# step group is active so generic lines read [train][INFO] ...). All go to stderr
+# so stdout stays the scripts' machine channel (batch branch name, JSON, etc.).
+_train_emit() {
+  local level="$1"; shift
+  if [[ -n "${TRAIN_STEP:-}" && "${TRAIN_STEP}" != "train" ]]; then
+    printf '[train][%s][%s] %s\n' "${TRAIN_STEP}" "${level}" "$*" >&2
+  else
+    printf '[train][%s] %s\n' "${level}" "$*" >&2
+  fi
+}
+
+# --- GitHub Actions grouping + annotations (no-op off-Actions) ----------------
+# Each pipeline step's output is wrapped in ::group::/::endgroup:: so the
+# workflow log is collapsible per step. Off Actions ($GITHUB_ACTIONS unset) these
+# print a plain banner to stderr so a local dry-run still reads cleanly.
+train_group() {
+  TRAIN_STEP="$1"
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    printf '::group::[train] %s — %s\n' "$1" "${2:-}" >&2
+  else
+    printf '\n----- [train] %s — %s -----\n' "$1" "${2:-}" >&2
+  fi
+}
+train_endgroup() {
+  [[ -n "${GITHUB_ACTIONS:-}" ]] && printf '::endgroup::\n' >&2 || true
+  TRAIN_STEP="train"
+}
+
+# train_notice / train_annotate_warn: surface landings + escalations in the run's
+# annotations (the Actions summary banner). No-op (but still logged) off Actions.
+train_notice() {
+  [[ -n "${GITHUB_ACTIONS:-}" ]] && printf '::notice::%s\n' "$*" >&2 || true
+  train_decision "$*"
+}
+train_annotate_warn() {
+  [[ -n "${GITHUB_ACTIONS:-}" ]] && printf '::warning::%s\n' "$*" >&2 || true
+  train_warn "$*"
+}
+
+# --- step timing --------------------------------------------------------------
+# train_step_begin <name> records a monotonic start; train_step_end <name> emits
+# the elapsed seconds and appends "<name>=<secs>" to TRAIN_TIMINGS_FILE (if set)
+# for the metrics JSON. Uses SECONDS-derived epoch math (portable, no bc).
+train_now() { date -u +%s; }
+declare -A _TRAIN_STEP_START 2>/dev/null || true
+train_step_begin() { _TRAIN_STEP_START["$1"]="$(train_now)"; }
+train_step_end() {
+  local name="$1" start now dur
+  start="${_TRAIN_STEP_START[$name]:-}"
+  [[ -z "${start}" ]] && return 0
+  now="$(train_now)"; dur=$(( now - start ))
+  train_log "phase '${name}' took ${dur}s"
+  [[ -n "${TRAIN_TIMINGS_FILE:-}" ]] && printf '%s=%s\n' "${name}" "${dur}" >>"${TRAIN_TIMINGS_FILE}"
+  printf '%s' "${dur}"
+}
+
+# --- Step Summary dashboard ---------------------------------------------------
+# train_summary <markdown-line...>: append a line to $GITHUB_STEP_SUMMARY (the
+# Actions Summary tab) AND mirror it to stdout so a local dry-run prints the same
+# dashboard. TRAIN_SUMMARY_FILE overrides the sink (tests / local capture).
+train_summary() {
+  local sink="${TRAIN_SUMMARY_FILE:-${GITHUB_STEP_SUMMARY:-}}"
+  if [[ -n "${sink}" ]]; then
+    printf '%s\n' "$*" >>"${sink}"
+  fi
+  printf '%s\n' "$*"
+}
 
 # train_side_effect: the single chokepoint for every state-mutating action.
 # In live mode (TRAIN_APPLY=1) it executes the command; otherwise it logs the
@@ -115,4 +198,95 @@ train_shard_paths() {
   local shard_name="$1" config="${2:-${TRAIN_SHARDS_CONFIG}}"
   jq -r --arg n "${shard_name}" \
     '.shards[] | select(.name == $n) | .paths[]' "${config}"
+}
+
+# --- machine-readable metrics (per-run counters) ------------------------------
+# A flat key=value counter store backed by TRAIN_METRICS_KV (a temp file). The
+# orchestrator bumps counters as decisions are made, then train_metrics_render
+# emits a single merge-train-metrics.json uploaded as a workflow artifact.
+#
+# Counter keys (documented in ADR-0055 "Instrumentation"):
+#   candidates selected included landed escalated
+#   skipped_conflict flake_reruns forward_fixes attribution_drops
+#   smartci_shard_count
+# Plus the run outcome (string) and per-phase durations (from TRAIN_TIMINGS_FILE).
+train_metric_set() {  # key value
+  [[ -z "${TRAIN_METRICS_KV:-}" ]] && return 0
+  printf '%s=%s\n' "$1" "$2" >>"${TRAIN_METRICS_KV}"
+}
+# train_metric_get <key> [default]: last-write-wins read of a counter.
+train_metric_get() {
+  local key="$1" def="${2:-0}" val
+  [[ -z "${TRAIN_METRICS_KV:-}" || ! -s "${TRAIN_METRICS_KV:-/dev/null}" ]] && { printf '%s' "${def}"; return 0; }
+  val="$(grep -E "^${key}=" "${TRAIN_METRICS_KV}" | tail -1 | cut -d= -f2-)"
+  printf '%s' "${val:-${def}}"
+}
+train_metric_inc() {  # key [by]
+  local key="$1" by="${2:-1}" cur
+  cur="$(train_metric_get "${key}" 0)"
+  train_metric_set "${key}" "$(( cur + by ))"
+}
+
+# train_timings_json: turn the "<phase>=<secs>" lines into a JSON object.
+train_timings_json() {
+  local f="${TRAIN_TIMINGS_FILE:-}"
+  if [[ -z "${f}" || ! -s "${f}" ]]; then echo '{}'; return 0; fi
+  # Last write wins per phase so a re-run phase (re-assemble) reports its latest.
+  awk -F= 'NF>=2 {t[$1]=$2} END {for (k in t) print k"="t[k]}' "${f}" \
+    | jq -R 'split("=") | {(.[0]): (.[1]|tonumber)}' | jq -s 'add // {}'
+}
+
+# train_metrics_render <run_timestamp> <mode> <trunk_sha> <last_landed_sha> <outcome> [shard_descriptor]
+#   Emit the full merge-train-metrics.json document on stdout.
+train_metrics_render() {
+  local ts="$1" mode="$2" trunk_sha="$3" last_landed="$4" outcome="$5" shard_desc="${6:-}"
+  local shard_count run_all
+  shard_count="$(train_metric_get smartci_shard_count 0)"
+  run_all="false"
+  if [[ -n "${shard_desc}" ]] && jq -e . >/dev/null 2>&1 <<<"${shard_desc}"; then
+    run_all="$(jq -r '.run_all // false' <<<"${shard_desc}")"
+  fi
+  [[ "${run_all}" != "true" && "${run_all}" != "false" ]] && run_all="false"
+  local last_json="null"; [[ -n "${last_landed}" && "${last_landed}" != "null" ]] && last_json="\"${last_landed}\""
+
+  jq -n \
+    --arg ts "${ts}" \
+    --arg mode "${mode}" \
+    --arg trunk "${trunk_sha}" \
+    --argjson last "${last_json}" \
+    --arg outcome "${outcome}" \
+    --argjson candidates "$(train_metric_get candidates 0)" \
+    --argjson selected "$(train_metric_get selected 0)" \
+    --argjson included "$(train_metric_get included 0)" \
+    --argjson landed "$(train_metric_get landed 0)" \
+    --argjson escalated "$(train_metric_get escalated 0)" \
+    --argjson skipped_conflict "$(train_metric_get skipped_conflict 0)" \
+    --argjson skipped_select "$(train_metric_get skipped_select 0)" \
+    --argjson flake_reruns "$(train_metric_get flake_reruns 0)" \
+    --argjson forward_fixes "$(train_metric_get forward_fixes 0)" \
+    --argjson attribution_drops "$(train_metric_get attribution_drops 0)" \
+    --argjson shard_count "${shard_count:-0}" \
+    --argjson run_all "${run_all:-false}" \
+    --argjson durations "$(train_timings_json)" \
+    '{
+      schema: "honua.merge-train.metrics/v1",
+      run_timestamp: $ts,
+      mode: $mode,
+      outcome: $outcome,
+      trunk_sha: $trunk,
+      last_landed_sha: $last,
+      counts: {
+        candidates: $candidates,
+        selected: $selected,
+        skipped_by_reason: { select_ineligible: $skipped_select, assemble_conflict: $skipped_conflict },
+        included: $included,
+        landed: $landed,
+        escalated: $escalated,
+        flake_reruns: $flake_reruns,
+        forward_fixes: $forward_fixes,
+        attribution_drops: $attribution_drops
+      },
+      smart_ci: { shard_count: $shard_count, run_all: $run_all },
+      phase_durations_seconds: $durations
+    }'
 }

--- a/scripts/ci/merge-train/select.sh
+++ b/scripts/ci/merge-train/select.sh
@@ -115,3 +115,67 @@ train_select() {
     fi
   done <<<"${ordered}"
 }
+
+# --- Phase 2 gate: overlap-dependency judgment (gated LLM) --------------------
+# When two candidate PRs heavily overlap in the files they change, landing the
+# newer one first can silently strand a logical dependency. The deterministic
+# Phase-1 behavior keeps strict oldest-first ordering; Phase 2 OPTIONALLY asks
+# Bedrock, only in the ambiguous (heavy-overlap) case, whether the later PR (B)
+# should wait for the earlier PR (A) to land first.
+#
+# train_pr_overlap_ratio <filesA-newline> <filesB-newline>: emit an integer
+# percentage (0-100) of B's files that also appear in A (|A∩B|/|B|). Pure +
+# testable; no network.
+train_pr_overlap_ratio() {
+  local files_a="$1" files_b="$2"
+  awk -v a="${files_a}" '
+    BEGIN { n = split(a, arr, "\n"); for (i=1;i<=n;i++) if (arr[i]!="") inA[arr[i]]=1 }
+    { if ($0 != "") { tot++; if ($0 in inA) hit++ } }
+    END { if (tot == 0) { print 0 } else { printf "%d\n", (hit*100)/tot } }
+  ' <<<"${files_b}"
+}
+
+# train_select_should_wait <prA> <filesA-newline> <prB> <filesB-newline>:
+# Decide whether candidate PR B should WAIT for PR A (B is the later/newer one).
+# Returns 0 = WAIT (skip B this batch), 1 = proceed (include B).
+#
+# Deterministic fallback (TRAIN_LLM=0, Bedrock error, or below-threshold
+# overlap): NEVER wait — keep oldest-first ordering, i.e. exactly Phase 1.
+# The LLM is consulted ONLY when overlap >= TRAIN_OVERLAP_PCT (default 60),
+# which is the "ambiguous" condition. Logs prompt-class + decision via train_log.
+: "${TRAIN_OVERLAP_PCT:=60}"
+train_select_should_wait() {
+  local pr_a="$1" files_a="$2" pr_b="$3" files_b="$4"
+
+  # Deterministic guard first: only an ambiguous heavy overlap consults the LLM.
+  local ratio; ratio="$(train_pr_overlap_ratio "${files_a}" "${files_b}")"
+  if [[ "${ratio}" -lt "${TRAIN_OVERLAP_PCT}" ]]; then
+    return 1   # not ambiguous: proceed (Phase-1 ordering)
+  fi
+  if ! declare -F bedrock_enabled >/dev/null 2>&1 || ! bedrock_enabled; then
+    train_log "llm[select.overlap] disabled; fallback=PROCEED (#${pr_b} not held; overlap ${ratio}%)"
+    return 1   # fallback: keep oldest-first, include B
+  fi
+
+  local sys usr ans
+  sys="You order code-review pull requests for a merge train. Two PRs change a heavily overlapping set of files. Answer with exactly one word: YES if PR B should wait for PR A to land first (e.g. B builds on A or would conflict/strand A), or NO if they are independent and B can land now. Output only YES or NO."
+  usr="PR A (#${pr_a}) changed files:
+$(printf '%s\n' "${files_a}" | sed '/^$/d')
+
+PR B (#${pr_b}) changed files:
+$(printf '%s\n' "${files_b}" | sed '/^$/d')
+
+File overlap of B onto A: ${ratio}%. Should PR B wait for PR A to land first? Answer YES or NO."
+  ans="$(bedrock_ask "${sys}" "${usr}")"
+
+  if bedrock_is_error "${ans}"; then
+    train_log "llm[select.overlap] bedrock error; fallback=PROCEED (#${pr_b} not held)"
+    return 1   # fallback on any LLM failure
+  fi
+  if bedrock_first_word_yes "${ans}"; then
+    train_log "llm[select.overlap] decision=WAIT (#${pr_b} waits for #${pr_a}; overlap ${ratio}%)"
+    return 0   # hold B this batch
+  fi
+  train_log "llm[select.overlap] decision=PROCEED (#${pr_b} independent of #${pr_a}; overlap ${ratio}%)"
+  return 1
+}

--- a/scripts/ci/merge-train/select.sh
+++ b/scripts/ci/merge-train/select.sh
@@ -56,7 +56,7 @@ train_select() {
     pr_list="${TRAIN_PR_LIST_JSON}"
   else
     pr_list="$(gh pr list --base "${TRAIN_BASE_BRANCH}" --state open \
-      --json number,headRefOid,isDraft,mergeable,mergeStateStatus,labels,createdAt,files \
+      --json number,headRefOid,isDraft,mergeable,mergeStateStatus,labels,createdAt,files,author \
       --limit 100)"
   fi
 
@@ -106,7 +106,8 @@ train_select() {
            --arg oid "$(jq -r '.headRefOid' <<<"${line}")" \
            --arg created "$(jq -r '.createdAt' <<<"${line}")" \
            --arg gate "${gate}" \
-      '{number:$n, headRefOid:$oid, createdAt:$created, gate:$gate}'
+           --arg author "$(jq -r '.author.login // .author.name // "?"' <<<"${line}")" \
+      '{number:$n, headRefOid:$oid, createdAt:$created, gate:$gate, author:$author}'
 
     count=$((count + 1))
     if [[ "${count}" -ge "${MAX_BATCH}" ]]; then

--- a/scripts/ci/merge-train/state.sh
+++ b/scripts/ci/merge-train/state.sh
@@ -100,3 +100,139 @@ train_state_read() {
     inblk      { print }
   '
 }
+
+# --- persistent over-time dashboard (the founder's "dashboard") ---------------
+# Aggregate metrics accumulate across LIVE runs in a second fenced block
+# (```json aggregate```) inside the SAME Merge Train State issue, with a
+# human-readable Markdown dashboard rendered above it. We chose the issue over a
+# committed docs file because it needs no commit/push per run (lower friction,
+# and the train must stay FF-CAS-clean about what it pushes to trunk). In
+# dry-run the dashboard renders to the Step Summary but is NOT persisted.
+
+# train_aggregate_block: emit the parsed ```json aggregate``` block (or empty).
+train_aggregate_block() {
+  local body
+  if [[ -n "${TRAIN_AGG_BODY_OVERRIDE:-}" ]]; then
+    body="${TRAIN_AGG_BODY_OVERRIDE}"
+  else
+    local num; num="$(train_state_issue_number)"
+    [[ -z "${num}" ]] && return 0
+    body="$(gh issue view "${num}" --json body --jq '.body' 2>/dev/null || echo "")"
+  fi
+  printf '%s\n' "${body}" | awk '
+    /^```json aggregate/ { inblk=1; next }
+    /^```/               { if (inblk) { inblk=0 }; next }
+    inblk                { print }
+  '
+}
+
+# train_aggregate_merge <prev-json> : read this run's per-run counters
+# (TRAIN_METRICS_KV) plus a time-to-land sample, fold them into prev, emit the
+# new aggregate JSON. Pure-ish (reads metric counters + env); no I/O writes.
+train_aggregate_merge() {
+  local prev="${1:-}" ttl_sample="${2:-}"
+  [[ -z "${prev}" ]] && prev='{}'
+
+  local landed_now flake_now esc_now batches_inc
+  landed_now="$(train_metric_get landed 0)"
+  flake_now="$(train_metric_get flake_reruns 0)"
+  esc_now="$(train_metric_get escalated 0)"
+  # A "batch" counts when at least one PR landed this run.
+  batches_inc=0; [[ "${landed_now}" -gt 0 ]] && batches_inc=1
+
+  jq -n \
+    --argjson prev "${prev}" \
+    --argjson landed_now "${landed_now}" \
+    --argjson flake_now "${flake_now}" \
+    --argjson esc_now "${esc_now}" \
+    --argjson batches_inc "${batches_inc}" \
+    --arg ttl "${ttl_sample}" \
+    --arg now "${TRAIN_RUN_TIMESTAMP:-}" \
+    '
+    ($prev.totals // {}) as $t
+    | ($prev.ttl_samples // []) as $samp
+    | (if ($ttl|length) > 0 then ($samp + [($ttl|tonumber)]) else $samp end) as $samp2
+    | ($samp2 | sort) as $sorted
+    | (if ($sorted|length) > 0 then $sorted[ (($sorted|length)/2) | floor ] else null end) as $median
+    | {
+        schema: "honua.merge-train.aggregate/v1",
+        updated: $now,
+        totals: {
+          batches:         (($t.batches // 0) + $batches_inc),
+          prs_landed:      (($t.prs_landed // 0) + $landed_now),
+          flake_reruns:    (($t.flake_reruns // 0) + $flake_now),
+          escalations:     (($t.escalations // 0) + $esc_now),
+          runs:            (($t.runs // 0) + 1)
+        },
+        median_time_to_land_seconds: $median,
+        ttl_samples: ($samp2 | .[-50:])
+      }'
+}
+
+# train_aggregate_dashboard_md <agg-json> <trunk_sha> <last_landed> : render the
+# human Markdown dashboard for the state issue (and Step Summary).
+train_aggregate_dashboard_md() {
+  local agg="$1" trunk="$2" last="$3"
+  local batches prs flake esc runs median rate
+  batches="$(jq -r '.totals.batches // 0' <<<"${agg}")"
+  prs="$(jq -r '.totals.prs_landed // 0' <<<"${agg}")"
+  flake="$(jq -r '.totals.flake_reruns // 0' <<<"${agg}")"
+  esc="$(jq -r '.totals.escalations // 0' <<<"${agg}")"
+  runs="$(jq -r '.totals.runs // 0' <<<"${agg}")"
+  median="$(jq -r '.median_time_to_land_seconds // "—"' <<<"${agg}")"
+  # flake-rerun rate = flake reruns / batches (guard div-by-zero).
+  if [[ "${batches}" -gt 0 ]]; then
+    rate="$(jq -rn --argjson f "${flake}" --argjson b "${batches}" '($f/$b)|.*100|floor/100')"
+  else
+    rate="0"
+  fi
+
+  printf '## Merge Train — aggregate dashboard\n\n'
+  printf '| Metric | Value |\n|---|---|\n'
+  printf '| Total batches landed | %s |\n' "${batches}"
+  printf '| PRs landed | %s |\n' "${prs}"
+  printf '| Train runs | %s |\n' "${runs}"
+  printf '| Median time-to-land | %s |\n' "$([[ "${median}" == "—" || "${median}" == "null" ]] && echo "—" || echo "${median}s")"
+  printf '| Flake-rerun rate (reruns/batch) | %s |\n' "${rate}"
+  printf '| Escalations | %s |\n' "${esc}"
+  printf '| Current trunk SHA | `%s` |\n' "${trunk:-—}"
+  printf '| Last-landed SHA | `%s` |\n' "${last:-—}"
+  printf '| Live flake signatures | `%s` |\n' "${TRAIN_FLAKE_REGEX}"
+  printf '\n'
+}
+
+# train_aggregate_update <trunk_sha> <last_landed> [ttl_sample_seconds]:
+# fold this run into the persisted aggregate and write it (with the machine-state
+# block preserved) back to the state issue. Side-effecting (gated by TRAIN_APPLY
+# via train_state_write); in dry-run it renders to the Step Summary only.
+train_aggregate_update() {
+  local trunk="$1" last="$2" ttl="${3:-}"
+  local prev agg
+  prev="$(train_aggregate_block)"
+  agg="$(train_aggregate_merge "${prev}" "${ttl}")"
+
+  # Render the human dashboard (always emitted to the Step Summary for visibility).
+  local md; md="$(train_aggregate_dashboard_md "${agg}" "${trunk}" "${last}")"
+  if train_have train_summary; then
+    while IFS= read -r line; do train_summary "${line}"; done <<<"${md}"
+  fi
+
+  # Persist only in LIVE mode (dry-run never writes the issue).
+  if [[ "${TRAIN_APPLY}" != "1" ]]; then
+    train_log "dry-run: aggregate dashboard rendered (not persisted to state issue)"
+    return 0
+  fi
+
+  # Read the current machine-state block back so we re-emit a complete body.
+  local state_json; state_json="$(train_state_read)"
+  [[ -z "${state_json}" ]] && state_json='{}'
+
+  local body="${TRAIN_AGG_BODY_FILE:-$(mktemp)}"
+  {
+    printf 'Machine-managed state for the optimistic batch merge train. Do not edit by hand.\n\n'
+    printf '%s' "${md}"
+    printf '\n```json\n%s\n```\n' "${state_json}"
+    printf '\n```json aggregate\n%s\n```\n' "${agg}"
+  } >"${body}"
+  train_state_write "${body}"
+}

--- a/scripts/ci/merge-train/train.sh
+++ b/scripts/ci/merge-train/train.sh
@@ -45,31 +45,68 @@ trap 'rm -rf "${TRAIN_WORK}"' EXIT
 export TRAIN_INCLUDED_FILE="${TRAIN_WORK}/included.tsv"
 export TRAIN_SKIPPED_FILE="${TRAIN_WORK}/skipped.tsv"
 export TRAIN_RUN_ID_FILE="${TRAIN_WORK}/run_id"
+# Instrumentation sinks (additive observability — no decision logic reads these).
+export TRAIN_TIMINGS_FILE="${TRAIN_WORK}/timings.kv"
+export TRAIN_METRICS_KV="${TRAIN_WORK}/metrics.kv"
+: >"${TRAIN_TIMINGS_FILE}"; : >"${TRAIN_METRICS_KV}"
+# Where the machine-readable metrics doc is written (uploaded as an artifact).
+: "${TRAIN_METRICS_OUT:=${TRAIN_REPO_ROOT}/merge-train-metrics.json}"
+# Run timestamp: prefer one injected by the workflow; else generate.
+: "${TRAIN_RUN_TIMESTAMP:=$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+# _train_mode_label: human label for the run mode.
+_train_mode_label() { [[ "${TRAIN_APPLY}" == "1" ]] && echo LIVE || echo DRY-RUN; }
+
+# _emit_metrics <outcome> <trunk_sha> <last_landed> [shard_descriptor]: render the
+# machine-readable metrics JSON to TRAIN_METRICS_OUT (best-effort; never fatal).
+_emit_metrics() {
+  local outcome="$1" trunk_sha="$2" last_landed="$3" shard_desc="${4:-}"
+  train_metrics_render "${TRAIN_RUN_TIMESTAMP}" "$(_train_mode_label)" \
+    "${trunk_sha}" "${last_landed}" "${outcome}" "${shard_desc}" \
+    >"${TRAIN_METRICS_OUT}" 2>/dev/null \
+    && train_log "metrics written: ${TRAIN_METRICS_OUT} (outcome=${outcome})" \
+    || train_warn "could not write metrics JSON"
+}
 
 main() {
-  train_log "mode: $( [[ "${TRAIN_APPLY}" == "1" ]] && echo LIVE || echo DRY-RUN ) MAX_BATCH=${MAX_BATCH}"
+  train_log "mode: $(_train_mode_label) MAX_BATCH=${MAX_BATCH} run=${TRAIN_RUN_TIMESTAMP}"
 
   # --- select ----------------------------------------------------------------
+  train_group select "pick ready PRs (oldest-first, capped at ${MAX_BATCH})"
+  train_step_begin select
   local selected
   selected="$(train_select | jq -s '.')"
   local prs
   prs="$(jq -r '.[].number' <<<"${selected}")"
+  local n_selected; n_selected="$(jq 'length' <<<"${selected}")"
+  train_metric_set selected "${n_selected}"
+  # candidates = total open PRs the selector evaluated (selected ones surface in
+  # the batch; the rest were skipped at select for draft/hold/conflict/CI-gate).
+  # TRAIN_CANDIDATE_COUNT lets the caller inject the raw count; else fall back to
+  # the selected count so the metric is never larger than reality.
+  train_metric_set candidates "${TRAIN_CANDIDATE_COUNT:-${n_selected}}"
+  train_metric_set skipped_select "$(( ${TRAIN_CANDIDATE_COUNT:-${n_selected}} - n_selected ))"
+  train_step_end select >/dev/null
   if [[ -z "${prs}" ]]; then
-    train_log "no ready PRs; nothing to do"
-    echo
-    echo "=== MERGE TRAIN DECISION (dry-run=$([[ "${TRAIN_APPLY}" == "1" ]] && echo 0 || echo 1)) ==="
-    echo "selected batch: (none)"
+    train_decision "no ready PRs; nothing to do"
+    train_endgroup
+    _emit_metrics "nothing-ready" "" "" ""
+    _dashboard "" "${selected}" "" "" "no ready PRs — nothing to select"
     return 0
   fi
-  train_log "candidate batch (oldest-first, capped): $(tr '\n' ' ' <<<"${prs}")"
+  train_decision "candidate batch (oldest-first, capped): $(tr '\n' ' ' <<<"${prs}")"
+  train_endgroup
 
   # --- trunk base ------------------------------------------------------------
   git -C "${TRAIN_REPO_ROOT}" fetch --quiet "${TRAIN_REMOTE}" "${TRAIN_BASE_BRANCH}"
   local trunk_sha trunk_sha7
   trunk_sha="$(git -C "${TRAIN_REPO_ROOT}" rev-parse "${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}")"
   trunk_sha7="${trunk_sha:0:7}"
+  train_log "trunk base: ${trunk_sha} (${trunk_sha7})"
 
   # --- assemble (transactional detect-and-skip) ------------------------------
+  train_group assemble "merge PR heads onto a fresh branch off ${TRAIN_BASE_BRANCH}"
+  train_step_begin assemble
   # state: write BEFORE assembling (resumable at assemble phase).
   _write_state "" "${trunk_sha}" "" "assemble" "" 0 0
   local batch
@@ -80,12 +117,21 @@ main() {
   local included skipped
   included="$(cut -f1 "${TRAIN_INCLUDED_FILE}" | tr '\n' ',' | sed 's/,$//')"
   skipped="$(cut -f1 "${TRAIN_SKIPPED_FILE}" | tr '\n' ' ')"
-  train_log "INCLUDED: ${included:-<none>}"
-  [[ -n "${skipped// /}" ]] && train_log "SKIPPED_CONFLICT: ${skipped}"
+  train_metric_set included "$(grep -c . "${TRAIN_INCLUDED_FILE}" 2>/dev/null || echo 0)"
+  train_metric_set skipped_conflict "$(grep -c . "${TRAIN_SKIPPED_FILE}" 2>/dev/null || echo 0)"
+  for pr in $(tr ',' ' ' <<<"${included}"); do
+    [[ -n "${pr}" ]] && train_decision "INCLUDE #${pr} (assembled clean)"
+  done
+  for pr in ${skipped}; do
+    [[ -n "${pr}" ]] && train_decision "SKIP #${pr} (conflict; aborted clean)"
+  done
+  train_step_end assemble >/dev/null
+  train_endgroup
 
   if [[ -z "${included}" ]]; then
-    train_warn "no PRs assembled cleanly; nothing to land"
-    _decision_report "${batch}" "${selected}" "${trunk_sha}" "" "(all skipped)"
+    train_annotate_warn "no PRs assembled cleanly; nothing to land"
+    _emit_metrics "nothing-ready" "${trunk_sha}" "" ""
+    _dashboard "${batch}" "${selected}" "${trunk_sha}" "" "all candidates skipped on conflict — nothing to land"
     return 0
   fi
 
@@ -97,20 +143,29 @@ main() {
   done
 
   # --- smart-ci + forward-fix + flake + attribute loop -----------------------
+  train_group smart-ci "compute shard subset for the batch's cumulative diff"
+  train_step_begin smart-ci
   local shard_descriptor
   shard_descriptor="$(train_smart_ci_shards "${batch}")"
-  train_log "smart-CI shard subset: ${shard_descriptor}"
+  train_metric_set smartci_shard_count "$(jq -r '(.shards // []) | length' <<<"${shard_descriptor}" 2>/dev/null || echo 0)"
+  train_decision "smart-CI shard subset: ${shard_descriptor}"
 
   local gate fwdfix=0 flake_reruns=0
   gate="$(train_smart_ci_run "${batch}")"
+  train_step_end smart-ci >/dev/null
+  train_endgroup
 
   if [[ "${TRAIN_APPLY}" != "1" ]]; then
     train_log "dry-run: stopping before CI gate evaluation/land (no pushes happened)"
-    _decision_report "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" ""
+    _emit_metrics "dry-run" "${trunk_sha}" "" "${shard_descriptor}"
+    _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
+      "dry-run: stopped before CI gate/land (no pushes happened)"
     return 0
   fi
 
   # Live-mode gate handling (forward-fix -> flake -> attribute -> land).
+  train_group ci-gate "evaluate CI Gate; forward-fix / classify-flake / attribute"
+  train_step_begin ci-gate
   while [[ "${gate}" != "SUCCESS" ]]; do
     local run_id; run_id="$(cat "${TRAIN_RUN_ID_FILE}" 2>/dev/null || echo "")"
     local failing; failing="$(train_failing_jobs "${run_id}")"
@@ -120,6 +175,8 @@ main() {
       _write_state "${batch}" "${trunk_sha}" "${included}" "forward-fix" "${run_id}" "${fwdfix}" "${flake_reruns}"
       if train_forward_fix "${batch}" "${fwdfix}"; then
         fwdfix=$((fwdfix + 1))
+        train_metric_set forward_fixes "${fwdfix}"
+        train_decision "forward-fix #${fwdfix} applied (dotnet format); re-running CI"
         gate="$(train_smart_ci_run "${batch}")"
         continue
       fi
@@ -129,6 +186,8 @@ main() {
     _write_state "${batch}" "${trunk_sha}" "${included}" "classify-flake" "${run_id}" "${fwdfix}" "${flake_reruns}"
     if train_classify_flake "${run_id}" "${flake_reruns}"; then
       flake_reruns=$((flake_reruns + 1))
+      train_metric_set flake_reruns "${flake_reruns}"
+      train_decision "flake signature matched; rerun #${flake_reruns} of failed jobs"
       # Re-poll the same run after rerun.
       while :; do
         local st; st="$(gh run view "${run_id}" --json status --jq '.status' 2>/dev/null || echo "")"
@@ -143,20 +202,32 @@ main() {
     _write_state "${batch}" "${trunk_sha}" "${included}" "attribute" "${run_id}" "${fwdfix}" "${flake_reruns}"
     local culprits; culprits="$(train_attribute "${failing}" "${TRAIN_INCLUDED_FILE}")"
     if [[ "${culprits}" == "ESCALATE_BATCH" ]]; then
-      train_warn "escalating entire batch; manual triage required"
+      train_metric_inc escalated "$(grep -c . "${TRAIN_INCLUDED_FILE}" 2>/dev/null || echo 0)"
+      train_annotate_warn "escalating entire batch; manual triage required"
       for pr in $(tr ',' ' ' <<<"${included}"); do
         train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_LANDING}"
       done
+      train_step_end ci-gate >/dev/null; train_endgroup
+      _emit_metrics "escalated-batch" "${trunk_sha}" "" "${shard_descriptor}"
+      _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
+        "ESCALATED whole batch: CI failure not attributable to a member diff"
       return 0
     fi
     # Drop culprits, rebuild minus them, re-CI.
     local remaining="${included}"
     for pr in ${culprits}; do
       train_drop_pr "${pr}" "real CI failure attributed to its diff"
+      train_metric_inc attribution_drops
+      train_metric_inc escalated
+      train_notice "DROP #${pr}: real CI failure attributed to its diff; rebuilding batch without it"
       remaining="$(tr ',' '\n' <<<"${remaining}" | grep -vx "${pr}" | tr '\n' ',' | sed 's/,$//')"
     done
     if [[ -z "${remaining}" ]]; then
-      train_warn "all members dropped; batch empty"
+      train_annotate_warn "all members dropped; batch empty"
+      train_step_end ci-gate >/dev/null; train_endgroup
+      _emit_metrics "all-dropped" "${trunk_sha}" "" "${shard_descriptor}"
+      _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
+        "all batch members dropped on attribution — batch empty"
       return 0
     fi
     included="${remaining}"
@@ -166,20 +237,43 @@ main() {
     included="$(cut -f1 "${TRAIN_INCLUDED_FILE}" | tr '\n' ',' | sed 's/,$//')"
     gate="$(train_smart_ci_run "${batch}")"
   done
+  train_step_end ci-gate >/dev/null
+  train_endgroup
 
   # --- land (FF-only CAS) ----------------------------------------------------
+  train_group land "fast-forward-only CAS push of the CI-green batch onto ${TRAIN_BASE_BRANCH}"
+  train_step_begin land
   _write_state "${batch}" "${trunk_sha}" "${included}" "land" "$(cat "${TRAIN_RUN_ID_FILE}" 2>/dev/null)" "${fwdfix}" "${flake_reruns}"
   local rc=0
   train_land "${batch}" "${trunk_sha}" "${TRAIN_INCLUDED_FILE}" || rc=$?
   if [[ "${rc}" == "10" ]]; then
-    train_warn "land deferred: trunk moved; the next scheduled run re-assembles"
+    train_annotate_warn "land deferred: trunk moved; the next scheduled run re-assembles"
+    train_step_end land >/dev/null; train_endgroup
+    _emit_metrics "trunk-moved-reassemble" "${trunk_sha}" "" "${shard_descriptor}"
+    _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
+      "land deferred: trunk moved (FF-CAS) — next run re-assembles"
     return 0
   fi
-  [[ "${rc}" != "0" ]] && { train_err "land failed (rc=${rc})"; return "${rc}"; }
+  if [[ "${rc}" != "0" ]]; then
+    train_err "land failed (rc=${rc})"
+    train_step_end land >/dev/null; train_endgroup
+    _emit_metrics "land-error" "${trunk_sha}" "" "${shard_descriptor}"
+    _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
+      "land FAILED (rc=${rc})"
+    return "${rc}"
+  fi
 
   local new_trunk; new_trunk="$(git -C "${TRAIN_REPO_ROOT}" rev-parse "${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}")"
+  train_metric_set landed "$(grep -c . "${TRAIN_INCLUDED_FILE}" 2>/dev/null || echo 0)"
   _write_state "" "${new_trunk}" "" "done" "" 0 0 "${batch_landed:-${new_trunk}}"
-  train_log "landed batch ${batch}; trunk now ${new_trunk:0:7}"
+  train_notice "LANDED batch ${batch} ($(tr ',' ' ' <<<"${included}")); trunk now ${new_trunk:0:7}"
+  train_step_end land >/dev/null
+  train_endgroup
+  _emit_metrics "landed" "${new_trunk}" "${new_trunk}" "${shard_descriptor}"
+  _dashboard "${batch}" "${selected}" "${new_trunk}" "${shard_descriptor}" \
+    "LANDED ${included} via FF-CAS; trunk now ${new_trunk:0:7}"
+  # Persistent over-time dashboard (state issue): aggregate after a successful land.
+  train_aggregate_update "${new_trunk}" "${new_trunk}"
 }
 
 # _write_state branch trunk_base included-csv phase run_id fwdfix flake [last_landed]
@@ -189,35 +283,118 @@ _write_state() {
   train_state_write "${body}"
 }
 
-# _decision_report: human-readable dry-run summary (the shadow-run output).
-_decision_report() {
+# _pr_decision <pr>: classify a candidate PR's outcome for the dashboard table.
+# Reads the included/skipped scratch files (decision logic already ran). Returns
+# "included" / "skipped (conflict)" / "escalated".
+_pr_decision() {
+  local pr="$1"
+  if grep -qE "^${pr}	" "${TRAIN_INCLUDED_FILE}" 2>/dev/null; then
+    echo "✅ included"
+  elif grep -qE "^${pr}	" "${TRAIN_SKIPPED_FILE}" 2>/dev/null; then
+    echo "⏭️ skipped — assemble conflict (aborted clean)"
+  else
+    echo "⏹️ not in batch"
+  fi
+}
+
+# _dashboard <batch> <selected-json> <trunk_sha> <shard_descriptor> <outcome-note>
+# The headline deliverable: a Markdown report appended to $GITHUB_STEP_SUMMARY
+# (and mirrored to stdout for local dry-runs). Reads only the scratch files /
+# metrics the decision logic already produced — it makes NO decisions.
+_dashboard() {
   local batch="$1" selected="$2" trunk_sha="$3" shard_descriptor="$4" note="$5"
-  echo
-  echo "=== MERGE TRAIN DECISION (dry-run) ==="
-  echo "trunk base:        ${trunk_sha} (${trunk_sha:0:7})"
-  echo "batch branch:      ${batch}"
-  echo
-  echo "candidate PRs (oldest-first, capped at MAX_BATCH=${MAX_BATCH}):"
-  jq -r '.[] | "  #\(.number)  created=\(.createdAt)  ci-gate=\(.gate)"' <<<"${selected}"
-  echo
-  echo "WOULD INCLUDE (assembled clean):"
-  if [[ -s "${TRAIN_INCLUDED_FILE}" ]]; then
-    while IFS=$'\t' read -r pr sha; do echo "  #${pr}  head=${sha:0:7}"; done <"${TRAIN_INCLUDED_FILE}"
+  local mode; mode="$(_train_mode_label)"
+
+  train_summary "## 🚂 Merge Train — ${mode} run"
+  train_summary ""
+  train_summary "| | |"
+  train_summary "|---|---|"
+  train_summary "| **Mode** | ${mode} ($([[ "${TRAIN_APPLY}" == "1" ]] && echo 'writes ACT' || echo 'no pushes/merges/comments')) |"
+  train_summary "| **Run timestamp** | ${TRAIN_RUN_TIMESTAMP} |"
+  train_summary "| **Trunk base** | \`${trunk_sha:-<none>}\` ${trunk_sha:+(${trunk_sha:0:7})} |"
+  train_summary "| **Batch branch** | \`${batch:-<none>}\` |"
+  train_summary "| **MAX_BATCH** | ${MAX_BATCH} |"
+  train_summary "| **Outcome** | ${note:-—} |"
+  train_summary ""
+
+  # --- candidates table ------------------------------------------------------
+  train_summary "### Candidates"
+  train_summary ""
+  if [[ "$(jq 'length' <<<"${selected}")" -gt 0 ]]; then
+    train_summary "| PR | Author | CI-Gate | Decision |"
+    train_summary "|---|---|---|---|"
+    local rows; rows="$(jq -r '.[] | "\(.number)\t\(.author // "?")\t\(.gate)"' <<<"${selected}")"
+    local num author gate decision
+    while IFS=$'\t' read -r num author gate; do
+      [[ -z "${num}" ]] && continue
+      decision="$(_pr_decision "${num}")"
+      train_summary "| #${num} | ${author} | ${gate} | ${decision} |"
+    done <<<"${rows}"
   else
-    echo "  (none)"
+    train_summary "_No PRs were eligible for selection this run._"
   fi
-  echo
-  echo "WOULD SKIP (conflict, aborted clean — zero residue):"
+  train_summary ""
+
+  # --- batch -----------------------------------------------------------------
+  local included_csv=""
+  [[ -s "${TRAIN_INCLUDED_FILE}" ]] && included_csv="$(cut -f1 "${TRAIN_INCLUDED_FILE}" 2>/dev/null | sed 's/^/#/' | tr '\n' ' ')"
+  train_summary "### Batch"
+  train_summary ""
+  train_summary "- **Branch:** \`${batch:-<none>}\`"
+  train_summary "- **Included PRs:** ${included_csv:-_(none)_}"
   if [[ -s "${TRAIN_SKIPPED_FILE}" ]]; then
-    while IFS=$'\t' read -r pr why; do echo "  #${pr}  ${why}"; done <"${TRAIN_SKIPPED_FILE}"
-  else
-    echo "  (none)"
+    local skipped_csv; skipped_csv="$(cut -f1 "${TRAIN_SKIPPED_FILE}" | sed 's/^/#/' | tr '\n' ' ')"
+    train_summary "- **Skipped (conflict):** ${skipped_csv}"
   fi
-  echo
-  echo "COMPUTED SMART-CI SHARD SUBSET (run on the cumulative batch diff):"
-  echo "  ${shard_descriptor:-<none>}"
-  [[ -n "${note}" ]] && { echo; echo "note: ${note}"; }
-  echo "======================================"
+  train_summary ""
+
+  # --- smart-CI shard set ----------------------------------------------------
+  train_summary "### Smart-CI shard set"
+  train_summary ""
+  if [[ -n "${shard_descriptor}" ]] && jq -e . >/dev/null 2>&1 <<<"${shard_descriptor}"; then
+    local run_all reason shards
+    run_all="$(jq -r '.run_all' <<<"${shard_descriptor}")"
+    reason="$(jq -r '.reason // ""' <<<"${shard_descriptor}")"
+    shards="$(jq -r '(.shards // []) | join(", ")' <<<"${shard_descriptor}")"
+    if [[ "${run_all}" == "true" ]]; then
+      train_summary "- **run_all:** \`true\` — ${reason:-full matrix}"
+    else
+      local shard_n; shard_n="$(jq -r '(.shards // []) | length' <<<"${shard_descriptor}")"
+      train_summary "- **Targeted (run_all=false), ${shard_n} shards:** ${shards:-_(none)_}"
+      [[ -n "${reason}" ]] && train_summary "- **Reason:** ${reason}"
+    fi
+  else
+    train_summary "_(not computed — no batch reached smart-CI)_"
+  fi
+  train_summary ""
+
+  # --- gate / heals / land ---------------------------------------------------
+  train_summary "### Run actions"
+  train_summary ""
+  train_summary "| Metric | Count |"
+  train_summary "|---|---|"
+  train_summary "| Candidates selected | $(train_metric_get selected 0) |"
+  train_summary "| Included | $(train_metric_get included 0) |"
+  train_summary "| Skipped (conflict) | $(train_metric_get skipped_conflict 0) |"
+  train_summary "| Forward-fixes applied | $(train_metric_get forward_fixes 0) |"
+  train_summary "| Flake reruns | $(train_metric_get flake_reruns 0) |"
+  train_summary "| Attribution drops | $(train_metric_get attribution_drops 0) |"
+  train_summary "| Escalated | $(train_metric_get escalated 0) |"
+  train_summary "| Landed | $(train_metric_get landed 0) |"
+  train_summary ""
+
+  # --- per-phase timings -----------------------------------------------------
+  if [[ -s "${TRAIN_TIMINGS_FILE:-/dev/null}" ]]; then
+    train_summary "### Per-phase timings"
+    train_summary ""
+    train_summary "| Phase | Seconds |"
+    train_summary "|---|---|"
+    awk -F= 'NF>=2 {t[$1]=$2} END {for (k in t) print k"\t"t[k]}' "${TRAIN_TIMINGS_FILE}" \
+      | while IFS=$'\t' read -r ph secs; do train_summary "| ${ph} | ${secs} |"; done
+    train_summary ""
+  fi
+
+  train_summary "_Machine-readable metrics: \`merge-train-metrics.json\` (workflow artifact). Aggregate over-time dashboard: the **Merge Train State** issue._"
 }
 
 main "$@"

--- a/scripts/ci/merge-train/train.sh
+++ b/scripts/ci/merge-train/train.sh
@@ -20,6 +20,10 @@ set -euo pipefail
 TRAIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 . "${TRAIN_DIR}/lib.sh"
+# Phase 2 (OPTIONAL, off by default): gated Bedrock LLM judgment helpers. Sourced
+# before the gated steps so bedrock_* exists; inert unless TRAIN_LLM=1.
+# shellcheck source=bedrock-invoke.sh
+. "${TRAIN_DIR}/bedrock-invoke.sh"
 # shellcheck source=select.sh
 . "${TRAIN_DIR}/select.sh"
 # shellcheck source=assemble.sh


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2039

## Summary
Reconciles the merge-train PR stack into ONE clean branch off current `trunk`,
combining the instrumentation work (PR #2040) and the Phase-2 Bedrock gates
(PR #2041), and rewiring Bedrock auth from OIDC to the dedicated access-key
secrets that now exist. **Supersedes #2040 and #2041**, which should be closed
once this lands.

Branched off `origin/ci/merge-train-phase1` (= trunk + the instrumentation
commit) and cherry-picked the Phase-2 delta on top via a 3-way merge against the
identical Phase-1 base, so only the real instrumentation×gate overlaps had to be
resolved. Both sets of edits to the shared files coexist: instrumentation
logging/grouping/metrics AND the Phase-2 gate hooks + deterministic fallbacks.

`TRAIN_LLM` (LLM layer) and `train_apply` (live landing) both default OFF on
every trigger; schedule/workflow_run are always deterministic dry-runs.

## Changes Made
- Cherry-picked the Phase-2 gated Bedrock LLM layer onto the instrumentation
  branch; `select.sh`, `classify-flake.sh`, `forward-fix.sh`, `train.sh`,
  `fixtures/validate-merge-train.sh`, ADR-0055 carry BOTH instrumentation and
  gate edits; added `bedrock-invoke.sh` (new, no conflict).
- Rewired Bedrock auth OIDC → access keys in `merge-train.yml`: removed
  `permissions: id-token: write`, the `HONUA_BEDROCK_ROLE_ARN` role-to-assume,
  and `aws-actions/configure-aws-credentials`. The train step now exports
  `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` from
  `secrets.BEDROCK_AWS_ACCESS_KEY_ID`/`BEDROCK_AWS_SECRET_ACCESS_KEY` plus
  `AWS_REGION=us-west-2`, only when `TRAIN_LLM=1`. `bedrock-invoke.sh` reads the
  standard AWS env, so the key secrets just work.
- Default model `us.anthropic.claude-haiku-4-5-20251001-v1:0` (verified ACTIVE
  cross-region inference profile), region `us-west-2`; both env-overridable
  (`BEDROCK_MODEL_ID`, `AWS_REGION`).
- Wired the landing token to the existing repo secret `MERGE_TRAIN_TOKEN`
  (fallback `GITHUB_TOKEN`), replacing the non-existent `HONUA_MERGE_TOKEN`.
- Updated ADR-0055 to KEY-based Bedrock auth (dedicated least-priv IAM user
  `honua-merge-train-bedrock`, the two key secrets, model, region) — not OIDC —
  and to `MERGE_TRAIN_TOKEN` for landing; `TRAIN_LLM` off by default.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

`bash scripts/ci/merge-train/fixtures/validate-merge-train.sh` → **68/68 pass**
(39 Phase-1 + 29 Phase-2), proving the merge preserved both. `bash -n` clean on
all merge-train scripts; `merge-train.yml` parses as YAML; no `matrix.*` in any
job-level `if:`; no `id-token`/`HONUA_BEDROCK_ROLE_ARN`/`configure-aws-credentials`
remnants in `merge-train.yml`. A dry-run `TRAIN_APPLY=0 train.sh` against the
real open PRs still renders the instrumentation dashboard (Step Summary,
candidates table, run-actions counters, per-phase timings, metrics JSON).

## Gate Impact
- [x] None — no gate impact

(CI/build untouched; this only changes the merge-train automation scripts +
workflow, which run on their own schedule and are dry-run/LLM-off by default.)

## Docs or Contract Impact
- [x] Documentation updated

ADR-0055 Phase-2 auth section rewritten to key-based Bedrock auth.

## Release/Deploy Impact
- [ ] None — no release/deploy impact

- [x] Ran scripts/ci/merge-train/fixtures/validate-merge-train.sh and all checks passed
