### PR TITLE
ci(merge-train): autonomous roll-forward auto-fix (pre-existing filter, surgical retry, Bedrock fix-agent)

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -40,6 +40,16 @@ on:
         type: boolean
         required: false
         default: false
+      use_autofix:
+        description: 'Enable the OPTIONAL roll-forward AI fix-agent (TRAIN_AUTOFIX=1). Off by default. When on, a batch-introduced REAL failure (after the pre-existing filter, not a flake) is patched FORWARD by Claude via Bedrock, surgically re-verified, then landed — instead of escalating. Capped at 2 attempts; still-failing => escalate. Requires the BEDROCK_AWS_* secrets.'
+        type: boolean
+        required: false
+        default: false
+      autofix_model:
+        description: 'Bedrock model id for the AI fix-agent (code edits). Default a Sonnet-class model; override per your account entitlement.'
+        type: string
+        required: false
+        default: ''
 
 # Serialize train runs: a batch in flight must finish before the next starts.
 # cancel-in-progress:false so we never abandon a half-landed batch mid-flight.
@@ -52,6 +62,7 @@ permissions:
   pull-requests: write   # merge PRs, edit labels, comment
   actions: write         # dispatch and rerun CI runs
   issues: write          # maintain the Merge Train State issue
+  id-token: write        # OIDC for AWS Bedrock (claude-code-action), when autofix on
 
 jobs:
   train:
@@ -87,6 +98,8 @@ jobs:
           DISPATCH_APPLY: ${{ github.event.inputs.train_apply }}
           DISPATCH_MAX_BATCH: ${{ github.event.inputs.max_batch }}
           DISPATCH_USE_LLM: ${{ github.event.inputs.use_llm }}
+          DISPATCH_USE_AUTOFIX: ${{ github.event.inputs.use_autofix }}
+          DISPATCH_AUTOFIX_MODEL: ${{ github.event.inputs.autofix_model }}
           HAVE_BEDROCK_KEYS: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID != '' && secrets.BEDROCK_AWS_SECRET_ACCESS_KEY != '' }}
         run: |
           set -euo pipefail
@@ -111,7 +124,43 @@ jobs:
             fi
           fi
           echo "train_llm=${llm}" >> "$GITHUB_OUTPUT"
-          echo "Resolved TRAIN_APPLY=${apply} (event=${EVENT_NAME}) MAX_BATCH=${mb} TRAIN_LLM=${llm}"
+          # TRAIN_AUTOFIX defaults to 0 for ALL triggers (like TRAIN_LLM). It can
+          # only turn on via an explicit workflow_dispatch with use_autofix=true,
+          # train_apply=true (autofix is a LIVE landing path), AND configured
+          # Bedrock access-key secrets. Scheduled / workflow_run are never autofix.
+          autofix=0
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" && "${DISPATCH_USE_AUTOFIX}" == "true" ]]; then
+            if [[ "${apply}" != "1" ]]; then
+              echo "::warning::use_autofix=true ignored: autofix only runs in LIVE mode (train_apply=true). Running without autofix."
+            elif [[ "${HAVE_BEDROCK_KEYS}" != "true" ]]; then
+              echo "::warning::use_autofix=true but secrets.BEDROCK_AWS_ACCESS_KEY_ID / BEDROCK_AWS_SECRET_ACCESS_KEY are unset; running without the AI fix-agent (TRAIN_AUTOFIX=0)."
+            else
+              autofix=1
+            fi
+          fi
+          echo "train_autofix=${autofix}" >> "$GITHUB_OUTPUT"
+          echo "autofix_model=${DISPATCH_AUTOFIX_MODEL}" >> "$GITHUB_OUTPUT"
+          echo "Resolved TRAIN_APPLY=${apply} (event=${EVENT_NAME}) MAX_BATCH=${mb} TRAIN_LLM=${llm} TRAIN_AUTOFIX=${autofix}"
+
+      # --- Roll-forward AI fix-agent setup (autofix only) --------------------
+      # These steps run ONLY when autofix is enabled (TRAIN_AUTOFIX=1), which is
+      # itself only possible on an explicit live workflow_dispatch with the
+      # Bedrock secrets present. They wire Claude-via-Bedrock so train.sh's
+      # in-loop fix step (TRAIN_AUTOFIX_STEP_CMD -> autofix-agent.sh) can patch a
+      # failing batch forward. The claude-code-action engine (its CLI) is the
+      # same one anthropics/claude-code-action wraps; we install it here and
+      # route it to Bedrock per docs/cloud-providers.md.
+      - name: Configure AWS credentials for Bedrock (autofix)
+        if: steps.mode.outputs.train_autofix == '1'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.BEDROCK_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.HONUA_BEDROCK_REGION || 'us-west-2' }}
+
+      - name: Install Claude Code CLI (autofix fix-agent engine, Bedrock)
+        if: steps.mode.outputs.train_autofix == '1'
+        run: npm install -g @anthropic-ai/claude-code
 
       - name: Run train
         env:
@@ -144,6 +193,22 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ vars.HONUA_BEDROCK_REGION || 'us-west-2' }}
           BEDROCK_MODEL_ID: ${{ vars.HONUA_BEDROCK_MODEL_ID || 'us.anthropic.claude-haiku-4-5-20251001-v1:0' }}
+          # OPTIONAL roll-forward AI fix-agent. TRAIN_AUTOFIX=0 on every default
+          # path; the autofix gate is inert and the train escalates fixable
+          # failures exactly like Phase 1. When 1 (explicit live dispatch +
+          # Bedrock secrets), a batch-introduced REAL failure is patched forward
+          # by the fix-agent (autofix-agent.sh, wired below), surgically
+          # re-verified, and landed; still-failing after the cap => escalate.
+          TRAIN_AUTOFIX: ${{ steps.mode.outputs.train_autofix }}
+          # The fix model (code edits) — a Sonnet-class default unless overridden.
+          TRAIN_AUTOFIX_MODEL: ${{ steps.mode.outputs.autofix_model != '' && steps.mode.outputs.autofix_model || (vars.HONUA_BEDROCK_AUTOFIX_MODEL_ID || 'us.anthropic.claude-sonnet-4-5-20250929-v1:0') }}
+          # CLAUDE_CODE_USE_BEDROCK routes the fix-agent CLI to Bedrock (matching
+          # anthropics/claude-code-action's use_bedrock:true). Only consumed when
+          # TRAIN_AUTOFIX=1; ignored otherwise.
+          CLAUDE_CODE_USE_BEDROCK: 1
+          # The in-loop fix step: train.sh invokes this wrapper as
+          # "<cmd> <batch> <request-file>". Only reached when TRAIN_AUTOFIX=1.
+          TRAIN_AUTOFIX_STEP_CMD: ${{ github.workspace }}/scripts/ci/merge-train/autofix-agent.sh
         run: |
           set -euo pipefail
           # Stamp a real ISO-8601 instant (the repository updated_at above is only

--- a/scripts/ci/merge-train/attribute.sh
+++ b/scripts/ci/merge-train/attribute.sh
@@ -94,3 +94,27 @@ train_drop_pr() {
   train_side_effect gh pr comment "${pr}" --body \
     "Merge train dropped this PR from the batch: ${reason}. Rebuild the batch will exclude it until the ${TRAIN_LABEL_ESCALATED} label is removed."
 }
+
+# train_escalate_batch <included-csv> <reason>: the loop-bug fix. When the train
+# escalates a WHOLE batch (a real, unfixable failure that is not attributable to,
+# or not fixable in, a single member), it MUST do BOTH of the following or the
+# next scheduled run re-selects the same doomed batch forever:
+#   1. apply train:escalated to EVERY culprit PR (so select excludes them), and
+#   2. remove the transient train:landing label from each (no longer in flight),
+#      and comment so the author knows why.
+# The caller is responsible for separately CLEARING active_batch from the state
+# issue (train.sh does this via _write_state "" ... "select" after escalating) so
+# the next run starts a fresh selection instead of resuming the escalated batch.
+# Side-effecting (gated by TRAIN_APPLY via train_side_effect).
+train_escalate_batch() {
+  local included_csv="$1" reason="$2"
+  local pr
+  for pr in $(tr ',' ' ' <<<"${included_csv}"); do
+    [[ -z "${pr}" ]] && continue
+    train_side_effect gh pr edit "${pr}" --add-label "${TRAIN_LABEL_ESCALATED}"
+    train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_LANDING}"
+    train_side_effect gh pr comment "${pr}" --body \
+      "Merge train escalated this batch to a human: ${reason}. This PR is held out of future batches until the ${TRAIN_LABEL_ESCALATED} label is removed."
+    train_decision "ESCALATE #${pr}: labeled ${TRAIN_LABEL_ESCALATED}, removed ${TRAIN_LABEL_LANDING}"
+  done
+}

