### PR TITLE
feat: collaborative-map realtime transport (sessions WS + saved-map op-log)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -4177,6 +4177,35 @@
       "maturity": "implemented"
     },
     {
+      "id": "get-api-v1-saved-maps-mapid-collaboration-operations",
+      "route": "/api/v1/saved-maps/{mapId}/collaboration/operations",
+      "method": "GET",
+      "family": "Portal Collaboration HTTP",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Collaboration.OperationLog.SavedMapOperationEndpointsTests.Append_AssignsMonotonicCursors_AndReplayReturnsThem"
+      ],
+      "proof_ledger_surface": "saved-map-collaboration",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-saved-maps-mapid-collaboration-sessions-stream",
+      "route": "/api/v1/saved-maps/{mapId}/collaboration/sessions/stream",
+      "method": "GET",
+      "family": "Portal Collaboration HTTP",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Collaboration.Sessions.CollaborationSessionStreamEndpointTests.Stream_WhenPeerJoins_ReceivesParticipantJoinedPresenceEvent",
+        "Honua.Server.Tests.Features.Collaboration.Sessions.CollaborationSessionStreamEndpointTests.Stream_WhenPeerSendsCursorFrame_FanOutsCursorEvent",
+        "Honua.Server.Tests.Features.Collaboration.Sessions.CollaborationSessionStreamEndpointTests.Stream_WithAuthorizedJoin_ReceivesConnectedStatusAndSnapshot",
+        "Honua.Server.Tests.Features.Collaboration.Sessions.CollaborationSessionStreamEndpointTests.Stream_WithoutAuthorization_RejectsUpgrade"
+      ],
+      "proof_ledger_surface": "saved-map-collaboration",
+      "maturity": "implemented"
+    },
+    {
       "id": "get-api-v1-streaming-features",
       "route": "/api/v1/streaming/features",
       "method": "GET",
@@ -5208,7 +5237,7 @@
         "Honua.Server.Tests.Features.CloudDemo.CloudDemoEndpointsTests.StoryCollection_AfterReset_ReturnsSeededOgcFeatures",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_FormatParameterOverridesAcceptHeader",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_ReturnsResponseWithPagingLinksAndTimeStamp",
-        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_With3dBbox_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_With3dBbox_AcceptsAndUsesHorizontalExtent",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithBbox_ExcludesNullGeometryFeatures",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithCql2TextTemporalInstantOnAttributeField_Returns200",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithCql2TextTemporalOnUndefinedField_Returns400",
@@ -13067,6 +13096,21 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.Collaboration.FeatureLocks.FeatureLockEndpointsTests.RenewAndRelease_WithSameHolder_ReturnSuccess"
+      ],
+      "proof_ledger_surface": "saved-map-collaboration",
+      "maturity": "implemented"
+    },
+    {
+      "id": "post-api-v1-saved-maps-mapid-collaboration-operations",
+      "route": "/api/v1/saved-maps/{mapId}/collaboration/operations",
+      "method": "POST",
+      "family": "Portal Collaboration HTTP",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Collaboration.OperationLog.SavedMapOperationEndpointsTests.Append_AssignsMonotonicCursors_AndReplayReturnsThem",
+        "Honua.Server.Tests.Features.Collaboration.OperationLog.SavedMapOperationEndpointsTests.Append_DuplicateOperationId_IsIdempotent",
+        "Honua.Server.Tests.Features.Collaboration.OperationLog.SavedMapOperationEndpointsTests.Append_WithoutAuthentication_ReturnsUnauthorized"
       ],
       "proof_ledger_surface": "saved-map-collaboration",
       "maturity": "implemented"

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -122,9 +122,11 @@
       "endpointPrefixes": [],
       "endpointExactMatches": [
         "/api/v1/saved-maps/{mapId}/collaboration/sessions/join",
+        "/api/v1/saved-maps/{mapId}/collaboration/sessions/stream",
         "/api/v1/saved-maps/{mapId}/collaboration/feature-locks/claim",
         "/api/v1/saved-maps/{mapId}/collaboration/feature-locks/renew",
-        "/api/v1/saved-maps/{mapId}/collaboration/feature-locks/release"
+        "/api/v1/saved-maps/{mapId}/collaboration/feature-locks/release",
+        "/api/v1/saved-maps/{mapId}/collaboration/operations"
       ],
       "endpointContains": [],
       "operationKeys": [],
@@ -142,6 +144,34 @@
           "ownerRepo": "honua-server",
           "status": "implemented",
           "linkedTicket": "honua-server#971",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "Authenticated WebSocket presence/cursor/selection/follow transport with Redis cross-node backplane; join authorized through the shared fail-closed saved-map collaboration authorizer. Integration tests assert connect+snapshot, cross-participant presence/cursor fan-out, and rejected unauthorized joins.",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionStreamEndpoint.cs",
+            "src/Honua.Server/Features/Collaboration/Sessions/RedisCollaborationSessionBackplane.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/Collaboration/Sessions/CollaborationSessionStreamEndpointTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "honua-server#971",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "Durable collaborative edit op-log: append assigns monotonic server cursors with operation-id/idempotency-key dedupe and typed conflict/resync responses; replay returns operations since a known cursor. Integration tests assert cursor monotonicity, idempotent duplicates, replay, and fail-closed authorization.",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/Features/Collaboration/Operations/SavedMapOperationEndpoints.cs",
+            "src/Honua.Core/Features/Collaboration/Operations/InMemorySavedMapOperationLogRepository.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/Collaboration/OperationLog/SavedMapOperationEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "honua-server#972",
           "versionCaptureRule": null
         }
       ]

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -778,9 +778,14 @@ public static class EndpointRegistry
 
         // Saved-map collaboration session seam.
         new("POST", "/api/v1/saved-maps/{mapId}/collaboration/sessions/join"),
+        // Realtime presence/cursor/follow WebSocket transport (#971/#1290).
+        new("GET", "/api/v1/saved-maps/{mapId}/collaboration/sessions/stream"),
         new("POST", "/api/v1/saved-maps/{mapId}/collaboration/feature-locks/claim"),
         new("POST", "/api/v1/saved-maps/{mapId}/collaboration/feature-locks/renew"),
         new("POST", "/api/v1/saved-maps/{mapId}/collaboration/feature-locks/release"),
+        // Durable collaborative edit op-log: append (cursor + idempotency) and replay (#972).
+        new("POST", "/api/v1/saved-maps/{mapId}/collaboration/operations"),
+        new("GET", "/api/v1/saved-maps/{mapId}/collaboration/operations"),
 
         // Public SDK-compatible scene discovery (#923).
         new("GET", "/api/scenes"),

--- a/src/Honua.Server/Features/Collaboration/CollaborationEndpoints.cs
+++ b/src/Honua.Server/Features/Collaboration/CollaborationEndpoints.cs
@@ -3,6 +3,7 @@
 
 using Honua.Server.Features.Collaboration.Sessions;
 using Honua.Server.Features.Collaboration.FeatureLocks;
+using Honua.Server.Features.Collaboration.Operations;
 
 namespace Honua.Server.Features.Collaboration;
 
@@ -12,5 +13,6 @@ internal static class CollaborationEndpoints
     {
         endpoints.MapCollaborationSessionEndpoints();
         endpoints.MapFeatureLockEndpoints();
+        endpoints.MapSavedMapOperationEndpoints();
     }
 }

