### PR TITLE
feat(sensorthings,edr): observation ingest + streaming and OGC API EDR (#1747, #1757)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -308,6 +308,32 @@
       "maturity": "implemented"
     },
     {
+      "id": "delete-api-v1-admin-oauth-clients-id",
+      "route": "/api/v1/admin/oauth-clients/{id}",
+      "method": "DELETE",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.GetAndDeleteClient_RemovesRegistration"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "delete-api-v1-admin-oauth-scopes-scope",
+      "route": "/api/v1/admin/oauth-scopes/{scope}",
+      "method": "DELETE",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "delete-api-v1-admin-oidc-providers-id",
       "route": "/api/v1/admin/oidc/providers/{id}",
       "method": "DELETE",
@@ -2222,6 +2248,46 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Get_AfterRegister_ReturnsDataset",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Get_Missing_Returns404"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-clients",
+      "route": "/api/v1/admin/oauth-clients",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.ManagementSurface_RequiresAdminAuthorization",
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterAndListClient_ReturnsSecretOnlyAtCreation"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-clients-id",
+      "route": "/api/v1/admin/oauth-clients/{id}",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.GetAndDeleteClient_RemovesRegistration"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-scopes",
+      "route": "/api/v1/admin/oauth-scopes",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -4287,6 +4353,87 @@
         "Honua.Server.Tests.ApiExplorerEndpointTests.Docs_WhenEnabled_ReturnsHtmlPage"
       ],
       "proof_ledger_surface": "platform-http",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-edr",
+      "route": "/edr",
+      "method": "GET",
+      "family": "OGC API - EDR 1.1",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Edr.EdrEndpointsTests.Edr_MetadataEndpoints_ExposeCollectionsWithPositionAndCubeQueries"
+      ],
+      "proof_ledger_surface": "ogc-api-edr",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-edr-collections",
+      "route": "/edr/collections",
+      "method": "GET",
+      "family": "OGC API - EDR 1.1",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Edr.EdrEndpointsTests.Edr_MetadataEndpoints_ExposeCollectionsWithPositionAndCubeQueries"
+      ],
+      "proof_ledger_surface": "ogc-api-edr",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-edr-collections-collectionid",
+      "route": "/edr/collections/{collectionId}",
+      "method": "GET",
+      "family": "OGC API - EDR 1.1",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Edr.EdrEndpointsTests.Edr_MetadataEndpoints_ExposeCollectionsWithPositionAndCubeQueries",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Edr.EdrEndpointsTests.Edr_UnknownCollection_Returns404"
+      ],
+      "proof_ledger_surface": "ogc-api-edr",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-edr-collections-collectionid-cube",
+      "route": "/edr/collections/{collectionId}/cube",
+      "method": "GET",
+      "family": "OGC API - EDR 1.1",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Edr.EdrEndpointsTests.Edr_Cube_MissingBbox_Returns400",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Edr.EdrEndpointsTests.Edr_Cube_ReturnsCoverageJsonGridSubset"
+      ],
+      "proof_ledger_surface": "ogc-api-edr",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-edr-collections-collectionid-position",
+      "route": "/edr/collections/{collectionId}/position",
+      "method": "GET",
+      "family": "OGC API - EDR 1.1",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Edr.EdrEndpointsTests.Edr_Position_InvalidCoords_Returns400",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Edr.EdrEndpointsTests.Edr_Position_ReturnsCoverageJsonPointSeries"
+      ],
+      "proof_ledger_surface": "ogc-api-edr",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-edr-conformance",
+      "route": "/edr/conformance",
+      "method": "GET",
+      "family": "OGC API - EDR 1.1",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Edr.EdrEndpointsTests.Edr_MetadataEndpoints_ExposeCollectionsWithPositionAndCubeQueries"
+      ],
+      "proof_ledger_surface": "ogc-api-edr",
       "maturity": "implemented"
     },
     {
@@ -9467,6 +9614,20 @@
       "maturity": "implemented"
     },
     {
+      "id": "get-sta-v1-1-observationsstream",
+      "route": "/sta/v1.1/ObservationsStream",
+      "method": "GET",
+      "family": "OGC SensorThings API v1.1",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.SensorThings.SensorThingsStreamEndpointsTests.ObservationsStream_Sse_EmitsConnectedThenPushesIngestedObservation",
+        "Honua.Server.Tests.Features.Protocols.SensorThings.SensorThingsStreamEndpointsTests.ObservationsStream_WithoutTransportHeader_Returns400"
+      ],
+      "proof_ledger_surface": "sensorthings-1.1",
+      "maturity": "implemented"
+    },
+    {
       "id": "get-sta-v1-1-observedproperties",
       "route": "/sta/v1.1/ObservedProperties",
       "method": "GET",
@@ -11858,6 +12019,20 @@
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Register_DuplicateId_Returns409",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Register_UnsafeEdgeTable_Returns400",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Register_ValidPayload_Returns201WithDto"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "post-api-v1-admin-oauth-clients",
+      "route": "/api/v1/admin/oauth-clients",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterAndListClient_ReturnsSecretOnlyAtCreation",
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterClient_WithInvalidClientType_ReturnsBadRequest"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -15984,6 +16159,48 @@
       "maturity": "implemented"
     },
     {
+      "id": "post-sta-v1-1-datastreams",
+      "route": "/sta/v1.1/Datastreams",
+      "method": "POST",
+      "family": "OGC SensorThings API v1.1",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.SensorThings.SensorThingsIngestEndpointsTests.PostDatastream_MissingBody_Returns400",
+        "Honua.Server.Tests.Features.Protocols.SensorThings.SensorThingsIngestEndpointsTests.PostDatastream_WithInlineRelatedEntities_CreatesQueryableDatastream"
+      ],
+      "proof_ledger_surface": "sensorthings-1.1",
+      "maturity": "implemented"
+    },
+    {
+      "id": "post-sta-v1-1-datastreams-id-observations",
+      "route": "/sta/v1.1/Datastreams({id})/Observations",
+      "method": "POST",
+      "family": "OGC SensorThings API v1.1",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.SensorThings.SensorThingsIngestEndpointsTests.PostObservation_OnDatastreamNavigation_PersistsToThatDatastream"
+      ],
+      "proof_ledger_surface": "sensorthings-1.1",
+      "maturity": "implemented"
+    },
+    {
+      "id": "post-sta-v1-1-observations",
+      "route": "/sta/v1.1/Observations",
+      "method": "POST",
+      "family": "OGC SensorThings API v1.1",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.SensorThings.SensorThingsIngestEndpointsTests.PostObservation_MissingDatastream_Returns404",
+        "Honua.Server.Tests.Features.Protocols.SensorThings.SensorThingsIngestEndpointsTests.PostObservation_SingleIntoSeededDatastream_PersistsAndIsReadable",
+        "Honua.Server.Tests.Features.Protocols.SensorThings.SensorThingsIngestEndpointsTests.PostObservations_BulkEnvelope_PersistsAllRows"
+      ],
+      "proof_ledger_surface": "sensorthings-1.1",
+      "maturity": "implemented"
+    },
+    {
       "id": "post-stac-search",
       "route": "/stac/search",
       "method": "POST",
@@ -16539,6 +16756,19 @@
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_ChangesMutableFields",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_Missing_Returns404",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_UnsafeVertexTable_Returns400"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "put-api-v1-admin-oauth-scopes",
+      "route": "/api/v1/admin/oauth-scopes",
+      "method": "PUT",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -2485,16 +2485,34 @@
       ],
       "endpointExactMatches": [],
       "endpointContains": [],
