### PR TITLE
test(api-governance): recognize generic GetFromJsonAsync<T> as endpoint backing

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Features/API/EndpointRegistryDriftTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/API/EndpointRegistryDriftTests.cs
@@ -465,11 +465,17 @@ public sealed class EndpointRegistryDriftTests : IAsyncLifetime
     {
         var pattern = method.ToUpperInvariant() switch
         {
-            "GET" => @"(?:\.Get(?:FromJson)?|Get\w*)Async\s*\(|new\s+HttpRequestMessage\s*\(\s*HttpMethod\.Get\s*,",
-            "POST" => @"(?:\.Post(?:AsJson)?|Post\w*)Async\s*\(|new\s+HttpRequestMessage\s*\(\s*HttpMethod\.Post\s*,",
-            "PUT" => @"(?:\.Put(?:AsJson)?|Put\w*)Async\s*\(|new\s+HttpRequestMessage\s*\(\s*HttpMethod\.Put\s*,",
-            "PATCH" => @"(?:\.Patch(?:AsJson)?|Patch\w*)Async\s*\(|new\s+HttpRequestMessage\s*\(\s*HttpMethod\.Patch\s*,",
-            "DELETE" => @"(?:\.Delete|Delete\w*)Async\s*\(|new\s+HttpRequestMessage\s*\(\s*HttpMethod\.Delete\s*,",
+            // The optional (?:<[^()]*>)? segment lets the verb match generic
+            // typed-deserialization helpers such as GetFromJsonAsync<T>(...) where a
+            // generic type-argument list sits between the method name and the call's
+            // opening parenthesis. Without it, an endpoint exercised only via
+            // GetFromJsonAsync<T> (e.g. GET /api/v1/admin/oauth-scopes) is reported as
+            // uncovered even though it has a backing HTTP request.
+            "GET" => @"(?:\.Get(?:FromJson)?|Get\w*)Async(?:<[^()]*>)?\s*\(|new\s+HttpRequestMessage\s*\(\s*HttpMethod\.Get\s*,",
+            "POST" => @"(?:\.Post(?:AsJson)?|Post\w*)Async(?:<[^()]*>)?\s*\(|new\s+HttpRequestMessage\s*\(\s*HttpMethod\.Post\s*,",
+            "PUT" => @"(?:\.Put(?:AsJson)?|Put\w*)Async(?:<[^()]*>)?\s*\(|new\s+HttpRequestMessage\s*\(\s*HttpMethod\.Put\s*,",
+            "PATCH" => @"(?:\.Patch(?:AsJson)?|Patch\w*)Async(?:<[^()]*>)?\s*\(|new\s+HttpRequestMessage\s*\(\s*HttpMethod\.Patch\s*,",
+            "DELETE" => @"(?:\.Delete|Delete\w*)Async(?:<[^()]*>)?\s*\(|new\s+HttpRequestMessage\s*\(\s*HttpMethod\.Delete\s*,",
             "HEAD" => @"new\s+HttpRequestMessage\s*\(\s*HttpMethod\.Head\s*,",
             _ => null
         };


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2104

## Summary
The `AllEndpointRegistryEntries_AreBackedByHttpRequests` API-governance architecture test scans integration-test method bodies for HTTP verb invocations that back each `EndpointRegistry` entry. Its verb regex required the call's opening parenthesis to immediately follow the `Async` method name, so a generic typed-deserialization helper such as `GetFromJsonAsync<T>(...)` — where a generic type-argument list sits between the method name and `(` — was not detected. `GET /api/v1/admin/oauth-scopes` is exercised only via `GetFromJsonAsync<ApiResponse<OAuthScopeResponse[]>>(...)`, so the endpoint was reported as uncovered despite having a real backing HTTP request, failing the **Server Tests (STAC and API Governance)** shard on trunk and blocking the merge train.

## Changes Made
- Allow an optional generic type-argument list (`(?:<[^()]*>)?`) before the call parenthesis in the GET/POST/PUT/PATCH/DELETE verb-detection patterns in `EndpointRegistryDriftTests.HasHttpVerbInvocation`.
- Added an explanatory comment documenting why typed `*Async<T>(...)` helpers must be recognized as endpoint backings.

## Testing
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
