### PR TITLE
fix(security): enforce scoped admin API-key permissions (#1985)

### DIFF
--- a/src/Honua.Hosting/Features/Authentication/AdminApiKeyPermission.cs
+++ b/src/Honua.Hosting/Features/Authentication/AdminApiKeyPermission.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+
+namespace Honua.Infrastructure.Authentication;
+
+/// <summary>
+/// Grammar and helpers for scoped <em>admin</em> API-key permission grants (#1985).
+/// </summary>
+/// <remarks>
+/// <para>
+/// An admin API key carries one or more permission grants (persisted on the key
+/// record and projected onto the principal as <c>permission</c> claims). Before
+/// #1985 these grants were stored but never enforced: every authenticated admin
+/// key was stamped with the <c>admin</c> role and therefore satisfied the
+/// <c>Admin</c> authorization policy regardless of how narrowly it was scoped, so
+/// a key minted as read-only (<c>admin:read</c>) could still mutate users, keys,
+/// deploys, and configuration.
+/// </para>
+/// <para>
+/// This helper interprets the admin grammar so the shared admin authorization
+/// policy can enforce it:
+/// <list type="bullet">
+///   <item><c>admin</c>, <c>*</c>, <c>admin:*</c> — full admin (read and write).</item>
+///   <item><c>admin:write</c>, <c>admin:manage</c> — admin write (implies read).</item>
+///   <item><c>admin:read</c> — admin read only (safe HTTP methods).</item>
+/// </list>
+/// A principal that carries the <c>admin</c> role but no <c>permission</c> claims
+/// at all (the bootstrap <c>HONUA_ADMIN_PASSWORD</c> key, a client certificate, or
+/// the Test dev-bypass) is treated as full admin so the legacy single-admin model
+/// is preserved and currently-working keys are never locked out. Layer-scoped
+/// write keys (#1637) never reach this policy because they authenticate with a
+/// non-admin role.
+/// </para>
+/// </remarks>
+internal static class AdminApiKeyPermission
+{
+    /// <summary>
+    /// Claim type used to project a key's permission grants onto the principal.
+    /// </summary>
+    public const string PermissionClaimType = "permission";
+
+    private const string AdminGrantPrefix = "admin:";
+
+    /// <summary>
+    /// Grants that confer full administration (read and write).
+    /// </summary>
+    private static readonly string[] FullAdminGrants = ["admin", "*", "admin:*"];
+
+    /// <summary>
+    /// Admin sub-grants that authorize mutating operations (each implies read).
+    /// </summary>
+    private static readonly string[] WriteSubGrants = ["write", "manage", "*"];
+
+    /// <summary>
+    /// Describes how much admin authority a principal's grants confer.
+    /// </summary>
+    internal enum AdminAccessLevel
+    {
+        /// <summary>No admin grant; the principal cannot reach admin surfaces.</summary>
+        None = 0,
+
+        /// <summary>Read-only admin (safe HTTP methods only).</summary>
+        Read = 1,
+
+        /// <summary>Full admin (read and write/mutate).</summary>
+        Write = 2,
+    }
+
+    /// <summary>
+    /// Computes the admin access level a principal's grants confer. A principal in
+    /// the <c>admin</c> role with no <c>permission</c> claims is treated as full
+    /// admin (bootstrap password, client certificate, or Test dev-bypass).
+    /// </summary>
+    /// <param name="principal">The authenticated principal.</param>
+    /// <returns>The effective <see cref="AdminAccessLevel"/>.</returns>
+    public static AdminAccessLevel ResolveAccessLevel(ClaimsPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        var sawPermissionClaim = false;
+        var level = AdminAccessLevel.None;
+
+        foreach (var claim in principal.FindAll(PermissionClaimType))
+        {
+            sawPermissionClaim = true;
+            var grantLevel = ClassifyGrant(claim.Value);
+            if (grantLevel > level)
+            {
+                level = grantLevel;
+            }
+        }
+
+        // A key carrying scoped grants is bounded by those grants. A principal with
+        // no permission claims (bootstrap password / client cert / dev-bypass) but
+        // the admin role retains full admin authority, preserving legacy behavior.
+        if (!sawPermissionClaim && principal.IsInRole("admin"))
+        {
+            return AdminAccessLevel.Write;
+        }
+
+        return level;
+    }
+
+    /// <summary>
+    /// Determines whether a principal is authorized for an admin request whose
+    /// HTTP method is <paramref name="httpMethod"/>. Safe (read) methods require at
+    /// least <see cref="AdminAccessLevel.Read"/>; mutating methods require
+    /// <see cref="AdminAccessLevel.Write"/>.
+    /// </summary>
+    /// <param name="principal">The authenticated principal.</param>
+    /// <param name="httpMethod">The request HTTP method.</param>
+    /// <returns><see langword="true"/> when the grants authorize the request.</returns>
+    public static bool IsAuthorized(ClaimsPrincipal principal, string? httpMethod)
+    {
+        var level = ResolveAccessLevel(principal);
+        if (level == AdminAccessLevel.None)
+        {
+            return false;
+        }
+
+        if (level == AdminAccessLevel.Write)
+        {
+            return true;
+        }
+
+        // Read-only admin: permit only safe, non-mutating HTTP methods.
+        return IsSafeMethod(httpMethod);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> for HTTP methods that do not mutate state and
+    /// are therefore permitted for a read-only admin key.
+    /// </summary>
+    /// <param name="httpMethod">The request HTTP method.</param>
+    /// <returns><see langword="true"/> when the method is safe/read-only.</returns>
+    public static bool IsSafeMethod(string? httpMethod)
+        => string.Equals(httpMethod, "GET", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(httpMethod, "HEAD", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(httpMethod, "OPTIONS", StringComparison.OrdinalIgnoreCase);
+
+    private static AdminAccessLevel ClassifyGrant(string? grant)
+    {
+        var trimmed = grant?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            return AdminAccessLevel.None;
+        }
+
+        foreach (var full in FullAdminGrants)
+        {
+            if (string.Equals(trimmed, full, StringComparison.OrdinalIgnoreCase))
+            {
+                return AdminAccessLevel.Write;
+            }
+        }
+
+        if (!trimmed.StartsWith(AdminGrantPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            // Non-admin grant (e.g. a layer-scoped write: grant). Confers no admin authority.
+            return AdminAccessLevel.None;
+        }
+
+        var sub = trimmed[AdminGrantPrefix.Length..].Trim();
+        if (sub.Length == 0)
+        {
+            return AdminAccessLevel.None;
+        }
+
+        foreach (var write in WriteSubGrants)
+        {
+            if (string.Equals(sub, write, StringComparison.OrdinalIgnoreCase))
+            {
+                return AdminAccessLevel.Write;
+            }
+        }
+
+        if (string.Equals(sub, "read", StringComparison.OrdinalIgnoreCase))
+        {
+            return AdminAccessLevel.Read;
+        }
+
+        // An unrecognized admin sub-grant (e.g. admin:users) is conservatively
+        // treated as read-only: it proves admin intent but not write intent, so it
+        // can observe but not mutate until the grant vocabulary is extended.
+        return AdminAccessLevel.Read;
+    }
+}

--- a/src/Honua.Hosting/Features/Authentication/AdminPermissionAuthorization.cs
+++ b/src/Honua.Hosting/Features/Authentication/AdminPermissionAuthorization.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+
+namespace Honua.Infrastructure.Authentication;
+
+/// <summary>
+/// Authorization requirement that enforces a scoped admin API key's persisted
+/// permission grants on the general request path (#1985).
+/// </summary>
+/// <remarks>
+/// The <c>Admin</c> family of policies previously required only the <c>admin</c>
+/// role, which every authenticated admin key received regardless of its scope.
+/// This requirement is added alongside that role check so a key minted as
+/// read-only (<c>admin:read</c>) can satisfy safe (GET/HEAD/OPTIONS) admin reads
+/// but is denied mutating (POST/PUT/PATCH/DELETE) admin operations. Full-admin
+/// principals (<c>admin:*</c>, the bootstrap password, client certificates, and
+/// the Test dev-bypass) are unaffected.
+/// </remarks>
+internal sealed class AdminPermissionRequirement : IAuthorizationRequirement;
+
+/// <summary>
+/// Evaluates <see cref="AdminPermissionRequirement"/> against the principal's
+/// admin permission grants and the current request's HTTP method.
+/// </summary>
+internal sealed class AdminPermissionAuthorizationHandler(
+    IHttpContextAccessor httpContextAccessor,
+    ILogger<AdminPermissionAuthorizationHandler> logger)
+    : AuthorizationHandler<AdminPermissionRequirement>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
+    private readonly ILogger<AdminPermissionAuthorizationHandler> _logger = logger;
+
+    /// <inheritdoc />
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        AdminPermissionRequirement requirement)
+    {
+        // The HTTP method is the behavior-changing input. Prefer the resource the
+        // authorization middleware supplies (HttpContext in minimal APIs) and fall
+        // back to the ambient accessor so the requirement also works when invoked
+        // outside the endpoint resource (e.g. imperative IAuthorizationService).
+        var httpContext = context.Resource as HttpContext ?? _httpContextAccessor.HttpContext;
+        var method = httpContext?.Request.Method;
+
+        if (AdminApiKeyPermission.IsAuthorized(context.User, method))
+        {
+            context.Succeed(requirement);
+        }
+        else
+        {
+            AuthenticationLog.ScopedAdminKeyDenied(_logger, method ?? "(unknown)");
+            // Do not call context.Fail(): leaving the requirement unmet yields a 403
+            // and lets other handlers/requirements report their own outcome.
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Honua.Hosting/Features/Authentication/AuthenticationExtensions.cs
+++ b/src/Honua.Hosting/Features/Authentication/AuthenticationExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using Honua.Infrastructure.Authentication.ClientCertificates;
 
 namespace Honua.Infrastructure.Authentication;
@@ -55,6 +56,15 @@ public static class AuthenticationExtensions
     {
         services.AddScoped<ApiKeyAuthenticationDependencies>();
 
+        // Required by AdminPermissionAuthorizationHandler to read the request method
+        // when authorization is evaluated outside the endpoint resource (#1985).
+        services.AddHttpContextAccessor();
+
+        // Enforces scoped admin API-key permissions on the general request path
+        // (#1985). Registered as a singleton authorization handler so it participates
+        // in every policy that adds AdminPermissionRequirement below.
+        services.AddSingleton<IAuthorizationHandler, AdminPermissionAuthorizationHandler>();
+
         // Add authentication with API key scheme
         _ = services.AddAuthentication(defaultScheme: ApiKeyScheme)
             .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>(
@@ -64,49 +74,29 @@ public static class AuthenticationExtensions
         // Add authorization policies
         _ = services.AddAuthorization(options =>
         {
-            options.AddPolicy(AdminPolicy, policy =>
-            {
-                _ = policy.RequireAuthenticatedUser();
-                _ = policy.RequireRole("admin");
-                policy.AuthenticationSchemes.Add(ApiKeyScheme);
-                policy.AuthenticationSchemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
-            });
-
-            options.AddPolicy(AdminPolicyAlias, policy =>
-            {
-                _ = policy.RequireAuthenticatedUser();
-                _ = policy.RequireRole("admin");
-                policy.AuthenticationSchemes.Add(ApiKeyScheme);
-                policy.AuthenticationSchemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
-            });
-
-            options.AddPolicy(TemporalHistoryReadPolicy, policy =>
-            {
-                _ = policy.RequireAuthenticatedUser();
-                _ = policy.RequireRole("admin");
-                policy.AuthenticationSchemes.Add(ApiKeyScheme);
-                policy.AuthenticationSchemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
-            });
-
-            options.AddPolicy(TemporalDiffReadPolicy, policy =>
-            {
-                _ = policy.RequireAuthenticatedUser();
-                _ = policy.RequireRole("admin");
-                policy.AuthenticationSchemes.Add(ApiKeyScheme);
-                policy.AuthenticationSchemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
-            });
-
-            options.AddPolicy(TemporalRollbackExecutePolicy, policy =>
-            {
-                _ = policy.RequireAuthenticatedUser();
-                _ = policy.RequireRole("admin");
-                policy.AuthenticationSchemes.Add(ApiKeyScheme);
-                policy.AuthenticationSchemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
-            });
-
+            options.AddPolicy(AdminPolicy, ConfigureAdminPolicy);
+            options.AddPolicy(AdminPolicyAlias, ConfigureAdminPolicy);
+            options.AddPolicy(TemporalHistoryReadPolicy, ConfigureAdminPolicy);
+            options.AddPolicy(TemporalDiffReadPolicy, ConfigureAdminPolicy);
+            options.AddPolicy(TemporalRollbackExecutePolicy, ConfigureAdminPolicy);
         });
 
         return services;
+    }
+
+    /// <summary>
+    /// Configures an admin-family authorization policy: an authenticated principal
+    /// in the <c>admin</c> role whose scoped permission grants authorize the request
+    /// (#1985). The role check preserves the legacy gate; the permission requirement
+    /// adds scoped-key enforcement so a read-only admin key cannot mutate.
+    /// </summary>
+    private static void ConfigureAdminPolicy(AuthorizationPolicyBuilder policy)
+    {
+        _ = policy.RequireAuthenticatedUser();
+        _ = policy.RequireRole("admin");
+        _ = policy.AddRequirements(new AdminPermissionRequirement());
+        policy.AuthenticationSchemes.Add(ApiKeyScheme);
+        policy.AuthenticationSchemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
     }
 
     /// <summary>

--- a/src/Honua.Hosting/Features/Authentication/AuthenticationLog.cs
+++ b/src/Honua.Hosting/Features/Authentication/AuthenticationLog.cs
@@ -161,4 +161,14 @@ internal static partial class AuthenticationLog
         Level = LogLevel.Error,
         Message = "SECURITY: HONUA_DEV_AUTH=true detected in Production environment. Refusing to start.")]
     public static partial void DevelopmentBypassInProductionFatal(ILogger logger);
+
+    /// <summary>
+    /// Logs when a scoped admin API key is denied an admin request because its
+    /// persisted permission grants do not authorize the request method (#1985).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 4114,
+        Level = LogLevel.Warning,
+        Message = "Scoped admin API key denied {Method} admin request: key permissions do not authorize this operation")]
+    public static partial void ScopedAdminKeyDenied(ILogger logger, string method);
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminApiKeyEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminApiKeyEndpointsTests.cs
@@ -155,6 +155,76 @@ public sealed class AdminApiKeyEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/api-keys")]
+    public async Task ReadOnlyScopedKey_CanReadAdminSurface()
+    {
+        // #1985: a key scoped to admin:read must still be able to perform safe
+        // (GET) admin reads — scoped enforcement narrows, it does not lock out.
+        var created = await CreateApiKeyAsync("scoped-read-key", permissions: ["admin:read"]);
+        using var readKeyClient = CreateApiKeyClient(created.Key);
+
+        var response = await readKeyClient.GetAsync("/api/v1/admin/api-keys");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/api-keys")]
+    [Endpoint("POST /api/v1/admin/api-keys/{id}/revoke")]
+    public async Task ReadOnlyScopedKey_CannotPerformMutatingAdminOperations()
+    {
+        // #1985 regression: before scoped enforcement an admin:read key was stamped
+        // Role=admin and silently passed every admin endpoint, including mutating
+        // ones. It must now be Forbidden (403) from creating, rotating, or revoking.
+        var created = await CreateApiKeyAsync("scoped-read-key-mutation", permissions: ["admin:read"]);
+        var victim = await CreateApiKeyAsync("scoped-read-key-victim", permissions: ["admin:read"]);
+        using var readKeyClient = CreateApiKeyClient(created.Key);
+
+        var createRequest = new CreateAdminApiKeyRequest
+        {
+            Name = "should-not-be-created",
+            Permissions = ["admin:*"],
+        };
+        var createResponse = await readKeyClient.PostAsJsonAsync("/api/v1/admin/api-keys", createRequest, _jsonOptions);
+        Assert.Equal(HttpStatusCode.Forbidden, createResponse.StatusCode);
+
+        var rotateResponse = await readKeyClient.PostAsync(
+            $"/api/v1/admin/api-keys/{created.ApiKey.Id}/rotate", content: null);
+        Assert.Equal(HttpStatusCode.Forbidden, rotateResponse.StatusCode);
+
+        var revokeResponse = await readKeyClient.PostAsync(
+            $"/api/v1/admin/api-keys/{victim.ApiKey.Id}/revoke", content: null);
+        Assert.Equal(HttpStatusCode.Forbidden, revokeResponse.StatusCode);
+
+        // The privilege-escalation attempt must not have mutated anything: the
+        // victim key still authenticates.
+        using var victimClient = CreateApiKeyClient(victim.Key);
+        var victimStillWorks = await victimClient.GetAsync("/api/v1/admin/api-keys");
+        Assert.Equal(HttpStatusCode.OK, victimStillWorks.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/api-keys")]
+    public async Task FullAdminScopedKey_RetainsFullAdminAuthority()
+    {
+        // #1985: the default-minted key carries admin:* and must keep full admin
+        // (read AND write) so existing keys are never locked out by enforcement.
+        var created = await CreateApiKeyAsync("scoped-full-admin-key", permissions: ["admin:*"]);
+        using var fullKeyClient = CreateApiKeyClient(created.Key);
+
+        var listResponse = await fullKeyClient.GetAsync("/api/v1/admin/api-keys");
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+
+        var createRequest = new CreateAdminApiKeyRequest
+        {
+            Name = "created-by-full-admin",
+            Permissions = ["admin:read"],
+        };
+        var createResponse = await fullKeyClient.PostAsJsonAsync("/api/v1/admin/api-keys", createRequest, _jsonOptions);
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+    }
+
+    [IntegrationTest]
     [Endpoint("POST /api/v1/admin/api-keys")]
     public async Task CreateApiKey_WithNullPermissions_ReturnsBadRequest()
     {

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/AdminApiKeyPermissionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/AdminApiKeyPermissionTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Infrastructure.Authentication;
+using Xunit;
+
+namespace Honua.Server.Tests.Infrastructure.Authentication;
+
+/// <summary>
+/// Unit tests for the scoped admin API-key permission grammar (#1985). These are
+/// pure, deterministic tests of <see cref="AdminApiKeyPermission"/> and do not
+/// require a database or Docker.
+/// </summary>
+public sealed class AdminApiKeyPermissionTests
+{
+    private static ClaimsPrincipal AdminPrincipal(params string[] permissions)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.Role, "admin") };
+        foreach (var permission in permissions)
+        {
+            claims.Add(new Claim(AdminApiKeyPermission.PermissionClaimType, permission));
+        }
+
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "Test"));
+    }
+
+    [Theory]
+    [InlineData("admin")]
+    [InlineData("*")]
+    [InlineData("admin:*")]
+    [InlineData("admin:write")]
+    [InlineData("admin:manage")]
+    public void ResolveAccessLevel_WriteCapableGrant_IsWrite(string grant)
+    {
+        var level = AdminApiKeyPermission.ResolveAccessLevel(AdminPrincipal(grant));
+
+        level.Should().Be(AdminApiKeyPermission.AdminAccessLevel.Write);
+    }
+
+    [Fact]
+    public void ResolveAccessLevel_ReadGrant_IsRead()
+    {
+        var level = AdminApiKeyPermission.ResolveAccessLevel(AdminPrincipal("admin:read"));
+
+        level.Should().Be(AdminApiKeyPermission.AdminAccessLevel.Read);
+    }
+
+    [Fact]
+    public void ResolveAccessLevel_NoPermissionClaimsButAdminRole_IsWrite()
+    {
+        // Bootstrap password / client certificate / dev-bypass: admin role, no
+        // scoped permission claims => full admin, preserving legacy behavior.
+        var level = AdminApiKeyPermission.ResolveAccessLevel(AdminPrincipal());
+
+        level.Should().Be(AdminApiKeyPermission.AdminAccessLevel.Write);
+    }
+
+    [Fact]
+    public void ResolveAccessLevel_OnlyNonAdminGrant_IsNone()
+    {
+        // A layer-scoped write: grant confers no admin authority.
+        var level = AdminApiKeyPermission.ResolveAccessLevel(AdminPrincipal("write:roads"));
+
+        level.Should().Be(AdminApiKeyPermission.AdminAccessLevel.None);
+    }
+
+    [Fact]
+    public void ResolveAccessLevel_MixedGrants_TakesHighest()
+    {
+        var level = AdminApiKeyPermission.ResolveAccessLevel(AdminPrincipal("admin:read", "admin:write"));
+
+        level.Should().Be(AdminApiKeyPermission.AdminAccessLevel.Write);
+    }
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("HEAD")]
+    [InlineData("OPTIONS")]
+    public void IsAuthorized_ReadKey_AllowsSafeMethods(string method)
+    {
+        AdminApiKeyPermission.IsAuthorized(AdminPrincipal("admin:read"), method).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    [InlineData("PATCH")]
+    [InlineData("DELETE")]
+    public void IsAuthorized_ReadKey_DeniesMutatingMethods(string method)
+    {
+        AdminApiKeyPermission.IsAuthorized(AdminPrincipal("admin:read"), method).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("POST")]
+    [InlineData("DELETE")]
+    public void IsAuthorized_FullAdminKey_AllowsEveryMethod(string method)
+    {
+        AdminApiKeyPermission.IsAuthorized(AdminPrincipal("admin:*"), method).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAuthorized_KeyWithoutAdminGrant_DeniesEvenSafeMethods()
+    {
+        AdminApiKeyPermission.IsAuthorized(AdminPrincipal("write:roads"), "GET").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Correctness/security hardening bundle. Of the four targeted tickets, only **#1985** required code changes — the other three are either already resolved on `trunk` or deferred (see below). The PR is therefore tightly scoped to the admin API-key authorization path.

## #1985 — Scoped admin API keys silently elevated to full admin (Closes)

**Bug:** per-key `Permissions` (e.g. `admin:read`) were persisted and projected onto the principal as `permission` claims, but the `Admin` authorization policy only required the `admin` role — which every authenticated admin key received. A scoped/read-only key therefore passed *every* admin endpoint (user/key management, deploy control, config/secrets discovery, license admin) — a privilege escalation.

**Fix (centralized, no per-endpoint retagging):**
- `AdminApiKeyPermission` — grammar that classifies admin grants into an access level: `admin` / `*` / `admin:*` / `admin:write` / `admin:manage` → **Write**; `admin:read` → **Read**; non-admin grants → **None**. A principal in the `admin` role with **no** `permission` claims (bootstrap `HONUA_ADMIN_PASSWORD`, client certificate, Test dev-bypass) resolves to **full admin**, so the legacy single-admin model and all existing `admin:*` keys keep working unchanged.
- `AdminPermissionRequirement` + handler — added to every Admin-family policy alongside the existing role check. Read-only keys may perform safe (GET/HEAD/OPTIONS) admin reads but are **Forbidden (403)** on mutating (POST/PUT/PATCH/DELETE) admin operations.

**Tests (all pass, run serially):**
- `AdminApiKeyPermissionTests` — 20 unit tests over the grammar (no Docker). **20/20 pass.**
- `AdminApiKeyEndpointsTests` — scoped `admin:read` key can read but is 403 on create/rotate/revoke, the escalation attempt mutates nothing, and `admin:*` retains full read+write. **8/8 pass** (5 pre-existing + 3 new).
- Regression: 42/42 auth tests + 9/9 UserManagement admin-mutation tests still green (full-admin paths unaffected).

## Already resolved on `trunk` (no change needed)

- **Refs #1980** (CSV header `stackalloc` DoS): `CsvFormatReader.NormalizeColumnName` already heap-falls-back via `ArrayPool` above a 256-char threshold; long-header regression test present in `CsvPreviewTests` (merged #1994). Verified.
- **Refs #2004** (ArcGisRest DNS-rebinding SSRF/TOCTOU): `ArcGisRestOutboundGuard` pins DNS and re-validates the resolved IP at connect time via `SocketsHttpHandler.ConnectCallback`, wired through `ServiceCollectionExtensions`; covered by `ArcGisRestOutboundGuardTests`. Verified.

These two can be closed by a maintainer.

## Deferred

- **Refs #1965** (re-block advisory Features.* shards): the ~16 rotted tests are diverse genuine drift (e.g. `timeInfo` null-vs-object, `SslMode` VerifyFull-vs-Require — both reproduced locally). Re-blocking the two advisory shards is all-or-nothing (every test must be green or the merge queue wedges again). Fixing all of them, while avoiding collision with the in-flight harness PRs #2049/#2061, is out of scope here and left for a dedicated follow-up.

## Notes
- Build: `Honua.Hosting` and `Honua.Server.Tests` build clean in Release with warnings-as-errors. `dotnet format --verify-no-changes` passes on both.
- Two pre-existing `FeatureCatalog` drift failures in `Honua.Architecture.Tests` (`DELETE /api/v1/admin/oauth-clients/{id}`) exist on `trunk` independent of this PR — this change touches no endpoints/registry.
- Do **not** arm auto-merge (repo uses a merge-queue/coordinator).