### PR TITLE
feat: federated-query planning core and admin surface (#341)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -308,6 +308,32 @@
       "maturity": "implemented"
     },
     {
+      "id": "delete-api-v1-admin-oauth-clients-id",
+      "route": "/api/v1/admin/oauth-clients/{id}",
+      "method": "DELETE",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.GetAndDeleteClient_RemovesRegistration"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "delete-api-v1-admin-oauth-scopes-scope",
+      "route": "/api/v1/admin/oauth-scopes/{scope}",
+      "method": "DELETE",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "delete-api-v1-admin-oidc-providers-id",
       "route": "/api/v1/admin/oidc/providers/{id}",
       "method": "DELETE",
@@ -587,6 +613,20 @@
       "maturity": "implemented"
     },
     {
+      "id": "delete-mcp",
+      "route": "/mcp",
+      "method": "DELETE",
+      "family": "MCP",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Delete_TerminatesSession_AndSubsequentUseReturns404",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Delete_UnknownSession_Returns404"
+      ],
+      "proof_ledger_surface": "mcp-operator",
+      "maturity": "implemented"
+    },
+    {
       "id": "delete-odata-features-layerid-layerid-objectid-objectid",
       "route": "/odata/Features(LayerId={layerId},ObjectId={objectId})",
       "method": "DELETE",
@@ -841,7 +881,9 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
-        "Honua.Server.Tests.Features.Admin.AdminApiKeyEndpointsTests.CreateAndListApiKeys_ReturnsPlaintextOnlyAtCreation"
+        "Honua.Server.Tests.Features.Admin.AdminApiKeyEndpointsTests.CreateAndListApiKeys_ReturnsPlaintextOnlyAtCreation",
+        "Honua.Server.Tests.Features.Admin.AdminApiKeyEndpointsTests.FullAdminApiKey_PassesAdminEndpoint",
+        "Honua.Server.Tests.Features.Admin.AdminApiKeyEndpointsTests.GenuinelyScopedApiKey_IsDeniedAdminEndpoint"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -1276,6 +1318,33 @@
         "Honua.Server.Tests.Features.Admin.AdminAuthorizationTests.GetFeatureOverview_WithoutAuth_Returns401",
         "Honua.Server.Tests.Features.Admin.PlatformAdminEndpointsTests.GetFeatureOverview_ProEdition_ShowsUpgradeMessagesForEnterprise",
         "Honua.Server.Tests.Features.Admin.PlatformAdminEndpointsTests.GetFeatureOverview_ReturnsEditionAndFeatures"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-federation-sources",
+      "route": "/api/v1/admin/federation/sources",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.Federation.FederationEndpointsTests.ListSources_ReturnsConfiguredSourcesWithoutCredentials"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-federation-sources-id-plan",
+      "route": "/api/v1/admin/federation/sources/{id}/plan",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.Federation.FederationEndpointsTests.PlanQuery_EsriRestWithWhereAndBbox_RefinesNothingAndPushesDown",
+        "Honua.Server.Tests.Features.Admin.Federation.FederationEndpointsTests.PlanQuery_UnknownSource_Returns404"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -2222,6 +2291,46 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Get_AfterRegister_ReturnsDataset",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Get_Missing_Returns404"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-clients",
+      "route": "/api/v1/admin/oauth-clients",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.ManagementSurface_RequiresAdminAuthorization",
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterAndListClient_ReturnsSecretOnlyAtCreation"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-clients-id",
+      "route": "/api/v1/admin/oauth-clients/{id}",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.GetAndDeleteClient_RemovesRegistration"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-oauth-scopes",
+      "route": "/api/v1/admin/oauth-scopes",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -4417,6 +4526,21 @@
         "Honua.Server.Tests.Infrastructure.Middleware.SecurityHeadersMiddlewareTests.SecurityHeaders_MultipleRequests_ConsistentlyAppliesHeaders"
       ],
       "proof_ledger_surface": "platform-http",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-mcp",
