### PR TITLE
feat: schema-per-tenant routing + usage metering seam (#346)

### DIFF
--- a/src/Honua.Core/Configuration/RequestScopedSchemaConfiguration.cs
+++ b/src/Honua.Core/Configuration/RequestScopedSchemaConfiguration.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using Microsoft.Extensions.Configuration;
+
+namespace Honua.Core.Configuration;
+
+/// <summary>
+/// Resolves whether the database connection pool must operate in request-scoped schema mode —
+/// where each request may issue a per-connection <c>SET search_path</c> override.
+/// </summary>
+/// <remarks>
+/// Request-scoped schema mode is required by two features that share the same physical
+/// mechanism:
+///  - <c>HONUA_TEST_SCHEMA_HEADERS</c>: per-test schema isolation driven by the
+///    <c>X-Honua-Test-Schema</c> header.
+///  - <c>MultiTenancy:SchemaRouting:Enabled</c>: schema-per-tenant isolation (issue #346).
+///
+/// When either is enabled, Npgsql multiplexing is disabled and connections are reset on pool
+/// return so per-request schema overrides cannot leak between requests. When both are
+/// disabled (the single-tenant default) the pool keeps its configured default schema and
+/// behavior is byte-identical to before this rail existed.
+/// </remarks>
+public static class RequestScopedSchemaConfiguration
+{
+    /// <summary>
+    /// The legacy switch that enables per-test schema isolation via request headers.
+    /// </summary>
+    public const string TestSchemaHeadersKey = "HONUA_TEST_SCHEMA_HEADERS";
+
+    /// <summary>
+    /// The switch that enables schema-per-tenant routing (issue #346).
+    /// </summary>
+    public const string TenantSchemaRoutingKey = "MultiTenancy:SchemaRouting:Enabled";
+
+    /// <summary>
+    /// Returns <see langword="true"/> when any feature requiring request-scoped schema mode is
+    /// enabled in the supplied configuration.
+    /// </summary>
+    /// <param name="configuration">The configuration root.</param>
+    /// <returns><see langword="true"/> when request-scoped schema mode is required.</returns>
+    public static bool IsEnabled(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        return configuration.GetValue<bool>(TestSchemaHeadersKey)
+            || configuration.GetValue<bool>(TenantSchemaRoutingKey);
+    }
+}

--- a/src/Honua.Core/Features/MultiTenancy/Abstractions/ITenantSchemaResolver.cs
+++ b/src/Honua.Core/Features/MultiTenancy/Abstractions/ITenantSchemaResolver.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.MultiTenancy.Abstractions;
+
+/// <summary>
+/// Maps a resolved tenant identifier to the PostgreSQL schema that physically isolates
+/// that tenant's data (schema-per-tenant isolation, issue #346).
+/// </summary>
+/// <remarks>
+/// This is the first increment of the schema-per-tenant rail: it deterministically derives
+/// (or looks up) a SQL-safe schema name from the tenant id resolved by the tenant context
+/// rail (#1144). The resolved schema is fed into the existing request-scoped
+/// <see cref="Honua.Core.Features.Infrastructure.Abstractions.ISchemaContext"/> so the proven
+/// <c>SET search_path</c> data path enforces isolation — the same primitive used for test
+/// schema isolation. Provisioning, onboarding flow, and billing are deferred (Refs #346).
+/// </remarks>
+public interface ITenantSchemaResolver
+{
+    /// <summary>
+    /// Resolves the database schema name for the supplied tenant id.
+    /// </summary>
+    /// <param name="tenantId">The tenant identifier resolved for the current request.</param>
+    /// <param name="schemaName">
+    /// When the method returns <see langword="true"/>, the SQL-safe schema name to route to.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when a valid schema name could be resolved; otherwise
+    /// <see langword="false"/> (for example when the tenant id does not map to a safe
+    /// identifier or is excluded from routing).
+    /// </returns>
+    bool TryResolveSchema(string tenantId, out string schemaName);
+}

--- a/src/Honua.Core/Features/MultiTenancy/Abstractions/ITenantUsageMeter.cs
+++ b/src/Honua.Core/Features/MultiTenancy/Abstractions/ITenantUsageMeter.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+
+namespace Honua.Core.Features.MultiTenancy.Abstractions;
+
+/// <summary>
+/// Per-tenant usage-metering counter hook (issue #346). Records billable signals
+/// (request counts today) so a future metering/billing pipeline has a measurement seam.
+/// </summary>
+/// <remarks>
+/// This first increment is an in-memory, process-local counter intended as the
+/// instrumentation seam — NOT a durable, cross-node billing ledger. Aggregation,
+/// persistence, storage/bandwidth dimensions, and billing export are deferred (Refs #346).
+/// Implementations must be safe for concurrent use across requests.
+/// </remarks>
+public interface ITenantUsageMeter
+{
+    /// <summary>
+    /// Records a single billable request for the supplied tenant and returns the new running
+    /// total for that tenant within the current process lifetime.
+    /// </summary>
+    /// <param name="tenantId">The tenant the request is attributed to.</param>
+    /// <returns>The updated request count for the tenant.</returns>
+    long RecordRequest(string tenantId);
+
+    /// <summary>
+    /// Returns a point-in-time snapshot of the recorded usage for every tenant seen so far.
+    /// </summary>
+    /// <returns>An immutable snapshot of tenant usage counters.</returns>
+    IReadOnlyList<TenantUsageSnapshot> Snapshot();
+}
+
+/// <summary>
+/// A point-in-time usage measurement for a single tenant.
+/// </summary>
+/// <param name="TenantId">The tenant the measurement belongs to.</param>
+/// <param name="RequestCount">The number of metered requests recorded for the tenant.</param>
+public readonly record struct TenantUsageSnapshot(string TenantId, long RequestCount);

--- a/src/Honua.Postgres/Features/Security/SecureConnectionDataSourceCache.cs
+++ b/src/Honua.Postgres/Features/Security/SecureConnectionDataSourceCache.cs
@@ -20,7 +20,8 @@ internal sealed class SecureConnectionDataSourceCache : IDisposable
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
-        _schemaHeadersEnabled = bool.TryParse(configuration["HONUA_TEST_SCHEMA_HEADERS"], out var schemaHeadersEnabled) && schemaHeadersEnabled;
+        // Request-scoped schema mode covers per-test schema headers and tenant schema routing (#346).
+        _schemaHeadersEnabled = RequestScopedSchemaConfiguration.IsEnabled(configuration);
         _connectionLimits = PostgresDataSourceFactory.ResolveConnectionLimits(configuration);
         // Preserve the configured default schema so named secure connections
         // get the same search_path embedded in their Options parameter as the

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -85,7 +85,9 @@ internal static class ServiceCollectionExtensions
     /// <returns>Updated service collection</returns>
     public static IServiceCollection AddPostgreSqlServices(this IServiceCollection services, IConfiguration configuration)
     {
-        var schemaHeadersEnabled = configuration.GetValue<bool>("HONUA_TEST_SCHEMA_HEADERS");
+        // Request-scoped schema mode is required by per-test schema headers AND by
+        // schema-per-tenant routing (#346); both share the same SET search_path mechanism.
+        var schemaHeadersEnabled = Honua.Core.Configuration.RequestScopedSchemaConfiguration.IsEnabled(configuration);
         var connectionLimits = PostgresDataSourceFactory.ResolveConnectionLimits(configuration);
 
         var defaultSchema = configuration["Database:Schema"];

--- a/src/Honua.Server/Features/Infrastructure/MultiTenancy/InMemoryTenantUsageMeter.cs
+++ b/src/Honua.Server/Features/Infrastructure/MultiTenancy/InMemoryTenantUsageMeter.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Honua.Core.Features.MultiTenancy.Abstractions;
+
+namespace Honua.Infrastructure.MultiTenancy;
+
+/// <summary>
+/// Process-local, thread-safe <see cref="ITenantUsageMeter"/> backing the usage-metering
+/// counter hook (issue #346). Registered as a singleton so counts accumulate across requests.
+/// </summary>
+/// <remarks>
+/// This is the instrumentation seam, not a durable billing ledger: counts reset on process
+/// restart and are not aggregated across scaled nodes. Persistence, storage/bandwidth
+/// dimensions, and billing export are deferred (Refs #346).
+/// </remarks>
+internal sealed class InMemoryTenantUsageMeter : ITenantUsageMeter
+{
+    private readonly ConcurrentDictionary<string, long> _counts = new();
+
+    /// <inheritdoc />
+    public long RecordRequest(string tenantId)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            return 0;
+        }
+
+        // AddOrUpdate keeps the counter consistent under concurrent requests for the same tenant.
+        return _counts.AddOrUpdate(tenantId, 1, static (_, current) => current + 1);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<TenantUsageSnapshot> Snapshot()
+    {
+        // Snapshot the dictionary into a stable, ordered list for deterministic responses.
+        return _counts
+            .ToArray()
+            .OrderBy(static pair => pair.Key, System.StringComparer.Ordinal)
+            .Select(static pair => new TenantUsageSnapshot(pair.Key, pair.Value))
+            .ToList();
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/MultiTenancy/TenantSchemaOptions.cs
+++ b/src/Honua.Server/Features/Infrastructure/MultiTenancy/TenantSchemaOptions.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+
+namespace Honua.Infrastructure.MultiTenancy;
+
+/// <summary>
+/// Configuration for schema-per-tenant routing (issue #346). Bound from the
+/// <c>MultiTenancy:SchemaRouting</c> configuration section.
+/// </summary>
+/// <remarks>
+/// Routing is <b>disabled by default</b> so that single-tenant deployments retain
+/// byte-identical behavior: when <see cref="Enabled"/> is <see langword="false"/> the
+/// tenant schema-routing middleware is not registered, no per-request
+/// <c>SET search_path</c> override is issued, and the database uses its configured
+/// default schema exactly as before.
+/// </remarks>
+public sealed class TenantSchemaOptions
+{
+    /// <summary>
+    /// Configuration section name in appsettings.json.
+    /// </summary>
+    public const string SectionName = "MultiTenancy:SchemaRouting";
+
+    /// <summary>
+    /// Gets or sets whether schema-per-tenant routing is enabled. Defaults to
+    /// <see langword="false"/> to preserve single-tenant behavior.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the prefix prepended to a tenant id to derive its schema name when no
+    /// explicit mapping is present in <see cref="SchemaMap"/>. The derived schema is
+    /// <c>{Prefix}{normalized-tenant-id}</c>, e.g. tenant <c>acme</c> -&gt; schema
+    /// <c>tenant_acme</c>. Must itself be a valid SQL identifier prefix.
+    /// </summary>
+    public string SchemaPrefix { get; set; } = "tenant_";
+
+    /// <summary>
+    /// Gets or sets explicit tenant-id -&gt; schema-name overrides. Lookups are
+    /// case-insensitive on the tenant id. Entries here take precedence over the derived
+    /// <see cref="SchemaPrefix"/> form, allowing tenants whose ids do not normalize to a
+    /// safe schema name to be routed explicitly.
+    /// </summary>
+    public Dictionary<string, string> SchemaMap { get; set; } = new(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets or sets the tenant ids that are excluded from schema routing (they continue to
+    /// use the connection's configured default schema). Typically the public/default tenant
+    /// used for anonymous OGC reads so unauthenticated traffic is unaffected. Matched
+    /// case-insensitively.
+    /// </summary>
+    public string[] UnroutedTenantIds { get; set; } = ["public"];
+}

--- a/src/Honua.Server/Features/Infrastructure/MultiTenancy/TenantSchemaResolver.cs
+++ b/src/Honua.Server/Features/Infrastructure/MultiTenancy/TenantSchemaResolver.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Text;
+using Honua.Core.Features.MultiTenancy.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.MultiTenancy;
+
+/// <summary>
+/// Default <see cref="ITenantSchemaResolver"/>: derives a SQL-safe PostgreSQL schema name
+/// from a tenant id, honoring explicit overrides and an exclusion list (issue #346).
+/// </summary>
+/// <remarks>
+/// Resolution order:
+///  1. <see cref="TenantSchemaOptions.UnroutedTenantIds"/> — excluded tenants resolve to
+///     <see langword="false"/> so the connection keeps its configured default schema.
+///  2. <see cref="TenantSchemaOptions.SchemaMap"/> — explicit tenant-id -&gt; schema overrides.
+///  3. Derived form <c>{SchemaPrefix}{normalized-tenant-id}</c>, where normalization lower-cases
+///     the id and replaces every character outside <c>[a-z0-9_]</c> with <c>_</c>.
+///
+/// Every resolved schema name is validated against the same safe-identifier allow-list used
+/// by the database search-path applier, so a tenant id can never inject SQL via the schema.
+/// </remarks>
+internal sealed class TenantSchemaResolver : ITenantSchemaResolver
+{
+    private readonly TenantSchemaOptions _options;
+
+    public TenantSchemaResolver(IOptions<TenantSchemaOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options.Value ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <inheritdoc />
+    public bool TryResolveSchema(string tenantId, out string schemaName)
+    {
+        schemaName = string.Empty;
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            return false;
+        }
+
+        var trimmed = tenantId.Trim();
+
+        // 1. Excluded tenants keep the default schema (e.g. the anonymous public tenant).
+        foreach (var unrouted in _options.UnroutedTenantIds)
+        {
+            if (!string.IsNullOrWhiteSpace(unrouted)
+                && string.Equals(unrouted.Trim(), trimmed, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        // 2. Explicit override map takes precedence over the derived form.
+        if (_options.SchemaMap.TryGetValue(trimmed, out var mapped) && IsSafeIdentifier(mapped))
+        {
+            schemaName = mapped.Trim();
+            return true;
+        }
+
+        // 3. Derived form: {prefix}{normalized-tenant-id}.
+        var prefix = _options.SchemaPrefix ?? string.Empty;
+        var derived = prefix + Normalize(trimmed);
+        if (!IsSafeIdentifier(derived))
+        {
+            return false;
+        }
+
+        schemaName = derived;
+        return true;
+    }
+
+    // Lower-case and replace any character outside [a-z0-9_] with '_'. Tenant ids may contain
+    // '-', '.', ':', '@' (allowed by the tenant rail) which are not valid in unquoted SQL
+    // identifiers, so they are folded to '_'. The prefix guarantees the result starts with a
+    // letter or underscore even when the tenant id begins with a digit.
+    private static string Normalize(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            var lower = char.ToLowerInvariant(ch);
+            var ok = (lower >= 'a' && lower <= 'z')
+                || (lower >= '0' && lower <= '9')
+                || lower == '_';
+            builder.Append(ok ? lower : '_');
+        }
+
+        return builder.ToString();
+    }
+
+    // Mirrors the ^[A-Za-z_][A-Za-z0-9_]*$ allow-list enforced by the search-path applier.
+    private static bool IsSafeIdentifier(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var trimmed = value.Trim();
+        var first = trimmed[0];
+        if (!((first >= 'A' && first <= 'Z') || (first >= 'a' && first <= 'z') || first == '_'))
+        {
+            return false;
+        }
+
+        for (var i = 1; i < trimmed.Length; i++)
+        {
+            var c = trimmed[i];
+            var ok = (c >= 'A' && c <= 'Z')
+                || (c >= 'a' && c <= 'z')
+                || (c >= '0' && c <= '9')
+                || c == '_';
+            if (!ok)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/MultiTenancy/TenantSchemaRoutingExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/MultiTenancy/TenantSchemaRoutingExtensions.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using Honua.Core.Features.MultiTenancy.Abstractions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.MultiTenancy;
+
+/// <summary>
+/// Service collection and application builder extensions for the schema-per-tenant routing
+/// and usage-metering increment (issue #346).
+/// </summary>
+public static class TenantSchemaRoutingExtensions
+{
+    /// <summary>
+    /// Registers the tenant schema resolver and the per-tenant usage meter, and binds
+    /// <see cref="TenantSchemaOptions"/> from the <c>MultiTenancy:SchemaRouting</c> section.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The configuration root used to bind options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// The usage meter is always registered (it is harmless when routing is disabled — it is
+    /// only invoked by the routing middleware, which is not added unless routing is enabled).
+    /// Schema routing itself is gated on <see cref="TenantSchemaOptions.Enabled"/> at the
+    /// middleware registration site so the default single-tenant pipeline is unchanged.
+    /// </remarks>
+    public static IServiceCollection AddHonuaTenantSchemaRouting(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddOptions<TenantSchemaOptions>()
+            .Bind(configuration.GetSection(TenantSchemaOptions.SectionName));
+
+        services.TryAddSingleton<ITenantUsageMeter, InMemoryTenantUsageMeter>();
+        services.TryAddSingleton<ITenantSchemaResolver, TenantSchemaResolver>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Determines whether schema-per-tenant routing is enabled in the supplied configuration.
+    /// Used both to decide whether to register the routing middleware and to put the database
+    /// connection pool into request-scoped schema mode.
+    /// </summary>
+    /// <param name="configuration">The configuration root.</param>
+    /// <returns><see langword="true"/> when routing is enabled; otherwise <see langword="false"/>.</returns>
+    public static bool IsTenantSchemaRoutingEnabled(this IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        return configuration.GetValue<bool>($"{TenantSchemaOptions.SectionName}:Enabled");
+    }
+
+    /// <summary>
+    /// Adds the <see cref="TenantSchemaRoutingMiddleware"/> to the request pipeline when
+    /// schema-per-tenant routing is enabled. Must run after <c>UseHonuaTenantContext</c> so the
+    /// tenant is resolved, and before any feature handler that reads the database. When routing
+    /// is disabled this is a no-op and the pipeline is byte-identical to single-tenant.
+    /// </summary>
+    /// <param name="app">The application builder.</param>
+    /// <returns>The application builder for chaining.</returns>
+    public static IApplicationBuilder UseHonuaTenantSchemaRouting(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        var options = app.ApplicationServices.GetService<IOptions<TenantSchemaOptions>>();
+        if (options?.Value.Enabled == true)
+        {
+            app.UseMiddleware<TenantSchemaRoutingMiddleware>();
+        }
+
+        return app;
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/MultiTenancy/TenantSchemaRoutingLog.cs
+++ b/src/Honua.Server/Features/Infrastructure/MultiTenancy/TenantSchemaRoutingLog.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Infrastructure.MultiTenancy;
+
+internal static partial class TenantSchemaRoutingLog
+{
+    [LoggerMessage(
+        EventId = 7101,
+        Level = LogLevel.Debug,
+        Message = "Routed tenant '{TenantId}' to schema '{Schema}' for path '{Path}'.")]
+    public static partial void Routed(ILogger logger, string tenantId, string schema, string? path);
+}

--- a/src/Honua.Server/Features/Infrastructure/MultiTenancy/TenantSchemaRoutingMiddleware.cs
+++ b/src/Honua.Server/Features/Infrastructure/MultiTenancy/TenantSchemaRoutingMiddleware.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Threading.Tasks;
+using Honua.Core.Features.MultiTenancy.Abstractions;
+using Honua.Infrastructure.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Infrastructure.MultiTenancy;
+
+/// <summary>
+/// Routes the current request to its tenant's PostgreSQL schema and records a usage signal
+/// (issue #346). Runs after <c>TenantContextMiddleware</c> has resolved <see cref="ITenantContext"/>
+/// and feeds the resolved schema into the request-scoped
+/// <see cref="Honua.Core.Features.Infrastructure.Abstractions.ISchemaContext"/> so the existing
+/// <c>SET search_path</c> data path enforces isolation.
+/// </summary>
+/// <remarks>
+/// This middleware is only registered when <see cref="TenantSchemaOptions.Enabled"/> is
+/// <see langword="true"/>. When disabled it is absent from the pipeline entirely, so
+/// single-tenant deployments retain byte-identical behavior (no schema context is written and
+/// the database keeps its configured default schema).
+///
+/// When a request carries an explicit test schema header (<c>X-Honua-Test-Schema</c>) the
+/// schema context is already populated by <c>TestSchemaMiddleware</c>; this middleware never
+/// overwrites a schema that another component already set, so test isolation continues to win.
+/// </remarks>
+internal sealed class TenantSchemaRoutingMiddleware(
+    RequestDelegate next,
+    ITenantSchemaResolver schemaResolver,
+    ITenantUsageMeter usageMeter,
+    ILogger<TenantSchemaRoutingMiddleware> logger)
+{
+    private readonly RequestDelegate _next = next ?? throw new ArgumentNullException(nameof(next));
+    private readonly ITenantSchemaResolver _schemaResolver = schemaResolver ?? throw new ArgumentNullException(nameof(schemaResolver));
+    private readonly ITenantUsageMeter _usageMeter = usageMeter ?? throw new ArgumentNullException(nameof(usageMeter));
+    private readonly ILogger<TenantSchemaRoutingMiddleware> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var tenantContext = context.RequestServices.GetService<ITenantContext>();
+        if (tenantContext is null || !tenantContext.RequireTenantId(out var tenantId, out _))
+        {
+            // No tenant resolved (anonymous with no default): leave the schema context untouched
+            // so the connection uses its configured default schema. Behavior matches single-tenant.
+            await _next(context).ConfigureAwait(false);
+            return;
+        }
+
+        // Usage-metering counter hook: attribute one request to the resolved tenant. This is the
+        // instrumentation seam; aggregation/persistence/billing are deferred (#346).
+        _usageMeter.RecordRequest(tenantId);
+
+        // Resolve the tenant's schema and route to it unless a schema is already pinned
+        // (e.g. by the test schema header) or the tenant is excluded from routing.
+        var schemaContext = context.RequestServices.GetService<SchemaContext>();
+        var routed = false;
+        if (schemaContext is not null
+            && string.IsNullOrWhiteSpace(schemaContext.CurrentSchema)
+            && _schemaResolver.TryResolveSchema(tenantId, out var schemaName))
+        {
+            schemaContext.CurrentSchema = schemaName;
+            routed = true;
+            TenantSchemaRoutingLog.Routed(_logger, tenantId, schemaName, context.Request.Path.Value);
+        }
+
+        try
+        {
+            await _next(context).ConfigureAwait(false);
+        }
+        finally
+        {
+            // Clear the AsyncLocal-backed schema we set so it never leaks onto a pooled thread
+            // after the request completes. Only clear what this middleware assigned.
+            if (routed && schemaContext is not null)
+            {
+                schemaContext.CurrentSchema = null;
+            }
+        }
+    }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -734,6 +734,10 @@ builder.Services.AddHonuaAuditLog();
 // the MultiTenancy configuration section; the inline callback is the wiring
 // point for environment-specific overrides.
 builder.Services.AddHonuaTenantContext(builder.Configuration, _ => { });
+// Configure schema-per-tenant routing + usage metering rail (#346). Disabled by
+// default (MultiTenancy:SchemaRouting:Enabled=false) so single-tenant deployments
+// retain byte-identical behavior; registration only adds the resolver/meter seam.
+builder.Services.AddHonuaTenantSchemaRouting(builder.Configuration);
 // Configure CORS policies
 builder.Services.AddCorsPolicies(builder.Configuration, builder.Environment);
 builder.Services.AddInputValidation(builder.Configuration);
@@ -1211,6 +1215,11 @@ app.UsePortalTokenAuthentication();
 // X-Honua-Tenant override header) are evaluated against the resolved principal
 // before any downstream feature handler reads ITenantContext (#1144).
 app.UseHonuaTenantContext();
+
+// Route the resolved tenant to its PostgreSQL schema and record a usage signal (#346).
+// No-op unless MultiTenancy:SchemaRouting:Enabled=true. Must run after tenant context
+// resolution and before any feature handler that reads the database.
+app.UseHonuaTenantSchemaRouting();
 
 // Audit-log middleware records security-relevant request outcomes. It runs after
 // auth so the audit actor is the authenticated principal, and before endpoint

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/MultiTenancy/TenantSchemaRoutingMiddlewareTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/MultiTenancy/TenantSchemaRoutingMiddlewareTests.cs
@@ -1,0 +1,250 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.Net;
+using System.Security.Claims;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.MultiTenancy.Abstractions;
+using Honua.Infrastructure.Middleware;
+using Honua.Infrastructure.MultiTenancy;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Features.Infrastructure.MultiTenancy;
+
+/// <summary>
+/// Integration tests for <see cref="Honua.Infrastructure.MultiTenancy.TenantSchemaRoutingMiddleware"/>
+/// (issue #346). Proves schema-per-tenant isolation (tenant A cannot observe tenant B's schema),
+/// that the default single-tenant pipeline is unchanged when routing is disabled, and that the
+/// usage-metering counter increments per request.
+/// </summary>
+[Protocol(TestProtocols.TestQuality)]
+public class TenantSchemaRoutingMiddlewareTests
+{
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /schema")]
+    public async Task RoutingEnabled_DerivesTenantSchemaFromTenantId()
+    {
+        var principal = AuthenticatedPrincipal(("tid", "acme"));
+
+        var client = await CreateAppAsync(
+            principals: new Dictionary<string, ClaimsPrincipal?> { ["default"] = principal },
+            defaultPrincipalKey: "default",
+            routingEnabled: true);
+
+        var response = await client.GetAsync("/schema");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Equal("tenant_acme", body);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /schema")]
+    public async Task RoutingDisabled_LeavesSchemaContextNull_DefaultBehaviorUnchanged()
+    {
+        // The single-tenant default: even with a resolved tenant, no schema override is issued
+        // because the middleware is not registered. The connection keeps its default schema.
+        var principal = AuthenticatedPrincipal(("tid", "acme"));
+
+        var client = await CreateAppAsync(
+            principals: new Dictionary<string, ClaimsPrincipal?> { ["default"] = principal },
+            defaultPrincipalKey: "default",
+            routingEnabled: false);
+
+        var response = await client.GetAsync("/schema");
+
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Equal("<null>", body);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /schema")]
+    public async Task RoutingEnabled_UnroutedPublicTenant_KeepsDefaultSchema()
+    {
+        // The anonymous public tenant is excluded from routing so unauthenticated OGC reads
+        // continue to use the connection's configured default schema.
+        var client = await CreateAppAsync(
+            principals: new Dictionary<string, ClaimsPrincipal?> { ["default"] = null },
+            defaultPrincipalKey: "default",
+            routingEnabled: true);
+
+        var response = await client.GetAsync("/schema");
+
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Equal("<null>", body);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /schema")]
+    public async Task TenantIsolation_TenantACannotReadTenantBSchema()
+    {
+        // Security property: two interleaved requests as different tenants must each be routed
+        // to their own schema only. Neither request may observe the other tenant's schema.
+        var principalA = AuthenticatedPrincipal(("tid", "alpha"));
+        var principalB = AuthenticatedPrincipal(("tid", "beta"));
+
+        var client = await CreateAppAsync(
+            principals: new Dictionary<string, ClaimsPrincipal?>
+            {
+                ["alpha"] = principalA,
+                ["beta"] = principalB,
+            },
+            routingEnabled: true);
+
+        using var reqA = new HttpRequestMessage(HttpMethod.Get, "/schema");
+        reqA.Headers.Add("X-Test-Principal", "alpha");
+        using var reqB = new HttpRequestMessage(HttpMethod.Get, "/schema");
+        reqB.Headers.Add("X-Test-Principal", "beta");
+
+        var taskA = client.SendAsync(reqA);
+        var taskB = client.SendAsync(reqB);
+        await Task.WhenAll(taskA, taskB);
+
+        var bodyA = await taskA.Result.Content.ReadAsStringAsync();
+        var bodyB = await taskB.Result.Content.ReadAsStringAsync();
+
+        Assert.Equal("tenant_alpha", bodyA);
+        Assert.Equal("tenant_beta", bodyB);
+        Assert.NotEqual(bodyA, bodyB);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /schema")]
+    public async Task TestSchemaHeaderWins_OverTenantRouting()
+    {
+        // When a pinned schema is already present (e.g. set by the test schema header), tenant
+        // routing must never overwrite it — test isolation continues to win.
+        var principal = AuthenticatedPrincipal(("tid", "acme"));
+
+        var client = await CreateAppAsync(
+            principals: new Dictionary<string, ClaimsPrincipal?> { ["default"] = principal },
+            defaultPrincipalKey: "default",
+            routingEnabled: true,
+            pinnedSchema: "pinned_test_schema");
+
+        var response = await client.GetAsync("/schema");
+
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Equal("pinned_test_schema", body);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /usage")]
+    public async Task UsageMeter_IncrementsPerRequest_PerTenant()
+    {
+        var principal = AuthenticatedPrincipal(("tid", "acme"));
+
+        var client = await CreateAppAsync(
+            principals: new Dictionary<string, ClaimsPrincipal?> { ["default"] = principal },
+            defaultPrincipalKey: "default",
+            routingEnabled: true);
+
+        // Three metered requests for the same tenant. The /usage read below is itself metered
+        // as it passes through the same routing middleware, so the observed count is 4.
+        await client.GetAsync("/schema");
+        await client.GetAsync("/schema");
+        await client.GetAsync("/schema");
+
+        var response = await client.GetAsync("/usage");
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal("acme=4", body);
+    }
+
+    private static ClaimsPrincipal AuthenticatedPrincipal((string Type, string Value) claim)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, "user-1"),
+            new(claim.Type, claim.Value),
+        };
+        var identity = new ClaimsIdentity(claims, authenticationType: "TestAuth");
+        return new ClaimsPrincipal(identity);
+    }
+
+    private static async Task<HttpClient> CreateAppAsync(
+        Dictionary<string, ClaimsPrincipal?> principals,
+        bool routingEnabled,
+        string? defaultPrincipalKey = null,
+        string? pinnedSchema = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        var settings = new Dictionary<string, string?>
+        {
+            ["MultiTenancy:SchemaRouting:Enabled"] = routingEnabled ? "true" : "false",
+        };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+
+        builder.Services.AddHonuaTenantContext(config, _ => { });
+        builder.Services.AddHonuaTenantSchemaRouting(config);
+
+        // Mirror the production registration of the request-scoped schema context.
+        builder.Services.AddScoped<SchemaContext>();
+        builder.Services.AddScoped<ISchemaContext>(sp => sp.GetRequiredService<SchemaContext>());
+
+        var app = builder.Build();
+
+        // Test-only principal injection middleware: selects the principal via X-Test-Principal
+        // (or the default key) and attaches it to HttpContext.User before tenant resolution.
+        app.Use(async (ctx, next) =>
+        {
+            string? key = ctx.Request.Headers.TryGetValue("X-Test-Principal", out var hv) && hv.Count > 0
+                ? hv[0]
+                : defaultPrincipalKey;
+
+            if (key is not null && principals.TryGetValue(key, out var principal) && principal is not null)
+            {
+                ctx.User = principal;
+            }
+
+            // Simulate a pinned schema (e.g. test schema header already applied) when requested.
+            if (pinnedSchema is not null)
+            {
+                ctx.RequestServices.GetRequiredService<SchemaContext>().CurrentSchema = pinnedSchema;
+            }
+
+            await next();
+        });
+
+        app.UseHonuaTenantContext();
+        app.UseHonuaTenantSchemaRouting();
+
+        // Report the schema the request was routed to (or <null> when none was set). Reads the
+        // same request-scoped schema context the database search-path applier reads.
+        app.MapGet("/schema", (ISchemaContext schema) =>
+            Results.Text(schema.CurrentSchema ?? "<null>"));
+
+        // Report the usage counter recorded for the resolved tenant.
+        app.MapGet("/usage", (ITenantContext tenant, ITenantUsageMeter meter) =>
+        {
+            var id = tenant.TenantId ?? "<null>";
+            foreach (var snapshot in meter.Snapshot())
+            {
+                if (string.Equals(snapshot.TenantId, id, StringComparison.Ordinal))
+                {
+                    return Results.Text($"{id}={snapshot.RequestCount}");
+                }
+            }
+
+            return Results.Text($"{id}=0");
+        });
+
+        await app.StartAsync();
+        return app.GetTestClient();
+    }
+}


### PR DESCRIPTION
## Summary

First coherent increment of multi-tenancy (#346): generalizes the existing `X-Honua-Test-Schema` / `HONUA_TEST_SCHEMA_HEADERS` request-scoped schema rail into a real **tenant -> schema resolver**, routes each request to its tenant's PostgreSQL schema over the proven `SET search_path` data path, and adds a per-tenant **usage-metering counter hook**.

## What's included

- **`ITenantSchemaResolver` / `TenantSchemaResolver`** — derives a SQL-safe schema name from the resolved tenant id (`{prefix}{normalized-id}`), with explicit `SchemaMap` overrides and an `UnroutedTenantIds` exclusion list (the anonymous `public` tenant is unrouted by default). Every resolved name is validated against the same `^[A-Za-z_][A-Za-z0-9_]*$` allow-list the search-path applier enforces, so a tenant id can never inject SQL via the schema.
- **`TenantSchemaRoutingMiddleware`** — runs after tenant-context resolution; feeds the resolved schema into the request-scoped `ISchemaContext`. Never overwrites a pinned schema (the test schema header continues to win) and clears only the schema it set.
- **`ITenantUsageMeter` / `InMemoryTenantUsageMeter`** — process-local, thread-safe per-tenant request counter (the metering instrumentation seam).
- **`RequestScopedSchemaConfiguration`** — single source of truth for whether the connection pool must run in request-scoped schema mode (test headers **or** tenant routing); consumed by `Honua.Postgres` pool setup.
- Wired `AddHonuaTenantSchemaRouting` + `UseHonuaTenantSchemaRouting` into `Program.cs`.

## Default behavior is unchanged

`MultiTenancy:SchemaRouting:Enabled` defaults to `false`. When disabled the routing middleware is **not registered**, no `SET search_path` override is issued, and the pool keeps its configured default schema — byte-identical to before this rail existed. The single-tenant path is the default.

## Tenant isolation (security property)

Integration tests (TestServer, no DB required) prove:
- A request as tenant A is routed only to tenant A's schema; **tenant A cannot observe tenant B's schema** (interleaved concurrent requests).
- The unrouted `public` tenant keeps the default schema.
- A pinned test-schema header wins over tenant routing.
- The usage counter increments per request, per tenant.

## Tests

- 6 new `TenantSchemaRoutingMiddlewareTests` — all pass. Full MultiTenancy suite (14 tests) green.
- Release build with `TreatWarningsAsErrors=true`: clean (server + tests).
- Architecture tests: 116/117 pass. The single failure (`CommittedCatalog_EqualsFreshlyGeneratedOutput`) is **pre-existing drift on `trunk`** in an unrelated OGC API 3D-bbox test rename (`GetItems_With3dBbox_*`); it is not touched by this branch and is out of scope here.

## Deferred (Refs #346)

Tenant registry/provisioning migration, self-service onboarding flow, tenant-scoped API keys, durable cross-node usage aggregation + billing export, and storage/bandwidth metering dimensions.

Refs #346