### PR TITLE
feat: activate app-level rate limiting (#355)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ Every `honua-server` PR runs a **Validate PR Template Compliance** check (in `ci
 ## MVP Deferrals (Operational Simplicity)
 
 The MVP intentionally defers enterprise/operational features to reduce complexity:
-- No app-level rate limiting; enforce at the edge (nginx/ALB/WAF).
+- Edge enforcement (nginx/ALB/WAF) remains the default rate-limiting posture (ADR-0004). An opt-in app-level rate limiter exists (`RateLimiting:Enabled`, off by default) that partitions by tenant/user/API-key and emits `429` + `Retry-After` (#355); it does not replace edge enforcement.
 - No secure-connection allowlist or connection audit trail; secure connections are encrypted or secret references only.
 - No security compliance framework, audit log storage, or compliance dashboards/monitoring.
 

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -388,6 +388,19 @@
       "maturity": "implemented"
     },
     {
+      "id": "delete-api-v1-admin-rate-limits-id",
+      "route": "/api/v1/admin/rate-limits/{id}",
+      "method": "DELETE",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.RateLimitEndpointsTests.PolicyCrud_CreateGetUpdateDelete_CompletesLifecycle"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "delete-api-v1-admin-rls-policies-id",
       "route": "/api/v1/admin/rls-policies/{id}",
       "method": "DELETE",
@@ -2785,6 +2798,46 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Admin.ProposalEndpointsTests.GetProposal_WhenFound_ReturnsPlanDetail",
         "Honua.Server.Tests.Features.Admin.ProposalEndpointsTests.GetProposal_WhenMissing_ReturnsNotFound"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-rate-limits",
+      "route": "/api/v1/admin/rate-limits",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.RateLimitEndpointsTests.ListPolicies_Activated_ReturnsSuccessEnvelope"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-rate-limits-status",
+      "route": "/api/v1/admin/rate-limits/status",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.RateLimitEndpointsTests.GetStatus_ForKnownPolicyKey_ReturnsStatusEnvelope",
+        "Honua.Server.Tests.Features.Admin.RateLimitEndpointsTests.GetStatus_MissingKey_ReturnsBadRequest"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-rate-limits-id",
+      "route": "/api/v1/admin/rate-limits/{id}",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.RateLimitEndpointsTests.PolicyCrud_CreateGetUpdateDelete_CompletesLifecycle"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -5208,7 +5261,7 @@
         "Honua.Server.Tests.Features.CloudDemo.CloudDemoEndpointsTests.StoryCollection_AfterReset_ReturnsSeededOgcFeatures",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_FormatParameterOverridesAcceptHeader",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_ReturnsResponseWithPagingLinksAndTimeStamp",
-        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_With3dBbox_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_With3dBbox_AcceptsAndUsesHorizontalExtent",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithBbox_ExcludesNullGeometryFeatures",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithCql2TextTemporalInstantOnAttributeField_Returns200",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithCql2TextTemporalOnUndefinedField_Returns400",
@@ -12204,6 +12257,19 @@
       "maturity": "implemented"
     },
     {
+      "id": "post-api-v1-admin-rate-limits",
+      "route": "/api/v1/admin/rate-limits",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.RateLimitEndpointsTests.PolicyCrud_CreateGetUpdateDelete_CompletesLifecycle"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "post-api-v1-admin-rls-policies",
       "route": "/api/v1/admin/rls-policies",
       "method": "POST",
@@ -16725,6 +16791,19 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.AdminEndpointTests.GetAdminOpenApiSpec_WithWrongHttpMethods_Returns405AndAllowHeader"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "put-api-v1-admin-rate-limits-id",
+      "route": "/api/v1/admin/rate-limits/{id}",
+      "method": "PUT",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.RateLimitEndpointsTests.PolicyCrud_CreateGetUpdateDelete_CompletesLifecycle"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -192,6 +192,14 @@ public static class EndpointRegistry
         new("GET", "/api/v1/admin/geocoding/providers"),
         new("GET", "/api/v1/admin/features"),
 
+        // v1 admin rate limit policy endpoints (#355)
+        new("GET", "/api/v1/admin/rate-limits"),
+        new("POST", "/api/v1/admin/rate-limits"),
+        new("GET", "/api/v1/admin/rate-limits/{id}"),
+        new("PUT", "/api/v1/admin/rate-limits/{id}"),
+        new("DELETE", "/api/v1/admin/rate-limits/{id}"),
+        new("GET", "/api/v1/admin/rate-limits/status"),
+
         // v1 admin compliance endpoints (#352)
         new("GET", "/api/v1/admin/compliance/dashboard"),
         new("GET", "/api/v1/admin/compliance/report"),

--- a/src/Honua.Server/Features/Admin/Services/InMemoryRateLimitPolicyStore.cs
+++ b/src/Honua.Server/Features/Admin/Services/InMemoryRateLimitPolicyStore.cs
@@ -8,8 +8,11 @@ using Honua.Core.Features.RateLimiting.Domain;
 namespace Honua.Server.Features.Admin.Services;
 
 /// <summary>
-/// In-memory rate limit policy store for the admin API surface.
-/// Will be replaced by a persistent implementation when #355 lands.
+/// In-memory rate limit policy store backing the admin API surface (issue #355).
+/// The activated slice is intentionally thin: policies are held per-node in memory so
+/// operators can model tenant/user/API-key quotas without standing up durable quota
+/// infrastructure. A persistent, cluster-shared implementation can replace this when
+/// concrete enterprise demand justifies distributed policy storage.
 /// </summary>
 internal sealed class InMemoryRateLimitPolicyStore : IRateLimitPolicyStore
 {

--- a/src/Honua.Server/Features/Infrastructure/RateLimiting/RateLimitingMiddleware.cs
+++ b/src/Honua.Server/Features/Infrastructure/RateLimiting/RateLimitingMiddleware.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 using System.Text.Json;
 using Honua.Core.Features.Infrastructure.Logging;
+using Honua.Core.Features.MultiTenancy.Abstractions;
 using Honua.Core.Features.RateLimiting.Abstractions;
 
 namespace Honua.Infrastructure.RateLimiting;
@@ -14,8 +15,15 @@ namespace Honua.Infrastructure.RateLimiting;
 /// <summary>
 /// Middleware for enforcing rate limits on incoming requests.
 /// </summary>
+/// <remarks>
+/// Requests are partitioned independently per tenant, per authenticated user/API key,
+/// and per source IP for anonymous traffic (issue #355). Limits are off by default and
+/// must be enabled and tuned through the <c>RateLimiting</c> configuration section; the
+/// MVP posture remains edge enforcement (ADR-0004) unless an operator opts in.
+/// </remarks>
 internal sealed partial class RateLimitingMiddleware
 {
+    private const string TenantKeyFamily = "tenant";
     private const string UserKeyFamily = "user";
     private const string IpKeyFamily = "ip";
     private const string UnknownKeyFamily = "unknown";
@@ -43,15 +51,21 @@ internal sealed partial class RateLimitingMiddleware
     /// </summary>
     /// <param name="next">The next middleware in the pipeline.</param>
     /// <param name="policyStore">Rate limit policy store.</param>
-    /// <param name="redis">Redis connection for distributed rate limiting.</param>
     /// <param name="options">Rate limiting options.</param>
     /// <param name="logger">Logger instance.</param>
+    /// <param name="redis">
+    /// Optional Redis connection for distributed (cross-node) rate limiting. Registered only
+    /// when durable coordination is configured, so it is passed in optionally by
+    /// <see cref="RateLimitingMiddlewareExtensions.UseRateLimiting"/> rather than required via
+    /// injection; when <see langword="null"/> the middleware falls back to process-local
+    /// fixed-window counters.
+    /// </param>
     public RateLimitingMiddleware(
         RequestDelegate next,
         IRateLimitPolicyStore policyStore,
-        IConnectionMultiplexer? redis,
         IOptions<RateLimitingOptions> options,
-        ILogger<RateLimitingMiddleware> logger)
+        ILogger<RateLimitingMiddleware> logger,
+        IConnectionMultiplexer? redis)
     {
         _next = next;
         _policyStore = policyStore;
@@ -98,7 +112,9 @@ internal sealed partial class RateLimitingMiddleware
     }
 
     /// <summary>
-    /// Determines the rate limit key for the request.
+    /// Determines the rate limit key for the request. The key is partitioned by tenant
+    /// (when one is resolved) and then by authenticated user/API key identity, falling
+    /// back to the source IP for anonymous traffic (issue #355).
     /// </summary>
     /// <param name="context">The HTTP context.</param>
     /// <returns>Rate limit key or null if no rate limiting should be applied.</returns>
@@ -118,6 +134,17 @@ internal sealed partial class RateLimitingMiddleware
             return null;
         }
 
+        // Tenant scope (resolved by TenantContextMiddleware, which runs earlier in the
+        // pipeline). When present it prefixes the bucket so two tenants sharing an
+        // identity provider — or an anonymous IP straddling tenants — never share a
+        // counter. The id is a stable opaque tenant identifier, never a secret.
+        var tenantPrefix = string.Empty;
+        var tenantContext = context.RequestServices?.GetService(typeof(ITenantContext)) as ITenantContext;
+        if (!string.IsNullOrEmpty(tenantContext?.TenantId))
+        {
+            tenantPrefix = $"{TenantKeyFamily}:{tenantContext.TenantId}|";
+        }
+
         // Key on the authenticated principal when one is present. Never derive the
         // bucket from raw, unauthenticated credentials (Authorization header or
         // ?api_key=): an attacker could mint a fresh bucket per request by sending
@@ -126,11 +153,11 @@ internal sealed partial class RateLimitingMiddleware
         var identity = context.User?.Identity;
         if (identity?.IsAuthenticated == true && !string.IsNullOrEmpty(identity.Name))
         {
-            return $"{UserKeyFamily}:{identity.Name}";
+            return $"{tenantPrefix}{UserKeyFamily}:{identity.Name}";
         }
 
         // Fall back to IP-based rate limiting for unauthenticated requests
-        return $"{IpKeyFamily}:{clientIp}";
+        return $"{tenantPrefix}{IpKeyFamily}:{clientIp}";
     }
 
     /// <summary>
@@ -338,6 +365,13 @@ internal sealed partial class RateLimitingMiddleware
         RateLimitingLog.RateLimitExceeded(_logger, keyFamily, keyHash, result.RequestCount, result.Limit);
 
         AddRateLimitHeaders(context, result);
+
+        // RFC 9110 Retry-After: advise clients how long to wait (in whole seconds, never
+        // negative) before retrying. Mirrors the X-RateLimit-Reset window boundary.
+        var retryAfterSeconds = Math.Max(0, (int)Math.Ceiling((result.WindowReset - DateTimeOffset.UtcNow).TotalSeconds));
+        context.Response.Headers.RetryAfter =
+            retryAfterSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
         context.Response.StatusCode = (int)HttpStatusCode.TooManyRequests;
         context.Response.ContentType = "application/json";
 
@@ -383,8 +417,10 @@ internal sealed partial class RateLimitingMiddleware
     }
 
     /// <summary>