--- a/scripts/ci/merge-train/autofix-agent.sh
+++ b/scripts/ci/merge-train/autofix-agent.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# autofix-agent.sh — the TRAIN_AUTOFIX_STEP_CMD wrapper the orchestrator invokes
+# to run the roll-forward AI fix-agent (Claude via Bedrock). Called as:
+#     autofix-agent.sh <batch-branch> <request-file>
+#
+# It runs the Claude Code agent HEADLESS in Bedrock mode against the request
+# prompt, with the batch branch already checked out, so the agent edits + commits
+# the fix in place. This is the same engine anthropics/claude-code-action wraps;
+# we invoke the CLI directly so it composes inside train.sh's loop (a GitHub
+# composite action cannot be called mid-bash-step).
+#
+# Bedrock wiring (mirrors anthropics/claude-code-action docs/cloud-providers.md):
+#   * CLAUDE_CODE_USE_BEDROCK=1               — route the model to AWS Bedrock.
+#   * AWS creds: supplied by the workflow via aws-actions/configure-aws-credentials
+#     (the BEDROCK_AWS_* access-key secrets) into the ambient AWS_* env.
+#   * AWS_REGION=us-west-2                     — the Bedrock region (overridable).
+#   * ANTHROPIC_MODEL=<TRAIN_AUTOFIX_MODEL>    — a Sonnet-class fix model.
+#
+# ASSUMPTION (stated for review): the `claude` CLI is on PATH in the workflow
+# (installed by the autofix step, e.g. `npm i -g @anthropic-ai/claude-code`), and
+# honors CLAUDE_CODE_USE_BEDROCK + ANTHROPIC_MODEL + the AWS chain, matching the
+# action's documented Bedrock behavior. If the CLI is absent, this wrapper exits
+# 0 WITHOUT committing, so train_autofix_committed sees no new commit and the
+# train safely falls back to escalation (never wedges).
+#
+# This wrapper makes NO commit of its own — the agent commits. The orchestrator
+# (train.sh) detects the new commit via train_autofix_committed.
+
+set -uo pipefail
+
+BATCH="${1:?batch branch required}"
+REQUEST_FILE="${2:?request file required}"
+
+REPO_ROOT="${TRAIN_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+# Ensure the batch branch is checked out so the agent edits the right tree.
+git -C "${REPO_ROOT}" checkout -q "${BATCH}" 2>/dev/null || true
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "::warning::autofix-agent: 'claude' CLI not found on PATH; skipping AI fix (train will escalate)." >&2
+  exit 0
+fi
+
+# Bedrock routing for the headless agent.
+export CLAUDE_CODE_USE_BEDROCK=1
+export AWS_REGION="${AWS_REGION:-us-west-2}"
+export ANTHROPIC_MODEL="${TRAIN_AUTOFIX_MODEL:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}"
+
+# Run headless. --print streams the agent's response; --permission-mode
+# acceptEdits lets it edit + commit without interactive approval. The request
+# file is the full fix-forward prompt (failing tests + error output + batch diff
+# + the "commit as Mike McDougall, no bot attribution, touch only what's needed"
+# instructions). We cap wall time so a hung agent can't stall the batch.
+PROMPT="$(cat "${REQUEST_FILE}")"
+TIMEOUT="${TRAIN_AUTOFIX_TIMEOUT:-900}"
+
+( cd "${REPO_ROOT}" && \
+  timeout "${TIMEOUT}" claude \
+    --print \
+    --permission-mode acceptEdits \
+    --allowed-tools "Edit,Write,Read,Bash" \
+    "${PROMPT}" ) \
+  || echo "::warning::autofix-agent: claude headless run exited non-zero or timed out; train will check for a partial commit." >&2
+
+# Intentionally exit 0: success/failure is judged by whether a NEW commit landed
+# on the batch branch (train_autofix_committed), not by this wrapper's rc.
+exit 0

