### PR TITLE
ci(merge-train): retry side-effects on secondary rate limits + self-chain on success only

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -257,8 +257,13 @@ jobs:
       # (train:escalated → excluded below), so when nothing is selectable we do NOT
       # re-dispatch and fall back to the schedule. Only applying runs chain (a dry-run
       # report must never spawn live runs).
+      # success() (not always()): a run that FAILED (e.g. a hard error the retries
+      # couldn't absorb) must NOT chain — otherwise a fast-failing run loops every
+      # ~2min and hammers the API. A failed run breaks the chain; the */15 schedule
+      # re-primes it. A normal run (landed / merged-through / escalated) exits 0 and
+      # chains as intended.
       - name: Self-chain next run while PRs remain
-        if: always() && steps.mode.outputs.train_apply == '1'
+        if: success() && steps.mode.outputs.train_apply == '1'
         env:
           # MUST be the PAT: a `gh workflow run` authenticated with GITHUB_TOKEN does
           # NOT trigger a new workflow run (GitHub's recursion guard), so the chain

--- a/scripts/ci/merge-train/lib.sh
+++ b/scripts/ci/merge-train/lib.sh
@@ -164,7 +164,36 @@ train_summary() {
 train_side_effect() {
   if [[ "${TRAIN_APPLY}" == "1" ]]; then
     train_log "APPLY: $*"
-    "$@"
+    # GitHub SECONDARY rate limits surface mid-burst as 401 "Bad credentials",
+    # 403/429, or "secondary rate limit"/"submitted too quickly" EVEN WITH a valid
+    # token and primary quota remaining (observed: 10-PR label burst 401'd on the
+    # 5th write after 4 succeeded). Those are transient, so back off and retry
+    # rather than failing the whole run. stderr is captured for inspection; stdout
+    # flows through untouched so callers that capture command output still work.
+    local attempt=1 max="${TRAIN_SIDE_EFFECT_RETRIES:-4}" delay="${TRAIN_SIDE_EFFECT_BACKOFF:-5}" rc errf
+    errf="$(mktemp 2>/dev/null || echo /tmp/train_se_err.$$)"
+    while :; do
+      # Run directly (NOT inside `if`) so $? is the COMMAND's exit code, not the
+      # if-statement's (which is 0 when the condition is false → would mask failures).
+      "$@" 2>"${errf}"
+      rc=$?
+      if [[ "${rc}" -eq 0 ]]; then
+        cat "${errf}" >&2 2>/dev/null || true
+        rm -f "${errf}"
+        return 0
+      fi
+      if [[ "${attempt}" -lt "${max}" ]] && grep -qiE \
+        "Bad credentials|secondary rate limit|rate limit|submitted too quickly|retry your request|abuse detection|status code: 40[39]|status code: 429|HTTP 40[39]|HTTP 429" \
+        "${errf}" 2>/dev/null; then
+        train_log "transient GitHub API failure (attempt ${attempt}/${max}, rc=${rc}); backing off ${delay}s and retrying"
+        sleep "${delay}"
+        attempt=$(( attempt + 1 )); delay=$(( delay * 3 )); : > "${errf}"
+        continue
+      fi
+      cat "${errf}" >&2 2>/dev/null || true
+      rm -f "${errf}"
+      return "${rc}"
+    done
   else
     train_log "DRY-RUN (skipped): $*"
     return 0


### PR DESCRIPTION
## Summary
A size-10 run failed mid-burst with 401 'Bad credentials' (GitHub secondary rate limit) and the now-firing self-chain looped fast-failing runs. Two fixes.

## Changes Made
- train_side_effect (lib.sh): retry with backoff on secondary-rate-limit signatures (401 Bad credentials / 403 / 429 / 'submitted too quickly'); run command directly so $? is the real exit code; capture stderr for the match, pass stdout through; non-transient failures fail fast.
- Self-chain step: if success() (was always()) so a hard-failed run never loops the chain; schedule re-primes.

## Breaking Changes
None.

## Gate Impact
- [x] No gate impact (merge-train CI-infra only)

## Testing
- [x] bash -n; YAML valid; fixtures 120/0; functional test confirms rc correctness (0/7/1) and stdout passthrough.

Related to #1387