-      "operationKeys": [],
+      "operationKeys": [
+        "SensorThings-1.1::datastream.create",
+        "SensorThings-1.1::sensor.ingest"
+      ],
       "proofs": [
         {
           "proofClass": "route-coverage",
-          "proofMechanism": "EndpointRegistry coverage plus endpoint integration tests for the SensorThings API (STA v1.1) Phase 1 read surface: Things/Sensors/ObservedProperties/Datastreams/Observations collections, by-id reads, and Datastream Observations navigation",
+          "proofMechanism": "EndpointRegistry coverage plus endpoint integration tests for the SensorThings API (STA v1.1) read surface (Phase 1: Things/Sensors/ObservedProperties/Datastreams/Observations collections, by-id reads, Datastream Observations navigation), the Phase 2 ingest surface (POST Observations single + bulk, POST Datastreams({id})/Observations, POST Datastreams), and the Phase 3 real-time observation stream (GET /sta/v1.1/ObservationsStream over SSE/WebSocket)",
           "executionLane": "ci:test-all+architecture",
           "evidenceLocations": [
             "src/Honua.Server/EndpointRegistry.cs",
             "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
-            "tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsReadEndpointsTests.cs"
+            "tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsReadEndpointsTests.cs",
+            "tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsIngestEndpointsTests.cs",
+            "tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsStreamEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "honua-server#1747",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "operation-coverage",
+          "proofMechanism": "SensorThings Phase 2 ingest operations datastream.create and sensor.ingest are registered in OperationRegistry and exercised by integration tests carrying [InterfaceOperation(SensorThings-1.1, ...)]",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/OperationRegistry.cs",
+            "tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsIngestEndpointsTests.cs"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
@@ -2503,14 +2521,58 @@
         },
         {
           "proofClass": "scenario-depth",
-          "proofMechanism": "SensorThings read integration tests retain conformance-shaped envelopes (@iot.id/@iot.selfLink/@iot.navigationLink), $expand=Observations inlining, $filter happy-path and negative-path ($filter 400), and $orderby descending observation ordering",
+          "proofMechanism": "SensorThings integration tests retain conformance-shaped read envelopes (@iot.id/@iot.selfLink/@iot.navigationLink), $expand=Observations inlining, $filter happy/negative paths, $orderby descending ordering, ingest round-trips (REST single + bulk appear in read queries; datastream.create creates a queryable datastream), and the real-time stream pushes a newly-ingested observation to a subscribed SSE client",
           "executionLane": "ci:test-all",
           "evidenceLocations": [
-            "tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsReadEndpointsTests.cs"
+            "tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsReadEndpointsTests.cs",
+            "tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsIngestEndpointsTests.cs",
+            "tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsStreamEndpointsTests.cs"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",
           "linkedTicket": "honua-server#1747",
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
+      "surfaceId": "ogc-api-edr",
+      "displayName": "OGC API - Environmental Data Retrieval (EDR)",
+      "surfaceKind": "http-route-family",
+      "protocol": "OGC API - EDR 1.1",
+      "canonicalIdentifier": "/edr",
+      "parentSurfaceId": null,
+      "endpointPrefixes": [
+        "/edr"
+      ],
+      "endpointExactMatches": [],
+      "endpointContains": [],
+      "operationKeys": [],
+      "proofs": [
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "EndpointRegistry coverage plus endpoint integration tests for the OGC API - EDR surface: landing, conformance, collections list/by-id (with data_queries position+cube and parameter_names), the position (point time-series) query, and the cube (area/subset) query over registered coverage/datacube collections, returning CoverageJSON",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/EndpointRegistry.cs",
+            "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
+            "tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Edr/EdrEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "honua-server#1757",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "scenario-depth",
+          "proofMechanism": "EDR position returns a CoverageJSON PointSeries with a t-axis and per-parameter NdArray ranges sampled from the canonical raster read pipeline; EDR cube returns a CoverageJSON Grid subset for a bbox; invalid coords/bbox return 400 and unknown collections return 404",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Edr/EdrEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "honua-server#1757",
           "versionCaptureRule": null
         }
       ]

--- a/src/Honua.Core/Features/SensorThings/Abstractions/IObservationChangeEventPublisher.cs
+++ b/src/Honua.Core/Features/SensorThings/Abstractions/IObservationChangeEventPublisher.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.SensorThings.Domain;
+
+namespace Honua.Core.Features.SensorThings.Abstractions;
+
+/// <summary>
+/// Publishes newly-ingested SensorThings observations to real-time stream subscribers
+/// (Phase 3). The SensorThings ingest path (Phase 2) calls this after a successful write
+/// so the observation-stream transport (SSE / WebSocket) can fan it out to connected
+/// clients. The default no-op implementation keeps ingest decoupled from streaming when
+/// the streaming surface is not registered.
+/// </summary>
+public interface IObservationChangeEventPublisher
+{
+    /// <summary>
+    /// Publishes a batch of newly-created observations. Implementations must not throw;
+    /// streaming is best-effort and must never fail the ingest write.
+    /// </summary>
+    /// <param name="observations">The observations that were persisted.</param>
+    void PublishObservations(IReadOnlyList<SensorThingsObservation> observations);
+}
+
+/// <summary>
+/// Default <see cref="IObservationChangeEventPublisher"/> that discards events. Registered
+/// when no streaming transport is wired so the ingest path always has a publisher to call.
+/// </summary>
+public sealed class NullObservationChangeEventPublisher : IObservationChangeEventPublisher
+{
+    /// <summary>Shared instance.</summary>
+    public static NullObservationChangeEventPublisher Instance { get; } = new();
+
+    /// <inheritdoc />
+    public void PublishObservations(IReadOnlyList<SensorThingsObservation> observations)
+    {
+        // Intentionally empty: no streaming transport registered.
+    }
+}

--- a/src/Honua.Core/Features/SensorThings/Abstractions/IObservationStore.cs
+++ b/src/Honua.Core/Features/SensorThings/Abstractions/IObservationStore.cs
@@ -55,4 +55,29 @@ public interface IObservationStore
 
     /// <summary>Gets a single observation by identifier, or <see langword="null"/> if absent.</summary>
     Task<SensorThingsObservation?> GetObservationAsync(long id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Ingests a batch of observations into the time-series store (Phase 2). Each input
+    /// row is assigned a server-generated identifier. The datastream referenced by
+    /// <see cref="ObservationIngestRow.DatastreamId"/> must already exist.
+    /// </summary>
+    /// <param name="rows">The observations to insert.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The persisted observations, in input order, with assigned identifiers.</returns>
+    Task<IReadOnlyList<SensorThingsObservation>> IngestObservationsAsync(
+        IReadOnlyList<ObservationIngestRow> rows,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates a new Datastream catalog entity and (when needed) the related Thing,
+    /// Sensor, and ObservedProperty entities referenced by it (Phase 2). Identifiers
+    /// referenced by the request that do not exist are created from the inline
+    /// definitions carried on <paramref name="request"/>.
+    /// </summary>
+    /// <param name="request">The datastream-creation request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created datastream.</returns>
+    Task<SensorThingsDatastream> CreateDatastreamAsync(
+        CreateDatastreamRequest request,
+        CancellationToken cancellationToken);
 }

--- a/src/Honua.Core/Features/SensorThings/Domain/SensorThingsCatalog.cs
+++ b/src/Honua.Core/Features/SensorThings/Domain/SensorThingsCatalog.cs
@@ -152,3 +152,64 @@ public readonly record struct ObservationQuery(
     bool OrderByDescending,
     int Skip,
     int Top);
+
+/// <summary>
+/// A single observation row supplied to <c>IObservationStore.IngestObservationsAsync</c>
+/// (Phase 2). The identifier is assigned by the store, so it is not carried here.
+/// </summary>
+/// <param name="DatastreamId">Identifier of the owning datastream.</param>
+/// <param name="PhenomenonTime">When the observed phenomenon occurred.</param>
+/// <param name="ResultTime">When the result was generated, if distinct.</param>
+/// <param name="Result">The numeric measurement result.</param>
+/// <param name="FeatureOfInterestId">Identifier of the related FeatureOfInterest, if any.</param>
+public readonly record struct ObservationIngestRow(
+    long DatastreamId,
+    DateTimeOffset PhenomenonTime,
+    DateTimeOffset? ResultTime,
+    double Result,
+    long? FeatureOfInterestId);
+
+/// <summary>
+/// Inline definition of a related catalog entity referenced by a
+/// <see cref="CreateDatastreamRequest"/>. When <see cref="Id"/> resolves to an existing
+/// row the existing entity is reused; otherwise a new row is created from these fields.
+/// </summary>
+/// <param name="Id">Stable identifier of the related entity. When 0, the store assigns one.</param>
+/// <param name="Name">Entity name (used only when creating a new entity).</param>
+/// <param name="Description">Entity description (used only when creating a new entity).</param>
+public readonly record struct RelatedEntityRef(long Id, string? Name, string? Description);
+
+/// <summary>
+/// Request to create a SensorThings <c>Datastream</c> and, when needed, the related
+/// Thing, Sensor, and ObservedProperty entities (Phase 2 <c>datastream.create</c>).
+/// </summary>
+public sealed record CreateDatastreamRequest
+{
+    /// <summary>Datastream name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Datastream description.</summary>
+    public required string Description { get; init; }
+
+    /// <summary>The O&amp;M observation type URI.</summary>
+    public string ObservationType { get; init; } =
+        "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement";
+
+    /// <summary>Unit-of-measurement display name.</summary>
+    public required string UnitName { get; init; }
+
+    /// <summary>Unit-of-measurement symbol.</summary>
+    public required string UnitSymbol { get; init; }
+
+    /// <summary>Unit-of-measurement definition URI.</summary>
+    public required string UnitDefinition { get; init; }
+
+    /// <summary>The related Thing (created when its id does not already exist).</summary>
+    public required RelatedEntityRef Thing { get; init; }
+
+    /// <summary>The related Sensor (created when its id does not already exist).</summary>
+    public required RelatedEntityRef Sensor { get; init; }
+
+    /// <summary>The related ObservedProperty (created when its id does not already exist).</summary>
+    public required RelatedEntityRef ObservedProperty { get; init; }
+}

--- a/src/Honua.Postgres/Features/SensorThings/PostgresObservationStore.cs
+++ b/src/Honua.Postgres/Features/SensorThings/PostgresObservationStore.cs
@@ -330,6 +330,220 @@ GROUP BY d.id, d.name, d.description, d.observation_type, d.unit_name, d.unit_sy
         return await reader.ReadAsync(cancellationToken).ConfigureAwait(false) ? ReadObservation(reader) : null;
     }
 
+    public async Task<IReadOnlyList<SensorThingsObservation>> IngestObservationsAsync(
+        IReadOnlyList<ObservationIngestRow> rows,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        await EnsureSchemaAsync(cancellationToken).ConfigureAwait(false);
+
+        if (rows.Count == 0)
+        {
+            return Array.Empty<SensorThingsObservation>();
+        }
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        var connection = lease.Connection;
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        // Reserve a contiguous id block atomically. The observation id is a plain bigint
+        // (the partition key participates in the PK), so a transactional MAX+offset keeps
+        // ids monotonic without a dedicated sequence and works on the self-healed schema.
+        long nextId;
+        await using (var maxCommand = new NpgsqlCommand(
+            "SELECT COALESCE(MAX(id), 0) FROM honua.sta_observation", connection, transaction))
+        {
+            var max = (long)(await maxCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) ?? 0L);
+            nextId = max + 1;
+        }
+
+        var results = new List<SensorThingsObservation>(rows.Count);
+        const string insertSql = @"
+INSERT INTO honua.sta_observation (id, datastream_id, phenomenon_time, result_time, result, feature_of_interest_id)
+VALUES (@id, @datastream_id, @phenomenon_time, @result_time, @result, @feature_of_interest_id)";
+
+        foreach (var row in rows)
+        {
+            var id = nextId++;
+            await using var command = new NpgsqlCommand(insertSql, connection, transaction);
+            command.Parameters.AddWithValue("id", NpgsqlDbType.Bigint, id);
+            command.Parameters.AddWithValue("datastream_id", NpgsqlDbType.Bigint, row.DatastreamId);
+            command.Parameters.AddWithValue("phenomenon_time", NpgsqlDbType.TimestampTz, row.PhenomenonTime);
+            command.Parameters.AddWithValue(
+                "result_time",
+                NpgsqlDbType.TimestampTz,
+                (object?)row.ResultTime ?? DBNull.Value);
+            command.Parameters.AddWithValue("result", NpgsqlDbType.Double, row.Result);
+            command.Parameters.AddWithValue(
+                "feature_of_interest_id",
+                NpgsqlDbType.Bigint,
+                (object?)row.FeatureOfInterestId ?? DBNull.Value);
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+            results.Add(new SensorThingsObservation
+            {
+                Id = id,
+                DatastreamId = row.DatastreamId,
+                PhenomenonTime = row.PhenomenonTime,
+                ResultTime = row.ResultTime,
+                Result = row.Result,
+                FeatureOfInterestId = row.FeatureOfInterestId
+            });
+        }
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return results;
+    }
+
+    public async Task<SensorThingsDatastream> CreateDatastreamAsync(
+        CreateDatastreamRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        await EnsureSchemaAsync(cancellationToken).ConfigureAwait(false);
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        var connection = lease.Connection;
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        var thingId = await UpsertRelatedAsync(
+            connection, transaction, "sta_thing", request.Thing, cancellationToken).ConfigureAwait(false);
+        var sensorId = await UpsertSensorAsync(
+            connection, transaction, request.Sensor, cancellationToken).ConfigureAwait(false);
+        var observedPropertyId = await UpsertObservedPropertyAsync(
+            connection, transaction, request.ObservedProperty, cancellationToken).ConfigureAwait(false);
+
+        var datastreamId = await NextIdAsync(connection, transaction, "sta_datastream", cancellationToken).ConfigureAwait(false);
+
+        const string insertSql = @"
+INSERT INTO honua.sta_datastream
+    (id, name, description, observation_type, unit_name, unit_symbol, unit_definition, thing_id, sensor_id, observed_property_id)
+VALUES (@id, @name, @description, @observation_type, @unit_name, @unit_symbol, @unit_definition, @thing_id, @sensor_id, @observed_property_id)";
+
+        await using (var command = new NpgsqlCommand(insertSql, connection, transaction))
+        {
+            command.Parameters.AddWithValue("id", NpgsqlDbType.Bigint, datastreamId);
+            command.Parameters.AddWithValue("name", NpgsqlDbType.Text, request.Name);
+            command.Parameters.AddWithValue("description", NpgsqlDbType.Text, request.Description);
+            command.Parameters.AddWithValue("observation_type", NpgsqlDbType.Text, request.ObservationType);
+            command.Parameters.AddWithValue("unit_name", NpgsqlDbType.Text, request.UnitName);
+            command.Parameters.AddWithValue("unit_symbol", NpgsqlDbType.Text, request.UnitSymbol);
+            command.Parameters.AddWithValue("unit_definition", NpgsqlDbType.Text, request.UnitDefinition);
+            command.Parameters.AddWithValue("thing_id", NpgsqlDbType.Bigint, thingId);
+            command.Parameters.AddWithValue("sensor_id", NpgsqlDbType.Bigint, sensorId);
+            command.Parameters.AddWithValue("observed_property_id", NpgsqlDbType.Bigint, observedPropertyId);
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+        return new SensorThingsDatastream
+        {
+            Id = datastreamId,
+            Name = request.Name,
+            Description = request.Description,
+            ObservationType = request.ObservationType,
+            UnitName = request.UnitName,
+            UnitSymbol = request.UnitSymbol,
+            UnitDefinition = request.UnitDefinition,
+            ThingId = thingId,
+            SensorId = sensorId,
+            ObservedPropertyId = observedPropertyId
+        };
+    }
+
+    private static async Task<long> NextIdAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string table,
+        CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(
+            $"SELECT COALESCE(MAX(id), 0) + 1 FROM honua.{table}", connection, transaction);
+        return (long)(await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) ?? 1L);
+    }
+
+    private static async Task<bool> ExistsAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string table,
+        long id,
+        CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(
+            $"SELECT 1 FROM honua.{table} WHERE id = @id", connection, transaction);
+        command.Parameters.AddWithValue("id", NpgsqlDbType.Bigint, id);
+        return await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) is not null;
+    }
+
+    private static async Task<long> UpsertRelatedAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string table,
+        RelatedEntityRef entity,
+        CancellationToken cancellationToken)
+    {
+        if (entity.Id > 0 && await ExistsAsync(connection, transaction, table, entity.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return entity.Id;
+        }
+
+        var id = entity.Id > 0 ? entity.Id : await NextIdAsync(connection, transaction, table, cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(
+            $"INSERT INTO honua.{table} (id, name, description) VALUES (@id, @name, @description)", connection, transaction);
+        command.Parameters.AddWithValue("id", NpgsqlDbType.Bigint, id);
+        command.Parameters.AddWithValue("name", NpgsqlDbType.Text, entity.Name ?? $"Thing {id}");
+        command.Parameters.AddWithValue("description", NpgsqlDbType.Text, entity.Description ?? string.Empty);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return id;
+    }
+
+    private static async Task<long> UpsertSensorAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        RelatedEntityRef entity,
+        CancellationToken cancellationToken)
+    {
+        if (entity.Id > 0 && await ExistsAsync(connection, transaction, "sta_sensor", entity.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return entity.Id;
+        }
+
+        var id = entity.Id > 0 ? entity.Id : await NextIdAsync(connection, transaction, "sta_sensor", cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(
+            "INSERT INTO honua.sta_sensor (id, name, description, encoding_type, metadata) VALUES (@id, @name, @description, 'application/pdf', '')",
+            connection,
+            transaction);
+        command.Parameters.AddWithValue("id", NpgsqlDbType.Bigint, id);
+        command.Parameters.AddWithValue("name", NpgsqlDbType.Text, entity.Name ?? $"Sensor {id}");
+        command.Parameters.AddWithValue("description", NpgsqlDbType.Text, entity.Description ?? string.Empty);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return id;
+    }
+
+    private static async Task<long> UpsertObservedPropertyAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        RelatedEntityRef entity,
+        CancellationToken cancellationToken)
+    {
+        if (entity.Id > 0 && await ExistsAsync(connection, transaction, "sta_observed_property", entity.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return entity.Id;
+        }
+
+        var id = entity.Id > 0 ? entity.Id : await NextIdAsync(connection, transaction, "sta_observed_property", cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(
+            "INSERT INTO honua.sta_observed_property (id, name, definition, description) VALUES (@id, @name, '', @description)",
+            connection,
+            transaction);
+        command.Parameters.AddWithValue("id", NpgsqlDbType.Bigint, id);
+        command.Parameters.AddWithValue("name", NpgsqlDbType.Text, entity.Name ?? $"ObservedProperty {id}");
+        command.Parameters.AddWithValue("description", NpgsqlDbType.Text, entity.Description ?? string.Empty);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return id;
+    }
+
     private static SensorThingsDatastream ReadDatastream(NpgsqlDataReader reader) => new()
     {
         Id = reader.GetInt64(0),

--- a/src/Honua.Protocols.OgcApi/Edr/EdrDependencies.cs
+++ b/src/Honua.Protocols.OgcApi/Edr/EdrDependencies.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Raster.Abstractions;
+
+namespace Honua.Protocols.Ogc.Api.Edr;
+
+/// <summary>
+/// Shared dependency bag for the OGC API - EDR handler. EDR is a thin query layer over the
+/// same registered coverages/datacubes that OGC API - Coverages and WCS expose, so it adapts
+/// to the shared metadata catalog (<see cref="IMetadataV2GraphProvider"/>) and the canonical
+/// raster read pipeline (<see cref="IRasterStore"/>) rather than reimplementing data access.
+/// </summary>
+internal sealed class EdrDependencies
+{
+    public EdrDependencies(
+        IMetadataV2GraphProvider graphProvider,
+        IRasterStore rasterStore)
+    {
+        GraphProvider = graphProvider ?? throw new ArgumentNullException(nameof(graphProvider));
+        RasterStore = rasterStore ?? throw new ArgumentNullException(nameof(rasterStore));
+    }
+
+    public IMetadataV2GraphProvider GraphProvider { get; }
+
+    public IRasterStore RasterStore { get; }
+}

--- a/src/Honua.Protocols.OgcApi/Edr/EdrEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Edr/EdrEndpoints.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Models;
+using Honua.Protocols.Ogc.Api.Edr.Models;
+using Honua.Protocols.Ogc.Common;
+
+namespace Honua.Protocols.Ogc.Api.Edr;
+
+/// <summary>
+/// OGC API - Environmental Data Retrieval (EDR) endpoints (#1757). Exposes
+/// <c>position</c> (point time-series) and <c>cube</c> (area/subset) queries over the
+/// registered coverage/datacube collections, returning CoverageJSON.
+/// </summary>
+public static class EdrEndpoints
+{
+    /// <summary>Maps the OGC API - EDR endpoints.</summary>
+    public static void MapEdrEndpoints(this IEndpointRouteBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        var group = app.MapGroup("/edr").WithTags("OGC API - EDR");
+
+        group.MapGet(string.Empty, GetLandingPage)
+            .WithDisplayName("EDR API Landing Page")
+            .WithName("GetEdrLandingPage")
+            .WithSummary("Get OGC API - EDR landing page")
+            .Produces<EdrLandingPage>(StatusCodes.Status200OK, MediaTypes.Json);
+
+        group.MapGet("/conformance", GetConformance)
+            .WithDisplayName("EDR API Conformance")
+            .WithName("GetEdrConformance")
+            .WithSummary("Get OGC API - EDR conformance classes")
+            .Produces<EdrConformance>(StatusCodes.Status200OK, MediaTypes.Json);
+
+        group.MapGet("/collections", GetCollections)
+            .WithDisplayName("EDR Collections")
+            .WithName("GetEdrCollections")
+            .WithSummary("List OGC API - EDR collections")
+            .Produces<EdrCollections>(StatusCodes.Status200OK, MediaTypes.Json);
+
+        group.MapGet("/collections/{collectionId}", GetCollection)
+            .WithDisplayName("EDR Collection")
+            .WithName("GetEdrCollection")
+            .WithSummary("Get OGC API - EDR collection metadata")
+            .Produces<EdrCollection>(StatusCodes.Status200OK, MediaTypes.Json)
+            .Produces(StatusCodes.Status404NotFound);
+
+        group.MapGet("/collections/{collectionId}/position", GetPosition)
+            .WithDisplayName("EDR Position Query")
+            .WithName("GetEdrPosition")
+            .WithSummary("EDR position (point time-series) query")
+            .WithDescription("Returns a CoverageJSON time-series at coords=POINT(lon lat). Optional: datetime, parameter-name.")
+            .Produces(StatusCodes.Status200OK, contentType: "application/prs.coveragejson+json")
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status404NotFound);
+
+        group.MapGet("/collections/{collectionId}/cube", GetCube)
+            .WithDisplayName("EDR Cube Query")
+            .WithName("GetEdrCube")
+            .WithSummary("EDR cube (area/subset) query")
+            .WithDescription("Returns a CoverageJSON grid subset for bbox=minLon,minLat,maxLon,maxLat. Optional: datetime, parameter-name, resolution-x.")
+            .Produces(StatusCodes.Status200OK, contentType: "application/prs.coveragejson+json")
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status404NotFound);
+    }
+
+    private static IResult GetLandingPage(HttpContext context)
+        => EdrHandler.GetLandingPage(context);
+
+    private static IResult GetConformance()
+        => EdrHandler.GetConformance();
+
+    private static Task<IResult> GetCollections(HttpContext context, EdrHandler handler)
+        => handler.GetCollectionsAsync(context, TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context));
+
+    private static Task<IResult> GetCollection(string collectionId, HttpContext context, EdrHandler handler)
+        => handler.GetCollectionAsync(context, collectionId, TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context));
+
+    private static Task<IResult> GetPosition(string collectionId, HttpContext context, EdrHandler handler)
+        => handler.GetPositionAsync(context, collectionId, TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context));
+
+    private static Task<IResult> GetCube(string collectionId, HttpContext context, EdrHandler handler)
+        => handler.GetCubeAsync(context, collectionId, TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context));
+}