-    /// Splits a rate-limit key (<c>family:value</c>) into a fixed family label and a short
-    /// correlation hash so neither the principal name nor the raw IP appears in log output.
+    /// Splits a rate-limit key into a fixed family label and a short correlation hash so
+    /// neither the tenant id, principal name, nor raw IP appears in log output. Keys may
+    /// be tenant-prefixed (<c>tenant:&lt;id&gt;|user:&lt;name&gt;</c>); the most specific
+    /// (rightmost) family is reported and the whole key is hashed for correlation.
     /// </summary>
     private static (string Family, string Hash) SplitRateLimitKey(string? rateLimitKey)
     {
@@ -393,21 +429,29 @@ internal sealed partial class RateLimitingMiddleware
             return (UnknownKeyFamily, LogValueRedactor.Hash(null));
         }
 
-        var separatorIndex = rateLimitKey.IndexOf(':', StringComparison.Ordinal);
-        if (separatorIndex <= 0)
+        // The bucket family is identified by the last segment so a tenant-prefixed key
+        // reports user/ip rather than the tenant scope marker.
+        var lastSegment = rateLimitKey;
+        var pipeIndex = rateLimitKey.LastIndexOf('|');
+        if (pipeIndex >= 0 && pipeIndex < rateLimitKey.Length - 1)
         {
-            return (UnknownKeyFamily, LogValueRedactor.Hash(rateLimitKey));
+            lastSegment = rateLimitKey[(pipeIndex + 1)..];
         }
 
