### PR TITLE
feat: back-office field export packages (#1160)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -308,6 +308,32 @@
       "maturity": "implemented"
     },
     {
+      "id": "delete-api-v1-admin-oauth-clients-id",
+      "route": "/api/v1/admin/oauth-clients/{id}",
+      "method": "DELETE",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.GetAndDeleteClient_RemovesRegistration"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "delete-api-v1-admin-oauth-scopes-scope",
+      "route": "/api/v1/admin/oauth-scopes/{scope}",
+      "method": "DELETE",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "delete-api-v1-admin-oidc-providers-id",
       "route": "/api/v1/admin/oidc/providers/{id}",
       "method": "DELETE",
@@ -587,6 +613,20 @@
       "maturity": "implemented"
     },
     {
+      "id": "delete-mcp",
+      "route": "/mcp",
+      "method": "DELETE",
+      "family": "MCP",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Delete_TerminatesSession_AndSubsequentUseReturns404",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Delete_UnknownSession_Returns404"
+      ],
+      "proof_ledger_surface": "mcp-operator",
+      "maturity": "implemented"
+    },
+    {
       "id": "delete-odata-features-layerid-layerid-objectid-objectid",
       "route": "/odata/Features(LayerId={layerId},ObjectId={objectId})",
       "method": "DELETE",
@@ -841,7 +881,9 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
-        "Honua.Server.Tests.Features.Admin.AdminApiKeyEndpointsTests.CreateAndListApiKeys_ReturnsPlaintextOnlyAtCreation"
+        "Honua.Server.Tests.Features.Admin.AdminApiKeyEndpointsTests.CreateAndListApiKeys_ReturnsPlaintextOnlyAtCreation",
+        "Honua.Server.Tests.Features.Admin.AdminApiKeyEndpointsTests.FullAdminApiKey_PassesAdminEndpoint",
+        "Honua.Server.Tests.Features.Admin.AdminApiKeyEndpointsTests.GenuinelyScopedApiKey_IsDeniedAdminEndpoint"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -1276,6 +1318,19 @@
         "Honua.Server.Tests.Features.Admin.AdminAuthorizationTests.GetFeatureOverview_WithoutAuth_Returns401",
         "Honua.Server.Tests.Features.Admin.PlatformAdminEndpointsTests.GetFeatureOverview_ProEdition_ShowsUpgradeMessagesForEnterprise",
         "Honua.Server.Tests.Features.Admin.PlatformAdminEndpointsTests.GetFeatureOverview_ReturnsEditionAndFeatures"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-field-workflows-exports",
+      "route": "/api/v1/admin/field-workflows/exports",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.FieldWorkflows.FieldExportEndpointsTests.CreateExport_GeoJson_ReturnsPackageRecordsAuditsAndListsHistory"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -2222,6 +2277,46 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Get_AfterRegister_ReturnsDataset",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Get_Missing_Returns404"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-clients",
+      "route": "/api/v1/admin/oauth-clients",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.ManagementSurface_RequiresAdminAuthorization",
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterAndListClient_ReturnsSecretOnlyAtCreation"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-clients-id",
+      "route": "/api/v1/admin/oauth-clients/{id}",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.GetAndDeleteClient_RemovesRegistration"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-scopes",
+      "route": "/api/v1/admin/oauth-scopes",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -4417,6 +4512,21 @@
         "Honua.Server.Tests.Infrastructure.Middleware.SecurityHeadersMiddlewareTests.SecurityHeaders_MultipleRequests_ConsistentlyAppliesHeaders"
       ],
       "proof_ledger_surface": "platform-http",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-mcp",
