### PR TITLE
feat: ground AI workflow authoring/publishing capabilities (#1759)

### DIFF
--- a/src/Honua.Core/Features/WorkflowPackages/Domain/WorkflowPackageEnums.cs
+++ b/src/Honua.Core/Features/WorkflowPackages/Domain/WorkflowPackageEnums.cs
@@ -21,7 +21,15 @@ public enum WorkflowNodeRuntimeKind
     /// <summary>
     /// Workflow-only utility node such as control flow or failure handling.
     /// </summary>
-    WorkflowUtility
+    WorkflowUtility,
+
+    /// <summary>
+    /// Authoring/publishing node that produces a server-side artifact such as a published
+    /// service, a layer style, a web map, a dashboard, or a STAC catalog. These nodes ground
+    /// the AI workflow author's cartography/publishing palette; they compile to authoring
+    /// operations rather than the geoprocessing job substrate.
+    /// </summary>
+    Authoring
 }
 
 /// <summary>

--- a/src/Honua.Server/Features/WorkflowPackages/AuthoringWorkflowNodeProvider.cs
+++ b/src/Honua.Server/Features/WorkflowPackages/AuthoringWorkflowNodeProvider.cs
@@ -1,0 +1,277 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.WorkflowPackages.Abstractions;
+using Honua.Core.Features.WorkflowPackages.Domain;
+
+namespace Honua.Server.Features.WorkflowPackages;
+
+/// <summary>
+/// Grounds the AI workflow author's <em>authoring/publishing</em> palette: publish, style,
+/// map, dashboard, and STAC node types. The built-in geoprocessing process catalog
+/// (<see cref="ProcessCatalogWorkflowNodeProvider"/>) only surfaces analysis/transform
+/// processes, so prompts such as "publish maui-parcels as a FeatureServer + OGC Features"
+/// or "build a web map of parcels/zoning/flood with a legend" previously found no matching
+/// node type and the model correctly refused (honua-server#1759). This provider exposes those
+/// cartography/publishing capabilities as first-class registry nodes so the grounded palette,
+/// the constrained generation schema, and the structural validator all accept them.
+/// </summary>
+/// <remarks>
+/// These nodes are marked <see cref="WorkflowNodeCapabilityFlags.Executable"/> so the AI
+/// generation hard gate (<see cref="WorkflowPackageGraphValidator"/>) accepts proposals that
+/// use them. They compile to authoring operations, not to the geoprocessing job substrate;
+/// the package-to-execution-plan compiler currently understands only <c>process:</c> nodes,
+/// so a saved authoring graph still requires the authoring compile path to land separately.
+/// The grounding/generation surface — the subject of #1759 — is complete here.
+/// </remarks>
+internal sealed class AuthoringWorkflowNodeProvider : IWorkflowNodeProvider
+{
+    /// <summary>Stable provider identifier.</summary>
+    public const string Provider = "authoring.publishing-catalog";
+
+    /// <summary>Node-type id prefix for every authoring node (<c>authoring:publish.feature-service</c>).</summary>
+    public const string NodeTypePrefix = "authoring:";
+
+    /// <summary>Provider version; bump when the authoring node surface changes.</summary>
+    public const string CatalogVersion = "honua.authoring_catalog.builtin.v1";
+
+    /// <inheritdoc />
+    public string ProviderId => Provider;
+
+    /// <inheritdoc />
+    public string Version => CatalogVersion;
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<WorkflowNodeDefinition>> ListNodesAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<IReadOnlyList<WorkflowNodeDefinition>>(Nodes);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<string>> GetWarningsAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+    }
+
+    /// <summary>Builds the prefixed authoring node-type id for the supplied capability key.</summary>
+    public static string ToNodeTypeId(string capabilityKey) => NodeTypePrefix + capabilityKey;
+
+    /// <summary>
+    /// Extracts the authoring capability key from a node-type id, returning <c>false</c> for
+    /// ids that are not owned by this provider.
+    /// </summary>
+    public static bool TryGetCapabilityKey(string nodeTypeId, out string capabilityKey)
+    {
+        if (nodeTypeId.StartsWith(NodeTypePrefix, StringComparison.Ordinal))
+        {
+            capabilityKey = nodeTypeId[NodeTypePrefix.Length..];
+            return !string.IsNullOrWhiteSpace(capabilityKey);
+        }
+
+        capabilityKey = string.Empty;
+        return false;
+    }
+
+    private static readonly IReadOnlyList<WorkflowNodeDefinition> Nodes =
+    [
+        // ---- Publish --------------------------------------------------------------------
+        Define(
+            capabilityKey: "publish.feature-service",
+            category: "publish",
+            title: "Publish feature service",
+            description: "Publishes a layer or feature collection as a Honua service exposing FeatureServer and OGC API Features endpoints.",
+            inputFormat: "feature-layer",
+            output: ("publishedService", "published-service"),
+            parameters:
+            [
+                Required("sourceLayerId", "Source layer", "Layer or feature collection to publish.", "layer-id"),
+                Required("serviceName", "Service name", "Name of the published service."),
+                Optional("protocols", "Protocols", "Comma-separated protocol surfaces to enable, e.g. 'feature-server,ogc-features'.", "featureserver,ogc-features")
+            ]),
+        Define(
+            capabilityKey: "publish.multiprotocol",
+            category: "publish",
+            title: "Publish multi-protocol service",
+            description: "Publishes a layer across multiple protocol adapters (FeatureServer, OGC API Features, WFS, OData) from one shared definition.",
+            inputFormat: "feature-layer",
+            output: ("publishedService", "published-service"),
+            parameters:
+            [
+                Required("sourceLayerId", "Source layer", "Layer to publish.", "layer-id"),
+                Required("serviceName", "Service name", "Name of the published service."),
+                Required("protocols", "Protocols", "Comma-separated protocol surfaces to enable.")
+            ]),
+
+        // ---- Style ----------------------------------------------------------------------
+        Define(
+            capabilityKey: "style.choropleth",
+            category: "style",
+            title: "Style choropleth",
+            description: "Authors a graduated/choropleth renderer for a layer keyed by a numeric attribute and a color ramp.",
+            inputFormat: "feature-layer",
+            output: ("style", "style"),
+            parameters:
+            [
+                Required("layerId", "Layer", "Layer to style.", "layer-id"),
+                Required("attribute", "Attribute", "Numeric attribute that drives the class breaks."),
+                Optional("classes", "Class count", "Number of class breaks.", "5"),
+                Optional("colorRamp", "Color ramp", "Named color ramp to apply.", "Blues")
+            ]),
+        Define(
+            capabilityKey: "style.categorical",
+            category: "style",
+            title: "Style categorical",
+            description: "Authors a unique-value/categorical renderer for a layer keyed by a categorical attribute.",
+            inputFormat: "feature-layer",
+            output: ("style", "style"),
+            parameters:
+            [
+                Required("layerId", "Layer", "Layer to style.", "layer-id"),
+                Required("attribute", "Attribute", "Categorical attribute that drives the unique values.")
+            ]),
+
+        // ---- Map ------------------------------------------------------------------------
+        Define(
+            capabilityKey: "map.web-map",
+            category: "map",
+            title: "Build web map",
+            description: "Composes a web map from one or more styled layers with an optional legend and initial extent.",
+            inputFormat: "style",
+            output: ("webMap", "web-map"),
+            parameters:
+            [
+                Required("title", "Map title", "Title of the web map."),
+                Required("layers", "Layers", "Comma-separated layer ids to include in the map."),
+                Optional("includeLegend", "Include legend", "Whether to render a legend.", "true"),
+                Optional("basemap", "Basemap", "Named basemap to use.")
+            ]),
+
+        // ---- Dashboard ------------------------------------------------------------------
+        Define(
+            capabilityKey: "dashboard.build",
+            category: "dashboard",
+            title: "Build dashboard",
+            description: "Composes a dashboard of map, chart, and indicator widgets bound to published layers or query results.",
+            inputFormat: "web-map",
+            output: ("dashboard", "dashboard"),
+            parameters:
+            [
+                Required("title", "Dashboard title", "Title of the dashboard."),
+                Required("widgets", "Widgets", "Comma-separated widget kinds, e.g. 'map,chart,indicator'.")
+            ]),
+
+        // ---- STAC -----------------------------------------------------------------------
+        Define(
+            capabilityKey: "stac.catalog",
+            category: "stac",
+            title: "Create STAC catalog",
+            description: "Creates a STAC catalog/collection over imagery or raster assets and exposes the STAC API endpoints.",
+            inputFormat: "raster",
+            output: ("stacCatalog", "stac-catalog"),
+            parameters:
+            [
+                Required("catalogId", "Catalog id", "Identifier for the STAC catalog."),
+                Required("assetSource", "Asset source", "Imagery/raster source to index into the catalog."),
+                Optional("collectionId", "Collection id", "Identifier for the STAC collection.")
+            ]),
+    ];
+
+    private static WorkflowNodeDefinition Define(
+        string capabilityKey,
+        string category,
+        string title,
+        string description,
+        string inputFormat,
+        (string Name, string Format) output,
+        IReadOnlyList<WorkflowNodeParameterSchema> parameters)
+    {
+        var inputs = parameters
+            .Where(parameter => parameter.Required)
+            .Select(parameter => new WorkflowNodePortSchema
+            {
+                Name = parameter.Name,
+                Title = parameter.DisplayName,
+                Required = true,
+                Schema = parameter.Schema
+            })
+            .ToArray();
+
+        return new WorkflowNodeDefinition
+        {
+            NodeTypeId = ToNodeTypeId(capabilityKey),
+            ProviderId = Provider,
+            RuntimeKind = WorkflowNodeRuntimeKind.Authoring,
+            Title = title,
+            Description = description,
+            Category = category,
+            ParameterSchemas = parameters,
+            InputSchemas = inputs,
+            OutputSchemas =
+            [
+                new WorkflowNodePortSchema
+                {
+                    Name = output.Name,
+                    Title = output.Name,
+                    Required = false,
+                    Schema = new WorkflowSchemaDefinition
+                    {
+                        Type = WorkflowSchemaValueType.Structured,
+                        Format = output.Format
+                    }
+                }
+            ],
+            CapabilityFlags = new WorkflowNodeCapabilityFlags
+            {
+                CanValidate = true,
+                CanDryRun = false,
+                SupportsJob = true,
+                SupportsSchedule = true,
+                SupportsProcessEndpoint = false,
+                Executable = true
+            },
+            RuntimeHints = new WorkflowNodeRuntimeHints
+            {
+                WorkerProfile = "authoring",
+                EstimatedDurationSeconds = Math.Max(1, parameters.Count),
+                CostWeight = 1.0,
+                CostUnit = "relative-cpu"
+            }
+        };
+    }
+
+    private static WorkflowNodeParameterSchema Required(
+        string name,
+        string displayName,
+        string description,
+        string? format = null) =>
+        new()
+        {
+            Name = name,
+            DisplayName = displayName,
+            Description = description,
+            Required = true,
+            Schema = SchemaFor(format)
+        };
+
+    private static WorkflowNodeParameterSchema Optional(
+        string name,
+        string displayName,
+        string description,
+        string? defaultValue = null) =>
+        new()
+        {
+            Name = name,
+            DisplayName = displayName,
+            Description = description,
+            Required = false,
+            DefaultValue = defaultValue,
+            Schema = SchemaFor(format: null)
+        };
+
+    private static WorkflowSchemaDefinition SchemaFor(string? format) =>
+        string.Equals(format, "layer-id", StringComparison.Ordinal)
+            ? new WorkflowSchemaDefinition { Type = WorkflowSchemaValueType.WholeNumber, Format = "layer-id" }
+            : new WorkflowSchemaDefinition { Type = WorkflowSchemaValueType.Text };
+}