-        var family = rateLimitKey[..separatorIndex];
-        var value = rateLimitKey[(separatorIndex + 1)..];
+        var separatorIndex = lastSegment.IndexOf(':', StringComparison.Ordinal);
+        var family = separatorIndex <= 0 ? UnknownKeyFamily : lastSegment[..separatorIndex];
 
-        return family switch
+        var resolvedFamily = family switch
         {
-            UserKeyFamily => (UserKeyFamily, LogValueRedactor.Hash(value)),
-            IpKeyFamily => (IpKeyFamily, LogValueRedactor.Hash(value)),
-            _ => (UnknownKeyFamily, LogValueRedactor.Hash(value))
+            TenantKeyFamily => TenantKeyFamily,
+            UserKeyFamily => UserKeyFamily,
+            IpKeyFamily => IpKeyFamily,
+            _ => UnknownKeyFamily
         };
+
+        // Hash the full key (including tenant prefix) so distinct buckets get distinct
+        // correlation hashes without exposing any identifier.
+        return (resolvedFamily, LogValueRedactor.Hash(rateLimitKey));
     }
 }
 

--- a/src/Honua.Server/Features/Infrastructure/RateLimiting/RateLimitingMiddlewareExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/RateLimiting/RateLimitingMiddlewareExtensions.cs
@@ -3,6 +3,8 @@
 
 using Honua.Core.Features.RateLimiting.Abstractions;
 using Honua.Server.Features.Admin.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 
