### PR TITLE
feat(scene): I3S SceneServer cluster — node pages, statistics, layerType, conformance fixture (#1809, #1811, #1812, #1813)

### DIFF
--- a/docs/contributor/i3s-sceneserver-smoke.md
+++ b/docs/contributor/i3s-sceneserver-smoke.md
@@ -1,0 +1,80 @@
+# I3S SceneServer manual smoke runbook (#1813)
+
+This runbook is the manual oracle for the parts of the Esri I3S SceneServer
+surface that no headless harness can assert: render fidelity in ArcGIS Pro and
+`@arcgis/core`. The automated `I3sConformanceFixtureTests` harness validates the
+protocol *shapes* (descriptor / node pages / statistics); this runbook validates
+that a real SceneLayer client *loads and traverses* the served scene.
+
+## Scope (what landed)
+
+- `…/SceneServer` and `…/SceneServer/layers/0` descriptors (service + layer),
+  Enterprise-gated, at the canonical `/rest/services/{id}/SceneServer` path and
+  the `/scenes/{id}/SceneServer` alias.
+- `…/layers/0/nodepages/{n}` — I3S 1.7 node pages projected from the hosted 3D
+  Tiles node tree (#1809): oriented bounding boxes in the index CRS, LOD
+  thresholds from geometric error, parent/child references by global node index,
+  and per-node geometry/attribute/material resource references.
+- `…/layers/0/statistics/f_{n}/0` — per-field statistics summary (#1811).
+- `layerType` mapping for `3DObject` / `Building` / `PointCloud` (#1812).
+
+## Deferred (NOT yet served — see #1810 / #1811)
+
+The descriptor and node pages reference geometry / attribute / texture resources
+by index, but the **binary node resources are not yet served**:
+
+- `…/nodes/{id}/geometries/0` — the glTF → I3S interleaved geometry-buffer
+  transcoder (positions / normals / UVs / colours / feature-ids; vertexCRS +
+  per-node MBS offset) is the deferred XL lane (#1810).
+- `…/nodes/{id}/textures/0` — texture serving (#1810).
+- `…/nodes/{id}/attributes/f_{n}/0` — native per-field binary attribute files
+  (#1811).
+
+A SceneLayer client will therefore discover the layer, traverse the node tree,
+and read field statistics, but will not render geometry until #1810/#1811 land.
+The node-page references are deliberately honest about which resources exist:
+they advertise the geometry/attribute index a client *would* fetch, matching the
+descriptor, but the corresponding binary routes are the tracked follow-up.
+
+## Prerequisites
+
+1. An Enterprise-licensed Honua server (`HonuaEdition.Enterprise`).
+2. A registered hosted scene with a loadable `tileset.json` (any 3D Tiles scene
+   the server already serves, e.g. the demo Maui buildings scene).
+3. ArcGIS Pro 3.x **or** a local page importing `@arcgis/core` ≥ 4.29.
+
+## Procedure — `@arcgis/core` SceneLayer load probe
+
+```js
+import SceneLayer from "@arcgis/core/layers/SceneLayer.js";
+
+const layer = new SceneLayer({
+  url: "https://<host>/rest/services/<sceneId>/SceneServer/layers/0",
+});
+
+await layer.load();
+console.log("loaded", layer.title, layer.geometryType);
+```
+
+Expected (this PR):
+
+- `layer.load()` resolves (the descriptor is conformant and advertises
+  `store.nodePages`).
+- The layer view requests `nodepages/0` and receives a valid node page (no 404).
+- Field statistics resolve at `…/statistics/f_0/0`.
+
+Known gap (until #1810/#1811):
+
+- The view will request `nodes/{id}/geometries/0` and receive 404 — geometry
+  does not render. This is expected and tracked.
+
+## Procedure — ArcGIS Pro
+
+1. Add Data → From Path → paste the `…/SceneServer` URL.
+2. Confirm the scene layer appears in the Contents pane with the correct
+   `layerType` (3D Object / Building / Point Cloud).
+3. Confirm Pro traverses node pages without descriptor errors.
+4. Geometry render and Identify are blocked until #1810/#1811.
+
+Record the Pro / browser version and the observed behaviour in the PR or the
+epic (#1805) when running this probe.

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -308,6 +308,32 @@
       "maturity": "implemented"
     },
     {
+      "id": "delete-api-v1-admin-oauth-clients-id",
+      "route": "/api/v1/admin/oauth-clients/{id}",
+      "method": "DELETE",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.GetAndDeleteClient_RemovesRegistration"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "delete-api-v1-admin-oauth-scopes-scope",
+      "route": "/api/v1/admin/oauth-scopes/{scope}",
+      "method": "DELETE",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "delete-api-v1-admin-oidc-providers-id",
       "route": "/api/v1/admin/oidc/providers/{id}",
       "method": "DELETE",
@@ -2222,6 +2248,46 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Get_AfterRegister_ReturnsDataset",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Get_Missing_Returns404"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-clients",
+      "route": "/api/v1/admin/oauth-clients",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.ManagementSurface_RequiresAdminAuthorization",
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterAndListClient_ReturnsSecretOnlyAtCreation"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-clients-id",
+      "route": "/api/v1/admin/oauth-clients/{id}",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.GetAndDeleteClient_RemovesRegistration"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-scopes",
+      "route": "/api/v1/admin/oauth-scopes",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -7119,6 +7185,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sConformanceFixtureTests.ServiceDescriptor_PassesProtocolShapeValidator",
         "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetService_AtGeoServicesPath_CommunityEdition_Returns403",
         "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetService_AtGeoServicesPath_ReturnsI3sServiceDescriptor"
       ],
@@ -7133,8 +7200,39 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sConformanceFixtureTests.LayerDescriptor_AdvertisesNodePages_AndPassesValidator",
         "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetLayer_AtGeoServicesPath_ReturnsThreeDObjectLayer",
-        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetLayer_DescriptorIsHonest_RichMetadataButNoFetchableNodeStore"
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetLayer_BuildingScene_AdvertisesBuildingLayerType",
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetLayer_DescriptorIsHonest_RichMetadataAndNodePages",
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetLayer_SceneWithLoadableTileset_AdvertisesNodePagesStore"
+      ],
+      "proof_ledger_surface": "i3s-sceneserver",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-rest-services-sceneid-sceneserver-layers-layerid-int-nodepages-pageid-int",
+      "route": "/rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodepages/{pageId:int}",
+      "method": "GET",
+      "family": "I3S",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sConformanceFixtureTests.NodePage_OutOfRange_Returns404",
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sConformanceFixtureTests.NodePage_ProjectsTilesetTree_AndPassesValidator"
+      ],
+      "proof_ledger_surface": "i3s-sceneserver",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-rest-services-sceneid-sceneserver-layers-layerid-int-statistics-fieldkey-0",
+      "route": "/rest/services/{sceneId}/SceneServer/layers/{layerId:int}/statistics/{fieldKey}/0",
+      "method": "GET",
+      "family": "I3S",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sConformanceFixtureTests.Statistics_ForObjectId_PassesValidator_AndCountsContentNodes",
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sConformanceFixtureTests.Statistics_UnknownField_Returns404"
       ],
       "proof_ledger_surface": "i3s-sceneserver",
       "maturity": "implemented"
@@ -9168,6 +9266,33 @@
         "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetLayer_ProtectedScene_WithoutAuth_ReturnsUnauthorized",
         "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetLayer_SceneWithPersistedExtent_PopulatesFullExtent",
         "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetLayer_UnknownLayerId_Returns404"
+      ],
+      "proof_ledger_surface": "scenes-3dtiles",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-scenes-sceneid-sceneserver-layers-layerid-int-nodepages-pageid-int",
+      "route": "/scenes/{sceneId}/SceneServer/layers/{layerId:int}/nodepages/{pageId:int}",
+      "method": "GET",
+      "family": "3D-Tiles",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetNodePage_ScenesAlias_CommunityEdition_Returns403",
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetNodePage_ScenesAlias_EnterpriseEdition_ReturnsNodePage"
+      ],
+      "proof_ledger_surface": "scenes-3dtiles",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-scenes-sceneid-sceneserver-layers-layerid-int-statistics-fieldkey-0",
+      "route": "/scenes/{sceneId}/SceneServer/layers/{layerId:int}/statistics/{fieldKey}/0",
+      "method": "GET",
+      "family": "3D-Tiles",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetStatistics_ScenesAlias_EnterpriseEdition_ReturnsStatistics"
       ],
       "proof_ledger_surface": "scenes-3dtiles",
       "maturity": "implemented"
@@ -11858,6 +11983,20 @@
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Register_DuplicateId_Returns409",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Register_UnsafeEdgeTable_Returns400",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Register_ValidPayload_Returns201WithDto"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "post-api-v1-admin-oauth-clients",
+      "route": "/api/v1/admin/oauth-clients",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterAndListClient_ReturnsSecretOnlyAtCreation",
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterClient_WithInvalidClientType_ReturnsBadRequest"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -16539,6 +16678,19 @@
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_ChangesMutableFields",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_Missing_Returns404",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_UnsafeVertexTable_Returns400"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "put-api-v1-admin-oauth-scopes",
+      "route": "/api/v1/admin/oauth-scopes",
+      "method": "PUT",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -3044,11 +3044,31 @@
             "src/Honua.Server/EndpointRegistry.cs",
             "src/Honua.Protocols.Scene/I3s/I3sSceneServerEndpoints.cs",
             "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
-            "tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs"
+            "tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs",
+            "tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sConformanceFixtureTests.cs"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
           "linkedTicket": "#1202",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "scenario-depth",
+          "proofMechanism": "I3S 1.7 node-page traversal (nodepages/{n} projected from the hosted 3D Tiles node tree: oriented bounding boxes in the index CRS, lodThreshold from geometric error, parent/child references by global node index, and per-node geometry/attribute/material resource references), per-field attribute statistics (statistics/f_{n}/0), and SceneDatasetType -> I3S layerType mapping (3DObject/Building/PointCloud) validated end-to-end against a Honua-authored synthetic I3S 1.7 conformance fixture by a protocol-shape validator; the served node pages reference geometry/attribute/texture by index but the binary node resources (nodes/{id}/geometries|textures|attributes) remain a tracked follow-up (#1810/#1811)",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "src/Honua.Scene/I3sNodePageProjector.cs",
+            "src/Honua.Scene/I3sNodeStore.cs",
+            "src/Honua.Scene/I3sSceneStatisticsBuilder.cs",
+            "src/Honua.Scene/I3sLayerTypeMap.cs",
+            "tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sConformanceFixtureTests.cs",
+            "tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sProtocolShapeValidator.cs",
+            "tests/dotnet/Honua.Core.Tests/Features/Scene/I3sNodePageProjectorTests.cs",
+            "tests/fixtures/scene/i3s/source-tileset/tileset.json"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#1809",
           "versionCaptureRule": null
         },
         {

--- a/src/Honua.Core.Abstractions/Features/Scene/Domain/SceneDatasetType.cs
+++ b/src/Honua.Core.Abstractions/Features/Scene/Domain/SceneDatasetType.cs
@@ -16,5 +16,18 @@ public enum SceneDatasetType
     /// <summary>
     /// Cesium-compatible terrain quantized-mesh dataset.
     /// </summary>
-    Terrain = 1
+    Terrain = 1,
+
+    /// <summary>
+    /// Building Scene Layer source (BIM / CityGML produced by
+    /// <c>BuildingSceneLayerBuilder</c>). Served to I3S clients as a
+    /// <c>Building</c> scene layer.
+    /// </summary>
+    Building = 2,
+
+    /// <summary>
+    /// Point-cloud source (LAS/LAZ/COPC streamed through the PNTS pipeline).
+    /// Served to I3S clients as a <c>PointCloud</c> scene layer.
+    /// </summary>
+    PointCloud = 3
 }

--- a/src/Honua.Postgres/Features/Scene/PostgresSceneDatasetRegistry.cs
+++ b/src/Honua.Postgres/Features/Scene/PostgresSceneDatasetRegistry.cs
@@ -22,6 +22,8 @@ internal sealed class PostgresSceneDatasetRegistry : ISceneDatasetRegistry, ISce
 {
     private const string DatasetTypeHostedTiles = "hosted_tiles";
     private const string DatasetTypeTerrain = "terrain";
+    private const string DatasetTypeBuilding = "building";
+    private const string DatasetTypePointCloud = "point_cloud";
     private const string StatusActive = "active";
     private const string StatusInactive = "inactive";
     private const string StatusValidationFailed = "validation_failed";
@@ -514,6 +516,8 @@ internal sealed class PostgresSceneDatasetRegistry : ISceneDatasetRegistry, ISce
     {
         SceneDatasetType.HostedTiles => DatasetTypeHostedTiles,
         SceneDatasetType.Terrain => DatasetTypeTerrain,
+        SceneDatasetType.Building => DatasetTypeBuilding,
+        SceneDatasetType.PointCloud => DatasetTypePointCloud,
         _ => DatasetTypeHostedTiles
     };
 
@@ -521,6 +525,8 @@ internal sealed class PostgresSceneDatasetRegistry : ISceneDatasetRegistry, ISce
     {
         DatasetTypeHostedTiles => SceneDatasetType.HostedTiles,
         DatasetTypeTerrain => SceneDatasetType.Terrain,
+        DatasetTypeBuilding => SceneDatasetType.Building,
+        DatasetTypePointCloud => SceneDatasetType.PointCloud,
         _ => throw new InvalidOperationException(
             string.Format(CultureInfo.InvariantCulture,
                 "Unknown scene dataset type '{0}' in registry.", value))

--- a/src/Honua.Protocols.Scene/I3s/I3sSceneServerEndpoints.cs
+++ b/src/Honua.Protocols.Scene/I3s/I3sSceneServerEndpoints.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Scene.Domain;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Validation;
+using Honua.Scene;
 using Honua.Scene.Assets;
 using Microsoft.AspNetCore.Mvc;
 
@@ -72,6 +73,42 @@ internal static partial class I3sSceneServerEndpoints
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 
+        // I3S node-page traversal (#1809): a conformant SceneLayer client walks
+        // the layer's HLOD tree through nodepages/{n}. Each page projects a
+        // fixed-size window of the tileset node tree (MBS/OBB in index CRS,
+        // lodThreshold from geometric error, child references, per-node
+        // geometry/attribute resource references). Enterprise-gated.
+        endpoints.MapGet(
+                "/rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodepages/{pageId:int}",
+                HandleGetNodePage)
+            .WithName("GetGeoServicesSceneNodePage")
+            .WithDisplayName("Get GeoServices SceneServer Node Page")
+            .WithSummary("Get an I3S node page projected from the scene's tileset node tree")
+            .WithDescription("Returns an I3S 1.7 node page (HLOD nodes with oriented bounding boxes, LOD thresholds, parent/child references, and per-node geometry/attribute resource references) projected from the hosted scene's 3D Tiles node tree. Enterprise edition.")
+            .WithTags(ScenesTag)
+            .Produces<I3sNodePageDocument>(StatusCodes.Status200OK, contentType: I3sContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status500InternalServerError);
+
+        // I3S per-field statistics (#1811): an ArcGIS client reads the field
+        // statistics summary to drive identify, classification, and renderer
+        // ranges. Served from the layer's attributeStorageInfo + tileset stats.
+        endpoints.MapGet(
+                "/rest/services/{sceneId}/SceneServer/layers/{layerId:int}/statistics/{fieldKey}/0",
+                HandleGetStatistics)
+            .WithName("GetGeoServicesSceneStatistics")
+            .WithDisplayName("Get GeoServices SceneServer Field Statistics")
+            .WithSummary("Get the I3S attribute statistics summary for a scene-layer field")
+            .WithDescription("Returns the I3S statistics summary (totalValuesCount, min/max, count) for one attributeStorageInfo field of a hosted scene layer, used by ArcGIS identify and classification. Enterprise edition.")
+            .WithTags(ScenesTag)
+            .Produces<I3sAttributeStatisticsDocument>(StatusCodes.Status200OK, contentType: I3sContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status500InternalServerError);
+
         // Legacy /scenes/{id}/SceneServer routes (#1202) retained as a
         // documented ALIAS of the GeoServices path above so existing clients and
         // links keep working. Both paths share the same handlers and descriptor.
@@ -103,6 +140,34 @@ internal static partial class I3sSceneServerEndpoints
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 
+        endpoints.MapGet(
+                "/scenes/{sceneId}/SceneServer/layers/{layerId:int}/nodepages/{pageId:int}",
+                HandleGetNodePage)
+            .WithName("GetI3sSceneNodePage")
+            .WithDisplayName("Get I3S Scene Node Page")
+            .WithSummary("Alias of the GeoServices SceneServer node-page route")
+            .WithDescription("Alias of /rest/services/{sceneId}/SceneServer/layers/{layerId}/nodepages/{pageId}. Returns an I3S 1.7 node page projected from the hosted scene's 3D Tiles node tree. Enterprise edition.")
+            .WithTags(ScenesTag)
+            .Produces<I3sNodePageDocument>(StatusCodes.Status200OK, contentType: I3sContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status500InternalServerError);
+
+        endpoints.MapGet(
+                "/scenes/{sceneId}/SceneServer/layers/{layerId:int}/statistics/{fieldKey}/0",
+                HandleGetStatistics)
+            .WithName("GetI3sSceneStatistics")
+            .WithDisplayName("Get I3S Scene Field Statistics")
+            .WithSummary("Alias of the GeoServices SceneServer field-statistics route")
+            .WithDescription("Alias of /rest/services/{sceneId}/SceneServer/layers/{layerId}/statistics/{fieldKey}/0. Returns the I3S attribute statistics summary for one scene-layer field. Enterprise edition.")
+            .WithTags(ScenesTag)
+            .Produces<I3sAttributeStatisticsDocument>(StatusCodes.Status200OK, contentType: I3sContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status500InternalServerError);
+
         return endpoints;
     }
 
@@ -123,7 +188,140 @@ internal static partial class I3sSceneServerEndpoints
         CancellationToken cancellationToken)
         => HandleAsync(sceneId, layerId, context, registry, licenseStatusProvider, cancellationToken);
 
+    private static Task<IResult> HandleGetNodePage(
+        string sceneId,
+        int layerId,
+        int pageId,
+        HttpContext context,
+        [FromServices] ISceneDatasetRegistry registry,
+        [FromServices] ILicenseStatusProvider licenseStatusProvider,
+        CancellationToken cancellationToken)
+        => HandleNodePageAsync(sceneId, layerId, pageId, context, registry, licenseStatusProvider, cancellationToken);
+
+    private static Task<IResult> HandleGetStatistics(
+        string sceneId,
+        int layerId,
+        string fieldKey,
+        HttpContext context,
+        [FromServices] ISceneDatasetRegistry registry,
+        [FromServices] ILicenseStatusProvider licenseStatusProvider,
+        CancellationToken cancellationToken)
+        => HandleStatisticsAsync(sceneId, layerId, fieldKey, context, registry, licenseStatusProvider, cancellationToken);
+
     private static async Task<IResult> HandleAsync(
+        string sceneId,
+        int? layerId,
+        HttpContext context,
+        ISceneDatasetRegistry registry,
+        ILicenseStatusProvider licenseStatusProvider,
+        CancellationToken cancellationToken)
+    {
+        var gate = await ResolveSceneAsync(sceneId, layerId, context, registry, licenseStatusProvider, cancellationToken)
+            .ConfigureAwait(false);
+        if (gate.Failure is { } failure)
+        {
+            return failure;
+        }
+
+        var scene = gate.Scene!;
+        var extent = await ResolveExtentAsync(context, scene, cancellationToken)
+            .ConfigureAwait(false);
+        var datasetType = await ResolveDatasetTypeAsync(context, scene, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Advertise store.nodePages only when the tileset actually projects to
+        // fetchable node pages (#1809), so a conformant client never requests a
+        // node URL that 404s.
+        var advertiseNodePages = I3sNodeStore.TryBuildNodePages(scene, out _);
+
+        if (layerId is null)
+        {
+            var service = I3sSceneServiceBuilder.BuildService(scene, extent, datasetType, advertiseNodePages);
+            return SerializeService(service);
+        }
+
+        var layer = I3sSceneServiceBuilder.BuildLayer(scene, extent, datasetType, advertiseNodePages);
+        return SerializeLayer(layer);
+    }
+
+    private static async Task<IResult> HandleNodePageAsync(
+        string sceneId,
+        int layerId,
+        int pageId,
+        HttpContext context,
+        ISceneDatasetRegistry registry,
+        ILicenseStatusProvider licenseStatusProvider,
+        CancellationToken cancellationToken)
+    {
+        var gate = await ResolveSceneAsync(sceneId, layerId, context, registry, licenseStatusProvider, cancellationToken)
+            .ConfigureAwait(false);
+        if (gate.Failure is { } failure)
+        {
+            return failure;
+        }
+
+        if (pageId < 0)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Node page index must be non-negative.");
+        }
+
+        if (!I3sNodeStore.TryBuildNodePages(gate.Scene!, out var pages) || pageId >= pages.Count)
+        {
+            // No loadable tileset (descriptor-only scene) or a page index past the
+            // projected node tree: a deterministic 404 rather than an empty body.
+            return StandardErrorHelpers.CreateNotFound(context, "Scene node page was not found.");
+        }
+
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(
+            pages[pageId],
+            I3sNodePageJsonContext.Default.I3sNodePageDocument);
+        return Results.Bytes(bytes, I3sContentType);
+    }
+
+    private static async Task<IResult> HandleStatisticsAsync(
+        string sceneId,
+        int layerId,
+        string fieldKey,
+        HttpContext context,
+        ISceneDatasetRegistry registry,
+        ILicenseStatusProvider licenseStatusProvider,
+        CancellationToken cancellationToken)
+    {
+        var gate = await ResolveSceneAsync(sceneId, layerId, context, registry, licenseStatusProvider, cancellationToken)
+            .ConfigureAwait(false);
+        if (gate.Failure is { } failure)
+        {
+            return failure;
+        }
+
+        var scene = gate.Scene!;
+        var extent = await ResolveExtentAsync(context, scene, cancellationToken).ConfigureAwait(false);
+        var datasetType = await ResolveDatasetTypeAsync(context, scene, cancellationToken).ConfigureAwait(false);
+
+        // The served field set is the layer descriptor's attributeStorageInfo, so
+        // a statistics request can only resolve a field the descriptor advertises.
+        var layer = I3sSceneServiceBuilder.BuildLayer(scene, extent, datasetType, advertiseNodePages: false);
+        var field = layer.AttributeStorageInfo?
+            .FirstOrDefault(a => string.Equals(a.Key, fieldKey, StringComparison.Ordinal));
+        if (field is null)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Scene statistics field was not found.");
+        }
+
+        var stats = I3sSceneStatisticsBuilder.Build(scene, field);
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(
+            stats,
+            I3sAttributeStatisticsJsonContext.Default.I3sAttributeStatisticsDocument);
+        return Results.Bytes(bytes, I3sContentType);
+    }
+
+    /// <summary>
+    /// Shared gate for every I3S SceneServer resource: validates the scene id,
+    /// enforces the Enterprise edition, rejects any non-zero layer id, resolves
+    /// the scene, and enforces its access policy. Returns the resolved scene on
+    /// success or the failing <see cref="IResult"/> to short-circuit with.
+    /// </summary>
+    private static async Task<SceneGateResult> ResolveSceneAsync(
         string sceneId,
         int? layerId,
         HttpContext context,
@@ -133,15 +331,15 @@ internal static partial class I3sSceneServerEndpoints
     {
         if (string.IsNullOrWhiteSpace(sceneId))
         {
-            return StandardErrorHelpers.CreateBadRequest(context, "Scene identifier is required.");
+            return new SceneGateResult(null, StandardErrorHelpers.CreateBadRequest(context, "Scene identifier is required."));
         }
 
         var edition = licenseStatusProvider.GetCurrentStatus().Edition;
         if (edition < HonuaEdition.Enterprise)
         {
-            return StandardErrorHelpers.CreateForbidden(
+            return new SceneGateResult(null, StandardErrorHelpers.CreateForbidden(
                 context,
-                $"I3S scene serving requires the Enterprise edition. Current edition: {edition}.");
+                $"I3S scene serving requires the Enterprise edition. Current edition: {edition}."));
         }
 
         // Only layer 0 exists per scene; reject any other index explicitly so a
@@ -149,13 +347,13 @@ internal static partial class I3sSceneServerEndpoints
         // layer-0 body.
         if (layerId is { } requestedLayerId && requestedLayerId != I3sSceneServiceBuilder.LayerId)
         {
-            return StandardErrorHelpers.CreateNotFound(context, "Scene layer was not found.");
+            return new SceneGateResult(null, StandardErrorHelpers.CreateNotFound(context, "Scene layer was not found."));
         }
 
         var scene = await registry.FindAsync(sceneId, cancellationToken).ConfigureAwait(false);
         if (scene is null)
         {
-            return StandardErrorHelpers.CreateNotFound(context, "Scene was not found.");
+            return new SceneGateResult(null, StandardErrorHelpers.CreateNotFound(context, "Scene was not found."));
         }
 
         if (scene.AccessPolicy is { } accessPolicy)
@@ -167,21 +365,35 @@ internal static partial class I3sSceneServerEndpoints
                 scope: AccessScope.Read);
             if (deniedResult is not null)
             {
-                return deniedResult;
+                return new SceneGateResult(null, deniedResult);
             }
         }
 
