### PR TITLE
ci(merge-train): wire merge-through-flakes into select (flake-only CI failures become ready)

### DIFF
--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -293,9 +293,71 @@ assert_eq "select: oldest-first, draft/hold/conflict/fail excluded" "${sel}" "[1
 unset TRAIN_PR_LIST_JSON
 # CI Gate state mapping.
 assert_eq "select: COMPLETED+SUCCESS => SUCCESS" "$(train_select_ci_gate_state '[{"name":"CI Gate","status":"COMPLETED","conclusion":"SUCCESS"}]')" "SUCCESS"
+# A bare FAILURE rollup with no detailsUrl/jobs => conservative FAIL (unchanged).
 assert_eq "select: COMPLETED+FAILURE => FAIL" "$(train_select_ci_gate_state '[{"name":"CI Gate","status":"COMPLETED","conclusion":"FAILURE"}]')" "FAIL"
 assert_eq "select: QUEUED => PENDING" "$(train_select_ci_gate_state '[{"name":"CI Gate","status":"QUEUED","conclusion":""}]')" "PENDING"
 assert_eq "select: absent => MISSING" "$(train_select_ci_gate_state '[]')" "MISSING"
+
+echo
+echo "== select: merge-through-flakes (FAILURE => FLAKE only when flake-only) =="
+# Mock the run-id + per-run failing-job + per-job-log lookups (no network).
+# A CI Gate FAILURE rollup carries a detailsUrl with the run id; the classifier
+# fetches that run's failed leaf jobs, then (for shard jobs) their logs.
+GATE_FAIL='[{"name":"CI Gate","status":"COMPLETED","conclusion":"FAILURE","detailsUrl":"https://github.com/honua-io/honua-server/actions/runs/424242/job/9"}]'
+export TRAIN_SELECT_FAILED_JOBS_FOR_RUN=__sel_failed_jobs
+export TRAIN_SELECT_JOB_LOG_FOR=__sel_job_log
+# Per-fixture job/log fixtures keyed off SEL_CASE. Each failing-job line is
+# "<conclusion>\t<name>" (matching the live `gh run view --json jobs` shape).
+__sel_failed_jobs() {  # <run-id>
+  case "${SEL_CASE:-}" in
+    aggregator)  printf 'failure\tCI Gate\nfailure\tTest Suite Summary\n' ;;
+    cancelshard) printf 'cancelled\tServer Tests (Server Features Misc)\nfailure\tTest Suite Summary\nfailure\tCI Gate\n' ;;
+    shard_flake) printf 'failure\tServer Tests (STAC and API Governance)\nfailure\tTest Suite Summary\nfailure\tCI Gate\n' ;;
+    foundation)  printf 'failure\t.NET Foundation Tests\nfailure\tServer Tests (STAC and API Governance)\nfailure\tTest Suite Summary\nfailure\tCI Gate\n' ;;
+    buildfmt)    printf 'failure\tBuild & Format\nfailure\tTest Suite Summary\nfailure\tCI Gate\n' ;;
+    shard_real)  printf 'failure\tServer Tests (STAC and API Governance)\nfailure\tTest Suite Summary\nfailure\tCI Gate\n' ;;
+    nojobs)      : ;;
+    *) : ;;
+  esac
+}
+__sel_job_log() {  # <run-id> <job-name>
+  case "${SEL_CASE:-}" in
+    shard_flake) printf 'ERROR 40P01: deadlock detected during seed\n' ;;
+    shard_real)  printf 'Assert.Equal() Failure: expected 3 actual 4\n' ;;
+    *) : ;;
+  esac
+}
+export -f __sel_failed_jobs __sel_job_log
+
+# (a) aggregator-only failure (CI Gate + Test Suite Summary) => FLAKE (ready).
+assert_eq "select(flake): aggregator-only FAILURE => FLAKE" \
+  "$(SEL_CASE=aggregator train_select_ci_gate_state "${GATE_FAIL}")" "FLAKE"
+# (b) shard FAILURE whose log matches 40P01 flake regex => FLAKE.
+assert_eq "select(flake): 40P01 shard log => FLAKE" \
+  "$(SEL_CASE=shard_flake train_select_ci_gate_state "${GATE_FAIL}")" "FLAKE"
+# (b2) a CANCELLED shard alongside aggregators (cancel-cascade) => FLAKE.
+assert_eq "select(flake): cancelled shard => FLAKE" \
+  "$(SEL_CASE=cancelshard train_select_ci_gate_state "${GATE_FAIL}")" "FLAKE"
+# (c) real-gate job (.NET Foundation Tests) failed => FAIL (skip).
+assert_eq "select(flake): .NET Foundation Tests failed => FAIL" \
+  "$(SEL_CASE=foundation train_select_ci_gate_state "${GATE_FAIL}")" "FAIL"
+# (d) real-gate job (Build & Format) failed => FAIL.
+assert_eq "select(flake): Build & Format failed => FAIL" \
+  "$(SEL_CASE=buildfmt train_select_ci_gate_state "${GATE_FAIL}")" "FAIL"
+# (extra) shard FAILURE with a real assertion log (no flake regex) => FAIL.
+assert_eq "select(flake): real shard assertion => FAIL" \
+  "$(SEL_CASE=shard_real train_select_ci_gate_state "${GATE_FAIL}")" "FAIL"
+# (extra) no failing jobs fetchable => conservative FAIL.
+assert_eq "select(flake): unfetchable jobs => FAIL (conservative)" \
+  "$(SEL_CASE=nojobs train_select_ci_gate_state "${GATE_FAIL}")" "FAIL"
+# (e) SUCCESS unchanged (and PENDING/MISSING never touch the run lookups).
+assert_eq "select(flake): SUCCESS unchanged" \
+  "$(train_select_ci_gate_state '[{"name":"CI Gate","status":"COMPLETED","conclusion":"SUCCESS"}]')" "SUCCESS"
+assert_eq "select(flake): PENDING unchanged" \
+  "$(train_select_ci_gate_state '[{"name":"CI Gate","status":"IN_PROGRESS","conclusion":""}]')" "PENDING"
+assert_eq "select(flake): MISSING unchanged" \
+  "$(train_select_ci_gate_state '[]')" "MISSING"
+unset TRAIN_SELECT_FAILED_JOBS_FOR_RUN TRAIN_SELECT_JOB_LOG_FOR
 
 echo
 echo "== Phase 2: gated Bedrock LLM judgments (mock; no real Bedrock) =="

