### PR TITLE
fix(security): RLS edit/cache bypass, replica watermark, version-post lost-update, densify/exportTiles DoS

### DIFF
--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresChangeTracker.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresChangeTracker.cs
@@ -24,7 +24,18 @@ internal sealed class PostgresChangeTracker : IChangeTracker
 
     public async Task<long> GetCurrentGenerationAsync(CancellationToken cancellationToken = default)
     {
-        const string sql = "SELECT last_value FROM honua.sync_generation";
+        // Committed high-watermark for replica sync. The honua.sync_generation sequence reports
+        // its last ALLOCATED value (last_value), which includes generations consumed by edit
+        // transactions that have called nextval but not yet committed. A replica that persisted
+        // last_value as its cursor and then selected strictly generation > cursor would skip any
+        // lower-generation change that committed after the cursor was read (commit order != gen
+        // order under concurrency), losing it from the replica forever (#2062). Reading the
+        // committed MAX(generation) from honua.feature_changes instead gives a watermark the
+        // puller can advance to without skipping an in-flight write; migration 067 takes a
+        // generation-allocation advisory lock in the change-tracking triggers so generation order
+        // equals commit order and this committed-MAX watermark is gap-free. Mirrors the proven
+        // honua.fieldcollection_changes pattern (PostgresFieldCollectionSyncStore).
+        const string sql = "SELECT COALESCE(MAX(generation), 0) FROM honua.feature_changes";
 
         await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var command = new NpgsqlCommand(sql, connection);

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresVersionManager.ReconcilePost.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresVersionManager.ReconcilePost.cs
@@ -229,13 +229,29 @@ internal sealed partial class PostgresVersionManager
         await SetVersionStateAsync(versionId, VersionState.Posting, cancellationToken).ConfigureAwait(false);
         try
         {
-            var (applied, serverGeneration) = await ReplayOverlayOntoDefaultAsync(versionId, cancellationToken).ConfigureAwait(false);
-            await AdvanceCommonAncestorAsync(versionId, serverGeneration, cancellationToken).ConfigureAwait(false);
-            activity?.SetTag("honua.version.applied_changes", applied);
-            activity?.SetTag("honua.version.server_generation", serverGeneration);
+            var replay = await ReplayOverlayOntoDefaultAsync(versionId, cancellationToken).ConfigureAwait(false);
+
+            // A clean CountPendingConflictsAsync only reflects the conflict set computed by the LAST
+            // reconcile. The version lock serializes reconcile/post for THIS version but does not block
+            // DEFAULT writers, so a DEFAULT edit committed between that reconcile and this post would be
+            // silently overwritten by the whole-row overlay replay (lost update). ReplayOverlayOntoDefault
+            // re-validates each overlay row's captured base_* image against the LIVE DEFAULT row inside the
+            // post transaction; if any update/delete target diverged, it rolls back and reports the
+            // divergent keys here so the caller must reconcile again instead of clobbering (#2063).
+            if (replay.Conflicted)
+            {
+                activity?.SetTag("honua.version.conflict_count", replay.ConflictingKeys.Count);
+                activity?.SetTag("honua.version.outcome", "blocked_by_default_drift");
+                activity?.SetStatus(ActivityStatusCode.Ok);
+                return new VersionPostResult(Posted: false, AppliedChanges: 0, ServerGeneration: 0, BlockedByConflicts: true);
+            }
+
+            await AdvanceCommonAncestorAsync(versionId, replay.ServerGeneration, cancellationToken).ConfigureAwait(false);
+            activity?.SetTag("honua.version.applied_changes", replay.Applied);
+            activity?.SetTag("honua.version.server_generation", replay.ServerGeneration);
             activity?.SetTag("honua.version.outcome", "posted");
             activity?.SetStatus(ActivityStatusCode.Ok);
-            return new VersionPostResult(Posted: true, AppliedChanges: applied, ServerGeneration: serverGeneration, BlockedByConflicts: false);
+            return new VersionPostResult(Posted: true, AppliedChanges: replay.Applied, ServerGeneration: replay.ServerGeneration, BlockedByConflicts: false);
         }
         finally
         {
@@ -251,7 +267,7 @@ internal sealed partial class PostgresVersionManager
     /// DEFAULT change-tracking trigger fires per row (no version GUC set), advancing the generation and
     /// recording NULL-version DEFAULT changes. Returns the applied row count and the post generation.
     /// </summary>
-    private async Task<(int Applied, long ServerGeneration)> ReplayOverlayOntoDefaultAsync(
+    private async Task<OverlayReplayResult> ReplayOverlayOntoDefaultAsync(
         Guid versionId,
         CancellationToken cancellationToken)
     {
@@ -264,12 +280,63 @@ internal sealed partial class PostgresVersionManager
         var transaction = (NpgsqlTransaction)dbTransaction;
         await using var __ = transaction;
 
+        // Optimistic-concurrency guard (#2063): an update/delete overlay row may only be replayed when the
+        // LIVE DEFAULT row still matches the base image the branch captured on first touch. If DEFAULT was
+        // edited since (committed by a concurrent DEFAULT writer the version lock cannot block), the
+        // whole-row replay would silently discard that committed edit. Detect every diverged
+        // (layer_id, objectid) target BEFORE writing, inside this transaction, and abort the post when any
+        // exists so the operator must reconcile again. IS NOT DISTINCT FROM makes the comparison NULL-safe
+        // (a NULL base must match a NULL live value); geometry is compared by binary identity so any
+        // re-write of the DEFAULT geometry counts as drift, matching the strict lost-update semantics.
+        // Inserts (operation = 1) carry no base image and create a new objectid, so they are not guarded
+        // here. FOR UPDATE on the matched DEFAULT rows pins them for the duration of the transaction so a
+        // DEFAULT writer cannot slip a committed edit between this check and the replay.
+        var conflictingKeys = new List<(int LayerId, long ObjectId)>();
+        await using (var driftCommand = new NpgsqlCommand(
+            $"""
+            SELECT ve.layer_id, ve.objectid
+            FROM honua.version_edits ve
+            LEFT JOIN {featuresTable} f
+              ON f.layer_id = ve.layer_id AND f.objectid = ve.objectid
+            WHERE ve.version_id = @version
+              AND ve.operation IN (2, 3)
+              -- A branch delete whose DEFAULT row is already gone is a convergent no-op (DEFAULT
+              -- reached the desired end state), not drift — exclude it so it does not spuriously
+              -- block the post. Every other update/delete target must still match its captured base.
+              AND NOT (ve.operation = 3 AND f.objectid IS NULL)
+              AND NOT (
+                    f.geometry IS NOT DISTINCT FROM ve.base_geometry
+                AND f.attributes IS NOT DISTINCT FROM ve.base_attributes
+              )
+            FOR UPDATE OF f
+            """,
+            connection)
+        { Transaction = transaction })
+        {
+            driftCommand.Parameters.AddWithValue("version", versionId);
+            await using var reader = await driftCommand.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                conflictingKeys.Add((reader.GetInt32(0), reader.GetInt64(1)));
+            }
+        }
+
+        if (conflictingKeys.Count > 0)
+        {
+            // DEFAULT drifted under at least one update/delete target. Roll back so nothing is overwritten;
+            // the caller surfaces a conflict and the operator must re-reconcile against the new DEFAULT.
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return new OverlayReplayResult(Applied: 0, ServerGeneration: 0, Conflicted: true, ConflictingKeys: conflictingKeys);
+        }
+
         var applied = 0;
 
-        // Deletes: remove DEFAULT rows the branch deleted.
+        // Deletes: remove DEFAULT rows the branch deleted, only while DEFAULT still matches the captured
+        // base image (defense-in-depth alongside the drift pre-check above).
         await using (var deleteCommand = new NpgsqlCommand(
             $"DELETE FROM {featuresTable} f USING honua.version_edits ve " +
-            "WHERE ve.version_id = @version AND ve.operation = 3 AND f.layer_id = ve.layer_id AND f.objectid = ve.objectid",
+            "WHERE ve.version_id = @version AND ve.operation = 3 AND f.layer_id = ve.layer_id AND f.objectid = ve.objectid " +
+            "AND f.geometry IS NOT DISTINCT FROM ve.base_geometry AND f.attributes IS NOT DISTINCT FROM ve.base_attributes",
             connection)
         { Transaction = transaction })
         {
@@ -277,11 +344,13 @@ internal sealed partial class PostgresVersionManager
             applied += await deleteCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        // Updates: overwrite DEFAULT geometry/attributes for branch-updated rows.
+        // Updates: overwrite DEFAULT geometry/attributes for branch-updated rows, only while DEFAULT still
+        // matches the captured base image.
         await using (var updateCommand = new NpgsqlCommand(
             $"UPDATE {featuresTable} f SET geometry = ve.geometry, attributes = ve.attributes " +
             "FROM honua.version_edits ve " +
-            "WHERE ve.version_id = @version AND ve.operation = 2 AND f.layer_id = ve.layer_id AND f.objectid = ve.objectid",
+            "WHERE ve.version_id = @version AND ve.operation = 2 AND f.layer_id = ve.layer_id AND f.objectid = ve.objectid " +
+            "AND f.geometry IS NOT DISTINCT FROM ve.base_geometry AND f.attributes IS NOT DISTINCT FROM ve.base_attributes",
             connection)
         { Transaction = transaction })
         {
@@ -311,15 +380,26 @@ internal sealed partial class PostgresVersionManager
         }
 
         long serverGeneration;
-        await using (var genCommand = new NpgsqlCommand("SELECT last_value FROM honua.sync_generation", connection) { Transaction = transaction })
+        await using (var genCommand = new NpgsqlCommand("SELECT COALESCE(MAX(generation), 0) FROM honua.feature_changes", connection) { Transaction = transaction })
         {
             var result = await genCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
             serverGeneration = result is long gen ? gen : 0;
         }
 
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-        return (applied, serverGeneration);
+        return new OverlayReplayResult(applied, serverGeneration, Conflicted: false, ConflictingKeys: conflictingKeys);
     }
+
+    /// <summary>
+    /// Outcome of replaying a version's overlay onto DEFAULT. <see cref="Conflicted"/> is set (and nothing
+    /// is written) when a concurrent DEFAULT edit diverged from the overlay's captured base image for an
+    /// update/delete target, listing the divergent keys (#2063).
+    /// </summary>
+    private sealed record OverlayReplayResult(
+        int Applied,
+        long ServerGeneration,
+        bool Conflicted,
+        IReadOnlyList<(int LayerId, long ObjectId)> ConflictingKeys);
 
     private async Task<GdbVersion?> LoadVersionAsync(Guid versionId, CancellationToken cancellationToken)
     {

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
@@ -379,7 +379,13 @@ internal sealed class FeatureServerEditsHandler(
             try
             {
                 Feature? existingFeature = existingFeatures.TryGetValue(objectId, out var resolvedFeature) ? resolvedFeature : null;
-                if (!ShouldUseInternalObjectIdFastPath(resource) && existingFeature is null)
+                // The pre-read (ResolveFeaturesByGeoServicesObjectIdsAsync) is RLS-enforced on
+                // both the fast path and the custom-objectid path, so a null result means the
+                // row does not exist OR is hidden from this caller by row-level security. The
+                // edit SQL filters only on (layer_id, objectid) with no RLS predicate, so the
+                // not-found rejection MUST be unconditional — skipping it on the default-OBJECTID
+                // fast path would let a caller mutate an RLS-hidden row (#2066).
+                if (existingFeature is null)
                 {
                     context.HasValidationErrors = true;
                     context.UpdateResults![i] = CreateFailureResult(
@@ -471,7 +477,12 @@ internal sealed class FeatureServerEditsHandler(
             }
 
             Feature? existingFeature = existingFeatures.TryGetValue(objectId, out var resolvedFeature) ? resolvedFeature : null;
-            if (!ShouldUseInternalObjectIdFastPath(resource) && existingFeature is null)
+            // The pre-read is RLS-enforced on both the fast path and the custom-objectid path,
+            // so a null result means the row is missing OR hidden from this caller by RLS. The
+            // DELETE SQL filters only on (layer_id, objectid) with no RLS predicate, so the
+            // not-found rejection MUST be unconditional — skipping it on the default-OBJECTID
+            // fast path would let a caller delete an RLS-hidden row (#2066).
+            if (existingFeature is null)
             {
                 context.HasValidationErrors = true;
                 context.DeleteResults![i] = CreateFailureResult(
@@ -481,33 +492,11 @@ internal sealed class FeatureServerEditsHandler(
                 continue;
             }
 
-            var internalObjectId = existingFeature?.Id ?? objectId;
+            var internalObjectId = existingFeature.Value.Id;
             context.DeleteIds.Add(internalObjectId);
             context.DeleteResponseObjectIds.Add(objectId);
             context.DeleteIndexes.Add(i);
-            context.DeleteFeatures.Add(existingFeature ?? await ReadDeleteFeatureSnapshotAsync(storageLayerId, internalObjectId, cancellationToken));
-        }
-    }
-
-    private async Task<Feature?> ReadDeleteFeatureSnapshotAsync(
-        int layerId,
-        long objectId,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            return await _featureReader.GetAsync(layerId, objectId, cancellationToken);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            // The snapshot only enriches delete events/plugin hooks; a read failure
-            // must not fail the delete itself, but it should leave an operator signal.
-            FeatureServerLog.DeleteSnapshotReadFailed(_logger, layerId, objectId, ex);
-            return null;
+            context.DeleteFeatures.Add(existingFeature);
         }
     }
 

--- a/src/Honua.Protocols.GeoServices/GeometryService/Services/GeometryServiceHandler.cs
+++ b/src/Honua.Protocols.GeoServices/GeometryService/Services/GeometryServiceHandler.cs
@@ -32,6 +32,14 @@ internal sealed class GeometryServiceHandler(
     private const int MaxGeometryJsonLengthUpperBound = 10_000_000;
     private const int MaxRelationPairsPerRequest = 100_000;
     private const double MeanEarthRadiusMeters = 6_371_000d;
+
+    // Densify generates ceil(segmentLength / maxSegmentLength) interpolated vertices per
+    // segment into an in-memory CoordinateList. A tiny maxSegmentLength over a large extent
+    // (e.g. a 2,000,000-unit polyline at maxSegmentLength=0.001 → 2e9 coordinates) would OOM
+    // the host before any response is written (#2064). Cap the total interpolated output so
+    // the unauthenticated /densify endpoint cannot be turned into an OOM DoS. ~16M vertices
+    // is far beyond any legitimate densify request yet bounded to a few hundred MB worst case.
+    private const double MaxDensifiedVerticesPerGeometry = 16_000_000d;
     private const string InvalidGeometryInputMessage = "Invalid geometry input.";
     private const string InvalidSpatialReferenceMessage =
         "must be a valid spatial reference WKID, EPSG code, CRS URI, WKT string, or spatial reference object.";
@@ -2558,6 +2566,18 @@ internal sealed class GeometryServiceHandler(
         foreach (var geomJson in parameters.GeometryJsonStrings)
         {
             var geometry = ReadGeometry(geomJson);
+            // Bound the interpolated output BEFORE densifying. NTS adds roughly
+            // (totalLength / maxSegmentLength) coordinates; reject when that would exceed the
+            // per-geometry vertex cap so a tiny maxSegmentLength over a large extent cannot OOM
+            // the host (#2064). maxSegmentLength is already validated > 0 / finite upstream.
+            var estimatedVertices = geometry.Length / parameters.MaxSegmentLength;
+            if (double.IsNaN(estimatedVertices)
+                || estimatedVertices > MaxDensifiedVerticesPerGeometry)
+            {
+                throw new ArgumentException(
+                    "densify would generate too many vertices; maxSegmentLength is too small for the geometry extent.");
+            }
+
             var result = NetTopologySuite.Densify.Densifier.Densify(geometry, parameters.MaxSegmentLength);
             densified.Add(writer.Write(result));
         }

--- a/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.ExportTiles.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.ExportTiles.cs
@@ -42,6 +42,7 @@ internal static partial class MapServerEndpoints
         ExportRenderLayer[] Layers,
         RenderLayerDescriptor[] RenderLayers,
         ExportTileCoordinate[] Tiles,
+        long TotalTileCount,
         double[] Bounds,
         int MinZoom,
         int MaxZoom,
@@ -57,10 +58,13 @@ internal static partial class MapServerEndpoints
             return error;
         }
 
-        var estimatedSizeBytes = checked(plan!.Tiles.LongLength * ExportTilesTileSizeBytesEstimate);
+        // Report the TRUE tile count (not the maxTiles-bounded build size) so the estimate stays
+        // meaningful even when the request exceeds the transfer limit; the bounded build only ever
+        // exists to keep the allocation from OOM-ing the host (#2065).
+        var estimatedSizeBytes = checked(plan!.TotalTileCount * ExportTilesTileSizeBytesEstimate);
         var response = new ExportTilesEstimateResponse
         {
-            TileCount = plan.Tiles.LongLength,
+            TileCount = plan.TotalTileCount,
             Size = estimatedSizeBytes,
             SizeUnit = "bytes",
             EstimatedSizeBytes = estimatedSizeBytes,
@@ -444,6 +448,7 @@ internal static partial class MapServerEndpoints
             renderLayers,
             descriptors,
             selectedTiles,
+            totalTileCount,
             bounds,
             minZoom,
             maxZoom,

--- a/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.ExportTiles.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.ExportTiles.cs
@@ -365,14 +365,10 @@ internal static partial class MapServerEndpoints
         }
 
         var bounds = NormalizeExportTilesBounds(extentTransform.Extent);
-        var allTiles = BuildExportTileCoordinates(bounds, requestedZooms);
-        var exceededTransferLimit = allTiles.Length > maxTiles;
-        var selectedTiles = allTiles.Take(maxTiles).ToArray();
-        if (selectedTiles.Length == 0)
-        {
-            return (null, StandardErrorHelpers.CreateBadRequest(context, "exportTiles selected no tiles."));
-        }
 
+        // Run service validation and the access-policy gate BEFORE materializing the tile
+        // grid so an unauthenticated request against a non-existent or unauthorized service
+        // is rejected without allocating anything (#2065).
         var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
         var serviceResult = await ServiceResourceValidationHelpers.ValidateServiceV2Async(
             resourceValidator,
@@ -397,6 +393,28 @@ internal static partial class MapServerEndpoints
         if (accessError != null)
         {
             return (null, accessError);
+        }
+
+        // Compute the total tile count Σ(xMax-xMin+1)*(yMax-yMin+1) per zoom level FIRST and
+        // reject when it exceeds maxTiles, BEFORE building the full grid. The previous code
+        // materialized every coordinate then .Take(maxTiles)'d, so a whole-world request at a
+        // high zoom (e.g. z18 → ~6.9e10 entries) allocated hundreds of GB before any cap was
+        // applied — an unauthenticated OOM DoS (#2065).
+        var totalTileCount = CountExportTileCoordinates(bounds, requestedZooms);
+        var exceededTransferLimit = totalTileCount > maxTiles;
+        if (totalTileCount <= 0)
+        {
+            return (null, StandardErrorHelpers.CreateBadRequest(context, "exportTiles selected no tiles."));
+        }
+
+        // Bound the build to maxTiles tiles. When the request exceeds the transfer limit the
+        // estimate path still reports exceededTransferLimit; the export path returns only the
+        // first maxTiles tiles (never the unbounded full grid).
+        var buildLimit = (int)Math.Min(totalTileCount, maxTiles);
+        var selectedTiles = BuildExportTileCoordinates(bounds, requestedZooms, buildLimit);
+        if (selectedTiles.Length == 0)
+        {
+            return (null, StandardErrorHelpers.CreateBadRequest(context, "exportTiles selected no tiles."));
         }
 
         var renderSelection = ResolveRenderLayers(
@@ -783,13 +801,49 @@ internal static partial class MapServerEndpoints
         return [minLon, minLat, maxLon, maxLat];
     }
 
-    private static ExportTileCoordinate[] BuildExportTileCoordinates(double[] bounds, IReadOnlyList<int> levels)
+    /// <summary>
+    /// Counts the total number of tiles the request would produce as
+    /// <c>Σ (xMax-xMin+1)*(yMax-yMin+1)</c> across the requested zoom levels, using
+    /// <see cref="long"/> arithmetic so a whole-world high-zoom request cannot overflow.
+    /// This is computed before the grid is materialized so the caller can reject an
+    /// over-limit request without allocating the full coordinate list (#2065).
+    /// </summary>
+    private static long CountExportTileCoordinates(double[] bounds, IReadOnlyList<int> levels)
     {
         var minLon = bounds[0];
         var minLat = bounds[1];
         var maxLon = bounds[2];
         var maxLat = bounds[3];
-        var coordinates = new List<ExportTileCoordinate>();
+        long total = 0;
+
+        foreach (var z in levels)
+        {
+            var n = 1 << z;
+            var xMin = LonToExportTileX(minLon, z, n);
+            var xMax = LonToExportTileX(maxLon, z, n);
+            var yMin = LatToExportTileY(maxLat, z, n);
+            var yMax = LatToExportTileY(minLat, z, n);
+
+            var width = (long)(xMax - xMin + 1);
+            var height = (long)(yMax - yMin + 1);
+            total += width * height;
+        }
+
+        return total;
+    }
+
+    private static ExportTileCoordinate[] BuildExportTileCoordinates(
+        double[] bounds,
+        IReadOnlyList<int> levels,
+        int maxTiles)
+    {
+        var minLon = bounds[0];
+        var minLat = bounds[1];
+        var maxLon = bounds[2];
+        var maxLat = bounds[3];
+        // Pre-size to the bounded cap, never the (potentially enormous) full grid, so the
+        // build itself can never allocate more than maxTiles coordinates (#2065).
+        var coordinates = new List<ExportTileCoordinate>(Math.Max(0, maxTiles));
 
         foreach (var z in levels)
         {
@@ -803,6 +857,11 @@ internal static partial class MapServerEndpoints
             {
                 for (var y = yMin; y <= yMax; y++)
                 {
+                    if (coordinates.Count >= maxTiles)
+                    {
+                        return [.. coordinates];
+                    }
+
                     coordinates.Add(new ExportTileCoordinate(z, x, y));
                 }
             }

--- a/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Tile.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Tile.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using Honua.Core.Configuration;
+using Honua.Core.Features.Authorization.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
@@ -101,9 +102,11 @@ internal static partial class MapServerEndpoints
             activity?.SetTag(HonuaTelemetry.Tags.TileY, y);
             activity?.SetTag(HonuaTelemetry.Tags.TileX, x);
 
-            var renderLayers = publishedLayers
+            var renderResources = publishedLayers
                 .Where(layer => IsTileLayerVisibleByDefault(layer.Resource))
                 .Where(layer => AccessPolicyHelpers.IsResourceAccessible(context, layer.Resource, service))
+                .ToArray();
+            var renderLayers = renderResources
                 .Select(BuildTileRenderDescriptor)
                 .ToArray();
             var maxFeatures = service.Settings?.MaxFeaturesPerLayer ?? MaxFeaturesPerLayer;
@@ -111,6 +114,15 @@ internal static partial class MapServerEndpoints
             var storage = context.RequestServices.GetService<ICloudFileStorage>();
             var storageOptions = context.RequestServices.GetService<IOptions<CloudStorageOptions>>()?.Value;
             var tileCacheKeyIndex = context.RequestServices.GetService<ITileCacheKeyIndex>();
+            // The rendered PNG contains RLS-filtered feature geometry for the *current*
+            // principal, so the cloud tile cache key MUST be partitioned by the effective
+            // RLS predicate. Without it, principal A's tile would be served to principal B
+            // for the same z/x/y, leaking rows RLS hides from B (#2067).
+            var rlsFilterSource = context.RequestServices.GetService<IRowLevelSecurityFilterSource>();
+            var rlsFingerprint = await BuildTileRlsFingerprintAsync(
+                rlsFilterSource,
+                renderResources,
+                cancellationToken).ConfigureAwait(false);
             var tileCacheKey = BuildMapServerTileCacheKey(
                 storageOptions,
                 snapshot,
@@ -119,6 +131,7 @@ internal static partial class MapServerEndpoints
                 renderLayers,
                 serviceSrid,
                 maxFeatures,
+                rlsFingerprint,
                 z,
                 y,
                 x);
@@ -246,6 +259,45 @@ internal static partial class MapServerEndpoints
     private static bool IsTileLayerVisibleByDefault(MetadataV2Resource resource)
         => resource.Display?.DefaultVisibility ?? true;
 
+    /// <summary>
+    /// Builds a stable fingerprint of the effective row-level-security predicate for the
+    /// current principal across the tile's render layers. The fingerprint partitions the
+    /// cloud tile cache so a tile rendered from one principal's RLS-visible rows is never
+    /// served to a principal with different RLS visibility (#2067). The fingerprint folds
+    /// in both the parameterized predicate SQL and its bound claim values, since two
+    /// principals can share a policy shape but bind different claim values (different rows).
+    /// A layer with no applicable policy contributes an empty marker so the unconstrained
+    /// case stays distinct from any constrained one.
+    /// </summary>
+    private static async Task<string> BuildTileRlsFingerprintAsync(
+        IRowLevelSecurityFilterSource? rlsFilterSource,
+        IReadOnlyList<TileLayerDescriptor> renderResources,
+        CancellationToken cancellationToken)
+    {
+        if (rlsFilterSource is null || renderResources.Count == 0)
+        {
+            return "none";
+        }
+
+        var parts = new List<string>(renderResources.Count);
+        foreach (var layer in renderResources.OrderBy(static l => l.StorageLayerId))
+        {
+            var fragment = await rlsFilterSource.ResolveAsync(layer.Resource, cancellationToken).ConfigureAwait(false);
+            if (fragment is null)
+            {
+                parts.Add($"{layer.StorageLayerId}:");
+                continue;
+            }
+
+            var values = string.Join(
+                ',',
+                fragment.Parameters.Select(static p => p?.ToString() ?? " "));
+            parts.Add($"{layer.StorageLayerId}:{fragment.Sql}={values}");
+        }
+
+        return GeoServicesCloudTileCache.Hash(string.Join('|', parts));
+    }
+
     private static string BuildMapServerTileCacheKey(
         CloudStorageOptions? storageOptions,
         MetadataV2GraphSnapshot snapshot,
@@ -254,6 +306,7 @@ internal static partial class MapServerEndpoints
         IReadOnlyList<RenderLayerDescriptor> renderLayers,
         int serviceSrid,
         int maxFeatures,
+        string rlsFingerprint,
         int z,
         int y,
         int x)
@@ -273,7 +326,8 @@ internal static partial class MapServerEndpoints
             service.Metadata.Id,
             serviceSrid.ToString(CultureInfo.InvariantCulture),
             maxFeatures.ToString(CultureInfo.InvariantCulture),
-            renderLayerKey));
+            renderLayerKey,
+            rlsFingerprint));
 
         return GeoServicesCloudTileCache.BuildObjectKey(
             storageOptions,

--- a/src/Honua.Server/Migrations/067_SerializeChangeLogGenerationAllocation.sql
+++ b/src/Honua.Server/Migrations/067_SerializeChangeLogGenerationAllocation.sql
@@ -1,0 +1,145 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration: 067_SerializeChangeLogGenerationAllocation.sql
+-- Description: Closes a silent replica-sync data-loss window (#2062). The DEFAULT and version
+--              change-tracking triggers assign each change a generation via
+--              nextval('honua.sync_generation'). A Postgres sequence is non-transactional:
+--              nextval advances last_value immediately and globally and is never rolled back,
+--              while the corresponding honua.feature_changes row only becomes visible when ITS
+--              transaction commits. Under concurrent editing, transactions commit out of
+--              generation order, so a change with a LOWER generation can commit AFTER a higher
+--              one. The replica cursor previously read the sequence last_value as its watermark
+--              and the next delta selected strictly generation > cursor, so any lower-generation
+--              change that committed after the watermark was read was skipped on the replica
+--              forever (and was invisible to upload/apply conflict detection, silently clobbering
+--              committed server edits).
+--
+--              This migration mirrors the proven honua.fieldcollection_changes pattern
+--              (PostgresFieldCollectionSyncStore): take a transaction-scoped generation-allocation
+--              advisory lock IMMEDIATELY before nextval and hold it through commit, so for every
+--              honua.feature_changes writer generation order equals commit order. Combined with the
+--              cursor read switching from the sequence last_value to
+--              COALESCE(MAX(generation),0) FROM honua.feature_changes (PostgresChangeTracker),
+--              the committed-MAX watermark can never skip an in-flight lower generation.
+--
+--              The lock is keyed by a single feature-changes namespace so the DEFAULT trigger and
+--              the version-overlay trigger serialize against each other (both write the same table
+--              and share the sequence). It is acquired inside the trigger, so it is held only for
+--              the brief window between generation allocation and commit and never crosses a
+--              user-visible lock boundary. Every other line of both functions is byte-identical to
+--              050_AddChangeLogAttribution.sql, so attribution/version behavior is unchanged.
+-- Dependencies: Requires honua.feature_changes, honua.sync_generation, honua.track_feature_changes,
+--               and honua.track_version_edits (012, 048, 049, 050).
+
+-- Generation-allocation advisory lock namespace for honua.feature_changes writers.
+-- Distinct from the FieldCollection generation lock (0x0894FC60) so the two change-log
+-- families never alias inside the advisory-lock space. The literal mirrors ticket #2062.
+
+CREATE OR REPLACE FUNCTION honua.track_feature_changes()
+RETURNS TRIGGER AS $$
+DECLARE
+    gen BIGINT;
+    lid INT;
+    oid BIGINT;
+    op SMALLINT;
+    ver TEXT;
+    ver_uuid UUID;
+    attr_actor TEXT;
+    attr_source SMALLINT;
+    attr_operation TEXT;
+    attr_source_id TEXT;
+    raw_source TEXT;
+BEGIN
+    -- Hold the generation-allocation lock from nextval through commit so generation order
+    -- equals commit order for honua.feature_changes writers (#2062). Released on commit/rollback.
+    PERFORM pg_advisory_xact_lock(144047712, 0); -- 0x0894FE60
+    gen := nextval('honua.sync_generation');
+
+    IF TG_OP = 'INSERT' THEN
+        lid := NEW.layer_id;
+        oid := NEW.objectid;
+        op := 1;
+    ELSIF TG_OP = 'UPDATE' THEN
+        lid := NEW.layer_id;
+        oid := NEW.objectid;
+        op := 2;
+    ELSIF TG_OP = 'DELETE' THEN
+        lid := OLD.layer_id;
+        oid := OLD.objectid;
+        op := 3;
+    END IF;
+
+    ver := current_setting('honua.gdb_version', true);
+    IF ver IS NULL OR ver = '' THEN
+        ver_uuid := NULL;
+    ELSE
+        ver_uuid := ver::UUID;
+    END IF;
+
+    attr_actor := NULLIF(current_setting('honua.temporal_actor', true), '');
+    raw_source := NULLIF(current_setting('honua.temporal_source', true), '');
+    IF raw_source IS NULL THEN
+        attr_source := NULL;
+    ELSE
+        attr_source := raw_source::SMALLINT;
+    END IF;
+    attr_operation := NULLIF(current_setting('honua.temporal_operation', true), '');
+    attr_source_id := NULLIF(current_setting('honua.temporal_source_id', true), '');
+
+    INSERT INTO honua.feature_changes
+        (generation, layer_id, objectid, operation, version_id, actor, source, operation_name, source_id)
+    VALUES
+        (gen, lid, oid, op, ver_uuid, attr_actor, attr_source, attr_operation, attr_source_id);
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION honua.track_version_edits()
+RETURNS TRIGGER AS $$
+DECLARE
+    gen BIGINT;
+    attr_actor TEXT;
+    attr_source SMALLINT;
+    attr_operation TEXT;
+    attr_source_id TEXT;
+    raw_source TEXT;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+
+    -- Same generation-allocation lock as the DEFAULT trigger so DEFAULT and version-overlay
+    -- writers share one serialization point and the committed-MAX watermark is gap-free (#2062).
+    PERFORM pg_advisory_xact_lock(144047712, 0); -- 0x0894FE60
+    gen := nextval('honua.sync_generation');
+
+    attr_actor := NULLIF(current_setting('honua.temporal_actor', true), '');
+    raw_source := NULLIF(current_setting('honua.temporal_source', true), '');
+    IF raw_source IS NULL THEN
+        attr_source := NULL;
+    ELSE
+        attr_source := raw_source::SMALLINT;
+    END IF;
+    attr_operation := NULLIF(current_setting('honua.temporal_operation', true), '');
+    attr_source_id := NULLIF(current_setting('honua.temporal_source_id', true), '');
+
+    INSERT INTO honua.feature_changes
+        (generation, layer_id, objectid, operation, version_id, actor, source, operation_name, source_id)
+    VALUES
+        (gen, NEW.layer_id, NEW.objectid, NEW.operation, NEW.version_id,
+         attr_actor, attr_source, attr_operation, attr_source_id);
+
+    NEW.branch_gen := gen;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION honua.track_feature_changes() IS
+    'Records DEFAULT feature changes with version + attribution; serializes generation allocation so generation order = commit order (#1166 slice 4, #1272, #2062)';
+COMMENT ON FUNCTION honua.track_version_edits() IS
+    'Records branch overlay mutations with version + attribution; serializes generation allocation so generation order = commit order (#1166 slice 4, #1272, ADR-0051, #2062)';

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceMeasureAnalysisTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceMeasureAnalysisTests.cs
@@ -250,6 +250,68 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
         response.Be400BadRequest();
     }
 
+    [IntegrationTest]
+    [Operation(Operations.Densify)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/densify")]
+    public async Task Densify_TinyMaxSegmentLengthOverLargeExtent_Returns400WithoutOom()
+    {
+        // #2064: a 2,000,000-unit polyline at maxSegmentLength=0.001 would densify to ~2e9
+        // interpolated coordinates synchronously and OOM the host. The vertex-count guard must
+        // reject it with a 400 (fast, allocation-free) instead of attempting the densify.
+        var body = """
+        {
+            "geometries": {
+                "geometryType": "esriGeometryPolyline",
+                "geometries": [
+                    {"paths": [[[0,0],[2000000,0]]]}
+                ]
+            },
+            "sr": "3857",
+            "maxSegmentLength": 0.001
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/densify",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.Be400BadRequest();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Densify)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/densify")]
+    public async Task Densify_ReasonableMaxSegmentLengthOverLargeExtent_StillSucceeds()
+    {
+        // The cap must not reject legitimate densify requests: a 2,000,000-unit segment at
+        // maxSegmentLength=1000 yields ~2000 vertices, far under the per-geometry cap.
+        var body = """
+        {
+            "geometries": {
+                "geometryType": "esriGeometryPolyline",
+                "geometries": [
+                    {"paths": [[[0,0],[2000000,0]]]}
+                ]
+            },
+            "sr": "3857",
+            "maxSegmentLength": 1000.0
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/densify",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceResponse);
+        result.Should().NotBeNull();
+        result!.Geometries.Should().HaveCount(1);
+        var paths = result.Geometries![0];
+        paths.TryGetProperty("paths", out var pathsElement).Should().BeTrue();
+        pathsElement[0].GetArrayLength().Should().BeGreaterThan(2);
+    }
+
     // --- convexHull ---
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
@@ -381,6 +381,28 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.Export)]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/estimateExportTilesSize")]
+    public async Task MapServer_EstimateExportTilesSize_WholeWorldHighZoom_DoesNotMaterializeFullGrid()
+    {
+        // #2065: a whole-world high-zoom estimate (~6.9e10 tiles at z18) previously built the full
+        // coordinate grid before applying maxTiles, allocating hundreds of GB -> OOM. The count must
+        // be computed first and the build bounded by maxTiles, so this returns promptly with the true
+        // count, ExceededTransferLimit=true, and no out-of-memory.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/estimateExportTilesSize?f=json&minZoom=0&maxZoom=18&exportExtent=-180,-85,180,85&maxTiles=1");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        var estimate = JsonSerializer.Deserialize(content, MapServerJsonContext.Default.ExportTilesEstimateResponse);
+
+        estimate.Should().NotBeNull();
+        // The reported count is the true (very large) total, but the build was bounded to maxTiles.
+        estimate!.TileCount.Should().BeGreaterThan(1_000_000_000L);
+        estimate.ExceededTransferLimit.Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Export)]
     [Endpoint("GET /rest/services/{serviceId}/MapServer/exportTiles")]
     [Endpoint("POST /rest/services/{serviceId}/MapServer/exportTiles")]
     public async Task MapServer_ExportTiles_WritesZipArchiveToCloudStorage()

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/RowLevelSecurityEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/RowLevelSecurityEndpointsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -127,6 +128,69 @@ public sealed class RowLevelSecurityEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /api/v1/admin/rls-policies")]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/deleteFeatures")]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/updateFeatures")]
+    public async Task RlsPolicy_BlocksEditAndDeleteOfHiddenRow_OnDefaultObjectIdLayer()
+    {
+        // #2066: on a default-OBJECTID layer, the edit not-found guard was skipped on the fast
+        // path, so a caller could delete/update a row RLS hides from them by its OBJECTID. The
+        // guard must now reject the hidden objectId ("Feature not found") and leave the row intact.
+        var adminClient = CreateAdminClient();
+        Guid? policyId = null;
+
+        try
+        {
+            // Capture a 'test'-category row's OBJECTID BEFORE the policy exists (unrestricted query).
+            var rowsBefore = await QueryObjectIdsByCategoryAsync(claimCategory: "test");
+            rowsBefore.Should().HaveCount(CategoryTestCount);
+            var hiddenObjectId = rowsBefore[0].ObjectId;
+
+            policyId = await CreatePolicyAsync(adminClient);
+
+            // Caller's claim is 'sample' — the 'test' row is RLS-hidden from them.
+            var visibleToSample = await QueryObjectIdsByCategoryAsync(claimCategory: "sample");
+            visibleToSample.Should().OnlyContain(r => r.Category == "sample");
+            visibleToSample.Should().NotContain(r => r.ObjectId == hiddenObjectId);
+
+            // deleteFeatures of the hidden objectId must NOT succeed — either rejected outright
+            // (write-RBAC) or returned as a per-row failure ("Feature not found" from the RLS guard).
+            var deleteSucceeded = await EditHiddenRowSucceededAsync(
+                claimCategory: "sample",
+                path: $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/deleteFeatures",
+                form: [new KeyValuePair<string, string>("objectIds", hiddenObjectId.ToString(CultureInfo.InvariantCulture))],
+                resultsProperty: "deleteResults");
+            deleteSucceeded.Should().BeFalse("an RLS-hidden row must not be deletable via its OBJECTID");
+
+            // updateFeatures of the hidden objectId must likewise not succeed.
+            var updateFeatureJson =
+                "[{\"attributes\":{\"objectid\":" + hiddenObjectId.ToString(CultureInfo.InvariantCulture) + ",\"category\":\"pwned\"}}]";
+            var updateSucceeded = await EditHiddenRowSucceededAsync(
+                claimCategory: "sample",
+                path: $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/updateFeatures",
+                form: [new KeyValuePair<string, string>("features", updateFeatureJson)],
+                resultsProperty: "updateResults");
+            updateSucceeded.Should().BeFalse("an RLS-hidden row must not be updatable via its OBJECTID");
+
+            // The row still exists and is unchanged: drop the policy and re-query unrestricted.
+            _ = await adminClient.DeleteAsync($"/api/v1/admin/rls-policies/{policyId.Value}");
+            policyId = null;
+
+            var rowsAfter = await QueryObjectIdsByCategoryAsync(claimCategory: "test");
+            rowsAfter.Should().Contain(r => r.ObjectId == hiddenObjectId && r.Category == "test",
+                "the RLS-hidden row must survive the blocked edit/delete intact");
+        }
+        finally
+        {
+            if (policyId.HasValue)
+            {
+                _ = await adminClient.DeleteAsync($"/api/v1/admin/rls-policies/{policyId.Value}");
+            }
+        }
+    }
+
+    [IntegrationTest]
     [Operation(Operations.Metadata)]
     [Endpoint("POST /api/v1/admin/rls-policies")]
     public async Task RlsPolicyEndpoints_RejectAnonymousCallers()
@@ -197,6 +261,72 @@ public sealed class RowLevelSecurityEndpointsTests : IAsyncLifetime
             payload,
             RlsPolicyJsonContext.Default.ApiResponseIReadOnlyListRlsPolicyResponse);
         return parsed?.Data ?? Array.Empty<RlsPolicyResponse>();
+    }
+
+    private async Task<IReadOnlyList<(long ObjectId, string? Category)>> QueryObjectIdsByCategoryAsync(string? claimCategory)
+    {
+        var client = _fixture.CreateClient();
+        client.DefaultRequestHeaders.Add(RlsClaimsTestAuthHandler.UserHeader, "rls-user");
+        if (!string.IsNullOrEmpty(claimCategory))
+        {
+            client.DefaultRequestHeaders.Add(RlsClaimsTestAuthHandler.CategoryHeader, claimCategory);
+        }
+
+        var response = await client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?where=1%3D1&outFields=*&returnGeometry=false&f=json");
+
+        var payload = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, payload);
+
+        using var document = JsonDocument.Parse(payload);
+        return document.RootElement
+            .GetProperty("features")
+            .EnumerateArray()
+            .Select(feature =>
+            {
+                var attributes = feature.GetProperty("attributes");
+                var objectId = attributes.GetProperty("objectid").GetInt64();
+                var category = attributes.GetProperty("category").GetString();
+                return (objectId, category);
+            })
+            .ToList();
+    }
+
+    /// <summary>
+    /// Issues an edit/delete for the hidden objectId as the RLS-constrained caller and reports
+    /// whether the mutation SUCCEEDED. A successful per-row result on a 200 response is the bypass;
+    /// any non-success status (write-RBAC rejection) or a per-row failure is a correct block.
+    /// </summary>
+    private async Task<bool> EditHiddenRowSucceededAsync(
+        string claimCategory,
+        string path,
+        IEnumerable<KeyValuePair<string, string>> form,
+        string resultsProperty)
+    {
+        var client = _fixture.CreateClient();
+        client.DefaultRequestHeaders.Add(RlsClaimsTestAuthHandler.UserHeader, "rls-user");
+        client.DefaultRequestHeaders.Add(RlsClaimsTestAuthHandler.CategoryHeader, claimCategory);
+
+        var body = new List<KeyValuePair<string, string>>(form) { new("f", "json") };
+        var response = await client.PostAsync(path, new FormUrlEncodedContent(body));
+        var payload = await response.Content.ReadAsStringAsync();
+
+        if (response.StatusCode != HttpStatusCode.OK)
+        {
+            // Write-RBAC rejected the request entirely; the row was never touched.
+            return false;
+        }
+
+        using var document = JsonDocument.Parse(payload);
+        if (!document.RootElement.TryGetProperty(resultsProperty, out var results)
+            || results.ValueKind != JsonValueKind.Array
+            || results.GetArrayLength() == 0)
+        {
+            return false;
+        }
+
+        return results[0].TryGetProperty("success", out var success)
+            && success.ValueKind == JsonValueKind.True;
     }
 
     private async Task<IReadOnlyList<string?>> QueryCategoriesAsync(string? claimCategory)


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2066
Closes #2067
Closes #2062
Closes #2063
Closes #2064
Closes #2065

## Summary
Fixes six verified P1 security/integrity bugs found in the second-pass audits, one focused commit each (plus three test commits). Two RLS authorization bypasses, two write-path data-loss bugs, and two unauthenticated OOM DoS vectors. They span Protocols.GeoServices, Postgres, and Server migrations — fine for one PR since each is independently scoped.

## Changes Made
- **#2066 (RLS edit bypass):** `FeatureServerEditsHandler` skipped the not-found rejection on the default-`OBJECTID` fast path, letting a caller update/delete an RLS-hidden row by its OBJECTID. The RLS-enforced pre-read returns null for a hidden row, but the edit SQL filters only on `(layer_id, objectid)`. Made the not-found rejection **unconditional** for both update and delete. The custom-objectid and `?where=` paths were already safe.
- **#2067 (cross-principal RLS tile-cache leak):** `BuildMapServerTileCacheKey` omitted any principal/RLS dimension, so principal A's RLS-filtered PNG could be served to principal B for the same z/x/y. Resolve the effective RLS predicate (SQL + bound claim values) for the tile's render layers via `IRowLevelSecurityFilterSource` and fold a stable hash into the cache key. ImageServer's tile cache is raster-mosaic only (no RLS feature reader) — left unchanged, matching the issue's assessment.
- **#2062 (replica-sync watermark data loss):** The cursor read the non-transactional sequence `last_value`, so a lower-generation edit committing out of order after the watermark was read was skipped on replicas forever. Switched `PostgresChangeTracker.GetCurrentGenerationAsync` to `COALESCE(MAX(generation),0) FROM honua.feature_changes`, and added a generation-allocation advisory lock to the DEFAULT and version change-tracking triggers (migration `067`) so generation order equals commit order — mirroring the proven `fieldcollection_changes` pattern.
- **#2063 (branch-post lost update):** `ReplayOverlayOntoDefaultAsync` keyed UPDATE/DELETE only on `(layer_id, objectid)`, gated solely by a stale prior-reconcile conflict count, silently overwriting DEFAULT edits committed since. Now re-validates each update/delete overlay row's captured `base_geometry`/`base_attributes` against the live DEFAULT row inside the post transaction (`IS NOT DISTINCT FROM`, NULL-safe; matched rows pinned `FOR UPDATE`); on any divergence it rolls back and surfaces a conflict instead of clobbering. The optimistic predicate is also applied to the UPDATE/DELETE WHERE as defense-in-depth.
- **#2064 (densify OOM DoS):** Anonymous `/densify` passed `maxSegmentLength` straight to NTS, allowing ~2e9 interpolated vertices from a tiny value over a large extent. Estimate the output vertex count (`geometry.Length / maxSegmentLength`) and reject over a per-geometry cap before densifying.
- **#2065 (exportTiles OOM DoS):** `estimateExportTilesSize`/`exportTiles` built the full tile grid (z18 whole-world ≈ 6.9e10 entries) before `.Take(maxTiles)`. Now compute the count `Σ(xMax-xMin+1)*(yMax-yMin+1)` first (long arithmetic), reject/flag when it exceeds maxTiles, run service validation and the access-policy gate before building the grid, and bound the build to maxTiles coordinates. The estimate response reports the true total count with `ExceededTransferLimit`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Added focused tests: RLS edit/delete not-found guard on a default-OBJECTID layer (#2066); densify vertex-cap rejects the DoS payload while a reasonable request still succeeds (#2064); exportTiles whole-world high-zoom estimate returns promptly with the true count + `ExceededTransferLimit` instead of OOM (#2065). Full solution builds clean under Release + `TreatWarningsAsErrors` (0 warnings, 0 errors); `dotnet format --verify-no-changes` clean on all changed files; change-tracker unit tests pass. Docker was unavailable locally, so the new Testcontainers-backed integration tests run in CI. Two pre-existing `feature-catalog.json` drift failures around `oauth-clients`/`oidc-providers` admin endpoints are unrelated to this PR (none of these changes touch those areas).

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires database migration

Adds migration `067_SerializeChangeLogGenerationAllocation.sql` (`CREATE OR REPLACE` of two existing trigger functions to take a generation-allocation advisory lock before `nextval`). Idempotent and backward-compatible; every other line is byte-identical to migration `050`.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
