### PR TITLE
ci(merge-train): give autofix per-failing-job error logs (was fixing blind)

### DIFF
--- a/scripts/ci/merge-train/classify-flake.sh
+++ b/scripts/ci/merge-train/classify-flake.sh
@@ -38,6 +38,27 @@ train_run_logs_match_flake() {
   return 1
 }
 
+# train_failing_job_logs <run-id>: concatenated per-failing-job log TAILS, for the
+# autofix's error context. `gh run view --log-failed` returns EMPTY on a large
+# run_all batch CI (the #2060 bug), so without this the autofix fixed BLIND — no
+# error output, and no test FQNs when the failures are non-shard jobs (Build &
+# Format, CI Router Validation). Per-job logs are bounded and carry the real
+# errors (format diff, unmapped-class, assertion tails). Each job's tail is capped
+# and the whole is capped so it can't blow the prompt.
+train_failing_job_logs() {
+  local run_id="$1" jids jid out="" cap="${TRAIN_AUTOFIX_PERJOB_CAP:-5000}"
+  jids="$(gh run view "${run_id}" --json jobs \
+    --jq '[.jobs[] | select(.conclusion=="failure")] | .[].databaseId' 2>/dev/null || echo "")"
+  if [[ -z "${jids}" ]]; then
+    gh run view "${run_id}" --log-failed 2>/dev/null | tail -c 12000 || echo ""
+    return 0
+  fi
+  for jid in ${jids}; do
+    out+="$(gh run view --job "${jid}" --log 2>/dev/null | tail -c "${cap}" || true)"$'\n'
+  done
+  printf '%s' "${out}" | tail -c 12000
+}
+
 # train_classify_flake <run-id> <rerun-count>: if the failure looks like a flake
 # and we are under the rerun cap, issue ONE rerun and return 0 (caller re-polls).
 # Otherwise return 1 (treat as real -> attribute). The rerun is side-effecting

--- a/scripts/ci/merge-train/train.sh
+++ b/scripts/ci/merge-train/train.sh
@@ -287,7 +287,11 @@ main() {
       _write_state "${batch}" "${trunk_sha}" "${included}" "autofix" "${run_id}" "${fwdfix}" "${flake_reruns}"
       local fqns errout
       fqns="$(train_failed_test_names "${run_id}")"
-      errout="$(gh run view "${run_id}" --log-failed 2>/dev/null | tail -c 12000 || echo "")"
+      # Per-FAILING-JOB logs, not `--log-failed` (which is EMPTY on a run_all batch
+      # CI — the #2060 bug). Without this the autofix had no error context and fixed
+      # blind, so its commits never resolved the failure (esp. non-shard jobs like
+      # Build & Format / CI Router Validation that have no test FQNs at all).
+      errout="$(train_failing_job_logs "${run_id}")"
       if train_autofix_attempt "${batch}" "${failing}" "${fqns}" "${errout}" "${autofix_attempts}"; then
         autofix_attempts=$((autofix_attempts + 1))
         train_metric_set autofix_attempts "${autofix_attempts}"


### PR DESCRIPTION
## Summary
With #2119 the autofix model runs+commits, but its fixes don't resolve the failure because it fixes BLIND: errout came from `gh run view --log-failed` = EMPTY on a run_all batch CI (the #2060 bug). So the model got job names but no error output, and no test FQNs for non-shard jobs (Build & Format, CI Router Validation). New train_failing_job_logs feeds each failed job's own log tail.

## Changes Made
- classify-flake.sh: add train_failing_job_logs (per-job log tails, bounded/capped).
- train.sh: autofix errout now uses it instead of empty --log-failed.

## Breaking Changes
None.
## Gate Impact
- [x] No gate impact (merge-train CI-infra only)
## Testing
- [x] bash -n; fixtures 124/0.

Related to #1387