### PR TITLE
feat(scene): auto-dispatch LAZ/COPC + projected-CRS point clouds to pcloud.translate on ingest (#1854)

### DIFF
--- a/src/Honua.Core/Features/Scene/Abstractions/IPointCloudDecompressor.cs
+++ b/src/Honua.Core/Features/Scene/Abstractions/IPointCloudDecompressor.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+
+namespace Honua.Core.Features.Scene.Abstractions;
+
+/// <summary>
+/// Binds a request principal to an <see cref="IPointCloudDecompressor"/> (#1854).
+/// Decompression authorizes and submits the worker job under the calling
+/// operator's identity, which is only available per request, so the long-lived
+/// dependencies live in the factory and the principal is supplied when the
+/// ingest endpoint creates the per-request decompressor. A registered factory
+/// signals to the ingest path that out-of-tree LAZ/COPC decompression is
+/// available; its absence falls back to rejecting compressed/projected input.
+/// </summary>
+public interface IPointCloudDecompressorFactory
+{
+    /// <summary>Creates a decompressor bound to the supplied request principal.</summary>
+    /// <param name="principal">The authenticated operator the worker job runs under.</param>
+    IPointCloudDecompressor Create(ClaimsPrincipal principal);
+}
+
+/// <summary>
+/// Decompresses a LAZ/COPC point-cloud buffer (and, when the source is in a
+/// projected CRS, reprojects it to geographic EPSG:4979) into the uncompressed
+/// LAS the pure-managed scene tiler consumes (#1854).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The managed <c>LasPointCloudReader</c> + tiler can only consume uncompressed,
+/// geographic LAS. Real-world point clouds are almost always LAZ/COPC and are
+/// frequently delivered in a projected CRS, so the admin scene-ingest path
+/// detects those cases on upload and dispatches the heavyweight, native
+/// decompression/reprojection work out of process via the <c>pcloud.translate</c>
+/// process (PDAL, built on laz-perf + PROJ), then tiles the returned LAS inline.
+/// </para>
+/// <para>
+/// This abstraction keeps the <c>Honua.Scene</c> tiling subsystem free of any
+/// dependency on the geoprocessing/job runtime: <c>Honua.Scene</c> defines the
+/// pure-managed reader and tiler, while the server composition root binds an
+/// implementation that submits the canonical process plan and awaits the worker
+/// artifact. When no implementation is registered (for example a build without a
+/// point-cloud worker), the ingest path falls back to rejecting compressed input
+/// as before.
+/// </para>
+/// </remarks>
+public interface IPointCloudDecompressor
+{
+    /// <summary>
+    /// Decompresses <paramref name="source"/> (LAZ or COPC) to uncompressed LAS,
+    /// reprojecting to geographic EPSG:4979 when <paramref name="sourceSrs"/>
+    /// names a projected CRS. An uncompressed-but-projected source is accepted and
+    /// reprojected; a geographic source is decompressed verbatim.
+    /// </summary>
+    /// <param name="source">The uploaded LAZ/COPC (or projected uncompressed LAS) bytes.</param>
+    /// <param name="sourceSrs">
+    /// Optional source CRS token (for example <c>EPSG:32610</c> or a bare positive
+    /// EPSG integer). When supplied and non-geographic, reprojection to
+    /// EPSG:4979 is applied; when omitted or geographic, no reprojection occurs.
+    /// </param>
+    /// <param name="cancellationToken">Cancels the dispatch and any polling.</param>
+    /// <returns>The decompressed (and, where applicable, reprojected) uncompressed LAS bytes.</returns>
+    /// <exception cref="PointCloudDecompressionException">
+    /// The worker rejected the input, failed, timed out, or produced no artifact.
+    /// </exception>
+    Task<byte[]> DecompressAsync(byte[] source, string? sourceSrs, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Raised when out-of-process point-cloud decompression/reprojection
+/// (<c>pcloud.translate</c>) fails. Carries a stable, non-sensitive message the
+/// ingest endpoint maps to a problem-detail without leaking worker internals.
+/// </summary>
+public sealed class PointCloudDecompressionException : Exception
+{
+    /// <summary>Creates a <see cref="PointCloudDecompressionException"/>.</summary>
+    /// <param name="message">A non-sensitive, human-readable failure description.</param>
+    public PointCloudDecompressionException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Creates a <see cref="PointCloudDecompressionException"/> wrapping an inner cause.</summary>
+    /// <param name="message">A non-sensitive, human-readable failure description.</param>
+    /// <param name="innerException">The underlying cause.</param>
+    public PointCloudDecompressionException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Honua.Scene/PointCloud/PointCloudCompressionDetector.cs
+++ b/src/Honua.Scene/PointCloud/PointCloudCompressionDetector.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Scene.PointCloud;
+
+/// <summary>
+/// Non-throwing companion to <see cref="LasPointCloudReader"/> that classifies an
+/// uploaded point-cloud buffer without parsing it (#1854). The ingest dispatch
+/// path uses it to decide, before any tiling, whether a buffer must first be
+/// routed through the out-of-tree <c>pcloud.translate</c> worker (LAZ/COPC
+/// decompression) rather than being rejected outright.
+/// </summary>
+/// <remarks>
+/// The pure-managed <see cref="LasPointCloudReader"/> can only parse uncompressed
+/// LAS; it throws <see cref="LasFormatException"/> for a compressed buffer. The
+/// detector reads the single point-data-record-format byte and reports the
+/// compression flag so the caller can pre-emptively dispatch decompression
+/// instead of catching the reader's exception, keeping the rejected-vs-dispatch
+/// decision explicit at the ingest boundary.
+/// </remarks>
+public static class PointCloudCompressionDetector
+{
+    // The LAS public header carries the point-data-record-format byte at offset
+    // 104. laszip sets bit 7 (0x80) to flag LAZ arithmetic compression; bit 6
+    // (0x40) is the COPC indicator. The base format lives in the low 6 bits.
+    private const int PointFormatByteOffset = 104;
+    private const byte LazCompressionFlag = 0x80;
+    private const byte CopcIndicatorFlag = 0x40;
+    private const int LasfSignatureLength = 4;
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="source"/> is a LASF
+    /// buffer whose point-data-record-format byte carries the LAZ or COPC
+    /// compression flag. Returns <see langword="false"/> for an uncompressed LAS,
+    /// a non-LASF buffer, or a buffer too short to carry the format byte; those
+    /// are left for <see cref="LasPointCloudReader"/> to accept or reject.
+    /// </summary>
+    public static bool IsCompressed(ReadOnlySpan<byte> source)
+    {
+        if (source.Length <= PointFormatByteOffset)
+        {
+            return false;
+        }
+
+        if (!HasLasfSignature(source))
+        {
+            return false;
+        }
+
+        var rawPointFormat = source[PointFormatByteOffset];
+        return (rawPointFormat & LazCompressionFlag) != 0 || (rawPointFormat & CopcIndicatorFlag) != 0;
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="source"/> begins with the ASPRS
+    /// <c>LASF</c> public-header signature. A buffer lacking it is neither LAS nor
+    /// LAZ/COPC and is left for the reader to reject with its stable error.
+    /// </summary>
+    public static bool HasLasfSignature(ReadOnlySpan<byte> source)
+        => source.Length >= LasfSignatureLength
+            && source[0] == (byte)'L'
+            && source[1] == (byte)'A'
+            && source[2] == (byte)'S'
+            && source[3] == (byte)'F';
+}

--- a/src/Honua.Server/Features/Admin/Scene/GeoprocessingPointCloudDecompressor.cs
+++ b/src/Honua.Server/Features/Admin/Scene/GeoprocessingPointCloudDecompressor.cs
@@ -1,0 +1,301 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Security.Claims;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Scene.Abstractions;
+using Honua.Geoprocessing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Admin.Scene;
+
+/// <summary>
+/// <see cref="IPointCloudDecompressor"/> backed by the canonical geoprocessing job
+/// runtime (#1854). It builds a single-step <c>pcloud.translate</c>
+/// <see cref="AnalysisPlan"/>, submits it through <see cref="IGeoprocessingJobService"/>
+/// (which stamps the native runtime profile so the dispatch routes to the
+/// out-of-tree PDAL worker), polls the job to a terminal state, and returns the
+/// decompressed uncompressed-LAS bytes the managed scene tiler consumes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the worker-boundary crossing the <c>Honua.Scene</c> tiling subsystem
+/// deliberately does not take: the scene assembly stays free of any
+/// geoprocessing/job dependency, and the server composition root binds this
+/// adapter so the admin point-cloud ingest endpoint can decompress LAZ/COPC (or
+/// reproject a projected source) before tiling. The actual decompression is the
+/// thin-adapter-over-canonical-pipeline path AGENTS.md prescribes — no LAS/LAZ
+/// parsing, no 3D-Tiles generation lives here.
+/// </para>
+/// <para>
+/// The decompressed LAS round-trips back through the existing managed
+/// <c>LasPointCloudReader</c> + <c>PointCloudTilesetBuilder</c>, so the ingest
+/// outcome is identical to a natively-uploaded uncompressed LAS.
+/// </para>
+/// </remarks>
+internal sealed partial class GeoprocessingPointCloudDecompressor : IPointCloudDecompressor
+{
+    /// <summary>The canonical process id handled by the out-of-tree PDAL worker.</summary>
+    public const string ProcessId = "pcloud.translate";
+
+    private const string LasArtifactContentType = "application/vnd.las";
+    private const string DataUriPrefix = "data:";
+
+    private readonly IGeoprocessingJobService _jobService;
+    private readonly ClaimsPrincipal _principal;
+    private readonly IOptions<PointCloudDecompressionOptions> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<GeoprocessingPointCloudDecompressor> _logger;
+
+    public GeoprocessingPointCloudDecompressor(
+        IGeoprocessingJobService jobService,
+        ClaimsPrincipal principal,
+        IOptions<PointCloudDecompressionOptions> options,
+        ILogger<GeoprocessingPointCloudDecompressor> logger,
+        TimeProvider? timeProvider = null)
+    {
+        _jobService = jobService ?? throw new ArgumentNullException(nameof(jobService));
+        _principal = principal ?? throw new ArgumentNullException(nameof(principal));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <inheritdoc />
+    public async Task<byte[]> DecompressAsync(byte[] source, string? sourceSrs, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (source.Length == 0)
+        {
+            throw new PointCloudDecompressionException("Point-cloud source buffer is empty.");
+        }
+
+        var opts = _options.Value;
+
+        var inputs = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["source"] = Convert.ToBase64String(source),
+        };
+        if (!string.IsNullOrWhiteSpace(sourceSrs))
+        {
+            inputs["sourceSrs"] = sourceSrs.Trim();
+        }
+
+        var planId = $"pcloud-translate-{Guid.NewGuid():N}";
+        var plan = new AnalysisPlan
+        {
+            PlanId = planId,
+            IntentId = planId,
+            Steps =
+            [
+                new AnalysisPlanStep
+                {
+                    StepId = "translate",
+                    Kind = AnalysisPlanStepKind.Geoprocess,
+                    ProcessId = ProcessId,
+                    Inputs = inputs,
+                },
+            ],
+            Outputs = [ArtifactKind.Raster],
+        };
+
+        await _jobService
+            .EnsureCallerAuthorizedAsync(_principal, OperatorResourceType.Job, OperatorOperation.Create, cancellationToken)
+            .ConfigureAwait(false);
+
+        ExecutionJobRecord job;
+        try
+        {
+            job = await _jobService
+                .SubmitJobAsync(plan, idempotencyKey: null, _principal, protocolMetadata: null, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException and not PointCloudDecompressionException)
+        {
+            Log.SubmitFailed(_logger, ex);
+            throw new PointCloudDecompressionException(
+                "Failed to submit the point-cloud decompression job to the geoprocessing runtime.", ex);
+        }
+
+        var terminal = await PollToTerminalAsync(job, opts, cancellationToken).ConfigureAwait(false);
+        if (terminal.Status != ExecutionJobStatus.Succeeded)
+        {
+            throw new PointCloudDecompressionException(
+                $"Point-cloud decompression job ended with status '{terminal.Status}'.");
+        }
+
+        var package = await _jobService
+            .GetJobResultsAsync(terminal.OperationId, _principal, cancellationToken)
+            .ConfigureAwait(false);
+
+        var las = ExtractLasArtifact(package);
+        Log.Completed(_logger, terminal.OperationId, las.Length);
+        return las;
+    }
+
+    private async Task<ExecutionJobRecord> PollToTerminalAsync(
+        ExecutionJobRecord job,
+        PointCloudDecompressionOptions opts,
+        CancellationToken cancellationToken)
+    {
+        if (IsTerminal(job.Status))
+        {
+            return job;
+        }
+
+        var deadline = _timeProvider.GetUtcNow() + opts.Timeout;
+        var current = job;
+        while (!IsTerminal(current.Status))
+        {
+            if (_timeProvider.GetUtcNow() >= deadline)
+            {
+                throw new PointCloudDecompressionException(
+                    $"Point-cloud decompression job '{current.OperationId}' did not complete within {opts.Timeout}.");
+            }
+
+            await Task.Delay(opts.PollInterval, _timeProvider, cancellationToken).ConfigureAwait(false);
+            current = await _jobService
+                .GetJobAsync(current.OperationId, _principal, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return current;
+    }
+
+    private static byte[] ExtractLasArtifact(AnalysisResultPackage package)
+    {
+        foreach (var artifact in package.Artifacts)
+        {
+            if (TryDecodeLasDataUri(artifact.Uri, out var bytes))
+            {
+                return bytes;
+            }
+        }
+
+        throw new PointCloudDecompressionException(
+            "Point-cloud decompression job produced no uncompressed-LAS artifact.");
+    }
+
+    /// <summary>
+    /// Decodes a <c>data:application/vnd.las;base64,&lt;payload&gt;</c> artifact URI
+    /// into its LAS bytes. Returns <see langword="false"/> for any other URI shape
+    /// so the caller can skip non-LAS artifacts.
+    /// </summary>
+    internal static bool TryDecodeLasDataUri(string? uri, out byte[] bytes)
+    {
+        bytes = [];
+        if (string.IsNullOrWhiteSpace(uri) || !uri.StartsWith(DataUriPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var commaIndex = uri.IndexOf(',', StringComparison.Ordinal);
+        if (commaIndex < 0)
+        {
+            return false;
+        }
+
+        var header = uri.AsSpan(DataUriPrefix.Length, commaIndex - DataUriPrefix.Length);
+        if (!header.Contains(LasArtifactContentType, StringComparison.OrdinalIgnoreCase)
+            || !header.Contains("base64", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        try
+        {
+            bytes = Convert.FromBase64String(uri[(commaIndex + 1)..]);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        return bytes.Length != 0;
+    }
+
+    private static bool IsTerminal(ExecutionJobStatus status)
+        => status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed or ExecutionJobStatus.Cancelled;
+
+    private static partial class Log
+    {
+        [LoggerMessage(EventId = 8490, Level = LogLevel.Error,
+            Message = "Point-cloud decompression job submission failed.")]
+        public static partial void SubmitFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(EventId = 8491, Level = LogLevel.Information,
+            Message = "Point-cloud decompression job {OperationId} completed; decompressed LAS is {Bytes} bytes.")]
+        public static partial void Completed(ILogger logger, string operationId, int bytes);
+    }
+}
+
+/// <summary>
+/// Composition-root factory that binds the request principal to a
+/// <see cref="GeoprocessingPointCloudDecompressor"/> (#1854). The decompressor
+/// authorizes and submits under the calling admin operator's identity, which is
+/// only available per-request, so the long-lived dependencies are captured here
+/// and the principal is supplied when the ingest endpoint creates the
+/// per-request instance.
+/// </summary>
+internal sealed class GeoprocessingPointCloudDecompressorFactory : IPointCloudDecompressorFactory
+{
+    private readonly IGeoprocessingJobService _jobService;
+    private readonly IOptions<PointCloudDecompressionOptions> _options;
+    private readonly ILogger<GeoprocessingPointCloudDecompressor> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    public GeoprocessingPointCloudDecompressorFactory(
+        IGeoprocessingJobService jobService,
+        IOptions<PointCloudDecompressionOptions> options,
+        ILogger<GeoprocessingPointCloudDecompressor> logger,
+        TimeProvider? timeProvider = null)
+    {
+        _jobService = jobService ?? throw new ArgumentNullException(nameof(jobService));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <inheritdoc />
+    public IPointCloudDecompressor Create(ClaimsPrincipal principal)
+        => new GeoprocessingPointCloudDecompressor(_jobService, principal, _options, _logger, _timeProvider);
+}
+
+/// <summary>
+/// Tunables for the out-of-process point-cloud decompression dispatch (#1854):
+/// how long the ingest request waits for the <c>pcloud.translate</c> worker and
+/// how frequently it polls the job for completion.
+/// </summary>
+internal sealed class PointCloudDecompressionOptions
+{
+    /// <summary>Configuration section binding key.</summary>
+    public const string SectionName = "Scene:PointCloud:Decompression";
+
+    /// <summary>Maximum time the ingest request waits for the worker to finish. Default 5 minutes.</summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>Interval between job-status polls while waiting. Default 1 second.</summary>
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>Parses an invariant timespan/seconds value, falling back to <paramref name="fallback"/>.</summary>
+    internal static TimeSpan ParseDuration(string? raw, TimeSpan fallback)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return fallback;
+        }
+        if (TimeSpan.TryParse(raw, CultureInfo.InvariantCulture, out var span) && span > TimeSpan.Zero)
+        {
+            return span;
+        }
+        if (double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds) && seconds > 0)
+        {
+            return TimeSpan.FromSeconds(seconds);
+        }
+        return fallback;
+    }
+}

--- a/src/Honua.Server/Features/Admin/ScenePointCloudIngestEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/ScenePointCloudIngestEndpoints.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using Honua.Core.Exceptions;
 using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Scene.Abstractions;
 using Honua.Core.Features.Scene.Domain;
 using Honua.Core.Features.Scene.PointCloud;
 using Honua.Infrastructure.Authentication;
@@ -30,9 +31,12 @@ namespace Honua.Server.Features.Admin;
 /// policy; the Enterprise entitlement is enforced inside the handler so an
 /// authenticated non-Enterprise operator receives a 402 with an upgrade message
 /// rather than a silent 404. The heavy LAS → 3D Tiles conversion is pure-managed
-/// (no native PDAL/py3dtiles dependency), so the tileset is materialised inline;
-/// compressed LAZ and Cloud-Optimized Point Cloud (COPC) inputs are rejected with
-/// a 400 problem-detail and are a documented follow-up.
+/// (no native PDAL/py3dtiles dependency), so the tileset is materialised inline.
+/// Compressed LAZ/COPC uploads — and uncompressed LAS in a projected source CRS —
+/// are auto-dispatched to the out-of-tree <c>pcloud.translate</c> worker (#1854),
+/// which returns uncompressed geographic (EPSG:4979) LAS that the managed tiler
+/// then ingests inline; when no decompressor is registered such input is rejected
+/// with a 400 problem-detail as before.
 /// </remarks>
 internal static partial class ScenePointCloudIngestEndpoints
 {
@@ -121,6 +125,10 @@ internal static partial class ScenePointCloudIngestEndpoints
         {
             return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, crsError!);
         }
+        if (!TryParseSourceEpsg(form, out var sourceEpsg, out var epsgError))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, epsgError!);
+        }
 
         byte[] document;
         await using (var stream = file.OpenReadStream())
@@ -128,6 +136,41 @@ internal static partial class ScenePointCloudIngestEndpoints
             using var buffer = new MemoryStream(file.Length > 0 ? (int)file.Length : 0);
             await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
             document = buffer.ToArray();
+        }
+
+        // Auto-dispatch (#1854): a compressed (LAZ/COPC) buffer or a projected
+        // source CRS cannot be tiled by the pure-managed reader, so route it
+        // through the out-of-tree pcloud.translate worker to obtain uncompressed,
+        // geographic (EPSG:4979) LAS, then tile that inline. When no decompressor
+        // is registered the compressed/projected input falls through to the
+        // managed reader, which rejects it with the documented 400 as before.
+        var isCompressed = PointCloudCompressionDetector.IsCompressed(document);
+        var needsWorker = isCompressed || sourceEpsg is not null;
+        if (needsWorker)
+        {
+            var factory = context.RequestServices.GetService<IPointCloudDecompressorFactory>();
+            if (factory is not null)
+            {
+                try
+                {
+                    var decompressor = factory.Create(context.User);
+                    ScenePointCloudIngestLog.DecompressionDispatched(logger, isCompressed, sourceEpsg ?? "<none>");
+                    document = await decompressor
+                        .DecompressAsync(document, sourceEpsg, cancellationToken)
+                        .ConfigureAwait(false);
+
+                    // The worker returns geographic lon/lat/ellipsoidal-height LAS
+                    // (EPSG:4979), so the managed tiler uses the longitude-first
+                    // pass-through regardless of the source's axis-order hint.
+                    sourceCrs = PointCloudSourceCrs.GeographicLonLat;
+                }
+                catch (PointCloudDecompressionException dex)
+                {
+                    ScenePointCloudIngestLog.IngestRejected(logger, "PCLOUD_DECOMPRESS", dex.Message);
+                    return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest,
+                        $"Point-cloud decompression failed: {dex.Message}");
+                }
+            }
         }
 
         var request = new PointCloudSceneIngestRequest(
@@ -236,6 +279,64 @@ internal static partial class ScenePointCloudIngestEndpoints
         }
     }
 
+    /// <summary>
+    /// Geographic WGS-84/NAD83 CRS tokens the managed tiler already accepts as a
+    /// pass-through; declaring one of these as the source needs no reprojection.
+    /// Mirrors the worker's <c>IsGeographicSrs</c> guard.
+    /// </summary>
+    private static readonly HashSet<string> GeographicSrsTokens =
+        new(StringComparer.OrdinalIgnoreCase) { "EPSG:4326", "EPSG:4979", "OGC:CRS84", "EPSG:4269" };
+
+    /// <summary>
+    /// Parses the optional <c>sourceEpsg</c> form field — the source point cloud's
+    /// CRS (#1854). A projected/unknown CRS is normalised to an <c>EPSG:&lt;code&gt;</c>
+    /// (or validated <c>AUTHORITY:CODE</c>) token and returned so the ingest path
+    /// reprojects to geographic EPSG:4979 via the worker. A geographic source (or
+    /// an omitted field) returns a <see langword="null"/> token (no reprojection).
+    /// The accepted shape mirrors the worker's conservative CRS-token guard so a
+    /// shell-influencing value is rejected at the HTTP boundary.
+    /// </summary>
+    private static bool TryParseSourceEpsg(IFormCollection form, out string? value, out string? error)
+    {
+        value = null;
+        error = null;
+        var raw = form["sourceEpsg"];
+        if (raw.Count == 0 || string.IsNullOrWhiteSpace(raw[0]))
+        {
+            return true;
+        }
+
+        var token = raw[0]!.Trim();
+
+        // Bare positive integer EPSG code -> EPSG:<code>.
+        if (int.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out var epsg))
+        {
+            if (epsg <= 0)
+            {
+                error = "sourceEpsg must be a positive EPSG code.";
+                return false;
+            }
+            token = string.Create(CultureInfo.InvariantCulture, $"EPSG:{epsg}");
+        }
+        else
+        {
+            var parts = token.Split(':', 2);
+            if (parts.Length != 2
+                || parts[0].Length is 0 or > 16 || !parts[0].All(char.IsLetterOrDigit)
+                || parts[1].Length is 0 or > 16 || !parts[1].All(char.IsLetterOrDigit))
+            {
+                error = "sourceEpsg must be a positive EPSG code or an 'AUTHORITY:CODE' token (e.g. 'EPSG:32610').";
+                return false;
+            }
+            token = string.Concat(parts[0].ToUpperInvariant(), ":", parts[1].ToUpperInvariant());
+        }
+
+        // A geographic source needs no reprojection: leave the token null so the
+        // dispatch only engages for projected sources (or compressed buffers).
+        value = GeographicSrsTokens.Contains(token) ? null : token;
+        return true;
+    }
+
     private static bool TryParseOptionalInt(
         IFormCollection form, string key, out int? value, out string? error)
     {
@@ -320,5 +421,9 @@ internal static partial class ScenePointCloudIngestEndpoints
         [LoggerMessage(EventId = 8483, Level = LogLevel.Warning,
             Message = "Point-cloud ingest scene cache invalidation failed for scene {SceneId}; subsequent reads may serve stale content until cache expires.")]
         public static partial void CacheInvalidationFailed(ILogger logger, string sceneId, Exception exception);
+
+        [LoggerMessage(EventId = 8484, Level = LogLevel.Information,
+            Message = "Point-cloud ingest dispatched out-of-tree decompression: compressed={Compressed}, sourceEpsg={SourceEpsg}")]
+        public static partial void DecompressionDispatched(ILogger logger, bool compressed, string sourceEpsg);
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/Scene/SceneGenerationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Scene/SceneGenerationServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using Honua.Core.Features.Publishing.Abstractions;
 using Honua.Core.Features.Scene.Abstractions;
 using Honua.Postgres.Features.Scene;
+using Honua.Server.Features.Admin.Scene;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Honua.Infrastructure.Scene;
@@ -52,6 +53,16 @@ internal static class SceneGenerationServiceCollectionExtensions
         // other scene executors so the Enterprise-gated admin point-cloud ingest
         // endpoint can resolve it.
         services.TryAddScoped<PointCloudScenePublishExecutor>();
+
+        // LAZ/COPC decompression + projected-CRS reprojection auto-dispatch
+        // (#1854): a factory that binds the request principal to a decompressor
+        // submitting the canonical pcloud.translate worker job. Registered as a
+        // singleton over the always-present IGeoprocessingJobService; the ingest
+        // endpoint resolves it optionally and only engages it for compressed or
+        // projected uploads, so an absent worker still rejects such input cleanly.
+        services.Configure<PointCloudDecompressionOptions>(
+            configuration.GetSection(PointCloudDecompressionOptions.SectionName));
+        services.TryAddSingleton<IPointCloudDecompressorFactory, GeoprocessingPointCloudDecompressorFactory>();
 
         return services;
     }

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/PointCloud/PointCloudCompressionDetectorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/PointCloud/PointCloudCompressionDetectorTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.Scene.PointCloud;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.PointCloud;
+
+/// <summary>
+/// Unit coverage for <see cref="PointCloudCompressionDetector"/> (#1854): the
+/// non-throwing buffer classifier the ingest dispatch path uses to decide
+/// whether an uploaded point cloud must be routed through the out-of-tree
+/// decompression worker before the managed tiler can read it.
+/// </summary>
+public sealed class PointCloudCompressionDetectorTests
+{
+    [UnitTest]
+    public void IsCompressed_UncompressedLas_ReturnsFalse()
+    {
+        var las = LasFixtureBuilder.BuildFormat3(SinglePoint());
+
+        PointCloudCompressionDetector.IsCompressed(las).Should().BeFalse();
+        PointCloudCompressionDetector.HasLasfSignature(las).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void IsCompressed_LazCompressedFlag_ReturnsTrue()
+    {
+        // laszip sets bit 7 (0x80) of the point-data-record-format byte.
+        var laz = LasFixtureBuilder.MarkCompressed(LasFixtureBuilder.BuildFormat3(SinglePoint()));
+
+        PointCloudCompressionDetector.IsCompressed(laz).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void IsCompressed_CopcIndicatorFlag_ReturnsTrue()
+    {
+        // Bit 6 (0x40) is the COPC indicator; treated as compressed for dispatch.
+        var copc = LasFixtureBuilder.BuildFormat3(SinglePoint());
+        copc[104] = (byte)(copc[104] | 0x40);
+
+        PointCloudCompressionDetector.IsCompressed(copc).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void IsCompressed_NonLasfBuffer_ReturnsFalse()
+    {
+        // A non-LASF buffer is left for the reader to reject; the detector must
+        // not mis-classify arbitrary bytes whose offset-104 byte happens to have
+        // a high bit set as a compressed point cloud.
+        var noise = new byte[256];
+        for (var i = 0; i < noise.Length; i++)
+        {
+            noise[i] = 0xFF;
+        }
+
+        PointCloudCompressionDetector.IsCompressed(noise).Should().BeFalse();
+        PointCloudCompressionDetector.HasLasfSignature(noise).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void IsCompressed_BufferShorterThanFormatByte_ReturnsFalse()
+    {
+        PointCloudCompressionDetector.IsCompressed(Encoding.ASCII.GetBytes("LASF")).Should().BeFalse();
+        PointCloudCompressionDetector.IsCompressed(ReadOnlySpan<byte>.Empty).Should().BeFalse();
+    }
+
+    private static IReadOnlyList<LasFixtureBuilder.Point> SinglePoint()
+        => [new LasFixtureBuilder.Point(-122.5, 37.5, 12.0, 100, 2, 10, 20, 30)];
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/Scene/FakeGeoprocessingJobService.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/Scene/FakeGeoprocessingJobService.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Geoprocessing;
+using Honua.Server.Features.Admin.Scene;
+
+namespace Honua.Server.Tests.Features.Admin.Scene;
+
+/// <summary>
+/// In-memory <see cref="IGeoprocessingJobService"/> double for the point-cloud
+/// decompression dispatch tests (#1854). Captures the submitted plan and the
+/// authorization request, then drives <see cref="GetJobAsync"/> through a scripted
+/// status sequence (the last scripted status is sticky; an empty sequence stays
+/// <see cref="ExecutionJobStatus.Running"/> forever to exercise the timeout). The
+/// result package surfaces a single configurable artifact URI.
+/// </summary>
+internal sealed class FakeGeoprocessingJobService : IGeoprocessingJobService
+{
+    private readonly Queue<ExecutionJobStatus> _statuses;
+    private readonly string? _artifactUri;
+    private string _jobId = string.Empty;
+    private ExecutionJobStatus _lastStatus = ExecutionJobStatus.Running;
+
+    public FakeGeoprocessingJobService(Queue<ExecutionJobStatus> statuses, string? artifactUri)
+    {
+        _statuses = statuses;
+        _artifactUri = artifactUri;
+    }
+
+    /// <summary>The plan captured at submit time, for assertions.</summary>
+    public AnalysisPlan? SubmittedPlan { get; private set; }
+
+    /// <summary>The (resource, operation) the dispatcher authorized against.</summary>
+    public (OperatorResourceType Resource, OperatorOperation Operation)? AuthorizedFor { get; private set; }
+
+    /// <summary>Number of <see cref="GetJobAsync"/> polls.</summary>
+    public int GetJobCalls { get; private set; }
+
+    /// <summary>When set, <see cref="SubmitJobAsync"/> throws it (simulating a runtime failure).</summary>
+    public Exception? SubmitException { get; set; }
+
+    public Task EnsureCallerAuthorizedAsync(
+        ClaimsPrincipal principal,
+        OperatorResourceType resourceType,
+        OperatorOperation operation,
+        CancellationToken cancellationToken = default)
+    {
+        AuthorizedFor = (resourceType, operation);
+        return Task.CompletedTask;
+    }
+
+    public Task<ExecutionJobRecord> SubmitJobAsync(
+        AnalysisPlan plan,
+        string? idempotencyKey,
+        ClaimsPrincipal principal,
+        IReadOnlyDictionary<string, string>? protocolMetadata = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (SubmitException is not null)
+        {
+            throw SubmitException;
+        }
+
+        SubmittedPlan = plan;
+        _jobId = $"job-{Guid.NewGuid():N}";
+        return Task.FromResult(NewRecord(NextStatus()));
+    }
+
+    public Task<ExecutionJobRecord> GetJobAsync(
+        string jobId,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
+        GetJobCalls++;
+        return Task.FromResult(NewRecord(NextStatus()));
+    }
+
+    public Task<AnalysisResultPackage> GetJobResultsAsync(
+        string jobId,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
+        var artifacts = _artifactUri is null
+            ? Array.Empty<ArtifactRef>()
+            : [new ArtifactRef
+            {
+                ArtifactId = "a1",
+                Kind = ArtifactKind.Raster,
+                Label = "Decompressed LAS",
+                Uri = _artifactUri,
+                ContentType = "application/vnd.las",
+            }];
+
+        var package = AnalysisResultPackage.CreateCompleted(
+            "rp-1",
+            new ResultSummary { Title = "Point cloud" },
+            artifacts,
+            workspaceRefs: [],
+            provenance: new ProvenanceRecord
+            {
+                Sources = [],
+                ProcessDefinitions = [GeoprocessingPointCloudDecompressor.ProcessId],
+            });
+        return Task.FromResult(package);
+    }
+
+    public Task CancelJobAsync(string jobId, ClaimsPrincipal principal, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public PlanValidationResult ValidatePlan(AnalysisPlan plan, ClaimsPrincipal principal)
+        => throw new NotSupportedException();
+
+    public DryRunResult DryRunPlan(AnalysisPlan plan, ClaimsPrincipal principal)
+        => throw new NotSupportedException();
+
+    private ExecutionJobStatus NextStatus()
+    {
+        if (_statuses.Count > 0)
+        {
+            _lastStatus = _statuses.Dequeue();
+        }
+        return _lastStatus;
+    }
+
+    private ExecutionJobRecord NewRecord(ExecutionJobStatus status)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new ExecutionJobRecord
+        {
+            OperationId = _jobId,
+            Status = status,
+            CreatedAt = now,
+            UpdatedAt = now,
+            Spec = new ExecutionJobSpec
+            {
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                Kind = ExecutionJobKind.Geoprocessing,
+                WorkloadName = "pcloud.translate",
+                RuntimeProfile = "native",
+            },
+        };
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/Scene/GeoprocessingPointCloudDecompressorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/Scene/GeoprocessingPointCloudDecompressorTests.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Scene.Abstractions;
+using Honua.Server.Features.Admin.Scene;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Admin.Scene;
+
+/// <summary>
+/// Fake-driven coverage for <see cref="GeoprocessingPointCloudDecompressor"/>
+/// (#1854): the server-side auto-dispatch that submits the canonical
+/// <c>pcloud.translate</c> worker plan, polls the job to a terminal state, and
+/// returns the decompressed uncompressed-LAS bytes. A fake job service stands in
+/// for the durable job runtime and the out-of-tree PDAL worker, so the
+/// dispatch/detection logic is verified without Redis or a live PDAL install —
+/// mirroring the worker-side <c>PdalPointCloudConvertExecutorTests</c>
+/// fake-runner pattern. The poll interval is driven to near-zero so the tests run
+/// in milliseconds against the real clock.
+/// </summary>
+public sealed class GeoprocessingPointCloudDecompressorTests
+{
+    private static readonly byte[] DecompressedLas = Encoding.UTF8.GetBytes("LASF-fake-decompressed");
+
+    [UnitTest]
+    public async Task DecompressAsync_SucceededJob_DecodesLasArtifactAndSubmitsNativeTranslatePlan()
+    {
+        var job = new FakeGeoprocessingJobService(Statuses(ExecutionJobStatus.Succeeded), LasArtifact(DecompressedLas));
+        var sut = NewDecompressor(job);
+
+        var result = await sut.DecompressAsync(Encoding.UTF8.GetBytes("fake-laz"), sourceSrs: null, CancellationToken.None);
+
+        result.Should().Equal(DecompressedLas);
+        job.SubmittedPlan.Should().NotBeNull();
+        var step = job.SubmittedPlan!.Steps.Should().ContainSingle().Subject;
+        step.ProcessId.Should().Be(GeoprocessingPointCloudDecompressor.ProcessId);
+        step.Kind.Should().Be(AnalysisPlanStepKind.Geoprocess);
+        step.Inputs.Should().ContainKey("source");
+        step.Inputs.Should().NotContainKey("sourceSrs");
+        job.AuthorizedFor.Should().Be((OperatorResourceType.Job, OperatorOperation.Create));
+    }
+
+    [UnitTest]
+    public async Task DecompressAsync_ProjectedSourceSrs_ForwardsSourceSrsInput()
+    {
+        var job = new FakeGeoprocessingJobService(Statuses(ExecutionJobStatus.Succeeded), LasArtifact(DecompressedLas));
+        var sut = NewDecompressor(job);
+
+        _ = await sut.DecompressAsync(Encoding.UTF8.GetBytes("fake-laz"), sourceSrs: "EPSG:32610", CancellationToken.None);
+
+        job.SubmittedPlan!.Steps[0].Inputs.Should().Contain(new KeyValuePair<string, string>("sourceSrs", "EPSG:32610"));
+    }
+
+    [UnitTest]
+    public async Task DecompressAsync_PollsUntilTerminal()
+    {
+        // Queued -> Running -> Succeeded: the dispatcher must poll past the
+        // non-terminal states before reading the artifact.
+        var job = new FakeGeoprocessingJobService(
+            Statuses(ExecutionJobStatus.Queued, ExecutionJobStatus.Running, ExecutionJobStatus.Succeeded),
+            LasArtifact(DecompressedLas));
+        var sut = NewDecompressor(job);
+
+        var result = await sut.DecompressAsync(Encoding.UTF8.GetBytes("fake-laz"), null, CancellationToken.None);
+
+        result.Should().Equal(DecompressedLas);
+        job.GetJobCalls.Should().BeGreaterThanOrEqualTo(2);
+    }
+
+    [UnitTest]
+    public async Task DecompressAsync_FailedJob_ThrowsDecompressionException()
+    {
+        var job = new FakeGeoprocessingJobService(Statuses(ExecutionJobStatus.Failed), artifactUri: null);
+        var sut = NewDecompressor(job);
+
+        var act = () => sut.DecompressAsync(Encoding.UTF8.GetBytes("fake-laz"), null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<PointCloudDecompressionException>()
+            .Where(e => e.Message.Contains("Failed", StringComparison.Ordinal));
+    }
+
+    [UnitTest]
+    public async Task DecompressAsync_SucceededButNoLasArtifact_ThrowsDecompressionException()
+    {
+        var job = new FakeGeoprocessingJobService(
+            Statuses(ExecutionJobStatus.Succeeded),
+            artifactUri: "data:application/octet-stream;base64,QUJD"); // not a LAS artifact
+        var sut = NewDecompressor(job);
+
+        var act = () => sut.DecompressAsync(Encoding.UTF8.GetBytes("fake-laz"), null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<PointCloudDecompressionException>()
+            .Where(e => e.Message.Contains("no uncompressed-LAS artifact", StringComparison.Ordinal));
+    }
+
+    [UnitTest]
+    public async Task DecompressAsync_SubmitThrows_WrappedAsDecompressionException()
+    {
+        var job = new FakeGeoprocessingJobService(Statuses(ExecutionJobStatus.Succeeded), LasArtifact(DecompressedLas))
+        {
+            SubmitException = new InvalidOperationException("queue down"),
+        };
+        var sut = NewDecompressor(job);
+
+        var act = () => sut.DecompressAsync(Encoding.UTF8.GetBytes("fake-laz"), null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<PointCloudDecompressionException>()
+            .Where(e => e.Message.Contains("submit", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [UnitTest]
+    public async Task DecompressAsync_NeverTerminal_TimesOut()
+    {
+        var job = new FakeGeoprocessingJobService(Statuses(), LasArtifact(DecompressedLas)); // always Running
+        var sut = NewDecompressor(job, timeout: TimeSpan.FromMilliseconds(40));
+
+        var act = () => sut.DecompressAsync(Encoding.UTF8.GetBytes("fake-laz"), null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<PointCloudDecompressionException>()
+            .Where(e => e.Message.Contains("did not complete", StringComparison.Ordinal));
+    }
+
+    [UnitTest]
+    public async Task DecompressAsync_EmptySource_Throws()
+    {
+        var job = new FakeGeoprocessingJobService(Statuses(ExecutionJobStatus.Succeeded), LasArtifact(DecompressedLas));
+        var sut = NewDecompressor(job);
+
+        var act = () => sut.DecompressAsync([], null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<PointCloudDecompressionException>();
+    }
+
+    [UnitTest]
+    public void TryDecodeLasDataUri_RoundTripsLasPayload()
+    {
+        var uri = LasArtifact(DecompressedLas);
+
+        GeoprocessingPointCloudDecompressor.TryDecodeLasDataUri(uri, out var bytes).Should().BeTrue();
+        bytes.Should().Equal(DecompressedLas);
+    }
+
+    [UnitTest]
+    public void TryDecodeLasDataUri_RejectsNonLasOrMalformedUris()
+    {
+        GeoprocessingPointCloudDecompressor.TryDecodeLasDataUri(null, out _).Should().BeFalse();
+        GeoprocessingPointCloudDecompressor.TryDecodeLasDataUri("https://x/y.las", out _).Should().BeFalse();
+        GeoprocessingPointCloudDecompressor.TryDecodeLasDataUri("data:application/octet-stream;base64,QUJD", out _).Should().BeFalse();
+        GeoprocessingPointCloudDecompressor.TryDecodeLasDataUri("data:application/vnd.las;base64,%%%", out _).Should().BeFalse();
+        GeoprocessingPointCloudDecompressor.TryDecodeLasDataUri("data:application/vnd.las,nobase64", out _).Should().BeFalse();
+    }
+
+    private static string LasArtifact(byte[] payload)
+        => $"data:application/vnd.las;base64,{Convert.ToBase64String(payload)}";
+
+    private static GeoprocessingPointCloudDecompressor NewDecompressor(
+        FakeGeoprocessingJobService job, TimeSpan? timeout = null)
+    {
+        var options = Options.Create(new PointCloudDecompressionOptions
+        {
+            Timeout = timeout ?? TimeSpan.FromSeconds(5),
+            PollInterval = TimeSpan.FromMilliseconds(1),
+        });
+        return new GeoprocessingPointCloudDecompressor(
+            job,
+            new ClaimsPrincipal(new ClaimsIdentity(claims: [], authenticationType: "test")),
+            options,
+            NullLogger<GeoprocessingPointCloudDecompressor>.Instance);
+    }
+
+    private static Queue<ExecutionJobStatus> Statuses(params ExecutionJobStatus[] statuses)
+        => new(statuses);
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/ScenePointCloudIngestEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/ScenePointCloudIngestEndpointsTests.cs
@@ -4,8 +4,10 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Security.Claims;
 using System.Text;
 using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Scene.Abstractions;
 using Honua.Server.Features.Admin.Models;
 using Honua.Server.Tests.Features.Infrastructure.Scene;
 using Honua.TestKit;
@@ -117,11 +119,125 @@ public class ScenePointCloudIngestEndpointsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/scenes/ingest/pointcloud")]
-    public async Task Ingest_LazCompressed_Returns400()
+    public async Task Ingest_LazCompressed_WithoutWorker_Returns400()
     {
+        // The default fixture has no live point-cloud worker, so the auto-dispatch
+        // (#1854) submits the pcloud.translate plan, the runtime cannot run it, and
+        // the decompression failure surfaces as a 400 problem-detail — the
+        // compressed buffer is still never tiled by the managed reader.
         using var upload = BuildUpload(
             PointCloudSceneFixtures.MarkCompressed(PointCloudSceneFixtures.ColoredGridGeographic()),
             ("sceneId", "pcloud-laz-rejected"));
+
+        var response = await _client.PostAsync(IngestUrl, upload);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/pointcloud")]
+    public async Task Ingest_LazCompressed_WithDecompressor_Returns201AndServesTileset()
+    {
+        // With a decompressor registered (#1854), a LAZ upload is routed through
+        // the worker, which returns uncompressed geographic LAS; the managed tiler
+        // then tiles it inline exactly as for a natively-uploaded LAS. A fake
+        // factory stands in for the out-of-tree PDAL worker so the dispatch path
+        // is exercised end-to-end without a live PDAL install.
+        var outputRoot = Path.Combine(Path.GetTempPath(), $"honua-pcloud-laz-{Guid.NewGuid():N}");
+        var fixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .WithTestLicense(HonuaEdition.Enterprise)
+            .ReplaceService<IPointCloudDecompressorFactory>(
+                new FakePointCloudDecompressorFactory(PointCloudSceneFixtures.ColoredGridGeographic()))
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+                builder.UseSetting("SceneGeneration:OutputRoot", outputRoot);
+            });
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
+            using var upload = BuildUpload(
+                PointCloudSceneFixtures.MarkCompressed(PointCloudSceneFixtures.ColoredGridGeographic()),
+                ("sceneId", "pcloud-laz-ingested"),
+                ("editionGate", "enterprise"));
+
+            var response = await client.PostAsync(IngestUrl, upload);
+
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+            var body = await response.Content.ReadFromJsonAsync<PointCloudIngestResponse>();
+            Assert.NotNull(body);
+            Assert.Equal("pcloud-laz-ingested", body!.SceneId);
+            Assert.Equal(256, body.PointCount);
+
+            var tileset = await client.GetAsync("/scenes/pcloud-laz-ingested/tileset.json");
+            Assert.Equal(HttpStatusCode.OK, tileset.StatusCode);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+            if (Directory.Exists(outputRoot))
+            {
+                Directory.Delete(outputRoot, recursive: true);
+            }
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/pointcloud")]
+    public async Task Ingest_ProjectedSourceEpsg_WithDecompressor_ReprojectsAndServesTileset()
+    {
+        // A projected sourceEpsg on an (uncompressed) LAS upload also routes through
+        // the worker for reprojection to geographic EPSG:4979 before tiling.
+        var outputRoot = Path.Combine(Path.GetTempPath(), $"honua-pcloud-proj-{Guid.NewGuid():N}");
+        var fakeFactory = new FakePointCloudDecompressorFactory(PointCloudSceneFixtures.ColoredGridGeographic());
+        var fixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .WithTestLicense(HonuaEdition.Enterprise)
+            .ReplaceService<IPointCloudDecompressorFactory>(fakeFactory)
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+                builder.UseSetting("SceneGeneration:OutputRoot", outputRoot);
+            });
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
+            using var upload = BuildUpload(
+                PointCloudSceneFixtures.ColoredGridGeographic(),
+                ("sceneId", "pcloud-proj-ingested"),
+                ("sourceEpsg", "EPSG:32610"),
+                ("editionGate", "enterprise"));
+
+            var response = await client.PostAsync(IngestUrl, upload);
+
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+            Assert.Equal("EPSG:32610", fakeFactory.LastSourceSrs);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+            if (Directory.Exists(outputRoot))
+            {
+                Directory.Delete(outputRoot, recursive: true);
+            }
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/scenes/ingest/pointcloud")]
+    public async Task Ingest_InvalidSourceEpsg_Returns400()
+    {
+        using var upload = BuildUpload(
+            PointCloudSceneFixtures.ColoredGridGeographic(),
+            ("sceneId", "pcloud-bad-epsg"),
+            ("sourceEpsg", "EPSG:32610; rm -rf /"));
 
         var response = await _client.PostAsync(IngestUrl, upload);
 
@@ -214,6 +330,30 @@ public class ScenePointCloudIngestEndpointsTests : IAsyncLifetime
         finally
         {
             await proFixture.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Test double for <see cref="IPointCloudDecompressorFactory"/> standing in for
+    /// the out-of-tree PDAL worker: returns a fixed uncompressed-geographic LAS so
+    /// the ingest auto-dispatch path (#1854) can be exercised end-to-end through
+    /// the HTTP surface without a live worker, and records the requested source CRS.
+    /// </summary>
+    private sealed class FakePointCloudDecompressorFactory(byte[] decompressedLas) : IPointCloudDecompressorFactory
+    {
+        private readonly byte[] _decompressedLas = decompressedLas;
+
+        public string? LastSourceSrs { get; private set; }
+
+        public IPointCloudDecompressor Create(ClaimsPrincipal principal) => new FakeDecompressor(this);
+
+        private sealed class FakeDecompressor(FakePointCloudDecompressorFactory owner) : IPointCloudDecompressor
+        {
+            public Task<byte[]> DecompressAsync(byte[] source, string? sourceSrs, CancellationToken cancellationToken)
+            {
+                owner.LastSourceSrs = sourceSrs;
+                return Task.FromResult(owner._decompressedLas);
+            }
         }
     }
 }


### PR DESCRIPTION
## Issue Link
Closes #1854

## Summary
Completes the remaining #1854 slice that #1971 explicitly deferred. #1971 made `pcloud.translate` (the out-of-tree PDAL worker that decompresses LAZ/COPC and reprojects a projected source to geographic EPSG:4979, emitting uncompressed LAS) reachable through the canonical process pipeline. The missing piece was the **scene-ingest auto-dispatch**: the admin point-cloud ingest endpoint still rejected compressed/projected uploads with a 400.

This wires that path. On upload the endpoint now detects a compressed (LAZ/COPC) buffer or a projected source CRS, dispatches `pcloud.translate` to obtain uncompressed geographic LAS, and tiles that LAS inline through the existing pure-managed `LasPointCloudReader` + `PointCloudTilesetBuilder` (#1840) — the outcome is identical to a natively-uploaded uncompressed LAS.

## What was already on trunk vs what this adds
**Already on trunk (#1971 + #1840):**
- `PdalPointCloudConvertJobExecutor` (`pcloud.translate`) in the GDAL worker: shells `pdal translate` to decompress LAZ/COPC and reproject projected sources to EPSG:4979, returning uncompressed LAS.
- `pcloud.translate` registered in `BuiltInProcessCatalog` (native profile) + `ProcessPlanValidator` submit-time guard.
- Pure-managed uncompressed-LAS → 3D Tiles ingest endpoint, which **rejected** LAZ/COPC and projected CRS with a 400.

**Added here:**
- `PointCloudCompressionDetector` (`Honua.Scene`): non-throwing LAZ/COPC compression-flag classifier so the ingest path pre-emptively dispatches instead of catching the reader's rejection.
- `IPointCloudDecompressor` + `IPointCloudDecompressorFactory` (`Honua.Core` abstractions): keep `Honua.Scene` free of any geoprocessing/job dependency (the worker-boundary AGENTS.md flags); the server composition root binds the implementation. `PointCloudDecompressionException` maps to a 400.
- `GeoprocessingPointCloudDecompressor` (`Honua.Server`): builds a single-step `pcloud.translate` `AnalysisPlan`, submits via `IGeoprocessingJobService` (native runtime profile routes it to the worker), polls the job to terminal, and decodes the `application/vnd.las` data-URI artifact. A factory binds the per-request principal.
- Endpoint: optional `sourceEpsg` form field (conservative `EPSG`/`AUTHORITY:CODE` allow-shape mirroring the worker's CRS-token guard); compressed-or-projected uploads route through the decompressor when one is registered, otherwise fall back to the documented 400. No new route.

## Boundary note (re: open #2074)
#2074 touches the I3S SceneServer **serving** surface; this PR is entirely on the **ingest-dispatch** path and the worker boundary, so there is no overlap. `Honua.Scene` gains no new project reference — the geoprocessing/job dependency lives only in the `Honua.Server` adapter behind the Core abstraction.

## Testing
- Release build, warnings-as-errors (`MSBUILDDISABLENODEREUSE=1 ... -p:NuGetAudit=false -p:UseSharedCompilation=false`): clean, 0 warnings/0 errors (Honua.Server + transitive Scene/Core/Geoprocessing, and both test projects).
- `dotnet format`: no changes.
- **Unit-tested (CI-runnable, serial):**
  - `PointCloudCompressionDetectorTests` (Core.Tests): 5/5 — LAZ/COPC flags, uncompressed, non-LASF, short buffers.
  - `GeoprocessingPointCloudDecompressorTests` (Server.Tests): 10/10 with a fake `IGeoprocessingJobService` (no Redis / no PDAL) — native `pcloud.translate` plan construction, `sourceSrs` forwarding, poll-until-terminal, failed-job, no-LAS-artifact, submit-failure mapping, timeout, empty-source, and data-URI decode. Mirrors the worker-side `PdalPointCloudConvertExecutorTests` fake-runner pattern.
  - `ScenePointCloudIngestEndpointsTests` (Server.Tests, Testcontainers): 10/10 — including the new LAZ-with-decompressor → 201 + tileset serves, projected `sourceEpsg` → reproject → 201, invalid `sourceEpsg` → 400, and LAZ-without-worker → 400.
- **CI-only / out of scope:** a true end-to-end run with a live PDAL worker (CI lacks one); the dispatch/detection logic is fully covered with fakes per the ticket's guidance.

Pre-existing on trunk and unrelated to this change: 2 `FeatureCatalogDriftTests` failures for `DELETE /api/v1/admin/oauth-clients/{id}` (verified present on a clean `origin/trunk` checkout). This PR adds no new endpoint route, so EndpointRegistry/feature-catalog/proof-ledger need no update.

## Gate Impact
PR gates (build, test, governance).

## Breaking Changes
None.