--- a/scripts/ci/merge-train/autofix.sh
+++ b/scripts/ci/merge-train/autofix.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Roll-forward AI fix-agent (the capstone) — replaces escalation for FIXABLE
+# batch-introduced failures. GATED behind TRAIN_AUTOFIX (default 0, off), exactly
+# like TRAIN_LLM. When a batch has REAL, batch-introduced failures (survived the
+# pre-existing filter, not a known flake), instead of escalating, the train asks
+# an AI fix-agent (Claude via Bedrock, run by the merge-train.yml claude-code
+# step) to PATCH the batch branch FORWARD, then surgically re-verifies only the
+# failed tests, then lands. Capped at TRAIN_AUTOFIX_CAP (default 2) attempts;
+# still-failing after the cap => THEN escalate as genuinely-hard.
+#
+# SPLIT OF RESPONSIBILITY (script vs workflow):
+#   * This script DECIDES (gate + cap), PREPARES the fix request (branch, failing
+#     tests + error output, batch diff) into a request file, and CONSUMES the
+#     result (did the agent commit?). It makes ZERO Bedrock calls itself.
+#   * merge-train.yml's `autofix` step runs anthropics/claude-code-action wired
+#     for Bedrock (use_bedrock=true + aws-actions/configure-aws-credentials with
+#     the BEDROCK_AWS_* secrets, AWS_REGION=us-west-2, --model the configurable
+#     fix model). The action reads the request file as its prompt, edits the
+#     working tree on the batch branch, and commits (authored Mike McDougall, no
+#     bot attribution). The script then checks whether a new commit landed.
+#
+# This file is SOURCEABLE: defines functions only; no work at source time. With
+# TRAIN_AUTOFIX=0 every gate is inert and the train behaves exactly like today
+# (escalate on a real, attributable, non-flake failure).
+
+# --- configuration knobs (env-overridable) -----------------------------------
+# TRAIN_AUTOFIX gates the ENTIRE roll-forward AI fix layer. 0 (default) => the
+# train escalates fixable failures exactly like Phase 1. 1 => fixable failures
+# route to the AI fix-agent (the merge-train.yml autofix step) before escalation.
+: "${TRAIN_AUTOFIX:=0}"
+# Max AI fix attempts per batch before escalating as genuinely-hard.
+: "${TRAIN_AUTOFIX_CAP:=2}"
+# The fix model. Configurable; default a Sonnet-class model for code edits (the
+# fix-agent edits code, unlike the cheap Haiku classification gates). Operators
+# override via the workflow input / repo var.
+: "${TRAIN_AUTOFIX_MODEL:=us.anthropic.claude-sonnet-4-5-20250929-v1:0}"
+
+# autofix_enabled: is the roll-forward AI fix layer turned on? (TRAIN_AUTOFIX=1)
+autofix_enabled() { [[ "${TRAIN_AUTOFIX:-0}" == "1" ]]; }
+
+# train_autofix_request_file: where the fix request (the prompt the claude-code
+# action consumes) is written. Defaults under TRAIN_WORK; the workflow points the
+# action's prompt at this path.
+: "${TRAIN_AUTOFIX_REQUEST_FILE:=${TRAIN_WORK:-/tmp}/autofix-request.md}"
+# Where the script records the batch HEAD sha BEFORE the fix, so it can detect
+# whether the action produced a new commit.
+: "${TRAIN_AUTOFIX_PREHEAD_FILE:=${TRAIN_WORK:-/tmp}/autofix-prehead}"
+
+# train_autofix_write_request <batch-branch> <introduced-failing-jobs-newline> \
+#   <failing-test-fqns-newline> <error-output> : render the fix-request prompt
+# the claude-code action consumes. Includes the batch branch, the
+# BATCH-INTRODUCED failing tests + their error output, and the batch diff. The
+# instruction is FIX-FORWARD: patch brittle/wrong tests OR a genuine mechanical
+# bug, commit to the batch branch (authored Mike McDougall, NO bot attribution),
+# touch ONLY what is needed. READ-ONLY w.r.t. git (just renders a file).
+train_autofix_write_request() {
+  local batch="$1" jobs="$2" fqns="$3" errout="$4"
+  local req="${TRAIN_AUTOFIX_REQUEST_FILE}"
+  mkdir -p "$(dirname "${req}")" 2>/dev/null || true
+
+  local diff
+  if [[ -n "${TRAIN_AUTOFIX_DIFF_CMD:-}" ]]; then
+    diff="$("${TRAIN_AUTOFIX_DIFF_CMD}" "${batch}")"
+  else
+    diff="$(git -C "${TRAIN_REPO_ROOT}" diff "${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}...${batch}" 2>/dev/null || echo "")"
+  fi
+  # Cap the diff we embed so a huge batch can't blow the prompt.
+  diff="$(printf '%s' "${diff}" | head -c "${TRAIN_AUTOFIX_DIFF_CAP:-60000}")"
+  errout="$(printf '%s' "${errout}" | tail -c "${TRAIN_AUTOFIX_ERR_CAP:-12000}")"
+
+  {
+    printf '# Merge-train roll-forward fix request\n\n'
+    printf 'You are fixing a failing batch on the merge train. The batch branch is `%s`, ' "${batch}"
+    printf 'already checked out. The batch combines several PRs that each passed CI alone but '
+    printf 'the assembled batch has the BATCH-INTRODUCED failures below (pre-existing trunk '
+    printf 'failures have already been subtracted — do NOT chase those).\n\n'
+
+    printf '## Fix forward — your task\n\n'
+    printf -- '- Make the BATCH-INTRODUCED failing tests pass by patching FORWARD.\n'
+    printf -- '- A failure is fixable in two shapes: (a) a brittle/wrong test (e.g. a test '
+    printf 'asserting an Esri-only field this server does not owe, or an over-specific snapshot) '
+    printf '— correct or relax the test to the contract we actually implement; OR (b) a genuine '
+    printf 'mechanical bug in the change — fix the code.\n'
+    printf -- '- Touch ONLY what is needed to make the listed tests pass. Do not refactor, '
+    printf 'reformat unrelated files, or change behavior beyond the failure.\n'
+    printf -- '- Commit your fix to the batch branch. Author the commit as `Mike McDougall '
+    printf '<mike@honua.io>`. Add NO bot attribution: no Co-Authored-By, no "Generated with", no emoji.\n'
+    printf -- '- Use a conventional-commit message, e.g. `fix(merge-train): ...` or `test: ...`.\n'
+    printf -- '- If the failure is NOT safely fixable forward (a real product regression that '
+    printf 'needs author judgment), make NO commit and say so — the train will escalate to a human.\n\n'
+
+    printf '## Batch-introduced failing jobs\n\n```\n%s\n```\n\n' "$(printf '%s\n' "${jobs}" | sed '/^$/d')"
+
+    if [[ -n "$(printf '%s' "${fqns}" | sed '/^$/d')" ]]; then
+      printf '## Batch-introduced failing tests (FQNs)\n\n```\n%s\n```\n\n' "$(printf '%s\n' "${fqns}" | sed '/^$/d')"
+    fi
+
+    printf '## Failing test error output\n\n```\n%s\n```\n\n' "${errout}"
+
+    printf '## Batch diff (vs %s/%s)\n\n```diff\n%s\n```\n' "${TRAIN_REMOTE}" "${TRAIN_BASE_BRANCH}" "${diff}"
+  } >"${req}"
+
+  printf '%s' "${req}"
+}
+
+# train_autofix_record_prehead <batch-branch>: stash the batch HEAD sha before
+# the AI fix step runs, so train_autofix_committed can tell if a fix commit
+# landed. READ-ONLY w.r.t. remote (local rev-parse only).
+train_autofix_record_prehead() {
+  local batch="$1"
+  local sha
+  sha="$(git -C "${TRAIN_REPO_ROOT}" rev-parse "${batch}" 2>/dev/null || echo "")"
+  printf '%s\n' "${sha}" >"${TRAIN_AUTOFIX_PREHEAD_FILE}"
+  printf '%s' "${sha}"
+}
+
+# train_autofix_committed <batch-branch>: did the AI fix step produce a NEW
+# commit on the batch branch since train_autofix_record_prehead? Returns 0 (yes,
+# a fix was committed) / 1 (no change — the agent declined or failed).
+# Test override: TRAIN_AUTOFIX_POSTHEAD forces the post-fix sha (offline fixtures).
+train_autofix_committed() {
+  local batch="$1"
+  local pre post
+  pre="$(cat "${TRAIN_AUTOFIX_PREHEAD_FILE}" 2>/dev/null || echo "")"
+  if [[ -n "${TRAIN_AUTOFIX_POSTHEAD:-}" ]]; then
+    post="${TRAIN_AUTOFIX_POSTHEAD}"
+  else
+    post="$(git -C "${TRAIN_REPO_ROOT}" rev-parse "${batch}" 2>/dev/null || echo "")"
+  fi
+  [[ -n "${post}" && "${post}" != "${pre}" ]]
+}
+
+# train_run_autofix_step <batch> <request-file>: invoke the AI fix-agent. The
+# REAL invocation is the merge-train.yml claude-code-action step (Bedrock); this
+# function is the seam the orchestrator calls so the whole loop is testable
+# offline. When TRAIN_AUTOFIX_STEP_CMD is set (the workflow exports it to point at
+# the action wrapper, or a fixture sets it to a fake), it is invoked as
+#   "${TRAIN_AUTOFIX_STEP_CMD}" <batch> <request-file>
+# and is expected to (live) edit + commit on the batch branch. Side-effecting; in
+# dry-run we LOG only and make no commit (so a dry-run is provably read-only).
+train_run_autofix_step() {
+  local batch="$1" req="$2"
+  if [[ "${TRAIN_APPLY:-0}" != "1" ]]; then
+    train_log "DRY-RUN (skipped): invoke AI fix-agent on ${batch} (request: ${req})"
+    return 0
+  fi
+  if [[ -n "${TRAIN_AUTOFIX_STEP_CMD:-}" ]]; then
+    "${TRAIN_AUTOFIX_STEP_CMD}" "${batch}" "${req}"
+    return 0
+  fi
+  # No step command wired (e.g. running the script directly outside the workflow
+  # that provides the claude-code-action). Treat as "no fix produced" so the
+  # caller falls back to escalation rather than wedging.
+  train_warn "no TRAIN_AUTOFIX_STEP_CMD wired; AI fix step is a no-op (caller will escalate)"
+  return 0
+}
+
+# train_autofix_attempt <batch> <introduced-jobs> <fqns> <errout> <attempt>:
+# one full fix attempt: write the request, record pre-head, run the AI fix step,
+# detect a commit. Returns:
+#   0  => a fix commit was produced (caller surgically re-verifies).
+#   1  => no commit produced / cap reached (caller escalates).
+# Honors TRAIN_AUTOFIX_CAP.
+train_autofix_attempt() {
+  local batch="$1" jobs="$2" fqns="$3" errout="$4" attempt="${5:-0}"
+  if ! autofix_enabled; then
+    train_log "autofix disabled (TRAIN_AUTOFIX=0); not attempting AI fix"
+    return 1
+  fi
+  if [[ "${attempt}" -ge "${TRAIN_AUTOFIX_CAP}" ]]; then
+    train_warn "autofix cap (${TRAIN_AUTOFIX_CAP}) reached; escalating"
+    return 1
+  fi
+
+  local req; req="$(train_autofix_write_request "${batch}" "${jobs}" "${fqns}" "${errout}")"
+  train_log "autofix attempt $((attempt + 1)): request written to ${req} (model ${TRAIN_AUTOFIX_MODEL})"
+  train_autofix_record_prehead "${batch}" >/dev/null
+  train_run_autofix_step "${batch}" "${req}"
+
+  if train_autofix_committed "${batch}"; then
+    train_decision "autofix attempt $((attempt + 1)) produced a fix commit on ${batch}; surgically re-verifying"
+    return 0
+  fi
+  train_warn "autofix attempt $((attempt + 1)) produced no commit; treating as unfixable"
+  return 1
+}

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -15,6 +15,18 @@
 #   7. ff-cas-race       -> concurrent trunk advance => FF push rejected +
 #                           re-assemble signaled (rc=10).
 #
+# Roll-forward auto-fix loop (offline-mocked; NO real Bedrock/AI calls):
+#   Cap.1 pre-existing filter -> all-pre-existing => rc11 (land); some
+#                                batch-introduced => survives (rc0); subtraction.
+#   Cap.3 surgical retry      -> FQN parse (VSTest + xUnit) => dotnet-test
+#                                --filter "FullyQualifiedName=..." (+ JS/Py); no
+#                                FQNs => rc2 (fall back, never a full shard rerun).
+#   Cap.2 escalation          -> labels every culprit train:escalated, removes
+#                                train:landing, clears active_batch (phase=select).
+#   Cap.4 autofix gate        -> TRAIN_AUTOFIX=0 inert (escalate like today);
+#                                TRAIN_AUTOFIX=1 fix path (mock agent commits,
+#                                no bot attribution; cap enforced; decline=>escalate).
+#
 # Run: scripts/ci/merge-train/fixtures/validate-merge-train.sh
 # Exit 0 = all pass.
 
@@ -83,6 +95,9 @@ export TRAIN_REPO_ROOT="${WORK}"
 . "${TRAIN_DIR}/smart-ci.sh"
 . "${TRAIN_DIR}/forward-fix.sh"
 . "${TRAIN_DIR}/classify-flake.sh"
+. "${TRAIN_DIR}/surgical.sh"
+. "${TRAIN_DIR}/preexisting.sh"
+. "${TRAIN_DIR}/autofix.sh"
 . "${TRAIN_DIR}/attribute.sh"
 . "${TRAIN_DIR}/land.sh"
 . "${TRAIN_DIR}/select.sh"
@@ -465,6 +480,168 @@ FAKE_BEDROCK_ANSWER="${BEDROCK_ERROR_SENTINEL}" train_forward_fix_heal_safe "ser
 TRAIN_LLM=0 ans_disabled="$(bedrock_ask sys usr)"; assert_eq "p2 bedrock_ask: disabled => sentinel" "${ans_disabled}" "${BEDROCK_ERROR_SENTINEL}"
 
 unset TRAIN_BEDROCK_ASK_CMD FAKE_BEDROCK_ANSWER TRAIN_LLM
