### PR TITLE
test: fix stale workflow node registry palette provider assertion

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Features/WorkflowPackages/WorkflowPackageEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/WorkflowPackages/WorkflowPackageEndpointsTests.cs
@@ -90,8 +90,10 @@ public sealed class WorkflowPackageEndpointsTests : IAsyncLifetime
         using var doc = await ReadJsonAsync(response);
         var data = doc.RootElement.GetProperty("data");
         data.GetProperty("registryVersion").GetString().Should().NotBeNullOrWhiteSpace();
-        data.GetProperty("providers")[0].GetProperty("providerId").GetString()
-            .Should().Be("geoprocessing.process-catalog");
+        var providerIds = data.GetProperty("providers").EnumerateArray()
+            .Select(provider => provider.GetProperty("providerId").GetString())
+            .ToArray();
+        providerIds.Should().Contain("geoprocessing.process-catalog");
 
         var bufferNode = data.GetProperty("nodes")
             .EnumerateArray()


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1759

## Summary
Fixes the deterministic failure of `GetRegistry_ReturnsServerOwnedProcessPalette` in the "Server Tests (Workflow Packages)" CI shard, which was blocking the merge train. PR #1759 added a second workflow node provider (`AuthoringWorkflowNodeProvider`, id `authoring.publishing-catalog`) alongside the existing `ProcessCatalogWorkflowNodeProvider` (id `geoprocessing.process-catalog`). `WorkflowNodeRegistry` orders providers by `ProviderId` using `StringComparer.Ordinal`, so `authoring.publishing-catalog` now sorts ahead of `geoprocessing.process-catalog` and occupies `providers[0]`. The test still hard-coded `providers[0]` to `geoprocessing.process-catalog` and began failing with `actual "authoring.publishing…" vs expected "geoprocessing.proces…"`.

Root cause: the new provider is intended; the test assertion was stale (it predated the second provider and #1759 updated `Honua.Ai.Tests` but missed this `Honua.Server.Tests` assertion). The production ordering is correct, so the fix is on the test side.

## Changes Made
- Relax the provider assertion in `GetRegistry_ReturnsServerOwnedProcessPalette` to verify `geoprocessing.process-catalog` is **present** in the providers collection instead of pinning it to a fixed index `[0]`.
- This keeps the test robust to provider count/ordering changes (e.g. the newly added authoring provider).

## Testing
- [x] Integration tests added/updated
- [ ] Unit tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Note: `dotnet build Honua.sln -c Release /p:TreatWarningsAsErrors=true` is clean (0 warnings/0 errors) and `dotnet format --verify-no-changes` passes for the edited file. The integration test itself could not be executed in this environment because no Docker daemon / PostGIS / Redis is available (Testcontainers fails at `DockerClient.PingAsync`); the test compiles and is discoverable. CI (with Docker) will run it. The change is provably safe: both providers are registered in `WorkflowPackageServiceCollectionExtensions`, so `geoprocessing.process-catalog` is guaranteed present in the collection.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
