### PR TITLE
fix(tests): seed honua.rbac_roles so RBAC integration shards stop flaking (#1568)

### DIFF
--- a/tests/dotnet/Honua.Architecture.Tests/SeedRbacTableParityTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/SeedRbacTableParityTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Xunit;
+
+namespace Honua.Architecture.Tests;
+
+/// <summary>
+/// Drift guard for the integration-test seed (honua-server#1568).
+///
+/// The integration-test web host runs with <c>HONUA_SKIP_MIGRATIONS=true</c> and a
+/// <c>NullDatabaseMigrationRunner</c>, so production DbUp migrations never run against the
+/// test database. The durable RBAC stores (<c>PostgresRoleStore</c>,
+/// <c>PostgresRlsPolicyStore</c>) are still registered against the default <c>honua</c>
+/// schema, and they read explicitly-qualified <c>honua.rbac_*</c> tables regardless of the
+/// per-test <c>search_path</c>. Those tables therefore have to exist in the shared
+/// <c>honua</c> schema that the test seed (<c>tests/seed/server.yaml</c>) hand-mirrors from
+/// the production migrations.
+///
+/// When migration 041 added <c>honua.rbac_roles</c>/<c>rbac_role_permissions</c> the seed
+/// was not updated to match, so RBAC-touching integration tests intermittently/consistently
+/// failed with <c>relation "honua.rbac_roles" does not exist</c>, which then cascaded into
+/// unrelated assertion failures across whatever shard ran the RBAC path (the EndpointRegistry
+/// coverage test, OData paging assertions, etc.). This test fails fast and deterministically
+/// at build time if a durable authorization store references a <c>honua.*</c> table the seed
+/// has not mirrored, instead of surfacing later as a hard-to-attribute integration-shard flake.
+/// </summary>
+[Trait("Category", "Architecture")]
+public sealed class SeedRbacTableParityTests
+{
+    // Captures the table name from `SchemaSearchPath.QualifyTable("<table>", ...)` call sites
+    // in the Postgres authorization stores. These are the tables the stores read from the
+    // default `honua` schema in the migration-skipping test host.
+    private static readonly Regex QualifyTableCall = new(
+        "QualifyTable\\(\\s*\"(?<table>[A-Za-z_][A-Za-z0-9_]*)\"",
+        RegexOptions.CultureInvariant);
+
+    // Captures `CREATE TABLE [IF NOT EXISTS] honua.<table>` from the seed YAML.
+    private static readonly Regex SeedCreateTable = new(
+        "CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?honua\\.(?<table>[A-Za-z_][A-Za-z0-9_]*)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    [ArchitectureTest]
+    public void ServerSeed_ShouldMirror_EveryDurableAuthorizationStoreTable()
+    {
+        var projectRoot = FindProjectRoot(Directory.GetCurrentDirectory());
+
+        var requiredTables = EnumerateAuthorizationStoreTables(projectRoot);
+        requiredTables.Should().NotBeEmpty(
+            "the Postgres authorization stores must reference at least one honua.* table; " +
+            "an empty result means the source scan is broken, not that there is nothing to guard.");
+
+        var seedTables = EnumerateSeedTables(projectRoot);
+
+        var missing = requiredTables
+            .Where(table => !seedTables.Contains(table))
+            .OrderBy(table => table, StringComparer.Ordinal)
+            .ToArray();
+
+        missing.Should().BeEmpty(
+            "the migration-skipping integration-test host registers the durable authorization stores " +
+            "against the default 'honua' schema, so every honua.* table they query must be created by " +
+            "tests/seed/server.yaml. Mirror the corresponding migration DDL into the seed (honua-server#1568). " +
+            $"Missing: {string.Join(", ", missing)}.");
+    }
+
+    private static HashSet<string> EnumerateAuthorizationStoreTables(string projectRoot)
+    {
+        var authorizationDirectory = Path.Combine(
+            projectRoot, "src", "Honua.Postgres", "Features", "Authorization");
+
+        var tables = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var file in Directory.EnumerateFiles(authorizationDirectory, "*.cs", SearchOption.AllDirectories))
+        {
+            var source = File.ReadAllText(file);
+            foreach (Match match in QualifyTableCall.Matches(source))
+            {
+                tables.Add(match.Groups["table"].Value);
+            }
+        }
+
+        return tables;
+    }
+
+    private static HashSet<string> EnumerateSeedTables(string projectRoot)
+    {
+        var seedPath = Path.Combine(projectRoot, "tests", "seed", "server.yaml");
+        File.Exists(seedPath).Should().BeTrue($"the integration-test seed must exist at {seedPath}.");
+
+        var seed = File.ReadAllText(seedPath);
+        var tables = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (Match match in SeedCreateTable.Matches(seed))
+        {
+            tables.Add(match.Groups["table"].Value);
+        }
+
+        return tables;
+    }
+
+    private static string FindProjectRoot(string startDirectory)
+    {
+        var current = new DirectoryInfo(startDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Honua.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate Honua.sln from the current test directory.");
+    }
+}

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -117,6 +117,78 @@ sql:
               UNIQUE (role, service, layer, attribute, claim_type)
       );
   - "CREATE INDEX IF NOT EXISTS idx_rbac_rls_policies_scope ON honua.rbac_rls_policies (service, layer);"
+  # Persistent RBAC role/permission store (#1374). Mirrors migration
+  # 041_CreateRbacRoleStore.sql so the migration-skipping integration fixture has
+  # the honua.rbac_roles / rbac_role_permissions / rbac_role_memberships tables.
+  # Without these, PostgresRoleStore queries 500 with
+  # `relation "honua.rbac_roles" does not exist`, cascading into unrelated
+  # shard failures (honua-server#1568).
+  - |
+      CREATE TABLE IF NOT EXISTS honua.rbac_roles (
+          role_id       UUID         PRIMARY KEY,
+          name          VARCHAR(128) NOT NULL,
+          description   TEXT,
+          is_built_in   BOOLEAN      NOT NULL DEFAULT FALSE,
+          created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+          updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+      );
+  - "CREATE UNIQUE INDEX IF NOT EXISTS uq_rbac_roles_name_lower ON honua.rbac_roles (LOWER(name));"
+  - |
+      CREATE TABLE IF NOT EXISTS honua.rbac_role_permissions (
+          role_id       UUID         NOT NULL,
+          service       VARCHAR(256) NOT NULL,
+          layer         VARCHAR(256) NOT NULL,
+          operation     VARCHAR(64)  NOT NULL,
+          CONSTRAINT rbac_role_permissions_role_fk
+              FOREIGN KEY (role_id) REFERENCES honua.rbac_roles(role_id) ON DELETE CASCADE,
+          CONSTRAINT rbac_role_permissions_unique
+              UNIQUE (role_id, service, layer, operation)
+      );
+  - "CREATE INDEX IF NOT EXISTS idx_rbac_role_permissions_role ON honua.rbac_role_permissions (role_id);"
+  - |
+      CREATE TABLE IF NOT EXISTS honua.rbac_role_memberships (
+          role_id       UUID         NOT NULL,
+          user_id       VARCHAR(256) NOT NULL,
+          created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+          CONSTRAINT rbac_role_memberships_role_fk
+              FOREIGN KEY (role_id) REFERENCES honua.rbac_roles(role_id) ON DELETE CASCADE,
+          CONSTRAINT rbac_role_memberships_pk PRIMARY KEY (role_id, user_id)
+      );
+  - "CREATE INDEX IF NOT EXISTS idx_rbac_role_memberships_user ON honua.rbac_role_memberships (user_id);"
+  - |
+      CREATE OR REPLACE FUNCTION honua.rbac_set_updated_at()
+      RETURNS TRIGGER AS $$
+      BEGIN
+          NEW.updated_at = NOW();
+          RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+  - "DROP TRIGGER IF EXISTS trg_rbac_roles_updated_at ON honua.rbac_roles;"
+  - |
+      CREATE TRIGGER trg_rbac_roles_updated_at
+          BEFORE UPDATE ON honua.rbac_roles
+          FOR EACH ROW
+          EXECUTE FUNCTION honua.rbac_set_updated_at();
+  - |
+      INSERT INTO honua.rbac_roles (role_id, name, description, is_built_in)
+      VALUES
+          ('00000000-0000-0000-0000-000000000001', 'admin',  'Full administrative access', TRUE),
+          ('00000000-0000-0000-0000-000000000003', 'editor', 'Read and write access to all services and layers', TRUE),
+          ('00000000-0000-0000-0000-000000000002', 'viewer', 'Read-only access to all services and layers', TRUE)
+      ON CONFLICT (role_id) DO NOTHING;
+  - |
+      INSERT INTO honua.rbac_role_permissions (role_id, service, layer, operation)
+      VALUES
+          ('00000000-0000-0000-0000-000000000001', '*', '*', '*'),
+          ('00000000-0000-0000-0000-000000000003', '*', '*', 'query'),
+          ('00000000-0000-0000-0000-000000000003', '*', '*', 'insert'),
+          ('00000000-0000-0000-0000-000000000003', '*', '*', 'update'),
+          ('00000000-0000-0000-0000-000000000003', '*', '*', 'delete'),
+          ('00000000-0000-0000-0000-000000000003', '*', '*', 'export'),
+          ('00000000-0000-0000-0000-000000000003', '*', '*', 'metadata'),
+          ('00000000-0000-0000-0000-000000000002', '*', '*', 'query'),
+          ('00000000-0000-0000-0000-000000000002', '*', '*', 'metadata')
+      ON CONFLICT (role_id, service, layer, operation) DO NOTHING;
   - |
       CREATE TABLE IF NOT EXISTS honua.analysis_content_items (
           item_id            TEXT        PRIMARY KEY,


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1568

## Summary
Integration-test shards (e.g. "Server Tests (STAC and API Governance)", "Server Tests (OData Core)", and other RBAC-touching shards) were failing with `ERROR: relation "honua.rbac_roles" does not exist`, which cascaded into unrelated assertion failures (the EndpointRegistry API-surface-coverage architecture test reporting endpoints "uncovered" because the covering test crashed; OData `$top=0` assertions failing because the request 500'd). A single missing table made many tests in a shard fail and got mis-blamed on whatever PR was in the batch.

**Root cause:** The integration-test web host runs with `HONUA_SKIP_MIGRATIONS=true` and a `NullDatabaseMigrationRunner`, so production DbUp migrations never run against the test database. Instead `tests/seed/server.yaml` hand-mirrors the migration DDL into the shared `honua` schema. The durable `PostgresRoleStore` / `PostgresRlsPolicyStore` are still registered against the default `honua` schema and read explicitly-qualified `honua.rbac_*` tables (via `SchemaSearchPath.QualifyTable`), so those reads always hit the shared `honua` schema regardless of the per-test `search_path`. When migration `041_CreateRbacRoleStore.sql` added `honua.rbac_roles` / `rbac_role_permissions` / `rbac_role_memberships`, the seed was never updated to match. The seed only had the unrelated `honua.rbac_rls_policies` table, so any code path that read the RBAC role tables hit a missing relation. The error was intermittent per-shard only because it surfaced exactly when a test exercised an RBAC read on a code path that did not swallow `UndefinedTable` — which then 500'd and cascaded. This is independent of PR #2049 (the 40P01 deadlock serialization rework); that change reworks schema create/drop ordering and does not create the RBAC tables.

**Fix:** Mirror migration 041 into the test seed, and add an architecture guard that prevents this exact class of drift from recurring silently.

## Changes Made
- Add the RBAC role-store DDL to `tests/seed/server.yaml`, mirroring `041_CreateRbacRoleStore.sql`: `honua.rbac_roles`, `honua.rbac_role_permissions`, `honua.rbac_role_memberships` (+ indexes, the `rbac_set_updated_at` trigger, and the built-in admin/editor/viewer role + grant seed rows). Every statement is idempotent (`CREATE ... IF NOT EXISTS` / `ON CONFLICT`), matching the surrounding seed style.
- Add `tests/dotnet/Honua.Architecture.Tests/SeedRbacTableParityTests.cs`: a build-time guard that scans the Postgres authorization stores for their `SchemaSearchPath.QualifyTable("<table>", ...)` call sites and asserts every referenced `honua.*` table is created by `tests/seed/server.yaml`. Future migrations that add a durable-store table now fail this test deterministically at build time instead of as an attribution-scrambling integration-shard flake.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Verified against a host PostGIS (`postgis/postgis:18-3.6`) via `HONUA_TEST_DB_URL`, mirroring CI's high-parallelism Testcontainers setup (xUnit `maxParallelThreads: -1`):
- **Reproduction:** with the seed change removed, `RoleEndpointsTests` fails **8/9** on a fresh DB with the `relation "honua.rbac_roles" does not exist` 500 cascade.
- **Fix:** with the change, the STAC, OData, and RBAC integration classes pass repeatedly on a fresh database (DB schemas dropped between iterations), **zero** "relation does not exist" and **zero** cascaded coverage/assertion failures. Per fully-green iteration: `RoleEndpointsTests` 9/9, `StacSearchTests`+`StacCollectionsTests` 36/36, `ODataPaginationTests`+`ODataEndpointTests` 89/89.
- The new `SeedRbacTableParityTests` passes with the fix and fails without it.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

This is test-infrastructure only; no production code, migration, or runtime behavior changes. The production `honua.rbac_*` tables are already created by migration 041 at deploy time.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
