### PR TITLE
feat: wire plugin computed-field projection into FeatureServer query (#1562)

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerQueryHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerQueryHandler.cs
@@ -1045,12 +1045,16 @@ internal sealed partial class FeatureServerQueryHandler(
                     ? query with { Limit = distinctScanLimit, Offset = null }
                     : query;
                 var queryStopwatch = Stopwatch.StartNew();
+                // Pass the authenticated caller so plugin computed-field providers (#1562) can
+                // scope derived values per-actor. Projection inside the executor is a no-op unless
+                // the Enterprise plugin SDK is licensed, enabled, and a provider is registered.
                 QueryResult<Feature> result = await _queryExecutor.QueryWithValidationAsync(
                     queryLayer.Service,
                     queryLayer.Resource,
                     queryLayer.Publication,
                     queryLayer.StorageLayerId,
                     queryForExecution,
+                    context.User?.Identity?.Name,
                     cancellationToken).ConfigureAwait(false);
                 queryStopwatch.Stop();
                 var queryOperation = isParquet ? "query_parquet" : isArrow ? "query_arrow" : "query";

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureServerQueryExecutor.V2.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureServerQueryExecutor.V2.cs
@@ -7,6 +7,7 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Shared.Models;
+using Honua.Plugins.Abstractions;
 using Honua.Protocols.GeoServices.FeatureServer.Models;
 
 namespace Honua.Protocols.GeoServices.FeatureServer.Services;
@@ -81,6 +82,40 @@ internal sealed partial class FeatureServerQueryExecutor
         int storageLayerId,
         FeatureQuery query,
         CancellationToken cancellationToken)
+        => await QueryWithValidationAsync(
+            service,
+            resource,
+            publication,
+            storageLayerId,
+            query,
+            actor: null,
+            cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Materializes a FeatureServer query and applies plugin computed-field projection
+    /// (<see cref="IComputedFieldProvider"/>, issue #1562) to each returned feature before it is
+    /// formatted. Projection is a no-op unless the Enterprise plugin SDK is licensed, enabled, and
+    /// at least one computed-field provider is registered, so the common path adds no overhead.
+    /// The raw GeoServices/Geobuf/FlatGeobuf fast paths bypass the canonical <see cref="Feature"/>
+    /// representation and therefore do not (yet) carry computed fields; those formats are tracked
+    /// separately in the phase-2 follow-ups for #1562.
+    /// </summary>
+    /// <param name="service">The owning V2 service.</param>
+    /// <param name="resource">The queried V2 resource (carries layer identity for the compute context).</param>
+    /// <param name="publication">The publication binding the resource to the service.</param>
+    /// <param name="storageLayerId">The resolved storage layer id.</param>
+    /// <param name="query">The canonical feature query.</param>
+    /// <param name="actor">The authenticated caller, when known; flows into the compute context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The query result whose features include any projected computed fields.</returns>
+    public async Task<QueryResult<Feature>> QueryWithValidationAsync(
+        MetadataV2Service service,
+        MetadataV2Resource resource,
+        MetadataV2Publication publication,
+        int storageLayerId,
+        FeatureQuery query,
+        string? actor,
+        CancellationToken cancellationToken)
     {
         var reader = await ResolveReaderV2Async(
             service,
@@ -89,7 +124,40 @@ internal sealed partial class FeatureServerQueryExecutor
             storageLayerId,
             FeatureProviderReadOperation.Query,
             cancellationToken).ConfigureAwait(false);
-        return await QueryWithValidationAsync(reader, storageLayerId, query, cancellationToken).ConfigureAwait(false);
+        var result = await QueryWithValidationAsync(reader, storageLayerId, query, cancellationToken).ConfigureAwait(false);
+        return await ProjectComputedFieldsAsync(result, resource, storageLayerId, actor, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<QueryResult<Feature>> ProjectComputedFieldsAsync(
+        QueryResult<Feature> result,
+        MetadataV2Resource resource,
+        int storageLayerId,
+        string? actor,
+        CancellationToken cancellationToken)
+    {
+        if (!_computedFieldPipeline.HasComputedFields || result.Items.IsDefaultOrEmpty)
+        {
+            return result;
+        }
+
+        var context = new ComputedFieldContext(
+            ServiceId: resource.Metadata.Id,
+            LayerId: storageLayerId,
+            ResourceName: resource.Metadata.Name,
+            Actor: actor);
+
+        var builder = ImmutableArray.CreateBuilder<Feature>(result.Items.Length);
+        foreach (var feature in result.Items)
+        {
+            builder.Add(await _computedFieldPipeline
+                .ProjectAsync(feature, context, cancellationToken)
+                .ConfigureAwait(false));
+        }
+
+        return QueryResult<Feature>.Create(
+            totalCount: result.TotalCount,
+            items: builder.MoveToImmutable(),
+            hasMoreResults: result.HasMoreResults);
     }
 
     public async Task<byte[]?> QueryFlatGeobufWithValidationAsync(

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureServerQueryExecutor.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureServerQueryExecutor.cs
@@ -11,6 +11,7 @@ using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Shared.Models;
+using Honua.Plugins.Abstractions;
 using Honua.Protocols.GeoServices.FeatureServer.Models;
 
 namespace Honua.Protocols.GeoServices.FeatureServer.Services;
@@ -26,19 +27,25 @@ internal sealed partial class FeatureServerQueryExecutor
     private readonly StreamingQueryFormatter _streamingFormatter;
     private readonly FeatureProviderQueryRouter? _providerQueryRouter;
     private readonly IMetadataV2GraphProvider? _metadataGraphProvider;
+    private readonly IComputedFieldPipeline _computedFieldPipeline;
 
     public FeatureServerQueryExecutor(
         IFeatureReader featureReader,
         IStreamingFeatureStore streamingFeatureStore,
         StreamingQueryFormatter streamingFormatter,
         FeatureProviderQueryRouter? providerQueryRouter = null,
-        IMetadataV2GraphProvider? metadataGraphProvider = null)
+        IMetadataV2GraphProvider? metadataGraphProvider = null,
+        IComputedFieldPipeline? computedFieldPipeline = null)
     {
         _featureReader = featureReader ?? throw new ArgumentNullException(nameof(featureReader));
         _streamingFeatureStore = streamingFeatureStore ?? throw new ArgumentNullException(nameof(streamingFeatureStore));
         _streamingFormatter = streamingFormatter ?? throw new ArgumentNullException(nameof(streamingFormatter));
         _providerQueryRouter = providerQueryRouter;
         _metadataGraphProvider = metadataGraphProvider;
+        // Plugin computed-field projection (#1562). Optional so direct-construction tests keep
+        // working; defaults to the zero-overhead no-op pipeline when no Enterprise plugin SDK is
+        // present. Applied at the materialized-Feature query seam in the V2 overload below.
+        _computedFieldPipeline = computedFieldPipeline ?? NoOpComputedFieldPipeline.Instance;
     }
 
     public bool SupportsGeobufOutput => _featureReader is IGeobufFeatureStore;

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Shared.Models;
+using Honua.Plugins.Abstractions;
 using Honua.Protocols.GeoServices.FeatureServer.Models;
 using Honua.Protocols.GeoServices.FeatureServer.Services;
 using Honua.TestKit.Infrastructure;
@@ -607,11 +608,87 @@ public sealed class FeatureServerQueryExecutorTests
         properties.GetProperty("name").GetString().Should().Be("alpha");
     }
 
+    [Fact]
+    public async Task QueryWithValidationAsync_V2_WithComputedFieldPipeline_ProjectsComputedFields()
+    {
+        var featureReader = Substitute.For<IFeatureReader>();
+        featureReader.QueryAsync(7, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(QueryResult<Feature>.Create(
+                totalCount: 1,
+                items: ImmutableArray.Create(CreateFeature(1, "alpha")))));
+
+        var pipeline = new StubComputedFieldPipeline("computed", "value");
+        var sut = CreateSut(featureReader, computedFieldPipeline: pipeline);
+        var service = CreateService();
+        var resource = CreateResource();
+        var publication = CreatePublication(service, resource);
+
+        var result = await sut.QueryWithValidationAsync(
+            service,
+            resource,
+            publication,
+            7,
+            new FeatureQuery(),
+            actor: "tester",
+            CancellationToken.None);
+
+        result.Items.Should().HaveCount(1);
+        result.Items[0].Attributes.Should().ContainKey("computed").WhoseValue.Should().Be("value");
+        result.Items[0].Attributes.Should().ContainKey("name");
+        result.TotalCount.Should().Be(1);
+        pipeline.LastContext.Should().NotBeNull();
+        pipeline.LastContext!.ServiceId.Should().Be(resource.Metadata.Id);
+        pipeline.LastContext.LayerId.Should().Be(7);
+        pipeline.LastContext.Actor.Should().Be("tester");
+    }
+
+    [Fact]
+    public async Task QueryWithValidationAsync_V2_WithoutComputedFields_LeavesFeaturesUnchanged()
+    {
+        var featureReader = Substitute.For<IFeatureReader>();
+        var feature = CreateFeature(1, "alpha");
+        featureReader.QueryAsync(7, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(QueryResult<Feature>.Create(
+                totalCount: 1,
+                items: ImmutableArray.Create(feature))));
+
+        // Default executor uses the no-op pipeline (no Enterprise plugin SDK / no providers).
+        var sut = CreateSut(featureReader);
+        var service = CreateService();
+        var resource = CreateResource();
+        var publication = CreatePublication(service, resource);
+
+        var result = await sut.QueryWithValidationAsync(
+            service,
+            resource,
+            publication,
+            7,
+            new FeatureQuery(),
+            actor: null,
+            CancellationToken.None);
+
+        result.Items.Should().ContainSingle().Which.Should().Be(feature);
+    }
+
+    private sealed class StubComputedFieldPipeline(string fieldName, object? value) : IComputedFieldPipeline
+    {
+        public ComputedFieldContext? LastContext { get; private set; }
+
+        public bool HasComputedFields => true;
+
+        public ValueTask<Feature> ProjectAsync(Feature feature, ComputedFieldContext context, CancellationToken cancellationToken)
+        {
+            LastContext = context;
+            return ValueTask.FromResult(feature with { Attributes = feature.Attributes.SetItem(fieldName, value) });
+        }
+    }
+
     private static FeatureServerQueryExecutor CreateSut(
         IFeatureReader featureReader,
         IStreamingFeatureStore? streamingStore = null,
         FeatureProviderQueryRouter? providerQueryRouter = null,
-        IMetadataV2GraphProvider? metadataGraphProvider = null)
+        IMetadataV2GraphProvider? metadataGraphProvider = null,
+        IComputedFieldPipeline? computedFieldPipeline = null)
     {
         streamingStore ??= Substitute.For<IStreamingFeatureStore>();
         var formatter = new StreamingQueryFormatter(Options.Create(new LimitsOptions()));
@@ -621,7 +698,8 @@ public sealed class FeatureServerQueryExecutorTests
             streamingStore,
             formatter,
             providerQueryRouter,
-            metadataGraphProvider);
+            metadataGraphProvider,
+            computedFieldPipeline);
     }
 
     private static FeatureProviderQueryRouter CreateProviderRouter(IFeatureReader reader)


