### PR TITLE
feat(mcp): add Mcp-Session-Id sessions and SSE transport (#1954)

### DIFF
--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpEndpointExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpEndpointExtensions.cs
@@ -1,18 +1,28 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Text;
 using System.Text.Json;
 using Honua.Ai.Protocols.Mcp.Models;
+using Microsoft.Net.Http.Headers;
 
 namespace Honua.Ai.Protocols.Mcp;
 
 /// <summary>
-/// Maps the single JSON-RPC endpoint that hosts the MCP operator surface.
-/// Accepts both individual requests and JSON-RPC 2.0 batches, and enforces
-/// the MCP request-id rules (string or integer only). Note that
-/// <c>initialize</c> is single-request-only per MCP 2025-03-26 lifecycle —
-/// any batch containing an <c>initialize</c> element is rejected wholesale
-/// because the server cannot negotiate a protocol version mid-batch.
+/// Maps the JSON-RPC endpoint that hosts the MCP operator surface using the
+/// Streamable-HTTP transport (MCP 2025-03-26). Accepts both individual requests
+/// and JSON-RPC 2.0 batches on <c>POST /mcp</c>, enforces the MCP request-id
+/// rules (string or integer only), and manages <c>Mcp-Session-Id</c> sessions:
+/// a session id is issued on <c>initialize</c> and validated (HTTP 404 on an
+/// unknown id) on every subsequent request. The transport negotiates the
+/// response content type from the client's <c>Accept</c> header — emitting a
+/// single Server-Sent-Events <c>message</c> frame when the client accepts
+/// <c>text/event-stream</c>, and plain JSON otherwise. <c>GET /mcp</c> opens an
+/// SSE stream the server can push notifications over, and <c>DELETE /mcp</c>
+/// terminates a session.
+/// Note that <c>initialize</c> is single-request-only per MCP 2025-03-26
+/// lifecycle — any batch containing an <c>initialize</c> element is rejected
+/// wholesale because the server cannot negotiate a protocol version mid-batch.
 /// </summary>
 internal static class McpEndpointExtensions
 {
@@ -22,6 +32,7 @@ internal static class McpEndpointExtensions
     public const string RoutePath = "/mcp";
 
     private const string JsonMimeType = "application/json";
+    private const string EventStreamMimeType = "text/event-stream";
 
     /// <summary>
     /// HTTP status code returned for accepted JSON-RPC notifications. The MCP
@@ -44,26 +55,45 @@ internal static class McpEndpointExtensions
     internal static readonly JsonElement JsonNullId = CreateJsonNullElement();
 
     /// <summary>
-    /// Maps <c>POST /mcp</c> for JSON-RPC dispatch.
+    /// Maps <c>POST /mcp</c> for JSON-RPC dispatch, <c>GET /mcp</c> for the
+    /// server-to-client SSE stream, and <c>DELETE /mcp</c> for session
+    /// termination.
     /// </summary>
     public static IEndpointRouteBuilder MapMcpOperatorSurface(this IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 
         endpoints.MapPost(RoutePath,
-                static (HttpContext context, CancellationToken ct) => HandleAsync(context, ct))
+                static (HttpContext context, CancellationToken ct) => HandlePostAsync(context, ct))
             .WithDisplayName("MCP Operator Surface")
             .WithName("McpOperatorSurface")
             .WithSummary("MCP JSON-RPC dispatcher for planning, execution, lifecycle, and results.")
-            .WithDescription("Accepts JSON-RPC 2.0 requests. Single-request-only: initialize (MCP lifecycle forbids batching). Single or batched: notifications/initialized, tools/list, tools/call, resources/list, resources/templates/list, and resources/read.")
+            .WithDescription("Accepts JSON-RPC 2.0 requests over the Streamable-HTTP transport. Issues an Mcp-Session-Id on initialize and validates it on subsequent requests. Responds with application/json or, when the client accepts text/event-stream, a single SSE message frame. Single-request-only: initialize (MCP lifecycle forbids batching). Single or batched: notifications/initialized, tools/list, tools/call, resources/list, resources/templates/list, and resources/read.")
+            .WithTags("Mcp");
+
+        endpoints.MapGet(RoutePath,
+                static (HttpContext context, CancellationToken ct) => HandleGetAsync(context, ct))
+            .WithDisplayName("MCP Operator Surface (SSE stream)")
+            .WithName("McpOperatorSurfaceStream")
+            .WithSummary("Opens the MCP server-to-client Server-Sent-Events stream.")
+            .WithDescription("Streamable-HTTP transport GET endpoint. Opens a text/event-stream the server uses to push notifications (e.g. progress, listChanged). Requires a valid Mcp-Session-Id.")
+            .WithTags("Mcp");
+
+        endpoints.MapDelete(RoutePath,
+                static (HttpContext context, CancellationToken ct) => HandleDeleteAsync(context, ct))
+            .WithDisplayName("MCP Operator Surface (session termination)")
+            .WithName("McpOperatorSurfaceTerminate")
+            .WithSummary("Terminates an MCP session.")
+            .WithDescription("Streamable-HTTP transport DELETE endpoint. Removes the session identified by the Mcp-Session-Id header.")
             .WithTags("Mcp");
 
         return endpoints;
     }
 
-    private static async Task HandleAsync(HttpContext context, CancellationToken cancellationToken)
+    private static async Task HandlePostAsync(HttpContext context, CancellationToken cancellationToken)
     {
         var surface = context.RequestServices.GetRequiredService<McpOperatorSurface>();
+        var sessions = context.RequestServices.GetRequiredService<McpSessionManager>();
         var logger = context.RequestServices.GetRequiredService<ILogger<McpOperatorSurface>>();
 
         JsonDocument? document;
@@ -88,6 +118,23 @@ internal static class McpEndpointExtensions
         using (document)
         {
             var root = document.RootElement;
+            var isInitialize = IsInitialize(root);
+
+            // Streamable-HTTP session enforcement: when the client presents an
+            // Mcp-Session-Id it MUST be one this server issued, otherwise the
+            // spec requires HTTP 404 so the client knows to re-initialize. The
+            // initialize request itself never carries a (validated) session id —
+            // it is how a session is established — so it bypasses validation.
+            if (!isInitialize
+                && context.Request.Headers.TryGetValue(McpSessionManager.SessionHeaderName, out var presented)
+                && !string.IsNullOrEmpty(presented.ToString())
+                && !sessions.IsValid(presented.ToString()))
+            {
+                McpLog.SessionRejected(logger, "unknown-or-expired");
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                return;
+            }
+
             if (root.ValueKind == JsonValueKind.Array)
             {
                 await HandleBatchAsync(context, surface, root, cancellationToken).ConfigureAwait(false);
@@ -113,8 +160,89 @@ internal static class McpEndpointExtensions
                 return;
             }
 
+            // A successful initialize establishes a session. Issue the id on the
+            // Mcp-Session-Id response header so the client echoes it on every
+            // subsequent request.
+            if (isInitialize && response.Error is null)
+            {
+                var sessionId = sessions.CreateSession();
+                context.Response.Headers[McpSessionManager.SessionHeaderName] = sessionId;
+                McpLog.SessionIssued(logger, sessionId);
+            }
+
             await WriteSingleAsync(context, response, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Handles <c>GET /mcp</c>: opens the server-to-client SSE stream defined by
+    /// the Streamable-HTTP transport. A valid <c>Mcp-Session-Id</c> is required;
+    /// the client must also accept <c>text/event-stream</c>. The stream stays
+    /// open (emitting no events in this increment — server-initiated progress and
+    /// listChanged notifications are a follow-up) until the client disconnects.
+    /// </summary>
+    private static async Task HandleGetAsync(HttpContext context, CancellationToken cancellationToken)
+    {
+        var sessions = context.RequestServices.GetRequiredService<McpSessionManager>();
+        var logger = context.RequestServices.GetRequiredService<ILogger<McpOperatorSurface>>();
+
+        if (!AcceptsEventStream(context))
+        {
+            // The transport reserves GET for the SSE channel; a client that does
+            // not accept text/event-stream cannot use it.
+            context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+            return;
+        }
+
+        var sessionId = context.Request.Headers[McpSessionManager.SessionHeaderName].ToString();
+        if (string.IsNullOrEmpty(sessionId) || !sessions.IsValid(sessionId))
+        {
+            McpLog.SessionRejected(logger, "stream-requires-valid-session");
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        StartEventStream(context);
+        // Flush the response head so the client (and proxies) see the open SSE
+        // stream immediately, before any server-initiated frame is available.
+        await context.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        // Hold the stream open for server-initiated messages. No frames are
+        // pushed yet (progress/listChanged land in a follow-up); the stream
+        // closes when the client cancels or disconnects.
+        try
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Client disconnected — normal stream teardown.
+        }
+    }
+
+    /// <summary>
+    /// Handles <c>DELETE /mcp</c>: terminates the session named by the
+    /// <c>Mcp-Session-Id</c> header. Returns 204 when a session was removed and
+    /// 404 when the id is unknown, per the Streamable-HTTP transport.
+    /// </summary>
+    private static Task HandleDeleteAsync(HttpContext context, CancellationToken cancellationToken)
+    {
+        var sessions = context.RequestServices.GetRequiredService<McpSessionManager>();
+        var logger = context.RequestServices.GetRequiredService<ILogger<McpOperatorSurface>>();
+
+        var sessionId = context.Request.Headers[McpSessionManager.SessionHeaderName].ToString();
+        if (string.IsNullOrEmpty(sessionId))
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Task.CompletedTask;
+        }
+
+        var found = sessions.Terminate(sessionId);
+        McpLog.SessionTerminated(logger, sessionId, found);
+        context.Response.StatusCode = found
+            ? StatusCodes.Status204NoContent
+            : StatusCodes.Status404NotFound;
+        return Task.CompletedTask;
     }
 
     private static async Task HandleBatchAsync(
@@ -177,15 +305,7 @@ internal static class McpEndpointExtensions
             return;
         }
 
-        context.Response.StatusCode = StatusCodes.Status200OK;
-        context.Response.ContentType = JsonMimeType;
-        await JsonSerializer
-            .SerializeAsync(
-                context.Response.Body,
-                responses,
-                McpJsonContext.Default.ListMcpJsonRpcResponse,
-                cancellationToken)
-            .ConfigureAwait(false);
+        await WriteBatchAsync(context, responses, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -250,10 +370,108 @@ internal static class McpEndpointExtensions
         CancellationToken cancellationToken)
     {
         context.Response.StatusCode = StatusCodes.Status200OK;
+
+        if (AcceptsEventStream(context))
+        {
+            // Streamable-HTTP: when the client accepts text/event-stream the
+            // server MAY answer a POST with an SSE stream. We emit the single
+            // JSON-RPC response as one `message` event and close the stream.
+            var payload = JsonSerializer.Serialize(response, McpJsonContext.Default.McpJsonRpcResponse);
+            StartEventStream(context);
+            await WriteEventAsync(context, payload, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
         context.Response.ContentType = JsonMimeType;
         await JsonSerializer
             .SerializeAsync(context.Response.Body, response, McpJsonContext.Default.McpJsonRpcResponse, cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    private static async Task WriteBatchAsync(
+        HttpContext context,
+        List<McpJsonRpcResponse> responses,
+        CancellationToken cancellationToken)
+    {
+        context.Response.StatusCode = StatusCodes.Status200OK;
+
+        if (AcceptsEventStream(context))
+        {
+            var payload = JsonSerializer.Serialize(responses, McpJsonContext.Default.ListMcpJsonRpcResponse);
+            StartEventStream(context);
+            await WriteEventAsync(context, payload, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        context.Response.ContentType = JsonMimeType;
+        await JsonSerializer
+            .SerializeAsync(
+                context.Response.Body,
+                responses,
+                McpJsonContext.Default.ListMcpJsonRpcResponse,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the request's <c>Accept</c> header advertises
+    /// <c>text/event-stream</c> (exactly or via a <c>*/*</c> / <c>text/*</c>
+    /// wildcard), meaning the server may answer with a Server-Sent-Events stream.
+    /// </summary>
+    private static bool AcceptsEventStream(HttpContext context)
+    {
+        var accept = context.Request.Headers.Accept;
+        if (accept.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var value in accept)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                continue;
+            }
+
+            foreach (var media in value.Split(','))
+            {
+                // Strip any q-value/parameters after ';' and trim whitespace.
+                var token = media.Split(';', 2)[0].Trim();
+                if (token.Equals(EventStreamMimeType, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void StartEventStream(HttpContext context)
+    {
+        context.Response.ContentType = EventStreamMimeType;
+        // SSE responses must not be cached or buffered along the path.
+        context.Response.Headers[HeaderNames.CacheControl] = "no-cache";
+        context.Response.Headers[HeaderNames.Connection] = "keep-alive";
+    }
+
+    /// <summary>
+    /// Writes a single SSE <c>message</c> event whose <c>data:</c> field carries
+    /// the JSON-RPC payload, terminated by the blank line the SSE wire format
+    /// requires, then flushes so the client receives the frame promptly.
+    /// </summary>
+    private static async Task WriteEventAsync(HttpContext context, string json, CancellationToken cancellationToken)
+    {
+        var builder = new StringBuilder();
+        builder.Append("event: message\n");
+        // A JSON payload never contains a raw newline at the top level after
+        // serialization, so a single data: line is sufficient; the blank line
+        // delimits the event per the SSE specification.
+        builder.Append("data: ").Append(json).Append("\n\n");
+
+        var bytes = Encoding.UTF8.GetBytes(builder.ToString());
+        await context.Response.Body.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+        await context.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private static McpJsonRpcResponse ErrorResponse(JsonElement id, McpJsonRpcError error) => new()
@@ -261,6 +479,18 @@ internal static class McpEndpointExtensions
         Id = id,
         Error = error
     };
+
+    /// <summary>
+    /// Returns <c>true</c> when the supplied JSON element is a single JSON-RPC
+    /// object whose <c>method</c> is <c>initialize</c>. Used by the transport to
+    /// decide whether to bypass session validation and whether to issue a new
+    /// session id on success.
+    /// </summary>
+    private static bool IsInitialize(JsonElement message) =>
+        message.ValueKind == JsonValueKind.Object
+        && message.TryGetProperty("method", out var methodElement)
+        && methodElement.ValueKind == JsonValueKind.String
+        && string.Equals(methodElement.GetString(), "initialize", StringComparison.Ordinal);
 
     /// <summary>
     /// Returns <c>true</c> when any element of the batch carries the
@@ -273,14 +503,7 @@ internal static class McpEndpointExtensions
     {
         foreach (var element in batch.EnumerateArray())
         {
-            if (element.ValueKind != JsonValueKind.Object)
-            {
-                continue;
-            }
-
-            if (element.TryGetProperty("method", out var methodElement)
-                && methodElement.ValueKind == JsonValueKind.String
-                && string.Equals(methodElement.GetString(), "initialize", StringComparison.Ordinal))
+            if (IsInitialize(element))
             {
                 return true;
             }

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpLog.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpLog.cs
@@ -56,4 +56,13 @@ internal static partial class McpLog
 
     [LoggerMessage(8165, LogLevel.Warning, "MCP dispatch failed unexpectedly: Method={Method}")]
     public static partial void DispatchFailed(ILogger logger, string method, Exception exception);
+
+    [LoggerMessage(8166, LogLevel.Debug, "MCP session issued: SessionId={SessionId}")]
+    public static partial void SessionIssued(ILogger logger, string sessionId);
+
+    [LoggerMessage(8167, LogLevel.Information, "MCP session rejected: Reason={Reason}")]
+    public static partial void SessionRejected(ILogger logger, string reason);
+
+    [LoggerMessage(8168, LogLevel.Debug, "MCP session terminated: SessionId={SessionId}, Found={Found}")]
+    public static partial void SessionTerminated(ILogger logger, string sessionId, bool found);
 }

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
@@ -139,6 +139,11 @@ internal static class McpServiceCollectionExtensions
 
         services.TryAddSingleton<McpOperatorSurface>();
 
+        // Streamable-HTTP session registry (honua-server#1954). A process-wide
+        // singleton so a session id issued on initialize is recognized on every
+        // subsequent POST/GET/DELETE handled by the same host.
+        services.TryAddSingleton<McpSessionManager>();
+
         return services;
     }
 

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpSessionManager.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpSessionManager.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+
+namespace Honua.Ai.Protocols.Mcp;
+
+/// <summary>
+/// Tracks MCP Streamable-HTTP sessions for the operator surface. The
+/// Streamable-HTTP transport (MCP 2025-03-26) lets a server assign a session id
+/// during <c>initialize</c> and return it on the <c>Mcp-Session-Id</c> response
+/// header; the client MUST then echo that id on every subsequent request. The
+/// server validates the id and returns HTTP 404 once a session is unknown or
+/// terminated so the client knows to re-initialize.
+/// See https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#session-management.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is an in-process registry: session state lives in the host's memory and
+/// is not shared across replicas. That matches the current single-process MCP
+/// usage and the session-affinity expectation in the spec ("the server MAY make
+/// the session sticky"). A Redis-backed implementation can replace this behind
+/// the same surface when multi-node MCP fan-out lands (honua-server#1954
+/// follow-up).
+/// </para>
+/// <para>
+/// Session ids are required by the spec to be globally unique, cryptographically
+/// secure, and to contain only visible ASCII characters (0x21–0x7E). A 256-bit
+/// random value rendered as lowercase hex satisfies all three.
+/// </para>
+/// </remarks>
+internal sealed class McpSessionManager
+{
+    /// <summary>
+    /// HTTP header carrying the MCP session id on initialize responses and on
+    /// every subsequent client request, per the Streamable-HTTP transport.
+    /// </summary>
+    public const string SessionHeaderName = "Mcp-Session-Id";
+
+    private const int SessionIdByteLength = 32; // 256 bits.
+
+    private readonly ConcurrentDictionary<string, byte> _sessions = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Creates and registers a new session, returning its id. Invoked when the
+    /// server accepts an <c>initialize</c> request and chooses to operate in
+    /// stateful (session-bearing) mode.
+    /// </summary>
+    public string CreateSession()
+    {
+        var id = GenerateSessionId();
+        _sessions[id] = 0;
+        return id;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the supplied session id is currently active.
+    /// </summary>
+    public bool IsValid(string sessionId) =>
+        !string.IsNullOrEmpty(sessionId) && _sessions.ContainsKey(sessionId);
+
+    /// <summary>
+    /// Terminates a session so subsequent requests bearing its id are rejected
+    /// with HTTP 404. Returns <c>true</c> when an active session was removed.
+    /// Invoked when a client issues <c>DELETE /mcp</c> to end the session.
+    /// </summary>
+    public bool Terminate(string sessionId) =>
+        !string.IsNullOrEmpty(sessionId) && _sessions.TryRemove(sessionId, out _);
+
+    private static string GenerateSessionId()
+    {
+        Span<byte> buffer = stackalloc byte[SessionIdByteLength];
+        RandomNumberGenerator.Fill(buffer);
+        return Convert.ToHexStringLower(buffer);
+    }
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -1267,9 +1267,13 @@ public static class EndpointRegistry
         new("GET", "/samples/stac-ops"),
 
         // MCP operator surface (#728) — JSON-RPC dispatch over a single route.
+        // Streamable-HTTP transport (#1954) adds the SSE GET stream and the
+        // session-termination DELETE alongside the POST dispatcher.
         new("POST", "/v1/grounding/spec/mutate"),
         new("POST", "/v1/grounding/spec/summarize"),
         new("POST", "/mcp"),
+        new("GET", "/mcp"),
+        new("DELETE", "/mcp"),
 
         // Spec plan / apply engine (#789).
         new("POST", "/v1/spec/validate"),

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpEndpointIntegrationTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpEndpointIntegrationTests.cs
@@ -791,11 +791,222 @@ public sealed class McpEndpointIntegrationTests : IAsyncLifetime
         error.GetProperty("data").GetProperty("code").GetString().Should().Be("invalid_argument");
     }
 
-    private async Task<HttpResponseMessage> PostRpcAsync(string body)
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("POST /mcp")]
+    [InterfaceOperation(TestProtocols.Mcp, "initialize")]
+    public async Task Initialize_Success_IssuesMcpSessionIdHeader()
     {
-        using var content = new StringContent(body, Encoding.UTF8);
+        var response = await PostRpcAsync("""
+            {"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+                "protocolVersion":"2025-03-26",
+                "capabilities":{},
+                "clientInfo":{"name":"honua-tests","version":"1.0.0"}
+            }}
+            """);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Streamable-HTTP transport: a successful initialize establishes a
+        // session and returns its id on the Mcp-Session-Id response header.
+        response.Headers.TryGetValues("Mcp-Session-Id", out var values).Should().BeTrue();
+        var sessionId = values!.Single();
+        sessionId.Should().NotBeNullOrWhiteSpace();
+        // Session ids must contain only visible ASCII per the spec; hex satisfies it.
+        sessionId.Should().MatchRegex("^[0-9a-f]+$");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("POST /mcp")]
+    public async Task Initialize_Failure_DoesNotIssueSessionHeader()
+    {
+        // A rejected initialize (missing params) must not establish a session.
+        var response = await PostRpcAsync("""
+            {"jsonrpc":"2.0","id":1,"method":"initialize"}
+            """);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.TryGetValues("Mcp-Session-Id", out _).Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("POST /mcp")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/list")]
+    public async Task Request_WithIssuedSessionId_IsAccepted()
+    {
+        var sessionId = await InitializeAndGetSessionIdAsync();
+
+        var response = await PostRpcAsync(
+            """{"jsonrpc":"2.0","id":2,"method":"tools/list"}""",
+            sessionId);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = await ReadJsonAsync(response);
+        document.RootElement.TryGetProperty("error", out _).Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("POST /mcp")]
+    public async Task Request_WithUnknownSessionId_Returns404()
+    {
+        // The Streamable-HTTP transport requires HTTP 404 when a client presents
+        // an Mcp-Session-Id the server never issued (or that has expired), so the
+        // client knows to re-run initialize.
+        var response = await PostRpcAsync(
+            """{"jsonrpc":"2.0","id":2,"method":"tools/list"}""",
+            sessionId: "deadbeefdeadbeefdeadbeefdeadbeef");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("DELETE /mcp")]
+    public async Task Delete_TerminatesSession_AndSubsequentUseReturns404()
+    {
+        var sessionId = await InitializeAndGetSessionIdAsync();
+
+        using var deleteRequest = new HttpRequestMessage(HttpMethod.Delete, "/mcp");
+        deleteRequest.Headers.Add("Mcp-Session-Id", sessionId);
+        var deleteResponse = await _client.SendAsync(deleteRequest);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // After termination the same id must be rejected with 404.
+        var afterDelete = await PostRpcAsync(
+            """{"jsonrpc":"2.0","id":3,"method":"tools/list"}""",
+            sessionId);
+        afterDelete.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("DELETE /mcp")]
+    public async Task Delete_UnknownSession_Returns404()
+    {
+        using var deleteRequest = new HttpRequestMessage(HttpMethod.Delete, "/mcp");
+        deleteRequest.Headers.Add("Mcp-Session-Id", "00000000000000000000000000000000");
+        var response = await _client.SendAsync(deleteRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("POST /mcp")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/list")]
+    public async Task Request_WithEventStreamAccept_ReturnsSseMessageFrame()
+    {
+        // Streamable-HTTP: when the client accepts text/event-stream the server
+        // may answer a POST with a single SSE `message` event carrying the
+        // JSON-RPC response, rather than a plain application/json body.
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp")
+        {
+            Content = JsonContent("""{"jsonrpc":"2.0","id":"sse-1","method":"tools/list"}""")
+        };
+        request.Headers.Accept.Clear();
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/event-stream");
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("event: message");
+        body.Should().Contain("data: ");
+
+        // The data line must carry a parseable JSON-RPC response with the echoed id.
+        var dataLine = body
+            .Split('\n')
+            .Single(line => line.StartsWith("data: ", StringComparison.Ordinal))["data: ".Length..];
+        using var document = JsonDocument.Parse(dataLine);
+        document.RootElement.GetProperty("id").GetString().Should().Be("sse-1");
+        document.RootElement.GetProperty("result").GetProperty("tools").ValueKind
+            .Should().Be(JsonValueKind.Array);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /mcp")]
+    public async Task Get_WithValidSession_OpensEventStream()
+    {
+        var sessionId = await InitializeAndGetSessionIdAsync();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/mcp");
+        request.Headers.Add("Mcp-Session-Id", sessionId);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        // The SSE channel stays open for server-initiated messages; read only the
+        // response head (status + headers) so the test does not block on the body.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var response = await _client.SendAsync(
+            request, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/event-stream");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /mcp")]
+    public async Task Get_WithoutValidSession_Returns404()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/mcp");
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        var response = await _client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /mcp")]
+    public async Task Get_WithoutEventStreamAccept_Returns405()
+    {
+        var sessionId = await InitializeAndGetSessionIdAsync();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/mcp");
+        request.Headers.Add("Mcp-Session-Id", sessionId);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(JsonMediaType));
+
+        var response = await _client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+    }
+
+    private async Task<string> InitializeAndGetSessionIdAsync()
+    {
+        var response = await PostRpcAsync("""
+            {"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+                "protocolVersion":"2025-03-26",
+                "capabilities":{},
+                "clientInfo":{"name":"honua-tests","version":"1.0.0"}
+            }}
+            """);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.TryGetValues("Mcp-Session-Id", out var values).Should().BeTrue();
+        return values!.Single();
+    }
+
+    private static StringContent JsonContent(string body)
+    {
+        var content = new StringContent(body, Encoding.UTF8);
         content.Headers.ContentType = new MediaTypeHeaderValue(JsonMediaType);
-        return await _client.PostAsync("/mcp", content);
+        return content;
+    }
+
+    private async Task<HttpResponseMessage> PostRpcAsync(string body, string? sessionId = null)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp")
+        {
+            Content = JsonContent(body)
+        };
+        if (sessionId is not null)
+        {
+            request.Headers.Add("Mcp-Session-Id", sessionId);
+        }
+
+        return await _client.SendAsync(request);
     }
 
     private static async Task<JsonDocument> ReadJsonAsync(HttpResponseMessage response)

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpSessionManagerTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpSessionManagerTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Linq;
+using FluentAssertions;
+using Honua.Ai.Protocols.Mcp;
+using Honua.TestKit.Attributes;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Unit tests for the MCP Streamable-HTTP session registry (honua-server#1954).
+/// These run without Docker/PostGIS so the session-id issuance and validation
+/// invariants are covered even when the full integration harness is unavailable.
+/// </summary>
+public sealed class McpSessionManagerTests
+{
+    [UnitTest]
+    public void CreateSession_IssuesUniqueVisibleAsciiIds()
+    {
+        var manager = new McpSessionManager();
+
+        var ids = Enumerable.Range(0, 100).Select(_ => manager.CreateSession()).ToArray();
+
+        ids.Should().OnlyContain(id => !string.IsNullOrWhiteSpace(id));
+        ids.Distinct().Should().HaveCount(ids.Length, "session ids must be globally unique");
+        // The spec requires session ids to contain only visible ASCII (0x21-0x7E).
+        ids.Should().OnlyContain(id => id.All(c => c >= '!' && c <= '~'));
+    }
+
+    [UnitTest]
+    public void IsValid_ReturnsTrueForIssuedSession_AndFalseOtherwise()
+    {
+        var manager = new McpSessionManager();
+        var id = manager.CreateSession();
+
+        manager.IsValid(id).Should().BeTrue();
+        manager.IsValid("never-issued").Should().BeFalse();
+        manager.IsValid(string.Empty).Should().BeFalse();
+        manager.IsValid(null!).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void Terminate_RemovesSession_AndIsIdempotent()
+    {
+        var manager = new McpSessionManager();
+        var id = manager.CreateSession();
+
+        manager.Terminate(id).Should().BeTrue();
+        manager.IsValid(id).Should().BeFalse();
+        // A second termination of the same id reports no active session removed.
+        manager.Terminate(id).Should().BeFalse();
+        manager.Terminate("never-issued").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1954

## Summary
First, foundational slice of the MCP Streamable-HTTP transport (#1954). Adds
`Mcp-Session-Id` session handling and the Server-Sent-Events response path to the
operator surface so the MCP transport matches the 2025-03-26 Streamable-HTTP
spec the server targets. This establishes the session + streaming plumbing the
remaining #1954 acceptance criteria (progress notifications, `listChanged`
firing, protocol-revision bump) build on top of; those are intentionally
deferred to follow-up PRs and the issue stays open.

## Changes Made
- Issue an `Mcp-Session-Id` on a successful `initialize` and echo/validate it on
  subsequent `POST /mcp` requests; return HTTP 404 when a presented id is unknown
  or terminated so the client knows to re-initialize. Stateless clients (no
  session header) remain supported.
- Add the SSE response path: when the client accepts `text/event-stream`, the
  POST response is framed as a single SSE `message` event; new `GET /mcp` opens
  the server-to-client SSE stream and new `DELETE /mcp` terminates a session.
- New `McpSessionManager` (DI singleton) issues 256-bit cryptographically-random,
  visible-ASCII session ids and tracks them in process.
- Register `GET /mcp` and `DELETE /mcp` in `EndpointRegistry`; add session/SSE
  log events.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

`McpSessionManager` unit tests (issuance uniqueness/charset, validation,
idempotent termination) pass under Release. New integration tests cover session
issuance on initialize, accept on valid id, 404 on unknown id, SSE message
framing on POST, and the GET/DELETE session endpoints. The `[Collection("Database")]`
integration tests require a Docker/PostGIS daemon that is unavailable in this
environment, so they were build-verified only; the endpoint-registry-drift and
endpoint-authorization-guard architecture tests pass.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
