### PR TITLE
feat: broker-agnostic feature-change event sink abstraction (#357)

### DIFF
--- a/src/Honua.Hosting/Features/Events/FeatureChangeEventSinkBroadcaster.cs
+++ b/src/Honua.Hosting/Features/Events/FeatureChangeEventSinkBroadcaster.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.Events;
+
+/// <summary>
+/// Fans a durably persisted feature-change event out to every registered
+/// <see cref="IFeatureChangeEventSink"/> with per-sink failure isolation (#357).
+/// </summary>
+/// <remarks>
+/// The canonical publish path calls <see cref="Dispatch"/> after it has appended
+/// the event to the store and broadcast it to live sessions. Sink delivery runs
+/// off the write hot path so a slow or failing transport never blocks the
+/// originating edit. Each sink is invoked independently; a sink that throws is
+/// logged and metered but does not affect durable storage, live streaming, or
+/// sibling sinks. When sinks are disabled or none are registered, dispatch is a
+/// cheap no-op.
+/// </remarks>
+internal sealed partial class FeatureChangeEventSinkBroadcaster
+{
+    private readonly IReadOnlyList<IFeatureChangeEventSink> _sinks;
+    private readonly ILogger<FeatureChangeEventSinkBroadcaster> _logger;
+    private readonly bool _enabled;
+
+    public FeatureChangeEventSinkBroadcaster(
+        IEnumerable<IFeatureChangeEventSink> sinks,
+        IOptions<FeatureChangeEventSinkOptions> options,
+        ILogger<FeatureChangeEventSinkBroadcaster> logger)
+    {
+        ArgumentNullException.ThrowIfNull(sinks);
+        ArgumentNullException.ThrowIfNull(options);
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _enabled = options.Value?.Enabled ?? false;
+        // Materialize once: the set of sinks is fixed at registration time, and
+        // the publish hot path must not re-enumerate a deferred LINQ pipeline.
+        _sinks = _enabled ? [.. sinks] : [];
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether any sink will receive events. False when
+    /// sinks are disabled by configuration or none are registered.
+    /// </summary>
+    public bool HasActiveSinks => _sinks.Count > 0;
+
+    /// <summary>
+    /// Hands the persisted event to each registered sink. Returns immediately;
+    /// sink delivery is observed in the background so the write path is never
+    /// blocked. Safe to call when no sinks are active.
+    /// </summary>
+    public void Dispatch(FeatureChangeEvent featureEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(featureEvent);
+
+        if (_sinks.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var sink in _sinks)
+        {
+            // Each sink is observed independently. PublishToSinkAsync never throws,
+            // so the discarded task carries no unobserved exception.
+            _ = PublishToSinkAsync(sink, featureEvent, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Awaits delivery to every registered sink. Exposed for the strict publish
+    /// path and tests that need deterministic completion. Per-sink failures are
+    /// isolated and never propagate.
+    /// </summary>
+    public async Task DispatchAndWaitAsync(FeatureChangeEvent featureEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(featureEvent);
+
+        if (_sinks.Count == 0)
+        {
+            return;
+        }
+
+        var pending = new List<Task>(_sinks.Count);
+        foreach (var sink in _sinks)
+        {
+            pending.Add(PublishToSinkAsync(sink, featureEvent, cancellationToken));
+        }
+
+        await Task.WhenAll(pending).ConfigureAwait(false);
+    }
+
+    private async Task PublishToSinkAsync(
+        IFeatureChangeEventSink sink,
+        FeatureChangeEvent featureEvent,
+        CancellationToken cancellationToken)
+    {
+        var tag = new KeyValuePair<string, object?>("sink", sink.Name);
+        try
+        {
+            await sink.PublishAsync(featureEvent, cancellationToken).ConfigureAwait(false);
+            FeatureChangeEventSinkMetrics.Published.Add(1, tag);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Host shutdown; not a delivery failure.
+        }
+        catch (Exception ex)
+        {
+            FeatureChangeEventSinkMetrics.Failed.Add(1, tag);
+            LogSinkPublishFailed(_logger, sink.Name, featureEvent.EventId, ex);
+        }
+    }
+
+    [LoggerMessage(
+        EventId = 9400,
+        Level = LogLevel.Warning,
+        Message = "Feature-change event sink '{Sink}' failed to publish event {EventId}; durable storage and live streaming are unaffected.")]
+    private static partial void LogSinkPublishFailed(ILogger logger, string sink, string eventId, Exception exception);
+}

--- a/src/Honua.Hosting/Features/Events/FeatureChangeEventSinkMetrics.cs
+++ b/src/Honua.Hosting/Features/Events/FeatureChangeEventSinkMetrics.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics.Metrics;
+using Honua.ServiceDefaults;
+
+namespace Honua.Infrastructure.Events;
+
+/// <summary>
+/// Metrics emitted when committed feature-change events are fanned out to
+/// broker-agnostic sinks (#357).
+/// </summary>
+internal static class FeatureChangeEventSinkMetrics
+{
+    private static readonly Meter Meter = HonuaTelemetry.Meter;
+
+    /// <summary>
+    /// Events successfully published to a sink, tagged by sink name.
+    /// </summary>
+    public static readonly Counter<long> Published = Meter.CreateCounter<long>(
+        "honua.event_sink.published_total",
+        "events",
+        "Feature-change events successfully published to an event-bus sink.");
+
+    /// <summary>
+    /// Events whose sink publish attempt failed, tagged by sink name. A sink
+    /// failure is isolated and does not affect durable storage, live streaming,
+    /// or sibling sinks.
+    /// </summary>
+    public static readonly Counter<long> Failed = Meter.CreateCounter<long>(
+        "honua.event_sink.failed_total",
+        "events",
+        "Feature-change events whose sink publish attempt failed.");
+}

--- a/src/Honua.Hosting/Features/Events/FeatureChangeEventSinkOptions.cs
+++ b/src/Honua.Hosting/Features/Events/FeatureChangeEventSinkOptions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Events;
+
+/// <summary>
+/// Configuration for broker-agnostic feature-change event sinks (#357).
+/// </summary>
+/// <remarks>
+/// Sinks are off by default. When disabled, no sink fan-out is wired and the
+/// publish path behaves exactly as it did before sinks existed (durable append
+/// plus live streaming only). Enabling sinks activates the in-process broadcaster
+/// and any registered sink adapters (the live Kafka/NATS adapters are delivered
+/// in a follow-up increment).
+/// </remarks>
+public sealed class FeatureChangeEventSinkOptions
+{
+    /// <summary>
+    /// Configuration section name bound from application configuration.
+    /// </summary>
+    public const string SectionName = "FeatureChangeEvents:Sinks";
+
+    /// <summary>
+    /// Enables fan-out of committed feature-change events to registered sinks.
+    /// Defaults to <see langword="false"/> so existing deployments are unaffected.
+    /// </summary>
+    public bool Enabled { get; set; }
+}

--- a/src/Honua.Hosting/Features/Events/IFeatureChangeEventSink.cs
+++ b/src/Honua.Hosting/Features/Events/IFeatureChangeEventSink.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Events;
+
+/// <summary>
+/// Broker-agnostic destination for committed feature-change events.
+/// </summary>
+/// <remarks>
+/// Sinks are the extension point for enterprise event-bus integrations (#357):
+/// concrete Kafka and NATS JetStream adapters implement this interface and are
+/// registered alongside the in-process default. The canonical publish path
+/// (<c>FeatureStreamPublisher</c>) durably appends an event, fans it out to live
+/// streaming sessions, then hands the persisted event to every registered sink
+/// through <see cref="FeatureChangeEventSinkBroadcaster"/>. Sinks therefore see
+/// the same normalized envelope as replay and webhook delivery and never observe
+/// an event that was not durably stored.
+/// <para>
+/// Implementations must be resilient: a sink that throws must not break the
+/// originating write, the durable append, live streaming, or sibling sinks. The
+/// broadcaster isolates per-sink failures and runs sinks off the write hot path.
+/// </para>
+/// </remarks>
+internal interface IFeatureChangeEventSink
+{
+    /// <summary>
+    /// Gets a stable identifier used in diagnostics and metrics (for example
+    /// <c>kafka</c>, <c>nats</c>, or <c>noop</c>).
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Publishes a durably persisted feature-change event to the underlying
+    /// transport. Called after the event has been appended to the event store
+    /// and broadcast to live sessions.
+    /// </summary>
+    /// <param name="featureEvent">The persisted, normalized feature-change event.</param>
+    /// <param name="cancellationToken">A token that signals host shutdown.</param>
+    Task PublishAsync(FeatureChangeEvent featureEvent, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Hosting/Features/Events/NoOpFeatureChangeEventSink.cs
+++ b/src/Honua.Hosting/Features/Events/NoOpFeatureChangeEventSink.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Events;
+
+/// <summary>
+/// Default <see cref="IFeatureChangeEventSink"/> that discards events.
+/// </summary>
+/// <remarks>
+/// Registered so the sink fan-out path is exercised end-to-end (and observable
+/// via metrics) even when no broker adapter is configured. Concrete Kafka and
+/// NATS adapters (#357) are additive: they register alongside this sink and the
+/// broadcaster delivers to all of them.
+/// </remarks>
+internal sealed class NoOpFeatureChangeEventSink : IFeatureChangeEventSink
+{
+    /// <inheritdoc />
+    public string Name => "noop";
+
+    /// <inheritdoc />
+    public Task PublishAsync(FeatureChangeEvent featureEvent, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}

--- a/src/Honua.Server/Features/Admin/Services/ConfigurationDocumentationService.cs
+++ b/src/Honua.Server/Features/Admin/Services/ConfigurationDocumentationService.cs
@@ -76,6 +76,7 @@ public sealed class ConfigurationDocumentationService
             BuildFeatureStreamingSection(),
             BuildFeatureChangeEventsSection(),
             BuildFeatureChangeWebhookSection(),
+            BuildFeatureChangeEventSinksSection(),
             BuildManifestApprovalSection(),
             BuildManifestApprovalWebhookSection(),
             BuildGitOpsWatchSection(),
@@ -607,6 +608,20 @@ public sealed class ConfigurationDocumentationService
                     "Default approval timeout in minutes", 1440),
                 BuildProperty("ManifestApproval:ExpiryScanIntervalSeconds", "ManifestApproval__ExpiryScanIntervalSeconds", "integer",
                     "Background scan interval for expiring pending approvals", 60)
+            ]
+        };
+    }
+
+    private ConfigurationSection BuildFeatureChangeEventSinksSection()
+    {
+        return new ConfigurationSection
+        {
+            Name = "FeatureChangeEvents.Sinks",
+            Description = "Broker-agnostic event-bus sinks for committed feature-change events",
+            Properties =
+            [
+                BuildProperty("FeatureChangeEvents:Sinks:Enabled", "FeatureChangeEvents__Sinks__Enabled", "boolean",
+                    "Enable fan-out of committed feature-change events to registered event-bus sinks", false)
             ]
         };
     }

--- a/src/Honua.Server/Features/Streaming/FeatureStreamPublisher.cs
+++ b/src/Honua.Server/Features/Streaming/FeatureStreamPublisher.cs
@@ -16,12 +16,14 @@ internal sealed partial class FeatureStreamPublisher(
     IFeatureChangeEventStore store,
     FeatureStreamSessionManager sessionManager,
     ILogger<FeatureStreamPublisher> logger,
-    IFeatureChangeRetryQueue? retryQueue = null) : IFeatureChangeEventPublisher
+    IFeatureChangeRetryQueue? retryQueue = null,
+    FeatureChangeEventSinkBroadcaster? sinkBroadcaster = null) : IFeatureChangeEventPublisher
 {
     private readonly IFeatureChangeEventStore _store = store ?? throw new ArgumentNullException(nameof(store));
     private readonly FeatureStreamSessionManager _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
     private readonly ILogger<FeatureStreamPublisher> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private readonly IFeatureChangeRetryQueue? _retryQueue = retryQueue;
+    private readonly FeatureChangeEventSinkBroadcaster? _sinkBroadcaster = sinkBroadcaster;
 
     public async Task PublishAsync(FeatureChangeEventRequest request, CancellationToken cancellationToken = default)
     {
@@ -74,6 +76,11 @@ internal sealed partial class FeatureStreamPublisher(
             FeatureStreamMessage.Data(envelope, persisted.GeometryEnvelope, persisted.PropertiesJson));
 
         LogLocalEventBroadcast(_logger, delivered, persisted.Cursor);
+
+        // Fan the durably persisted event out to broker-agnostic sinks (#357).
+        // Sink delivery runs off the write hot path with per-sink failure isolation,
+        // so a slow or failing transport never blocks the originating edit.
+        _sinkBroadcaster?.Dispatch(persisted);
     }
 
     internal static FeatureStreamEnvelope ToEnvelope(FeatureChangeEvent e)

--- a/src/Honua.Server/Startup/FeatureEventsAndStreamingRegistration.cs
+++ b/src/Honua.Server/Startup/FeatureEventsAndStreamingRegistration.cs
@@ -80,12 +80,22 @@ internal static partial class FeatureEventsAndStreamingRegistration
                 sp.GetRequiredService<FeatureStreamSessionManager>(),
                 sp.GetRequiredService<ILogger<FeatureChangeRetryQueue>>(),
                 sp.GetService<IConnectionMultiplexer>()));
+        // Broker-agnostic event-bus sinks (#357). The publish path fans committed
+        // feature-change events out to every registered sink through the broadcaster.
+        // Sinks are off by default; the no-op sink keeps the fan-out path exercised
+        // and observable. Concrete Kafka/NATS adapters register additional sinks in a
+        // follow-up increment (they require a live broker).
+        services.AddOptions<FeatureChangeEventSinkOptions>()
+            .Bind(configuration.GetSection(FeatureChangeEventSinkOptions.SectionName));
+        services.AddSingleton<IFeatureChangeEventSink, NoOpFeatureChangeEventSink>();
+        services.AddSingleton<FeatureChangeEventSinkBroadcaster>();
         services.AddSingleton<IFeatureChangeEventPublisher>(sp =>
             new FeatureStreamPublisher(
                 sp.GetRequiredService<IFeatureChangeEventStore>(),
                 sp.GetRequiredService<FeatureStreamSessionManager>(),
                 sp.GetRequiredService<ILogger<FeatureStreamPublisher>>(),
-                sp.GetRequiredService<IFeatureChangeRetryQueue>()));
+                sp.GetRequiredService<IFeatureChangeRetryQueue>(),
+                sp.GetRequiredService<FeatureChangeEventSinkBroadcaster>()));
         services.AddSingleton<FeatureMutationEventService>();
 
         // Feature-change transactional outbox (#692). Capability provider, dispatcher, health,

