### PR TITLE
feat(ai): Azure OpenAI / AI Foundry chat provider (Bedrock parity)

### DIFF
--- a/src/Honua.Ai/Features/DashboardGeneration/DashboardGenerationService.cs
+++ b/src/Honua.Ai/Features/DashboardGeneration/DashboardGenerationService.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Honua.Ai.Providers.AzureOpenAi;
 using Honua.Ai.Providers.Bedrock;
 using Honua.Ai.WorkflowGeneration;
 using Honua.Ai.WorkflowGeneration.Models;
@@ -28,6 +29,7 @@ public sealed class DashboardGenerationService : IDashboardGenerationService
     private readonly WorkflowGenerationConfiguration _configuration;
     private readonly WorkflowGenerationApiKeyResolver _apiKeyResolver;
     private readonly IBedrockChatClientFactory _bedrockChatClientFactory;
+    private readonly AzureOpenAiAuthResolver _azureAuthResolver;
     private readonly ILogger<DashboardGenerationService> _logger;
 
     public DashboardGenerationService(
@@ -35,12 +37,15 @@ public sealed class DashboardGenerationService : IDashboardGenerationService
         IOptions<WorkflowGenerationConfiguration> options,
         WorkflowGenerationApiKeyResolver apiKeyResolver,
         IBedrockChatClientFactory bedrockChatClientFactory,
-        ILogger<DashboardGenerationService> logger)
+        ILogger<DashboardGenerationService> logger,
+        AzureOpenAiAuthResolver? azureAuthResolver = null)
     {
         _httpClientFactory = httpClientFactory;
         _configuration = options.Value;
         _apiKeyResolver = apiKeyResolver;
         _bedrockChatClientFactory = bedrockChatClientFactory;
+        _azureAuthResolver = azureAuthResolver
+            ?? new AzureOpenAiAuthResolver(apiKeyResolver, new DefaultAzureOpenAiTokenProvider());
         _logger = logger;
     }
 
@@ -60,13 +65,20 @@ public sealed class DashboardGenerationService : IDashboardGenerationService
         // Bedrock targets the regional runtime endpoint via the AWS credential chain, so it needs no
         // endpoint URL — only a model id. OpenAI-compatible/Anthropic providers require an endpoint.
         var isBedrock = string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase);
+        var isAzureOpenAi = string.Equals(providerId, WorkflowGenerationConfiguration.AzureOpenAiProviderId, StringComparison.OrdinalIgnoreCase);
         var endpointMissing = !isBedrock && string.IsNullOrWhiteSpace(options?.Endpoint);
-        if (options is null || endpointMissing || string.IsNullOrWhiteSpace(options.Model))
+        // Azure OpenAI routes by deployment name, so a configured deployment satisfies the
+        // model requirement even when no raw model id is set.
+        var modelMissing = string.IsNullOrWhiteSpace(options?.Model)
+            && !(isAzureOpenAi && !string.IsNullOrWhiteSpace(options?.Deployment));
+        if (options is null || endpointMissing || modelMissing)
         {
             return Unsupported($"Dashboard generation provider '{providerId}' is not configured on this server.");
         }
 
-        var model = string.IsNullOrWhiteSpace(request.Model) ? options.Model! : request.Model!;
+        var model = string.IsNullOrWhiteSpace(request.Model)
+            ? (string.IsNullOrWhiteSpace(options.Model) ? options.Deployment : options.Model)
+            : request.Model!;
 
         var providerRequest = new DashboardGenerationProviderRequest
         {
@@ -151,6 +163,13 @@ public sealed class DashboardGenerationService : IDashboardGenerationService
         if (string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase))
         {
             return await CallBedrockAsync(request, options, providerId, model, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Azure OpenAI is OpenAI-compatible but deployment-routed (Azure URL + api-key/Entra auth);
+        // route it through the shared Azure structured-generation client.
+        if (string.Equals(providerId, WorkflowGenerationConfiguration.AzureOpenAiProviderId, StringComparison.OrdinalIgnoreCase))
+        {
+            return await CallAzureOpenAiAsync(request, options, providerId, model, cancellationToken).ConfigureAwait(false);
         }
 
         try
@@ -274,6 +293,57 @@ public sealed class DashboardGenerationService : IDashboardGenerationService
         {
             GenerationProviderLog.ProviderRequestFailed(_logger, providerId, ex);
             return ErrorProposal("Bedrock request failed.");
+        }
+    }
+
+    private async Task<DashboardGenerationModelProposal> CallAzureOpenAiAsync(
+        DashboardGenerationProviderRequest request,
+        WorkflowGenerationProviderOptions options,
+        string providerId,
+        string model,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var credential = await _azureAuthResolver.ResolveAsync(providerId, options, cancellationToken).ConfigureAwait(false);
+
+            var client = _httpClientFactory.CreateClient("workflow-generation");
+            client.Timeout = TimeSpan.FromSeconds(options.TimeoutSeconds);
+
+            var result = await AzureOpenAiStructuredGenerationClient.GenerateAsync(
+                client,
+                options,
+                model,
+                credential.ApiKey,
+                credential.AccessToken,
+                DashboardGenerationPrompt.BuildSystem(request),
+                DashboardGenerationPrompt.BuildUser(request),
+                "dashboard_proposal",
+                DashboardGenerationSchema.Build(),
+                cancellationToken).ConfigureAwait(false);
+
+            if (!result.Succeeded)
+            {
+                GenerationProviderLog.ProviderRequestFailed(_logger, providerId, new InvalidOperationException(result.Error));
+                return ErrorProposal(result.Error ?? "Azure OpenAI request failed.");
+            }
+
+            var proposal = JsonSerializer.Deserialize(result.Json!, DashboardGenerationJsonContext.Default.DashboardGenerationModelProposal);
+            return proposal ?? ErrorProposal("Failed to deserialize the dashboard proposal from the Azure OpenAI response.");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            GenerationProviderLog.ProviderResponseParseFailed(_logger, providerId, ex);
+            return ErrorProposal("Azure OpenAI response could not be parsed.");
+        }
+        catch (HttpRequestException ex)
+        {
+            GenerationProviderLog.ProviderRequestFailed(_logger, providerId, ex);
+            return ErrorProposal("Azure OpenAI request failed.");
         }
     }
 

--- a/src/Honua.Ai/Features/Providers/AzureOpenAi/AzureOpenAiAuthResolver.cs
+++ b/src/Honua.Ai/Features/Providers/AzureOpenAi/AzureOpenAiAuthResolver.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Ai.WorkflowGeneration;
+using Honua.Core.Features.WorkflowPackages.Generation;
+
+namespace Honua.Ai.Providers.AzureOpenAi;
+
+/// <summary>
+/// Resolved Azure OpenAI credentials: at most one of <see cref="ApiKey"/> /
+/// <see cref="AccessToken"/> is non-empty, with the Entra (Managed-Identity) token preferred when
+/// available, falling back to the api-key.
+/// </summary>
+public readonly record struct AzureOpenAiCredential(string ApiKey, string? AccessToken)
+{
+    /// <summary>Whether either an api-key or an Entra access token was resolved.</summary>
+    public bool HasCredential => !string.IsNullOrWhiteSpace(ApiKey) || !string.IsNullOrWhiteSpace(AccessToken);
+}
+
+/// <summary>
+/// Resolves Azure OpenAI authentication. Entra Managed Identity is the preferred auth (acquired via
+/// <see cref="IAzureOpenAiTokenProvider"/>); when a Managed Identity is not available the resolver
+/// falls back to a configured api-key — resolved through the shared
+/// <see cref="WorkflowGenerationApiKeyResolver"/> so secret references and the per-provider
+/// environment-variable fallback work identically to the other providers.
+/// </summary>
+public sealed class AzureOpenAiAuthResolver
+{
+    private readonly WorkflowGenerationApiKeyResolver _apiKeyResolver;
+    private readonly IAzureOpenAiTokenProvider _tokenProvider;
+
+    /// <summary>Creates an Azure OpenAI auth resolver over the shared key resolver and a token provider.</summary>
+    public AzureOpenAiAuthResolver(
+        WorkflowGenerationApiKeyResolver apiKeyResolver,
+        IAzureOpenAiTokenProvider tokenProvider)
+    {
+        _apiKeyResolver = apiKeyResolver;
+        _tokenProvider = tokenProvider;
+    }
+
+    /// <summary>
+    /// Resolves a credential for the supplied provider. Prefers an Entra token; on absence falls
+    /// back to the configured api-key (which may be a secret reference or env-var fallback).
+    /// </summary>
+    internal async Task<AzureOpenAiCredential> ResolveAsync(
+        string providerId,
+        WorkflowGenerationProviderOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        // Prefer Entra Managed Identity. Only attempt a token when no explicit api-key is
+        // configured, so an operator who sets a key gets deterministic key auth.
+        var apiKey = await _apiKeyResolver.ResolveAsync(providerId, options, cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(apiKey))
+        {
+            return new AzureOpenAiCredential(apiKey, AccessToken: null);
+        }
+
+        var token = await _tokenProvider.GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+        return new AzureOpenAiCredential(ApiKey: string.Empty, AccessToken: token);
+    }
+}

