### PR TITLE
ci(merge-train): forward-fix restores-with-retry before dotnet format; tolerate missing build-lock

### DIFF
--- a/scripts/ci/merge-train/forward-fix.sh
+++ b/scripts/ci/merge-train/forward-fix.sh
@@ -49,7 +49,17 @@ train_forward_fix() {
     # Test override: a fake formatter that touches files deterministically.
     "${TRAIN_FORMAT_CMD}" "${batch}"
   else
-    ( cd "${TRAIN_REPO_ROOT}" && with-build-lock dotnet format Honua.sln )
+    # `dotnet format` needs the solution RESTORED to load+reformat projects, and
+    # restore is flaky (that's why CI uses scripts/ci/dotnet-restore-retry.sh).
+    # The old cold `dotnet format` had no retry-restore, so a transient restore
+    # failure produced NO changes — which the train mis-read as "not format-
+    # fixable" and ESCALATED instead of healing the format and landing forward.
+    # Also: `with-build-lock` is a LOCAL multi-agent dev tool that may be absent
+    # on the CI runner (where this actually runs), so use it only if present.
+    local _wbl=""; command -v with-build-lock >/dev/null 2>&1 && _wbl="with-build-lock"
+    ( cd "${TRAIN_REPO_ROOT}" \
+        && ${_wbl} scripts/ci/dotnet-restore-retry.sh Honua.sln \
+        && ${_wbl} dotnet format Honua.sln --no-restore )
   fi
 
   if git -C "${TRAIN_REPO_ROOT}" diff --quiet; then


### PR DESCRIPTION
## Summary
The format forward-fix (the agent's deterministic format heal = fix-forward) was producing NO changes and the train mis-read that as 'not format-fixable' and ESCALATED instead of healing+landing. Causes: (1) cold `dotnet format` with no retry-restore (format needs a restored solution; restore is flaky — CI uses dotnet-restore-retry.sh); (2) it wrapped the call in with-build-lock, a LOCAL multi-agent tool absent on the CI runner.

## Changes Made
- forward-fix.sh: restore with retry first, `dotnet format --no-restore`, use with-build-lock only if present.

## Breaking Changes
None.

## Gate Impact
- [x] No gate impact (merge-train CI-infra only)

## Testing
- [x] bash -n; fixtures 124/0.

Related to #1387