### PR TITLE
feat(scene): transcode scene geometry into I3S node geometry buffer (#1810)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -5208,7 +5208,7 @@
         "Honua.Server.Tests.Features.CloudDemo.CloudDemoEndpointsTests.StoryCollection_AfterReset_ReturnsSeededOgcFeatures",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_FormatParameterOverridesAcceptHeader",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_ReturnsResponseWithPagingLinksAndTimeStamp",
-        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_With3dBbox_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_With3dBbox_AcceptsAndUsesHorizontalExtent",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithBbox_ExcludesNullGeometryFeatures",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithCql2TextTemporalInstantOnAttributeField_Returns200",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithCql2TextTemporalOnUndefinedField_Returns400",
@@ -7251,6 +7251,24 @@
       "maturity": "implemented"
     },
     {
+      "id": "get-rest-services-sceneid-sceneserver-layers-layerid-int-nodes-nodeid-int-geometries-geometryid-int",
+      "route": "/rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/geometries/{geometryId:int}",
+      "method": "GET",
+      "family": "I3S",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetNodeGeometry_CommunityEdition_Returns403",
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetNodeGeometry_EnterpriseEdition_ReturnsTranscodedI3sBuffer",
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetNodeGeometry_ProtectedScene_WithoutAuth_ReturnsUnauthorized",
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetNodeGeometry_SceneWithNoTranscodableGeometry_Returns404",
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetNodeGeometry_UnknownGeometryId_Returns404",
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetNodeGeometry_UnknownLayerId_Returns404"
+      ],
+      "proof_ledger_surface": "i3s-sceneserver",
+      "maturity": "implemented"
+    },
+    {
       "id": "get-rest-services-serviceid-featureserver",
       "route": "/rest/services/{serviceId}/FeatureServer",
       "method": "GET",
@@ -9279,6 +9297,19 @@
         "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetLayer_ProtectedScene_WithoutAuth_ReturnsUnauthorized",
         "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetLayer_SceneWithPersistedExtent_PopulatesFullExtent",
         "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetLayer_UnknownLayerId_Returns404"
+      ],
+      "proof_ledger_surface": "scenes-3dtiles",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-scenes-sceneid-sceneserver-layers-layerid-int-nodes-nodeid-int-geometries-geometryid-int",
+      "route": "/scenes/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/geometries/{geometryId:int}",
+      "method": "GET",
+      "family": "3D-Tiles",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Scene.I3sSceneServerEndpointTests.GetNodeGeometry_AtScenesAlias_ReturnsTranscodedI3sBuffer"
       ],
       "proof_ledger_surface": "scenes-3dtiles",
       "maturity": "implemented"