+
+echo
+echo "== Roll-forward Cap. 1: pre-existing-failure filter (deterministic, no AI) =="
+# Mock trunk's latest CI run id + its failing jobs/tests. The batch's failing
+# jobs are subtracted against trunk's; only batch-INTRODUCED ones survive.
+export TRAIN_TRUNK_RUN_ID=trunk-run-1
+__trunk_jobs() {  # <run-id>
+  case "${PE_CASE:-}" in
+    all_pre)  printf 'Server Tests (STAC and API Governance)\n' ;;   # trunk already red here
+    some_new) printf 'Server Tests (STAC and API Governance)\n' ;;
+    none_pre) : ;;
+    *) : ;;
+  esac
+}
+export -f __trunk_jobs
+export TRAIN_FAILING_JOBS_FOR_RUN=__trunk_jobs
+
+# (a) ALL batch failures are also on trunk => filter returns rc11 (treat as PASS).
+set +e
+PE_CASE=all_pre train_preexisting_filter batch-run-9 "Server Tests (STAC and API Governance)" >/dev/null
+rc_pe=$?
+set -e
+assert_eq "preexisting: all-pre-existing => rc11 (land)" "${rc_pe}" "11"
+
+# (b) The batch introduced a NEW failing job not on trunk => it survives (rc0)
+# and only the introduced job is emitted (the pre-existing STAC one is stripped).
+set +e
+survivors="$(PE_CASE=some_new train_preexisting_filter batch-run-9 \
+  $'Server Tests (STAC and API Governance)\nServer Tests (FeatureServer Endpoints)')"
+rc_pe2=$?
+set -e
+assert_eq "preexisting: some-introduced => rc0 (act)" "${rc_pe2}" "0"
+assert_contains "preexisting: introduced job survives" "${survivors}" "FeatureServer Endpoints"
+assert_not_contains "preexisting: pre-existing job stripped" "${survivors}" "STAC and API Governance"
+
+# (c) trunk has NO failures => every batch failure is batch-introduced (rc0).
+set +e
+survivors2="$(PE_CASE=none_pre train_preexisting_filter batch-run-9 'Server Tests (FeatureServer Endpoints)')"
+rc_pe3=$?
+set -e
+assert_eq "preexisting: clean-trunk => all introduced (rc0)" "${rc_pe3}" "0"
+assert_contains "preexisting: introduced survives on clean trunk" "${survivors2}" "FeatureServer Endpoints"
+# subtraction primitive
+assert_eq "preexisting: subtract removes baseline lines" \
+  "$(train_subtract_lines $'a\nb' $'a\nb\nc' | tr '\n' ' ' | xargs)" "c"
+unset TRAIN_TRUNK_RUN_ID TRAIN_FAILING_JOBS_FOR_RUN
+
+echo
+echo "== Roll-forward Cap. 3: surgical retry (filter built from failed FQNs) =="
+# Parse failed FQNs from VSTest + xUnit reporter lines, then build the
+# dotnet-test --filter and the JS/Python equivalents.
+LOG=$'Failed Honua.Core.Tests.Query.FilterTests.Parses_Nested [12 ms]\n[xUnit.net 00:00:00.42]    Honua.Server.Tests.Stac.ItemTests.Returns200 [FAIL]\n  Passed Honua.Core.Tests.Query.FilterTests.Other [1 ms]'
+fqns="$(train_parse_failed_test_names "${LOG}")"
+assert_contains "surgical: parsed VSTest FQN" "${fqns}" "Honua.Core.Tests.Query.FilterTests.Parses_Nested"
+assert_contains "surgical: parsed xUnit [FAIL] FQN" "${fqns}" "Honua.Server.Tests.Stac.ItemTests.Returns200"
+assert_not_contains "surgical: passed test not collected" "${fqns}" "FilterTests.Other"
+filter="$(train_build_test_filter "${fqns}")"
+assert_contains "surgical: --filter has FullyQualifiedName= for each FQN" "${filter}" "FullyQualifiedName=Honua.Core.Tests.Query.FilterTests.Parses_Nested"
+assert_contains "surgical: --filter OR-joins FQNs" "${filter}" "|FullyQualifiedName=Honua.Server.Tests.Stac.ItemTests.Returns200"
+# Exactly two FQNs => exactly one pipe separator.
+assert_eq "surgical: two FQNs => single pipe" "$(awk -F'|' '{print NF-1}' <<<"${filter}")" "1"
+# JS + Python equivalents (leaf-name based).
+js="$(train_build_js_test_pattern "${fqns}")"
+assert_contains "surgical(js): jest -t pattern uses leaf names" "${js}" "Parses_Nested"
+py="$(train_build_py_test_pattern "${fqns}")"
+assert_contains "surgical(py): pytest -k uses ' or ' join" "${py}" " or "
+# Surgical rerun honors the test-runner seam and reports pass/fail per project.
+export TRAIN_TEST_PROJECT_FOR=__test_proj
+__test_proj() { printf 'tests/dotnet/Fake.Tests/Fake.Tests.csproj\n'; }
+export -f __test_proj
+GOT_FILTER="${SCRATCH}/got_filter"; : >"${GOT_FILTER}"
+__runner_ok() { printf '%s\n' "$2" >"${GOT_FILTER}"; return 0; }
+__runner_fail() { return 1; }
+export -f __runner_ok __runner_fail
+export TRAIN_SURGICAL_RUNNER=__runner_ok
+train_surgical_rerun some-run "${fqns}" && ok "surgical: green rerun => rc0" || bad "surgical: should pass"
+assert_contains "surgical: runner received the FullyQualifiedName filter" "$(cat "${GOT_FILTER}")" "FullyQualifiedName="
+export TRAIN_SURGICAL_RUNNER=__runner_fail
+train_surgical_rerun some-run "${fqns}" && bad "surgical: failing rerun should be rc!=0" || ok "surgical: failing rerun => rc1"
+# No FQNs => rc2 (caller must fall back, never a full rerun).
+set +e; train_surgical_rerun some-run ""; rc_sr=$?; set -e
+assert_eq "surgical: no FQNs => rc2 (fall back, no full shard rerun)" "${rc_sr}" "2"
+unset TRAIN_SURGICAL_RUNNER TRAIN_TEST_PROJECT_FOR
+
+echo
+echo "== Roll-forward Cap. 2: escalation labels culprits + clears active_batch =="
+# train_escalate_batch (dry-run logs the side effects): assert it would add
+# train:escalated to EVERY member, remove train:landing, and that the state-issue
+# write that clears active_batch renders included:[] phase:select.
+ESC_LOG="$(TRAIN_APPLY=0 train_escalate_batch "1944,1961,1969,1971,1972" "not attributable" 2>&1)"
+for n in 1944 1961 1969 1971 1972; do
+  assert_contains "escalate: #${n} gets train:escalated" "${ESC_LOG}" "gh pr edit ${n} --add-label train:escalated"
+  assert_contains "escalate: #${n} loses train:landing" "${ESC_LOG}" "gh pr edit ${n} --remove-label train:landing"
+done
+# Clearing active_batch: the state body the train writes on escalation.
+cleared="$(train_state_render "" deadbeef "" select "" 0 0 null)"
+csj="$(printf '%s\n' "${cleared}" | awk '/^```json/{f=1;next}/^```/{f=0}f')"
+assert_eq "escalate: active_batch.branch cleared" "$(jq -r '.active_batch.branch' <<<"${csj}")" ""
+assert_eq "escalate: active_batch.included cleared" "$(jq -rc '.active_batch.included' <<<"${csj}")" "[]"
+assert_eq "escalate: phase reset to select" "$(jq -r '.active_batch.phase' <<<"${csj}")" "select"
+
+echo
+echo "== Roll-forward Cap. 4: autofix disabled (TRAIN_AUTOFIX=0) => behaves like today =="
+export TRAIN_AUTOFIX=0
+# autofix gate is inert: no attempt, returns rc1 (caller escalates), no commit.
+set +e
+TRAIN_AUTOFIX=0 train_autofix_attempt some-batch "Server Tests (X)" "Pkg.Tests.T1" "boom" 0
+rc_af=$?
+set -e
+assert_eq "autofix(off): disabled => rc1 (escalate path, like Phase 1)" "${rc_af}" "1"
+assert_eq "autofix(off): autofix_enabled is false" "$(autofix_enabled && echo on || echo off)" "off"
+
+echo "== Roll-forward Cap. 4: autofix enabled => fix path (mocked, no real Bedrock) =="
+export TRAIN_AUTOFIX=1 TRAIN_APPLY=1
+export TRAIN_WORK="${SCRATCH}"
+export TRAIN_AUTOFIX_REQUEST_FILE="${SCRATCH}/autofix-req.md"
+export TRAIN_AUTOFIX_PREHEAD_FILE="${SCRATCH}/autofix-prehead"
+# A fake fix-agent that, like a real one, commits a change on the batch branch.
+git fetch -q origin trunk; git checkout -q -B autofix-batch origin/trunk
+export TRAIN_AUTOFIX_DIFF_CMD=__af_diff
+__af_diff() { printf 'diff --git a/x b/x\n+changed\n'; }
+export -f __af_diff
+__fake_fixagent() {  # <batch> <request-file>
+  # The agent edits + commits on the batch branch (NO bot attribution).
+  echo "fixed" >> shared.txt
+  git add -A
+  git commit -q -m "fix(merge-train): correct brittle test assertion"
+}
+export -f __fake_fixagent
+export TRAIN_AUTOFIX_STEP_CMD=__fake_fixagent
+set +e
+train_autofix_attempt autofix-batch "Server Tests (X)" $'Pkg.Tests.T1\nPkg.Tests.T2' "Assert.Equal failure" 0
+rc_af2=$?
+set -e
+assert_eq "autofix(on): agent committed a fix => rc0 (verify path)" "${rc_af2}" "0"
+# The request prompt embeds the fix-forward contract + the failing FQNs + diff.
+req_body="$(cat "${TRAIN_AUTOFIX_REQUEST_FILE}")"
+assert_contains "autofix(on): request embeds failing FQN" "${req_body}" "Pkg.Tests.T1"
+assert_contains "autofix(on): request says fix FORWARD" "${req_body}" "Fix forward"
+assert_contains "autofix(on): request forbids bot attribution" "${req_body}" "Add NO bot attribution"
+assert_contains "autofix(on): request authors as Mike McDougall" "${req_body}" "Mike McDougall"
+# The fix commit carries NO bot attribution.
+git -C "${WORK}" log -1 --pretty='%an <%ae>%n%b' autofix-batch | grep -Eqi 'co-authored-by|generated with|🤖' \
+  && bad "autofix(on): bot attribution present" || ok "autofix(on): fix commit has no bot attribution"
+# Cap: at the cap, no attempt is made (rc1 => escalate).
+set +e
+TRAIN_AUTOFIX_CAP=2 train_autofix_attempt autofix-batch "Server Tests (X)" "Pkg.Tests.T1" "boom" 2
+rc_cap=$?
+set -e
+assert_eq "autofix(on): at cap => rc1 (escalate genuinely-hard)" "${rc_cap}" "1"
+# Agent declines (makes no commit) => rc1 (escalate).
+__noop_agent() { :; }
+export -f __noop_agent
+export TRAIN_AUTOFIX_STEP_CMD=__noop_agent
+set +e
+train_autofix_attempt autofix-batch "Server Tests (X)" "Pkg.Tests.T1" "boom" 0
+rc_noc=$?
+set -e
+assert_eq "autofix(on): agent declined (no commit) => rc1 (escalate)" "${rc_noc}" "1"
+unset TRAIN_AUTOFIX TRAIN_AUTOFIX_STEP_CMD TRAIN_AUTOFIX_DIFF_CMD TRAIN_AUTOFIX_CAP
+export TRAIN_APPLY=0
+git checkout -q origin/trunk 2>/dev/null || true
 
 echo
 printf 'RESULT: %d passed, %d failed\n' "${PASS}" "${FAIL}"

