### PR TITLE
fix: round-3 RLS/correctness sweep (gRPC RLS, spatialRel operands, reverse datum, Postgres paging)

### DIFF
--- a/src/Honua.Core/Features/Infrastructure/Crs/ProjPipelineInverter.cs
+++ b/src/Honua.Core/Features/Infrastructure/Crs/ProjPipelineInverter.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Infrastructure.Crs;
+
+/// <summary>
+/// Inverts a PROJ pipeline string so a reverse-direction datum transformation
+/// (toSrid &#8594; fromSrid) applies the geodetic shift in the correct direction.
+/// </summary>
+/// <remarks>
+/// The datum-transformation catalog stores one authoritative forward PROJ pipeline
+/// per source/target pair and synthesizes the reverse direction at load time. A PROJ
+/// pipeline is direction-sensitive: a <c>+proj=hgridshift</c> (NADCON/NTv2) step run
+/// forward shifts coordinates the opposite way from its inverse. Emitting the forward
+/// pipeline for a reverse selection shifts coordinates the wrong way — roughly twice
+/// the intended NADCON correction (#2069). The PROJ-canonical inverse of a
+/// <c>+proj=pipeline</c> reverses the step order and toggles the <c>+inv</c> flag on
+/// each step; an identity <c>+proj=noop</c> is its own inverse.
+/// </remarks>
+public static class ProjPipelineInverter
+{
+    private const string PipelinePrefix = "+proj=pipeline";
+    private const string StepToken = "+step";
+    private const string InvToken = "+inv";
+
+    /// <summary>
+    /// Returns the PROJ pipeline string oriented for the requested direction. When
+    /// <paramref name="forward"/> is <see langword="true"/> the pipeline is returned
+    /// unchanged; otherwise the PROJ-canonical inverse is returned.
+    /// </summary>
+    /// <param name="pipeline">The forward PROJ pipeline string from the catalog.</param>
+    /// <param name="forward">
+    /// <see langword="true"/> for the forward (source &#8594; target) direction;
+    /// <see langword="false"/> to invert the pipeline.
+    /// </param>
+    /// <returns>The direction-oriented PROJ pipeline string.</returns>
+    public static string Orient(string pipeline, bool forward)
+        => forward ? pipeline : Invert(pipeline);
+
+    /// <summary>
+    /// Inverts a PROJ pipeline string. Non-pipeline proj strings that carry no
+    /// direction-sensitive step (for example the exact-identity <c>+proj=noop</c>) are
+    /// returned unchanged; multi-step <c>+proj=pipeline</c> strings have their step
+    /// order reversed and the <c>+inv</c> flag toggled on each step.
+    /// </summary>
+    /// <param name="pipeline">The PROJ pipeline string to invert.</param>
+    /// <returns>The inverted PROJ pipeline string.</returns>
+    public static string Invert(string pipeline)
+    {
+        var trimmed = pipeline.Trim();
+
+        // A bare identity is self-inverse; reversing/inv-toggling it is a no-op anyway.
+        if (trimmed.Equals("+proj=noop", StringComparison.Ordinal))
+        {
+            return trimmed;
+        }
+
+        // Only +proj=pipeline strings have an unambiguous structural inverse (reverse
+        // the steps, toggle +inv). For any other proj string we cannot safely synthesize
+        // an inverse here, so return it unchanged rather than emit a wrong-direction guess.
+        if (!trimmed.StartsWith(PipelinePrefix, StringComparison.Ordinal))
+        {
+            return trimmed;
+        }
+
+        // Split into the pipeline header (tokens before the first +step) and the steps.
+        var steps = new List<List<string>>();
+        List<string>? current = null;
+        var header = new List<string>();
+
+        foreach (var token in trimmed.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (token.Equals(StepToken, StringComparison.Ordinal))
+            {
+                current = new List<string>();
+                steps.Add(current);
+                continue;
+            }
+
+            if (current is null)
+            {
+                header.Add(token);
+            }
+            else
+            {
+                current.Add(token);
+            }
+        }
+
+        steps.Reverse();
+
+        var result = new List<string>(header);
+        foreach (var step in steps)
+        {
+            result.Add(StepToken);
+
+            // Toggle the +inv flag for this step.
+            var hadInv = step.Remove(InvToken);
+            result.AddRange(step);
+            if (!hadInv)
+            {
+                result.Add(InvToken);
+            }
+        }
+
+        return string.Join(' ', result);
+    }
+}