--- a/src/Honua.Protocols.OgcApi/Edr/EdrHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Edr/EdrHandler.cs
@@ -1,0 +1,595 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Models;
+using Honua.Infrastructure.Validation;
+using Honua.Protocols.Ogc.Api.Edr.Models;
+using Honua.Protocols.Ogc.Common;
+
+namespace Honua.Protocols.Ogc.Api.Edr;
+
+/// <summary>
+/// OGC API - Environmental Data Retrieval (EDR) handler (#1757). Adapts EDR
+/// <c>position</c> (point time-series) and <c>cube</c> (area/subset) queries onto the
+/// registered coverage/datacube catalog: collections are the same storage layers exposed
+/// through OGC API - Coverages, point sampling rides <see cref="IRasterStore.IdentifyAsync"/>,
+/// and cube subsetting samples the canonical raster read pipeline on a bounded grid. Results
+/// are returned as CoverageJSON.
+/// </summary>
+internal sealed class EdrHandler
+{
+    private const string CoveragesProtocol = "OGC-API-Coverages";
+    private const string Crs84 = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
+    private const string CoverageJsonMediaType = "application/prs.coveragejson+json";
+
+    // Bound the cube sampling grid so an unbounded bbox cannot fan out into a huge
+    // number of point-sample reads; EDR cube here is a sampled subset, not a full export.
+    private const int MaxCubeAxisSamples = 50;
+    private const int DefaultCubeAxisSamples = 8;
+
+    private readonly IMetadataV2GraphProvider _graphProvider;
+    private readonly IRasterStore _rasterStore;
+
+    public EdrHandler(EdrDependencies dependencies)
+    {
+        ArgumentNullException.ThrowIfNull(dependencies);
+        _graphProvider = dependencies.GraphProvider;
+        _rasterStore = dependencies.RasterStore;
+    }
+
+    public static IResult GetLandingPage(HttpContext context)
+    {
+        var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+        var basePath = $"{baseUrl}/edr";
+        var links = ImmutableArray.Create(
+            Link.Create(basePath, RelationTypes.Self, MediaTypes.Json, "EDR landing page"),
+            Link.Create($"{basePath}/conformance", RelationTypes.Conformance, MediaTypes.Json, "Conformance"),
+            Link.Create($"{basePath}/collections", RelationTypes.Data, MediaTypes.Json, "EDR collections"));
+        return Results.Json(new EdrLandingPage { Links = links }, EdrJsonContext.Default.EdrLandingPage);
+    }
+
+    public static IResult GetConformance()
+    {
+        var conformsTo = ImmutableArray.Create(
+            "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/core",
+            "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/position",
+            "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/cube",
+            "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/json",
+            "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/covjson");
+        return Results.Json(new EdrConformance { ConformsTo = conformsTo }, EdrJsonContext.Default.EdrConformance);
+    }
+
+    public async Task<IResult> GetCollectionsAsync(HttpContext context, CancellationToken cancellationToken)
+    {
+        var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+        var snapshot = await _graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+
+        var byResource = new Dictionary<string, (MetadataV2Publication Publication, MetadataV2Service Service, MetadataV2Resource Resource)>(StringComparer.Ordinal);
+        foreach (var publication in snapshot.Graph.Publications)
+        {
+            if (!snapshot.Index.ServicesById.TryGetValue(publication.ServiceId, out var service) ||
+                !IsProtocolEnabled(service, CoveragesProtocol))
+            {
+                continue;
+            }
+
+            var resource = snapshot.ResolveResource(publication);
+            if (resource is null || !AccessPolicyHelpers.IsResourceAccessible(context, resource, service))
+            {
+                continue;
+            }
+
+            if (!byResource.TryGetValue(resource.Metadata.Id, out var existing) ||
+                (publication.IsPrimary && !existing.Publication.IsPrimary))
+            {
+                byResource[resource.Metadata.Id] = (publication, service, resource);
+            }
+        }
+
+        var collections = ImmutableArray.CreateBuilder<EdrCollection>();
+        foreach (var entry in byResource.Values.OrderBy(t => snapshot.ResolveStorageLayerId(t.Publication) ?? int.MaxValue))
+        {
+            var storageLayerId = snapshot.ResolveStorageLayerId(entry.Publication);
+            if (!storageLayerId.HasValue)
+            {
+                continue;
+            }
+
+            var raster = await GetRasterAsync(storageLayerId.Value, cancellationToken).ConfigureAwait(false);
+            if (raster is null)
+            {
+                continue;
+            }
+
+            collections.Add(BuildCollection(entry.Resource, storageLayerId.Value, raster.Value, baseUrl));
+        }
+
+        var links = ImmutableArray.Create(
+            Link.Create($"{baseUrl}/edr/collections", RelationTypes.Self, MediaTypes.Json, "EDR collections"),
+            Link.Create($"{baseUrl}/edr", "parent", MediaTypes.Json, "Landing page"));
+
+        return Results.Json(
+            new EdrCollections { Collections = collections.ToImmutable(), Links = links },
+            EdrJsonContext.Default.EdrCollections);
+    }
+
+    public async Task<IResult> GetCollectionAsync(HttpContext context, string collectionId, CancellationToken cancellationToken)
+    {
+        var resolution = await ResolveAsync(context, collectionId, cancellationToken).ConfigureAwait(false);
+        if (resolution.Error is not null)
+        {
+            return resolution.Error;
+        }
+
+        var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+        var collection = BuildCollection(resolution.Resource!, resolution.StorageLayerId, resolution.Raster, baseUrl);
+        return Results.Json(collection, EdrJsonContext.Default.EdrCollection);
+    }
+
+    public async Task<IResult> GetPositionAsync(HttpContext context, string collectionId, CancellationToken cancellationToken)
+    {
+        var resolution = await ResolveAsync(context, collectionId, cancellationToken).ConfigureAwait(false);
+        if (resolution.Error is not null)
+        {
+            return resolution.Error;
+        }
+
+        var coords = context.Request.Query["coords"].ToString();
+        if (!TryParsePoint(coords, out var lon, out var lat))
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context, "Query parameter 'coords' must be a WKT POINT, e.g. coords=POINT(-122.4 37.8).");
+        }
+
+        var raster = resolution.Raster;
+        if (!WithinExtent(raster.Extent, lon, lat))
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context, "Requested position is outside the collection spatial extent.");
+        }
+
+        var instant = ResolveInstant(context.Request.Query["datetime"].ToString(), raster);
+        var requestedParameters = ParseParameterNames(context.Request.Query["parameter-name"].ToString());
+
+        var pixel = await _rasterStore
+            .IdentifyAsync(resolution.StorageLayerId, raster.Id, lon, lat, srid: 4326, rendering: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        var parameters = BuildParameters(raster, requestedParameters);
+        var ranges = ImmutableDictionary.CreateBuilder<string, CoverageJsonRange>();
+        foreach (var parameterName in parameters.Keys)
+        {
+            var band = BandIndex(parameterName);
+            var value = pixel.BandValues.TryGetValue(band, out var raw) ? ToDouble(raw) : null;
+            ranges[parameterName] = new CoverageJsonRange
+            {
+                AxisNames = ImmutableArray.Create("t"),
+                Shape = ImmutableArray.Create(1),
+                Values = ImmutableArray.Create(value)
+            };
+        }
+
+        var domain = new CoverageJsonDomain
+        {
+            DomainType = "PointSeries",
+            Axes = ImmutableDictionary<string, CoverageJsonAxis>.Empty
+                .Add("x", new CoverageJsonAxis { Values = ImmutableArray.Create(lon) })
+                .Add("y", new CoverageJsonAxis { Values = ImmutableArray.Create(lat) }),
+            Referencing = BuildReferencing()
+        };
+
+        var coverage = new CoverageJson
+        {
+            Domain = domain,
+            Parameters = parameters,
+            Ranges = ranges.ToImmutable()
+        };
+
+        // The single time instant is carried on the domain via a t-axis serialized as a
+        // CoverageJSON time axis (ISO-8601 string values) alongside the numeric x/y axes.
+        return JsonWithTimeAxis(coverage, instant);
+    }
+
+    public async Task<IResult> GetCubeAsync(HttpContext context, string collectionId, CancellationToken cancellationToken)
+    {
+        var resolution = await ResolveAsync(context, collectionId, cancellationToken).ConfigureAwait(false);
+        if (resolution.Error is not null)
+        {
+            return resolution.Error;
+        }
+
+        if (!TryParseBbox(context.Request.Query["bbox"].ToString(), out var minX, out var minY, out var maxX, out var maxY))
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context, "Query parameter 'bbox' must be 'minLon,minLat,maxLon,maxLat'.");
+        }
+
+        var resolutionCount = ResolveCubeSampleCount(context.Request.Query["resolution-x"].ToString());
+        var raster = resolution.Raster;
+        var instant = ResolveInstant(context.Request.Query["datetime"].ToString(), raster);
+        var requestedParameters = ParseParameterNames(context.Request.Query["parameter-name"].ToString());
+        var parameters = BuildParameters(raster, requestedParameters);
+
+        // Sample a bounded regular grid of cell centres inside the bbox using the canonical
+        // point-sample pipeline; this returns genuine cube values without decoding raster bytes.
+        var xValues = AxisValues(minX, maxX, resolutionCount);
+        var yValues = AxisValues(minY, maxY, resolutionCount);
+
+        var samples = new Dictionary<string, double?[]>(StringComparer.Ordinal);
+        foreach (var parameterName in parameters.Keys)
+        {
+            samples[parameterName] = new double?[xValues.Length * yValues.Length];
+        }
+
+        var index = 0;
+        for (var yi = 0; yi < yValues.Length; yi++)
+        {
+            for (var xi = 0; xi < xValues.Length; xi++)
+            {
+                var pixel = await _rasterStore
+                    .IdentifyAsync(resolution.StorageLayerId, raster.Id, xValues[xi], yValues[yi], srid: 4326, rendering: null, cancellationToken)
+                    .ConfigureAwait(false);
+
+                foreach (var parameterName in parameters.Keys)
+                {
+                    var band = BandIndex(parameterName);
+                    samples[parameterName][index] = pixel.BandValues.TryGetValue(band, out var raw) ? ToDouble(raw) : null;
+                }
+
+                index++;
+            }
+        }
+
+        var ranges = ImmutableDictionary.CreateBuilder<string, CoverageJsonRange>();
+        foreach (var (parameterName, values) in samples)
+        {
+            ranges[parameterName] = new CoverageJsonRange
+            {
+                AxisNames = ImmutableArray.Create("y", "x"),
+                Shape = ImmutableArray.Create(yValues.Length, xValues.Length),
+                Values = values.ToImmutableArray()
+            };
+        }
+
+        var domain = new CoverageJsonDomain
+        {
+            DomainType = "Grid",
+            Axes = ImmutableDictionary<string, CoverageJsonAxis>.Empty
+                .Add("x", new CoverageJsonAxis { Values = xValues.ToImmutableArray() })
+                .Add("y", new CoverageJsonAxis { Values = yValues.ToImmutableArray() }),
+            Referencing = BuildReferencing()
+        };
+
+        var coverage = new CoverageJson
+        {
+            Domain = domain,
+            Parameters = parameters,
+            Ranges = ranges.ToImmutable()
+        };
+
+        return JsonWithTimeAxis(coverage, instant);
+    }
+
+    // ---- resolution ----
+
+    private readonly record struct EdrResolution(
+        MetadataV2Resource? Resource,
+        int StorageLayerId,
+        RasterInfo Raster,
+        IResult? Error);
+
+    private async Task<EdrResolution> ResolveAsync(HttpContext context, string collectionId, CancellationToken cancellationToken)
+    {
+        var validation = await LayerValidationHelpers.ValidateCollectionWithAccessV2Async(
+            context, collectionId, requiredProtocol: CoveragesProtocol, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!validation.IsValid)
+        {
+            return new EdrResolution(null, 0, default, validation.ErrorResult);
+        }
+
+        var snapshot = await _graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        var storageLayerId = snapshot.ResolveStorageLayerId(validation.Publication!);
+        if (!storageLayerId.HasValue)
+        {
+            return new EdrResolution(null, 0, default,
+                StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' does not expose a coverage."));
+        }
+
+        var raster = await GetRasterAsync(storageLayerId.Value, cancellationToken).ConfigureAwait(false);
+        if (raster is null)
+        {
+            return new EdrResolution(null, 0, default,
+                StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' does not expose a coverage."));
+        }
+
+        return new EdrResolution(validation.Resource!, storageLayerId.Value, raster.Value, null);
+    }
+
+    private async Task<RasterInfo?> GetRasterAsync(int layerId, CancellationToken cancellationToken)
+    {
+        var raster = await _rasterStore.GetPrimaryRasterInfoAsync(layerId, cancellationToken).ConfigureAwait(false);
+        if (raster is null)
+        {
+            return null;
+        }
+
+        if (raster.Value.Extent is null)
+        {
+            var extent = await _rasterStore.GetExtentAsync(layerId, raster.Value.Id, cancellationToken).ConfigureAwait(false);
+            if (extent.HasValue)
+            {
+                raster = raster.Value with { Extent = extent };
+            }
+        }
+
+        return raster;
+    }
+
+    // ---- metadata building ----
+
+    private static EdrCollection BuildCollection(MetadataV2Resource resource, int storageLayerId, RasterInfo raster, string baseUrl)
+    {
+        var collectionId = storageLayerId.ToString(CultureInfo.InvariantCulture);
+        var basePath = $"{baseUrl}/edr/collections/{Uri.EscapeDataString(collectionId)}";
+        var outputFormats = ImmutableArray.Create("CoverageJSON");
+
+        Extent? extent = null;
+        if (raster.Extent is { } e)
+        {
+            extent = new Extent
+            {
+                Spatial = new SpatialExtent
+                {
+                    BoundingBox = ImmutableArray.Create(
+                        ImmutableArray.Create(e.XMin, e.YMin, e.XMax, e.YMax)),
+                    Crs = Crs84
+                }
+            };
+        }
+
+        var links = ImmutableArray.Create(
+            Link.Create(basePath, RelationTypes.Self, MediaTypes.Json, resource.Metadata.Title ?? resource.Metadata.Name),
+            Link.Create($"{baseUrl}/edr/collections", "parent", MediaTypes.Json, "EDR collections"),
+            Link.Create($"{basePath}/position", "data", CoverageJsonMediaType, "Position query"),
+            Link.Create($"{basePath}/cube", "data", CoverageJsonMediaType, "Cube query"));
+
+        var variables = new EdrQueryVariables { QueryType = "position", OutputFormats = outputFormats };
+        var dataQueries = new EdrDataQueries
+        {
+            Position = new EdrDataQuery
+            {
+                Link = new EdrQueryLink { Href = $"{basePath}/position", Variables = variables }
+            },
+            Cube = new EdrDataQuery
+            {
+                Link = new EdrQueryLink
+                {
+                    Href = $"{basePath}/cube",
+                    Variables = variables with { QueryType = "cube" }
+                }
+            }
+        };
+
+        return new EdrCollection
+        {
+            Id = collectionId,
+            Title = resource.Metadata.Title ?? resource.Metadata.Name,
+            Description = resource.Metadata.Description,
+            Links = links,
+            Extent = extent,
+            DataQueries = dataQueries,
+            Crs = ImmutableArray.Create("CRS84"),
+            OutputFormats = outputFormats,
+            ParameterNames = BuildParameters(raster, requested: null)
+        };
+    }
+
+    private static ImmutableDictionary<string, EdrParameter> BuildParameters(RasterInfo raster, IReadOnlyCollection<string>? requested)
+    {
+        var builder = ImmutableDictionary.CreateBuilder<string, EdrParameter>();
+        var bandCount = Math.Max(1, raster.BandCount);
+        for (var band = 1; band <= bandCount; band++)
+        {
+            var name = $"band_{band.ToString(CultureInfo.InvariantCulture)}";
+            if (requested is { Count: > 0 } && !requested.Contains(name, StringComparer.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            builder[name] = new EdrParameter
+            {
+                Description = $"Coverage band {band.ToString(CultureInfo.InvariantCulture)}",
+                ObservedProperty = new EdrObservedProperty { Label = name }
+            };
+        }
+
+        if (builder.Count == 0)
+        {
+            builder["band_1"] = new EdrParameter
+            {
+                Description = "Coverage band 1",
+                ObservedProperty = new EdrObservedProperty { Label = "band_1" }
+            };
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static ImmutableArray<CoverageJsonReferencing> BuildReferencing() =>
+        ImmutableArray.Create(
+            new CoverageJsonReferencing
+            {
+                Coordinates = ImmutableArray.Create("x", "y"),
+                System = new CoverageJsonReferenceSystem
+                {
+                    Type = "GeographicCRS",
+                    Id = "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            },
+            new CoverageJsonReferencing
+            {
+                Coordinates = ImmutableArray.Create("t"),
+                System = new CoverageJsonReferenceSystem { Type = "TemporalRS", Id = "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian" }
+            });
+
+    // ---- parsing helpers ----
+
+    private static bool TryParsePoint(string coords, out double lon, out double lat)
+    {
+        lon = 0;
+        lat = 0;
+        if (string.IsNullOrWhiteSpace(coords))
+        {
+            return false;
+        }
+
+        var trimmed = coords.Trim();
+        var open = trimmed.IndexOf('(');
+        var close = trimmed.IndexOf(')');
+        if (!trimmed.StartsWith("POINT", StringComparison.OrdinalIgnoreCase) || open < 0 || close <= open)
+        {
+            return false;
+        }
+
+        var inner = trimmed[(open + 1)..close];
+        var parts = inner.Split([' ', ','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return parts.Length >= 2
+            && double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out lon)
+            && double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out lat);
+    }
+
+    private static bool TryParseBbox(string bbox, out double minX, out double minY, out double maxX, out double maxY)
+    {
+        minX = minY = maxX = maxY = 0;
+        if (string.IsNullOrWhiteSpace(bbox))
+        {
+            return false;
+        }
+
+        var parts = bbox.Split(',', StringSplitOptions.TrimEntries);
+        if (parts.Length != 4)
+        {
+            return false;
+        }
+
+        if (!double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out minX) ||
+            !double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out minY) ||
+            !double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out maxX) ||
+            !double.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out maxY))
+        {
+            return false;
+        }
+
+        return maxX > minX && maxY > minY;
+    }
+
+    private static string[] ParseParameterNames(string value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? Array.Empty<string>()
+            : value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static string ResolveInstant(string datetime, RasterInfo raster)
+    {
+        if (!string.IsNullOrWhiteSpace(datetime) &&
+            DateTimeOffset.TryParse(
+                datetime.Split('/')[0],
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var parsed))
+        {
+            return Iso(parsed);
+        }
+
+        return Iso(raster.AcquisitionDate ?? raster.CreatedAt);
+    }
+
+    private static int ResolveCubeSampleCount(string resolutionX)
+    {
+        if (int.TryParse(resolutionX, NumberStyles.Integer, CultureInfo.InvariantCulture, out var count) && count > 0)
+        {
+            return Math.Min(count, MaxCubeAxisSamples);
+        }
+
+        return DefaultCubeAxisSamples;
+    }
+
+    private static double[] AxisValues(double min, double max, int count)
+    {
+        if (count <= 1)
+        {
+            return [(min + max) / 2.0];
+        }
+
+        var step = (max - min) / count;
+        var values = new double[count];
+        for (var i = 0; i < count; i++)
+        {
+            // Cell-centre sampling.
+            values[i] = min + step * (i + 0.5);
+        }
+
+        return values;
+    }
+
+    private static bool WithinExtent(RasterExtent? extent, double lon, double lat)
+    {
+        if (extent is not { } e)
+        {
+            return true; // No declared extent: accept and let the store decide.
+        }
+
+        return lon >= e.XMin && lon <= e.XMax && lat >= e.YMin && lat <= e.YMax;
+    }
+
+    private static int BandIndex(string parameterName)
+    {
+        var underscore = parameterName.LastIndexOf('_');
+        return underscore >= 0
+            && int.TryParse(parameterName[(underscore + 1)..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var band)
+            && band > 0
+                ? band
+                : 1;
+    }
+
+    private static double? ToDouble(object? value) => value switch
+    {
+        null => null,
+        double d => d,
+        float f => f,
+        int i => i,
+        long l => l,
+        short s => s,
+        byte b => b,
+        decimal m => (double)m,
+        IConvertible convertible => convertible.ToDouble(CultureInfo.InvariantCulture),
+        _ => null
+    };
+
+    private static string Iso(DateTimeOffset value) =>
+        value.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+
+    private static bool IsProtocolEnabled(MetadataV2Service? service, string protocol) =>
+        service?.Protocols.Any(enabled => string.Equals(enabled, protocol, StringComparison.OrdinalIgnoreCase)) == true;
+
+    // CoverageJSON puts the t-axis values (ISO strings) on the domain alongside numeric
+    // x/y axes; the source-gen NdArray axis dictionary is numeric-only, so the time axis is
+    // merged into the serialized document via a post-step that adds the "t" string axis.
+    private static IResult JsonWithTimeAxis(CoverageJson coverage, string instant)
+    {
+        var node = System.Text.Json.JsonSerializer.SerializeToNode(coverage, EdrJsonContext.Default.CoverageJson)!;
+        var axes = node["domain"]!["axes"]!.AsObject();
+        var timeAxis = System.Text.Json.JsonSerializer.SerializeToNode(
+            new CoverageJsonTimeAxis { Values = ImmutableArray.Create(instant) },
+            EdrJsonContext.Default.CoverageJsonTimeAxis)!;
+        axes["t"] = timeAxis;
+        return Results.Text(node.ToJsonString(), CoverageJsonMediaType);
+    }
+}

--- a/src/Honua.Protocols.OgcApi/Edr/EdrServiceCollectionExtensions.cs
+++ b/src/Honua.Protocols.OgcApi/Edr/EdrServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Protocols.Ogc.Api.Edr;
+
+/// <summary>
+/// Service collection extensions for OGC API - EDR feature registration.
+/// </summary>
+internal static class EdrServiceCollectionExtensions
+{
+    /// <summary>Registers OGC API - EDR services with dependency injection.</summary>
+    public static IServiceCollection AddEdr(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddScoped<EdrDependencies>();
+        services.AddScoped<EdrHandler>();
+
+        return services;
+    }
+}

--- a/src/Honua.Protocols.OgcApi/Edr/Models/EdrModels.cs
+++ b/src/Honua.Protocols.OgcApi/Edr/Models/EdrModels.cs
@@ -1,0 +1,245 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+using Honua.Protocols.Ogc.Common;
+
+namespace Honua.Protocols.Ogc.Api.Edr.Models;
+
+/// <summary>OGC API - EDR landing page.</summary>
+internal sealed record EdrLandingPage
+{
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = "Honua OGC API Environmental Data Retrieval";
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } =
+        "Position and cube queries over registered environmental coverages / datacubes.";
+
+    [JsonPropertyName("links")]
+    public required ImmutableArray<Link> Links { get; init; }
+}
+
+/// <summary>OGC API - EDR conformance declaration.</summary>
+internal sealed record EdrConformance
+{
+    [JsonPropertyName("conformsTo")]
+    public required ImmutableArray<string> ConformsTo { get; init; }
+}
+
+/// <summary>The EDR collections document.</summary>
+internal sealed record EdrCollections
+{
+    [JsonPropertyName("collections")]
+    public required ImmutableArray<EdrCollection> Collections { get; init; }
+
+    [JsonPropertyName("links")]
+    public required ImmutableArray<Link> Links { get; init; }
+}
+
+/// <summary>An EDR collection: a coverage/datacube exposing position and cube queries.</summary>
+internal sealed record EdrCollection
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("links")]
+    public required ImmutableArray<Link> Links { get; init; }
+
+    [JsonPropertyName("extent")]
+    public Extent? Extent { get; init; }
+
+    [JsonPropertyName("data_queries")]
+    public required EdrDataQueries DataQueries { get; init; }
+
+    [JsonPropertyName("crs")]
+    public required ImmutableArray<string> Crs { get; init; }
+
+    [JsonPropertyName("output_formats")]
+    public required ImmutableArray<string> OutputFormats { get; init; }
+
+    [JsonPropertyName("parameter_names")]
+    public required ImmutableDictionary<string, EdrParameter> ParameterNames { get; init; }
+}
+
+/// <summary>The supported EDR query families for a collection.</summary>
+internal sealed record EdrDataQueries
+{
+    [JsonPropertyName("position")]
+    public EdrDataQuery? Position { get; init; }
+
+    [JsonPropertyName("cube")]
+    public EdrDataQuery? Cube { get; init; }
+}
+
+/// <summary>Metadata for a single EDR query family.</summary>
+internal sealed record EdrDataQuery
+{
+    [JsonPropertyName("link")]
+    public required EdrQueryLink Link { get; init; }
+}
+
+/// <summary>A link describing an EDR query endpoint.</summary>
+internal sealed record EdrQueryLink
+{
+    [JsonPropertyName("href")]
+    public required string Href { get; init; }
+
+    [JsonPropertyName("rel")]
+    public string Rel { get; init; } = "data";
+
+    [JsonPropertyName("variables")]
+    public EdrQueryVariables? Variables { get; init; }
+}
+
+/// <summary>Query-type variables for an EDR data query.</summary>
+internal sealed record EdrQueryVariables
+{
+    [JsonPropertyName("query_type")]
+    public required string QueryType { get; init; }
+
+    [JsonPropertyName("output_formats")]
+    public required ImmutableArray<string> OutputFormats { get; init; }
+}
+
+/// <summary>An EDR parameter (observed property / coverage range field).</summary>
+internal sealed record EdrParameter
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "Parameter";
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("unit")]
+    public EdrUnit? Unit { get; init; }
+
+    [JsonPropertyName("observedProperty")]
+    public required EdrObservedProperty ObservedProperty { get; init; }
+}
+
+/// <summary>An EDR unit-of-measurement object.</summary>
+internal sealed record EdrUnit
+{
+    [JsonPropertyName("label")]
+    public required string Label { get; init; }
+
+    [JsonPropertyName("symbol")]
+    public string? Symbol { get; init; }
+}
+
+/// <summary>An EDR observed-property descriptor.</summary>
+internal sealed record EdrObservedProperty
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    [JsonPropertyName("label")]
+    public required string Label { get; init; }
+}
+
+// ---- CoverageJSON response models (RFC-style, used for position + cube) ----
+
+/// <summary>A CoverageJSON Coverage document returned by position/cube queries.</summary>
+internal sealed record CoverageJson
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "Coverage";
+
+    [JsonPropertyName("domain")]
+    public required CoverageJsonDomain Domain { get; init; }
+
+    [JsonPropertyName("parameters")]
+    public required ImmutableDictionary<string, EdrParameter> Parameters { get; init; }
+
+    [JsonPropertyName("ranges")]
+    public required ImmutableDictionary<string, CoverageJsonRange> Ranges { get; init; }
+}
+
+/// <summary>The CoverageJSON domain (axes definition).</summary>
+internal sealed record CoverageJsonDomain
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "Domain";
+
+    [JsonPropertyName("domainType")]
+    public required string DomainType { get; init; }
+
+    [JsonPropertyName("axes")]
+    public required ImmutableDictionary<string, CoverageJsonAxis> Axes { get; init; }
+
+    [JsonPropertyName("referencing")]
+    public required ImmutableArray<CoverageJsonReferencing> Referencing { get; init; }
+}
+
+/// <summary>A CoverageJSON axis (a list of coordinate values).</summary>
+internal sealed record CoverageJsonAxis
+{
+    [JsonPropertyName("values")]
+    public required ImmutableArray<double> Values { get; init; }
+}
+
+/// <summary>A CoverageJSON temporal axis (a list of ISO-8601 instants).</summary>
+internal sealed record CoverageJsonTimeAxis
+{
+    [JsonPropertyName("values")]
+    public required ImmutableArray<string> Values { get; init; }
+}
+
+/// <summary>A CoverageJSON referencing-system entry.</summary>
+internal sealed record CoverageJsonReferencing
+{
+    [JsonPropertyName("coordinates")]
+    public required ImmutableArray<string> Coordinates { get; init; }
+
+    [JsonPropertyName("system")]
+    public required CoverageJsonReferenceSystem System { get; init; }
+}
+
+/// <summary>A CoverageJSON reference system.</summary>
+internal sealed record CoverageJsonReferenceSystem
+{
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
+
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+}
+
+/// <summary>A CoverageJSON NdArray range of values for a single parameter.</summary>
+internal sealed record CoverageJsonRange
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "NdArray";
+
+    [JsonPropertyName("dataType")]
+    public string DataType { get; init; } = "float";
+
+    [JsonPropertyName("axisNames")]
+    public required ImmutableArray<string> AxisNames { get; init; }
+
+    [JsonPropertyName("shape")]
+    public required ImmutableArray<int> Shape { get; init; }
+
+    [JsonPropertyName("values")]
+    public required ImmutableArray<double?> Values { get; init; }
+}
+
+/// <summary>Source-generated JSON context for EDR + CoverageJSON wire models.</summary>
+[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(EdrLandingPage))]
+[JsonSerializable(typeof(EdrConformance))]
+[JsonSerializable(typeof(EdrCollections))]
+[JsonSerializable(typeof(EdrCollection))]
+[JsonSerializable(typeof(CoverageJson))]
+[JsonSerializable(typeof(CoverageJsonTimeAxis))]
+internal sealed partial class EdrJsonContext : System.Text.Json.Serialization.JsonSerializerContext
+{
+}