--- a/scripts/ci/merge-train/select.sh
+++ b/scripts/ci/merge-train/select.sh
@@ -9,11 +9,123 @@
 # READ-ONLY: this step never mutates anything (only gh ... --json reads), so it
 # runs identically in dry-run and live mode.
 
-# train_select_ci_gate_state <pr-json>: classify the CI Gate check for one PR.
-# Emits one of: SUCCESS | FLAKE | FAIL | PENDING | MISSING.
+# Real-gate job names: a CI Gate failure caused by ANY of these is never a flake
+# (a human must fix it), so the whole PR stays FAIL even under merge-through. The
+# pattern is matched with grep -E against each failing leaf job's name.
+: "${TRAIN_REAL_GATE_JOB_REGEX:=Build & Format|Analyze C#|\.NET Foundation Tests|Architecture|CI Router|OpenAPI|drift}"
+# Aggregator-only job names: these are roll-ups (the required "CI Gate" check and
+# the shard fan-in summary). When the ONLY failing jobs are aggregators, a shard
+# was cancelled/flaked underneath them — treat that as a flake, not a real break.
+: "${TRAIN_AGGREGATOR_JOB_REGEX:=^(CI Gate|Test Suite Summary)$}"
+
+# train_select_run_id_from_rollup <gate-json>: extract the Actions run id from a
+# CI Gate CheckRun's detailsUrl (.../actions/runs/<id>/job/<jobid>). Empty if
+# unparseable. Test override: TRAIN_SELECT_RUN_ID forces a fixed id.
+train_select_run_id_from_rollup() {
+  if [[ -n "${TRAIN_SELECT_RUN_ID:-}" ]]; then printf '%s' "${TRAIN_SELECT_RUN_ID}"; return 0; fi
+  local gate="$1" url
+  url="$(jq -r '.detailsUrl // ""' <<<"${gate}")"
+  printf '%s' "${url}" | grep -oE 'runs/[0-9]+' | grep -oE '[0-9]+' | head -1
+}
+
+# train_select_run_failed_jobs <run-id>: emit the run's non-successful leaf jobs,
+# one per line as "<conclusion><TAB><name>" (conclusion lower-cased, e.g.
+# "failure" / "cancelled" / "timed_out"). Live path uses `gh run view --json
+# jobs`. Test override: TRAIN_SELECT_FAILED_JOBS_FOR_RUN <cmd> is called with the
+# run id and must print the SAME "<conclusion>\t<name>" lines (offline fixtures,
+# no network).
+train_select_run_failed_jobs() {
+  local run_id="$1"
+  if [[ -n "${TRAIN_SELECT_FAILED_JOBS_FOR_RUN:-}" ]]; then
+    "${TRAIN_SELECT_FAILED_JOBS_FOR_RUN}" "${run_id}"
+    return 0
+  fi
+  [[ -z "${run_id}" ]] && return 0
+  gh run view "${run_id}" --json jobs \
+    --jq '.jobs[]
+          | select(.conclusion=="failure" or .conclusion=="cancelled"
+                   or .conclusion=="timed_out" or .conclusion=="startup_failure")
+          | (.conclusion) + "\t" + (.name)' \
+    2>/dev/null || true
+}
+
+# train_select_job_log <run-id> <job-name>: emit the failing job's log text for
+# flake-regex matching. Live path uses `gh run view --log-failed`. Test override:
+# TRAIN_SELECT_JOB_LOG_FOR <cmd> is called with (run id, job name).
+train_select_job_log() {
+  local run_id="$1" job="$2"
+  if [[ -n "${TRAIN_SELECT_JOB_LOG_FOR:-}" ]]; then
+    "${TRAIN_SELECT_JOB_LOG_FOR}" "${run_id}" "${job}"
+    return 0
+  fi
+  [[ -z "${run_id}" ]] && return 0
+  gh run view "${run_id}" --log-failed 2>/dev/null || true
+}
+
+# train_select_failure_is_flake_only <run-id>: merge-through-flakes classifier.
+# Inspects the non-successful leaf jobs of the single latest CI run and decides
+# whether a CI Gate FAILURE is flake-only (downgradeable to FLAKE) or a real
+# break (FAIL). Returns 0 = flake-only (=> FLAKE), 1 = real break OR
+# undeterminable (=> FAIL).
+#
+# Each input line is "<conclusion>\t<name>". Rules (conservative — default to
+# FAIL on any uncertainty):
+#   * NO non-successful jobs fetched (jobs unavailable) => FAIL.
+#   * ANY failing job whose NAME matches the real-gate regex => FAIL (a human
+#     must fix it). Note: only an actual `failure` real-gate job is
+#     authoritative; a `cancelled` real-gate job is just runner starvation.
+#   * Otherwise every non-successful job must be one of:
+#       - an aggregator-only roll-up (CI Gate / Test Suite Summary — a shard
+#         under them cancelled/flaked), OR
+#       - a CANCELLED / TIMED_OUT / STARTUP_FAILURE shard (runner starvation /
+#         cancel-cascade — treated as flake), OR
+#       - a `failure` shard whose log matches the flake regex.
+#     If even one `failure` shard's log does NOT match (or can't be fetched),
+#     => FAIL.
+train_select_failure_is_flake_only() {
+  local run_id="$1"
+  local jobs line concl job
+  jobs="$(train_select_run_failed_jobs "${run_id}")"
+  # No jobs => can't prove it's a flake; be conservative.
+  [[ -z "${jobs}" ]] && return 1
+
+  # A real-gate job that actually FAILED is authoritative: never a flake.
+  if printf '%s\n' "${jobs}" \
+       | grep -E '^failure'"$(printf '\t')" \
+       | grep -Eq "${TRAIN_REAL_GATE_JOB_REGEX}"; then
+    return 1
+  fi
+
+  # Every remaining non-successful job must be an aggregator roll-up, a
+  # cancelled/timed-out/startup-failure shard, or a flake-log `failure` shard.
+  while IFS= read -r line; do
+    [[ -z "${line}" ]] && continue
+    concl="${line%%$'\t'*}"
+    job="${line#*$'\t'}"
+    if printf '%s' "${job}" | grep -Eq "${TRAIN_AGGREGATOR_JOB_REGEX}"; then
+      continue   # aggregator-only failure => underlying shard cancelled/flaked
+    fi
+    case "${concl}" in
+      cancelled|timed_out|startup_failure)
+        continue ;;   # runner starvation / cancel-cascade => flake
+    esac
+    # A `failure` shard job: its log must match the flake regex.
+    local log
+    log="$(train_select_job_log "${run_id}" "${job}")"
+    if ! train_log_is_flake "${log}"; then
+      return 1   # real shard failure (or unfetchable log) => not flake-only
+    fi
+  done <<<"${jobs}"
+  return 0
+}
+
+# train_select_ci_gate_state <pr-json> [gate-json]: classify the CI Gate check
+# for one PR. Emits one of: SUCCESS | FLAKE | FAIL | PENDING | MISSING.
 # Reads the statusCheckRollup entry named "CI Gate" (the single required check).