--- a/src/Honua.Server/Features/Collaboration/Operations/SavedMapOperationApiModels.cs
+++ b/src/Honua.Server/Features/Collaboration/Operations/SavedMapOperationApiModels.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Collaboration.Operations;
+using Honua.Infrastructure.Models;
+
+namespace Honua.Server.Features.Collaboration.Operations;
+
+/// <summary>
+/// Client request to append one saved-map collaborative edit operation (#972). The wire shape
+/// flattens the typed core identifiers/cursors to JSON-friendly scalars.
+/// </summary>
+internal sealed record SavedMapOperationAppendApiRequest
+{
+    /// <summary>Client-generated operation id. Duplicates are replayed idempotently per map.</summary>
+    [Required]
+    [StringLength(200, MinimumLength = 1)]
+    public string? OperationId { get; init; }
+
+    /// <summary>Actor submitting the operation. When omitted, the authenticated principal is used.</summary>
+    public string? ActorId { get; init; }
+
+    /// <summary>Client base cursor/revision the edit was authored against. Defaults to the empty-log base.</summary>
+    public long BaseCursor { get; init; }
+
+    /// <summary>Operation kind used by the MVP conflict policy and future WebMapDoc integration.</summary>
+    [Required]
+    public SavedMapOperationKind? Kind { get; init; }
+
+    /// <summary>Operation payload. Stored opaquely by the MVP log.</summary>
+    public JsonElement Payload { get; init; }
+
+    /// <summary>Optional idempotency key. When supplied, duplicates are replayed idempotently per map.</summary>
+    [StringLength(200)]
+    public string? IdempotencyKey { get; init; }
+}
+
+/// <summary>Wire projection of an accepted saved-map operation envelope.</summary>
+internal sealed record SavedMapOperationEnvelopeDto
+{
+    /// <summary>Client operation id.</summary>
+    public required string OperationId { get; init; }
+
+    /// <summary>Saved map id.</summary>
+    public required string MapId { get; init; }
+
+    /// <summary>Actor id.</summary>
+    public required string ActorId { get; init; }
+
+    /// <summary>Client base cursor used at append time.</summary>
+    public required long BaseCursor { get; init; }
+
+    /// <summary>Operation kind.</summary>
+    public required SavedMapOperationKind Kind { get; init; }
+
+    /// <summary>Monotonic server cursor assigned to the operation.</summary>
+    public required long ServerCursor { get; init; }
+
+    /// <summary>Server timestamp when the operation was accepted.</summary>
+    public required DateTimeOffset AcceptedAt { get; init; }
+
+    /// <summary>Operation payload.</summary>
+    public JsonElement Payload { get; init; }
+
+    /// <summary>Idempotency key, when supplied.</summary>
+    public string? IdempotencyKey { get; init; }
+}
+
+/// <summary>Append response: accepted operation plus the current head cursor and idempotency flag.</summary>
+internal sealed record SavedMapOperationAppendApiResponse
+{
+    /// <summary>Append status: <c>accepted</c>, <c>conflict</c>, or <c>resyncRequired</c>.</summary>
+    public required string Status { get; init; }
+
+    /// <summary>Accepted operation when status is <c>accepted</c>.</summary>
+    public SavedMapOperationEnvelopeDto? Operation { get; init; }
+
+    /// <summary>Current saved-map operation-log head cursor.</summary>
+    public required long HeadCursor { get; init; }
+
+    /// <summary>True when an accepted result was replayed from a duplicate id/idempotency key.</summary>
+    public bool IsDuplicate { get; init; }
+
+    /// <summary>Conflict details when status is <c>conflict</c>.</summary>
+    public SavedMapOperationConflictDto? Conflict { get; init; }
+
+    /// <summary>Explanatory message for non-accepted results.</summary>
+    public string? Message { get; init; }
+}
+
+/// <summary>Wire projection of a conflict response.</summary>
+internal sealed record SavedMapOperationConflictDto
+{
+    /// <summary>Stable conflict code.</summary>
+    public required string Code { get; init; }
+
+    /// <summary>Human-readable conflict message.</summary>
+    public required string Message { get; init; }
+
+    /// <summary>Client base cursor that produced the conflict.</summary>
+    public required long BaseCursor { get; init; }
+
+    /// <summary>Current head cursor.</summary>
+    public required long HeadCursor { get; init; }
+
+    /// <summary>Concurrent operations that made the append unsafe.</summary>
+    public required IReadOnlyList<SavedMapOperationEnvelopeDto> ConflictingOperations { get; init; }
+}
+
+/// <summary>Replay response: operations since a cursor plus replay-window metadata.</summary>
+internal sealed record SavedMapOperationReplayApiResponse
+{
+    /// <summary>Replay status: <c>ok</c> or <c>resyncRequired</c>.</summary>
+    public required string Status { get; init; }
+
+    /// <summary>Cursor the caller replayed after.</summary>
+    public required long SinceCursor { get; init; }
+
+    /// <summary>Current head cursor.</summary>
+    public required long HeadCursor { get; init; }
+
+    /// <summary>Earliest cursor the retained log can replay from.</summary>
+    public required long MinimumReplayCursor { get; init; }
+
+    /// <summary>Operations accepted after the requested cursor, ordered by server cursor.</summary>
+    public required IReadOnlyList<SavedMapOperationEnvelopeDto> Operations { get; init; }
+
+    /// <summary>Explanatory message for resync-required results.</summary>
+    public string? Message { get; init; }
+}
+
+/// <summary>Source-generated JSON context for the saved-map operation-log API surface.</summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true,
+    WriteIndented = false)]
+[JsonSerializable(typeof(SavedMapOperationAppendApiRequest))]
+[JsonSerializable(typeof(SavedMapOperationAppendApiResponse))]
+[JsonSerializable(typeof(SavedMapOperationReplayApiResponse))]
+[JsonSerializable(typeof(SavedMapOperationEnvelopeDto))]
+[JsonSerializable(typeof(SavedMapOperationConflictDto))]
+[JsonSerializable(typeof(ApiResponse<SavedMapOperationAppendApiResponse>))]
+[JsonSerializable(typeof(ApiResponse<SavedMapOperationReplayApiResponse>))]
+[JsonSerializable(typeof(ApiResponse<object>))]
+internal sealed partial class SavedMapOperationJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Collaboration/Operations/SavedMapOperationEndpoints.cs
+++ b/src/Honua.Server/Features/Collaboration/Operations/SavedMapOperationEndpoints.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using Honua.Core.Features.Collaboration.Operations;
+using Honua.Infrastructure.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Collaboration.Operations;
+
+/// <summary>
+/// HTTP adapter over the saved-map collaborative edit operation log (#972): a durable op-log
+/// append with monotonic server cursors plus idempotent dedupe, and a replay/catchup read from a
+/// known cursor. Conflicts and out-of-window cursors surface as typed responses rather than silent
+/// overwrites. Authorization reuses the fail-closed saved-map collaboration authorizer so join and
+/// op-log writes share one identity/RBAC seam.
+/// </summary>
+internal static class SavedMapOperationEndpoints
+{
+    internal sealed class SavedMapOperationLogCategory;
+
+    public static void MapSavedMapOperationEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/saved-maps/{mapId}/collaboration/operations")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Saved Maps", "Collaboration")
+            // Require an authenticated principal up front so unauthenticated requests fail at the
+            // middleware boundary before reaching the per-map authorizer.
+            .RequireAuthorization();
+
+        group.MapPost("", HandleAppend)
+            .WithDisplayName("Append Saved Map Collaboration Operation")
+            .WithMetadata(new HttpMethodMetadata([HttpMethods.Post]))
+            .Produces<ApiResponse<SavedMapOperationAppendApiResponse>>()
+            .Produces<ApiResponse<SavedMapOperationAppendApiResponse>>(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        group.MapGet("", HandleReplay)
+            .WithDisplayName("Replay Saved Map Collaboration Operations")
+            .WithMetadata(new HttpMethodMetadata([HttpMethods.Get]))
+            .Produces<ApiResponse<SavedMapOperationReplayApiResponse>>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+    }
+
+    private static async Task<IResult> HandleAppend(
+        string mapId,
+        [FromBody] SavedMapOperationAppendApiRequest request,
+        [FromServices] ISavedMapOperationLogRepository repository,
+        HttpContext context)
+    {
+        if (!TryValidate(request, out var validationError) ||
+            string.IsNullOrWhiteSpace(request.OperationId) ||
+            request.Kind is null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                string.IsNullOrEmpty(validationError) ? "operationId and kind are required." : validationError);
+        }
+
+        if (request.BaseCursor < 0)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "baseCursor must be zero or positive.");
+        }
+
+        var actorId = ResolveActorId(request.ActorId, context.User);
+        if (actorId is null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                "actorId is required when the principal has no stable identifier.");
+        }
+
+        var appendRequest = new SavedMapOperationAppendRequest
+        {
+            OperationId = new SavedMapOperationId(request.OperationId.Trim()),
+            MapId = new SavedMapId(mapId),
+            ActorId = new SavedMapActorId(actorId),
+            BaseCursor = new SavedMapOperationCursor(request.BaseCursor),
+            Kind = request.Kind.Value,
+            Payload = request.Payload,
+            IdempotencyKey = string.IsNullOrWhiteSpace(request.IdempotencyKey) ? null : request.IdempotencyKey.Trim()
+        };
+
+        var result = await repository.AppendAsync(appendRequest, context.RequestAborted).ConfigureAwait(false);
+
+        var response = new SavedMapOperationAppendApiResponse
+        {
+            Status = ToWireStatus(result.Status),
+            Operation = result.Operation is null ? null : ToDto(result.Operation),
+            HeadCursor = result.HeadCursor.Value,
+            IsDuplicate = result.IsDuplicate,
+            Conflict = result.Conflict is null ? null : ToDto(result.Conflict),
+            Message = result.Message
+        };
+
+        return result.Status switch
+        {
+            SavedMapOperationAppendStatus.Accepted => Results.Json(
+                ApiResponse<SavedMapOperationAppendApiResponse>.CreateSuccess(response),
+                SavedMapOperationJsonContext.Default.ApiResponseSavedMapOperationAppendApiResponse),
+            SavedMapOperationAppendStatus.Conflict => Results.Json(
+                ApiResponse<SavedMapOperationAppendApiResponse>.Failure(
+                    result.Message ?? "The operation conflicts with concurrent edits.", response),
+                SavedMapOperationJsonContext.Default.ApiResponseSavedMapOperationAppendApiResponse,
+                statusCode: StatusCodes.Status409Conflict),
+            _ => Results.Json(
+                ApiResponse<SavedMapOperationAppendApiResponse>.Failure(
+                    result.Message ?? "The base cursor is outside the retained replay window.", response),
+                SavedMapOperationJsonContext.Default.ApiResponseSavedMapOperationAppendApiResponse,
+                statusCode: StatusCodes.Status409Conflict)
+        };
+    }
+
+    private static async Task<IResult> HandleReplay(
+        string mapId,
+        [FromServices] ISavedMapOperationLogRepository repository,
+        HttpContext context,
+        [FromQuery] long? since = null)
+    {
+        var sinceCursor = since.GetValueOrDefault(0);
+        if (sinceCursor < 0)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "since must be zero or positive.");
+        }
+
+        var result = await repository.ReplayAsync(
+                new SavedMapId(mapId),
+                new SavedMapOperationCursor(sinceCursor),
+                context.RequestAborted)
+            .ConfigureAwait(false);
+
+        var response = new SavedMapOperationReplayApiResponse
+        {
+            Status = result.Status == SavedMapOperationReplayStatus.Ok ? "ok" : "resyncRequired",
+            SinceCursor = result.SinceCursor.Value,
+            HeadCursor = result.HeadCursor.Value,
+            MinimumReplayCursor = result.MinimumReplayCursor.Value,
+            Operations = result.Operations.Select(ToDto).ToArray(),
+            Message = result.Message
+        };
+
+        return Results.Json(
+            ApiResponse<SavedMapOperationReplayApiResponse>.CreateSuccess(response),
+            SavedMapOperationJsonContext.Default.ApiResponseSavedMapOperationReplayApiResponse);
+    }
+
+    private static string ToWireStatus(SavedMapOperationAppendStatus status) => status switch
+    {
+        SavedMapOperationAppendStatus.Accepted => "accepted",
+        SavedMapOperationAppendStatus.Conflict => "conflict",
+        _ => "resyncRequired"
+    };
+
+    private static SavedMapOperationEnvelopeDto ToDto(SavedMapOperationEnvelope operation) => new()
+    {
+        OperationId = operation.OperationId.Value,
+        MapId = operation.MapId.Value,
+        ActorId = operation.ActorId.Value,
+        BaseCursor = operation.BaseCursor.Value,
+        Kind = operation.Kind,
+        ServerCursor = operation.ServerCursor.Value,
+        AcceptedAt = operation.AcceptedAt,
+        Payload = operation.Payload,
+        IdempotencyKey = operation.IdempotencyKey
+    };
+
+    private static SavedMapOperationConflictDto ToDto(SavedMapOperationConflictResponse conflict) => new()
+    {
+        Code = conflict.Code,
+        Message = conflict.Message,
+        BaseCursor = conflict.BaseCursor.Value,
+        HeadCursor = conflict.HeadCursor.Value,
+        ConflictingOperations = conflict.ConflictingOperations.Select(ToDto).ToArray()
+    };
+
+    private static string? ResolveActorId(string? requestedActorId, ClaimsPrincipal principal)
+    {
+        if (!string.IsNullOrWhiteSpace(requestedActorId))
+        {
+            return requestedActorId.Trim();
+        }
+
+        var claimed = principal.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? principal.FindFirstValue("sub")
+            ?? principal.FindFirstValue(ClaimTypes.Name);
+        return string.IsNullOrWhiteSpace(claimed) ? null : claimed.Trim();
+    }
+
+    private static bool TryValidate(SavedMapOperationAppendApiRequest request, out string error)
+    {
+        var results = new List<ValidationResult>();
+        if (Validator.TryValidateObject(request, new ValidationContext(request), results, validateAllProperties: true))
+        {
+            error = string.Empty;
+            return true;
+        }
+
+        error = string.Join(", ", results.Select(r => r.ErrorMessage));
+        if (string.IsNullOrEmpty(error))
+        {
+            error = "Request validation failed.";
+        }
+
+        return false;
+    }
+}