+      "route": "/mcp",
+      "method": "GET",
+      "family": "MCP",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Get_WithValidSession_OpensEventStream",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Get_WithoutEventStreamAccept_Returns405",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Get_WithoutValidSession_Returns404"
+      ],
+      "proof_ledger_surface": "mcp-operator",
       "maturity": "implemented"
     },
     {
@@ -11864,6 +11988,20 @@
       "maturity": "implemented"
     },
     {
+      "id": "post-api-v1-admin-oauth-clients",
+      "route": "/api/v1/admin/oauth-clients",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterAndListClient_ReturnsSecretOnlyAtCreation",
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.RegisterClient_WithInvalidClientType_ReturnsBadRequest"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "post-api-v1-admin-observability-alerts-eventid-acknowledge",
       "route": "/api/v1/admin/observability/alerts/{eventId}/acknowledge",
       "method": "POST",
@@ -13266,7 +13404,9 @@
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.EmptyBatch_ReturnsInvalidRequestWithNullId",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.EmptyBody_ReturnsParseErrorWithNullId",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.FractionalId_IsRejectedAsInvalidRequest",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Initialize_Failure_DoesNotIssueSessionHeader",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Initialize_MissingClientInfo_ReturnsInvalidArgumentJsonRpcError",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Initialize_Success_IssuesMcpSessionIdHeader",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Initialize_WithSupportedVersion_NegotiatesAndReturnsServerInfo",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Initialize_WithUnsupportedVersion_FallsBackToLatestServerVersion",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Initialize_WithoutParams_ReturnsInvalidArgumentJsonRpcError",
@@ -13279,6 +13419,9 @@
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.NullId_IsRejectedAsInvalidRequest",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ObjectId_IsRejectedAsInvalidRequest",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.PrimitiveBody_ReturnsInvalidRequestWithNullId",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Request_WithEventStreamAccept_ReturnsSseMessageFrame",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Request_WithIssuedSessionId_IsAccepted",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Request_WithUnknownSessionId_Returns404",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ResourceTemplatesList_AdvertisesParameterizedUris",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ResourcesList_ExcludesParameterizedUris",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ResourcesRead_UnknownUri_ReturnsResourceNotFoundJsonRpcCode",
@@ -15993,8 +16136,10 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_AllItemsHaveStacFields",
+        "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WhenMorePagesExist_EmitsConformantPostNextLink",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithBbox_ReturnsFilteredResults",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithBody_ReturnsItems",
+        "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidPaginationToken_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidSortDirection_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidThreeDimensionalBbox_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithOutOfRangeBbox_ReturnsBadRequest",
@@ -16540,6 +16685,19 @@
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_ChangesMutableFields",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_Missing_Returns404",
         "Honua.Server.Tests.Features.Admin.NetworkDatasetAdminEndpointsTests.Update_UnsafeVertexTable_Returns400"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "put-api-v1-admin-oauth-scopes",
+      "route": "/api/v1/admin/oauth-scopes",
+      "method": "PUT",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OAuthClientEndpointsTests.DefineListDeleteScope_RoundTrips"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"

--- a/src/Honua.Core/Features/Federation/Abstractions/IFederationQueryPlanner.cs
+++ b/src/Honua.Core/Features/Federation/Abstractions/IFederationQueryPlanner.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Federation.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.Federation.Abstractions;
+
+/// <summary>
+/// Plans how a canonical <see cref="FeatureQuery"/> is split across a federated source and
+/// the local federation layer: which predicates push down to the remote source and which
+/// are refined locally. Planning is pure and deterministic so it can run offline, ahead of
+/// any remote call, and be unit-tested without a live remote warehouse.
+/// </summary>
+public interface IFederationQueryPlanner
+{
+    /// <summary>
+    /// Resolves the offline push-down capabilities for a federated source kind.
+    /// </summary>
+    /// <param name="kind">The transport family of the remote source.</param>
+    /// <returns>The capabilities used to drive push-down decisions.</returns>
+    FederatedSourceCapabilities ResolveCapabilities(FederatedSourceKind kind);
+
+    /// <summary>
+    /// Builds the federation plan for a query against a single source.
+    /// </summary>
+    /// <param name="source">The target federated source descriptor.</param>
+    /// <param name="query">The canonical query to plan.</param>
+    /// <param name="joinsLocalLayer">
+    /// <see langword="true"/> when the query combines the remote source with a local
+    /// PostGIS layer, which forces a local join step.
+    /// </param>
+    /// <returns>The push-down / local-refinement plan.</returns>
+    FederationQueryPlan Plan(FederatedSourceDescriptor source, in FeatureQuery query, bool joinsLocalLayer);
+}

--- a/src/Honua.Core/Features/Federation/Abstractions/IFederationSourceRegistry.cs
+++ b/src/Honua.Core/Features/Federation/Abstractions/IFederationSourceRegistry.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.Federation.Domain;
+
+namespace Honua.Core.Features.Federation.Abstractions;
+
+/// <summary>
+/// Read access to the configured federated data sources for a deployment. Implementations
+/// resolve sources from configuration (or, in a later increment, from the metadata-resource
+/// store) and never expose transport credentials.
+/// </summary>
+public interface IFederationSourceRegistry
+{
+    /// <summary>
+    /// Gets all configured federated sources, including disabled ones.
+    /// </summary>
+    ImmutableArray<FederatedSourceDescriptor> GetSources();
+
+    /// <summary>
+    /// Attempts to resolve a single source by its identifier.
+    /// </summary>
+    /// <param name="id">The source identifier (case-insensitive).</param>
+    /// <param name="descriptor">The resolved descriptor when found.</param>
+    /// <returns><see langword="true"/> when a source with the identifier exists.</returns>
+    bool TryGetSource(string id, out FederatedSourceDescriptor descriptor);
+}

--- a/src/Honua.Core/Features/Federation/Domain/FederatedSourceCapabilities.cs
+++ b/src/Honua.Core/Features/Federation/Domain/FederatedSourceCapabilities.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Federation.Domain;
+
+/// <summary>
+/// Describes which canonical query predicates a federated source can evaluate remotely
+/// (push-down) versus which the federation layer must evaluate locally after fetching
+/// candidate rows. Capabilities are a pure function of the <see cref="FederatedSourceKind"/>
+/// and are resolved offline, so query planning never contacts the remote source.
+/// </summary>
+public sealed record FederatedSourceCapabilities
+{
+    /// <summary>
+    /// Gets a value indicating whether attribute (<c>WHERE</c> / CQL2) predicates push down.
+    /// </summary>
+    public required bool SupportsAttributeFilterPushdown { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether spatial (bbox / envelope) predicates push down.
+    /// </summary>
+    public required bool SupportsSpatialFilterPushdown { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether spatial relationships beyond a simple envelope
+    /// intersection (for example <c>Within</c>, <c>Crosses</c>, distance, nearest-neighbor)
+    /// push down. When <see langword="false"/> the federation layer fetches an envelope
+    /// superset and refines the exact relationship locally.
+    /// </summary>
+    public required bool SupportsExactSpatialRelationshipPushdown { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether temporal interval predicates push down.
+    /// </summary>
+    public required bool SupportsTemporalFilterPushdown { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether ordering (<c>ORDER BY</c>) pushes down. When
+    /// <see langword="false"/> the federation layer applies the sort locally.
+    /// </summary>
+    public required bool SupportsOrderByPushdown { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether result paging (offset/limit) pushes down. When
+    /// <see langword="false"/> the federation layer must over-fetch and page locally.
+    /// </summary>
+    public required bool SupportsPagingPushdown { get; init; }
+}

--- a/src/Honua.Core/Features/Federation/Domain/FederatedSourceDescriptor.cs
+++ b/src/Honua.Core/Features/Federation/Domain/FederatedSourceDescriptor.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Federation.Domain;
+
+/// <summary>
+/// Configuration descriptor for a federated data source. A descriptor names a remote
+/// source, declares its transport <see cref="FederatedSourceKind"/>, and points at the
+/// remote service endpoint plus the remote layer/collection that backs a federated join.
+/// </summary>
+/// <remarks>
+/// The descriptor carries only non-secret configuration. Transport credentials are
+/// resolved separately through the existing secure-connection / secret-reference
+/// infrastructure, so a descriptor is safe to surface through the Admin API and to use in
+/// offline query planning. See issue #341.
+/// </remarks>
+public sealed record FederatedSourceDescriptor
+{
+    /// <summary>
+    /// Gets the stable identifier for the source, unique within the deployment.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Gets the human-readable display name for the source.
+    /// </summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the transport family of the remote source.
+    /// </summary>
+    public required FederatedSourceKind Kind { get; init; }
+
+    /// <summary>
+    /// Gets the base endpoint URL of the remote service.
+    /// </summary>
+    public required Uri Endpoint { get; init; }
+
+    /// <summary>
+    /// Gets the remote layer or collection identifier that this source exposes for
+    /// federated joins (for example an Esri layer id, an OGC collection id, or a Honua
+    /// service/layer id).
+    /// </summary>
+    public required string RemoteLayer { get; init; }
+
+    /// <summary>
+    /// Gets the per-request timeout applied to remote calls. Combined with the circuit
+    /// breaker, this bounds the blast radius of a slow or failing remote source.
+    /// </summary>
+    public required TimeSpan RequestTimeout { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the source is currently enabled for federation.
+    /// Disabled sources are configurable and inspectable but excluded from query planning.
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+}

--- a/src/Honua.Core/Features/Federation/Domain/FederatedSourceKind.cs
+++ b/src/Honua.Core/Features/Federation/Domain/FederatedSourceKind.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Federation.Domain;
+
+/// <summary>
+/// Transport family of a federated data source. The kind determines which query
+/// predicates a remote source can evaluate in-place (push-down) versus which the
+/// federation layer must evaluate locally after fetching candidate rows.
+/// </summary>
+/// <remarks>
+/// See issue #341 (federated queries) and ADR-0024 (enterprise tier). The kind is a
+/// pure capability discriminator; it carries no transport credentials and is safe to
+/// evaluate offline, which keeps query planning deterministic and testable without a
+/// live remote warehouse.
+/// </remarks>
+public enum FederatedSourceKind
+{
+    /// <summary>
+    /// Another Honua instance reached over the canonical gRPC feature-service transport.
+    /// Honua-to-Honua sources share the canonical filter model, so attribute, spatial,
+    /// and temporal predicates all push down.
+    /// </summary>
+    HonuaGrpc,
+
+    /// <summary>
+    /// A remote Esri ArcGIS REST feature service reached over HTTP. The Esri REST query
+    /// API accepts a SQL-like <c>where</c> clause and a spatial envelope, so attribute and
+    /// spatial predicates push down but temporal interval filters are evaluated locally.
+    /// </summary>
+    EsriRest,
+
+    /// <summary>
+    /// A remote OGC API - Features or WFS endpoint reached over HTTP. CQL2 attribute and
+    /// bbox spatial predicates push down; richer spatial relationships and ordering are
+    /// evaluated locally.
+    /// </summary>
+    OgcWfs
+}

--- a/src/Honua.Core/Features/Federation/Domain/FederationQueryPlan.cs
+++ b/src/Honua.Core/Features/Federation/Domain/FederationQueryPlan.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+
+namespace Honua.Core.Features.Federation.Domain;
+
+/// <summary>
+/// Identifies a single canonical predicate that a federated query carries.
+/// </summary>
+public enum FederationPredicateKind
+{
+    /// <summary>Attribute filter (<c>WHERE</c> / parameterized SQL / object-id set).</summary>
+    AttributeFilter,
+
+    /// <summary>Spatial filter (envelope or richer spatial relationship).</summary>
+    SpatialFilter,
+
+    /// <summary>Temporal interval filter.</summary>
+    TemporalFilter,
+
+    /// <summary>Result ordering (<c>ORDER BY</c>).</summary>
+    OrderBy,
+
+    /// <summary>Result paging (offset/limit).</summary>
+    Paging
+}
+
+/// <summary>
+/// Records where a single predicate is evaluated in a federated query: pushed down to the
+/// remote source, or evaluated locally by the federation layer after rows are fetched.
+/// </summary>
+/// <param name="Predicate">The predicate this decision applies to.</param>
+/// <param name="PushedDown">
+/// <see langword="true"/> when the remote source evaluates the predicate; otherwise the
+/// federation layer evaluates it locally.
+/// </param>
+/// <param name="Reason">Human-readable explanation for the decision (diagnostics / Admin UI).</param>
+public readonly record struct FederationPredicateDecision(
+    FederationPredicateKind Predicate,
+    bool PushedDown,
+    string Reason);
+
+/// <summary>
+/// The plan produced for a single federated source: which predicates the remote source
+/// evaluates, which the federation layer refines locally, and whether a local join step is
+/// required to combine the remote rows with a local PostGIS layer.
+/// </summary>
+public sealed record FederationQueryPlan
+{
+    /// <summary>
+    /// Gets the source this plan targets.
+    /// </summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>
+    /// Gets the resolved capabilities used to build the plan.
+    /// </summary>
+    public required FederatedSourceCapabilities Capabilities { get; init; }
+
+    /// <summary>
+    /// Gets the per-predicate push-down decisions.
+    /// </summary>
+    public required ImmutableArray<FederationPredicateDecision> Decisions { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether any predicate must be evaluated locally after the
+    /// remote fetch. When <see langword="true"/> the federation layer over-fetches a
+    /// candidate superset from the remote source and refines it locally.
+    /// </summary>
+    public bool RequiresLocalRefinement => Decisions.Any(static d => !d.PushedDown);
+
+    /// <summary>
+    /// Gets a value indicating whether the plan combines the remote source with a local
+    /// PostGIS layer through a local join step.
+    /// </summary>
+    public required bool RequiresLocalJoin { get; init; }
+}

--- a/src/Honua.Core/Features/Federation/ServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Federation/ServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Federation.Abstractions;
+using Honua.Core.Features.Federation.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Core.Features.Federation;
+
+/// <summary>
+/// Service registration helpers for the federated-query planning core (issue #341).
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the federation query planner. The planner is pure and stateless, so it is
+    /// registered as a singleton.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddFederationCore(this IServiceCollection services)
+    {
+        services.TryAddSingleton<IFederationQueryPlanner, FederationQueryPlanner>();
+        return services;
+    }
+}

--- a/src/Honua.Core/Features/Federation/Services/FederationQueryPlanner.cs
+++ b/src/Honua.Core/Features/Federation/Services/FederationQueryPlanner.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.Federation.Abstractions;
+using Honua.Core.Features.Federation.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.Federation.Services;
+
+/// <summary>
+/// Pure, deterministic federation query planner. Given a canonical <see cref="FeatureQuery"/>
+/// and a federated source, it decides which predicates push down to the remote source and
+/// which are refined locally, following the "push filters to remote, join locally" strategy
+/// in issue #341. The planner performs no I/O, so it is safe to run offline and is exercised
+/// by unit tests with no live remote source.
+/// </summary>
+internal sealed class FederationQueryPlanner : IFederationQueryPlanner
+{
+    public FederatedSourceCapabilities ResolveCapabilities(FederatedSourceKind kind) => kind switch
+    {
+        // Honua-to-Honua over gRPC shares the canonical filter model end to end, so every
+        // predicate family pushes down.
+        FederatedSourceKind.HonuaGrpc => new FederatedSourceCapabilities
+        {
+            SupportsAttributeFilterPushdown = true,
+            SupportsSpatialFilterPushdown = true,
+            SupportsExactSpatialRelationshipPushdown = true,
+            SupportsTemporalFilterPushdown = true,
+            SupportsOrderByPushdown = true,
+            SupportsPagingPushdown = true,
+        },
+
+        // Esri ArcGIS REST query accepts a SQL-like WHERE, an envelope, ORDER BY, and
+        // result paging, but only envelope-grade spatial relationships and no first-class
+        // temporal-interval predicate, so exact spatial relationships and temporal filters
+        // are refined locally.
+        FederatedSourceKind.EsriRest => new FederatedSourceCapabilities
+        {
+            SupportsAttributeFilterPushdown = true,
+            SupportsSpatialFilterPushdown = true,
+            SupportsExactSpatialRelationshipPushdown = false,
+            SupportsTemporalFilterPushdown = false,
+            SupportsOrderByPushdown = true,
+            SupportsPagingPushdown = true,
+        },
+
+        // OGC API - Features / WFS accept CQL2 attribute predicates and a bbox, but the
+        // baseline conformance classes do not guarantee exact spatial relationships,
+        // temporal filtering, or ordering, so those are refined locally.
+        FederatedSourceKind.OgcWfs => new FederatedSourceCapabilities
+        {
+            SupportsAttributeFilterPushdown = true,
+            SupportsSpatialFilterPushdown = true,
+            SupportsExactSpatialRelationshipPushdown = false,
+            SupportsTemporalFilterPushdown = false,
+            SupportsOrderByPushdown = false,
+            SupportsPagingPushdown = true,
+        },
+
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown federated source kind."),
+    };
+
+    public FederationQueryPlan Plan(FederatedSourceDescriptor source, in FeatureQuery query, bool joinsLocalLayer)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var capabilities = ResolveCapabilities(source.Kind);
+        var decisions = ImmutableArray.CreateBuilder<FederationPredicateDecision>();
+
+        if (HasAttributeFilter(query))
+        {
+            decisions.Add(Decide(
+                FederationPredicateKind.AttributeFilter,
+                capabilities.SupportsAttributeFilterPushdown,
+                "attribute (WHERE / object-id) predicate"));
+        }
+
+        if (query.SpatialFilter is { } spatial)
+        {
+            var exact = RequiresExactSpatialRelationship(spatial);
+            var pushed = capabilities.SupportsSpatialFilterPushdown &&
+                (!exact || capabilities.SupportsExactSpatialRelationshipPushdown);
+
+            var reason = !capabilities.SupportsSpatialFilterPushdown
+                ? "spatial predicate unsupported remotely"
+                : exact && !capabilities.SupportsExactSpatialRelationshipPushdown
+                    ? "exact spatial relationship refined locally over a pushed-down envelope superset"
+                    : "spatial (envelope) predicate";
+
+            decisions.Add(new FederationPredicateDecision(FederationPredicateKind.SpatialFilter, pushed, reason));
+        }
+
+        if (query.TemporalFilter is not null)
+        {
+            decisions.Add(Decide(
+                FederationPredicateKind.TemporalFilter,
+                capabilities.SupportsTemporalFilterPushdown,
+                "temporal interval predicate"));
+        }
+
+        if (query.OrderBy is { IsDefaultOrEmpty: false })
+        {
+            decisions.Add(Decide(
+                FederationPredicateKind.OrderBy,
+                capabilities.SupportsOrderByPushdown,
+                "result ordering"));
+        }
+
+        if (query.Limit is not null || query.Offset is not null)
+        {
+            // Paging can only push down when the full sort is also remote; otherwise the
+            // remote page would be computed over an unordered (or locally re-sorted) set
+            // and would not match the federated result page.
+            var orderPushedDown = !(query.OrderBy is { IsDefaultOrEmpty: false }) || capabilities.SupportsOrderByPushdown;
+            var pushed = capabilities.SupportsPagingPushdown && orderPushedDown;
+            var reason = !capabilities.SupportsPagingPushdown
+                ? "paging unsupported remotely; over-fetch and page locally"
+                : orderPushedDown
+                    ? "offset/limit paging"
+                    : "ordering refined locally, so paging is applied locally after the sort";
+
+            decisions.Add(new FederationPredicateDecision(FederationPredicateKind.Paging, pushed, reason));
+        }
+
+        return new FederationQueryPlan
+        {
+            SourceId = source.Id,
+            Capabilities = capabilities,
+            Decisions = decisions.ToImmutable(),
+            RequiresLocalJoin = joinsLocalLayer,
+        };
+    }
+
+    private static FederationPredicateDecision Decide(FederationPredicateKind kind, bool supported, string label) =>
+        new(kind, supported, supported ? $"{label} pushed to remote source" : $"{label} refined locally");
+
+    private static bool HasAttributeFilter(in FeatureQuery query) =>
+        !string.IsNullOrWhiteSpace(query.Where) ||
+        query.SqlFilter is not null ||
+        (query.ObjectIds is { IsDefaultOrEmpty: false });
+
+    private static bool RequiresExactSpatialRelationship(in SpatialFilter spatial) =>
+        spatial.SpatialRelationship switch
+        {
+            SpatialRelationship.Intersects => false,
+            SpatialRelationship.EnvelopeIntersects => false,
+            _ => true,
+        };
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -1311,6 +1311,10 @@ public static class EndpointRegistry
         new("DELETE", "/api/v1/admin/multidim-coverages/{id}"),
         new("POST", "/api/v1/admin/multidim-coverages/{id}/refresh"),
         new("GET", "/api/v1/admin/multidim-coverages/jobs/{jobId}"),
+
+        // Federated-query source configuration and query-plan inspection (#341).
+        new("GET", "/api/v1/admin/federation/sources"),
+        new("GET", "/api/v1/admin/federation/sources/{id}/plan"),
     ];
 }
 

--- a/src/Honua.Server/Features/Admin/Federation/ConfiguredFederationSourceRegistry.cs
+++ b/src/Honua.Server/Features/Admin/Federation/ConfiguredFederationSourceRegistry.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.Federation.Abstractions;
+using Honua.Core.Features.Federation.Domain;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Admin.Federation;
+
+/// <summary>
+/// Configuration-backed <see cref="IFederationSourceRegistry"/>. Materializes the bound
+/// <see cref="FederationSourceOptions"/> into validated <see cref="FederatedSourceDescriptor"/>
+/// instances. Entries with a missing identifier or an unparsable endpoint URL are skipped so
+/// a single malformed config entry cannot take the federation surface offline.
+/// </summary>
+internal sealed class ConfiguredFederationSourceRegistry : IFederationSourceRegistry
+{
+    private readonly ImmutableArray<FederatedSourceDescriptor> _sources;
+    private readonly ImmutableDictionary<string, FederatedSourceDescriptor> _byId;
+
+    public ConfiguredFederationSourceRegistry(IOptions<FederationSourceOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var builder = ImmutableArray.CreateBuilder<FederatedSourceDescriptor>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var config in options.Value.Sources)
+        {
+            if (string.IsNullOrWhiteSpace(config.Id) ||
+                string.IsNullOrWhiteSpace(config.RemoteLayer) ||
+                !Uri.TryCreate(config.Endpoint, UriKind.Absolute, out var endpoint) ||
+                !seen.Add(config.Id))
+            {
+                continue;
+            }
+
+            builder.Add(new FederatedSourceDescriptor
+            {
+                Id = config.Id,
+                DisplayName = string.IsNullOrWhiteSpace(config.DisplayName) ? config.Id : config.DisplayName,
+                Kind = config.Kind,
+                Endpoint = endpoint,
+                RemoteLayer = config.RemoteLayer,
+                RequestTimeout = TimeSpan.FromSeconds(config.RequestTimeoutSeconds),
+                Enabled = config.Enabled,
+            });
+        }
+
+        _sources = builder.ToImmutable();
+        _byId = _sources.ToImmutableDictionary(static s => s.Id, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public ImmutableArray<FederatedSourceDescriptor> GetSources() => _sources;
+
+    public bool TryGetSource(string id, out FederatedSourceDescriptor descriptor)
+    {
+        if (!string.IsNullOrWhiteSpace(id) && _byId.TryGetValue(id, out var found))
+        {
+            descriptor = found;
+            return true;
+        }
+
+        descriptor = null!;
+        return false;
+    }
+}

--- a/src/Honua.Server/Features/Admin/Federation/FederationEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/Federation/FederationEndpoints.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.Federation.Abstractions;
+using Honua.Core.Features.Federation.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Server.Features.Admin.Federation.Models;
+using Honua.Infrastructure.Authentication;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Admin.Federation;
+
+/// <summary>
+/// Log category for federation admin endpoints.
+/// </summary>
+internal sealed class FederationEndpointsLog;
+
+/// <summary>
+/// Admin endpoints for federated-query source configuration and query-plan inspection
+/// (issue #341). The list endpoint exposes the configured sources (no credentials); the
+/// plan endpoint runs the offline <see cref="IFederationQueryPlanner"/> against a sample
+/// query so operators can see which predicates push down to a remote source versus which
+/// are refined locally — without contacting the remote source.
+/// </summary>
+internal static class FederationEndpoints
+{
+    /// <summary>
+    /// Maps the federation admin endpoints.
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    public static void MapFederationEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/federation/sources")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Federation")
+            .RequireAdminAuthorization();
+
+        group.MapGet("/", HandleListSources)
+            .WithDisplayName("List Federated Sources")
+            .WithSummary("List configured federated sources (cross-instance and external proxy)");
+
+        group.MapGet("/{id}/plan", HandlePlanQuery)
+            .WithDisplayName("Plan Federated Query")
+            .WithSummary("Show push-down vs local-refinement plan for a sample query against a source");
+    }
+
+    private static IResult HandleListSources(
+        [FromServices] IFederationSourceRegistry registry,
+        [FromServices] ILogger<FederationEndpointsLog> logger)
+    {
+        var sources = registry.GetSources();
+        var responses = sources.Select(ToResponse).ToArray();
+
+        FederationLog.SourcesListed(logger, responses.Length);
+
+        return Results.Json(responses, FederationJsonContext.Default.FederationSourceResponseArray);
+    }
+
+    private static IResult HandlePlanQuery(
+        string id,
+        [FromServices] IFederationSourceRegistry registry,
+        [FromServices] IFederationQueryPlanner planner,
+        [FromServices] ILogger<FederationEndpointsLog> logger,
+        string? where = null,
+        bool bbox = false,
+        bool joinLocal = false)
+    {
+        if (!registry.TryGetSource(id, out var source))
+        {
+            return TypedResults.NotFound();
+        }
+
+        var query = BuildSampleQuery(where, bbox);
+        var plan = planner.Plan(source, in query, joinLocal);
+
+        FederationLog.QueryPlanned(logger, source.Id, plan.RequiresLocalRefinement, plan.RequiresLocalJoin);
+
+        var response = new FederationQueryPlanResponse
+        {
+            SourceId = plan.SourceId,
+            SampleWhere = where,
+            SampleBbox = bbox,
+            Decisions = plan.Decisions
+                .Select(static d => new FederationPredicateDecisionResponse
+                {
+                    Predicate = d.Predicate.ToString(),
+                    PushedDown = d.PushedDown,
+                    Reason = d.Reason,
+                })
+                .ToArray(),
+            RequiresLocalRefinement = plan.RequiresLocalRefinement,
+            RequiresLocalJoin = plan.RequiresLocalJoin,
+        };
+
+        return Results.Json(response, FederationJsonContext.Default.FederationQueryPlanResponse);
+    }
+
+    private static FeatureQuery BuildSampleQuery(string? where, bool bbox)
+    {
+        var query = new FeatureQuery { Where = string.IsNullOrWhiteSpace(where) ? null : where };
+
+        if (bbox)
+        {
+            // A simple axis-aligned envelope-intersects predicate: the canonical representation
+            // of a viewport bbox. WKB content is irrelevant to planning, which keys off the
+            // spatial relationship only, so an empty geometry keeps the endpoint side-effect free.
+            query = query with
+            {
+                SpatialFilter = new SpatialFilter
+                {
+                    Geometry = Array.Empty<byte>(),
+                    SpatialRelationship = SpatialRelationship.EnvelopeIntersects,
+                    IsSimpleEnvelope = true,
+                },
+            };
+        }
+
+        return query;
+    }
+
+    private static FederationSourceResponse ToResponse(FederatedSourceDescriptor source) => new()
+    {
+        Id = source.Id,
+        DisplayName = source.DisplayName,
+        Kind = source.Kind.ToString(),
+        Endpoint = source.Endpoint.ToString(),
+        RemoteLayer = source.RemoteLayer,
+        RequestTimeoutSeconds = (int)source.RequestTimeout.TotalSeconds,
+        Enabled = source.Enabled,
+    };
+}

--- a/src/Honua.Server/Features/Admin/Federation/FederationJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Federation/FederationJsonContext.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Server.Features.Admin.Federation.Models;
+
+namespace Honua.Server.Features.Admin.Federation;
+
+/// <summary>
+/// AOT-safe JSON serialization context for the federation admin surface (issue #341).
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(FederationSourceResponse))]
+[JsonSerializable(typeof(FederationSourceResponse[]))]
+[JsonSerializable(typeof(FederationQueryPlanResponse))]
+[JsonSerializable(typeof(string))]
+internal sealed partial class FederationJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Admin/Federation/FederationLog.cs
+++ b/src/Honua.Server/Features/Admin/Federation/FederationLog.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Admin.Federation;
+
+/// <summary>
+/// Source-generated structured logging for the federation admin surface (issue #341).
+/// </summary>
+internal static partial class FederationLog
+{
+    [LoggerMessage(EventId = 4500, Level = LogLevel.Information,
+        Message = "Listed {Count} federated sources")]
+    public static partial void SourcesListed(ILogger logger, int count);
+
+    [LoggerMessage(EventId = 4501, Level = LogLevel.Information,
+        Message = "Planned federated query for source '{SourceId}' (localRefinement={RequiresLocalRefinement}, localJoin={RequiresLocalJoin})")]
+    public static partial void QueryPlanned(ILogger logger, string sourceId, bool requiresLocalRefinement, bool requiresLocalJoin);
+}

--- a/src/Honua.Server/Features/Admin/Federation/FederationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Admin/Federation/FederationServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Federation;
+using Honua.Core.Features.Federation.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Features.Admin.Federation;
+
+/// <summary>
+/// Service registration for the federation admin surface and query planner (issue #341).
+/// </summary>
+public static class FederationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the federation query planner, the configuration-backed source registry, and
+    /// binds <see cref="FederationSourceOptions"/> from the <c>Federation</c> section.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddFederationServices(this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.Configure<FederationSourceOptions>(configuration.GetSection(FederationSourceOptions.SectionName));
+        services.AddFederationCore();
+        services.TryAddSingleton<IFederationSourceRegistry, ConfiguredFederationSourceRegistry>();
+
+        return services;
+    }
+}