-# A failing CI Gate is downgraded to FLAKE only when the failing run's logs
-# match the flake regex (caller decides whether to actually rerun).
+# A failing CI Gate is downgraded to FLAKE only when the failing run's leaf jobs
+# are flake-only (aggregator-only roll-ups and/or flake-regex log matches), so
+# the train can process its flaky backlog. Real-gate-job failures stay FAIL.
+# Bounded: inspects only the SINGLE latest CI run for the PR.
 train_select_ci_gate_state() {
   local rollup_json="$1"
   local gate
@@ -28,10 +140,20 @@ train_select_ci_gate_state() {
     echo "PENDING"; return 0
   fi
   case "${conclusion}" in
-    SUCCESS) echo "SUCCESS" ;;
-    FAILURE|TIMED_OUT|CANCELLED|STARTUP_FAILURE|ACTION_REQUIRED) echo "FAIL" ;;
-    *) echo "FAIL" ;;
+    SUCCESS) echo "SUCCESS"; return 0 ;;
+    FAILURE|TIMED_OUT|CANCELLED|STARTUP_FAILURE|ACTION_REQUIRED) : ;;
+    *) echo "FAIL"; return 0 ;;
   esac
+
+  # CI Gate failed. Merge-through-flakes: downgrade to FLAKE iff the failure is
+  # flake-only. Inspect the single latest run's failing leaf jobs.
+  local run_id
+  run_id="$(train_select_run_id_from_rollup "${gate}")"
+  if train_select_failure_is_flake_only "${run_id}"; then
+    echo "FLAKE"
+  else
+    echo "FAIL"
+  fi
 }
 
 # train_pr_has_hold_label <labels-json>: true if any opt-out label present.