--- a/src/Honua.Server/Features/Collaboration/Operations/SavedMapOperationServices.cs
+++ b/src/Honua.Server/Features/Collaboration/Operations/SavedMapOperationServices.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Collaboration.Operations;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Features.Collaboration.Operations;
+
+/// <summary>
+/// Dependency injection for the saved-map collaborative edit operation log (#972). Registers the
+/// MVP conflict policy and the in-memory durable-seam repository. A durable Postgres-backed
+/// repository can override <see cref="ISavedMapOperationLogRepository"/> later without touching
+/// the HTTP adapter.
+/// </summary>
+internal static class SavedMapOperationServices
+{
+    public static IServiceCollection AddSavedMapOperationLog(this IServiceCollection services)
+    {
+        services.TryAddSingleton<ISavedMapOperationConflictPolicy, MvpSavedMapOperationConflictPolicy>();
+        services.TryAddSingleton<ISavedMapOperationLogRepository>(static sp =>
+            new InMemorySavedMapOperationLogRepository(
+                sp.GetRequiredService<ISavedMapOperationConflictPolicy>(),
+                sp.GetService<TimeProvider>()));
+        return services;
+    }
+}

--- a/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionEndpoints.cs
+++ b/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionEndpoints.cs
@@ -26,6 +26,16 @@ internal static class CollaborationSessionEndpoints
             .Produces<ApiResponse<CollaborationJoinResponse>>()
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        // Authenticated WebSocket presence/cursor/selection/follow stream (#971/#1290). The join
+        // is authorized through the same fail-closed authorizer before the upgrade, so an
+        // unauthorized client receives a typed 401/403 rather than an opaque socket close.
+        group.MapGet("/stream", CollaborationSessionStreamEndpoint.HandleStream)
+            .WithDisplayName("Stream Saved Map Collaboration Session")
+            .WithMetadata(new HttpMethodMetadata([HttpMethods.Get]))
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
     }
 
     private static async Task<IResult> HandleJoin(

--- a/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionJsonContext.cs
+++ b/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionJsonContext.cs
@@ -20,6 +20,9 @@ namespace Honua.Server.Features.Collaboration.Sessions;
 [JsonSerializable(typeof(CollaborationCursor))]
 [JsonSerializable(typeof(CollaborationSelection))]
 [JsonSerializable(typeof(CollaborationFollowState))]
+[JsonSerializable(typeof(CollaborationBackplaneMessage))]
+[JsonSerializable(typeof(CollaborationClientFrame))]
+[JsonSerializable(typeof(CollaborationStatusFrame))]
 [JsonSerializable(typeof(ApiResponse<CollaborationJoinResponse>))]
 internal sealed partial class CollaborationSessionJsonContext : JsonSerializerContext
 {

--- a/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionModels.cs
+++ b/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionModels.cs
@@ -124,6 +124,48 @@ internal sealed record CollaborationFanOutResult
     public required int DeliveredCount { get; init; }
 }
 
+/// <summary>
+/// Cross-node collaboration broadcast envelope published over the Redis backplane. The
+/// originating instance id lets each node ignore its own echoes and prevents fan-out loops.
+/// </summary>
+internal sealed record CollaborationBackplaneMessage
+{
+    public required string OriginInstanceId { get; init; }
+
+    public required CollaborationEventEnvelope Event { get; init; }
+}
+
+/// <summary>
+/// WebSocket control frame sent by a collaboration client to update its presence/cursor/follow
+/// state over the live session stream. The frame <see cref="Type"/> mirrors the documented
+/// collaboration event vocabulary.
+/// </summary>
+internal sealed record CollaborationClientFrame
+{
+    public string? Type { get; init; }
+
+    public CollaborationCursor? Cursor { get; init; }
+
+    public CollaborationSelection? Selection { get; init; }
+
+    public Guid? FollowSessionId { get; init; }
+}
+
+/// <summary>
+/// Status/error frame emitted to a collaboration WebSocket client for connection lifecycle
+/// and control acknowledgements.
+/// </summary>
+internal sealed record CollaborationStatusFrame
+{
+    public required string Type { get; init; }
+
+    public required string Status { get; init; }
+
+    public string? Message { get; init; }
+
+    public Guid? SessionId { get; init; }
+}
+
 internal enum SavedMapCollaborationAuthorizationStatus
 {
     Authorized,

--- a/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionServices.cs
+++ b/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionServices.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Linq;
 using System.Security.Claims;
 using Honua.Server.Features.Collaboration.FeatureLocks;
+using Honua.Server.Features.Collaboration.Operations;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using StackExchange.Redis;
 
 namespace Honua.Server.Features.Collaboration.Sessions;
 
@@ -13,11 +16,29 @@ internal static class CollaborationSessionServices
     {
         services.TryAddSingleton<ICollaborationSessionClock, SystemCollaborationSessionClock>();
         services.TryAddSingleton<ISavedMapCollaborationAuthorizer, FailClosedSavedMapCollaborationAuthorizer>();
+
+        // Redis backplane for multi-replica presence/cursor fan-out (#971/#1290). Registered only
+        // when a multiplexer is configured so single-node and Redis-less deployments fall back to
+        // local-only delivery via the default no-op backplane. The same instance is the publish
+        // seam and the hosted subscriber, mirroring the feature-stream cluster-broadcast pattern.
+        if (services.Any(static d => d.ServiceType == typeof(IConnectionMultiplexer)))
+        {
+            services.TryAddSingleton<RedisCollaborationSessionBackplane>();
+            services.TryAddSingleton<ICollaborationSessionBackplane>(
+                static sp => sp.GetRequiredService<RedisCollaborationSessionBackplane>());
+            services.AddHostedService(static sp => sp.GetRequiredService<RedisCollaborationSessionBackplane>());
+        }
+        else
+        {
+            services.TryAddSingleton<ICollaborationSessionBackplane>(NullCollaborationSessionBackplane.Instance);
+        }
+
         services.TryAddSingleton<InMemoryCollaborationSessionService>();
         // The transport has no leave/heartbeat HTTP surface yet; the background sweep is what
         // keeps the singleton presence/outbox state bounded when participants stop polling.
         services.AddHostedService<CollaborationSessionPruneService>();
         services.AddFeatureLockCollaboration();
+        services.AddSavedMapOperationLog();
         return services;
     }
 }

--- a/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionStreamEndpoint.cs
+++ b/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionStreamEndpoint.cs
@@ -1,0 +1,390 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.IO;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Honua.Infrastructure.Models;
+
+namespace Honua.Server.Features.Collaboration.Sessions;
+
+/// <summary>
+/// Authenticated WebSocket transport for a saved-map collaboration session (#971/#1290): the
+/// join handshake authorizes through the shared <see cref="ISavedMapCollaborationAuthorizer"/>,
+/// streams the presence snapshot plus participant join/leave/heartbeat/cursor/selection/follow
+/// events for the map, and accepts client control frames that update the joining participant's
+/// own presence. Cross-node fan-out is provided by the Redis backplane registered alongside the
+/// in-memory session service. Mirrors the feature-stream WebSocket writer/receiver pattern.
+/// </summary>
+internal static partial class CollaborationSessionStreamEndpoint
+{
+    private const int MaxControlFrameBytes = 16 * 1024;
+    private static readonly TimeSpan WriterIdleTimeout = TimeSpan.FromSeconds(20);
+
+    internal sealed class CollaborationStreamLogCategory;
+
+    public static async Task HandleStream(
+        string mapId,
+        InMemoryCollaborationSessionService sessions,
+        ILogger<CollaborationStreamLogCategory> logger,
+        HttpContext context)
+    {
+        if (!context.WebSockets.IsWebSocketRequest)
+        {
+            // The route is upgrade-only; a plain GET is a client error.
+            await StandardErrorHelpers.CreateBadRequest(
+                    context,
+                    "The collaboration session stream requires a WebSocket upgrade request.")
+                .ExecuteAsync(context)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        // Authorize and register the participant BEFORE upgrading so an unauthorized join fails
+        // with a typed HTTP status (401/403) instead of an opaque socket close. The authorizer is
+        // the same fail-closed identity/RBAC seam used by the HTTP join endpoint.
+        var join = await sessions.JoinAsync(
+                mapId,
+                new CollaborationJoinRequest
+                {
+                    DisplayName = context.Request.Query["displayName"].ToString() is { Length: > 0 } dn ? dn : null,
+                    ClientInstanceId = context.Request.Query["clientInstanceId"].ToString() is { Length: > 0 } ci ? ci : null
+                },
+                context.User,
+                context.RequestAborted)
+            .ConfigureAwait(false);
+
+        if (join.Response is null)
+        {
+            var failure = join.Authorization.Status switch
+            {
+                SavedMapCollaborationAuthorizationStatus.RequiresAuthentication =>
+                    StandardErrorHelpers.CreateUnauthorized(
+                        context,
+                        join.Authorization.Detail ?? "Authentication is required to join this collaboration session."),
+                _ => StandardErrorHelpers.CreateForbidden(
+                    context,
+                    join.Authorization.Detail ?? "You are not allowed to join this collaboration session.")
+            };
+            await failure.ExecuteAsync(context).ConfigureAwait(false);
+            return;
+        }
+
+        var sessionId = join.Response.SessionId;
+        using var webSocket = await context.WebSockets.AcceptWebSocketAsync().ConfigureAwait(false);
+        var writeLock = new SemaphoreSlim(1, 1);
+
+        try
+        {
+            // Initial frames: connection status + the current presence snapshot so the client can
+            // render the "N here" roster immediately without a separate REST round-trip.
+            await SendStatusAsync(
+                webSocket,
+                writeLock,
+                new CollaborationStatusFrame
+                {
+                    Type = "status",
+                    Status = "connected",
+                    Message = "Collaboration session connected.",
+                    SessionId = sessionId
+                },
+                context.RequestAborted).ConfigureAwait(false);
+
+            await SendEnvelopeAsync(
+                webSocket,
+                writeLock,
+                new CollaborationEventEnvelope
+                {
+                    Type = CollaborationSessionEventTypes.Snapshot,
+                    EventId = Guid.NewGuid(),
+                    MapId = mapId,
+                    SessionId = sessionId,
+                    Timestamp = join.Response.Snapshot.GeneratedAt,
+                    Snapshot = join.Response.Snapshot
+                },
+                context.RequestAborted).ConfigureAwait(false);
+
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(context.RequestAborted);
+            var writerTask = WriteLoopAsync(webSocket, writeLock, sessions, sessionId, logger, linkedCts.Token);
+            await ReceiveLoopAsync(webSocket, sessions, sessionId, logger, linkedCts.Token).ConfigureAwait(false);
+
+            await linkedCts.CancelAsync().ConfigureAwait(false);
+            await writerTask.ConfigureAwait(false);
+        }
+        finally
+        {
+            // Always remove the participant so presence does not leak when the socket closes.
+            sessions.Leave(sessionId, reason: "disconnected");
+            writeLock.Dispose();
+
+            if (webSocket.State is WebSocketState.Open or WebSocketState.CloseReceived)
+            {
+                try
+                {
+                    await webSocket.CloseAsync(
+                        WebSocketCloseStatus.NormalClosure,
+                        "Collaboration session closed.",
+                        CancellationToken.None).ConfigureAwait(false);
+                }
+                catch (WebSocketException)
+                {
+                    // Client already gone.
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Socket already disposed.
+                }
+            }
+        }
+    }
+
+    private static async Task WriteLoopAsync(
+        WebSocket webSocket,
+        SemaphoreSlim writeLock,
+        InMemoryCollaborationSessionService sessions,
+        Guid sessionId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested && webSocket.State == WebSocketState.Open)
+            {
+                // Wait for outbox events without busy-polling. A periodic timeout lets the loop
+                // re-check session liveness even when no events arrive so a pruned participant's
+                // writer terminates promptly.
+                using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                waitCts.CancelAfter(WriterIdleTimeout);
+
+                bool stillPresent;
+                try
+                {
+                    stillPresent = await sessions.WaitForEventsAsync(sessionId, waitCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (waitCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    // Idle timeout — loop back and re-check liveness.
+                    continue;
+                }
+
+                if (!stillPresent)
+                {
+                    break;
+                }
+
+                foreach (var ev in sessions.DrainEvents(sessionId))
+                {
+                    if (webSocket.State != WebSocketState.Open)
+                    {
+                        return;
+                    }
+
+                    await SendEnvelopeAsync(webSocket, writeLock, ev, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Normal shutdown.
+        }
+        catch (WebSocketException)
+        {
+            // Client disconnected.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Socket disposed.
+        }
+    }
+
+    private static async Task ReceiveLoopAsync(
+        WebSocket webSocket,
+        InMemoryCollaborationSessionService sessions,
+        Guid sessionId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (webSocket.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
+            {
+                var (closeRequested, text, sizeExceeded) =
+                    await ReceiveTextAsync(webSocket, cancellationToken).ConfigureAwait(false);
+                if (closeRequested || sizeExceeded)
+                {
+                    break;
+                }
+
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    continue;
+                }
+
+                ApplyControlFrame(sessions, sessionId, text, logger);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Normal shutdown.
+        }
+        catch (WebSocketException)
+        {
+            // Client disconnected.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Socket disposed.
+        }
+    }
+
+    private static void ApplyControlFrame(
+        InMemoryCollaborationSessionService sessions,
+        Guid sessionId,
+        string text,
+        ILogger logger)
+    {
+        CollaborationClientFrame? frame;
+        try
+        {
+            frame = JsonSerializer.Deserialize(
+                text,
+                CollaborationSessionJsonContext.Default.CollaborationClientFrame);
+        }
+        catch (JsonException)
+        {
+            // Malformed control frames are ignored; presence remains unchanged.
+            return;
+        }
+
+        if (frame is null || string.IsNullOrWhiteSpace(frame.Type))
+        {
+            return;
+        }
+
+        try
+        {
+            switch (frame.Type.Trim().ToLowerInvariant())
+            {
+                case "heartbeat":
+                case "ping":
+                    sessions.Heartbeat(sessionId);
+                    break;
+                case "cursor":
+                    if (frame.Cursor is not null)
+                    {
+                        sessions.UpdateCursor(sessionId, frame.Cursor);
+                    }
+
+                    break;
+                case "selection":
+                    if (frame.Selection is not null)
+                    {
+                        sessions.UpdateSelection(sessionId, frame.Selection);
+                    }
+
+                    break;
+                case "follow":
+                    if (frame.FollowSessionId is { } target)
+                    {
+                        sessions.Follow(sessionId, target);
+                    }
+
+                    break;
+                case "unfollow":
+                    sessions.Unfollow(sessionId);
+                    break;
+                default:
+                    // Unknown control type — ignore to stay forward-compatible with SDK clients.
+                    break;
+            }
+        }
+        catch (KeyNotFoundException)
+        {
+            // Session or follow target vanished concurrently; drop the update.
+        }
+    }
+
+    private static async Task<(bool CloseRequested, string? Text, bool SizeExceeded)> ReceiveTextAsync(
+        WebSocket webSocket,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new byte[4096];
+        using var stream = new MemoryStream();
+
+        while (true)
+        {
+            var result = await webSocket.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                return (true, null, false);
+            }
+
+            if (result.MessageType != WebSocketMessageType.Text)
+            {
+                return (false, null, false);
+            }
+
+            if (stream.Length + result.Count > MaxControlFrameBytes)
+            {
+                return (false, null, true);
+            }
+
+            stream.Write(buffer, 0, result.Count);
+            if (result.EndOfMessage)
+            {
+                return (false, Encoding.UTF8.GetString(stream.ToArray()), false);
+            }
+        }
+    }
+
+    private static Task SendStatusAsync(
+        WebSocket webSocket,
+        SemaphoreSlim writeLock,
+        CollaborationStatusFrame frame,
+        CancellationToken cancellationToken)
+        => SendJsonAsync(
+            webSocket,
+            writeLock,
+            JsonSerializer.SerializeToUtf8Bytes(frame, CollaborationSessionJsonContext.Default.CollaborationStatusFrame),
+            cancellationToken);
+
+    private static Task SendEnvelopeAsync(
+        WebSocket webSocket,
+        SemaphoreSlim writeLock,
+        CollaborationEventEnvelope envelope,
+        CancellationToken cancellationToken)
+        => SendJsonAsync(
+            webSocket,
+            writeLock,
+            JsonSerializer.SerializeToUtf8Bytes(envelope, CollaborationSessionJsonContext.Default.CollaborationEventEnvelope),
+            cancellationToken);
+
+    private static async Task SendJsonAsync(
+        WebSocket webSocket,
+        SemaphoreSlim writeLock,
+        byte[] payload,
+        CancellationToken cancellationToken)
+    {
+        if (webSocket.State != WebSocketState.Open)
+        {
+            return;
+        }
+
+        // Writer loop and the initial handshake share one socket; SendAsync is not safe to call
+        // concurrently, so every send takes the per-connection write lock.
+        await writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (webSocket.State == WebSocketState.Open)
+            {
+                await webSocket.SendAsync(payload, WebSocketMessageType.Text, endOfMessage: true, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            writeLock.Release();
+        }
+    }
+}

--- a/src/Honua.Server/Features/Collaboration/Sessions/ICollaborationSessionBackplane.cs
+++ b/src/Honua.Server/Features/Collaboration/Sessions/ICollaborationSessionBackplane.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Collaboration.Sessions;
+
+/// <summary>
+/// Cross-node fan-out seam for saved-map collaboration presence/cursor/follow events.
+/// A multi-replica deployment publishes locally-originated events to all peers so a
+/// participant connected to one node observes presence and cursors produced on another.
+/// </summary>
+/// <remarks>
+/// The backplane is best-effort and fire-and-forget: a transient outage degrades to
+/// local-only delivery, matching the feature-stream cluster-broadcast contract. The
+/// default registration is a no-op so single-node and Redis-less deployments work
+/// unchanged.
+/// </remarks>
+internal interface ICollaborationSessionBackplane
+{
+    /// <summary>
+    /// Publishes a locally-originated collaboration event to peer nodes. Implementations
+    /// must not block the caller and must swallow transport failures.
+    /// </summary>
+    void Publish(CollaborationEventEnvelope ev);
+}
+
+/// <summary>
+/// No-op backplane used when no Redis multiplexer is registered. Cross-node fan-out is
+/// disabled and all delivery is local to the process.
+/// </summary>
+internal sealed class NullCollaborationSessionBackplane : ICollaborationSessionBackplane
+{
+    /// <summary>Shared singleton instance.</summary>
+    public static NullCollaborationSessionBackplane Instance { get; } = new();
+
+    private NullCollaborationSessionBackplane()
+    {
+    }
+
+    /// <inheritdoc />
+    public void Publish(CollaborationEventEnvelope ev)
+    {
+        // Intentionally no-op: single-node delivery is handled by the in-memory outboxes.
+    }
+}

--- a/src/Honua.Server/Features/Collaboration/Sessions/InMemoryCollaborationSessionService.cs
+++ b/src/Honua.Server/Features/Collaboration/Sessions/InMemoryCollaborationSessionService.cs
@@ -17,13 +17,16 @@ internal sealed class InMemoryCollaborationSessionService
     private readonly ConcurrentDictionary<Guid, string> _sessionMapIndex = new();
     private readonly ISavedMapCollaborationAuthorizer _authorizer;
     private readonly ICollaborationSessionClock _clock;
+    private readonly ICollaborationSessionBackplane _backplane;
 
     public InMemoryCollaborationSessionService(
         ISavedMapCollaborationAuthorizer authorizer,
-        ICollaborationSessionClock clock)
+        ICollaborationSessionClock clock,
+        ICollaborationSessionBackplane? backplane = null)
     {
         _authorizer = authorizer ?? throw new ArgumentNullException(nameof(authorizer));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _backplane = backplane ?? NullCollaborationSessionBackplane.Instance;
     }
 
     public async ValueTask<CollaborationJoinResult> JoinAsync(
@@ -57,6 +60,7 @@ internal sealed class InMemoryCollaborationSessionService
         };
 
         CollaborationSessionSnapshot snapshot;
+        CollaborationEventEnvelope joined;
         while (true)
         {
             var channel = _channels.GetOrAdd(mapId, static id => new MapChannel(id));
@@ -74,7 +78,7 @@ internal sealed class InMemoryCollaborationSessionService
                 channel.Participants.Add(sessionId, new ParticipantState(participant));
                 _sessionMapIndex[sessionId] = mapId;
 
-                var joined = CreateEvent(
+                joined = CreateEvent(
                     CollaborationSessionEventTypes.ParticipantJoined,
                     mapId,
                     participant,
@@ -85,6 +89,8 @@ internal sealed class InMemoryCollaborationSessionService
                 break;
             }
         }
+
+        _backplane.Publish(joined);
 
         return new CollaborationJoinResult
         {
@@ -188,7 +194,7 @@ internal sealed class InMemoryCollaborationSessionService
                 Follow = updatedPresence.Follow
             };
             var delivered = FanOutLocked(channel, ev, excludeSessionId: sessionId);
-            return new CollaborationFanOutResult { Event = ev, DeliveredCount = delivered };
+            return Publish(new CollaborationFanOutResult { Event = ev, DeliveredCount = delivered });
         }
     }
 
@@ -212,6 +218,7 @@ internal sealed class InMemoryCollaborationSessionService
             return false;
         }
 
+        CollaborationEventEnvelope left;
         lock (channel.Sync)
         {
             if (!channel.Participants.Remove(sessionId, out var state))
@@ -220,9 +227,12 @@ internal sealed class InMemoryCollaborationSessionService
                 return false;
             }
 
+            // Waking the leaving participant's writer lets it observe the removed session and
+            // terminate promptly instead of blocking until its next idle timeout.
+            state.OutboxSignal.Set();
             _sessionMapIndex.TryRemove(sessionId, out _);
             ClearFollowsTargetingLocked(channel, mapId, sessionId, _clock.UtcNow);
-            var left = CreateEvent(
+            left = CreateEvent(
                 CollaborationSessionEventTypes.ParticipantLeft,
                 mapId,
                 state.Presence,
@@ -230,8 +240,10 @@ internal sealed class InMemoryCollaborationSessionService
             { Participant = state.Presence };
             FanOutLocked(channel, left, excludeSessionId: sessionId);
             RemoveChannelIfEmpty(mapId, channel);
-            return true;
         }
+
+        _backplane.Publish(left);
+        return true;
     }
 
     public int PruneStaleParticipants(TimeSpan maxIdle)
@@ -243,6 +255,7 @@ internal sealed class InMemoryCollaborationSessionService
 
         var now = _clock.UtcNow;
         var removed = 0;
+        var publishQueue = new List<CollaborationEventEnvelope>();
         foreach (var (mapId, channel) in _channels)
         {
             lock (channel.Sync)
@@ -259,6 +272,8 @@ internal sealed class InMemoryCollaborationSessionService
                         continue;
                     }
 
+                    // Wake the pruned participant's writer so a stale WebSocket terminates promptly.
+                    state.OutboxSignal.Set();
                     _sessionMapIndex.TryRemove(sessionId, out _);
                     removed++;
                     ClearFollowsTargetingLocked(channel, mapId, sessionId, now);
@@ -270,10 +285,16 @@ internal sealed class InMemoryCollaborationSessionService
                         now) with
                     { Participant = state.Presence };
                     FanOutLocked(channel, left, excludeSessionId: sessionId);
+                    publishQueue.Add(left);
                 }
 
                 RemoveChannelIfEmpty(mapId, channel);
             }
