### PR TITLE
feat(coverages/tiles): datacube->tile render binding (Shape B) (#1835)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -308,6 +308,32 @@
       "maturity": "implemented"
     },
     {
+      "id": "delete-api-v1-admin-oauth-clients-id",
+      "route": "/api/v1/admin/oauth-clients/{id}",
+      "method": "DELETE",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.GetAndDeleteClient_RemovesRegistration"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "delete-api-v1-admin-oauth-scopes-scope",
+      "route": "/api/v1/admin/oauth-scopes/{scope}",
+      "method": "DELETE",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "delete-api-v1-admin-oidc-providers-id",
       "route": "/api/v1/admin/oidc/providers/{id}",
       "method": "DELETE",
@@ -2227,6 +2253,46 @@
       "maturity": "implemented"
     },
     {
+      "id": "get-api-v1-admin-oauth-clients",
+      "route": "/api/v1/admin/oauth-clients",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.ManagementSurface_RequiresAdminAuthorization",
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterAndListClient_ReturnsSecretOnlyAtCreation"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-clients-id",
+      "route": "/api/v1/admin/oauth-clients/{id}",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.GetAndDeleteClient_RemovesRegistration"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-scopes",
+      "route": "/api/v1/admin/oauth-scopes",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "get-api-v1-admin-observability-alerts",
       "route": "/api/v1/admin/observability/alerts",
       "method": "GET",
@@ -3755,6 +3821,19 @@
         "Honua.Server.Tests.Features.WorkflowPackages.WorkflowPackageEndpointsTests.WorkflowLifecycle_ValidatesDryRunsPublishesTargetsAndStampsJobProvenance"
       ],
       "proof_ledger_surface": "console-content-rbac",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-datacubes-layerid-tiles-tilematrixsetid-z-x-y",