@@ -39,13 +41,31 @@ public static class RateLimitingMiddlewareExtensions
 
     /// <summary>
     /// Adds the rate limiting middleware to the application pipeline.
-    /// Should be registered after authentication but before authorization.
+    /// Should be registered after authentication and tenant resolution so request buckets
+    /// partition by tenant and authenticated user/API-key identity.
     /// </summary>
     /// <param name="app">The application builder</param>
     /// <returns>The application builder for method chaining</returns>
     public static IApplicationBuilder UseRateLimiting(this IApplicationBuilder app)
     {
-        return app.UseMiddleware<RateLimitingMiddleware>();
+        ArgumentNullException.ThrowIfNull(app);
+
+        // Construct the middleware explicitly rather than via UseMiddleware<T> so the
+        // optional IConnectionMultiplexer can be resolved with GetService (it is registered
+        // only when durable coordination is configured; UseMiddleware<T> would call
+        // GetRequiredService and throw on single-node hosts). The policy store and options
+        // are singletons, so a single middleware instance is safe to reuse across requests.
+        var services = app.ApplicationServices;
+        var policyStore = services.GetRequiredService<IRateLimitPolicyStore>();
+        var options = services.GetRequiredService<IOptions<RateLimitingOptions>>();
+        var logger = services.GetRequiredService<ILogger<RateLimitingMiddleware>>();
+        var redis = services.GetService<IConnectionMultiplexer>();
+
+        return app.Use(next =>
+        {
+            var middleware = new RateLimitingMiddleware(next, policyStore, options, logger, redis);
+            return middleware.InvokeAsync;
+        });
     }
 }
 

--- a/src/Honua.Server/Features/Infrastructure/RateLimiting/RateLimitingOptions.cs
+++ b/src/Honua.Server/Features/Infrastructure/RateLimiting/RateLimitingOptions.cs
@@ -16,13 +16,16 @@ internal sealed class RateLimitingOptions
     public const string SectionName = "RateLimiting";
 
     /// <summary>
-    /// Whether rate limiting is enabled. Default is true.
+    /// Whether app-level rate limiting is enabled. Default is <see langword="false"/>:
+    /// the MVP/baseline posture enforces limits at the edge (nginx/ALB/WAF) per ADR-0004,
+    /// so operators must opt in by setting <c>RateLimiting:Enabled=true</c> (issue #355).
     /// </summary>
-    public bool Enabled { get; set; } = true;
+    public bool Enabled { get; set; }
 
     /// <summary>