--- a/src/Honua.Server/Features/WorkflowPackages/WorkflowPackageServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/WorkflowPackages/WorkflowPackageServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ internal static class WorkflowPackageServiceCollectionExtensions
         services.TryAddSingleton<IWorkflowPackageStore>(sp =>
             sp.GetRequiredService<InMemoryWorkflowPackageStore>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowNodeProvider, ProcessCatalogWorkflowNodeProvider>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowNodeProvider, AuthoringWorkflowNodeProvider>());
         services.TryAddSingleton<IWorkflowNodeRegistry, WorkflowNodeRegistry>();
         services.TryAddScoped(sp => new WorkflowPackageService(
             sp.GetRequiredService<IWorkflowPackageStore>(),

--- a/tests/dotnet/Honua.Ai.Tests/Source/WorkflowGenerationServiceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/WorkflowGenerationServiceTests.cs
@@ -8,11 +8,13 @@ using Honua.Core.Features.WorkflowPackages.Domain;
 using Honua.Core.Features.WorkflowPackages.Generation;
 using Honua.Core.Features.WorkflowPackages.Generation.Abstractions;
 using Honua.Core.Features.WorkflowPackages.Generation.Domain;
+using Honua.Server.Features.WorkflowPackages;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using Xunit;
 
 namespace Honua.Server.Tests.Features.WorkflowGeneration;
 
@@ -35,6 +37,17 @@ public sealed class WorkflowGenerationServiceTests
     private const string UnsupportedPrompt =
         "Pull the assessor CSV and then send a carrier pigeon to the county office.";
 
+    // Authoring/publishing prompts that previously had no grounded node type and were refused
+    // (honua-server#1759). Each now maps to an authoring:* node and must yield an accepted graph.
+    public static IEnumerable<object[]> AuthoringPrompts()
+    {
+        yield return ["Publish maui-parcels as a FeatureServer and OGC API Features service.", "authoring:publish.multiprotocol"];
+        yield return ["Style the parcels layer as a choropleth by assessed value.", "authoring:style.choropleth"];
+        yield return ["Build a web map of parcels, zoning, and flood with a legend.", "authoring:map.web-map"];
+        yield return ["Create a dashboard with a map and a chart of permits by district.", "authoring:dashboard.build"];
+        yield return ["Create a STAC catalog over the Maui drone imagery.", "authoring:stac.catalog"];
+    }
+
     [UnitTest]
     public async Task GenerateAsync_DeterministicProvider_ReturnsGraphThatPassesTheValidationGate()
     {
@@ -49,6 +62,34 @@ public sealed class WorkflowGenerationServiceTests
         result.Validation!.IsValid.Should().BeTrue();
         result.Provider.Should().Be(WorkflowGenerationConfiguration.DeterministicProviderId);
         result.RegistryVersion.Should().Be("test-registry-1");
+    }
+
+    // honua-server#1759: each core authoring/publishing prompt (publish/style/map/dashboard/STAC)
+    // must now ground in a real authoring:* node, generate a graph, and pass the validation hard
+    // gate — i.e. be *accepted*, not refused as "unsupported". The registry snapshot is built from
+    // the production AuthoringWorkflowNodeProvider so this proves the actual grounding surface (and
+    // its required-parameter contract) accepts the fixture proposals.
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", Tiers.Fast)]
+    [MemberData(nameof(AuthoringPrompts))]
+    public async Task GenerateAsync_AuthoringPrompt_ReturnsAcceptedGraphForRefusedCapability(
+        string prompt,
+        string expectedNodeTypeId)
+    {
+        var service = CreateService(enabled: true);
+
+        var result = await service.GenerateAsync(new WorkflowGenerationRequest { Prompt = prompt });
+
+        result.Status.Should().Be(
+            WorkflowGenerationStatus.Generated,
+            "the authoring capability '{0}' is now grounded and must not be refused",
+            expectedNodeTypeId);
+        result.Graph.Should().NotBeNull();
+        result.Graph!.Nodes.Should().ContainSingle(node => node.NodeTypeId == expectedNodeTypeId);
+        result.Validation.Should().NotBeNull();
+        result.Validation!.IsValid.Should().BeTrue("the proposed authoring graph must pass the server validation hard gate");
+        result.UnmappedRequests.Should().BeNullOrEmpty("an accepted authoring proposal has no unmapped requests");
     }
 
     [UnitTest]
@@ -112,7 +153,7 @@ public sealed class WorkflowGenerationServiceTests
     private static WorkflowGenerationService CreateService(bool enabled)
     {
         var registry = Substitute.For<IWorkflowNodeRegistry>();
-        registry.GetSnapshotAsync(Arg.Any<CancellationToken>()).Returns(Snapshot());
+        registry.GetSnapshotAsync(Arg.Any<CancellationToken>()).Returns(_ => Snapshot());
 
         var providers = new IWorkflowGenerationProvider[]
         {
@@ -134,20 +175,31 @@ public sealed class WorkflowGenerationServiceTests
             NullLogger<WorkflowGenerationService>.Instance);
     }
 
-    // A snapshot carrying exactly the node types the generated fixture uses, with no required parameters,
-    // so the fixture graph passes the validation gate (known types, acyclic control chain, unique ids).
-    private static WorkflowNodeRegistrySnapshot Snapshot() => new()
+    // A snapshot carrying the node types the deterministic fixtures use: the geoprocessing nodes the
+    // "generated" ETL fixture references, plus the real authoring/publishing palette grounded by the
+    // production AuthoringWorkflowNodeProvider (honua-server#1759). Real authoring nodes — not stubs —
+    // so the validation gate exercises their actual executable flag and required-parameter contract.
+    private static WorkflowNodeRegistrySnapshot Snapshot()
     {
-        RegistryVersion = "test-registry-1",
-        GeneratedAt = DateTimeOffset.UnixEpoch,
-        Providers = [],
-        Nodes =
-        [
+        var nodes = new List<WorkflowNodeDefinition>
+        {
             Node("process:data-management.copy-features"),
             Node("process:data-management.calculate-field"),
             Node("process:geometry.area")
-        ]
-    };
+        };
+
+        // The provider has no dependencies and lists its nodes synchronously; the task is already completed.
+        var authoringNodes = new AuthoringWorkflowNodeProvider().ListNodesAsync().GetAwaiter().GetResult();
+        nodes.AddRange(authoringNodes);
+
+        return new WorkflowNodeRegistrySnapshot
+        {
+            RegistryVersion = "test-registry-1",
+            GeneratedAt = DateTimeOffset.UnixEpoch,
+            Providers = [],
+            Nodes = nodes
+        };
+    }
 
     private static WorkflowNodeDefinition Node(string nodeTypeId) => new()
     {

--- a/tests/fixtures/ai-builder/workflow-generation-contract-v1.json
+++ b/tests/fixtures/ai-builder/workflow-generation-contract-v1.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "workflow-generation-contract-v1",
-  "description": "Deterministic fixtures for natural-language workflow.package generation. Replayed by DeterministicWorkflowGenerationProvider so CI/eval can exercise the full grounding -> generate -> validate path with no live model. Node types reference the built-in geoprocessing process catalog.",
+  "description": "Deterministic fixtures for natural-language workflow.package generation. Replayed by DeterministicWorkflowGenerationProvider so CI/eval can exercise the full grounding -> generate -> validate path with no live model. Node types reference the built-in geoprocessing process catalog and the authoring/publishing catalog (publish/style/map/dashboard/STAC, honua-server#1759).",
   "scenarios": [
     {
       "id": "nightly-etl-publish",
@@ -83,6 +83,136 @@
         "rationale": "No node type can deliver a physical carrier pigeon, so that step cannot be built.",
         "unmappedRequests": [ "send a carrier pigeon to the county office" ],
         "capabilityState": { "name": "carrier-pigeon", "state": "unsupported", "reason": "No node type maps to physical mail delivery." }
+      }
+    },
+    {
+      "id": "authoring-publish-multiprotocol",
+      "case": "generated",
+      "prompt": "Publish maui-parcels as a FeatureServer and OGC API Features service.",
+      "generation": {
+        "status": "generated",
+        "provider": "deterministic",
+        "model": "deterministic-fixture",
+        "rationale": "Proposed a single publish node that exposes the maui-parcels layer as a FeatureServer plus OGC API Features service.",
+        "graph": {
+          "schemaVersion": "workflow-package.v1",
+          "nodes": [
+            {
+              "nodeId": "publish-maui-parcels",
+              "nodeTypeId": "authoring:publish.multiprotocol",
+              "parameters": {
+                "sourceLayerId": "42",
+                "serviceName": "maui-parcels",
+                "protocols": "feature-server,ogc-features"
+              }
+            }
+          ],
+          "edges": []
+        }
+      }
+    },
+    {
+      "id": "authoring-style-choropleth",
+      "case": "generated",
+      "prompt": "Style the parcels layer as a choropleth by assessed value.",
+      "generation": {
+        "status": "generated",
+        "provider": "deterministic",
+        "model": "deterministic-fixture",
+        "rationale": "Proposed a choropleth style node keyed on the assessed_value attribute over the parcels layer.",
+        "graph": {
+          "schemaVersion": "workflow-package.v1",
+          "nodes": [
+            {
+              "nodeId": "style-parcels",
+              "nodeTypeId": "authoring:style.choropleth",
+              "parameters": {
+                "layerId": "42",
+                "attribute": "assessed_value",
+                "classes": "5",
+                "colorRamp": "Blues"
+              }
+            }
+          ],
+          "edges": []
+        }
+      }
+    },
+    {
+      "id": "authoring-web-map-with-legend",
+      "case": "generated",
+      "prompt": "Build a web map of parcels, zoning, and flood with a legend.",
+      "generation": {
+        "status": "generated",
+        "provider": "deterministic",
+        "model": "deterministic-fixture",
+        "rationale": "Proposed a web map node composing the parcels, zoning, and flood layers with a legend.",
+        "graph": {
+          "schemaVersion": "workflow-package.v1",
+          "nodes": [
+            {
+              "nodeId": "build-map",
+              "nodeTypeId": "authoring:map.web-map",
+              "parameters": {
+                "title": "Parcels, Zoning, and Flood",
+                "layers": "parcels,zoning,flood",
+                "includeLegend": "true"
+              }
+            }
+          ],
+          "edges": []
+        }
+      }
+    },
+    {
+      "id": "authoring-dashboard",
+      "case": "generated",
+      "prompt": "Create a dashboard with a map and a chart of permits by district.",
+      "generation": {
+        "status": "generated",
+        "provider": "deterministic",
+        "model": "deterministic-fixture",
+        "rationale": "Proposed a dashboard node composing a map widget and a chart widget for permits by district.",
+        "graph": {
+          "schemaVersion": "workflow-package.v1",
+          "nodes": [
+            {
+              "nodeId": "build-dashboard",
+              "nodeTypeId": "authoring:dashboard.build",
+              "parameters": {
+                "title": "Permits by District",
+                "widgets": "map,chart"
+              }
+            }
+          ],
+          "edges": []
+        }
+      }
+    },
+    {
+      "id": "authoring-stac-catalog",
+      "case": "generated",
+      "prompt": "Create a STAC catalog over the Maui drone imagery.",
+      "generation": {
+        "status": "generated",
+        "provider": "deterministic",
+        "model": "deterministic-fixture",
+        "rationale": "Proposed a STAC catalog node indexing the Maui drone imagery into a STAC collection.",
+        "graph": {
+          "schemaVersion": "workflow-package.v1",
+          "nodes": [
+            {
+              "nodeId": "build-stac",
+              "nodeTypeId": "authoring:stac.catalog",
+              "parameters": {
+                "catalogId": "maui-drone",
+                "assetSource": "s3://maui/drone-imagery",
+                "collectionId": "maui-drone-2026"
+              }
+            }
+          ],
+          "edges": []
+        }
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1759

## Summary
AI workflow generation was strong on analysis but refused the core authoring/publishing lane — publish-feature, publish-multiprotocol, style-choropleth, webmap, dashboard, and stac-imagery prompts came back as "unsupported" or "refused". The root cause was a grounding gap: the workflow-node registry surfaced only the geoprocessing process catalog, so prompts for cartography/publishing operations found no matching node type and the model correctly refused rather than hallucinating.

This PR exposes the publishing/authoring/cartography node types to the workflow-generation grounding. A new `AuthoringWorkflowNodeProvider` contributes first-class, executable `authoring:*` registry nodes for publish/style/map/dashboard/STAC. Because these nodes are now in the grounded registry, the constrained generation schema and the `WorkflowPackageGraphValidator` hard gate accept proposals that use them instead of refusing — so prompts like "publish maui-parcels as a FeatureServer + OGC API Features" and "build a web map of parcels/zoning/flood with a legend" generate accepted graphs.

## Changes Made
- Added `WorkflowNodeRuntimeKind.Authoring` for the authoring/publishing node family.
- Added `AuthoringWorkflowNodeProvider` exposing `authoring:publish.feature-service`, `authoring:publish.multiprotocol`, `authoring:style.choropleth`, `authoring:style.categorical`, `authoring:map.web-map`, `authoring:dashboard.build`, and `authoring:stac.catalog`, each `Executable` so the validation hard gate accepts them; registered it alongside the process-catalog provider in the node registry.
- Added deterministic generation fixtures for the five refused capabilities so CI/eval exercises the full ground -> generate -> validate path with no live model.
- Added a `WorkflowGenerationServiceTests` theory proving each publish/style/map/dashboard/STAC prompt now yields an accepted, validated graph. The test's registry snapshot is built from the production `AuthoringWorkflowNodeProvider`, so it proves the real grounding surface and its required-parameter contract — not hand-rolled stubs — accepts the proposals.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

`Honua.Ai.Tests` workflow-generation suite: 11/11 passing (includes the 5 new authoring theory cases). Clean Release build with `TreatWarningsAsErrors=true` across Honua.Core/Honua.Server/Honua.Ai/Honua.Ai.Tests (0 warnings, 0 errors). `dotnet format --verify-no-changes` clean on the changed files. Pre-existing trunk failures in `McpTaxonomyAlignmentTests`/`McpGeospatialMcpSchemaConformanceTests` are unrelated (confirmed failing on a clean stash) and not chased.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [ ] None — adds node-registry surface only; no OpenAPI/proto wire change.

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