+      "route": "/api/v1/datacubes/{layerId}/tiles/{tileMatrixSetId}/{z}/{x}/{y}",
+      "method": "GET",
+      "family": "Datacube Tiles HTTP",
+      "protocol": "http-route",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Zarr.DatacubeTileEndpointTests.DatacubeTile_LayerWithoutServableCoverage_Returns404"
+      ],
+      "proof_ledger_surface": "datacube-tiles",
       "maturity": "implemented"
     },
     {
@@ -11864,6 +11943,20 @@
       "maturity": "implemented"
     },
     {
+      "id": "post-api-v1-admin-oauth-clients",
+      "route": "/api/v1/admin/oauth-clients",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterAndListClient_ReturnsSecretOnlyAtCreation",
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterClient_WithInvalidClientType_ReturnsBadRequest"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "post-api-v1-admin-observability-alerts-eventid-acknowledge",
       "route": "/api/v1/admin/observability/alerts/{eventId}/acknowledge",
       "method": "POST",
@@ -15993,8 +16086,10 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_AllItemsHaveStacFields",
+        "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WhenMorePagesExist_EmitsConformantPostNextLink",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithBbox_ReturnsFilteredResults",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithBody_ReturnsItems",
+        "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidPaginationToken_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidSortDirection_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidThreeDimensionalBbox_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithOutOfRangeBbox_ReturnsBadRequest",
@@ -16540,6 +16635,19 @@
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_ChangesMutableFields",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_Missing_Returns404",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_UnsafeVertexTable_Returns400"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "put-api-v1-admin-oauth-scopes",
+      "route": "/api/v1/admin/oauth-scopes",
+      "method": "PUT",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "updatedUtc": "2026-06-03T00:00:00Z",
+  "updatedUtc": "2026-06-23T00:00:00Z",
   "surfaces": [
     {
       "surfaceId": "capability-manifest",
@@ -379,6 +379,55 @@
           "ownerRepo": "honua-server",
           "status": "implemented",
           "linkedTicket": "#502",
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
+      "surfaceId": "datacube-tiles",
+      "displayName": "Datacube (Zarr coverage) tile rendering",
+      "surfaceKind": "http-route",
+      "protocol": "Datacube Tiles HTTP",
+      "canonicalIdentifier": "/api/v1/datacubes/{layerId}/tiles/{tileMatrixSetId}/{z}/{x}/{y}",
+      "parentSurfaceId": null,
+      "endpointPrefixes": [
+        "/api/v1/datacubes/"
+      ],
+      "endpointExactMatches": [],
+      "endpointContains": [],
+      "operationKeys": [],
+      "proofs": [
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "EndpointRegistry coverage plus DatacubeTileEndpointTests assert the public GET tile route is backed by a real HTTP request and returns 404 when a layer has no servable Zarr coverage; ZarrTileSlicePlannerTests and ZarrTileRendererTests prove tile-bbox->grid-index mapping, time/elevation axis resolution, no-intersection handling, and PNG encoding.",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/EndpointRegistry.cs",
+            "src/Honua.Server/Features/Protocols/Zarr/ZarrEndpoints.cs",
+            "src/Honua.Core/Features/Raster/ZarrParser/ZarrTileSlicePlanner.cs",
+            "src/Honua.Core/Features/Raster/ZarrParser/ZarrTileRenderer.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/Protocols/Zarr/DatacubeTileEndpointTests.cs",
+            "tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrTileSlicePlannerTests.cs",
+            "tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrTileRendererTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#1835",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "scenario-depth",
+          "proofMechanism": "A datacube tile binds a (z/x/y, time, elevation, variable) Zarr coverage slice to an RGBA PNG: the tile bbox is mapped to a half-open grid-index window, time and vertical axes are resolved through the shared CF axis indexers (#1790), the bounded subset is read via IZarrSubsetReader, the little-endian dtype buffer is decoded and colour-mapped, and the result is encoded by the managed AOT-safe PNG encoder. Temporal parameters use the neutral Core-level Iso8601TemporalIntervalParser rather than any OGC protocol parser.",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "src/Honua.Core/Features/Raster/ZarrParser/Iso8601TemporalIntervalParser.cs",
+            "src/Honua.Core/Features/Raster/ZarrParser/CfTimeAxisIndexer.cs",
+            "src/Honua.Core/Features/Raster/ZarrParser/PngEncoder.cs",
+            "tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrTileRendererTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#1835",
           "versionCaptureRule": null
         }
       ]

--- a/docs/reference/protocols/cloud-native-formats.md
+++ b/docs/reference/protocols/cloud-native-formats.md
@@ -46,6 +46,8 @@ NetCDF4, HDF5, and GRIB sources are registered via `POST /api/v1/admin/multidim-
 
 The Zarr reader (`ZarrMetadataExtractor`/`ZarrSubsetReader`) reads both **Zarr v2** (`.zgroup`/`.zarray`/`.zattrs`) and **Zarr v3** (`zarr.json`, `node_type` group/array). For v3 it normalizes the `data_type` name (e.g. `float32` → numpy `<f4`), reads the `c/`-prefixed default chunk-key encoding (or the `v2` dotted encoding), and gates the codec pipeline — uncompressed and `gzip`-coded little-endian chunks are supported; `blosc`, `zstd`, sharding, `crc32c`, and big-endian are rejected cleanly.
 
+Registered Zarr coverages can also be rendered as PNG map tiles via `GET /api/v1/datacubes/{layerId}/tiles/{tileMatrixSetId}/{z}/{x}/{y}` (optional `variable`, `datetime`, and `elevation` grid-index query parameters). This is a read-only serving surface that does not advertise an OGC tiles conformance class. The tile bbox is mapped to a half-open grid-index window, the time and vertical axes are resolved through the shared CF axis indexers, the bounded slice is read through the Zarr subset pipeline, and the dtype buffer is colour-mapped and encoded by the managed AOT-safe PNG encoder. Temporal parsing uses the neutral Core-level `Iso8601TemporalIntervalParser` so the datacube tile path takes no dependency on any OGC protocol family. The tile gridset CRS must match the coverage storage CRS today; cross-CRS reprojection of the tile window is a follow-up.
+
 ## Related
 
 - [Data formats matrix](../data-formats.md) — full import/export format support

--- a/src/Honua.Core/Features/Raster/ZarrParser/Iso8601TemporalIntervalParser.cs
+++ b/src/Honua.Core/Features/Raster/ZarrParser/Iso8601TemporalIntervalParser.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+
+namespace Honua.Core.Features.Raster.ZarrParser;
+
+/// <summary>
+/// Neutral, protocol-agnostic parser for an RFC 3339 / ISO 8601 datetime parameter
+/// expressed as an instant or a half-open interval. Lives in <see cref="Honua.Core"/>
+/// so coverage/datacube tile rendering and the OGC protocol adapters can share one
+/// implementation instead of any protocol family taking a dependency on another's
+/// temporal parser. Pure and AOT-safe.
+/// </summary>
+public static class Iso8601TemporalIntervalParser
+{
+    /// <summary>
+    /// Parses an OGC-style datetime parameter into a <c>(start, end)</c> pair without
+    /// requiring a layer or any protocol context. Supported forms: a single instant,
+    /// <c>start/end</c>, <c>../end</c>, and <c>start/..</c>. For an instant <c>T</c>,
+    /// both <paramref name="start"/> and <paramref name="end"/> are set to <c>T</c>.
+    /// An empty/whitespace input is accepted and resolves to <c>(null, null)</c>.
+    /// </summary>
+    /// <param name="datetime">The raw datetime parameter, or null.</param>
+    /// <param name="start">Resolved interval start, or null when open/unset.</param>
+    /// <param name="end">Resolved interval end, or null when open/unset.</param>
+    /// <param name="errorMessage">Client-safe error when the method returns false.</param>
+    /// <returns>True when the value is empty or a well-formed instant/interval.</returns>
+    public static bool TryParseRange(
+        string? datetime,
+        out DateTimeOffset? start,
+        out DateTimeOffset? end,
+        out string? errorMessage)
+    {
+        start = null;
+        end = null;
+        errorMessage = null;
+
+        if (string.IsNullOrWhiteSpace(datetime))
+        {
+            return true;
+        }
+
+        var parts = datetime.Split('/', StringSplitOptions.TrimEntries);
+
+        if (parts.Length == 1)
+        {
+            if (!TryParseDateTimeOffset(parts[0], out var instant))
+            {
+                errorMessage = "Invalid datetime parameter.";
+                return false;
+            }
+
+            start = instant;
+            end = instant;
+            return true;
+        }
+
+        if (parts.Length == 2)
+        {
+            if (!string.IsNullOrWhiteSpace(parts[0]) && parts[0] != "..")
+            {
+                if (!TryParseDateTimeOffset(parts[0], out var parsedStart))
+                {
+                    errorMessage = "Invalid datetime parameter.";
+                    return false;
+                }
+
+                start = parsedStart;
+            }
+
+            if (!string.IsNullOrWhiteSpace(parts[1]) && parts[1] != "..")
+            {
+                if (!TryParseDateTimeOffset(parts[1], out var parsedEnd))
+                {
+                    errorMessage = "Invalid datetime parameter.";
+                    return false;
+                }
+
+                end = parsedEnd;
+            }
+
+            if (start is null && end is null)
+            {
+                errorMessage = "Invalid datetime parameter.";
+                return false;
+            }
+
+            if (start is { } s && end is { } e && s > e)
+            {
+                errorMessage = "Invalid datetime parameter.";
+                return false;
+            }
+
+            return true;
+        }
+
+        errorMessage = "Invalid datetime parameter.";
+        return false;
+    }
+
+    private static bool TryParseDateTimeOffset(string value, out DateTimeOffset parsed)
+        => DateTimeOffset.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out parsed);
+}

--- a/src/Honua.Core/Features/Raster/ZarrParser/PngEncoder.cs
+++ b/src/Honua.Core/Features/Raster/ZarrParser/PngEncoder.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using System.IO.Compression;
+
+namespace Honua.Core.Features.Raster.ZarrParser;
+
+/// <summary>
+/// Minimal AOT-safe PNG encoder for 8-bit RGBA images. Emits a single IDAT chunk
+/// with filter type 0 (None) per scanline, compressed with the managed zlib
+/// (<see cref="ZLibStream"/>) deflate codec. Used to render Zarr coverage slices to
+/// map tiles without taking a dependency on a native imaging library.
+/// </summary>
+internal static class PngEncoder
+{
+    private static readonly byte[] Signature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    /// <summary>
+    /// Encodes an 8-bit RGBA pixel buffer (row-major, 4 bytes/pixel) to a PNG.
+    /// </summary>
+    public static byte[] Encode(byte[] rgba, int width, int height)
+    {
+        ArgumentNullException.ThrowIfNull(rgba);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        var expected = checked(width * height * 4);
+        if (rgba.Length < expected)
+        {
+            throw new ArgumentException("RGBA buffer is smaller than width*height*4.", nameof(rgba));
+        }
+
+        using var output = new MemoryStream();
+        output.Write(Signature);
+
+        // IHDR: width, height, bit depth 8, colour type 6 (truecolour + alpha),
+        // compression 0, filter 0, interlace 0.
+        Span<byte> ihdr = stackalloc byte[13];
+        BinaryPrimitives.WriteInt32BigEndian(ihdr[..4], width);
+        BinaryPrimitives.WriteInt32BigEndian(ihdr.Slice(4, 4), height);
+        ihdr[8] = 8;
+        ihdr[9] = 6;
+        ihdr[10] = 0;
+        ihdr[11] = 0;
+        ihdr[12] = 0;
+        WriteChunk(output, "IHDR", ihdr);
+
+        WriteChunk(output, "IDAT", BuildIdat(rgba, width, height));
+        WriteChunk(output, "IEND", ReadOnlySpan<byte>.Empty);
+
+        return output.ToArray();
+    }
+
+    private static byte[] BuildIdat(byte[] rgba, int width, int height)
+    {
+        var stride = width * 4;
+        using var compressed = new MemoryStream();
+        using (var zlib = new ZLibStream(compressed, CompressionLevel.Optimal, leaveOpen: true))
+        {
+            var scanline = new byte[stride + 1];
+            for (var y = 0; y < height; y++)
+            {
+                scanline[0] = 0; // filter type: None
+                Buffer.BlockCopy(rgba, y * stride, scanline, 1, stride);
+                zlib.Write(scanline, 0, scanline.Length);
+            }
+        }
+
+        return compressed.ToArray();
+    }
+
+    private static void WriteChunk(Stream output, string type, ReadOnlySpan<byte> data)
+    {
+        Span<byte> length = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(length, data.Length);
+        output.Write(length);
+
+        Span<byte> typeBytes = stackalloc byte[4];
+        for (var i = 0; i < 4; i++)
+        {
+            typeBytes[i] = (byte)type[i];
+        }
+        output.Write(typeBytes);
+        if (!data.IsEmpty)
+        {
+            output.Write(data);
+        }
+
+        var crc = Crc32.Compute(typeBytes, data);
+        Span<byte> crcBytes = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(crcBytes, crc);
+        output.Write(crcBytes);
+    }
+
+    /// <summary>
+    /// Standard PNG CRC-32 (IEEE 802.3) over a chunk's type and data bytes.
+    /// </summary>
+    private static class Crc32
+    {
+        private static readonly uint[] Table = BuildTable();
+
+        public static uint Compute(ReadOnlySpan<byte> type, ReadOnlySpan<byte> data)
+        {
+            var crc = 0xFFFFFFFFu;
+            foreach (var b in type)
+            {
+                crc = Table[(crc ^ b) & 0xFF] ^ (crc >> 8);
+            }
+            foreach (var b in data)
+            {
+                crc = Table[(crc ^ b) & 0xFF] ^ (crc >> 8);
+            }
+            return crc ^ 0xFFFFFFFFu;
+        }
+
+        private static uint[] BuildTable()
+        {
+            var table = new uint[256];
+            for (var n = 0u; n < 256; n++)
+            {
+                var c = n;
+                for (var k = 0; k < 8; k++)
+                {
+                    c = (c & 1) != 0 ? 0xEDB88320u ^ (c >> 1) : c >> 1;
+                }
+                table[n] = c;
+            }
+            return table;
+        }
+    }
+}

--- a/src/Honua.Core/Features/Raster/ZarrParser/ZarrTileRenderer.cs
+++ b/src/Honua.Core/Features/Raster/ZarrParser/ZarrTileRenderer.cs
@@ -1,0 +1,292 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using Honua.Core.Features.Raster.Domain;
+
+namespace Honua.Core.Features.Raster.ZarrParser;
+
+/// <summary>
+/// Renders a single-band Zarr coverage slice to an RGBA PNG map tile. AOT-safe and
+/// dependency-light: decodes the little-endian subset buffer into a 2D value grid,
+/// maps each value to a colour (linear colormap interpolation, or a grayscale ramp
+/// over the slice min/max when no colormap is supplied), nearest-samples the grid
+/// into the requested tile pixel dimensions, and encodes a PNG with the managed
+/// DEFLATE encoder. NaN / fill values render fully transparent.
+/// </summary>
+public static class ZarrTileRenderer
+{
+    /// <summary>Default tile edge length in pixels.</summary>
+    public const int DefaultTileSize = 256;
+
+    /// <summary>
+    /// Renders a resolved tile slice to a PNG.
+    /// </summary>
+    /// <param name="result">Decoded subset payload from <see cref="Abstractions.IZarrSubsetReader"/>.</param>
+    /// <param name="slice">Resolved slice plan describing the X/Y dimension positions.</param>
+    /// <param name="tileSize">Output tile edge length in pixels.</param>
+    /// <param name="colormap">Optional colormap; grayscale auto-ramp is used when null.</param>
+    /// <param name="fillValue">Optional source fill value rendered transparent.</param>
+    /// <returns>PNG-encoded RGBA tile.</returns>
+    public static byte[] Render(
+        ZarrSubsetResult result,
+        ZarrTileSlicePlan slice,
+        int tileSize = DefaultTileSize,
+        RasterColormap? colormap = null,
+        double? fillValue = null)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(slice);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(tileSize);
+
+        var height = result.Shape[slice.YDimensionIndex];
+        var width = result.Shape[slice.XDimensionIndex];
+        if (width <= 0 || height <= 0)
+        {
+            throw new InvalidOperationException("Zarr tile slice has no spatial extent.");
+        }
+
+        // The decoded buffer is row-major over the full subset shape. Every
+        // non-spatial axis is length 1, so the linear position of grid cell (y, x)
+        // is y*strideY + x*strideX where the strides are the products of the trailing
+        // subset dimensions; computing them explicitly keeps the mapping correct
+        // regardless of where the Y and X axes sit in the dimension order.
+        var (strideY, strideX) = ComputeSpatialStrides(result.Shape, slice.YDimensionIndex, slice.XDimensionIndex);
+        var values = DecodeBuffer(result);
+
+        // Build the value->colour mapping. With a colormap, interpolate between stops;
+        // otherwise auto-ramp grayscale over the finite value range.
+        var ramp = colormap is null ? ResolveRange(values, fillValue) : default;
+
+        var pixels = new byte[tileSize * tileSize * 4];
+        for (var py = 0; py < tileSize; py++)
+        {
+            // Nearest sample row from the grid (north-up: grid row 0 is the top).
+            var gy = height == 1 ? 0 : (int)((long)py * height / tileSize);
+            if (gy >= height)
+            {
+                gy = height - 1;
+            }
+
+            for (var px = 0; px < tileSize; px++)
+            {
+                var gx = width == 1 ? 0 : (int)((long)px * width / tileSize);
+                if (gx >= width)
+                {
+                    gx = width - 1;
+                }
+
+                var index = (gy * strideY) + (gx * strideX);
+                var value = index >= 0 && index < values.Length ? values[index] : double.NaN;
+                var offset = ((py * tileSize) + px) * 4;
+                WritePixel(pixels.AsSpan(offset), value, colormap, ramp, fillValue);
+            }
+        }
+
+        return PngEncoder.Encode(pixels, tileSize, tileSize);
+    }
+
+    private static (int StrideY, int StrideX) ComputeSpatialStrides(int[] shape, int yDim, int xDim)
+    {
+        var strideY = 1;
+        for (var i = yDim + 1; i < shape.Length; i++)
+        {
+            strideY *= shape[i];
+        }
+
+        var strideX = 1;
+        for (var i = xDim + 1; i < shape.Length; i++)
+        {
+            strideX *= shape[i];
+        }
+
+        return (strideY, strideX);
+    }
+
+    private static double[] DecodeBuffer(ZarrSubsetResult result)
+    {
+        var dtype = Normalize(result.DataType);
+        var elementSize = ElementSize(dtype, result.DataType);
+        var count = result.Data.Length / elementSize;
+        var values = new double[count];
+        var data = result.Data.AsSpan();
+
+        switch (dtype)
+        {
+            case "f4":
+                ReadAll(data, count, 4, values, static s => BinaryPrimitives.ReadSingleLittleEndian(s));
+                break;
+            case "f8":
+                ReadAll(data, count, 8, values, static s => BinaryPrimitives.ReadDoubleLittleEndian(s));
+                break;
+            case "i1":
+                for (var i = 0; i < count && i < data.Length; i++)
+                {
+                    values[i] = (sbyte)data[i];
+                }
+                break;
+            case "u1":
+            case "b1":
+                for (var i = 0; i < count && i < data.Length; i++)
+                {
+                    values[i] = data[i];
+                }
+                break;
+            case "i2":
+                ReadAll(data, count, 2, values, static s => BinaryPrimitives.ReadInt16LittleEndian(s));
+                break;
+            case "u2":
+                ReadAll(data, count, 2, values, static s => BinaryPrimitives.ReadUInt16LittleEndian(s));
+                break;
+            case "i4":
+                ReadAll(data, count, 4, values, static s => BinaryPrimitives.ReadInt32LittleEndian(s));
+                break;
+            case "u4":
+                ReadAll(data, count, 4, values, static s => BinaryPrimitives.ReadUInt32LittleEndian(s));
+                break;
+            case "i8":
+                ReadAll(data, count, 8, values, static s => BinaryPrimitives.ReadInt64LittleEndian(s));
+                break;
+            case "u8":
+                ReadAll(data, count, 8, values, static s => BinaryPrimitives.ReadUInt64LittleEndian(s));
+                break;
+            default:
+                throw new InvalidOperationException($"Zarr dtype '{result.DataType}' is not supported for tile rendering.");
+        }
+
+        return values;
+    }
+
+    private static void ReadAll(ReadOnlySpan<byte> data, int count, int size, double[] values, ReadSample read)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            var offset = i * size;
+            if (offset + size > data.Length)
+            {
+                values[i] = double.NaN;
+                continue;
+            }
+            values[i] = read(data.Slice(offset, size));
+        }
+    }
+
+    private delegate double ReadSample(ReadOnlySpan<byte> source);
+
+    private static (double Min, double Max) ResolveRange(double[] values, double? fillValue)
+    {
+        var min = double.PositiveInfinity;
+        var max = double.NegativeInfinity;
+        foreach (var value in values)
+        {
+            if (!double.IsFinite(value) || (fillValue is { } fill && value == fill))
+            {
+                continue;
+            }
+            if (value < min)
+            {
+                min = value;
+            }
+            if (value > max)
+            {
+                max = value;
+            }
+        }
+
+        if (!double.IsFinite(min) || !double.IsFinite(max))
+        {
+            return (0, 1);
+        }
+        return max > min ? (min, max) : (min, min + 1);
+    }
+
+    private static void WritePixel(
+        Span<byte> pixel,
+        double value,
+        RasterColormap? colormap,
+        (double Min, double Max) ramp,
+        double? fillValue)
+    {
+        if (!double.IsFinite(value) || (fillValue is { } fill && value == fill))
+        {
+            pixel[0] = 0;
+            pixel[1] = 0;
+            pixel[2] = 0;
+            pixel[3] = 0;
+            return;
+        }
+
+        if (colormap is not null)
+        {
+            var (r, g, b, a) = SampleColormap(colormap, value);
+            pixel[0] = r;
+            pixel[1] = g;
+            pixel[2] = b;
+            pixel[3] = a;
+            return;
+        }
+
+        var normalized = (value - ramp.Min) / (ramp.Max - ramp.Min);
+        var gray = (byte)Math.Clamp((int)Math.Round(normalized * 255.0), 0, 255);
+        pixel[0] = gray;
+        pixel[1] = gray;
+        pixel[2] = gray;
+        pixel[3] = 255;
+    }
+
+    private static (byte R, byte G, byte B, byte A) SampleColormap(RasterColormap colormap, double value)
+    {
+        var entries = colormap.Entries;
+        if (entries.Count == 0)
+        {
+            return (0, 0, 0, 0);
+        }
+
+        if (value <= entries[0].Value)
+        {
+            var first = entries[0];
+            return (first.Red, first.Green, first.Blue, first.Alpha);
+        }
+
+        var last = entries[^1];
+        if (value >= last.Value)
+        {
+            return (last.Red, last.Green, last.Blue, last.Alpha);
+        }
+
+        for (var i = 1; i < entries.Count; i++)
+        {
+            var hi = entries[i];
+            if (value > hi.Value)
+            {
+                continue;
+            }
+
+            var lo = entries[i - 1];
+            var span = hi.Value - lo.Value;
+            var t = span <= 0 ? 0 : (value - lo.Value) / span;
+            return (
+                Lerp(lo.Red, hi.Red, t),
+                Lerp(lo.Green, hi.Green, t),
+                Lerp(lo.Blue, hi.Blue, t),
+                Lerp(lo.Alpha, hi.Alpha, t));
+        }
+
+        return (last.Red, last.Green, last.Blue, last.Alpha);
+    }
+
+    private static byte Lerp(byte a, byte b, double t)
+        => (byte)Math.Clamp((int)Math.Round(a + ((b - a) * t)), 0, 255);
+
+    private static int ElementSize(string normalized, string original) => normalized switch
+    {
+        "i1" or "u1" or "b1" => 1,
+        "i2" or "u2" => 2,
+        "f4" or "i4" or "u4" => 4,
+        "f8" or "i8" or "u8" => 8,
+        _ => throw new InvalidOperationException($"Zarr dtype '{original}' is not supported for tile rendering.")
+    };
+
+    private static string Normalize(string dtype)
+        => dtype.Length > 0 && dtype[0] is '<' or '|' or '=' ? dtype[1..] : dtype;
+}

--- a/src/Honua.Core/Features/Raster/ZarrParser/ZarrTileSlicePlanner.cs
+++ b/src/Honua.Core/Features/Raster/ZarrParser/ZarrTileSlicePlanner.cs
@@ -1,0 +1,282 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Raster.Domain;
+
+namespace Honua.Core.Features.Raster.ZarrParser;
+
+/// <summary>
+/// A tile bounding box expressed in the coverage's storage CRS, used to resolve
+/// a Zarr grid-index window for tile rendering.
+/// </summary>
+/// <param name="MinX">Western edge in storage-CRS units.</param>
+/// <param name="MinY">Southern edge in storage-CRS units.</param>
+/// <param name="MaxX">Eastern edge in storage-CRS units.</param>
+/// <param name="MaxY">Northern edge in storage-CRS units.</param>
+public readonly record struct ZarrTileBounds(double MinX, double MinY, double MaxX, double MaxY);
+
+/// <summary>
+/// A resolved plan for rendering one Zarr coverage slice to a map tile: the bounded
+/// subset request plus the indices of the X and Y dimensions within the subset shape
+/// so the renderer can iterate the 2D grid in row-major order.
+/// </summary>
+/// <param name="Plan">Bounded subset plan over the target variable.</param>
+/// <param name="YDimensionIndex">Index of the Y (row) dimension in the array shape.</param>
+/// <param name="XDimensionIndex">Index of the X (column) dimension in the array shape.</param>
+/// <param name="GridXMin">Storage-CRS X coordinate of the western edge of the selected window.</param>
+/// <param name="GridYMax">Storage-CRS Y coordinate of the northern edge of the selected window.</param>
+/// <param name="CellWidth">Storage-CRS width of one grid cell along X.</param>
+/// <param name="CellHeight">Storage-CRS height of one grid cell along Y (positive magnitude).</param>
+public sealed record ZarrTileSlicePlan(
+    ZarrCoverageSubsetPlan Plan,
+    int YDimensionIndex,
+    int XDimensionIndex,
+    double GridXMin,
+    double GridYMax,
+    double CellWidth,
+    double CellHeight);
+
+/// <summary>
+/// Resolves a tile request (bbox in storage CRS plus optional time / vertical /
+/// extra-dimension index selections) into a bounded 2D Zarr subset suitable for
+/// rasterizing to a map tile. Shared, pure, and AOT-safe so the tile adapter never
+/// builds an independent Zarr index path. Builds on the coordinate/time-axis
+/// resolution introduced for OGC API Coverages (#1790) rather than duplicating it.
+/// </summary>
+public static class ZarrTileSlicePlanner
+{
+    /// <summary>
+    /// Builds a tile slice plan for one variable of a georeferenced Zarr store.
+    /// </summary>
+    /// <param name="metadata">Scanned store metadata. Must declare a CRS and extent.</param>
+    /// <param name="variable">Variable name, or null to use the store's primary variable.</param>
+    /// <param name="bounds">Tile bounds in the store's storage CRS.</param>
+    /// <param name="datetime">Optional requested instant/interval for the time axis (resolved to a single index when present).</param>
+    /// <param name="verticalIndex">Optional zero-based index on the vertical/elevation axis. Defaults to 0 when the array has a non-spatial, non-temporal axis.</param>
+    /// <param name="maxOutputBytes">Upper bound for the decoded subset payload.</param>
+    /// <param name="plan">Resolved plan when the method returns true.</param>
+    /// <param name="error">Client-safe error when the method returns false.</param>
+    /// <returns>True when the tile intersects the coverage and the slice resolves within limits.</returns>
+    public static bool TryPlan(
+        ZarrStoreMetadata metadata,
+        string? variable,
+        ZarrTileBounds bounds,
+        (DateTimeOffset? Start, DateTimeOffset? End)? datetime,
+        int? verticalIndex,
+        long maxOutputBytes,
+        out ZarrTileSlicePlan? plan,
+        out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxOutputBytes);
+
+        plan = null;
+        error = null;
+
+        if (metadata.Srid <= 0)
+        {
+            error = "The coverage is not georeferenced; tile rendering requires a declared CRS and extent.";
+            return false;
+        }
+
+        var array = ResolveArray(metadata, variable, out error);
+        if (array is null)
+        {
+            return false;
+        }
+
+        var xDim = FindSpatialDimension(metadata, array, isX: true);
+        var yDim = FindSpatialDimension(metadata, array, isX: false);
+        if (xDim < 0 || yDim < 0)
+        {
+            error = "The coverage variable does not declare resolvable X and Y dimensions for tile rendering.";
+            return false;
+        }
+
+        var extent = metadata.Extent;
+        var width = array.Shape[xDim];
+        var height = array.Shape[yDim];
+        if (width <= 0 || height <= 0 || extent.XMax <= extent.XMin || extent.YMax <= extent.YMin)
+        {
+            error = "The coverage extent or grid dimensions are degenerate; tile rendering is unavailable.";
+            return false;
+        }
+
+        var cellWidth = (extent.XMax - extent.XMin) / width;
+        var cellHeight = (extent.YMax - extent.YMin) / height;
+
+        // Map the tile bbox to a half-open grid-index window on each spatial axis.
+        // Row 0 is the northernmost row (north-up convention).
+        var xStart = (int)Math.Floor((bounds.MinX - extent.XMin) / cellWidth);
+        var xStop = (int)Math.Ceiling((bounds.MaxX - extent.XMin) / cellWidth);
+        var yStart = (int)Math.Floor((extent.YMax - bounds.MaxY) / cellHeight);
+        var yStop = (int)Math.Ceiling((extent.YMax - bounds.MinY) / cellHeight);
+
+        xStart = Math.Clamp(xStart, 0, width);
+        xStop = Math.Clamp(xStop, 0, width);
+        yStart = Math.Clamp(yStart, 0, height);
+        yStop = Math.Clamp(yStop, 0, height);
+
+        if (xStop <= xStart || yStop <= yStart)
+        {
+            error = "The requested tile does not intersect the coverage extent.";
+            return false;
+        }
+
+        var subsets = new List<ZarrCoverageDimensionSubset>(array.Shape.Length)
+        {
+            new(array.DimensionNames[xDim], xStart, xStop),
+            new(array.DimensionNames[yDim], yStart, yStop),
+        };
+
+        // Resolve every remaining (non-spatial) axis to a single index. The time axis
+        // honours the datetime request via the shared CF indexer; other axes use the
+        // supplied vertical index (default 0).
+        for (var i = 0; i < array.Shape.Length; i++)
+        {
+            if (i == xDim || i == yDim)
+            {
+                continue;
+            }
+
+            var name = array.DimensionNames[i];
+            var isTime = metadata.TemporalDimension is { } t &&
+                string.Equals(t, name, StringComparison.OrdinalIgnoreCase);
+
+            if (isTime)
+            {
+                if (!TryResolveTimeIndex(metadata, array.Shape[i], datetime, out var timeIndex, out error))
+                {
+                    return false;
+                }
+                subsets.Add(new ZarrCoverageDimensionSubset(name, timeIndex, timeIndex + 1));
+                continue;
+            }
+
+            var index = verticalIndex ?? 0;
+            if (index < 0 || index >= array.Shape[i])
+            {
+                error = string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"The requested index {index} on dimension '{name}' is outside the axis range [0, {array.Shape[i] - 1}].");
+                return false;
+            }
+            subsets.Add(new ZarrCoverageDimensionSubset(name, index, index + 1));
+        }
+
+        if (!ZarrCoverageSubsetPlanner.TryPlan(metadata, array.Name, subsets, maxOutputBytes, out var subsetPlan, out error))
+        {
+            return false;
+        }
+
+        var request = subsetPlan!.Request;
+        var gridXMin = extent.XMin + (request.Start[xDim] * cellWidth);
+        var gridYMax = extent.YMax - (request.Start[yDim] * cellHeight);
+
+        plan = new ZarrTileSlicePlan(
+            subsetPlan,
+            YDimensionIndex: yDim,
+            XDimensionIndex: xDim,
+            GridXMin: gridXMin,
+            GridYMax: gridYMax,
+            CellWidth: cellWidth,
+            CellHeight: cellHeight);
+        return true;
+    }
+
+    private static ZarrArrayMetadata? ResolveArray(ZarrStoreMetadata metadata, string? variable, out string? error)
+    {
+        error = null;
+        if (metadata.Arrays.Length == 0)
+        {
+            error = "The Zarr store does not expose any variables.";
+            return null;
+        }
+
+        var resolved = string.IsNullOrWhiteSpace(variable)
+            ? metadata.PrimaryVariable ?? metadata.Arrays[0].Name
+            : variable;
+
+        foreach (var candidate in metadata.Arrays)
+        {
+            if (string.Equals(candidate.Name, resolved, StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+
+        error = $"Variable '{resolved}' is not available in the coverage.";
+        return null;
+    }
+
+    private static int FindSpatialDimension(ZarrStoreMetadata metadata, ZarrArrayMetadata array, bool isX)
+    {
+        var declared = isX ? metadata.SpatialXDimension : metadata.SpatialYDimension;
+        for (var i = 0; i < array.DimensionNames.Length; i++)
+        {
+            var name = array.DimensionNames[i];
+            if (declared is not null)
+            {
+                if (string.Equals(declared, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return i;
+                }
+                continue;
+            }
+
+            var lower = name.ToLowerInvariant();
+            var matches = isX
+                ? lower is "x" or "lon" or "longitude"
+                : lower is "y" or "lat" or "latitude";
+            if (matches)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool TryResolveTimeIndex(
+        ZarrStoreMetadata metadata,
+        int axisLength,
+        (DateTimeOffset? Start, DateTimeOffset? End)? datetime,
+        out int index,
+        out string? error)
+    {
+        index = 0;
+        error = null;
+
+        // No datetime requested: default to the first (index 0) sample.
+        if (datetime is not { } window || (window.Start is null && window.End is null))
+        {
+            return true;
+        }
+
+        if (metadata.Temporal is not { } temporal)
+        {
+            error = "The coverage does not declare a resolvable time axis for the requested datetime.";
+            return false;
+        }
+
+        if (!CfTimeAxisIndexer.TryResolveTimeIndexRange(
+                temporal.Start,
+                temporal.End,
+                temporal.StepCount,
+                window.Start,
+                window.End,
+                out var low,
+                out var high,
+                out error))
+        {
+            return false;
+        }
+
+        // A tile renders a single slice: take the low end of the resolved range,
+        // clamped to the axis.
+        index = Math.Clamp(low, 0, Math.Max(0, axisLength - 1));
+        _ = high;
+        return true;
+    }
+}

--- a/src/Honua.Protocols.Ogc.Shared/Common/OgcTemporalFilterParser.cs
+++ b/src/Honua.Protocols.Ogc.Shared/Common/OgcTemporalFilterParser.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
-using System.Globalization;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Raster.ZarrParser;
 
 namespace Honua.Protocols.Ogc.Common;
 
@@ -60,87 +60,16 @@ internal static class OgcTemporalFilterParser
     /// Parses an OGC API datetime parameter (RFC 3339 instant or interval) into a
     /// (start, end) pair without requiring a layer. Supported forms: instant,
     /// <c>start/end</c>, <c>../end</c>, <c>start/..</c>. For an instant T both
-    /// <paramref name="start"/> and <paramref name="end"/> are set to T.
+    /// <paramref name="start"/> and <paramref name="end"/> are set to T. Delegates to
+    /// the neutral <see cref="Iso8601TemporalIntervalParser"/> in <c>Honua.Core</c> so
+    /// the OGC adapters and the coverage/datacube tile path share one implementation.
     /// </summary>
     public static bool TryParseRange(
         string? datetime,
         out DateTimeOffset? start,
         out DateTimeOffset? end,
         out string? errorMessage)
-    {
-        start = null;
-        end = null;
-        errorMessage = null;
-
-        if (string.IsNullOrWhiteSpace(datetime))
-        {
-            return true;
-        }
-
-        var parts = datetime.Split('/', StringSplitOptions.TrimEntries);
-
-        if (parts.Length == 1)
-        {
-            if (!TryParseDateTimeOffset(parts[0], out var instant))
-            {
-                errorMessage = "Invalid datetime parameter.";
-                return false;
-            }
-
-            start = instant;
-            end = instant;
-            return true;
-        }
-
-        if (parts.Length == 2)
-        {
-            if (!string.IsNullOrWhiteSpace(parts[0]) && parts[0] != "..")
-            {
-                if (!TryParseDateTimeOffset(parts[0], out var parsedStart))
-                {
-                    errorMessage = "Invalid datetime parameter.";
-                    return false;
-                }
-
-                start = parsedStart;
-            }
-
-            if (!string.IsNullOrWhiteSpace(parts[1]) && parts[1] != "..")
-            {
-                if (!TryParseDateTimeOffset(parts[1], out var parsedEnd))
-                {
-                    errorMessage = "Invalid datetime parameter.";
-                    return false;
-                }
-
-                end = parsedEnd;
-            }
-
-            if (start is null && end is null)
-            {
-                errorMessage = "Invalid datetime parameter.";
-                return false;
-            }
-
-            if (start is { } s && end is { } e && s > e)
-            {
-                errorMessage = "Invalid datetime parameter.";
-                return false;
-            }
-
-            return true;
-        }
-
-        errorMessage = "Invalid datetime parameter.";
-        return false;
-    }
-
-    private static bool TryParseDateTimeOffset(string value, out DateTimeOffset parsed)
-        => DateTimeOffset.TryParse(
-            value,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-            out parsed);
+        => Iso8601TemporalIntervalParser.TryParseRange(datetime, out start, out end, out errorMessage);
 
     private static bool TryResolveTemporalFieldsV2(
         MetadataV2Resource resource,

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -1237,6 +1237,9 @@ public static class EndpointRegistry
         new("DELETE", "/api/v1/admin/zarr-stores/{id}"),
         new("POST", "/api/v1/admin/zarr-stores/{id}/refresh"),
 
+        // Datacube tile rendering (#1835): Zarr coverage slice -> PNG map tile
+        new("GET", "/api/v1/datacubes/{layerId}/tiles/{tileMatrixSetId}/{z}/{x}/{y}"),
+
         // STAC (SpatioTemporal Asset Catalog)
         new("GET", "/stac"),
         new("GET", "/stac/conformance"),

--- a/src/Honua.Server/Features/Protocols/Zarr/ZarrEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Zarr/ZarrEndpoints.cs
@@ -1,11 +1,14 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Raster.ZarrParser;
+using Honua.Core.Features.Tiles;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Models;
 using Honua.Server.Features.Protocols.Zarr.Models;
@@ -58,6 +61,172 @@ internal static class ZarrEndpoints
         group.MapPost("/{id:long}/refresh", HandleRefresh)
             .WithDisplayName("Refresh Zarr Metadata")
             .WithSummary("Re-scan Zarr metadata from the backing store");
+
+        // Public datacube tile serving (#1835, Shape B): bind a registered Zarr
+        // coverage slice (z/x/y + time + elevation + variable) to a PNG map tile.
+        // Read-only; does not advertise an OGC conformance class, so it leaves the
+        // CITE tile surfaces untouched.
+        var tiles = endpoints.MapGroup("/api/v{version:apiVersion}/datacubes/{layerId:int}/tiles")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Datacubes", "Tiles");
+
+        tiles.MapGet("/{tileMatrixSetId}/{z:int}/{x:int}/{y:int}", HandleDatacubeTile)
+            .WithDisplayName("Datacube Tile")
+            .WithSummary("Render a registered Zarr coverage slice as a PNG map tile");
+    }
+
+    /// <summary>
+    /// Decoded payload cap for a single tile slice. A 256x256 float64 grid plus a
+    /// little headroom; the planner rejects anything larger before any read happens.
+    /// </summary>
+    private const long MaxTileSliceBytes = 4L * 1024L * 1024L;
+
+    private static async Task<IResult> HandleDatacubeTile(
+        HttpContext context,
+        int layerId,
+        string tileMatrixSetId,
+        int z,
+        int x,
+        int y,
+        [FromServices] IZarrStore store,
+        [FromServices] IZarrSubsetReader subsetReader,
+        [FromServices] IEnumerable<ICloudRangeReader> rangeReaders,
+        [FromServices] ITileMatrixSetRegistry tileMatrixSets,
+        ILogger<ZarrEndpointsLog> logger,
+        CancellationToken cancellationToken)
+    {
+        if (x < 0 || y < 0 || z < 0)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Tile coordinates must be non-negative.");
+        }
+
+        var registrations = await store.ListByLayerAsync(layerId, cancellationToken).ConfigureAwait(false);
+        ZarrRegistration? servable = null;
+        foreach (var candidate in registrations)
+        {
+            if (candidate.Metadata is not null)
+            {
+                servable = candidate;
+                break;
+            }
+        }
+
+        if (servable is null || servable.Metadata is null)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "No servable Zarr coverage is registered for this layer.");
+        }
+
+        var metadata = servable.Metadata;
+
+        if (!tileMatrixSets.TryGetGeometry(tileMatrixSetId, z, out var geometry))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, $"Tile matrix set '{tileMatrixSetId}' is not supported.");
+        }
+
+        // Resolvable case: the gridset CRS matches the coverage storage CRS so the
+        // tile bbox maps directly to grid indices. Cross-CRS reprojection of the
+        // tile window is deferred (#1835 follow-up).
+        if (geometry.Srid != metadata.Srid)
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                $"Tile matrix set '{tileMatrixSetId}' (EPSG:{geometry.Srid.ToString(CultureInfo.InvariantCulture)}) does not match the coverage CRS (EPSG:{metadata.Srid.ToString(CultureInfo.InvariantCulture)}). Request a matching gridset.");
+        }
+
+        if (geometry.GetTileBounds(x, y, z) is not { } bounds)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, $"Tile level {z.ToString(CultureInfo.InvariantCulture)} is not part of '{tileMatrixSetId}'.");
+        }
+
+        var variable = GetQueryValue(context, "variable");
+        var datetimeRaw = GetQueryValue(context, "datetime");
+        (DateTimeOffset? Start, DateTimeOffset? End)? datetime = null;
+        if (!string.IsNullOrWhiteSpace(datetimeRaw))
+        {
+            // Neutral, Core-level RFC 3339 instant/interval parser. The datacube tile
+            // family resolves temporal parameters through Honua.Core and does not depend
+            // on the OGC protocol family for temporal parsing.
+            if (!Iso8601TemporalIntervalParser.TryParseRange(datetimeRaw, out var start, out var end, out var dtError))
+            {
+                return StandardErrorHelpers.CreateBadRequest(context, dtError ?? "Invalid datetime parameter.");
+            }
+            datetime = (start, end);
+        }
+
+        int? verticalIndex = null;
+        var elevationRaw = GetQueryValue(context, "elevation");
+        if (!string.IsNullOrWhiteSpace(elevationRaw))
+        {
+            if (!int.TryParse(elevationRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) || parsed < 0)
+            {
+                return StandardErrorHelpers.CreateBadRequest(context, "The elevation parameter must be a non-negative grid index.");
+            }
+            verticalIndex = parsed;
+        }
+
+        var tileBounds = new ZarrTileBounds(bounds.XMin, bounds.YMin, bounds.XMax, bounds.YMax);
+        if (!ZarrTileSlicePlanner.TryPlan(metadata, variable, tileBounds, datetime, verticalIndex, MaxTileSliceBytes, out var slice, out var planError))
+        {
+            // A tile that misses the coverage extent is an empty (transparent) tile,
+            // which clients expect as a 204 rather than an error.
+            if (planError is { } message && message.Contains("does not intersect", StringComparison.Ordinal))
+            {
+                return Results.NoContent();
+            }
+            return StandardErrorHelpers.CreateBadRequest(context, planError ?? "The tile could not be resolved against the coverage.");
+        }
+
+        var rangeReader = rangeReaders.FirstOrDefault(reader => reader.Provider == servable.Provider);
+        if (rangeReader is null)
+        {
+            return StandardErrorHelpers.CreateInternalServerError(context, "The storage backend for this coverage is not configured.");
+        }
+
+        ZarrSubsetResult result;
+        try
+        {
+            result = await subsetReader.ReadSubsetAsync(
+                    rangeReader,
+                    servable.Bucket,
+                    servable.RootPath,
+                    metadata,
+                    slice!.Plan.Request,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, ex.Message);
+        }
+        catch (InvalidDataException)
+        {
+            return StandardErrorHelpers.CreateInternalServerError(context, "The Zarr store returned invalid data for this tile.");
+        }
+
+        var fillValue = slice.Plan.Array.FillValue as double?;
+        var png = ZarrTileRenderer.Render(result, slice, ZarrTileRenderer.DefaultTileSize, colormap: null, fillValue: fillValue);
+        ZarrLog.DatacubeTileRendered(logger, layerId, result.Variable, z, x, y, png.Length);
+        return Results.Bytes(png, "image/png");
+    }
+
+    /// <summary>
+    /// Reads a single trimmed query-string value without taking a dependency on any
+    /// protocol family's request helpers.
+    /// </summary>
+    private static string? GetQueryValue(HttpContext context, string key)
+    {
+        if (!context.Request.Query.TryGetValue(key, out var values))
+        {
+            return null;
+        }
+
+        var value = values.ToString();
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
     }
 
     private static async Task<IResult> HandleRegister(

--- a/src/Honua.Server/Features/Protocols/Zarr/ZarrLog.cs
+++ b/src/Honua.Server/Features/Protocols/Zarr/ZarrLog.cs
@@ -45,4 +45,10 @@ internal static partial class ZarrLog
         Level = LogLevel.Error,
         Message = "Zarr metadata scan failed for {RegistrationId}")]
     public static partial void MetadataScanFailed(ILogger logger, Exception ex, long registrationId);
+
+    [LoggerMessage(
+        EventId = 7926,
+        Level = LogLevel.Debug,
+        Message = "Rendered datacube tile for layer {LayerId} variable '{Variable}' at {Z}/{X}/{Y} ({Bytes} bytes)")]
+    public static partial void DatacubeTileRendered(ILogger logger, int layerId, string variable, int z, int x, int y, int bytes);
 }

--- a/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrTileRendererTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrTileRendererTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Raster.ZarrParser;
+using Xunit;
+
+namespace Honua.Core.Tests.Raster.ZarrParser;
+
+public class ZarrTileRendererTests
+{
+    private static readonly byte[] PngSignature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    [Fact]
+    public async Task Render_GeoreferencedSlice_ProducesValidPng()
+    {
+        var (metadata, reader) = await BuildAsync();
+
+        var bounds = new ZarrTileBounds(0, 0, 8, 8);
+        ZarrTileSlicePlanner.TryPlan(metadata, null, bounds, null, null, 4 * 1024 * 1024, out var slice, out var error)
+            .Should().BeTrue(error);
+
+        var subset = await new ZarrSubsetReader().ReadSubsetAsync(reader, "bucket", "tiles/render", metadata, slice!.Plan.Request);
+
+        var png = ZarrTileRenderer.Render(subset, slice, tileSize: 64);
+
+        png.AsSpan(0, 8).ToArray().Should().Equal(PngSignature);
+        ReadPngDimensions(png).Should().Be((64, 64));
+    }
+
+    [Fact]
+    public async Task Render_WithColormap_MapsValuesToColours()
+    {
+        var (metadata, reader) = await BuildAsync();
+
+        var bounds = new ZarrTileBounds(0, 0, 8, 8);
+        ZarrTileSlicePlanner.TryPlan(metadata, null, bounds, null, null, 4 * 1024 * 1024, out var slice, out _)
+            .Should().BeTrue();
+        var subset = await new ZarrSubsetReader().ReadSubsetAsync(reader, "bucket", "tiles/render", metadata, slice!.Plan.Request);
+
+        var colormap = new RasterColormap
+        {
+            Entries =
+            [
+                new RasterColormapEntry(0, 0, 0, 0, 255),
+                new RasterColormapEntry(14, 255, 255, 255, 255),
+            ],
+        };
+
+        var png = ZarrTileRenderer.Render(subset, slice, tileSize: 8, colormap: colormap);
+
+        png.AsSpan(0, 8).ToArray().Should().Equal(PngSignature);
+        png.Length.Should().BeGreaterThan(8);
+    }
+
+    private static async Task<(ZarrStoreMetadata Metadata, InMemoryZarrRangeReader Reader)> BuildAsync()
+    {
+        var objects = ZarrFixtureBuilder.BuildGroupedZlib(
+            root: "tiles/render",
+            rows: 8,
+            cols: 8,
+            chunkRows: 4,
+            chunkCols: 4,
+            sample: (r, c) => r + c,
+            srid: 4326,
+            xMin: 0,
+            yMin: 0,
+            xMax: 8,
+            yMax: 8);
+        var reader = new InMemoryZarrRangeReader(objects);
+        var metadata = await new ZarrMetadataExtractor().ReadMetadataAsync(reader, "bucket", "tiles/render");
+        return (metadata, reader);
+    }
+
+    private static (int Width, int Height) ReadPngDimensions(byte[] png)
+    {
+        // IHDR data begins at byte 16 (8 signature + 4 length + 4 type).
+        var width = BinaryPrimitives.ReadInt32BigEndian(png.AsSpan(16, 4));
+        var height = BinaryPrimitives.ReadInt32BigEndian(png.AsSpan(20, 4));
+        return (width, height);
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrTileSlicePlannerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrTileSlicePlannerTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Raster.ZarrParser;
+using Xunit;
+
+namespace Honua.Core.Tests.Raster.ZarrParser;
+
+public class ZarrTileSlicePlannerTests
+{
+    [Fact]
+    public async Task TryPlan_TileWithinExtent_ResolvesSpatialWindow()
+    {
+        var metadata = await BuildMetadataAsync(
+            ZarrFixtureBuilder.BuildGroupedZlib(
+                root: "tiles/grid",
+                rows: 8,
+                cols: 8,
+                chunkRows: 4,
+                chunkCols: 4,
+                sample: (r, c) => r + c,
+                srid: 4326,
+                xMin: 0,
+                yMin: 0,
+                xMax: 8,
+                yMax: 8),
+            "tiles/grid");
+
+        // Bottom-left quadrant of the extent (x in [0,4], y in [0,4]).
+        var bounds = new ZarrTileBounds(0, 0, 4, 4);
+        var ok = ZarrTileSlicePlanner.TryPlan(
+            metadata, variable: null, bounds, datetime: null, verticalIndex: null,
+            maxOutputBytes: 1024 * 1024, out var slice, out var error);
+
+        ok.Should().BeTrue(error);
+        slice.Should().NotBeNull();
+        var request = slice!.Plan.Request;
+        // Y dimension is index 0 (row), X is index 1 (col).
+        slice.YDimensionIndex.Should().Be(0);
+        slice.XDimensionIndex.Should().Be(1);
+        // X window [0,4); Y window covers the southern half -> rows [4,8).
+        request.Start[1].Should().Be(0);
+        request.Stop[1].Should().Be(4);
+        request.Start[0].Should().Be(4);
+        request.Stop[0].Should().Be(8);
+    }
+
+    [Fact]
+    public async Task TryPlan_TileOutsideExtent_ReportsNoIntersection()
+    {
+        var metadata = await BuildMetadataAsync(
+            ZarrFixtureBuilder.BuildGroupedZlib(
+                root: "tiles/miss",
+                rows: 8,
+                cols: 8,
+                chunkRows: 4,
+                chunkCols: 4,
+                sample: (r, c) => 1f,
+                srid: 4326,
+                xMin: 0,
+                yMin: 0,
+                xMax: 8,
+                yMax: 8),
+            "tiles/miss");
+
+        var bounds = new ZarrTileBounds(100, 100, 110, 110);
+        var ok = ZarrTileSlicePlanner.TryPlan(
+            metadata, variable: null, bounds, datetime: null, verticalIndex: null,
+            maxOutputBytes: 1024 * 1024, out var slice, out var error);
+
+        ok.Should().BeFalse();
+        slice.Should().BeNull();
+        error.Should().Contain("does not intersect");
+    }
+
+    [Fact]
+    public async Task TryPlan_NotGeoreferenced_Rejected()
+    {
+        var metadata = await BuildMetadataAsync(
+            ZarrFixtureBuilder.BuildSingleVariableUncompressed(
+                root: "tiles/plain",
+                rows: 8,
+                cols: 8,
+                chunkRows: 4,
+                chunkCols: 4,
+                sample: (r, c) => 1f),
+            "tiles/plain");
+
+        var bounds = new ZarrTileBounds(0, 0, 4, 4);
+        var ok = ZarrTileSlicePlanner.TryPlan(
+            metadata, variable: null, bounds, datetime: null, verticalIndex: null,
+            maxOutputBytes: 1024 * 1024, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().Contain("georeferenced");
+    }
+
+    [Fact]
+    public async Task TryPlan_TimeAxis_ResolvesSingleTimeIndex()
+    {
+        var metadata = await BuildMetadataAsync(
+            ZarrFixtureBuilder.BuildGroupedWithTime(
+                root: "tiles/ts",
+                timeSteps: 5,
+                rows: 8,
+                cols: 8,
+                includeTemporalAttrs: true),
+            "tiles/ts");
+
+        var bounds = new ZarrTileBounds(-180, -90, 0, 90);
+        var ok = ZarrTileSlicePlanner.TryPlan(
+            metadata,
+            variable: null,
+            bounds,
+            datetime: (new DateTimeOffset(2026, 1, 3, 0, 0, 0, TimeSpan.Zero), new DateTimeOffset(2026, 1, 3, 0, 0, 0, TimeSpan.Zero)),
+            verticalIndex: null,
+            maxOutputBytes: 4 * 1024 * 1024,
+            out var slice,
+            out var error);
+
+        ok.Should().BeTrue(error);
+        var request = slice!.Plan.Request;
+        // time axis is dimension 0; 2026-01-03 is the 3rd sample (index 2).
+        request.Start[0].Should().Be(2);
+        request.Stop[0].Should().Be(3);
+    }
+
+    private static async Task<ZarrStoreMetadata> BuildMetadataAsync(System.Collections.Generic.Dictionary<string, byte[]> objects, string root)
+    {
+        var reader = new InMemoryZarrRangeReader(objects);
+        return await new ZarrMetadataExtractor().ReadMetadataAsync(reader, "bucket", root);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Zarr/DatacubeTileEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Zarr/DatacubeTileEndpointTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Protocols.Zarr;
+
+/// <summary>
+/// Endpoint-level coverage for the datacube (Zarr coverage) slice -> tile render route (#1835),
+/// exercising the public GET so it is backed by a real HTTP request (EndpointRegistryDriftTests).
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Tile)]
+public sealed class DatacubeTileEndpointTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/datacubes/{layerId}/tiles/{tileMatrixSetId}/{z}/{x}/{y}")]
+    public async Task DatacubeTile_LayerWithoutServableCoverage_Returns404()
+    {
+        // The default test layer has no registered Zarr coverage, so the datacube tile
+        // handler resolves no servable coverage and returns 404.
+        var response = await _client.GetAsync(
+            $"/api/v1/datacubes/{WebAppFixture.TestLayerId}/tiles/WebMercatorQuad/0/0/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}


### PR DESCRIPTION
Closes #1835.

## Shape B: datacube -> tile render binding

Binds a registered Zarr coverage slice `(z/x/y, time, elevation, variable)` to a rasterized RGBA PNG map tile, completing the Shape B follow-up to #1792 / #1820. Sequenced after #1790 so it reuses that PR's coordinate/time-axis resolution rather than duplicating it.

### What it does
- New public route `GET /api/v1/datacubes/{layerId}/tiles/{tileMatrixSetId}/{z}/{x}/{y}` (read-only). Resolves the servable Zarr coverage for the layer, maps the tile bbox to a half-open grid-index window, resolves time/vertical axes, reads a bounded subset through `IZarrSubsetReader`, colour-maps the dtype buffer, and returns `image/png`. Optional `variable`, `datetime`, and `elevation` query parameters. A tile that misses the coverage extent returns `204`.

### Architecture
- All slice/render logic lives in neutral `Honua.Core` helpers (`ZarrTileSlicePlanner`, `ZarrTileRenderer`, `PngEncoder`, `Iso8601TemporalIntervalParser`) under `Features/Raster/ZarrParser`. **The datacube tile path takes no dependency on `Honua.Protocols.Ogc` internals** — temporal parsing uses the Core-level `Iso8601TemporalIntervalParser`, and `OgcTemporalFilterParser` now delegates to that same Core parser (no behaviour change) so the two share one implementation. This avoids the ProtocolFamilies violation that reverted the earlier attempt.
- AOT-safe: no reflection, managed DEFLATE PNG encoder, little-endian binary decode.
- Does not advertise any OGC tiles conformance class, so the CITE tile surfaces are untouched.
- The tile gridset CRS must match the coverage storage CRS today; cross-CRS reprojection of the tile window is noted as a follow-up.

### Governance
- Route registered in `EndpointRegistry.cs`.
- New `datacube-tiles` surface added to the public-interface proof ledger.
- Feature catalog (`feature-catalog.json`) regenerated.
- Documented in `docs/reference/protocols/cloud-native-formats.md`.

### Tests (all green, run serially)
- `ZarrTileSlicePlannerTests`, `ZarrTileRendererTests` (Core unit, 6 tests).
- `DatacubeTileEndpointTests` (Server integration, real HTTP, 404 when no servable coverage).
- Architecture suite 116/116 pass: ProtocolFamilies, EveryEndpointRegistryRoute proof-ledger surface, and the feature-catalog drift guards.
- Release build with `TreatWarningsAsErrors`: 0 warnings, 0 errors.