### PR TITLE
fix(licensing): honor LicenseContentSecretRef in bootstrap entitlement probe

### DIFF
--- a/src/Honua.Hosting/Features/Licensing/FileBackedLicenseService.cs
+++ b/src/Honua.Hosting/Features/Licensing/FileBackedLicenseService.cs
@@ -106,10 +106,27 @@ internal sealed class FileBackedLicenseService :
     /// Callers must pass <c>honorDevGrant: false</c> in Production so the override never relaxes a
     /// startup gate without a signed license (the host-level guard fails the process closed there).
     /// </summary>
+    /// <param name="configuration">The host configuration carrying the <c>Licensing</c> section.</param>
+    /// <param name="loggerFactory">Factory for the transient bootstrap logger.</param>
+    /// <param name="honorDevGrant">
+    /// When <see langword="true"/>, a valid <c>Licensing:DevGrantEdition</c> short-circuits the
+    /// snapshot to that edition. Must be <see langword="false"/> in Production.
+    /// </param>
+    /// <param name="secretResolver">
+    /// The same <see cref="ILicenseContentSecretResolver"/> that <c>AddHonuaLicensing</c> registers
+    /// for the per-request license service. Supplying it here lets the bootstrap snapshot honor
+    /// <c>Licensing:LicenseContentSecretRef</c> (e.g. a Secrets-Manager-only Pro license); without
+    /// it a secret-ref license degrades to Community at bootstrap and a startup gate such as the
+    /// Redis-cache probe stays off for the process lifetime (honua-server#1755). It is optional so
+    /// hosts without a secret resolver (or built with the cloud SDK excluded) still resolve file /
+    /// inline / Community licenses correctly.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token for the snapshot load.</param>
     internal static async Task<LicenseSnapshot> LoadBootstrapSnapshotAsync(
         IConfiguration configuration,
         ILoggerFactory loggerFactory,
         bool honorDevGrant = false,
+        ILicenseContentSecretResolver? secretResolver = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(configuration);
@@ -127,7 +144,8 @@ internal sealed class FileBackedLicenseService :
         var service = new FileBackedLicenseService(
             Options.Create(options),
             new BouncyCastleEd25519Verifier(),
-            loggerFactory.CreateLogger<FileBackedLicenseService>());
+            loggerFactory.CreateLogger<FileBackedLicenseService>(),
+            secretResolver);
         await service.StartAsync(cancellationToken).ConfigureAwait(false);
         return service.GetSnapshot();
     }

--- a/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
+++ b/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
@@ -99,10 +99,47 @@ internal static class StartupConfigurationHelpers
         }
 
         using var loggerFactory = LoggerFactory.Create(static builder => builder.AddConsole());
+
+        // Resolve the bootstrap snapshot with the SAME license-content secret resolver that
+        // AddHonuaLicensing wires for the per-request service. Without it a Secrets-Manager-only
+        // Pro license (Licensing:LicenseContentSecretRef) resolves as Community at bootstrap, so
+        // this gate sees no caching.redis entitlement and the IConnectionMultiplexer never gets
+        // wired for the process lifetime even when the SM license carries it (honua-server#1755).
+        var secretResolver = CreateBootstrapLicenseSecretResolver(loggerFactory);
         var snapshot = await FileBackedLicenseService
-            .LoadBootstrapSnapshotAsync(configuration, loggerFactory, honorDevGrant: !environment.IsProduction())
+            .LoadBootstrapSnapshotAsync(
+                configuration,
+                loggerFactory,
+                honorDevGrant: !environment.IsProduction(),
+                secretResolver: secretResolver)
             .ConfigureAwait(false);
         return snapshot.HasEntitlement("caching.redis");