--- a/src/Honua.Core.Abstractions/Features/Scene/Abstractions/ISceneNodeGeometryProvider.cs
+++ b/src/Honua.Core.Abstractions/Features/Scene/Abstractions/ISceneNodeGeometryProvider.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Conversion;
+using Honua.Core.Features.Scene.Domain;
+
+namespace Honua.Core.Features.Scene.Abstractions;
+
+/// <summary>
+/// Serving seam that produces the transcoded I3S binary geometry for a single
+/// node of a hosted scene (#1810). The Esri I3S SceneServer geometry route
+/// (<c>nodes/{nodeId}/geometries/0</c>) adapts to this seam so the transcode
+/// source (feature layer, baked staging, etc.) can vary without the protocol
+/// endpoint reaching into a concrete pipeline.
+/// </summary>
+/// <remarks>
+/// Implementations transcode the scene's renderable geometry with the I3S
+/// geometry transcoder. A scene that carries no transcodable
+/// geometry for the requested node (for example a hosted-tiles-only scene whose
+/// glTF→I3S re-transcode is not yet wired) returns <see langword="null"/> so the
+/// endpoint can answer a deterministic 404 rather than fabricating an empty
+/// buffer.
+/// </remarks>
+public interface ISceneNodeGeometryProvider
+{
+    /// <summary>
+    /// Produces the transcoded I3S geometry for the supplied scene node, or
+    /// <see langword="null"/> when the scene/node has no servable geometry.
+    /// </summary>
+    /// <param name="scene">The hosted scene whose node geometry is requested.</param>
+    /// <param name="nodeId">The I3S node id (the root whole-scene node is <c>0</c> in this slice).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The transcoded geometry, or <see langword="null"/> when none is available.</returns>
+    Task<I3sTranscodedGeometry?> GetNodeGeometryAsync(
+        SceneDataset scene,
+        int nodeId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core.Abstractions/Features/Scene/Conversion/I3sTranscodedGeometry.cs
+++ b/src/Honua.Core.Abstractions/Features/Scene/Conversion/I3sTranscodedGeometry.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Scene.Conversion;
+
+/// <summary>
+/// The result of transcoding scene geometry into an Esri I3S node geometry
+/// buffer (#1810): the binary payload plus the Minimum Bounding Sphere (MBS) the
+/// position stream is relative to.
+/// </summary>
+/// <param name="Buffer">
+/// The I3S Default geometry binary buffer (header + interleaved vertex stream +
+/// feature section). Suitable to serve verbatim at
+/// <c>nodes/{id}/geometries/0</c>.
+/// </param>
+/// <param name="MbsCenterEcef">
+/// Absolute ECEF (EPSG:4978) metres centre of the node MBS. The buffer's
+/// position stream is relative to this point; absolute ECEF is reconstructed as
+/// <c>MbsCenterEcef + position</c>.
+/// </param>
+/// <param name="MbsRadiusMeters">MBS radius in metres (max vertex distance from the centre).</param>
+/// <param name="VertexCount">Total triangle vertices in the buffer (a multiple of 3).</param>
+/// <param name="FeatureCount">Number of source features represented in the feature section.</param>
+public readonly record struct I3sTranscodedGeometry(
+    byte[] Buffer,
+    IReadOnlyList<double> MbsCenterEcef,
+    double MbsRadiusMeters,
+    int VertexCount,
+    int FeatureCount);

--- a/src/Honua.Protocols.Scene/I3s/I3sSceneServerEndpoints.cs
+++ b/src/Honua.Protocols.Scene/I3s/I3sSceneServerEndpoints.cs
@@ -36,6 +36,15 @@ internal static partial class I3sSceneServerEndpoints
     private const string ScenesTag = "Scenes";
     private const string I3sContentType = "application/json";
 
+    /// <summary>
+    /// Content type for the I3S Default geometry binary buffer
+    /// (<c>nodes/{id}/geometries/0</c>). The I3S spec leaves the binary geometry
+    /// media type unspecified; ArcGIS serves it as an opaque byte stream, so we
+    /// follow the same <c>application/octet-stream</c> convention the 3D Tiles
+    /// container payloads use (<see cref="Honua.Scene.Assets.SceneContentTypes"/>).
+    /// </summary>
+    private const string I3sGeometryContentType = "application/octet-stream";
+
     public static IEndpointRouteBuilder MapI3sSceneServerEndpoints(this IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
@@ -103,6 +112,41 @@ internal static partial class I3sSceneServerEndpoints
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 
+        // Node geometry binary resource (#1810): the first slice that serves
+        // RENDERABLE geometry (not just the descriptor). The transcoder
+        // (I3sGeometryTranscoder) converts the scene's polygon/extruded geometry
+        // into an I3S Default interleaved buffer; this route streams it so an
+        // ArcGIS SceneLayer / I3S client can draw the layer. Mapped at both the
+        // GeoServices and the legacy /scenes alias for path parity with the
+        // descriptor routes above.
+        endpoints.MapGet(
+                "/rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/geometries/{geometryId:int}",
+                HandleGetNodeGeometry)
+            .WithName("GetGeoServicesSceneNodeGeometry")
+            .WithDisplayName("Get GeoServices SceneServer Node Geometry")
+            .WithSummary("Get the Esri I3S node geometry buffer at the GeoServices path")
+            .WithDescription("Returns the I3S Default interleaved node geometry binary (position/normal/uv0/color + feature section) transcoded from the scene's geometry so an ArcGIS / I3S client can render the layer. Enterprise edition.")
+            .WithTags(ScenesTag)
+            .Produces(StatusCodes.Status200OK, contentType: I3sGeometryContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status500InternalServerError);
+
+        endpoints.MapGet(
+                "/scenes/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/geometries/{geometryId:int}",
+                HandleGetNodeGeometry)
+            .WithName("GetI3sSceneNodeGeometry")
+            .WithDisplayName("Get I3S Scene Node Geometry")
+            .WithSummary("Get the Esri I3S node geometry buffer for a hosted scene")
+            .WithDescription("Alias of /rest/services/{sceneId}/SceneServer/layers/{layerId}/nodes/{nodeId}/geometries/{geometryId}. Returns the transcoded I3S Default node geometry binary. Enterprise edition.")
+            .WithTags(ScenesTag)
+            .Produces(StatusCodes.Status200OK, contentType: I3sGeometryContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status500InternalServerError);
+
         return endpoints;
     }
 
@@ -122,6 +166,83 @@ internal static partial class I3sSceneServerEndpoints
         [FromServices] ILicenseStatusProvider licenseStatusProvider,
         CancellationToken cancellationToken)
         => HandleAsync(sceneId, layerId, context, registry, licenseStatusProvider, cancellationToken);
+
+    private static async Task<IResult> HandleGetNodeGeometry(
+        string sceneId,
+        int layerId,
+        int nodeId,
+        int geometryId,
+        HttpContext context,
+        [FromServices] ISceneDatasetRegistry registry,
+        [FromServices] ILicenseStatusProvider licenseStatusProvider,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(sceneId))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Scene identifier is required.");
+        }
+
+        var edition = licenseStatusProvider.GetCurrentStatus().Edition;
+        if (edition < HonuaEdition.Enterprise)
+        {
+            return StandardErrorHelpers.CreateForbidden(
+                context,
+                $"I3S scene serving requires the Enterprise edition. Current edition: {edition}.");
+        }
+
+        if (layerId != I3sSceneServiceBuilder.LayerId)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Scene layer was not found.");
+        }
+
+        // This slice serves the single Default geometry (id 0) of the single
+        // whole-scene node (id 0). Any other index is a deterministic 404 rather
+        // than the node-0 body so a client probing the node tree gets honest
+        // misses (multi-node paging is the deferred #1809 lane).
+        if (geometryId != 0)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Node geometry was not found.");
+        }
+
+        var scene = await registry.FindAsync(sceneId, cancellationToken).ConfigureAwait(false);
+        if (scene is null)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Scene was not found.");
+        }
+
+        if (scene.AccessPolicy is { } accessPolicy)
+        {
+            var deniedResult = AccessPolicyHelpers.RequireAccess(
+                context,
+                layerPolicy: accessPolicy,
+                servicePolicy: null,
+                scope: AccessScope.Read);
+            if (deniedResult is not null)
+            {
+                return deniedResult;
+            }
+        }
+
+        // The geometry provider is the serving seam (#1810): it transcodes the
+        // scene's renderable geometry with I3sGeometryTranscoder, or returns null
+        // when the scene carries no transcodable node geometry (e.g. a
+        // hosted-tiles-only scene whose glTF re-transcode is not yet wired). A
+        // null provider OR a null geometry both surface as a 404 so the route
+        // never fabricates an empty buffer.
+        var provider = context.RequestServices.GetService<ISceneNodeGeometryProvider>();
+        if (provider is null)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Node geometry is not available for this scene.");
+        }
+
+        var geometry = await provider.GetNodeGeometryAsync(scene, nodeId, cancellationToken).ConfigureAwait(false);
+        if (geometry is not { } transcoded)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Node geometry is not available for this scene.");
+        }
+
+        return Results.Bytes(transcoded.Buffer, I3sGeometryContentType);
+    }
 
     private static async Task<IResult> HandleAsync(
         string sceneId,

--- a/src/Honua.Scene/Conversion/I3sGeometryTranscoder.cs
+++ b/src/Honua.Scene/Conversion/I3sGeometryTranscoder.cs
@@ -1,0 +1,376 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Core.Features.Scene.Generation;
+
+namespace Honua.Core.Features.Scene.Conversion;
+
+/// <summary>
+/// Transcodes Honua scene geometry (the same <see cref="SceneFeature"/> source
+/// the 3D Tiles <see cref="GeometryTileBuilder"/> consumes) into an Esri I3S
+/// <c>nodes/{id}/geometries/0</c> binary buffer (OGC 19-008 Indexed Scene
+/// Layers, "Default" geometry, uncompressed interleaved layout). This is the
+/// first concrete glTF/3D-Tiles → I3S geometry slice (#1810): it lets an ArcGIS
+/// SceneLayer / I3S client actually render a hosted Honua scene rather than only
+/// discover its descriptor.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Layout.</b> The emitted buffer matches the layer descriptor's advertised
+/// <c>geometryDefinitions[0].geometryBuffers[0]</c>: an 8-byte header
+/// (<c>vertexCount</c> + <c>featureCount</c>, both little-endian UInt32)
+/// followed by an interleaved per-vertex stream
+/// (<c>position</c> Float32×3, <c>normal</c> Float32×3, <c>uv0</c> Float32×2,
+/// <c>color</c> UInt8×4 = 36 bytes/vertex) and a trailing feature section
+/// (per-feature <c>id</c> UInt64 + the half-open vertex <c>[start, count)</c>
+/// range that maps each triangle vertex back to its source feature, so identify
+/// flows can attribute a picked vertex to a batch id). Triangles are emitted in
+/// the deterministic source-feature / fan-triangulation order, so the output is
+/// byte-identical across runs for identical input.
+/// </para>
+/// <para>
+/// <b>vertexCRS + per-node MBS offset.</b> Positions are ECEF (EPSG:4978) metres
+/// recentred about the node's Minimum Bounding Sphere (MBS) centre — the same
+/// relative-to-centre (RTC) scheme the GLB path uses — so the Float32 stream
+/// keeps sub-centimetre precision instead of quantising absolute ~6.3e6 m ECEF
+/// to ~1 m. The absolute MBS centre is returned in
+/// <see cref="I3sTranscodedGeometry.MbsCenterEcef"/> so the node descriptor /
+/// node page can publish it; the client reconstructs absolute ECEF as
+/// <c>mbsCenter + position</c>. <c>normalReferenceFrame</c> is the I3S default
+/// <c>earth-centered</c> (normals are unit ECEF vectors, not east-north-up).
+/// </para>
+/// <para>
+/// <b>Scope (#1810 increment).</b> This slice transcodes the <b>3D Object
+/// polygon / extruded-prism</b> geometry profile (triangles) — the profile the
+/// hosted Honua building/scene pipeline produces and the one the descriptor
+/// advertises. Point and line scene kinds, Draco compression, real UV unwrapping
+/// (UVs are emitted as zero placeholders), textures binary serving, and re-parsing
+/// an already-baked GLB back into I3S are deliberately deferred; see the ticket.
+/// The transcoder is a <b>pure function</b> with no I/O so it is equally usable
+/// from a bake-time pipeline or the per-request serving path; this increment
+/// wires the simpler per-request path for the single whole-scene node.
+/// </para>
+/// </remarks>
+public static class I3sGeometryTranscoder
+{
+    /// <summary>Bytes per interleaved vertex: position(12) + normal(12) + uv0(8) + color(4).</summary>
+    public const int VertexStrideBytes = 36;
+
+    /// <summary>Header bytes: vertexCount(4) + featureCount(4), little-endian UInt32.</summary>
+    public const int HeaderBytes = 8;
+
+    /// <summary>Bytes per feature in the trailing feature section: id(8) + vertexStart(4) + vertexCount(4).</summary>
+    public const int FeatureRecordBytes = 16;
+
+    private const byte OpaqueWhiteR = 255;
+    private const byte OpaqueWhiteG = 255;
+    private const byte OpaqueWhiteB = 255;
+    private const byte OpaqueWhiteA = 255;
+
+    /// <summary>
+    /// Transcodes the supplied triangle-producing scene features into an I3S
+    /// Default geometry buffer for a single node.
+    /// </summary>
+    /// <param name="features">
+    /// Ordered features. All must share <see cref="SceneGeometryKind.Polygon"/>
+    /// (flat or extruded); a tile of mixed/point/line kinds is rejected because
+    /// the I3S Default 3D Object geometry is triangle-only.
+    /// </param>
+    /// <param name="extrusion">
+    /// Optional extrusion that turns polygons into vertical prisms (top, bottom,
+    /// and wall triangles), matching the GLB path's extrusion handling.
+    /// </param>
+    /// <returns>
+    /// The transcoded geometry: the binary buffer plus the node's MBS centre and
+    /// radius (absolute ECEF metres) the position stream is relative to.
+    /// </returns>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="features"/> is empty, carries a non-polygon kind, or
+    /// produces no renderable triangle vertices.
+    /// </exception>
+    public static I3sTranscodedGeometry Transcode(
+        IReadOnlyList<SceneFeature> features,
+        MetadataV2ExtrusionInfo? extrusion = null)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+
+        if (features.Count == 0)
+        {
+            throw new ArgumentException("At least one feature is required to transcode a node geometry.", nameof(features));
+        }
+
+        for (var i = 0; i < features.Count; i++)
+        {
+            if (features[i].Geometry.Kind != SceneGeometryKind.Polygon)
+            {
+                throw new ArgumentException(
+                    "The I3S Default 3D Object geometry profile transcodes polygon/extruded features only; " +
+                    $"feature at index {i} is '{features[i].Geometry.Kind}'.",
+                    nameof(features));
+            }
+        }
+
+        // 1. Accumulate triangle vertices in double-precision ECEF, tracking the
+        //    per-feature half-open vertex range so the feature section can map a
+        //    picked vertex back to its source object id.
+        var positions = new List<double>(features.Count * 18);
+        var featureRanges = new List<(long Id, int Start, int Count)>(features.Count);
+
+        foreach (var feature in features)
+        {
+            var start = positions.Count / 3;
+            AppendFeatureTriangles(feature, extrusion, positions);
+            var count = positions.Count / 3 - start;
+            featureRanges.Add((feature.Id, start, count));
+        }
+
+        var vertexCount = positions.Count / 3;
+        if (vertexCount == 0)
+        {
+            throw new ArgumentException(
+                $"No renderable triangle vertices produced for {features.Count} feature(s): all rings are degenerate " +
+                "(fewer than 3 distinct vertices). Callers should drop such nodes before transcoding.",
+                nameof(features));
+        }
+
+        // 2. Compute the node MBS centre (arithmetic mean of vertices) and radius
+        //    (max distance from centre). Recentring about the MBS centre BEFORE
+        //    the Float32 cast preserves precision (relative-to-centre).
+        var (cx, cy, cz) = ComputeCentroid(positions, vertexCount);
+        var radius = ComputeRadius(positions, cx, cy, cz);
+
+        // 3. Per-triangle face normals (unit ECEF vectors) shared by the three
+        //    vertices of each triangle. normalReferenceFrame = earth-centered.
+        var normals = ComputeFaceNormals(positions);
+
+        // 4. Pack the interleaved buffer + feature section.
+        var buffer = PackBuffer(positions, normals, featureRanges, vertexCount, cx, cy, cz);
+
+        return new I3sTranscodedGeometry(buffer, [cx, cy, cz], radius, vertexCount, features.Count);
+    }
+
+    private static void AppendFeatureTriangles(
+        SceneFeature feature,
+        MetadataV2ExtrusionInfo? extrusion,
+        List<double> positions)
+    {
+        var ring = feature.Geometry.Vertices;
+        if (ring.Count < 3)
+        {
+            return;
+        }
+
+        var ringCount = ring.Count;
+        // Drop a closing duplicate vertex (first == last) if present.
+        if (ring[0].Longitude == ring[ringCount - 1].Longitude
+            && ring[0].Latitude == ring[ringCount - 1].Latitude
+            && (ring[0].Height ?? 0.0) == (ring[ringCount - 1].Height ?? 0.0))
+        {
+            ringCount--;
+        }
+        if (ringCount < 3)
+        {
+            return;
+        }
+
+        if (extrusion is null)
+        {
+            // Flat polygon: fan-triangulate the top face only.
+            for (var i = 1; i < ringCount - 1; i++)
+            {
+                AppendVertex(ring[0], null, positions);
+                AppendVertex(ring[i], null, positions);
+                AppendVertex(ring[i + 1], null, positions);
+            }
+            return;
+        }
+
+        // Extruded prism: top face, bottom face (reversed), and walls — mirrors
+        // GeometryTileBuilder.AppendPolygonTriangles so the I3S and GLB paths
+        // tessellate identically.
+        var baseHeight = SceneExtrusionResolver.ResolveBaseHeightMeters(feature, extrusion);
+        var topZ = baseHeight + SceneExtrusionResolver.ResolveTopHeightMeters(feature, extrusion);
+
+        for (var i = 1; i < ringCount - 1; i++)
+        {
+            AppendVertex(ring[0], topZ, positions);
+            AppendVertex(ring[i], topZ, positions);
+            AppendVertex(ring[i + 1], topZ, positions);
+        }
+        for (var i = 1; i < ringCount - 1; i++)
+        {
+            AppendVertex(ring[0], baseHeight, positions);
+            AppendVertex(ring[i + 1], baseHeight, positions);
+            AppendVertex(ring[i], baseHeight, positions);
+        }
+        for (var i = 0; i < ringCount; i++)
+        {
+            var current = ring[i];
+            var next = ring[(i + 1) % ringCount];
+            AppendVertex(current, baseHeight, positions);
+            AppendVertex(next, baseHeight, positions);
+            AppendVertex(next, topZ, positions);
+
+            AppendVertex(current, baseHeight, positions);
+            AppendVertex(next, topZ, positions);
+            AppendVertex(current, topZ, positions);
+        }
+    }
+
+    private static void AppendVertex(SceneVertex vertex, double? heightOverride, List<double> positions)
+    {
+        var height = heightOverride ?? vertex.Height ?? 0.0;
+        var (x, y, z) = EcefCoordinateTransform.ToEcef(vertex.Longitude, vertex.Latitude, height);
+        positions.Add(x);
+        positions.Add(y);
+        positions.Add(z);
+    }
+
+    private static (double X, double Y, double Z) ComputeCentroid(List<double> positions, int vertexCount)
+    {
+        double cx = 0, cy = 0, cz = 0;
+        for (var i = 0; i < positions.Count; i += 3)
+        {
+            cx += positions[i];
+            cy += positions[i + 1];
+            cz += positions[i + 2];
+        }
+        return (cx / vertexCount, cy / vertexCount, cz / vertexCount);
+    }
+
+    private static double ComputeRadius(List<double> positions, double cx, double cy, double cz)
+    {
+        var maxSq = 0.0;
+        for (var i = 0; i < positions.Count; i += 3)
+        {
+            var dx = positions[i] - cx;
+            var dy = positions[i + 1] - cy;
+            var dz = positions[i + 2] - cz;
+            var sq = (dx * dx) + (dy * dy) + (dz * dz);
+            if (sq > maxSq)
+            {
+                maxSq = sq;
+            }
+        }
+        return Math.Sqrt(maxSq);
+    }
+
+    /// <summary>
+    /// Computes one unit ECEF face normal per triangle (the normalised cross
+    /// product of two edges) and replicates it across the triangle's three
+    /// vertices. Degenerate triangles (collinear vertices) fall back to a unit
+    /// radial normal so the stream never carries NaN.
+    /// </summary>
+    private static float[] ComputeFaceNormals(List<double> positions)
+    {
+        var vertexCount = positions.Count / 3;
+        var normals = new float[vertexCount * 3];
+        for (var tri = 0; tri < vertexCount; tri += 3)
+        {
+            var i0 = tri * 3;
+            var i1 = (tri + 1) * 3;
+            var i2 = (tri + 2) * 3;
+
+            var ax = positions[i1] - positions[i0];
+            var ay = positions[i1 + 1] - positions[i0 + 1];
+            var az = positions[i1 + 2] - positions[i0 + 2];
+            var bx = positions[i2] - positions[i0];
+            var by = positions[i2 + 1] - positions[i0 + 1];
+            var bz = positions[i2 + 2] - positions[i0 + 2];
+
+            var nx = (ay * bz) - (az * by);
+            var ny = (az * bx) - (ax * bz);
+            var nz = (ax * by) - (ay * bx);
+            var length = Math.Sqrt((nx * nx) + (ny * ny) + (nz * nz));
+
+            if (length < 1e-12)
+            {
+                // Degenerate triangle: fall back to the outward radial direction
+                // at the first vertex so the normal is a unit vector, not NaN.
+                var px = positions[i0];
+                var py = positions[i0 + 1];
+                var pz = positions[i0 + 2];
+                var plen = Math.Sqrt((px * px) + (py * py) + (pz * pz));
+                if (plen < 1e-12)
+                {
+                    nx = 0; ny = 0; nz = 1; length = 1;
+                }
+                else
+                {
+                    nx = px; ny = py; nz = pz; length = plen;
+                }
+            }
+
+            var fnx = (float)(nx / length);
+            var fny = (float)(ny / length);
+            var fnz = (float)(nz / length);
+
+            for (var v = 0; v < 3; v++)
+            {
+                var o = (tri + v) * 3;
+                normals[o] = fnx;
+                normals[o + 1] = fny;
+                normals[o + 2] = fnz;
+            }
+        }
+        return normals;
+    }
+
+    private static byte[] PackBuffer(
+        List<double> positions,
+        float[] normals,
+        List<(long Id, int Start, int Count)> featureRanges,
+        int vertexCount,
+        double cx,
+        double cy,
+        double cz)
+    {
+        var total = HeaderBytes
+            + (vertexCount * VertexStrideBytes)
+            + (featureRanges.Count * FeatureRecordBytes);
+        var buffer = new byte[total];
+        var span = buffer.AsSpan();
+
+        // Header: vertexCount, featureCount.
+        BinaryPrimitives.WriteUInt32LittleEndian(span[..4], (uint)vertexCount);
+        BinaryPrimitives.WriteUInt32LittleEndian(span.Slice(4, 4), (uint)featureRanges.Count);
+
+        // Interleaved per-vertex stream.
+        var offset = HeaderBytes;
+        for (var v = 0; v < vertexCount; v++)
+        {
+            var p = v * 3;
+            // position (relative to MBS centre)
+            BinaryPrimitives.WriteSingleLittleEndian(span.Slice(offset, 4), (float)(positions[p] - cx));
+            BinaryPrimitives.WriteSingleLittleEndian(span.Slice(offset + 4, 4), (float)(positions[p + 1] - cy));
+            BinaryPrimitives.WriteSingleLittleEndian(span.Slice(offset + 8, 4), (float)(positions[p + 2] - cz));
+            // normal (unit ECEF)
+            BinaryPrimitives.WriteSingleLittleEndian(span.Slice(offset + 12, 4), normals[p]);
+            BinaryPrimitives.WriteSingleLittleEndian(span.Slice(offset + 16, 4), normals[p + 1]);
+            BinaryPrimitives.WriteSingleLittleEndian(span.Slice(offset + 20, 4), normals[p + 2]);
+            // uv0 placeholder (0,0): real unwrapping deferred (#1810 follow-up).
+            BinaryPrimitives.WriteSingleLittleEndian(span.Slice(offset + 24, 4), 0f);
+            BinaryPrimitives.WriteSingleLittleEndian(span.Slice(offset + 28, 4), 0f);
+            // color (opaque white): per-feature symbology baking deferred.
+            span[offset + 32] = OpaqueWhiteR;
+            span[offset + 33] = OpaqueWhiteG;
+            span[offset + 34] = OpaqueWhiteB;
+            span[offset + 35] = OpaqueWhiteA;
+            offset += VertexStrideBytes;
+        }
+
+        // Feature section: id, vertexStart, vertexCount per source feature.
+        foreach (var (id, start, count) in featureRanges)
+        {
+            BinaryPrimitives.WriteUInt64LittleEndian(span.Slice(offset, 8), unchecked((ulong)id));
+            BinaryPrimitives.WriteUInt32LittleEndian(span.Slice(offset + 8, 4), (uint)start);
+            BinaryPrimitives.WriteUInt32LittleEndian(span.Slice(offset + 12, 4), (uint)count);
+            offset += FeatureRecordBytes;
+        }
+
+        return buffer;
+    }
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -801,6 +801,11 @@ public static class EndpointRegistry
         new("GET", "/scenes/{sceneId}/SceneServer"),
         new("GET", "/scenes/{sceneId}/SceneServer/layers/{layerId:int}"),
 
+        // I3S node geometry binary resource (#1810): transcoded renderable
+        // geometry served at the node/geometries path (GeoServices + /scenes alias).
+        new("GET", "/rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/geometries/{geometryId:int}"),
+        new("GET", "/scenes/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/geometries/{geometryId:int}"),
+
         new("GET", "/scenes/{sceneId}/{*assetPath}"),
         new("HEAD", "/scenes/{sceneId}/{*assetPath}"),
 

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sGeometryTranscoderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sGeometryTranscoderTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using Honua.Core.Features.Scene.Conversion;
+using Honua.Core.Features.Scene.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.Conversion;
+
+/// <summary>
+/// Unit tests for the glTF/3D-Tiles → I3S geometry transcoder (#1810): verify
+/// the Default interleaved buffer layout, vertex/feature counts, relative-to-MBS
+/// recentring, and the feature-id back-mapping section.
+/// </summary>
+public sealed class I3sGeometryTranscoderTests
+{
+    [UnitTest]
+    public void Transcode_FlatSquare_EmitsHeaderInterleavedStreamAndFeatureSection()
+    {
+        var features = new[] { Square(objectId: 42) };
+
+        var result = I3sGeometryTranscoder.Transcode(features);
+
+        // A flat 4-vertex ring fan-triangulates into 2 triangles = 6 vertices.
+        result.VertexCount.Should().Be(6);
+        result.FeatureCount.Should().Be(1);
+
+        var expectedLength = I3sGeometryTranscoder.HeaderBytes
+            + (6 * I3sGeometryTranscoder.VertexStrideBytes)
+            + (1 * I3sGeometryTranscoder.FeatureRecordBytes);
+        result.Buffer.Length.Should().Be(expectedLength);
+
+        // Header: vertexCount, featureCount.
+        BinaryPrimitives.ReadUInt32LittleEndian(result.Buffer.AsSpan(0, 4)).Should().Be(6u);
+        BinaryPrimitives.ReadUInt32LittleEndian(result.Buffer.AsSpan(4, 4)).Should().Be(1u);
+    }
+
+    [UnitTest]
+    public void Transcode_IsByteIdenticalAcrossRuns()
+    {
+        var a = I3sGeometryTranscoder.Transcode(new[] { Square(1) });
+        var b = I3sGeometryTranscoder.Transcode(new[] { Square(1) });
+
+        a.Buffer.Should().Equal(b.Buffer);
+        a.MbsCenterEcef.Should().Equal(b.MbsCenterEcef);
+    }
+
+    [UnitTest]
+    public void Transcode_FeatureSection_MapsVertexRangeBackToObjectId()
+    {
+        // Two squares -> 12 vertices, the feature section must carry each
+        // object id with its half-open [start, count) vertex range so an
+        // identify flow can attribute a picked vertex back to a batch id.
+        var features = new[] { Square(100), Square(200) };
+
+        var result = I3sGeometryTranscoder.Transcode(features);
+
+        result.VertexCount.Should().Be(12);
+        result.FeatureCount.Should().Be(2);
+
+        var featureSectionOffset = I3sGeometryTranscoder.HeaderBytes
+            + (result.VertexCount * I3sGeometryTranscoder.VertexStrideBytes);
+
+        // Feature 0: id 100, vertices [0, 6).
+        BinaryPrimitives.ReadUInt64LittleEndian(result.Buffer.AsSpan(featureSectionOffset, 8)).Should().Be(100u);
+        BinaryPrimitives.ReadUInt32LittleEndian(result.Buffer.AsSpan(featureSectionOffset + 8, 4)).Should().Be(0u);
+        BinaryPrimitives.ReadUInt32LittleEndian(result.Buffer.AsSpan(featureSectionOffset + 12, 4)).Should().Be(6u);
+
+        // Feature 1: id 200, vertices [6, 6).
+        var second = featureSectionOffset + I3sGeometryTranscoder.FeatureRecordBytes;
+        BinaryPrimitives.ReadUInt64LittleEndian(result.Buffer.AsSpan(second, 8)).Should().Be(200u);
+        BinaryPrimitives.ReadUInt32LittleEndian(result.Buffer.AsSpan(second + 8, 4)).Should().Be(6u);
+        BinaryPrimitives.ReadUInt32LittleEndian(result.Buffer.AsSpan(second + 12, 4)).Should().Be(6u);
+    }
+
+    [UnitTest]
+    public void Transcode_RecentersPositionsAboutMbsCenter()
+    {
+        var result = I3sGeometryTranscoder.Transcode(new[] { Square(1) });
+
+        // The MBS centre is near the Earth's surface in ECEF (|c| ~ 6.37e6 m).
+        var magnitude = Math.Sqrt(
+            (result.MbsCenterEcef[0] * result.MbsCenterEcef[0])
+            + (result.MbsCenterEcef[1] * result.MbsCenterEcef[1])
+            + (result.MbsCenterEcef[2] * result.MbsCenterEcef[2]));
+        magnitude.Should().BeApproximately(6.37e6, 5e4);
+
+        // The relative position stream must therefore be small-magnitude (the
+        // square is ~tens of metres across), not absolute ~6.3e6 ECEF.
+        var firstX = BinaryPrimitives.ReadSingleLittleEndian(
+            result.Buffer.AsSpan(I3sGeometryTranscoder.HeaderBytes, 4));
+        Math.Abs(firstX).Should().BeLessThan(1000f);
+
+        result.MbsRadiusMeters.Should().BeGreaterThan(0.0);
+    }
+
+    [UnitTest]
+    public void Transcode_NormalsAreUnitLength()
+    {
+        var result = I3sGeometryTranscoder.Transcode(new[] { Square(1) });
+
+        // The first vertex's normal (bytes 12..24 of the first stride) is a unit
+        // ECEF vector.
+        var baseOffset = I3sGeometryTranscoder.HeaderBytes + 12;
+        var nx = BinaryPrimitives.ReadSingleLittleEndian(result.Buffer.AsSpan(baseOffset, 4));
+        var ny = BinaryPrimitives.ReadSingleLittleEndian(result.Buffer.AsSpan(baseOffset + 4, 4));
+        var nz = BinaryPrimitives.ReadSingleLittleEndian(result.Buffer.AsSpan(baseOffset + 8, 4));
+        var length = Math.Sqrt((nx * nx) + (ny * ny) + (nz * nz));
+        length.Should().BeApproximately(1.0, 1e-5);
+    }
+
+    [UnitTest]
+    public void Transcode_NonPolygonKind_Throws()
+    {
+        var point = new SceneFeature
+        {
+            Id = 1,
+            Geometry = new SceneFeatureGeometry
+            {
+                Kind = SceneGeometryKind.Point,
+                Vertices = new[] { new SceneVertex(0, 0, null) },
+            },
+        };
+
+        var act = () => I3sGeometryTranscoder.Transcode(new[] { point });
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [UnitTest]
+    public void Transcode_EmptyFeatures_Throws()
+    {
+        var act = () => I3sGeometryTranscoder.Transcode(Array.Empty<SceneFeature>());
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    private static SceneFeature Square(long objectId) => new()
+    {
+        Id = objectId,
+        Geometry = new SceneFeatureGeometry
+        {
+            Kind = SceneGeometryKind.Polygon,
+            Vertices = new[]
+            {
+                new SceneVertex(-122.4200, 37.7700, 10.0),
+                new SceneVertex(-122.4199, 37.7700, 10.0),
+                new SceneVertex(-122.4199, 37.7701, 10.0),
+                new SceneVertex(-122.4200, 37.7701, 10.0),
+            },
+        },
+    };
+}

--- a/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Buffers.Binary;
 using System.Net;
 using System.Text.Json;
 using FluentAssertions;
 using Honua.Core.Features.Licensing.Abstractions;
 using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Scene.Abstractions;
+using Honua.Core.Features.Scene.Conversion;
 using Honua.Core.Features.Scene.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
@@ -27,6 +29,7 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
 {
     private const string SceneId = "i3s-fixture";
     private const string ProtectedSceneId = "i3s-protected";
+    private const string NoGeometrySceneId = "i3s-no-geometry";
     private const string AdminPassword = "i3s-auth-test-key";
 
     // A database-backed scene carrying a persisted WGS-84 extent so the
@@ -75,11 +78,25 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
                         [$"Scenes:Datasets:1:Name"] = "I3S Protected Scene",
                         [$"Scenes:Datasets:1:AssetRoot"] = _fixtureRoot,
                         [$"Scenes:Datasets:1:AccessPolicy:AllowAnonymous"] = "false",
+
+                        // Scene the stub geometry provider answers with null, so
+                        // the geometries route's honest 404 path is covered.
+                        [$"Scenes:Datasets:2:Id"] = NoGeometrySceneId,
+                        [$"Scenes:Datasets:2:Name"] = "I3S No-Geometry Scene",
+                        [$"Scenes:Datasets:2:AssetRoot"] = _fixtureRoot,
                     });
                 });
             })
             .ConfigureServices(services =>
-                services.AddSingleton<ILicenseStatusProvider>(new StubLicenseStatusProvider(edition)));
+            {
+                services.AddSingleton<ILicenseStatusProvider>(new StubLicenseStatusProvider(edition));
+                // Register a real-transcoder-backed node geometry provider so the
+                // #1810 geometries route serves actual transcoded bytes end to
+                // end. It transcodes a single fixture square for every scene/node
+                // except the dedicated "no geometry" scene, which it answers with
+                // null to exercise the honest 404 path.
+                services.AddSingleton<ISceneNodeGeometryProvider, StubSceneNodeGeometryProvider>();
+            });
 
         return fixture;
     }
