### PR TITLE
ci(merge-train): FF land push authenticates as admin PAT (fix GH013 reject)

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -76,6 +76,12 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # The FF land pushes directly to trunk, so the git push must be
+          # authenticated as the merge-train PAT (a repo admin that the trunk
+          # ruleset bypass covers). The default GITHUB_TOKEN pushes as
+          # github-actions[bot], which has no ruleset bypass, so the push is
+          # rejected with GH013 "changes must be made through a pull request".
+          token: ${{ secrets.MERGE_TRAIN_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Configure git identity
         # REQUIRED: the train creates real commits (assemble merge commits,


### PR DESCRIPTION
The train's FF land push was rejected by the trunk ruleset (GH013, mislabeled 'trunk moved') because checkout used GITHUB_TOKEN → push as github-actions[bot] (no bypass). Use MERGE_TRAIN_TOKEN for checkout so the push is an admin push covered by the ruleset bypass. Last blocker to autonomous landing.