### PR TITLE
ci(merge-train): fire format forward-fix when format job co-fails with CI Gate aggregator

### DIFF
--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -177,6 +177,13 @@ echo "== Case 4: format-drift (forward-fix path) =="
 train_is_format_only_failure "build / Format Verification" && ok "fwdfix: single format job => format-only" || bad "fwdfix: should be format-only"
 train_is_format_only_failure $'build / Format Verification\nserver-tests (Core)' && bad "fwdfix: multi-failure must NOT be format-only" || ok "fwdfix: multi-failure not format-only"
 train_is_format_only_failure "server-tests (Core)" && bad "fwdfix: non-format must NOT be format-only" || ok "fwdfix: non-format not format-only"
+# Real-world: the format job ALWAYS co-fails with the CI Gate (and often Test Suite
+# Summary) aggregators. After stripping non-blocking/aggregator jobs the sole real
+# failure is the format job => format-only (this is what was broken: it escalated).
+train_is_format_only_failure $'Build & Format Check\nCI Gate' && ok "fwdfix: format+CI Gate aggregator => format-only" || bad "fwdfix: format+aggregator must be format-only"
+train_is_format_only_failure $'Build & Format Check\nCI Gate\nTest Suite Summary' && ok "fwdfix: format+2 aggregators => format-only" || bad "fwdfix: format+aggregators must be format-only"
+train_is_format_only_failure $'Build & Format Check\nCI Gate\nServer Tests (OData Core)' && bad "fwdfix: format+REAL shard must NOT be format-only" || ok "fwdfix: format+real shard not format-only"
+train_is_format_only_failure $'CI Gate\nTest Suite Summary' && bad "fwdfix: aggregators-only must NOT be format-only" || ok "fwdfix: aggregators-only not format-only"
 # Fake formatter that produces a change -> forward-fix commits it.
 git fetch -q origin trunk; git checkout -q -B fwdfix-batch origin/trunk
 export TRAIN_FORMAT_CMD=__fake_fmt

--- a/scripts/ci/merge-train/forward-fix.sh
+++ b/scripts/ci/merge-train/forward-fix.sh
@@ -16,10 +16,20 @@
 # ONLY when exactly one job failed AND its name matches the format job.
 train_is_format_only_failure() {
   local failing="$1"
+  # Aggregator / non-blocking meta-jobs (CI Gate, Test Suite Summary, and the
+  # non-blocking aux jobs in TRAIN_NONBLOCKING_JOBS) fail as a CONSEQUENCE of the
+  # real failure — they must NOT count toward "is the sole real failure a format
+  # failure". Without this strip, a format-only batch reds on BOTH "Build & Format
+  # Check" AND "CI Gate" (n=2 -> not format-only), so the forward-fix NEVER fired
+  # and the batch escalated instead of auto-running `dotnet format`. Strip them,
+  # then require exactly one remaining (real) failing job whose name is the format
+  # job.
+  local real
+  real="$(printf '%s\n' "${failing}" | sed '/^$/d' | grep -vxiF "${TRAIN_NONBLOCKING_JOBS}" || true)"
   local n
-  n="$(printf '%s\n' "${failing}" | sed '/^$/d' | wc -l | tr -d ' ')"
+  n="$(printf '%s\n' "${real}" | sed '/^$/d' | wc -l | tr -d ' ')"
   [[ "${n}" == "1" ]] || return 1
-  printf '%s\n' "${failing}" | grep -Eqi 'format'
+  printf '%s\n' "${real}" | grep -Eqi 'format'
 }
 
 # train_forward_fix <batch-branch> <attempt-count>: apply dotnet format, commit,


### PR DESCRIPTION
## Summary
The train's format forward-fix never fired in practice: `train_is_format_only_failure` required exactly ONE failing job, but a format-only batch always reds on BOTH 'Build & Format Check' AND the 'CI Gate' aggregator (n=2), so it escalated the whole batch instead of auto-running `dotnet format`. This stranded every fleet PR with a format violation (e.g. #2091).

## Changes Made
- Strip TRAIN_NONBLOCKING_JOBS (CI Gate, Test Suite Summary, non-blocking aux) before the format-only count, then require exactly one remaining real failing job = the format job.
- Added fixtures: format+CI Gate => format-only; format+2 aggregators => format-only; format+real shard => NOT format-only; aggregators-only => NOT.

## Breaking Changes
None.

## Gate Impact
- [x] No gate impact (merge-train CI-infra only)

## Testing
- [x] Fixture suite 124/0 including the 4 new format-only cases.

Related to #1387