--- a/src/Honua.Protocols.SensorThings/Models/SensorThingsModels.cs
+++ b/src/Honua.Protocols.SensorThings/Models/SensorThingsModels.cs
@@ -193,6 +193,106 @@ public sealed record StaDatastream
     public StaObservedProperty? ObservedProperty { get; init; }
 }
 
+/// <summary>
+/// Request body for STA Observation ingest (Phase 2). Posted either to
+/// <c>/sta/v1.1/Observations</c> (with <see cref="Datastream"/> carrying the target
+/// id) or to <c>/sta/v1.1/Datastreams({id})/Observations</c> (datastream taken from
+/// the route).
+/// </summary>
+public sealed record StaObservationCreate
+{
+    /// <summary>When the phenomenon occurred (ISO-8601). Defaults to now when omitted.</summary>
+    [JsonPropertyName("phenomenonTime")]
+    public string? PhenomenonTime { get; init; }
+
+    /// <summary>When the result was generated (ISO-8601), if distinct.</summary>
+    [JsonPropertyName("resultTime")]
+    public string? ResultTime { get; init; }
+
+    /// <summary>The numeric measurement result.</summary>
+    [JsonPropertyName("result")]
+    public required double Result { get; init; }
+
+    /// <summary>The owning Datastream reference (carries the target <c>@iot.id</c>).</summary>
+    [JsonPropertyName("Datastream")]
+    public StaEntityReference? Datastream { get; init; }
+}
+
+/// <summary>A SensorThings deep-insert / link reference carrying a target entity id.</summary>
+public sealed record StaEntityReference
+{
+    /// <summary>The referenced entity identifier (<c>@iot.id</c>).</summary>
+    [JsonPropertyName("@iot.id")]
+    public long IotId { get; init; }
+
+    /// <summary>Optional name used when the referenced entity is created inline.</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    /// <summary>Optional description used when the referenced entity is created inline.</summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+}
+
+/// <summary>
+/// Bulk ingest envelope: a <c>value</c> array of observations posted in one request to
+/// <c>/sta/v1.1/Observations</c>. Honua extension to the single-create body for efficient
+/// IoT ingest (<c>sensor.ingest</c> operation).
+/// </summary>
+public sealed record StaObservationBulkCreate
+{
+    /// <summary>The observations to ingest.</summary>
+    [JsonPropertyName("value")]
+    public required IReadOnlyList<StaObservationCreate> Value { get; init; }
+}
+
+/// <summary>Result of a bulk ingest: the count persisted and the assigned identifiers.</summary>
+public sealed record StaObservationBulkResult
+{
+    /// <summary>Number of observations persisted.</summary>
+    [JsonPropertyName("@iot.count")]
+    public required long Count { get; init; }
+
+    /// <summary>Assigned identifiers, in input order.</summary>
+    [JsonPropertyName("value")]
+    public required IReadOnlyList<long> Value { get; init; }
+}
+
+/// <summary>
+/// Request body for STA Datastream creation (Phase 2 <c>datastream.create</c>). Inline
+/// Thing / Sensor / ObservedProperty references are created when their ids do not exist.
+/// </summary>
+public sealed record StaDatastreamCreate
+{
+    /// <summary>Datastream name.</summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>Datastream description.</summary>
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    /// <summary>The O&amp;M observation type URI.</summary>
+    [JsonPropertyName("observationType")]
+    public string? ObservationType { get; init; }
+
+    /// <summary>Unit of measurement for the datastream's results.</summary>
+    [JsonPropertyName("unitOfMeasurement")]
+    public required StaUnitOfMeasurement UnitOfMeasurement { get; init; }
+
+    /// <summary>The related Thing.</summary>
+    [JsonPropertyName("Thing")]
+    public required StaEntityReference Thing { get; init; }
+
+    /// <summary>The related Sensor.</summary>
+    [JsonPropertyName("Sensor")]
+    public required StaEntityReference Sensor { get; init; }
+
+    /// <summary>The related ObservedProperty.</summary>
+    [JsonPropertyName("ObservedProperty")]
+    public required StaEntityReference ObservedProperty { get; init; }
+}
+
 /// <summary>STA v1.1 <c>Observation</c> entity DTO.</summary>
 public sealed record StaObservation
 {

--- a/src/Honua.Protocols.SensorThings/SensorThingsEndpoints.Ingest.cs
+++ b/src/Honua.Protocols.SensorThings/SensorThingsEndpoints.Ingest.cs
@@ -1,0 +1,319 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.IO;
+using Honua.Core.Features.SensorThings.Abstractions;
+using Honua.Core.Features.SensorThings.Domain;
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Models;
+using Honua.Protocols.SensorThings.Models;
+using Honua.Protocols.SensorThings.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Protocols.SensorThings;
+
+/// <summary>
+/// OGC SensorThings API (STA v1.1) Phase 2 ingest surface (#1747): REST + bulk
+/// observation creation and Datastream creation. These map to the unified
+/// <c>sensor.ingest</c> and <c>datastream.create</c> operations so the console and
+/// AI toolset reach ingest identically. New observations are published to the
+/// real-time observation stream (Phase 3) through
+/// <see cref="IObservationChangeEventPublisher"/>.
+/// </summary>
+internal static partial class SensorThingsIngestEndpoints
+{
+    /// <summary>Maps the SensorThings Phase 2 ingest endpoints.</summary>
+    public static IEndpointRouteBuilder MapSensorThingsIngestEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost("/sta/v1.1/Observations", HandleCreateObservations)
+            .WithDisplayName("STA Create Observations")
+            .WithName("StaCreateObservations")
+            .WithSummary("Ingest one or more Observations (sensor.ingest)")
+            .WithTags("SensorThings")
+            .Accepts<StaObservationCreate>("application/json")
+            .Produces<StaObservation>(201, "application/json")
+            .Produces<StaObservationBulkResult>(201, "application/json")
+            .Produces(400)
+            .Produces(404);
+
+        endpoints.MapPost("/sta/v1.1/Datastreams({id:long})/Observations", HandleCreateDatastreamObservation)
+            .WithDisplayName("STA Create Datastream Observation")
+            .WithName("StaCreateDatastreamObservation")
+            .WithSummary("Ingest an Observation into a Datastream (sensor.ingest)")
+            .WithTags("SensorThings")
+            .Accepts<StaObservationCreate>("application/json")
+            .Produces<StaObservation>(201, "application/json")
+            .Produces(400)
+            .Produces(404);
+
+        endpoints.MapPost("/sta/v1.1/Datastreams", HandleCreateDatastream)
+            .WithDisplayName("STA Create Datastream")
+            .WithName("StaCreateDatastream")
+            .WithSummary("Create a Datastream (datastream.create)")
+            .WithTags("SensorThings")
+            .Accepts<StaDatastreamCreate>("application/json")
+            .Produces<StaDatastream>(201, "application/json")
+            .Produces(400);
+
+        return endpoints;
+    }
+
+    private static string StaBase(HttpContext context) =>
+        $"{BaseUrlResolver.GetBaseUrl(context)}{SensorThingsEndpoints.BasePath}";
+
+    // ---- Observation ingest ----
+
+    private static async Task<IResult> HandleCreateObservations(
+        HttpContext context,
+        [FromServices] IObservationStore store,
+        [FromServices] IObservationChangeEventPublisher publisher)
+    {
+        var ct = context.RequestAborted;
+
+        // Read the body once; a bulk envelope ({ "value": [...] }) and a single observation
+        // are distinguished by inspecting for a top-level "value" array member.
+        string body;
+        using (var bodyReader = new StreamReader(context.Request.Body, System.Text.Encoding.UTF8))
+        {
+            body = await bodyReader.ReadToEndAsync(ct).ConfigureAwait(false);
+        }
+
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body is required.");
+        }
+
+        bool isBulk;
+        try
+        {
+            using var probe = System.Text.Json.JsonDocument.Parse(body);
+            isBulk = probe.RootElement.ValueKind == System.Text.Json.JsonValueKind.Object &&
+                probe.RootElement.TryGetProperty("value", out var valueElement) &&
+                valueElement.ValueKind == System.Text.Json.JsonValueKind.Array;
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body must be valid JSON.");
+        }
+
+        if (isBulk)
+        {
+            var bulk = System.Text.Json.JsonSerializer.Deserialize(
+                body, SensorThingsJsonContext.Default.StaObservationBulkCreate);
+            if (bulk is null or { Value.Count: 0 })
+            {
+                return StandardErrorHelpers.CreateBadRequest(context, "Bulk ingest requires a non-empty 'value' array.");
+            }
+
+            return await IngestBulkAsync(context, store, publisher, bulk, ct).ConfigureAwait(false);
+        }
+
+        StaObservationCreate? single;
+        try
+        {
+            single = System.Text.Json.JsonSerializer.Deserialize(
+                body, SensorThingsJsonContext.Default.StaObservationCreate);
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body must be a valid Observation or { \"value\": [...] } envelope.");
+        }
+
+        if (single is null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body must be a valid Observation.");
+        }
+
+        var datastreamId = single.Datastream?.IotId ?? 0;
+        if (datastreamId <= 0)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "An Observation must reference a Datastream by @iot.id.");
+        }
+
+        return await IngestSingleAsync(context, store, publisher, datastreamId, single, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<IResult> HandleCreateDatastreamObservation(
+        long id,
+        HttpContext context,
+        [FromServices] IObservationStore store,
+        [FromServices] IObservationChangeEventPublisher publisher)
+    {
+        var ct = context.RequestAborted;
+        StaObservationCreate? single;
+        try
+        {
+            single = await context.Request.ReadFromJsonAsync(
+                SensorThingsJsonContext.Default.StaObservationCreate, ct).ConfigureAwait(false);
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body must be a valid Observation.");
+        }
+
+        if (single is null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body must be a valid Observation.");
+        }
+
+        return await IngestSingleAsync(context, store, publisher, id, single, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<IResult> IngestSingleAsync(
+        HttpContext context,
+        IObservationStore store,
+        IObservationChangeEventPublisher publisher,
+        long datastreamId,
+        StaObservationCreate body,
+        CancellationToken ct)
+    {
+        if (await store.GetDatastreamAsync(datastreamId, ct).ConfigureAwait(false) is null)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, $"Datastream({datastreamId}) not found.");
+        }
+
+        if (!TryBuildRow(datastreamId, body, out var row, out var error))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, error);
+        }
+
+        var persisted = await store.IngestObservationsAsync(new[] { row }, ct).ConfigureAwait(false);
+        publisher.PublishObservations(persisted);
+
+        var staBase = StaBase(context);
+        var observation = StaEntityMapper.MapObservation(persisted[0], staBase);
+        context.Response.Headers.Location = observation.IotSelfLink;
+        return Results.Json(observation, SensorThingsJsonContext.Default.StaObservation, statusCode: 201);
+    }
+
+    private static async Task<IResult> IngestBulkAsync(
+        HttpContext context,
+        IObservationStore store,
+        IObservationChangeEventPublisher publisher,
+        StaObservationBulkCreate bulk,
+        CancellationToken ct)
+    {
+        var rows = new List<ObservationIngestRow>(bulk.Value.Count);
+        foreach (var item in bulk.Value)
+        {
+            var datastreamId = item.Datastream?.IotId ?? 0;
+            if (datastreamId <= 0)
+            {
+                return StandardErrorHelpers.CreateBadRequest(context, "Each Observation must reference a Datastream by @iot.id.");
+            }
+
+            if (!TryBuildRow(datastreamId, item, out var row, out var error))
+            {
+                return StandardErrorHelpers.CreateBadRequest(context, error);
+            }
+
+            rows.Add(row);
+        }
+
+        // Validate referenced datastreams exist (deduplicated).
+        foreach (var datastreamId in rows.Select(r => r.DatastreamId).Distinct())
+        {
+            if (await store.GetDatastreamAsync(datastreamId, ct).ConfigureAwait(false) is null)
+            {
+                return StandardErrorHelpers.CreateNotFound(context, $"Datastream({datastreamId}) not found.");
+            }
+        }
+
+        var persisted = await store.IngestObservationsAsync(rows, ct).ConfigureAwait(false);
+        publisher.PublishObservations(persisted);
+
+        return Results.Json(
+            new StaObservationBulkResult { Count = persisted.Count, Value = persisted.Select(o => o.Id).ToList() },
+            SensorThingsJsonContext.Default.StaObservationBulkResult,
+            statusCode: 201);
+    }
+
+    private static bool TryBuildRow(
+        long datastreamId,
+        StaObservationCreate body,
+        out ObservationIngestRow row,
+        out string error)
+    {
+        row = default;
+        error = string.Empty;
+
+        var phenomenonTime = DateTimeOffset.UtcNow;
+        if (!string.IsNullOrWhiteSpace(body.PhenomenonTime))
+        {
+            if (!TryParseInstant(body.PhenomenonTime, out phenomenonTime))
+            {
+                error = $"phenomenonTime '{body.PhenomenonTime}' is not a valid ISO-8601 instant.";
+                return false;
+            }
+        }
+
+        DateTimeOffset? resultTime = null;
+        if (!string.IsNullOrWhiteSpace(body.ResultTime))
+        {
+            if (!TryParseInstant(body.ResultTime, out var rt))
+            {
+                error = $"resultTime '{body.ResultTime}' is not a valid ISO-8601 instant.";
+                return false;
+            }
+
+            resultTime = rt;
+        }
+
+        row = new ObservationIngestRow(datastreamId, phenomenonTime, resultTime, body.Result, FeatureOfInterestId: null);
+        return true;
+    }
+
+    private static bool TryParseInstant(string value, out DateTimeOffset instant) =>
+        DateTimeOffset.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out instant);
+
+    // ---- Datastream create ----
+
+    private static async Task<IResult> HandleCreateDatastream(
+        HttpContext context,
+        [FromServices] IObservationStore store)
+    {
+        var ct = context.RequestAborted;
+        StaDatastreamCreate? body;
+        try
+        {
+            body = await context.Request.ReadFromJsonAsync(
+                SensorThingsJsonContext.Default.StaDatastreamCreate, ct).ConfigureAwait(false);
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body must be a valid Datastream.");
+        }
+
+        if (body is null || string.IsNullOrWhiteSpace(body.Name))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "A Datastream requires a name, description, and unitOfMeasurement.");
+        }
+
+        var request = new CreateDatastreamRequest
+        {
+            Name = body.Name,
+            Description = body.Description,
+            ObservationType = string.IsNullOrWhiteSpace(body.ObservationType)
+                ? "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement"
+                : body.ObservationType,
+            UnitName = body.UnitOfMeasurement.Name,
+            UnitSymbol = body.UnitOfMeasurement.Symbol,
+            UnitDefinition = body.UnitOfMeasurement.Definition,
+            Thing = new RelatedEntityRef(body.Thing.IotId, body.Thing.Name, body.Thing.Description),
+            Sensor = new RelatedEntityRef(body.Sensor.IotId, body.Sensor.Name, body.Sensor.Description),
+            ObservedProperty = new RelatedEntityRef(
+                body.ObservedProperty.IotId, body.ObservedProperty.Name, body.ObservedProperty.Description)
+        };
+
+        var created = await store.CreateDatastreamAsync(request, ct).ConfigureAwait(false);
+        var staBase = StaBase(context);
+        var datastream = StaEntityMapper.MapDatastream(created, staBase, expandedObservations: null);
+        context.Response.Headers.Location = datastream.IotSelfLink;
+        return Results.Json(datastream, SensorThingsJsonContext.Default.StaDatastream, statusCode: 201);
+    }
+}