+        }
+
+        foreach (var ev in publishQueue)
+        {
+            _backplane.Publish(ev);
         }
 
         return removed;
@@ -295,8 +316,80 @@ internal sealed class InMemoryCollaborationSessionService
 
             var events = state.Outbox.ToArray();
             state.Outbox.Clear();
+            // Reset the signal only while holding the lock so a concurrent enqueue either
+            // happens-before this drain (already captured above) or re-sets afterwards.
+            state.OutboxSignal.Reset();
             return events;
         }
+    }
+
+    /// <summary>
+    /// Waits until the participant's outbox has pending events or the session ends. Returns
+    /// <see langword="false"/> when the participant is no longer present (left or pruned), which
+    /// the WebSocket writer treats as a terminal condition. Used by the streaming transport to
+    /// avoid busy-polling <see cref="DrainEvents"/>.
+    /// </summary>
+    public async Task<bool> WaitForEventsAsync(Guid sessionId, CancellationToken cancellationToken)
+    {
+        if (!TryResolveSession(sessionId, out _, out var channel))
+        {
+            return false;
+        }
+
+        AsyncManualResetSignal signal;
+        lock (channel.Sync)
+        {
+            if (!channel.Participants.TryGetValue(sessionId, out var state))
+            {
+                return false;
+            }
+
+            if (state.Outbox.Count > 0)
+            {
+                return true;
+            }
+
+            signal = state.OutboxSignal;
+        }
+
+        await signal.WaitAsync(cancellationToken).ConfigureAwait(false);
+        return TryResolveSession(sessionId, out _, out _);
+    }
+
+    /// <summary>
+    /// Applies a collaboration event that originated on another node (delivered over the Redis
+    /// backplane) to the local participant outboxes for its map. Remote events are never
+    /// re-published, preventing fan-out loops between nodes. The actor's own session is excluded
+    /// so a participant does not receive an echo of its own action from a peer node.
+    /// </summary>
+    public void ApplyRemoteEvent(CollaborationEventEnvelope ev)
+    {
+        ArgumentNullException.ThrowIfNull(ev);
+        if (!_channels.TryGetValue(ev.MapId, out var channel))
+        {
+            // No local participants for this map on this node; nothing to deliver.
+            return;
+        }
+
+        lock (channel.Sync)
+        {
+            if (channel.Removed)
+            {
+                return;
+            }
+
+            FanOutLocked(channel, ev, excludeSessionId: ev.SessionId ?? Guid.Empty);
+        }
+    }
+
+    private CollaborationFanOutResult Publish(CollaborationFanOutResult result)
+    {
+        // Cross-node fan-out happens after the local outboxes have been written so a single-node
+        // deployment never pays for the backplane round-trip on its hot path. The backplane is
+        // best-effort: a Redis outage degrades to local-only delivery, mirroring the feature-stream
+        // cluster-broadcast contract.
+        _backplane.Publish(result.Event);
+        return result;
     }
 
     private CollaborationFanOutResult UpdateParticipant(
@@ -325,7 +418,7 @@ internal sealed class InMemoryCollaborationSessionService
                 CreateEvent(eventType, mapId, updatedPresence, now) with { Participant = updatedPresence },
                 updatedPresence);
             var delivered = FanOutLocked(channel, ev, excludeSessionId: sessionId);