--- a/src/Honua.Server/Features/Admin/Federation/FederationSourceOptions.cs
+++ b/src/Honua.Server/Features/Admin/Federation/FederationSourceOptions.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+using Honua.Core.Features.Federation.Domain;
+
+namespace Honua.Server.Features.Admin.Federation;
+
+/// <summary>
+/// Configuration-bound list of federated sources for the deployment (issue #341).
+/// Sources are declared under the <c>Federation</c> configuration section. This is the
+/// first increment of the federation source registry; a later increment can promote it to
+/// the metadata-resource store (ADR-0023) without changing the read abstraction.
+/// </summary>
+public sealed class FederationSourceOptions
+{
+    /// <summary>
+    /// Configuration section name for binding from environment / appsettings.
+    /// </summary>
+    public const string SectionName = "Federation";
+
+    /// <summary>
+    /// Gets or sets the configured federated sources.
+    /// </summary>
+    public IReadOnlyList<FederationSourceConfig> Sources { get; set; } = Array.Empty<FederationSourceConfig>();
+}
+
+/// <summary>
+/// A single configured federated source entry.
+/// </summary>
+public sealed class FederationSourceConfig
+{
+    /// <summary>
+    /// Gets the stable identifier, unique within the deployment.
+    /// </summary>
+    [Required]
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the human-readable display name.
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the transport family of the source.
+    /// </summary>
+    public FederatedSourceKind Kind { get; init; }
+
+    /// <summary>
+    /// Gets the base endpoint URL of the remote service.
+    /// </summary>
+    [Required]
+    public string Endpoint { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the remote layer or collection identifier exposed for federated joins.
+    /// </summary>
+    [Required]
+    public string RemoteLayer { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the per-request timeout in seconds applied to remote calls. Defaults to 30s.
+    /// </summary>
+    [Range(1, 600)]
+    public int RequestTimeoutSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// Gets a value indicating whether the source is enabled for federation.
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+}

--- a/src/Honua.Server/Features/Admin/Federation/Models/FederationModels.cs
+++ b/src/Honua.Server/Features/Admin/Federation/Models/FederationModels.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Admin.Federation.Models;
+
+/// <summary>
+/// Admin response payload describing a configured federated source. Carries no transport
+/// credentials.
+/// </summary>
+internal sealed record FederationSourceResponse
+{
+    /// <summary>Stable source identifier.</summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Human-readable display name.</summary>
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>Transport family (HonuaGrpc, EsriRest, OgcWfs).</summary>
+    public string Kind { get; init; } = string.Empty;
+
+    /// <summary>Base endpoint URL of the remote service.</summary>
+    public string Endpoint { get; init; } = string.Empty;
+
+    /// <summary>Remote layer/collection identifier exposed for federated joins.</summary>
+    public string RemoteLayer { get; init; } = string.Empty;
+
+    /// <summary>Per-request timeout applied to remote calls, in seconds.</summary>
+    public int RequestTimeoutSeconds { get; init; }
+
+    /// <summary>Whether the source is enabled for federation.</summary>
+    public bool Enabled { get; init; }
+}
+
+/// <summary>
+/// One predicate placement decision within a federation query plan.
+/// </summary>
+internal sealed record FederationPredicateDecisionResponse
+{
+    /// <summary>The predicate family (AttributeFilter, SpatialFilter, TemporalFilter, OrderBy, Paging).</summary>
+    public string Predicate { get; init; } = string.Empty;
+
+    /// <summary>Whether the predicate is evaluated by the remote source (true) or locally (false).</summary>
+    public bool PushedDown { get; init; }
+
+    /// <summary>Human-readable explanation for the decision.</summary>
+    public string Reason { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Admin response payload describing the plan for a sample query against a federated source.
+/// </summary>
+internal sealed record FederationQueryPlanResponse
+{
+    /// <summary>The source the plan targets.</summary>
+    public string SourceId { get; init; } = string.Empty;
+
+    /// <summary>The sample query <c>where</c> clause the plan was built for.</summary>
+    public string? SampleWhere { get; init; }
+
+    /// <summary>Whether a sample bbox spatial predicate was included.</summary>
+    public bool SampleBbox { get; init; }
+
+    /// <summary>Per-predicate push-down decisions.</summary>
+    public IReadOnlyList<FederationPredicateDecisionResponse> Decisions { get; init; } =
+        Array.Empty<FederationPredicateDecisionResponse>();
+
+    /// <summary>Whether any predicate must be refined locally after the remote fetch.</summary>
+    public bool RequiresLocalRefinement { get; init; }
+
+    /// <summary>Whether the plan combines the remote source with a local PostGIS layer.</summary>
+    public bool RequiresLocalJoin { get; init; }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -24,6 +24,7 @@ using Honua.Core.Features.Share.Abstractions;
 using Honua.Core.Features.Styling;
 using Honua.Core.Features.Styling.Abstractions;
 using Honua.Server.Features.Admin;
+using Honua.Server.Features.Admin.Federation;
 using Honua.Server.Features.Admin.Jobs;
 using Honua.Server.Features.Admin.OperateFixtures;
 using Honua.Server.Features.Admin.Share;
@@ -487,6 +488,9 @@ builder.Services.AddCloudFileStorage(builder.Configuration);
 // Configure file upload security limits
 builder.Services.Configure<FileUploadSecurityOptions>(
     builder.Configuration.GetSection(FileUploadSecurityOptions.SectionName));
+
+// Federated-query planning and source configuration (#341).
+builder.Services.AddFederationServices(builder.Configuration);
 
 // Register configuration validators to ensure application fails fast on invalid configuration
 StartupConfigurationHelpers.RegisterConfigurationValidators(builder.Services);
@@ -1310,6 +1314,7 @@ app.MapComplianceAdminEndpoints();
 
 // Configure secure connection management endpoints
 app.MapSecureConnectionEndpoints();
+app.MapFederationEndpoints();
 app.MapClientCertificateAdminEndpoints();
 
 // Configure control plane IAM endpoints (#511)

--- a/tests/dotnet/Honua.Core.Tests/Features/Federation/FederationQueryPlannerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Federation/FederationQueryPlannerTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.Federation;
+using Honua.Core.Features.Federation.Abstractions;
+using Honua.Core.Features.Federation.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Honua.Core.Tests.Features.Federation;
+
+/// <summary>
+/// Unit tests for the pure federation query planner (issue #341). The planner runs offline,
+/// so these tests exercise the push-down / local-refinement decisions with no remote source.
+/// </summary>
+public sealed class FederationQueryPlannerTests
+{
+    private readonly IFederationQueryPlanner _planner = BuildPlanner();
+
+    private static IFederationQueryPlanner BuildPlanner()
+    {
+        var services = new ServiceCollection();
+        services.AddFederationCore();
+        return services.BuildServiceProvider().GetRequiredService<IFederationQueryPlanner>();
+    }
+
+    private static FederatedSourceDescriptor Source(FederatedSourceKind kind) => new()
+    {
+        Id = $"src-{kind}",
+        DisplayName = kind.ToString(),
+        Kind = kind,
+        Endpoint = new System.Uri("https://remote.example.com/"),
+        RemoteLayer = "0",
+        RequestTimeout = System.TimeSpan.FromSeconds(30),
+    };
+
+    [UnitTest]
+    public void AddFederationCore_RegistersPlanner()
+    {
+        Assert.NotNull(_planner);
+    }
+
+    [UnitTest]
+    public void ResolveCapabilities_HonuaGrpc_PushesEverythingDown()
+    {
+        var caps = _planner.ResolveCapabilities(FederatedSourceKind.HonuaGrpc);
+
+        Assert.True(caps.SupportsAttributeFilterPushdown);
+        Assert.True(caps.SupportsSpatialFilterPushdown);
+        Assert.True(caps.SupportsExactSpatialRelationshipPushdown);
+        Assert.True(caps.SupportsTemporalFilterPushdown);
+        Assert.True(caps.SupportsOrderByPushdown);
+        Assert.True(caps.SupportsPagingPushdown);
+    }
+
+    [UnitTest]
+    public void ResolveCapabilities_EsriRest_RefinesExactSpatialAndTemporalLocally()
+    {
+        var caps = _planner.ResolveCapabilities(FederatedSourceKind.EsriRest);
+
+        Assert.True(caps.SupportsAttributeFilterPushdown);
+        Assert.True(caps.SupportsSpatialFilterPushdown);
+        Assert.False(caps.SupportsExactSpatialRelationshipPushdown);
+        Assert.False(caps.SupportsTemporalFilterPushdown);
+        Assert.True(caps.SupportsOrderByPushdown);
+    }
+
+    [UnitTest]
+    public void ResolveCapabilities_OgcWfs_DoesNotPushOrderByDown()
+    {
+        var caps = _planner.ResolveCapabilities(FederatedSourceKind.OgcWfs);
+
+        Assert.True(caps.SupportsAttributeFilterPushdown);
+        Assert.True(caps.SupportsSpatialFilterPushdown);
+        Assert.False(caps.SupportsOrderByPushdown);
+    }
+
+    [UnitTest]
+    public void Plan_HonuaGrpc_AttributeFilter_PushesDownWithNoLocalRefinement()
+    {
+        var query = FeatureQuery.WithWhere("population > 1000");
+
+        var plan = _planner.Plan(Source(FederatedSourceKind.HonuaGrpc), in query, joinsLocalLayer: false);
+
+        var decision = Assert.Single(plan.Decisions, d => d.Predicate == FederationPredicateKind.AttributeFilter);
+        Assert.True(decision.PushedDown);
+        Assert.False(plan.RequiresLocalRefinement);
+        Assert.False(plan.RequiresLocalJoin);
+    }
+
+    [UnitTest]
+    public void Plan_EsriRest_ExactSpatialRelationship_RefinedLocally()
+    {
+        var query = FeatureQuery.WithSpatialFilter(new SpatialFilter
+        {
+            Geometry = System.Array.Empty<byte>(),
+            SpatialRelationship = SpatialRelationship.Within,
+        });
+
+        var plan = _planner.Plan(Source(FederatedSourceKind.EsriRest), in query, joinsLocalLayer: false);
+
+        var spatial = Assert.Single(plan.Decisions, d => d.Predicate == FederationPredicateKind.SpatialFilter);
+        Assert.False(spatial.PushedDown);
+        Assert.True(plan.RequiresLocalRefinement);
+    }
+
+    [UnitTest]
+    public void Plan_EsriRest_EnvelopeIntersects_PushesDown()
+    {
+        var query = FeatureQuery.WithSpatialFilter(new SpatialFilter
+        {
+            Geometry = System.Array.Empty<byte>(),
+            SpatialRelationship = SpatialRelationship.EnvelopeIntersects,
+            IsSimpleEnvelope = true,
+        });
+
+        var plan = _planner.Plan(Source(FederatedSourceKind.EsriRest), in query, joinsLocalLayer: false);
+
+        var spatial = Assert.Single(plan.Decisions, d => d.Predicate == FederationPredicateKind.SpatialFilter);
+        Assert.True(spatial.PushedDown);
+    }
+
+    [UnitTest]
+    public void Plan_EsriRest_TemporalFilter_RefinedLocally()
+    {
+        var query = new FeatureQuery
+        {
+            TemporalFilter = new TemporalFilter
+            {
+                PropertyName = "observed_at",
+                PropertyType = TemporalPropertyType.DateTime,
+                Start = System.DateTimeOffset.UnixEpoch,
+            },
+        };
+
+        var plan = _planner.Plan(Source(FederatedSourceKind.EsriRest), in query, joinsLocalLayer: false);
+
+        var temporal = Assert.Single(plan.Decisions, d => d.Predicate == FederationPredicateKind.TemporalFilter);
+        Assert.False(temporal.PushedDown);
+    }
+
+    [UnitTest]
+    public void Plan_OgcWfs_OrderByLocal_ForcesPagingLocal()
+    {
+        var query = new FeatureQuery
+        {
+            OrderBy = ImmutableArray.Create(OrderByClause.Asc("name")),
+            Limit = 50,
+            Offset = 100,
+        };
+
+        var plan = _planner.Plan(Source(FederatedSourceKind.OgcWfs), in query, joinsLocalLayer: false);
+
+        var orderBy = Assert.Single(plan.Decisions, d => d.Predicate == FederationPredicateKind.OrderBy);
+        var paging = Assert.Single(plan.Decisions, d => d.Predicate == FederationPredicateKind.Paging);
+        Assert.False(orderBy.PushedDown);
+        Assert.False(paging.PushedDown);
+    }
+
+    [UnitTest]
+    public void Plan_HonuaGrpc_OrderByThenPaging_BothPushDown()
+    {
+        var query = new FeatureQuery
+        {
+            OrderBy = ImmutableArray.Create(OrderByClause.Asc("name")),
+            Limit = 50,
+        };
+
+        var plan = _planner.Plan(Source(FederatedSourceKind.HonuaGrpc), in query, joinsLocalLayer: false);
+
+        Assert.True(Assert.Single(plan.Decisions, d => d.Predicate == FederationPredicateKind.OrderBy).PushedDown);
+        Assert.True(Assert.Single(plan.Decisions, d => d.Predicate == FederationPredicateKind.Paging).PushedDown);
+    }
+
+    [UnitTest]
+    public void Plan_NoPredicates_ProducesEmptyDecisionsButCanRequireJoin()
+    {
+        var query = new FeatureQuery();
+
+        var plan = _planner.Plan(Source(FederatedSourceKind.HonuaGrpc), in query, joinsLocalLayer: true);
+
+        Assert.Empty(plan.Decisions);
+        Assert.False(plan.RequiresLocalRefinement);
+        Assert.True(plan.RequiresLocalJoin);
+    }
+
+    [UnitTest]
+    public void Plan_NullSource_Throws()
+    {
+        var query = new FeatureQuery();
+
+        Assert.Throws<System.ArgumentNullException>(() => _planner.Plan(null!, in query, joinsLocalLayer: false));
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/Federation/FederationEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/Federation/FederationEndpointsTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Federation.Domain;
+using Honua.Server.Features.Admin.Federation;
+using Honua.Server.Features.Admin.Federation.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Features.Admin.Federation;
+
+/// <summary>
+/// Integration tests for the federation admin surface (issue #341). Sources are supplied
+/// through the bound <c>Federation</c> configuration section, so these tests exercise the
+/// configuration-backed registry and the offline query planner end to end without contacting
+/// any remote source.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Configuration)]
+public sealed class FederationEndpointsTests : IAsyncLifetime
+{
+    private const string Route = "/api/v1/admin/federation/sources";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly WebAppFixture _fixture;
+    private System.Net.Http.HttpClient _client = null!;
+
+    public FederationEndpointsTests()
+    {
+        // Bind the federation source list through the same options the production registry
+        // reads. ConfigureServices maps onto ConfigureTestServices, which the fixture applies
+        // last so this post-configuration wins over the empty default.
+        _fixture = new WebAppFixture()
+            .ConfigureServices(services =>
+            {
+                services.Configure<FederationSourceOptions>(options =>
+                {
+                    options.Sources = new[]
+                    {
+                        new FederationSourceConfig
+                        {
+                            Id = "esri-parcels",
+                            DisplayName = "County Parcels (Esri)",
+                            Kind = FederatedSourceKind.EsriRest,
+                            Endpoint = "https://gis.example.gov/arcgis/rest/services/Parcels/FeatureServer",
+                            RemoteLayer = "0",
+                            RequestTimeoutSeconds = 15,
+                        },
+                        new FederationSourceConfig
+                        {
+                            Id = "peer-honua",
+                            Kind = FederatedSourceKind.HonuaGrpc,
+                            Endpoint = "https://peer.example.com",
+                            RemoteLayer = "roads",
+                        },
+                    };
+                });
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/federation/sources")]
+    public async Task ListSources_ReturnsConfiguredSourcesWithoutCredentials()
+    {
+        var response = await _client.GetAsync(Route);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var sources = await response.Content.ReadFromJsonAsync<FederationSourceResponse[]>(JsonOptions);
+
+        sources.Should().NotBeNull();
+        sources!.Should().HaveCount(2);
+        sources.Should().Contain(s => s.Id == "esri-parcels" && s.Kind == "EsriRest" && s.RequestTimeoutSeconds == 15);
+        sources.Should().Contain(s => s.Id == "peer-honua" && s.Kind == "HonuaGrpc");
+
+        var raw = await response.Content.ReadAsStringAsync();
+        raw.Should().NotContain("password", "federation source descriptors carry no transport credentials");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/federation/sources/{id}/plan")]
+    public async Task PlanQuery_EsriRestWithWhereAndBbox_RefinesNothingAndPushesDown()
+    {
+        var response = await _client.GetAsync($"{Route}/esri-parcels/plan?where=zoning%3D%27R1%27&bbox=true&joinLocal=true");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var plan = await response.Content.ReadFromJsonAsync<FederationQueryPlanResponse>(JsonOptions);
+
+        plan.Should().NotBeNull();
+        plan!.SourceId.Should().Be("esri-parcels");
+        plan.RequiresLocalJoin.Should().BeTrue();
+        plan.Decisions.Should().Contain(d => d.Predicate == "AttributeFilter" && d.PushedDown);
+        plan.Decisions.Should().Contain(d => d.Predicate == "SpatialFilter" && d.PushedDown);
+        plan.RequiresLocalRefinement.Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/federation/sources/{id}/plan")]
+    public async Task PlanQuery_UnknownSource_Returns404()
+    {
+        var response = await _client.GetAsync($"{Route}/does-not-exist/plan?where=1%3D1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}


### PR DESCRIPTION
## Summary

First mergeable increment of federated queries (#341). Adds the cross-source query-planning scaffolding that lets a single query be split across a federated source and the local layer, using existing canonical models and test doubles — no live external warehouse credentials required.

### What this adds

- **Federation core (`Honua.Core`)** — domain models (`FederatedSourceKind`, `FederatedSourceDescriptor`, `FederatedSourceCapabilities`, `FederationQueryPlan`) and a pure, deterministic `FederationQueryPlanner`. Given a canonical `FeatureQuery` and a source, it decides which predicates push down to the remote source (Honua gRPC, Esri REST, OGC WFS) versus which the federation layer refines locally — the "push filters to remote, join locally" strategy from the issue. No I/O, so it is fully unit-testable offline.
- **Federation admin surface (`Honua.Server`)** — a configuration-bound source registry (`Federation` section) and two endpoints:
  - `GET /api/v1/admin/federation/sources` — list configured sources (no credentials).
  - `GET /api/v1/admin/federation/sources/{id}/plan` — show the push-down vs local-refinement plan for a sample query against a source.
  Routes registered in `EndpointRegistry`; `feature-catalog.json` regenerated via the canonical emitter (also picks up a pre-existing stale `oauth-clients` entry). Covered by the existing `control-plane-admin` proof-ledger surface (`/api/v1/admin/` prefix).

### Tests (run serially)

- Core unit tests: 12/12 (`FederationQueryPlannerTests`).
- Server integration tests: 3/3 (`FederationEndpointsTests`, Testcontainers + PostGIS).
- Architecture tests: 116/116.
- Release build with `TreatWarningsAsErrors=true`: 0 warnings, 0 errors.

### Deferred (require live external warehouses / remote instances)

- Honua→Honua gRPC and Esri/WFS HTTP transports that actually fetch and join remote rows.
- Per-source latency/error metrics and circuit-breaker wiring on the live remote path (resilience/circuit-breaker infra already exists in `Honua.Core/Features/Infrastructure/Resilience` to build on).
- Admin-UI CRUD over the source registry (currently configuration-driven; can be promoted to the metadata-resource store per ADR-0023 without changing the read abstraction).

Refs #341.