+      "route": "/mcp",
+      "method": "GET",
+      "family": "MCP",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Get_WithValidSession_OpensEventStream",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Get_WithoutEventStreamAccept_Returns405",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Get_WithoutValidSession_Returns404"
+      ],
+      "proof_ledger_surface": "mcp-operator",
       "maturity": "implemented"
     },
     {
@@ -10901,6 +11011,21 @@
       "maturity": "implemented"
     },
     {
+      "id": "post-api-v1-admin-field-workflows-exports",
+      "route": "/api/v1/admin/field-workflows/exports",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.FieldWorkflows.FieldExportEndpointsTests.CreateExport_Csv_ReturnsCsvWithHeaderAndFilteredRows",
+        "Honua.Server.Tests.Features.FieldWorkflows.FieldExportEndpointsTests.CreateExport_GeoJson_ReturnsPackageRecordsAuditsAndListsHistory",
+        "Honua.Server.Tests.Features.FieldWorkflows.FieldExportEndpointsTests.CreateExport_InvalidFormat_Returns400"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "post-api-v1-admin-field-workflows-submissions-submissionid-assignment",
       "route": "/api/v1/admin/field-workflows/submissions/{submissionId}/assignment",
       "method": "POST",
@@ -11859,6 +11984,20 @@
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Register_DuplicateId_Returns409",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Register_UnsafeEdgeTable_Returns400",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Register_ValidPayload_Returns201WithDto"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "post-api-v1-admin-oauth-clients",
+      "route": "/api/v1/admin/oauth-clients",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterAndListClient_ReturnsSecretOnlyAtCreation",
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterClient_WithInvalidClientType_ReturnsBadRequest"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -13266,7 +13405,9 @@
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.EmptyBatch_ReturnsInvalidRequestWithNullId",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.EmptyBody_ReturnsParseErrorWithNullId",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.FractionalId_IsRejectedAsInvalidRequest",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Initialize_Failure_DoesNotIssueSessionHeader",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Initialize_MissingClientInfo_ReturnsInvalidArgumentJsonRpcError",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Initialize_Success_IssuesMcpSessionIdHeader",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Initialize_WithSupportedVersion_NegotiatesAndReturnsServerInfo",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Initialize_WithUnsupportedVersion_FallsBackToLatestServerVersion",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Initialize_WithoutParams_ReturnsInvalidArgumentJsonRpcError",
@@ -13279,6 +13420,9 @@
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.NullId_IsRejectedAsInvalidRequest",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ObjectId_IsRejectedAsInvalidRequest",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.PrimitiveBody_ReturnsInvalidRequestWithNullId",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Request_WithEventStreamAccept_ReturnsSseMessageFrame",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Request_WithIssuedSessionId_IsAccepted",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Request_WithUnknownSessionId_Returns404",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ResourceTemplatesList_AdvertisesParameterizedUris",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ResourcesList_ExcludesParameterizedUris",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ResourcesRead_UnknownUri_ReturnsResourceNotFoundJsonRpcCode",
@@ -15993,8 +16137,10 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_AllItemsHaveStacFields",
+        "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WhenMorePagesExist_EmitsConformantPostNextLink",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithBbox_ReturnsFilteredResults",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithBody_ReturnsItems",
+        "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidPaginationToken_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidSortDirection_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidThreeDimensionalBbox_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithOutOfRangeBbox_ReturnsBadRequest",
@@ -16540,6 +16686,19 @@
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_ChangesMutableFields",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_Missing_Returns404",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_UnsafeVertexTable_Returns400"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "put-api-v1-admin-oauth-scopes",
+      "route": "/api/v1/admin/oauth-scopes",
+      "method": "PUT",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -530,6 +530,52 @@
       ]
     },
     {
+      "surfaceId": "field-workflows",
+      "displayName": "Back-office field workflows (review/QA and export packages)",
+      "surfaceKind": "http-route-family",
+      "protocol": "Admin API",
+      "canonicalIdentifier": "/api/v1/admin/field-workflows/**",
+      "parentSurfaceId": "control-plane-admin",
+      "endpointPrefixes": [
+        "/api/v1/admin/field-workflows/"
+      ],
+      "endpointExactMatches": [],
+      "endpointContains": [],
+      "operationKeys": [],
+      "proofs": [
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "EndpointRegistry coverage with FieldReviewEndpointsTests (#1159 list/get/assign/decide/comment) and FieldExportEndpointsTests (#1160 GeoJSON/CSV export generation, filtered record sets, audited export history, invalid-format rejection) integration tests.",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/EndpointRegistry.cs",
+            "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/FieldWorkflows/FieldReviewEndpointsTests.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/FieldWorkflows/FieldExportEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#1160",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "contract-governance",
+          "proofMechanism": "Source-generated FieldReviewJsonContext and FieldExportJsonContext keep the review and export wire shapes AOT-safe; the back-office field workflows API doc documents review state transitions, the export filter, export package contents, and the privacy posture (no raw values/geometry duplicated).",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "src/Honua.Core/Features/FieldWorkflows/Review/FieldReviewJsonContext.cs",
+            "src/Honua.Core/Features/FieldWorkflows/Export/FieldExportJsonContext.cs",
+            "src/Honua.Core/Features/FieldWorkflows/Export/FieldExportContracts.cs",
+            "docs/internal/developer/back-office-field-workflows-api.md"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#1160",
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
       "surfaceId": "content-publication-registry",
       "displayName": "Content publication registry and published artifact routes",
       "surfaceKind": "http-route-family",

--- a/docs/internal/developer/back-office-field-workflows-api.md
+++ b/docs/internal/developer/back-office-field-workflows-api.md
@@ -6,6 +6,7 @@ Covers:
 
 - **#1158** — published-form offline compatibility & migration signals (layered on the [Form Package API](../../reference/admin-api/forms.md)).
 - **#1159** — field data review & QA over mobile-submitted records.
+- **#1160** — back-office field export packages (on-demand GeoJSON / CSV record sets, audited export history).
 
 Related slices: [Form Package API](../../reference/admin-api/forms.md), [FieldCollection Mobile Sync API](fieldcollection-mobile-sync-api.md).
 
@@ -62,6 +63,47 @@ Expected failures: `400` (invalid body, invalid decision status, bad filter valu
 
 > **Sync status note:** `syncStatus` is derived from the underlying submission lifecycle (`synced` / `rejected` / `failed` / `pending`) so reviewers never read provider-internal status values. Submitted geometry is applied to the target feature at submit time and is not duplicated in the review projection (`geometry` is null); use the target FeatureServer/OGC read surfaces for current geometry.
 
+## Field export packages (#1160)
+
+Back-office operators generate **on-demand export packages** over the same reviewed
+record set the review surface exposes. The export selection reuses the review filter
+(project/form/service/layer/date-range/review-state/sync-state/conflict) so an export
+contains exactly the records a reviewer can see. Every export is **audited**
+(`AuditEventType.AdminAction`, `resourceType = field_export`) and gated by **admin
+authorization**. Each generated package is recorded durably in
+`honua.field_export_records` so operators retain an audit trail and mobile screens can
+surface export availability without re-running the export.
+
+Routes are registered when an `IFieldExportStore` is available (Postgres provider).
+
+| Method | Route | Success | Contract |
+|---|---|---:|---|
+| `POST` | `/api/v1/admin/field-workflows/exports` | `200` | Generates and streams the export package. Body `FieldExportRequest`; the response body is the serialized record set (`application/geo+json` or `text/csv`) with `Content-Disposition: attachment`, plus `X-Honua-Export-Id` / `X-Honua-Export-Count` headers. |
+| `GET` | `/api/v1/admin/field-workflows/exports` | `200` | Lists previously generated export records (`FieldExportRecordListResult`); `no-store`. Query: `limit` (1–500, default 50), `offset`. |
+
+### `FieldExportRequest` (`Honua.Core.Features.FieldWorkflows.Export`)
+
+`format` (`geojson` (default) \| `csv`), plus the review filter fields: `formId`,
+`serviceId`, `layerId`, `reviewStatus`, `assignedTo`, `syncStatus`, `hasConflict`,
+`submittedFrom`, `submittedTo` (ISO-8601). Expected failures: `400` (invalid `format`
+or `reviewStatus`).
+
+### Record-set contents
+
+The package emits the review-resolved submission projection
+(`submissionId`, `formId`, `formVersion`, `serviceId`, `layerId`, `targetFeatureId`,
+`operation`, `syncStatus`, `hasValidationIssues`, `hasConflict`, `submitterHash`,
+`deviceId`, `attachmentCount`, `submittedAt`, and the review state:
+`reviewStatus`, `assignedTo`, `decidedBy`, `decidedAt`, `decisionNote`). As with the
+review projection, raw user-entered field values and submitted geometry are **not**
+duplicated (`honua.form_submissions` persists only sanitized submission metadata for
+privacy; GeoJSON `geometry` is `null`). Use the target FeatureServer/OGC read surfaces
+for applied geometry and attribute values.
+
+> **Deferred (follow-up slices of #1160):** scheduled/recurring report packages,
+> PDF and GeoPackage report formats, attachment bundling, and console report-template
+> authoring. These build on this on-demand record-set export and remain tracked on #1160.
+
 ## SDK / mobile dependency surface
 
 Mobile and console consume these contracts via published packages only:
@@ -74,6 +116,6 @@ Mobile-side follow-ups are limited to UX/adapters that call these routes and bin
 
 ## Source map
 
-- Core contracts: `src/Honua.Core/Features/Forms/Packages/FormCompatibilityContracts.cs`, `src/Honua.Core/Features/FieldWorkflows/Review/`.
-- Server routes/services: `src/Honua.Server/Features/Forms/` (compatibility), `src/Honua.Server/Features/FieldWorkflows/Review/`.
-- Postgres persistence: `src/Honua.Postgres/Features/FieldWorkflows/PostgresFieldReviewStore.cs` (migration `050_CreateFieldReview.sql`).
+- Core contracts: `src/Honua.Core/Features/Forms/Packages/FormCompatibilityContracts.cs`, `src/Honua.Core/Features/FieldWorkflows/Review/`, `src/Honua.Core/Features/FieldWorkflows/Export/`.
+- Server routes/services: `src/Honua.Server/Features/Forms/` (compatibility), `src/Honua.Server/Features/FieldWorkflows/Review/`, `src/Honua.Server/Features/FieldWorkflows/Export/`.
+- Postgres persistence: `src/Honua.Postgres/Features/FieldWorkflows/PostgresFieldReviewStore.cs` (migration `050_CreateFieldReview.sql`), `src/Honua.Postgres/Features/FieldWorkflows/PostgresFieldExportStore.cs` (migration `067_CreateFieldExportRecords.sql`).

--- a/src/Honua.Core/Features/FieldWorkflows/Export/FieldExportContracts.cs
+++ b/src/Honua.Core/Features/FieldWorkflows/Export/FieldExportContracts.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.FieldWorkflows.Review;
+
+namespace Honua.Core.Features.FieldWorkflows.Export;
+
+/// <summary>
+/// Server-owned, format identifiers for back-office field export packages (#1160).
+/// </summary>
+public static class FieldExportFormat
+{
+    /// <summary>GeoJSON <c>FeatureCollection</c> record set.</summary>
+    public const string GeoJson = "geojson";
+
+    /// <summary>Flat CSV record set.</summary>
+    public const string Csv = "csv";
+
+    /// <summary>Enumerates the supported export formats.</summary>
+    public static readonly string[] All = [GeoJson, Csv];
+
+    /// <summary>Whether the supplied value is a recognized export format.</summary>
+    public static bool IsValid(string? format)
+        => format is not null && Array.Exists(All, f => string.Equals(f, format, StringComparison.Ordinal));
+
+    /// <summary>The MIME content type emitted for the supplied format.</summary>
+    public static string ContentType(string format) => format switch
+    {
+        GeoJson => "application/geo+json",
+        Csv => "text/csv; charset=utf-8",
+        _ => "application/octet-stream"
+    };
+
+    /// <summary>The file extension (without leading dot) for the supplied format.</summary>
+    public static string Extension(string format) => format switch
+    {
+        GeoJson => "geojson",
+        Csv => "csv",
+        _ => "bin"
+    };
+}
+
+/// <summary>
+/// Request describing a back-office field export package: the record-set filter
+/// (project/form/service/layer/date-range/review-state) and the desired output
+/// format. The filter mirrors <see cref="FieldReviewQuery"/> so an export selects
+/// exactly the reviewed records the review surface exposes. This is the canonical
+/// server contract consumed by the console and by mobile SDK clients; mobile must
+/// not define a local equivalent.
+/// </summary>
+public sealed class FieldExportRequest
+{
+    /// <summary>Output format, one of <see cref="FieldExportFormat"/>. Defaults to GeoJSON.</summary>
+    [JsonPropertyName("format")]
+    public string Format { get; init; } = FieldExportFormat.GeoJson;
+
+    /// <summary>Restrict to a single form package id.</summary>
+    [JsonPropertyName("formId")]
+    public string? FormId { get; init; }
+
+    /// <summary>Restrict to a single target service id (project scope).</summary>
+    [JsonPropertyName("serviceId")]
+    public string? ServiceId { get; init; }
+
+    /// <summary>Restrict to a single target layer id.</summary>
+    [JsonPropertyName("layerId")]
+    public int? LayerId { get; init; }
+
+    /// <summary>Restrict to a single review status, one of <see cref="FieldReviewStatus"/>.</summary>
+    [JsonPropertyName("reviewStatus")]
+    public string? ReviewStatus { get; init; }
+
+    /// <summary>Restrict to records assigned to a reviewer.</summary>
+    [JsonPropertyName("assignedTo")]
+    public string? AssignedTo { get; init; }
+
+    /// <summary>Restrict to a single sync status, one of <see cref="FieldSyncStatus"/>.</summary>
+    [JsonPropertyName("syncStatus")]
+    public string? SyncStatus { get; init; }
+
+    /// <summary>When set, restrict to records flagged as conflicting.</summary>
+    [JsonPropertyName("hasConflict")]
+    public bool? HasConflict { get; init; }
+
+    /// <summary>Inclusive lower bound on submission time.</summary>
+    [JsonPropertyName("submittedFrom")]
+    public DateTimeOffset? SubmittedFrom { get; init; }
+
+    /// <summary>Inclusive upper bound on submission time.</summary>
+    [JsonPropertyName("submittedTo")]
+    public DateTimeOffset? SubmittedTo { get; init; }
+}
+
+/// <summary>
+/// Durable, audited record of a generated field export package. Persisted on every
+/// export so back-office operators retain an audit trail of what was exported, by
+/// whom, and against which filter. Mobile screens can list these records to surface
+/// export availability without re-running the export.
+/// </summary>
+public sealed class FieldExportRecord
+{
+    /// <summary>Stable export identifier.</summary>
+    [JsonPropertyName("exportId")]
+    public Guid ExportId { get; init; }
+
+    /// <summary>Output format the package was generated in.</summary>
+    [JsonPropertyName("format")]
+    public string Format { get; init; } = string.Empty;
+
+    /// <summary>Number of submission records included in the package.</summary>
+    [JsonPropertyName("recordCount")]
+    public long RecordCount { get; init; }
+
+    /// <summary>Sanitized JSON description of the filter applied to the export.</summary>
+    [JsonPropertyName("filter")]
+    public string Filter { get; init; } = "{}";
+
+    /// <summary>Actor that generated the export.</summary>
+    [JsonPropertyName("requestedBy")]
+    public string RequestedBy { get; init; } = string.Empty;
+
+    /// <summary>UTC timestamp the export was generated.</summary>
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset CreatedAt { get; init; }
+}
+
+/// <summary>
+/// Page of export records returned by an export-history listing.
+/// </summary>
+public sealed class FieldExportRecordListResult
+{
+    /// <summary>Export records in this page, newest first.</summary>
+    [JsonPropertyName("items")]
+    public FieldExportRecord[] Items { get; init; } = [];
+
+    /// <summary>Total export records, ignoring paging.</summary>
+    [JsonPropertyName("total")]
+    public long Total { get; init; }
+
+    /// <summary>Limit applied to this page.</summary>
+    [JsonPropertyName("limit")]
+    public int Limit { get; init; }
+
+    /// <summary>Offset applied to this page.</summary>
+    [JsonPropertyName("offset")]
+    public int Offset { get; init; }
+}
+
+/// <summary>
+/// The materialized output of a field export package: the selected record set and
+/// the durable record describing the export.
+/// </summary>
+public sealed class FieldExportPackage
+{
+    /// <summary>The durable export record (also persisted for the audit trail).</summary>
+    public FieldExportRecord Record { get; init; } = new();
+
+    /// <summary>The selected submission records included in the package.</summary>
+    public FieldSubmissionRecord[] Items { get; init; } = [];
+}

--- a/src/Honua.Core/Features/FieldWorkflows/Export/FieldExportJsonContext.cs
+++ b/src/Honua.Core/Features/FieldWorkflows/Export/FieldExportJsonContext.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.FieldWorkflows.Export;
+
+/// <summary>
+/// Source-generated JSON context for back-office field export contracts.
+/// </summary>
+[JsonSourceGenerationOptions(
+    JsonSerializerDefaults.General,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(FieldExportRequest))]
+[JsonSerializable(typeof(FieldExportRecord))]
+[JsonSerializable(typeof(FieldExportRecord[]))]
+[JsonSerializable(typeof(FieldExportRecordListResult))]
+public sealed partial class FieldExportJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Core/Features/FieldWorkflows/Export/IFieldExportStore.cs
+++ b/src/Honua.Core/Features/FieldWorkflows/Export/IFieldExportStore.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.FieldWorkflows.Export;
+
+/// <summary>
+/// Durable store for back-office field export packages (#1160). Selects the
+/// reviewed submission record set matching an export filter and persists an
+/// audited <see cref="FieldExportRecord"/> describing each generated package.
+/// </summary>
+public interface IFieldExportStore
+{
+    /// <summary>
+    /// Selects the submission record set matching <paramref name="request"/> and
+    /// persists a durable export record. Returns the materialized package
+    /// (selected records plus the persisted export record).
+    /// </summary>
+    Task<FieldExportPackage> CreateExportAsync(
+        FieldExportRequest request,
+        string requestedBy,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists previously generated export records, newest first.
+    /// </summary>
+    Task<FieldExportRecordListResult> ListExportsAsync(
+        int limit,
+        int offset,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Postgres/Features/FieldWorkflows/PostgresFieldExportStore.cs
+++ b/src/Honua.Postgres/Features/FieldWorkflows/PostgresFieldExportStore.cs
@@ -1,0 +1,408 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.FieldWorkflows.Export;
+using Honua.Core.Features.FieldWorkflows.Review;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Infrastructure;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.FieldWorkflows;
+
+/// <summary>
+/// PostgreSQL-backed store for back-office field export packages (#1160). Selects
+/// the reviewed submission record set via the same projection the review surface
+/// uses (<c>honua.form_submissions</c> joined with
+/// <c>honua.field_submission_reviews</c>) and persists an audited export record in
+/// <c>honua.field_export_records</c>.
+/// </summary>
+internal sealed class PostgresFieldExportStore : IFieldExportStore
+{
+    private const int MaxExportRows = 50_000;
+    private const int MaxListLimit = 500;
+
+    private readonly IAdoNetDatabaseConnectionProvider _connectionProvider;
+    private readonly string _submissionsTable;
+    private readonly string _attachmentsTable;
+    private readonly string _reviewsTable;
+    private readonly string _exportsTable;
+
+    public PostgresFieldExportStore(IAdoNetDatabaseConnectionProvider connectionProvider)
+    {
+        _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+        _submissionsTable = SchemaSearchPath.QualifyTable("form_submissions", "honua");
+        _attachmentsTable = SchemaSearchPath.QualifyTable("form_submission_attachments", "honua");
+        _reviewsTable = SchemaSearchPath.QualifyTable("field_submission_reviews", "honua");
+        _exportsTable = SchemaSearchPath.QualifyTable("field_export_records", "honua");
+    }
+
+    public async Task<FieldExportPackage> CreateExportAsync(
+        FieldExportRequest request,
+        string requestedBy,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(requestedBy);
+
+        var where = BuildWhereClause(request);
+        var selectSql = $"""
+            SELECT
+                s.submission_id, s.form_id, s.form_version, s.service_id, s.layer_id,
+                s.target_feature_id, s.operation, s.status, s.actor_hash,
+                s.request_summary::text, s.validation_json::text, s.created_at,
+                COALESCE(r.status, 'pending') AS review_status,
+                r.assigned_to, r.decided_by, r.decided_at, r.decision_note,
+                COALESCE(r.updated_at, s.created_at) AS review_updated_at,
+                r.etag AS review_etag, COALESCE(r.has_conflict, false) AS has_conflict,
+                (SELECT COUNT(*) FROM {_attachmentsTable} a
+                    WHERE a.submission_id = s.submission_id AND a.status = 'accepted') AS attachment_count
+            FROM {_submissionsTable} s
+            LEFT JOIN {_reviewsTable} r ON r.submission_id = s.submission_id
+            {where}
+            ORDER BY s.created_at DESC, s.submission_id
+            LIMIT @max_rows
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        var items = new List<FieldSubmissionRecord>();
+        await using (var command = new NpgsqlCommand(selectSql, connection))
+        {
+            AddFilterParameters(command, request);
+            command.Parameters.AddWithValue("max_rows", NpgsqlDbType.Integer, MaxExportRows);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                items.Add(ReadRecord(reader));
+            }
+        }
+
+        var exportId = Guid.NewGuid();
+        var filterJson = BuildFilterJson(request);
+        var insertSql = $"""
+            INSERT INTO {_exportsTable}
+                (export_id, format, record_count, filter, requested_by, created_at)
+            VALUES (@export_id, @format, @record_count, @filter, @requested_by, now())
+            RETURNING export_id, format, record_count, filter::text, requested_by, created_at
+            """;
+
+        FieldExportRecord record;
+        await using (var command = new NpgsqlCommand(insertSql, connection))
+        {
+            command.Parameters.AddWithValue("export_id", NpgsqlDbType.Uuid, exportId);
+            command.Parameters.AddWithValue("format", NpgsqlDbType.Text, request.Format);
+            command.Parameters.AddWithValue("record_count", NpgsqlDbType.Bigint, (long)items.Count);
+            command.Parameters.AddWithValue("filter", NpgsqlDbType.Jsonb, filterJson);
+            command.Parameters.AddWithValue("requested_by", NpgsqlDbType.Text, requestedBy);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            _ = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            record = ReadExportRecord(reader);
+        }
+
+        return new FieldExportPackage
+        {
+            Record = record,
+            Items = items.ToArray()
+        };
+    }
+
+    public async Task<FieldExportRecordListResult> ListExportsAsync(
+        int limit,
+        int offset,
+        CancellationToken cancellationToken = default)
+    {
+        var clampedLimit = Math.Clamp(limit <= 0 ? 50 : limit, 1, MaxListLimit);
+        var clampedOffset = Math.Max(0, offset);
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        long total;
+        await using (var countCommand = new NpgsqlCommand($"SELECT COUNT(*) FROM {_exportsTable}", connection))
+        {
+            total = (long)(await countCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) ?? 0L);
+        }
+
+        var listSql = $"""
+            SELECT export_id, format, record_count, filter::text, requested_by, created_at
+            FROM {_exportsTable}
+            ORDER BY created_at DESC, export_id
+            LIMIT @limit OFFSET @offset
+            """;
+
+        var items = new List<FieldExportRecord>();
+        await using (var command = new NpgsqlCommand(listSql, connection))
+        {
+            command.Parameters.AddWithValue("limit", NpgsqlDbType.Integer, clampedLimit);
+            command.Parameters.AddWithValue("offset", NpgsqlDbType.Integer, clampedOffset);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                items.Add(ReadExportRecord(reader));
+            }
+        }
+
+        return new FieldExportRecordListResult
+        {
+            Items = items.ToArray(),
+            Total = total,
+            Limit = clampedLimit,
+            Offset = clampedOffset
+        };
+    }
+
+    private static string BuildWhereClause(FieldExportRequest request)
+    {
+        var clauses = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(request.FormId))
+        {
+            clauses.Add("s.form_id = @form_id");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ServiceId))
+        {
+            clauses.Add("s.service_id = @service_id");
+        }
+
+        if (request.LayerId is not null)
+        {
+            clauses.Add("s.layer_id = @layer_id");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ReviewStatus))
+        {
+            clauses.Add("COALESCE(r.status, 'pending') = @review_status");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.AssignedTo))
+        {
+            clauses.Add("r.assigned_to = @assigned_to");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.SyncStatus))
+        {
+            clauses.Add("s.status = @sync_status");
+        }
+
+        if (request.HasConflict is not null)
+        {
+            clauses.Add("COALESCE(r.has_conflict, false) = @has_conflict");
+        }
+
+        if (request.SubmittedFrom is not null)
+        {
+            clauses.Add("s.created_at >= @submitted_from");
+        }
+
+        if (request.SubmittedTo is not null)
+        {
+            clauses.Add("s.created_at <= @submitted_to");
+        }
+
+        return clauses.Count > 0 ? "WHERE " + string.Join(" AND ", clauses) : string.Empty;
+    }
+
+    private static void AddFilterParameters(NpgsqlCommand command, FieldExportRequest request)
+    {
+        if (!string.IsNullOrWhiteSpace(request.FormId))
+        {
+            command.Parameters.AddWithValue("form_id", NpgsqlDbType.Text, request.FormId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ServiceId))
+        {
+            command.Parameters.AddWithValue("service_id", NpgsqlDbType.Text, request.ServiceId);
+        }
+
+        if (request.LayerId is int layerId)
+        {
+            command.Parameters.AddWithValue("layer_id", NpgsqlDbType.Integer, layerId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ReviewStatus))
+        {
+            command.Parameters.AddWithValue("review_status", NpgsqlDbType.Text, request.ReviewStatus);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.AssignedTo))
+        {
+            command.Parameters.AddWithValue("assigned_to", NpgsqlDbType.Text, request.AssignedTo);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.SyncStatus))
+        {
+            command.Parameters.AddWithValue("sync_status", NpgsqlDbType.Text, MapSyncStatusToSubmissionStatus(request.SyncStatus));
+        }
+
+        if (request.HasConflict is bool hasConflict)
+        {
+            command.Parameters.AddWithValue("has_conflict", NpgsqlDbType.Boolean, hasConflict);
+        }
+
+        if (request.SubmittedFrom is DateTimeOffset from)
+        {
+            command.Parameters.AddWithValue("submitted_from", NpgsqlDbType.TimestampTz, from);
+        }
+
+        if (request.SubmittedTo is DateTimeOffset to)
+        {
+            command.Parameters.AddWithValue("submitted_to", NpgsqlDbType.TimestampTz, to);
+        }
+    }
+
+    private static string BuildFilterJson(FieldExportRequest request)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("format", request.Format);
+            WriteOptionalString(writer, "formId", request.FormId);
+            WriteOptionalString(writer, "serviceId", request.ServiceId);
+            if (request.LayerId is int layerId)
+            {
+                writer.WriteNumber("layerId", layerId);
+            }
+
+            WriteOptionalString(writer, "reviewStatus", request.ReviewStatus);
+            WriteOptionalString(writer, "assignedTo", request.AssignedTo);
+            WriteOptionalString(writer, "syncStatus", request.SyncStatus);
+            if (request.HasConflict is bool hasConflict)
+            {
+                writer.WriteBoolean("hasConflict", hasConflict);
+            }
+
+            if (request.SubmittedFrom is DateTimeOffset from)
+            {
+                writer.WriteString("submittedFrom", from);
+            }
+
+            if (request.SubmittedTo is DateTimeOffset to)
+            {
+                writer.WriteString("submittedTo", to);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+
+        static void WriteOptionalString(Utf8JsonWriter writer, string name, string? value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                writer.WriteString(name, value);
+            }
+        }
+    }
+
+    private static FieldExportRecord ReadExportRecord(NpgsqlDataReader reader)
+        => new()
+        {
+            ExportId = reader.GetGuid(0),
+            Format = reader.GetString(1),
+            RecordCount = reader.GetInt64(2),
+            Filter = reader.IsDBNull(3) ? "{}" : reader.GetString(3),
+            RequestedBy = reader.GetString(4),
+            CreatedAt = reader.GetFieldValue<DateTimeOffset>(5)
+        };
+
+    private static FieldSubmissionRecord ReadRecord(NpgsqlDataReader reader)
+    {
+        var requestSummaryJson = reader.IsDBNull(9) ? null : reader.GetString(9);
+        var validationJson = reader.IsDBNull(10) ? null : reader.GetString(10);
+        var submissionStatus = reader.GetString(7);
+        var deviceId = ExtractStringMember(requestSummaryJson, "clientId");
+
+        return new FieldSubmissionRecord
+        {
+            SubmissionId = reader.GetGuid(0),
+            FormId = reader.GetString(1),
+            FormVersion = reader.GetInt32(2),
+            ServiceId = reader.GetString(3),
+            LayerId = reader.GetInt32(4),
+            TargetFeatureId = reader.IsDBNull(5) ? null : reader.GetInt64(5),
+            Operation = reader.GetString(6),
+            SyncStatus = MapSubmissionStatusToSyncStatus(submissionStatus),
+            HasValidationIssues = validationJson is not null,
+            Validation = ParseJson(validationJson),
+            Geometry = null,
+            SubmitterHash = reader.IsDBNull(8) ? null : reader.GetString(8),
+            DeviceId = deviceId,
+            AttachmentCount = (int)reader.GetInt64(20),
+            HasConflict = reader.GetBoolean(19),
+            SubmittedAt = reader.GetFieldValue<DateTimeOffset>(11),
+            Review = new FieldReviewState
+            {
+                Status = reader.GetString(12),
+                AssignedTo = reader.IsDBNull(13) ? null : reader.GetString(13),
+                DecidedBy = reader.IsDBNull(14) ? null : reader.GetString(14),
+                DecidedAt = reader.IsDBNull(15) ? null : reader.GetFieldValue<DateTimeOffset>(15),
+                DecisionNote = reader.IsDBNull(16) ? null : reader.GetString(16),
+                UpdatedAt = reader.GetFieldValue<DateTimeOffset>(17),
+                ETag = reader.IsDBNull(18) ? string.Empty : reader.GetString(18)
+            }
+        };
+    }
+
+    private static JsonElement? ParseJson(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? ExtractStringMember(string? json, string member)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.ValueKind == JsonValueKind.Object
+                && document.RootElement.TryGetProperty(member, out var value)
+                && value.ValueKind == JsonValueKind.String
+                    ? value.GetString()
+                    : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string MapSubmissionStatusToSyncStatus(string submissionStatus)
+        => submissionStatus switch
+        {
+            "accepted" => FieldSyncStatus.Synced,
+            "rejected" => FieldSyncStatus.Rejected,
+            "failed" => FieldSyncStatus.Failed,
+            _ => FieldSyncStatus.Pending
+        };
+
+    private static string MapSyncStatusToSubmissionStatus(string syncStatus)
+        => syncStatus switch
+        {
+            FieldSyncStatus.Synced => "accepted",
+            FieldSyncStatus.Rejected => "rejected",
+            FieldSyncStatus.Failed => "failed",
+            _ => "pending"
+        };
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -173,6 +173,10 @@ internal static class ServiceCollectionExtensions
         services.AddScoped<Honua.Core.Features.FieldWorkflows.Review.IFieldReviewStore,
             Features.FieldWorkflows.PostgresFieldReviewStore>();
 
+        // Register back-office field export store (#1160)
+        services.AddScoped<Honua.Core.Features.FieldWorkflows.Export.IFieldExportStore,
+            Features.FieldWorkflows.PostgresFieldExportStore>();
+
         // Register Metadata v2 graph store (Postgres-backed JSONB + sidecar indexes)
         services.AddScoped<IMetadataV2GraphStore>(serviceProvider =>
             new Features.Metadata.PostgresMetadataV2GraphStore(

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -586,6 +586,10 @@ public static class EndpointRegistry
         new("POST", "/api/v1/admin/field-workflows/submissions/{submissionId}/decision"),
         new("POST", "/api/v1/admin/field-workflows/submissions/{submissionId}/comments"),
 
+        // Back-office field export packages (#1160)
+        new("POST", "/api/v1/admin/field-workflows/exports"),
+        new("GET", "/api/v1/admin/field-workflows/exports"),
+
         new("POST", "/api/v1/admin/tile-operations/jobs"),
         new("GET", "/api/v1/admin/tile-operations/jobs/{jobId}"),
         new("GET", "/api/v1/admin/tile-operations/jobs"),

--- a/src/Honua.Server/Features/FieldWorkflows/Export/FieldExportEndpoints.cs
+++ b/src/Honua.Server/Features/FieldWorkflows/Export/FieldExportEndpoints.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FieldWorkflows.Export;
+using Honua.Infrastructure.Authentication;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.FieldWorkflows.Export;
+
+/// <summary>
+/// Admin REST surface for back-office field export packages (#1160). Every route
+/// requires admin authorization and adapts to the shared
+/// <see cref="FieldExportService"/>; every export is audited and respects the same
+/// tenancy/RBAC posture as the review surface.
+/// </summary>
+internal static class FieldExportEndpoints
+{
+    public static IEndpointRouteBuilder MapFieldExportEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var serviceInspector = endpoints.ServiceProvider.GetService<IServiceProviderIsService>();
+        if (serviceInspector is not null && !serviceInspector.IsService(typeof(IFieldExportStore)))
+        {
+            return endpoints;
+        }
+
+        var admin = endpoints.MapGroup("/api/v{version:apiVersion}/admin/field-workflows/exports")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "FieldWorkflows")
+            .RequireAdminAuthorization();
+
+        admin.MapPost("", HandleCreate)
+            .WithName("CreateFieldExport")
+            .WithSummary("Generate a field export package over selected projects/forms/date-ranges/review-states (GeoJSON or CSV).")
+            .WithMetadata(new HttpMethodMetadata([HttpMethods.Post]))
+            .Produces(StatusCodes.Status200OK, contentType: "application/geo+json")
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        admin.MapGet("", HandleList)
+            .WithName("ListFieldExports")
+            .WithSummary("List previously generated field export packages (audit trail).")
+            .WithMetadata(new HttpMethodMetadata([HttpMethods.Get]))
+            .Produces<FieldExportRecordListResult>();
+
+        return endpoints;
+    }
+
+    private static Task<IResult> HandleCreate(
+        HttpContext context,
+        [FromServices] FieldExportService service)
+        => service.CreateAsync(context);
+
+    private static Task<IResult> HandleList(
+        HttpContext context,
+        [FromServices] FieldExportService service)
+        => service.ListAsync(context);
+}

--- a/src/Honua.Server/Features/FieldWorkflows/Export/FieldExportSerializer.cs
+++ b/src/Honua.Server/Features/FieldWorkflows/Export/FieldExportSerializer.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using Honua.Core.Features.FieldWorkflows.Export;
+using Honua.Core.Features.FieldWorkflows.Review;
+
+namespace Honua.Server.Features.FieldWorkflows.Export;
+
+/// <summary>
+/// Serializes a back-office field export record set into the requested format
+/// (GeoJSON <c>FeatureCollection</c> or CSV). Emits the review-resolved submission
+/// projection (form/service/layer/operation/sync state, submitter hash, device id,
+/// attachment count, review state, decision metadata, timestamps). Raw field values
+/// are intentionally excluded; <c>honua.form_submissions</c> persists only sanitized
+/// submission metadata for privacy, so the export carries metadata and review/audit
+/// state rather than user-entered values or raw geometry.
+/// </summary>
+internal static class FieldExportSerializer
+{
+    private static readonly string[] CsvHeader =
+    [
+        "submissionId", "formId", "formVersion", "serviceId", "layerId",
+        "targetFeatureId", "operation", "syncStatus", "hasValidationIssues",
+        "hasConflict", "submitterHash", "deviceId", "attachmentCount", "submittedAt",
+        "reviewStatus", "assignedTo", "decidedBy", "decidedAt", "decisionNote"
+    ];
+
+    /// <summary>
+    /// Serializes <paramref name="items"/> into a UTF-8 byte payload for the
+    /// supplied <paramref name="format"/>.
+    /// </summary>
+    public static byte[] Serialize(string format, FieldSubmissionRecord[] items)
+        => format switch
+        {
+            FieldExportFormat.Csv => SerializeCsv(items),
+            _ => SerializeGeoJson(items)
+        };
+
+    private static byte[] SerializeGeoJson(FieldSubmissionRecord[] items)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new System.Text.Json.Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "FeatureCollection");
+            writer.WriteStartArray("features");
+
+            foreach (var item in items)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("type", "Feature");
+
+                // No raw geometry is persisted for field submissions (privacy); the
+                // GeoJSON geometry is null and the record metadata lives in properties.
+                writer.WriteNull("geometry");
+
+                writer.WriteStartObject("properties");
+                writer.WriteString("submissionId", item.SubmissionId.ToString());
+                writer.WriteString("formId", item.FormId);
+                writer.WriteNumber("formVersion", item.FormVersion);
+                writer.WriteString("serviceId", item.ServiceId);
+                writer.WriteNumber("layerId", item.LayerId);
+                if (item.TargetFeatureId is long targetFeatureId)
+                {
+                    writer.WriteNumber("targetFeatureId", targetFeatureId);
+                }
+
+                writer.WriteString("operation", item.Operation);
+                writer.WriteString("syncStatus", item.SyncStatus);
+                writer.WriteBoolean("hasValidationIssues", item.HasValidationIssues);
+                writer.WriteBoolean("hasConflict", item.HasConflict);
+                WriteOptional(writer, "submitterHash", item.SubmitterHash);
+                WriteOptional(writer, "deviceId", item.DeviceId);
+                writer.WriteNumber("attachmentCount", item.AttachmentCount);
+                writer.WriteString("submittedAt", item.SubmittedAt);
+                writer.WriteString("reviewStatus", item.Review.Status);
+                WriteOptional(writer, "assignedTo", item.Review.AssignedTo);
+                WriteOptional(writer, "decidedBy", item.Review.DecidedBy);
+                if (item.Review.DecidedAt is DateTimeOffset decidedAt)
+                {
+                    writer.WriteString("decidedAt", decidedAt);
+                }
+
+                WriteOptional(writer, "decisionNote", item.Review.DecisionNote);
+                writer.WriteEndObject();
+
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        return stream.ToArray();
+
+        static void WriteOptional(System.Text.Json.Utf8JsonWriter writer, string name, string? value)
+        {
+            if (value is not null)
+            {
+                writer.WriteString(name, value);
+            }
+        }
+    }
+
+    private static byte[] SerializeCsv(FieldSubmissionRecord[] items)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine(string.Join(',', CsvHeader));
+
+        foreach (var item in items)
+        {
+            var fields = new[]
+            {
+                item.SubmissionId.ToString(),
+                item.FormId,
+                item.FormVersion.ToString(CultureInfo.InvariantCulture),
+                item.ServiceId,
+                item.LayerId.ToString(CultureInfo.InvariantCulture),
+                item.TargetFeatureId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+                item.Operation,
+                item.SyncStatus,
+                item.HasValidationIssues ? "true" : "false",
+                item.HasConflict ? "true" : "false",
+                item.SubmitterHash ?? string.Empty,
+                item.DeviceId ?? string.Empty,
+                item.AttachmentCount.ToString(CultureInfo.InvariantCulture),
+                item.SubmittedAt.ToString("O", CultureInfo.InvariantCulture),
+                item.Review.Status,
+                item.Review.AssignedTo ?? string.Empty,
+                item.Review.DecidedBy ?? string.Empty,
+                item.Review.DecidedAt?.ToString("O", CultureInfo.InvariantCulture) ?? string.Empty,
+                item.Review.DecisionNote ?? string.Empty
+            };
+
+            builder.AppendLine(string.Join(',', Array.ConvertAll(fields, EscapeCsv)));
+        }
+
+        return Encoding.UTF8.GetBytes(builder.ToString());
+    }
+
+    private static string EscapeCsv(string value)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        var mustQuote = value.IndexOfAny([',', '"', '\n', '\r']) >= 0;
+        if (!mustQuote)
+        {
+            return value;
+        }
+
+        return "\"" + value.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/Honua.Server/Features/FieldWorkflows/Export/FieldExportService.cs
+++ b/src/Honua.Server/Features/FieldWorkflows/Export/FieldExportService.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Security.Claims;
+using System.Text.Json;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.FieldWorkflows.Export;
+using Honua.Core.Features.FieldWorkflows.Review;
+using Honua.Infrastructure.Models;
+using Honua.ServiceDefaults;
+
+namespace Honua.Server.Features.FieldWorkflows.Export;
+
+/// <summary>
+/// Back-office field export package service (#1160). Adapts admin requests into the
+/// shared <see cref="IFieldExportStore"/>, serializes the selected record set with
+/// <see cref="FieldExportSerializer"/>, audits every export, and maps failures
+/// through shared problem helpers. Authorization is enforced at the route group via
+/// <c>RequireAdminAuthorization</c>.
+/// </summary>
+internal sealed class FieldExportService
+{
+    private const int MaxListLimit = 500;
+
+    private readonly IFieldExportStore _store;
+    private readonly IAuditLog _auditLog;
+    private readonly ILogger<FieldExportService> _logger;
+
+    public FieldExportService(
+        IFieldExportStore store,
+        IAuditLog auditLog,
+        ILogger<FieldExportService> logger)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _auditLog = auditLog ?? throw new ArgumentNullException(nameof(auditLog));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IResult> CreateAsync(HttpContext context)
+    {
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("FieldExport.Create");
+        activity?.SetTag("honua.protocol", "field-workflows");
+        activity?.SetTag("honua.operation", "create-export");
+
+        var request = await ReadAsync(context, FieldExportJsonContext.Default.FieldExportRequest).ConfigureAwait(false)
+            ?? new FieldExportRequest();
+
+        var format = string.IsNullOrWhiteSpace(request.Format) ? FieldExportFormat.GeoJson : request.Format.Trim().ToLowerInvariant();
+        if (!FieldExportFormat.IsValid(format))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status400BadRequest,
+                $"format must be one of: {string.Join(", ", FieldExportFormat.All)}.");
+        }
+
+        var reviewStatus = Trimmed(request.ReviewStatus);
+        if (reviewStatus is not null && !FieldReviewStatus.IsValid(reviewStatus))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status400BadRequest,
+                $"reviewStatus must be one of: {string.Join(", ", FieldReviewStatus.All)}.");
+        }
+
+        var normalized = new FieldExportRequest
+        {
+            Format = format,
+            FormId = Trimmed(request.FormId),
+            ServiceId = Trimmed(request.ServiceId),
+            LayerId = request.LayerId,
+            ReviewStatus = reviewStatus,
+            AssignedTo = Trimmed(request.AssignedTo),
+            SyncStatus = Trimmed(request.SyncStatus),
+            HasConflict = request.HasConflict,
+            SubmittedFrom = request.SubmittedFrom,
+            SubmittedTo = request.SubmittedTo
+        };
+
+        var actor = ResolveActor(context);
+        var package = await _store.CreateExportAsync(normalized, actor, context.RequestAborted).ConfigureAwait(false);
+        var payload = FieldExportSerializer.Serialize(format, package.Items);
+
+        activity?.SetTag("honua.result_count", package.Items.Length);
+        activity?.SetTag("honua.export_format", format);
+
+        await RecordAuditAsync(context, "field.export.create", package.Record.ExportId, AuditOutcome.Success,
+            $"{{\"format\":{JsonString(format)},\"recordCount\":{package.Record.RecordCount.ToString(CultureInfo.InvariantCulture)}}}").ConfigureAwait(false);
+        FieldExportLog.Created(_logger, package.Record.ExportId, format, package.Record.RecordCount);
+
+        ApplyNoStore(context.Response);
+        context.Response.Headers["X-Honua-Export-Id"] = package.Record.ExportId.ToString();
+        context.Response.Headers["X-Honua-Export-Count"] = package.Record.RecordCount.ToString(CultureInfo.InvariantCulture);
+        var filename = $"field-export-{package.Record.ExportId}.{FieldExportFormat.Extension(format)}";
+        context.Response.Headers.ContentDisposition = $"attachment; filename=\"{filename}\"";
+        return Results.Bytes(payload, FieldExportFormat.ContentType(format));
+    }
+
+    public async Task<IResult> ListAsync(HttpContext context)
+    {
+        var limit = TryParseInt(context.Request.Query["limit"]) is int l ? Math.Clamp(l, 1, MaxListLimit) : 50;
+        var offset = TryParseInt(context.Request.Query["offset"]) is int o ? Math.Max(0, o) : 0;
+
+        var result = await _store.ListExportsAsync(limit, offset, context.RequestAborted).ConfigureAwait(false);
+        ApplyNoStore(context.Response);
+        return Results.Json(result, FieldExportJsonContext.Default.FieldExportRecordListResult);
+    }
+
+    private static async Task<T?> ReadAsync<T>(HttpContext context, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> typeInfo)
+        where T : class
+    {
+        if (context.Request.ContentLength is 0 || context.Request.ContentLength is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return await JsonSerializer.DeserializeAsync(context.Request.Body, typeInfo, context.RequestAborted).ConfigureAwait(false);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? Trimmed(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static int? TryParseInt(string? value)
+        => int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) ? parsed : null;
+
+    private static void ApplyNoStore(HttpResponse response)
+    {
+        response.Headers.CacheControl = "no-store";
+        response.Headers.Pragma = "no-cache";
+    }
+
+    private static string ResolveActor(HttpContext context)
+        => context.User.FindFirstValue(ClaimTypes.NameIdentifier)
+           ?? context.User.Identity?.Name
+           ?? AuditEvent.AnonymousActor;
+
+    private static string JsonString(string? value)
+        => value is null ? "null" : "\"" + JsonEncodedText.Encode(value) + "\"";
+
+    private Task RecordAuditAsync(
+        HttpContext context,
+        string action,
+        Guid exportId,
+        AuditOutcome outcome,
+        string details)
+        => _auditLog.RecordAsync(new AuditEvent
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            EventType = AuditEventType.AdminAction,
+            Actor = ResolveActor(context),
+            ActorType = context.User.Identity?.IsAuthenticated == true ? AuditActorType.UserId : AuditActorType.Anonymous,
+            ResourceType = "field_export",
+            ResourceId = exportId.ToString(),
+            Action = action,
+            Outcome = outcome,
+            CorrelationId = context.TraceIdentifier,
+            RemoteIp = context.Connection.RemoteIpAddress?.ToString(),
+            UserAgent = context.Request.Headers.UserAgent.ToString(),
+            Details = details
+        }, context.RequestAborted);
+}
+
+internal static partial class FieldExportLog
+{
+    [LoggerMessage(EventId = 118510, Level = LogLevel.Information, Message = "Generated field export {ExportId} ({Format}) covering {RecordCount} records.")]
+    public static partial void Created(ILogger logger, Guid exportId, string format, long recordCount);
+}

--- a/src/Honua.Server/Features/FieldWorkflows/FieldWorkflowsServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/FieldWorkflows/FieldWorkflowsServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Server.Features.FieldWorkflows.Export;
 using Honua.Server.Features.FieldWorkflows.Review;
 
 namespace Honua.Server.Features.FieldWorkflows;
@@ -16,6 +17,7 @@ internal static class FieldWorkflowsServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddScoped<FieldReviewService>();
+        services.AddScoped<FieldExportService>();
 
         return services;
     }

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -22,6 +22,7 @@ using Honua.Protocols.GeoServices.FeatureServer;
 using Honua.Server.Features.Geocoding;
 using Honua.Server.Features.Forms;
 using Honua.Server.Features.FieldWorkflows;
+using Honua.Server.Features.FieldWorkflows.Export;
 using Honua.Server.Features.FieldWorkflows.Review;
 using Honua.Ai.Grounding.Spec;
 using Honua.Protocols.GeoServices.GeometryService;
@@ -235,6 +236,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapGeocodingEndpoints();
         endpoints.MapFormPackageEndpoints();
         endpoints.MapFieldReviewEndpoints();
+        endpoints.MapFieldExportEndpoints();
         endpoints.MapCogEndpoints();
         endpoints.MapMultidimensionalCoverageEndpoints();
         endpoints.MapZarrEndpoints();

--- a/src/Honua.Server/Migrations/067_CreateFieldExportRecords.sql
+++ b/src/Honua.Server/Migrations/067_CreateFieldExportRecords.sql
@@ -1,0 +1,21 @@
+-- Migration: 067_CreateFieldExportRecords.sql
+-- Back-office field export packages (#1160). Durable, audited record of each
+-- generated field export package (format, filter, record count, requester) layered
+-- over the existing honua.form_submissions / honua.field_submission_reviews record
+-- set without mutating submissions or review state.
+
+CREATE SCHEMA IF NOT EXISTS honua;
+
+CREATE TABLE IF NOT EXISTS honua.field_export_records (
+    export_id     UUID        NOT NULL PRIMARY KEY,
+    format        TEXT        NOT NULL,
+    record_count  BIGINT      NOT NULL DEFAULT 0,
+    filter        JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    requested_by  TEXT        NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT field_export_records_valid_format
+        CHECK (format IN ('geojson', 'csv'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_field_export_records_created
+    ON honua.field_export_records(created_at DESC);

--- a/tests/dotnet/Honua.Architecture.Tests/ErrorHandlingPolicyTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/ErrorHandlingPolicyTests.cs
@@ -77,6 +77,7 @@ public sealed class ErrorHandlingPolicyTests
         Path.Combine("src", "Honua.Server", "Features", "DataEnrichment", "DataEnrichmentEndpoints.cs"),
         Path.Combine("src", "Honua.Server", "Features", "FileStorage", "FileStorageEndpoints.cs"),
         Path.Combine("src", "Honua.Server", "Features", "Forms", "FormPackageEndpoints.cs"),
+        Path.Combine("src", "Honua.Server", "Features", "FieldWorkflows", "Export", "FieldExportEndpoints.cs"),
         Path.Combine("src", "Honua.Server", "Features", "FieldWorkflows", "Review", "FieldReviewEndpoints.cs"),
         Path.Combine("src", "Honua.Server", "Features", "Geocoding", "GeocodingEndpoints.cs"),
         Path.Combine("src", "Honua.Server", "Features", "Infrastructure", "Caching", "CachingEndpoints.cs"),

--- a/tests/dotnet/Honua.Server.Tests/Features/FieldWorkflows/FieldExportEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/FieldWorkflows/FieldExportEndpointsTests.cs
@@ -1,0 +1,233 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.FieldWorkflows.Export;
+using Honua.Core.Features.FieldWorkflows.Review;
+using Honua.Core.Features.Forms.Packages;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Features.FieldWorkflows;
+
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+public sealed class FieldExportEndpointsTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Configuration)]
+    [Endpoint("POST /api/v1/admin/field-workflows/exports")]
+    [Endpoint("GET /api/v1/admin/field-workflows/exports")]
+    public async Task CreateExport_GeoJson_ReturnsPackageRecordsAuditsAndListsHistory()
+    {
+        var submissionId = await SeedSubmissionAsync("export-geojson", "Inspection export A");
+
+        var response = await _fixture.Client.PostAsync(
+            "/api/v1/admin/field-workflows/exports",
+            JsonContent(new FieldExportRequest { Format = FieldExportFormat.GeoJson },
+                FieldExportJsonContext.Default.FieldExportRequest));
+
+        var body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/geo+json");
+        response.Headers.GetValues("X-Honua-Export-Id").Should().ContainSingle();
+
+        using var document = JsonDocument.Parse(body);
+        document.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        var features = document.RootElement.GetProperty("features");
+        features.GetArrayLength().Should().BeGreaterThanOrEqualTo(1);
+
+        var exported = false;
+        foreach (var feature in features.EnumerateArray())
+        {
+            var props = feature.GetProperty("properties");
+            if (props.GetProperty("submissionId").GetString() == submissionId.ToString())
+            {
+                props.GetProperty("syncStatus").GetString().Should().Be(FieldSyncStatus.Synced);
+                props.GetProperty("reviewStatus").GetString().Should().Be(FieldReviewStatus.Pending);
+                feature.GetProperty("geometry").ValueKind.Should().Be(JsonValueKind.Null);
+                exported = true;
+            }
+        }
+
+        exported.Should().BeTrue("the seeded submission must appear in the export package");
+
+        // The export is recorded for the audit trail.
+        var auditCount = await CountAuditAsync("field.export.create");
+        auditCount.Should().BeGreaterThanOrEqualTo(1);
+
+        // Export history lists the generated package.
+        var history = await GetJsonAsync(
+            "/api/v1/admin/field-workflows/exports",
+            FieldExportJsonContext.Default.FieldExportRecordListResult);
+        history.Total.Should().BeGreaterThanOrEqualTo(1);
+        history.Items.Should().Contain(item =>
+            item.Format == FieldExportFormat.GeoJson && item.RecordCount >= 1);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Configuration)]
+    [Endpoint("POST /api/v1/admin/field-workflows/exports")]
+    public async Task CreateExport_Csv_ReturnsCsvWithHeaderAndFilteredRows()
+    {
+        var included = await SeedSubmissionAsync("export-csv-included", "Included record");
+        _ = await SeedSubmissionAsync("export-csv-other-service", "Other record");
+
+        // Reject the "included" record so we can filter by review status.
+        var decision = await _fixture.Client.PostAsync(
+            $"/api/v1/admin/field-workflows/submissions/{included}/decision",
+            JsonContent(new FieldReviewDecisionRequest { Status = FieldReviewStatus.Rejected },
+                FieldReviewJsonContext.Default.FieldReviewDecisionRequest));
+        decision.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var response = await _fixture.Client.PostAsync(
+            "/api/v1/admin/field-workflows/exports",
+            JsonContent(new FieldExportRequest
+            {
+                Format = FieldExportFormat.Csv,
+                ReviewStatus = FieldReviewStatus.Rejected
+            },
+            FieldExportJsonContext.Default.FieldExportRequest));
+
+        var csv = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, csv);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/csv");
+
+        var lines = csv.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        lines[0].Should().StartWith("submissionId,formId,formVersion");
+        csv.Should().Contain(included.ToString());
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Configuration)]
+    [Endpoint("POST /api/v1/admin/field-workflows/exports")]
+    public async Task CreateExport_InvalidFormat_Returns400()
+    {
+        var response = await _fixture.Client.PostAsync(
+            "/api/v1/admin/field-workflows/exports",
+            JsonContent(new FieldExportRequest { Format = "pdf" },
+                FieldExportJsonContext.Default.FieldExportRequest));
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    private async Task<Guid> SeedSubmissionAsync(string suffix, string name)
+    {
+        using var scope = _fixture.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IFormPackageStore>();
+
+        var draft = await store.SaveDraftAsync(CreatePackage("Field export " + suffix), "test-admin");
+        var published = await store.PublishAsync(
+            draft.FormId,
+            draft.Version,
+            new FormPackageValidationResult { IsValid = true },
+            "test-admin")
+            ?? throw new InvalidOperationException("Failed to publish seeded form package.");
+
+        var submission = new FormSubmissionRequest
+        {
+            IdempotencyKey = suffix,
+            Operation = FormSubmissionOperations.Create,
+            ClientId = "field-client-1",
+            Values = new Dictionary<string, JsonElement>
+            {
+                ["name"] = JsonDocument.Parse(JsonSerializer.Serialize(name)).RootElement.Clone()
+            }
+        };
+
+        var submissionId = Guid.NewGuid();
+        var claimed = await store.CreateSubmissionAsync(
+            submissionId,
+            suffix,
+            "actor-hash-" + suffix,
+            "request-hash-" + suffix,
+            published,
+            submission,
+            "pending");
+        claimed.Should().BeTrue();
+
+        await store.CompleteSubmissionAsync(
+            submissionId,
+            new FormSubmissionResponse
+            {
+                SubmissionId = submissionId,
+                Status = "accepted",
+                FormId = published.FormId,
+                FormVersion = published.Version,
+                Operation = FormSubmissionOperations.Create,
+                TargetFeatureId = 1
+            },
+            "accepted");
+
+        return submissionId;
+    }
+
+    private async Task<long> CountAuditAsync(string action)
+    {
+        await using var connection = await _fixture.Postgres.GetConnectionAsync(_fixture.CurrentSchema);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM honua.audit_log
+            WHERE resource_type = 'field_export'
+              AND action = @action;
+            """;
+        command.Parameters.AddWithValue("action", action);
+        return (long)(await command.ExecuteScalarAsync() ?? 0L);
+    }
+
+    private async Task<T> GetJsonAsync<T>(string path, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> jsonTypeInfo)
+    {
+        var response = await _fixture.Client.GetAsync(path);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadAsStringAsync();
+        var value = JsonSerializer.Deserialize(payload, jsonTypeInfo);
+        value.Should().NotBeNull(payload);
+        return value!;
+    }
+
+    private static StringContent JsonContent<T>(T value, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> jsonTypeInfo)
+        => new(JsonSerializer.Serialize(value, jsonTypeInfo), Encoding.UTF8, "application/json");
+
+    private static FormPackageDocument CreatePackage(string title)
+        => new()
+        {
+            Title = title,
+            Target = new FormTargetDefinition
+            {
+                ServiceId = WebAppFixture.TestServiceId,
+                LayerId = WebAppFixture.TestLayerId
+            },
+            Sections =
+            [
+                new FormSectionDefinition { SectionId = "main", Label = "Main", FieldIds = ["name"] }
+            ],
+            Fields =
+            [
+                new FormFieldDefinition
+                {
+                    FieldId = "name",
+                    Label = "Name",
+                    Type = "text",
+                    TargetField = "name",
+                    Required = true,
+                    SectionId = "main"
+                }
+            ],
+            SubmitPolicy = new FormSubmitPolicy
+            {
+                AllowedOperations = [FormSubmissionOperations.Create],
+                RequiresGeometry = true
+            },
+            OfflinePolicy = new FormOfflinePolicy { Enabled = true }
+        };
+}

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -1242,7 +1242,19 @@ sql:
           created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
       );
   - "CREATE INDEX IF NOT EXISTS idx_field_review_comments_submission ON honua.field_review_comments(submission_id, created_at);"
+  - |
+      CREATE TABLE IF NOT EXISTS honua.field_export_records (
+          export_id     UUID        NOT NULL PRIMARY KEY,
+          format        TEXT        NOT NULL,
+          record_count  BIGINT      NOT NULL DEFAULT 0,
+          filter        JSONB       NOT NULL DEFAULT '{}'::jsonb,
+          requested_by  TEXT        NOT NULL,
+          created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+          CONSTRAINT field_export_records_valid_format CHECK (format IN ('geojson', 'csv'))
+      );
+  - "CREATE INDEX IF NOT EXISTS idx_field_export_records_created ON honua.field_export_records(created_at DESC);"
   - "ALTER TABLE IF EXISTS honua.form_package_versions DISABLE TRIGGER USER;"
+  - "DELETE FROM honua.field_export_records;"
   - "DELETE FROM honua.field_review_comments;"
   - "DELETE FROM honua.field_submission_reviews;"
   - "DELETE FROM honua.form_submission_attachments;"


### PR DESCRIPTION
## Summary

First coherent, mergeable slice of **#1160 (back-office field exports & report package parity)**: an **on-demand field export package** surface for back-office operators.

Admin users generate export packages over selected projects/forms/layers/date-ranges/review-states and download the result as **GeoJSON** or **CSV**. The selection reuses the same filter shape as the #1159 review surface, so an export contains exactly the reviewed records a supervisor can see. Every export is **admin-authorized**, **audited** (`resourceType = field_export`), and recorded durably for an export-history audit trail.

### Endpoints (registered in EndpointRegistry, feature catalog, proof ledger)
- `POST /api/v1/admin/field-workflows/exports` — generate + stream the package (`application/geo+json` or `text/csv`, `Content-Disposition: attachment`, `X-Honua-Export-Id`/`-Count` headers).
- `GET /api/v1/admin/field-workflows/exports` — list previously generated export records.

### Architecture
- Contracts + `IFieldExportStore` live in `Honua.Core/Features/FieldWorkflows/Export` (server contracts, not mobile DTOs — AC #3).
- Postgres store adapts the shared review record-set projection (no duplicate data-access path); new `honua.field_export_records` table via **migration 067**, mirrored into `tests/seed/server.yaml`.
- Thin Minimal-API adapter delegating to a shared `FieldExportService` (AOT-safe source-generated JSON, structured logging, shared problem helpers, telemetry).

## Acceptance criteria status
- [x] Admin users can generate export packages for selected projects/forms/date-ranges/review-states.
- [x] Export generation respects RBAC (admin auth) and audit requirements.
- [x] Mobile dependencies exposed via server contracts (`Honua.Core...Export`), not `honua-mobile` DTOs.
- [x] Tests cover export authorization path, package creation, filtered record sets, and a mobile-submitted fixture.

## Deferred (still tracked on #1160)
Scheduled/recurring report packages, PDF and GeoPackage report formats, attachment bundling, and console report-template authoring. Raw field values and submitted geometry are intentionally **not** duplicated in the export — `honua.form_submissions` persists only sanitized submission metadata for privacy (GeoJSON `geometry` is `null`); the export carries the review-resolved metadata + audit/review state.

## Tests
- `Honua.Architecture.Tests`: **116 passed** (endpoint registry coverage, proof-ledger governance, feature-catalog drift, error-handling policy). Regenerated `feature-catalog.json` (also caught up pre-existing oauth/mcp drift).
- `Honua.Server.Tests` (Testcontainers + PostGIS, run serially): `FieldExportEndpointsTests` + `FieldReviewEndpointsTests` **7 passed**.
- Release build with warnings-as-errors: **0 warnings, 0 errors** (Core, Postgres, Server).

Refs #1160.