-        var extent = await ResolveExtentAsync(context, scene, cancellationToken)
-            .ConfigureAwait(false);
+        return new SceneGateResult(scene, null);
+    }
 
-        if (layerId is null)
+    private readonly record struct SceneGateResult(SceneDataset? Scene, IResult? Failure);
+
+    /// <summary>
+    /// Resolves the dataset's I3S source kind for layerType mapping (#1812). The
+    /// lean <see cref="SceneDataset"/> read model carries no source kind, so the
+    /// type is read from the persisted <see cref="SceneDatasetRecord"/> when a
+    /// registration service is available; config-registry scenes fall back to the
+    /// default hosted-tiles (<c>3DObject</c>) kind.
+    /// </summary>
+    private static async Task<SceneDatasetType> ResolveDatasetTypeAsync(
+        HttpContext context,
+        SceneDataset scene,
+        CancellationToken cancellationToken)
+    {
+        var registration = context.RequestServices.GetService<ISceneRegistrationService>();
+        if (registration is null)
         {
-            var service = I3sSceneServiceBuilder.BuildService(scene, extent);
-            return SerializeService(service);
+            return SceneDatasetType.HostedTiles;
         }
 
-        var layer = I3sSceneServiceBuilder.BuildLayer(scene, extent);
-        return SerializeLayer(layer);
+        var record = await registration.GetBySceneIdAsync(scene.Id, cancellationToken).ConfigureAwait(false);
+        return record?.DatasetType ?? SceneDatasetType.HostedTiles;
     }
 
     private static IResult SerializeService(I3sSceneServiceDocument service)

