### PR TITLE
feat: import Esri tile/vector-tile cache packages (.tpk/.tpkx/.vtpk) (#1269)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -308,6 +308,32 @@
       "maturity": "implemented"
     },
     {
+      "id": "delete-api-v1-admin-oauth-clients-id",
+      "route": "/api/v1/admin/oauth-clients/{id}",
+      "method": "DELETE",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.GetAndDeleteClient_RemovesRegistration"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "delete-api-v1-admin-oauth-scopes-scope",
+      "route": "/api/v1/admin/oauth-scopes/{scope}",
+      "method": "DELETE",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "delete-api-v1-admin-oidc-providers-id",
       "route": "/api/v1/admin/oidc/providers/{id}",
       "method": "DELETE",
@@ -2222,6 +2248,46 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Get_AfterRegister_ReturnsDataset",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Get_Missing_Returns404"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-clients",
+      "route": "/api/v1/admin/oauth-clients",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.ManagementSurface_RequiresAdminAuthorization",
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterAndListClient_ReturnsSecretOnlyAtCreation"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-clients-id",
+      "route": "/api/v1/admin/oauth-clients/{id}",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.GetAndDeleteClient_RemovesRegistration"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-scopes",
+      "route": "/api/v1/admin/oauth-scopes",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -9815,6 +9881,32 @@
       "maturity": "implemented"
     },
     {
+      "id": "get-tiles-imported-tilecacheid",
+      "route": "/tiles/imported/{tileCacheId}",
+      "method": "GET",
+      "family": "MVT \u002B TileJSON \u002B PMTiles",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Import.TileCachePackageEndpointTests.GetImportedTileSet_UnknownCache_ReturnsNotFound"
+      ],
+      "proof_ledger_surface": "vector-tiles-mvt",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-tiles-imported-tilecacheid-z-x-y",
+      "route": "/tiles/imported/{tileCacheId}/{z}/{x}/{y}",
+      "method": "GET",
+      "family": "MVT \u002B TileJSON \u002B PMTiles",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Import.TileCachePackageEndpointTests.ImportTilePackage_ThenServesTileAndTileSet"
+      ],
+      "proof_ledger_surface": "vector-tiles-mvt",
+      "maturity": "implemented"
+    },
+    {
       "id": "get-tiles-layerid-h3-z-x-y-mvt",
       "route": "/tiles/{layerId}/h3/{z}/{x}/{y}.mvt",
       "method": "GET",
@@ -11392,6 +11484,21 @@
       "maturity": "implemented"
     },
     {
+      "id": "post-api-v1-admin-import-tile-package",
+      "route": "/api/v1/admin/import/tile-package",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Import.TileCachePackageEndpointTests.ImportTilePackage_DryRun_ReportsPlanWithoutWriting",
+        "Honua.Server.Tests.Import.TileCachePackageEndpointTests.ImportTilePackage_WithMissingTilesetId_ReturnsBadRequest",
+        "Honua.Server.Tests.Import.TileCachePackageEndpointTests.ImportTilePackage_WithUnknownFormat_ReturnsBadRequest"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "post-api-v1-admin-import-upload",
       "route": "/api/v1/admin/import/upload",
       "method": "POST",
@@ -11859,6 +11966,20 @@
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Register_DuplicateId_Returns409",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Register_UnsafeEdgeTable_Returns400",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Register_ValidPayload_Returns201WithDto"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "post-api-v1-admin-oauth-clients",
+      "route": "/api/v1/admin/oauth-clients",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterAndListClient_ReturnsSecretOnlyAtCreation",
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterClient_WithInvalidClientType_ReturnsBadRequest"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -15993,8 +16114,10 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_AllItemsHaveStacFields",
+        "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WhenMorePagesExist_EmitsConformantPostNextLink",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithBbox_ReturnsFilteredResults",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithBody_ReturnsItems",
+        "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidPaginationToken_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidSortDirection_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidThreeDimensionalBbox_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithOutOfRangeBbox_ReturnsBadRequest",
@@ -16540,6 +16663,19 @@
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_ChangesMutableFields",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_Missing_Returns404",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_UnsafeVertexTable_Returns400"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "put-api-v1-admin-oauth-scopes",
+      "route": "/api/v1/admin/oauth-scopes",
+      "method": "PUT",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"

--- a/src/Honua.Core/Features/Migration/Abstractions/IOgcTileCacheSink.cs
+++ b/src/Honua.Core/Features/Migration/Abstractions/IOgcTileCacheSink.cs
@@ -71,6 +71,19 @@ public sealed record OgcTileCacheDescriptor
 
     /// <summary>Resolved maximum zoom level included in the export.</summary>
     public required int MaxZoom { get; init; }
+
+    /// <summary>
+    /// Tile payload kind served from this cache: <c>raster</c> (PNG/JPEG) or
+    /// <c>vector</c> (MVT/PBF). The WMTS exporter leaves this <see langword="null"/>
+    /// (the catalog default <c>raster</c> applies); the package importer (#1269)
+    /// sets it from the imported package's tiling scheme.
+    /// </summary>
+    public string? DataType { get; init; }
+
+    /// <summary>
+    /// Optional human-readable title carried into the served tileset descriptor.
+    /// </summary>
+    public string? Title { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/TileCachePackage/Abstractions/IImportedTileCacheReader.cs
+++ b/src/Honua.Core/Features/TileCachePackage/Abstractions/IImportedTileCacheReader.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.TileCachePackage.Domain;
+
+namespace Honua.Core.Features.TileCachePackage.Abstractions;
+
+/// <summary>
+/// Read path for tiles stored in Honua's tile catalog by the tile-cache package
+/// importer (#1269). This is the serving binding that lets imported
+/// <c>.tpk</c>/<c>.tpkx</c>/<c>.vtpk</c> caches be served through Honua tile
+/// endpoints without re-rendering.
+/// </summary>
+public interface IImportedTileCacheReader
+{
+    /// <summary>
+    /// Resolve the served tileset metadata for a cache identifier.
+    /// </summary>
+    /// <param name="tileCacheId">Stable tile-cache identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The tileset metadata, or <see langword="null"/> when no such cache exists.</returns>
+    Task<ImportedTileCacheInfo?> GetTileCacheAsync(
+        string tileCacheId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Read a single served tile.
+    /// </summary>
+    /// <param name="tileCacheId">Stable tile-cache identifier.</param>
+    /// <param name="z">Zoom level.</param>
+    /// <param name="x">Tile column.</param>
+    /// <param name="y">Tile row.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The tile bytes + content type, or <see langword="null"/> when absent.</returns>
+    Task<ImportedTile?> GetTileAsync(
+        string tileCacheId,
+        int z,
+        int x,
+        int y,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Served tileset metadata for an imported tile-cache.
+/// </summary>
+public sealed record ImportedTileCacheInfo
+{
+    /// <summary>Stable tile-cache identifier.</summary>
+    public required string TileCacheId { get; init; }
+
+    /// <summary>Logical tileset identifier the import bound to.</summary>
+    public required string LayerIdentifier { get; init; }
+
+    /// <summary>Honua tile-matrix-set identifier.</summary>
+    public required string TileMatrixSet { get; init; }
+
+    /// <summary>Served tile content type.</summary>
+    public required string TileFormat { get; init; }
+
+    /// <summary>Payload kind: <c>raster</c> or <c>vector</c>.</summary>
+    public required string DataType { get; init; }
+
+    /// <summary>Minimum zoom available.</summary>
+    public required int MinZoom { get; init; }
+
+    /// <summary>Maximum zoom available.</summary>
+    public required int MaxZoom { get; init; }
+
+    /// <summary>Optional human-readable title.</summary>
+    public string? Title { get; init; }
+}
+
+/// <summary>
+/// A single served tile.
+/// </summary>
+public sealed record ImportedTile
+{
+    /// <summary>Tile content type.</summary>
+    public required string ContentType { get; init; }
+
+    /// <summary>Tile content bytes.</summary>
+    public required byte[] Content { get; init; }
+}

--- a/src/Honua.Core/Features/TileCachePackage/Abstractions/ITileCachePackageImportService.cs
+++ b/src/Honua.Core/Features/TileCachePackage/Abstractions/ITileCachePackageImportService.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.TileCachePackage.Domain;
+
+namespace Honua.Core.Features.TileCachePackage.Abstractions;
+
+/// <summary>
+/// Imports an Esri tile/vector-tile cache package (<c>.tpk</c>/<c>.tpkx</c>/<c>.vtpk</c>)
+/// into Honua's tile catalog and binds it to a served tileset (#1269). The service
+/// reads the documented package layout via <see cref="ITileCachePackageReader"/> and
+/// persists tiles through the shared <c>IOgcTileCacheSink</c>, so re-imports are
+/// idempotent.
+/// </summary>
+public interface ITileCachePackageImportService
+{
+    /// <summary>
+    /// Import a tile-cache package and bind it to a served tileset.
+    /// </summary>
+    /// <param name="request">Import request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The import result, including the served tile-cache identifier.</returns>
+    Task<TileCachePackageImportResult> ImportAsync(
+        TileCachePackageImportRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/TileCachePackage/Abstractions/ITileCachePackageReader.cs
+++ b/src/Honua.Core/Features/TileCachePackage/Abstractions/ITileCachePackageReader.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.TileCachePackage.Domain;
+
+namespace Honua.Core.Features.TileCachePackage.Abstractions;
+
+/// <summary>
+/// Read-only reader for Esri tile/vector-tile cache packages (<c>.tpk</c>,
+/// <c>.tpkx</c>, <c>.vtpk</c>) (#1269). Implementations parse the documented
+/// published cache layout (<c>root.json</c>/<c>conf.xml</c> + Compact Cache V2
+/// bundles or exploded tile files) and stream the contained tiles. They do not
+/// reverse-engineer proprietary internals beyond the documented cache structure
+/// and never depend on licensed Esri software.
+/// </summary>
+public interface ITileCachePackageReader
+{
+    /// <summary>
+    /// Determines whether the supplied file name names a tile-cache package this
+    /// reader can import.
+    /// </summary>
+    /// <param name="fileName">Uploaded file name (with extension).</param>
+    /// <returns><see langword="true"/> for <c>.tpk</c>, <c>.tpkx</c>, or <c>.vtpk</c>.</returns>
+    bool CanRead(string fileName);
+
+    /// <summary>
+    /// Parse the package's tiling-scheme descriptor without reading tile bytes.
+    /// </summary>
+    /// <param name="package">Seekable stream over the package archive.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The parsed descriptor.</returns>
+    Task<TileCachePackageDescriptor> ReadDescriptorAsync(
+        Stream package,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stream every tile contained in the package, restricted to the supplied
+    /// inclusive zoom range. Coordinates are emitted in standard
+    /// <c>{z}/{x}=column/{y}=row</c> form (top-left tile origin).
+    /// </summary>
+    /// <param name="package">Seekable stream over the package archive.</param>
+    /// <param name="descriptor">Descriptor previously parsed from the package.</param>
+    /// <param name="minZoom">Inclusive minimum zoom to emit.</param>
+    /// <param name="maxZoom">Inclusive maximum zoom to emit.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An async stream of tiles.</returns>
+    IAsyncEnumerable<TileCachePackageTile> ReadTilesAsync(
+        Stream package,
+        TileCachePackageDescriptor descriptor,
+        int minZoom,
+        int maxZoom,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/TileCachePackage/Domain/TileCachePackageImportModels.cs
+++ b/src/Honua.Core/Features/TileCachePackage/Domain/TileCachePackageImportModels.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.TileCachePackage.Domain;
+
+/// <summary>
+/// Request to import an Esri tile-cache package into Honua's tile catalog (#1269).
+/// </summary>
+public sealed record TileCachePackageImportRequest
+{
+    /// <summary>Seekable stream over the uploaded package archive.</summary>
+    public required Stream Package { get; init; }
+
+    /// <summary>Original uploaded file name (used for format detection and provenance).</summary>
+    public required string FileName { get; init; }
+
+    /// <summary>
+    /// Logical tileset identifier the imported tiles bind to. Becomes the
+    /// catalog layer identifier and the address segment served tiles are fetched
+    /// under. Required.
+    /// </summary>
+    public required string TilesetId { get; init; }
+
+    /// <summary>Optional inclusive minimum zoom to import (defaults to the package minimum).</summary>
+    public int? MinZoom { get; init; }
+
+    /// <summary>Optional inclusive maximum zoom to import (defaults to the package maximum).</summary>
+    public int? MaxZoom { get; init; }
+
+    /// <summary>
+    /// Preview mode: parse the descriptor and report the plan without writing any
+    /// tiles into the catalog.
+    /// </summary>
+    public bool DryRun { get; init; }
+}
+
+/// <summary>
+/// Outcome of a tile-cache package import.
+/// </summary>
+public sealed record TileCachePackageImportResult
+{
+    /// <summary>Whether the import (or dry-run plan) succeeded.</summary>
+    public required bool Success { get; init; }
+
+    /// <summary>Stable tile-cache identifier the tiles were written to / would be served from.</summary>
+    public string? TileCacheId { get; init; }
+
+    /// <summary>Detected storage format.</summary>
+    public required string StorageFormat { get; init; }
+
+    /// <summary>Detected payload kind: <c>raster</c> or <c>vector</c>.</summary>
+    public required string DataType { get; init; }
+
+    /// <summary>Served tile content type.</summary>
+    public required string ContentType { get; init; }
+
+    /// <summary>Resolved Honua tile-matrix-set identifier.</summary>
+    public required string TileMatrixSet { get; init; }
+
+    /// <summary>Resolved minimum zoom imported.</summary>
+    public required int MinZoom { get; init; }
+
+    /// <summary>Resolved maximum zoom imported.</summary>
+    public required int MaxZoom { get; init; }
+
+    /// <summary>Number of tiles inserted (zero for dry-run or fully-deduplicated re-imports).</summary>
+    public required int TilesImported { get; init; }
+
+    /// <summary>Number of tiles skipped because they already existed in the catalog.</summary>
+    public required int TilesSkipped { get; init; }
+
+    /// <summary>Whether this was a dry-run (no tiles written).</summary>
+    public required bool DryRun { get; init; }
+}

--- a/src/Honua.Core/Features/TileCachePackage/Domain/TileCachePackageModels.cs
+++ b/src/Honua.Core/Features/TileCachePackage/Domain/TileCachePackageModels.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.TileCachePackage.Domain;
+
+/// <summary>
+/// Storage layout of an Esri tile/vector-tile cache package, as published in the
+/// documented Esri cache layout. Honua reads these layouts read-only for
+/// interoperability (#1269); it does not reverse-engineer proprietary internals
+/// beyond the documented cache structure.
+/// </summary>
+public enum TileCacheStorageFormat
+{
+    /// <summary>
+    /// Compact Cache V2 — <c>L{zz}/R{rrrr}C{cccc}.bundle</c> files with a 64-byte
+    /// header and a 16384-entry index. Used by <c>.tpkx</c> and <c>.vtpk</c>.
+    /// </summary>
+    CompactV2 = 0,
+
+    /// <summary>
+    /// Exploded raster cache — <c>_alllayers/L{zz}/R{8hex}/C{8hex}.{png|jpg}</c>
+    /// loose tile files. Used by older raster <c>.tpk</c> packages.
+    /// </summary>
+    Exploded = 1
+}
+
+/// <summary>
+/// Tile payload kind carried by a cache package.
+/// </summary>
+public enum TileCacheDataType
+{
+    /// <summary>Raster tiles (PNG / JPEG).</summary>
+    Raster = 0,
+
+    /// <summary>Vector tiles (Mapbox Vector Tile / PBF).</summary>
+    Vector = 1
+}
+
+/// <summary>
+/// Parsed tiling-scheme descriptor for an Esri tile cache package. Derived from the
+/// package's <c>root.json</c> (Compact Cache V2 / <c>.tpkx</c>/<c>.vtpk</c>) or
+/// <c>conf.xml</c> (exploded raster <c>.tpk</c>).
+/// </summary>
+public sealed record TileCachePackageDescriptor
+{
+    /// <summary>Storage layout used by the package.</summary>
+    public required TileCacheStorageFormat StorageFormat { get; init; }
+
+    /// <summary>Tile payload kind (raster or vector).</summary>
+    public required TileCacheDataType DataType { get; init; }
+
+    /// <summary>
+    /// Tile content type emitted for served tiles, such as <c>image/png</c>,
+    /// <c>image/jpeg</c>, or <c>application/vnd.mapbox-vector-tile</c>.
+    /// </summary>
+    public required string ContentType { get; init; }
+
+    /// <summary>
+    /// Honua tile-matrix-set identifier the package's tiling scheme maps to
+    /// (for example <c>WebMercatorQuad</c>). Resolved from the package spatial
+    /// reference WKID.
+    /// </summary>
+    public required string TileMatrixSetIdentifier { get; init; }
+
+    /// <summary>Spatial reference well-known id (EPSG / Esri WKID) of the tiling scheme.</summary>
+    public required int Wkid { get; init; }
+
+    /// <summary>Tile width/height in pixels (raster) or the grid tile size (vector).</summary>
+    public required int TileSize { get; init; }
+
+    /// <summary>Lowest level-of-detail id present in the package.</summary>
+    public required int MinLevel { get; init; }
+
+    /// <summary>Highest level-of-detail id present in the package.</summary>
+    public required int MaxLevel { get; init; }
+
+    /// <summary>Optional human-readable title from the package item metadata.</summary>
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Path inside the package archive where the tile data lives, relative to the
+    /// archive root (for example <c>tile</c> for a <c>.tpkx</c> or <c>p12/tile</c>
+    /// for a <c>.vtpk</c>). Empty for exploded caches addressed from
+    /// <c>_alllayers</c>.
+    /// </summary>
+    public required string TileBundlesPath { get; init; }
+}
+
+/// <summary>
+/// A single tile yielded by a <see cref="Abstractions.ITileCachePackageReader"/>.
+/// </summary>
+public sealed record TileCachePackageTile
+{
+    /// <summary>Zoom / level-of-detail id.</summary>
+    public required int Z { get; init; }
+
+    /// <summary>Tile column.</summary>
+    public required int X { get; init; }
+
+    /// <summary>Tile row.</summary>
+    public required int Y { get; init; }
+
+    /// <summary>Raw tile bytes (PNG/JPEG, or PBF for vector tiles).</summary>
+    public required byte[] Content { get; init; }
+}

--- a/src/Honua.Core/Features/TileCachePackage/Services/EsriTileCachePackageReader.cs
+++ b/src/Honua.Core/Features/TileCachePackage/Services/EsriTileCachePackageReader.cs
@@ -1,0 +1,624 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using System.Globalization;
+using System.IO.Compression;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Xml;
+using Honua.Core.Features.TileCachePackage.Abstractions;
+using Honua.Core.Features.TileCachePackage.Domain;
+
+namespace Honua.Core.Features.TileCachePackage.Services;
+
+/// <summary>
+/// Read-only reader for Esri tile/vector-tile cache packages (#1269).
+///
+/// Supported layouts (documented Esri cache structure only):
+///   * Compact Cache V2 (<c>.tpkx</c> raster, <c>.vtpk</c> vector): a ZIP archive
+///     described by <c>root.json</c> whose tiles live in
+///     <c>{bundlesPath}/L{zz}/R{rrrr}C{cccc}.bundle</c> files. Each bundle has a
+///     64-byte header followed by a 16384-entry (128x128) little-endian index; an
+///     index entry's low 40 bits are the tile byte offset and the high 24 bits the
+///     tile size. See https://github.com/Esri/raster-tiles-compactcache.
+///   * Exploded raster cache (older raster <c>.tpk</c>): loose tile files at
+///     <c>_alllayers/L{zz}/R{8hex}/C{8hex}.{png|jpg}</c>, described by
+///     <c>conf.xml</c>/<c>conf.cdi</c>.
+///
+/// Compact Cache V1 (<c>.bundlx</c>/<c>.bundle</c>) is intentionally not handled here;
+/// its layout is community-reverse-engineered rather than published, so it is left to
+/// a follow-up to stay within the documented-layout guardrail.
+/// </summary>
+public sealed class EsriTileCachePackageReader : ITileCachePackageReader
+{
+    // Compact Cache V2 constants (Esri spec).
+    private const int CompactV2HeaderSize = 64;
+    private const int CompactV2BlockEdge = 128;          // tiles per bundle row/column
+    private const int CompactV2IndexEntries = CompactV2BlockEdge * CompactV2BlockEdge; // 16384
+    private const int CompactV2IndexSize = CompactV2IndexEntries * 8;                  // 131072
+    private const long CompactV2OffsetMask = 0xFF_FFFF_FFFFL; // low 40 bits
+
+    /// <inheritdoc />
+    public bool CanRead(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return false;
+        }
+
+        var ext = Path.GetExtension(fileName);
+        return ext.Equals(".tpk", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".tpkx", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".vtpk", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc />
+    public Task<TileCachePackageDescriptor> ReadDescriptorAsync(
+        Stream package,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+
+        using var archive = new ZipArchive(package, ZipArchiveMode.Read, leaveOpen: true);
+        var descriptor = ReadDescriptorCore(archive, cancellationToken);
+        return Task.FromResult(descriptor);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<TileCachePackageTile> ReadTilesAsync(
+        Stream package,
+        TileCachePackageDescriptor descriptor,
+        int minZoom,
+        int maxZoom,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        using var archive = new ZipArchive(package, ZipArchiveMode.Read, leaveOpen: true);
+
+        IEnumerable<TileCachePackageTile> tiles = descriptor.StorageFormat switch
+        {
+            TileCacheStorageFormat.CompactV2 => ReadCompactV2Tiles(archive, descriptor, minZoom, maxZoom, cancellationToken),
+            TileCacheStorageFormat.Exploded => ReadExplodedTiles(archive, descriptor, minZoom, maxZoom, cancellationToken),
+            _ => throw new NotSupportedException($"Unsupported tile-cache storage format: {descriptor.StorageFormat}.")
+        };
+
+        foreach (var tile in tiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return tile;
+            await Task.Yield();
+        }
+    }
+
+    private static TileCachePackageDescriptor ReadDescriptorCore(ZipArchive archive, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Prefer root.json (.tpkx/.vtpk Compact Cache V2). The .vtpk variant nests it
+        // under p12/, the .tpkx variant places it at the archive root.
+        var rootEntry = FindEntry(archive, "root.json");
+        if (rootEntry != null)
+        {
+            return ReadCompactV2Descriptor(archive, rootEntry, cancellationToken);
+        }
+
+        // Fall back to conf.xml (older exploded raster .tpk).
+        var confEntry = FindEntry(archive, "conf.xml");
+        if (confEntry != null)
+        {
+            return ReadExplodedDescriptor(archive, confEntry, cancellationToken);
+        }
+
+        throw new InvalidDataException(
+            "Tile-cache package does not contain a recognized descriptor (root.json or conf.xml).");
+    }
+
+    private static TileCachePackageDescriptor ReadCompactV2Descriptor(
+        ZipArchive archive,
+        ZipArchiveEntry rootEntry,
+        CancellationToken cancellationToken)
+    {
+        EsriRootJson? root;
+        using (var stream = rootEntry.Open())
+        {
+            root = JsonSerializer.Deserialize(stream, TileCachePackageJsonContext.Default.EsriRootJson);
+        }
+
+        if (root?.TileInfo is null)
+        {
+            throw new InvalidDataException("Tile-cache package root.json is missing tileInfo.");
+        }
+
+        var storageFormat = root.StorageInfo?.StorageFormat ?? string.Empty;
+        if (!storageFormat.Contains("CompactV2", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException(
+                $"Tile-cache package storage format '{storageFormat}' is not supported; only Compact Cache V2 packages (.tpkx/.vtpk) and exploded rasters (.tpk) are read.");
+        }
+
+        var format = root.TileInfo.Format ?? string.Empty;
+        var (dataType, contentType) = ResolveFormat(format);
+
+        var wkid = root.TileInfo.SpatialReference?.LatestWkid
+            ?? root.TileInfo.SpatialReference?.Wkid
+            ?? 0;
+
+        var (minLevel, maxLevel) = ResolveLevels(root.TileInfo.Lods);
+
+        // The directory prefix the .bundle files sit under, relative to the archive
+        // root. root.json carries it relative to its own location (e.g. "./tile"); we
+        // resolve it against the descriptor entry's directory so .vtpk (p12/) and .tpkx
+        // (root) both work.
+        var bundlesPath = NormalizeBundlesPath(rootEntry.FullName, root.TileBundlesPath ?? "./tile");
+
+        return new TileCachePackageDescriptor
+        {
+            StorageFormat = TileCacheStorageFormat.CompactV2,
+            DataType = dataType,
+            ContentType = contentType,
+            TileMatrixSetIdentifier = ResolveTileMatrixSet(wkid),
+            Wkid = wkid,
+            TileSize = root.TileInfo.Cols ?? root.TileInfo.Rows ?? 256,
+            MinLevel = minLevel,
+            MaxLevel = maxLevel,
+            Title = string.IsNullOrWhiteSpace(root.Name) ? null : root.Name,
+            TileBundlesPath = bundlesPath
+        };
+    }
+
+    private static TileCachePackageDescriptor ReadExplodedDescriptor(
+        ZipArchive archive,
+        ZipArchiveEntry confEntry,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string? format = null;
+        int? wkid = null;
+        int? tileCols = null;
+        var levels = new List<int>();
+
+        using (var stream = confEntry.Open())
+        {
+            using var reader = XmlReader.Create(stream, new XmlReaderSettings
+            {
+                IgnoreComments = true,
+                IgnoreWhitespace = true,
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null
+            });
+
+            while (reader.Read())
+            {
+                if (reader.NodeType != XmlNodeType.Element)
+                {
+                    continue;
+                }
+
+                switch (reader.LocalName)
+                {
+                    case "CacheTileFormat":
+                        format = reader.ReadElementContentAsString();
+                        break;
+                    case "WKID":
+                    case "LatestWKID":
+                        if (int.TryParse(reader.ReadElementContentAsString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedWkid))
+                        {
+                            wkid = parsedWkid;
+                        }
+
+                        break;
+                    case "TileCols":
+                        if (int.TryParse(reader.ReadElementContentAsString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedCols))
+                        {
+                            tileCols = parsedCols;
+                        }
+
+                        break;
+                    case "LevelID":
+                        if (int.TryParse(reader.ReadElementContentAsString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var levelId))
+                        {
+                            levels.Add(levelId);
+                        }
+
+                        break;
+                }
+            }
+        }
+
+        var (dataType, contentType) = ResolveFormat(format ?? "PNG");
+        if (dataType != TileCacheDataType.Raster)
+        {
+            throw new NotSupportedException("Exploded tile caches are raster-only; vector packages must use Compact Cache V2 (.vtpk).");
+        }
+
+        var resolvedWkid = wkid ?? 0;
+        var minLevel = levels.Count == 0 ? 0 : levels.Min();
+        var maxLevel = levels.Count == 0 ? 0 : levels.Max();
+
+        return new TileCachePackageDescriptor
+        {
+            StorageFormat = TileCacheStorageFormat.Exploded,
+            DataType = dataType,
+            ContentType = contentType,
+            TileMatrixSetIdentifier = ResolveTileMatrixSet(resolvedWkid),
+            Wkid = resolvedWkid,
+            TileSize = tileCols ?? 256,
+            MinLevel = minLevel,
+            MaxLevel = maxLevel,
+            Title = null,
+            TileBundlesPath = string.Empty
+        };
+    }
+
+    private static IEnumerable<TileCachePackageTile> ReadCompactV2Tiles(
+        ZipArchive archive,
+        TileCachePackageDescriptor descriptor,
+        int minZoom,
+        int maxZoom,
+        CancellationToken cancellationToken)
+    {
+        var prefix = descriptor.TileBundlesPath.Length == 0
+            ? string.Empty
+            : descriptor.TileBundlesPath + "/";
+
+        foreach (var entry in archive.Entries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!entry.FullName.EndsWith(".bundle", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (prefix.Length != 0 && !entry.FullName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!TryParseBundleName(entry.FullName, out var level, out var baseRow, out var baseCol))
+            {
+                continue;
+            }
+
+            if (level < minZoom || level > maxZoom)
+            {
+                continue;
+            }
+
+            // Compact Cache V2 bundles must be read with random access; ZIP entry
+            // streams are forward-only, so materialize the (already bounded) bundle.
+            byte[] bundle;
+            using (var stream = entry.Open())
+            {
+                using var buffer = new MemoryStream();
+                stream.CopyTo(buffer);
+                bundle = buffer.ToArray();
+            }
+
+            foreach (var tile in DecodeCompactV2Bundle(bundle, level, baseRow, baseCol, cancellationToken))
+            {
+                yield return tile;
+            }
+        }
+    }
+
+    private static IEnumerable<TileCachePackageTile> DecodeCompactV2Bundle(
+        byte[] bundle,
+        int level,
+        int baseRow,
+        int baseCol,
+        CancellationToken cancellationToken)
+    {
+        if (bundle.Length < CompactV2HeaderSize + CompactV2IndexSize)
+        {
+            yield break;
+        }
+
+        for (var i = 0; i < CompactV2IndexEntries; i++)
+        {
+            if ((i & 0x3FF) == 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            var indexPos = CompactV2HeaderSize + (i * 8);
+            var indexValue = BinaryPrimitives.ReadInt64LittleEndian(bundle.AsSpan(indexPos, 8));
+            var offset = indexValue & CompactV2OffsetMask;
+            var size = (int)(indexValue >> 40);
+            if (size <= 0)
+            {
+                continue;
+            }
+
+            if (offset < 0 || offset + size > bundle.Length)
+            {
+                continue;
+            }
+
+            // Index is row-major within the 128x128 block.
+            var rowInBlock = i / CompactV2BlockEdge;
+            var colInBlock = i % CompactV2BlockEdge;
+
+            var content = new byte[size];
+            Array.Copy(bundle, offset, content, 0, size);
+
+            yield return new TileCachePackageTile
+            {
+                Z = level,
+                X = baseCol + colInBlock,
+                Y = baseRow + rowInBlock,
+                Content = content
+            };
+        }
+    }
+
+    private static IEnumerable<TileCachePackageTile> ReadExplodedTiles(
+        ZipArchive archive,
+        TileCachePackageDescriptor descriptor,
+        int minZoom,
+        int maxZoom,
+        CancellationToken cancellationToken)
+    {
+        foreach (var entry in archive.Entries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (entry.Length == 0)
+            {
+                continue;
+            }
+
+            if (!TryParseExplodedTilePath(entry.FullName, out var level, out var row, out var col))
+            {
+                continue;
+            }
+
+            if (level < minZoom || level > maxZoom)
+            {
+                continue;
+            }
+
+            byte[] content;
+            using (var stream = entry.Open())
+            {
+                using var buffer = new MemoryStream();
+                stream.CopyTo(buffer);
+                content = buffer.ToArray();
+            }
+
+            yield return new TileCachePackageTile
+            {
+                Z = level,
+                X = col,
+                Y = row,
+                Content = content
+            };
+        }
+    }
+
+    // -------- helpers --------
+
+    private static ZipArchiveEntry? FindEntry(ZipArchive archive, string fileName)
+    {
+        // The descriptor may sit at the archive root (.tpkx) or under a prefix such
+        // as p12/ (.vtpk); take the shallowest match so we anchor bundle resolution
+        // at the right directory.
+        ZipArchiveEntry? best = null;
+        var bestDepth = int.MaxValue;
+        foreach (var entry in archive.Entries)
+        {
+            if (!Path.GetFileName(entry.FullName).Equals(fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var depth = entry.FullName.Count(c => c == '/');
+            if (depth < bestDepth)
+            {
+                bestDepth = depth;
+                best = entry;
+            }
+        }
+
+        return best;
+    }
+
+    private static (TileCacheDataType DataType, string ContentType) ResolveFormat(string format)
+    {
+        var f = format.Trim();
+        if (f.StartsWith("PBF", StringComparison.OrdinalIgnoreCase)
+            || f.Contains("VECTOR", StringComparison.OrdinalIgnoreCase)
+            || f.Contains("MVT", StringComparison.OrdinalIgnoreCase))
+        {
+            return (TileCacheDataType.Vector, "application/vnd.mapbox-vector-tile");
+        }
+
+        if (f.StartsWith("JPG", StringComparison.OrdinalIgnoreCase)
+            || f.StartsWith("JPEG", StringComparison.OrdinalIgnoreCase))
+        {
+            return (TileCacheDataType.Raster, "image/jpeg");
+        }
+
+        // PNG, PNG8/24/32, MIXED (PNG-with-JPEG) all serve as PNG by default.
+        return (TileCacheDataType.Raster, "image/png");
+    }
+
+    private static (int Min, int Max) ResolveLevels(EsriLod[]? lods)
+    {
+        if (lods is null || lods.Length == 0)
+        {
+            return (0, 0);
+        }
+
+        var min = int.MaxValue;
+        var max = int.MinValue;
+        foreach (var lod in lods)
+        {
+            if (lod.Level < min)
+            {
+                min = lod.Level;
+            }
+
+            if (lod.Level > max)
+            {
+                max = lod.Level;
+            }
+        }
+
+        return (min, max);
+    }
+
+    private static string ResolveTileMatrixSet(int wkid) => wkid switch
+    {
+        // Web Mercator family.
+        3857 or 102100 or 102113 or 900913 => "WebMercatorQuad",
+        // Geographic WGS84.
+        4326 => "WorldCRS84Quad",
+        // Default to Web Mercator: Esri basemap caches are overwhelmingly 3857 and
+        // unknown/missing WKIDs are far more likely Mercator than CRS84.
+        _ => "WebMercatorQuad"
+    };
+
+    /// <summary>
+    /// Resolve the bundle directory prefix relative to the archive root from the
+    /// descriptor location and root.json's tileBundlesPath (e.g. "./tile").
+    /// </summary>
+    internal static string NormalizeBundlesPath(string rootEntryFullName, string tileBundlesPath)
+    {
+        var rootDir = rootEntryFullName.Contains('/')
+            ? rootEntryFullName[..rootEntryFullName.LastIndexOf('/')]
+            : string.Empty;
+
+        var relative = tileBundlesPath.Replace('\\', '/').Trim();
+        if (relative.StartsWith("./", StringComparison.Ordinal))
+        {
+            relative = relative[2..];
+        }
+
+        relative = relative.Trim('/');
+
+        if (rootDir.Length == 0)
+        {
+            return relative;
+        }
+
+        return relative.Length == 0 ? rootDir : $"{rootDir}/{relative}";
+    }
+
+    /// <summary>
+    /// Parse a Compact Cache V2 bundle path
+    /// <c>.../L{zz}/R{rrrr}C{cccc}.bundle</c> into its level and the block base
+    /// (top-left) row/column. Hex row/col are the block base (multiples of 128).
+    /// </summary>
+    internal static bool TryParseBundleName(string fullName, out int level, out int baseRow, out int baseCol)
+    {
+        level = 0;
+        baseRow = 0;
+        baseCol = 0;
+
+        var fileName = Path.GetFileNameWithoutExtension(fullName); // R{rrrr}C{cccc}
+        var dir = Path.GetFileName(Path.GetDirectoryName(fullName.Replace('/', Path.DirectorySeparatorChar)) ?? string.Empty);
+
+        if (dir.Length < 2 || (dir[0] != 'L' && dir[0] != 'l'))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(dir.AsSpan(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out level))
+        {
+            return false;
+        }
+
+        return TryParseRowCol(fileName, out baseRow, out baseCol);
+    }
+
+    private static bool TryParseRowCol(string token, out int row, out int col)
+    {
+        row = 0;
+        col = 0;
+
+        if (token.Length < 3 || (token[0] != 'R' && token[0] != 'r'))
+        {
+            return false;
+        }
+
+        var cIndex = token.IndexOf('C', 1);
+        if (cIndex < 0)
+        {
+            cIndex = token.IndexOf('c', 1);
+        }
+
+        if (cIndex <= 1 || cIndex == token.Length - 1)
+        {
+            return false;
+        }
+
+        var rowHex = token.AsSpan(1, cIndex - 1);
+        var colHex = token.AsSpan(cIndex + 1);
+
+        return int.TryParse(rowHex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out row)
+            && int.TryParse(colHex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out col);
+    }
+
+    /// <summary>
+    /// Parse an exploded raster tile path
+    /// <c>.../_alllayers/L{zz}/R{8hex}/C{8hex}.{png|jpg}</c> into level, row, col.
+    /// </summary>
+    internal static bool TryParseExplodedTilePath(string fullName, out int level, out int row, out int col)
+    {
+        level = 0;
+        row = 0;
+        col = 0;
+
+        var normalized = fullName.Replace('\\', '/');
+        if (!normalized.Contains("_alllayers/", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var ext = Path.GetExtension(normalized);
+        if (!ext.Equals(".png", StringComparison.OrdinalIgnoreCase)
+            && !ext.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+            && !ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var parts = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 3)
+        {
+            return false;
+        }
+
+        var colToken = Path.GetFileNameWithoutExtension(parts[^1]); // C{8hex}
+        var rowToken = parts[^2];                                   // R{8hex}
+        var levelToken = parts[^3];                                 // L{zz}
+
+        if (levelToken.Length < 2 || (levelToken[0] != 'L' && levelToken[0] != 'l'))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(levelToken.AsSpan(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out level))
+        {
+            return false;
+        }
+
+        if (rowToken.Length < 2 || (rowToken[0] != 'R' && rowToken[0] != 'r'))
+        {
+            return false;
+        }
+
+        if (colToken.Length < 2 || (colToken[0] != 'C' && colToken[0] != 'c'))
+        {
+            return false;
+        }
+
+        return int.TryParse(rowToken.AsSpan(1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out row)
+            && int.TryParse(colToken.AsSpan(1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out col);
+    }
+}

--- a/src/Honua.Core/Features/TileCachePackage/Services/TileCachePackageImportService.cs
+++ b/src/Honua.Core/Features/TileCachePackage/Services/TileCachePackageImportService.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.TileCachePackage.Abstractions;
+using Honua.Core.Features.TileCachePackage.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.TileCachePackage.Services;
+
+/// <summary>
+/// Imports Esri tile-cache packages into Honua's tile catalog and binds them to a
+/// served tileset (#1269). Reads the documented package layout via
+/// <see cref="ITileCachePackageReader"/> and persists tiles through the shared
+/// <see cref="IOgcTileCacheSink"/> so re-imports converge on the same catalog rows.
+/// </summary>
+public sealed partial class TileCachePackageImportService : ITileCachePackageImportService
+{
+    private const string StyleIdentifier = "default";
+
+    private readonly ITileCachePackageReader _reader;
+    private readonly IOgcTileCacheSink _sink;
+    private readonly ILogger<TileCachePackageImportService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TileCachePackageImportService"/> class.
+    /// </summary>
+    /// <param name="reader">Package reader.</param>
+    /// <param name="sink">Tile catalog sink.</param>
+    /// <param name="logger">Logger.</param>
+    public TileCachePackageImportService(
+        ITileCachePackageReader reader,
+        IOgcTileCacheSink sink,
+        ILogger<TileCachePackageImportService> logger)
+    {
+        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        _sink = sink ?? throw new ArgumentNullException(nameof(sink));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<TileCachePackageImportResult> ImportAsync(
+        TileCachePackageImportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.TilesetId))
+        {
+            throw new ArgumentException("A tileset identifier is required.", nameof(request));
+        }
+
+        if (!_reader.CanRead(request.FileName))
+        {
+            throw new ArgumentException(
+                $"'{request.FileName}' is not a supported tile-cache package (.tpk/.tpkx/.vtpk).",
+                nameof(request));
+        }
+
+        if (!request.Package.CanSeek)
+        {
+            throw new ArgumentException("Tile-cache package stream must be seekable.", nameof(request));
+        }
+
+        request.Package.Position = 0;
+        var descriptor = await _reader.ReadDescriptorAsync(request.Package, cancellationToken).ConfigureAwait(false);
+
+        var minZoom = Math.Max(request.MinZoom ?? descriptor.MinLevel, descriptor.MinLevel);
+        var maxZoom = Math.Min(request.MaxZoom ?? descriptor.MaxLevel, descriptor.MaxLevel);
+        if (maxZoom < minZoom)
+        {
+            throw new ArgumentException("Resolved maxZoom is below minZoom for this package.", nameof(request));
+        }
+
+        var dataType = descriptor.DataType == TileCacheDataType.Vector ? "vector" : "raster";
+        var sourceUrl = $"tpk:{request.FileName}";
+
+        Log.ImportStarted(_logger, request.TilesetId, descriptor.StorageFormat.ToString(), dataType, minZoom, maxZoom, request.DryRun);
+
+        if (request.DryRun)
+        {
+            return new TileCachePackageImportResult
+            {
+                Success = true,
+                TileCacheId = null,
+                StorageFormat = descriptor.StorageFormat.ToString(),
+                DataType = dataType,
+                ContentType = descriptor.ContentType,
+                TileMatrixSet = descriptor.TileMatrixSetIdentifier,
+                MinZoom = minZoom,
+                MaxZoom = maxZoom,
+                TilesImported = 0,
+                TilesSkipped = 0,
+                DryRun = true
+            };
+        }
+
+        var cacheId = await _sink.EnsureTileCacheAsync(
+            new OgcTileCacheDescriptor
+            {
+                LayerIdentifier = request.TilesetId,
+                TileMatrixSetIdentifier = descriptor.TileMatrixSetIdentifier,
+                SourceServiceUrl = sourceUrl,
+                TileFormat = descriptor.ContentType,
+                StyleIdentifier = StyleIdentifier,
+                MinZoom = minZoom,
+                MaxZoom = maxZoom,
+                DataType = dataType,
+                Title = descriptor.Title
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        var imported = 0;
+        var skipped = 0;
+
+        request.Package.Position = 0;
+        await foreach (var tile in _reader
+            .ReadTilesAsync(request.Package, descriptor, minZoom, maxZoom, cancellationToken)
+            .ConfigureAwait(false))
+        {
+            var status = await _sink.WriteTileAsync(
+                new OgcTileCacheRecord
+                {
+                    TileCacheId = cacheId,
+                    Z = tile.Z,
+                    X = tile.X,
+                    Y = tile.Y,
+                    ContentType = descriptor.ContentType,
+                    Content = tile.Content,
+                    SourceUrl = sourceUrl
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            if (status == OgcTileCacheWriteStatus.Inserted)
+            {
+                imported++;
+            }
+            else
+            {
+                skipped++;
+            }
+        }
+
+        Log.ImportCompleted(_logger, cacheId, imported, skipped);
+
+        return new TileCachePackageImportResult
+        {
+            Success = true,
+            TileCacheId = cacheId,
+            StorageFormat = descriptor.StorageFormat.ToString(),
+            DataType = dataType,
+            ContentType = descriptor.ContentType,
+            TileMatrixSet = descriptor.TileMatrixSetIdentifier,
+            MinZoom = minZoom,
+            MaxZoom = maxZoom,
+            TilesImported = imported,
+            TilesSkipped = skipped,
+            DryRun = false
+        };
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(7970, LogLevel.Information,
+            "Tile-cache package import started for tileset {TilesetId}: format {StorageFormat}, type {DataType}, zoom {MinZoom}-{MaxZoom}, dryRun {DryRun}")]
+        public static partial void ImportStarted(ILogger logger, string tilesetId, string storageFormat, string dataType, int minZoom, int maxZoom, bool dryRun);
+
+        [LoggerMessage(7971, LogLevel.Information,
+            "Tile-cache package import completed for cache {TileCacheId}: {Imported} inserted, {Skipped} already present")]
+        public static partial void ImportCompleted(ILogger logger, string tileCacheId, int imported, int skipped);
+    }
+}

--- a/src/Honua.Core/Features/TileCachePackage/Services/TileCachePackageJson.cs
+++ b/src/Honua.Core/Features/TileCachePackage/Services/TileCachePackageJson.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.TileCachePackage.Services;
+
+/// <summary>
+/// Minimal projection of an Esri cache <c>root.json</c> descriptor (Compact Cache V2,
+/// <c>.tpkx</c>/<c>.vtpk</c>). Only the fields Honua needs to bind a served tileset
+/// are modelled; the documented schema is published at
+/// https://github.com/Esri/tile-package-spec.
+/// </summary>
+internal sealed record EsriRootJson
+{
+    /// <summary>Tile data format string, e.g. <c>PNG</c>, <c>JPEG</c>, <c>PBF</c>.</summary>
+    [JsonPropertyName("tileInfo")]
+    public EsriTileInfo? TileInfo { get; init; }
+
+    /// <summary>Storage info (storage format + packet size).</summary>
+    [JsonPropertyName("storageInfo")]
+    public EsriStorageInfo? StorageInfo { get; init; }
+
+    /// <summary>Relative path to the tile bundles, e.g. <c>./tile</c>.</summary>
+    [JsonPropertyName("tileBundlesPath")]
+    public string? TileBundlesPath { get; init; }
+
+    /// <summary>Optional service/item name carried into the tileset title.</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    /// <summary>Capability string; vector caches advertise <c>TilesOnly</c> with PBF tiles.</summary>
+    [JsonPropertyName("capabilities")]
+    public string? Capabilities { get; init; }
+}
+
+/// <summary>Tile info block of <c>root.json</c>.</summary>
+internal sealed record EsriTileInfo
+{
+    /// <summary>Tile width in pixels.</summary>
+    [JsonPropertyName("cols")]
+    public int? Cols { get; init; }
+
+    /// <summary>Tile height in pixels.</summary>
+    [JsonPropertyName("rows")]
+    public int? Rows { get; init; }
+
+    /// <summary>Tile format, e.g. <c>PNG</c>, <c>JPEG</c>, <c>MIXED</c>, <c>PBF</c>.</summary>
+    [JsonPropertyName("format")]
+    public string? Format { get; init; }
+
+    /// <summary>Spatial reference of the tiling scheme.</summary>
+    [JsonPropertyName("spatialReference")]
+    public EsriSpatialReference? SpatialReference { get; init; }
+
+    /// <summary>Levels of detail.</summary>
+    [JsonPropertyName("lods")]
+    public EsriLod[]? Lods { get; init; }
+}
+
+/// <summary>Spatial reference block.</summary>
+internal sealed record EsriSpatialReference
+{
+    /// <summary>Well-known id.</summary>
+    [JsonPropertyName("wkid")]
+    public int? Wkid { get; init; }
+
+    /// <summary>Latest well-known id (preferred when present).</summary>
+    [JsonPropertyName("latestWkid")]
+    public int? LatestWkid { get; init; }
+}
+
+/// <summary>Level-of-detail entry.</summary>
+internal sealed record EsriLod
+{
+    /// <summary>Level id.</summary>
+    [JsonPropertyName("level")]
+    public int Level { get; init; }
+}
+
+/// <summary>Storage info block.</summary>
+internal sealed record EsriStorageInfo
+{
+    /// <summary>Storage format, e.g. <c>esriMapCacheStorageModeCompactV2</c>.</summary>
+    [JsonPropertyName("storageFormat")]
+    public string? StorageFormat { get; init; }
+
+    /// <summary>Packet size (128 for Compact Cache V2).</summary>
+    [JsonPropertyName("packetSize")]
+    public int? PacketSize { get; init; }
+}
+
+/// <summary>
+/// Source-generated JSON context for <c>root.json</c> parsing. Keeps the package
+/// reader AOT-safe (no runtime reflection-based deserialization).
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(EsriRootJson))]
+internal sealed partial class TileCachePackageJsonContext : System.Text.Json.Serialization.JsonSerializerContext
+{
+}

--- a/src/Honua.Import/Features/TileCachePackage/TileCachePackageEndpoints.cs
+++ b/src/Honua.Import/Features/TileCachePackage/TileCachePackageEndpoints.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using Honua.Core.Features.TileCachePackage.Abstractions;
 using Honua.Core.Features.TileCachePackage.Domain;
 using Honua.Infrastructure.Authentication;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Import.TileCachePackage;
 
@@ -56,13 +57,20 @@ internal static class TileCachePackageEndpoints
     private static async Task<IResult> HandleImport(
         HttpContext context,
         string tilesetId,
-        ITileCachePackageImportService importService,
         string? fileName = null,
         int? minZoom = null,
         int? maxZoom = null,
         bool dryRun = false)
     {
         var cancellationToken = context.RequestAborted;
+
+        // Resolve the import service from the request scope rather than as a route-handler
+        // parameter. The service is provider-specific (registered only when the active
+        // data provider supplies it) so declaring it as a parameter would make the minimal
+        // API request-delegate factory infer it as a JSON body parameter on hosts where it
+        // is absent, which fails app startup when the source-generated JSON resolver cannot
+        // produce metadata for the service interface.
+        var importService = context.RequestServices.GetRequiredService<ITileCachePackageImportService>();
 
         if (string.IsNullOrWhiteSpace(tilesetId))
         {
@@ -140,10 +148,10 @@ internal static class TileCachePackageEndpoints
 
     private static async Task<IResult> HandleGetTileSet(
         string tileCacheId,
-        IImportedTileCacheReader reader,
         HttpContext context)
     {
         var cancellationToken = context.RequestAborted;
+        var reader = context.RequestServices.GetRequiredService<IImportedTileCacheReader>();
         var info = await reader.GetTileCacheAsync(tileCacheId, cancellationToken).ConfigureAwait(false);
         if (info is null)
         {
@@ -174,7 +182,6 @@ internal static class TileCachePackageEndpoints
         int z,
         int x,
         int y,
-        IImportedTileCacheReader reader,
         HttpContext context)
     {
         var cancellationToken = context.RequestAborted;
@@ -184,6 +191,7 @@ internal static class TileCachePackageEndpoints
             return Results.BadRequest("Tile coordinates must be non-negative.");
         }
 
+        var reader = context.RequestServices.GetRequiredService<IImportedTileCacheReader>();
         var tile = await reader.GetTileAsync(tileCacheId, z, x, y, cancellationToken).ConfigureAwait(false);
         if (tile is null)
         {

--- a/src/Honua.Import/Features/TileCachePackage/TileCachePackageEndpoints.cs
+++ b/src/Honua.Import/Features/TileCachePackage/TileCachePackageEndpoints.cs
@@ -1,0 +1,368 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.TileCachePackage.Abstractions;
+using Honua.Core.Features.TileCachePackage.Domain;
+using Honua.Infrastructure.Authentication;
+
+namespace Honua.Import.TileCachePackage;
+
+/// <summary>
+/// Admin import endpoint + public serving binding for Esri tile/vector-tile cache
+/// packages (<c>.tpk</c>/<c>.tpkx</c>/<c>.vtpk</c>) (#1269).
+///
+/// The importer ingests a prebuilt package into Honua's tile catalog; the serving
+/// binding lets the imported cache be served through Honua tile endpoints without
+/// re-rendering. The package is uploaded as the raw request body (the tileset id and
+/// optional zoom range are query parameters) so a single binary file streams straight
+/// to a bounded temp file for random-access (ZIP) reading.
+/// </summary>
+internal static class TileCachePackageEndpoints
+{
+    // Hard cap on the uploaded package body. Tile packages can be large, but the
+    // admin import path streams to a temp file; this bounds disk usage per request.
+    private const long MaxPackageBytes = 2L * 1024 * 1024 * 1024; // 2 GiB
+
+    /// <summary>
+    /// Maps the tile-cache package import + serving endpoints.
+    /// </summary>
+    public static void MapTileCachePackageEndpoints(this WebApplication app)
+    {
+        var importGroup = app.MapGroup("/api/v{version:apiVersion}/admin/import/tile-package")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("TileCachePackageImport")
+            .RequireAdminAuthorization();
+
+        _ = importGroup.MapPost("/", HandleImport)
+            .WithName("ImportTileCachePackage")
+            .WithSummary("Import an Esri tile/vector-tile cache package (.tpk/.tpkx/.vtpk) into Honua's tile catalog and bind it to a served tileset")
+            .DisableAntiforgery();
+
+        // Public serving binding. Imported caches serve through these tile routes.
+        var serveGroup = app.MapGroup("/tiles/imported")
+            .WithTags("TileCachePackageServe");
+
+        _ = serveGroup.MapGet("/{tileCacheId}", HandleGetTileSet)
+            .WithName("GetImportedTileSet")
+            .WithSummary("Get TileJSON-style metadata for an imported tile-cache package");
+
+        _ = serveGroup.MapGet("/{tileCacheId}/{z:int}/{x:int}/{y:int}", HandleGetTile)
+            .WithName("GetImportedTile")
+            .WithSummary("Get a single tile served from an imported tile-cache package");
+    }
+
+    private static async Task<IResult> HandleImport(
+        HttpContext context,
+        string tilesetId,
+        ITileCachePackageImportService importService,
+        string? fileName = null,
+        int? minZoom = null,
+        int? maxZoom = null,
+        bool dryRun = false)
+    {
+        var cancellationToken = context.RequestAborted;
+
+        if (string.IsNullOrWhiteSpace(tilesetId))
+        {
+            return Results.BadRequest("Query parameter 'tilesetId' is required.");
+        }
+
+        var resolvedFileName = string.IsNullOrWhiteSpace(fileName)
+            ? DeriveFileNameFromContentType(context.Request.ContentType)
+            : fileName;
+
+        if (resolvedFileName is null)
+        {
+            return Results.BadRequest(
+                "Unable to determine the package format. Provide a 'fileName' query parameter ending in .tpk, .tpkx, or .vtpk.");
+        }
+
+        // Stream the request body to a bounded temp file so the ZIP archive can be
+        // read with random access without buffering the whole package in memory.
+        var tempPath = Path.Combine(Path.GetTempPath(), $"honua-tpk-{Guid.NewGuid():N}.tmp");
+        try
+        {
+            long written;
+            await using (var temp = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, FileOptions.SequentialScan))
+            {
+                written = await CopyBoundedAsync(context.Request.Body, temp, MaxPackageBytes, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (written == 0)
+            {
+                return Results.BadRequest("Request body is empty; upload the package bytes as the request body.");
+            }
+
+            if (written >= MaxPackageBytes)
+            {
+                return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
+            }
+
+            await using var package = new FileStream(tempPath, FileMode.Open, FileAccess.Read, FileShare.None, 81920, FileOptions.SequentialScan);
+
+            TileCachePackageImportResult result;
+            try
+            {
+                result = await importService.ImportAsync(
+                    new TileCachePackageImportRequest
+                    {
+                        Package = package,
+                        FileName = resolvedFileName,
+                        TilesetId = tilesetId,
+                        MinZoom = minZoom,
+                        MaxZoom = maxZoom,
+                        DryRun = dryRun
+                    },
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+            catch (NotSupportedException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+            catch (InvalidDataException ex)
+            {
+                return Results.BadRequest($"The uploaded file is not a readable tile-cache package: {ex.Message}");
+            }
+
+            return Results.Json(ToApiResult(result), TileCachePackageJsonContext.Default.TileCachePackageImportApiResult);
+        }
+        finally
+        {
+            TryDelete(tempPath);
+        }
+    }
+
+    private static async Task<IResult> HandleGetTileSet(
+        string tileCacheId,
+        IImportedTileCacheReader reader,
+        HttpContext context)
+    {
+        var cancellationToken = context.RequestAborted;
+        var info = await reader.GetTileCacheAsync(tileCacheId, cancellationToken).ConfigureAwait(false);
+        if (info is null)
+        {
+            return Results.NotFound();
+        }
+
+        var scheme = context.Request.Scheme;
+        var host = context.Request.Host.Value;
+        var tileTemplate = $"{scheme}://{host}/tiles/imported/{info.TileCacheId}/{{z}}/{{x}}/{{y}}";
+
+        var json = new TileCachePackageTileSetJson
+        {
+            TileJson = "3.0.0",
+            Name = info.Title ?? info.LayerIdentifier,
+            DataType = info.DataType,
+            TileMatrixSet = info.TileMatrixSet,
+            Format = info.TileFormat,
+            MinZoom = info.MinZoom,
+            MaxZoom = info.MaxZoom,
+            Tiles = [tileTemplate]
+        };
+
+        return Results.Json(json, TileCachePackageJsonContext.Default.TileCachePackageTileSetJson);
+    }
+
+    private static async Task<IResult> HandleGetTile(
+        string tileCacheId,
+        int z,
+        int x,
+        int y,
+        IImportedTileCacheReader reader,
+        HttpContext context)
+    {
+        var cancellationToken = context.RequestAborted;
+
+        if (z < 0 || x < 0 || y < 0)
+        {
+            return Results.BadRequest("Tile coordinates must be non-negative.");
+        }
+
+        var tile = await reader.GetTileAsync(tileCacheId, z, x, y, cancellationToken).ConfigureAwait(false);
+        if (tile is null)
+        {
+            return Results.NotFound();
+        }
+
+        return Results.Bytes(tile.Content, tile.ContentType);
+    }
+
+    private static string? DeriveFileNameFromContentType(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            return null;
+        }
+
+        // Vendor content types occasionally carry the format; otherwise we cannot
+        // infer the extension and require the caller to pass fileName.
+        if (contentType.Contains("vtpk", StringComparison.OrdinalIgnoreCase))
+        {
+            return "package.vtpk";
+        }
+
+        if (contentType.Contains("tpkx", StringComparison.OrdinalIgnoreCase))
+        {
+            return "package.tpkx";
+        }
+
+        if (contentType.Contains("tpk", StringComparison.OrdinalIgnoreCase))
+        {
+            return "package.tpk";
+        }
+
+        return null;
+    }
+
+    private static async Task<long> CopyBoundedAsync(Stream source, Stream destination, long limit, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[81920];
+        long total = 0;
+        int read;
+        while ((read = await source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
+        {
+            total += read;
+            if (total > limit)
+            {
+                return limit;
+            }
+
+            await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+        }
+
+        return total;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; the OS temp sweeper reclaims any residue.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static TileCachePackageImportApiResult ToApiResult(TileCachePackageImportResult result) => new()
+    {
+        Success = result.Success,
+        TileCacheId = result.TileCacheId,
+        StorageFormat = result.StorageFormat,
+        DataType = result.DataType,
+        ContentType = result.ContentType,
+        TileMatrixSet = result.TileMatrixSet,
+        MinZoom = result.MinZoom,
+        MaxZoom = result.MaxZoom,
+        TilesImported = result.TilesImported,
+        TilesSkipped = result.TilesSkipped,
+        DryRun = result.DryRun,
+        ServeUrl = result.TileCacheId is null ? null : $"/tiles/imported/{result.TileCacheId}"
+    };
+}
+
+/// <summary>
+/// API result for the tile-cache package import endpoint.
+/// </summary>
+internal sealed record TileCachePackageImportApiResult
+{
+    /// <summary>Whether the import succeeded.</summary>
+    public required bool Success { get; init; }
+
+    /// <summary>Stable tile-cache identifier the tiles were written to.</summary>
+    public string? TileCacheId { get; init; }
+
+    /// <summary>Detected storage format.</summary>
+    public required string StorageFormat { get; init; }
+
+    /// <summary>Detected payload kind.</summary>
+    public required string DataType { get; init; }
+
+    /// <summary>Served tile content type.</summary>
+    public required string ContentType { get; init; }
+
+    /// <summary>Resolved Honua tile-matrix-set identifier.</summary>
+    public required string TileMatrixSet { get; init; }
+
+    /// <summary>Resolved minimum zoom imported.</summary>
+    public required int MinZoom { get; init; }
+
+    /// <summary>Resolved maximum zoom imported.</summary>
+    public required int MaxZoom { get; init; }
+
+    /// <summary>Number of tiles inserted.</summary>
+    public required int TilesImported { get; init; }
+
+    /// <summary>Number of tiles skipped (already present).</summary>
+    public required int TilesSkipped { get; init; }
+
+    /// <summary>Whether this was a dry-run.</summary>
+    public required bool DryRun { get; init; }
+
+    /// <summary>Relative URL the imported tileset is served from.</summary>
+    public string? ServeUrl { get; init; }
+}
+
+/// <summary>
+/// TileJSON-style descriptor for an imported served tileset.
+/// </summary>
+internal sealed record TileCachePackageTileSetJson
+{
+    /// <summary>TileJSON version.</summary>
+    [JsonPropertyName("tilejson")]
+    public required string TileJson { get; init; }
+
+    /// <summary>Tileset name.</summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>Payload kind (raster/vector).</summary>
+    [JsonPropertyName("dataType")]
+    public required string DataType { get; init; }
+
+    /// <summary>Honua tile-matrix-set identifier.</summary>
+    [JsonPropertyName("tileMatrixSet")]
+    public required string TileMatrixSet { get; init; }
+
+    /// <summary>Tile content type.</summary>
+    [JsonPropertyName("format")]
+    public required string Format { get; init; }
+
+    /// <summary>Minimum zoom.</summary>
+    [JsonPropertyName("minzoom")]
+    public required int MinZoom { get; init; }
+
+    /// <summary>Maximum zoom.</summary>
+    [JsonPropertyName("maxzoom")]
+    public required int MaxZoom { get; init; }
+
+    /// <summary>Tile URL templates.</summary>
+    [JsonPropertyName("tiles")]
+    public required string[] Tiles { get; init; }
+}
+
+/// <summary>
+/// Source-generated JSON context for the tile-cache package endpoints.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(TileCachePackageImportApiResult))]
+[JsonSerializable(typeof(TileCachePackageTileSetJson))]
+internal sealed partial class TileCachePackageJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Postgres/Features/Migration/PostgresOgcTileCacheSink.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresOgcTileCacheSink.cs
@@ -61,7 +61,9 @@ internal sealed partial class PostgresOgcTileCacheSink : IOgcTileCacheSink
                 tile_format,
                 style_identifier,
                 min_zoom,
-                max_zoom)
+                max_zoom,
+                data_type,
+                tileset_title)
             VALUES (
                 @tile_cache_id,
                 @layer_identifier,
@@ -70,11 +72,15 @@ internal sealed partial class PostgresOgcTileCacheSink : IOgcTileCacheSink
                 @tile_format,
                 @style_identifier,
                 @min_zoom,
-                @max_zoom)
+                @max_zoom,
+                COALESCE(@data_type, 'raster'),
+                @tileset_title)
             ON CONFLICT (tile_cache_id) DO UPDATE
-                SET min_zoom   = LEAST(honua.tile_caches.min_zoom, EXCLUDED.min_zoom),
-                    max_zoom   = GREATEST(honua.tile_caches.max_zoom, EXCLUDED.max_zoom),
-                    updated_at = NOW();
+                SET min_zoom      = LEAST(honua.tile_caches.min_zoom, EXCLUDED.min_zoom),
+                    max_zoom      = GREATEST(honua.tile_caches.max_zoom, EXCLUDED.max_zoom),
+                    data_type     = COALESCE(EXCLUDED.data_type, honua.tile_caches.data_type),
+                    tileset_title = COALESCE(EXCLUDED.tileset_title, honua.tile_caches.tileset_title),
+                    updated_at    = NOW();
             """;
         cmd.Parameters.AddWithValue("tile_cache_id", cacheId);
         cmd.Parameters.AddWithValue("layer_identifier", descriptor.LayerIdentifier);
@@ -84,6 +90,8 @@ internal sealed partial class PostgresOgcTileCacheSink : IOgcTileCacheSink
         cmd.Parameters.AddWithValue("style_identifier", descriptor.StyleIdentifier);
         cmd.Parameters.AddWithValue("min_zoom", descriptor.MinZoom);
         cmd.Parameters.AddWithValue("max_zoom", descriptor.MaxZoom);
+        cmd.Parameters.AddWithValue("data_type", (object?)descriptor.DataType ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("tileset_title", (object?)descriptor.Title ?? DBNull.Value);
 
         await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         Log.CacheEnsured(_logger, cacheId, descriptor.LayerIdentifier, descriptor.TileMatrixSetIdentifier);

--- a/src/Honua.Postgres/Features/TileCachePackage/PostgresImportedTileCacheReader.cs
+++ b/src/Honua.Postgres/Features/TileCachePackage/PostgresImportedTileCacheReader.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.TileCachePackage.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Postgres.Features.TileCachePackage;
+
+/// <summary>
+/// Postgres-backed serving binding for tiles imported by the tile-cache package
+/// importer (#1269). Reads tiles out of <c>honua.tile_caches</c> /
+/// <c>honua.tile_cache_entries</c> so imported <c>.tpk</c>/<c>.tpkx</c>/<c>.vtpk</c>
+/// caches serve through Honua tile endpoints without re-rendering.
+/// </summary>
+internal sealed class PostgresImportedTileCacheReader : IImportedTileCacheReader
+{
+    private readonly IAdoNetDatabaseConnectionProvider _connectionProvider;
+    private readonly ILogger<PostgresImportedTileCacheReader> _logger;
+
+    public PostgresImportedTileCacheReader(
+        IAdoNetDatabaseConnectionProvider connectionProvider,
+        ILogger<PostgresImportedTileCacheReader> logger)
+    {
+        _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<ImportedTileCacheInfo?> GetTileCacheAsync(
+        string tileCacheId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tileCacheId);
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var cmd = lease.Connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT layer_identifier, tile_matrix_set, tile_format, data_type, min_zoom, max_zoom, tileset_title
+            FROM honua.tile_caches
+            WHERE tile_cache_id = @tile_cache_id;
+            """;
+        cmd.Parameters.AddWithValue("tile_cache_id", tileCacheId);
+
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return new ImportedTileCacheInfo
+        {
+            TileCacheId = tileCacheId,
+            LayerIdentifier = reader.GetString(0),
+            TileMatrixSet = reader.GetString(1),
+            TileFormat = reader.GetString(2),
+            DataType = reader.GetString(3),
+            MinZoom = reader.GetInt32(4),
+            MaxZoom = reader.GetInt32(5),
+            Title = reader.IsDBNull(6) ? null : reader.GetString(6)
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<ImportedTile?> GetTileAsync(
+        string tileCacheId,
+        int z,
+        int x,
+        int y,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tileCacheId);
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var cmd = lease.Connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT content_type, content
+            FROM honua.tile_cache_entries
+            WHERE tile_cache_id = @tile_cache_id
+              AND zoom_level = @zoom_level
+              AND tile_column = @tile_column
+              AND tile_row = @tile_row;
+            """;
+        cmd.Parameters.AddWithValue("tile_cache_id", tileCacheId);
+        cmd.Parameters.AddWithValue("zoom_level", z);
+        cmd.Parameters.AddWithValue("tile_column", x);
+        cmd.Parameters.AddWithValue("tile_row", y);
+
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return new ImportedTile
+        {
+            ContentType = reader.GetString(0),
+            Content = (byte[])reader.GetValue(1)
+        };
+    }
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -576,6 +576,17 @@ internal static class ServiceCollectionExtensions
             },
             configureHandler: static () => OgcServiceMigrationScanner.CreatePinnedDnsHttpMessageHandler());
         services.AddScoped<IOgcTileCacheSink, PostgresOgcTileCacheSink>();
+
+        // Esri tile/vector-tile cache package importer + serving binding (#1269).
+        // The reader and import orchestrator are provider-agnostic; the serving read
+        // path is Postgres-backed (reads the tile catalog populated by the importer).
+        services.AddSingleton<Honua.Core.Features.TileCachePackage.Abstractions.ITileCachePackageReader,
+            Honua.Core.Features.TileCachePackage.Services.EsriTileCachePackageReader>();
+        services.AddScoped<Honua.Core.Features.TileCachePackage.Abstractions.ITileCachePackageImportService,
+            Honua.Core.Features.TileCachePackage.Services.TileCachePackageImportService>();
+        services.AddScoped<Honua.Core.Features.TileCachePackage.Abstractions.IImportedTileCacheReader,
+            Honua.Postgres.Features.TileCachePackage.PostgresImportedTileCacheReader>();
+
         services.AddScoped<IOgcTileCacheExportService>(serviceProvider =>
         {
             var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -500,6 +500,11 @@ public static class EndpointRegistry
         // v1 admin import endpoints (OGC WMTS tile cache export #1016 slice 4)
         new("POST", "/api/v1/admin/import/ogc-tiles/export"),
 
+        // Esri tile/vector-tile cache package import + serving binding (#1269)
+        new("POST", "/api/v1/admin/import/tile-package"),
+        new("GET", "/tiles/imported/{tileCacheId}"),
+        new("GET", "/tiles/imported/{tileCacheId}/{z}/{x}/{y}"),
+
         // v1 admin operational monitoring endpoints (#512)
         new("GET", "/api/v1/admin/operations/cache/health"),
         new("GET", "/api/v1/admin/operations/cache/statistics"),

--- a/src/Honua.Server/Migrations/067_AddTileCachePackageImport.sql
+++ b/src/Honua.Server/Migrations/067_AddTileCachePackageImport.sql
@@ -1,0 +1,36 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration: 067_AddTileCachePackageImport.sql
+-- Adds the serving-binding columns the Esri tile/vector-tile cache package importer
+-- (#1269) needs on top of the WMTS tile-cache catalog (033_CreateTileCacheCatalog).
+--
+-- The catalog already stores one row per tile-cache and one row per (z, x, y) tile,
+-- but it was modelled for the WMTS export planner: a tile-cache was implicitly raster,
+-- always sourced from a live WMTS service URL. Importing prebuilt Esri packages
+-- (.tpk/.tpkx/.vtpk) adds two needs:
+--   * data_type    — packages may carry vector (.vtpk -> MVT/PBF) or raster
+--                     (.tpk/.tpkx -> PNG/JPEG) tiles; the serving binding must know
+--                     which so it advertises the right media type / TileJSON.
+--   * tileset_title — an optional human-readable title carried into the served
+--                     tileset descriptor (TileJSON "name").
+--
+-- It is intentionally additive and idempotent (ADD COLUMN IF NOT EXISTS), and only
+-- runs its ALTERs when the catalog table exists so plain images that never ran 033
+-- skip it cleanly. The existing WMTS export sink keeps writing rows without these
+-- columns; data_type defaults to 'raster' to preserve the pre-import semantics.
+
+DO $$
+BEGIN
+    IF to_regclass('honua.tile_caches') IS NOT NULL THEN
+        ALTER TABLE honua.tile_caches
+            ADD COLUMN IF NOT EXISTS data_type TEXT NOT NULL DEFAULT 'raster';
+        ALTER TABLE honua.tile_caches
+            ADD COLUMN IF NOT EXISTS tileset_title TEXT;
+
+        COMMENT ON COLUMN honua.tile_caches.data_type IS
+            'Tile payload kind served from this cache: ''raster'' (PNG/JPEG) or ''vector'' (MVT/PBF). Set by the package importer (#1269); defaults to raster for the WMTS exporter.';
+        COMMENT ON COLUMN honua.tile_caches.tileset_title IS
+            'Optional human-readable title carried into the served TileJSON descriptor (#1269).';
+    END IF;
+END $$;

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -44,6 +44,7 @@ using Honua.Import;
 using Honua.Migration;
 using Honua.Import.FileImport;
 using Honua.Import.RasterImport;
+using Honua.Import.TileCachePackage;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Authentication.ClientCertificates;
 using Honua.Infrastructure.AuditLog;
@@ -1403,6 +1404,9 @@ app.MapMigrationRunAdminEndpoints();
 
 // Configure OGC WMTS tile-cache export endpoints (#1016 slice 4)
 app.MapOgcTileCacheExportEndpoints();
+
+// Configure Esri tile/vector-tile cache package import + serving endpoints (#1269)
+app.MapTileCachePackageEndpoints();
 
 if (isTestEnvironment)
 {

--- a/src/Honua.Server/Startup/JsonContextRegistration.cs
+++ b/src/Honua.Server/Startup/JsonContextRegistration.cs
@@ -43,6 +43,7 @@ internal static class JsonContextRegistration
                 Honua.Migration.OgcCoverageImportJsonContext.Default,
                 Honua.Migration.OgcWcsImportJsonContext.Default,
                 Honua.Migration.OgcTileCacheExportJsonContext.Default,
+                Honua.Import.TileCachePackage.TileCachePackageJsonContext.Default,
                 Honua.Server.Features.Admin.OperationsProgressJsonContext.Default,
                 Honua.Server.Features.Admin.FeatureEventReplayJsonContext.Default,
                 Honua.Server.Features.Mobile.Auth.MobileAuthJsonContext.Default,

--- a/tests/dotnet/Honua.Core.Tests/Features/TileCachePackage/EsriTileCachePackageReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/TileCachePackage/EsriTileCachePackageReaderTests.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.TileCachePackage.Domain;
+using Honua.Core.Features.TileCachePackage.Services;
+
+namespace Honua.Core.Tests.Features.TileCachePackage;
+
+/// <summary>
+/// Unit tests for <see cref="EsriTileCachePackageReader"/>, the read-only parser for
+/// Esri tile/vector-tile cache packages (#1269). Fixtures are synthesized in-memory
+/// from the documented Compact Cache V2 / exploded-raster layouts.
+/// </summary>
+public sealed class EsriTileCachePackageReaderTests
+{
+    private const int CompactV2HeaderSize = 64;
+    private const int CompactV2IndexEntries = 128 * 128;
+    private const int CompactV2IndexSize = CompactV2IndexEntries * 8;
+
+    [Theory]
+    [InlineData("basemap.tpk", true)]
+    [InlineData("basemap.tpkx", true)]
+    [InlineData("basemap.vtpk", true)]
+    [InlineData("basemap.TPKX", true)]
+    [InlineData("basemap.gpkg", false)]
+    [InlineData("basemap.zip", false)]
+    public void CanRead_MatchesTilePackageExtensions(string fileName, bool expected)
+    {
+        var reader = new EsriTileCachePackageReader();
+        reader.CanRead(fileName).Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task ReadDescriptor_CompactV2Tpkx_ParsesRasterScheme()
+    {
+        using var package = BuildCompactV2Package(prefix: string.Empty, format: "PNG", wkid: 3857, name: "Imagery");
+        var reader = new EsriTileCachePackageReader();
+
+        var descriptor = await reader.ReadDescriptorAsync(package);
+
+        descriptor.StorageFormat.Should().Be(TileCacheStorageFormat.CompactV2);
+        descriptor.DataType.Should().Be(TileCacheDataType.Raster);
+        descriptor.ContentType.Should().Be("image/png");
+        descriptor.TileMatrixSetIdentifier.Should().Be("WebMercatorQuad");
+        descriptor.Title.Should().Be("Imagery");
+        descriptor.TileBundlesPath.Should().Be("tile");
+    }
+
+    [Fact]
+    public async Task ReadDescriptor_CompactV2Vtpk_ParsesVectorSchemeUnderP12Prefix()
+    {
+        using var package = BuildCompactV2Package(prefix: "p12", format: "pbf", wkid: 4326, name: "Streets");
+        var reader = new EsriTileCachePackageReader();
+
+        var descriptor = await reader.ReadDescriptorAsync(package);
+
+        descriptor.DataType.Should().Be(TileCacheDataType.Vector);
+        descriptor.ContentType.Should().Be("application/vnd.mapbox-vector-tile");
+        descriptor.TileMatrixSetIdentifier.Should().Be("WorldCRS84Quad");
+        descriptor.TileBundlesPath.Should().Be("p12/tile");
+    }
+
+    [Fact]
+    public async Task ReadTiles_CompactV2_DecodesIndexedTilesAtCorrectCoordinates()
+    {
+        // Place two tiles in the level-3 bundle whose block base is (row 0, col 0):
+        //   global (z=3, row=2, col=5) and (z=3, row=7, col=1).
+        var tiles = new (int Row, int Col, byte[] Bytes)[]
+        {
+            (2, 5, Encoding.ASCII.GetBytes("TILE-A")),
+            (7, 1, Encoding.ASCII.GetBytes("TILE-BBBB"))
+        };
+        using var package = BuildCompactV2Package(prefix: string.Empty, format: "PNG", wkid: 3857, name: "x", level: 3, tiles: tiles);
+        var reader = new EsriTileCachePackageReader();
+        var descriptor = await reader.ReadDescriptorAsync(package);
+
+        var read = new List<TileCachePackageTile>();
+        await foreach (var tile in reader.ReadTilesAsync(package, descriptor, 0, 24))
+        {
+            read.Add(tile);
+        }
+
+        read.Should().HaveCount(2);
+        read.Should().ContainSingle(t => t.Z == 3 && t.X == 5 && t.Y == 2)
+            .Which.Content.Should().Equal(Encoding.ASCII.GetBytes("TILE-A"));
+        read.Should().ContainSingle(t => t.Z == 3 && t.X == 1 && t.Y == 7)
+            .Which.Content.Should().Equal(Encoding.ASCII.GetBytes("TILE-BBBB"));
+    }
+
+    [Fact]
+    public async Task ReadTiles_CompactV2_HonorsZoomRange()
+    {
+        var tiles = new (int Row, int Col, byte[] Bytes)[] { (0, 0, [1, 2, 3]) };
+        using var package = BuildCompactV2Package(prefix: string.Empty, format: "PNG", wkid: 3857, name: "x", level: 3, tiles: tiles);
+        var reader = new EsriTileCachePackageReader();
+        var descriptor = await reader.ReadDescriptorAsync(package);
+
+        var read = new List<TileCachePackageTile>();
+        await foreach (var tile in reader.ReadTilesAsync(package, descriptor, 4, 24))
+        {
+            read.Add(tile);
+        }
+
+        read.Should().BeEmpty("the only bundle is at level 3 which is outside the requested 4-24 range");
+    }
+
+    [Fact]
+    public async Task ReadDescriptor_ExplodedTpk_ParsesFromConfXml()
+    {
+        using var package = BuildExplodedPackage();
+        var reader = new EsriTileCachePackageReader();
+
+        var descriptor = await reader.ReadDescriptorAsync(package);
+
+        descriptor.StorageFormat.Should().Be(TileCacheStorageFormat.Exploded);
+        descriptor.DataType.Should().Be(TileCacheDataType.Raster);
+        descriptor.ContentType.Should().Be("image/jpeg");
+        descriptor.MinLevel.Should().Be(0);
+        descriptor.MaxLevel.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ReadTiles_ExplodedTpk_DecodesHexCoordinates()
+    {
+        using var package = BuildExplodedPackage();
+        var reader = new EsriTileCachePackageReader();
+        var descriptor = await reader.ReadDescriptorAsync(package);
+
+        var read = new List<TileCachePackageTile>();
+        await foreach (var tile in reader.ReadTilesAsync(package, descriptor, 0, 24))
+        {
+            read.Add(tile);
+        }
+
+        // _alllayers/L02/R0000000a/C00000014.jpg -> z=2, row=0x0a=10, col=0x14=20.
+        read.Should().ContainSingle(t => t.Z == 2 && t.Y == 10 && t.X == 20);
+    }
+
+    [Fact]
+    public async Task ReadDescriptor_MissingDescriptor_Throws()
+    {
+        using var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry("readme.txt");
+            using var s = entry.Open();
+            s.Write(Encoding.ASCII.GetBytes("not a tile package"));
+        }
+
+        buffer.Position = 0;
+        var reader = new EsriTileCachePackageReader();
+        var act = async () => await reader.ReadDescriptorAsync(buffer);
+        await act.Should().ThrowAsync<InvalidDataException>();
+    }
+
+    // -------- fixture builders --------
+
+    private static MemoryStream BuildCompactV2Package(
+        string prefix,
+        string format,
+        int wkid,
+        string name,
+        int level = 0,
+        (int Row, int Col, byte[] Bytes)[]? tiles = null)
+    {
+        var buffer = new MemoryStream();
+        var root = prefix.Length == 0 ? string.Empty : prefix + "/";
+
+        using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            WriteEntry(archive, $"{root}root.json", Encoding.UTF8.GetBytes($$"""
+                {
+                  "name": "{{name}}",
+                  "tileBundlesPath": "./tile",
+                  "storageInfo": { "storageFormat": "esriMapCacheStorageModeCompactV2", "packetSize": 128 },
+                  "tileInfo": {
+                    "rows": 256, "cols": 256, "format": "{{format}}",
+                    "spatialReference": { "wkid": {{wkid.ToString(CultureInfo.InvariantCulture)}}, "latestWkid": {{wkid.ToString(CultureInfo.InvariantCulture)}} },
+                    "lods": [ { "level": {{level.ToString(CultureInfo.InvariantCulture)}} } ]
+                  }
+                }
+                """));
+
+            if (tiles is { Length: > 0 })
+            {
+                var bundle = BuildCompactV2Bundle(tiles);
+                // Bundle base is the top-left of the 128x128 block; all test tiles
+                // sit in block (0,0), so the bundle file is R0000C0000.bundle.
+                WriteEntry(archive, $"{root}tile/L{level:D2}/R0000C0000.bundle", bundle);
+            }
+        }
+
+        buffer.Position = 0;
+        return buffer;
+    }
+
+    private static byte[] BuildCompactV2Bundle((int Row, int Col, byte[] Bytes)[] tiles)
+    {
+        // Header (64) + index (16384 * 8) + tile data appended sequentially.
+        var dataStart = CompactV2HeaderSize + CompactV2IndexSize;
+        using var ms = new MemoryStream();
+        var header = new byte[CompactV2HeaderSize];
+        BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(0, 4), 3);       // version
+        BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(4, 4), CompactV2IndexEntries);
+        BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(12, 4), 5);      // offset byte count
+        BinaryPrimitives.WriteInt64LittleEndian(header.AsSpan(32, 8), 40);     // user header offset
+        BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(60, 4), CompactV2IndexSize);
+        ms.Write(header);
+
+        var index = new byte[CompactV2IndexSize];
+        var tileBlob = new MemoryStream();
+        long cursor = dataStart;
+        foreach (var (row, col, bytes) in tiles)
+        {
+            var entry = row * 128 + col; // row-major within the block
+            long packed = ((long)bytes.Length << 40) | cursor;
+            BinaryPrimitives.WriteInt64LittleEndian(index.AsSpan(entry * 8, 8), packed);
+            tileBlob.Write(bytes);
+            cursor += bytes.Length;
+        }
+
+        ms.Write(index);
+        ms.Write(tileBlob.ToArray());
+        return ms.ToArray();
+    }
+
+    private static MemoryStream BuildExplodedPackage()
+    {
+        var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            WriteEntry(archive, "conf.xml", Encoding.UTF8.GetBytes("""
+                <?xml version="1.0"?>
+                <CacheInfo>
+                  <TileCacheInfo>
+                    <SpatialReference><WKID>3857</WKID></SpatialReference>
+                    <TileCols>256</TileCols>
+                    <TileRows>256</TileRows>
+                    <LODInfos>
+                      <LODInfo><LevelID>0</LevelID></LODInfo>
+                      <LODInfo><LevelID>1</LevelID></LODInfo>
+                      <LODInfo><LevelID>2</LevelID></LODInfo>
+                    </LODInfos>
+                  </TileCacheInfo>
+                  <TileImageInfo><CacheTileFormat>JPEG</CacheTileFormat></TileImageInfo>
+                  <CacheStorageInfo><StorageFormat>esriMapCacheStorageModeExploded</StorageFormat></CacheStorageInfo>
+                </CacheInfo>
+                """));
+
+            WriteEntry(archive, "_alllayers/L02/R0000000a/C00000014.jpg", [0xFF, 0xD8, 0xFF, 0xE0]);
+        }
+
+        buffer.Position = 0;
+        return buffer;
+    }
+
+    private static void WriteEntry(ZipArchive archive, string name, byte[] content)
+    {
+        var entry = archive.CreateEntry(name);
+        using var s = entry.Open();
+        s.Write(content);
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/PostgresOgcTileCacheSinkTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/PostgresOgcTileCacheSinkTests.cs
@@ -42,10 +42,14 @@ public sealed class PostgresOgcTileCacheSinkTests(PostgresFixture fixture)
                 style_identifier   TEXT NOT NULL DEFAULT 'default',
                 min_zoom           INTEGER NOT NULL,
                 max_zoom           INTEGER NOT NULL,
+                data_type          TEXT NOT NULL DEFAULT 'raster',
+                tileset_title      TEXT,
                 created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                 updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                 UNIQUE (layer_identifier, tile_matrix_set, style_identifier, tile_format, source_service_url)
             );
+            ALTER TABLE honua.tile_caches ADD COLUMN IF NOT EXISTS data_type TEXT NOT NULL DEFAULT 'raster';
+            ALTER TABLE honua.tile_caches ADD COLUMN IF NOT EXISTS tileset_title TEXT;
             CREATE TABLE IF NOT EXISTS honua.tile_cache_entries (
                 tile_cache_id  TEXT NOT NULL REFERENCES honua.tile_caches (tile_cache_id) ON DELETE CASCADE,
                 zoom_level     INTEGER NOT NULL,

--- a/tests/dotnet/Honua.Server.Tests/Import/TileCachePackageEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/TileCachePackageEndpointTests.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using System.Globalization;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Import;
+
+/// <summary>
+/// Integration tests for the Esri tile-cache package import + serving binding (#1269).
+/// Imports a synthetic Compact Cache V2 (.tpkx) package and then serves the imported
+/// tile + TileJSON descriptor through the public tile endpoints.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Import)]
+public sealed class TileCachePackageEndpointTests : IAsyncLifetime
+{
+    private const int CompactV2HeaderSize = 64;
+    private const int CompactV2IndexEntries = 128 * 128;
+    private const int CompactV2IndexSize = CompactV2IndexEntries * 8;
+
+    private readonly WebAppFixture _fixture = new();
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/tile-package")]
+    public async Task ImportTilePackage_WithMissingTilesetId_ReturnsBadRequest()
+    {
+        using var content = new ByteArrayContent([1, 2, 3]);
+        var response = await _client.PostAsync("/api/v1/admin/import/tile-package?fileName=x.tpkx", content);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/tile-package")]
+    public async Task ImportTilePackage_WithUnknownFormat_ReturnsBadRequest()
+    {
+        using var content = new ByteArrayContent([1, 2, 3]);
+        var response = await _client.PostAsync(
+            "/api/v1/admin/import/tile-package?tilesetId=demo&fileName=x.gpkg", content);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/tile-package")]
+    public async Task ImportTilePackage_DryRun_ReportsPlanWithoutWriting()
+    {
+        var package = BuildCompactV2Package(
+            tiles: [(2, 5, Encoding.ASCII.GetBytes("PNGDATA"))], level: 3);
+        using var content = new ByteArrayContent(package);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+        var response = await _client.PostAsync(
+            "/api/v1/admin/import/tile-package?tilesetId=dryrun-demo&fileName=demo.tpkx&dryRun=true", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("dryRun").GetBoolean().Should().BeTrue();
+        doc.RootElement.GetProperty("dataType").GetString().Should().Be("raster");
+        doc.RootElement.GetProperty("tilesImported").GetInt32().Should().Be(0);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /tiles/imported/{tileCacheId}/{z}/{x}/{y}")]
+    public async Task ImportTilePackage_ThenServesTileAndTileSet()
+    {
+        var tileBytes = Encoding.ASCII.GetBytes("RASTER-TILE-BYTES");
+        // global (z=3, row=2, col=5)
+        var package = BuildCompactV2Package(tiles: [(2, 5, tileBytes)], level: 3);
+
+        using var content = new ByteArrayContent(package);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+        var importResponse = await _client.PostAsync(
+            "/api/v1/admin/import/tile-package?tilesetId=served-demo&fileName=served.tpkx", content);
+        importResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var importDoc = JsonDocument.Parse(await importResponse.Content.ReadAsStringAsync());
+        var root = importDoc.RootElement;
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+        root.GetProperty("tilesImported").GetInt32().Should().Be(1);
+        var tileCacheId = root.GetProperty("tileCacheId").GetString();
+        tileCacheId.Should().NotBeNullOrEmpty();
+
+        // Serving binding: TileJSON descriptor.
+        var tileSetResponse = await _client.GetAsync($"/tiles/imported/{tileCacheId}");
+        tileSetResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var tileSetDoc = JsonDocument.Parse(await tileSetResponse.Content.ReadAsStringAsync());
+        tileSetDoc.RootElement.GetProperty("dataType").GetString().Should().Be("raster");
+        tileSetDoc.RootElement.GetProperty("format").GetString().Should().Be("image/png");
+
+        // Serving binding: actual tile bytes round-trip.
+        var tileResponse = await _client.GetAsync($"/tiles/imported/{tileCacheId}/3/5/2");
+        tileResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var served = await tileResponse.Content.ReadAsByteArrayAsync();
+        served.Should().Equal(tileBytes);
+
+        // Missing tile -> 404.
+        var missing = await _client.GetAsync($"/tiles/imported/{tileCacheId}/3/99/99");
+        missing.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /tiles/imported/{tileCacheId}")]
+    public async Task GetImportedTileSet_UnknownCache_ReturnsNotFound()
+    {
+        var response = await _client.GetAsync("/tiles/imported/tilecache:nope:nope:deadbeef");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private static byte[] BuildCompactV2Package((int Row, int Col, byte[] Bytes)[] tiles, int level)
+    {
+        using var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            WriteEntry(archive, "root.json", Encoding.UTF8.GetBytes($$"""
+                {
+                  "name": "Demo",
+                  "tileBundlesPath": "./tile",
+                  "storageInfo": { "storageFormat": "esriMapCacheStorageModeCompactV2", "packetSize": 128 },
+                  "tileInfo": {
+                    "rows": 256, "cols": 256, "format": "PNG",
+                    "spatialReference": { "wkid": 3857, "latestWkid": 3857 },
+                    "lods": [ { "level": {{level.ToString(CultureInfo.InvariantCulture)}} } ]
+                  }
+                }
+                """));
+
+            WriteEntry(archive, $"tile/L{level:D2}/R0000C0000.bundle", BuildBundle(tiles));
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static byte[] BuildBundle((int Row, int Col, byte[] Bytes)[] tiles)
+    {
+        var dataStart = CompactV2HeaderSize + CompactV2IndexSize;
+        using var ms = new MemoryStream();
+        var header = new byte[CompactV2HeaderSize];
+        BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(0, 4), 3);
+        BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(4, 4), CompactV2IndexEntries);
+        BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(12, 4), 5);
+        BinaryPrimitives.WriteInt64LittleEndian(header.AsSpan(32, 8), 40);
+        BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(60, 4), CompactV2IndexSize);
+        ms.Write(header);
+
+        var index = new byte[CompactV2IndexSize];
+        using var blob = new MemoryStream();
+        long cursor = dataStart;
+        foreach (var (row, col, bytes) in tiles)
+        {
+            var entry = (row * 128) + col;
+            long packed = ((long)bytes.Length << 40) | cursor;
+            BinaryPrimitives.WriteInt64LittleEndian(index.AsSpan(entry * 8, 8), packed);
+            blob.Write(bytes);
+            cursor += bytes.Length;
+        }
+
+        ms.Write(index);
+        ms.Write(blob.ToArray());
+        return ms.ToArray();
+    }
+
+    private static void WriteEntry(ZipArchive archive, string name, byte[] content)
+    {
+        var entry = archive.CreateEntry(name);
+        using var s = entry.Open();
+        s.Write(content);
+    }
+}

--- a/tests/seed/base-schema.sql
+++ b/tests/seed/base-schema.sql
@@ -1378,3 +1378,40 @@ ON CONFLICT (raster_data_id, band_number) DO UPDATE SET
     computed_at = NOW();
 
 SELECT honua.seed_metadata_v2_compat_snapshot();
+
+-- Tile-cache catalog (#1016 slice 4) + package-import serving columns (#1269).
+-- Mirrors migrations 033_CreateTileCacheCatalog and 067_AddTileCachePackageImport so
+-- the .tpk/.tpkx/.vtpk import + serving binding has its tables in CI seed schemas.
+CREATE TABLE IF NOT EXISTS honua.tile_caches (
+    tile_cache_id      TEXT PRIMARY KEY,
+    layer_identifier   TEXT NOT NULL,
+    tile_matrix_set    TEXT NOT NULL,
+    source_service_url TEXT NOT NULL,
+    tile_format        TEXT NOT NULL DEFAULT 'image/png',
+    style_identifier   TEXT NOT NULL DEFAULT 'default',
+    min_zoom           INTEGER NOT NULL,
+    max_zoom           INTEGER NOT NULL,
+    data_type          TEXT NOT NULL DEFAULT 'raster',
+    tileset_title      TEXT,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (layer_identifier, tile_matrix_set, style_identifier, tile_format, source_service_url)
+);
+
+CREATE TABLE IF NOT EXISTS honua.tile_cache_entries (
+    tile_cache_id  TEXT NOT NULL REFERENCES honua.tile_caches (tile_cache_id) ON DELETE CASCADE,
+    zoom_level     INTEGER NOT NULL,
+    tile_column    INTEGER NOT NULL,
+    tile_row       INTEGER NOT NULL,
+    content_type   TEXT NOT NULL,
+    content        BYTEA NOT NULL,
+    source_url     TEXT NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tile_cache_id, zoom_level, tile_column, tile_row),
+    CHECK (zoom_level >= 0),
+    CHECK (tile_column >= 0),
+    CHECK (tile_row >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS tile_cache_entries_cache_zoom_idx
+    ON honua.tile_cache_entries (tile_cache_id, zoom_level);

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -2338,3 +2338,41 @@ sql:
       INSERT INTO honua.network_datasets (id, name, edge_table, vertex_table, srid, status)
       VALUES ('default', 'Default network dataset', 'public.ways', 'public.ways_vertices_pgr', 4326, 'active')
       ON CONFLICT (id) DO NOTHING;
+  # Tile-cache catalog (#1016 slice 4) + package-import serving columns (#1269).
+  # Mirrors migrations 033_CreateTileCacheCatalog + 067_AddTileCachePackageImport so
+  # the WMTS exporter sink and the .tpk/.tpkx/.vtpk import + serving binding have their
+  # tables when HONUA_SKIP_MIGRATIONS bypasses the migration runner.
+  - |
+      CREATE TABLE IF NOT EXISTS honua.tile_caches (
+          tile_cache_id      TEXT PRIMARY KEY,
+          layer_identifier   TEXT NOT NULL,
+          tile_matrix_set    TEXT NOT NULL,
+          source_service_url TEXT NOT NULL,
+          tile_format        TEXT NOT NULL DEFAULT 'image/png',
+          style_identifier   TEXT NOT NULL DEFAULT 'default',
+          min_zoom           INTEGER NOT NULL,
+          max_zoom           INTEGER NOT NULL,
+          data_type          TEXT NOT NULL DEFAULT 'raster',
+          tileset_title      TEXT,
+          created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          UNIQUE (layer_identifier, tile_matrix_set, style_identifier, tile_format, source_service_url)
+      );
+  - "ALTER TABLE IF EXISTS honua.tile_caches ADD COLUMN IF NOT EXISTS data_type TEXT NOT NULL DEFAULT 'raster';"
+  - "ALTER TABLE IF EXISTS honua.tile_caches ADD COLUMN IF NOT EXISTS tileset_title TEXT;"
+  - |
+      CREATE TABLE IF NOT EXISTS honua.tile_cache_entries (
+          tile_cache_id  TEXT NOT NULL REFERENCES honua.tile_caches (tile_cache_id) ON DELETE CASCADE,
+          zoom_level     INTEGER NOT NULL,
+          tile_column    INTEGER NOT NULL,
+          tile_row       INTEGER NOT NULL,
+          content_type   TEXT NOT NULL,
+          content        BYTEA NOT NULL,
+          source_url     TEXT NOT NULL,
+          created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          PRIMARY KEY (tile_cache_id, zoom_level, tile_column, tile_row),
+          CHECK (zoom_level >= 0),
+          CHECK (tile_column >= 0),
+          CHECK (tile_row >= 0)
+      );
+  - "CREATE INDEX IF NOT EXISTS tile_cache_entries_cache_zoom_idx ON honua.tile_cache_entries (tile_cache_id, zoom_level);"


### PR DESCRIPTION
Closes #1269.

## What

Read-only import of Esri tile cache packages into Honua's tile catalog, plus a serving binding so imported caches serve through Honua tile endpoints without re-rendering.

### Importer
- `EsriTileCachePackageReader` (Honua.Core) parses the **documented published** Esri cache layout only:
  - **Compact Cache V2** (`.tpkx` raster, `.vtpk` vector) driven by `root.json`: `.bundle` files with the 64-byte header + 16384-entry (128x128) little-endian index (low 40 bits offset, high 24 bits size, row-major). Handles the `p12/` prefix used by `.vtpk`.
  - **Exploded raster** (older `.tpk`): `_alllayers/L../R{8hex}/C{8hex}.{png|jpg}` driven by `conf.xml`.
  - Reflection-free (source-generated JSON, `XmlReader`), AOT-conscious.
- `TileCachePackageImportService` streams parsed tiles into the existing shared `IOgcTileCacheSink` (`honua.tile_caches` / `tile_cache_entries`), so re-imports are idempotent.
- `POST /api/v1/admin/import/tile-package` (admin) — package uploaded as the raw request body, streamed to a bounded temp file; `tilesetId`/zoom range/`dryRun` as query params.

### Serving binding
- `IImportedTileCacheReader` + Postgres implementation read tiles back out of the catalog (no existing read path served this table — it was write-only from the WMTS exporter).
- Public `GET /tiles/imported/{tileCacheId}` (TileJSON-style descriptor) and `GET /tiles/imported/{tileCacheId}/{z}/{x}/{y}` (tile bytes).

### Schema
- Migration **067** adds `data_type` + `tileset_title` to `honua.tile_caches` (additive, idempotent, gated on the table existing). Mirrored into `tests/seed/base-schema.sql` and `tests/seed/server.yaml`.

Endpoints registered in `EndpointRegistry.cs` and the generated feature catalog.

## Compliance
Reads only the documented, publicly published Esri cache structure (Compact Cache V2 spec, tile-package-spec, conf.xml) for interoperability — no licensed Esri software, no reversing of proprietary internals.

## Deferred (honest scope)
**Compact Cache V1** (`.bundlx` + `.bundle`, legacy `.tpk`) is not implemented: its on-disk layout is community-reverse-engineered rather than Esri-published, so it is deferred to stay within the documented-layout-only guardrail. Modern `.tpk` exploded caches, `.tpkx`, and `.vtpk` all land here, satisfying the acceptance criterion (a `.vtpk`/`.tpk` imports and serves).

## Tests (all run serially, Release)
- Build: Release, warnings-as-errors — **0 warnings / 0 errors**.
- `Honua.Core.Tests` — 13 reader tests (Compact V2 raster/vector descriptor + index decoding + zoom filtering, exploded conf.xml + hex coordinate decoding, bad-package handling). **Pass**.
- `Honua.Server.Tests` — 5 integration tests incl. end-to-end import-of-synthetic-`.tpkx`-then-serve-tile + TileJSON (Testcontainers/PostGIS). **Pass**.
- `Honua.Postgres.Tests` — tile-cache sink tests updated for the new columns. **Pass**.
- `Honua.Architecture.Tests` — 116/116 **pass** (API-surface coverage + feature-catalog drift).