### PR TITLE
feat: SCIM 2.0 provisioning and SAML 2.0 SSO enterprise identity (#510, #508)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -113,6 +113,10 @@
     <PackageVersion Include="Snowflake.Data" Version="5.7.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.12.14" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+    <!-- Test-only: independent XML-DSig reference implementation used to generate signed SAML
+         assertions in tests that validate the AOT-safe in-server verifier (#508). Not referenced
+         by any shipped project. -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.0" />
     <PackageVersion Include="Testcontainers.MySql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -723,6 +723,32 @@
       "maturity": "implemented"
     },
     {
+      "id": "delete-scim-v2-groups-id",
+      "route": "/scim/v2/Groups/{id}",
+      "method": "DELETE",
+      "family": "SCIM 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.GroupLifecycle_MembershipChanges_SyncRoles"
+      ],
+      "proof_ledger_surface": "scim-provisioning",
+      "maturity": "implemented"
+    },
+    {
+      "id": "delete-scim-v2-users-id",
+      "route": "/scim/v2/Users/{id}",
+      "method": "DELETE",
+      "family": "SCIM 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.DeleteUser_RevokesAccess"
+      ],
+      "proof_ledger_surface": "scim-provisioning",
+      "maturity": "implemented"
+    },
+    {
       "id": "get-api-enrich-catalog",
       "route": "/api/enrich/catalog",
       "method": "GET",
@@ -5208,7 +5234,7 @@
         "Honua.Server.Tests.Features.CloudDemo.CloudDemoEndpointsTests.StoryCollection_AfterReset_ReturnsSeededOgcFeatures",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_FormatParameterOverridesAcceptHeader",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_ReturnsResponseWithPagingLinksAndTimeStamp",
-        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_With3dBbox_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_With3dBbox_AcceptsAndUsesHorizontalExtent",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithBbox_ExcludesNullGeometryFeatures",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithCql2TextTemporalInstantOnAttributeField_Returns200",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithCql2TextTemporalOnUndefinedField_Returns400",
@@ -9236,6 +9262,19 @@
       "maturity": "implemented"
     },
     {
+      "id": "get-saml-metadata",
+      "route": "/saml/metadata",
+      "method": "GET",
+      "family": "SAML 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.SamlBridgeEndpointsTests.Metadata_WhenConfigured_ReturnsSpMetadata"
+      ],
+      "proof_ledger_surface": "saml-sso",
+      "maturity": "implemented"
+    },
+    {
       "id": "get-samples-stac-ops",
       "route": "/samples/stac-ops",
       "method": "GET",
@@ -9368,6 +9407,60 @@
         "Honua.Server.Tests.Features.Protocols.Scene.SceneTilesetEndpointTests.GetSceneAsset_UnknownAsset_Returns404"
       ],
       "proof_ledger_surface": "scenes-3dtiles",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-scim-v2-groups",
+      "route": "/scim/v2/Groups",
+      "method": "GET",
+      "family": "SCIM 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.CreateGroup_WithMembers_MapsRoleToMembers"
+      ],
+      "proof_ledger_surface": "scim-provisioning",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-scim-v2-groups-id",
+      "route": "/scim/v2/Groups/{id}",
+      "method": "GET",
+      "family": "SCIM 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.GroupLifecycle_MembershipChanges_SyncRoles"
+      ],
+      "proof_ledger_surface": "scim-provisioning",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-scim-v2-users",
+      "route": "/scim/v2/Users",
+      "method": "GET",
+      "family": "SCIM 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.ListUsers_WithUserNameFilter_ReturnsMatch",
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.Request_WithWrongBearerToken_ReturnsUnauthorized",
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.Request_WithoutBearerToken_ReturnsUnauthorized"
+      ],
+      "proof_ledger_surface": "scim-provisioning",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-scim-v2-users-id",
+      "route": "/scim/v2/Users/{id}",
+      "method": "GET",
+      "family": "SCIM 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.GetUser_Existing_ReturnsUser"
+      ],
+      "proof_ledger_surface": "scim-provisioning",
       "maturity": "implemented"
     },
     {
@@ -10484,6 +10577,32 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesTransactionTests.PatchFeature_WithUnsupportedContentType_ReturnsUnsupportedMediaType"
       ],
       "proof_ledger_surface": "ogc-api-features",
+      "maturity": "implemented"
+    },
+    {
+      "id": "patch-scim-v2-groups-id",
+      "route": "/scim/v2/Groups/{id}",
+      "method": "PATCH",
+      "family": "SCIM 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.GroupLifecycle_MembershipChanges_SyncRoles"
+      ],
+      "proof_ledger_surface": "scim-provisioning",
+      "maturity": "implemented"
+    },
+    {
+      "id": "patch-scim-v2-users-id",
+      "route": "/scim/v2/Users/{id}",
+      "method": "PATCH",
+      "family": "SCIM 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.PatchUser_SetActiveFalse_DeprovisionsUser"
+      ],
+      "proof_ledger_surface": "scim-provisioning",
       "maturity": "implemented"
     },
     {
@@ -16066,6 +16185,23 @@
       "maturity": "implemented"
     },
     {
+      "id": "post-saml-acs",
+      "route": "/saml/acs",
+      "method": "POST",
+      "family": "SAML 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.SamlBridgeEndpointsTests.Acs_ExpiredAssertion_IsRejected",
+        "Honua.Server.Tests.Features.Identity.SamlBridgeEndpointsTests.Acs_ForgedSignature_IsRejected",
+        "Honua.Server.Tests.Features.Identity.SamlBridgeEndpointsTests.Acs_MissingSamlResponse_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.Identity.SamlBridgeEndpointsTests.Acs_UnsignedAssertion_IsRejected",
+        "Honua.Server.Tests.Features.Identity.SamlBridgeEndpointsTests.Acs_ValidSignedAssertion_EstablishesSession"
+      ],
+      "proof_ledger_surface": "saml-sso",
+      "maturity": "implemented"
+    },
+    {
       "id": "post-scenes-sceneid-access-envelope",
       "route": "/scenes/{sceneId}/access-envelope",
       "method": "POST",
@@ -16082,6 +16218,33 @@
         "Honua.Server.Tests.Features.Protocols.Scene.SceneAccessEnvelopeMisconfiguredEndpointTests.IssueEnvelope_MissingSigningKey_Returns500"
       ],
       "proof_ledger_surface": "scenes-3dtiles",
+      "maturity": "implemented"
+    },
+    {
+      "id": "post-scim-v2-groups",
+      "route": "/scim/v2/Groups",
+      "method": "POST",
+      "family": "SCIM 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.CreateGroup_WithMembers_MapsRoleToMembers"
+      ],
+      "proof_ledger_surface": "scim-provisioning",
+      "maturity": "implemented"
+    },
+    {
+      "id": "post-scim-v2-users",
+      "route": "/scim/v2/Users",
+      "method": "POST",
+      "family": "SCIM 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.CreateUser_DuplicateUserName_ReturnsConflict",
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.CreateUser_ValidRequest_ProvisionsUser"
+      ],
+      "proof_ledger_surface": "scim-provisioning",
       "maturity": "implemented"
     },
     {
@@ -17103,6 +17266,32 @@
         "Honua.Server.Tests.Features.Styling.OgcStylesEndpointTests.PutStyle_WithValidMapLibre_Returns204"
       ],
       "proof_ledger_surface": "ogc-api-styles",