--- a/src/Honua.Protocols.SensorThings/SensorThingsEndpoints.cs
+++ b/src/Honua.Protocols.SensorThings/SensorThingsEndpoints.cs
@@ -57,6 +57,13 @@ internal static class SensorThingsEndpoints
             .Produces<StaEntitySet<StaObservation>>(200, "application/json")
             .Produces(404);
 
+        // Phase 2 ingest (REST/bulk observation creation + datastream creation) and
+        // Phase 3 real-time streaming (SSE/WebSocket) are mapped from their partial-class
+        // files so each route stays a literal MapPost/MapGet the source-scan governance can
+        // anchor to an EndpointRegistry entry.
+        endpoints.MapSensorThingsIngestEndpoints();
+        Streaming.ObservationStreamEndpoints.MapSensorThingsStreamEndpoints(endpoints);
+
         return endpoints;
     }
 

--- a/src/Honua.Protocols.SensorThings/SensorThingsJsonContext.cs
+++ b/src/Honua.Protocols.SensorThings/SensorThingsJsonContext.cs
@@ -23,6 +23,11 @@ namespace Honua.Protocols.SensorThings;
 [JsonSerializable(typeof(StaDatastream))]
 [JsonSerializable(typeof(StaObservation))]
 [JsonSerializable(typeof(StaUnitOfMeasurement))]