--- a/src/Honua.Ai/Features/Providers/AzureOpenAi/AzureOpenAiEndpoint.cs
+++ b/src/Honua.Ai/Features/Providers/AzureOpenAi/AzureOpenAiEndpoint.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.WorkflowPackages.Generation;
+
+namespace Honua.Ai.Providers.AzureOpenAi;
+
+/// <summary>
+/// Builds the Azure OpenAI / Azure AI Foundry chat-completions request URL from the resource
+/// endpoint, deployment name, and api-version. Azure OpenAI is OpenAI-API-compatible at the body
+/// level but differs in routing: requests target
+/// <c>{endpoint}/openai/deployments/{deployment}/chat/completions?api-version={version}</c> rather
+/// than the OpenAI <c>{endpoint}/chat/completions</c> shape, so the request body, response parsing,
+/// and structured-output <c>json_schema</c> handling can all be shared with the OpenAI-compatible
+/// path — only the URL and auth header differ.
+/// </summary>
+internal static class AzureOpenAiEndpoint
+{
+    /// <summary>
+    /// Resolves the deployment name to route by: the explicit <see cref="WorkflowGenerationProviderOptions.Deployment"/>
+    /// when set, otherwise the model id (Azure deployments are commonly named after the model).
+    /// </summary>
+    internal static string ResolveDeployment(WorkflowGenerationProviderOptions options, string model)
+        => string.IsNullOrWhiteSpace(options.Deployment) ? model : options.Deployment;
+
+    /// <summary>Resolves the api-version query value, falling back to the supported default.</summary>
+    internal static string ResolveApiVersion(WorkflowGenerationProviderOptions options)
+        => string.IsNullOrWhiteSpace(options.ApiVersion)
+            ? WorkflowGenerationConfiguration.DefaultAzureOpenAiApiVersion
+            : options.ApiVersion;
+
+    /// <summary>
+    /// Builds the absolute chat-completions URL for the supplied resource endpoint, deployment, and
+    /// api-version.
+    /// </summary>
+    internal static string BuildChatCompletionsUri(string endpoint, string deployment, string apiVersion)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(endpoint);
+        ArgumentException.ThrowIfNullOrWhiteSpace(deployment);
+        ArgumentException.ThrowIfNullOrWhiteSpace(apiVersion);
+
+        var baseUri = endpoint.TrimEnd('/');
+        var encodedDeployment = Uri.EscapeDataString(deployment);
+        var encodedVersion = Uri.EscapeDataString(apiVersion);
+        return $"{baseUri}/openai/deployments/{encodedDeployment}/chat/completions?api-version={encodedVersion}";
+    }
+}

--- a/src/Honua.Ai/Features/Providers/AzureOpenAi/AzureOpenAiStructuredGenerationClient.cs
+++ b/src/Honua.Ai/Features/Providers/AzureOpenAi/AzureOpenAiStructuredGenerationClient.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Honua.Ai.WorkflowGeneration.Models;
+using Honua.Core.Features.WorkflowPackages.Generation;
+
+namespace Honua.Ai.Providers.AzureOpenAi;
+
+/// <summary>
+/// Outcome of a single structured Azure OpenAI generation turn. Either <see cref="Json"/> carries
+/// the model's structured proposal (the json_schema-constrained completion content), or
+/// <see cref="Error"/> describes why no proposal was produced (truncation, empty response, HTTP
+/// failure, …). Mirrors <c>BedrockStructuredResult</c> so the calling services treat both cloud
+/// backends identically.
+/// </summary>
+internal readonly record struct AzureOpenAiStructuredResult(string? Json, string? Error)
+{
+    internal bool Succeeded => Json is not null;
+
+    internal static AzureOpenAiStructuredResult Ok(string json) => new(json, null);
+
+    internal static AzureOpenAiStructuredResult Failed(string error) => new(null, error);
+}
+
+/// <summary>
+/// Shared Azure OpenAI / Azure AI Foundry backend for the studio generation flows that speak to an
+/// OpenAI-compatible <c>/chat/completions</c> endpoint with a strict <c>json_schema</c> response
+/// format (workflow, dashboard, report, and the other Vega-Lite document generators).
+///
+/// Azure OpenAI is OpenAI-API-compatible at the body level, so the request/response DTOs and the
+/// strict-schema structured-output handling are reused verbatim from the OpenAI-compatible path —
+/// only the deployment-routed URL and the Azure auth header (<c>api-key</c> for a key, or a Bearer
+/// Entra/Managed-Identity token) differ. Truncation (<c>finish_reason == "length"</c>) is surfaced
+/// as an actionable error rather than an opaque deserialize failure, matching the OpenAI provider.
+/// </summary>
+internal static class AzureOpenAiStructuredGenerationClient
+{
+    /// <summary>
+    /// Runs one structured generation turn against Azure OpenAI and returns the proposal JSON.
+    /// </summary>
+    /// <param name="httpClient">A configured client (timeout set by the caller).</param>
+    /// <param name="options">Resolved provider options (endpoint, deployment, api-version, limits).</param>
+    /// <param name="model">Effective model id (request override or provider default).</param>
+    /// <param name="apiKey">Resolved api-key, or empty when using Entra auth.</param>
+    /// <param name="accessToken">Resolved Entra/Managed-Identity bearer token, or null.</param>
+    /// <param name="systemPrompt">System grounding prompt.</param>
+    /// <param name="userPrompt">User prompt.</param>
+    /// <param name="schemaName">The json_schema name (for example <c>workflow_proposal</c>).</param>
+    /// <param name="schema">The proposal JSON schema the completion must conform to.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    internal static async Task<AzureOpenAiStructuredResult> GenerateAsync(
+        HttpClient httpClient,
+        WorkflowGenerationProviderOptions options,
+        string model,
+        string apiKey,
+        string? accessToken,
+        string systemPrompt,
+        string userPrompt,
+        string schemaName,
+        JsonElement schema,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(model);
+
+        if (string.IsNullOrWhiteSpace(apiKey) && string.IsNullOrWhiteSpace(accessToken))
+        {
+            return AzureOpenAiStructuredResult.Failed(
+                "Azure OpenAI is not authenticated: configure an ApiKey or grant the host a Managed Identity with access to the resource.");
+        }
+
+        var chatRequest = new OpenAiChatCompletionRequest
+        {
+            // Azure routes by deployment in the URL; the body "model" field is ignored but still
+            // sent as the effective model id for parity/telemetry.
+            Model = model,
+            MaxTokens = options.MaxTokens,
+            Temperature = 0.0,
+            Messages =
+            [
+                new OpenAiMessage { Role = "system", Content = systemPrompt },
+                new OpenAiMessage { Role = "user", Content = userPrompt }
+            ],
+            ResponseFormat = new OpenAiResponseFormat
+            {
+                Type = "json_schema",
+                JsonSchema = new OpenAiJsonSchema
+                {
+                    Name = schemaName,
+                    Strict = true,
+                    Schema = schema
+                }
+            }
+        };
+
+        var deployment = AzureOpenAiEndpoint.ResolveDeployment(options, model);
+        var apiVersion = AzureOpenAiEndpoint.ResolveApiVersion(options);
+        var uri = AzureOpenAiEndpoint.BuildChatCompletionsUri(options.Endpoint, deployment, apiVersion);
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, uri);
+
+        // Azure auth: prefer an Entra/Managed-Identity bearer token (the recommended path); fall
+        // back to the resource api-key header when no token is available.
+        if (!string.IsNullOrWhiteSpace(accessToken))
+        {
+            httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        }
+        else
+        {
+            httpRequest.Headers.TryAddWithoutValidation("api-key", apiKey);
+        }
+
+        var requestJson = JsonSerializer.Serialize(
+            chatRequest, WorkflowGenerationJsonContext.Default.OpenAiChatCompletionRequest);
+        httpRequest.Content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+
+        using var response = await httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            return AzureOpenAiStructuredResult.Failed(
+                $"Azure OpenAI returned HTTP {(int)response.StatusCode}. {Truncate(body, 500)}");
+        }
+
+        var responseJson = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        var chatResponse = JsonSerializer.Deserialize(
+            responseJson, WorkflowGenerationJsonContext.Default.OpenAiChatCompletionResponse);
+
+        var choice = chatResponse?.Choices is { Length: > 0 } choices ? choices[0] : null;
+
+        // Surface max_tokens truncation explicitly: a "length" finish_reason means the JSON body is
+        // truncated, so deserialization downstream would fail with an opaque message instead of an
+        // actionable one (matches the OpenAI-compatible provider, #1979).
+        if (string.Equals(choice?.FinishReason, "length", StringComparison.Ordinal))
+        {
+            return AzureOpenAiStructuredResult.Failed(
+                "Azure OpenAI response was truncated (finish_reason=length / max_tokens reached); try a higher MaxTokens.");
+        }
+
+        var content = choice?.Message?.Content;
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return AzureOpenAiStructuredResult.Failed("Azure OpenAI returned an empty response.");
+        }
+
+        return AzureOpenAiStructuredResult.Ok(content);
+    }
+
+    private static string Truncate(string value, int max) =>
+        value.Length <= max ? value : value[..max];
+}