-            return new CollaborationFanOutResult { Event = ev, DeliveredCount = delivered };
+            return Publish(new CollaborationFanOutResult { Event = ev, DeliveredCount = delivered });
         }
     }
 
@@ -365,6 +458,7 @@ internal sealed class InMemoryCollaborationSessionService
             }
 
             state.Outbox.Enqueue(ev);
+            state.OutboxSignal.Set();
             delivered++;
         }
 
@@ -512,5 +606,49 @@ internal sealed class InMemoryCollaborationSessionService
         public CollaborationParticipantPresence Presence { get; set; }
 
         public Queue<CollaborationEventEnvelope> Outbox { get; } = new();
+
+        /// <summary>
+        /// Pulsed whenever an event is enqueued onto <see cref="Outbox"/> so a WebSocket
+        /// writer loop can wake without polling. The signal is set when events are pending
+        /// and reset by the writer when it drains them.
+        /// </summary>
+        public AsyncManualResetSignal OutboxSignal { get; } = new();
+    }
+
+    /// <summary>
+    /// Minimal manual-reset async signal used to wake a single WebSocket writer when its
+    /// participant outbox receives events. Multiple sets coalesce; a single wait observes them.
+    /// </summary>
+    internal sealed class AsyncManualResetSignal
+    {
+        private volatile TaskCompletionSource<bool> _tcs =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Set() => _tcs.TrySetResult(true);
+
+        public Task WaitAsync(CancellationToken cancellationToken)
+        {
+            var tcs = _tcs;
+            if (tcs.Task.IsCompleted)
+            {
+                return tcs.Task;
+            }
+
+            // Replace the completed source on the next reset cycle; the waiter races with Set,
+            // and a coalesced Set is acceptable because the writer always drains the full outbox.
+            return tcs.Task.WaitAsync(cancellationToken);
+        }
+
+        public void Reset()
+        {
+            var current = _tcs;
+            if (current.Task.IsCompleted)
+            {
+                Interlocked.CompareExchange(
+                    ref _tcs,
+                    new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously),
+                    current);
+            }
+        }
     }
 }