--- a/src/Honua.Protocols.Scene/I3s/I3sSceneServiceBuilder.cs
+++ b/src/Honua.Protocols.Scene/I3s/I3sSceneServiceBuilder.cs
@@ -3,6 +3,7 @@
 
 using Honua.Core.Features.Scene.Conversion;
 using Honua.Core.Features.Scene.Domain;
+using Honua.Scene;
 
 namespace Honua.Protocols.Scene.I3s;
 
@@ -66,9 +67,21 @@ internal static class I3sSceneServiceBuilder
     /// z-bearing <c>fullExtent</c>; otherwise the vertical extent is omitted
     /// rather than fabricated.
     /// </param>
+    /// <param name="datasetType">
+    /// The dataset's I3S source kind, mapped to the advertised <c>layerType</c>
+    /// and store <c>profile</c> (#1812).
+    /// </param>
+    /// <param name="advertiseNodePages">
+    /// When <see langword="true"/>, the store advertises <c>nodePages</c> and a
+    /// <c>defaultGeometrySchema</c> so a conformant client traverses the layer
+    /// through <c>nodepages/{n}</c> (#1809). Only set when the tileset actually
+    /// projects to fetchable node pages.
+    /// </param>
     public static I3sSceneLayerDocument BuildLayer(
         SceneDataset scene,
-        SceneExtent? extent)
+        SceneExtent? extent,
+        SceneDatasetType datasetType = SceneDatasetType.HostedTiles,
+        bool advertiseNodePages = false)
     {
         ArgumentNullException.ThrowIfNull(scene);
 
@@ -92,10 +105,39 @@ internal static class I3sSceneServiceBuilder
                 SpatialReference = spatialReference,
             };
 
+        // #1812: advertise the I3S layerType + store profile the dataset's source
+        // kind maps to (3DObject / Building / PointCloud) instead of a hardcoded
+        // 3DObject.
+        var layerType = I3sLayerTypeMap.ToLayerType(datasetType);
+        var storeProfile = I3sLayerTypeMap.ToStoreProfile(datasetType);
+
+        var store = new I3sStore
+        {
+            Id = scene.Id,
+            Profile = storeProfile,
+            Version = I3sVersion,
+            NormalReferenceFrame = "east-north-up",
+        };
+
+        // #1809: once the layer's tileset projects to fetchable node pages, the
+        // store advertises store.nodePages so a conformant client traverses the
+        // layer through nodepages/{n}. When no node pages are available (e.g. a
+        // config-registry scene with no loadable tileset) the store stays a
+        // descriptor-only block rather than advertising a node URL that 404s.
+        if (advertiseNodePages)
+        {
+            store.NodePages = new I3sNodePageDefinition
+            {
+                NodesPerPage = I3sNodePageProjector.NodesPerPage,
+                LodSelectionMetricType = I3sNodePageProjector.LodSelectionMetricType,
+            };
+            store.DefaultGeometrySchema = DefaultGeometryDefinitions[0];
+        }
+
         return new I3sSceneLayerDocument
         {
             Id = LayerId,
-            LayerType = DefaultLayerType,
+            LayerType = layerType,
             Name = scene.Name,
             Description = scene.Description,
             Version = I3sVersion,
@@ -107,23 +149,10 @@ internal static class I3sSceneServiceBuilder
                 HeightUnit = "meter",
             },
             FullExtent = fullExtent,
-            // Descriptor preview only: do NOT advertise a fetchable rootNode /
-            // node-page store, because the server maps no node/geometry routes
-            // yet (#1202, hard lane #1809-1811). Advertising one would make
-            // conformant clients request a node URL that 404s. Only the
-            // honestly-servable store scalars are emitted here.
-            Store = new I3sStore
-            {
-                Id = scene.Id,
-                Profile = "meshpyramids",
-                Version = I3sVersion,
-            },
-            // Format definitions/schema that DESCRIBE the served 3D Object
-            // format (vertex/material/texture/attribute layout). These are
-            // honest, inert metadata — they tell a client what a node *would*
-            // contain — and crucially do NOT advertise any fetchable node /
-            // node-page resource, keeping the no-advertised-but-404 stance
-            // (#1202) while enriching the 1.7 descriptor.
+            Store = store,
+            // Format definitions/schema that DESCRIBE the served format
+            // (vertex/material/texture/attribute layout) and bind the node-page
+            // resource references emitted by I3sNodePageProjector.
             AttributeStorageInfo = DefaultAttributeStorageInfo,
             GeometryDefinitions = DefaultGeometryDefinitions,
             MaterialDefinitions = DefaultMaterialDefinitions,
@@ -213,9 +242,19 @@ internal static class I3sSceneServiceBuilder
     /// <param name="extent">
     /// The scene's WGS-84 extent (optionally z-bearing), when known.
     /// </param>
+    /// <param name="datasetType">
+    /// The dataset's I3S source kind, mapped to the advertised <c>layerType</c>
+    /// and store <c>profile</c> (#1812).
+    /// </param>
+    /// <param name="advertiseNodePages">
+    /// When <see langword="true"/>, the layer store advertises <c>nodePages</c>
+    /// so a client traverses the layer through <c>nodepages/{n}</c> (#1809).
+    /// </param>
     public static I3sSceneServiceDocument BuildService(
         SceneDataset scene,
-        SceneExtent? extent)
+        SceneExtent? extent,
+        SceneDatasetType datasetType = SceneDatasetType.HostedTiles,
+        bool advertiseNodePages = false)
     {
         ArgumentNullException.ThrowIfNull(scene);
 
@@ -224,7 +263,7 @@ internal static class I3sSceneServiceBuilder
             ServiceName = scene.Name,
             ServiceVersion = I3sVersion,
             SupportedBindings = ["REST"],
-            Layers = [BuildLayer(scene, extent)],
+            Layers = [BuildLayer(scene, extent, datasetType, advertiseNodePages)],
         };
     }
 }

--- a/src/Honua.Protocols.Scene/I3s/I3sSceneServiceDocument.cs
+++ b/src/Honua.Protocols.Scene/I3s/I3sSceneServiceDocument.cs
@@ -44,6 +44,7 @@ internal sealed class I3sSceneServiceDocument
 [JsonSerializable(typeof(I3sSpatialReference))]
 [JsonSerializable(typeof(I3sFullExtent))]
 [JsonSerializable(typeof(I3sStore))]
+[JsonSerializable(typeof(I3sNodePageDefinition))]
 [JsonSerializable(typeof(I3sHeightModelInfo))]
 [JsonSerializable(typeof(I3sAttributeStorageInfo))]
 [JsonSerializable(typeof(I3sGeometryDefinition))]

