### PR TITLE
ci(merge-train): batch-and-fix — stop requiring green per-PR CI to batch

### DIFF
--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -304,7 +304,10 @@ export TRAIN_PR_LIST_JSON='[
   {"number":15,"headRefOid":"fff","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","labels":[],"createdAt":"2026-01-06T00:00:00Z","gate":"FAIL"}
 ]'
 MAX_BATCH=3 sel="$(MAX_BATCH=3 train_select | jq -s -c '[.[].number]')"
-assert_eq "select: oldest-first, draft/hold/conflict/fail excluded" "${sel}" "[11,10]"
+# Optimistic batch-and-fix: draft/hold/conflict are still excluded, but a CI
+# FAILURE no longer excludes a PR — it is batched and judged by the ONE batch CI
+# (autofix/attribute handle real breaks). #15 (gate=FAIL) is now INCLUDED.
+assert_eq "select: oldest-first; draft/hold/conflict excluded; CI-fail INCLUDED" "${sel}" "[11,10,15]"
 unset TRAIN_PR_LIST_JSON
 # CI Gate state mapping.
 assert_eq "select: COMPLETED+SUCCESS => SUCCESS" "$(train_select_ci_gate_state '[{"name":"CI Gate","status":"COMPLETED","conclusion":"SUCCESS"}]')" "SUCCESS"

--- a/scripts/ci/merge-train/select.sh
+++ b/scripts/ci/merge-train/select.sh
@@ -219,9 +219,16 @@ train_select() {
       gate="$(train_select_ci_gate_state "${rollup}")"
     fi
 
+    # OPTIMISTIC BATCH-AND-FIX: do NOT require a green per-PR CI to batch a PR.
+    # The ONE batch CI is the authoritative gate; real failures are fixed forward
+    # (autofix) or the culprit is attributed + dropped (train:escalated), so a
+    # genuinely-broken PR self-excludes after one try. This is what buys "less
+    # CI" — one batch run judges N PRs instead of gating on N green per-PR runs.
+    # The gate value is retained only as an informational signal and for the
+    # all-green direct-merge fast-path in train.sh.
     case "${gate}" in
       SUCCESS|FLAKE) : ;;
-      *) train_log "skip #${number}: CI Gate=${gate}"; continue ;;
+      *) train_log "include #${number} despite CI Gate=${gate}: batch CI + autofix is the judge" ;;
     esac
 
     jq -nc --argjson n "${number}" \


### PR DESCRIPTION
The agent only batched already-green PRs, so it paid N per-PR CIs PLUS the batch CI (more CI, not less) and never batched/fixed failing PRs. Now select batches any mergeable+non-draft+non-held PR regardless of its own CI; the ONE batch CI judges, autofix fixes failures forward, attribution drops genuinely-broken culprits. This is the optimistic batch-and-fix design: one CI run amortized over N PRs.