--- a/src/Honua.Server/Features/Collaboration/Sessions/RedisCollaborationSessionBackplane.cs
+++ b/src/Honua.Server/Features/Collaboration/Sessions/RedisCollaborationSessionBackplane.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using StackExchange.Redis;
+
+namespace Honua.Server.Features.Collaboration.Sessions;
+
+/// <summary>
+/// Redis-backed cross-node fan-out for saved-map collaboration presence/cursor/follow events.
+/// Mirrors the feature-stream cluster-broadcast pattern: locally-originated events are published
+/// to a shared channel and peer nodes re-inject them into their local participant outboxes,
+/// excluding their own echoes via the originating instance id.
+/// </summary>
+/// <remarks>
+/// Best-effort: a transient Redis outage degrades to local-only delivery. The subscription is
+/// established once on host start; publish swallows transport failures so a collaboration mutation
+/// never fails because the backplane is unavailable.
+/// </remarks>
+internal sealed partial class RedisCollaborationSessionBackplane
+    : ICollaborationSessionBackplane, IHostedService
+{
+    private static readonly RedisChannel BroadcastChannel =
+        new("collaboration:session:broadcast", RedisChannel.PatternMode.Literal);
+
+    private readonly IConnectionMultiplexer _redis;
+    private readonly InMemoryCollaborationSessionService _sessions;
+    private readonly ILogger<RedisCollaborationSessionBackplane> _logger;
+    private readonly string _instanceId = Guid.NewGuid().ToString("N");
+    private ISubscriber? _subscriber;
+    private volatile bool _enabled;
+    private int _publishFailureLogged;
+    private int _receiveFailureLogged;
+
+    public RedisCollaborationSessionBackplane(
+        IConnectionMultiplexer redis,
+        InMemoryCollaborationSessionService sessions,
+        ILogger<RedisCollaborationSessionBackplane> logger)
+    {
+        _redis = redis ?? throw new ArgumentNullException(nameof(redis));
+        _sessions = sessions ?? throw new ArgumentNullException(nameof(sessions));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            _subscriber = _redis.GetSubscriber();
+            _subscriber.Subscribe(BroadcastChannel, HandleBroadcast);
+            _enabled = true;
+            Log.BackplaneSubscribed(_logger);
+        }
+        catch (Exception ex)
+        {
+            // Redis-less or unreachable: stay disabled and fall back to local-only delivery.
+            Log.BackplaneUnavailable(_logger, ex);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            _subscriber?.Unsubscribe(BroadcastChannel, HandleBroadcast);
+        }
+        catch (Exception ex)
+        {
+            Log.BackplaneUnavailable(_logger, ex);
+        }
+
+        _enabled = false;
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void Publish(CollaborationEventEnvelope ev)
+    {
+        var subscriber = _subscriber;
+        if (!_enabled || subscriber is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var payload = JsonSerializer.Serialize(
+                new CollaborationBackplaneMessage { OriginInstanceId = _instanceId, Event = ev },
+                CollaborationSessionJsonContext.Default.CollaborationBackplaneMessage);
+
+            // Fire-and-forget: collaboration fan-out must never block on the backplane.
+            subscriber.Publish(BroadcastChannel, payload, CommandFlags.FireAndForget);
+        }
+        catch (Exception ex)
+        {
+            if (Interlocked.Exchange(ref _publishFailureLogged, 1) == 0)
+            {
+                Log.BackplanePublishFailed(_logger, ex);
+            }
+        }
+    }
+
+    private void HandleBroadcast(RedisChannel channel, RedisValue value)
+    {
+        if (!_enabled || value.IsNullOrEmpty)
+        {
+            return;
+        }
+
+        try
+        {
+            var message = JsonSerializer.Deserialize(
+                value.ToString(),
+                CollaborationSessionJsonContext.Default.CollaborationBackplaneMessage);
+
+            if (message is null ||
+                string.Equals(message.OriginInstanceId, _instanceId, StringComparison.Ordinal))
+            {
+                // Own echo or malformed payload — ignore.
+                return;
+            }
+
+            _sessions.ApplyRemoteEvent(message.Event);
+        }
+        catch (Exception ex)
+        {
+            if (Interlocked.Exchange(ref _receiveFailureLogged, 1) == 0)
+            {
+                Log.BackplaneReceiveFailed(_logger, ex);
+            }
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 7440,
+            Level = LogLevel.Information,
+            Message = "Collaboration session backplane subscribed to the Redis broadcast channel.")]
+        public static partial void BackplaneSubscribed(ILogger logger);
+
+        [LoggerMessage(
+            EventId = 7441,
+            Level = LogLevel.Warning,
+            Message = "Collaboration session backplane is unavailable; falling back to local-only delivery.")]
+        public static partial void BackplaneUnavailable(ILogger logger, Exception exception);
+
+        [LoggerMessage(
+            EventId = 7442,
+            Level = LogLevel.Warning,
+            Message = "Collaboration session backplane publish failed; cross-node fan-out is degraded.")]
+        public static partial void BackplanePublishFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(
+            EventId = 7443,
+            Level = LogLevel.Warning,
+            Message = "Collaboration session backplane received a malformed broadcast.")]
+        public static partial void BackplaneReceiveFailed(ILogger logger, Exception exception);
+    }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -851,6 +851,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Protocols.Elevation.VisibilityJsonContext.Default,
         Honua.Server.Features.Collaboration.Sessions.CollaborationSessionJsonContext.Default,
         Honua.Server.Features.Collaboration.FeatureLocks.FeatureLockJsonContext.Default,
+        Honua.Server.Features.Collaboration.Operations.SavedMapOperationJsonContext.Default,
         Honua.Core.Features.Authorization.Domain.OperatorAuthorizationJsonContext.Default,
         Honua.Server.Features.Admin.ObservabilityJsonContext.Default,
         Honua.Server.Features.Admin.InvestigationJsonContext.Default,

--- a/src/Honua.Server/Startup/JsonContextRegistration.cs
+++ b/src/Honua.Server/Startup/JsonContextRegistration.cs
@@ -109,6 +109,7 @@ internal static class JsonContextRegistration
                 Honua.Server.Features.DataEnrichment.Models.EnrichmentJsonContext.Default,
                 Honua.Server.Features.Collaboration.Sessions.CollaborationSessionJsonContext.Default,
                 Honua.Server.Features.Collaboration.FeatureLocks.FeatureLockJsonContext.Default,
+                Honua.Server.Features.Collaboration.Operations.SavedMapOperationJsonContext.Default,
                 Honua.Core.Features.Authorization.Domain.OperatorAuthorizationJsonContext.Default,
                 Honua.Protocols.Ogc.Api.Processes.OgcProcessesJsonContext.Default);
         });

