### PR TITLE
ci(merge-train): batch size 3->10 + fix self-chain condition (train_apply is '1')

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -34,7 +34,7 @@ on:
         description: 'Max PRs per batch.'
         type: string
         required: false
-        default: '3'
+        default: '10'
       use_llm:
         description: 'Enable the OPTIONAL gated Bedrock LLM judgment layer (TRAIN_LLM=1). Off by default; every gate has a deterministic fallback. Requires secrets.BEDROCK_AWS_ACCESS_KEY_ID / secrets.BEDROCK_AWS_SECRET_ACCESS_KEY.'
         type: boolean
@@ -121,7 +121,7 @@ jobs:
             apply=1
           fi
           echo "train_apply=${apply}" >> "$GITHUB_OUTPUT"
-          mb="${DISPATCH_MAX_BATCH:-3}"; [[ -z "${mb}" ]] && mb=3
+          mb="${DISPATCH_MAX_BATCH:-10}"; [[ -z "${mb}" ]] && mb=10
           echo "max_batch=${mb}" >> "$GITHUB_OUTPUT"
           # TRAIN_LLM: on whenever we're applying live AND Bedrock keys exist
           # (autonomous schedule/workflow_run, or an explicit dispatch).
@@ -283,7 +283,7 @@ jobs:
           if [[ "${ready:-0}" -gt 0 ]]; then
             echo "Dispatching the next train run (continuous drain; concurrency-guarded, single-instance)."
             gh workflow run merge-train.yml --repo "${GITHUB_REPOSITORY}" --ref trunk \
-              -f train_apply=true -f use_llm=true -f use_autofix=true -f max_batch=3
+              -f train_apply=true -f use_llm=true -f use_autofix=true -f max_batch=10
           else
             echo "No selectable PRs remain — chain stops; the */15 schedule remains as the backstop."
           fi

--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -258,7 +258,7 @@ jobs:
       # re-dispatch and fall back to the schedule. Only applying runs chain (a dry-run
       # report must never spawn live runs).
       - name: Self-chain next run while PRs remain
-        if: always() && steps.mode.outputs.train_apply == 'true'
+        if: always() && steps.mode.outputs.train_apply == '1'
         env:
           # MUST be the PAT: a `gh workflow run` authenticated with GITHUB_TOKEN does
           # NOT trigger a new workflow run (GitHub's recursion guard), so the chain


### PR DESCRIPTION
## Summary
Two throughput fixes for the merge train:
1. Batch size 3 -> 10. The batch CI runs all 63 shards regardless of batch size, so landing more PRs per run is the same ~2h CI cost; 3-per-batch under-utilized it while the fleet adds PRs faster than it drains.
2. Fix the #2075 self-chain condition: the resolve step emits train_apply=1/0 (not true/false), so the self-chain if guarded on =='true' was SKIPPED every run — continuous drain never fired. Now ==' 1'.

## Changes Made
- max_batch default + resolve fallback + self-chain dispatch: 3 -> 10.
- Self-chain step if: steps.mode.outputs.train_apply == '1' (was 'true').

## Breaking Changes
None.

## Gate Impact
- [x] No gate impact (merge-train CI-infra only)

## Testing
- [x] YAML validated; verified run 28082323935 resolved TRAIN_APPLY=1 while the self-chain step was completed/skipped, confirming the '1' vs 'true' bug.

Related to #1387