### PR TITLE
feat(ai): dedicated PlanAnalysis provider seam for the MCP server-side planner (#1955)

### DIFF
--- a/src/Honua.Ai/Features/AiBuilder/AiBuilderServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/AiBuilder/AiBuilderServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Honua.Core.Features.WorkflowPackages.Generation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Honua.Ai.AiBuilder;
 
@@ -55,6 +56,17 @@ internal static class AiBuilderServiceCollectionExtensions
 
         services.AddAiBuilderFixtures();
 
+        // Bind the dedicated PlanAnalysis seam so the live planner can resolve its
+        // provider override (PlanAnalysis:Provider) at request time. The fixture
+        // path ignores it; binding is cheap and keeps a single registration site.
+        // The validator only checks the provider override (against the same
+        // allow-list as WorkflowGeneration) and is a no-op when no override is set.
+        services.AddOptions<PlanAnalysisConfiguration>()
+            .Bind(configuration.GetSection(PlanAnalysisConfiguration.SectionName))
+            .ValidateOnStart();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IValidateOptions<PlanAnalysisConfiguration>, PlanAnalysisConfigurationValidator>());
+
         if (ShouldUseLivePlanner(configuration))
         {
             services.TryAddSingleton<IPlanAnalysisService, LivePlanAnalysisService>();
@@ -81,26 +93,68 @@ internal static class AiBuilderServiceCollectionExtensions
     }
 
     /// <summary>
-    /// True when an AI workflow-generation provider is configured such that the
-    /// live plan lane should run instead of fixture replay: the feature is
-    /// enabled and the default provider id is a live provider (anything other
-    /// than the deterministic fixture provider).
+    /// True when the live (provider-backed) plan lane should run instead of the
+    /// deterministic fixture replay.
     /// </summary>