### PR DESCRIPTION
# Pull Request

## Issue Link
No tracking issue — bug is self-evident on `trunk`: `train_select_ci_gate_state` in `scripts/ci/merge-train/select.sh` never implemented the FLAKE downgrade its own comment promised.

## Summary
The merge train's `select` step is meant to do **merge-through-flakes**: a CI Gate failure caused only by flakes should be treated as a *ready* PR so the train can process its flaky backlog (its whole reason to exist). But `train_select_ci_gate_state()` marked **every** CI Gate `FAILURE` as `FAIL` and skipped it — the FLAKE downgrade its own comment promised was never implemented. This wires that downgrade in, so flake-only CI failures become ready and enter the batch.

This is safe because the batch smart-CI re-validates every selected PR: a flake-only PR that is actually broken fails the batch CI and is attributed/dropped, never landed. Select only lets flake-red PRs *into* the batch.

## Changes Made
- `train_select_ci_gate_state` now downgrades a CI Gate `FAILURE`/`TIMED_OUT`/`CANCELLED`/`STARTUP_FAILURE`/`ACTION_REQUIRED` to `FLAKE` (already accepted as ready by the select loop) when the failure is **flake-only**; `SUCCESS`/`PENDING`/`MISSING` are unchanged.
- Added flake-only classifier `train_select_failure_is_flake_only`, bounded to the **single latest** CI run per PR:
  - **FAIL** if any real-gate job (`Build & Format`, `Analyze C#`, `.NET Foundation Tests`, `Architecture`, `CI Router`, `OpenAPI`, `drift`) actually *failed* — never a flake, a human must fix.
  - Otherwise **FLAKE** when every non-successful job is either an aggregator roll-up (`CI Gate`, `Test Suite Summary`), a `cancelled`/`timed_out`/`startup_failure` shard (runner starvation / cancel-cascade), or a `failure` shard whose log matches the shared flake regex (reused via `train_log_is_flake` from `lib.sh`).
  - Conservative default to **FAIL** when jobs/logs cannot be fetched (never merge-through an unknown).
- Helpers: `train_select_run_id_from_rollup` (run id from the CI Gate CheckRun `detailsUrl`), `train_select_run_failed_jobs` (`<conclusion>\t<name>` per non-successful leaf job), `train_select_job_log` — each with a test-override hook so fixtures run offline.
- Extended `fixtures/validate-merge-train.sh` with offline-mocked classification cases (aggregator-only, cancelled shard, 40P01 shard log, `.NET Foundation Tests` fail, `Build & Format` fail, real shard assertion, unfetchable jobs, SUCCESS/PENDING/MISSING unchanged). Assertion total **68 → 78**, all passing.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

`bash -n` passes on all merge-train scripts. The fixture harness passes 78/78 (was 68). Read-only live classification against the 4 currently-red PRs:

| PR | failing jobs | classified |
|----|--------------|-----------|
| #1944 | `Server Tests (Server Features Misc)` (cancelled) + aggregators | **FLAKE** |
| #1961 | aggregators only | **FLAKE** |
| #1969 | aggregators only | **FLAKE** |
| #1963 | `.NET Foundation Tests` (failure) + `Server Tests (STAC and API Governance)` + aggregators | **FAIL** |

Matches expectations: the three cancel-cascade PRs become ready; the PR with a real named Foundation failure stays skipped.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