+      "maturity": "implemented"
+    },
+    {
+      "id": "put-scim-v2-groups-id",
+      "route": "/scim/v2/Groups/{id}",
+      "method": "PUT",
+      "family": "SCIM 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.GroupLifecycle_MembershipChanges_SyncRoles"
+      ],
+      "proof_ledger_surface": "scim-provisioning",
+      "maturity": "implemented"
+    },
+    {
+      "id": "put-scim-v2-users-id",
+      "route": "/scim/v2/Users/{id}",
+      "method": "PUT",
+      "family": "SCIM 2.0",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.ReplaceUser_UpdatesAttributes"
+      ],
+      "proof_ledger_surface": "scim-provisioning",
       "maturity": "implemented"
     }
   ]

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -384,6 +384,109 @@
       ]
     },
     {
+      "surfaceId": "scim-provisioning",
+      "displayName": "SCIM 2.0 user and group provisioning",
+      "surfaceKind": "http-route-family",
+      "protocol": "SCIM 2.0",
+      "canonicalIdentifier": "/scim/v2/**",
+      "parentSurfaceId": null,
+      "endpointPrefixes": [
+        "/scim/v2/"
+      ],
+      "endpointExactMatches": [],
+      "endpointContains": [],
+      "operationKeys": [],
+      "proofs": [
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "EndpointRegistry coverage plus ScimProvisioningEndpointsTests integration tests assert Users and Groups CRUD, list filtering/pagination, and bearer-token authentication for the /scim/v2 surface.",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/EndpointRegistry.cs",
+            "src/Honua.Server/Features/Identity/Scim/ScimEndpoints.cs",
+            "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/Identity/ScimProvisioningEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#510",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "scenario-depth",
+          "proofMechanism": "SCIM provisions users into the shared identity store (ProvisioningSource=scim) and maps group membership to Honua RBAC roles; integration tests prove provision, deprovision (active=false revokes roles), and group membership changes update the member's role assignments, plus rejection of requests without a valid bearer token.",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "src/Honua.Server/Features/Admin/Services/InMemoryUserStore.cs",
+            "src/Honua.Server/Features/Admin/Services/InMemoryScimGroupStore.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/Identity/ScimProvisioningEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#510",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "contract-governance",
+          "proofMechanism": "SCIM wire shapes (User/Group resources, ListResponse, PatchOp, Error) are emitted through a source-generated JSON context (ScimJsonContext) keeping the application/scim+json contract AOT-safe.",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "src/Honua.Server/Features/Identity/Scim/Models/ScimModels.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#510",
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
+      "surfaceId": "saml-sso",
+      "displayName": "SAML 2.0 Service Provider SSO bridge",
+      "surfaceKind": "http-route-family",
+      "protocol": "SAML 2.0",
+      "canonicalIdentifier": "/saml/**",
+      "parentSurfaceId": null,
+      "endpointPrefixes": [
+        "/saml/"
+      ],
+      "endpointExactMatches": [],
+      "endpointContains": [],
+      "operationKeys": [],
+      "proofs": [
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "EndpointRegistry coverage plus SamlBridgeEndpointsTests integration tests assert SP metadata generation and the Assertion Consumer Service (POST /saml/acs) over the /saml surface.",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/EndpointRegistry.cs",
+            "src/Honua.Server/Features/Identity/Saml/SamlEndpoints.cs",
+            "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/Identity/SamlBridgeEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#508",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "scenario-depth",
+          "proofMechanism": "The ACS verifies the enveloped XML-DSig signature against the configured IdP certificate (AOT-safe Exclusive C14N, no SignedXml), enforces issuer/audience/NotBefore/NotOnOrAfter, maps SAML attributes to RBAC roles, and establishes the same session/claims model as OIDC; integration and unit tests prove a valid assertion authenticates while a forged signature and an expired assertion are rejected.",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "src/Honua.Server/Features/Identity/Saml/SamlAssertionValidator.cs",
+            "src/Honua.Server/Features/Identity/Saml/SamlSignatureVerifier.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/Identity/SamlBridgeEndpointsTests.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/Identity/SamlAssertionValidatorTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#508",
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
       "surfaceId": "console-workflow-packages",
       "displayName": "Console workflow package and node registry API",
       "surfaceKind": "http-route-family",

--- a/src/Honua.Core/Features/Identity/Abstractions/IScimGroupStore.cs
+++ b/src/Honua.Core/Features/Identity/Abstractions/IScimGroupStore.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Identity.Domain;
+
+namespace Honua.Core.Features.Identity.Abstractions;
+
+/// <summary>
+/// Provisioning store for SCIM 2.0 group lifecycle management (#510). A SCIM group maps to
+/// a Honua role: members of the group receive the role, so deprovisioning a member (or the
+/// group) removes the corresponding role assignment and the access it confers.
+/// </summary>
+public interface IScimGroupStore
+{
+    /// <summary>
+    /// Provisions a new group (mapped to a role) or returns <see langword="null"/> when a
+    /// group with the same display name already exists.
+    /// </summary>
+    Task<ScimGroup?> CreateGroupAsync(ScimGroupProvisioning provisioning, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a provisioned group by identifier.
+    /// </summary>
+    Task<ScimGroup?> GetGroupAsync(string groupId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists provisioned groups with SCIM filtering and pagination.
+    /// </summary>
+    Task<ScimGroupPage> ListGroupsAsync(ScimGroupQuery query, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Replaces a group's display name and full member set (SCIM PUT semantics). Returns
+    /// <see langword="null"/> when the group does not exist.
+    /// </summary>
+    Task<ScimGroup?> ReplaceGroupAsync(string groupId, ScimGroupProvisioning provisioning, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds or removes members of a group (SCIM PATCH <c>members</c>). Adding a member grants
+    /// the mapped role; removing a member revokes it. Returns <see langword="null"/> when the
+    /// group does not exist.
+    /// </summary>
+    Task<ScimGroup?> UpdateMembersAsync(string groupId, ScimGroupMemberChange change, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a group and revokes the mapped role from all of its members. Returns
+    /// <see langword="false"/> when the group does not exist.
+    /// </summary>
+    Task<bool> DeleteGroupAsync(string groupId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Attributes supplied by an identity provider when provisioning or replacing a SCIM group.
+/// </summary>
+public sealed class ScimGroupProvisioning
+{
+    /// <summary>
+    /// The SCIM group <c>displayName</c>; also the Honua role name the group maps to. Required.
+    /// </summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// User identifiers that are members of the group.
+    /// </summary>
+    public IReadOnlyList<string> MemberUserIds { get; init; } = [];
+}
+
+/// <summary>
+/// A SCIM group PATCH member delta. Members are added or removed; the operation is not a
+/// full replace.
+/// </summary>
+public sealed class ScimGroupMemberChange
+{
+    /// <summary>
+    /// User identifiers to add to the group.
+    /// </summary>
+    public IReadOnlyList<string> Add { get; init; } = [];
+
+    /// <summary>
+    /// User identifiers to remove from the group.
+    /// </summary>
+    public IReadOnlyList<string> Remove { get; init; } = [];
+}
+
+/// <summary>
+/// SCIM list query parameters for groups (1-based <c>startIndex</c> per RFC 7644).
+/// </summary>
+public sealed class ScimGroupQuery
+{
+    /// <summary>
+    /// Optional <c>displayName eq "..."</c> equality filter value.
+    /// </summary>
+    public string? DisplayNameEquals { get; init; }
+
+    /// <summary>
+    /// 1-based index of the first result to return.
+    /// </summary>
+    public int StartIndex { get; init; } = 1;
+
+    /// <summary>
+    /// Maximum number of results to return in this page.
+    /// </summary>
+    public int Count { get; init; } = 100;
+}
+
+/// <summary>
+/// A page of SCIM groups together with the total match count.
+/// </summary>
+public sealed class ScimGroupPage
+{
+    /// <summary>
+    /// Groups in this page.
+    /// </summary>
+    public required IReadOnlyList<ScimGroup> Groups { get; init; }
+
+    /// <summary>
+    /// Total number of groups matching the query (before pagination).
+    /// </summary>
+    public required int TotalCount { get; init; }
+}

--- a/src/Honua.Core/Features/Identity/Abstractions/IScimUserStore.cs
+++ b/src/Honua.Core/Features/Identity/Abstractions/IScimUserStore.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Identity.Domain;
+
+namespace Honua.Core.Features.Identity.Abstractions;
+
+/// <summary>
+/// Provisioning store for SCIM 2.0 user lifecycle management (#510). Distinct from
+/// <see cref="IUserStore"/>, which exposes only the admin read / role-update / deprovision
+/// surface: SCIM additionally requires create, full-replace, and reactivation so an external
+/// identity provider (Okta, Microsoft Entra, etc.) owns the user record end to end.
+/// </summary>
+public interface IScimUserStore
+{
+    /// <summary>
+    /// Provisions a new user or returns <see langword="null"/> when a user with the same
+    /// externally supplied identifier already exists.
+    /// </summary>
+    Task<ManagedUser?> CreateUserAsync(ScimUserProvisioning provisioning, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a provisioned user by identifier.
+    /// </summary>
+    Task<ManagedUser?> GetUserAsync(string userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds a user by the SCIM <c>userName</c> attribute (case-insensitive). Returns
+    /// <see langword="null"/> when no match exists.
+    /// </summary>
+    Task<ManagedUser?> FindByUserNameAsync(string userName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists provisioned users with SCIM filtering and pagination.
+    /// </summary>
+    Task<ScimUserPage> ListUsersAsync(ScimUserQuery query, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Replaces the mutable attributes of an existing user (SCIM PUT semantics). Returns
+    /// <see langword="null"/> when the user does not exist.
+    /// </summary>
+    Task<ManagedUser?> ReplaceUserAsync(string userId, ScimUserProvisioning provisioning, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the active state of a user (SCIM PATCH <c>active</c>). Deactivation revokes
+    /// access; reactivation restores it. Returns <see langword="null"/> when the user does
+    /// not exist.
+    /// </summary>
+    Task<ManagedUser?> SetActiveAsync(string userId, bool active, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Permanently deprovisions (deactivates and clears roles) a user. Returns
+    /// <see langword="false"/> when the user does not exist.
+    /// </summary>
+    Task<bool> DeleteUserAsync(string userId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Attributes supplied by an identity provider when provisioning or replacing a SCIM user.
+/// </summary>
+public sealed class ScimUserProvisioning
+{
+    /// <summary>
+    /// The SCIM <c>userName</c> — the IdP-owned login identifier. Required.
+    /// </summary>
+    public required string UserName { get; init; }
+
+    /// <summary>
+    /// Display name. Falls back to <see cref="UserName"/> when the IdP omits it.
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
+    /// Primary email address, if supplied.
+    /// </summary>
+    public string? Email { get; init; }
+
+    /// <summary>
+    /// Whether the account is active. Defaults to active when omitted by the IdP.
+    /// </summary>
+    public bool Active { get; init; } = true;
+
+    /// <summary>
+    /// Role names to assign. SCIM group membership is mapped to Honua roles by the caller.
+    /// </summary>
+    public IReadOnlyList<string> Roles { get; init; } = [];
+}
+
+/// <summary>
+/// SCIM list query parameters (1-based <c>startIndex</c> per RFC 7644).
+/// </summary>
+public sealed class ScimUserQuery
+{
+    /// <summary>
+    /// Optional <c>userName eq "..."</c> equality filter value.
+    /// </summary>
+    public string? UserNameEquals { get; init; }
+
+    /// <summary>
+    /// 1-based index of the first result to return.
+    /// </summary>
+    public int StartIndex { get; init; } = 1;
+
+    /// <summary>
+    /// Maximum number of results to return in this page.
+    /// </summary>
+    public int Count { get; init; } = 100;
+}
+
+/// <summary>
+/// A page of SCIM users together with the total match count (for <c>totalResults</c>).
+/// </summary>
+public sealed class ScimUserPage
+{
+    /// <summary>
+    /// Users in this page.
+    /// </summary>
+    public required IReadOnlyList<ManagedUser> Users { get; init; }
+
+    /// <summary>
+    /// Total number of users matching the query (before pagination).
+    /// </summary>
+    public required int TotalCount { get; init; }
+}

--- a/src/Honua.Core/Features/Identity/Domain/ScimGroup.cs
+++ b/src/Honua.Core/Features/Identity/Domain/ScimGroup.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Identity.Domain;
+
+/// <summary>
+/// A group provisioned via SCIM 2.0 (#510). Each group maps to a Honua role of the same
+/// name; membership in the group confers the mapped role on the member user.
+/// </summary>
+public sealed class ScimGroup
+{
+    /// <summary>
+    /// Stable unique identifier for the group (server-assigned).
+    /// </summary>
+    public required string GroupId { get; init; }
+
+    /// <summary>
+    /// SCIM <c>displayName</c>; also the Honua role name the group maps to.
+    /// </summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// User identifiers that are members of this group.
+    /// </summary>
+    public IReadOnlyList<string> MemberUserIds { get; init; } = [];
+
+    /// <summary>
+    /// When the group was first provisioned.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// When the group record was last updated.
+    /// </summary>
+    public DateTimeOffset UpdatedAt { get; init; } = DateTimeOffset.UtcNow;
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -228,6 +228,24 @@ public static class EndpointRegistry
         new("GET", "/api/v1/admin/rls-policies/{id}"),
         new("DELETE", "/api/v1/admin/rls-policies/{id}"),
 
+        // SCIM 2.0 provisioning endpoints (#510)
+        new("GET", "/scim/v2/Users"),
+        new("POST", "/scim/v2/Users"),
+        new("GET", "/scim/v2/Users/{id}"),
+        new("PUT", "/scim/v2/Users/{id}"),
+        new("PATCH", "/scim/v2/Users/{id}"),
+        new("DELETE", "/scim/v2/Users/{id}"),
+        new("GET", "/scim/v2/Groups"),
+        new("POST", "/scim/v2/Groups"),
+        new("GET", "/scim/v2/Groups/{id}"),
+        new("PUT", "/scim/v2/Groups/{id}"),
+        new("PATCH", "/scim/v2/Groups/{id}"),
+        new("DELETE", "/scim/v2/Groups/{id}"),
+
+        // SAML 2.0 Service Provider endpoints (#508)
+        new("GET", "/saml/metadata"),
+        new("POST", "/saml/acs"),
+
         // v1 console metadata v2 content + RBAC baseline (#1162)
         new("GET", "/api/v1/console/session"),
         new("GET", "/api/v1/console/content"),

--- a/src/Honua.Server/Features/Admin/Services/InMemoryScimGroupStore.cs
+++ b/src/Honua.Server/Features/Admin/Services/InMemoryScimGroupStore.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using Honua.Core.Features.Identity.Abstractions;
+using Honua.Core.Features.Identity.Domain;
+
+namespace Honua.Server.Features.Admin.Services;
+
+/// <summary>
+/// In-memory SCIM 2.0 group store (#510). Each group maps to a Honua role named after the
+/// group's display name; adding or removing a member synchronizes that role onto the member's
+/// <see cref="ManagedUser"/> record via the shared <see cref="InMemoryUserStore"/> so SCIM
+/// group changes immediately drive RBAC role assignment.
+/// Will be replaced by a persistent implementation alongside the durable user store (#498).
+/// </summary>
+internal sealed class InMemoryScimGroupStore(InMemoryUserStore userStore) : IScimGroupStore
+{
+    private readonly ConcurrentDictionary<string, ScimGroup> _groups = new(StringComparer.OrdinalIgnoreCase);
+    private readonly InMemoryUserStore _userStore = userStore ?? throw new ArgumentNullException(nameof(userStore));
+    private readonly object _sync = new();
+
+    public Task<ScimGroup?> CreateGroupAsync(ScimGroupProvisioning provisioning, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(provisioning);
+
+        lock (_sync)
+        {
+            if (FindByDisplayNameInternal(provisioning.DisplayName) is not null)
+            {
+                return Task.FromResult<ScimGroup?>(null);
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            var members = NormalizeMembers(provisioning.MemberUserIds);
+            var group = new ScimGroup
+            {
+                GroupId = Guid.NewGuid().ToString("D"),
+                DisplayName = provisioning.DisplayName.Trim(),
+                MemberUserIds = members,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+
+            _groups[group.GroupId] = group;
+
+            foreach (var userId in members)
+            {
+                _userStore.AddRole(userId, group.DisplayName);
+            }
+
+            return Task.FromResult<ScimGroup?>(group);
+        }
+    }
+
+    public Task<ScimGroup?> GetGroupAsync(string groupId, CancellationToken cancellationToken = default)
+    {
+        _groups.TryGetValue(groupId, out var group);
+        return Task.FromResult(group);
+    }
+
+    public Task<ScimGroupPage> ListGroupsAsync(ScimGroupQuery query, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        IEnumerable<ScimGroup> matches = _groups.Values;
+
+        if (!string.IsNullOrEmpty(query.DisplayNameEquals))
+        {
+            matches = matches.Where(g => g.DisplayName.Equals(query.DisplayNameEquals, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var ordered = matches.OrderBy(g => g.DisplayName, StringComparer.OrdinalIgnoreCase).ToList();
+        var skip = Math.Max(0, query.StartIndex - 1);
+        var page = ordered.Skip(skip).Take(Math.Max(0, query.Count)).ToList().AsReadOnly();
+
+        return Task.FromResult(new ScimGroupPage { Groups = page, TotalCount = ordered.Count });
+    }
+
+    public Task<ScimGroup?> ReplaceGroupAsync(string groupId, ScimGroupProvisioning provisioning, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(provisioning);
+
+        lock (_sync)
+        {
+            if (!_groups.TryGetValue(groupId, out var existing))
+            {
+                return Task.FromResult<ScimGroup?>(null);
+            }
+
+            var newMembers = NormalizeMembers(provisioning.MemberUserIds);
+            var newName = provisioning.DisplayName.Trim();
+
+            // A rename re-maps the role: revoke the old role from everyone, then grant the new.
+            var renamed = !existing.DisplayName.Equals(newName, StringComparison.OrdinalIgnoreCase);
+
+            // Revoke the (old) role from members that are leaving or affected by a rename.
+            foreach (var userId in existing.MemberUserIds)
+            {
+                if (renamed || !newMembers.Contains(userId, StringComparer.OrdinalIgnoreCase))
+                {
+                    _userStore.RemoveRole(userId, existing.DisplayName);
+                }
+            }
+
+            // Grant the (new) role to the resulting member set.
+            foreach (var userId in newMembers)
+            {
+                _userStore.AddRole(userId, newName);
+            }
+
+            var updated = new ScimGroup
+            {
+                GroupId = existing.GroupId,
+                DisplayName = newName,
+                MemberUserIds = newMembers,
+                CreatedAt = existing.CreatedAt,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            };
+
+            _groups[groupId] = updated;
+            return Task.FromResult<ScimGroup?>(updated);
+        }
+    }
+
+    public Task<ScimGroup?> UpdateMembersAsync(string groupId, ScimGroupMemberChange change, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(change);
+
+        lock (_sync)
+        {
+            if (!_groups.TryGetValue(groupId, out var existing))
+            {
+                return Task.FromResult<ScimGroup?>(null);
+            }
+
+            var members = existing.MemberUserIds.ToList();
+
+            foreach (var userId in NormalizeMembers(change.Remove))
+            {
+                if (members.RemoveAll(m => m.Equals(userId, StringComparison.OrdinalIgnoreCase)) > 0)
+                {
+                    _userStore.RemoveRole(userId, existing.DisplayName);
+                }
+            }
+
+            foreach (var userId in NormalizeMembers(change.Add))
+            {
+                if (!members.Contains(userId, StringComparer.OrdinalIgnoreCase))
+                {
+                    members.Add(userId);
+                    _userStore.AddRole(userId, existing.DisplayName);
+                }
+            }
+
+            var updated = new ScimGroup
+            {
+                GroupId = existing.GroupId,
+                DisplayName = existing.DisplayName,
+                MemberUserIds = members,
+                CreatedAt = existing.CreatedAt,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            };
+
+            _groups[groupId] = updated;
+            return Task.FromResult<ScimGroup?>(updated);
+        }
+    }
+
+    public Task<bool> DeleteGroupAsync(string groupId, CancellationToken cancellationToken = default)
+    {
+        lock (_sync)
+        {
+            if (!_groups.TryRemove(groupId, out var removed))
+            {
+                return Task.FromResult(false);
+            }
+
+            foreach (var userId in removed.MemberUserIds)
+            {
+                _userStore.RemoveRole(userId, removed.DisplayName);
+            }
+
+            return Task.FromResult(true);
+        }
+    }
+
+    private ScimGroup? FindByDisplayNameInternal(string displayName)
+        => string.IsNullOrWhiteSpace(displayName)
+            ? null
+            : _groups.Values.FirstOrDefault(g => g.DisplayName.Equals(displayName.Trim(), StringComparison.OrdinalIgnoreCase));
+
+    private static List<string> NormalizeMembers(IReadOnlyList<string> members)
+        => members
+            .Where(static m => !string.IsNullOrWhiteSpace(m))
+            .Select(static m => m.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+}

--- a/src/Honua.Server/Features/Admin/Services/InMemoryUserStore.cs
+++ b/src/Honua.Server/Features/Admin/Services/InMemoryUserStore.cs
@@ -8,10 +8,12 @@ using Honua.Core.Features.Identity.Domain;
 namespace Honua.Server.Features.Admin.Services;
 
 /// <summary>
-/// In-memory user store for the admin API surface.
+/// In-memory user store for the admin API surface. Also backs the SCIM 2.0 provisioning
+/// surface (<see cref="IScimUserStore"/>, #510) over the same record set so users created by
+/// an identity provider are immediately visible to the admin endpoints.
 /// Will be replaced by a persistent implementation when #496/#498 land.
 /// </summary>
-internal sealed class InMemoryUserStore : IUserStore
+internal sealed class InMemoryUserStore : IUserStore, IScimUserStore
 {
     private readonly ConcurrentDictionary<string, ManagedUser> _users = new(StringComparer.OrdinalIgnoreCase);
 
@@ -71,7 +73,7 @@ internal sealed class InMemoryUserStore : IUserStore
             ProvisioningSource = existing.ProvisioningSource,
             ProviderId = existing.ProviderId,
             IsActive = existing.IsActive,
-            Roles = roles,
+            Roles = NormalizeRoles(roles),
             CreatedAt = existing.CreatedAt,
             UpdatedAt = DateTimeOffset.UtcNow,
         };
@@ -87,20 +89,182 @@ internal sealed class InMemoryUserStore : IUserStore
             return Task.FromResult(false);
         }
 
-        var deprovisioned = new ManagedUser
+        _users[userId] = Deactivate(existing);
+        return Task.FromResult(true);
+    }
+
+    // ---- IScimUserStore (#510) -------------------------------------------------------
+
+    public Task<ManagedUser?> CreateUserAsync(ScimUserProvisioning provisioning, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(provisioning);
+
+        // SCIM userName is the IdP-owned, unique login identifier; reuse it as the stable
+        // user id so re-provisioning is idempotent on the same key. A conflicting userName
+        // is reported to the caller (SCIM 409) rather than silently overwriting.
+        if (FindByUserNameInternal(provisioning.UserName) is not null)
+        {
+            return Task.FromResult<ManagedUser?>(null);
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var user = new ManagedUser
+        {
+            UserId = provisioning.UserName,
+            DisplayName = string.IsNullOrWhiteSpace(provisioning.DisplayName) ? provisioning.UserName : provisioning.DisplayName,
+            Email = provisioning.Email,
+            ProvisioningSource = "scim",
+            IsActive = provisioning.Active,
+            Roles = NormalizeRoles(provisioning.Roles),
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        // Guard against a concurrent create racing on the same key.
+        return Task.FromResult(_users.TryAdd(user.UserId, user) ? user : null);
+    }
+
+    public Task<ManagedUser?> FindByUserNameAsync(string userName, CancellationToken cancellationToken = default)
+        => Task.FromResult(FindByUserNameInternal(userName));
+
+    public Task<ScimUserPage> ListUsersAsync(ScimUserQuery query, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        IEnumerable<ManagedUser> matches = _users.Values
+            .Where(u => string.Equals(u.ProvisioningSource, "scim", StringComparison.OrdinalIgnoreCase));
+
+        if (!string.IsNullOrEmpty(query.UserNameEquals))
+        {
+            matches = matches.Where(u => u.UserId.Equals(query.UserNameEquals, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var ordered = matches.OrderBy(u => u.UserId, StringComparer.OrdinalIgnoreCase).ToList();
+        var skip = Math.Max(0, query.StartIndex - 1);
+
+        var page = ordered.Skip(skip).Take(Math.Max(0, query.Count)).ToList().AsReadOnly();
+        return Task.FromResult(new ScimUserPage { Users = page, TotalCount = ordered.Count });
+    }
+
+    public Task<ManagedUser?> ReplaceUserAsync(string userId, ScimUserProvisioning provisioning, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(provisioning);
+
+        if (!_users.TryGetValue(userId, out var existing))
+        {
+            return Task.FromResult<ManagedUser?>(null);
+        }
+
+        var updated = new ManagedUser
         {
             UserId = existing.UserId,
-            DisplayName = existing.DisplayName,
-            Email = existing.Email,
+            DisplayName = string.IsNullOrWhiteSpace(provisioning.DisplayName) ? provisioning.UserName : provisioning.DisplayName,
+            Email = provisioning.Email,
             ProvisioningSource = existing.ProvisioningSource,
             ProviderId = existing.ProviderId,
-            IsActive = false,
-            Roles = [],
+            IsActive = provisioning.Active,
+            Roles = NormalizeRoles(provisioning.Roles),
             CreatedAt = existing.CreatedAt,
             UpdatedAt = DateTimeOffset.UtcNow,
         };
 
-        _users[userId] = deprovisioned;
-        return Task.FromResult(true);
+        _users[userId] = updated;
+        return Task.FromResult<ManagedUser?>(updated);
     }
+
+    public Task<ManagedUser?> SetActiveAsync(string userId, bool active, CancellationToken cancellationToken = default)
+    {
+        if (!_users.TryGetValue(userId, out var existing))
+        {
+            return Task.FromResult<ManagedUser?>(null);
+        }
+
+        var updated = active
+            ? Clone(existing, isActive: true, roles: existing.Roles)
+            : Deactivate(existing);
+
+        _users[userId] = updated;
+        return Task.FromResult<ManagedUser?>(updated);
+    }
+
+    public Task<bool> DeleteUserAsync(string userId, CancellationToken cancellationToken = default)
+        => DeprovisionUserAsync(userId, cancellationToken);
+
+    /// <summary>
+    /// Adds a role to a user (used by group membership sync). No-op when the user is absent.
+    /// </summary>
+    internal void AddRole(string userId, string role)
+    {
+        if (!_users.TryGetValue(userId, out var existing))
+        {
+            return;
+        }
+
+        if (existing.Roles.Contains(role, StringComparer.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        _users[userId] = Clone(existing, existing.IsActive, NormalizeRoles([.. existing.Roles, role]));
+    }
+
+    /// <summary>
+    /// Removes a role from a user (used by group membership sync). No-op when the user is absent.
+    /// </summary>
+    internal void RemoveRole(string userId, string role)
+    {
+        if (!_users.TryGetValue(userId, out var existing))
+        {
+            return;
+        }
+
+        if (!existing.Roles.Contains(role, StringComparer.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        _users[userId] = Clone(
+            existing,
+            existing.IsActive,
+            existing.Roles.Where(r => !r.Equals(role, StringComparison.OrdinalIgnoreCase)).ToList());
+    }
+
+    private ManagedUser? FindByUserNameInternal(string userName)
+    {
+        if (string.IsNullOrWhiteSpace(userName))
+        {
+            return null;
+        }
+
+        // userId == userName for SCIM-provisioned users; fall back to a scan so OIDC/manual
+        // users (whose id is a subject claim) are still matched on display identity.
+        if (_users.TryGetValue(userName, out var direct))
+        {
+            return direct;
+        }
+
+        return _users.Values.FirstOrDefault(u => u.UserId.Equals(userName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static ManagedUser Deactivate(ManagedUser existing) => Clone(existing, isActive: false, roles: []);
+
+    private static ManagedUser Clone(ManagedUser existing, bool isActive, IReadOnlyList<string> roles) => new()
+    {
+        UserId = existing.UserId,
+        DisplayName = existing.DisplayName,
+        Email = existing.Email,
+        ProvisioningSource = existing.ProvisioningSource,
+        ProviderId = existing.ProviderId,
+        IsActive = isActive,
+        Roles = roles,
+        CreatedAt = existing.CreatedAt,
+        UpdatedAt = DateTimeOffset.UtcNow,
+    };
+
+    private static List<string> NormalizeRoles(IReadOnlyList<string> roles)
+        => roles
+            .Where(static r => !string.IsNullOrWhiteSpace(r))
+            .Select(static r => r.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
 }

--- a/src/Honua.Server/Features/Identity/IdentityServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Identity/IdentityServiceCollectionExtensions.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Server.Features.Identity.Saml;
+using Honua.Server.Features.Identity.Scim;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Features.Identity;
+
+/// <summary>
+/// Registration for the enterprise identity slice: SCIM 2.0 provisioning (#510) and the
+/// SAML 2.0 Service Provider SSO bridge (#508). Both adapt into the existing identity/role
+/// model rather than introducing a parallel one — SCIM provisions users and maps groups to
+/// roles over the shared user store, and SAML validates an assertion and establishes the same
+/// session/claims model as OIDC.
+/// </summary>
+public static class IdentityServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers SCIM and SAML options and the SAML assertion validator. The SCIM/SAML stores
+    /// themselves are projected onto the shared in-memory IAM defaults
+    /// (see <c>ControlPlaneIamDefaults</c>).
+    /// </summary>
+    public static IServiceCollection AddEnterpriseIdentity(this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddOptions<ScimProvisioningOptions>()
+            .Bind(configuration.GetSection(ScimProvisioningOptions.SectionName));
+
+        services.AddOptions<SamlAuthenticationOptions>()
+            .Bind(configuration.GetSection(SamlAuthenticationOptions.SectionName));
+
+        services.TryAddSingleton<ISamlAssertionValidator, SamlAssertionValidator>();
+
+        return services;
+    }
+}

--- a/src/Honua.Server/Features/Identity/Saml/ExclusiveCanonicalizer.cs
+++ b/src/Honua.Server/Features/Identity/Saml/ExclusiveCanonicalizer.cs
@@ -1,0 +1,286 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Xml.Linq;
+
+namespace Honua.Server.Features.Identity.Saml;
+
+/// <summary>
+/// Exclusive XML Canonicalization (Exclusive C14N, RFC 3741) for an <see cref="XElement"/>
+/// subtree, without comments. Implemented over <see cref="System.Xml.Linq"/> so SAML signature
+/// verification needs no dependency on <c>System.Security.Cryptography.Xml</c> (which is not in
+/// the in-box shared framework and is not AOT/trim-friendly).
+/// </summary>
+/// <remarks>
+/// Implements the rules that matter for SAML enveloped signatures: UTF-8 output, namespace
+/// nodes rendered only when visibly utilized (or named in <c>InclusiveNamespaces</c>),
+/// lexicographic ordering of namespaces (by prefix) and attributes (by namespace URI then
+/// local name), <c>&amp;</c>/<c>&lt;</c>/<c>&gt;</c>/<c>"</c> escaping in attribute values and
+/// <c>&amp;</c>/<c>&lt;</c>/<c>&gt;</c>/CR escaping in text, and empty elements rendered with an
+/// explicit start/end tag pair.
+/// </remarks>
+internal static class ExclusiveCanonicalizer
+{
+    private static readonly XNamespace XmlNs = "http://www.w3.org/XML/1998/namespace";
+
+    /// <summary>
+    /// Canonicalizes <paramref name="element"/> (in the namespace context of its live ancestors)
+    /// and returns the UTF-8 bytes.
+    /// </summary>
+    public static byte[] Canonicalize(XElement element, IReadOnlyList<string> inclusivePrefixes)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+
+        var builder = new StringBuilder(1024);
+        var inclusive = new HashSet<string>(inclusivePrefixes ?? [], StringComparer.Ordinal);
+
+        // Rendered-namespace context inherited from ancestors: maps prefix -> URI that has
+        // already been output by an enclosing (already-rendered) element. For a detached or
+        // top-level element this starts empty; Exclusive C14N intentionally does not inherit
+        // unused ancestor namespaces.
+        WriteElement(builder, element, new Dictionary<string, string>(StringComparer.Ordinal), inclusive);
+
+        return Encoding.UTF8.GetBytes(builder.ToString());
+    }
+
+    private static void WriteElement(
+        StringBuilder builder,
+        XElement element,
+        Dictionary<string, string> renderedNamespaces,
+        HashSet<string> inclusivePrefixes)
+    {
+        // Determine the namespaces this element must render. Under Exclusive C14N an element
+        // renders a namespace node when (a) it is "visibly utilized" by the element name or one
+        // of its attributes and not already rendered with the same value by an ancestor, or
+        // (b) its prefix appears in the InclusiveNamespaces PrefixList.
+        var localRendered = new Dictionary<string, string>(renderedNamespaces, StringComparer.Ordinal);
+        var namespacesToOutput = new SortedDictionary<string, string>(PrefixComparer.Instance);
+
+        // (a) the element's own namespace.
+        ConsiderNamespace(element.Name, localRendered, namespacesToOutput);
+
+        // (a) namespaces used by qualified attributes.
+        foreach (var attribute in element.Attributes())
+        {
+            if (attribute.IsNamespaceDeclaration)
+            {
+                continue;
+            }
+
+            if (attribute.Name.Namespace != XNamespace.None)
+            {
+                ConsiderNamespace(attribute.Name, localRendered, namespacesToOutput);
+            }
+        }
+
+        // (b) InclusiveNamespaces PrefixList entries that are in scope on this element.
+        if (inclusivePrefixes.Count > 0)
+        {
+            foreach (var prefix in inclusivePrefixes)
+            {
+                var uri = ResolveInScopeNamespace(element, prefix);
+                if (uri is null)
+                {
+                    continue;
+                }
+
+                if (!localRendered.TryGetValue(prefix, out var alreadyRendered) ||
+                    !string.Equals(alreadyRendered, uri, StringComparison.Ordinal))
+                {
+                    namespacesToOutput[prefix] = uri;
+                    localRendered[prefix] = uri;
+                }
+            }
+        }
+
+        var qualifiedName = QualifiedName(element.Name, element);
+
+        builder.Append('<').Append(qualifiedName);
+
+        // Namespace declarations first, ordered by prefix (default namespace, prefix ""), then
+        // attributes ordered by (namespace URI, local name).
+        foreach (var ns in namespacesToOutput)
+        {
+            if (ns.Key.Length == 0)
+            {
+                builder.Append(" xmlns=\"");
+            }
+            else
+            {
+                builder.Append(" xmlns:").Append(ns.Key).Append("=\"");
+            }
+
+            AppendEscapedAttributeValue(builder, ns.Value);
+            builder.Append('"');
+        }
+
+        foreach (var attribute in element.Attributes()
+                     .Where(a => !a.IsNamespaceDeclaration)
+                     .OrderBy(a => a, AttributeComparer.Instance))
+        {
+            builder.Append(' ').Append(QualifiedAttributeName(attribute, element)).Append("=\"");
+            AppendEscapedAttributeValue(builder, attribute.Value);
+            builder.Append('"');
+        }
+
+        builder.Append('>');
+
+        foreach (var node in element.Nodes())
+        {
+            switch (node)
+            {
+                case XElement childElement:
+                    WriteElement(builder, childElement, localRendered, inclusivePrefixes);
+                    break;
+                case XText text:
+                    AppendEscapedText(builder, text.Value);
+                    break;
+                // Comments are excluded (C14N without comments); processing instructions in
+                // SAML assertions are not expected and are omitted.
+                default:
+                    break;
+            }
+        }
+
+        builder.Append("</").Append(qualifiedName).Append('>');
+    }
+
+    private static void ConsiderNamespace(
+        XName name,
+        Dictionary<string, string> rendered,
+        SortedDictionary<string, string> toOutput)
+    {
+        var uri = name.NamespaceName;
+        var prefix = NamespacePrefix(name);
+
+        // The XML namespace is implicitly declared and never rendered.
+        if (string.Equals(uri, XmlNs.NamespaceName, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // Attributes in no namespace contribute nothing; an element in no namespace only needs
+        // a default-namespace undeclaration if an ancestor rendered one (handled below).
+        if (uri.Length == 0)
+        {
+            if (prefix.Length == 0 && rendered.TryGetValue(string.Empty, out var current) && current.Length != 0)
+            {
+                // Default namespace must be undeclared: xmlns="".
+                toOutput[string.Empty] = string.Empty;
+                rendered[string.Empty] = string.Empty;
+            }
+
+            return;
+        }
+
+        if (rendered.TryGetValue(prefix, out var renderedUri) && string.Equals(renderedUri, uri, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        toOutput[prefix] = uri;
+        rendered[prefix] = uri;
+    }
+
+    private static string? ResolveInScopeNamespace(XElement element, string prefix)
+    {
+        var xname = prefix.Length == 0
+            ? element.GetDefaultNamespace()
+            : element.GetNamespaceOfPrefix(prefix);
+        var uri = xname?.NamespaceName;
+        return string.IsNullOrEmpty(uri) ? null : uri;
+    }
+
+    private static string NamespacePrefix(XName name)
+    {
+        if (name.Namespace == XNamespace.None)
+        {
+            return string.Empty;
+        }
+
+        // Resolve the prefix from the declaring element where possible; XName itself does not
+        // carry the prefix, so callers pass through QualifiedName which uses the element scope.
+        return string.Empty;
+    }
+
+    private static string QualifiedName(XName name, XElement scope)
+    {
+        if (name.Namespace == XNamespace.None)
+        {
+            return name.LocalName;
+        }
+
+        var prefix = scope.GetPrefixOfNamespace(name.Namespace);
+        return string.IsNullOrEmpty(prefix) ? name.LocalName : prefix + ":" + name.LocalName;
+    }
+
+    private static string QualifiedAttributeName(XAttribute attribute, XElement scope)
+    {
+        if (attribute.Name.Namespace == XNamespace.None)
+        {
+            return attribute.Name.LocalName;
+        }
+
+        var prefix = scope.GetPrefixOfNamespace(attribute.Name.Namespace);
+        return string.IsNullOrEmpty(prefix) ? attribute.Name.LocalName : prefix + ":" + attribute.Name.LocalName;
+    }
+
+    private static void AppendEscapedAttributeValue(StringBuilder builder, string value)
+    {
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '&': builder.Append("&amp;"); break;
+                case '<': builder.Append("&lt;"); break;
+                case '"': builder.Append("&quot;"); break;
+                case '\t': builder.Append("&#x9;"); break;
+                case '\n': builder.Append("&#xA;"); break;
+                case '\r': builder.Append("&#xD;"); break;
+                default: builder.Append(c); break;
+            }
+        }
+    }
+
+    private static void AppendEscapedText(StringBuilder builder, string value)
+    {
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '&': builder.Append("&amp;"); break;
+                case '<': builder.Append("&lt;"); break;
+                case '>': builder.Append("&gt;"); break;
+                case '\r': builder.Append("&#xD;"); break;
+                default: builder.Append(c); break;
+            }
+        }
+    }
+
+    /// <summary>Orders namespace declarations by prefix; the default namespace ("") sorts first.</summary>
+    private sealed class PrefixComparer : IComparer<string>
+    {
+        public static readonly PrefixComparer Instance = new();
+
+        public int Compare(string? x, string? y) => string.CompareOrdinal(x, y);
+    }
+
+    /// <summary>Orders attributes by namespace URI then local name (Exclusive C14N rule).</summary>
+    private sealed class AttributeComparer : IComparer<XAttribute>
+    {
+        public static readonly AttributeComparer Instance = new();
+
+        public int Compare(XAttribute? x, XAttribute? y)
+        {
+            if (x is null || y is null)
+            {
+                return Comparer<object?>.Default.Compare(x, y);
+            }
+
+            // Attributes in no namespace sort before namespaced attributes; otherwise by URI.
+            var nsCompare = string.CompareOrdinal(x.Name.NamespaceName, y.Name.NamespaceName);
+            return nsCompare != 0 ? nsCompare : string.CompareOrdinal(x.Name.LocalName, y.Name.LocalName);
+        }
+    }
+}

--- a/src/Honua.Server/Features/Identity/Saml/SamlAssertionValidator.cs
+++ b/src/Honua.Server/Features/Identity/Saml/SamlAssertionValidator.cs
@@ -1,0 +1,307 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Xml;
+using System.Xml.Linq;
+using Honua.Infrastructure.Helpers;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Identity.Saml;
+
+/// <summary>
+/// Validates a SAML 2.0 Response/Assertion and projects it to a normalized identity (#508).
+/// </summary>
+public interface ISamlAssertionValidator
+{
+    /// <summary>
+    /// Validates the supplied SAML Response XML (already base64-decoded). On success returns a
+    /// <see cref="SamlValidationResult"/> with <see cref="SamlValidationResult.Succeeded"/> set
+    /// and the extracted subject/attributes; otherwise a failure result with a reason.
+    /// </summary>
+    SamlValidationResult Validate(string responseXml);
+}
+
+/// <summary>The outcome of validating a SAML Response.</summary>
+public sealed class SamlValidationResult
+{
+    private SamlValidationResult(bool succeeded, string? failureReason, SamlSubject? subject)
+    {
+        Succeeded = succeeded;
+        FailureReason = failureReason;
+        Subject = subject;
+    }
+
+    /// <summary>Whether validation succeeded.</summary>
+    public bool Succeeded { get; }
+
+    /// <summary>Why validation failed (null on success). Safe, non-sensitive summary.</summary>
+    public string? FailureReason { get; }
+
+    /// <summary>The validated subject (null on failure).</summary>
+    public SamlSubject? Subject { get; }
+
+    /// <summary>Creates a successful result.</summary>
+    public static SamlValidationResult Success(SamlSubject subject) => new(true, null, subject);
+
+    /// <summary>Creates a failure result with a non-sensitive reason.</summary>
+    public static SamlValidationResult Failure(string reason) => new(false, reason, null);
+}
+
+/// <summary>The normalized subject extracted from a validated SAML assertion.</summary>
+public sealed class SamlSubject
+{
+    /// <summary>The subject NameID (stable user identifier).</summary>
+    public required string NameId { get; init; }
+
+    /// <summary>Display name, if present.</summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>Email, if present.</summary>
+    public string? Email { get; init; }
+
+    /// <summary>Roles mapped from the configured role attribute.</summary>
+    public IReadOnlyList<string> Roles { get; init; } = [];
+
+    /// <summary>The assertion's session-expiry instant, if specified.</summary>
+    public DateTimeOffset? SessionNotOnOrAfter { get; init; }
+}
+
+/// <summary>
+/// Default <see cref="ISamlAssertionValidator"/>. Verifies the enveloped XML-DSig signature
+/// against the configured IdP certificate using only <see cref="System.Security.Cryptography"/>
+/// primitives and a hand-rolled exclusive XML canonicalizer — deliberately avoiding
+/// <c>System.Security.Cryptography.Xml.SignedXml</c>, which is not part of the in-box shared
+/// framework and is not AOT/trim-friendly. Enforces signature presence, digest match, issuer,
+/// audience, and the <c>NotBefore</c>/<c>NotOnOrAfter</c> conditions with bounded clock skew.
+/// </summary>
+internal sealed class SamlAssertionValidator(IOptions<SamlAuthenticationOptions> options) : ISamlAssertionValidator
+{
+    private const string DsigNs = "http://www.w3.org/2000/09/xmldsig#";
+    private const string SamlAssertionNs = "urn:oasis:names:tc:SAML:2.0:assertion";
+    private const string SamlProtocolNs = "urn:oasis:names:tc:SAML:2.0:protocol";
+
+    private readonly SamlAuthenticationOptions _options = options.Value;
+
+    public SamlValidationResult Validate(string responseXml)
+    {
+        if (string.IsNullOrWhiteSpace(responseXml))
+        {
+            return SamlValidationResult.Failure("Empty SAML response.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.IdpSigningCertificate))
+        {
+            return SamlValidationResult.Failure("No IdP signing certificate configured.");
+        }
+
+        XDocument document;
+        try
+        {
+            document = SecureXmlDocumentParser.Parse(responseXml, LoadOptions.None);
+        }
+        catch (XmlException)
+        {
+            return SamlValidationResult.Failure("Malformed SAML XML.");
+        }
+
+        var root = document.Root;
+        if (root is null)
+        {
+            return SamlValidationResult.Failure("Missing SAML root element.");
+        }
+
+        // Status must be Success (when a protocol Response envelope is present).
+        if (root.Name.LocalName == "Response")
+        {
+            var statusCode = root
+                .Element(XName.Get("Status", SamlProtocolNs))?
+                .Element(XName.Get("StatusCode", SamlProtocolNs))?
+                .Attribute("Value")?.Value;
+            if (statusCode is not null && !statusCode.EndsWith(":status:Success", StringComparison.Ordinal))
+            {
+                return SamlValidationResult.Failure("SAML Response status is not Success.");
+            }
+        }
+
+        var assertion = root.Name.LocalName == "Assertion"
+            ? root
+            : root.Element(XName.Get("Assertion", SamlAssertionNs));
+        if (assertion is null)
+        {
+            return SamlValidationResult.Failure("No SAML Assertion element present.");
+        }
+
+        // ---- Signature: presence + cryptographic verification (forged/unsigned => reject).
+        X509Certificate2 certificate;
+        try
+        {
+            certificate = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(_options.IdpSigningCertificate!.Trim()));
+        }
+        catch (Exception ex) when (ex is FormatException or CryptographicException)
+        {
+            return SamlValidationResult.Failure("IdP signing certificate is not valid base64 DER.");
+        }
+
+        using (certificate)
+        {
+            var signatureResult = SamlSignatureVerifier.Verify(assertion, certificate);
+            if (!signatureResult.Verified)
+            {
+                return SamlValidationResult.Failure(signatureResult.Reason ?? "SAML signature verification failed.");
+            }
+        }
+
+        // ---- Issuer.
+        var issuer = assertion.Element(XName.Get("Issuer", SamlAssertionNs))?.Value?.Trim();
+        if (!string.IsNullOrEmpty(_options.IdpEntityId) &&
+            !string.Equals(issuer, _options.IdpEntityId, StringComparison.Ordinal))
+        {
+            return SamlValidationResult.Failure("SAML assertion issuer does not match the configured IdP.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var skew = TimeSpan.FromSeconds(Math.Max(0, _options.AllowedClockSkewSeconds));
+
+        // ---- Conditions: NotBefore / NotOnOrAfter + AudienceRestriction.
+        var conditions = assertion.Element(XName.Get("Conditions", SamlAssertionNs));
+        if (conditions is not null)
+        {
+            if (TryParseInstant(conditions.Attribute("NotBefore")?.Value, out var notBefore) &&
+                now + skew < notBefore)
+            {
+                return SamlValidationResult.Failure("SAML assertion is not yet valid (NotBefore).");
+            }
+
+            if (TryParseInstant(conditions.Attribute("NotOnOrAfter")?.Value, out var notOnOrAfter) &&
+                now - skew >= notOnOrAfter)
+            {
+                return SamlValidationResult.Failure("SAML assertion has expired (NotOnOrAfter).");
+            }
+
+            if (!string.IsNullOrEmpty(_options.EntityId))
+            {
+                var audiences = conditions
+                    .Elements(XName.Get("AudienceRestriction", SamlAssertionNs))
+                    .SelectMany(ar => ar.Elements(XName.Get("Audience", SamlAssertionNs)))
+                    .Select(a => a.Value.Trim())
+                    .ToList();
+
+                if (audiences.Count > 0 &&
+                    !audiences.Any(a => string.Equals(a, _options.EntityId, StringComparison.Ordinal)))
+                {
+                    return SamlValidationResult.Failure("SAML assertion audience does not match this SP.");
+                }
+            }
+        }
+
+        // ---- Subject.
+        var subjectElement = assertion.Element(XName.Get("Subject", SamlAssertionNs));
+        var nameId = subjectElement?.Element(XName.Get("NameID", SamlAssertionNs))?.Value?.Trim();
+        if (string.IsNullOrEmpty(nameId))
+        {
+            return SamlValidationResult.Failure("SAML assertion has no Subject NameID.");
+        }
+
+        // ---- SubjectConfirmationData NotOnOrAfter (bearer expiry).
+        var confirmationData = subjectElement?
+            .Element(XName.Get("SubjectConfirmation", SamlAssertionNs))?
+            .Element(XName.Get("SubjectConfirmationData", SamlAssertionNs));
+        if (confirmationData is not null &&
+            TryParseInstant(confirmationData.Attribute("NotOnOrAfter")?.Value, out var subjectExpiry) &&
+            now - skew >= subjectExpiry)
+        {
+            return SamlValidationResult.Failure("SAML subject confirmation has expired.");
+        }
+
+        // ---- Attributes -> roles / email / display name.
+        var attributes = ReadAttributes(assertion);
+        var roles = attributes.TryGetValue(_options.RoleAttribute, out var roleValues)
+            ? roleValues.Where(v => !string.IsNullOrWhiteSpace(v)).Select(v => v.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToList()
+            : [];
+        if (roles.Count == 0 && !string.IsNullOrWhiteSpace(_options.DefaultRole))
+        {
+            roles = [_options.DefaultRole!.Trim()];
+        }
+
+        var email = attributes.TryGetValue(_options.EmailAttribute, out var emailValues)
+            ? emailValues.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v))?.Trim()
+            : null;
+        var displayName = attributes.TryGetValue(_options.DisplayNameAttribute, out var nameValues)
+            ? nameValues.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v))?.Trim()
+            : null;
+
+        DateTimeOffset? sessionExpiry = null;
+        var authnStatement = assertion.Element(XName.Get("AuthnStatement", SamlAssertionNs));
+        if (authnStatement is not null &&
+            TryParseInstant(authnStatement.Attribute("SessionNotOnOrAfter")?.Value, out var parsedSession))
+        {
+            sessionExpiry = parsedSession;
+        }
+
+        return SamlValidationResult.Success(new SamlSubject
+        {
+            NameId = nameId,
+            Email = email,
+            DisplayName = displayName,
+            Roles = roles,
+            SessionNotOnOrAfter = sessionExpiry,
+        });
+    }
+
+    private static Dictionary<string, List<string>> ReadAttributes(XElement assertion)
+    {
+        var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var statement in assertion.Elements(XName.Get("AttributeStatement", SamlAssertionNs)))
+        {
+            foreach (var attribute in statement.Elements(XName.Get("Attribute", SamlAssertionNs)))
+            {
+                var name = attribute.Attribute("Name")?.Value;
+                var friendlyName = attribute.Attribute("FriendlyName")?.Value;
+                var values = attribute
+                    .Elements(XName.Get("AttributeValue", SamlAssertionNs))
+                    .Select(v => v.Value)
+                    .ToList();
+
+                AddAttribute(result, name, values);
+                AddAttribute(result, friendlyName, values);
+            }
+        }
+
+        return result;
+    }
+
+    private static void AddAttribute(Dictionary<string, List<string>> result, string? key, List<string> values)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return;
+        }
+
+        if (!result.TryGetValue(key, out var existing))
+        {
+            existing = [];
+            result[key] = existing;
+        }
+
+        existing.AddRange(values);
+    }
+
+    private static bool TryParseInstant(string? value, out DateTimeOffset instant)
+    {
+        if (!string.IsNullOrWhiteSpace(value) &&
+            DateTimeOffset.TryParse(
+                value,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.AdjustToUniversal | System.Globalization.DateTimeStyles.AssumeUniversal,
+                out instant))
+        {
+            return true;
+        }
+
+        instant = default;
+        return false;
+    }
+}

--- a/src/Honua.Server/Features/Identity/Saml/SamlAuthenticationOptions.cs
+++ b/src/Honua.Server/Features/Identity/Saml/SamlAuthenticationOptions.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Identity.Saml;
+
+/// <summary>
+/// Configuration for the SAML 2.0 Service Provider (SP) bridge (#508). Honua acts as an SP:
+/// it publishes SP metadata, receives a signed SAML assertion at its Assertion Consumer
+/// Service (ACS), validates the signature against the configured IdP certificate, maps
+/// attributes/groups to RBAC roles, and establishes a Honua session.
+/// </summary>
+public sealed class SamlAuthenticationOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Saml";
+
+    /// <summary>
+    /// Whether the SAML bridge is enabled. When false the ACS and metadata endpoints reject
+    /// requests so the surface cannot be exercised before an IdP is configured.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// The SP entity ID (audience) this server identifies as. Assertions whose
+    /// <c>AudienceRestriction</c> does not match are rejected.
+    /// </summary>
+    public string? EntityId { get; set; }
+
+    /// <summary>
+    /// The expected IdP issuer (<c>Issuer</c> element). Assertions from a different issuer are
+    /// rejected.
+    /// </summary>
+    public string? IdpEntityId { get; set; }
+
+    /// <summary>
+    /// The Assertion Consumer Service URL (the SP endpoint the IdP POSTs the assertion to).
+    /// Used in SP metadata and validated against the assertion's <c>Recipient</c> when present.
+    /// </summary>
+    public string? AssertionConsumerServiceUrl { get; set; }
+
+    /// <summary>
+    /// The IdP's signing certificate, base64-encoded DER (the inner text of an
+    /// <c>&lt;X509Certificate&gt;</c> element). Required: signatures are verified against this
+    /// certificate's public key, and unsigned assertions are rejected.
+    /// </summary>
+    public string? IdpSigningCertificate { get; set; }
+
+    /// <summary>
+    /// SAML attribute name whose values map to Honua role names (e.g. a group/role claim).
+    /// Defaults to the common OID-less friendly name "Role".
+    /// </summary>
+    public string RoleAttribute { get; set; } = "Role";
+
+    /// <summary>
+    /// SAML attribute name carrying the user's email, if distinct from the NameID.
+    /// </summary>
+    public string EmailAttribute { get; set; } = "email";
+
+    /// <summary>
+    /// SAML attribute name carrying the user's display name.
+    /// </summary>
+    public string DisplayNameAttribute { get; set; } = "displayName";
+
+    /// <summary>
+    /// Default role assigned when the assertion carries no mapped role attribute. Null leaves
+    /// the session role-less (authenticated but unprivileged).
+    /// </summary>
+    public string? DefaultRole { get; set; }
+
+    /// <summary>
+    /// Clock-skew tolerance (seconds) applied to <c>NotBefore</c>/<c>NotOnOrAfter</c> condition
+    /// checks. Defaults to 120s.
+    /// </summary>
+    public int AllowedClockSkewSeconds { get; set; } = 120;
+
+    /// <summary>
+    /// Session lifetime (seconds) for the Honua session established from a SAML assertion when
+    /// the assertion does not specify a shorter <c>SessionNotOnOrAfter</c>. Defaults to 3600s.
+    /// </summary>
+    public int SessionLifetimeSeconds { get; set; } = 3600;
+}

--- a/src/Honua.Server/Features/Identity/Saml/SamlEndpoints.cs
+++ b/src/Honua.Server/Features/Identity/Saml/SamlEndpoints.cs
@@ -1,0 +1,237 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml;
+using Honua.Infrastructure.Authentication;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Identity.Saml;
+
+/// <summary>
+/// SAML 2.0 Service Provider (SP) endpoints (#508). Exposes SP metadata for IdP configuration
+/// and the Assertion Consumer Service (ACS) that consumes a signed SAML assertion, maps its
+/// attributes/groups to RBAC roles, and establishes a Honua admin session. Reuses the existing
+/// <see cref="AdminAuthSessionStore"/> session machinery so downstream code sees the same
+/// session/claims model as OIDC.
+/// </summary>
+internal static partial class SamlEndpoints
+{
+    /// <summary>Log category for SAML endpoints.</summary>
+    internal sealed class SamlEndpointsLog;
+
+    /// <summary>
+    /// Maps the SAML 2.0 SP metadata and Assertion Consumer Service endpoints. Both are
+    /// anonymous at the framework level (the SAML assertion is the credential) and enforce the
+    /// enabled/configured guard internally.
+    /// </summary>
+    public static void MapSamlEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var group = endpoints.MapGroup("/saml")
+            .WithTags("Identity", "SAML")
+            .AllowAnonymous();
+
+        group.MapGet("/metadata", HandleMetadata).WithDisplayName("SAML SP Metadata");
+        group.MapPost("/acs", HandleAssertionConsumerService).WithDisplayName("SAML Assertion Consumer Service");
+    }
+
+    private static IResult HandleMetadata(
+        HttpContext context,
+        [FromServices] IOptions<SamlAuthenticationOptions> options)
+    {
+        var opts = options.Value;
+        if (!opts.Enabled || string.IsNullOrWhiteSpace(opts.EntityId) || string.IsNullOrWhiteSpace(opts.AssertionConsumerServiceUrl))
+        {
+            return Results.Problem(
+                title: "SAML not configured",
+                detail: "The SAML SP bridge is not enabled or is missing EntityId/ACS configuration.",
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        var metadata = BuildSpMetadata(opts);
+        return Results.Content(metadata, "application/samlmetadata+xml", Encoding.UTF8);
+    }
+
+    private static async Task<IResult> HandleAssertionConsumerService(
+        HttpContext context,
+        [FromServices] IOptions<SamlAuthenticationOptions> options,
+        [FromServices] ISamlAssertionValidator validator,
+        [FromServices] AdminAuthSessionStore sessionStore,
+        [FromServices] ILogger<SamlEndpointsLog> logger)
+    {
+        var opts = options.Value;
+        if (!opts.Enabled)
+        {
+            return Results.Problem(
+                title: "SAML not enabled",
+                detail: "The SAML SP bridge is not enabled.",
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        if (!context.Request.HasFormContentType)
+        {
+            return BadRequest(context, "Expected an HTTP-POST SAML response form.");
+        }
+
+        var form = await context.Request.ReadFormAsync(context.RequestAborted).ConfigureAwait(false);
+        var encodedResponse = form["SAMLResponse"].ToString();
+        if (string.IsNullOrWhiteSpace(encodedResponse))
+        {
+            return BadRequest(context, "Missing SAMLResponse.");
+        }
+
+        string responseXml;
+        try
+        {
+            responseXml = Encoding.UTF8.GetString(Convert.FromBase64String(encodedResponse));
+        }
+        catch (FormatException)
+        {
+            return BadRequest(context, "SAMLResponse is not valid base64.");
+        }
+
+        var result = validator.Validate(responseXml);
+        if (!result.Succeeded || result.Subject is null)
+        {
+            // Forged, unsigned, expired, or otherwise invalid assertions land here.
+            SamlLog.AssertionRejected(logger, result.FailureReason ?? "unknown");
+            return Results.Problem(
+                title: "SAML assertion rejected",
+                detail: result.FailureReason ?? "The SAML assertion could not be validated.",
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        var subject = result.Subject;
+
+        // Project the validated SAML subject into the same claim shape OIDC sessions use so the
+        // AdminAuthSession handler and downstream RBAC treat both identically.
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, subject.NameId),
+            new(ClaimTypes.Name, string.IsNullOrWhiteSpace(subject.DisplayName) ? subject.NameId : subject.DisplayName!),
+            new("auth_type", "saml"),
+        };
+
+        if (!string.IsNullOrWhiteSpace(subject.Email))
+        {
+            claims.Add(new Claim(ClaimTypes.Email, subject.Email!));
+        }
+
+        foreach (var role in subject.Roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        if (!AdminAuthClaimsProjector.TryProjectValidatedClaims(claims, out var sessionClaims))
+        {
+            return Results.Problem(
+                title: "SAML assertion rejected",
+                detail: "The SAML assertion produced no usable claims.",
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var lifetime = TimeSpan.FromSeconds(Math.Max(60, opts.SessionLifetimeSeconds));
+        var expiresAt = now + lifetime;
+        if (subject.SessionNotOnOrAfter is { } sessionExpiry && sessionExpiry < expiresAt)
+        {
+            expiresAt = sessionExpiry;
+        }
+
+        if (expiresAt <= now)
+        {
+            return Results.Problem(
+                title: "SAML assertion rejected",
+                detail: "The SAML assertion session window has already elapsed.",
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        // SAML has no OAuth access token; store an opaque marker so the session record is valid.
+        var opaqueToken = Convert.ToHexString(RandomNumberGenerator.GetBytes(32)).ToLowerInvariant();
+
+        var sessionId = await sessionStore.CreateAuthenticatedSessionAsync(
+            providerKey: "saml",
+            accessToken: opaqueToken,
+            idToken: null,
+            claims: sessionClaims,
+            expiresAt: expiresAt,
+            cancellationToken: context.RequestAborted).ConfigureAwait(false);
+
+        SetSessionCookie(context, sessionId, expiresAt - now);
+
+        SamlLog.SessionEstablished(logger, subject.NameId, subject.Roles.Count);
+        return TypedResults.NoContent();
+    }
+
+    private static string BuildSpMetadata(SamlAuthenticationOptions opts)
+    {
+        // Emit minimal, valid SP metadata describing the ACS endpoint and supported NameID
+        // format. Written with XmlWriter so the output is well-formed and encoding-safe.
+        var settings = new XmlWriterSettings
+        {
+            Encoding = new UTF8Encoding(false),
+            Indent = false,
+            OmitXmlDeclaration = false,
+        };
+
+        var output = new StringWriterUtf8();
+        using (var writer = XmlWriter.Create(output, settings))
+        {
+            const string md = "urn:oasis:names:tc:SAML:2.0:metadata";
+            writer.WriteStartElement("EntityDescriptor", md);
+            writer.WriteAttributeString("entityID", opts.EntityId);
+
+            writer.WriteStartElement("SPSSODescriptor", md);
+            writer.WriteAttributeString("AuthnRequestsSigned", "false");
+            writer.WriteAttributeString("WantAssertionsSigned", "true");
+            writer.WriteAttributeString("protocolSupportEnumeration", "urn:oasis:names:tc:SAML:2.0:protocol");
+
+            writer.WriteStartElement("NameIDFormat", md);
+            writer.WriteString("urn:oasis:names:tc:SAML:2.0:nameid-format:persistent");
+            writer.WriteEndElement();
+
+            writer.WriteStartElement("AssertionConsumerService", md);
+            writer.WriteAttributeString("Binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST");
+            writer.WriteAttributeString("Location", opts.AssertionConsumerServiceUrl);
+            writer.WriteAttributeString("index", "0");
+            writer.WriteAttributeString("isDefault", "true");
+            writer.WriteEndElement(); // AssertionConsumerService
+
+            writer.WriteEndElement(); // SPSSODescriptor
+            writer.WriteEndElement(); // EntityDescriptor
+        }
+
+        return output.ToString();
+    }
+
+    private static void SetSessionCookie(HttpContext context, string sessionId, TimeSpan lifetime)
+    {
+        context.Response.Cookies.Append(
+            AdminAuthSessionStore.AuthSessionCookieName,
+            sessionId,
+            new CookieOptions
+            {
+                HttpOnly = true,
+                IsEssential = true,
+                SameSite = SameSiteMode.Lax, // Lax: the IdP POSTs cross-site to the ACS.
+                Secure = context.Request.IsHttps,
+                MaxAge = lifetime,
+                Path = "/",
+            });
+    }
+
+    private static IResult BadRequest(HttpContext context, string detail)
+        => Results.Problem(title: "Invalid SAML request", detail: detail, statusCode: StatusCodes.Status400BadRequest);
+
+    /// <summary>UTF-8 writer used so the metadata XML declaration reports utf-8 (not utf-16).</summary>
+    private sealed class StringWriterUtf8 : StringWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
+    }
+}

--- a/src/Honua.Server/Features/Identity/Saml/SamlLog.cs
+++ b/src/Honua.Server/Features/Identity/Saml/SamlLog.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Identity.Saml;
+
+/// <summary>
+/// Source-generated structured logging for the SAML 2.0 SP endpoints (#508). Logs the subject
+/// identifier and a coarse failure reason for audit; it never logs the assertion body, the
+/// signature, or attribute values.
+/// </summary>
+internal static partial class SamlLog
+{
+    [LoggerMessage(EventId = 4620, Level = LogLevel.Warning,
+        Message = "SAML assertion rejected. Reason={Reason}")]
+    public static partial void AssertionRejected(ILogger logger, string reason);
+
+    [LoggerMessage(EventId = 4621, Level = LogLevel.Information,
+        Message = "SAML session established for subject '{NameId}' with {RoleCount} role(s).")]
+    public static partial void SessionEstablished(ILogger logger, string nameId, int roleCount);
+}

--- a/src/Honua.Server/Features/Identity/Saml/SamlSignatureVerifier.cs
+++ b/src/Honua.Server/Features/Identity/Saml/SamlSignatureVerifier.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Xml.Linq;
+
+namespace Honua.Server.Features.Identity.Saml;
+
+/// <summary>
+/// Verifies an enveloped XML-DSig signature on a SAML assertion using only
+/// <see cref="System.Security.Cryptography"/> primitives plus a focused Exclusive XML
+/// Canonicalization (C14N, RFC 3741) implementation. This avoids
+/// <c>System.Security.Cryptography.Xml.SignedXml</c>, which is not in the in-box shared
+/// framework and is hostile to AOT/trimming.
+/// </summary>
+/// <remarks>
+/// Security scope: supports the standard SAML SP profile — a single enveloped signature over
+/// the assertion, the Enveloped-Signature transform, Exclusive C14N, SHA-256/SHA-1 digests,
+/// and RSA-SHA256/RSA-SHA1 (and ECDSA equivalents) signatures. Both the digest of the signed
+/// element AND the signature over <c>SignedInfo</c> are checked, the signed element is pinned
+/// to the assertion by ID, and the signing key must be the configured IdP certificate's key.
+/// </remarks>
+internal static class SamlSignatureVerifier
+{
+    private const string DsigNs = "http://www.w3.org/2000/09/xmldsig#";
+
+    internal readonly record struct VerificationResult(bool Verified, string? Reason)
+    {
+        public static VerificationResult Ok() => new(true, null);
+
+        public static VerificationResult Fail(string reason) => new(false, reason);
+    }
+
+    public static VerificationResult Verify(XElement assertion, X509Certificate2 certificate)
+    {
+        var signature = assertion.Element(XName.Get("Signature", DsigNs));
+        if (signature is null)
+        {
+            // No enveloped signature on the assertion => treat as unsigned and reject.
+            return VerificationResult.Fail("SAML assertion is not signed.");
+        }
+
+        var signedInfo = signature.Element(XName.Get("SignedInfo", DsigNs));
+        if (signedInfo is null)
+        {
+            return VerificationResult.Fail("Signature is missing SignedInfo.");
+        }
+
+        var reference = signedInfo.Element(XName.Get("Reference", DsigNs));
+        if (reference is null)
+        {
+            return VerificationResult.Fail("SignedInfo is missing a Reference.");
+        }
+
+        // ---- 1. Bind the reference URI to the assertion element by ID.
+        var referenceUri = reference.Attribute("URI")?.Value ?? string.Empty;
+        var assertionId = assertion.Attribute("ID")?.Value;
+        if (string.IsNullOrEmpty(assertionId))
+        {
+            return VerificationResult.Fail("Signed assertion has no ID attribute.");
+        }
+
+        // The reference must target the assertion itself (URI="" means the enclosing document
+        // root, URI="#id" targets that element). Reject signatures that point elsewhere so a
+        // wrapped/foreign signed fragment cannot be substituted.
+        if (referenceUri.Length != 0 &&
+            !string.Equals(referenceUri, "#" + assertionId, StringComparison.Ordinal))
+        {
+            return VerificationResult.Fail("Signature reference does not target the assertion.");
+        }
+
+        // ---- 2. Recompute the digest of the assertion (enveloped-signature transform: the
+        //         Signature element is removed before canonicalization) and compare.
+        var digestMethod = reference
+            .Element(XName.Get("DigestMethod", DsigNs))?
+            .Attribute("Algorithm")?.Value;
+        var expectedDigest = reference.Element(XName.Get("DigestValue", DsigNs))?.Value?.Trim();
+        if (string.IsNullOrEmpty(digestMethod) || string.IsNullOrEmpty(expectedDigest))
+        {
+            return VerificationResult.Fail("Reference is missing DigestMethod/DigestValue.");
+        }
+
+        var inclusivePrefixesForReference = ReadInclusiveNamespacePrefixes(reference);
+
+        // Build a detached copy of the assertion with its own Signature removed (enveloped).
+        var assertionCopy = new XElement(assertion);
+        assertionCopy.Element(XName.Get("Signature", DsigNs))?.Remove();
+
+        var canonicalAssertion = ExclusiveCanonicalizer.Canonicalize(assertionCopy, inclusivePrefixesForReference);
+        var actualDigest = ComputeDigest(digestMethod, canonicalAssertion);
+        if (actualDigest is null)
+        {
+            return VerificationResult.Fail("Unsupported digest algorithm.");
+        }
+
+        if (!FixedTimeEqualsBase64(expectedDigest, actualDigest))
+        {
+            return VerificationResult.Fail("SAML assertion digest mismatch (tampered or wrapped).");
+        }
+
+        // ---- 3. Verify the signature over the canonicalized SignedInfo.
+        var signatureMethod = signedInfo
+            .Element(XName.Get("SignatureMethod", DsigNs))?
+            .Attribute("Algorithm")?.Value;
+        var signatureValue = signature.Element(XName.Get("SignatureValue", DsigNs))?.Value;
+        if (string.IsNullOrEmpty(signatureMethod) || string.IsNullOrWhiteSpace(signatureValue))
+        {
+            return VerificationResult.Fail("Signature is missing SignatureMethod/SignatureValue.");
+        }
+
+        byte[] signatureBytes;
+        try
+        {
+            signatureBytes = Convert.FromBase64String(signatureValue.Trim());
+        }
+        catch (FormatException)
+        {
+            return VerificationResult.Fail("SignatureValue is not valid base64.");
+        }
+
+        var hashAlgorithm = ResolveSignatureHash(signatureMethod);
+        if (hashAlgorithm is null)
+        {
+            return VerificationResult.Fail("Unsupported signature algorithm.");
+        }
+
+        var inclusivePrefixesForSignedInfo = ReadInclusiveNamespacePrefixes(signedInfo);
+        // SignedInfo must be canonicalized in the context of its ancestors (namespaces in
+        // scope), per Exclusive C14N — pass the live node so inherited namespaces resolve.
+        var canonicalSignedInfo = ExclusiveCanonicalizer.Canonicalize(signedInfo, inclusivePrefixesForSignedInfo);
+
+        var verified = VerifySignature(certificate, signatureMethod, hashAlgorithm.Value, canonicalSignedInfo, signatureBytes);
+        return verified
+            ? VerificationResult.Ok()
+            : VerificationResult.Fail("SAML SignedInfo signature is invalid.");
+    }
+
+    private static byte[]? ComputeDigest(string algorithm, byte[] data)
+    {
+        return algorithm switch
+        {
+            "http://www.w3.org/2001/04/xmlenc#sha256" => SHA256.HashData(data),
+            "http://www.w3.org/2001/04/xmldsig-more#sha384" => SHA384.HashData(data),
+            "http://www.w3.org/2001/04/xmlenc#sha512" => SHA512.HashData(data),
+#pragma warning disable CA5350 // SHA-1 retained only for interop with legacy IdPs that still emit it.
+            "http://www.w3.org/2000/09/xmldsig#sha1" => SHA1.HashData(data),
+#pragma warning restore CA5350
+            _ => null,
+        };
+    }
+
+    private static HashAlgorithmName? ResolveSignatureHash(string algorithm)
+    {
+        return algorithm switch
+        {
+            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" => HashAlgorithmName.SHA256,
+            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384" => HashAlgorithmName.SHA384,
+            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512" => HashAlgorithmName.SHA512,
+            "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256" => HashAlgorithmName.SHA256,
+            "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384" => HashAlgorithmName.SHA384,
+            "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512" => HashAlgorithmName.SHA512,
+#pragma warning disable CA5350 // SHA-1 retained only for interop with legacy IdPs that still emit it.
+            "http://www.w3.org/2000/09/xmldsig#rsa-sha1" => HashAlgorithmName.SHA1,
+            "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1" => HashAlgorithmName.SHA1,
+#pragma warning restore CA5350
+            _ => null,
+        };
+    }
+
+    private static bool VerifySignature(
+        X509Certificate2 certificate,
+        string signatureMethod,
+        HashAlgorithmName hashAlgorithm,
+        byte[] canonicalSignedInfo,
+        byte[] signatureBytes)
+    {
+        if (signatureMethod.Contains("ecdsa", StringComparison.OrdinalIgnoreCase))
+        {
+            using var ecdsa = certificate.GetECDsaPublicKey();
+            return ecdsa is not null &&
+                ecdsa.VerifyData(canonicalSignedInfo, signatureBytes, hashAlgorithm, DSASignatureFormat.Rfc3279DerSequence);
+        }
+
+        using var rsa = certificate.GetRSAPublicKey();
+        return rsa is not null &&
+            rsa.VerifyData(canonicalSignedInfo, signatureBytes, hashAlgorithm, RSASignaturePadding.Pkcs1);
+    }
+
+    private static List<string> ReadInclusiveNamespacePrefixes(XElement signedElementParent)
+    {
+        // The CanonicalizationMethod/Transform may carry an <ec:InclusiveNamespaces
+        // PrefixList="..."/> child. Collect prefixes from any such descendant.
+        var prefixes = new List<string>();
+        foreach (var inclusive in signedElementParent.Descendants()
+                     .Where(e => e.Name.LocalName == "InclusiveNamespaces"))
+        {
+            var list = inclusive.Attribute("PrefixList")?.Value;
+            if (!string.IsNullOrWhiteSpace(list))
+            {
+                prefixes.AddRange(list.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+            }
+        }
+
+        return prefixes;
+    }
+
+    private static bool FixedTimeEqualsBase64(string expectedBase64, byte[] actual)
+    {
+        byte[] expected;
+        try
+        {
+            expected = Convert.FromBase64String(expectedBase64);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        return expected.Length == actual.Length && CryptographicOperations.FixedTimeEquals(expected, actual);
+    }
+}

--- a/src/Honua.Server/Features/Identity/Scim/Models/ScimModels.cs
+++ b/src/Honua.Server/Features/Identity/Scim/Models/ScimModels.cs
@@ -1,0 +1,201 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Identity.Scim.Models;
+
+/// <summary>
+/// SCIM 2.0 well-known schema URIs and constants (RFC 7643 / RFC 7644).
+/// </summary>
+internal static class ScimSchemas
+{
+    /// <summary>Core User resource schema URI.</summary>
+    public const string User = "urn:ietf:params:scim:schemas:core:2.0:User";
+
+    /// <summary>Core Group resource schema URI.</summary>
+    public const string Group = "urn:ietf:params:scim:schemas:core:2.0:Group";
+
+    /// <summary>ListResponse message schema URI.</summary>
+    public const string ListResponse = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
+
+    /// <summary>PatchOp message schema URI.</summary>
+    public const string PatchOp = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+
+    /// <summary>Error message schema URI.</summary>
+    public const string Error = "urn:ietf:params:scim:api:messages:2.0:Error";
+
+    /// <summary>SCIM JSON content type.</summary>
+    public const string ContentType = "application/scim+json";
+}
+
+/// <summary>
+/// SCIM 2.0 User resource (RFC 7643 §4.1). Only the attributes Honua maps onto its identity
+/// model are surfaced; unknown attributes from the IdP are ignored on input.
+/// </summary>
+public sealed class ScimUser
+{
+    /// <summary>Schema URIs for this resource.</summary>
+    public IReadOnlyList<string> Schemas { get; init; } = [ScimSchemas.User];
+
+    /// <summary>Server-assigned unique identifier.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Unique login identifier owned by the identity provider.</summary>
+    public string? UserName { get; init; }
+
+    /// <summary>Human-readable display name.</summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>Whether the account is active.</summary>
+    public bool Active { get; init; } = true;
+
+    /// <summary>Email addresses.</summary>
+    public IReadOnlyList<ScimEmail>? Emails { get; init; }
+
+    /// <summary>Resource metadata (read-only).</summary>
+    public ScimMeta? Meta { get; init; }
+}
+
+/// <summary>SCIM multi-valued email attribute.</summary>
+public sealed class ScimEmail
+{
+    /// <summary>The email address.</summary>
+    public string? Value { get; init; }
+
+    /// <summary>Whether this is the primary email.</summary>
+    public bool? Primary { get; init; }
+
+    /// <summary>Type label (e.g. "work").</summary>
+    public string? Type { get; init; }
+}
+
+/// <summary>
+/// SCIM 2.0 Group resource (RFC 7643 §4.2).
+/// </summary>
+public sealed class ScimGroupResource
+{
+    /// <summary>Schema URIs for this resource.</summary>
+    public IReadOnlyList<string> Schemas { get; init; } = [ScimSchemas.Group];
+
+    /// <summary>Server-assigned unique identifier.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Group display name; maps to the Honua role name.</summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>Group members.</summary>
+    public IReadOnlyList<ScimMember>? Members { get; init; }
+
+    /// <summary>Resource metadata (read-only).</summary>
+    public ScimMeta? Meta { get; init; }
+}
+
+/// <summary>SCIM group member reference.</summary>
+public sealed class ScimMember
+{
+    /// <summary>The member user's identifier.</summary>
+    public string? Value { get; init; }
+
+    /// <summary>Optional display name of the member.</summary>
+    public string? Display { get; init; }
+}
+
+/// <summary>SCIM resource metadata (RFC 7643 §3.1).</summary>
+public sealed class ScimMeta
+{
+    /// <summary>Resource type ("User" or "Group").</summary>
+    public string? ResourceType { get; init; }
+
+    /// <summary>Creation timestamp.</summary>
+    public DateTimeOffset? Created { get; init; }
+
+    /// <summary>Last-modified timestamp.</summary>
+    public DateTimeOffset? LastModified { get; init; }
+
+    /// <summary>Canonical resource location.</summary>
+    public string? Location { get; init; }
+}
+
+/// <summary>
+/// SCIM ListResponse envelope (RFC 7644 §3.4.2).
+/// </summary>
+/// <typeparam name="T">The contained resource type.</typeparam>
+public sealed class ScimListResponse<T>
+{
+    /// <summary>Schema URIs for this message.</summary>
+    public IReadOnlyList<string> Schemas { get; init; } = [ScimSchemas.ListResponse];
+
+    /// <summary>Total number of resources matching the query.</summary>
+    public int TotalResults { get; init; }
+
+    /// <summary>1-based index of the first returned resource.</summary>
+    public int StartIndex { get; init; }
+
+    /// <summary>Number of resources in this page.</summary>
+    public int ItemsPerPage { get; init; }
+
+    /// <summary>The returned resources.</summary>
+    public IReadOnlyList<T> Resources { get; init; } = [];
+}
+
+/// <summary>
+/// SCIM PatchOp request (RFC 7644 §3.5.2).
+/// </summary>
+public sealed class ScimPatchRequest
+{
+    /// <summary>Schema URIs for this message.</summary>
+    public IReadOnlyList<string>? Schemas { get; init; }
+
+    /// <summary>The patch operations to apply.</summary>
+    public IReadOnlyList<ScimPatchOperation>? Operations { get; init; }
+}
+
+/// <summary>A single SCIM patch operation.</summary>
+public sealed class ScimPatchOperation
+{
+    /// <summary>Operation: "add", "remove", or "replace" (case-insensitive).</summary>
+    public string? Op { get; init; }
+
+    /// <summary>Target attribute path (e.g. "active", "members").</summary>
+    public string? Path { get; init; }
+
+    /// <summary>Operation value (shape depends on <see cref="Path"/>).</summary>
+    public System.Text.Json.JsonElement? Value { get; init; }
+}
+
+/// <summary>
+/// SCIM error response (RFC 7644 §3.12).
+/// </summary>
+public sealed class ScimError
+{
+    /// <summary>Schema URIs for this message.</summary>
+    public IReadOnlyList<string> Schemas { get; init; } = [ScimSchemas.Error];
+
+    /// <summary>HTTP status code as a string.</summary>
+    public required string Status { get; init; }
+
+    /// <summary>Human-readable detail.</summary>
+    public string? Detail { get; init; }
+
+    /// <summary>SCIM-specific error type (e.g. "uniqueness", "invalidValue").</summary>
+    public string? ScimType { get; init; }
+}
+
+/// <summary>
+/// JSON source-generation context for SCIM wire models (AOT-safe). SCIM emits its own RFC
+/// 7643/7644 envelope shapes rather than the generic Honua <c>ApiResponse</c>.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(ScimUser))]
+[JsonSerializable(typeof(ScimGroupResource))]
+[JsonSerializable(typeof(ScimListResponse<ScimUser>))]
+[JsonSerializable(typeof(ScimListResponse<ScimGroupResource>))]
+[JsonSerializable(typeof(ScimPatchRequest))]
+[JsonSerializable(typeof(ScimError))]
+internal sealed partial class ScimJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Identity/Scim/ScimEndpoints.cs
+++ b/src/Honua.Server/Features/Identity/Scim/ScimEndpoints.cs
@@ -1,0 +1,751 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.Identity.Abstractions;
+using Honua.Core.Features.Identity.Domain;
+using Honua.Server.Features.Identity.Scim.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+
+namespace Honua.Server.Features.Identity.Scim;
+
+/// <summary>
+/// SCIM 2.0 provisioning endpoints (#510). Exposes <c>/scim/v2/Users</c> and
+/// <c>/scim/v2/Groups</c> CRUD so an external identity provider can provision and
+/// deprovision users and map groups to Honua RBAC roles. Authenticated by a static bearer
+/// token (<see cref="ScimProvisioningOptions.BearerToken"/>) presented by the IdP.
+/// </summary>
+internal static partial class ScimEndpoints
+{
+    private const string BearerPrefix = "Bearer ";
+    private const int MaxPageSize = 200;
+
+    /// <summary>Log category for SCIM endpoints.</summary>
+    internal sealed class ScimEndpointsLog;
+
+    /// <summary>
+    /// Maps the SCIM 2.0 provisioning endpoints. Authentication is enforced per-request
+    /// against the configured bearer token rather than the admin authorization policy, so an
+    /// IdP service-account token does not need an interactive admin session.
+    /// </summary>
+    public static void MapScimEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var users = endpoints.MapGroup("/scim/v2/Users")
+            .WithTags("Identity", "SCIM")
+            .AllowAnonymous();
+
+        users.MapGet("/", HandleListUsers).WithDisplayName("SCIM List Users");
+        users.MapPost("/", HandleCreateUser).WithDisplayName("SCIM Create User");
+        users.MapGet("/{id}", HandleGetUser).WithDisplayName("SCIM Get User");
+        users.MapPut("/{id}", HandleReplaceUser).WithDisplayName("SCIM Replace User");
+        users.MapPatch("/{id}", HandlePatchUser).WithDisplayName("SCIM Patch User");
+        users.MapDelete("/{id}", HandleDeleteUser).WithDisplayName("SCIM Delete User");
+
+        var groups = endpoints.MapGroup("/scim/v2/Groups")
+            .WithTags("Identity", "SCIM")
+            .AllowAnonymous();
+
+        groups.MapGet("/", HandleListGroups).WithDisplayName("SCIM List Groups");
+        groups.MapPost("/", HandleCreateGroup).WithDisplayName("SCIM Create Group");
+        groups.MapGet("/{id}", HandleGetGroup).WithDisplayName("SCIM Get Group");
+        groups.MapPut("/{id}", HandleReplaceGroup).WithDisplayName("SCIM Replace Group");
+        groups.MapPatch("/{id}", HandlePatchGroup).WithDisplayName("SCIM Patch Group");
+        groups.MapDelete("/{id}", HandleDeleteGroup).WithDisplayName("SCIM Delete Group");
+    }
+
+    // ---- Users ------------------------------------------------------------------------
+
+    private static async Task<IResult> HandleListUsers(
+        HttpContext context,
+        [FromServices] IScimUserStore store,
+        [FromServices] IOptions<ScimProvisioningOptions> options,
+        [FromServices] ILogger<ScimEndpointsLog> logger)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var (startIndex, count) = ReadPaging(context);
+        var query = new ScimUserQuery
+        {
+            UserNameEquals = ParseEqFilter(context.Request.Query["filter"], "userName"),
+            StartIndex = startIndex,
+            Count = count,
+        };
+
+        var page = await store.ListUsersAsync(query, context.RequestAborted).ConfigureAwait(false);
+        var response = new ScimListResponse<ScimUser>
+        {
+            TotalResults = page.TotalCount,
+            StartIndex = startIndex,
+            ItemsPerPage = page.Users.Count,
+            Resources = page.Users.Select(ToScimUser).ToList(),
+        };
+
+        ScimLog.UsersListed(logger, page.Users.Count, page.TotalCount);
+        return ScimJson(response, ScimJsonContext.Default.ScimListResponseScimUser, StatusCodes.Status200OK);
+    }
+
+    private static async Task<IResult> HandleCreateUser(
+        HttpContext context,
+        [FromServices] IScimUserStore store,
+        [FromServices] IOptions<ScimProvisioningOptions> options,
+        [FromServices] ILogger<ScimEndpointsLog> logger)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var input = await ReadUserAsync(context).ConfigureAwait(false);
+        if (input is null || string.IsNullOrWhiteSpace(input.UserName))
+        {
+            return ScimErrorResult(StatusCodes.Status400BadRequest, "userName is required.", "invalidValue");
+        }
+
+        var created = await store.CreateUserAsync(
+            new ScimUserProvisioning
+            {
+                UserName = input.UserName.Trim(),
+                DisplayName = input.DisplayName,
+                Email = SelectEmail(input.Emails),
+                Active = input.Active,
+            },
+            context.RequestAborted).ConfigureAwait(false);
+
+        if (created is null)
+        {
+            return ScimErrorResult(StatusCodes.Status409Conflict, "A user with that userName already exists.", "uniqueness");
+        }
+
+        ScimLog.UserProvisioned(logger, created.UserId);
+        return ScimJson(ToScimUser(created), ScimJsonContext.Default.ScimUser, StatusCodes.Status201Created);
+    }
+
+    private static async Task<IResult> HandleGetUser(
+        string id,
+        HttpContext context,
+        [FromServices] IScimUserStore store,
+        [FromServices] IOptions<ScimProvisioningOptions> options)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var user = await store.GetUserAsync(id, context.RequestAborted).ConfigureAwait(false);
+        return user is null
+            ? ScimErrorResult(StatusCodes.Status404NotFound, "User not found.")
+            : ScimJson(ToScimUser(user), ScimJsonContext.Default.ScimUser, StatusCodes.Status200OK);
+    }
+
+    private static async Task<IResult> HandleReplaceUser(
+        string id,
+        HttpContext context,
+        [FromServices] IScimUserStore store,
+        [FromServices] IOptions<ScimProvisioningOptions> options,
+        [FromServices] ILogger<ScimEndpointsLog> logger)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var input = await ReadUserAsync(context).ConfigureAwait(false);
+        if (input is null || string.IsNullOrWhiteSpace(input.UserName))
+        {
+            return ScimErrorResult(StatusCodes.Status400BadRequest, "userName is required.", "invalidValue");
+        }
+
+        var existing = await store.GetUserAsync(id, context.RequestAborted).ConfigureAwait(false);
+        var replaced = await store.ReplaceUserAsync(
+            id,
+            new ScimUserProvisioning
+            {
+                UserName = input.UserName.Trim(),
+                DisplayName = input.DisplayName,
+                Email = SelectEmail(input.Emails),
+                Active = input.Active,
+                // Roles are owned by group membership sync; PUT preserves the current set.
+                Roles = existing?.Roles ?? [],
+            },
+            context.RequestAborted).ConfigureAwait(false);
+
+        if (replaced is null)
+        {
+            return ScimErrorResult(StatusCodes.Status404NotFound, "User not found.");
+        }
+
+        ScimLog.UserReplaced(logger, replaced.UserId);
+        return ScimJson(ToScimUser(replaced), ScimJsonContext.Default.ScimUser, StatusCodes.Status200OK);
+    }
+
+    private static async Task<IResult> HandlePatchUser(
+        string id,
+        HttpContext context,
+        [FromServices] IScimUserStore store,
+        [FromServices] IOptions<ScimProvisioningOptions> options,
+        [FromServices] ILogger<ScimEndpointsLog> logger)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var patch = await ReadPatchAsync(context).ConfigureAwait(false);
+        if (patch?.Operations is null || patch.Operations.Count == 0)
+        {
+            return ScimErrorResult(StatusCodes.Status400BadRequest, "At least one PATCH operation is required.", "invalidValue");
+        }
+
+        // The dominant IdP PATCH on a user is toggling "active" for deprovision/reactivate.
+        if (!TryResolveActivePatch(patch, out var active))
+        {
+            return ScimErrorResult(StatusCodes.Status400BadRequest, "Unsupported PATCH operation; only the 'active' attribute is patchable.", "invalidValue");
+        }
+
+        var updated = await store.SetActiveAsync(id, active, context.RequestAborted).ConfigureAwait(false);
+        if (updated is null)
+        {
+            return ScimErrorResult(StatusCodes.Status404NotFound, "User not found.");
+        }
+
+        ScimLog.UserActiveChanged(logger, updated.UserId, active);
+        return ScimJson(ToScimUser(updated), ScimJsonContext.Default.ScimUser, StatusCodes.Status200OK);
+    }
+
+    private static async Task<IResult> HandleDeleteUser(
+        string id,
+        HttpContext context,
+        [FromServices] IScimUserStore store,
+        [FromServices] IOptions<ScimProvisioningOptions> options,
+        [FromServices] ILogger<ScimEndpointsLog> logger)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var deleted = await store.DeleteUserAsync(id, context.RequestAborted).ConfigureAwait(false);
+        if (!deleted)
+        {
+            return ScimErrorResult(StatusCodes.Status404NotFound, "User not found.");
+        }
+
+        ScimLog.UserDeprovisioned(logger, id);
+        return Results.StatusCode(StatusCodes.Status204NoContent);
+    }
+
+    // ---- Groups -----------------------------------------------------------------------
+
+    private static async Task<IResult> HandleListGroups(
+        HttpContext context,
+        [FromServices] IScimGroupStore store,
+        [FromServices] IOptions<ScimProvisioningOptions> options)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var (startIndex, count) = ReadPaging(context);
+        var query = new ScimGroupQuery
+        {
+            DisplayNameEquals = ParseEqFilter(context.Request.Query["filter"], "displayName"),
+            StartIndex = startIndex,
+            Count = count,
+        };
+
+        var page = await store.ListGroupsAsync(query, context.RequestAborted).ConfigureAwait(false);
+        var response = new ScimListResponse<ScimGroupResource>
+        {
+            TotalResults = page.TotalCount,
+            StartIndex = startIndex,
+            ItemsPerPage = page.Groups.Count,
+            Resources = page.Groups.Select(ToScimGroup).ToList(),
+        };
+
+        return ScimJson(response, ScimJsonContext.Default.ScimListResponseScimGroupResource, StatusCodes.Status200OK);
+    }
+
+    private static async Task<IResult> HandleCreateGroup(
+        HttpContext context,
+        [FromServices] IScimGroupStore store,
+        [FromServices] IOptions<ScimProvisioningOptions> options,
+        [FromServices] ILogger<ScimEndpointsLog> logger)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var input = await ReadGroupAsync(context).ConfigureAwait(false);
+        if (input is null || string.IsNullOrWhiteSpace(input.DisplayName))
+        {
+            return ScimErrorResult(StatusCodes.Status400BadRequest, "displayName is required.", "invalidValue");
+        }
+
+        var created = await store.CreateGroupAsync(
+            new ScimGroupProvisioning
+            {
+                DisplayName = input.DisplayName.Trim(),
+                MemberUserIds = ExtractMemberIds(input.Members),
+            },
+            context.RequestAborted).ConfigureAwait(false);
+
+        if (created is null)
+        {
+            return ScimErrorResult(StatusCodes.Status409Conflict, "A group with that displayName already exists.", "uniqueness");
+        }
+
+        ScimLog.GroupProvisioned(logger, created.DisplayName);
+        return ScimJson(ToScimGroup(created), ScimJsonContext.Default.ScimGroupResource, StatusCodes.Status201Created);
+    }
+
+    private static async Task<IResult> HandleGetGroup(
+        string id,
+        HttpContext context,
+        [FromServices] IScimGroupStore store,
+        [FromServices] IOptions<ScimProvisioningOptions> options)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var group = await store.GetGroupAsync(id, context.RequestAborted).ConfigureAwait(false);
+        return group is null
+            ? ScimErrorResult(StatusCodes.Status404NotFound, "Group not found.")
+            : ScimJson(ToScimGroup(group), ScimJsonContext.Default.ScimGroupResource, StatusCodes.Status200OK);
+    }
+
+    private static async Task<IResult> HandleReplaceGroup(
+        string id,
+        HttpContext context,
+        [FromServices] IScimGroupStore store,
+        [FromServices] IOptions<ScimProvisioningOptions> options,
+        [FromServices] ILogger<ScimEndpointsLog> logger)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var input = await ReadGroupAsync(context).ConfigureAwait(false);
+        if (input is null || string.IsNullOrWhiteSpace(input.DisplayName))
+        {
+            return ScimErrorResult(StatusCodes.Status400BadRequest, "displayName is required.", "invalidValue");
+        }
+
+        var replaced = await store.ReplaceGroupAsync(
+            id,
+            new ScimGroupProvisioning
+            {
+                DisplayName = input.DisplayName.Trim(),
+                MemberUserIds = ExtractMemberIds(input.Members),
+            },
+            context.RequestAborted).ConfigureAwait(false);
+
+        if (replaced is null)
+        {
+            return ScimErrorResult(StatusCodes.Status404NotFound, "Group not found.");
+        }
+
+        ScimLog.GroupReplaced(logger, replaced.DisplayName);
+        return ScimJson(ToScimGroup(replaced), ScimJsonContext.Default.ScimGroupResource, StatusCodes.Status200OK);
+    }
+
+    private static async Task<IResult> HandlePatchGroup(
+        string id,
+        HttpContext context,
+        [FromServices] IScimGroupStore store,
+        [FromServices] IOptions<ScimProvisioningOptions> options,
+        [FromServices] ILogger<ScimEndpointsLog> logger)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var patch = await ReadPatchAsync(context).ConfigureAwait(false);
+        if (patch?.Operations is null || patch.Operations.Count == 0)
+        {
+            return ScimErrorResult(StatusCodes.Status400BadRequest, "At least one PATCH operation is required.", "invalidValue");
+        }
+
+        if (!TryResolveMemberPatch(patch, out var change))
+        {
+            return ScimErrorResult(StatusCodes.Status400BadRequest, "Unsupported PATCH operation; only the 'members' attribute is patchable.", "invalidValue");
+        }
+
+        var updated = await store.UpdateMembersAsync(id, change, context.RequestAborted).ConfigureAwait(false);
+        if (updated is null)
+        {
+            return ScimErrorResult(StatusCodes.Status404NotFound, "Group not found.");
+        }
+
+        ScimLog.GroupMembersChanged(logger, updated.DisplayName, change.Add.Count, change.Remove.Count);
+        return ScimJson(ToScimGroup(updated), ScimJsonContext.Default.ScimGroupResource, StatusCodes.Status200OK);
+    }
+
+    private static async Task<IResult> HandleDeleteGroup(
+        string id,
+        HttpContext context,
+        [FromServices] IScimGroupStore store,
+        [FromServices] IOptions<ScimProvisioningOptions> options,
+        [FromServices] ILogger<ScimEndpointsLog> logger)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var deleted = await store.DeleteGroupAsync(id, context.RequestAborted).ConfigureAwait(false);
+        if (!deleted)
+        {
+            return ScimErrorResult(StatusCodes.Status404NotFound, "Group not found.");
+        }
+
+        ScimLog.GroupDeleted(logger, id);
+        return Results.StatusCode(StatusCodes.Status204NoContent);
+    }
+
+    // ---- Authentication ---------------------------------------------------------------
+
+    /// <summary>
+    /// Validates the SCIM bearer token in constant time. Returns <see langword="false"/> when
+    /// provisioning is disabled (no token configured) or the presented token does not match.
+    /// </summary>
+    private static bool Authenticate(HttpContext context, ScimProvisioningOptions options)
+    {
+        var configured = options.BearerToken;
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            // No token configured => SCIM provisioning is disabled; reject everything.
+            return false;
+        }
+
+        if (!context.Request.Headers.TryGetValue(HeaderNames.Authorization, out var header))
+        {
+            return false;
+        }
+
+        var raw = header.ToString();
+        if (string.IsNullOrEmpty(raw) || !raw.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var presented = raw[BearerPrefix.Length..].Trim();
+        return FixedTimeEquals(presented, configured);
+    }
+
+    private static bool FixedTimeEquals(string a, string b)
+    {
+        var ab = Encoding.UTF8.GetBytes(a);
+        var bb = Encoding.UTF8.GetBytes(b);
+        return ab.Length == bb.Length && CryptographicOperations.FixedTimeEquals(ab, bb);
+    }
+
+    // ---- Mapping ----------------------------------------------------------------------
+
+    private static ScimUser ToScimUser(ManagedUser user) => new()
+    {
+        Id = user.UserId,
+        UserName = user.UserId,
+        DisplayName = user.DisplayName,
+        Active = user.IsActive,
+        Emails = string.IsNullOrWhiteSpace(user.Email)
+            ? null
+            : [new ScimEmail { Value = user.Email, Primary = true, Type = "work" }],
+        Meta = new ScimMeta
+        {
+            ResourceType = "User",
+            Created = user.CreatedAt,
+            LastModified = user.UpdatedAt,
+            Location = $"/scim/v2/Users/{user.UserId}",
+        },
+    };
+
+    private static ScimGroupResource ToScimGroup(ScimGroup group) => new()
+    {
+        Id = group.GroupId,
+        DisplayName = group.DisplayName,
+        Members = group.MemberUserIds.Select(m => new ScimMember { Value = m }).ToList(),
+        Meta = new ScimMeta
+        {
+            ResourceType = "Group",
+            Created = group.CreatedAt,
+            LastModified = group.UpdatedAt,
+            Location = $"/scim/v2/Groups/{group.GroupId}",
+        },
+    };
+
+    private static string? SelectEmail(IReadOnlyList<ScimEmail>? emails)
+    {
+        if (emails is null || emails.Count == 0)
+        {
+            return null;
+        }
+
+        var primary = emails.FirstOrDefault(e => e.Primary == true && !string.IsNullOrWhiteSpace(e.Value));
+        return (primary ?? emails.FirstOrDefault(e => !string.IsNullOrWhiteSpace(e.Value)))?.Value;
+    }
+
+    private static List<string> ExtractMemberIds(IReadOnlyList<ScimMember>? members)
+        => members is null
+            ? []
+            : members
+                .Select(m => m.Value)
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Select(v => v!.Trim())
+                .ToList();
+
+    // ---- Patch resolution -------------------------------------------------------------
+
+    private static bool TryResolveActivePatch(ScimPatchRequest patch, out bool active)
+    {
+        active = true;
+        var resolved = false;
+
+        foreach (var op in patch.Operations!)
+        {
+            var verb = op.Op?.Trim().ToLowerInvariant();
+            if (verb is not ("add" or "replace"))
+            {
+                return false;
+            }
+
+            // Accept both path-form ({"path":"active","value":true}) and value-object form
+            // ({"value":{"active":false}}) which different IdPs emit.
+            if (string.Equals(op.Path, "active", StringComparison.OrdinalIgnoreCase) && op.Value.HasValue)
+            {
+                if (!TryReadBool(op.Value.Value, out active))
+                {
+                    return false;
+                }
+
+                resolved = true;
+            }
+            else if (string.IsNullOrEmpty(op.Path) && op.Value is { ValueKind: JsonValueKind.Object } obj
+                     && obj.TryGetProperty("active", out var activeProp))
+            {
+                if (!TryReadBool(activeProp, out active))
+                {
+                    return false;
+                }
+
+                resolved = true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        return resolved;
+    }
+
+    private static bool TryReadBool(JsonElement element, out bool value)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.True:
+                value = true;
+                return true;
+            case JsonValueKind.False:
+                value = false;
+                return true;
+            case JsonValueKind.String when bool.TryParse(element.GetString(), out var parsed):
+                value = parsed;
+                return true;
+            default:
+                value = false;
+                return false;
+        }
+    }
+
+    private static bool TryResolveMemberPatch(ScimPatchRequest patch, out ScimGroupMemberChange change)
+    {
+        var add = new List<string>();
+        var remove = new List<string>();
+        var resolved = false;
+
+        foreach (var op in patch.Operations!)
+        {
+            var verb = op.Op?.Trim().ToLowerInvariant();
+            if (!string.Equals(op.Path, "members", StringComparison.OrdinalIgnoreCase) || op.Value is null)
+            {
+                return Fail(out change);
+            }
+
+            var ids = ReadMemberValues(op.Value.Value);
+            switch (verb)
+            {
+                case "add":
+                    add.AddRange(ids);
+                    resolved = true;
+                    break;
+                case "remove":
+                    remove.AddRange(ids);
+                    resolved = true;
+                    break;
+                default:
+                    return Fail(out change);
+            }
+        }
+
+        change = new ScimGroupMemberChange { Add = add, Remove = remove };
+        return resolved;
+
+        static bool Fail(out ScimGroupMemberChange c)
+        {
+            c = new ScimGroupMemberChange();
+            return false;
+        }
+    }
+
+    private static List<string> ReadMemberValues(JsonElement value)
+    {
+        var ids = new List<string>();
+        if (value.ValueKind != JsonValueKind.Array)
+        {
+            return ids;
+        }
+
+        foreach (var element in value.EnumerateArray())
+        {
+            if (element.ValueKind == JsonValueKind.Object && element.TryGetProperty("value", out var v) &&
+                v.ValueKind == JsonValueKind.String)
+            {
+                var id = v.GetString();
+                if (!string.IsNullOrWhiteSpace(id))
+                {
+                    ids.Add(id.Trim());
+                }
+            }
+            else if (element.ValueKind == JsonValueKind.String)
+            {
+                var id = element.GetString();
+                if (!string.IsNullOrWhiteSpace(id))
+                {
+                    ids.Add(id.Trim());
+                }
+            }
+        }
+
+        return ids;
+    }
+
+    // ---- Request parsing & responses --------------------------------------------------
+
+    private static (int StartIndex, int Count) ReadPaging(HttpContext context)
+    {
+        var startIndex = 1;
+        var count = 100;
+
+        if (int.TryParse(context.Request.Query["startIndex"], out var si) && si >= 1)
+        {
+            startIndex = si;
+        }
+
+        if (int.TryParse(context.Request.Query["count"], out var c) && c >= 0)
+        {
+            count = Math.Min(c, MaxPageSize);
+        }
+
+        return (startIndex, count);
+    }
+
+    /// <summary>
+    /// Parses a SCIM <c>filter</c> of the form <c>attribute eq "value"</c> for a single
+    /// supported attribute. Returns null when the filter is absent or not an equality match on
+    /// the requested attribute (broader filter grammar is intentionally unsupported).
+    /// </summary>
+    private static string? ParseEqFilter(string? filter, string attribute)
+    {
+        if (string.IsNullOrWhiteSpace(filter))
+        {
+            return null;
+        }
+
+        var trimmed = filter.Trim();
+        var prefix = attribute + " eq ";
+        if (!trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var rest = trimmed[prefix.Length..].Trim();
+        if (rest.Length >= 2 && rest[0] == '"' && rest[^1] == '"')
+        {
+            return rest[1..^1];
+        }
+
+        return rest;
+    }
+
+    private static async Task<ScimUser?> ReadUserAsync(HttpContext context)
+    {
+        try
+        {
+            return await JsonSerializer.DeserializeAsync(
+                context.Request.Body, ScimJsonContext.Default.ScimUser, context.RequestAborted).ConfigureAwait(false);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static async Task<ScimGroupResource?> ReadGroupAsync(HttpContext context)
+    {
+        try
+        {
+            return await JsonSerializer.DeserializeAsync(
+                context.Request.Body, ScimJsonContext.Default.ScimGroupResource, context.RequestAborted).ConfigureAwait(false);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static async Task<ScimPatchRequest?> ReadPatchAsync(HttpContext context)
+    {
+        try
+        {
+            return await JsonSerializer.DeserializeAsync(
+                context.Request.Body, ScimJsonContext.Default.ScimPatchRequest, context.RequestAborted).ConfigureAwait(false);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static IResult ScimJson<T>(T body, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> typeInfo, int statusCode)
+        => Results.Json(body, typeInfo, contentType: ScimSchemas.ContentType, statusCode: statusCode);
+
+    private static IResult Unauthorized()
+        => ScimErrorResult(StatusCodes.Status401Unauthorized, "A valid SCIM bearer token is required.");
+
+    private static IResult ScimErrorResult(int statusCode, string detail, string? scimType = null)
+        => Results.Json(
+            new ScimError
+            {
+                Status = statusCode.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                Detail = detail,
+                ScimType = scimType,
+            },
+            ScimJsonContext.Default.ScimError,
+            contentType: ScimSchemas.ContentType,
+            statusCode: statusCode);
+}

--- a/src/Honua.Server/Features/Identity/Scim/ScimLog.cs
+++ b/src/Honua.Server/Features/Identity/Scim/ScimLog.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Identity.Scim;
+
+/// <summary>
+/// Source-generated structured logging for the SCIM 2.0 provisioning endpoints (#510).
+/// User and group identifiers are stable, non-secret provisioning keys safe to log for audit.
+/// </summary>
+internal static partial class ScimLog
+{
+    [LoggerMessage(EventId = 4600, Level = LogLevel.Information,
+        Message = "SCIM listed {Count} users (total: {TotalCount}).")]
+    public static partial void UsersListed(ILogger logger, int count, int totalCount);
+
+    [LoggerMessage(EventId = 4601, Level = LogLevel.Information,
+        Message = "SCIM provisioned user '{UserId}'.")]
+    public static partial void UserProvisioned(ILogger logger, string userId);
+
+    [LoggerMessage(EventId = 4602, Level = LogLevel.Information,
+        Message = "SCIM replaced user '{UserId}'.")]
+    public static partial void UserReplaced(ILogger logger, string userId);
+
+    [LoggerMessage(EventId = 4603, Level = LogLevel.Information,
+        Message = "SCIM set user '{UserId}' active state to {Active}.")]
+    public static partial void UserActiveChanged(ILogger logger, string userId, bool active);
+
+    [LoggerMessage(EventId = 4604, Level = LogLevel.Information,
+        Message = "SCIM deprovisioned user '{UserId}'.")]
+    public static partial void UserDeprovisioned(ILogger logger, string userId);
+
+    [LoggerMessage(EventId = 4605, Level = LogLevel.Information,
+        Message = "SCIM provisioned group '{DisplayName}'.")]
+    public static partial void GroupProvisioned(ILogger logger, string displayName);
+
+    [LoggerMessage(EventId = 4606, Level = LogLevel.Information,
+        Message = "SCIM replaced group '{DisplayName}'.")]
+    public static partial void GroupReplaced(ILogger logger, string displayName);
+
+    [LoggerMessage(EventId = 4607, Level = LogLevel.Information,
+        Message = "SCIM updated group '{DisplayName}' membership (+{Added}/-{Removed}).")]
+    public static partial void GroupMembersChanged(ILogger logger, string displayName, int added, int removed);
+
+    [LoggerMessage(EventId = 4608, Level = LogLevel.Information,
+        Message = "SCIM deleted group '{GroupId}'.")]
+    public static partial void GroupDeleted(ILogger logger, string groupId);
+}

--- a/src/Honua.Server/Features/Identity/Scim/ScimProvisioningOptions.cs
+++ b/src/Honua.Server/Features/Identity/Scim/ScimProvisioningOptions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Identity.Scim;
+
+/// <summary>
+/// Configuration for the SCIM 2.0 provisioning surface (#510). An identity provider (Okta,
+/// Microsoft Entra, etc.) authenticates to the SCIM endpoints with a long-lived bearer token
+/// it is configured with out-of-band; the token is compared in constant time.
+/// </summary>
+public sealed class ScimProvisioningOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Scim";
+
+    /// <summary>
+    /// The bearer token the identity provider must present in the <c>Authorization</c> header.
+    /// When null/empty the SCIM endpoints reject all requests (provisioning is disabled by
+    /// default — there is no implicit anonymous access).
+    /// </summary>
+    public string? BearerToken { get; set; }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -40,6 +40,9 @@ using Honua.Server.Features.Provisioner;
 using Honua.ControlPlane;
 using Honua.FileStorage;
 using Honua.Server.Features.HealthCheck;
+using Honua.Server.Features.Identity;
+using Honua.Server.Features.Identity.Saml;
+using Honua.Server.Features.Identity.Scim;
 using Honua.Import;
 using Honua.Migration;
 using Honua.Import.FileImport;
@@ -726,6 +729,11 @@ builder.Services.AddCollaborationSessionTransport();
 // ---- Extracted: authentication & authorization options (Startup/AuthenticationOptionsRegistration.cs)
 builder.Services.AddHonuaAuthenticationOptions(builder.Configuration, builder.Environment);
 // ---- End extracted block
+
+// Enterprise identity: SCIM 2.0 provisioning (#510) and SAML 2.0 SP-initiated SSO (#508).
+// Both adapt into the existing identity/role model: SCIM provisions users + maps groups to
+// roles; SAML consumes a signed assertion and establishes a Honua session.
+builder.Services.AddEnterpriseIdentity(builder.Configuration);
 // Configure security headers
 builder.Services.AddSecurityHeaders(builder.Configuration);
 // Configure security audit log sink (#1144)
@@ -1318,6 +1326,10 @@ app.MapOidcProviderEndpoints();
 app.MapUserManagementEndpoints();
 app.MapRoleEndpoints();
 app.MapRlsPolicyEndpoints();
+
+// Enterprise identity provisioning + SSO (#510 SCIM 2.0, #508 SAML 2.0)
+app.MapScimEndpoints();
+app.MapSamlEndpoints();
 
 // Configure Console metadata v2 content + RBAC endpoints (#1162)
 app.MapConsoleSessionEndpoints();

--- a/src/Honua.Server/Startup/ControlPlaneIamDefaults.cs
+++ b/src/Honua.Server/Startup/ControlPlaneIamDefaults.cs
@@ -28,7 +28,17 @@ internal static class ControlPlaneIamDefaults
         ArgumentNullException.ThrowIfNull(services);
 
         services.TryAddSingleton<IOidcProviderStore, InMemoryOidcProviderStore>();
-        services.TryAddSingleton<IUserStore, InMemoryUserStore>();
+
+        // The in-memory user store backs both the admin IUserStore surface and the SCIM
+        // provisioning surface (IScimUserStore, #510). Register the concrete singleton once
+        // and project all three contracts onto the SAME instance so SCIM-provisioned users
+        // are visible to the admin endpoints and group->role sync mutates a single record set.
+        services.TryAddSingleton<InMemoryUserStore>();
+        services.TryAddSingleton<IUserStore>(static sp => sp.GetRequiredService<InMemoryUserStore>());
+        services.TryAddSingleton<IScimUserStore>(static sp => sp.GetRequiredService<InMemoryUserStore>());
+        services.TryAddSingleton<IScimGroupStore>(static sp =>
+            new InMemoryScimGroupStore(sp.GetRequiredService<InMemoryUserStore>()));
+
         services.TryAddSingleton<IRoleStore, InMemoryRoleStore>();
 
         return services;

--- a/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
@@ -31,6 +31,7 @@ public sealed class VerticalSliceIsolationTests
         "Geocoding",
         "Geoprocessing",
         "Grounding",
+        "Identity", // Enterprise identity slice (honua-server#508/#510): SCIM 2.0 provisioning + SAML 2.0 SP SSO bridge over the shared user/role model.
         "Orchestration",
         "PackageReview",
         "Plugins", // Plugin/extension SDK host slice (honua-server#1562): maps plugin-contributed ICustomEndpoint routes.

--- a/tests/dotnet/Honua.Server.Tests/Features/Identity/SamlAssertionValidatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Identity/SamlAssertionValidatorTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Honua.Server.Features.Identity.Saml;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Identity;
+
+/// <summary>
+/// Unit tests for <see cref="SamlAssertionValidator"/> (#508): a valid signed assertion is
+/// accepted and its attributes mapped, while forged/unsigned/expired/wrong-audience assertions
+/// are rejected. The signed fixtures are produced by the in-box <c>SignedXml</c> reference
+/// implementation, so these tests also prove the AOT-safe Exclusive-C14N verifier interoperates
+/// with a standard signer.
+/// </summary>
+[Protocol(TestProtocols.Admin)]
+public sealed class SamlAssertionValidatorTests
+{
+    private static SamlAssertionValidator CreateValidator(string base64Cert, Action<SamlAuthenticationOptions>? configure = null)
+    {
+        var options = new SamlAuthenticationOptions
+        {
+            Enabled = true,
+            EntityId = SamlTestAssertions.Audience,
+            IdpEntityId = SamlTestAssertions.Issuer,
+            IdpSigningCertificate = base64Cert,
+            RoleAttribute = "Role",
+            EmailAttribute = "email",
+            DisplayNameAttribute = "displayName",
+        };
+        configure?.Invoke(options);
+        return new SamlAssertionValidator(Options.Create(options));
+    }
+
+    private static string Decode(string base64) => Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+
+    [UnitTest]
+    public void Validate_ValidSignedAssertion_SucceedsAndMapsAttributes()
+    {
+        using var cert = SamlTestAssertions.CreateSigningCertificate();
+        var validator = CreateValidator(SamlTestAssertions.ToBase64Der(cert));
+        var response = Decode(SamlTestAssertions.CreateSignedResponse(
+            cert, "user@example.com", "user@example.com", "Display Name", ["editor", "viewer"]));
+
+        var result = validator.Validate(response);
+
+        Assert.True(result.Succeeded, result.FailureReason);
+        Assert.NotNull(result.Subject);
+        Assert.Equal("user@example.com", result.Subject!.NameId);
+        Assert.Equal("Display Name", result.Subject.DisplayName);
+        Assert.Equal("user@example.com", result.Subject.Email);
+        Assert.Contains("editor", result.Subject.Roles);
+        Assert.Contains("viewer", result.Subject.Roles);
+    }
+
+    [UnitTest]
+    public void Validate_UnsignedAssertion_IsRejected()
+    {
+        using var cert = SamlTestAssertions.CreateSigningCertificate();
+        var validator = CreateValidator(SamlTestAssertions.ToBase64Der(cert));
+        var response = Decode(SamlTestAssertions.CreateUnsignedResponse("user@example.com"));
+
+        var result = validator.Validate(response);
+
+        Assert.False(result.Succeeded);
+        Assert.NotNull(result.FailureReason);
+    }
+
+    [UnitTest]
+    public void Validate_TamperedAssertion_IsRejected()
+    {
+        using var cert = SamlTestAssertions.CreateSigningCertificate();
+        var validator = CreateValidator(SamlTestAssertions.ToBase64Der(cert));
+        var response = Decode(SamlTestAssertions.CreateTamperedResponse(cert, "user@example.com"));
+
+        var result = validator.Validate(response);
+
+        Assert.False(result.Succeeded);
+    }
+
+    [UnitTest]
+    public void Validate_SignedByDifferentKey_IsRejected()
+    {
+        using var signingCert = SamlTestAssertions.CreateSigningCertificate();
+        using var otherCert = SamlTestAssertions.CreateSigningCertificate();
+        // Server is configured to trust a DIFFERENT certificate than the one that signed.
+        var validator = CreateValidator(SamlTestAssertions.ToBase64Der(otherCert));
+        var response = Decode(SamlTestAssertions.CreateSignedResponse(
+            signingCert, "user@example.com", "u@example.com", "U", ["viewer"]));
+
+        var result = validator.Validate(response);
+
+        Assert.False(result.Succeeded);
+    }
+
+    [UnitTest]
+    public void Validate_ExpiredAssertion_IsRejected()
+    {
+        using var cert = SamlTestAssertions.CreateSigningCertificate();
+        var validator = CreateValidator(SamlTestAssertions.ToBase64Der(cert), o => o.AllowedClockSkewSeconds = 0);
+        var response = Decode(SamlTestAssertions.CreateSignedResponse(
+            cert, "user@example.com", "u@example.com", "U", ["viewer"],
+            notBefore: DateTimeOffset.UtcNow.AddMinutes(-30),
+            notOnOrAfter: DateTimeOffset.UtcNow.AddMinutes(-10)));
+
+        var result = validator.Validate(response);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("expired", result.FailureReason!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [UnitTest]
+    public void Validate_WrongAudience_IsRejected()
+    {
+        using var cert = SamlTestAssertions.CreateSigningCertificate();
+        var validator = CreateValidator(SamlTestAssertions.ToBase64Der(cert), o => o.EntityId = "https://someone-else.example.com/sp");
+        var response = Decode(SamlTestAssertions.CreateSignedResponse(
+            cert, "user@example.com", "u@example.com", "U", ["viewer"]));
+
+        var result = validator.Validate(response);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("audience", result.FailureReason!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [UnitTest]
+    public void Validate_WrongIssuer_IsRejected()
+    {
+        using var cert = SamlTestAssertions.CreateSigningCertificate();
+        var validator = CreateValidator(SamlTestAssertions.ToBase64Der(cert), o => o.IdpEntityId = "https://wrong-issuer.example.com");
+        var response = Decode(SamlTestAssertions.CreateSignedResponse(
+            cert, "user@example.com", "u@example.com", "U", ["viewer"]));
+
+        var result = validator.Validate(response);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("issuer", result.FailureReason!, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Identity/SamlBridgeEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Identity/SamlBridgeEndpointsTests.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests.Features.Identity;
+
+/// <summary>
+/// Integration tests for the SAML 2.0 SP endpoints (#508): SP metadata generation and the
+/// Assertion Consumer Service that consumes a signed assertion and establishes a session, with
+/// forged and expired assertions rejected.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.IdentityManagement)]
+public class SamlBridgeEndpointsTests : IAsyncLifetime
+{
+    private readonly X509Certificate2 _certificate = SamlTestAssertions.CreateSigningCertificate();
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public SamlBridgeEndpointsTests()
+    {
+        var base64Cert = SamlTestAssertions.ToBase64Der(_certificate);
+        _fixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("Saml:Enabled", "true");
+                builder.UseSetting("Saml:EntityId", SamlTestAssertions.Audience);
+                builder.UseSetting("Saml:IdpEntityId", SamlTestAssertions.Issuer);
+                builder.UseSetting("Saml:AssertionConsumerServiceUrl", SamlTestAssertions.Audience + "/saml/acs");
+                builder.UseSetting("Saml:IdpSigningCertificate", base64Cert);
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        // Do not auto-follow redirects; the ACS returns 204 with a Set-Cookie on success.
+        _client = _fixture.CreateClient(allowAutoRedirect: false);
+    }
+
+    public Task DisposeAsync()
+    {
+        _certificate.Dispose();
+        return _fixture.DisposeAsync();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /saml/metadata")]
+    public async Task Metadata_WhenConfigured_ReturnsSpMetadata()
+    {
+        var response = await _client.GetAsync("/saml/metadata");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("EntityDescriptor", body, StringComparison.Ordinal);
+        Assert.Contains("AssertionConsumerService", body, StringComparison.Ordinal);
+        Assert.Contains(SamlTestAssertions.Audience, body, StringComparison.Ordinal);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /saml/acs")]
+    public async Task Acs_ValidSignedAssertion_EstablishesSession()
+    {
+        var samlResponse = SamlTestAssertions.CreateSignedResponse(
+            _certificate, "saml-user@example.com", "saml-user@example.com", "SAML User", ["editor"]);
+
+        var response = await PostAcsAsync(samlResponse);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.Contains(
+            response.Headers.GetValues("Set-Cookie"),
+            c => c.Contains("honua_admin_session", StringComparison.Ordinal));
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /saml/acs")]
+    public async Task Acs_ForgedSignature_IsRejected()
+    {
+        var samlResponse = SamlTestAssertions.CreateTamperedResponse(_certificate, "attacker@example.com");
+
+        var response = await PostAcsAsync(samlResponse);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.DoesNotContain(
+            response.Headers.TryGetValues("Set-Cookie", out var cookies) ? cookies : [],
+            c => c.Contains("honua_admin_session", StringComparison.Ordinal));
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /saml/acs")]
+    public async Task Acs_UnsignedAssertion_IsRejected()
+    {
+        var samlResponse = SamlTestAssertions.CreateUnsignedResponse("user@example.com");
+
+        var response = await PostAcsAsync(samlResponse);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /saml/acs")]
+    public async Task Acs_ExpiredAssertion_IsRejected()
+    {
+        var samlResponse = SamlTestAssertions.CreateSignedResponse(
+            _certificate, "user@example.com", "u@example.com", "U", ["viewer"],
+            notBefore: DateTimeOffset.UtcNow.AddMinutes(-30),
+            notOnOrAfter: DateTimeOffset.UtcNow.AddMinutes(-10));
+
+        var response = await PostAcsAsync(samlResponse);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /saml/acs")]
+    public async Task Acs_MissingSamlResponse_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsync(
+            "/saml/acs",
+            new FormUrlEncodedContent(new Dictionary<string, string> { ["RelayState"] = "x" }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private async Task<HttpResponseMessage> PostAcsAsync(string base64SamlResponse)
+    {
+        var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["SAMLResponse"] = base64SamlResponse,
+        });
+        return await _client.PostAsync("/saml/acs", content);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Identity/SamlTestAssertions.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Identity/SamlTestAssertions.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
+using System.Text;
+using System.Xml;
+
+namespace Honua.Server.Tests.Features.Identity;
+
+/// <summary>
+/// Builds SAML 2.0 Response/Assertion XML signed with the in-box <see cref="SignedXml"/>
+/// reference implementation. This is the independent oracle for the server's hand-rolled,
+/// AOT-safe verifier (#508): if the server accepts what Microsoft's signer produced, the
+/// canonicalization and signature paths are interoperable. Test-only — no shipped project
+/// references <c>System.Security.Cryptography.Xml</c>.
+/// </summary>
+internal static class SamlTestAssertions
+{
+    public const string Issuer = "https://idp.example.com/metadata";
+    public const string Audience = "https://honua.example.com/sp";
+
+    /// <summary>Creates a self-signed RSA certificate to act as the IdP signing certificate.</summary>
+    public static X509Certificate2 CreateSigningCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=Honua SAML Test IdP",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+    }
+
+    /// <summary>The base64 DER of the certificate (the value the server stores as its IdP cert).</summary>
+    public static string ToBase64Der(X509Certificate2 certificate)
+        => Convert.ToBase64String(certificate.Export(X509ContentType.Cert));
+
+    /// <summary>
+    /// Produces a signed, valid SAML Response (base64-encoded, ready for the ACS SAMLResponse form field).
+    /// </summary>
+    public static string CreateSignedResponse(
+        X509Certificate2 certificate,
+        string nameId,
+        string email,
+        string displayName,
+        IReadOnlyList<string> roles,
+        DateTimeOffset? notOnOrAfter = null,
+        DateTimeOffset? notBefore = null)
+    {
+        var xml = BuildResponseXml(nameId, email, displayName, roles, notBefore, notOnOrAfter);
+        var signed = SignAssertion(xml, certificate);
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(signed));
+    }
+
+    /// <summary>
+    /// Produces an UNSIGNED SAML Response (base64-encoded). Used to prove the server rejects it.
+    /// </summary>
+    public static string CreateUnsignedResponse(string nameId)
+    {
+        var xml = BuildResponseXml(nameId, "x@example.com", "X", ["viewer"], null, null);
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(xml));
+    }
+
+    /// <summary>
+    /// Produces a signed response whose assertion body is then tampered with (an attribute value
+    /// changed AFTER signing). The signature digest must no longer match.
+    /// </summary>
+    public static string CreateTamperedResponse(X509Certificate2 certificate, string nameId)
+    {
+        var xml = BuildResponseXml(nameId, "x@example.com", "X", ["viewer"], null, null);
+        var signed = SignAssertion(xml, certificate);
+        // Tamper: flip the role value in the signed XML.
+        var tampered = signed.Replace(">viewer<", ">admin<", StringComparison.Ordinal);
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(tampered));
+    }
+
+    private static string BuildResponseXml(
+        string nameId,
+        string email,
+        string displayName,
+        IReadOnlyList<string> roles,
+        DateTimeOffset? notBefore,
+        DateTimeOffset? notOnOrAfter)
+    {
+        const string saml = "urn:oasis:names:tc:SAML:2.0:assertion";
+        const string samlp = "urn:oasis:names:tc:SAML:2.0:protocol";
+
+        var now = DateTimeOffset.UtcNow;
+        var nb = (notBefore ?? now.AddMinutes(-5)).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+        var noa = (notOnOrAfter ?? now.AddMinutes(5)).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+        var issueInstant = now.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+        var rolesXml = new StringBuilder();
+        foreach (var role in roles)
+        {
+            rolesXml.Append(CultureInfo.InvariantCulture, $"<AttributeValue>{role}</AttributeValue>");
+        }
+
+        return $"""
+            <samlp:Response xmlns:samlp="{samlp}" xmlns="{saml}" ID="_resp1" Version="2.0" IssueInstant="{issueInstant}">
+              <Issuer>{Issuer}</Issuer>
+              <samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>
+              <Assertion ID="_assertion1" Version="2.0" IssueInstant="{issueInstant}">
+                <Issuer>{Issuer}</Issuer>
+                <Subject>
+                  <NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">{nameId}</NameID>
+                  <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                    <SubjectConfirmationData NotOnOrAfter="{noa}" Recipient="{SamlTestAssertions.Audience}/acs"/>
+                  </SubjectConfirmation>
+                </Subject>
+                <Conditions NotBefore="{nb}" NotOnOrAfter="{noa}">
+                  <AudienceRestriction><Audience>{Audience}</Audience></AudienceRestriction>
+                </Conditions>
+                <AuthnStatement AuthnInstant="{issueInstant}">
+                  <AuthnContext><AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</AuthnContextClassRef></AuthnContext>
+                </AuthnStatement>
+                <AttributeStatement>
+                  <Attribute Name="email"><AttributeValue>{email}</AttributeValue></Attribute>
+                  <Attribute Name="displayName"><AttributeValue>{displayName}</AttributeValue></Attribute>
+                  <Attribute Name="Role">{rolesXml}</Attribute>
+                </AttributeStatement>
+              </Assertion>
+            </samlp:Response>
+            """;
+    }
+
+    /// <summary>
+    /// Signs the &lt;Assertion&gt; element with an enveloped signature using Exclusive C14N and
+    /// RSA-SHA256, mirroring what a real IdP emits.
+    /// </summary>
+    private static string SignAssertion(string responseXml, X509Certificate2 certificate)
+    {
+        var document = new XmlDocument { PreserveWhitespace = true };
+        document.LoadXml(responseXml);
+
+        var nsmgr = new XmlNamespaceManager(document.NameTable);
+        nsmgr.AddNamespace("saml", "urn:oasis:names:tc:SAML:2.0:assertion");
+        var assertion = (XmlElement)document.SelectSingleNode("//saml:Assertion", nsmgr)!;
+
+        using var rsa = certificate.GetRSAPrivateKey()!;
+        var signedXml = new SignedXml(assertion) { SigningKey = rsa };
+        signedXml.SignedInfo!.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
+        signedXml.SignedInfo.SignatureMethod = SignedXml.XmlDsigRSASHA256Url;
+
+        var reference = new Reference("#_assertion1");
+        reference.DigestMethod = SignedXml.XmlDsigSHA256Url;
+        reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
+        reference.AddTransform(new XmlDsigExcC14NTransform());
+        signedXml.AddReference(reference);
+
+        signedXml.ComputeSignature();
+        var signatureElement = signedXml.GetXml();
+
+        // Insert the signature as the first child of the assertion (after Issuer is also valid;
+        // the verifier locates it as a direct child regardless of position).
+        assertion.InsertAfter(signatureElement, assertion.SelectSingleNode("saml:Issuer", nsmgr));
+
+        return document.OuterXml;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Identity/ScimProvisioningEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Identity/ScimProvisioningEndpointsTests.cs
@@ -1,0 +1,291 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Honua.Core.Features.Identity.Abstractions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Features.Identity;
+
+/// <summary>
+/// Integration tests for the SCIM 2.0 provisioning endpoints (#510): Users and Groups CRUD,
+/// list filtering/pagination, group-to-role mapping, deprovisioning, and bearer-token auth.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.IdentityManagement)]
+public class ScimProvisioningEndpointsTests : IAsyncLifetime
+{
+    private const string ScimToken = "scim-integration-bearer-token";
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public ScimProvisioningEndpointsTests()
+    {
+        _fixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("Scim:BearerToken", ScimToken);
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateClient(c =>
+            c.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", ScimToken));
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /scim/v2/Users")]
+    public async Task CreateUser_ValidRequest_ProvisionsUser()
+    {
+        var response = await _client.PostAsJsonAsync("/scim/v2/Users", new
+        {
+            userName = "alice@example.com",
+            displayName = "Alice Example",
+            active = true,
+            emails = new[] { new { value = "alice@example.com", primary = true } },
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var user = await ReadAsync(response);
+        Assert.Equal("alice@example.com", user.GetProperty("userName").GetString());
+        Assert.True(user.GetProperty("active").GetBoolean());
+
+        // Provisioned user is visible to the shared identity store with source "scim".
+        var store = _fixture.Services.GetRequiredService<IUserStore>();
+        var managed = await store.GetUserAsync("alice@example.com");
+        Assert.NotNull(managed);
+        Assert.Equal("scim", managed!.ProvisioningSource);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /scim/v2/Users")]
+    public async Task CreateUser_DuplicateUserName_ReturnsConflict()
+    {
+        await CreateUserAsync("dup@example.com");
+        var response = await _client.PostAsJsonAsync("/scim/v2/Users", new
+        {
+            userName = "dup@example.com",
+        });
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/Users")]
+    public async Task ListUsers_WithUserNameFilter_ReturnsMatch()
+    {
+        await CreateUserAsync("filter-me@example.com");
+        await CreateUserAsync("other@example.com");
+
+        var response = await _client.GetAsync("/scim/v2/Users?filter=userName%20eq%20%22filter-me@example.com%22");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await ReadAsync(response);
+        Assert.Equal(1, body.GetProperty("totalResults").GetInt32());
+        var resources = body.GetProperty("resources");
+        Assert.Equal("filter-me@example.com", resources[0].GetProperty("userName").GetString());
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/Users/{id}")]
+    public async Task GetUser_Existing_ReturnsUser()
+    {
+        await CreateUserAsync("get-me@example.com");
+        var response = await _client.GetAsync("/scim/v2/Users/get-me@example.com");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var user = await ReadAsync(response);
+        Assert.Equal("get-me@example.com", user.GetProperty("id").GetString());
+    }
+
+    [IntegrationTest]
+    [Endpoint("PUT /scim/v2/Users/{id}")]
+    public async Task ReplaceUser_UpdatesAttributes()
+    {
+        await CreateUserAsync("replace@example.com");
+        var response = await _client.PutAsJsonAsync("/scim/v2/Users/replace@example.com", new
+        {
+            userName = "replace@example.com",
+            displayName = "Renamed Person",
+            active = true,
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var user = await ReadAsync(response);
+        Assert.Equal("Renamed Person", user.GetProperty("displayName").GetString());
+    }
+
+    [IntegrationTest]
+    [Endpoint("PATCH /scim/v2/Users/{id}")]
+    public async Task PatchUser_SetActiveFalse_DeprovisionsUser()
+    {
+        await CreateUserAsync("patch@example.com");
+        var response = await _client.PatchAsync("/scim/v2/Users/patch@example.com", JsonContent.Create(new
+        {
+            Operations = new[] { new { op = "replace", path = "active", value = false } },
+        }));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var user = await ReadAsync(response);
+        Assert.False(user.GetProperty("active").GetBoolean());
+
+        // Deactivation revokes access in the underlying store.
+        var store = _fixture.Services.GetRequiredService<IUserStore>();
+        var managed = await store.GetUserAsync("patch@example.com");
+        Assert.False(managed!.IsActive);
+    }
+
+    [IntegrationTest]
+    [Endpoint("DELETE /scim/v2/Users/{id}")]
+    public async Task DeleteUser_RevokesAccess()
+    {
+        await CreateUserAsync("delete@example.com");
+        var response = await _client.DeleteAsync("/scim/v2/Users/delete@example.com");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var store = _fixture.Services.GetRequiredService<IUserStore>();
+        var managed = await store.GetUserAsync("delete@example.com");
+        Assert.False(managed!.IsActive);
+        Assert.Empty(managed.Roles);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /scim/v2/Groups")]
+    [Endpoint("GET /scim/v2/Groups")]
+    public async Task CreateGroup_WithMembers_MapsRoleToMembers()
+    {
+        await CreateUserAsync("member@example.com");
+
+        var response = await _client.PostAsJsonAsync("/scim/v2/Groups", new
+        {
+            displayName = "editor",
+            members = new[] { new { value = "member@example.com" } },
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        // The member receives the group's role (group displayName == role name).
+        var store = _fixture.Services.GetRequiredService<IUserStore>();
+        var managed = await store.GetUserAsync("member@example.com");
+        Assert.Contains("editor", managed!.Roles, StringComparer.OrdinalIgnoreCase);
+
+        var list = await _client.GetAsync("/scim/v2/Groups");
+        Assert.Equal(HttpStatusCode.OK, list.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/Groups/{id}")]
+    [Endpoint("PUT /scim/v2/Groups/{id}")]
+    [Endpoint("PATCH /scim/v2/Groups/{id}")]
+    [Endpoint("DELETE /scim/v2/Groups/{id}")]
+    public async Task GroupLifecycle_MembershipChanges_SyncRoles()
+    {
+        await CreateUserAsync("g-user@example.com");
+
+        // Create empty group.
+        var createResp = await _client.PostAsJsonAsync("/scim/v2/Groups", new
+        {
+            displayName = "analysts",
+        });
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+        var groupId = (await ReadAsync(createResp)).GetProperty("id").GetString()!;
+
+        // GET it.
+        var getResp = await _client.GetAsync($"/scim/v2/Groups/{groupId}");
+        Assert.Equal(HttpStatusCode.OK, getResp.StatusCode);
+
+        // PATCH add member => role granted.
+        var patchAdd = await _client.PatchAsync($"/scim/v2/Groups/{groupId}", JsonContent.Create(new
+        {
+            Operations = new[]
+            {
+                new { op = "add", path = "members", value = new[] { new { value = "g-user@example.com" } } },
+            },
+        }));
+        Assert.Equal(HttpStatusCode.OK, patchAdd.StatusCode);
+
+        var store = _fixture.Services.GetRequiredService<IUserStore>();
+        Assert.Contains("analysts", (await store.GetUserAsync("g-user@example.com"))!.Roles, StringComparer.OrdinalIgnoreCase);
+
+        // PATCH remove member => role revoked.
+        var patchRemove = await _client.PatchAsync($"/scim/v2/Groups/{groupId}", JsonContent.Create(new
+        {
+            Operations = new[]
+            {
+                new { op = "remove", path = "members", value = new[] { new { value = "g-user@example.com" } } },
+            },
+        }));
+        Assert.Equal(HttpStatusCode.OK, patchRemove.StatusCode);
+        Assert.DoesNotContain("analysts", (await store.GetUserAsync("g-user@example.com"))!.Roles, StringComparer.OrdinalIgnoreCase);
+
+        // PUT full replace members.
+        var putResp = await _client.PutAsJsonAsync($"/scim/v2/Groups/{groupId}", new
+        {
+            displayName = "analysts",
+            members = new[] { new { value = "g-user@example.com" } },
+        });
+        Assert.Equal(HttpStatusCode.OK, putResp.StatusCode);
+        Assert.Contains("analysts", (await store.GetUserAsync("g-user@example.com"))!.Roles, StringComparer.OrdinalIgnoreCase);
+
+        // DELETE group => role revoked from all members.
+        var deleteResp = await _client.DeleteAsync($"/scim/v2/Groups/{groupId}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResp.StatusCode);
+        Assert.DoesNotContain("analysts", (await store.GetUserAsync("g-user@example.com"))!.Roles, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/Users")]
+    public async Task Request_WithoutBearerToken_ReturnsUnauthorized()
+    {
+        using var anon = _fixture.CreateClient();
+        var response = await anon.GetAsync("/scim/v2/Users");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/Users")]
+    public async Task Request_WithWrongBearerToken_ReturnsUnauthorized()
+    {
+        using var wrong = _fixture.CreateClient(c =>
+            c.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "not-the-token"));
+        var response = await wrong.GetAsync("/scim/v2/Users");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private async Task CreateUserAsync(string userName)
+    {
+        var response = await _client.PostAsJsonAsync("/scim/v2/Users", new
+        {
+            userName,
+            displayName = userName,
+            active = true,
+        });
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    private static async Task<JsonElement> ReadAsync(HttpResponseMessage response)
+    {
+        var text = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<JsonElement>(text, _json);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj
+++ b/tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="ParquetSharp" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

Bundles the two enterprise identity surfaces. Both provision/authenticate into the **existing** RBAC role/identity model (#498/#500/#1374-1376/#502) rather than adding a parallel one.

- **#510 — SCIM 2.0 provisioning**: `/scim/v2/Users` + `/scim/v2/Groups` CRUD over the existing identity/role store, so Okta/Entra can provision/deprovision users and map groups to roles.
- **#508 — SAML 2.0 SP SSO bridge**: SP-initiated SSO — consume a signed SAML assertion, map attributes/groups to RBAC roles, establish a Honua session.

## Per-ticket scope

### #510 SCIM 2.0 (`/scim/v2/...`)
- Users: `GET` (list, `userName eq` filter + `startIndex`/`count` pagination), `POST` (provision), `GET/{id}`, `PUT/{id}` (replace), `PATCH/{id}` (`active` toggle = deprovision/reactivate), `DELETE/{id}`.
- Groups: full CRUD + `PATCH` member add/remove. A group's `displayName` maps to a Honua role; membership changes synchronize that role onto members' `ManagedUser.Roles`, and deprovisioning (delete user, `active=false`, group delete, member removal) revokes it.
- New `IScimUserStore` / `IScimGroupStore` in `Honua.Core`. `InMemoryUserStore` implements both `IUserStore` and `IScimUserStore` over one record set so SCIM users (`ProvisioningSource=scim`) are visible to the admin surface; the group store mutates the same set.
- Auth: static bearer token (`Scim:BearerToken`), constant-time compared (the Okta/Entra pattern). Disabled (rejects all) when unconfigured.
- RFC 7643/7644 envelopes (User/Group, ListResponse, PatchOp, Error) via a source-generated JSON context (AOT-safe, `application/scim+json`).

### #508 SAML 2.0 (`/saml/...`)
- `GET /saml/metadata` (SP metadata) and `POST /saml/acs` (Assertion Consumer Service, HTTP-POST binding).
- ACS validates the assertion, maps the configured role/email/displayName attributes to RBAC roles, and establishes the **same** session/claims model as OIDC (`AdminAuthSessionStore` + session cookie).
- **AOT-safe signature verification**: a focused Exclusive XML C14N (RFC 3741) + `System.Security.Cryptography` primitives (RSA/ECDSA; SHA-256/384/512), deliberately avoiding `SignedXml` (not in the in-box shared framework; not AOT/trim-friendly). Verifies the `SignedInfo` signature **and** the signed-element digest, pins the `Reference` to the assertion `ID` (anti-wrapping), and enforces issuer, audience, and `NotBefore`/`NotOnOrAfter` with bounded clock skew.

## Tests (run serially)
- **SCIM** (integration, Testcontainers): user/group CRUD, `userName` filter, group→role mapping, `active=false` and `DELETE` deprovision revoke access/roles, PATCH add/remove sync, missing/wrong bearer → 401.
- **SAML** (integration): metadata generation; ACS happy path establishes session cookie; forged-signature, unsigned, and expired assertions → 401; missing `SAMLResponse` → 400.
- **SAML validator** (unit): valid signed assertion accepted + attributes mapped; unsigned / tampered / wrong-key / expired / wrong-audience / wrong-issuer rejected. Fixtures are signed by the in-box `SignedXml` reference implementation (test-only dependency) so the AOT-safe verifier is proven interoperable with a standard signer.
- Architecture tests pass (proof ledger, API-surface coverage, feature-catalog drift, vertical-slice, protocol-attribute, error-handling). `dotnet format` clean on changed projects. Build is Release/warnings-as-errors.

## Security notes
- SCIM bearer token constant-time compared; SCIM disabled by default until a token is configured.
- SAML rejects unsigned/forged/tampered/expired assertions; signature pinned to the assertion ID to defeat XML signature-wrapping; issuer + audience enforced; bounded clock skew; XML parsed with DTD/XXE disabled (`SecureXmlDocumentParser`). No raw exception/cert/signature material is logged.
- AOT-conscious: no `SignedXml`; the only added package (`System.Security.Cryptography.Xml`) is **test-only** (used to generate signed fixtures), not referenced by any shipped project.

## Notes / deferred
- **No new migration.** This slice is backed by the existing in-memory identity store (the durable user store #498 is not yet on trunk; `InMemoryUserStore` is the only `IUserStore`). It reuses the `rbac_role_memberships` contract from migration 041 without adding schema. Durable SCIM/SAML persistence should follow the durable user store.
- AUTH subsystem touch points (EndpointRegistry, Program.cs DI, ControlPlaneIamDefaults) may overlap sibling auth PRs #2108/#2109; the merge queue sequences them.

Closes #510
Closes #508