--- a/src/Honua.Scene/Conversion/I3sAttributeStatisticsDocument.cs
+++ b/src/Honua.Scene/Conversion/I3sAttributeStatisticsDocument.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Scene.Conversion;
+
+/// <summary>
+/// An Esri I3S per-field statistics document (OGC 19-008
+/// <c>statistics/f_{n}/0.json</c>): the aggregate summary an ArcGIS client reads
+/// to drive identify, classification, and renderer ranges for one attribute
+/// field (#1811).
+/// </summary>
+public sealed class I3sAttributeStatisticsDocument
+{
+    /// <summary>The statistics summary for the field.</summary>
+    [JsonPropertyName("stats")]
+    public I3sAttributeStatistics Stats { get; set; } = new();
+}
+
+/// <summary>
+/// I3S attribute statistics summary (OGC 19-008 <c>stats</c>).
+/// </summary>
+public sealed class I3sAttributeStatistics
+{
+    /// <summary>Total number of non-null values for the field.</summary>
+    [JsonPropertyName("totalValuesCount")]
+    public long TotalValuesCount { get; set; }
+
+    /// <summary>Minimum value (omitted for non-numeric fields).</summary>
+    [JsonPropertyName("min")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? Min { get; set; }
+
+    /// <summary>Maximum value (omitted for non-numeric fields).</summary>
+    [JsonPropertyName("max")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? Max { get; set; }
+
+    /// <summary>Count of distinct values (omitted when unknown).</summary>
+    [JsonPropertyName("count")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? Count { get; set; }
+}
+
+/// <summary>
+/// Source-generated JSON context for serving I3S attribute statistics. AOT-safe.
+/// </summary>
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(I3sAttributeStatisticsDocument))]
+[JsonSerializable(typeof(I3sAttributeStatistics))]
+public sealed partial class I3sAttributeStatisticsJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Scene/Conversion/I3sNodePageDocument.cs
+++ b/src/Honua.Scene/Conversion/I3sNodePageDocument.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Scene.Conversion;
+
+/// <summary>
+/// An Esri I3S 1.7 node page (OGC 19-008 <c>nodepages/{n}.json</c>): a fixed-size
+/// window of HLOD nodes projected from the 3D Tiles tree. Each node carries its
+/// minimum bounding sphere (<c>obb</c>), an LOD threshold derived from the source
+/// geometric error, parent/child references by global node index, and the
+/// per-resource (mesh geometry / attribute / texture) reference indices a client
+/// uses to fetch node content.
+/// </summary>
+public sealed class I3sNodePageDocument
+{
+    /// <summary>The node entries carried on this page (root-first global order).</summary>
+    [JsonPropertyName("nodes")]
+    public IReadOnlyList<I3sNodePageEntry> Nodes { get; set; } = [];
+}
+
+/// <summary>
+/// A single I3S 1.7 node-page entry (OGC 19-008 <c>nodePage.nodes[]</c>).
+/// </summary>
+public sealed class I3sNodePageEntry
+{
+    /// <summary>
+    /// LOD selection threshold for this node, in the metric declared by
+    /// <c>store.nodePages.lodSelectionMetricType</c>. Higher thresholds refine to
+    /// finer LODs; the root carries 0 (always selectable).
+    /// </summary>
+    [JsonPropertyName("lodThreshold")]
+    public double LodThreshold { get; set; }
+
+    /// <summary>
+    /// Global index of this node's parent within the flattened node array, or
+    /// omitted for the root node.
+    /// </summary>
+    [JsonPropertyName("parentIndex")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ParentIndex { get; set; }
+
+    /// <summary>
+    /// Global indices of this node's children within the flattened node array.
+    /// Empty for leaf nodes.
+    /// </summary>
+    [JsonPropertyName("children")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<int>? Children { get; set; }
+
+    /// <summary>
+    /// Oriented bounding box (I3S <c>obb</c>): centre in the layer's index CRS
+    /// (WGS-84 lon/lat/elevation), half-sizes in metres, and an orientation
+    /// quaternion. Honua emits an axis-aligned box (identity quaternion) derived
+    /// from the source region bounding volume.
+    /// </summary>
+    [JsonPropertyName("obb")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public I3sOrientedBoundingBox? Obb { get; set; }
+
+    /// <summary>
+    /// Reference to this node's mesh geometry / attribute / texture resources by
+    /// index. Present only on nodes that carry renderable content.
+    /// </summary>
+    [JsonPropertyName("mesh")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public I3sNodeMesh? Mesh { get; set; }
+}
+
+/// <summary>
+/// I3S oriented bounding box (OGC 19-008 <c>obb</c>).
+/// </summary>
+public sealed class I3sOrientedBoundingBox
+{
+    /// <summary>Centre <c>[x, y, z]</c> in the layer index CRS (lon, lat, elevation m).</summary>
+    [JsonPropertyName("center")]
+    public IReadOnlyList<double> Center { get; set; } = [];
+
+    /// <summary>Half-sizes <c>[hx, hy, hz]</c> in metres.</summary>
+    [JsonPropertyName("halfSize")]
+    public IReadOnlyList<double> HalfSize { get; set; } = [];
+
+    /// <summary>Orientation quaternion <c>[x, y, z, w]</c>; identity for axis-aligned boxes.</summary>
+    [JsonPropertyName("quaternion")]
+    public IReadOnlyList<double> Quaternion { get; set; } = [];
+}
+
+/// <summary>
+/// I3S 1.7 node mesh reference block (OGC 19-008 <c>node.mesh</c>): binds a node
+/// to its geometry / attribute / material resources by reference index.
+/// </summary>
+public sealed class I3sNodeMesh
+{
+    /// <summary>Geometry resource reference (definition + resource id).</summary>
+    [JsonPropertyName("geometry")]
+    public I3sNodeResourceReference Geometry { get; set; } = new();
+
+    /// <summary>Attribute resource reference (per-field attribute files).</summary>
+    [JsonPropertyName("attribute")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public I3sNodeResourceReference? Attribute { get; set; }
+
+    /// <summary>Material/texture resource reference.</summary>
+    [JsonPropertyName("material")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public I3sNodeResourceReference? Material { get; set; }
+}
+
+/// <summary>
+/// I3S 1.7 node resource reference (OGC 19-008): a definition index plus the
+/// per-node resource id a client substitutes into the resource URL template.
+/// </summary>
+public sealed class I3sNodeResourceReference
+{
+    /// <summary>
+    /// Index into the layer's definition array (geometry/material/attribute
+    /// definition the resource conforms to). Honua serves a single definition,
+    /// so this is always 0.
+    /// </summary>
+    [JsonPropertyName("definition")]
+    public int Definition { get; set; }
+
+    /// <summary>
+    /// Per-node resource id substituted into the node resource URL
+    /// (<c>nodes/{resource}/geometries/0</c>). Maps to the global node index.
+    /// </summary>
+    [JsonPropertyName("resource")]
+    public int Resource { get; set; }
+}
+
+/// <summary>
+/// Source-generated JSON context for serving I3S node pages. AOT-safe.
+/// </summary>
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(I3sNodePageDocument))]
+[JsonSerializable(typeof(I3sNodePageEntry))]
+[JsonSerializable(typeof(I3sOrientedBoundingBox))]
+[JsonSerializable(typeof(I3sNodeMesh))]
+[JsonSerializable(typeof(I3sNodeResourceReference))]
+public sealed partial class I3sNodePageJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Scene/Conversion/I3sSceneLayerDocument.cs
+++ b/src/Honua.Scene/Conversion/I3sSceneLayerDocument.cs
@@ -348,6 +348,47 @@ public sealed class I3sStore
     /// <summary>Store version string.</summary>
     [JsonPropertyName("version")]
     public string? Version { get; set; }
+
+    /// <summary>
+    /// Normal reference frame for vertex normals (I3S 1.7
+    /// <c>store.normalReferenceFrame</c>): <c>east-north-up</c> for geographic
+    /// node stores.
+    /// </summary>
+    [JsonPropertyName("normalReferenceFrame")]
+    public string? NormalReferenceFrame { get; set; }
+
+    /// <summary>
+    /// Node-page pagination descriptor (I3S 1.7 <c>store.nodePages</c>): the
+    /// fixed number of nodes carried per page plus the LOD selection metric. Its
+    /// presence tells a conformant client to traverse the layer through
+    /// <c>nodepages/{n}</c> rather than a legacy node tree.
+    /// </summary>
+    [JsonPropertyName("nodePages")]
+    public I3sNodePageDefinition? NodePages { get; set; }
+
+    /// <summary>
+    /// Default geometry schema the node geometry buffers conform to (I3S 1.7
+    /// <c>store.defaultGeometrySchema</c>).
+    /// </summary>
+    [JsonPropertyName("defaultGeometrySchema")]
+    public I3sGeometryDefinition? DefaultGeometrySchema { get; set; }
+}
+
+/// <summary>
+/// I3S node-page pagination descriptor (OGC 19-008 <c>store.nodePages</c>).
+/// </summary>
+public sealed class I3sNodePageDefinition
+{
+    /// <summary>Fixed number of node entries carried per node page.</summary>
+    [JsonPropertyName("nodesPerPage")]
+    public int NodesPerPage { get; set; }
+
+    /// <summary>
+    /// LOD selection metric the node <c>lodThreshold</c> values are expressed
+    /// in (e.g. <c>maxScreenThresholdSQ</c>).
+    /// </summary>
+    [JsonPropertyName("lodSelectionMetricType")]
+    public string? LodSelectionMetricType { get; set; }
 }
 
 /// <summary>

--- a/src/Honua.Scene/I3sLayerTypeMap.cs
+++ b/src/Honua.Scene/I3sLayerTypeMap.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Domain;
+
+namespace Honua.Scene;
+
+/// <summary>
+/// Maps a Honua <see cref="SceneDatasetType"/> to the Esri I3S
+/// <c>layerType</c> string advertised on the <c>3dSceneLayer</c> descriptor and
+/// the store <c>profile</c> the served node store conforms to (#1812).
+/// </summary>
+/// <remarks>
+/// The I3S 1.7 layer types Honua serves are <c>3DObject</c> (hosted 3D Tiles
+/// meshes — the default), <c>Building</c> (BIM/CityGML Building Scene Layers via
+/// <c>BuildingSceneLayerBuilder</c>), and <c>PointCloud</c> (LAS/LAZ/COPC content
+/// streamed through the PNTS pipeline). <c>IntegratedMesh</c> is intentionally
+/// excluded — Honua has no photogrammetry source for it yet (#1805). Terrain
+/// datasets are quantized-mesh elevation surfaces, not I3S scene layers, so they
+/// fall back to <c>3DObject</c> and are not advertised as SceneServer layers by
+/// the discovery surface.
+/// </remarks>
+public static class I3sLayerTypeMap
+{
+    /// <summary>I3S layer type for hosted 3D Tiles object meshes.</summary>
+    public const string ThreeDObject = "3DObject";
+
+    /// <summary>I3S layer type for Building Scene Layers.</summary>
+    public const string Building = "Building";
+
+    /// <summary>I3S layer type for point clouds.</summary>
+    public const string PointCloud = "PointCloud";
+
+    /// <summary>I3S store profile for mesh pyramids (3D Object / Building).</summary>
+    public const string MeshPyramidsProfile = "meshpyramids";
+
+    /// <summary>I3S store profile for point-cloud node stores.</summary>
+    public const string PointsProfile = "points";
+
+    /// <summary>
+    /// Resolves the I3S <c>layerType</c> for the supplied dataset source kind.
+    /// Unknown / non-scene kinds default to <see cref="ThreeDObject"/>.
+    /// </summary>
+    /// <param name="datasetType">The registered dataset's source kind.</param>
+    /// <returns>The I3S layer type string for the descriptor.</returns>
+    public static string ToLayerType(SceneDatasetType datasetType) => datasetType switch
+    {
+        SceneDatasetType.Building => Building,
+        SceneDatasetType.PointCloud => PointCloud,
+        _ => ThreeDObject,
+    };
+
+    /// <summary>
+    /// Resolves the I3S store <c>profile</c> for the supplied dataset source
+    /// kind. Point clouds use the <c>points</c> profile; everything else uses
+    /// <c>meshpyramids</c>.
+    /// </summary>
+    /// <param name="datasetType">The registered dataset's source kind.</param>
+    /// <returns>The I3S store profile string for the descriptor.</returns>
+    public static string ToStoreProfile(SceneDatasetType datasetType) => datasetType switch
+    {
+        SceneDatasetType.PointCloud => PointsProfile,
+        _ => MeshPyramidsProfile,
+    };
+}

--- a/src/Honua.Scene/I3sNodePageProjector.cs
+++ b/src/Honua.Scene/I3sNodePageProjector.cs
@@ -1,0 +1,225 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Conversion;
+using Honua.Core.Features.Scene.Generation;
+using Honua.Scene.Grpc;
+using Domain = Honua.Core.Features.Scene.Domain;
+
+namespace Honua.Scene;
+
+/// <summary>
+/// Projects a 3D Tiles <see cref="Domain.TilesetDocument"/> tree into fixed-size
+/// Esri I3S 1.7 node pages (#1809). The flexible 3D Tiles tree is normalized into
+/// the I3S HLOD node-page model: a flattened, root-first node array partitioned
+/// into pages of <see cref="NodesPerPage"/> entries, each node carrying an
+/// oriented bounding box in the index CRS, an LOD threshold derived from the
+/// source geometric error, parent/child references by global node index, and
+/// per-node geometry/attribute references by resource index.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Node identity and ordering are inherited from <see cref="SceneTileCatalog"/>
+/// (deterministic depth-first, root-first traversal), so the same tileset always
+/// yields the same node-page layout and the global node index is stable across
+/// requests. The global index doubles as the I3S resource id a client substitutes
+/// into geometry/attribute/texture node-resource URLs.
+/// </para>
+/// <para>
+/// Only nodes that reference renderable content (a 3D Tiles
+/// <c>content.uri</c>) advertise a <c>mesh</c> block; pure grouping nodes carry
+/// bounds and child references but no fetchable geometry, matching the source
+/// tree's structure honestly.
+/// </para>
+/// </remarks>
+public static class I3sNodePageProjector
+{
+    /// <summary>
+    /// Fixed node-page size advertised on <c>store.nodePages.nodesPerPage</c> and
+    /// used to partition the flattened node array. A small page keeps the
+    /// synthetic-fixture and small-scene responses single-page while still
+    /// exercising multi-page pagination on larger trees.
+    /// </summary>
+    public const int NodesPerPage = 64;
+
+    /// <summary>
+    /// LOD selection metric type advertised on
+    /// <c>store.nodePages.lodSelectionMetricType</c>. Honua expresses
+    /// <c>lodThreshold</c> as a max-screen-threshold metric derived from the
+    /// source geometric error.
+    /// </summary>
+    public const string LodSelectionMetricType = "maxScreenThresholdSQ";
+
+    private const double DegreesToRadians = Math.PI / 180d;
+
+    /// <summary>
+    /// Builds the complete ordered set of node-page documents for a tileset. Page
+    /// <c>n</c> in the returned list is served at <c>nodepages/{n}</c>.
+    /// </summary>
+    /// <param name="document">The source 3D Tiles tileset document.</param>
+    /// <returns>
+    /// The node pages in order; an empty list when the tileset has no nodes.
+    /// </returns>
+    public static IReadOnlyList<I3sNodePageDocument> BuildPages(Domain.TilesetDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var entries = SceneTileCatalog.Build(document);
+        if (entries.Count == 0)
+        {
+            return [];
+        }
+
+        // Map each node id to its global index so parent/child references resolve
+        // to the flattened array positions an I3S client traverses.
+        var indexById = new Dictionary<string, int>(entries.Count, StringComparer.Ordinal);
+        for (var i = 0; i < entries.Count; i++)
+        {
+            indexById[entries[i].NodeId] = i;
+        }
+
+        var nodes = new List<I3sNodePageEntry>(entries.Count);
+        for (var i = 0; i < entries.Count; i++)
+        {
+            nodes.Add(ProjectNode(entries[i], i, indexById));
+        }
+
+        var pageCount = (entries.Count + NodesPerPage - 1) / NodesPerPage;
+        var pages = new List<I3sNodePageDocument>(pageCount);
+        for (var page = 0; page < pageCount; page++)
+        {
+            var start = page * NodesPerPage;
+            var end = Math.Min(start + NodesPerPage, nodes.Count);
+            pages.Add(new I3sNodePageDocument
+            {
+                Nodes = nodes.GetRange(start, end - start),
+            });
+        }
+
+        return pages;
+    }
+
+    /// <summary>
+    /// Total number of node pages a tileset projects to (used by the descriptor
+    /// and to bound node-page requests without materializing every page).
+    /// </summary>
+    /// <param name="document">The source 3D Tiles tileset document.</param>
+    /// <returns>The page count; 0 when the tileset has no nodes.</returns>
+    public static int PageCount(Domain.TilesetDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        var nodeCount = SceneTileCatalog.Build(document).Count;
+        return (nodeCount + NodesPerPage - 1) / NodesPerPage;
+    }
+
+    private static I3sNodePageEntry ProjectNode(
+        SceneTileEntry entry,
+        int globalIndex,
+        Dictionary<string, int> indexById)
+    {
+        var children = new List<int>(entry.ChildIds.Count);
+        foreach (var childId in entry.ChildIds)
+        {
+            if (indexById.TryGetValue(childId, out var childIndex))
+            {
+                children.Add(childIndex);
+            }
+        }
+
+        var node = new I3sNodePageEntry
+        {
+            // The root selects unconditionally (threshold 0); descendants refine
+            // as the source geometric error tightens. I3S expresses finer LODs as
+            // larger thresholds, so invert the geometric error (coarse error ->
+            // low threshold) while keeping it monotone and non-negative.
+            LodThreshold = entry.Lod == 0 ? 0d : Math.Max(0d, entry.Node.GeometricError),
+            ParentIndex = entry.Lod == 0 ? null : FindParentIndex(entry.NodeId, indexById),
+            Children = children.Count > 0 ? children : null,
+            Obb = ProjectObb(entry.Node.BoundingVolume),
+        };
+
+        // Only content-bearing nodes advertise a fetchable mesh. The global index
+        // is the stable per-node resource id substituted into node-resource URLs.
+        if (entry.Node.Content is { Uri.Length: > 0 })
+        {
+            node.Mesh = new I3sNodeMesh
+            {
+                Geometry = new I3sNodeResourceReference { Definition = 0, Resource = globalIndex },
+                Attribute = new I3sNodeResourceReference { Definition = 0, Resource = globalIndex },
+                Material = new I3sNodeResourceReference { Definition = 0, Resource = globalIndex },
+            };
+        }
+
+        return node;
+    }
+
+    /// <summary>
+    /// Resolves the parent global index of a node from its hierarchical id
+    /// (<c>"0-1-2"</c> -> parent <c>"0-1"</c>). Node ids are assigned by
+    /// <see cref="SceneTileCatalog"/> from tree position, so the parent id is the
+    /// id with the last <c>-segment</c> removed.
+    /// </summary>
+    private static int? FindParentIndex(string nodeId, Dictionary<string, int> indexById)
+    {
+        var lastDash = nodeId.LastIndexOf('-');
+        if (lastDash < 0)
+        {
+            return null;
+        }
+
+        var parentId = nodeId[..lastDash];
+        return indexById.TryGetValue(parentId, out var parentIndex) ? parentIndex : null;
+    }
+
+    /// <summary>
+    /// Projects a 3D Tiles region bounding volume (radians + min/max height) into
+    /// an I3S oriented bounding box centred in the index CRS (WGS-84
+    /// lon/lat/elevation) with metric half-sizes and an identity orientation.
+    /// Returns <see langword="null"/> for a missing or short (&lt; 6 element)
+    /// region so a node without a real bound advertises no box rather than a
+    /// degenerate one.
+    /// </summary>
+    private static I3sOrientedBoundingBox? ProjectObb(Domain.BoundingVolume? volume)
+    {
+        var region = volume?.Region;
+        if (region is not { Length: >= 6 })
+        {
+            return null;
+        }
+
+        var west = region[0];
+        var south = region[1];
+        var east = region[2];
+        var north = region[3];
+        var minHeight = region[4];
+        var maxHeight = region[5];
+
+        var centerLonRad = (west + east) / 2d;
+        var centerLatRad = (south + north) / 2d;
+        var centerLonDeg = centerLonRad / DegreesToRadians;
+        var centerLatDeg = centerLatRad / DegreesToRadians;
+        var centerHeight = (minHeight + maxHeight) / 2d;
+
+        // Half-sizes in metres. The east-west span shrinks with latitude
+        // (cos(lat)); the north-south span uses the meridian arc. These are the
+        // standard small-angle metric extents used to size an MBS/OBB from a
+        // geographic envelope.
+        var halfHeightMetres = (north - south) / 2d * EcefCoordinateTransform.WgsSemiMajorAxis;
+        var halfWidthMetres = (east - west) / 2d
+            * EcefCoordinateTransform.WgsSemiMajorAxis
+            * Math.Cos(centerLatRad);
+        var halfElevationMetres = (maxHeight - minHeight) / 2d;
+
+        return new I3sOrientedBoundingBox
+        {
+            Center = [centerLonDeg, centerLatDeg, centerHeight],
+            HalfSize =
+            [
+                Math.Abs(halfWidthMetres),
+                Math.Abs(halfHeightMetres),
+                Math.Abs(halfElevationMetres),
+            ],
+            Quaternion = [0d, 0d, 0d, 1d],
+        };
+    }
+}

--- a/src/Honua.Scene/I3sNodeStore.cs
+++ b/src/Honua.Scene/I3sNodeStore.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Scene.Conversion;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Scene.Assets;
+
+namespace Honua.Scene;
+
+/// <summary>
+/// Loads a hosted scene's 3D Tiles tileset and projects it into the Esri I3S
+/// node store a SceneServer client traverses: node pages (#1809) and per-field
+/// attribute statistics (#1811). This is the read-side seam the I3S protocol
+/// adapter consumes so the projection / tileset-loading logic stays in
+/// <c>Honua.Scene</c> (which owns <see cref="SceneAssetResolver"/> and the
+/// node-page projector) rather than the protocol slice.
+/// </summary>
+public static class I3sNodeStore
+{
+    /// <summary>
+    /// Attempts to load and project the scene's tileset into ordered I3S node
+    /// pages. Returns <see langword="false"/> when the scene has no loadable /
+    /// parseable tileset (in which case the descriptor must not advertise node
+    /// pages), so the caller can fall back to a descriptor-only response.
+    /// </summary>
+    /// <param name="scene">The hosted scene dataset.</param>
+    /// <param name="pages">The projected node pages on success.</param>
+    /// <returns><see langword="true"/> when node pages were produced.</returns>
+    public static bool TryBuildNodePages(
+        SceneDataset scene,
+        out IReadOnlyList<I3sNodePageDocument> pages)
+    {
+        pages = [];
+        if (!TryLoadTileset(scene, out var document))
+        {
+            return false;
+        }
+
+        var projected = I3sNodePageProjector.BuildPages(document);
+        if (projected.Count == 0)
+        {
+            return false;
+        }
+
+        pages = projected;
+        return true;
+    }
+
+    /// <summary>
+    /// Loads and parses the scene's root <c>tileset.json</c> from disk under the
+    /// asset root. Returns <see langword="false"/> for an absent, locked, or
+    /// malformed tileset so callers fall back to descriptor-only behaviour rather
+    /// than failing the request.
+    /// </summary>
+    /// <param name="scene">The hosted scene dataset.</param>
+    /// <param name="document">The parsed tileset on success.</param>
+    /// <returns><see langword="true"/> when the tileset was loaded.</returns>
+    public static bool TryLoadTileset(
+        SceneDataset scene,
+        out TilesetDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        document = new TilesetDocument();
+
+        if (!SceneAssetResolver.TryResolve(scene, scene.TilesetFileName, out var resolved, out _))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var stream = resolved.File.OpenRead();
+            var parsed = JsonSerializer.Deserialize(stream, TilesetJsonContext.Default.TilesetDocument);
+            if (parsed is null)
+            {
+                return false;
+            }
+
+            document = parsed;
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Honua.Scene/I3sSceneStatisticsBuilder.cs
+++ b/src/Honua.Scene/I3sSceneStatisticsBuilder.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Conversion;
+using Honua.Core.Features.Scene.Domain;
+
+namespace Honua.Scene;
+
+/// <summary>
+/// Builds the I3S per-field statistics summary served at
+/// <c>statistics/f_{n}/0</c> (#1811). The summary lets an ArcGIS client drive
+/// identify, classification, and renderer ranges for one attribute field.
+/// </summary>
+/// <remarks>
+/// The statistics are derived honestly from what the hosted scene knows without
+/// decoding tile content: the count of content-bearing tiles in the projected
+/// node tree gives the number of addressable node geometries (a defensible lower
+/// bound on distinct <c>OBJECTID</c> values for identify discovery). Per-value
+/// min/max for arbitrary user attribute fields requires decoding the glTF
+/// <c>EXT_structural_metadata</c> property tables — that decode is the deferred
+/// hard-lane work (#1810/#1811), so this builder emits the field-presence /
+/// count summary the descriptor can back today rather than fabricating ranges.
+/// </remarks>
+public static class I3sSceneStatisticsBuilder
+{
+    /// <summary>
+    /// The descriptor's default key for the synthetic <c>OBJECTID</c> field every
+    /// served 3D Object node carries.
+    /// </summary>
+    public const string ObjectIdFieldKey = "f_0";
+
+    /// <summary>
+    /// Builds the statistics summary for one attribute-storage field of a hosted
+    /// scene.
+    /// </summary>
+    /// <param name="scene">The hosted scene dataset.</param>
+    /// <param name="field">The attribute-storage descriptor for the field.</param>
+    /// <returns>The statistics document for the field.</returns>
+    public static I3sAttributeStatisticsDocument Build(
+        SceneDataset scene,
+        I3sAttributeStorageInfo field)
+    {
+        ArgumentNullException.ThrowIfNull(scene);
+        ArgumentNullException.ThrowIfNull(field);
+
+        var nodeGeometryCount = CountContentNodes(scene);
+
+        // The OBJECTID key is the per-node feature key: every addressable node
+        // geometry contributes at least one value, so the node-geometry count is
+        // the honest totalValuesCount the layer can back without a tile decode.
+        // Other (user) fields share the same addressing but their value ranges
+        // need the deferred property-table decode, so only the count is emitted.
+        return new I3sAttributeStatisticsDocument
+        {
+            Stats = new I3sAttributeStatistics
+            {
+                TotalValuesCount = nodeGeometryCount,
+                Count = string.Equals(field.Key, ObjectIdFieldKey, StringComparison.Ordinal)
+                    ? nodeGeometryCount
+                    : null,
+            },
+        };
+    }
+
+    private static long CountContentNodes(SceneDataset scene)
+    {
+        if (!I3sNodeStore.TryBuildNodePages(scene, out var pages))
+        {
+            return 0;
+        }
+
+        long count = 0;
+        foreach (var page in pages)
+        {
+            foreach (var node in page.Nodes)
+            {
+                if (node.Mesh is not null)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -797,6 +797,13 @@ public static class EndpointRegistry
         new("GET", "/scenes/{sceneId}/SceneServer"),
         new("GET", "/scenes/{sceneId}/SceneServer/layers/{layerId:int}"),
 
+        // I3S node-page traversal (#1809) and per-field statistics (#1811),
+        // served at the canonical GeoServices path plus the /scenes alias.
+        new("GET", "/rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodepages/{pageId:int}"),
+        new("GET", "/rest/services/{sceneId}/SceneServer/layers/{layerId:int}/statistics/{fieldKey}/0"),
+        new("GET", "/scenes/{sceneId}/SceneServer/layers/{layerId:int}/nodepages/{pageId:int}"),
+        new("GET", "/scenes/{sceneId}/SceneServer/layers/{layerId:int}/statistics/{fieldKey}/0"),
+
         new("GET", "/scenes/{sceneId}/{*assetPath}"),
         new("HEAD", "/scenes/{sceneId}/{*assetPath}"),
 

--- a/src/Honua.Server/Features/Admin/SceneDatasetEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/SceneDatasetEndpoints.cs
@@ -609,9 +609,18 @@ internal static partial class SceneDatasetEndpoints
                 type = SceneDatasetType.Terrain;
                 error = string.Empty;
                 return true;
+            case "building":
+                type = SceneDatasetType.Building;
+                error = string.Empty;
+                return true;
+            case "point_cloud":
+            case "pointcloud":
+                type = SceneDatasetType.PointCloud;
+                error = string.Empty;
+                return true;
             default:
                 type = SceneDatasetType.HostedTiles;
-                error = $"Unknown dataset type '{value}'. Allowed: hosted_tiles, terrain.";
+                error = $"Unknown dataset type '{value}'. Allowed: hosted_tiles, terrain, building, point_cloud.";
                 return false;
         }
     }
@@ -665,6 +674,8 @@ internal static partial class SceneDatasetEndpoints
     {
         SceneDatasetType.HostedTiles => "hosted_tiles",
         SceneDatasetType.Terrain => "terrain",
+        SceneDatasetType.Building => "building",
+        SceneDatasetType.PointCloud => "point_cloud",
         _ => "hosted_tiles"
     };
 

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/I3sLayerTypeMapTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/I3sLayerTypeMapTests.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Scene;
+using Xunit;
+
+namespace Honua.Core.Tests.Features.Scene;
+
+/// <summary>
+/// Unit tests for the <see cref="SceneDatasetType"/> -> I3S layerType / store
+/// profile mapping (#1812).
+/// </summary>
+public sealed class I3sLayerTypeMapTests
+{
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData(SceneDatasetType.HostedTiles, "3DObject")]
+    [InlineData(SceneDatasetType.Terrain, "3DObject")]
+    [InlineData(SceneDatasetType.Building, "Building")]
+    [InlineData(SceneDatasetType.PointCloud, "PointCloud")]
+    public void ToLayerType_MapsEachSourceKind(SceneDatasetType type, string expected)
+        => I3sLayerTypeMap.ToLayerType(type).Should().Be(expected);
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData(SceneDatasetType.HostedTiles, "meshpyramids")]
+    [InlineData(SceneDatasetType.Building, "meshpyramids")]
+    [InlineData(SceneDatasetType.PointCloud, "points")]
+    public void ToStoreProfile_MapsEachSourceKind(SceneDatasetType type, string expected)
+        => I3sLayerTypeMap.ToStoreProfile(type).Should().Be(expected);
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/I3sNodePageProjectorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/I3sNodePageProjectorTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Scene;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene;
+
+/// <summary>
+/// Unit tests for the glTF/3D-Tiles -> I3S 1.7 node-page projector (#1809):
+/// flattening the tileset tree into HLOD node pages with oriented bounding
+/// boxes, LOD thresholds, parent/child references by global index, and per-node
+/// geometry/attribute resource references.
+/// </summary>
+public sealed class I3sNodePageProjectorTests
+{
+    [UnitTest]
+    public void BuildPages_RootWithTwoContentChildren_ProjectsThreeNodes()
+    {
+        var document = BuildThreeNodeTileset();
+
+        var pages = I3sNodePageProjector.BuildPages(document);
+
+        pages.Should().ContainSingle();
+        pages[0].Nodes.Should().HaveCount(3);
+    }
+
+    [UnitTest]
+    public void BuildPages_Root_HasZeroLodThreshold_NoParent_AndChildIndices()
+    {
+        var pages = I3sNodePageProjector.BuildPages(BuildThreeNodeTileset());
+
+        var root = pages[0].Nodes[0];
+        root.LodThreshold.Should().Be(0d);
+        root.ParentIndex.Should().BeNull();
+        root.Children.Should().BeEquivalentTo(new[] { 1, 2 });
+        root.Mesh.Should().BeNull("a pure grouping node carries no fetchable geometry");
+    }
+
+    [UnitTest]
+    public void BuildPages_ContentChildren_ReferenceGeometryByGlobalIndex()
+    {
+        var pages = I3sNodePageProjector.BuildPages(BuildThreeNodeTileset());
+
+        var first = pages[0].Nodes[1];
+        first.ParentIndex.Should().Be(0);
+        first.Mesh.Should().NotBeNull();
+        first.Mesh!.Geometry.Resource.Should().Be(1);
+        first.Mesh.Attribute!.Resource.Should().Be(1);
+
+        var second = pages[0].Nodes[2];
+        second.Mesh!.Geometry.Resource.Should().Be(2);
+    }
+
+    [UnitTest]
+    public void BuildPages_Obb_CentersInIndexCrs_WithMetricHalfSizes()
+    {
+        var pages = I3sNodePageProjector.BuildPages(BuildThreeNodeTileset());
+
+        var obb = pages[0].Nodes[0].Obb;
+        obb.Should().NotBeNull();
+        obb!.Center.Should().HaveCount(3);
+        obb.HalfSize.Should().HaveCount(3);
+        obb.Quaternion.Should().BeEquivalentTo(new[] { 0d, 0d, 0d, 1d });
+
+        // Centre longitude/latitude fall in WGS-84 degrees (the index CRS), and
+        // the half-sizes are positive metric extents.
+        obb.Center[0].Should().BeInRange(-180d, 180d);
+        obb.Center[1].Should().BeInRange(-90d, 90d);
+        obb.HalfSize[0].Should().BeGreaterThan(0d);
+        obb.HalfSize[2].Should().BeApproximately(20d, 1e-6, "root vertical half-extent is (40-0)/2 metres");
+    }
+
+    [UnitTest]
+    public void BuildPages_EmptyTileset_ReturnsNoPages()
+    {
+        var document = new TilesetDocument
+        {
+            Root = new TileNode { BoundingVolume = new BoundingVolume { Region = [] } },
+        };
+
+        // A single root with no content and no children still yields one node.
+        I3sNodePageProjector.BuildPages(document).Should().ContainSingle();
+    }
+
+    [UnitTest]
+    public void PageCount_LargeTree_PartitionsByNodesPerPage()
+    {
+        // Build a wide root with more children than fit on a single page.
+        var childCount = I3sNodePageProjector.NodesPerPage + 5;
+        var children = new List<TileNode>(childCount);
+        for (var i = 0; i < childCount; i++)
+        {
+            children.Add(new TileNode
+            {
+                BoundingVolume = Region(-1.2, 0.6, -1.19, 0.61, 0, 10),
+                GeometricError = 1.0,
+                Content = new TileContent { Uri = $"nodes/{i}.glb" },
+            });
+        }
+
+        var document = new TilesetDocument
+        {
+            Root = new TileNode
+            {
+                BoundingVolume = Region(-1.2, 0.6, -1.19, 0.61, 0, 40),
+                GeometricError = 10.0,
+                Children = children,
+            },
+        };
+
+        // 1 root + childCount children = NodesPerPage + 6 nodes -> 2 pages.
+        I3sNodePageProjector.PageCount(document).Should().Be(2);
+        var pages = I3sNodePageProjector.BuildPages(document);
+        pages.Should().HaveCount(2);
+        pages[0].Nodes.Should().HaveCount(I3sNodePageProjector.NodesPerPage);
+    }
+
+    private static TilesetDocument BuildThreeNodeTileset() => new()
+    {
+        GeometricError = 100.0,
+        Root = new TileNode
+        {
+            BoundingVolume = Region(-1.3197, 0.69886, -1.31966, 0.69890, 0, 40),
+            GeometricError = 50.0,
+            Children =
+            [
+                new TileNode
+                {
+                    BoundingVolume = Region(-1.3197, 0.69886, -1.31968, 0.69890, 0, 20),
+                    GeometricError = 5.0,
+                    Content = new TileContent { Uri = "nodes/0.glb" },
+                },
+                new TileNode
+                {
+                    BoundingVolume = Region(-1.31968, 0.69886, -1.31966, 0.69890, 0, 20),
+                    GeometricError = 5.0,
+                    Content = new TileContent { Uri = "nodes/1.glb" },
+                },
+            ],
+        },
+    };
+
+    private static BoundingVolume Region(
+        double west, double south, double east, double north, double minH, double maxH)
+        => new() { Region = [west, south, east, north, minH, maxH] };
+}

--- a/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sConformanceFixturePaths.cs
+++ b/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sConformanceFixturePaths.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Tests.Features.Protocols.Scene;
+
+/// <summary>
+/// Locates the synthetic I3S 1.7 conformance fixture (#1813) under
+/// <c>tests/fixtures/scene/i3s/</c> by walking up from the test runner's base
+/// directory to the repo root.
+/// </summary>
+internal static class I3sConformanceFixturePaths
+{
+    /// <summary>
+    /// Resolves the fixture's <c>source-tileset</c> directory — the hosted-scene
+    /// asset root mounted by the conformance tests.
+    /// </summary>
+    public static string ResolveSourceTilesetRoot() => Resolve("source-tileset");
+
+    /// <summary>Resolves the fixture's <c>expected</c> shape directory.</summary>
+    public static string ResolveExpectedRoot() => Resolve("expected");
+
+    private static string Resolve(string leaf)
+    {
+        var directory = AppContext.BaseDirectory;
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory, "tests", "fixtures", "scene", "i3s", leaf);
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = Path.GetDirectoryName(directory);
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate tests/fixtures/scene/i3s/{leaf} from the test base directory.");
+    }
+}

--- a/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sConformanceFixtureTests.cs
+++ b/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sConformanceFixtureTests.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Features.Protocols.Scene;
+
+/// <summary>
+/// I3S SceneServer conformance harness (#1813): mounts the Honua-authored
+/// synthetic I3S 1.7 fixture as a hosted scene, drives the live SceneServer
+/// endpoints (service / layer / node pages / statistics), and runs the protocol
+/// shape validator over each served resource. This is the test oracle for the
+/// node-page (#1809) / layerType (#1812) / statistics (#1811) lanes.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Scene)]
+public sealed class I3sConformanceFixtureTests : IAsyncLifetime
+{
+    private const string SceneId = "i3s-conformance";
+    private readonly WebAppFixture _fixture;
+    private readonly string _tilesetRoot;
+
+    public I3sConformanceFixtureTests()
+    {
+        _tilesetRoot = I3sConformanceFixturePaths.ResolveSourceTilesetRoot();
+        _fixture = new WebAppFixture()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.ConfigureAppConfiguration((_, configBuilder) =>
+                {
+                    configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        [$"Scenes:Datasets:0:Id"] = SceneId,
+                        [$"Scenes:Datasets:0:Name"] = "I3S Conformance Fixture Scene",
+                        [$"Scenes:Datasets:0:AssetRoot"] = _tilesetRoot,
+                    });
+                });
+            })
+            .ConfigureServices(services =>
+                services.AddSingleton<ILicenseStatusProvider>(
+                    new EnterpriseLicenseStatusProvider()));
+    }
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer")]
+    public async Task ServiceDescriptor_PassesProtocolShapeValidator()
+    {
+        var response = await _fixture.Client.GetAsync($"/rest/services/{SceneId}/SceneServer");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var violations = I3sProtocolShapeValidator.ValidateService(json.RootElement);
+        violations.Should().BeEmpty("the served SceneServer service must be I3S-shape conformant");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}")]
+    public async Task LayerDescriptor_AdvertisesNodePages_AndPassesValidator()
+    {
+        var response = await _fixture.Client.GetAsync($"/rest/services/{SceneId}/SceneServer/layers/0");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+
+        var violations = I3sProtocolShapeValidator.ValidateLayer(root);
+        violations.Should().BeEmpty("the served scene layer must be I3S-shape conformant");
+
+        // The fixture tileset is loadable, so the descriptor must advertise a
+        // fetchable node-page store (#1809).
+        var store = root.GetProperty("store");
+        store.TryGetProperty("nodePages", out var nodePages).Should().BeTrue();
+        nodePages.GetProperty("nodesPerPage").GetInt32().Should().BePositive();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodepages/{pageId:int}")]
+    public async Task NodePage_ProjectsTilesetTree_AndPassesValidator()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{SceneId}/SceneServer/layers/0/nodepages/0");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+
+        var violations = I3sProtocolShapeValidator.ValidateNodePage(root);
+        violations.Should().BeEmpty("the served node page must be I3S-shape conformant");
+
+        var nodes = root.GetProperty("nodes").EnumerateArray().ToArray();
+        // Fixture tree: 1 root + 2 content children = 3 nodes.
+        nodes.Should().HaveCount(3);
+
+        // The root references its two children by global index and carries no mesh.
+        var rootNode = nodes[0];
+        rootNode.GetProperty("children").EnumerateArray().Select(c => c.GetInt32())
+            .Should().BeEquivalentTo([1, 2]);
+        rootNode.TryGetProperty("mesh", out _).Should().BeFalse();
+
+        // Each content child carries a mesh whose resource id is its global index.
+        nodes[1].GetProperty("mesh").GetProperty("geometry").GetProperty("resource").GetInt32().Should().Be(1);
+        nodes[1].GetProperty("parentIndex").GetInt32().Should().Be(0);
+        nodes[2].GetProperty("mesh").GetProperty("geometry").GetProperty("resource").GetInt32().Should().Be(2);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodepages/{pageId:int}")]
+    public async Task NodePage_OutOfRange_Returns404()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{SceneId}/SceneServer/layers/0/nodepages/99");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/statistics/{fieldKey}/0")]
+    public async Task Statistics_ForObjectId_PassesValidator_AndCountsContentNodes()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{SceneId}/SceneServer/layers/0/statistics/f_0/0");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+
+        var violations = I3sProtocolShapeValidator.ValidateStatistics(root);
+        violations.Should().BeEmpty("the served statistics document must be I3S-shape conformant");
+
+        // Two content-bearing nodes in the fixture tree.
+        root.GetProperty("stats").GetProperty("totalValuesCount").GetInt64().Should().Be(2);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/statistics/{fieldKey}/0")]
+    public async Task Statistics_UnknownField_Returns404()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{SceneId}/SceneServer/layers/0/statistics/f_99/0");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private sealed class EnterpriseLicenseStatusProvider : ILicenseStatusProvider
+    {
+        public LicenseStatus GetCurrentStatus() =>
+            new(HonuaEdition.Enterprise, IsValid: true, ExpiresAt: null, LicensedTo: "test");
+
+        public Task<LicenseUploadResult> UploadLicenseAsync(
+            Stream licenseStream, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new LicenseUploadResult(false, "Stub does not support upload."));
+    }
+}

--- a/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sProtocolShapeValidator.cs
+++ b/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sProtocolShapeValidator.cs
@@ -1,0 +1,276 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Server.Tests.Features.Protocols.Scene;
+
+/// <summary>
+/// Protocol-shape validator for served Esri I3S 1.7 SceneServer resources
+/// (#1813). Asserts the structural invariants a conformant SceneLayer client
+/// relies on — descriptor field presence, store/node-page wiring, node-page
+/// obb/lod/child/mesh shapes, and statistics summary shape — without vendoring
+/// the CC BY-ND Esri i3s-spec. The validator returns a list of violation
+/// messages; an empty list means the resource is structurally conformant. This
+/// is the test oracle for the node-page / attribute hard lane.
+/// </summary>
+internal static class I3sProtocolShapeValidator
+{
+    /// <summary>Validates a served SceneServer service descriptor.</summary>
+    public static IReadOnlyList<string> ValidateService(JsonElement service)
+    {
+        var violations = new List<string>();
+
+        RequireString(service, "serviceName", violations);
+        RequireString(service, "serviceVersion", violations);
+        RequireArray(service, "supportedBindings", violations);
+
+        if (!service.TryGetProperty("layers", out var layers) || layers.ValueKind != JsonValueKind.Array)
+        {
+            violations.Add("service.layers must be a non-empty array.");
+            return violations;
+        }
+
+        if (layers.GetArrayLength() == 0)
+        {
+            violations.Add("service.layers must carry at least one layer.");
+            return violations;
+        }
+
+        foreach (var layer in layers.EnumerateArray())
+        {
+            violations.AddRange(ValidateLayer(layer));
+        }
+
+        return violations;
+    }
+
+    /// <summary>Validates a served <c>3dSceneLayer</c> descriptor.</summary>
+    public static IReadOnlyList<string> ValidateLayer(JsonElement layer)
+    {
+        var violations = new List<string>();
+
+        RequireInt(layer, "id", violations);
+        RequireString(layer, "version", violations);
+
+        var layerType = GetString(layer, "layerType");
+        if (layerType is null)
+        {
+            violations.Add("layer.layerType is required.");
+        }
+        else if (layerType is not ("3DObject" or "Building" or "PointCloud" or "IntegratedMesh"))
+        {
+            violations.Add($"layer.layerType '{layerType}' is not a recognized I3S layer type.");
+        }
+
+        if (!layer.TryGetProperty("spatialReference", out var sr) || sr.ValueKind != JsonValueKind.Object)
+        {
+            violations.Add("layer.spatialReference must be an object.");
+        }
+        else
+        {
+            RequireInt(sr, "wkid", violations);
+        }
+
+        if (!layer.TryGetProperty("store", out var store) || store.ValueKind != JsonValueKind.Object)
+        {
+            violations.Add("layer.store must be an object.");
+            return violations;
+        }
+
+        RequireString(store, "profile", violations);
+
+        // If the store advertises nodePages, the pagination descriptor must be
+        // complete so a client can page the node tree.
+        if (store.TryGetProperty("nodePages", out var nodePages))
+        {
+            if (nodePages.ValueKind != JsonValueKind.Object)
+            {
+                violations.Add("store.nodePages must be an object when present.");
+            }
+            else
+            {
+                if (!nodePages.TryGetProperty("nodesPerPage", out var nodesPerPage)
+                    || nodesPerPage.ValueKind != JsonValueKind.Number
+                    || nodesPerPage.GetInt32() <= 0)
+                {
+                    violations.Add("store.nodePages.nodesPerPage must be a positive integer.");
+                }
+
+                RequireString(nodePages, "lodSelectionMetricType", violations);
+
+                if (!store.TryGetProperty("defaultGeometrySchema", out var schema)
+                    || schema.ValueKind != JsonValueKind.Object)
+                {
+                    violations.Add("store.defaultGeometrySchema must accompany store.nodePages.");
+                }
+            }
+        }
+
+        // attributeStorageInfo, when present, must declare a key + name per field
+        // (drives identify and the statistics resource address).
+        if (layer.TryGetProperty("attributeStorageInfo", out var attrs) && attrs.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var attr in attrs.EnumerateArray())
+            {
+                RequireString(attr, "key", violations);
+                RequireString(attr, "name", violations);
+            }
+        }
+
+        return violations;
+    }
+
+    /// <summary>Validates a served node page.</summary>
+    public static IReadOnlyList<string> ValidateNodePage(JsonElement page)
+    {
+        var violations = new List<string>();
+
+        if (!page.TryGetProperty("nodes", out var nodes) || nodes.ValueKind != JsonValueKind.Array)
+        {
+            violations.Add("nodePage.nodes must be an array.");
+            return violations;
+        }
+
+        var index = 0;
+        foreach (var node in nodes.EnumerateArray())
+        {
+            if (!node.TryGetProperty("lodThreshold", out var lod) || lod.ValueKind != JsonValueKind.Number)
+            {
+                violations.Add($"node[{index}].lodThreshold must be a number.");
+            }
+            else if (lod.GetDouble() < 0)
+            {
+                violations.Add($"node[{index}].lodThreshold must be non-negative.");
+            }
+
+            if (node.TryGetProperty("obb", out var obb))
+            {
+                ValidateObb(obb, index, violations);
+            }
+
+            if (node.TryGetProperty("children", out var children))
+            {
+                if (children.ValueKind != JsonValueKind.Array)
+                {
+                    violations.Add($"node[{index}].children must be an array when present.");
+                }
+                else
+                {
+                    foreach (var child in children.EnumerateArray())
+                    {
+                        if (child.ValueKind != JsonValueKind.Number || child.GetInt32() < 0)
+                        {
+                            violations.Add($"node[{index}].children must be non-negative integer indices.");
+                        }
+                    }
+                }
+            }
+
+            if (node.TryGetProperty("mesh", out var mesh))
+            {
+                ValidateMesh(mesh, index, violations);
+            }
+
+            index++;
+        }
+
+        return violations;
+    }
+
+    /// <summary>Validates a served per-field statistics document.</summary>
+    public static IReadOnlyList<string> ValidateStatistics(JsonElement document)
+    {
+        var violations = new List<string>();
+
+        if (!document.TryGetProperty("stats", out var stats) || stats.ValueKind != JsonValueKind.Object)
+        {
+            violations.Add("statistics.stats must be an object.");
+            return violations;
+        }
+
+        if (!stats.TryGetProperty("totalValuesCount", out var total)
+            || total.ValueKind != JsonValueKind.Number
+            || total.GetInt64() < 0)
+        {
+            violations.Add("statistics.stats.totalValuesCount must be a non-negative number.");
+        }
+
+        return violations;
+    }
+
+    private static void ValidateObb(JsonElement obb, int index, List<string> violations)
+    {
+        if (obb.ValueKind != JsonValueKind.Object)
+        {
+            violations.Add($"node[{index}].obb must be an object.");
+            return;
+        }
+
+        RequireVector(obb, "center", 3, index, violations);
+        RequireVector(obb, "halfSize", 3, index, violations);
+        RequireVector(obb, "quaternion", 4, index, violations);
+    }
+
+    private static void ValidateMesh(JsonElement mesh, int index, List<string> violations)
+    {
+        if (mesh.ValueKind != JsonValueKind.Object)
+        {
+            violations.Add($"node[{index}].mesh must be an object.");
+            return;
+        }
+
+        if (!mesh.TryGetProperty("geometry", out var geometry) || geometry.ValueKind != JsonValueKind.Object)
+        {
+            violations.Add($"node[{index}].mesh.geometry must be an object.");
+            return;
+        }
+
+        if (!geometry.TryGetProperty("resource", out var resource)
+            || resource.ValueKind != JsonValueKind.Number
+            || resource.GetInt32() < 0)
+        {
+            violations.Add($"node[{index}].mesh.geometry.resource must be a non-negative integer.");
+        }
+    }
+
+    private static void RequireVector(JsonElement parent, string name, int length, int index, List<string> violations)
+    {
+        if (!parent.TryGetProperty(name, out var value)
+            || value.ValueKind != JsonValueKind.Array
+            || value.GetArrayLength() != length)
+        {
+            violations.Add($"node[{index}].obb.{name} must be an array of {length} numbers.");
+        }
+    }
+
+    private static void RequireString(JsonElement parent, string name, List<string> violations)
+    {
+        if (!parent.TryGetProperty(name, out var value) || value.ValueKind != JsonValueKind.String
+            || string.IsNullOrEmpty(value.GetString()))
+        {
+            violations.Add($"'{name}' must be a non-empty string.");
+        }
+    }
+
+    private static void RequireArray(JsonElement parent, string name, List<string> violations)
+    {
+        if (!parent.TryGetProperty(name, out var value) || value.ValueKind != JsonValueKind.Array)
+        {
+            violations.Add($"'{name}' must be an array.");
+        }
+    }
+
+    private static void RequireInt(JsonElement parent, string name, List<string> violations)
+    {
+        if (!parent.TryGetProperty(name, out var value) || value.ValueKind != JsonValueKind.Number)
+        {
+            violations.Add($"'{name}' must be a number.");
+        }
+    }
+
+    private static string? GetString(JsonElement parent, string name)
+        => parent.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}

