### PR TITLE
chore(ci): close out lean merge_group gate + fix runbook doc links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ on:
   # heavy job is `if:`-gated to `pull_request`/schedule and SKIPS on
   # merge_group; the PR-time aggregator `CI Gate` likewise does not run on
   # merge_group. The merge-queue REQUIRED check must be `Merge Queue Gate`,
-  # NOT `CI Gate`. See docs/internal/contributor/merge-queue-runbook.md.
+  # NOT `CI Gate`. See docs/internal/contributor/lean-merge-queue-runbook.md.
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/docs/internal/contributor/adr/0055-optimistic-batch-merge-train.md
+++ b/docs/internal/contributor/adr/0055-optimistic-batch-merge-train.md
@@ -13,7 +13,7 @@ batch. A human flips it live later. Phases 2/3 are tracked as roadmap below.
 honua-server merges one PR at a time. GitHub's native merge queue was disabled
 (2026-06-18, ruleset 17808547) after batch sizes of ~5 caused runner
 starvation, ejected the front PR, reformed the group, and spiralled into zombie
-runs (see `docs/internal/contributor/merge-queue-runbook.md`). The lean
+runs (see `docs/internal/contributor/lean-merge-queue-runbook.md`). The lean
 `Merge Queue Gate` job replaced the full matrix on `merge_group`, but the queue
 itself is off, so throughput is gated by serial human merges.
 


### PR DESCRIPTION
## Summary

Closes #2026.

The lean `merge_group` gate that #2026 asks for was actually implemented and merged in **#2027**: `ci.yml` already runs a single lean `Merge Queue Gate` job on `merge_group` (build + format + Server Fast unit smoke + Architecture tests), every heavy job and the PR-time `CI Gate` aggregator skip on `merge_group`, concurrency keys on the per-batch queue ref, and `docs/internal/contributor/lean-merge-queue-runbook.md` documents the re-enable steps for ruleset 17808547.

However, **#2027 did not use `Closes #2026`, so the issue stayed open**, and it left **two broken doc-links** pointing at a non-existent `docs/internal/contributor/merge-queue-runbook.md` (the runbook is named `lean-merge-queue-runbook.md`). This PR fixes those links and closes the tracking issue.

I verified the full acceptance criteria are already satisfied on trunk:
- Lean `Merge Queue Gate` runs on `merge_group` (NOT AOT/docker/shard matrix) — `ci.yml` job `merge-queue-gate`, `if: github.event_name == 'merge_group'`.
- All heavy jobs + `CI Gate` skip on `merge_group` — static job-graph trace confirms **only** `Merge Queue Gate` runs on a batched commit; all 21 other jobs cascade-skip.
- Concurrency safe (per-batch queue ref keying).
- Runbook present under `docs/internal/contributor/`.
- PR/`pull_request` lane unchanged.
- Ruleset NOT flipped live (left as the documented follow-up).

## Changes Made

- Repoint the `merge_group` header comment in `.github/workflows/ci.yml` from `merge-queue-runbook.md` to the actual `lean-merge-queue-runbook.md`.
- Repoint the same stale link in `docs/internal/contributor/adr/0055-optimistic-batch-merge-train.md`.

## Breaking Changes

None.

## Gate Impact

- [x] CI/governance plumbing only (workflow comment + ADR doc link). No job behavior, triggers, or required checks change.

## Testing

- [x] Static verification: all `.github/workflows/*.yml` parse (`python -c "import yaml,glob;..."`); parsed `if:`/`needs:` job-graph trace confirms the `merge_group` event routes ONLY to `Merge Queue Gate`; no remaining references to the non-existent runbook filename.