-    /// Global rate limit for requests per minute per IP/API key.
-    /// Default is 1000 requests per minute.
+    /// Global rate limit for requests per minute per partition (tenant/user/API key/IP).
+    /// Defaults to a generous 1000 requests per minute so an accidental enable does not
+    /// throttle legitimate traffic; tune per deployment.
     /// </summary>
     [Range(1, 100000, ErrorMessage = "GlobalRequestsPerMinute must be between 1 and 100000")]
     public int GlobalRequestsPerMinute { get; set; } = 1000;

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -737,7 +737,11 @@ builder.Services.AddHonuaTenantContext(builder.Configuration, _ => { });
 // Configure CORS policies
 builder.Services.AddCorsPolicies(builder.Configuration, builder.Environment);
 builder.Services.AddInputValidation(builder.Configuration);
-// Rate limiting disabled per project requirements
+// App-level rate limiting services (issue #355). Off by default — operators opt in via
+// RateLimiting:Enabled. Registers options validation, the policy store backing the admin
+// surface, and the partitioned middleware. Edge enforcement (ADR-0004) remains the
+// baseline; this is the opt-in identity-aware (tenant/user/API-key) enterprise slice.
+builder.Services.AddRateLimiting(builder.Configuration);
 
 // Configure API versioning for admin endpoints
 builder.Services.AddApiVersioning(options =>
@@ -1217,7 +1221,11 @@ app.UseHonuaTenantContext();
 // execution so 401/403/5xx responses are still observed (#1144).
 app.UseHonuaAuditLog();
 
-// Rate limiting disabled per project requirements
+// App-level rate limiting (issue #355). Runs after authentication and tenant resolution
+// so buckets partition by tenant + authenticated user/API-key identity (falling back to
+// source IP for anonymous traffic). No-ops unless RateLimiting:Enabled is set; the MVP
+// posture is still edge enforcement (ADR-0004).
+app.UseRateLimiting();
 
 // Add limits enforcement middleware (after auth, before request logging)
 app.UseLimitsEnforcement();
@@ -1304,6 +1312,11 @@ app.MapAdminInfoEndpoints();
 app.MapCacheAdminEndpoints();
 app.MapGeocodingAdminEndpoints();
 app.MapFeatureOverviewEndpoints();
+
+// Rate limit policy administration (issue #355): CRUD + status for tenant/user/API-key
+// quota policies. Admin-authorized; the policies are consumed by the rate limiting
+// middleware registered above.
+app.MapRateLimitEndpoints();
 
 // Configure compliance admin endpoints (SOC 2 / FedRAMP readiness, key rotation, report export) (#352)
 app.MapComplianceAdminEndpoints();

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/RateLimitEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/RateLimitEndpointsTests.cs
@@ -2,6 +2,9 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -10,10 +13,11 @@ using Microsoft.AspNetCore.Hosting;
 namespace Honua.Server.Tests.Features.Admin;
 
 /// <summary>
-/// Integration tests confirming the MVP runtime does not expose application rate-limit admin endpoints.
+/// Integration tests for the activated app-level rate-limit policy admin surface (#355).
 /// </summary>
 [Collection("Database")]
 [Protocol(TestProtocols.Admin)]
+[Operation(Operations.Security)]
 public sealed class RateLimitEndpointsTests : IAsyncLifetime
 {
     private const string AdminPassword = "ratelimit-admin-key";
@@ -42,12 +46,101 @@ public sealed class RateLimitEndpointsTests : IAsyncLifetime
     public Task DisposeAsync() => _fixture.DisposeAsync();
 
     [IntegrationTest]
-    [Operation(Operations.Security)]
     [Endpoint("GET /api/v1/admin/rate-limits")]
-    public async Task GetRateLimitPolicies_MvpRuntime_ReturnsNotFound()
+    public async Task ListPolicies_Activated_ReturnsSuccessEnvelope()
     {
         var response = await _client.GetAsync("/api/v1/admin/rate-limits");
 
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        document.RootElement.GetProperty("data").ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/rate-limits")]
+    [Endpoint("GET /api/v1/admin/rate-limits/{id}")]
+    [Endpoint("PUT /api/v1/admin/rate-limits/{id}")]
+    [Endpoint("DELETE /api/v1/admin/rate-limits/{id}")]
+    public async Task PolicyCrud_CreateGetUpdateDelete_CompletesLifecycle()
+    {
+        var createPayload = new
+        {
+            name = $"tenant-cap-{Guid.NewGuid():N}",
+            scope = "tenant",
+            key = $"tenant-{Guid.NewGuid():N}",
+            requestsPerWindow = 1000,
+            windowDurationSeconds = 60d,
+            enabled = true,
+        };
+
+        var createResponse = await _client.PostAsJsonAsync("/api/v1/admin/rate-limits", createPayload);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        using var createDocument = JsonDocument.Parse(await createResponse.Content.ReadAsStringAsync());
+        createDocument.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        var policyId = createDocument.RootElement.GetProperty("data").GetProperty("policyId").GetGuid();
+        policyId.Should().NotBeEmpty();
+
+        var getResponse = await _client.GetAsync($"/api/v1/admin/rate-limits/{policyId}");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using (var getDocument = JsonDocument.Parse(await getResponse.Content.ReadAsStringAsync()))
+        {
+            getDocument.RootElement.GetProperty("data").GetProperty("requestsPerWindow").GetInt32().Should().Be(1000);
+        }
+
+        var updatePayload = new { requestsPerWindow = 250, enabled = false };
+        var updateResponse = await _client.PutAsJsonAsync($"/api/v1/admin/rate-limits/{policyId}", updatePayload);
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using (var updateDocument = JsonDocument.Parse(await updateResponse.Content.ReadAsStringAsync()))
+        {
+            var data = updateDocument.RootElement.GetProperty("data");
+            data.GetProperty("requestsPerWindow").GetInt32().Should().Be(250);
+            data.GetProperty("enabled").GetBoolean().Should().BeFalse();
+        }
+
+        var deleteResponse = await _client.DeleteAsync($"/api/v1/admin/rate-limits/{policyId}");
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var getAfterDelete = await _client.GetAsync($"/api/v1/admin/rate-limits/{policyId}");
+        getAfterDelete.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/rate-limits/status")]
+    public async Task GetStatus_MissingKey_ReturnsBadRequest()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/rate-limits/status");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/rate-limits/status")]
+    public async Task GetStatus_ForKnownPolicyKey_ReturnsStatusEnvelope()
+    {
+        var key = $"tenant-{Guid.NewGuid():N}";
+        var createPayload = new
+        {
+            name = $"status-policy-{Guid.NewGuid():N}",
+            scope = "tenant",
+            key,
+            requestsPerWindow = 500,
+            windowDurationSeconds = 60d,
+            enabled = true,
+        };
+
+        var createResponse = await _client.PostAsJsonAsync("/api/v1/admin/rate-limits", createPayload);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var statusResponse = await _client.GetAsync($"/api/v1/admin/rate-limits/status?key={Uri.EscapeDataString(key)}");
+        statusResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var statusDocument = JsonDocument.Parse(await statusResponse.Content.ReadAsStringAsync());
+        statusDocument.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        statusDocument.RootElement.GetProperty("data").GetProperty("key").GetString().Should().Be(key);
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Middleware/RateLimitingMiddlewareTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Middleware/RateLimitingMiddlewareTests.cs
@@ -2,12 +2,15 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Net;
+using System.Security.Claims;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Core.Features.MultiTenancy.Abstractions;
 using Honua.Core.Features.RateLimiting.Abstractions;
 using Honua.Infrastructure.RateLimiting;
 using Honua.TestKit.Attributes;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -69,7 +72,95 @@ public sealed class RateLimitingMiddlewareTests
         responseDocument.RootElement.GetProperty("details").TryGetProperty("window_reset", out _).Should().BeTrue();
     }
 
-    private static RateLimitingMiddleware CreateMiddleware()
+    [UnitTest]
+    public async Task InvokeAsync_WhenRateLimitExceeded_EmitsRetryAfterHeader()
+    {
+        var middleware = CreateMiddleware();
+
+        var firstContext = CreateContext("198.51.100.40");
+        await middleware.InvokeAsync(firstContext);
+
+        var secondContext = CreateContext("198.51.100.40");
+        await middleware.InvokeAsync(secondContext);
+
+        secondContext.Response.StatusCode.Should().Be(StatusCodes.Status429TooManyRequests);
+
+        var retryAfter = secondContext.Response.Headers.RetryAfter.ToString();
+        retryAfter.Should().NotBeNullOrEmpty("a 429 must advise clients when to retry (RFC 9110)");
+        int.TryParse(retryAfter, out var seconds).Should().BeTrue("Retry-After is emitted as a delay in seconds");
+        seconds.Should().BeInRange(0, 60);
+    }
+
+    [UnitTest]
+    public async Task InvokeAsync_UnderLimit_AllowsRequestThrough()
+    {
+        // Limit of 5; a single request is comfortably under the limit and must pass.
+        var middleware = CreateMiddleware(limit: 5);
+
+        var context = CreateContext("198.51.100.50");
+        await middleware.InvokeAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        context.Response.Headers["X-RateLimit-Remaining"].ToString().Should().Be("4");
+    }
+
+    [UnitTest]
+    public async Task InvokeAsync_WhenDisabled_DoesNotRateLimitEvenWhenOverLimit()
+    {
+        // Disabled is the shipped default. Even far beyond the configured limit, every
+        // request must pass through untouched and no rate-limit headers are written.
+        var middleware = CreateMiddleware(enabled: false, limit: 1);
+
+        for (var i = 0; i < 10; i++)
+        {
+            var context = CreateContext("198.51.100.60");
+            await middleware.InvokeAsync(context);
+
+            context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+            context.Response.Headers.ContainsKey("X-RateLimit-Limit").Should().BeFalse();
+        }
+    }
+
+    [UnitTest]
+    public async Task InvokeAsync_PartitionsByAuthenticatedUser_IndependentlyOfOtherUsers()
+    {
+        var middleware = CreateMiddleware(limit: 1);
+
+        // Alice consumes her single-request budget from the same IP.
+        var aliceFirst = CreateContext("198.51.100.70", user: "alice");
+        await middleware.InvokeAsync(aliceFirst);
+        var aliceSecond = CreateContext("198.51.100.70", user: "alice");
+        await middleware.InvokeAsync(aliceSecond);
+
+        // Bob shares the IP but has his own bucket — his first request must still pass.
+        var bobFirst = CreateContext("198.51.100.70", user: "bob");
+        await middleware.InvokeAsync(bobFirst);
+
+        aliceFirst.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        aliceSecond.Response.StatusCode.Should().Be(StatusCodes.Status429TooManyRequests);
+        bobFirst.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    [UnitTest]
+    public async Task InvokeAsync_PartitionsByTenant_IndependentlyForSameUserName()
+    {
+        var middleware = CreateMiddleware(limit: 1);
+
+        // Same principal name, but two different tenants must not share a counter.
+        var tenantAFirst = CreateContext("198.51.100.80", user: "svc", tenantId: "tenant-a");
+        await middleware.InvokeAsync(tenantAFirst);
+        var tenantASecond = CreateContext("198.51.100.80", user: "svc", tenantId: "tenant-a");
+        await middleware.InvokeAsync(tenantASecond);
+
+        var tenantBFirst = CreateContext("198.51.100.80", user: "svc", tenantId: "tenant-b");
+        await middleware.InvokeAsync(tenantBFirst);
+
+        tenantAFirst.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        tenantASecond.Response.StatusCode.Should().Be(StatusCodes.Status429TooManyRequests);
+        tenantBFirst.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    private static RateLimitingMiddleware CreateMiddleware(bool enabled = true, int limit = 1)
     {
         var policyStore = Substitute.For<IRateLimitPolicyStore>();
 
@@ -80,16 +171,20 @@ public sealed class RateLimitingMiddlewareTests
                 return Task.CompletedTask;
             },
             policyStore,
-            redis: null,
             Options.Create(new RateLimitingOptions
             {
-                Enabled = true,
-                GlobalRequestsPerMinute = 1
+                Enabled = enabled,
+                GlobalRequestsPerMinute = limit
             }),
-            NullLogger<RateLimitingMiddleware>.Instance);
+            NullLogger<RateLimitingMiddleware>.Instance,
+            redis: null);
     }
 
-    private static DefaultHttpContext CreateContext(string remoteIp, string? localIp = null)
+    private static DefaultHttpContext CreateContext(
+        string remoteIp,
+        string? localIp = null,
+        string? user = null,
+        string? tenantId = null)
     {
         var context = new DefaultHttpContext();
         context.Request.Path = "/rest/services/test/FeatureServer/0/query";
@@ -100,6 +195,40 @@ public sealed class RateLimitingMiddlewareTests
             context.Connection.LocalIpAddress = IPAddress.Parse(localIp);
         }
 
+        if (!string.IsNullOrWhiteSpace(user))
+        {
+            var identity = new ClaimsIdentity(
+                [new Claim(ClaimTypes.Name, user)],
+                authenticationType: "Test");
+            context.User = new ClaimsPrincipal(identity);
+        }
+
+        var services = new ServiceCollection();
+        services.AddSingleton<ITenantContext>(new StubTenantContext(tenantId));
+        context.RequestServices = services.BuildServiceProvider();
+
         return context;
+    }
+
+    private sealed class StubTenantContext(string? tenantId) : ITenantContext
+    {
+        public string? TenantId { get; } = tenantId;
+
+        public TenantContextSource Source { get; } =
+            tenantId is null ? TenantContextSource.Anonymous : TenantContextSource.Claim;
+
+        public bool RequireTenantId(out string resolvedTenantId, out string? reason)
+        {
+            if (string.IsNullOrEmpty(TenantId))
+            {
+                resolvedTenantId = string.Empty;
+                reason = "no tenant context resolved";
+                return false;
+            }
+
+            resolvedTenantId = TenantId;
+            reason = null;
+            return true;
+        }
     }
 }


