### PR TITLE
ci: drop per-PR CI; the merge train's batch CI is the only gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,15 @@ on:
     # Full integration lane. PR CI is selective; release workflows own
     # packaging/publishing smoke.
     - cron: '0 9 * * *'
-  pull_request:
-    branches: [trunk]
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  # NO per-PR `pull_request` trigger. In the optimistic merge-train model the
+  # ONE batch CI (dispatched by the train on a `train/batch/*` branch via
+  # workflow_dispatch) is the authoritative gate; running the full matrix on
+  # every individual PR too is pure double-work — N per-PR runs + the batch run
+  # — and the flood of per-PR CI completions storms the train's `workflow_run`
+  # trigger so badly that no train run survives to land. The heavy jobs below
+  # gate on `event_name != 'merge_group'`, so the train's workflow_dispatch (and
+  # the nightly schedule) still run them; only the per-PR fan-out is dropped.
+  # A genuinely-broken PR is caught when the train batches it (attribute+drop).
   # Merge queue (LEAN gate): GitHub batches approved PRs and runs CI once on
   # the combined commit before fast-forwarding trunk. The full ~45-job matrix
   # (AOT, docker, the 30+-shard Server Tests fanout, browser/MCP lanes) already


### PR DESCRIPTION
Per-PR CI was running the full matrix on every PR AND again on the train batch (double work), and the storm of per-PR CI completions cancelled train runs before they could land. Remove the pull_request trigger; the train's workflow_dispatch batch CI still runs the full/targeted matrix (heavy jobs gate on event_name != merge_group). One CI run per batch, no per-PR fan-out, no storm.