### PR TITLE
fix(ai): detect Bedrock max_tokens truncation on workflow generation (#1760)

### DIFF
--- a/src/Honua.Ai/Features/Providers/Bedrock/BedrockStructuredGenerationClient.cs
+++ b/src/Honua.Ai/Features/Providers/Bedrock/BedrockStructuredGenerationClient.cs
@@ -104,6 +104,16 @@ internal static class BedrockStructuredGenerationClient
                 return BedrockStructuredResult.Failed("Bedrock declined the request (content filtered).");
             }
 
+            // Surface max_tokens truncation explicitly. The Converse adapter maps StopReason.Max_tokens
+            // to ChatFinishReason.Length; the forced tool-call JSON is then cut off mid-payload and the
+            // caller's deserialize fails with an opaque generic parse error instead of an actionable
+            // message (mirrors the workflow/OpenAI/Anthropic providers from #1979).
+            if (response.FinishReason == ChatFinishReason.Length)
+            {
+                return BedrockStructuredResult.Failed(
+                    "Bedrock response was truncated (max_tokens reached); try a higher MaxTokens.");
+            }
+
             var call = response.Messages
                 .SelectMany(m => m.Contents)
                 .OfType<FunctionCallContent>()

--- a/src/Honua.Ai/Features/WorkflowGeneration/BedrockWorkflowGenerationProvider.cs
+++ b/src/Honua.Ai/Features/WorkflowGeneration/BedrockWorkflowGenerationProvider.cs
@@ -132,6 +132,21 @@ internal sealed class BedrockWorkflowGenerationProvider : IWorkflowGenerationPro
                 return WorkflowGenerationProposal.Error(Reason, _providerId, model);
             }
 
+            // Surface max_tokens truncation explicitly. Bedrock's Converse adapter maps a
+            // StopReason.Max_tokens to ChatFinishReason.Length; when that happens the forced
+            // tool-call's JSON arguments are cut off mid-payload, so the DeserializeProposal below
+            // would fail (or silently drop fields) and flatten to the opaque generic
+            // "Provider response could not be parsed." Larger workflows (e.g. vector-tiles,
+            // geocoding) are the ones that overflow MaxTokens, which is exactly the #1760 symptom.
+            // The OpenAI-compatible and Anthropic providers already do this (#1979); the Bedrock
+            // provider was missed.
+            if (response.FinishReason == ChatFinishReason.Length)
+            {
+                const string Reason = "Provider response was truncated (max_tokens reached); try a higher MaxTokens.";
+                WorkflowGenerationLog.GenerationFailed(_logger, _providerId, Reason);
+                return WorkflowGenerationProposal.Error(Reason, _providerId, model);
+            }
+
             var call = response.Messages
                 .SelectMany(m => m.Contents)
                 .OfType<FunctionCallContent>()

--- a/tests/dotnet/Honua.Ai.Tests/Source/BedrockStudioProviderTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/BedrockStudioProviderTests.cs
@@ -10,7 +10,9 @@ using Honua.Ai.ReportGeneration;
 using Honua.Ai.WorkflowGeneration;
 using Honua.Core.Features.Publishing.Dashboards;
 using Honua.Core.Features.Publishing.Reports;
+using Honua.Core.Features.WorkflowPackages.Domain;
 using Honua.Core.Features.WorkflowPackages.Generation;
+using Honua.Core.Features.WorkflowPackages.Generation.Domain;
 using Honua.TestKit.Attributes;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -151,6 +153,70 @@ public sealed class BedrockStudioProviderTests
 
         result.Status.Should().Be("error");
     }