--- a/src/Honua.Ai/Features/Providers/AzureOpenAi/IAzureOpenAiTokenProvider.cs
+++ b/src/Honua.Ai/Features/Providers/AzureOpenAi/IAzureOpenAiTokenProvider.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Azure.Core;
+using Azure.Identity;
+
+namespace Honua.Ai.Providers.AzureOpenAi;
+
+/// <summary>
+/// Acquires an Entra (Azure AD) access token for the Azure OpenAI / Cognitive Services data plane.
+/// Abstracted so the provider can be unit-tested without a live Managed Identity, while production
+/// resolves the real <see cref="DefaultAzureCredential"/>-backed implementation. Returning
+/// <see langword="null"/> signals "no Entra credential available" so the caller can fall back to
+/// an api-key (or surface an actionable error).
+/// </summary>
+public interface IAzureOpenAiTokenProvider
+{
+    /// <summary>
+    /// Returns a bearer token for the Azure OpenAI data plane
+    /// (scope <c>https://cognitiveservices.azure.com/.default</c>), or <see langword="null"/> when
+    /// no Entra credential is available in the current environment.
+    /// </summary>
+    Task<string?> GetAccessTokenAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Production <see cref="IAzureOpenAiTokenProvider"/> backed by <see cref="DefaultAzureCredential"/>
+/// (Managed Identity in Azure-hosted environments; developer credential locally). This is the only
+/// type that imports the Azure SDK for the AI provider, keeping the SDK surface confined the same
+/// way the Bedrock adapter confines the AWS SDK — Honua.Core / Honua.Hosting / Honua.Server stay
+/// SDK-free (enforced by CloudSdkIsolationTests).
+/// </summary>
+internal sealed class DefaultAzureOpenAiTokenProvider : IAzureOpenAiTokenProvider
+{
+    /// <summary>The Azure OpenAI data-plane scope for Entra (AAD) token acquisition.</summary>
+    private static readonly string[] Scopes = ["https://cognitiveservices.azure.com/.default"];
+
+    private readonly TokenCredential _credential;
+
+    public DefaultAzureOpenAiTokenProvider()
+        : this(new DefaultAzureCredential())
+    {
+    }
+
+    internal DefaultAzureOpenAiTokenProvider(TokenCredential credential)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        _credential = credential;
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> GetAccessTokenAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var token = await _credential
+                .GetTokenAsync(new TokenRequestContext(Scopes), cancellationToken)
+                .ConfigureAwait(false);
+            return token.Token;
+        }
+        catch (CredentialUnavailableException)
+        {
+            // No Managed Identity / developer credential in this environment — let the caller fall
+            // back to an api-key rather than failing the request outright.
+            return null;
+        }
+        catch (AuthenticationFailedException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Honua.Ai/Features/ReportGeneration/ReportGenerationService.cs
+++ b/src/Honua.Ai/Features/ReportGeneration/ReportGenerationService.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Honua.Ai.Providers.AzureOpenAi;
 using Honua.Ai.Providers.Bedrock;
 using Honua.Ai.WorkflowGeneration;
 using Honua.Ai.WorkflowGeneration.Models;
@@ -27,6 +28,7 @@ public sealed class ReportGenerationService : IReportGenerationService
     private readonly WorkflowGenerationConfiguration _configuration;
     private readonly WorkflowGenerationApiKeyResolver _apiKeyResolver;
     private readonly IBedrockChatClientFactory _bedrockChatClientFactory;
+    private readonly AzureOpenAiAuthResolver _azureAuthResolver;
     private readonly ILogger<ReportGenerationService> _logger;
 
     public ReportGenerationService(
@@ -34,12 +36,15 @@ public sealed class ReportGenerationService : IReportGenerationService
         IOptions<WorkflowGenerationConfiguration> options,
         WorkflowGenerationApiKeyResolver apiKeyResolver,
         IBedrockChatClientFactory bedrockChatClientFactory,
-        ILogger<ReportGenerationService> logger)
+        ILogger<ReportGenerationService> logger,
+        AzureOpenAiAuthResolver? azureAuthResolver = null)
     {
         _httpClientFactory = httpClientFactory;
         _configuration = options.Value;
         _apiKeyResolver = apiKeyResolver;
         _bedrockChatClientFactory = bedrockChatClientFactory;
+        _azureAuthResolver = azureAuthResolver
+            ?? new AzureOpenAiAuthResolver(apiKeyResolver, new DefaultAzureOpenAiTokenProvider());
         _logger = logger;
     }
 
@@ -59,13 +64,20 @@ public sealed class ReportGenerationService : IReportGenerationService
         // Bedrock targets the regional runtime endpoint via the AWS credential chain, so it needs no
         // endpoint URL — only a model id. OpenAI-compatible/Anthropic providers require an endpoint.
         var isBedrock = string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase);
+        var isAzureOpenAi = string.Equals(providerId, WorkflowGenerationConfiguration.AzureOpenAiProviderId, StringComparison.OrdinalIgnoreCase);
         var endpointMissing = !isBedrock && string.IsNullOrWhiteSpace(options?.Endpoint);
-        if (options is null || endpointMissing || string.IsNullOrWhiteSpace(options.Model))
+        // Azure OpenAI routes by deployment name, so a configured deployment satisfies the
+        // model requirement even when no raw model id is set.
+        var modelMissing = string.IsNullOrWhiteSpace(options?.Model)
+            && !(isAzureOpenAi && !string.IsNullOrWhiteSpace(options?.Deployment));
+        if (options is null || endpointMissing || modelMissing)
         {
             return Unsupported($"Report generation provider '{providerId}' is not configured on this server.");
         }
 