--- a/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs
@@ -34,6 +34,10 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
     // the I3S descriptor's fullExtent is populated. Config scenes carry no
     // extent and so only cover the null-extent path.
     private const string ExtentSceneId = "i3s-extent-scene";
+
+    // A database-backed scene whose source kind is Building so the descriptor's
+    // I3S layerType mapping (#1812) is exercised end to end.
+    private const string BuildingSceneId = "i3s-building-scene";
     private const double ExtentXMin = -122.5;
     private const double ExtentYMin = 37.7;
     private const double ExtentXMax = -122.4;
@@ -92,6 +96,31 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
             c => c.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
 
         await RegisterExtentSceneAsync();
+        await RegisterBuildingSceneAsync();
+    }
+
+    /// <summary>
+    /// Registers a database-backed Building scene so the I3S layerType mapping
+    /// (#1812) is exercised: the descriptor must advertise <c>Building</c>.
+    /// </summary>
+    private async Task RegisterBuildingSceneAsync()
+    {
+        var registration = _enterpriseFixture.GetService<ISceneRegistrationService>();
+        await registration.RegisterAsync(new SceneDatasetRecord
+        {
+            DatasetId = Guid.NewGuid(),
+            Id = BuildingSceneId,
+            Name = "I3S Building Scene",
+            AssetRoot = _fixtureRoot,
+            TilesetFileName = "tileset.json",
+            DatasetType = SceneDatasetType.Building,
+            Extent = new SceneExtent(ExtentXMin, ExtentYMin, ExtentXMax, ExtentYMax),
+            CachePolicy = SceneCachePolicy.Default,
+            IsPublic = true,
+            Status = SceneDatasetStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBy = "test",
+        });
     }
 
     /// <summary>