--- a/tests/dotnet/Honua.Server.Tests/Features/Collaboration/OperationLog/SavedMapOperationEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Collaboration/OperationLog/SavedMapOperationEndpointsTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace Honua.Server.Tests.Features.Collaboration.OperationLog;
+
+/// <summary>
+/// Integration coverage for the saved-map collaborative edit operation log endpoints
+/// (honua-server#972): durable append with monotonic server cursors, idempotent dedupe by
+/// operation id, cursor replay/catchup, and fail-closed authorization.
+/// </summary>
+[Protocol(Honua.TestKit.Constants.ProtocolNames.Streaming)]
+[Operation(Honua.TestKit.Constants.Operations.Streaming)]
+public sealed class SavedMapOperationEndpointsTests
+{
+    private const string AdminPassword = "saved-map-operations-test-key";
+    private const string MapId = "saved-map:ops";
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/saved-maps/{mapId}/collaboration/operations")]
+    [Endpoint("GET /api/v1/saved-maps/{mapId}/collaboration/operations")]
+    public async Task Append_AssignsMonotonicCursors_AndReplayReturnsThem()
+    {
+        using var factory = CreateFactory();
+        using var client = CreateAdminClient(factory);
+
+        var first = await AppendAsync(client, "op-1", baseCursor: 0);
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        var firstBody = await ReadJsonAsync(first);
+        firstBody.GetProperty("data").GetProperty("status").GetString().Should().Be("accepted");
+        var firstCursor = firstBody.GetProperty("data").GetProperty("operation").GetProperty("serverCursor").GetInt64();
+        firstCursor.Should().Be(1);
+
+        var second = await AppendAsync(client, "op-2", baseCursor: firstCursor);
+        var secondBody = await ReadJsonAsync(second);
+        secondBody.GetProperty("data").GetProperty("operation").GetProperty("serverCursor").GetInt64().Should().Be(2);
+
+        using var replay = await client.GetAsync(
+            $"/api/v1/saved-maps/{MapId}/collaboration/operations?since=0");
+        replay.StatusCode.Should().Be(HttpStatusCode.OK);
+        var replayBody = await ReadJsonAsync(replay);
+        replayBody.GetProperty("data").GetProperty("status").GetString().Should().Be("ok");
+        replayBody.GetProperty("data").GetProperty("headCursor").GetInt64().Should().Be(2);
+        replayBody.GetProperty("data").GetProperty("operations").GetArrayLength().Should().Be(2);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/saved-maps/{mapId}/collaboration/operations")]
+    public async Task Append_DuplicateOperationId_IsIdempotent()
+    {
+        using var factory = CreateFactory();
+        using var client = CreateAdminClient(factory);
+
+        var first = await AppendAsync(client, "op-dupe", baseCursor: 0);
+        var firstBody = await ReadJsonAsync(first);
+        var firstCursor = firstBody.GetProperty("data").GetProperty("operation").GetProperty("serverCursor").GetInt64();
+
+        var duplicate = await AppendAsync(client, "op-dupe", baseCursor: 0);
+        duplicate.StatusCode.Should().Be(HttpStatusCode.OK);
+        var duplicateBody = await ReadJsonAsync(duplicate);
+        duplicateBody.GetProperty("data").GetProperty("status").GetString().Should().Be("accepted");
+        duplicateBody.GetProperty("data").GetProperty("isDuplicate").GetBoolean().Should().BeTrue();
+        duplicateBody.GetProperty("data").GetProperty("operation").GetProperty("serverCursor").GetInt64()
+            .Should().Be(firstCursor, "a replayed duplicate must not advance the cursor");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/saved-maps/{mapId}/collaboration/operations")]
+    public async Task Append_WithoutAuthentication_ReturnsUnauthorized()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var response = await AppendAsync(client, "op-anon", baseCursor: 0);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private static async Task<HttpResponseMessage> AppendAsync(HttpClient client, string operationId, long baseCursor)
+    {
+        var body = $$"""
+            {
+              "operationId": "{{operationId}}",
+              "kind": "SetMetadataField",
+              "baseCursor": {{baseCursor}},
+              "payload": { "title": "Updated" }
+            }
+            """;
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        return await client.PostAsync($"/api/v1/saved-maps/{MapId}/collaboration/operations", content)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task<JsonElement> ReadJsonAsync(HttpResponseMessage response)
+    {
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return document.RootElement.Clone();
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory()
+    {
+        return new TestWebApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, configBuilder) =>
+                {
+                    configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["HONUA_DEV_AUTH"] = "false",
+                        ["HONUA_ADMIN_PASSWORD"] = AdminPassword
+                    });
+                });
+            });
+    }
+
+    private static HttpClient CreateAdminClient(WebApplicationFactory<Program> factory)
+    {
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", AdminPassword);
+        return client;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Collaboration/Sessions/CollaborationSessionStreamEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Collaboration/Sessions/CollaborationSessionStreamEndpointTests.cs
@@ -1,0 +1,204 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.WebSockets;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Server.Features.Collaboration.Sessions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Tests.Features.Collaboration.Sessions;
+
+/// <summary>
+/// Integration coverage for the authenticated WebSocket collaboration session transport
+/// (honua-server#971/#1290): join handshake + presence snapshot, cross-participant presence
+/// fan-out, cursor control frames, and fail-closed authorization for unauthorized joins.
+/// </summary>
+[Protocol(Honua.TestKit.Constants.ProtocolNames.Streaming)]
+[Operation(Honua.TestKit.Constants.Operations.Streaming)]
+public sealed class CollaborationSessionStreamEndpointTests
+{
+    private const string AdminPassword = "collaboration-stream-test-key";
+    private const string MapId = "saved-map:ops";
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/saved-maps/{mapId}/collaboration/sessions/stream")]
+    public async Task Stream_WithAuthorizedJoin_ReceivesConnectedStatusAndSnapshot()
+    {
+        using var factory = CreateFactory(allowJoin: true);
+        var wsClient = factory.Server.CreateWebSocketClient();
+        wsClient.ConfigureRequest = request => request.Headers["X-API-Key"] = AdminPassword;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        using var ws = await wsClient.ConnectAsync(
+            new Uri($"ws://localhost/api/v1/saved-maps/{MapId}/collaboration/sessions/stream?displayName=Ada"),
+            cts.Token);
+
+        ws.State.Should().Be(WebSocketState.Open);
+
+        var connected = await ReceiveJsonAsync(ws, cts.Token);
+        connected.GetProperty("type").GetString().Should().Be("status");
+        connected.GetProperty("status").GetString().Should().Be("connected");
+
+        var snapshot = await ReceiveJsonAsync(ws, cts.Token);
+        snapshot.GetProperty("type").GetString().Should().Be("snapshot");
+        snapshot.GetProperty("snapshot").GetProperty("mapId").GetString().Should().Be(MapId);
+        snapshot.GetProperty("snapshot").GetProperty("participants").GetArrayLength().Should().Be(1);
+
+        await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/saved-maps/{mapId}/collaboration/sessions/stream")]
+    public async Task Stream_WhenPeerJoins_ReceivesParticipantJoinedPresenceEvent()
+    {
+        using var factory = CreateFactory(allowJoin: true);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        var firstClient = factory.Server.CreateWebSocketClient();
+        firstClient.ConfigureRequest = request => request.Headers["X-API-Key"] = AdminPassword;
+        using var first = await firstClient.ConnectAsync(
+            new Uri($"ws://localhost/api/v1/saved-maps/{MapId}/collaboration/sessions/stream?displayName=Ada"),
+            cts.Token);
+
+        // Drain the first client's connect + snapshot frames.
+        _ = await ReceiveJsonAsync(first, cts.Token);
+        _ = await ReceiveJsonAsync(first, cts.Token);
+
+        // A second participant joins the same map; the first must observe the presence event.
+        var secondClient = factory.Server.CreateWebSocketClient();
+        secondClient.ConfigureRequest = request => request.Headers["X-API-Key"] = AdminPassword;
+        using var second = await secondClient.ConnectAsync(
+            new Uri($"ws://localhost/api/v1/saved-maps/{MapId}/collaboration/sessions/stream?displayName=Bob"),
+            cts.Token);
+
+        var joined = await ReceiveJsonAsync(first, cts.Token);
+        joined.GetProperty("type").GetString().Should().Be("participant.joined");
+        joined.GetProperty("participant").GetProperty("displayName").GetString().Should().Be("Bob");
+
+        await first.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None);
+        await second.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/saved-maps/{mapId}/collaboration/sessions/stream")]
+    public async Task Stream_WhenPeerSendsCursorFrame_FanOutsCursorEvent()
+    {
+        using var factory = CreateFactory(allowJoin: true);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        var firstClient = factory.Server.CreateWebSocketClient();
+        firstClient.ConfigureRequest = request => request.Headers["X-API-Key"] = AdminPassword;
+        using var first = await firstClient.ConnectAsync(
+            new Uri($"ws://localhost/api/v1/saved-maps/{MapId}/collaboration/sessions/stream?displayName=Ada"),
+            cts.Token);
+        _ = await ReceiveJsonAsync(first, cts.Token);
+        _ = await ReceiveJsonAsync(first, cts.Token);
+
+        var secondClient = factory.Server.CreateWebSocketClient();
+        secondClient.ConfigureRequest = request => request.Headers["X-API-Key"] = AdminPassword;
+        using var second = await secondClient.ConnectAsync(
+            new Uri($"ws://localhost/api/v1/saved-maps/{MapId}/collaboration/sessions/stream?displayName=Bob"),
+            cts.Token);
+        _ = await ReceiveJsonAsync(second, cts.Token);
+        _ = await ReceiveJsonAsync(second, cts.Token);
+
+        // Drain the participant.joined event the second peer's join produced on the first socket.
+        var joined = await ReceiveJsonAsync(first, cts.Token);
+        joined.GetProperty("type").GetString().Should().Be("participant.joined");
+
+        await SendJsonAsync(
+            second,
+            """{"type":"cursor","cursor":{"longitude":-122.4,"latitude":37.7,"zoom":12}}""",
+            cts.Token);
+
+        var cursor = await ReceiveJsonAsync(first, cts.Token);
+        cursor.GetProperty("type").GetString().Should().Be("cursor.updated");
+        cursor.GetProperty("cursor").GetProperty("longitude").GetDouble().Should().BeApproximately(-122.4, 0.0001);
+
+        await first.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None);
+        await second.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/saved-maps/{mapId}/collaboration/sessions/stream")]
+    public async Task Stream_WithoutAuthorization_RejectsUpgrade()
+    {
+        using var factory = CreateFactory(allowJoin: false);
+        var wsClient = factory.Server.CreateWebSocketClient();
+        wsClient.ConfigureRequest = request => request.Headers["X-API-Key"] = AdminPassword;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        // The fail-closed authorizer denies the join, so the upgrade is rejected before the
+        // socket is accepted. The TestServer surfaces the rejection as a handshake exception.
+        var connect = async () => await wsClient.ConnectAsync(
+            new Uri($"ws://localhost/api/v1/saved-maps/{MapId}/collaboration/sessions/stream"),
+            cts.Token);
+
+        await connect.Should().ThrowAsync<Exception>();
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory(bool allowJoin)
+    {
+        return new TestWebApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, configBuilder) =>
+                {
+                    configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["HONUA_DEV_AUTH"] = "false",
+                        ["HONUA_ADMIN_PASSWORD"] = AdminPassword
+                    });
+                });
+
+                if (allowJoin)
+                {
+                    builder.ConfigureTestServices(services =>
+                    {
+                        services.RemoveAll<ISavedMapCollaborationAuthorizer>();
+                        services.AddSingleton<ISavedMapCollaborationAuthorizer, AllowSavedMapCollaborationAuthorizer>();
+                    });
+                }
+            });
+    }
+
+    private static async Task<JsonElement> ReceiveJsonAsync(WebSocket ws, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[16 * 1024];
+        using var stream = new System.IO.MemoryStream();
+        while (true)
+        {
+            var result = await ws.ReceiveAsync(buffer, cancellationToken);
+            stream.Write(buffer, 0, result.Count);
+            if (result.EndOfMessage)
+            {
+                break;
+            }
+        }
+
+        using var document = JsonDocument.Parse(stream.ToArray());
+        return document.RootElement.Clone();
+    }
+
+    private static Task SendJsonAsync(WebSocket ws, string json, CancellationToken cancellationToken)
+        => ws.SendAsync(Encoding.UTF8.GetBytes(json), WebSocketMessageType.Text, true, cancellationToken);
+
+    private sealed class AllowSavedMapCollaborationAuthorizer : ISavedMapCollaborationAuthorizer
+    {
+        public ValueTask<SavedMapCollaborationAuthorizationResult> AuthorizeJoinAsync(
+            string mapId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken) =>
+            ValueTask.FromResult(SavedMapCollaborationAuthorizationResult.Allow());
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Collaboration/Sessions/InMemoryCollaborationSessionServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Collaboration/Sessions/InMemoryCollaborationSessionServiceTests.cs
@@ -176,8 +176,75 @@ public sealed class InMemoryCollaborationSessionServiceTests
         result.Authorization.Status.Should().Be(SavedMapCollaborationAuthorizationStatus.RequiresAuthentication);
     }
 
