### PR TITLE
feat: terraform repositoryLane in release-train manifest (#1729)

### DIFF
--- a/release/honua-2026-05-preview.json
+++ b/release/honua-2026-05-preview.json
@@ -270,6 +270,22 @@
       ]
     },
     {
+      "id": "terraform-rc-module-metadata",
+      "owningRepo": "honua-io/honua-iac",
+      "requirement": "Terraform module/version metadata points at the release candidate rather than placeholder/latest metadata.",
+      "evidenceState": "blocked",
+      "latestEvidence": null,
+      "waiver": null,
+      "blockers": [
+        {
+          "repo": "honua-io/honua-iac",
+          "number": 67,
+          "url": "https://github.com/honua-io/honua-iac/issues/67",
+          "reason": "Terraform versioned module/release pipeline remains open; release-candidate Terraform module metadata evidence is not attached."
+        }
+      ]
+    },
+    {
       "id": "release-train-scoreboard",
       "owningRepo": "honua-io/honua-devops",
       "requirement": "A release-train matrix is published and referenced by server, admin, SDK, devops, and docs release notes.",

--- a/tests/dotnet/Honua.Architecture.Tests/ReleaseTrainManifestTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/ReleaseTrainManifestTests.cs
@@ -28,6 +28,7 @@ public sealed class ReleaseTrainManifestTests
         "mobile-dotnet-sdk-train",
         "helm-release-candidate-metadata",
         "admin-docs-supported-surfaces",
+        "terraform-rc-module-metadata",
         "release-train-scoreboard",
         "release-candidate-image-compatibility",
         "release-evidence-pack",


### PR DESCRIPTION
## Summary

Adds the missing Terraform `repositoryLane` to the release-train manifest so the compatibility-train RC validator (honua-devops#41) no longer reports terraform as an uncovered, unowned surface.

### #1729 — terraform manifest lane (Closes)

The validator requires five surfaces — `server sdk admin helm terraform`. The producer manifest `release/honua-2026-05-preview.json` had no lane whose `owningRepo` is `honua-io/honua-iac`, so terraform surfaced as a synthetic/unowned gap (unlike admin → honua-server-admin#78 and helm → honua-helm#1, which carry owning follow-ups).

- Added a `terraform-rc-module-metadata` lane owned by `honua-io/honua-iac`, modeled on the helm/admin lanes: `blocked` with an owning blocker pointing at a newly filed terraform follow-up (**honua-iac#67**), whose requirement is that Terraform module/version metadata points at the release candidate rather than placeholder/latest metadata. The gap is now honestly owned rather than synthetic.
- Extended `ReleaseTrainManifestTests.RequiredLaneIds` so the architecture test enforces the lane's presence going forward.
- No generator change needed: `scripts/release/build-release-manifest.sh` and its smoke test already carry a terraform/`honua-iac` lane through the producer↔consumer round-trip; only the committed manifest lacked the lane.

### #1879 — DEM/sensor height mensuration (NOT in this PR)

`#1879`'s DEM-backed height-measure slice **already landed on `trunk`** via PR #1907 (deferred parity batch). The `MeasureDemHeightAsync` path in `ImageServerMeasureHandler.cs` differences ground elevation at the base/top points against the raster's `raster_sensor_metadata.dem_source` DEM, emits the real `sensorName`, and keeps an honest 501 for shadow-based / photogrammetric / no-DEM cases. Three integration tests already cover it (`Measure_HeightOperation_WithDemMetadata_ReturnsDifferencedHeight` = 80 m, no-DEM → 501, point-outside-DEM → 501). No remaining in-scope work, so #1879 is **not** bundled here. Issue #1879 stays open only for the explicitly-deferred shadow/photogrammetric height.

## Verification

- Release build (`-p:TreatWarningsAsErrors=true -p:NuGetAudit=false -p:UseSharedCompilation=false`): **0 warnings, 0 errors**.
- `Honua.Architecture.Tests` → `ReleaseTrainManifestTests`: **5/5 passed** (serial), including the new required-lane assertion.
- `scripts/release/smoke-build-release-manifest.sh`: passed, including the honua-devops validator round-trip recognizing the terraform surface.