+    }
+
+    /// <summary>
+    /// Constructs the provider-specific <see cref="ILicenseContentSecretResolver"/> for the
+    /// bootstrap entitlement probe, mirroring the resolver <c>AddHonuaLicensing</c> registers in
+    /// DI. The AWSSDK surface stays confined to <c>Honua.Aws</c> behind the same
+    /// <c>HONUA_EXCLUDE_AWS</c> guard the runtime wiring uses; when the cloud SDK is excluded the
+    /// probe falls back to file / inline / Community resolution exactly as before. Constructing the
+    /// resolver here is cheap — it only touches the network when a secret reference is configured
+    /// and resolved (its AWS client is created lazily).
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1859:Use concrete types when possible for improved performance",
+        Justification = "The return type must stay the cloud-neutral abstraction: in the " +
+            "HONUA_EXCLUDE_AWS build profile the concrete resolver type does not exist, so the " +
+            "method returns null typed as the interface.")]
+    private static ILicenseContentSecretResolver? CreateBootstrapLicenseSecretResolver(ILoggerFactory loggerFactory)
+    {
+#if HONUA_EXCLUDE_AWS
+        _ = loggerFactory;
+        return null;
+#else
+        return new Honua.Aws.Features.Licensing.AwsSecretsManagerLicenseContentResolver(
+            loggerFactory.CreateLogger<Honua.Aws.Features.Licensing.AwsSecretsManagerLicenseContentResolver>());
+#endif
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/Licensing/FileBackedLicenseServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Licensing/FileBackedLicenseServiceTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using FluentAssertions;
 using Honua.Core.Features.Licensing.Domain;
 using Honua.Infrastructure.Licensing;
+using Microsoft.Extensions.Configuration;
 using Honua.TestKit.Helpers;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -395,6 +396,95 @@ public sealed class FileBackedLicenseServiceTests
         resolver.ResolveCallCount.Should().Be(0);
         logger.Entries.Should().Contain(entry => entry.EventId == 10011 && entry.Level == LogLevel.Warning);
     }
