### PR TITLE
ci(merge-train): feed autofix prompt via stdin (was eaten by variadic --allowed-tools)

### DIFF
--- a/scripts/ci/merge-train/autofix-agent.sh
+++ b/scripts/ci/merge-train/autofix-agent.sh
@@ -60,12 +60,20 @@ export ANTHROPIC_SMALL_FAST_MODEL="${TRAIN_AUTOFIX_SMALL_MODEL:-us.anthropic.cla
 PROMPT="$(cat "${REQUEST_FILE}")"
 TIMEOUT="${TRAIN_AUTOFIX_TIMEOUT:-900}"
 
+# Feed the prompt via STDIN, NOT as a positional arg. `--allowed-tools` is
+# VARIADIC: it greedily swallowed BOTH "Edit,Write,Read,Bash" AND the trailing
+# "${PROMPT}" positional, so the whole fix-request got parsed as bogus tool rules
+# ("Ignoring --allowedTools rule '(requires `ST_*`)'", "'(#1719):**'", ...), claude
+# was left with NO prompt, and exited immediately: "Error: Input must be provided
+# either through stdin or as a prompt argument when using --print". The model NEVER
+# ran — every prior "autofix produced no commit" was THIS, not Claude failing to
+# fix. Piping the prompt on stdin keeps --allowed-tools to its single value and
+# delivers the prompt unambiguously. printf (not echo) so content isn't mangled.
 ( cd "${REPO_ROOT}" && \
-  timeout "${TIMEOUT}" claude \
+  printf '%s' "${PROMPT}" | timeout "${TIMEOUT}" claude \
     --print \
     --dangerously-skip-permissions \
-    --allowed-tools "Edit,Write,Read,Bash" \
-    "${PROMPT}" < /dev/null ) \
+    --allowed-tools "Edit,Write,Read,Bash" ) \
   || echo "::warning::autofix-agent: claude headless run exited non-zero or timed out; train will check for a partial commit." >&2
 
 # Intentionally exit 0: success/failure is judged by whether a NEW commit landed


### PR DESCRIPTION
## Summary
The agent's AI autofix has NEVER run the model: `claude --print --allowed-tools "Edit,Write,Read,Bash" "$PROMPT"` — --allowed-tools is variadic and swallowed the trailing $PROMPT positional, so claude got no prompt and exited <1s ('Input must be provided ... when using --print'). Every 'autofix produced no commit -> escalate' was this, not the model failing. Fix: pipe the prompt on stdin.

## Changes Made
- autofix-agent.sh: `printf '%s' "$PROMPT" | claude --print --allowed-tools ...` (prompt via stdin).

## Breaking Changes
None.
## Gate Impact
- [x] No gate impact (merge-train CI-infra only)
## Testing
- [x] bash -n; fixtures 124/0; confirmed via run-log the prior invocation exited on 'Input must be provided'.

Related to #1387