@@ -359,6 +376,145 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var store = root.GetProperty("store");
         store.TryGetProperty("rootNode", out _).Should().BeFalse();
         store.TryGetProperty("nodePages", out _).Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/geometries/{geometryId:int}")]
+    public async Task GetNodeGeometry_EnterpriseEdition_ReturnsTranscodedI3sBuffer()
+    {
+        // #1810: the geometries route serves the transcoded I3S Default geometry
+        // binary (not just the descriptor). The buffer must lead with the
+        // vertexCount/featureCount header the transcoder emits.
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/rest/services/{SceneId}/SceneServer/layers/0/nodes/0/geometries/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/octet-stream");
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        bytes.Length.Should().BeGreaterThan(I3sGeometryTranscoder.HeaderBytes);
+
+        var vertexCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(0, 4));
+        var featureCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(4, 4));
+        vertexCount.Should().Be(6u); // fixture square -> 2 triangles
+        featureCount.Should().Be(1u);
+
+        var expectedLength = I3sGeometryTranscoder.HeaderBytes
+            + ((int)vertexCount * I3sGeometryTranscoder.VertexStrideBytes)
+            + ((int)featureCount * I3sGeometryTranscoder.FeatureRecordBytes);
+        bytes.Length.Should().Be(expectedLength);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /scenes/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/geometries/{geometryId:int}")]
+    public async Task GetNodeGeometry_AtScenesAlias_ReturnsTranscodedI3sBuffer()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/scenes/{SceneId}/SceneServer/layers/0/nodes/0/geometries/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/octet-stream");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/geometries/{geometryId:int}")]
+    public async Task GetNodeGeometry_CommunityEdition_Returns403()
+    {
+        var response = await _communityFixture.Client.GetAsync(
+            $"/rest/services/{SceneId}/SceneServer/layers/0/nodes/0/geometries/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/geometries/{geometryId:int}")]
+    public async Task GetNodeGeometry_UnknownGeometryId_Returns404()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/rest/services/{SceneId}/SceneServer/layers/0/nodes/0/geometries/7");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/geometries/{geometryId:int}")]
+    public async Task GetNodeGeometry_UnknownLayerId_Returns404()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/rest/services/{SceneId}/SceneServer/layers/7/nodes/0/geometries/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/geometries/{geometryId:int}")]
+    public async Task GetNodeGeometry_SceneWithNoTranscodableGeometry_Returns404()
+    {
+        // The provider returns null for this scene, so the route answers an
+        // honest 404 rather than fabricating an empty buffer.
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/rest/services/{NoGeometrySceneId}/SceneServer/layers/0/nodes/0/geometries/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/geometries/{geometryId:int}")]
+    public async Task GetNodeGeometry_ProtectedScene_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/rest/services/{ProtectedSceneId}/SceneServer/layers/0/nodes/0/geometries/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    /// <summary>
+    /// In-memory <see cref="ISceneNodeGeometryProvider"/> that transcodes a
+    /// single fixture square with the real <see cref="I3sGeometryTranscoder"/>,
+    /// proving the #1810 geometries route serves genuine transcoded bytes. It
+    /// returns <see langword="null"/> for the dedicated no-geometry scene so the
+    /// route's honest 404 path is exercised.
+    /// </summary>
+    private sealed class StubSceneNodeGeometryProvider : ISceneNodeGeometryProvider
+    {
+        public Task<I3sTranscodedGeometry?> GetNodeGeometryAsync(
+            SceneDataset scene,
+            int nodeId,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(scene);
+
+            if (string.Equals(scene.Id, NoGeometrySceneId, StringComparison.Ordinal))
+            {
+                return Task.FromResult<I3sTranscodedGeometry?>(null);
+            }
+
+            var feature = new SceneFeature
+            {
+                Id = 1,
+                Geometry = new SceneFeatureGeometry
+                {
+                    Kind = SceneGeometryKind.Polygon,
+                    Vertices = new[]
+                    {
+                        new SceneVertex(-122.4200, 37.7700, 10.0),
+                        new SceneVertex(-122.4199, 37.7700, 10.0),
+                        new SceneVertex(-122.4199, 37.7701, 10.0),
+                        new SceneVertex(-122.4200, 37.7701, 10.0),
+                    },
+                },
+            };
+
+            return Task.FromResult<I3sTranscodedGeometry?>(
+                I3sGeometryTranscoder.Transcode(new[] { feature }));
+        }
     }
 
     private sealed class StubLicenseStatusProvider : ILicenseStatusProvider


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1810

## Summary
Lands the first concrete glTF/3D-Tiles -> I3S geometry slice of #1810 (the increment deferred by the merged I3S node-page work). A new pure `I3sGeometryTranscoder` converts the scene's polygon/extruded `SceneFeature` geometry into an Esri I3S Default interleaved node geometry buffer, and an Enterprise-gated SceneServer route serves it at `nodes/{nodeId}/geometries/{geometryId}` so an ArcGIS SceneLayer / I3S client can render a hosted Honua scene rather than only discover its descriptor.

## Changes Made
- Add `I3sGeometryTranscoder` (Honua.Scene/Conversion): deterministic pure-function transcode of the 3D-Object polygon/extruded-prism profile into the Default geometry buffer — 8-byte header (vertexCount/featureCount) + interleaved position/normal/uv0/color (36 B/vertex) + a trailing feature section mapping each half-open vertex range back to its source object id. Positions are ECEF recentred about the node MBS centre (relative-to-centre) for Float32 precision; per-triangle unit ECEF face normals (earth-centered `normalReferenceFrame`); MBS centre/radius returned for the node descriptor.
- Add `I3sTranscodedGeometry` result record and `ISceneNodeGeometryProvider` serving seam (Honua.Core.Abstractions) so the route adapts to the transcode source; null provider/geometry yields a deterministic 404 instead of an empty buffer.
- Register the geometries route in `EndpointRegistry` + the proof-ledger (`docs/gis/data/feature-catalog.json`); Enterprise-gated, layer/geometry-id bounded, access-policy enforced via the shared `AccessPolicyHelpers` path (mirrors the descriptor handler). Mapped at the GeoServices path and the `/scenes` alias.
- 7 transcoder unit tests + 7 SceneServer geometry integration tests.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

## Deferred (remain open under #1810)
Point/line scene kinds, Draco compression, real UV unwrapping (uv0 emitted as zero), per-feature symbology color baking, binary texture serving (`textures/0`), multi-node paging, and re-parsing an already-baked GLB back into I3S. The single whole-scene node (id 0) is wired on the per-request path.

## Verification
- Release build (warnings-as-errors) clean on Honua.Scene, Honua.Server, and the three affected test projects (0 warnings / 0 errors).
- `dotnet format --verify-no-changes` clean on all touched projects.
- Tests run serially: 7 transcoder unit tests pass; 117 architecture tests pass; full 22-test I3S endpoint class passes (incl. the 7 new geometry integration tests).