+
+    [UnitTest]
+    public async Task LoadBootstrapSnapshotAsync_LicenseContentSecretRef_WithResolver_ActivatesProEntitlements()
+    {
+        // honua-server#1755: the bootstrap entitlement probe must honor a Secrets-Manager-only Pro
+        // license (Licensing:LicenseContentSecretRef) just like the per-request service does, so a
+        // startup gate such as the Redis-cache probe sees its caching.redis entitlement.
+        const string secretRef = "aws:secretsmanager:honua/license-pro";
+        var license = LicenseTestSupport.CreateSignedLicense(
+            HonuaEdition.Pro,
+            expiresAt: DateTimeOffset.UtcNow.AddDays(365),
+            entitlements: ["caching.redis", "analytics.clustering"]);
+        var envelopeJson = Encoding.UTF8.GetString(license.LicenseData);
+        var resolver = new FakeLicenseSecretResolver(envelopeJson);
+
+        var configuration = BuildLicenseConfiguration(new Dictionary<string, string?>
+        {
+            ["Licensing:LicenseContentSecretRef"] = secretRef,
+            ["Licensing:TrustedKeys:" + LicenseTestSupport.KeyId] = license.PublicKeySetting
+        });
+
+        using var loggerFactory = LoggerFactory.Create(static builder => { });
+        var snapshot = await FileBackedLicenseService.LoadBootstrapSnapshotAsync(
+            configuration,
+            loggerFactory,
+            honorDevGrant: false,
+            secretResolver: resolver);
+
+        snapshot.Edition.Should().Be(HonuaEdition.Pro);
+        snapshot.IsValid.Should().BeTrue();
+        snapshot.HasEntitlement("caching.redis").Should().BeTrue(
+            "the SM-resolved Pro license carries caching.redis, so the bootstrap Redis-cache gate must see it");
+        snapshot.HasEntitlement("analytics.clustering").Should().BeTrue();
+        resolver.ResolveCallCount.Should().Be(1);
+    }
+
+    [UnitTest]
+    public async Task LoadBootstrapSnapshotAsync_LicenseContentSecretRef_NoResolver_FallsBackToCommunity()
+    {
+        // Reproduces the pre-fix bug shape: with no resolver supplied, an SM-only Pro license
+        // cannot be fetched at bootstrap and the snapshot degrades to Community (no caching.redis).
+        var configuration = BuildLicenseConfiguration(new Dictionary<string, string?>
+        {
+            ["Licensing:LicenseContentSecretRef"] = "aws:secretsmanager:honua/license-pro"
+        });
+
+        using var loggerFactory = LoggerFactory.Create(static builder => { });
+        var snapshot = await FileBackedLicenseService.LoadBootstrapSnapshotAsync(
+            configuration,
+            loggerFactory,
+            honorDevGrant: false,
+            secretResolver: null);
+
+        snapshot.Edition.Should().Be(HonuaEdition.Community);
+        snapshot.HasEntitlement("caching.redis").Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task LoadBootstrapSnapshotAsync_InlineCommunityLicense_StillResolvesCorrectly()
+    {
+        // A file/inline Community license must continue to resolve correctly when a resolver is
+        // present — the resolver only fires for a secret reference (none configured here).
+        var license = LicenseTestSupport.CreateSignedLicense(HonuaEdition.Community);
+        var resolver = new FakeLicenseSecretResolver("should-not-be-read");
+
+        var configuration = BuildLicenseConfiguration(new Dictionary<string, string?>
+        {
+            ["Licensing:LicenseContent"] = Encoding.UTF8.GetString(license.LicenseData),
+            ["Licensing:TrustedKeys:" + LicenseTestSupport.KeyId] = license.PublicKeySetting
+        });
+
+        using var loggerFactory = LoggerFactory.Create(static builder => { });
+        var snapshot = await FileBackedLicenseService.LoadBootstrapSnapshotAsync(
+            configuration,
+            loggerFactory,
+            honorDevGrant: false,
+            secretResolver: resolver);
+
+        snapshot.Edition.Should().Be(HonuaEdition.Community);
+        snapshot.IsValid.Should().BeTrue();
+        snapshot.HasEntitlement("caching.redis").Should().BeFalse(
+            "caching.redis is a Pro entitlement and must stay inactive for a Community license");
+        resolver.ResolveCallCount.Should().Be(0);
+    }
+
+    private static IConfiguration BuildLicenseConfiguration(Dictionary<string, string?> settings)
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
 
     [UnitTest]
     public async Task UploadLicenseAsync_OversizedStream_StopsReadingAfterSizeLimit()


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1755

## Summary
The bootstrap Redis-cache entitlement probe (`IsRedisCacheEntitledAsync` → `LoadBootstrapSnapshotAsync`) constructed `FileBackedLicenseService` **without** the license-content secret resolver. A Secrets-Manager-only Pro license (`Licensing:LicenseContentSecretRef`) therefore resolved as **Community** at bootstrap, leaving `redisCacheEntitled=false` for the whole process lifetime even when the SM license carried `caching.redis`. Per-request entitlement checks (via the resolver-backed service `AddHonuaLicensing` registers) were unaffected.

This PR threads the **same** `ILicenseContentSecretResolver` the per-request path uses into the bootstrap snapshot loader, so `LicenseContentSecretRef` is honored at bootstrap. Deferring the gate was not viable: the probe runs before DI is built and its result drives whether the Redis cache is even registered in `Program.cs`, so the resolver must be available at the probe point. The AWS resolver is cheap to construct (its AWS client is lazy and only touches the network when a secret ref is configured and resolved), and it is wired behind the same `HONUA_EXCLUDE_AWS` guard `AddHonuaLicensing` already uses.

## Changes Made
- `LoadBootstrapSnapshotAsync` now accepts an optional `ILicenseContentSecretResolver` and passes it to the `FileBackedLicenseService` constructor (the constructor already supported it for the per-request path).
- `IsRedisCacheEntitledAsync` constructs the provider secret resolver (`AwsSecretsManagerLicenseContentResolver` behind `#if !HONUA_EXCLUDE_AWS`, mirroring `LicensingRegistration.AddHonuaLicensing`) and supplies it to the bootstrap snapshot loader. Cloud-SDK-excluded builds fall back to file/inline/Community resolution unchanged.
- Added focused unit tests: an SM-licensed (secret-ref) Pro license now yields `caching.redis` at bootstrap; no-resolver still degrades to Community (pre-fix bug shape); and a Community license still resolves correctly with a resolver present.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