+[JsonSerializable(typeof(StaObservationCreate))]
+[JsonSerializable(typeof(StaObservationBulkCreate))]
+[JsonSerializable(typeof(StaObservationBulkResult))]
+[JsonSerializable(typeof(StaDatastreamCreate))]
+[JsonSerializable(typeof(StaEntityReference))]
 internal sealed partial class SensorThingsJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Protocols.SensorThings/SensorThingsServiceCollectionExtensions.cs
+++ b/src/Honua.Protocols.SensorThings/SensorThingsServiceCollectionExtensions.cs
@@ -1,8 +1,13 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.SensorThings.Abstractions;
 using Honua.Protocols.SensorThings.Services;
+using Honua.Protocols.SensorThings.Streaming;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
 
 namespace Honua.Protocols.SensorThings;
 
@@ -14,13 +19,26 @@ internal static class SensorThingsServiceCollectionExtensions
     /// <summary>
     /// Adds SensorThings API services. The observations store
     /// (<see cref="Honua.Core.Features.SensorThings.Abstractions.IObservationStore"/>)
-    /// is registered by the active data provider.
+    /// is registered by the active data provider. The Phase 2 ingest path publishes new
+    /// observations to the Phase 3 real-time stream through
+    /// <see cref="IObservationChangeEventPublisher"/>, implemented by the singleton
+    /// <see cref="ObservationStreamSessionManager"/> (Redis cross-node fan-out when a
+    /// multiplexer is registered, single-node otherwise).
     /// </summary>
     public static IServiceCollection AddSensorThings(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 
         services.TryAddScoped<StaObservationFilterTranslator>();
+
+        // The session manager is both the observation-stream transport and the
+        // change-event publisher consumed by the ingest path.
+        services.TryAddSingleton(sp => new ObservationStreamSessionManager(
+            sp.GetRequiredService<ILogger<ObservationStreamSessionManager>>(),
+            sp.GetService<IConnectionMultiplexer>()));
+        services.TryAddSingleton<IObservationChangeEventPublisher>(sp =>
+            sp.GetRequiredService<ObservationStreamSessionManager>());
+        services.AddHostedService<ObservationStreamHeartbeatService>();
 
         return services;
     }

--- a/src/Honua.Protocols.SensorThings/Streaming/ObservationStreamEndpoints.cs
+++ b/src/Honua.Protocols.SensorThings/Streaming/ObservationStreamEndpoints.cs
@@ -1,0 +1,251 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.IO;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Protocols.SensorThings.Streaming;
+
+/// <summary>
+/// OGC SensorThings real-time observation streaming endpoint (Phase 3, #1747).
+/// A single route serves both Server-Sent Events (<c>Accept: text/event-stream</c>) and
+/// WebSocket (upgrade request) transports, reusing the bounded-channel session pattern of
+/// the server feature-change stream. Newly-ingested observations (Phase 2) are pushed to
+/// connected clients in near-real-time without an MQTT broker dependency.
+/// </summary>
+internal static class ObservationStreamEndpoints
+{
+    private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(25);
+
+    /// <summary>Maps the SensorThings observation-stream endpoint.</summary>
+    public static IEndpointRouteBuilder MapSensorThingsStreamEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/sta/v1.1/ObservationsStream", HandleStream)
+            .WithDisplayName("STA Observation Stream")
+            .WithName("StaObservationStream")
+            .WithSummary("Stream new Observations in real time (SSE or WebSocket)")
+            .WithDescription(
+                "Opens a real-time stream of newly-ingested Observations. SSE: send " +
+                "Accept: text/event-stream. WebSocket: send an Upgrade request. " +
+                "Optional query param: datastreamId (tail a single Datastream).")
+            .WithTags("SensorThings")
+            .Produces(200, contentType: "text/event-stream")
+            .Produces(400);
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleStream(
+        HttpContext context,
+        [FromServices] ObservationStreamSessionManager sessionManager)
+    {
+        long? datastreamId = null;
+        if (context.Request.Query.TryGetValue("datastreamId", out var raw) &&
+            long.TryParse(raw.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            datastreamId = parsed;
+        }
+
+        var isWebSocket = context.WebSockets.IsWebSocketRequest;
+        var accept = context.Request.Headers.Accept.ToString();
+        var isSse = accept.Contains("text/event-stream", StringComparison.OrdinalIgnoreCase);
+
+        if (!isWebSocket && !isSse)
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                "WebSocket upgrade or Accept: text/event-stream header required.");
+        }
+
+        if (isWebSocket)
+        {
+            await HandleWebSocketAsync(context, sessionManager, datastreamId).ConfigureAwait(false);
+        }
+        else
+        {
+            await HandleSseAsync(context, sessionManager, datastreamId).ConfigureAwait(false);
+        }
+
+        return Results.Empty;
+    }
+
+    private static async Task HandleSseAsync(
+        HttpContext context,
+        ObservationStreamSessionManager sessionManager,
+        long? datastreamId)
+    {
+        var session = sessionManager.TryCreateSession("SSE", datastreamId);
+        if (session is null)
+        {
+            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            return;
+        }
+
+        using var sessionLease = session;
+        context.Response.ContentType = "text/event-stream";
+        context.Response.Headers.CacheControl = "no-cache";
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            context.RequestAborted, session.DisconnectToken);
+        var ct = linkedCts.Token;
+
+        try
+        {
+            await WriteSseAsync(
+                context.Response,
+                "status",
+                JsonSerializer.Serialize(
+                    new ObservationStreamStatus { Status = "connected", DatastreamId = datastreamId },
+                    ObservationStreamJsonContext.Default.ObservationStreamStatus),
+                ct).ConfigureAwait(false);
+            await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+
+            while (!ct.IsCancellationRequested)
+            {
+                using var readCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                var readTask = session.Reader.WaitToReadAsync(readCts.Token).AsTask();
+                var timeoutTask = Task.Delay(HeartbeatInterval, readCts.Token);
+                var completed = await Task.WhenAny(readTask, timeoutTask).ConfigureAwait(false);
+                readCts.Cancel();
+
+                if (completed == timeoutTask)
+                {
+                    await SwallowAsync(readTask).ConfigureAwait(false);
+                    await WriteSseAsync(context.Response, "heartbeat", "{}", ct).ConfigureAwait(false);
+                    await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+                    continue;
+                }
+
+                await SwallowAsync(timeoutTask).ConfigureAwait(false);
+                if (!await readTask.ConfigureAwait(false))
+                {
+                    break;
+                }
+
+                while (session.Reader.TryRead(out var frame))
+                {
+                    if (frame.IsHeartbeat)
+                    {
+                        await WriteSseAsync(context.Response, "heartbeat", "{}", ct).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        var json = JsonSerializer.Serialize(frame, ObservationStreamJsonContext.Default.ObservationStreamFrame);
+                        await WriteSseAsync(context.Response, "observation", json, ct).ConfigureAwait(false);
+                    }
+                }
+
+                await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Normal disconnect.
+        }
+        catch (IOException)
+        {
+            // Client disconnected.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Response disposed.
+        }
+    }
+
+    private static async Task HandleWebSocketAsync(
+        HttpContext context,
+        ObservationStreamSessionManager sessionManager,
+        long? datastreamId)
+    {
+        var session = sessionManager.TryCreateSession("WebSocket", datastreamId);
+        if (session is null)
+        {
+            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            return;
+        }
+
+        using var sessionLease = session;
+        using var socket = await context.WebSockets.AcceptWebSocketAsync().ConfigureAwait(false);
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            context.RequestAborted, session.DisconnectToken);
+        var ct = linkedCts.Token;
+
+        try
+        {
+            await SendSocketAsync(
+                socket,
+                JsonSerializer.Serialize(
+                    new ObservationStreamStatus { Status = "connected", DatastreamId = datastreamId },
+                    ObservationStreamJsonContext.Default.ObservationStreamStatus),
+                ct).ConfigureAwait(false);
+
+            while (!ct.IsCancellationRequested && socket.State == WebSocketState.Open)
+            {
+                using var readCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                var readTask = session.Reader.WaitToReadAsync(readCts.Token).AsTask();
+                var timeoutTask = Task.Delay(HeartbeatInterval, readCts.Token);
+                var completed = await Task.WhenAny(readTask, timeoutTask).ConfigureAwait(false);
+                readCts.Cancel();
+
+                if (completed == timeoutTask)
+                {
+                    await SwallowAsync(readTask).ConfigureAwait(false);
+                    await SendSocketAsync(socket, "{\"heartbeat\":true}", ct).ConfigureAwait(false);
+                    continue;
+                }
+
+                await SwallowAsync(timeoutTask).ConfigureAwait(false);
+                if (!await readTask.ConfigureAwait(false))
+                {
+                    break;
+                }
+
+                while (session.Reader.TryRead(out var frame))
+                {
+                    if (frame.IsHeartbeat)
+                    {
+                        await SendSocketAsync(socket, "{\"heartbeat\":true}", ct).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        var json = JsonSerializer.Serialize(frame, ObservationStreamJsonContext.Default.ObservationStreamFrame);
+                        await SendSocketAsync(socket, json, ct).ConfigureAwait(false);
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Normal disconnect.
+        }
+        catch (WebSocketException)
+        {
+            // Client closed abruptly.
+        }
+    }
+
+    private static Task WriteSseAsync(HttpResponse response, string eventName, string json, CancellationToken ct) =>
+        response.WriteAsync(string.Concat("event: ", eventName, "\ndata: ", json, "\n\n"), ct);
+
+    private static Task SendSocketAsync(WebSocket socket, string json, CancellationToken ct) =>
+        socket.SendAsync(Encoding.UTF8.GetBytes(json), WebSocketMessageType.Text, endOfMessage: true, ct);
+
+    private static async Task SwallowAsync(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when the alternate waiter is cancelled.
+        }
+    }
+}

--- a/src/Honua.Protocols.SensorThings/Streaming/ObservationStreamHeartbeatService.cs
+++ b/src/Honua.Protocols.SensorThings/Streaming/ObservationStreamHeartbeatService.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Hosting;
+
+namespace Honua.Protocols.SensorThings.Streaming;
+
+/// <summary>
+/// Pulses observation-stream heartbeats so idle SSE/WebSocket connections stay alive
+/// behind proxies. Lightweight: a single timer loop that fans a keep-alive frame out to
+/// all sessions; transports also self-heartbeat on read timeout, so this is belt-and-braces.
+/// </summary>
+internal sealed class ObservationStreamHeartbeatService : BackgroundService
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(25);
+    private readonly ObservationStreamSessionManager _sessionManager;
+
+    public ObservationStreamHeartbeatService(ObservationStreamSessionManager sessionManager)
+    {
+        _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(Interval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                if (_sessionManager.SessionCount > 0)
+                {
+                    _sessionManager.BroadcastHeartbeat();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+    }
+}

--- a/src/Honua.Protocols.SensorThings/Streaming/ObservationStreamModels.cs
+++ b/src/Honua.Protocols.SensorThings/Streaming/ObservationStreamModels.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json.Serialization;
+using Honua.Core.Features.SensorThings.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Protocols.SensorThings.Streaming;
+
+/// <summary>
+/// A single frame pushed to an observation-stream client. Either a heartbeat (keep-alive)
+/// or a newly-ingested observation rendered in a compact, STA-shaped form.
+/// </summary>
+public sealed record ObservationStreamFrame
+{
+    /// <summary>True when this frame is a keep-alive heartbeat rather than an observation.</summary>
+    [JsonIgnore]
+    public bool IsHeartbeat { get; init; }
+
+    /// <summary>Observation identifier (<c>@iot.id</c>).</summary>
+    [JsonPropertyName("@iot.id")]
+    public long IotId { get; init; }
+
+    /// <summary>Identifier of the owning datastream.</summary>
+    [JsonPropertyName("datastreamId")]
+    public long DatastreamId { get; init; }
+
+    /// <summary>Phenomenon time (ISO-8601).</summary>
+    [JsonPropertyName("phenomenonTime")]
+    public string? PhenomenonTime { get; init; }
+
+    /// <summary>The numeric measurement result.</summary>
+    [JsonPropertyName("result")]
+    public double Result { get; init; }
+
+    /// <summary>Builds a frame from a persisted observation.</summary>
+    public static ObservationStreamFrame FromObservation(SensorThingsObservation observation) => new()
+    {
+        IsHeartbeat = false,
+        IotId = observation.Id,
+        DatastreamId = observation.DatastreamId,
+        PhenomenonTime = observation.PhenomenonTime
+            .ToUniversalTime()
+            .ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'", CultureInfo.InvariantCulture),
+        Result = observation.Result
+    };
+
+    /// <summary>Builds a keep-alive heartbeat frame.</summary>
+    public static ObservationStreamFrame Heartbeat() => new() { IsHeartbeat = true };
+}
+
+/// <summary>Status frame emitted on the SSE/WebSocket handshake.</summary>
+public sealed record ObservationStreamStatus
+{
+    /// <summary>Connection status token (e.g. <c>connected</c>).</summary>
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    /// <summary>The datastream id this stream is scoped to, or null for all.</summary>
+    [JsonPropertyName("datastreamId")]
+    public long? DatastreamId { get; init; }
+}
+
+/// <summary>Redis pub/sub envelope used to fan observation frames out across nodes.</summary>
+internal sealed record ClusterBroadcastDto(string OriginInstanceId, ObservationStreamFrame Frame);
+
+/// <summary>Source-generated JSON context for observation-stream frames.</summary>
+[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(ObservationStreamFrame))]
+[JsonSerializable(typeof(ObservationStreamStatus))]
+[JsonSerializable(typeof(ClusterBroadcastDto))]
+internal sealed partial class ObservationStreamJsonContext : System.Text.Json.Serialization.JsonSerializerContext
+{
+}
+
+/// <summary>Source-generated log messages for the observation-stream transport.</summary>
+internal static partial class ObservationStreamLog
+{
+    [LoggerMessage(EventId = 5100, Level = LogLevel.Debug, Message = "Observation stream session {SessionId} created ({Transport}, datastream {DatastreamId}).")]
+    public static partial void SessionCreated(ILogger logger, Guid sessionId, string transport, long? datastreamId);
+
+    [LoggerMessage(EventId = 5101, Level = LogLevel.Warning, Message = "Observation stream cluster fan-out unavailable; degraded to single-node delivery.")]
+    public static partial void ClusterUnavailable(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 5102, Level = LogLevel.Warning, Message = "Observation stream cluster publish failed.")]
+    public static partial void ClusterPublishFailed(ILogger logger, Exception exception);
+}