+
+    [UnitTest]
+    public async Task BedrockWorkflowProvider_WhenResponseTruncatedAtMaxTokens_ReturnsTruncationError()
+    {
+        // Regression for #1760: large workflow prompts (vector-tiles, geocoding) overflow MaxTokens,
+        // so Bedrock returns a truncated tool-call. The Converse adapter maps StopReason.Max_tokens to
+        // ChatFinishReason.Length; the provider must surface an actionable truncation message instead of
+        // the opaque generic "Provider response could not be parsed." (#1979 added this to the
+        // OpenAI/Anthropic providers but skipped the Bedrock provider.)
+        var factory = Substitute.For<IBedrockChatClientFactory>();
+        factory.Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>())
+            .Returns(_ =>
+            {
+                // A tool-call whose JSON arguments were cut off mid-object — what a truncated
+                // Converse response actually surfaces — paired with FinishReason == Length.
+                var truncated = new FunctionCallContent(
+                    "call-1",
+                    "emit_workflow",
+                    new Dictionary<string, object?> { ["status"] = "generated", ["graph"] = null });
+                return new FakeChatClient(new ChatResponse(new ChatMessage(ChatRole.Assistant, [truncated]))
+                {
+                    FinishReason = ChatFinishReason.Length
+                });
+            });
+
+        var provider = new BedrockWorkflowGenerationProvider(
+            WorkflowGenerationConfiguration.BedrockProviderId,
+            factory,
+            BedrockOptions(),
+            NullLogger<BedrockWorkflowGenerationProvider>.Instance);
+
+        var result = await provider.GenerateAsync(new WorkflowGenerationProviderRequest
+        {
+            Prompt = "Generate vector tiles (PMTiles) for maui-roads and publish as a tile service.",
+            Registry = WorkflowRegistrySnapshot()
+        });
+
+        result.Status.Should().Be(WorkflowGenerationStatus.Error);
+        result.ErrorMessage.Should().Contain("truncated");
+        result.ErrorMessage.Should().Contain("MaxTokens");
+        result.ErrorMessage.Should().NotContain("could not be parsed");
+    }
+
+    private static WorkflowNodeRegistrySnapshot WorkflowRegistrySnapshot() => new()
+    {
+        RegistryVersion = "test-registry-1",
+        GeneratedAt = DateTimeOffset.UnixEpoch,
+        Providers = [],
+        Nodes =
+        [
+            new WorkflowNodeDefinition
+            {
+                NodeTypeId = "process:data-management.copy-features",
+                ProviderId = "test",
+                RuntimeKind = WorkflowNodeRuntimeKind.Geoprocessing,
+                Title = "Copy Features",
+                Description = "Copy features",
+                Category = "transform",
+                ParameterSchemas = [],
+                CapabilityFlags = new WorkflowNodeCapabilityFlags { Executable = true },
+                RuntimeHints = new WorkflowNodeRuntimeHints()
+            }
+        ]
+    };
 
     [UnitTest]
     public void BedrockWorkflowProvider_IsConfigured_WhenModelIsSet()


### PR DESCRIPTION
## Related Issue

Closes #1760

## Summary

`Provider response could not be parsed` was returned specifically for the vector-tiles and geocoding workflow prompts on demo.honua.io (Bedrock/Claude). The root cause is the same `max_tokens` truncation identified in #1979 — but that fix only covered the OpenAI-compatible and Anthropic providers (and stated "the Anthropic provider already reads stop_reason"). The **Bedrock** provider, which is what demo.honua.io actually runs, was never given the truncation guard.

The Bedrock Converse adapter already maps `StopReason.Max_tokens` to `ChatFinishReason.Length`, but neither `BedrockWorkflowGenerationProvider` nor the shared `BedrockStructuredGenerationClient` (dashboard/report/app) inspected it. A truncated tool-call payload then deserialized into a broken/empty proposal or threw `JsonException`, which flattened to the opaque generic message. Larger workflows (vector-tiles, geocoding) are exactly the prompts that overflow `MaxTokens`, matching the content-specific symptom in the issue.

## Changes Made

- Detect `ChatFinishReason.Length` in `BedrockWorkflowGenerationProvider` and return an actionable truncation error ("Provider response was truncated (max_tokens reached); try a higher MaxTokens.") instead of falling through to the generic parse error.
- Apply the same guard in the shared `BedrockStructuredGenerationClient` so dashboard/report/app generation on Bedrock get the same actionable message.
- Add a focused regression test (`BedrockWorkflowProvider_WhenResponseTruncatedAtMaxTokens_ReturnsTruncationError`) driving the provider with a `ChatFinishReason.Length` response and asserting the truncation message (not "could not be parsed").

## Breaking Changes

None.

## Gate Impact

- [x] No gate-tier impact (error-message hardening only; no API surface or behavior change on success paths)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Built `src/Honua.Ai` in Release with warnings-as-errors (0 warnings, 0 errors), ran the Bedrock provider unit tests (7/7 passing including the new regression test), and `dotnet format --verify-no-changes` on the changed files reports no changes.