--- a/src/Honua.DuckDB/Features/FeatureStore/Services/DuckDBFeatureQueryBuilder.cs
+++ b/src/Honua.DuckDB/Features/FeatureStore/Services/DuckDBFeatureQueryBuilder.cs
@@ -873,10 +873,15 @@ internal sealed partial class DuckDBFeatureQueryBuilder : IFeatureQueryBuilder
         {
             SpatialRelationship.Intersects =>
                 $"ST_Intersects({geomCol}, {filterGeomParam})",
+            // Esri semantics: esriSpatialRelWithin = filter geometry is within feature geometry;
+            // esriSpatialRelContains = filter geometry contains feature geometry. Lead with the
+            // filter geometry to match the canonical PostGIS reference (#2068). Reversing the
+            // operands inverts the relationship (ST_Within(A,B) == ST_Contains(B,A)) and returns
+            // the wrong (typically empty) result set.
             SpatialRelationship.Within =>
-                $"ST_Within({geomCol}, {filterGeomParam})",
+                $"ST_Within({filterGeomParam}, {geomCol})",
             SpatialRelationship.Contains =>
-                $"ST_Contains({geomCol}, {filterGeomParam})",
+                $"ST_Contains({filterGeomParam}, {geomCol})",
             SpatialRelationship.EnvelopeIntersects =>
                 $"ST_Intersects(ST_Envelope({geomCol}), ST_Envelope({filterGeomParam}))",
             SpatialRelationship.Crosses =>

--- a/src/Honua.Oracle/Features/FeatureStore/Services/OracleFeatureQueryBuilder.cs
+++ b/src/Honua.Oracle/Features/FeatureStore/Services/OracleFeatureQueryBuilder.cs
@@ -252,10 +252,16 @@ internal static partial class OracleFeatureQueryBuilder
                 $"SDO_RELATE({geomCol}, {filterExpr}, 'mask=ANYINTERACT') = 'TRUE'",
             SpatialRelationship.EnvelopeIntersects =>
                 $"SDO_RELATE(SDO_GEOM.SDO_MBR({geomCol}), {filterExpr}, 'mask=ANYINTERACT') = 'TRUE'",
+            // Esri semantics: esriSpatialRelWithin = filter geometry is within feature geometry;
+            // esriSpatialRelContains = filter geometry contains feature geometry. Lead with the
+            // filter geometry to match the canonical PostGIS reference (#2068). SDO_RELATE masks
+            // are operand-order sensitive: SDO_RELATE(A, B, 'mask=INSIDE') means A is inside B, so
+            // the filter geometry must be the first operand. Reversing inverts the relationship and
+            // returns the wrong (typically empty) result set.
             SpatialRelationship.Within =>
-                $"SDO_RELATE({geomCol}, {filterExpr}, 'mask=INSIDE+COVEREDBY') = 'TRUE'",
+                $"SDO_RELATE({filterExpr}, {geomCol}, 'mask=INSIDE+COVEREDBY') = 'TRUE'",
             SpatialRelationship.Contains =>
-                $"SDO_RELATE({geomCol}, {filterExpr}, 'mask=CONTAINS+COVERS') = 'TRUE'",
+                $"SDO_RELATE({filterExpr}, {geomCol}, 'mask=CONTAINS+COVERS') = 'TRUE'",
             SpatialRelationship.Disjoint =>
                 $"NOT (SDO_RELATE({geomCol}, {filterExpr}, 'mask=ANYINTERACT') = 'TRUE')",
             _ => throw new NotSupportedException(

--- a/src/Honua.Postgres/Features/FeatureStore/Services/DatumTransformSql.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/DatumTransformSql.cs
@@ -31,7 +31,15 @@ internal static class DatumTransformSql
     {
         if (selection?.ProjPipeline is { Length: > 0 } pipeline)
         {
-            return $"ST_Transform({operand}, {QuoteLiteral(pipeline)}, {toSrid})";
+            // A PROJ pipeline is direction-sensitive (a +proj=hgridshift NADCON/NTv2 step
+            // shifts the opposite way from its inverse). The catalog stores the forward
+            // pipeline verbatim for reverse selections and only flips TransformForward, so the
+            // reverse direction must invert the pipeline here — otherwise a reverse selection
+            // (e.g. NAD83 -> NAD27) would apply the forward shift and move coordinates roughly
+            // twice the intended correction in the wrong direction (#2069). Mirrors the
+            // import-path guard, but applies the inverse rather than dropping the pipeline.
+            var orientedPipeline = ProjPipelineInverter.Orient(pipeline, selection.TransformForward);
+            return $"ST_Transform({operand}, {QuoteLiteral(orientedPipeline)}, {toSrid})";
         }
 
         return $"ST_Transform({operand}, {toSrid})";

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Ordering.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Ordering.cs
@@ -55,23 +55,16 @@ internal sealed partial class FeatureQueryBuilder
             _ => string.Empty
         };
 
+    // Any server-side page (Limit or Offset) needs a stable tiebreaker order so the same
+    // rows are not skipped or duplicated across pages. A first page with a LIKE filter is no
+    // exception: when Limit is set but no ORDER BY is appended the database returns an arbitrary
+    // heap/plan order, while the next page (which injects ORDER BY objectid because it has an
+    // Offset) is drawn from a different ordering, silently skipping and duplicating rows across
+    // the page boundary (#2070). Mirrors the sibling MySQL provider, which has no LIKE carve-out.
     private static bool RequiresStablePageOrder(FeatureQuery query)
         => query.Offset.HasValue ||
            query.SpatialFilter.HasValue ||
-           (query.Limit.HasValue && !IsUnorderedFirstPageLikeFilter(query));
-
-    private static bool IsUnorderedFirstPageLikeFilter(FeatureQuery query)
-    {
-        if (!query.Limit.HasValue ||
-            query.Offset.HasValue ||
-            query.SpatialFilter.HasValue ||
-            query.OrderBy.HasValue)
-        {
-            return false;
-        }
-
-        return query.SqlFilter?.Sql.Contains(" LIKE ", StringComparison.OrdinalIgnoreCase) == true;
-    }
+           query.Limit.HasValue;
 
     private static bool HasObjectIdOrdering(FeatureQuery query)
     {

--- a/src/Honua.Redshift/Features/FeatureStore/Services/RedshiftFeatureQueryBuilder.cs
+++ b/src/Honua.Redshift/Features/FeatureStore/Services/RedshiftFeatureQueryBuilder.cs
@@ -256,10 +256,15 @@ internal static partial class RedshiftFeatureQueryBuilder
                 $"ST_Intersects({geomCol}, {filterExpr})",
             SpatialRelationship.EnvelopeIntersects =>
                 $"ST_Intersects(ST_Envelope({geomCol}), ST_Envelope({filterExpr}))",
+            // Esri semantics: esriSpatialRelWithin = filter geometry is within feature geometry;
+            // esriSpatialRelContains = filter geometry contains feature geometry. Lead with the
+            // filter geometry to match the canonical PostGIS reference (#2068). Reversing the
+            // operands inverts the relationship (ST_Within(A,B) == ST_Contains(B,A)) and returns
+            // the wrong (typically empty) result set.
             SpatialRelationship.Within =>
-                $"ST_Within({geomCol}, {filterExpr})",
+                $"ST_Within({filterExpr}, {geomCol})",
             SpatialRelationship.Contains =>
-                $"ST_Contains({geomCol}, {filterExpr})",
+                $"ST_Contains({filterExpr}, {geomCol})",
             SpatialRelationship.Disjoint =>
                 $"ST_Disjoint({geomCol}, {filterExpr})",
             _ => throw new NotSupportedException(

--- a/src/Honua.Server/Features/Protocols/Grpc/HonuaFeatureService.cs
+++ b/src/Honua.Server/Features/Protocols/Grpc/HonuaFeatureService.cs
@@ -261,6 +261,15 @@ internal sealed class HonuaFeatureService : Proto.FeatureService.FeatureServiceB
             throw new RpcException(new Status(StatusCode.InvalidArgument, ex.Message));
         }
 
+        // RLS / permanent-filter enforcement runs only on the read path; the edit SQL
+        // filters by (layer_id, objectid) with no row-level predicate. So every update/delete
+        // target MUST be pre-resolved through the RLS-enforced reader and fail closed when a
+        // row is hidden from the caller — otherwise a caller could mutate or delete a row RLS
+        // hides from them by supplying its objectid (#2071). Adds carry no objectid and are
+        // not pre-read. Mirrors the GeoServices/OData/WFS-T not-found guards (#2066).
+        await EnsureEditTargetsVisibleAsync(
+            request.LayerId, editBatch, context.CancellationToken).ConfigureAwait(false);
+
         var grpcHttpContext = context.GetHttpContext()
             ?? throw new InvalidOperationException("HttpContext is required for gRPC outbox dispatch.");
 
@@ -300,6 +309,58 @@ internal sealed class HonuaFeatureService : Proto.FeatureService.FeatureServiceB
             context).ConfigureAwait(false);
 
         return GrpcConversionHelpers.ToProtoApplyEditsResponse(result);
+    }
+
+    /// <summary>
+    /// Pre-reads every update and delete target through the RLS-enforced
+    /// <see cref="IFeatureReader.GetAsync(int, long, CancellationToken)"/> so the gRPC edit
+    /// surface enforces the same row-level visibility as the read path. A row that is hidden
+    /// from the caller by a row-level-security policy or a metadata permanent filter resolves
+    /// to <see langword="null"/>; the request is rejected (fail closed) rather than mutating or
+    /// deleting it, because the underlying edit SQL filters only on <c>(layer_id, objectid)</c>
+    /// with no RLS predicate (#2071). Adds carry no objectid and are not pre-read.
+    /// </summary>
+    private async Task EnsureEditTargetsVisibleAsync(
+        int layerId,
+        FeatureEditBatch editBatch,
+        CancellationToken cancellationToken)
+    {
+        if (editBatch.Updates.IsDefaultOrEmpty && editBatch.Deletes.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        // Collect distinct target objectids across updates and deletes; a single hidden/missing
+        // target fails the whole batch closed.
+        var targets = new HashSet<long>();
+        if (!editBatch.Updates.IsDefaultOrEmpty)
+        {
+            foreach (var update in editBatch.Updates)
+            {
+                targets.Add(update.Id);
+            }
+        }
+
+        if (!editBatch.Deletes.IsDefaultOrEmpty)
+        {
+            foreach (var objectId in editBatch.Deletes)
+            {
+                targets.Add(objectId);
+            }
+        }
+
+        foreach (var objectId in targets)
+        {
+            var existing = await _featureReader
+                .GetAsync(layerId, objectId, cancellationToken)
+                .ConfigureAwait(false);
+            if (existing is null)
+            {
+                throw new RpcException(new Status(
+                    StatusCode.NotFound,
+                    $"Feature with objectid {objectId} was not found."));
+            }
+        }
     }
 
     private async Task PublishFeatureChangeEventsAsync(

--- a/src/Honua.Snowflake/Features/FeatureStore/Services/SnowflakeFeatureQueryBuilder.cs
+++ b/src/Honua.Snowflake/Features/FeatureStore/Services/SnowflakeFeatureQueryBuilder.cs
@@ -235,10 +235,14 @@ internal static partial class SnowflakeFeatureQueryBuilder
         {
             SpatialRelationship.Intersects or SpatialRelationship.EnvelopeIntersects =>
                 $"ST_INTERSECTS({geomCol}, {filterExpr})",
+            // Esri semantics: esriSpatialRelWithin = filter geometry is within feature geometry;
+            // esriSpatialRelContains = filter geometry contains feature geometry. Lead with the
+            // filter geometry to match the canonical PostGIS reference (#2068). Reversing the
+            // operands inverts the relationship and returns the wrong (typically empty) result set.
             SpatialRelationship.Within =>
-                $"ST_WITHIN({geomCol}, {filterExpr})",
+                $"ST_WITHIN({filterExpr}, {geomCol})",
             SpatialRelationship.Contains =>
-                $"ST_CONTAINS({geomCol}, {filterExpr})",
+                $"ST_CONTAINS({filterExpr}, {geomCol})",
             SpatialRelationship.Disjoint =>
                 $"ST_DISJOINT({geomCol}, {filterExpr})",
             _ => throw new NotSupportedException(

--- a/src/Honua.SqlServer/Features/FeatureStore/Services/SqlServerFeatureQueryBuilder.cs
+++ b/src/Honua.SqlServer/Features/FeatureStore/Services/SqlServerFeatureQueryBuilder.cs
@@ -251,10 +251,14 @@ internal static partial class SqlServerFeatureQueryBuilder
                 $"{geomCol}.STIntersects({filterExpr}) = 1",
             SpatialRelationship.EnvelopeIntersects =>
                 $"{geomCol}.STEnvelope().STIntersects({filterExpr}.STEnvelope()) = 1",
+            // Esri semantics: esriSpatialRelWithin = filter geometry is within feature geometry;
+            // esriSpatialRelContains = filter geometry contains feature geometry. Lead with the
+            // filter geometry to match the canonical PostGIS reference (#2068). Reversing the
+            // operands inverts the relationship and returns the wrong (typically empty) result set.
             SpatialRelationship.Within =>
-                $"{geomCol}.STWithin({filterExpr}) = 1",
+                $"{filterExpr}.STWithin({geomCol}) = 1",
             SpatialRelationship.Contains =>
-                $"{geomCol}.STContains({filterExpr}) = 1",
+                $"{filterExpr}.STContains({geomCol}) = 1",
             SpatialRelationship.Disjoint =>
                 $"{geomCol}.STDisjoint({filterExpr}) = 1",
             _ => throw new NotSupportedException(

--- a/tests/dotnet/Honua.Core.Tests/Features/Infrastructure/Crs/ProjPipelineInverterTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Infrastructure/Crs/ProjPipelineInverterTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Crs;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Infrastructure.Crs;
+
+/// <summary>
+/// Unit tests for <see cref="ProjPipelineInverter"/>. A reverse-direction datum
+/// transformation must apply the geodetic shift the opposite way; emitting the forward
+/// pipeline corrupts coordinates (~2x the intended NADCON correction, #2069).
+/// </summary>
+public sealed class ProjPipelineInverterTests
+{
+    [UnitTest]
+    public void Orient_Forward_ReturnsPipelineUnchanged()
+    {
+        const string pipeline = "+proj=pipeline +step +proj=hgridshift +grids=us_noaa_conus.tif";
+
+        ProjPipelineInverter.Orient(pipeline, forward: true).Should().Be(pipeline);
+    }
+
+    [UnitTest]
+    public void Invert_MultiStepPipeline_ReversesStepsAndTogglesInv()
+    {
+        const string forward =
+            "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad " +
+            "+step +proj=hgridshift +grids=us_noaa_conus.tif " +
+            "+step +proj=unitconvert +xy_in=rad +xy_out=deg";
+
+        var inverted = ProjPipelineInverter.Invert(forward);
+
+        inverted.Should().Be(
+            "+proj=pipeline " +
+            "+step +proj=unitconvert +xy_in=rad +xy_out=deg +inv " +
+            "+step +proj=hgridshift +grids=us_noaa_conus.tif +inv " +
+            "+step +proj=unitconvert +xy_in=deg +xy_out=rad +inv");
+    }
+
+    [UnitTest]
+    public void Invert_StepAlreadyInverted_RemovesInv()
+    {
+        const string pipeline = "+proj=pipeline +step +proj=hgridshift +grids=g.tif +inv";
+
+        ProjPipelineInverter.Invert(pipeline)
+            .Should().Be("+proj=pipeline +step +proj=hgridshift +grids=g.tif");
+    }
+
+    [UnitTest]
+    public void Invert_DoubleInversion_RoundTripsToOriginal()
+    {
+        const string forward =
+            "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad " +
+            "+step +proj=hgridshift +grids=us_noaa_conus.tif " +
+            "+step +proj=unitconvert +xy_in=rad +xy_out=deg";
+
+        ProjPipelineInverter.Invert(ProjPipelineInverter.Invert(forward)).Should().Be(forward);
+    }
+
+    [UnitTest]
+    public void Invert_Noop_IsSelfInverse()
+    {
+        ProjPipelineInverter.Invert("+proj=noop").Should().Be("+proj=noop");
+    }
+}

--- a/tests/dotnet/Honua.DuckDB.Tests/DuckDBFeatureQueryBuilderTests.cs
+++ b/tests/dotnet/Honua.DuckDB.Tests/DuckDBFeatureQueryBuilderTests.cs
@@ -198,6 +198,41 @@ public class DuckDBFeatureQueryBuilderTests
     }
 
     [Fact]
+    public void BuildSelectQuery_WithinFilter_LeadsWithFilterGeometry()
+    {
+        // Esri esriSpatialRelWithin = filter geometry is within feature geometry, so the filter
+        // geometry must be the FIRST operand: ST_Within(filter, feature). Leading with the
+        // feature column inverts the relationship and returns the wrong (empty) set (#2068).
+        var wkb = new byte[] { 1, 2, 3, 4 };
+        var query = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.Create(wkb, SpatialRelationship.Within, 4326)
+        };
+
+        var result = _builder.BuildSelectQuery(TestLayerId, query);
+
+        Assert.Contains("ST_Within(ST_GeomFromWKB($", result.Sql);
+        Assert.DoesNotContain("ST_Within(\"geom\"", result.Sql);
+    }
+
+    [Fact]
+    public void BuildSelectQuery_ContainsFilter_LeadsWithFilterGeometry()
+    {
+        // Esri esriSpatialRelContains = filter geometry contains feature geometry: the filter
+        // geometry must be the FIRST operand, ST_Contains(filter, feature) (#2068).
+        var wkb = new byte[] { 1, 2, 3, 4 };
+        var query = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.Create(wkb, SpatialRelationship.Contains, 4326)
+        };
+
+        var result = _builder.BuildSelectQuery(TestLayerId, query);
+
+        Assert.Contains("ST_Contains(ST_GeomFromWKB($", result.Sql);
+        Assert.DoesNotContain("ST_Contains(\"geom\"", result.Sql);
+    }
+
+    [Fact]
     public void BuildSelectQuery_SpatialFilter_DifferentSrid_TransformsToLayerSrid()
     {
         // Layer is 4326; client supplies a Web Mercator (3857) filter geometry.

--- a/tests/dotnet/Honua.Oracle.Tests/OracleFeatureQueryBuilderTests.cs
+++ b/tests/dotnet/Honua.Oracle.Tests/OracleFeatureQueryBuilderTests.cs
@@ -145,7 +145,10 @@ public class OracleFeatureQueryBuilderTests
 
         var result = OracleFeatureQueryBuilder.BuildSelectQuery(mapping, query, _attributeColumns);
 
-        Assert.Contains("SDO_RELATE(\"SHAPE\", SDO_UTIL.FROM_WKBGEOMETRY(:p0), 'mask=INSIDE+COVEREDBY') = 'TRUE'", result.Sql, StringComparison.Ordinal);
+        // Esri esriSpatialRelWithin = filter geometry within feature geometry. SDO_RELATE masks
+        // are operand-order sensitive: SDO_RELATE(A, B, 'mask=INSIDE') means A is inside B, so
+        // the filter geometry must be the FIRST operand (#2068).
+        Assert.Contains("SDO_RELATE(SDO_UTIL.FROM_WKBGEOMETRY(:p0), \"SHAPE\", 'mask=INSIDE+COVEREDBY') = 'TRUE'", result.Sql, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -159,7 +162,10 @@ public class OracleFeatureQueryBuilderTests
 
         var result = OracleFeatureQueryBuilder.BuildSelectQuery(mapping, query, _attributeColumns);
 
-        Assert.Contains("SDO_RELATE(\"SHAPE\", SDO_UTIL.FROM_WKBGEOMETRY(:p0), 'mask=CONTAINS+COVERS') = 'TRUE'", result.Sql, StringComparison.Ordinal);
+        // Esri esriSpatialRelContains = filter geometry contains feature geometry. SDO_RELATE
+        // masks are operand-order sensitive, so the filter geometry must be the FIRST operand:
+        // SDO_RELATE(filter, feature, 'mask=CONTAINS') (#2068).
+        Assert.Contains("SDO_RELATE(SDO_UTIL.FROM_WKBGEOMETRY(:p0), \"SHAPE\", 'mask=CONTAINS+COVERS') = 'TRUE'", result.Sql, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/DatumTransformSqlTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/DatumTransformSqlTests.cs
@@ -55,6 +55,67 @@ public sealed class DatumTransformSqlTests
     }
 
     [UnitTest]
+    public void BuildTransformExpression_ReverseSelection_InvertsPipeline()
+    {
+        // A reverse selection (e.g. NAD83 -> NAD27) carries the forward NADCON pipeline verbatim
+        // with TransformForward=false. Emitting it as-is would shift coordinates the wrong way —
+        // roughly twice the intended NADCON correction (#2069). The emitted pipeline must invert
+        // the direction-sensitive hgridshift step (+inv) and reverse the step order.
+        var selection = new DatumTransformationSelection
+        {
+            Name = "NAD_1927_To_NAD_1983_NADCON",
+            FromSrid = 4326,
+            ToSrid = 4269,
+            ProjPipeline = "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=hgridshift +grids=us_noaa_conus.tif +step +proj=unitconvert +xy_in=rad +xy_out=deg",
+            TransformForward = false
+        };
+
+        var sql = DatumTransformSql.BuildTransformExpression("geom", 4269, selection);
+
+        sql.Should().Be(
+            "ST_Transform(geom, '+proj=pipeline " +
+            "+step +proj=unitconvert +xy_in=rad +xy_out=deg +inv " +
+            "+step +proj=hgridshift +grids=us_noaa_conus.tif +inv " +
+            "+step +proj=unitconvert +xy_in=deg +xy_out=rad +inv', 4269)");
+    }
+
+    [UnitTest]
+    public void BuildTransformExpression_ForwardSelection_KeepsPipelineVerbatim()
+    {
+        // The forward direction must be emitted exactly as catalogued (no +inv).
+        var selection = new DatumTransformationSelection
+        {
+            Name = "NAD_1927_To_NAD_1983_NADCON",
+            FromSrid = 4267,
+            ToSrid = 4269,
+            ProjPipeline = "+proj=pipeline +step +proj=hgridshift +grids=us_noaa_conus.tif",
+            TransformForward = true
+        };
+
+        var sql = DatumTransformSql.BuildTransformExpression("geom", 4269, selection);
+
+        sql.Should().Be("ST_Transform(geom, '+proj=pipeline +step +proj=hgridshift +grids=us_noaa_conus.tif', 4269)");
+    }
+
+    [UnitTest]
+    public void BuildTransformExpression_ReverseNoopSelection_StaysNoop()
+    {
+        // +proj=noop is self-inverse; a reverse identity selection must stay identity.
+        var selection = new DatumTransformationSelection
+        {
+            Name = "NAD_1983_To_WGS_1984_1",
+            FromSrid = 4326,
+            ToSrid = 4269,
+            ProjPipeline = "+proj=noop",
+            TransformForward = false
+        };
+
+        var sql = DatumTransformSql.BuildTransformExpression("geom", 4269, selection);
+
+        sql.Should().Be("ST_Transform(geom, '+proj=noop', 4269)");
+    }
+
+    [UnitTest]
     public void BuildTransformExpression_PipelineWithSingleQuote_IsEscaped()
     {
         var selection = new DatumTransformationSelection

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderOrderingTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderOrderingTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Queries.Filters;
 using Honua.Postgres.Features.FeatureStore.Services;
 using Microsoft.Extensions.ObjectPool;
 using FeatureStoreStringBuilderPooledObjectPolicy = Honua.Postgres.Features.FeatureStore.Services.StringBuilderPooledObjectPolicy;
@@ -95,5 +96,25 @@ public sealed class FeatureQueryBuilderOrderingTests
         result.Sql.Should().Contain("ASC NULLS FIRST");
         result.Sql.Should().Contain("DESC");
         result.Sql.Should().NotContain("DESC NULLS");
+    }
+
+    [Fact]
+    public void BuildQuery_FirstPageLikeFilter_InjectsStableObjectIdOrder()
+    {
+        // A first page (Limit, no Offset, no OrderBy) with a LIKE filter must still receive a
+        // stable tiebreaker ORDER BY objectid. Without it, page 1 returns an arbitrary
+        // heap/plan order while page 2 (which carries an Offset and therefore injects
+        // ORDER BY objectid) is drawn from a different ordering, silently skipping and
+        // duplicating rows across the page boundary (#2070).
+        var queryBuilder = CreateBuilder();
+        var query = new FeatureQuery
+        {
+            Limit = 10,
+            SqlFilter = new SqlFragment("attributes->>'name' LIKE @p0", new object?[] { "A%" })
+        };
+
+        var result = queryBuilder.BuildSelectRawGeoJsonQuery(layerId: 1, query);
+
+        result.Sql.Should().Contain("ORDER BY objectid ASC");
     }
 }

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderSelectProjectionTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderSelectProjectionTests.cs
@@ -85,8 +85,13 @@ public sealed class FeatureQueryBuilderSelectProjectionTests
     }
 
     [Fact]
-    public void BuildSelectQuery_WithFirstPageLikeFilter_DoesNotAddImplicitObjectIdOrderBy()
+    public void BuildSelectQuery_WithFirstPageLikeFilter_AddsImplicitObjectIdOrderBy()
     {
+        // A first page (Limit, no Offset) with a LIKE filter must still get a stable tiebreaker
+        // ORDER BY objectid. Without it the database returns an arbitrary heap/plan order while
+        // the next page (which injects ORDER BY objectid because it carries an Offset) is drawn
+        // from a different ordering, silently skipping and duplicating rows across the page
+        // boundary (#2070). Mirrors the sibling MySQL provider, which has no LIKE carve-out.
         var queryBuilder = CreateQueryBuilder();
         var query = new FeatureQuery
         {
@@ -96,7 +101,7 @@ public sealed class FeatureQueryBuilderSelectProjectionTests
 
         var result = queryBuilder.BuildSelectQuery(layerId: 1, query);
 
-        result.Sql.Should().NotContain("ORDER BY objectid ASC");
+        result.Sql.Should().Contain("ORDER BY objectid ASC");
         result.Sql.Should().Contain("LIMIT $3");
         result.WhereParameters.Should().Equal("feature\\_999%");
     }

--- a/tests/dotnet/Honua.Redshift.Tests/RedshiftFeatureQueryBuilderTests.cs
+++ b/tests/dotnet/Honua.Redshift.Tests/RedshiftFeatureQueryBuilderTests.cs
@@ -193,8 +193,12 @@ public class RedshiftFeatureQueryBuilderTests
     }
 
     [Theory]
-    [InlineData(SpatialRelationship.Within, "ST_Within(\"geom\", ST_GeomFromWKB(@p0, 4326))")]
-    [InlineData(SpatialRelationship.Contains, "ST_Contains(\"geom\", ST_GeomFromWKB(@p0, 4326))")]
+    // Esri esriSpatialRelWithin/Contains: filter geometry is within/contains the feature, so the
+    // filter geometry must be the FIRST operand (ST_Within(filter, feature)). Disjoint is
+    // symmetric. Reversing Within/Contains inverts the relationship and returns the wrong
+    // (empty) set (#2068).
+    [InlineData(SpatialRelationship.Within, "ST_Within(ST_GeomFromWKB(@p0, 4326), \"geom\")")]
+    [InlineData(SpatialRelationship.Contains, "ST_Contains(ST_GeomFromWKB(@p0, 4326), \"geom\")")]
     [InlineData(SpatialRelationship.Disjoint, "ST_Disjoint(\"geom\", ST_GeomFromWKB(@p0, 4326))")]
     public void BuildSelectQuery_SpatialRelationships_EmitNativeFunctions(SpatialRelationship relationship, string expected)
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcFeatureServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcFeatureServiceTests.cs
@@ -77,6 +77,14 @@ public sealed class GrpcFeatureServiceTests
         _resourceValidator
             .ValidateServiceLayerV2Async("test", 0, Arg.Any<CancellationToken>())
             .Returns(ResourceValidationResult.Success(_testTriple));
+
+        // Default: every edit/delete target is visible to the caller through the RLS-enforced
+        // reader, so ApplyEdits' pre-read guard (#2071) passes. Tests that exercise an
+        // RLS-hidden row override GetAsync to return null for that objectid.
+        _featureReader
+            .GetAsync(Arg.Any<int>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => Task.FromResult<Feature?>(
+                Feature.Create(callInfo.ArgAt<long>(1), geometry: null)));
     }
 
     [UnitTest]
@@ -136,6 +144,111 @@ public sealed class GrpcFeatureServiceTests
         batch.Creates.Length.Should().Be(1);
         batch.Updates.Length.Should().Be(1);
         batch.Deletes.SequenceEqual(new long[] { 12 }).Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Endpoint("POST /grpc/geospatial.v1.FeatureService/ApplyEdits")]
+    [Operation(Operations.ApplyEdits)]
+    public async Task ApplyEdits_WhenDeleteTargetHiddenByRls_ThrowsNotFoundAndDoesNotWrite()
+    {
+        // RLS / permanent filters are enforced only on the read path; the edit SQL filters by
+        // (layer_id, objectid) with no row-level predicate. A row RLS hides from the caller
+        // resolves to null through the RLS-enforced reader, so the delete must fail closed and
+        // never reach the writer — otherwise a low-privilege caller could delete a hidden row by
+        // supplying its objectid (#2071).
+        _featureReader
+            .GetAsync(0, 999, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Feature?>(null));
+
+        var request = new Proto.ApplyEditsRequest
+        {
+            ServiceId = "test",
+            LayerId = 0
+        };
+        request.Deletes.Add(999);
+
+        var act = async () => await _sut.ApplyEdits(request, CreateCallContext());
+
+        var ex = await act.Should().ThrowAsync<RpcException>();
+        ex.Which.StatusCode.Should().Be(StatusCode.NotFound);
+        _featureWriter.ReceivedCalls()
+            .Should()
+            .NotContain(call => call.GetMethodInfo().Name == nameof(IFeatureWriter.ApplyEditsAsync));
+    }
+
+    [UnitTest]
+    [Endpoint("POST /grpc/geospatial.v1.FeatureService/ApplyEdits")]
+    [Operation(Operations.ApplyEdits)]
+    public async Task ApplyEdits_WhenUpdateTargetHiddenByRls_ThrowsNotFoundAndDoesNotWrite()
+    {
+        // Same RLS bypass via the update path (#2071): an update keyed by an RLS-hidden objectid
+        // must fail closed.
+        _featureReader
+            .GetAsync(0, 999, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Feature?>(null));
+
+        var request = new Proto.ApplyEditsRequest
+        {
+            ServiceId = "test",
+            LayerId = 0
+        };
+        request.Updates.Add(new Proto.Feature
+        {
+            Id = 999,
+            Attributes = { ["name"] = new Proto.AttributeValue { StringValue = "hidden row" } }
+        });
+
+        var act = async () => await _sut.ApplyEdits(request, CreateCallContext());
+
+        var ex = await act.Should().ThrowAsync<RpcException>();
+        ex.Which.StatusCode.Should().Be(StatusCode.NotFound);
+        _featureWriter.ReceivedCalls()
+            .Should()
+            .NotContain(call => call.GetMethodInfo().Name == nameof(IFeatureWriter.ApplyEditsAsync));
+    }
+
+    [UnitTest]
+    [Endpoint("POST /grpc/geospatial.v1.FeatureService/ApplyEdits")]
+    [Operation(Operations.ApplyEdits)]
+    public async Task ApplyEdits_AddsOnly_DoesNotPreReadAndWrites()
+    {
+        // Adds carry no objectid and are not subject to the visibility pre-read; an add-only
+        // batch must still reach the writer even when GetAsync would return null (#2071).
+        _featureReader
+            .GetAsync(Arg.Any<int>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Feature?>(null));
+
+        var applyResult = FeatureEditResult.Success(
+            createdCount: 1,
+            updatedCount: 0,
+            deletedCount: 0,
+            createResults: ImmutableArray.Create(EditOperationResult.Success(101)),
+            updateResults: ImmutableArray<EditOperationResult>.Empty,
+            deleteResults: ImmutableArray<EditOperationResult>.Empty);
+
+        _featureWriter
+            .ApplyEditsAsync(default, default, default)
+            .ReturnsForAnyArgs(Task.FromResult(applyResult));
+
+        var request = new Proto.ApplyEditsRequest
+        {
+            ServiceId = "test",
+            LayerId = 0
+        };
+        request.Adds.Add(new Proto.Feature
+        {
+            Attributes = { ["name"] = new Proto.AttributeValue { StringValue = "new feature" } }
+        });
+
+        var response = await _sut.ApplyEdits(request, CreateCallContext());
+
+        response.AddResults.Should().ContainSingle();
+        _featureReader.ReceivedCalls()
+            .Should()
+            .NotContain(call => call.GetMethodInfo().Name == nameof(IFeatureReader.GetAsync));
+        _featureWriter.ReceivedCalls()
+            .Should()
+            .Contain(call => call.GetMethodInfo().Name == nameof(IFeatureWriter.ApplyEditsAsync));
     }
 
     [UnitTest]

--- a/tests/dotnet/Honua.Snowflake.Tests/SnowflakeFeatureQueryBuilderTests.cs
+++ b/tests/dotnet/Honua.Snowflake.Tests/SnowflakeFeatureQueryBuilderTests.cs
@@ -201,11 +201,27 @@ public class SnowflakeFeatureQueryBuilderTests
         Assert.Contains("ST_INTERSECTS(\"SHAPE\"", result.Sql, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void BuildSelectQuery_DisjointFilter_MapsToStDisjoint()
+    {
+        var mapping = BuildMapping();
+        var query = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.Create([0x01], SpatialRelationship.Disjoint, srid: 4326)
+        };
+
+        var result = SnowflakeFeatureQueryBuilder.BuildSelectQuery(mapping, query, _attributeColumns);
+
+        Assert.Contains("ST_DISJOINT(\"SHAPE\"", result.Sql, StringComparison.Ordinal);
+    }
+
     [Theory]
+    // Esri esriSpatialRelWithin/Contains: filter geometry is within/contains the feature. The
+    // filter geometry must be the FIRST operand (ST_WITHIN(filter, feature)); leading with the
+    // feature column inverts the relationship and returns the wrong (empty) set (#2068).
     [InlineData(SpatialRelationship.Within, "ST_WITHIN")]
     [InlineData(SpatialRelationship.Contains, "ST_CONTAINS")]
-    [InlineData(SpatialRelationship.Disjoint, "ST_DISJOINT")]
-    public void BuildSelectQuery_RelationshipFilters_MapToStFunctions(SpatialRelationship relationship, string expectedFunction)
+    public void BuildSelectQuery_WithinContainsFilters_LeadWithFilterGeometry(SpatialRelationship relationship, string expectedFunction)
     {
         var mapping = BuildMapping();
         var query = new FeatureQuery
@@ -215,7 +231,7 @@ public class SnowflakeFeatureQueryBuilderTests
 
         var result = SnowflakeFeatureQueryBuilder.BuildSelectQuery(mapping, query, _attributeColumns);
 
-        Assert.Contains(expectedFunction + "(\"SHAPE\"", result.Sql, StringComparison.Ordinal);
+        Assert.Contains(expectedFunction + "(TO_GEOGRAPHY(?, TRUE), \"SHAPE\")", result.Sql, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/dotnet/Honua.SqlServer.Tests/SqlServerFeatureQueryBuilderTests.cs
+++ b/tests/dotnet/Honua.SqlServer.Tests/SqlServerFeatureQueryBuilderTests.cs
@@ -201,6 +201,39 @@ public class SqlServerFeatureQueryBuilderTests
     }
 
     [Fact]
+    public void BuildSelectQuery_WithinFilter_LeadsWithFilterGeometry()
+    {
+        // Esri esriSpatialRelWithin = filter geometry is within feature geometry, so the filter
+        // geometry must be the calling instance: filter.STWithin(feature). Leading with the
+        // feature column inverts the relationship and returns the wrong (empty) set (#2068).
+        var mapping = BuildMapping();
+        var query = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.Create([0x01], SpatialRelationship.Within, srid: 4326)
+        };
+
+        var result = SqlServerFeatureQueryBuilder.BuildSelectQuery(mapping, query, _attributeColumns);
+
+        Assert.Contains("geometry::STGeomFromWKB(@p0, 4326).STWithin([shape]) = 1", result.Sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildSelectQuery_ContainsFilter_LeadsWithFilterGeometry()
+    {
+        // Esri esriSpatialRelContains = filter geometry contains feature geometry, so the filter
+        // geometry must be the calling instance: filter.STContains(feature) (#2068).
+        var mapping = BuildMapping();
+        var query = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.Create([0x01], SpatialRelationship.Contains, srid: 4326)
+        };
+
+        var result = SqlServerFeatureQueryBuilder.BuildSelectQuery(mapping, query, _attributeColumns);
+
+        Assert.Contains("geometry::STGeomFromWKB(@p0, 4326).STContains([shape]) = 1", result.Sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BuildSelectQuery_GeographyEnvelopeIntersects_Throws()
     {
         var mapping = BuildMapping(SqlServerGeometryColumnType.Geography);


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2071
Closes #2068
Closes #2069
Closes #2070

## Summary
Round-3 data-correctness / authorization sweep: four verified P1 bugs across the gRPC edit surface, the non-PostGIS query builders, the CRS datum-transformation chokepoint, and the Postgres pagination ordering. Each fix is in its own commit with focused tests, and all touched projects build clean in Release with `TreatWarningsAsErrors`.

## Changes Made
- **#2071 (gRPC RLS bypass):** `HonuaFeatureService.ApplyEdits` pre-resolves every update/delete target through the RLS-enforced reader (`IFeatureReader.GetAsync`) and fails closed (`NotFound`) when a target row is hidden/missing. The edit SQL filters only on `(layer_id, objectid)` with no RLS predicate, so without the pre-read a low-privilege caller could mutate/delete a row RLS hides from them. Mirrors the GeoServices/OData/WFS-T guards (#2066). Adds carry no objectid and are not pre-read.
- **#2068 (Within/Contains reversed):** corrected the operand order in DuckDB, SQL Server, Oracle, Snowflake, and Redshift query builders so `Within`/`Contains` lead with the filter geometry (`ST_Within(filter, feature)` / `ST_Contains(filter, feature)`), matching the canonical PostGIS reference. Oracle's operand-order-sensitive `SDO_RELATE` masks now take the filter geometry first.
- **#2069 (reverse datum transform):** `DatumTransformSql.BuildTransformExpression` now honors `TransformForward` by emitting the PROJ-canonical inverse for reverse selections (new `ProjPipelineInverter`: reverse step order + toggle `+inv`; `+proj=noop` is self-inverse). Previously a reverse selection applied the forward NADCON shift, moving coordinates ~2x the intended correction the wrong way.
- **#2070 (Postgres pagination):** removed the `IsUnorderedFirstPageLikeFilter` carve-out so a stable `ORDER BY objectid` tiebreaker is always injected when `Limit` is set, matching the sibling MySQL provider. First-page LIKE queries no longer skip/duplicate rows across the page boundary.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Per-provider Within/Contains operand-order tests; reverse/forward/noop `BuildTransformExpression` + `ProjPipelineInverter` round-trip tests; first-page LIKE stable-order tests; gRPC ApplyEdits RLS-hidden update/delete fail-closed tests + adds-only no-pre-read test. All targeted suites green. (Pre-existing unrelated failures on trunk — `FeatureCatalogDriftTests`, `SqlServer BuildSelectQuery_SqlFilterOnlyWithoutWhere_PassesThroughForDirectCallers` — were confirmed present before these changes and are not touched here.)

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