### PR DESCRIPTION
## Issue Link
Closes #355

## Summary
Activates the opt-in app-level rate limiter as one thin enterprise slice over the existing (previously unwired) `RateLimiting` scaffolding. Edge enforcement (nginx/ALB/WAF, ADR-0004) remains the default posture; app-level limits stay **off unless** an operator sets `RateLimiting:Enabled`. When enabled, request buckets partition independently per tenant, per authenticated user/API-key, and per source IP for anonymous traffic, and over-limit responses return `429` with a `Retry-After` header.

## Changes Made
- Partition the rate-limit key by tenant (`ITenantContext`) then authenticated user/API-key identity, falling back to source IP for anonymous traffic, so two tenants/users never share a counter.
- Emit RFC 9110 `Retry-After` (whole seconds) alongside the existing `X-RateLimit-*` headers on `429` responses.
- Default `RateLimitingOptions.Enabled` to `false` (generous 1000 rpm if enabled) so the baseline path is unaffected and an accidental enable will not throttle legitimate traffic.
- Wire `AddRateLimiting` + `UseRateLimiting` into the host (after auth and tenant resolution) and register the rate-limit policy admin CRUD/status endpoints. `UseRateLimiting` constructs the middleware explicitly so the optional Redis multiplexer resolves via `GetService` and single-node hosts do not throw on `GetRequiredService`.
- Register the six `/api/v1/admin/rate-limits*` routes in `EndpointRegistry`, regenerate `docs/gis/data/feature-catalog.json`, and update the MVP-deferral note in `AGENTS.md`.
- Add middleware unit tests (tenant/user partitioning, `Retry-After`, under-limit pass, disabled-by-default pass) and admin endpoint integration tests for the activated CRUD/status surface.

Deferred (follow-ups): edition/license gating (#338) and durable cluster-shared policy storage; the in-memory per-node policy store backs the activated admin surface.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Build: `dotnet build Honua.sln -c Release -p:TreatWarningsAsErrors=true` → 0 warnings / 0 errors. `dotnet format --verify-no-changes` clean on changed files. Ran serially: middleware unit tests (8/8), rate-limit admin integration tests (4/4, Testcontainers + PostGIS), full architecture suite (117/117).

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [x] Documentation updated

New admin endpoints under the existing `/api/v1/admin/` control-plane surface (already covered by the `control-plane-admin` proof-ledger surface); feature catalog regenerated.

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

No database migration: policies are config/in-memory only. Behavior is off by default, so no runtime change unless `RateLimiting:Enabled` is set.

## Breaking Changes
None