--- a/scripts/ci/merge-train/lib.sh
+++ b/scripts/ci/merge-train/lib.sh
@@ -264,6 +264,9 @@ train_metrics_render() {
     --argjson skipped_select "$(train_metric_get skipped_select 0)" \
     --argjson flake_reruns "$(train_metric_get flake_reruns 0)" \
     --argjson forward_fixes "$(train_metric_get forward_fixes 0)" \
+    --argjson preexisting_passes "$(train_metric_get preexisting_passes 0)" \
+    --argjson autofix_attempts "$(train_metric_get autofix_attempts 0)" \
+    --argjson autofix_fixes "$(train_metric_get autofix_fixes 0)" \
     --argjson attribution_drops "$(train_metric_get attribution_drops 0)" \
     --argjson shard_count "${shard_count:-0}" \
     --argjson run_all "${run_all:-false}" \
@@ -284,6 +287,9 @@ train_metrics_render() {
         escalated: $escalated,
         flake_reruns: $flake_reruns,
         forward_fixes: $forward_fixes,
+        preexisting_passes: $preexisting_passes,
+        autofix_attempts: $autofix_attempts,
+        autofix_fixes: $autofix_fixes,
         attribution_drops: $attribution_drops
       },
       smart_ci: { shard_count: $shard_count, run_all: $run_all },

--- a/scripts/ci/merge-train/preexisting.sh
+++ b/scripts/ci/merge-train/preexisting.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Step 5.5 (NEW): pre-existing-failure filter — deterministic, no AI.
+#
+# Before the train blocks/escalates a failed batch, fetch the LATEST trunk CI
+# run's failing jobs (and, where available, failing test FQNs) and SUBTRACT any
+# that ALSO fail on trunk. Those are pre-existing failures — NOT the batch's
+# fault. If after subtraction there are ZERO batch-introduced failures, the batch
+# is treated as PASS and lands.
+#
+# This is the deterministic floor of the roll-forward design: a batch is never
+# blocked, escalated, or AI-patched for a failure that trunk already carries
+# (e.g. an already-red STAC api-validator conformance test). No Bedrock, no
+# heuristics — a pure set subtraction over CI's own reported failures.
+#
+# Two granularities, both subtractive, both READ-ONLY (run in dry-run and live):
+#   * job-level:  failing JOB names present on trunk are pre-existing.
+#   * test-level: failing test FQNs present on trunk are pre-existing.
+# A batch failure survives the filter only if it is a job/test NOT already
+# failing on trunk. The orchestrator uses the surviving set to decide land vs
+# classify/attribute/fix.
+
+# train_trunk_latest_ci_run_id: the databaseId of the most recent COMPLETED CI
+# run on the base branch (trunk). Empty if none/ungettable. READ-ONLY.
+# Test override: TRAIN_TRUNK_RUN_ID forces a fixed id (offline fixtures).
+train_trunk_latest_ci_run_id() {
+  if [[ -n "${TRAIN_TRUNK_RUN_ID:-}" ]]; then
+    printf '%s' "${TRAIN_TRUNK_RUN_ID}"
+    return 0
+  fi
+  gh run list --workflow ci.yml --branch "${TRAIN_BASE_BRANCH}" \
+    --status completed --limit 1 \
+    --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || echo ""
+}
+
+# train_run_failing_job_names <run-id>: emit the failing JOB names of a run, one
+# per line (sorted-unique). Live path uses `gh run view --json jobs`. Test
+# override: TRAIN_FAILING_JOBS_FOR_RUN <cmd> is invoked with the run id and must
+# print the same newline-separated job names.
+train_run_failing_job_names() {
+  local run_id="$1"
+  if [[ -n "${TRAIN_FAILING_JOBS_FOR_RUN:-}" ]]; then
+    "${TRAIN_FAILING_JOBS_FOR_RUN}" "${run_id}" | sed '/^$/d' | sort -u
+    return 0
+  fi
+  [[ -z "${run_id}" ]] && return 0
+  gh run view "${run_id}" --json jobs \
+    --jq '.jobs[] | select(.conclusion=="failure") | .name' 2>/dev/null \
+    | sed '/^$/d' | sort -u || true
+}
+
+# train_trunk_preexisting_jobs: the set of failing JOB names on trunk's latest
+# CI run (the pre-existing job-level failures). READ-ONLY; emits one per line.
+train_trunk_preexisting_jobs() {
+  local trunk_run; trunk_run="$(train_trunk_latest_ci_run_id)"
+  [[ -z "${trunk_run}" ]] && return 0
+  train_run_failing_job_names "${trunk_run}"
+}
+
+# train_trunk_preexisting_tests: the set of failing test FQNs on trunk's latest
+# CI run (the pre-existing test-level failures). READ-ONLY; emits one per line.
+# Depends on train_failed_test_names (surgical.sh) for FQN extraction.
+train_trunk_preexisting_tests() {
+  local trunk_run; trunk_run="$(train_trunk_latest_ci_run_id)"
+  [[ -z "${trunk_run}" ]] && return 0
+  if declare -F train_failed_test_names >/dev/null 2>&1; then
+    train_failed_test_names "${trunk_run}"
+  fi
+}
+
+# train_subtract_lines <baseline-stdin-via-$1> <candidate-stdin-via-$2>:
+# emit the lines in CANDIDATE that are NOT in BASELINE (set difference
+# candidate - baseline), sorted-unique. Both args are multi-line strings. Used to
+# strip pre-existing failures from the batch's failures.
+train_subtract_lines() {
+  local baseline="$1" candidate="$2"
+  local base_sorted cand_sorted
+  base_sorted="$(printf '%s\n' "${baseline}" | sed '/^$/d' | sort -u)"
+  cand_sorted="$(printf '%s\n' "${candidate}" | sed '/^$/d' | sort -u)"
+  # comm -23: lines only in candidate (file1) not in baseline (file2).
+  comm -23 <(printf '%s\n' "${cand_sorted}") <(printf '%s\n' "${base_sorted}")
+}
+
+# train_batch_introduced_jobs <batch-failing-jobs-newline>: subtract trunk's
+# pre-existing failing jobs from the batch's failing jobs. Emits the
+# batch-INTRODUCED failing job names (one per line). Empty output => every batch
+# failure is pre-existing on trunk (the batch introduced no new job failure).
+train_batch_introduced_jobs() {
+  local batch_failing="$1"
+  local trunk_jobs; trunk_jobs="$(train_trunk_preexisting_jobs)"
+  train_subtract_lines "${trunk_jobs}" "${batch_failing}"
+}
+
+# train_batch_introduced_tests <batch-failing-tests-newline>: subtract trunk's
+# pre-existing failing test FQNs from the batch's failing test FQNs. Emits the
+# batch-INTRODUCED failing test FQNs (one per line).
+train_batch_introduced_tests() {
+  local batch_failing="$1"
+  local trunk_tests; trunk_tests="$(train_trunk_preexisting_tests)"
+  train_subtract_lines "${trunk_tests}" "${batch_failing}"
+}
+
+# train_preexisting_filter <run-id> <batch-failing-jobs-newline>:
+# The orchestrator entrypoint. Given the batch's failing JOB names, compute the
+# batch-introduced subset (job-level minus trunk). Emits the surviving
+# batch-introduced job names on stdout (one per line). Return code:
+#   0  => at least one batch-introduced failure survives (caller must act).
+#   11 => ZERO batch-introduced failures (ALL pre-existing on trunk) => land.
+# READ-ONLY (no side effects); safe in dry-run and live.
+train_preexisting_filter() {
+  local _run_id="$1" batch_failing="$2"
+  local introduced
+  introduced="$(train_batch_introduced_jobs "${batch_failing}")"
+  if [[ -z "$(printf '%s' "${introduced}" | sed '/^$/d')" ]]; then
+    train_decision "pre-existing filter: every batch failure also fails on trunk; batch introduced NO new failures (treat as PASS)"
+    return 11
+  fi
+  printf '%s\n' "${introduced}" | sed '/^$/d'
+  return 0
+}

--- a/scripts/ci/merge-train/state.sh
+++ b/scripts/ci/merge-train/state.sh
@@ -9,7 +9,7 @@
 #   {
 #     "active_batch": {
 #       "branch": "...", "trunk_base": "<sha>", "included": [<pr>...],
-#       "phase": "select|assemble|smart-ci|forward-fix|attribute|land|done",
+#       "phase": "select|assemble|smart-ci|forward-fix|preexisting-filter|classify-flake|autofix|attribute|land|done",
 #       "run_id": <id|null>, "fwdfix_attempts": <n>, "flake_reruns": <n>
 #     },
 #     "config": { "max_batch": <n>, "flake_signatures": "<regex>" },

--- a/scripts/ci/merge-train/surgical.sh
+++ b/scripts/ci/merge-train/surgical.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Surgical retry — extract the EXACT failed test FQNs from a CI run and re-run
+# ONLY those, never a full shard rerun. Used for (a) post-AI-fix verification and
+# (b) a targeted retry when specific failing tests are known.
+#
+# Why surgical: `gh run rerun --failed` re-runs whole shards (tens of minutes,
+# tens of thousands of tests). When the exact failing tests are known, re-running
+# just them (`dotnet test <proj> --filter "FullyQualifiedName=A|FullyQualifiedName=B"`)
+# verifies a fix in seconds and proves the fix without re-paying the full matrix.
+# The train NEVER `gh run rerun --failed`s a shard when specific FQNs are known.
+
+# train_failed_test_names <run-id>: parse the failing-test FQNs from a CI run's
+# test results / logs, one FQN per line (sorted-unique). For .NET, xUnit/VSTest
+# failure lines read like:
+#     Failed Honua.Core.Tests.Query.FilterTests.Parses_Nested   [12 ms]
+#     [xUnit.net 00:00:00.42]   Honua.Server.Tests.Stac.ItemTests.Returns200 [FAIL]
+# We extract the dotted FQN token after "Failed " or before " [FAIL]".
+#
+# Live path scrapes `gh run view --log-failed`. Test override:
+# TRAIN_RUN_LOG_FOR <cmd> is invoked with the run id and must print the raw log
+# text (offline fixtures). TRAIN_FAILED_TESTS_FOR_RUN <cmd> can short-circuit and
+# emit the FQNs directly (used by the trunk-pre-existing-tests path).
+train_failed_test_names() {
+  local run_id="$1"
+  if [[ -n "${TRAIN_FAILED_TESTS_FOR_RUN:-}" ]]; then
+    "${TRAIN_FAILED_TESTS_FOR_RUN}" "${run_id}" | sed '/^$/d' | sort -u
+    return 0
+  fi
+  local log
+  if [[ -n "${TRAIN_RUN_LOG_FOR:-}" ]]; then
+    log="$("${TRAIN_RUN_LOG_FOR}" "${run_id}")"
+  elif [[ -n "${TRAIN_RUN_LOG_TEXT:-}" ]]; then
+    log="${TRAIN_RUN_LOG_TEXT}"
+  else
+    [[ -z "${run_id}" ]] && return 0
+    log="$(gh run view "${run_id}" --log-failed 2>/dev/null || echo "")"
+  fi
+  train_parse_failed_test_names "${log}"
+}
+
+# train_parse_failed_test_names <log-text>: pure parser (no I/O) — emit the
+# failing-test FQNs found in VSTest/xUnit/dotnet-test failure lines. Recognizes:
+#   * "Failed <FQN>"            (VSTest/dotnet-test console reporter)
+#   * "<FQN> [FAIL]"           (xUnit.net console reporter)
+#   * "Failed!  - ... <FQN>"   (defensively, an FQN token after "Failed")
+# An FQN is a dotted identifier path (>=1 dot), optionally with a method and
+# arguments stripped (we keep up to the method name, dropping "(args)").
+train_parse_failed_test_names() {
+  local text="$1"
+  printf '%s\n' "${text}" | awk '
+    {
+      line = $0
+      fqn = ""
+      # Pattern A: "... Failed <FQN> ..."  (VSTest reporter)
+      if (match(line, /Failed[[:space:]]+[A-Za-z_][A-Za-z0-9_.]*\.[A-Za-z0-9_]+/)) {
+        tok = substr(line, RSTART, RLENGTH)
+        sub(/^Failed[[:space:]]+/, "", tok)
+        fqn = tok
+      }
+      # Pattern B: "<FQN> [FAIL]"  (xUnit reporter) — overrides A if present.
+      if (match(line, /[A-Za-z_][A-Za-z0-9_.]*\.[A-Za-z0-9_]+[[:space:]]+\[FAIL\]/)) {
+        tok = substr(line, RSTART, RLENGTH)
+        sub(/[[:space:]]+\[FAIL\].*$/, "", tok)
+        fqn = tok
+      }
+      if (fqn != "") {
+        # Drop any trailing "(args)" parametrized-test suffix and method parens.
+        sub(/\(.*$/, "", fqn)
+        # Must contain at least one dot to be a real FQN.
+        if (index(fqn, ".") > 0) print fqn
+      }
+    }
+  ' | sed '/^$/d' | sort -u
+}
+
+# train_build_test_filter <fqn-list-newline>: build the dotnet-test --filter
+# expression that selects exactly those FQNs:
+#   "FullyQualifiedName=A|FullyQualifiedName=B"
+# Empty FQN list => empty string (caller must guard). Pure + testable.
+train_build_test_filter() {
+  local fqns="$1"
+  printf '%s\n' "${fqns}" | sed '/^$/d' | sort -u | awk '
+    { if (NR>1) printf "|"; printf "FullyQualifiedName=%s", $0 }
+    END { if (NR>0) printf "\n" }
+  '
+}
+
+# train_build_js_test_pattern <fqn-list-newline>: build a Jest/Vitest -t pattern
+# (alternation of the leaf test names) for the JS equivalent of a surgical rerun:
+#   "TestA|TestB"  (used as `jest -t "<pattern>"` / `vitest -t "<pattern>"`).
+# We use the trailing identifier of each FQN as the JS test name token.
+train_build_js_test_pattern() {
+  local fqns="$1"
+  printf '%s\n' "${fqns}" | sed '/^$/d' | sort -u | awk '
+    {
+      n = split($0, p, ".")
+      leaf = p[n]
+      if (NR>1) printf "|"; printf "%s", leaf
+    }
+    END { if (NR>0) printf "\n" }
+  '
+}
+
+# train_build_py_test_pattern <fqn-list-newline>: build a pytest -k expression
+# (alternation) for the Python equivalent: "TestA or TestB".
+train_build_py_test_pattern() {
+  local fqns="$1"
+  printf '%s\n' "${fqns}" | sed '/^$/d' | sort -u | awk '
+    {
+      n = split($0, p, ".")
+      leaf = p[n]
+      if (NR>1) printf " or "; printf "%s", leaf
+    }
+    END { if (NR>0) printf "\n" }
+  '
+}
+
+# train_surgical_test_projects <fqn-list-newline>: map failing FQNs back to the
+# test PROJECT(s) that own them, so the surgical rerun targets the right csproj.
+# Heuristic: the FQN's leading namespace segments name the test assembly, which
+# (by repo convention) maps to tests/dotnet/<Assembly>/<Assembly>.csproj. We take
+# the longest dotted prefix that matches a real *.csproj under tests/dotnet/.
+# Test override: TRAIN_TEST_PROJECT_FOR <cmd> is invoked with an FQN and prints
+# the project path (offline fixtures). Emits unique project paths.
+train_surgical_test_projects() {
+  local fqns="$1"
+  local fqn
+  while IFS= read -r fqn; do
+    [[ -z "${fqn}" ]] && continue
+    if [[ -n "${TRAIN_TEST_PROJECT_FOR:-}" ]]; then
+      "${TRAIN_TEST_PROJECT_FOR}" "${fqn}"
+      continue
+    fi
+    # Try progressively shorter dotted prefixes as the assembly/project name.
+    local prefix="${fqn}" proj=""
+    while [[ "${prefix}" == *.* ]]; do
+      prefix="${prefix%.*}"
+      local cand="${TRAIN_REPO_ROOT}/tests/dotnet/${prefix}/${prefix}.csproj"
+      if [[ -f "${cand}" ]]; then proj="${cand}"; break; fi
+    done
+    [[ -n "${proj}" ]] && printf '%s\n' "${proj}"
+  done <<<"$(printf '%s\n' "${fqns}" | sed '/^$/d' | sort -u)" | sort -u
+}
+
+# train_surgical_rerun <run-id> <fqn-list-newline>: re-run ONLY the given failing
+# tests via `dotnet test <proj> --filter "<filter>"`, per owning project. Returns
+# 0 if all targeted reruns pass, 1 if any fails, 2 if no FQNs / no project found
+# (caller must fall back). Side-effecting in the sense it runs tests, but it does
+# NOT push/merge/comment — it is a LOCAL verification under the build lock.
+#
+# Test override: TRAIN_SURGICAL_RUNNER <cmd> is invoked as
+#   "${TRAIN_SURGICAL_RUNNER}" <project> <filter>
+# and its exit code is used verbatim (offline fixtures never call dotnet).
+train_surgical_rerun() {
+  local run_id="$1" fqns="$2"
+  fqns="$(printf '%s\n' "${fqns}" | sed '/^$/d' | sort -u)"
+  if [[ -z "${fqns}" ]]; then
+    train_warn "surgical rerun: no FQNs supplied; nothing to re-run"
+    return 2
+  fi
+  local filter; filter="$(train_build_test_filter "${fqns}")"
+  if [[ -z "${filter}" ]]; then
+    train_warn "surgical rerun: empty filter; nothing to re-run"
+    return 2
+  fi
+  local projects; projects="$(train_surgical_test_projects "${fqns}")"
+  if [[ -z "${projects}" ]]; then
+    train_warn "surgical rerun: could not map FQNs to a test project; caller should fall back"
+    return 2
+  fi
+
+  local proj rc=0
+  while IFS= read -r proj; do
+    [[ -z "${proj}" ]] && continue
+    train_log "surgical rerun: dotnet test ${proj} --filter \"${filter}\""
+    if [[ -n "${TRAIN_SURGICAL_RUNNER:-}" ]]; then
+      "${TRAIN_SURGICAL_RUNNER}" "${proj}" "${filter}" || rc=1
+    else
+      ( cd "${TRAIN_REPO_ROOT}" && with-build-lock dotnet test "${proj}" --filter "${filter}" ) || rc=1
+    fi
+  done <<<"${projects}"
+  return "${rc}"
+}

--- a/scripts/ci/merge-train/train.sh
+++ b/scripts/ci/merge-train/train.sh
@@ -8,8 +8,16 @@
 #
 # Phases (also the resume points written to the state issue before each
 # side-effecting step):
-#   select -> assemble -> smart-ci -> [forward-fix] -> [classify-flake] ->
-#   [attribute -> rebuild] -> land -> done
+#   select -> assemble -> smart-ci -> [forward-fix] -> [pre-existing-filter] ->
+#   [classify-flake] -> [autofix (Bedrock fix-agent + surgical re-verify)] ->
+#   [attribute -> rebuild | escalate] -> land -> done
+#
+# Roll-forward auto-fix loop (autonomous): the ci-gate eval no longer dead-ends a
+# non-format failure straight to a human. It (1) subtracts trunk's pre-existing
+# failures (land if zero batch-introduced), (3) surgically re-verifies only the
+# failed tests, and (4) — when TRAIN_AUTOFIX=1 — patches the batch FORWARD via an
+# AI fix-agent (Claude/Bedrock), landing if green and escalating only when truly
+# stuck (and THEN labeling culprits + clearing active_batch so it never loops).
 #
 # Usage:
 #   TRAIN_APPLY=0 scripts/ci/merge-train/train.sh            # shadow / dry-run
@@ -34,6 +42,12 @@ TRAIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${TRAIN_DIR}/forward-fix.sh"
 # shellcheck source=classify-flake.sh
 . "${TRAIN_DIR}/classify-flake.sh"
+# shellcheck source=surgical.sh
+. "${TRAIN_DIR}/surgical.sh"
+# shellcheck source=preexisting.sh
+. "${TRAIN_DIR}/preexisting.sh"
+# shellcheck source=autofix.sh
+. "${TRAIN_DIR}/autofix.sh"
 # shellcheck source=attribute.sh
 . "${TRAIN_DIR}/attribute.sh"
 # shellcheck source=land.sh
@@ -167,9 +181,13 @@ main() {
     return 0
   fi
 
-  # Live-mode gate handling (forward-fix -> flake -> attribute -> land).
-  train_group ci-gate "evaluate CI Gate; forward-fix / classify-flake / attribute"
+  # Live-mode gate handling. Roll-forward pipeline (each step independently
+  # valuable, evaluated in this order):
+  #   forward-fix(format) -> PRE-EXISTING FILTER -> classify-flake ->
+  #   [AUTOFIX (Bedrock fix-agent + surgical re-verify)] -> attribute/escalate.
+  train_group ci-gate "evaluate CI Gate; forward-fix / pre-existing filter / flake / autofix / attribute"
   train_step_begin ci-gate
+  local autofix_attempts=0
   while [[ "${gate}" != "SUCCESS" ]]; do
     local run_id; run_id="$(cat "${TRAIN_RUN_ID_FILE}" 2>/dev/null || echo "")"
     local failing; failing="$(train_failing_jobs "${run_id}")"
@@ -186,7 +204,25 @@ main() {
       fi
     fi
 
-    # classify-flake BEFORE attribute.
+    # --- (1) PRE-EXISTING-FAILURE FILTER (deterministic, no AI) --------------
+    # Subtract trunk's latest-CI failing jobs from the batch's failing jobs. If
+    # ZERO batch-introduced failures remain, the batch is red ONLY because trunk
+    # is already red (e.g. a STAC api-validator conformance test) — treat the
+    # batch as PASS and land. Otherwise narrow the working set to the
+    # batch-introduced failures for flake/autofix/attribute.
+    _write_state "${batch}" "${trunk_sha}" "${included}" "preexisting-filter" "${run_id}" "${fwdfix}" "${flake_reruns}"
+    local introduced rc_pe=0
+    introduced="$(train_preexisting_filter "${run_id}" "${failing}")" || rc_pe=$?
+    if [[ "${rc_pe}" == "11" ]]; then
+      train_metric_set preexisting_passes 1
+      train_notice "pre-existing filter: all batch failures are pre-existing on trunk; landing"
+      gate="SUCCESS"
+      continue
+    fi
+    # From here on, evaluate only the BATCH-INTRODUCED failing jobs.
+    failing="${introduced}"
+
+    # --- classify-flake (on the batch-introduced failures) -------------------
     _write_state "${batch}" "${trunk_sha}" "${included}" "classify-flake" "${run_id}" "${fwdfix}" "${flake_reruns}"
     if train_classify_flake "${run_id}" "${flake_reruns}"; then
       flake_reruns=$((flake_reruns + 1))
@@ -202,15 +238,46 @@ main() {
       continue
     fi
 
-    # attribute (real failure).
+    # --- (4) ROLL-FORWARD AI FIX-AGENT (capstone; gated TRAIN_AUTOFIX) -------
+    # A REAL, batch-introduced, non-flake failure. With autofix enabled, ask the
+    # Bedrock fix-agent to patch the batch branch forward, then SURGICALLY
+    # re-verify only the failed tests. On green, re-run smart-CI and continue;
+    # if still failing after the cap, fall through to escalate.
+    if autofix_enabled; then
+      _write_state "${batch}" "${trunk_sha}" "${included}" "autofix" "${run_id}" "${fwdfix}" "${flake_reruns}"
+      local fqns errout
+      fqns="$(train_failed_test_names "${run_id}")"
+      errout="$(gh run view "${run_id}" --log-failed 2>/dev/null | tail -c 12000 || echo "")"
+      if train_autofix_attempt "${batch}" "${failing}" "${fqns}" "${errout}" "${autofix_attempts}"; then
+        autofix_attempts=$((autofix_attempts + 1))
+        train_metric_set autofix_attempts "${autofix_attempts}"
+        # Surgically re-verify ONLY the failed tests (never a full shard rerun).
+        if [[ -n "$(printf '%s' "${fqns}" | sed '/^$/d')" ]] && train_surgical_rerun "${run_id}" "${fqns}"; then
+          train_metric_set autofix_fixes "$(( $(train_metric_get autofix_fixes 0) + 1 ))"
+          train_notice "autofix verified by surgical rerun; pushing fix and re-running smart-CI on ${batch}"
+          gate="$(train_smart_ci_run "${batch}")"
+          continue
+        else
+          train_warn "autofix commit did not pass surgical re-verify; re-running smart-CI to re-evaluate"
+          gate="$(train_smart_ci_run "${batch}")"
+          continue
+        fi
+      fi
+      # autofix declined / produced no commit / cap reached => escalate below.
+      train_warn "autofix did not produce a landable fix; escalating as genuinely-hard"
+    fi
+
+    # --- (2) attribute + escalate (real failure, not autofixed) -------------
     _write_state "${batch}" "${trunk_sha}" "${included}" "attribute" "${run_id}" "${fwdfix}" "${flake_reruns}"
     local culprits; culprits="$(train_attribute "${failing}" "${TRAIN_INCLUDED_FILE}")"
     if [[ "${culprits}" == "ESCALATE_BATCH" ]]; then
       train_metric_inc escalated "$(grep -c . "${TRAIN_INCLUDED_FILE}" 2>/dev/null || echo 0)"
       train_annotate_warn "escalating entire batch; manual triage required"
-      for pr in $(tr ',' ' ' <<<"${included}"); do
-        train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_LANDING}"
-      done
+      # LOOP-BUG FIX: label EVERY member train:escalated (so select excludes them)
+      # AND clear active_batch from the state issue, or the next run re-selects
+      # the same doomed batch forever.
+      train_escalate_batch "${included}" "CI failure not attributable to a single member diff (and not autofixable)"
+      _write_state "" "${trunk_sha}" "" "select" "" 0 0
       train_step_end ci-gate >/dev/null; train_endgroup
       _emit_metrics "escalated-batch" "${trunk_sha}" "" "${shard_descriptor}"
       _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
@@ -228,6 +295,9 @@ main() {
     done
     if [[ -z "${remaining}" ]]; then
       train_annotate_warn "all members dropped; batch empty"
+      # Clear active_batch so the next run starts a fresh selection (the dropped
+      # PRs already carry train:escalated and are excluded by select).
+      _write_state "" "${trunk_sha}" "" "select" "" 0 0
       train_step_end ci-gate >/dev/null; train_endgroup
       _emit_metrics "all-dropped" "${trunk_sha}" "" "${shard_descriptor}"
       _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
@@ -381,7 +451,10 @@ _dashboard() {
   train_summary "| Included | $(train_metric_get included 0) |"
   train_summary "| Skipped (conflict) | $(train_metric_get skipped_conflict 0) |"
   train_summary "| Forward-fixes applied | $(train_metric_get forward_fixes 0) |"
+  train_summary "| Pre-existing-only passes | $(train_metric_get preexisting_passes 0) |"
   train_summary "| Flake reruns | $(train_metric_get flake_reruns 0) |"
+  train_summary "| Autofix attempts | $(train_metric_get autofix_attempts 0) |"
+  train_summary "| Autofix fixes landed | $(train_metric_get autofix_fixes 0) |"
   train_summary "| Attribution drops | $(train_metric_get attribution_drops 0) |"
   train_summary "| Escalated | $(train_metric_get escalated 0) |"
   train_summary "| Landed | $(train_metric_get landed 0) |"


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2044

## Summary
Makes the honua-server merge train **autonomously fix and land** batch failures instead of dead-ending every non-format failure to a human. Replaces the escalate-on-real-failure behavior with a roll-forward loop: subtract pre-existing trunk failures, surgically re-run only the failing tests, and (when explicitly enabled) patch the batch FORWARD with an AI fix-agent (Claude via Bedrock) before landing — escalating only when genuinely stuck.

All new autonomy is **off by default** behind the `TRAIN_AUTOFIX` gate (mirroring the existing `TRAIN_LLM` gate). The deterministic capabilities (pre-existing filter, escalation-loop fix, surgical retry) are always on but are pure, side-effect-bounded, and verified offline. **Do not merge-to-enable**: this PR is for review of the autonomy before it's switched on live.

Four independently valuable capabilities, in build order:

1. **Pre-existing-failure filter (deterministic, no AI).** Before blocking/escalating a failed batch, fetch trunk's latest CI run's failing jobs and **subtract** them from the batch's failing jobs. If zero batch-introduced failures remain, the batch is red only because trunk is already red (e.g. the STAC api-validator conformance test) → treat as PASS and land. New `preexisting.sh` (`train_preexisting_filter`, `train_subtract_lines`, trunk-run lookups). Applied in the ci-gate eval before classify/attribute/escalate.

2. **Escalation labeling + state cleanup (loop-bug fix).** On a real, unfixable escalation the train now applies `train:escalated` to **every** culprit PR (so `select` excludes them), removes `train:landing`, comments, AND clears `active_batch` (phase=`select`) on the state issue. Previously it only logged "escalating" and did neither, so the next run re-selected the same doomed batch forever (the live #1944/1961/1969/1971/1972 case). New `train_escalate_batch` in `attribute.sh`; `train.sh` clears `active_batch` on both whole-batch escalation and all-members-dropped.

3. **Surgical retry (only the failed tests, never a full rerun).** Extract the exact failed-test FQNs from a run and re-run only those: `dotnet test <proj> --filter "FullyQualifiedName=A|FullyQualifiedName=B"` (with Jest/Vitest `-t` and pytest `-k` equivalents). Never `gh run rerun --failed` a whole shard when specific FQNs are known. New `surgical.sh` (`train_failed_test_names`, `train_parse_failed_test_names`, `train_build_test_filter`, `train_surgical_rerun`).

4. **Roll-forward AI fix-agent (capstone; gated `TRAIN_AUTOFIX`, default off).** When a batch has batch-introduced real failures (survived the pre-existing filter, not a known flake), instead of escalating, the train asks an AI fix-agent (Claude via Bedrock) to patch the batch branch FORWARD — correct a brittle/wrong test (e.g. one asserting an Esri-only field we don't owe) OR fix a genuine mechanical bug — commit to the batch branch (authored Mike McDougall, no bot attribution), touch only what's needed. Then **surgically re-verify only the failed tests**; green → land; still failing after the cap (2) → **then** escalate as genuinely-hard. New `autofix.sh` (request preparation + commit detection) and `autofix-agent.sh` (the headless Claude/Bedrock runner wired as `TRAIN_AUTOFIX_STEP_CMD`).

### How the AI fix step is wired to Bedrock
- `merge-train.yml` gains `use_autofix` / `autofix_model` dispatch inputs. `TRAIN_AUTOFIX=1` is only possible on an explicit **live** `workflow_dispatch` (`train_apply=true`) **with** the `BEDROCK_AWS_*` secrets present; scheduled/`workflow_run` runs are never autofix.
- When enabled, gated steps run `aws-actions/configure-aws-credentials@v4` (the existing `BEDROCK_AWS_ACCESS_KEY_ID`/`_SECRET` access-key secrets, `aws-region=us-west-2`) and install the Claude Code CLI — the same engine `anthropics/claude-code-action` wraps.
- `train.sh`'s in-loop fix invokes `autofix-agent.sh`, which runs the agent **headless** with `CLAUDE_CODE_USE_BEDROCK=1`, `AWS_REGION=us-west-2`, `ANTHROPIC_MODEL=<TRAIN_AUTOFIX_MODEL>` (default a configurable Sonnet-class model for code edits), and the prepared fix-forward prompt. The agent edits + commits; the orchestrator detects the new commit.
- **Assumption (stated for review):** the in-loop design calls the Claude Code CLI engine directly (a GitHub composite action can't be invoked mid-bash-step). The Bedrock routing (`use_bedrock` ⇒ `CLAUDE_CODE_USE_BEDROCK=1` + the AWS chain + `--model`/`ANTHROPIC_MODEL`) matches `anthropics/claude-code-action`'s `docs/cloud-providers.md`. If the CLI is absent the wrapper exits 0 without committing, so the train safely falls back to escalation (never wedges).

### Safety model
- **Deterministic floor:** the pre-existing filter and surgical verify are pure set/FQN operations over CI's own reported failures — no heuristics, no AI.
- **Surgical verify:** a fix is only trusted after the exact failed tests pass; the full batch is then re-CI'd before landing.
- **Fix-attempt cap (2):** bounded AI attempts; still-failing → escalate.
- **Escalate only when truly stuck**, and when it does, the culprits are labeled and `active_batch` cleared so the train never loops.
- **Off by default:** `TRAIN_AUTOFIX` defaults to 0 everywhere; merging this PR cannot make the train auto-patch anything.

## Changes Made
- Added `scripts/ci/merge-train/preexisting.sh` (Cap. 1), `surgical.sh` (Cap. 3), `autofix.sh` + `autofix-agent.sh` (Cap. 4).
- `attribute.sh`: new `train_escalate_batch` (Cap. 2 loop-bug fix).
- `train.sh`: rewired the ci-gate loop (forward-fix → pre-existing filter → flake → autofix → attribute/escalate); clears `active_batch` on escalation paths; new metrics.
- `lib.sh` / `state.sh`: new metric keys + phase names in the metrics JSON and state schema.
- `.github/workflows/merge-train.yml`: `use_autofix`/`autofix_model` inputs, `id-token` permission, gated AWS-creds + Claude-CLI steps, `TRAIN_AUTOFIX`/`CLAUDE_CODE_USE_BEDROCK` wiring. No `matrix.*` in any job-level `if:`.
- `fixtures/validate-merge-train.sh`: +42 offline-mocked assertions (no real Bedrock/AI). **120 total passing** (was 78).

## Testing
- [x] Unit tests added/updated

Offline fixture harness (`fixtures/validate-merge-train.sh`): **120 passed, 0 failed** (78 prior + 42 new). New cases: all-pre-existing → land (rc11); some batch-introduced → survives (rc0); surgical `--filter` built from parsed FQNs (no FQNs → fall back, never full shard rerun); escalation labels every culprit + clears `active_batch`; autofix disabled (`TRAIN_AUTOFIX=0`) behaves like today; autofix enabled fix path (mock agent commits with no bot attribution, cap enforced, decline → escalate). `bash -n` passes on all scripts; `python3 yaml.safe_load` passes on the workflow; no `matrix.*` in any `if:`. No real Bedrock/AI calls anywhere in tests.

## Gate Impact
- [x] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