-        var model = string.IsNullOrWhiteSpace(request.Model) ? options.Model! : request.Model!;
+        var model = string.IsNullOrWhiteSpace(request.Model)
+            ? (string.IsNullOrWhiteSpace(options.Model) ? options.Deployment : options.Model)
+            : request.Model!;
 
         var providerRequest = new ReportGenerationProviderRequest
         {
@@ -150,6 +162,13 @@ public sealed class ReportGenerationService : IReportGenerationService
         if (string.Equals(providerId, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase))
         {
             return await CallBedrockAsync(request, options, providerId, model, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Azure OpenAI is OpenAI-compatible but deployment-routed (Azure URL + api-key/Entra auth);
+        // route it through the shared Azure structured-generation client.
+        if (string.Equals(providerId, WorkflowGenerationConfiguration.AzureOpenAiProviderId, StringComparison.OrdinalIgnoreCase))
+        {
+            return await CallAzureOpenAiAsync(request, options, providerId, model, cancellationToken).ConfigureAwait(false);
         }
 
         try
@@ -273,6 +292,57 @@ public sealed class ReportGenerationService : IReportGenerationService
         {
             GenerationProviderLog.ProviderRequestFailed(_logger, providerId, ex);
             return ErrorProposal("Bedrock request failed.");
+        }
+    }
+
+    private async Task<ReportGenerationModelProposal> CallAzureOpenAiAsync(
+        ReportGenerationProviderRequest request,
+        WorkflowGenerationProviderOptions options,
+        string providerId,
+        string model,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var credential = await _azureAuthResolver.ResolveAsync(providerId, options, cancellationToken).ConfigureAwait(false);
+
+            var client = _httpClientFactory.CreateClient("workflow-generation");
+            client.Timeout = TimeSpan.FromSeconds(options.TimeoutSeconds);
+
+            var result = await AzureOpenAiStructuredGenerationClient.GenerateAsync(
+                client,
+                options,
+                model,
+                credential.ApiKey,
+                credential.AccessToken,
+                ReportGenerationPrompt.BuildSystem(request),
+                ReportGenerationPrompt.BuildUser(request),
+                "report_proposal",
+                ReportGenerationSchema.Build(),
+                cancellationToken).ConfigureAwait(false);
+
+            if (!result.Succeeded)
+            {
+                GenerationProviderLog.ProviderRequestFailed(_logger, providerId, new InvalidOperationException(result.Error));
+                return ErrorProposal(result.Error ?? "Azure OpenAI request failed.");
+            }
+
+            var proposal = JsonSerializer.Deserialize(result.Json!, ReportGenerationJsonContext.Default.ReportGenerationModelProposal);
+            return proposal ?? ErrorProposal("Failed to deserialize the report proposal from the Azure OpenAI response.");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            GenerationProviderLog.ProviderResponseParseFailed(_logger, providerId, ex);
+            return ErrorProposal("Azure OpenAI response could not be parsed.");
+        }
+        catch (HttpRequestException ex)
+        {
+            GenerationProviderLog.ProviderRequestFailed(_logger, providerId, ex);
+            return ErrorProposal("Azure OpenAI request failed.");
         }
     }
 

--- a/src/Honua.Ai/Features/WorkflowGeneration/AzureOpenAiWorkflowGenerationProvider.cs
+++ b/src/Honua.Ai/Features/WorkflowGeneration/AzureOpenAiWorkflowGenerationProvider.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Text.Json;
+using Honua.Ai.Providers.AzureOpenAi;
+using Honua.Ai.WorkflowGeneration.Models;
+using Honua.Ai.WorkflowGeneration.Prompts;
+using Honua.Core.Features.WorkflowPackages.Generation;
+using Honua.Core.Features.WorkflowPackages.Generation.Abstractions;
+using Honua.Core.Features.WorkflowPackages.Generation.Domain;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Ai.WorkflowGeneration;
+
+/// <summary>
+/// Workflow generation provider for Azure OpenAI / Azure AI Foundry (provider id
+/// <c>azureopenai</c>). Azure OpenAI is OpenAI-API-compatible, so structured output is obtained the
+/// same way as the OpenAI-compatible provider — a strict <c>json_schema</c> response format
+/// constrained to the grounded node whitelist — over the deployment-routed Azure URL
+/// (<c>{endpoint}/openai/deployments/{deployment}/chat/completions?api-version=…</c>). Auth uses
+/// Entra Managed Identity (preferred) or an <c>api-key</c>. This lets the workflow studio flow run
+/// on Azure-hosted AI for Bedrock parity, without a local Ollama/Qwen model.
+/// </summary>
+internal sealed class AzureOpenAiWorkflowGenerationProvider : IWorkflowGenerationProvider
+{
+    private readonly string _providerId;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly AzureOpenAiAuthResolver _authResolver;
+    private readonly WorkflowGenerationConfiguration _configuration;
+    private readonly ILogger<AzureOpenAiWorkflowGenerationProvider> _logger;
+
+    public AzureOpenAiWorkflowGenerationProvider(
+        string providerId,
+        IHttpClientFactory httpClientFactory,
+        AzureOpenAiAuthResolver authResolver,
+        IOptions<WorkflowGenerationConfiguration> options,
+        ILogger<AzureOpenAiWorkflowGenerationProvider> logger)
+    {
+        _providerId = providerId;
+        _httpClientFactory = httpClientFactory;
+        _authResolver = authResolver;
+        _configuration = options.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string ProviderId => _providerId;
+
+    /// <inheritdoc />
+    public bool IsConfigured
+    {
+        get
+        {
+            // Azure needs a resource endpoint and a deployment (or model) to route by. Auth is via
+            // Managed Identity (preferred) or a key, so the key is not required to be "configured".
+            var options = _configuration.GetProvider(_providerId);
+            return options is not null
+                && !string.IsNullOrWhiteSpace(options.Endpoint)
+                && (!string.IsNullOrWhiteSpace(options.Deployment) || !string.IsNullOrWhiteSpace(options.Model));
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<WorkflowGenerationProposal> GenerateAsync(
+        WorkflowGenerationProviderRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var options = _configuration.GetProvider(_providerId);
+        if (options is null || string.IsNullOrWhiteSpace(options.Endpoint))
+        {
+            return WorkflowGenerationProposal.Error($"Provider '{_providerId}' is not configured.", _providerId);
+        }
+
+        var model = string.IsNullOrWhiteSpace(request.ModelOverride) ? options.Model : request.ModelOverride!;
+        if (string.IsNullOrWhiteSpace(model) && string.IsNullOrWhiteSpace(options.Deployment))
+        {
+            return WorkflowGenerationProposal.Error($"Provider '{_providerId}' is not configured.", _providerId);
+        }
+
+        // The effective model id used for telemetry/usage; the Azure URL routes by deployment.
+        var effectiveModel = string.IsNullOrWhiteSpace(model) ? options.Deployment : model;
+
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("honua.workflowgen.generate");
+        activity?.SetTag("workflowgen.provider", _providerId);
+        activity?.SetTag("workflowgen.model", effectiveModel);
+        WorkflowGenerationLog.GenerationRequested(_logger, _providerId, effectiveModel);
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var credential = await _authResolver.ResolveAsync(_providerId, options, cancellationToken).ConfigureAwait(false);
+
+            var client = _httpClientFactory.CreateClient("workflow-generation");
+            client.Timeout = TimeSpan.FromSeconds(options.TimeoutSeconds);
+
+            var result = await AzureOpenAiStructuredGenerationClient.GenerateAsync(
+                client,
+                options,
+                effectiveModel,
+                credential.ApiKey,
+                credential.AccessToken,
+                WorkflowGenerationPrompt.BuildSystem(request),
+                WorkflowGenerationPrompt.BuildUser(request),
+                "workflow_proposal",
+                WorkflowGenerationSchema.Build(request.Registry.Nodes),
+                cancellationToken).ConfigureAwait(false);
+
+            if (!result.Succeeded)
+            {
+                WorkflowGenerationLog.GenerationFailed(_logger, _providerId, result.Error ?? "Azure OpenAI request failed.");
+                return WorkflowGenerationProposal.Error(result.Error ?? "Provider request failed.", _providerId, effectiveModel);
+            }
+
+            var proposalModel = JsonSerializer.Deserialize(
+                result.Json!, WorkflowGenerationJsonContext.Default.WorkflowGenerationModelProposal);
+            if (proposalModel is null)
+            {
+                const string Reason = "Failed to deserialize the workflow proposal from the provider response.";
+                WorkflowGenerationLog.GenerationFailed(_logger, _providerId, Reason);
+                return WorkflowGenerationProposal.Error(Reason, _providerId, effectiveModel);
+            }
+
+            stopwatch.Stop();
+            var usage = new WorkflowGenerationUsage
+            {
+                LatencyMs = stopwatch.ElapsedMilliseconds
+            };
+
+            var proposal = WorkflowGenerationProposalMapper.ToProposal(proposalModel, _providerId, effectiveModel, usage);
+            WorkflowGenerationLog.GenerationProduced(
+                _logger, proposal.Status, _providerId, proposal.Graph?.Nodes.Count ?? 0);
+            activity?.SetTag("workflowgen.success", true);
+            activity?.SetTag("workflowgen.status", proposal.Status.ToString());
+            return proposal;
+        }
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        {
+            WorkflowGenerationLog.GenerationFailed(_logger, _providerId, "Request timed out.");
+            return WorkflowGenerationProposal.Error("Provider request timed out.", _providerId, effectiveModel);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (HttpRequestException ex)
+        {
+            WorkflowGenerationLog.GenerationFailed(_logger, _providerId, ex.Message);
+            return WorkflowGenerationProposal.Error("Provider request failed.", _providerId, effectiveModel);
+        }
+        catch (JsonException ex)
+        {
+            WorkflowGenerationLog.GenerationFailed(_logger, _providerId, ex.Message);
+            return WorkflowGenerationProposal.Error("Provider response could not be parsed.", _providerId, effectiveModel);
+        }
+    }
+}

--- a/src/Honua.Ai/Features/WorkflowGeneration/WorkflowGenerationService.cs
+++ b/src/Honua.Ai/Features/WorkflowGeneration/WorkflowGenerationService.cs
@@ -194,6 +194,8 @@ internal sealed class WorkflowGenerationService : IWorkflowGenerationService
         WorkflowGenerationConfiguration.LocalProviderId => "Local GIS model",
         WorkflowGenerationConfiguration.OpenAiProviderId => "GPT (OpenAI)",
         WorkflowGenerationConfiguration.AnthropicProviderId => "Claude (Anthropic)",
+        WorkflowGenerationConfiguration.BedrockProviderId => "Claude (AWS Bedrock)",
+        WorkflowGenerationConfiguration.AzureOpenAiProviderId => "GPT (Azure OpenAI)",
         WorkflowGenerationConfiguration.DeterministicProviderId => "Deterministic (fixtures)",
         _ => providerId
     };

--- a/src/Honua.Ai/Features/WorkflowGeneration/WorkflowGenerationServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/WorkflowGeneration/WorkflowGenerationServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Ai.Providers.AzureOpenAi;
 using Honua.Ai.Providers.Bedrock;
 using Honua.Core.Features.Infrastructure.Resilience;
 using Honua.Core.Features.WorkflowPackages.Generation;
@@ -66,6 +67,12 @@ internal static class WorkflowGenerationServiceCollectionExtensions
         // dashboard/report/workflow generators run on cloud AI without a local Ollama/Qwen model.
         services.TryAddSingleton<IBedrockChatClientFactory, BedrockChatClientFactory>();
 
+        // Azure OpenAI / AI Foundry: the shared OpenAI-compatible backend the studio generation
+        // flows use when the selected provider id is "azureopenai" (deployment-routed Azure URL,
+        // Entra Managed Identity preferred over an api-key). Mirrors the Bedrock factory wiring.
+        services.TryAddSingleton<IAzureOpenAiTokenProvider, DefaultAzureOpenAiTokenProvider>();
+        services.TryAddSingleton<AzureOpenAiAuthResolver>();
+
         services.AddSingleton<IWorkflowGenerationProvider>(sp =>
             ActivatorUtilities.CreateInstance<OpenAiCompatibleWorkflowGenerationProvider>(
                 sp, WorkflowGenerationConfiguration.LocalProviderId));
@@ -78,6 +85,9 @@ internal static class WorkflowGenerationServiceCollectionExtensions
         services.AddSingleton<IWorkflowGenerationProvider>(sp =>
             ActivatorUtilities.CreateInstance<BedrockWorkflowGenerationProvider>(
                 sp, WorkflowGenerationConfiguration.BedrockProviderId));
+        services.AddSingleton<IWorkflowGenerationProvider>(sp =>
+            ActivatorUtilities.CreateInstance<AzureOpenAiWorkflowGenerationProvider>(
+                sp, WorkflowGenerationConfiguration.AzureOpenAiProviderId));
 
         services.TryAddSingleton<IWorkflowGenerationService, WorkflowGenerationService>();
         return services;

--- a/src/Honua.Ai/Honua.Ai.csproj
+++ b/src/Honua.Ai/Honua.Ai.csproj
@@ -61,6 +61,12 @@
          IChatClient so the dashboard/report/workflow generators can run on cloud AI
          (no local Ollama/Qwen). Mirrors the honua-devops agent's Bedrock provider. -->
     <PackageReference Include="AWSSDK.BedrockRuntime" />
+    <!-- Azure OpenAI / AI Foundry provider for the studio generation flows. Azure OpenAI is
+         OpenAI-API-compatible, so only the deployment-routed URL and auth differ; Azure.Identity
+         supplies Entra Managed-Identity tokens (the preferred Azure auth) for the
+         AzureOpenAiStructuredGenerationClient. Confined to Honua.Ai exactly like the Bedrock SDK
+         above, so Honua.Core / Honua.Hosting / Honua.Server stay SDK-free (CloudSdkIsolationTests). -->
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.AI" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
   </ItemGroup>

--- a/src/Honua.Core/Features/WorkflowPackages/Generation/WorkflowGenerationConfiguration.cs
+++ b/src/Honua.Core/Features/WorkflowPackages/Generation/WorkflowGenerationConfiguration.cs
@@ -31,6 +31,15 @@ public sealed class WorkflowGenerationConfiguration
     /// <summary>Default AWS region for the Bedrock provider when none is configured.</summary>
     public const string DefaultBedrockRegion = "us-west-2";
 
+    /// <summary>Stable id for the Azure OpenAI / Azure AI Foundry provider.</summary>
+    public const string AzureOpenAiProviderId = "azureopenai";
+
+    /// <summary>
+    /// Default Azure OpenAI REST API version used when a provider block does not set one.
+    /// A GA version that supports the strict <c>json_schema</c> structured-output response format.
+    /// </summary>
+    public const string DefaultAzureOpenAiApiVersion = "2024-10-21";
+
     /// <summary>Stable id for the deterministic fixture-replay provider.</summary>
     public const string DeterministicProviderId = "deterministic";
 
@@ -99,6 +108,21 @@ public sealed class WorkflowGenerationProviderOptions
 
     /// <summary>Maximum tokens for the model response.</summary>
     public int MaxTokens { get; set; } = 4096;
+
+    /// <summary>
+    /// Azure OpenAI deployment name. Azure routes requests by deployment name rather than the
+    /// raw model id, so the <c>azureopenai</c> provider uses this to build the
+    /// <c>/openai/deployments/{deployment}/chat/completions</c> URL. Ignored by the other
+    /// providers. When empty the provider falls back to <see cref="Model"/>.
+    /// </summary>
+    public string Deployment { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Azure OpenAI REST <c>api-version</c> query parameter (for example <c>2024-10-21</c>).
+    /// Ignored by the other providers. When empty the provider falls back to
+    /// <see cref="WorkflowGenerationConfiguration.DefaultAzureOpenAiApiVersion"/>.
+    /// </summary>
+    public string ApiVersion { get; set; } = string.Empty;
 }
 
 /// <summary>
@@ -126,12 +150,13 @@ public sealed class WorkflowGenerationConfigurationValidator : ConfigurationVali
             || string.Equals(provider, WorkflowGenerationConfiguration.OpenAiProviderId, StringComparison.OrdinalIgnoreCase)
             || string.Equals(provider, WorkflowGenerationConfiguration.AnthropicProviderId, StringComparison.OrdinalIgnoreCase)
             || string.Equals(provider, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(provider, WorkflowGenerationConfiguration.AzureOpenAiProviderId, StringComparison.OrdinalIgnoreCase)
             || string.Equals(provider, WorkflowGenerationConfiguration.DeterministicProviderId, StringComparison.OrdinalIgnoreCase);
 
         if (!isKnown)
         {
             errors.Add($"WorkflowGeneration:DefaultProvider '{provider}' is not a supported provider id. "
-                + "Supported values: 'local', 'openai', 'anthropic', 'bedrock', 'deterministic'.");
+                + "Supported values: 'local', 'openai', 'anthropic', 'bedrock', 'azureopenai', 'deterministic'.");
             return;
         }
 
@@ -154,6 +179,31 @@ public sealed class WorkflowGenerationConfigurationValidator : ConfigurationVali
         if (string.Equals(provider, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase))
         {
             ValidateRequiredString(providerOptions.Model, $"WorkflowGeneration:Providers:{provider}:Model", errors);
+            ValidateRange(providerOptions.TimeoutSeconds, 5, 300, $"WorkflowGeneration:Providers:{provider}:TimeoutSeconds", errors);
+            ValidateRange(providerOptions.MaxTokens, 256, 32_768, $"WorkflowGeneration:Providers:{provider}:MaxTokens", errors);
+            return;
+        }
+
+        // Azure OpenAI / AI Foundry targets the resource endpoint
+        // (https://{resource}.openai.azure.com) and routes by deployment name. Auth is via
+        // Entra Managed Identity (preferred) or an api-key, so the api-key is optional here —
+        // only the endpoint, deployment (or model), api-version, and limits are validated.
+        if (string.Equals(provider, WorkflowGenerationConfiguration.AzureOpenAiProviderId, StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrWhiteSpace(providerOptions.Endpoint))
+            {
+                errors.Add($"WorkflowGeneration:Providers:{provider}:Endpoint cannot be empty");
+            }
+            else
+            {
+                ValidateUrl(providerOptions.Endpoint, $"WorkflowGeneration:Providers:{provider}:Endpoint", errors, requireHttps: true);
+            }
+
+            if (string.IsNullOrWhiteSpace(providerOptions.Deployment) && string.IsNullOrWhiteSpace(providerOptions.Model))
+            {
+                errors.Add($"WorkflowGeneration:Providers:{provider}:Deployment (or :Model) must be set — Azure OpenAI routes by deployment name.");
+            }
+
             ValidateRange(providerOptions.TimeoutSeconds, 5, 300, $"WorkflowGeneration:Providers:{provider}:TimeoutSeconds", errors);
             ValidateRange(providerOptions.MaxTokens, 256, 32_768, $"WorkflowGeneration:Providers:{provider}:MaxTokens", errors);
             return;

--- a/tests/dotnet/Honua.Ai.Tests/Source/AzureOpenAiStudioLiveTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/AzureOpenAiStudioLiveTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Ai.DashboardGeneration;
+using Honua.Ai.Providers.AzureOpenAi;
+using Honua.Ai.WorkflowGeneration;
+using Honua.Core.Features.Publishing.Dashboards;
+using Honua.Core.Features.WorkflowPackages.Generation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Honua.Server.Tests.Features.Providers.AzureOpenAi;
+
+/// <summary>
+/// Live end-to-end test that drives a studio generation flow (dashboard generation) against REAL
+/// Azure OpenAI / Azure AI Foundry using the production HTTP path and Entra Managed Identity (or an
+/// api-key) — no local model.
+///
+/// Gated on <c>HONUA_AI_LIVE_AZURE_OPENAI=1</c> so it never runs in CI / on machines without Azure
+/// access. Configure with environment variables:
+/// <list type="bullet">
+///   <item><c>HONUA_AI_LIVE_AZURE_OPENAI=1</c> — opt in.</item>
+///   <item><c>HONUA_AI_AZURE_OPENAI_ENDPOINT</c> — resource endpoint, e.g. https://{res}.openai.azure.com (required).</item>
+///   <item><c>HONUA_AI_AZURE_OPENAI_DEPLOYMENT</c> — deployment name (required).</item>
+///   <item><c>HONUA_AI_AZURE_OPENAI_API_VERSION</c> — api-version (optional; defaults to the supported GA version).</item>
+///   <item><c>HONUA_WORKFLOWGEN_AZUREOPENAI_API_KEY</c> — api-key (optional; Managed Identity is used when absent).</item>
+/// </list>
+/// </summary>
+public sealed class AzureOpenAiStudioLiveTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public AzureOpenAiStudioLiveTests(ITestOutputHelper output) => _output = output;
+
+    private static bool LiveEnabled =>
+        string.Equals(Environment.GetEnvironmentVariable("HONUA_AI_LIVE_AZURE_OPENAI"), "1", StringComparison.Ordinal);
+
+    private const string SkipReason =
+        "Live Azure OpenAI test. Set HONUA_AI_LIVE_AZURE_OPENAI=1, HONUA_AI_AZURE_OPENAI_ENDPOINT and HONUA_AI_AZURE_OPENAI_DEPLOYMENT to run.";
+
+    [Fact]
+    public async Task DashboardGeneration_RunsEndToEndOnRealAzureOpenAi()
+    {
+        if (!LiveEnabled)
+        {
+            // Not opted in: this is a live test requiring Azure access. Treated as a no-op so the
+            // offline suite stays green. See SkipReason for how to enable.
+            _output.WriteLine("SKIPPED: " + SkipReason);
+            return;
+        }
+
+        var endpoint = Environment.GetEnvironmentVariable("HONUA_AI_AZURE_OPENAI_ENDPOINT");
+        endpoint.Should().NotBeNullOrWhiteSpace("the Azure endpoint must be supplied via HONUA_AI_AZURE_OPENAI_ENDPOINT");
+        var deployment = Environment.GetEnvironmentVariable("HONUA_AI_AZURE_OPENAI_DEPLOYMENT");
+        deployment.Should().NotBeNullOrWhiteSpace("the Azure deployment must be supplied via HONUA_AI_AZURE_OPENAI_DEPLOYMENT");
+        var apiVersion = Environment.GetEnvironmentVariable("HONUA_AI_AZURE_OPENAI_API_VERSION");
+
+        var options = Options.Create(new WorkflowGenerationConfiguration
+        {
+            Enabled = true,
+            DefaultProvider = WorkflowGenerationConfiguration.AzureOpenAiProviderId,
+            MaxRepairAttempts = 1,
+            Providers =
+            {
+                [WorkflowGenerationConfiguration.AzureOpenAiProviderId] = new WorkflowGenerationProviderOptions
+                {
+                    Endpoint = endpoint!,
+                    Deployment = deployment!,
+                    ApiVersion = apiVersion ?? string.Empty,
+                    MaxTokens = 4096,
+                    TimeoutSeconds = 120
+                }
+            }
+        });
+
+        var apiKeyResolver = new WorkflowGenerationApiKeyResolver();
+        var authResolver = new AzureOpenAiAuthResolver(apiKeyResolver, new DefaultAzureOpenAiTokenProvider());
+
+        var service = new DashboardGenerationService(
+            httpClientFactory: new SimpleHttpClientFactory(),
+            options: options,
+            apiKeyResolver: apiKeyResolver,
+            bedrockChatClientFactory: new Honua.Ai.Providers.Bedrock.BedrockChatClientFactory(),
+            logger: NullLogger<DashboardGenerationService>.Instance,
+            azureAuthResolver: authResolver);
+
+        var result = await service.GenerateAsync(new DashboardGenerationRequest
+        {
+            Prompt = "Build a fleet operations dashboard with a KPI panel for total active vehicles and a bar chart of incidents by region."
+        });
+
+        _output.WriteLine($"status={result.Status} provider={result.Provider} model={result.Model}");
+        _output.WriteLine($"rationale={result.Rationale}");
+        if (result.Document is { } document)
+        {
+            _output.WriteLine("document=" + document.GetRawText());
+        }
+
+        result.Provider.Should().Be(WorkflowGenerationConfiguration.AzureOpenAiProviderId);
+        result.Status.Should().BeOneOf("generated", "needs-clarification", "unsupported", "error");
+        result.Status.Should().NotBe("unsupported", "the Azure OpenAI provider must be reachable and configured");
+    }
+
+    private sealed class SimpleHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/AzureOpenAiStudioProviderTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/AzureOpenAiStudioProviderTests.cs
@@ -1,0 +1,332 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Ai.Providers.AzureOpenAi;
+using Honua.Ai.WorkflowGeneration;
+using Honua.Core.Features.WorkflowPackages.Domain;
+using Honua.Core.Features.WorkflowPackages.Generation;
+using Honua.Core.Features.WorkflowPackages.Generation.Abstractions;
+using Honua.Core.Features.WorkflowPackages.Generation.Domain;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Providers.AzureOpenAi;
+
+/// <summary>
+/// Offline wiring tests for the Azure OpenAI / Azure AI Foundry provider that backs the studio
+/// generation flows. These prove — without a live Azure endpoint (the HTTP layer is mocked) — that:
+/// <list type="bullet">
+///   <item>The shared config accepts the <c>azureopenai</c> provider id with endpoint + deployment
+///   and no api-key (Entra Managed Identity is the preferred auth).</item>
+///   <item>The deployment-routed URL and the api-key / Entra auth header are built correctly.</item>
+///   <item>The workflow provider maps a strict json_schema completion into the proposal contract.</item>
+///   <item>A truncated completion (<c>finish_reason=length</c>) surfaces an actionable error rather
+///   than an opaque deserialize failure.</item>
+/// </list>
+/// A live end-to-end test against real Azure OpenAI lives in <c>AzureOpenAiStudioLiveTests</c>,
+/// gated on <c>HONUA_AI_LIVE_AZURE_OPENAI=1</c>.
+/// </summary>
+public sealed class AzureOpenAiStudioProviderTests
+{
+    private const string Endpoint = "https://contoso.openai.azure.com";
+
+    [UnitTest]
+    public void ConfigurationValidator_AcceptsAzureOpenAiWithEndpointAndDeployment_NoKey()
+    {
+        var validator = new WorkflowGenerationConfigurationValidator();
+        var options = new WorkflowGenerationConfiguration
+        {
+            Enabled = true,
+            DefaultProvider = WorkflowGenerationConfiguration.AzureOpenAiProviderId,
+            Providers =
+            {
+                [WorkflowGenerationConfiguration.AzureOpenAiProviderId] = new WorkflowGenerationProviderOptions
+                {
+                    // No api-key — Azure uses Entra Managed Identity by default.
+                    Endpoint = Endpoint,
+                    Deployment = "gpt-4o",
+                    ApiVersion = "2024-10-21"
+                }
+            }
+        };
+
+        var result = validator.Validate(name: null, options);
+
+        result.Succeeded.Should().BeTrue(because: "Azure needs only an endpoint + deployment; Managed Identity supplies auth");
+    }
+
+    [UnitTest]
+    public void ConfigurationValidator_RejectsAzureOpenAiWithoutEndpoint()
+    {
+        var validator = new WorkflowGenerationConfigurationValidator();
+        var options = new WorkflowGenerationConfiguration
+        {
+            Enabled = true,
+            DefaultProvider = WorkflowGenerationConfiguration.AzureOpenAiProviderId,
+            Providers =
+            {
+                [WorkflowGenerationConfiguration.AzureOpenAiProviderId] = new WorkflowGenerationProviderOptions
+                {
+                    Deployment = "gpt-4o"
+                }
+            }
+        };
+
+        var result = validator.Validate(name: null, options);
+
+        result.Failed.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void ConfigurationValidator_RejectsAzureOpenAiWithoutDeploymentOrModel()
+    {
+        var validator = new WorkflowGenerationConfigurationValidator();
+        var options = new WorkflowGenerationConfiguration
+        {
+            Enabled = true,
+            DefaultProvider = WorkflowGenerationConfiguration.AzureOpenAiProviderId,
+            Providers =
+            {
+                [WorkflowGenerationConfiguration.AzureOpenAiProviderId] = new WorkflowGenerationProviderOptions
+                {
+                    Endpoint = Endpoint
+                }
+            }
+        };
+
+        var result = validator.Validate(name: null, options);
+
+        result.Failed.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Endpoint_BuildsDeploymentRoutedUriWithApiVersion()
+    {
+        var uri = AzureOpenAiEndpoint.BuildChatCompletionsUri(
+            "https://contoso.openai.azure.com/",
+            "gpt-4o",
+            "2024-10-21");
+
+        uri.Should().Be("https://contoso.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-10-21");
+    }
+
+    [UnitTest]
+    public void AzureOpenAiWorkflowProvider_IsConfigured_WhenEndpointAndDeploymentAreSet()
+    {
+        var configured = NewProvider(new StubHttpClientFactory(new StubChatHandler(["{}"])), DefaultOptions());
+
+        configured.IsConfigured.Should().BeTrue();
+        configured.ProviderId.Should().Be(WorkflowGenerationConfiguration.AzureOpenAiProviderId);
+
+        var unconfigured = NewProvider(
+            new StubHttpClientFactory(new StubChatHandler(["{}"])),
+            Options.Create(new WorkflowGenerationConfiguration { Enabled = true }));
+
+        unconfigured.IsConfigured.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task Generate_WithKeyAuth_SendsApiKeyHeaderToDeploymentUrl_AndMapsProposal()
+    {
+        const string Proposal = """
+        { "status": "needs-clarification", "rationale": "Which fleet region should this workflow target?", "clarifications": [] }
+        """;
+
+        var handler = new StubChatHandler([WrapAsChatCompletion(Proposal, finishReason: "stop")]);
+        var provider = NewProvider(new StubHttpClientFactory(handler), KeyAuthOptions());
+
+        var proposal = await provider.GenerateAsync(Request());
+
+        proposal.Status.Should().Be(WorkflowGenerationStatus.NeedsClarification);
+        proposal.ProviderId.Should().Be(WorkflowGenerationConfiguration.AzureOpenAiProviderId);
+        proposal.Model.Should().Be("gpt-4o");
+
+        // The request was routed to the deployment URL and authenticated with the api-key header.
+        handler.LastRequestUri.Should().Be(
+            "https://contoso.openai.azure.com/openai/deployments/gpt-4o-deploy/chat/completions?api-version=2024-10-21");
+        handler.LastApiKeyHeader.Should().Be("test-azure-key");
+        handler.LastAuthorizationHeader.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task Generate_WithEntraToken_SendsBearerHeader_WhenNoKeyConfigured()
+    {
+        const string Proposal = """
+        { "status": "needs-clarification", "rationale": "Clarify the schedule.", "clarifications": [] }
+        """;
+
+        var handler = new StubChatHandler([WrapAsChatCompletion(Proposal, finishReason: "stop")]);
+        var provider = NewProvider(
+            new StubHttpClientFactory(handler),
+            DefaultOptions(),
+            tokenProvider: new StubTokenProvider("entra-access-token"));
+
+        var proposal = await provider.GenerateAsync(Request());
+
+        proposal.Status.Should().Be(WorkflowGenerationStatus.NeedsClarification);
+        handler.LastAuthorizationHeader.Should().Be("Bearer entra-access-token");
+        handler.LastApiKeyHeader.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task Generate_WhenCompletionTruncated_ReturnsActionableError()
+    {
+        // A "length" finish_reason means max_tokens was reached and the JSON is truncated.
+        var handler = new StubChatHandler([WrapAsChatCompletion("{ \"status\": \"gener", finishReason: "length")]);
+        var provider = NewProvider(new StubHttpClientFactory(handler), KeyAuthOptions());
+
+        var proposal = await provider.GenerateAsync(Request());
+
+        proposal.Status.Should().Be(WorkflowGenerationStatus.Error);
+        proposal.ErrorMessage.Should().Contain("truncated");
+        proposal.ErrorMessage.Should().Contain("MaxTokens");
+    }
+
+    [UnitTest]
+    public async Task Generate_WhenNoCredential_ReturnsAuthenticationError()
+    {
+        var handler = new StubChatHandler(["{}"], throwIfCalled: true);
+        var provider = NewProvider(
+            new StubHttpClientFactory(handler),
+            DefaultOptions(),
+            tokenProvider: new StubTokenProvider(token: null));
+
+        var proposal = await provider.GenerateAsync(Request());
+
+        proposal.Status.Should().Be(WorkflowGenerationStatus.Error);
+        proposal.ErrorMessage.Should().Contain("not authenticated");
+    }
+
+    // -- helpers --------------------------------------------------------------------------
+
+    private static AzureOpenAiWorkflowGenerationProvider NewProvider(
+        IHttpClientFactory httpClientFactory,
+        IOptions<WorkflowGenerationConfiguration> options,
+        IAzureOpenAiTokenProvider? tokenProvider = null)
+    {
+        var apiKeyResolver = new WorkflowGenerationApiKeyResolver();
+        var authResolver = new AzureOpenAiAuthResolver(
+            apiKeyResolver,
+            tokenProvider ?? new StubTokenProvider(token: null));
+        return new AzureOpenAiWorkflowGenerationProvider(
+            WorkflowGenerationConfiguration.AzureOpenAiProviderId,
+            httpClientFactory,
+            authResolver,
+            options,
+            NullLogger<AzureOpenAiWorkflowGenerationProvider>.Instance);
+    }
+
+    private static IOptions<WorkflowGenerationConfiguration> DefaultOptions() =>
+        Options.Create(new WorkflowGenerationConfiguration
+        {
+            Enabled = true,
+            DefaultProvider = WorkflowGenerationConfiguration.AzureOpenAiProviderId,
+            MaxRepairAttempts = 0,
+            Providers =
+            {
+                [WorkflowGenerationConfiguration.AzureOpenAiProviderId] = new WorkflowGenerationProviderOptions
+                {
+                    Endpoint = Endpoint,
+                    Model = "gpt-4o",
+                    Deployment = "gpt-4o-deploy",
+                    ApiVersion = "2024-10-21",
+                    MaxTokens = 2048,
+                    TimeoutSeconds = 30
+                }
+            }
+        });
+
+    private static IOptions<WorkflowGenerationConfiguration> KeyAuthOptions()
+    {
+        var options = DefaultOptions();
+        options.Value.GetProvider(WorkflowGenerationConfiguration.AzureOpenAiProviderId)!.ApiKey = "test-azure-key";
+        return options;
+    }
+
+    private static WorkflowGenerationProviderRequest Request() => new()
+    {
+        Prompt = "Copy features then calculate a field",
+        Registry = Snapshot()
+    };
+
+    private static WorkflowNodeRegistrySnapshot Snapshot() => new()
+    {
+        RegistryVersion = "test-registry-1",
+        GeneratedAt = DateTimeOffset.UnixEpoch,
+        Providers = [],
+        Nodes =
+        [
+            Node("process:data-management.copy-features"),
+            Node("process:geometry.area")
+        ]
+    };
+
+    private static WorkflowNodeDefinition Node(string nodeTypeId) => new()
+    {
+        NodeTypeId = nodeTypeId,
+        ProviderId = "test",
+        RuntimeKind = WorkflowNodeRuntimeKind.Geoprocessing,
+        Title = nodeTypeId,
+        Description = nodeTypeId,
+        Category = "transform",
+        ParameterSchemas = [],
+        CapabilityFlags = new WorkflowNodeCapabilityFlags { Executable = true },
+        RuntimeHints = new WorkflowNodeRuntimeHints()
+    };
+
+    /// <summary>Wrap a model proposal JSON in an OpenAI-compatible chat-completion envelope.</summary>
+    private static string WrapAsChatCompletion(string proposalContent, string finishReason)
+    {
+        var content = JsonSerializer.Serialize(proposalContent);
+        return $$"""
+            { "id": "chatcmpl-test", "choices": [ { "index": 0, "message": { "role": "assistant", "content": {{content}} }, "finish_reason": "{{finishReason}}" } ], "usage": { "prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30 } }
+            """;
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private sealed class StubChatHandler(IReadOnlyList<string> responses, bool throwIfCalled = false) : HttpMessageHandler
+    {
+        private int _call;
+
+        public string? LastRequestUri { get; private set; }
+
+        public string? LastApiKeyHeader { get; private set; }
+
+        public string? LastAuthorizationHeader { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (throwIfCalled)
+            {
+                throw new InvalidOperationException("The provider must not call Azure when no credential is available.");
+            }
+
+            LastRequestUri = request.RequestUri?.ToString();
+            LastApiKeyHeader = request.Headers.TryGetValues("api-key", out var values) ? values.FirstOrDefault() : null;
+            LastAuthorizationHeader = request.Headers.Authorization?.ToString();
+
+            var index = Math.Min(_call, responses.Count - 1);
+            _call++;
+            var body = responses.Count == 0 ? "{}" : responses[index];
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class StubTokenProvider(string? token) : IAzureOpenAiTokenProvider
+    {
+        public Task<string?> GetAccessTokenAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(token);
+    }
+}


### PR DESCRIPTION
Adds an **Azure OpenAI / Azure AI Foundry** workflow-generation provider (id `azureopenai`) so the studio AI flows run on Azure-hosted models, mirroring the existing Bedrock provider (#1737).

Closes #1744

## Approach
Azure OpenAI is OpenAI-API-compatible at the body level, so this **reuses the OpenAI-compatible HTTP path** (request/response DTOs, strict `json_schema` structured output, `finish_reason=length` truncation detection) rather than introducing a heavy new chat-client adapter. Only the Azure specifics are added:

- **Deployment-routed URL**: `{endpoint}/openai/deployments/{deployment}/chat/completions?api-version={version}`.
- **Auth**: Entra **Managed Identity preferred** (`Azure.Identity` `DefaultAzureCredential`, Cognitive Services data-plane scope) via a mockable `IAzureOpenAiTokenProvider`; falls back to an `api-key` header resolved through the shared secret-aware `WorkflowGenerationApiKeyResolver` (so secret refs + `HONUA_WORKFLOWGEN_AZUREOPENAI_API_KEY` env fallback work like the other providers).

## Selection & config
Selected by provider id `azureopenai` (e.g. `WorkflowGeneration:DefaultProvider=azureopenai`) through the same provider switch as Bedrock. New per-provider options: `Endpoint`, `Deployment`, `ApiVersion` (defaults to a GA version supporting `json_schema`). Validator requires endpoint + deployment (or model); the api-key is optional because Managed Identity is the default. Wired into the workflow provider registration and the dashboard / report provider switch — the same surface Bedrock covers.

## Cloud-SDK isolation
The `Azure.Identity` reference is confined to `Honua.Ai` exactly like the existing `AWSSDK.BedrockRuntime` Bedrock reference, so `Honua.Core` / `Honua.Hosting` / `Honua.Server` stay SDK-free. `CloudSdkIsolationTests` stays green (4/4).

## Tests
- `Honua.Ai.Tests` **10/10 passed** (HTTP mocked, no live Azure call): successful structured generation + proposal mapping, truncation -> actionable error, api-key vs Entra-token header selection, no-credential error, URL builder, validator + `IsConfigured` wiring.
- Opt-in live test (`AzureOpenAiStudioLiveTests`, gated on `HONUA_AI_LIVE_AZURE_OPENAI=1`), mirroring the Bedrock live test.
- `CloudSdkIsolationTests` **4/4 passed**; `dotnet format --verify-no-changes` clean; Release build with `TreatWarningsAsErrors` clean.