--- a/tests/dotnet/Honua.Server.Tests/Features/Streaming/FeatureChangeEventSinkBroadcasterTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Streaming/FeatureChangeEventSinkBroadcasterTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Infrastructure.Events;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Streaming;
+
+/// <summary>
+/// Unit tests for the broker-agnostic feature-change event sink broadcaster (#357),
+/// verifying fan-out, the disabled/no-sink defaults, and per-sink failure isolation.
+/// </summary>
+public sealed class FeatureChangeEventSinkBroadcasterTests
+{
+    private static FeatureChangeEvent SampleEvent(string eventId = "evt-1") => new()
+    {
+        EventId = eventId,
+        Cursor = 1,
+        Timestamp = DateTimeOffset.UtcNow,
+        ServiceId = "svc",
+        LayerId = 0,
+        ObjectId = 7,
+        Operation = "insert",
+        Protocol = "rest",
+        RequestId = "req-1"
+    };
+
+    private static FeatureChangeEventSinkBroadcaster Create(
+        bool enabled,
+        params IFeatureChangeEventSink[] sinks)
+        => new(
+            sinks,
+            Options.Create(new FeatureChangeEventSinkOptions { Enabled = enabled }),
+            NullLogger<FeatureChangeEventSinkBroadcaster>.Instance);
+
+    [UnitTest]
+    public async Task DispatchAndWaitAsync_WhenEnabled_PublishesToEverySink()
+    {
+        var first = new RecordingSink("first");
+        var second = new RecordingSink("second");
+        var broadcaster = Create(enabled: true, first, second);
+
+        Assert.True(broadcaster.HasActiveSinks);
+
+        await broadcaster.DispatchAndWaitAsync(SampleEvent());
+
+        Assert.Single(first.Received);
+        Assert.Single(second.Received);
+        Assert.Equal("evt-1", first.Received[0]);
+    }
+
+    [UnitTest]
+    public async Task DispatchAndWaitAsync_WhenDisabled_DoesNotPublish()
+    {
+        var sink = new RecordingSink("noop-default");
+        var broadcaster = Create(enabled: false, sink);
+
+        Assert.False(broadcaster.HasActiveSinks);
+
+        await broadcaster.DispatchAndWaitAsync(SampleEvent());
+
+        Assert.Empty(sink.Received);
+    }
+
+    [UnitTest]
+    public async Task DispatchAndWaitAsync_WhenNoSinksRegistered_IsNoOp()
+    {
+        var broadcaster = Create(enabled: true);
+
+        Assert.False(broadcaster.HasActiveSinks);
+
+        // Must complete without throwing even though no sinks are present.
+        await broadcaster.DispatchAndWaitAsync(SampleEvent());
+    }
+
+    [UnitTest]
+    public async Task DispatchAndWaitAsync_WhenSinkThrows_IsolatesFailureFromSiblings()
+    {
+        var failing = new ThrowingSink("kafka");
+        var healthy = new RecordingSink("nats");
+        var broadcaster = Create(enabled: true, failing, healthy);
+
+        // The failing sink must not prevent the healthy sink from receiving the event,
+        // and the failure must not propagate to the caller (the write path).
+        await broadcaster.DispatchAndWaitAsync(SampleEvent());
+
+        Assert.Single(healthy.Received);
+    }
+
+    [UnitTest]
+    public void Dispatch_WhenDisabled_IsNoOpAndDoesNotThrow()
+    {
+        var sink = new RecordingSink("noop");
+        var broadcaster = Create(enabled: false, sink);
+
+        broadcaster.Dispatch(SampleEvent());
+
+        Assert.Empty(sink.Received);
+    }
+
+    private sealed class RecordingSink(string name) : IFeatureChangeEventSink
+    {
+        public string Name { get; } = name;
+        public List<string> Received { get; } = [];
+
+        public Task PublishAsync(FeatureChangeEvent featureEvent, CancellationToken cancellationToken = default)
+        {
+            Received.Add(featureEvent.EventId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingSink(string name) : IFeatureChangeEventSink
+    {
+        public string Name { get; } = name;
+
+        public Task PublishAsync(FeatureChangeEvent featureEvent, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("sink transport unavailable");
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Streaming/FeatureStreamPublisherTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Streaming/FeatureStreamPublisherTests.cs
@@ -311,6 +311,81 @@ public sealed class FeatureStreamPublisherTests : IDisposable
         Assert.True(msg.Envelope.GeometryChanged);
     }
 
+    [UnitTest]
+    public async Task PublishAsync_WhenSinksEnabled_FansEventToSink()
+    {
+        // Event-bus sink fan-out (#357): a committed edit reaches every registered
+        // sink with the same persisted envelope after durable append and streaming.
+        var sink = new SignalingSink();
+        var broadcaster = new FeatureChangeEventSinkBroadcaster(
+            [sink],
+            Options.Create(new FeatureChangeEventSinkOptions { Enabled = true }),
+            NullLogger<FeatureChangeEventSinkBroadcaster>.Instance);
+        var publisher = new FeatureStreamPublisher(
+            _store,
+            _sessionManager,
+            NullLogger<FeatureStreamPublisher>.Instance,
+            retryQueue: null,
+            sinkBroadcaster: broadcaster);
+
+        await publisher.PublishAsync(new FeatureChangeEventRequest
+        {
+            ServiceId = "svc-sink",
+            LayerId = 0,
+            ObjectId = 11,
+            Operation = "create",
+            Protocol = "rest",
+            RequestId = "req-sink-1"
+        });
+
+        var received = await sink.Signal.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal("svc-sink", received.ServiceId);
+    }
+
+    [UnitTest]
+    public async Task PublishAsync_WithNoOpSinkOnly_DoesNotThrow()
+    {
+        // Default deployment: only the no-op sink is registered. Publishing must
+        // behave exactly as the storage+streaming path with no observable effect.
+        var broadcaster = new FeatureChangeEventSinkBroadcaster(
+            [new NoOpFeatureChangeEventSink()],
+            Options.Create(new FeatureChangeEventSinkOptions { Enabled = true }),
+            NullLogger<FeatureChangeEventSinkBroadcaster>.Instance);
+        var publisher = new FeatureStreamPublisher(
+            _store,
+            _sessionManager,
+            NullLogger<FeatureStreamPublisher>.Instance,
+            retryQueue: null,
+            sinkBroadcaster: broadcaster);
+
+        await publisher.PublishAsync(new FeatureChangeEventRequest
+        {
+            ServiceId = "svc-noop",
+            LayerId = 0,
+            ObjectId = 12,
+            Operation = "update",
+            Protocol = "rest",
+            RequestId = "req-noop-1"
+        });
+
+        var stored = await _store.QueryAsync(null, null, null, 10);
+        Assert.Single(stored);
+    }
+
+    private sealed class SignalingSink : IFeatureChangeEventSink
+    {
+        public TaskCompletionSource<FeatureChangeEvent> Signal { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string Name => "signaling";
+
+        public Task PublishAsync(FeatureChangeEvent featureEvent, CancellationToken cancellationToken = default)
+        {
+            Signal.TrySetResult(featureEvent);
+            return Task.CompletedTask;
+        }
+    }
+
     private sealed class ThrowingFeatureChangeEventStore : IFeatureChangeEventStore
     {
         public Task<FeatureChangeEvent> AppendAsync(FeatureChangeEventRequest request, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary

First mergeable increment of #357 (enterprise event bus — Kafka/NATS sinks). Adds the **broker-agnostic sink abstraction** that the live Kafka and NATS adapters will plug into, wired into the existing CDC publish path (built on the #316 foundation: event store, replay, webhooks, outbox, live streaming).

## What this increment delivers

- `IFeatureChangeEventSink` — broker-agnostic destination for committed feature-change events. The extension point for the Kafka and NATS JetStream adapters.
- `FeatureChangeEventSinkBroadcaster` — fans each durably persisted event out to every registered sink with **per-sink failure isolation**, off the write hot path. A slow/failing transport never blocks the originating edit, durable storage, live streaming, or sibling sinks.
- Wired into `FeatureStreamPublisher` after durable append + live-stream fan-out, so sinks observe the same normalized envelope as replay/webhook delivery and never see an event that was not durably stored.
- `NoOpFeatureChangeEventSink` default + config gating (`FeatureChangeEvents:Sinks:Enabled`, off by default — existing deployments are unaffected).
- Delivery/failure metrics (`honua.event_sink.published_total` / `honua.event_sink.failed_total`, tagged by sink).
- Config-documentation section for the new `FeatureChangeEvents:Sinks` options.

## Deferred (require a live broker)

Per the scope note, anything needing a running broker is deferred to follow-up increments and remains tracked by #357:

- Concrete Kafka sink + NATS JetStream sink adapters
- Exactly-once / idempotent-producer + dedup semantics
- Dead-letter queues with retry policies for sink delivery
- Avro/Protobuf schema registry
- Admin UI (event-bus config, DLQ viewer, delivery metrics)

The abstraction here is what those adapters register against, so they add without further core churn.

## Tests

Added unit tests (run serially, Release, warnings-as-errors):

- Publisher fires the sink on edits with the persisted envelope (`PublishAsync_WhenSinksEnabled_FansEventToSink`)
- No-op-only default path (`PublishAsync_WithNoOpSinkOnly_DoesNotThrow`)
- Broadcaster fan-out to every sink; disabled and no-sink no-op defaults; **per-sink failure isolation** (a throwing sink does not stop siblings or propagate to the write path)

`Honua.Server` build: Release, `TreatWarningsAsErrors=true`, 0 warnings. New + existing streaming-publisher tests: 17 passed. Architecture tests: the documentation/encapsulation/dependency/endpoint checks relevant to this change pass. Two pre-existing `FeatureCatalogDriftTests` failures (`DELETE /api/v1/admin/oauth-clients/{id}` missing from the committed catalog) are unrelated to this PR — it adds no routes.

## No migration

Sinks are config-driven, in-process fan-out — no schema change.

Refs #357