+    [UnitTest]
+    public async Task UpdateCursor_PublishesEventToBackplane_ForCrossNodeFanOut()
+    {
+        var clock = new FakeCollaborationClock(FixedUtcNow());
+        var backplane = new RecordingBackplane();
+        var service = new InMemoryCollaborationSessionService(
+            new AllowSavedMapCollaborationAuthorizer(), clock, backplane);
+        var alice = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Alice" }, Principal("alice"))).Response!;
+        backplane.Published.Clear();
+
+        service.UpdateCursor(alice.SessionId, new CollaborationCursor { Longitude = 1, Latitude = 2 });
+
+        backplane.Published.Should().ContainSingle(e => e.Type == CollaborationSessionEventTypes.CursorUpdated);
+    }
+
+    [UnitTest]
+    public async Task ApplyRemoteEvent_FromPeerNode_DeliversToLocalParticipantsExcludingOrigin()
+    {
+        var clock = new FakeCollaborationClock(FixedUtcNow());
+        var service = CreateService(clock);
+        var local = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Local" }, Principal("local"))).Response!;
+        _ = service.DrainEvents(local.SessionId);
+
+        // Simulate a cursor event produced by a participant on another node.
+        var remote = new CollaborationEventEnvelope
+        {
+            Type = CollaborationSessionEventTypes.CursorUpdated,
+            EventId = Guid.NewGuid(),
+            MapId = "map-a",
+            SessionId = Guid.NewGuid(),
+            Timestamp = clock.UtcNow,
+            Cursor = new CollaborationCursor { Longitude = -122.4, Latitude = 37.7 }
+        };
+        service.ApplyRemoteEvent(remote);
+
+        service.DrainEvents(local.SessionId).Should().ContainSingle(e =>
+            e.Type == CollaborationSessionEventTypes.CursorUpdated &&
+            e.Cursor!.Longitude == -122.4);
+    }
+
+    [UnitTest]
+    public async Task WaitForEventsAsync_SignalsWhenPeerEventArrives()
+    {
+        var clock = new FakeCollaborationClock(FixedUtcNow());
+        var service = CreateService(clock);
+        var alice = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Alice" }, Principal("alice"))).Response!;
+        var bob = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Bob" }, Principal("bob"))).Response!;
+        // Drain the join events so the wait below blocks until a new event arrives.
+        _ = service.DrainEvents(alice.SessionId);
+        _ = service.DrainEvents(bob.SessionId);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var wait = service.WaitForEventsAsync(alice.SessionId, cts.Token);
+        wait.IsCompleted.Should().BeFalse();
+
+        service.UpdateCursor(bob.SessionId, new CollaborationCursor { Longitude = 1, Latitude = 2 });
+
+        (await wait).Should().BeTrue();
+    }
+
     private static InMemoryCollaborationSessionService CreateService(FakeCollaborationClock clock) =>
         new(new AllowSavedMapCollaborationAuthorizer(), clock);
+
+    private sealed class RecordingBackplane : ICollaborationSessionBackplane
+    {
+        public List<CollaborationEventEnvelope> Published { get; } = [];
+
+        public void Publish(CollaborationEventEnvelope ev) => Published.Add(ev);
+    }
 
     private static DateTimeOffset FixedUtcNow() =>
         new(2026, 5, 12, 0, 0, 0, TimeSpan.Zero);


### PR DESCRIPTION
Bundles the first transport slice for saved-map collaboration. Builds on the existing FeatureStream WebSocket pattern and the in-memory collaboration session/op-log seams already on trunk (rather than reinventing them) and consumes the existing identity/RBAC authorizer for session-join authz.

## Per-ticket scope

### Refs #971 — Collab map session transport (first slice)
- **Done:** authenticated WebSocket `GET /api/v1/saved-maps/{mapId}/collaboration/sessions/stream`. Join is authorized through the existing fail-closed `ISavedMapCollaborationAuthorizer` **before** the upgrade, so unauthorized clients get a typed 401/403 rather than an opaque socket close. Streams the presence snapshot plus participant join/leave/heartbeat, cursor, selection and follow events; accepts client control frames (heartbeat/cursor/selection/follow/unfollow). Redis backplane for cross-node presence/cursor fan-out (registered only when a multiplexer is configured; single-node/Redis-less falls back to a no-op backplane — no external creds). Stale-participant pruning already runs via the existing hosted sweep.
- **Deferred:** durable reconnect catch-up of ephemeral state; per-client cursor rate-limit tuning beyond the existing outbox cap.

### Refs #972 — Saved-map collaborative op-log + conflict seam (first slice)
- **Done:** wires the existing Core `ISavedMapOperationLogRepository` + MVP conflict policy into DI and exposes them over HTTP — `POST .../collaboration/operations` (durable append: monotonic server cursor, operation-id/idempotency-key dedupe, typed conflict/resync responses) and `GET .../collaboration/operations?since=` (replay/catchup). Authorization shares the saved-map `RequireAuthorization` boundary.
- **Deferred:** durable Postgres-backed persistence + snapshot compaction (the in-memory repo is the documented MVP seam); CRDT/OT beyond last-writer-wins.

### Refs #1290 — Studio Map collaboration slice-2 (transport + RBAC join + presence/cursor stream)
- **Done:** the WS transport + Redis backplane + RBAC-scoped session join above satisfy the presence/cursor/follow stream contract for slice-2.
- **Deferred:** collaborative markup-layer CRUD; the ADR recording the transport decision.

## Tests (run serially, Release)
- WS: connect + presence snapshot, cross-participant `participant.joined` fan-out, cursor-frame fan-out, unauthorized-join rejected.
- Op-log: append assigns monotonic cursors + replay returns them, duplicate operation id is idempotent (no cursor advance), append without auth → 401.
- Unit: backplane publish hook, `ApplyRemoteEvent` cross-node re-injection (excludes origin), `WaitForEventsAsync` signal.
- Existing collaboration session/feature-lock/op-log tests still green; architecture tests (117) pass; feature-catalog + proof-ledger updated.

Release build is warnings-as-errors clean. New routes registered in `EndpointRegistry`, JSON contexts added to both resolver chains.