### PR TITLE
fix: enforce scoped admin API key permissions (#1985)

### DIFF
--- a/src/Honua.Hosting/Features/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/src/Honua.Hosting/Features/Authentication/ApiKeyAuthenticationHandler.cs
@@ -339,20 +339,49 @@ internal sealed class ApiKeyAuthenticationHandler(
         // ServiceDataEditorAuthorization pipeline against the scope claims below.
         var isScopedWriteKey = LayerScopedWriteKey.IsScopedWriteKey(permissions);
 
-        var claims = isScopedWriteKey
-            ? new List<Claim>
-            {
+        // A key is granted the blanket "admin" role only when its grants confer full
+        // administrative authority (issue #1985). The password-based bootstrap admin
+        // and the development bypass authenticate with null permissions and so remain
+        // full admins; an unscoped key (or one carrying admin / * / admin:* grants)
+        // likewise passes every admin endpoint. A key whose grants are genuinely
+        // scoped — neither a full-admin grant nor a write: grant — is authenticated as
+        // a NON-admin principal so it no longer silently passes RequireRole("admin").
+        // Its grants are surfaced as "permission" claims below for endpoint-level
+        // enforcement.
+        var confersFullAdmin = LayerScopedWriteKey.ConfersFullAdmin(permissions);
+
+        List<Claim> claims;
+        if (isScopedWriteKey)
+        {
+            claims =
+            [
                 new Claim(ClaimTypes.Name, apiKeyName ?? "layer-write-key"),
                 new Claim(ClaimTypes.Role, LayerScopedWriteKey.Role),
                 new Claim("auth_type", LayerScopedWriteKey.AuthType),
                 new Claim(LayerScopedWriteKey.ScopeClaimType, LayerScopedWriteKey.AuthType),
-            }
-            : new List<Claim>
-            {
+            ];
+        }
+        else if (confersFullAdmin)
+        {
+            claims =
+            [
                 new Claim(ClaimTypes.Name, "admin"),
                 new Claim(ClaimTypes.Role, "admin"),
                 new Claim("auth_type", authenticationType),
-            };
+            ];
+        }
+        else
+        {
+            // Genuinely scoped, non-admin, non-write key: authenticated but NOT an
+            // admin. It carries only its scoped "permission" claims (added below) and
+            // is denied any endpoint guarded by the admin role.
+            claims =
+            [
+                new Claim(ClaimTypes.Name, apiKeyName ?? "scoped-api-key"),
+                new Claim(ClaimTypes.Role, LayerScopedWriteKey.ScopedKeyRole),
+                new Claim("auth_type", authenticationType),
+            ];
+        }
 
         if (apiKeyId.HasValue)
         {

--- a/src/Honua.Hosting/Features/Authentication/LayerScopedWriteKey.cs
+++ b/src/Honua.Hosting/Features/Authentication/LayerScopedWriteKey.cs
@@ -66,6 +66,63 @@ internal static class LayerScopedWriteKey
     public const string Role = "layer-write-key";
 
     /// <summary>
+    /// Role assigned to a genuinely-scoped API key whose grants confer neither full
+    /// admin authority nor a layer-scoped <c>write:</c> grant (issue #1985). The role
+    /// is deliberately not <c>admin</c> so the key is denied any endpoint guarded by
+    /// the admin authorization policy; its scoped grants remain available as
+    /// <c>permission</c> claims for endpoint-level enforcement.
+    /// </summary>
+    public const string ScopedKeyRole = "scoped-api-key";
+
+    /// <summary>
+    /// Determines whether the supplied permission grants confer full administrative
+    /// authority — i.e. the key is unscoped and must satisfy every admin endpoint
+    /// (legacy behavior). This is the case when no permissions are supplied (the
+    /// password-based bootstrap admin and the development bypass authenticate with
+    /// <see langword="null"/> permissions, and the key store normalizes an empty
+    /// grant set to <c>admin:*</c>) or when at least one grant is a full-admin grant
+    /// (<c>admin</c>, <c>*</c>, or any <c>admin:</c>-prefixed grant such as
+    /// <c>admin:*</c>).
+    /// </summary>
+    /// <remarks>
+    /// A key whose grants are genuinely scoped — neither a full-admin grant nor a
+    /// layer-scoped <c>write:</c> grant — confers no admin authority. Such a key is
+    /// authenticated as a non-admin principal (issue #1985) so it no longer silently
+    /// passes the admin authorization policy; its grants are surfaced as
+    /// <c>permission</c> claims for endpoint-level enforcement.
+    /// </remarks>
+    /// <param name="permissions">The key's permission grants.</param>
+    /// <returns><see langword="true"/> when the key confers full admin authority.</returns>
+    public static bool ConfersFullAdmin(IReadOnlyList<string>? permissions)
+    {
+        if (permissions is null || permissions.Count == 0)
+        {
+            // Unscoped: bootstrap admin / dev bypass (null) and empty grant sets
+            // (normalized to admin:* by the key store) retain full admin authority.
+            return true;
+        }
+
+        var hasMeaningfulGrant = false;
+        foreach (var permission in permissions)
+        {
+            var trimmed = permission?.Trim();
+            if (string.IsNullOrEmpty(trimmed))
+            {
+                continue;
+            }
+
+            hasMeaningfulGrant = true;
+            if (IsAdminGrant(trimmed))
+            {
+                return true;
+            }
+        }
+
+        // A grant set consisting solely of blank entries is treated as unscoped.
+        return !hasMeaningfulGrant;
+    }
+
+    /// <summary>
     /// Determines whether the supplied permission grants describe a layer-scoped
     /// write key: at least one <c>write:</c> grant and no full-admin grant.
     /// </summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminApiKeyEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminApiKeyEndpointsTests.cs
@@ -175,6 +175,43 @@ public sealed class AdminApiKeyEndpointsTests : IAsyncLifetime
         }
     }
 
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/api-keys")]
+    public async Task GenuinelyScopedApiKey_IsDeniedAdminEndpoint()
+    {
+        // A key whose grants are genuinely scoped — neither a full-admin grant
+        // (admin / * / admin:*) nor a layer-scoped write: grant — must NOT be
+        // silently elevated to full admin (issue #1985). It authenticates but is
+        // forbidden from the admin surface guarded by RequireAdminAuthorization.
+        var scoped = await CreateApiKeyAsync("scoped-read-key", permissions: ["read:layers"]);
+        using var scopedClient = CreateApiKeyClient(scoped.Key);
+
+        var response = await scopedClient.GetAsync("/api/v1/admin/api-keys");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/api-keys")]
+    public async Task FullAdminApiKey_PassesAdminEndpoint()
+    {
+        // Backward compatibility: a key carrying a full-admin grant (and the
+        // default unscoped key, normalized to admin:*) still passes every admin
+        // endpoint (issue #1985).
+        var explicitAdmin = await CreateApiKeyAsync("explicit-admin-key", permissions: ["admin:*"]);
+        var defaultAdmin = await CreateApiKeyAsync("default-admin-key");
+        Assert.Equal("admin:*", Assert.Single(defaultAdmin.ApiKey.Permissions));
+
+        using var explicitAdminClient = CreateApiKeyClient(explicitAdmin.Key);
+        using var defaultAdminClient = CreateApiKeyClient(defaultAdmin.Key);
+
+        var explicitResponse = await explicitAdminClient.GetAsync("/api/v1/admin/api-keys");
+        var defaultResponse = await defaultAdminClient.GetAsync("/api/v1/admin/api-keys");
+
+        Assert.Equal(HttpStatusCode.OK, explicitResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, defaultResponse.StatusCode);
+    }
+
     private async Task<AdminApiKeySecretResponse> CreateApiKeyAsync(
         string name,
         DateTimeOffset? expiresAt = null,

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/LayerScopedWriteKeyTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/LayerScopedWriteKeyTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Infrastructure.Authentication;
+
+namespace Honua.Server.Tests.Infrastructure.Authentication;
+
+/// <summary>
+/// Unit tests for the permission-grant classification that governs whether an API
+/// key is elevated to the full <c>admin</c> role, kept as a layer-scoped write key,
+/// or restricted to a genuinely-scoped non-admin principal (issue #1985 / #1637).
+/// </summary>
+public sealed class LayerScopedWriteKeyTests
+{
+    [Fact]
+    public void ConfersFullAdmin_NullPermissions_ReturnsTrue()
+    {
+        // The password-based bootstrap admin and the development bypass authenticate
+        // with null permissions and must retain full admin authority.
+        LayerScopedWriteKey.ConfersFullAdmin(null).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConfersFullAdmin_EmptyPermissions_ReturnsTrue()
+    {
+        // The key store normalizes an empty grant set to admin:*; an empty set is unscoped.
+        LayerScopedWriteKey.ConfersFullAdmin([]).Should().BeTrue();
+        LayerScopedWriteKey.ConfersFullAdmin(["   "]).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("admin")]
+    [InlineData("*")]
+    [InlineData("admin:*")]
+    [InlineData("admin:read")]
+    [InlineData("ADMIN")]
+    public void ConfersFullAdmin_AdminGrants_ReturnsTrue(string grant)
+    {
+        LayerScopedWriteKey.ConfersFullAdmin([grant]).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConfersFullAdmin_AdminGrantAmongScopedGrants_ReturnsTrue()
+    {
+        LayerScopedWriteKey.ConfersFullAdmin(["read:layers", "admin"]).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("read:layers")]
+    [InlineData("metadata:read")]
+    [InlineData("write:demo/parcels")]
+    [InlineData("deploy:approve")]
+    public void ConfersFullAdmin_GenuinelyScopedGrants_ReturnsFalse(string grant)
+    {
+        // A grant set that carries no full-admin grant confers no admin authority,
+        // so the key must not satisfy the admin authorization policy (issue #1985).
+        LayerScopedWriteKey.ConfersFullAdmin([grant]).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsScopedWriteKey_WriteGrant_ReturnsTrue()
+    {
+        LayerScopedWriteKey.IsScopedWriteKey(["write:demo/parcels"]).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsScopedWriteKey_AdminGrant_ReturnsFalse()
+    {
+        LayerScopedWriteKey.IsScopedWriteKey(["write:demo", "admin"]).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsScopedWriteKey_ReadOnlyScopedGrant_ReturnsFalse()
+    {
+        // A genuinely-scoped read key is neither a write key nor an admin; it falls
+        // through to the restricted non-admin principal branch.
+        var permissions = new[] { "read:layers" };
+        LayerScopedWriteKey.IsScopedWriteKey(permissions).Should().BeFalse();
+        LayerScopedWriteKey.ConfersFullAdmin(permissions).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1985

## Summary
Scoped admin API keys were silently elevated to full admin. `ApiKeyAuthenticationHandler` stamped `Role=admin` on every key that was not a layer-scoped write key (#1637), regardless of its per-key `Permissions`, so the `AdminPolicy` `RequireRole("admin")` check passed for any valid key. The stored per-key permissions were surfaced as `permission` claims but never enforced on the general admin request path (the `OperatorAuthorizationEvaluator` was only consumed by deploy-approval gating).

This PR enforces per-key permissions: a key receives the blanket `admin` role only when its grants confer full administrative authority. A genuinely-scoped key (neither a full-admin grant nor a `write:` grant) is authenticated as a non-admin principal and is denied any endpoint guarded by the admin policy; its grants remain available as `permission` claims for endpoint-level enforcement.

**What I found on trunk (verified):**
- (a) Keys still carry a `Permissions` scope — stored in `AdminApiKeyRecord.Permissions`, surfaced as `permission` claims.
- (b) Still unenforced on the general admin path — only `LayerScopedWriteKey` (#1637) demoted `write:`-scoped keys to non-admin; any other scoped grant set (e.g. `read:layers`) was stamped full `admin`. The privilege-escalation gap was real for non-`write:`, non-admin scopes.
- The key store normalizes an empty grant set to `admin:*`, and the password bootstrap admin / dev bypass authenticate with `null` permissions — these are the unscoped full-admin paths preserved here.

## Changes Made
- Added `LayerScopedWriteKey.ConfersFullAdmin(permissions)`: full admin when permissions are null/empty (bootstrap admin, dev bypass, normalized `admin:*`) or contain a full-admin grant (`admin`, `*`, any `admin:`-prefixed grant).
- `ApiKeyAuthenticationHandler.CreateSuccessfulAuthenticationResult` now has three branches: layer-scoped write key (unchanged, `layer-write-key` role), full-admin key (`admin` role), and genuinely-scoped key (new `scoped-api-key` role — never satisfies `RequireRole("admin")`).
- Added the `LayerScopedWriteKey.ScopedKeyRole` constant.
- Tests: unit tests for the grant classification; integration tests asserting a genuinely-scoped key is denied an admin endpoint (403) and full-admin / default keys pass (200).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Unit tests (`LayerScopedWriteKeyTests`, 15 cases) pass locally. `Honua.Hosting` builds clean (Release, warnings-as-errors). Integration tests (`AdminApiKeyEndpointsTests`) require Testcontainers/Docker, which is unavailable on this host — they run in CI. `dotnet format --verify-no-changes` passes for the changed files.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

The admin API surface and key grammar are unchanged; this only changes which role a scoped key receives.

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None for legitimate use. Backward compatible: the password bootstrap admin, dev bypass, default unscoped keys, `admin:*` / `admin:read` keys, and existing layer-scoped write keys are unaffected. Only genuinely-scoped non-admin keys (previously silently full-admin) are now restricted — which is the security fix. Note: if the deployment only ever issues unscoped (full-admin) keys today, this enforcement is a correct no-op safeguard.

---

## Pre-PR Checklist
- [x] Ran the pre-PR equivalents (Release build of affected projects with warnings-as-errors, `dotnet format --verify-no-changes`, affected unit tests); Docker-gated integration tests run in CI (no local Docker)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