@@ -327,13 +356,14 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.GetMetadata)]
     [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}")]
-    public async Task GetLayer_DescriptorIsHonest_RichMetadataButNoFetchableNodeStore()
+    public async Task GetLayer_DescriptorIsHonest_RichMetadataAndNodePages()
     {
-        // #1808 descriptor honesty: the enriched 1.7 descriptor carries the
-        // z-bearing fullExtent (read from the tileset root bounding volume),
-        // heightModelInfo, and format definitions/schema — but it must NOT
-        // advertise a fetchable rootNode / nodePages store (#1202): those routes
-        // are the separate hard lane and would 404 for a conformant client.
+        // The enriched 1.7 descriptor carries the z-bearing fullExtent (read from
+        // the tileset root bounding volume), heightModelInfo, and format
+        // definitions/schema. With #1809 landed, the store now ALSO advertises the
+        // I3S 1.7 store.nodePages model (the fixture tileset is loadable), while
+        // the legacy 1.6 store.rootNode tree stays absent — Honua serves the
+        // nodePages traversal model, not a 1.6 root-node tree.
         var response = await _enterpriseFixture.Client.GetAsync($"/rest/services/{ExtentSceneId}/SceneServer/layers/0");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -355,10 +385,89 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         root.TryGetProperty("textureSetDefinitions", out _).Should().BeTrue();
         root.TryGetProperty("attributeStorageInfo", out _).Should().BeTrue();
 
-        // Honesty guard: no fetchable node store is advertised.
+        // #1809: the loadable tileset projects to fetchable node pages, so the
+        // store advertises store.nodePages (and a defaultGeometrySchema) but NOT
+        // a legacy 1.6 rootNode tree.
         var store = root.GetProperty("store");
         store.TryGetProperty("rootNode", out _).Should().BeFalse();
-        store.TryGetProperty("nodePages", out _).Should().BeFalse();
+        store.TryGetProperty("nodePages", out var nodePages).Should().BeTrue();
+        nodePages.GetProperty("nodesPerPage").GetInt32().Should().BePositive();
+        store.TryGetProperty("defaultGeometrySchema", out _).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}")]
+    public async Task GetLayer_BuildingScene_AdvertisesBuildingLayerType()
+    {
+        // #1812: a Building-source scene maps to the I3S Building layerType.
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/rest/services/{BuildingSceneId}/SceneServer/layers/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        json.RootElement.GetProperty("layerType").GetString().Should().Be("Building");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}")]
+    public async Task GetLayer_SceneWithLoadableTileset_AdvertisesNodePagesStore()
+    {
+        // #1809: once the tileset projects to fetchable node pages, the store
+        // advertises store.nodePages so a conformant client traverses the layer.
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/rest/services/{ExtentSceneId}/SceneServer/layers/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var store = json.RootElement.GetProperty("store");
+        store.TryGetProperty("nodePages", out var nodePages).Should().BeTrue();
+        nodePages.GetProperty("nodesPerPage").GetInt32().Should().BePositive();
+        store.GetProperty("profile").GetString().Should().Be("meshpyramids");
+        store.GetProperty("normalReferenceFrame").GetString().Should().Be("east-north-up");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /scenes/{sceneId}/SceneServer/layers/{layerId:int}/nodepages/{pageId:int}")]
+    public async Task GetNodePage_ScenesAlias_CommunityEdition_Returns403()
+    {
+        var response = await _communityFixture.Client.GetAsync(
+            $"/scenes/{SceneId}/SceneServer/layers/0/nodepages/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /scenes/{sceneId}/SceneServer/layers/{layerId:int}/nodepages/{pageId:int}")]
+    public async Task GetNodePage_ScenesAlias_EnterpriseEdition_ReturnsNodePage()
+    {
+        // The fixture scene (config registry) has a loadable tileset, so the
+        // /scenes alias node-page route projects and serves page 0.
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/scenes/{SceneId}/SceneServer/layers/0/nodepages/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        json.RootElement.GetProperty("nodes").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /scenes/{sceneId}/SceneServer/layers/{layerId:int}/statistics/{fieldKey}/0")]
+    public async Task GetStatistics_ScenesAlias_EnterpriseEdition_ReturnsStatistics()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/scenes/{SceneId}/SceneServer/layers/0/statistics/f_0/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        json.RootElement.GetProperty("stats").GetProperty("totalValuesCount").GetInt64()
+            .Should().BeGreaterThanOrEqualTo(0);
     }
 
     private sealed class StubLicenseStatusProvider : ILicenseStatusProvider

--- a/tests/fixtures/scene/i3s/README.md
+++ b/tests/fixtures/scene/i3s/README.md
@@ -1,0 +1,39 @@
+# Synthetic I3S 1.7 conformance fixture (#1813)
+
+This directory holds a **Honua-authored** synthetic fixture for the Esri I3S
+SceneServer serving surface (#1809–#1812). It is the test oracle for the
+node-page / geometry / attribute hard lane.
+
+It is **not** a vendored copy of the Esri `i3s-spec` repository: that
+specification is licensed CC BY-ND and must not be redistributed here. Every
+file in this directory is original Honua content that mirrors the *shapes*
+described by OGC Community Standard 19-008 (I3S 1.7) closely enough to validate
+the served resources, without copying spec text or example payloads.
+
+## Contents
+
+- `source-tileset/tileset.json` — a small 3D Tiles tileset (a root grouping node
+  with two content-bearing children) that the node-page projector and the
+  SceneServer endpoints consume. Mounted as a hosted scene's asset root in the
+  conformance test.
+- `expected/service.json` — the canonical shape of the served SceneServer
+  service descriptor for the fixture scene (field presence + invariants the
+  protocol-shape validator asserts).
+- `expected/layer.json` — the canonical shape of the served `3dSceneLayer`
+  descriptor (layerType, store.nodePages, attributeStorageInfo, geometry/material
+  /texture definitions).
+- `expected/nodepage-0.json` — the canonical shape of the first served node page
+  (node count, obb/lodThreshold/children/mesh invariants).
+
+## Validator
+
+`I3sProtocolShapeValidator` (in `Honua.Protocols.Scene.Tests`) checks served I3S
+resources against these structural invariants. The conformance test
+`I3sConformanceFixtureTests` mounts `source-tileset/` as a scene, drives the live
+SceneServer endpoints, and runs the validator over the responses.
+
+## Manual ArcGIS smoke runbook
+
+See [`docs/contributor/i3s-sceneserver-smoke.md`](../../../../docs/contributor/i3s-sceneserver-smoke.md)
+for the manual ArcGIS Pro / `@arcgis/core` `SceneLayer` load probe used to
+validate render fidelity that no headless harness can assert.

--- a/tests/fixtures/scene/i3s/expected/layer.json
+++ b/tests/fixtures/scene/i3s/expected/layer.json
@@ -1,0 +1,66 @@
+{
+  "id": 0,
+  "layerType": "3DObject",
+  "version": "1.7",
+  "spatialReference": {
+    "wkid": 4326,
+    "latestWkid": 4326,
+    "vcsWkid": 115700
+  },
+  "heightModelInfo": {
+    "heightModel": "ellipsoidal",
+    "vertCRS": "meter",
+    "heightUnit": "meter"
+  },
+  "store": {
+    "profile": "meshpyramids",
+    "version": "1.7",
+    "normalReferenceFrame": "east-north-up",
+    "nodePages": {
+      "nodesPerPage": 64,
+      "lodSelectionMetricType": "maxScreenThresholdSQ"
+    },
+    "defaultGeometrySchema": {
+      "geometryBuffers": [
+        {
+          "position": { "type": "Float32", "component": 3 },
+          "normal": { "type": "Float32", "component": 3 },
+          "uv0": { "type": "Float32", "component": 2 }
+        }
+      ]
+    }
+  },
+  "attributeStorageInfo": [
+    {
+      "key": "f_0",
+      "name": "OBJECTID",
+      "ordering": ["attributeValues"],
+      "attributeValues": { "valueType": "Oid32", "valuesPerElement": 1 }
+    }
+  ],
+  "geometryDefinitions": [
+    {
+      "geometryBuffers": [
+        {
+          "position": { "type": "Float32", "component": 3 },
+          "normal": { "type": "Float32", "component": 3 },
+          "uv0": { "type": "Float32", "component": 2 }
+        }
+      ]
+    }
+  ],
+  "materialDefinitions": [
+    {
+      "alphaMode": "OPAQUE",
+      "doubleSided": false,
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [1.0, 1.0, 1.0, 1.0],
+        "metallicFactor": 0.0,
+        "roughnessFactor": 1.0
+      }
+    }
+  ],
+  "textureSetDefinitions": [
+    { "formats": [{ "name": "0", "format": "jpg" }] }
+  ]
+}

--- a/tests/fixtures/scene/i3s/expected/nodepage-0.json
+++ b/tests/fixtures/scene/i3s/expected/nodepage-0.json
@@ -1,0 +1,41 @@
+{
+  "nodes": [
+    {
+      "lodThreshold": 0.0,
+      "children": [1, 2],
+      "obb": {
+        "center": [-122.6, 40.05, 20.0],
+        "halfSize": [9.9, 6.4, 20.0],
+        "quaternion": [0.0, 0.0, 0.0, 1.0]
+      }
+    },
+    {
+      "lodThreshold": 5.0,
+      "parentIndex": 0,
+      "obb": {
+        "center": [-122.6, 40.05, 10.0],
+        "halfSize": [4.9, 6.4, 10.0],
+        "quaternion": [0.0, 0.0, 0.0, 1.0]
+      },
+      "mesh": {
+        "geometry": { "definition": 0, "resource": 1 },
+        "attribute": { "definition": 0, "resource": 1 },
+        "material": { "definition": 0, "resource": 1 }
+      }
+    },
+    {
+      "lodThreshold": 5.0,
+      "parentIndex": 0,
+      "obb": {
+        "center": [-122.6, 40.05, 10.0],
+        "halfSize": [4.9, 6.4, 10.0],
+        "quaternion": [0.0, 0.0, 0.0, 1.0]
+      },
+      "mesh": {
+        "geometry": { "definition": 0, "resource": 2 },
+        "attribute": { "definition": 0, "resource": 2 },
+        "material": { "definition": 0, "resource": 2 }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/scene/i3s/expected/service.json
+++ b/tests/fixtures/scene/i3s/expected/service.json
@@ -1,0 +1,19 @@
+{
+  "serviceName": "I3S Conformance Fixture Scene",
+  "serviceVersion": "1.7",
+  "supportedBindings": ["REST"],
+  "layers": [
+    {
+      "id": 0,
+      "layerType": "3DObject",
+      "version": "1.7",
+      "store": {
+        "profile": "meshpyramids",
+        "nodePages": {
+          "nodesPerPage": 64,
+          "lodSelectionMetricType": "maxScreenThresholdSQ"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/scene/i3s/source-tileset/tileset.json
+++ b/tests/fixtures/scene/i3s/source-tileset/tileset.json
@@ -1,0 +1,57 @@
+{
+  "asset": {
+    "version": "1.1",
+    "generator": "honua-i3s-conformance-fixture"
+  },
+  "geometricError": 100.0,
+  "root": {
+    "boundingVolume": {
+      "region": [
+        -1.3197004795898053,
+        0.6988668696565959,
+        -1.3196595204101946,
+        0.6989078288362069,
+        0.0,
+        40.0
+      ]
+    },
+    "geometricError": 50.0,
+    "refine": "REPLACE",
+    "children": [
+      {
+        "boundingVolume": {
+          "region": [
+            -1.3197004795898053,
+            0.6988668696565959,
+            -1.3196800000000000,
+            0.6989078288362069,
+            0.0,
+            20.0
+          ]
+        },
+        "geometricError": 5.0,
+        "refine": "REPLACE",
+        "content": {
+          "uri": "nodes/0.glb"
+        }
+      },
+      {
+        "boundingVolume": {
+          "region": [
+            -1.3196800000000000,
+            0.6988668696565959,
+            -1.3196595204101946,
+            0.6989078288362069,
+            0.0,
+            20.0
+          ]
+        },
+        "geometricError": 5.0,
+        "refine": "REPLACE",
+        "content": {
+          "uri": "nodes/1.glb"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Promotes honua's **descriptor-only** I3S `SceneServer` preview into a traversable I3S 1.7 SceneLayer surface, wired over the existing hosted 3D Tiles scene infrastructure (this is wire-up over existing scene infra, not greenfield). Part of epic #1805.

Bundled cluster — one branch, one PR. Per-ticket done-vs-deferred below.

## Per-ticket status

### Closes #1809 — serve I3S node pages from the tileset node tree
- `I3sNodePageProjector` flattens the 3D Tiles tree (via `SceneTileCatalog`) into fixed-size I3S 1.7 node pages: oriented bounding boxes in the index CRS, `lodThreshold` from geometric error, parent/child references by **global node index**, per-node geometry/attribute/material **resource references**.
- New `GET …/layers/{id}/nodepages/{n}` endpoint at the GeoServices path + `/scenes` alias. Out-of-range page → 404; descriptor-only scenes (no loadable tileset) don't advertise node pages.
- Layer store now advertises `store.nodePages` + `defaultGeometrySchema` + `normalReferenceFrame` when the tileset is loadable.

### Closes #1812 — SceneDatasetType coverage for Building/Point + I3S layerType mapping
- `SceneDatasetType` extended with `Building` and `PointCloud`.
- `I3sLayerTypeMap` maps source kind → I3S `layerType` (`3DObject`/`Building`/`PointCloud`) and store `profile`, threaded through the descriptor builder, the Postgres registry mapper, and the admin dataset-type wire mapper. `IntegratedMesh` intentionally excluded (no photogrammetry source).

### Closes #1813 — I3S conformance fixture + SceneLayer client smoke harness
- Honua-authored synthetic I3S 1.7 fixture under `tests/fixtures/scene/i3s/` (no vendored CC BY-ND Esri spec).
- `I3sProtocolShapeValidator` (descriptor/nodepage/statistics shape oracle) + `I3sConformanceFixtureTests` driving the live endpoints through the validator.
- Manual ArcGIS `SceneLayer` smoke runbook at `docs/contributor/i3s-sceneserver-smoke.md`.

### Refs #1811 — native per-field attribute files + statistics (partial)
- **Done:** per-field statistics endpoint `GET …/layers/{id}/statistics/{fieldKey}/0` (`I3sSceneStatisticsBuilder`) — serves the I3S statistics summary (`totalValuesCount` from the content-node count) for the descriptor's `attributeStorageInfo` fields; unknown field → 404.
- **Deferred:** native binary per-field attribute files (`nodes/{id}/attributes/f_{n}/0`) require decoding the glTF `EXT_structural_metadata` property tables per node — that decode is the hard-lane work, tracked with #1810.

### Refs #1810 — glTF→I3S geometry transcoder + geometries/textures serving (deferred)
- The node pages reference geometry/attribute/texture **by index** (honest, matches the descriptor), but the binary node-resource routes (`nodes/{id}/geometries|textures|attributes`) and the glTF→I3S interleaved geometry-buffer transcoder are **not** in this PR. A SceneLayer client discovers the layer, traverses the node tree, and reads field statistics, but does not render geometry until #1810 lands. Documented in the smoke runbook.

## Governance
- New endpoints registered in `EndpointRegistry.cs`, each backed by an `[Endpoint]`-attributed integration test.
- Feature catalog (`docs/gis/data/feature-catalog.json`) regenerated from the live surface; proof ledger (`public-interface-proof.json`) updated with a node-page/statistics scenario-depth proof.
- No migration needed: `dataset_type` is an unconstrained `VARCHAR(32)`, so `building`/`point_cloud` values persist without DDL changes.

## Verification
- Release build, warnings-as-errors: **clean** (Honua.Scene, Honua.Protocols.Scene, Honua.Server, Core.Tests, Protocols.Scene.Tests, Architecture.Tests).
- `dotnet format --verify-no-changes`: clean.
- Scene tests (serial): **31/31 pass** (`I3sConformanceFixtureTests`, `I3sSceneServerEndpointTests`, `I3sSceneServiceBuilderTests`).
- Scene unit tests (serial): **13/13 pass** (`I3sNodePageProjectorTests`, `I3sLayerTypeMapTests`).
- Architecture/governance suite (serial): **116/116 pass** (EndpointRegistry coverage, feature-catalog drift, proof-ledger, SceneIsolation, protocol-family isolation).