+    /// <remarks>
+    /// The dedicated <c>PlanAnalysis</c> seam (#1955) takes precedence over the
+    /// Studio <c>WorkflowGeneration</c> gate so the MCP planner can be flipped
+    /// independently:
+    /// <list type="bullet">
+    ///   <item>If <c>PlanAnalysis:Enabled</c> is explicitly set, it decides the
+    ///   gate (true → live, false → fixtures) — the operator opts the MCP plan
+    ///   lane in or out without touching the Studio generation feature.</item>
+    ///   <item>Otherwise the planner inherits the <c>WorkflowGeneration</c> gate
+    ///   (the original behaviour).</item>
+    /// </list>
+    /// In both cases the <em>effective provider</em> must be a live provider —
+    /// <c>PlanAnalysis:Provider</c> when set, else
+    /// <c>WorkflowGeneration:DefaultProvider</c> — and not the deterministic
+    /// fixture-replay provider, otherwise the deterministic path is selected.
+    /// </remarks>
     internal static bool ShouldUseLivePlanner(IConfiguration configuration)
     {
-        var section = configuration.GetSection(WorkflowGenerationConfiguration.SectionName);
-        if (!section.GetValue<bool>("Enabled"))
+        var planSection = configuration.GetSection(PlanAnalysisConfiguration.SectionName);
+        var workflowSection = configuration.GetSection(WorkflowGenerationConfiguration.SectionName);
+
+        // PlanAnalysis:Enabled is authoritative when present; otherwise inherit
+        // the WorkflowGeneration gate.
+        var planEnabled = planSection.GetValue<bool?>("Enabled");
+        var gateEnabled = planEnabled ?? workflowSection.GetValue<bool>("Enabled");
+        if (!gateEnabled)
         {
             return false;
         }
 
-        var defaultProvider = (section.GetValue<string>("DefaultProvider")
-            ?? WorkflowGenerationConfiguration.LocalProviderId).Trim();
+        // PlanAnalysis:Provider overrides the WorkflowGeneration default provider
+        // for the plan lane. A blank override falls back to the WorkflowGeneration
+        // default so existing single-key deployments keep working.
+        var effectiveProvider = ResolveEffectiveProvider(planSection, workflowSection);
 
-        return defaultProvider.Length > 0
+        return effectiveProvider.Length > 0
             && !string.Equals(
-                defaultProvider,
+                effectiveProvider,
                 WorkflowGenerationConfiguration.DeterministicProviderId,
                 StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Resolves the provider id the live planner will use: the
+    /// <c>PlanAnalysis:Provider</c> override when non-blank, otherwise
+    /// <c>WorkflowGeneration:DefaultProvider</c> (itself defaulting to the local
+    /// provider id when unset).
+    /// </summary>
+    internal static string ResolveEffectiveProvider(
+        IConfigurationSection planSection,
+        IConfigurationSection workflowSection)
+    {
+        var planProvider = (planSection.GetValue<string>("Provider") ?? string.Empty).Trim();
+        if (planProvider.Length > 0)
+        {
+            return planProvider;
+        }
+
+        return (workflowSection.GetValue<string>("DefaultProvider")
+            ?? WorkflowGenerationConfiguration.LocalProviderId).Trim();
     }
 }

--- a/src/Honua.Ai/Features/AiBuilder/Planning/LivePlanAnalysisService.cs
+++ b/src/Honua.Ai/Features/AiBuilder/Planning/LivePlanAnalysisService.cs
@@ -9,6 +9,7 @@ using Honua.Core.Features.WorkflowPackages.Generation.Domain;
 using Honua.ServiceDefaults;
 using Honua.Ai.Protocols.Mcp.Models;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Honua.Ai.AiBuilder.Planning;
 
@@ -40,14 +41,23 @@ internal sealed class LivePlanAnalysisService : IPlanAnalysisService
     private readonly IWorkflowNodeRegistry _nodeRegistry;
     private readonly ILogger<LivePlanAnalysisService> _logger;
 
+    // PlanAnalysis:Provider override; null/blank means "use the WorkflowGeneration
+    // default provider". Normalised once at construction.
+    private readonly string? _providerOverride;
+
     public LivePlanAnalysisService(
         IWorkflowGenerationService generationService,
         IWorkflowNodeRegistry nodeRegistry,
+        IOptions<PlanAnalysisConfiguration> options,
         ILogger<LivePlanAnalysisService> logger)
     {
+        ArgumentNullException.ThrowIfNull(options);
+
         _generationService = generationService;
         _nodeRegistry = nodeRegistry;
         _logger = logger;
+
+        _providerOverride = options.Value.NormalizedProvider();
     }
 
     /// <inheritdoc />
@@ -62,7 +72,17 @@ internal sealed class LivePlanAnalysisService : IPlanAnalysisService
         try
         {
             result = await _generationService
-                .GenerateAsync(new WorkflowGenerationRequest { Prompt = intent }, cancellationToken)
+                .GenerateAsync(
+                    new WorkflowGenerationRequest
+                    {
+                        Prompt = intent,
+
+                        // Route the plan lane to the PlanAnalysis-selected provider
+                        // when one is configured; null lets the WorkflowGeneration
+                        // seam pick its configured default provider.
+                        ProviderId = _providerOverride
+                    },
+                    cancellationToken)
                 .ConfigureAwait(false);
         }
         catch (OperationCanceledException)

--- a/src/Honua.Ai/Features/AiBuilder/Planning/PlanAnalysisConfiguration.cs
+++ b/src/Honua.Ai/Features/AiBuilder/Planning/PlanAnalysisConfiguration.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.ServiceRegistration;
+using Honua.Core.Features.WorkflowPackages.Generation;
+
+namespace Honua.Ai.AiBuilder.Planning;
+
+/// <summary>
+/// Dedicated configuration seam for the server-side planner backing the
+/// <c>honua_plan_analysis</c> MCP tool ("Honua-brings-LLM"). It lets an operator
+/// gate and provider-select the live planner <em>independently</em> of the Studio
+/// <c>WorkflowGeneration</c> surface, while reusing the same provider plumbing
+/// (<c>WorkflowGeneration:Providers:*</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Precedence (see <see cref="AiBuilderServiceCollectionExtensions.ShouldUseLivePlanner"/>):
+/// </para>
+/// <list type="number">
+///   <item>When <c>PlanAnalysis:Enabled</c> is set, it is authoritative — an
+///   operator can force the live planner ON (or hold it OFF on the fixtures) for
+///   the MCP plan lane without touching the Studio generation feature, and vice
+///   versa.</item>
+///   <item>When <c>PlanAnalysis:Enabled</c> is unset (null), the planner inherits
+///   the <c>WorkflowGeneration</c> gate (back-compat: the original behaviour where
+///   the live planner rode entirely on <c>WorkflowGeneration:Enabled</c>).</item>
+///   <item><c>PlanAnalysis:Provider</c>, when set, overrides which provider id the
+///   live planner asks the shared <c>WorkflowGeneration</c> seam to use; when unset
+///   the planner falls back to <c>WorkflowGeneration:DefaultProvider</c>.</item>
+/// </list>
+/// <para>
+/// This configuration intentionally carries no per-provider connection block of its
+/// own. Endpoints, models, regions, and keys remain owned by
+/// <see cref="WorkflowGenerationConfiguration.Providers"/> so there is a single
+/// source of truth for provider credentials; <c>PlanAnalysis</c> only selects
+/// among them.
+/// </para>
+/// </remarks>
+public sealed class PlanAnalysisConfiguration
+{
+    /// <summary>The configuration section name.</summary>
+    public const string SectionName = "PlanAnalysis";
+
+    /// <summary>
+    /// Whether the live (provider-backed) planner is enabled for the MCP plan
+    /// lane. <see langword="null"/> (the default / unset) means "inherit the
+    /// <c>WorkflowGeneration</c> gate"; <see langword="true"/> forces the live
+    /// planner on; <see langword="false"/> pins the deterministic fixture replay
+    /// even when <c>WorkflowGeneration</c> is live.
+    /// </summary>
+    public bool? Enabled { get; set; }
+
+    /// <summary>
+    /// The provider id the live planner should use, overriding
+    /// <c>WorkflowGeneration:DefaultProvider</c>. Must reference a provider id
+    /// registered under <c>WorkflowGeneration:Providers</c> (for example
+    /// <c>anthropic</c> or <c>bedrock</c>). <see langword="null"/> / empty falls
+    /// back to the WorkflowGeneration default provider.
+    /// </summary>
+    public string? Provider { get; set; }
+
+    /// <summary>
+    /// Returns the trimmed provider override, or <see langword="null"/> when no
+    /// override is configured.
+    /// </summary>
+    public string? NormalizedProvider()
+    {
+        var provider = Provider?.Trim();
+        return string.IsNullOrEmpty(provider) ? null : provider;
+    }
+}
+
+/// <summary>
+/// Validates <see cref="PlanAnalysisConfiguration"/> at startup. Only the provider
+/// override is checked, against the same allow-list as
+/// <see cref="WorkflowGenerationConfigurationValidator"/>; per-provider connection
+/// fields are validated by WorkflowGeneration because PlanAnalysis selects, not
+/// declares, providers.
+/// </summary>
+public sealed class PlanAnalysisConfigurationValidator : ConfigurationValidator<PlanAnalysisConfiguration>
+{
+    /// <inheritdoc />
+    protected override void PerformFeatureSpecificValidation(PlanAnalysisConfiguration options, List<string> errors)
+    {
+        var provider = options.NormalizedProvider();
+        if (provider is null)
+        {
+            // No override: WorkflowGeneration owns provider validation.
+            return;
+        }
+
+        var isKnown =
+            string.Equals(provider, WorkflowGenerationConfiguration.LocalProviderId, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(provider, WorkflowGenerationConfiguration.OpenAiProviderId, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(provider, WorkflowGenerationConfiguration.AnthropicProviderId, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(provider, WorkflowGenerationConfiguration.BedrockProviderId, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(provider, WorkflowGenerationConfiguration.DeterministicProviderId, StringComparison.OrdinalIgnoreCase);
+
+        if (!isKnown)
+        {
+            errors.Add($"PlanAnalysis:Provider '{provider}' is not a supported provider id. "
+                + "Supported values: 'local', 'openai', 'anthropic', 'bedrock', 'deterministic'.");
+        }
+    }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/LivePlanAnalysisServiceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/LivePlanAnalysisServiceTests.cs
@@ -228,10 +228,160 @@ public sealed class LivePlanAnalysisServiceTests
             .Should().BeOfType<LivePlanAnalysisService>();
     }
 
+    // --- Dedicated PlanAnalysis seam (#1955): independent gate + provider override ---
+
+    [UnitTest]
+    public void ShouldUseLivePlanner_PlanAnalysisEnabledTrue_OverridesWorkflowGenerationDisabled()
+    {
+        // The Studio WorkflowGeneration feature is OFF, but the operator opts the
+        // MCP plan lane IN via the dedicated PlanAnalysis seam — naming a live
+        // provider there. The plan lane goes live without enabling Studio.
+        var configuration = BuildConfiguration(
+            enabled: false,
+            defaultProvider: "deterministic",
+            planEnabled: true,
+            planProvider: "bedrock");
+
+        AiBuilderServiceCollectionExtensions.ShouldUseLivePlanner(configuration).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void ShouldUseLivePlanner_PlanAnalysisEnabledFalse_PinsFixturesEvenWhenWorkflowGenerationLive()
+    {
+        // WorkflowGeneration is live, but the operator pins the MCP plan lane to
+        // deterministic fixtures via PlanAnalysis:Enabled=false.
+        var configuration = BuildConfiguration(
+            enabled: true,
+            defaultProvider: "bedrock",
+            planEnabled: false);
+
+        AiBuilderServiceCollectionExtensions.ShouldUseLivePlanner(configuration).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void ShouldUseLivePlanner_PlanAnalysisProviderOverridesDeterministicWorkflowDefault_IsTrue()
+    {
+        // WorkflowGeneration is enabled but its default provider is deterministic;
+        // PlanAnalysis:Provider overrides it to a live provider for the plan lane.
+        var configuration = BuildConfiguration(
+            enabled: true,
+            defaultProvider: "deterministic",
+            planProvider: "anthropic");
+
+        AiBuilderServiceCollectionExtensions.ShouldUseLivePlanner(configuration).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void ShouldUseLivePlanner_PlanAnalysisProviderDeterministic_OverridesLiveWorkflowDefault_IsFalse()
+    {
+        // Symmetric: an operator can pin the plan lane to deterministic even when
+        // the WorkflowGeneration default is a live provider.
+        var configuration = BuildConfiguration(
+            enabled: true,
+            defaultProvider: "bedrock",
+            planProvider: "deterministic");
+
+        AiBuilderServiceCollectionExtensions.ShouldUseLivePlanner(configuration).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task PlanAsync_PlanAnalysisProviderSet_RoutesGenerationToThatProvider()
+    {
+        // The PlanAnalysis:Provider override must steer the WorkflowGeneration seam
+        // to a DIFFERENT provider than its default. The default here is "bedrock";
+        // the override names "anthropic", so the anthropic provider is invoked.
+        var bedrock = RecordingProvider.Generated("bedrock", CannedGraph());
+        var anthropic = RecordingProvider.Generated("anthropic", CannedGraph());
+        var service = CreateLiveService(
+            new IWorkflowGenerationProvider[] { bedrock, anthropic },
+            new PlanAnalysisConfiguration { Provider = "anthropic" });
+
+        var output = await service.PlanAsync(BufferIntent, context: null, CancellationToken.None);
+
+        output.Status.Should().Be("planned");
+        anthropic.WasInvoked.Should().BeTrue("PlanAnalysis:Provider selected the anthropic provider");
+        bedrock.WasInvoked.Should().BeFalse("the override steered away from the WorkflowGeneration default");
+    }
+
+    [UnitTest]
+    public async Task PlanAsync_NoPlanAnalysisProvider_UsesWorkflowGenerationDefaultProvider()
+    {
+        // No override → the WorkflowGeneration default provider ("bedrock") runs.
+        var bedrock = RecordingProvider.Generated("bedrock", CannedGraph());
+        var anthropic = RecordingProvider.Generated("anthropic", CannedGraph());
+        var service = CreateLiveService(
+            new IWorkflowGenerationProvider[] { bedrock, anthropic },
+            new PlanAnalysisConfiguration());
+
+        var output = await service.PlanAsync(BufferIntent, context: null, CancellationToken.None);
+
+        output.Status.Should().Be("planned");
+        bedrock.WasInvoked.Should().BeTrue("absent an override the WorkflowGeneration default provider runs");
+        anthropic.WasInvoked.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void PlanAnalysisConfigurationValidator_UnknownProvider_Fails()
+    {
+        var validator = new PlanAnalysisConfigurationValidator();
+
+        var result = validator.Validate(name: null, new PlanAnalysisConfiguration { Provider = "gemini" });
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("gemini");
+    }
+
+    [UnitTest]
+    public void PlanAnalysisConfigurationValidator_NoProviderOverride_Succeeds()
+    {
+        var validator = new PlanAnalysisConfigurationValidator();
+
+        var result = validator.Validate(name: null, new PlanAnalysisConfiguration { Enabled = true });
+
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void PlanAnalysisConfigurationValidator_KnownProvider_Succeeds()
+    {
+        var validator = new PlanAnalysisConfigurationValidator();
+
+        var result = validator.Validate(name: null, new PlanAnalysisConfiguration { Provider = "anthropic" });
+
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void AddAiBuilderPlanAnalysis_PlanAnalysisEnabledOnly_ResolvesLivePlanner()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(Substitute.For<IWorkflowGenerationService>());
+        services.AddSingleton(Substitute.For<IWorkflowNodeRegistry>());
+
+        // WorkflowGeneration disabled; PlanAnalysis opts the lane in with a live provider.
+        services.AddAiBuilderPlanAnalysis(BuildConfiguration(
+            enabled: false,
+            defaultProvider: "deterministic",
+            planEnabled: true,
+            planProvider: "bedrock"));
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IPlanAnalysisService>()
+            .Should().BeOfType<LivePlanAnalysisService>();
+    }
+
     // Builds the live service over the REAL WorkflowGenerationService so the test
     // exercises the full seam (provider selection + node-registry grounding + the
     // hard validation gate), with only the provider faked.
-    private static LivePlanAnalysisService CreateLiveService(IWorkflowGenerationProvider fakeProvider)
+    private static LivePlanAnalysisService CreateLiveService(
+        IWorkflowGenerationProvider fakeProvider,
+        PlanAnalysisConfiguration? planOptions = null) =>
+        CreateLiveService(new[] { fakeProvider }, planOptions);
+
+    private static LivePlanAnalysisService CreateLiveService(
+        IReadOnlyList<IWorkflowGenerationProvider> fakeProviders,
+        PlanAnalysisConfiguration? planOptions = null)
     {
         var registry = Substitute.For<IWorkflowNodeRegistry>();
         registry.GetSnapshotAsync(Arg.Any<CancellationToken>()).Returns(Snapshot());
@@ -241,7 +391,7 @@ public sealed class LivePlanAnalysisServiceTests
         }
 
         var generationService = new WorkflowGenerationService(
-            new[] { fakeProvider },
+            fakeProviders,
             registry,
             Options.Create(new WorkflowGenerationConfiguration
             {
@@ -253,6 +403,7 @@ public sealed class LivePlanAnalysisServiceTests
         return new LivePlanAnalysisService(
             generationService,
             registry,
+            Options.Create(planOptions ?? new PlanAnalysisConfiguration()),
             NullLogger<LivePlanAnalysisService>.Instance);
     }
 
@@ -310,14 +461,30 @@ public sealed class LivePlanAnalysisServiceTests
             ProcessId = processId
         };
 
-    private static IConfiguration BuildConfiguration(bool enabled, string defaultProvider) =>
-        new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["WorkflowGeneration:Enabled"] = enabled ? "true" : "false",
-                ["WorkflowGeneration:DefaultProvider"] = defaultProvider
-            })
-            .Build();
+    private static IConfiguration BuildConfiguration(
+        bool enabled,
+        string defaultProvider,
+        bool? planEnabled = null,
+        string? planProvider = null)
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            ["WorkflowGeneration:Enabled"] = enabled ? "true" : "false",
+            ["WorkflowGeneration:DefaultProvider"] = defaultProvider
+        };
+
+        if (planEnabled is { } flag)
+        {
+            settings["PlanAnalysis:Enabled"] = flag ? "true" : "false";
+        }
+
+        if (planProvider is not null)
+        {
+            settings["PlanAnalysis:Provider"] = planProvider;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+    }
 
     private static AnalysisPlan ToDomainPlan(McpAnalysisPlanOutput plan)
     {
@@ -386,6 +553,45 @@ public sealed class LivePlanAnalysisServiceTests
             UnmappedRequests = [capability],
             ProviderId = "bedrock"
         });
+    }
+
+    /// <summary>
+    /// Fake provider carrying a fixed provider id that records whether it was
+    /// invoked, so tests can assert which provider the WorkflowGeneration seam
+    /// selected when the live planner applies the PlanAnalysis:Provider override.
+    /// </summary>
+    private sealed class RecordingProvider : IWorkflowGenerationProvider
+    {
+        private readonly WorkflowGenerationProposal _proposal;
+
+        private RecordingProvider(string providerId, WorkflowGenerationProposal proposal)
+        {
+            ProviderId = providerId;
+            _proposal = proposal;
+        }
+
+        public string ProviderId { get; }
+
+        public bool IsConfigured => true;
+
+        public bool WasInvoked { get; private set; }
+
+        public Task<WorkflowGenerationProposal> GenerateAsync(
+            WorkflowGenerationProviderRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            WasInvoked = true;
+            return Task.FromResult(_proposal);
+        }
+
+        public static RecordingProvider Generated(string providerId, WorkflowGraph graph) =>
+            new(providerId, new WorkflowGenerationProposal
+            {
+                Status = WorkflowGenerationStatus.Generated,
+                Graph = graph,
+                ProviderId = providerId,
+                Model = "fake-model"
+            });
     }
 
     /// <summary>


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1955

## Summary
Foundational slice of the **Honua-brings-LLM** server-side planner (#1955). The core live planner (`LivePlanAnalysisService` over the `WorkflowGeneration` seam, fixtures as fallback) already shipped on trunk via #1892/#1958; this PR closes the remaining checklist item: a **dedicated `PlanAnalysis` configuration seam** so the MCP `honua_plan_analysis` planner can be gated and provider-selected independently of the Studio `WorkflowGeneration` surface, instead of implicitly riding entirely on `WorkflowGeneration:Enabled` / `WorkflowGeneration:DefaultProvider`. It defaults to inheriting `WorkflowGeneration` so existing deployments are unaffected.

## Changes Made
- Add `PlanAnalysisConfiguration` (`PlanAnalysis:Enabled`, `PlanAnalysis:Provider`) plus `PlanAnalysisConfigurationValidator`, which validates the provider override against the same allow-list as `WorkflowGeneration` (`local`/`openai`/`anthropic`/`bedrock`/`deterministic`) and is a no-op when no override is set. Per-provider credentials remain owned by `WorkflowGeneration:Providers` — `PlanAnalysis` selects, it does not declare.
- `ShouldUseLivePlanner` now treats `PlanAnalysis:Enabled` as authoritative when present (force the live planner on, or pin fixtures off even when Studio generation is live), inheriting the `WorkflowGeneration` gate otherwise. The effective provider is `PlanAnalysis:Provider` when set, else `WorkflowGeneration:DefaultProvider`, and must be a live (non-deterministic) provider for the live lane to run.
- `LivePlanAnalysisService` applies the override by routing the generation request's `ProviderId`, so the plan lane can target a different provider than the WorkflowGeneration default.
- Bind + `ValidateOnStart` the options in `AddAiBuilderPlanAnalysis`.

Stubbed/deferred (tracked on #1955): the still-open tier/edition default-on policy, extending live lanes beyond `honua_plan_analysis` (validate/execute), and auto-resolving obvious layer bindings (→ #1949). This PR does not change the deployed demo gate.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

`LivePlanAnalysisServiceTests` (mocked `IWorkflowGenerationProvider`, no live LLM): 24/24 pass — new coverage for provider-override routing across two fake providers, independent-gate precedence (`PlanAnalysis:Enabled` over `WorkflowGeneration`), validator allow-list, and DI resolution; existing graceful-degradation (provider throws → structured `rejected`) coverage retained. `CloudSdkIsolationTests` + `HonuaAiIsolationTests`: 6/6 pass. Clean Release build with `TreatWarningsAsErrors=true`; `dotnet format --verify-no-changes` clean on changed files.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

The new `PlanAnalysis` section is optional; unset config preserves prior behaviour.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
