### PR TITLE
ci: map unmapped Honua.Server.Tests class to its shard (ADR-0037 router guard)

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -1009,8 +1009,8 @@
       "upload_operator_eval_report": false,
       "upload_odata_evidence": false,
       "csproj": "tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj",
-      "_comment": "Owns the AI test assembly (Honua.Ai.Tests): MCP protocol, AI builder, the Ai.Tests Reporting classes, and the AI Providers namespace. NOTE (#1899): Honua.Server.Tests.Features.Providers.* (e.g. the Bedrock live tests) matched no shard filter and never ran; the Providers clause was added so they run here (the Bedrock live test is gated on HONUA_AI_LIVE_BEDROCK and no-ops/passes when the env var is unset, so it is safe in CI).",
-      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Mcp|FullyQualifiedName~Honua.Server.Tests.Features.AiBuilder|FullyQualifiedName~Honua.Server.Tests.Features.Reporting|FullyQualifiedName~Honua.Server.Tests.Features.Providers",
+      "_comment": "Owns the AI test assembly (Honua.Ai.Tests): MCP protocol, AI builder, the Ai.Tests Reporting classes, the AI Providers namespace, and the natural-language WorkflowGeneration tests. NOTE (#1899): Honua.Server.Tests.Features.Providers.* (e.g. the Bedrock live tests) matched no shard filter and never ran; the Providers clause was added so they run here (the Bedrock live test is gated on HONUA_AI_LIVE_BEDROCK and no-ops/passes when the env var is unset, so it is safe in CI). The WorkflowGeneration clause was added (same #1899 class) because WorkflowGenerationServiceTests lives in this assembly (tests/dotnet/Honua.Ai.Tests/Source/WorkflowGenerationServiceTests.cs) and only a shard whose csproj == Honua.Ai.Tests can claim it.",
+      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Mcp|FullyQualifiedName~Honua.Server.Tests.Features.AiBuilder|FullyQualifiedName~Honua.Server.Tests.Features.Reporting|FullyQualifiedName~Honua.Server.Tests.Features.Providers|FullyQualifiedName~Honua.Server.Tests.Features.WorkflowGeneration",
       "paths": [
         "src/Honua.Ai/",
         "tests/dotnet/Honua.Ai.Tests/Source/",


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1899

## Summary
The ADR-0037 shard-routing guard (`scripts/ci/check-server-test-shard-coverage.py`, the `CI Router Validation` job) was hard-failing on every merge-train batch with `1 Honua.Server.Tests class(es) match NO shard filter and would never run in CI`, which fails the CI Gate and escalates the train.

A newly added test class, `Honua.Server.Tests.Features.WorkflowGeneration.WorkflowGenerationServiceTests` (in `tests/dotnet/Honua.Ai.Tests/Source/WorkflowGenerationServiceTests.cs`), lives in the `Honua.Ai.Tests` assembly but no shard whose resolved `csproj` is `Honua.Ai.Tests.csproj` had a filter that claimed its FQN. Only the **MCP** shard owns that assembly; its filter matched `Mcp|AiBuilder|Reporting|Providers` namespaces, none of which is `Features.WorkflowGeneration`. (The big `Features.*` coverage catch-all cannot claim it because that shard targets the Server.Tests monolith, not the AI assembly.)

Fix: extend the MCP shard's `filter` with a `FullyQualifiedName~Honua.Server.Tests.Features.WorkflowGeneration` clause so the class is claimed by exactly one shard. The MCP shard's `paths` already routes `tests/dotnet/Honua.Ai.Tests/Source/`, so diff-targeting was already correct — only the filter needed the new namespace.

After the change the guard reports `OK: all 577 Honua.Server.Tests classes are claimed by at least one shard filter` and exits 0.

## Changes Made
- Added a `FullyQualifiedName~Honua.Server.Tests.Features.WorkflowGeneration` clause to the MCP shard `filter` in `.github/ci-shards.json` (the shard that owns the `Honua.Ai.Tests` assembly).
- Updated the MCP shard `_comment` to document why the WorkflowGeneration clause was added (same #1899 class — only an `Honua.Ai.Tests`-targeting shard can claim a class in that assembly).

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed
<!-- Ran `python3 scripts/ci/check-server-test-shard-coverage.py` locally: exits 0, 0 orphans, WorkflowGenerationServiceTests claimed by exactly one shard (MCP). JSON validated. -->

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
<!-- CI-config-only change; the relevant validation is the shard-coverage guard, which was run locally and exits 0. No source/build change. -->
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