### PR DESCRIPTION
## Summary

Phase-2 plugin/extension SDK slice for #1562. Connects the existing-but-unwired `IComputedFieldPipeline` into the canonical GeoServices FeatureServer query path.

Phase 1 (#1561) shipped the computed-field abstraction (`IComputedFieldProvider`), the full pipeline implementation (Enterprise `plugin.sdk` gating, operator kill-switch, per-plugin circuit breaker / auto-disable, metrics, failure isolation), and unit coverage — but **nothing invoked it on a read path**. This PR wires it in.

## What this does

- Injects `IComputedFieldPipeline` into `FeatureServerQueryExecutor` as an **optional** ctor dependency, defaulting to the zero-overhead `NoOpComputedFieldPipeline`. The common production path and existing direct-construction tests are unchanged; the DI container resolves the singleton that `AddHonuaPlugins` always registers.
- Projects registered computed-field providers onto each returned feature at the single materialized-`Feature` seam — the V2 `FeatureServerQueryExecutor.QueryWithValidationAsync` overload — **before** formatting. This covers the dominant `f=json`/`geojson`/`pbf`/`parquet`/`arrow` FeatureServer query formats, which all flow through `QueryResult<Feature>`.
- Threads the authenticated caller through as the compute-context `Actor`, with service/layer identity sourced from the queried resource.
- Isolation, auto-disable, and metrics are handled inside the pipeline (phase 1). A faulting provider's field is omitted, never failing the query.

No new HTTP route is added, so there is no `EndpointRegistry` / feature-catalog / proof-ledger change.

## Done vs deferred (phase-2 is incremental)

**Done:** computed-field projection on the canonical `Feature`-based FeatureServer query formats.

**Deferred (still tracked under #1562):**
- The raw GeoServices / Geobuf / FlatGeobuf fast paths bypass the canonical `Feature` representation and do not yet carry computed fields (documented in code at the seam).
- Wiring computed fields into the OGC API Features, OData, WFS, and MVT read seams.
- Remaining phase-2 items: `[Plugin]` source generator, per-plugin config schema validation, cross-layer validation, and wiring the edit pipeline into the other edit protocols.

## Tests

- `FeatureServerQueryExecutorTests.QueryWithValidationAsync_V2_WithComputedFieldPipeline_ProjectsComputedFields` — projection adds the computed field and flows service/layer/actor context.
- `FeatureServerQueryExecutorTests.QueryWithValidationAsync_V2_WithoutComputedFields_LeavesFeaturesUnchanged` — the default no-op pipeline leaves features untouched.

Verification (Release, warnings-as-errors, run serially):
- `Honua.Protocols.GeoServices` builds clean (0 warnings).
- GeoServices tests: 24/24 pass (incl. 2 new).
- `Honua.Plugins.Tests`: 66/66 pass.
- Architecture tests: vertical-slice/plugin-isolation/proof-ledger pass. Two `FeatureCatalogDriftTests` failures are **pre-existing on `trunk`** (a `DELETE /api/v1/admin/oauth-clients/{id}` route in `EndpointRegistry` missing from `feature-catalog.json`) and are unrelated to this change, which adds no route.

Refs #1562