--- a/src/Honua.Protocols.SensorThings/Streaming/ObservationStreamSessionManager.cs
+++ b/src/Honua.Protocols.SensorThings/Streaming/ObservationStreamSessionManager.cs
@@ -1,0 +1,303 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Threading.Channels;
+using Honua.Core.Features.SensorThings.Abstractions;
+using Honua.Core.Features.SensorThings.Domain;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace Honua.Protocols.SensorThings.Streaming;
+
+/// <summary>
+/// Manages OGC SensorThings real-time observation-stream sessions (Phase 3, #1747).
+/// This mirrors the proven transport pattern of the server feature-change stream
+/// (<c>FeatureStreamSessionManager</c>): each connected client (SSE or WebSocket) gets
+/// a bounded channel, a heartbeat keeps idle connections alive, slow consumers whose
+/// buffer fills are dropped, and — when Redis is present — newly-ingested observations
+/// are fanned out across nodes via pub/sub. It also implements
+/// <see cref="IObservationChangeEventPublisher"/> so the Phase 2 ingest path pushes
+/// straight into the live fan-out. Observations are scoped per Datastream so a client
+/// can tail a single sensor feed.
+/// </summary>
+internal sealed class ObservationStreamSessionManager : IObservationChangeEventPublisher, IDisposable
+{
+    private static readonly RedisChannel BroadcastChannel =
+        new("sta:observation:stream:broadcast", RedisChannel.PatternMode.Literal);
+
+    private readonly ConcurrentDictionary<Guid, SessionEntry> _sessions = new();
+    private readonly ILogger<ObservationStreamSessionManager> _logger;
+    private readonly IConnectionMultiplexer? _redis;
+    private readonly ISubscriber? _subscriber;
+    private readonly string _instanceId = Guid.NewGuid().ToString("N");
+    private readonly int _maxConcurrentSessions;
+    private readonly int _maxBufferPerConnection;
+    private int _activeSessionCount;
+    private long _slowConsumerDrops;
+    private bool _clusterEnabled;
+
+    public ObservationStreamSessionManager(
+        ILogger<ObservationStreamSessionManager> logger,
+        IConnectionMultiplexer? redis = null,
+        int maxConcurrentSessions = 256,
+        int maxBufferPerConnection = 256)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _redis = redis;
+        _maxConcurrentSessions = maxConcurrentSessions;
+        _maxBufferPerConnection = maxBufferPerConnection;
+
+        if (_redis is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _subscriber = _redis.GetSubscriber();
+            _subscriber.Subscribe(BroadcastChannel, HandleClusterBroadcast);
+            _clusterEnabled = true;
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: degrade to single-node fan-out when Redis is unavailable.
+            ObservationStreamLog.ClusterUnavailable(_logger, ex);
+        }
+    }
+
+    /// <summary>Number of slow-consumer disconnects since startup.</summary>
+    public long SlowConsumerDrops => Interlocked.Read(ref _slowConsumerDrops);
+
+    /// <summary>Current active session count.</summary>
+    public int SessionCount => Volatile.Read(ref _activeSessionCount);
+
+    /// <summary>
+    /// Attempts to register a new session filtered to <paramref name="datastreamId"/>
+    /// (null = all datastreams). Returns null when the concurrent-session cap is reached.
+    /// </summary>
+    public ObservationStreamSession? TryCreateSession(string transport, long? datastreamId)
+    {
+        if (!TryReserveSlot())
+        {
+            return null;
+        }
+
+        var id = Guid.NewGuid();
+        var channel = Channel.CreateBounded<ObservationStreamFrame>(new BoundedChannelOptions(_maxBufferPerConnection)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite,
+            SingleReader = true,
+            SingleWriter = false
+        });
+        var cts = new CancellationTokenSource();
+        var entry = new SessionEntry(channel, cts, datastreamId, transport);
+        if (!_sessions.TryAdd(id, entry))
+        {
+            Interlocked.Decrement(ref _activeSessionCount);
+            cts.Dispose();
+            return null;
+        }
+
+        ObservationStreamLog.SessionCreated(_logger, id, transport, datastreamId);
+        return new ObservationStreamSession(id, channel.Reader, this, cts.Token);
+    }
+
+    private bool TryReserveSlot()
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref _activeSessionCount);
+            if (current >= _maxConcurrentSessions)
+            {
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _activeSessionCount, current + 1, current) == current)
+            {
+                return true;
+            }
+        }
+    }
+
+    /// <summary>Removes a session and releases its slot.</summary>
+    public void RemoveSession(Guid sessionId)
+    {
+        if (_sessions.TryRemove(sessionId, out var entry))
+        {
+            Interlocked.Decrement(ref _activeSessionCount);
+            entry.Cts.Cancel();
+            entry.Cts.Dispose();
+        }
+    }
+
+    /// <inheritdoc />
+    public void PublishObservations(IReadOnlyList<SensorThingsObservation> observations)
+    {
+        if (observations is null || observations.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var observation in observations)
+        {
+            var frame = ObservationStreamFrame.FromObservation(observation);
+            BroadcastLocally(frame);
+
+            if (_clusterEnabled && _subscriber is not null)
+            {
+                TryPublishCluster(frame);
+            }
+        }
+    }
+
+    private void TryPublishCluster(ObservationStreamFrame frame)
+    {
+        try
+        {
+            var payload = JsonSerializer.Serialize(
+                new ClusterBroadcastDto(_instanceId, frame),
+                ObservationStreamJsonContext.Default.ClusterBroadcastDto);
+            _subscriber!.Publish(BroadcastChannel, payload, CommandFlags.FireAndForget);
+        }
+        catch (Exception ex)
+        {
+            ObservationStreamLog.ClusterPublishFailed(_logger, ex);
+        }
+    }
+
+    private void HandleClusterBroadcast(RedisChannel channel, RedisValue value)
+    {
+        if (value.IsNullOrEmpty)
+        {
+            return;
+        }
+
+        try
+        {
+            var message = JsonSerializer.Deserialize(
+                value.ToString(), ObservationStreamJsonContext.Default.ClusterBroadcastDto);
+            if (message is null || string.Equals(message.OriginInstanceId, _instanceId, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            BroadcastLocally(message.Frame);
+        }
+        catch (Exception ex)
+        {
+            ObservationStreamLog.ClusterPublishFailed(_logger, ex);
+        }
+    }
+
+    private void BroadcastLocally(ObservationStreamFrame frame)
+    {
+        foreach (var (id, entry) in _sessions)
+        {
+            if (entry.Cts.IsCancellationRequested)
+            {
+                continue;
+            }
+
+            if (entry.DatastreamId is { } datastreamId && datastreamId != frame.DatastreamId)
+            {
+                continue;
+            }
+
+            // DropWrite bounded channel: a full buffer drops the frame and the reader
+            // observes the gap. Track the drop for slow-consumer visibility.
+            if (!entry.Channel.Writer.TryWrite(frame))
+            {
+                Interlocked.Increment(ref _slowConsumerDrops);
+            }
+        }
+    }
+
+    /// <summary>Sends a heartbeat frame to every active session.</summary>
+    public void BroadcastHeartbeat()
+    {
+        foreach (var (_, entry) in _sessions)
+        {
+            if (!entry.Cts.IsCancellationRequested)
+            {
+                entry.Channel.Writer.TryWrite(ObservationStreamFrame.Heartbeat());
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_subscriber is not null)
+        {
+            try
+            {
+                _subscriber.Unsubscribe(BroadcastChannel, HandleClusterBroadcast);
+            }
+            catch
+            {
+                // Best-effort shutdown.
+            }
+        }
+
+        foreach (var (_, entry) in _sessions)
+        {
+            entry.Cts.Cancel();
+            entry.Cts.Dispose();
+        }
+
+        _sessions.Clear();
+        Interlocked.Exchange(ref _activeSessionCount, 0);
+    }
+
+    private sealed class SessionEntry
+    {
+        public SessionEntry(
+            Channel<ObservationStreamFrame> channel,
+            CancellationTokenSource cts,
+            long? datastreamId,
+            string transport)
+        {
+            Channel = channel;
+            Cts = cts;
+            DatastreamId = datastreamId;
+            Transport = transport;
+        }
+
+        public Channel<ObservationStreamFrame> Channel { get; }
+        public CancellationTokenSource Cts { get; }
+        public long? DatastreamId { get; }
+        public string Transport { get; }
+    }
+}
+
+/// <summary>
+/// Handle returned to the transport loop: drains frames and signals disconnect.
+/// </summary>
+internal sealed class ObservationStreamSession : IDisposable
+{
+    private readonly ObservationStreamSessionManager _manager;
+
+    public ObservationStreamSession(
+        Guid sessionId,
+        ChannelReader<ObservationStreamFrame> reader,
+        ObservationStreamSessionManager manager,
+        CancellationToken disconnectToken)
+    {
+        SessionId = sessionId;
+        Reader = reader;
+        DisconnectToken = disconnectToken;
+        _manager = manager;
+    }
+
+    /// <summary>Unique session identifier.</summary>
+    public Guid SessionId { get; }
+
+    /// <summary>Channel reader for the transport loop.</summary>
+    public ChannelReader<ObservationStreamFrame> Reader { get; }
+
+    /// <summary>Fires when the session is removed.</summary>
+    public CancellationToken DisconnectToken { get; }
+
+    public void Dispose() => _manager.RemoveSession(SessionId);
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -1084,6 +1084,14 @@ public static class EndpointRegistry
         new("GET", "/ogc/coverages/collections/{collectionId}/schema"),
         new("GET", "/ogc/coverages/collections/{collectionId}/coverage"),
 
+        // OGC API - Environmental Data Retrieval (EDR) (#1757)
+        new("GET", "/edr"),
+        new("GET", "/edr/conformance"),
+        new("GET", "/edr/collections"),
+        new("GET", "/edr/collections/{collectionId}"),
+        new("GET", "/edr/collections/{collectionId}/position"),
+        new("GET", "/edr/collections/{collectionId}/cube"),
+
         // OGC API Processes
         new("GET", "/ogc/processes"),
         new("GET", "/ogc/processes/conformance"),
@@ -1262,6 +1270,12 @@ public static class EndpointRegistry
         new("GET", "/sta/v1.1/Datastreams({id})/Observations"),
         new("GET", "/sta/v1.1/Observations"),
         new("GET", "/sta/v1.1/Observations({id})"),
+
+        // OGC SensorThings API (STA v1.1) Phase 2 ingest + Phase 3 streaming (#1747)
+        new("POST", "/sta/v1.1/Observations"),
+        new("POST", "/sta/v1.1/Datastreams({id})/Observations"),
+        new("POST", "/sta/v1.1/Datastreams"),
+        new("GET", "/sta/v1.1/ObservationsStream"),
 
         // Hosted samples
         new("GET", "/samples/stac-ops"),

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -45,6 +45,7 @@ using Honua.Server.Features.Plugins;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Honua.Protocols.OData;
 using Honua.Protocols.Ogc.Api.Coverages;
+using Honua.Protocols.Ogc.Api.Edr;
 using Honua.Protocols.Ogc.Api.Features;
 using Honua.Protocols.Ogc.Api.Maps;
 using Honua.Protocols.Ogc.Api.Processes;
@@ -102,6 +103,7 @@ internal static class FeatureRegistrationExtensions
         services.AddImageServer(configuration);
         services.AddMapServer(configuration);
         services.AddOgcCoverages();
+        services.AddEdr();
         services.AddOgcFeatures(configuration);
         services.AddOgcMaps();
         services.AddOgcStyles();
@@ -261,6 +263,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapPMTilesProxyEndpoints();
         endpoints.MapStyleEndpoints();
         endpoints.MapOgcCoveragesEndpoints();
+        endpoints.MapEdrEndpoints();
         endpoints.MapOgcFeaturesEndpoints();
         endpoints.MapOgcMapsEndpoints();
         endpoints.MapOgcStylesEndpoints();

--- a/src/Honua.Server/OperationRegistry.cs
+++ b/src/Honua.Server/OperationRegistry.cs
@@ -36,6 +36,7 @@ public static class OperationRegistry
     private const string Grpc = "Grpc";
     private const string Mcp = "Mcp";
     private const string VersionManagementServer = "VersionManagementServer";
+    private const string SensorThings11 = "SensorThings-1.1";
 
     /// <summary>
     /// All public-interface operations that require integration test coverage.
@@ -143,6 +144,12 @@ public static class OperationRegistry
         new(VersionManagementServer, "resolveConflicts"),
         new(VersionManagementServer, "post"),
         new(VersionManagementServer, "jobStatus"),
+
+        // OGC SensorThings API (STA v1.1) Phase 2 ingest operations (#1747). These are
+        // surfaced on the unified operations toolset so the console + AI reach observation
+        // ingest and datastream creation identically (dotted operation identifiers).
+        new(SensorThings11, "datastream.create"),
+        new(SensorThings11, "sensor.ingest"),
     ];
 }
 

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Edr/EdrEndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Edr/EdrEndpointsTests.cs
@@ -1,0 +1,198 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Edr;
+
+/// <summary>
+/// Integration tests for the OGC API - Environmental Data Retrieval (EDR) surface (#1757):
+/// collections discovery, the position (point time-series) query, and the cube (area/subset)
+/// query over the registered coverage collection, returning CoverageJSON. Raster reads are
+/// mocked so position/cube exercise the canonical point-sample pipeline deterministically.
+/// </summary>
+[Collection("Database.OgcApiData")]
+[Protocol(TestProtocols.OgcApiCoverages)]
+public sealed class EdrEndpointsTests : IAsyncLifetime
+{
+    private const long TestRasterId = 521;
+    private readonly IRasterStore _rasterStore = Substitute.For<IRasterStore>();
+    private readonly WebAppFixture _fixture;
+
+    public EdrEndpointsTests()
+    {
+        ConfigureRasterStore(_rasterStore);
+        _fixture = new WebAppFixture().ReplaceService(_rasterStore);
+    }
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /edr")]
+    [Endpoint("GET /edr/conformance")]
+    [Endpoint("GET /edr/collections")]
+    [Endpoint("GET /edr/collections/{collectionId}")]
+    public async Task Edr_MetadataEndpoints_ExposeCollectionsWithPositionAndCubeQueries()
+    {
+        var landing = await _fixture.Client.GetAsync("/edr");
+        landing.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var conformance = await _fixture.Client.GetAsync("/edr/conformance");
+        var conformanceContent = await conformance.Content.ReadAsStringAsync();
+        conformance.StatusCode.Should().Be(HttpStatusCode.OK);
+        conformanceContent.Should().Contain("ogcapi-edr");
+
+        using var collectionsDoc = await GetJsonAsync("/edr/collections");
+        var collections = collectionsDoc.RootElement.GetProperty("collections").EnumerateArray().ToArray();
+        collections.Should().ContainSingle();
+        var collectionId = collections[0].GetProperty("id").GetString();
+        collectionId.Should().Be(WebAppFixture.TestLayerId.ToString(CultureInfo.InvariantCulture));
+
+        using var collectionDoc = await GetJsonAsync($"/edr/collections/{WebAppFixture.TestLayerId}");
+        var dataQueries = collectionDoc.RootElement.GetProperty("data_queries");
+        dataQueries.TryGetProperty("position", out _).Should().BeTrue();
+        dataQueries.TryGetProperty("cube", out _).Should().BeTrue();
+        collectionDoc.RootElement.GetProperty("parameter_names").TryGetProperty("band_1", out _).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /edr/collections/{collectionId}/position")]
+    public async Task Edr_Position_ReturnsCoverageJsonPointSeries()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/edr/collections/{WebAppFixture.TestLayerId}/position?coords=POINT(-122.4 37.8)&datetime=2026-06-20T00:00:00Z");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/prs.coveragejson+json");
+
+        using var doc = JsonDocument.Parse(content);
+        doc.RootElement.GetProperty("type").GetString().Should().Be("Coverage");
+        doc.RootElement.GetProperty("domain").GetProperty("domainType").GetString().Should().Be("PointSeries");
+        doc.RootElement.GetProperty("domain").GetProperty("axes").GetProperty("t").GetProperty("values")
+            .EnumerateArray().First().GetString().Should().Contain("2026-06-20");
+
+        var range = doc.RootElement.GetProperty("ranges").GetProperty("band_1");
+        range.GetProperty("values").EnumerateArray().First().GetDouble().Should().Be(11.0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /edr/collections/{collectionId}/cube")]
+    public async Task Edr_Cube_ReturnsCoverageJsonGridSubset()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/edr/collections/{WebAppFixture.TestLayerId}/cube?bbox=-122.5,37.7,-122.3,37.9&resolution-x=2");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        using var doc = JsonDocument.Parse(content);
+        doc.RootElement.GetProperty("domain").GetProperty("domainType").GetString().Should().Be("Grid");
+        var range = doc.RootElement.GetProperty("ranges").GetProperty("band_1");
+        // 2x2 sampling grid.
+        range.GetProperty("shape").EnumerateArray().Select(v => v.GetInt32()).Should().Equal(2, 2);
+        range.GetProperty("values").GetArrayLength().Should().Be(4);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("GET /edr/collections/{collectionId}/position")]
+    public async Task Edr_Position_InvalidCoords_Returns400()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/edr/collections/{WebAppFixture.TestLayerId}/position?coords=notapoint");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("GET /edr/collections/{collectionId}/cube")]
+    public async Task Edr_Cube_MissingBbox_Returns400()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/edr/collections/{WebAppFixture.TestLayerId}/cube");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("GET /edr/collections/{collectionId}")]
+    public async Task Edr_UnknownCollection_Returns404()
+    {
+        var response = await _fixture.Client.GetAsync("/edr/collections/9999999/position?coords=POINT(-122.4 37.8)");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private async Task<JsonDocument> GetJsonAsync(string uri)
+    {
+        var response = await _fixture.Client.GetAsync(uri);
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        return JsonDocument.Parse(content);
+    }
+
+    private static void ConfigureRasterStore(IRasterStore rasterStore)
+    {
+        var raster = CreateRasterInfo();
+
+        rasterStore.GetPrimaryRasterInfoAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<RasterInfo?>(null));
+        rasterStore.GetPrimaryRasterInfoAsync(WebAppFixture.TestLayerId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<RasterInfo?>(raster));
+
+        rasterStore.GetExtentAsync(WebAppFixture.TestLayerId, TestRasterId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<RasterExtent?>(raster.Extent));
+
+        // Deterministic point-sample: band_n returns 10 + n at every coordinate.
+        rasterStore.IdentifyAsync(
+                WebAppFixture.TestLayerId,
+                TestRasterId,
+                Arg.Any<double>(),
+                Arg.Any<double>(),
+                Arg.Any<int?>(),
+                Arg.Any<RasterIdentifyRendering?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => Task.FromResult(new PixelValueResult
+            {
+                X = call.ArgAt<double>(2),
+                Y = call.ArgAt<double>(3),
+                Srid = 4326,
+                HasData = true,
+                BandValues = new Dictionary<int, object?> { [1] = 11.0, [2] = 12.0, [3] = 13.0 }
+            }));
+    }
+
+    private static RasterInfo CreateRasterInfo()
+        => new()
+        {
+            Id = TestRasterId,
+            LayerId = WebAppFixture.TestLayerId,
+            Name = "test-coverage",
+            Width = 64,
+            Height = 64,
+            BandCount = 3,
+            PixelType = "32BF",
+            Srid = 4326,
+            NoDataValue = -9999,
+            GeoTransform = [-122.5, 0.003125, 0, 37.9, 0, -0.003125],
+            Extent = new RasterExtent { XMin = -122.5, YMin = 37.7, XMax = -122.3, YMax = 37.9, Srid = 4326 },
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+}

--- a/tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsIngestEndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsIngestEndpointsTests.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Protocols.SensorThings;
+
+/// <summary>
+/// Integration tests for the OGC SensorThings API (STA v1.1) Phase 2 ingest endpoints
+/// (#1747): REST/bulk observation creation and datastream creation. Ingested observations
+/// must be visible through the Phase 1 read API, proving the ingest → store → read loop.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.SensorThings)]
+public sealed class SensorThingsIngestEndpointsTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    private static StringContent Json(string body) => new(body, Encoding.UTF8, "application/json");
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /sta/v1.1/Observations")]
+    [InterfaceOperation(TestProtocols.SensorThings, "sensor.ingest")]
+    public async Task PostObservation_SingleIntoSeededDatastream_PersistsAndIsReadable()
+    {
+        var payload = Json("""
+            { "phenomenonTime": "2026-06-20T12:00:00Z", "result": 42.5, "Datastream": { "@iot.id": 1 } }
+            """);
+
+        var response = await _fixture.Client.PostAsync("/sta/v1.1/Observations", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var id = doc.RootElement.GetProperty("@iot.id").GetInt64();
+        id.Should().BeGreaterThan(0);
+        doc.RootElement.GetProperty("result").GetDouble().Should().Be(42.5);
+
+        // The new observation must be readable through the Phase 1 read API.
+        var read = await _fixture.Client.GetAsync($"/sta/v1.1/Observations({id})");
+        read.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /sta/v1.1/Observations")]
+    [InterfaceOperation(TestProtocols.SensorThings, "sensor.ingest")]
+    public async Task PostObservations_BulkEnvelope_PersistsAllRows()
+    {
+        var payload = Json("""
+            { "value": [
+                { "phenomenonTime": "2026-06-20T13:00:00Z", "result": 1.0, "Datastream": { "@iot.id": 1 } },
+                { "phenomenonTime": "2026-06-20T14:00:00Z", "result": 2.0, "Datastream": { "@iot.id": 1 } },
+                { "phenomenonTime": "2026-06-20T15:00:00Z", "result": 3.0, "Datastream": { "@iot.id": 1 } }
+            ] }
+            """);
+
+        var response = await _fixture.Client.PostAsync("/sta/v1.1/Observations", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("@iot.count").GetInt64().Should().Be(3);
+        doc.RootElement.GetProperty("value").GetArrayLength().Should().Be(3);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /sta/v1.1/Datastreams({id})/Observations")]
+    [InterfaceOperation(TestProtocols.SensorThings, "sensor.ingest")]
+    public async Task PostObservation_OnDatastreamNavigation_PersistsToThatDatastream()
+    {
+        var payload = Json("""{ "result": 7.0 }""");
+
+        var response = await _fixture.Client.PostAsync("/sta/v1.1/Datastreams(1)/Observations", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("result").GetDouble().Should().Be(7.0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /sta/v1.1/Observations")]
+    public async Task PostObservation_MissingDatastream_Returns404()
+    {
+        var payload = Json("""{ "result": 1.0, "Datastream": { "@iot.id": 999999 } }""");
+
+        var response = await _fixture.Client.PostAsync("/sta/v1.1/Observations", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /sta/v1.1/Datastreams")]
+    [InterfaceOperation(TestProtocols.SensorThings, "datastream.create")]
+    public async Task PostDatastream_WithInlineRelatedEntities_CreatesQueryableDatastream()
+    {
+        var payload = Json("""
+            {
+              "name": "Test Wind Speed",
+              "description": "Created by the ingest integration test",
+              "unitOfMeasurement": { "name": "metre per second", "symbol": "m/s", "definition": "http://unitsofmeasure.org/ucum.html#para-30" },
+              "Thing": { "name": "Test Station", "description": "test" },
+              "Sensor": { "name": "Anemometer", "description": "test" },
+              "ObservedProperty": { "name": "Wind Speed", "description": "test" }
+            }
+            """);
+
+        var response = await _fixture.Client.PostAsync("/sta/v1.1/Datastreams", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var id = doc.RootElement.GetProperty("@iot.id").GetInt64();
+        id.Should().BeGreaterThan(0);
+
+        // Created datastream must be readable, and ingest into it must round-trip.
+        var read = await _fixture.Client.GetAsync($"/sta/v1.1/Datastreams({id})");
+        read.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var observation = Json("""{ "result": 5.5 }""");
+        var ingest = await _fixture.Client.PostAsync($"/sta/v1.1/Datastreams({id})/Observations", observation);
+        ingest.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var observations = await _fixture.Client.GetAsync($"/sta/v1.1/Datastreams({id})/Observations");
+        using var obsDoc = JsonDocument.Parse(await observations.Content.ReadAsStringAsync());
+        obsDoc.RootElement.GetProperty("value").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /sta/v1.1/Datastreams")]
+    public async Task PostDatastream_MissingBody_Returns400()
+    {
+        var response = await _fixture.Client.PostAsync("/sta/v1.1/Datastreams", Json("{}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsStreamEndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsStreamEndpointsTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Protocols.SensorThings;
+
+/// <summary>
+/// Integration tests for the OGC SensorThings API (STA v1.1) Phase 3 real-time observation
+/// stream (#1747): the SSE transport handshake and live push of a newly-ingested observation.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.SensorThings)]
+public sealed class SensorThingsStreamEndpointsTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Streaming)]
+    [Endpoint("GET /sta/v1.1/ObservationsStream")]
+    public async Task ObservationsStream_WithoutTransportHeader_Returns400()
+    {
+        var response = await _fixture.Client.GetAsync("/sta/v1.1/ObservationsStream");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Streaming)]
+    [Endpoint("GET /sta/v1.1/ObservationsStream")]
+    public async Task ObservationsStream_Sse_EmitsConnectedThenPushesIngestedObservation()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/sta/v1.1/ObservationsStream?datastreamId=1");
+        request.Headers.TryAddWithoutValidation("Accept", "text/event-stream");
+
+        using var response = await _fixture.Client.SendAsync(
+            request, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("text/event-stream");
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cts.Token);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        // The handshake emits a "connected" status frame before any observation.
+        var handshake = await ReadUntilAsync(reader, "event: status", cts.Token);
+        handshake.Should().Contain("connected");
+
+        // Ingest an observation on datastream 1; the stream must push it.
+        var ingest = await _fixture.Client.PostAsync(
+            "/sta/v1.1/Datastreams(1)/Observations",
+            JsonContent.Create(new { result = 99.0 }),
+            cts.Token);
+        ingest.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var pushed = await ReadUntilAsync(reader, "event: observation", cts.Token);
+        pushed.Should().Contain("\"result\":99");
+        pushed.Should().Contain("\"datastreamId\":1");
+    }
+
+    /// <summary>
+    /// Reads SSE lines until a line containing <paramref name="marker"/> is seen, then returns
+    /// the marker line plus the following data line. Heartbeats are skipped.
+    /// </summary>
+    private static async Task<string> ReadUntilAsync(StreamReader reader, string marker, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var line = await reader.ReadLineAsync(cancellationToken);
+            if (line is null)
+            {
+                throw new InvalidOperationException($"Stream closed before '{marker}' was observed.");
+            }
+
+            if (line.Contains(marker, StringComparison.Ordinal))
+            {
+                var dataLine = await reader.ReadLineAsync(cancellationToken) ?? string.Empty;
+                return string.Concat(line, "\n", dataLine);
+            }
+        }
+
+        throw new OperationCanceledException(cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary

Two new real-time / environmental data API surfaces, delivered as real, building, tested increments.

### OGC SensorThings API (STA v1.1) — #1747
Phase 1 (entity model + read API + Observations time-series store + metadata-v2 publication type) already shipped on `trunk`. This PR adds:

- **Phase 2 — ingest**
  - `POST /sta/v1.1/Observations` (single observation **and** a `{ "value": [...] }` bulk envelope)
  - `POST /sta/v1.1/Datastreams({id})/Observations`
  - `POST /sta/v1.1/Datastreams` (creates the Datastream and, when their ids are absent, the related Thing / Sensor / ObservedProperty)
  - Backed by `IObservationStore.IngestObservationsAsync` / `CreateDatastreamAsync` on the Postgres store (transactional id assignment over the migration-059 tables).
  - Surfaced as the unified operations **`datastream.create`** and **`sensor.ingest`** in `OperationRegistry`.
- **Phase 3 — real-time streaming**
  - `GET /sta/v1.1/ObservationsStream` over **SSE and WebSocket**, optionally scoped to a `datastreamId`.
  - New `ObservationStreamSessionManager` reuses the proven feature-stream transport pattern (bounded per-connection channel, heartbeat keep-alive, slow-consumer drop, Redis cross-node fan-out) and implements `IObservationChangeEventPublisher`, so the Phase 2 ingest path pushes new observations straight into the live fan-out. **No MQTT broker dependency.**

### OGC API - Environmental Data Retrieval (EDR) — #1757
New `/edr` surface inside `Honua.Protocols.OgcApi`:
- Landing, conformance, collections list + by-id (with `data_queries` for position+cube and `parameter_names`).
- **`/edr/collections/{id}/position`** — point time-series (CoverageJSON `PointSeries`).
- **`/edr/collections/{id}/cube`** — area/subset query (CoverageJSON `Grid`).
- Thin adapter over the registered coverage/datacube catalog: collection discovery rides the shared metadata graph and value reads ride the canonical raster pipeline (`IRasterStore.IdentifyAsync`) — no reimplementation of data access.

## Per-ticket done vs. deferred

| Ticket | Status | Done | Deferred |
|---|---|---|---|
| #1747 | core complete | P1 read (pre-existing) + P2 REST/bulk ingest + `datastream.create`/`sensor.ingest` ops + P3 SSE/WebSocket streaming wired to ingest | P4 live camera feeds + STA-native MQTT pub/sub (need a live backend / broker) — Refs only |
| #1757 | complete | EDR landing/conformance/collections + **position** + **cube** over registered coverages, CoverageJSON output | none in scope |

Closes #1747
Closes #1757

## Governance & verification
- New routes registered in `EndpointRegistry`; new ops in `OperationRegistry`; proof-ledger surfaces updated (`sensorthings-1.1` extended, `ogc-api-edr` added); `feature-catalog.json` regenerated.
- Release build with `TreatWarningsAsErrors=true` across the solution: **0 warnings, 0 errors**.
- `dotnet format --verify-no-changes`: clean.
- Tests run **serially**:
  - `Honua.Protocols.SensorThings.Tests` — 22/22 (incl. ingest round-trips and live SSE push of an ingested observation).
  - EDR endpoint tests in `Honua.Protocols.OgcApi.Tests` — position/cube/metadata/error paths green.
  - `Honua.Architecture.Tests` — 116/116 (endpoint/operation coverage, proof-ledger, feature-catalog drift).
