### PR TITLE
feat(geoprocessing): declarative process-executor authoring model + auto-registration (#2122)

### DIFF
--- a/src/Honua.Core/Features/ControlPlane/Abstractions/IProcessExecutor.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/IProcessExecutor.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.ControlPlane.Abstractions;
+
+/// <summary>
+/// A self-describing per-process geoprocessing executor. Extends <see cref="IJobExecutor"/>
+/// with a self-declared set of process ids the executor handles, enabling the
+/// geoprocessing/GDAL dispatchers to auto-register and route by <c>processId</c>
+/// without a hand-maintained constructor that names every executor explicitly
+/// (the GP Devkit authoring contract, issue #2122).
+/// </summary>
+/// <remarks>
+/// An instance property (rather than a <c>[GpProcess]</c> attribute) is used so
+/// that executors which fan a single implementation out over several process ids
+/// — for example the GDAL surface and raster-statistics families — can compute
+/// their id set at construction time, and so the dispatcher can build its routing
+/// table from DI-resolved instances with no reflection (AOT-friendly). Each id in
+/// <see cref="ProcessIds"/> must be unique across the registered executor set;
+/// the dispatcher fails fast on a duplicate or empty declaration.
+/// </remarks>
+public interface IProcessExecutor : IJobExecutor
+{
+    /// <summary>
+    /// The non-empty set of canonical dotted process ids this executor handles
+    /// (e.g. <c>geometry.buffer</c>, or the several <c>surface.*</c> ids a single
+    /// GDAL surface executor serves). Comparison is ordinal. Must contain at least
+    /// one id; ids must not be null, empty, or whitespace.
+    /// </summary>
+    IReadOnlySet<string> ProcessIds { get; }
+}

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/ProcessExecutorRouteTable.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/ProcessExecutorRouteTable.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+
+namespace Honua.Core.Features.ControlPlane.Abstractions;
+
+/// <summary>
+/// Builds the per-process-id routing table a geoprocessing dispatcher uses to
+/// fan a claimed job out to the matching <see cref="IProcessExecutor"/>. Shared by
+/// the managed <c>GeoprocessingDispatchJobExecutor</c> and the native
+/// <c>GdalDispatchJobExecutor</c> so both get identical duplicate/empty-id
+/// diagnostics from a single auto-registration loop (issue #2122).
+/// </summary>
+public static class ProcessExecutorRouteTable
+{
+    /// <summary>
+    /// Builds an ordinal <c>processId -&gt; executor</c> map from the registered
+    /// executor set. Throws <see cref="InvalidOperationException"/> when an executor
+    /// declares no ids, declares a null/whitespace id, or when two executors claim
+    /// the same id — surfacing authoring mistakes at composition time rather than
+    /// silently dropping a process at runtime.
+    /// </summary>
+    /// <param name="executors">The DI-resolved per-process executors.</param>
+    /// <returns>A frozen ordinal lookup keyed by process id.</returns>
+    public static FrozenDictionary<string, IProcessExecutor> Build(
+        IEnumerable<IProcessExecutor> executors)
+    {
+        ArgumentNullException.ThrowIfNull(executors);
+
+        var map = new Dictionary<string, IProcessExecutor>(StringComparer.Ordinal);
+
+        foreach (var executor in executors)
+        {
+            ArgumentNullException.ThrowIfNull(executor);
+
+            var ids = executor.ProcessIds;
+            if (ids is null || ids.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Process executor '{executor.GetType().FullName}' declared no process ids; "
+                    + "every IProcessExecutor must handle at least one canonical process id.");
+            }
+
+            foreach (var id in ids)
+            {
+                if (string.IsNullOrWhiteSpace(id))
+                {
+                    throw new InvalidOperationException(
+                        $"Process executor '{executor.GetType().FullName}' declared a null or "
+                        + "whitespace process id; process ids must be non-empty dotted identifiers.");
+                }
+
+                if (map.TryGetValue(id, out var existing))
+                {
+                    throw new InvalidOperationException(
+                        $"Duplicate geoprocessing process id '{id}' declared by both "
+                        + $"'{existing.GetType().FullName}' and '{executor.GetType().FullName}'. "
+                        + "Each process id must be handled by exactly one executor.");
+                }
+
+                map[id] = executor;
+            }
+        }
+
+        return map.ToFrozenDictionary(StringComparer.Ordinal);
+    }
+}

--- a/src/Honua.Core/Features/Geoprocessing/Domain/ProcessSchemaJsonGenerator.cs
+++ b/src/Honua.Core/Features/Geoprocessing/Domain/ProcessSchemaJsonGenerator.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+
+namespace Honua.Core.Features.Geoprocessing.Domain;
+
+/// <summary>
+/// Emits a JSON Schema (draft 2020-12) document for a <see cref="ProcessDefinition"/>'s
+/// typed input parameters, plus a compact output descriptor for the artifact kinds the
+/// process produces. This is the authoring-contract schema surface the GP Devkit
+/// <c>describe</c> command (issue #2124) consumes; it derives entirely from the typed
+/// <see cref="ProcessParameterSpec"/> set rather than a hand-written schema, so the
+/// advertised schema can never drift from the catalog (issue #2122).
+/// </summary>
+/// <remarks>
+/// The document is written with a <see cref="Utf8JsonWriter"/> (no reflection-based
+/// serialization) so it stays AOT-safe.
+/// </remarks>
+public static class ProcessSchemaJsonGenerator
+{
+    private const string SchemaDialect = "https://json-schema.org/draft/2020-12/schema";
+
+    /// <summary>
+    /// Produces the JSON Schema document for the given process definition as a UTF-8
+    /// JSON string. The root object has <c>processId</c>, <c>title</c>,
+    /// <c>description</c>, <c>category</c>, <c>runtimeProfile</c>, an <c>inputs</c>
+    /// JSON Schema object (with <c>properties</c>/<c>required</c>), and an
+    /// <c>outputs</c> array describing the produced artifact kinds.
+    /// </summary>
+    /// <param name="process">The catalog process definition. Must not be null.</param>
+    /// <param name="indented">Whether to pretty-print the output.</param>
+    public static string Generate(ProcessDefinition process, bool indented = true)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = indented }))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("processId", process.ProcessId);
+            writer.WriteString("title", process.Title);
+            writer.WriteString("description", process.Description);
+            writer.WriteString("category", process.Category);
+            writer.WriteString("runtimeProfile", process.RuntimeProfile);
+
+            WriteInputsSchema(writer, process);
+            WriteOutputs(writer, process);
+
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    private static void WriteInputsSchema(Utf8JsonWriter writer, ProcessDefinition process)
+    {
+        writer.WritePropertyName("inputs");
+        writer.WriteStartObject();
+        writer.WriteString("$schema", SchemaDialect);
+        writer.WriteString("type", "object");
+
+        writer.WritePropertyName("properties");
+        writer.WriteStartObject();
+        foreach (var parameter in process.Parameters)
+        {
+            writer.WritePropertyName(parameter.Name);
+            WriteParameterSchema(writer, parameter);
+        }
+
+        writer.WriteEndObject();
+
+        // Required array — only the parameters flagged Required, in declared order.
+        writer.WritePropertyName("required");
+        writer.WriteStartArray();
+        foreach (var parameter in process.Parameters)
+        {
+            if (parameter.Required)
+            {
+                writer.WriteStringValue(parameter.Name);
+            }
+        }
+
+        writer.WriteEndArray();
+
+        // Authoring contract: the parameter set is closed.
+        writer.WriteBoolean("additionalProperties", false);
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteParameterSchema(Utf8JsonWriter writer, ProcessParameterSpec parameter)
+    {
+        writer.WriteStartObject();
+
+        var (jsonType, format) = MapType(parameter.ValueType);
+        writer.WriteString("type", jsonType);
+        if (format is not null)
+        {
+            writer.WriteString("format", format);
+        }
+
+        writer.WriteString("title", parameter.DisplayName);
+        writer.WriteString("description", parameter.Description);
+
+        if (parameter.DefaultValue is not null)
+        {
+            writer.WriteString("default", parameter.DefaultValue);
+        }
+
+        if (parameter.AllowedValues is { Count: > 0 })
+        {
+            writer.WritePropertyName("enum");
+            writer.WriteStartArray();
+            foreach (var allowed in parameter.AllowedValues)
+            {
+                writer.WriteStringValue(allowed);
+            }
+
+            writer.WriteEndArray();
+        }
+
+        // Surface the canonical Honua value type so authoring tools can render a
+        // precise editor (e.g. a WKB picker for Wkb, a layer chooser for LayerId)
+        // beyond the coarse JSON Schema primitive.
+        writer.WriteString("x-honua-value-type", parameter.ValueType.ToString());
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteOutputs(Utf8JsonWriter writer, ProcessDefinition process)
+    {
+        writer.WritePropertyName("outputs");
+        writer.WriteStartArray();
+        foreach (var kind in process.OutputArtifactKinds)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("artifactKind", kind.ToString());
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+    }
+
+    /// <summary>
+    /// Maps a Honua <see cref="ProcessParameterValueType"/> to a JSON Schema
+    /// <c>(type, format)</c> pair. Geometry/array/identifier types are represented by
+    /// their closest JSON Schema primitive plus a descriptive <c>format</c>; the
+    /// precise type is also carried on <c>x-honua-value-type</c>.
+    /// </summary>
+    private static (string Type, string? Format) MapType(ProcessParameterValueType valueType)
+        => valueType switch
+        {
+            ProcessParameterValueType.Text => ("string", null),
+            ProcessParameterValueType.WholeNumber => ("integer", "int32"),
+            ProcessParameterValueType.FloatingPoint => ("number", "double"),
+            ProcessParameterValueType.Flag => ("boolean", null),
+            ProcessParameterValueType.Wkb => ("string", "wkb-base64"),
+            ProcessParameterValueType.WkbArray => ("array", "wkb-base64"),
+            ProcessParameterValueType.Srid => ("integer", "srid"),
+            ProcessParameterValueType.LayerId => ("string", "layer-id"),
+            _ => ("string", null),
+        };
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/CsvSourceExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/CsvSourceExecutor.cs
@@ -29,7 +29,7 @@ namespace Honua.Geoprocessing.Execution;
 /// delimiter auto-detection and file-path streaming belong to a later streaming-source
 /// stream.
 /// </remarks>
-internal sealed class CsvSourceExecutor(IOptionsMonitor<GeoprocessingExecutorOptions> options) : IJobExecutor
+internal sealed class CsvSourceExecutor(IOptionsMonitor<GeoprocessingExecutorOptions> options) : IProcessExecutor
 {
     internal const string HandledProcessId = "source.csv";
 
@@ -44,6 +44,13 @@ internal sealed class CsvSourceExecutor(IOptionsMonitor<GeoprocessingExecutorOpt
         new[] { "lat", "latitude", "y" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options = options;
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutor.cs
@@ -26,7 +26,7 @@ namespace Honua.Geoprocessing.Execution;
 /// interpolation since they cannot be parameterized in DDL/DML. Every row's attributes JSONB
 /// carries a reserved <c>__pipeline_batch_id</c> key for soft-delete rollback.
 /// </summary>
-internal sealed partial class ExternalPostgisSinkExecutor : IJobExecutor
+internal sealed partial class ExternalPostgisSinkExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "sink.external-postgis";
 
@@ -63,6 +63,13 @@ internal sealed partial class ExternalPostgisSinkExecutor : IJobExecutor
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ExternalPostgisSinkExecutor>.Instance;
         _secureConnectionResolver = secureConnectionResolver;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureCollectionTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureCollectionTransformExecutor.cs
@@ -18,10 +18,11 @@ namespace Honua.Geoprocessing.Execution;
 /// shape: the executor is the sole worker-side behavior for a single dotted
 /// process id and surfaces automatically as a <c>process:&lt;id&gt;</c> workflow node.
 /// </summary>
-internal abstract partial class FeatureCollectionTransformExecutor : IJobExecutor
+internal abstract partial class FeatureCollectionTransformExecutor : IProcessExecutor
 {
     private protected readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options;
     private readonly ILogger _logger;
+    private IReadOnlySet<string>? _processIds;
 
     protected FeatureCollectionTransformExecutor(
         IOptionsMonitor<GeoprocessingExecutorOptions> options,
@@ -43,6 +44,10 @@ internal abstract partial class FeatureCollectionTransformExecutor : IJobExecuto
     /// The single dotted process id this executor handles (e.g. <c>transform.reproject</c>).
     /// </summary>
     protected abstract string ProcessId { get; }
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds =>
+        _processIds ??= new HashSet<string>(StringComparer.Ordinal) { ProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonFileSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonFileSinkExecutor.cs
@@ -20,7 +20,7 @@ namespace Honua.Geoprocessing.Execution;
 /// null geometry are written (GeoJSON permits a null geometry member) but counted as
 /// rejected so the result reflects them.
 /// </summary>
-internal sealed partial class GeoJsonFileSinkExecutor : IJobExecutor
+internal sealed partial class GeoJsonFileSinkExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "sink.geojson-file";
 
@@ -40,6 +40,13 @@ internal sealed partial class GeoJsonFileSinkExecutor : IJobExecutor
         : this(options, Microsoft.Extensions.Logging.Abstractions.NullLogger<GeoJsonFileSinkExecutor>.Instance)
     {
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonSourceExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonSourceExecutor.cs
@@ -22,11 +22,18 @@ namespace Honua.Geoprocessing.Execution;
 /// this executor accepts an <c>inline</c> GeoJSON document or an <c>input</c> data URI.
 /// File-path streaming for very large inputs belongs to a later streaming-source stream.
 /// </remarks>
-internal sealed class GeoJsonSourceExecutor(IOptionsMonitor<GeoprocessingExecutorOptions> options) : IJobExecutor
+internal sealed class GeoJsonSourceExecutor(IOptionsMonitor<GeoprocessingExecutorOptions> options) : IProcessExecutor
 {
     internal const string HandledProcessId = "source.geojson";
 
     private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options = options;
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryAreaJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryAreaJobExecutor.cs
@@ -28,7 +28,7 @@ namespace Honua.Geoprocessing.Execution;
 /// geodesic path is tracked as a follow-on slice alongside the geodesic
 /// buffer / length executors.
 /// </summary>
-internal sealed partial class GeometryAreaJobExecutor : IJobExecutor
+internal sealed partial class GeometryAreaJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog entry
@@ -48,6 +48,13 @@ internal sealed partial class GeometryAreaJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryBufferJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryBufferJobExecutor.cs
@@ -26,7 +26,7 @@ namespace Honua.Geoprocessing.Execution;
 /// terminally with a clean classification — the dispatcher is intentionally
 /// narrow until additional executors land.
 /// </summary>
-internal sealed partial class GeometryBufferJobExecutor : IJobExecutor
+internal sealed partial class GeometryBufferJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog entry in
@@ -44,6 +44,13 @@ internal sealed partial class GeometryBufferJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryCentroidJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryCentroidJobExecutor.cs
@@ -24,7 +24,7 @@ namespace Honua.Geoprocessing.Execution;
 /// of the input geometry type, matching the long-standing GeoServices and
 /// PostGIS <c>ST_Centroid</c> semantics.
 /// </summary>
-internal sealed partial class GeometryCentroidJobExecutor : IJobExecutor
+internal sealed partial class GeometryCentroidJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -42,6 +42,13 @@ internal sealed partial class GeometryCentroidJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryClipJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryClipJobExecutor.cs
@@ -23,7 +23,7 @@ namespace Honua.Geoprocessing.Execution;
 /// is used (not the polygon itself), so this executor materializes the
 /// clip envelope and intersects the target with it.
 /// </summary>
-internal sealed partial class GeometryClipJobExecutor : IJobExecutor
+internal sealed partial class GeometryClipJobExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "geometry.clip";
 
@@ -37,6 +37,13 @@ internal sealed partial class GeometryClipJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryConvexHullJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryConvexHullJobExecutor.cs
@@ -27,7 +27,7 @@ namespace Honua.Geoprocessing.Execution;
 /// hull over all member vertices, which is the canonical "hull of the
 /// union" behavior used by PostGIS <c>ST_ConvexHull</c>.
 /// </summary>
-internal sealed partial class GeometryConvexHullJobExecutor : IJobExecutor
+internal sealed partial class GeometryConvexHullJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -45,6 +45,13 @@ internal sealed partial class GeometryConvexHullJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryDifferenceJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryDifferenceJobExecutor.cs
@@ -25,7 +25,7 @@ namespace Honua.Geoprocessing.Execution;
 /// <see cref="GeometryIntersectJobExecutor"/>: both geometries must share the
 /// supplied SRID; reprojection is handled by <see cref="GeometryProjectJobExecutor"/>.
 /// </summary>
-internal sealed partial class GeometryDifferenceJobExecutor : IJobExecutor
+internal sealed partial class GeometryDifferenceJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -43,6 +43,13 @@ internal sealed partial class GeometryDifferenceJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryDissolveJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryDissolveJobExecutor.cs
@@ -30,7 +30,7 @@ namespace Honua.Geoprocessing.Execution;
 /// through the dissolve artifact shape so downstream consumers can rely
 /// on the FeatureCollection envelope.
 /// </summary>
-internal sealed partial class GeometryDissolveJobExecutor : IJobExecutor
+internal sealed partial class GeometryDissolveJobExecutor : IProcessExecutor
 {
     private const string FeatureCollectionDataUriPrefix = "data:application/geo+json;base64,";
     private const string DefaultGroupKey = "__all__";
@@ -51,6 +51,13 @@ internal sealed partial class GeometryDissolveJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryIntersectJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryIntersectJobExecutor.cs
@@ -19,7 +19,7 @@ namespace Honua.Geoprocessing.Execution;
 /// intersector geometry. Both geometries must share the supplied SRID;
 /// reprojection is handled by <see cref="GeometryProjectJobExecutor"/>.
 /// </summary>
-internal sealed partial class GeometryIntersectJobExecutor : IJobExecutor
+internal sealed partial class GeometryIntersectJobExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "geometry.intersect";
 
@@ -33,6 +33,13 @@ internal sealed partial class GeometryIntersectJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryLengthJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryLengthJobExecutor.cs
@@ -27,7 +27,7 @@ namespace Honua.Geoprocessing.Execution;
 /// <see cref="Geometry.Length"/> for line geometries; for polygons NTS
 /// returns the perimeter, which is consistent with the catalog description.
 /// </summary>
-internal sealed partial class GeometryLengthJobExecutor : IJobExecutor
+internal sealed partial class GeometryLengthJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -47,6 +47,13 @@ internal sealed partial class GeometryLengthJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryMakeValidJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryMakeValidJobExecutor.cs
@@ -27,7 +27,7 @@ namespace Honua.Geoprocessing.Execution;
 /// <c>data:application/geo+json;base64,</c> envelope, matching the rest of the
 /// deterministic single-geometry <c>geometry.*</c> family.
 /// </summary>
-internal sealed partial class GeometryMakeValidJobExecutor : IJobExecutor
+internal sealed partial class GeometryMakeValidJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -45,6 +45,13 @@ internal sealed partial class GeometryMakeValidJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryProjectJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryProjectJobExecutor.cs
@@ -24,7 +24,7 @@ namespace Honua.Geoprocessing.Execution;
 /// first-slice executor remains deterministic without a PostGIS round-trip;
 /// those pairs are tracked as a follow-on.
 /// </summary>
-internal sealed partial class GeometryProjectJobExecutor : IJobExecutor
+internal sealed partial class GeometryProjectJobExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "geometry.project";
 
@@ -41,6 +41,13 @@ internal sealed partial class GeometryProjectJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometrySimplifyJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometrySimplifyJobExecutor.cs
@@ -29,7 +29,7 @@ namespace Honua.Geoprocessing.Execution;
 /// <c>ST_Simplify</c> and can produce invalid geometries on near-tolerance
 /// vertices, which is why preservation is the default.
 /// </summary>
-internal sealed partial class GeometrySimplifyJobExecutor : IJobExecutor
+internal sealed partial class GeometrySimplifyJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -47,6 +47,13 @@ internal sealed partial class GeometrySimplifyJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometrySnapJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometrySnapJobExecutor.cs
@@ -28,7 +28,7 @@ namespace Honua.Geoprocessing.Execution;
 /// polygons. The reference geometry is consumed for vertex
 /// reference only; only the input geometry's coordinates are mutated.
 /// </summary>
-internal sealed partial class GeometrySnapJobExecutor : IJobExecutor
+internal sealed partial class GeometrySnapJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -46,6 +46,13 @@ internal sealed partial class GeometrySnapJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryUnionJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryUnionJobExecutor.cs
@@ -28,7 +28,7 @@ namespace Honua.Geoprocessing.Execution;
 /// All inputs must share the supplied SRID; reprojection is handled by
 /// <see cref="GeometryProjectJobExecutor"/>.
 /// </summary>
-internal sealed partial class GeometryUnionJobExecutor : IJobExecutor
+internal sealed partial class GeometryUnionJobExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "geometry.union";
 
@@ -42,6 +42,13 @@ internal sealed partial class GeometryUnionJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
@@ -32,114 +32,25 @@ namespace Honua.Geoprocessing.Execution;
 /// </summary>
 internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
 {
-    private readonly FrozenDictionary<string, IJobExecutor> _handlers;
+    private readonly FrozenDictionary<string, IProcessExecutor> _handlers;
     private readonly ILogger<GeoprocessingDispatchJobExecutor> _logger;
 
+    /// <summary>
+    /// Composes the dispatcher over the auto-registered per-process executors
+    /// (issue #2122). Each <see cref="IProcessExecutor"/> self-declares the process
+    /// ids it handles through <see cref="IProcessExecutor.ProcessIds"/>, so the
+    /// routing table is built from a single DI scan instead of a hand-maintained
+    /// constructor naming every executor. Duplicate or empty ids fail fast at
+    /// composition time via <see cref="ProcessExecutorRouteTable.Build"/>.
+    /// </summary>
     public GeoprocessingDispatchJobExecutor(
-        GeometryBufferJobExecutor buffer,
-        GeometryClipJobExecutor clip,
-        GeometryIntersectJobExecutor intersect,
-        GeometryProjectJobExecutor project,
-        GeometryAreaJobExecutor area,
-        GeometryUnionJobExecutor union,
-        GeometryCentroidJobExecutor centroid,
-        GeometryLengthJobExecutor length,
-        GeometryConvexHullJobExecutor convexHull,
-        GeometryDissolveJobExecutor dissolve,
-        GeometrySimplifyJobExecutor simplify,
-        GeometrySnapJobExecutor snap,
-        GeometryMakeValidJobExecutor makeValid,
-        GeometryDifferenceJobExecutor difference,
-        ManagedSpatialJoinExecutor spatialJoinManaged,
-        ManagedClusterExecutor clusterManaged,
-        ManagedBufferAggregateExecutor bufferAggregateManaged,
-        ManagedDensityExecutor densityManaged,
-        AttributeRenameTransformExecutor attributeRename,
-        AttributeCastTransformExecutor attributeCast,
-        ComputedFieldTransformExecutor computedField,
-        AttributeFilterTransformExecutor attributeFilter,
-        SpatialFilterTransformExecutor spatialFilter,
-        ClipTransformExecutor clip2,
-        DedupTransformExecutor dedup,
-        ReprojectTransformExecutor reproject,
-        GeoJsonSourceExecutor geoJsonSource,
-        CsvSourceExecutor csvSource,
-        GeoJsonFileSinkExecutor geoJsonFileSink,
-        QuarantineSinkExecutor quarantineSink,
-        ExternalPostgisSinkExecutor externalPostgisSink,
-        ImportDatasetJobExecutor importDataset,
+        IEnumerable<IProcessExecutor> executors,
         ILogger<GeoprocessingDispatchJobExecutor> logger)
     {
-        ArgumentNullException.ThrowIfNull(buffer);
-        ArgumentNullException.ThrowIfNull(clip);
-        ArgumentNullException.ThrowIfNull(intersect);
-        ArgumentNullException.ThrowIfNull(project);
-        ArgumentNullException.ThrowIfNull(area);
-        ArgumentNullException.ThrowIfNull(union);
-        ArgumentNullException.ThrowIfNull(centroid);
-        ArgumentNullException.ThrowIfNull(length);
-        ArgumentNullException.ThrowIfNull(convexHull);
-        ArgumentNullException.ThrowIfNull(dissolve);
-        ArgumentNullException.ThrowIfNull(simplify);
-        ArgumentNullException.ThrowIfNull(snap);
-        ArgumentNullException.ThrowIfNull(makeValid);
-        ArgumentNullException.ThrowIfNull(difference);
-        ArgumentNullException.ThrowIfNull(spatialJoinManaged);
-        ArgumentNullException.ThrowIfNull(clusterManaged);
-        ArgumentNullException.ThrowIfNull(bufferAggregateManaged);
-        ArgumentNullException.ThrowIfNull(densityManaged);
-        ArgumentNullException.ThrowIfNull(attributeRename);
-        ArgumentNullException.ThrowIfNull(attributeCast);
-        ArgumentNullException.ThrowIfNull(computedField);
-        ArgumentNullException.ThrowIfNull(attributeFilter);
-        ArgumentNullException.ThrowIfNull(spatialFilter);
-        ArgumentNullException.ThrowIfNull(clip2);
-        ArgumentNullException.ThrowIfNull(dedup);
-        ArgumentNullException.ThrowIfNull(reproject);
-        ArgumentNullException.ThrowIfNull(geoJsonSource);
-        ArgumentNullException.ThrowIfNull(csvSource);
-        ArgumentNullException.ThrowIfNull(geoJsonFileSink);
-        ArgumentNullException.ThrowIfNull(quarantineSink);
-        ArgumentNullException.ThrowIfNull(externalPostgisSink);
-        ArgumentNullException.ThrowIfNull(importDataset);
+        ArgumentNullException.ThrowIfNull(executors);
         ArgumentNullException.ThrowIfNull(logger);
 
-        _handlers = new Dictionary<string, IJobExecutor>(StringComparer.Ordinal)
-        {
-            [GeometryBufferJobExecutor.HandledProcessId] = buffer,
-            [GeometryClipJobExecutor.HandledProcessId] = clip,
-            [GeometryIntersectJobExecutor.HandledProcessId] = intersect,
-            [GeometryProjectJobExecutor.HandledProcessId] = project,
-            [GeometryAreaJobExecutor.HandledProcessId] = area,
-            [GeometryUnionJobExecutor.HandledProcessId] = union,
-            [GeometryCentroidJobExecutor.HandledProcessId] = centroid,
-            [GeometryLengthJobExecutor.HandledProcessId] = length,
-            [GeometryConvexHullJobExecutor.HandledProcessId] = convexHull,
-            [GeometryDissolveJobExecutor.HandledProcessId] = dissolve,
-            [GeometrySimplifyJobExecutor.HandledProcessId] = simplify,
-            [GeometrySnapJobExecutor.HandledProcessId] = snap,
-            [GeometryMakeValidJobExecutor.HandledProcessId] = makeValid,
-            [GeometryDifferenceJobExecutor.HandledProcessId] = difference,
-            [ManagedSpatialJoinExecutor.HandledProcessId] = spatialJoinManaged,
-            [ManagedClusterExecutor.HandledProcessId] = clusterManaged,
-            [ManagedBufferAggregateExecutor.HandledProcessId] = bufferAggregateManaged,
-            [ManagedDensityExecutor.HandledProcessId] = densityManaged,
-            [AttributeRenameTransformExecutor.HandledProcessId] = attributeRename,
-            [AttributeCastTransformExecutor.HandledProcessId] = attributeCast,
-            [ComputedFieldTransformExecutor.HandledProcessId] = computedField,
-            [AttributeFilterTransformExecutor.HandledProcessId] = attributeFilter,
-            [SpatialFilterTransformExecutor.HandledProcessId] = spatialFilter,
-            [ClipTransformExecutor.HandledProcessId] = clip2,
-            [DedupTransformExecutor.HandledProcessId] = dedup,
-            [ReprojectTransformExecutor.HandledProcessId] = reproject,
-            [GeoJsonSourceExecutor.HandledProcessId] = geoJsonSource,
-            [CsvSourceExecutor.HandledProcessId] = csvSource,
-            [GeoJsonFileSinkExecutor.HandledProcessId] = geoJsonFileSink,
-            [QuarantineSinkExecutor.HandledProcessId] = quarantineSink,
-            [ExternalPostgisSinkExecutor.HandledProcessId] = externalPostgisSink,
-            [ImportDatasetJobExecutor.HandledProcessId] = importDataset,
-        }.ToFrozenDictionary(StringComparer.Ordinal);
-
+        _handlers = ProcessExecutorRouteTable.Build(executors);
         _logger = logger;
     }
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ImportDatasetJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ImportDatasetJobExecutor.cs
@@ -58,7 +58,7 @@ namespace Honua.Geoprocessing.Execution;
 /// rather than checkpointing each row; finer-grained resume is deferred.
 /// </para>
 /// </summary>
-internal sealed partial class ImportDatasetJobExecutor : IJobExecutor
+internal sealed partial class ImportDatasetJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog entry
@@ -84,6 +84,13 @@ internal sealed partial class ImportDatasetJobExecutor : IJobExecutor
         _serviceScopeFactory = serviceScopeFactory;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/QuarantineSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/QuarantineSinkExecutor.cs
@@ -19,7 +19,7 @@ namespace Honua.Geoprocessing.Execution;
 /// rejected rows route here instead of aborting the run. Reconciled from the GeoETL
 /// baseline QuarantineSinkConnector onto the #1185 process/executor contract.
 /// </summary>
-internal sealed partial class QuarantineSinkExecutor : IJobExecutor
+internal sealed partial class QuarantineSinkExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "sink.quarantine";
 
@@ -41,6 +41,13 @@ internal sealed partial class QuarantineSinkExecutor : IJobExecutor
         : this(options, Microsoft.Extensions.Logging.Abstractions.NullLogger<QuarantineSinkExecutor>.Instance)
     {
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -93,82 +93,25 @@ internal static class GeoprocessingServiceCollectionExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
-        // Built-in production executors (ticket #1031). Slice 1 introduced the
-        // first concrete executor (geometry.buffer); slice 2 added geometry.clip,
-        // geometry.intersect, and geometry.project; slice 3 added geometry.area
-        // (per-feature measure) and geometry.union (collection aggregation);
-        // slice 4 added geometry.centroid, geometry.length, and
-        // geometry.convex-hull — rounding out the deterministic single-feature
-        // vector set; slice 5 lands the migration-priority shape transforms
-        // geometry.dissolve (group-aware aggregate), geometry.simplify
-        // (Douglas-Peucker), and geometry.snap (vertex conditioning) so the
-        // workspace covers the common parity targets before later slices
-        // tackle the heavyweight raster / surface families. The worker host
-        // keys executors by ExecutionJobKind, so the per-process executors
-        // are composed behind GeoprocessingDispatchJobExecutor — the single
-        // IJobExecutor registered for ExecutionJobKind.Geoprocessing — which
-        // routes claimed jobs to the matching handler.
-        services.TryAddSingleton<GeometryBufferJobExecutor>();
-        services.TryAddSingleton<GeometryClipJobExecutor>();
-        services.TryAddSingleton<GeometryIntersectJobExecutor>();
-        services.TryAddSingleton<GeometryProjectJobExecutor>();
-        services.TryAddSingleton<GeometryAreaJobExecutor>();
-        services.TryAddSingleton<GeometryUnionJobExecutor>();
-        services.TryAddSingleton<GeometryCentroidJobExecutor>();
-        services.TryAddSingleton<GeometryLengthJobExecutor>();
-        services.TryAddSingleton<GeometryConvexHullJobExecutor>();
-        services.TryAddSingleton<GeometryDissolveJobExecutor>();
-        services.TryAddSingleton<GeometrySimplifyJobExecutor>();
-        services.TryAddSingleton<GeometrySnapJobExecutor>();
-
-        // Catalog-honesty reconciliation onto #1185: geometry.make-valid and
-        // geometry.difference were advertised in the catalog (and flagged
-        // synchronous / first-slice automated) on trunk but had no executor, so
-        // a job submission could never reach them. Add the managed NTS executors
-        // (GeometryFixer / Geometry.Difference) so the advertised set is honest.
-        services.TryAddSingleton<GeometryMakeValidJobExecutor>();
-        services.TryAddSingleton<GeometryDifferenceJobExecutor>();
-
-        // Managed spatial-join (analytics.spatial-join-managed) — a job-dispatchable
-        // counterpart to trunk's analytics.spatial-join, which runs only through the
-        // synchronous PostGIS SpatialAnalytics protocol and is not job-routed. NTS
-        // STRtree aggregate join over two inline FeatureCollections; no Postgres.
-        services.TryAddSingleton<ManagedSpatialJoinExecutor>();
-
-        // Managed analytics counterparts for cluster / buffer-aggregate / density
-        // (#1260). Each is the workflow/codemod-reachable counterpart to the
-        // matching analytics.* PostGIS-protocol path: NTS over an inline
-        // FeatureCollection, no Postgres dependency, so the lean dispatcher can
-        // construct them unconditionally.
-        services.TryAddSingleton<ManagedClusterExecutor>();
-        services.TryAddSingleton<ManagedBufferAggregateExecutor>();
-        services.TryAddSingleton<ManagedDensityExecutor>();
-
-        // GeoETL transform executors reconciled from feat/geoetl-baseline onto the
-        // #1185 add-a-capability contract. Each reads/writes a FeatureCollection
-        // data URI and is composed behind GeoprocessingDispatchJobExecutor.
-        services.TryAddSingleton<AttributeRenameTransformExecutor>();
-        services.TryAddSingleton<AttributeCastTransformExecutor>();
-        services.TryAddSingleton<ComputedFieldTransformExecutor>();
-        services.TryAddSingleton<AttributeFilterTransformExecutor>();
-        services.TryAddSingleton<SpatialFilterTransformExecutor>();
-        services.TryAddSingleton<ClipTransformExecutor>();
-        services.TryAddSingleton<DedupTransformExecutor>();
-        services.TryAddSingleton<ReprojectTransformExecutor>();
-        services.TryAddSingleton<GeoJsonSourceExecutor>();
-        services.TryAddSingleton<CsvSourceExecutor>();
-        services.TryAddSingleton<GeoJsonFileSinkExecutor>();
-        services.TryAddSingleton<QuarantineSinkExecutor>();
-        services.TryAddSingleton<ExternalPostgisSinkExecutor>();
-
-        // Import-dataset orchestration executor (#1630). Owns the full durable
-        // import pipeline (fetch -> validate+chunk -> import -> flatten -> tile ->
-        // extent+MVT refresh -> provenance) by composing the existing provider
-        // services, which it resolves at execution time through an
-        // IServiceScopeFactory scope (the provider implementations live in the
-        // active data-provider assembly, out of reach for this module — the same
-        // pattern ExternalPostgisSinkExecutor uses).
-        services.TryAddSingleton<ImportDatasetJobExecutor>();
+        // Built-in production executors (ticket #1031; GP Devkit authoring
+        // contract #2122). Each per-process executor implements IProcessExecutor
+        // and self-declares the process id(s) it handles, so they are registered
+        // through a single auto-registration scan rather than ~31 hand-maintained
+        // lines, and GeoprocessingDispatchJobExecutor — the single IJobExecutor
+        // registered for ExecutionJobKind.Geoprocessing — builds its routing table
+        // by enumerating IProcessExecutor and keying by ProcessIds.
+        //
+        // The executor families composed behind the dispatcher:
+        //  - geometry.* deterministic single-feature / aggregate vector ops
+        //    (buffer/clip/intersect/project/area/union/centroid/length/
+        //     convex-hull/dissolve/simplify/snap), plus the catalog-honesty
+        //    reconciliation of geometry.make-valid + geometry.difference (#1185);
+        //  - analytics.*-managed NTS counterparts to the PostGIS-protocol analytics
+        //    paths (spatial-join/cluster/buffer-aggregate/density, #1260);
+        //  - transform.* / source.* / sink.* GeoETL executors (feat/geoetl-baseline
+        //    reconciled onto the #1185 add-a-capability contract);
+        //  - import.dataset durable import orchestration (#1630).
+        AddProcessExecutors(services);
 
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IJobExecutor, GeoprocessingDispatchJobExecutor>());
@@ -179,5 +122,70 @@ internal static class GeoprocessingServiceCollectionExtensions
         // Honua.Server.Features.Admin.Share (out of reach for this assembly).
 
         return services;
+    }
+
+    /// <summary>
+    /// Auto-registers every built-in <see cref="IProcessExecutor"/> (GP Devkit
+    /// authoring contract #2122). Each executor is registered as its concrete type
+    /// (so call sites that resolve a specific executor keep working) and is also
+    /// surfaced into the enumerable <see cref="IProcessExecutor"/> set the
+    /// <see cref="GeoprocessingDispatchJobExecutor"/> enumerates — both bound to the
+    /// SAME singleton instance via a resolving factory, so there is exactly one of
+    /// each. No reflection scan is used, keeping the registration AOT-safe; adding a
+    /// new managed process is a one-line <c>Register&lt;T&gt;</c> call here plus its
+    /// catalog entry.
+    /// </summary>
+    private static void AddProcessExecutors(IServiceCollection services)
+    {
+        Register<GeometryBufferJobExecutor>(services);
+        Register<GeometryClipJobExecutor>(services);
+        Register<GeometryIntersectJobExecutor>(services);
+        Register<GeometryProjectJobExecutor>(services);
+        Register<GeometryAreaJobExecutor>(services);
+        Register<GeometryUnionJobExecutor>(services);
+        Register<GeometryCentroidJobExecutor>(services);
+        Register<GeometryLengthJobExecutor>(services);
+        Register<GeometryConvexHullJobExecutor>(services);
+        Register<GeometryDissolveJobExecutor>(services);
+        Register<GeometrySimplifyJobExecutor>(services);
+        Register<GeometrySnapJobExecutor>(services);
+        Register<GeometryMakeValidJobExecutor>(services);
+        Register<GeometryDifferenceJobExecutor>(services);
+        Register<ManagedSpatialJoinExecutor>(services);
+        Register<ManagedClusterExecutor>(services);
+        Register<ManagedBufferAggregateExecutor>(services);
+        Register<ManagedDensityExecutor>(services);
+        Register<AttributeRenameTransformExecutor>(services);
+        Register<AttributeCastTransformExecutor>(services);
+        Register<ComputedFieldTransformExecutor>(services);
+        Register<AttributeFilterTransformExecutor>(services);
+        Register<SpatialFilterTransformExecutor>(services);
+        Register<ClipTransformExecutor>(services);
+        Register<DedupTransformExecutor>(services);
+        Register<ReprojectTransformExecutor>(services);
+        Register<GeoJsonSourceExecutor>(services);
+        Register<CsvSourceExecutor>(services);
+        Register<GeoJsonFileSinkExecutor>(services);
+        Register<QuarantineSinkExecutor>(services);
+        Register<ExternalPostgisSinkExecutor>(services);
+        Register<ImportDatasetJobExecutor>(services);
+    }
+
+    private static void Register<TExecutor>(IServiceCollection services)
+        where TExecutor : class, IProcessExecutor
+    {
+        services.TryAddSingleton<TExecutor>();
+
+        // Surface the same singleton into the IProcessExecutor enumerable the
+        // dispatcher consumes. Guard against a double-add so a repeated
+        // AddGeoprocessing call cannot register a duplicate id (which would trip
+        // the route-table duplicate-id guard at composition time).
+        if (!services.Any(d =>
+                d.ServiceType == typeof(IProcessExecutor)
+                && d.ImplementationFactory is not null
+                && d.ImplementationFactory.Method.ReturnType == typeof(TExecutor)))
+        {
+            services.AddSingleton<IProcessExecutor>(sp => sp.GetRequiredService<TExecutor>());
+        }
     }
 }

--- a/src/Honua.Worker.Gdal/Execution/GdalDispatchJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalDispatchJobExecutor.cs
@@ -26,60 +26,26 @@ internal sealed partial class GdalDispatchJobExecutor : IJobExecutor
     private static readonly IReadOnlySet<string> NativeProfileSet =
         new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
 
-    private readonly FrozenDictionary<string, IJobExecutor> _handlers;
+    private readonly FrozenDictionary<string, IProcessExecutor> _handlers;
     private readonly ILogger<GdalDispatchJobExecutor> _logger;
 
     /// <summary>
-    /// Composes the dispatcher over the registered GDAL-backed executors.
+    /// Composes the dispatcher over the auto-registered GDAL-backed executors
+    /// (issue #2122). Each <see cref="IProcessExecutor"/> self-declares the process
+    /// ids it handles through <see cref="IProcessExecutor.ProcessIds"/> — including
+    /// the <c>surface.*</c> and <c>raster.statistics/histogram</c> families that fan
+    /// a single executor over several ids — so the O(1) routing table is built from
+    /// a single DI scan via <see cref="ProcessExecutorRouteTable.Build"/> instead of
+    /// a hand-maintained constructor naming every executor and its id set.
     /// </summary>
     public GdalDispatchJobExecutor(
-        GdalVectorConvertJobExecutor vectorConvert,
-        GdalRasterReprojectJobExecutor rasterReproject,
-        GdalSurfaceJobExecutor surface,
-        GdalRasterClipJobExecutor rasterClip,
-        GdalRasterReprojectCatalogJobExecutor rasterReprojectCatalog,
-        GdalRasterStatisticsJobExecutor rasterStatistics,
-        GdalRasterZonalStatisticsJobExecutor rasterZonalStatistics,
-        GdalMultidimCoverageMetadataJobExecutor multidimCoverageMetadata,
-        PdalPointCloudConvertJobExecutor pointCloudConvert,
+        IEnumerable<IProcessExecutor> executors,
         ILogger<GdalDispatchJobExecutor> logger)
     {
-        ArgumentNullException.ThrowIfNull(vectorConvert);
-        ArgumentNullException.ThrowIfNull(rasterReproject);
-        ArgumentNullException.ThrowIfNull(surface);
-        ArgumentNullException.ThrowIfNull(rasterClip);
-        ArgumentNullException.ThrowIfNull(rasterReprojectCatalog);
-        ArgumentNullException.ThrowIfNull(rasterStatistics);
-        ArgumentNullException.ThrowIfNull(rasterZonalStatistics);
-        ArgumentNullException.ThrowIfNull(multidimCoverageMetadata);
-        ArgumentNullException.ThrowIfNull(pointCloudConvert);
+        ArgumentNullException.ThrowIfNull(executors);
         ArgumentNullException.ThrowIfNull(logger);
 
-        var handlers = new Dictionary<string, IJobExecutor>(StringComparer.Ordinal)
-        {
-            [GdalVectorConvertJobExecutor.HandledProcessId] = vectorConvert,
-            [GdalRasterReprojectJobExecutor.HandledProcessId] = rasterReproject,
-            [GdalRasterClipJobExecutor.HandledProcessId] = rasterClip,
-            [GdalRasterReprojectCatalogJobExecutor.HandledProcessId] = rasterReprojectCatalog,
-            [GdalRasterZonalStatisticsJobExecutor.HandledProcessId] = rasterZonalStatistics,
-            [GdalMultidimCoverageMetadataJobExecutor.HandledProcessId] = multidimCoverageMetadata,
-            [PdalPointCloudConvertJobExecutor.HandledProcessId] = pointCloudConvert,
-        };
-
-        // surface.* and raster.statistics/histogram each fan out a single executor
-        // over several process ids; copy them into the dispatcher's flat handler map
-        // so the routing decision stays O(1) per call.
-        foreach (var processId in GdalSurfaceJobExecutor.SupportedProcessIds)
-        {
-            handlers[processId] = surface;
-        }
-        foreach (var processId in GdalRasterStatisticsJobExecutor.SupportedProcessIds)
-        {
-            handlers[processId] = rasterStatistics;
-        }
-
-        _handlers = handlers.ToFrozenDictionary(StringComparer.Ordinal);
-
+        _handlers = ProcessExecutorRouteTable.Build(executors);
         _logger = logger;
     }
 

--- a/src/Honua.Worker.Gdal/Execution/GdalMultidimCoverageMetadataJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalMultidimCoverageMetadataJobExecutor.cs
@@ -30,7 +30,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalMultidimCoverageMetadataJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalMultidimCoverageMetadataJobExecutor> logger) : IJobExecutor
+    ILogger<GdalMultidimCoverageMetadataJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "coverage.multidim.metadata";
@@ -41,6 +41,13 @@ internal sealed partial class GdalMultidimCoverageMetadataJobExecutor(
         new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterClipJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterClipJobExecutor.cs
@@ -25,7 +25,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalRasterClipJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalRasterClipJobExecutor> logger) : IJobExecutor
+    ILogger<GdalRasterClipJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "raster.clip";
@@ -36,6 +36,13 @@ internal sealed partial class GdalRasterClipJobExecutor(
         new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectCatalogJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectCatalogJobExecutor.cs
@@ -22,7 +22,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalRasterReprojectCatalogJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalRasterReprojectCatalogJobExecutor> logger) : IJobExecutor
+    ILogger<GdalRasterReprojectCatalogJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "raster.reproject";
@@ -49,6 +49,13 @@ internal sealed partial class GdalRasterReprojectCatalogJobExecutor(
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectJobExecutor.cs
@@ -24,7 +24,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalRasterReprojectJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalRasterReprojectJobExecutor> logger) : IJobExecutor
+    ILogger<GdalRasterReprojectJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "gdal.gdalwarp";
@@ -35,6 +35,13 @@ internal sealed partial class GdalRasterReprojectJobExecutor(
         new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterStatisticsJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterStatisticsJobExecutor.cs
@@ -22,7 +22,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalRasterStatisticsJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalRasterStatisticsJobExecutor> logger) : IJobExecutor
+    ILogger<GdalRasterStatisticsJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>Process id for per-band statistics.</summary>
     public const string StatisticsProcessId = "raster.statistics";
@@ -38,6 +38,9 @@ internal sealed partial class GdalRasterStatisticsJobExecutor(
 
     private static readonly IReadOnlySet<string> NativeProfileSet =
         new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds => SupportedProcessIds;
 
     /// <inheritdoc />
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterZonalStatisticsJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterZonalStatisticsJobExecutor.cs
@@ -27,7 +27,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalRasterZonalStatisticsJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalRasterZonalStatisticsJobExecutor> logger) : IJobExecutor
+    ILogger<GdalRasterZonalStatisticsJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "raster.zonal-statistics";
@@ -46,6 +46,13 @@ internal sealed partial class GdalRasterZonalStatisticsJobExecutor(
         }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/Execution/GdalSurfaceJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalSurfaceJobExecutor.cs
@@ -25,7 +25,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalSurfaceJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalSurfaceJobExecutor> logger) : IJobExecutor
+    ILogger<GdalSurfaceJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>Process id for slope.</summary>
     public const string SlopeProcessId = "surface.slope";
@@ -62,6 +62,9 @@ internal sealed partial class GdalSurfaceJobExecutor(
 
     /// <summary>Process ids this executor routes.</summary>
     public static IReadOnlyCollection<string> SupportedProcessIds => HandledProcessIds;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds => HandledProcessIds;
 
     /// <inheritdoc />
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;

--- a/src/Honua.Worker.Gdal/Execution/GdalVectorConvertJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalVectorConvertJobExecutor.cs
@@ -24,7 +24,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalVectorConvertJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalVectorConvertJobExecutor> logger) : IJobExecutor
+    ILogger<GdalVectorConvertJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "gdal.ogr2ogr";
@@ -43,6 +43,13 @@ internal sealed partial class GdalVectorConvertJobExecutor(
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/Execution/PdalPointCloudConvertJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/PdalPointCloudConvertJobExecutor.cs
@@ -43,7 +43,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class PdalPointCloudConvertJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<PdalPointCloudConvertJobExecutor> logger) : IJobExecutor
+    ILogger<PdalPointCloudConvertJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "pcloud.translate";
@@ -61,6 +61,13 @@ internal sealed partial class PdalPointCloudConvertJobExecutor(
         new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
+++ b/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
@@ -83,17 +83,20 @@ public static class GdalWorkerServiceCollectionExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
-        // GDAL CLI runner + native-profile executors.
+        // GDAL CLI runner + native-profile executors. The per-process executors
+        // implement IProcessExecutor and self-declare their process id(s) (GP Devkit
+        // authoring contract #2122), so GdalDispatchJobExecutor builds its routing
+        // table by enumerating IProcessExecutor instead of a hand-maintained ctor.
         services.TryAddSingleton<IGdalCommandRunner, ProcessGdalCommandRunner>();
-        services.TryAddSingleton<GdalVectorConvertJobExecutor>();
-        services.TryAddSingleton<GdalRasterReprojectJobExecutor>();
-        services.TryAddSingleton<GdalSurfaceJobExecutor>();
-        services.TryAddSingleton<GdalRasterClipJobExecutor>();
-        services.TryAddSingleton<GdalRasterReprojectCatalogJobExecutor>();
-        services.TryAddSingleton<GdalRasterStatisticsJobExecutor>();
-        services.TryAddSingleton<GdalRasterZonalStatisticsJobExecutor>();
-        services.TryAddSingleton<GdalMultidimCoverageMetadataJobExecutor>();
-        services.TryAddSingleton<PdalPointCloudConvertJobExecutor>();
+        RegisterGdalExecutor<GdalVectorConvertJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterReprojectJobExecutor>(services);
+        RegisterGdalExecutor<GdalSurfaceJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterClipJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterReprojectCatalogJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterStatisticsJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterZonalStatisticsJobExecutor>(services);
+        RegisterGdalExecutor<GdalMultidimCoverageMetadataJobExecutor>(services);
+        RegisterGdalExecutor<PdalPointCloudConvertJobExecutor>(services);
 
         // Register the native dispatcher as the single IJobExecutor for the
         // Geoprocessing kind in this host. It declares AcceptedRuntimeProfiles =
@@ -122,5 +125,25 @@ public static class GdalWorkerServiceCollectionExtensions
         services.AddHostedService<JobReconciliationService>();
 
         return services;
+    }
+
+    /// <summary>
+    /// Registers a GDAL <see cref="IProcessExecutor"/> as its concrete type and
+    /// surfaces the same singleton into the enumerable <see cref="IProcessExecutor"/>
+    /// set <see cref="GdalDispatchJobExecutor"/> consumes — both bound to one
+    /// instance via a resolving factory (GP Devkit authoring contract #2122).
+    /// </summary>
+    private static void RegisterGdalExecutor<TExecutor>(IServiceCollection services)
+        where TExecutor : class, IProcessExecutor
+    {
+        services.TryAddSingleton<TExecutor>();
+
+        if (!services.Any(d =>
+                d.ServiceType == typeof(IProcessExecutor)
+                && d.ImplementationFactory is not null
+                && d.ImplementationFactory.Method.ReturnType == typeof(TExecutor)))
+        {
+            services.AddSingleton<IProcessExecutor>(sp => sp.GetRequiredService<TExecutor>());
+        }
     }
 }

--- a/tests/dotnet/Honua.Core.Tests/Features/ControlPlane/ProcessExecutorRouteTableTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/ControlPlane/ProcessExecutorRouteTableTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.ControlPlane;
+
+/// <summary>
+/// Unit tests for <see cref="ProcessExecutorRouteTable"/> — the shared
+/// auto-registration routing-table builder used by the managed and GDAL
+/// geoprocessing dispatchers (GP Devkit authoring contract #2122). Pins the
+/// fail-fast diagnostics that protect the authoring contract from a duplicate or
+/// empty process-id declaration.
+/// </summary>
+public sealed class ProcessExecutorRouteTableTests
+{
+    private sealed class FakeProcessExecutor(params string[] ids) : IProcessExecutor
+    {
+        public IReadOnlySet<string> ProcessIds { get; } =
+            new HashSet<string>(ids, StringComparer.Ordinal);
+
+        public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+        public Task<JobExecutionResult> ExecuteAsync(
+            ExecutionJobRecord job,
+            IJobExecutionContext context,
+            CancellationToken cancellationToken)
+            => Task.FromResult(JobExecutionResult.Succeeded());
+    }
+
+    [UnitTest]
+    public void Build_MapsEachDeclaredIdToItsExecutor()
+    {
+        var a = new FakeProcessExecutor("geometry.buffer");
+        var b = new FakeProcessExecutor("surface.slope", "surface.aspect");
+
+        var table = ProcessExecutorRouteTable.Build(new IProcessExecutor[] { a, b });
+
+        table.Should().HaveCount(3);
+        table["geometry.buffer"].Should().BeSameAs(a);
+        table["surface.slope"].Should().BeSameAs(b);
+        table["surface.aspect"].Should().BeSameAs(b);
+    }
+
+    [UnitTest]
+    public void Build_DuplicateIdAcrossExecutors_Throws()
+    {
+        var a = new FakeProcessExecutor("geometry.buffer");
+        var b = new FakeProcessExecutor("geometry.buffer");
+
+        var act = () => ProcessExecutorRouteTable.Build(new IProcessExecutor[] { a, b });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*geometry.buffer*");
+    }
+
+    [UnitTest]
+    public void Build_ExecutorWithNoIds_Throws()
+    {
+        var empty = new FakeProcessExecutor();
+
+        var act = () => ProcessExecutorRouteTable.Build(new IProcessExecutor[] { empty });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*no process ids*");
+    }
+
+    [UnitTest]
+    public void Build_ExecutorWithWhitespaceId_Throws()
+    {
+        var bad = new FakeProcessExecutor("  ");
+
+        var act = () => ProcessExecutorRouteTable.Build(new IProcessExecutor[] { bad });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*whitespace process id*");
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Geoprocessing/ProcessSchemaJsonGeneratorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Geoprocessing/ProcessSchemaJsonGeneratorTests.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Core.Tests.Features.Geoprocessing;
+
+/// <summary>
+/// Unit tests for <see cref="ProcessSchemaJsonGenerator"/> — the GP Devkit authoring
+/// contract's JSON Schema emission derived from a process's typed parameter set
+/// (issues #2122 / #2124). Pins the JSON Schema shape <c>describe</c> consumes so the
+/// advertised schema cannot silently drift from the catalog typing.
+/// </summary>
+[Protocol(ProtocolNames.TestQuality)]
+public sealed class ProcessSchemaJsonGeneratorTests
+{
+    private static ProcessDefinition SampleProcess() => new()
+    {
+        ProcessId = "geometry.buffer",
+        Title = "Buffer",
+        Description = "Buffers a geometry by a distance.",
+        Category = "geometry",
+        RuntimeProfile = "managed",
+        Parameters = new[]
+        {
+            new ProcessParameterSpec
+            {
+                Name = "wkb",
+                DisplayName = "Geometry (WKB)",
+                Description = "Input geometry as base64 WKB.",
+                ValueType = ProcessParameterValueType.Wkb,
+                Required = true,
+            },
+            new ProcessParameterSpec
+            {
+                Name = "srid",
+                DisplayName = "SRID",
+                Description = "Spatial reference identifier.",
+                ValueType = ProcessParameterValueType.Srid,
+                Required = true,
+            },
+            new ProcessParameterSpec
+            {
+                Name = "distance",
+                DisplayName = "Distance",
+                Description = "Buffer distance in CRS units.",
+                ValueType = ProcessParameterValueType.FloatingPoint,
+                Required = true,
+            },
+            new ProcessParameterSpec
+            {
+                Name = "geodesic",
+                DisplayName = "Geodesic",
+                Description = "Whether to buffer geodesically.",
+                ValueType = ProcessParameterValueType.Flag,
+                Required = false,
+                DefaultValue = "false",
+            },
+            new ProcessParameterSpec
+            {
+                Name = "method",
+                DisplayName = "Method",
+                Description = "Join method.",
+                ValueType = ProcessParameterValueType.Text,
+                Required = false,
+                AllowedValues = new[] { "round", "mitre", "bevel" },
+            },
+        },
+        OutputArtifactKinds = new[] { ArtifactKind.FeatureLayer },
+    };
+
+    [UnitTest]
+    public void Generate_ProducesValidJsonWithProcessMetadata()
+    {
+        var json = ProcessSchemaJsonGenerator.Generate(SampleProcess());
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        root.GetProperty("processId").GetString().Should().Be("geometry.buffer");
+        root.GetProperty("title").GetString().Should().Be("Buffer");
+        root.GetProperty("category").GetString().Should().Be("geometry");
+        root.GetProperty("runtimeProfile").GetString().Should().Be("managed");
+    }
+
+    [UnitTest]
+    public void Generate_RequiredArrayContainsOnlyRequiredParameters()
+    {
+        var json = ProcessSchemaJsonGenerator.Generate(SampleProcess());
+
+        using var doc = JsonDocument.Parse(json);
+        var inputs = doc.RootElement.GetProperty("inputs");
+
+        inputs.GetProperty("type").GetString().Should().Be("object");
+        inputs.GetProperty("additionalProperties").GetBoolean().Should().BeFalse();
+
+        var required = inputs.GetProperty("required")
+            .EnumerateArray()
+            .Select(e => e.GetString())
+            .ToArray();
+
+        required.Should().BeEquivalentTo("wkb", "srid", "distance");
+        required.Should().NotContain("geodesic");
+        required.Should().NotContain("method");
+    }
+
+    [UnitTest]
+    public void Generate_MapsValueTypesToJsonSchemaTypesAndFormats()
+    {
+        var json = ProcessSchemaJsonGenerator.Generate(SampleProcess());
+
+        using var doc = JsonDocument.Parse(json);
+        var props = doc.RootElement.GetProperty("inputs").GetProperty("properties");
+
+        var wkb = props.GetProperty("wkb");
+        wkb.GetProperty("type").GetString().Should().Be("string");
+        wkb.GetProperty("format").GetString().Should().Be("wkb-base64");
+        wkb.GetProperty("x-honua-value-type").GetString().Should().Be("Wkb");
+
+        props.GetProperty("srid").GetProperty("type").GetString().Should().Be("integer");
+        props.GetProperty("srid").GetProperty("format").GetString().Should().Be("srid");
+
+        props.GetProperty("distance").GetProperty("type").GetString().Should().Be("number");
+        props.GetProperty("geodesic").GetProperty("type").GetString().Should().Be("boolean");
+        props.GetProperty("geodesic").GetProperty("default").GetString().Should().Be("false");
+    }
+
+    [UnitTest]
+    public void Generate_EmitsEnumForAllowedValues()
+    {
+        var json = ProcessSchemaJsonGenerator.Generate(SampleProcess());
+
+        using var doc = JsonDocument.Parse(json);
+        var method = doc.RootElement.GetProperty("inputs").GetProperty("properties").GetProperty("method");
+
+        var values = method.GetProperty("enum").EnumerateArray().Select(e => e.GetString()).ToArray();
+        values.Should().BeEquivalentTo("round", "mitre", "bevel");
+    }
+
+    [UnitTest]
+    public void Generate_EmitsOutputArtifactKinds()
+    {
+        var json = ProcessSchemaJsonGenerator.Generate(SampleProcess());
+
+        using var doc = JsonDocument.Parse(json);
+        var outputs = doc.RootElement.GetProperty("outputs").EnumerateArray().ToArray();
+
+        outputs.Should().HaveCount(1);
+        outputs[0].GetProperty("artifactKind").GetString().Should().Be("FeatureLayer");
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Geoprocessing;
 using Honua.Geoprocessing.Execution;
@@ -313,7 +314,8 @@ public sealed class CatalogExecutableConformanceTests
         var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
         monitor.CurrentValue.Returns(options);
 
-        var dispatcher = new GeoprocessingDispatchJobExecutor(
+        IProcessExecutor[] executors =
+        {
             new GeometryBufferJobExecutor(monitor, NullLogger<GeometryBufferJobExecutor>.Instance),
             new GeometryClipJobExecutor(monitor, NullLogger<GeometryClipJobExecutor>.Instance),
             new GeometryIntersectJobExecutor(monitor, NullLogger<GeometryIntersectJobExecutor>.Instance),
@@ -348,6 +350,10 @@ public sealed class CatalogExecutableConformanceTests
             new ImportDatasetJobExecutor(
                 Substitute.For<IServiceScopeFactory>(),
                 NullLogger<ImportDatasetJobExecutor>.Instance),
+        };
+
+        var dispatcher = new GeoprocessingDispatchJobExecutor(
+            executors,
             NullLogger<GeoprocessingDispatchJobExecutor>.Instance);
 
         return dispatcher.SupportedProcessIds;

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
@@ -136,7 +136,12 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
         monitor.CurrentValue.Returns(options);
 
-        return new GeoprocessingDispatchJobExecutor(
+        // Auto-registration contract (#2122): the dispatcher routes by enumerating
+        // the IProcessExecutor set and keying on each executor's self-declared
+        // ProcessIds, so the test composes the same executor instances as a flat
+        // list instead of the former positional constructor.
+        IProcessExecutor[] executors =
+        {
             new GeometryBufferJobExecutor(monitor, NullLogger<GeometryBufferJobExecutor>.Instance),
             new GeometryClipJobExecutor(monitor, NullLogger<GeometryClipJobExecutor>.Instance),
             new GeometryIntersectJobExecutor(monitor, NullLogger<GeometryIntersectJobExecutor>.Instance),
@@ -171,6 +176,10 @@ public sealed class GeoprocessingDispatchJobExecutorTests
             new ImportDatasetJobExecutor(
                 Substitute.For<IServiceScopeFactory>(),
                 NullLogger<ImportDatasetJobExecutor>.Instance),
+        };
+
+        return new GeoprocessingDispatchJobExecutor(
+            executors,
             NullLogger<GeoprocessingDispatchJobExecutor>.Instance);
     }
 

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterExecutorTests.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.TestKit.Attributes;
 using Honua.Worker.Gdal.Execution;
@@ -718,7 +719,8 @@ public sealed class GdalRasterExecutorTests
     {
         var runner = FakeGdalCommandRunner.Failing(1, "n/a");
         var options = GdalJobFactory.Options(Path.Combine(Path.GetTempPath(), "honua-gdal-dispatch-test"));
-        return new GdalDispatchJobExecutor(
+        IProcessExecutor[] executors =
+        {
             new GdalVectorConvertJobExecutor(runner, options, NullLogger<GdalVectorConvertJobExecutor>.Instance),
             new GdalRasterReprojectJobExecutor(runner, options, NullLogger<GdalRasterReprojectJobExecutor>.Instance),
             new GdalSurfaceJobExecutor(runner, options, NullLogger<GdalSurfaceJobExecutor>.Instance),
@@ -728,6 +730,10 @@ public sealed class GdalRasterExecutorTests
             new GdalRasterZonalStatisticsJobExecutor(runner, options, NullLogger<GdalRasterZonalStatisticsJobExecutor>.Instance),
             new GdalMultidimCoverageMetadataJobExecutor(runner, options, NullLogger<GdalMultidimCoverageMetadataJobExecutor>.Instance),
             new PdalPointCloudConvertJobExecutor(runner, options, NullLogger<PdalPointCloudConvertJobExecutor>.Instance),
+        };
+
+        return new GdalDispatchJobExecutor(
+            executors,
             NullLogger<GdalDispatchJobExecutor>.Instance);
     }
 

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalWorkerExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalWorkerExecutorTests.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -78,7 +79,8 @@ public sealed class GdalWorkerExecutorTests
     {
         var runner = FakeGdalCommandRunner.Failing(1, "n/a");
         var options = GdalJobFactory.Options(Path.Combine(Path.GetTempPath(), "honua-gdal-dispatch-test"));
-        return new GdalDispatchJobExecutor(
+        IProcessExecutor[] executors =
+        {
             new GdalVectorConvertJobExecutor(runner, options, NullLogger<GdalVectorConvertJobExecutor>.Instance),
             new GdalRasterReprojectJobExecutor(runner, options, NullLogger<GdalRasterReprojectJobExecutor>.Instance),
             new GdalSurfaceJobExecutor(runner, options, NullLogger<GdalSurfaceJobExecutor>.Instance),
@@ -88,6 +90,10 @@ public sealed class GdalWorkerExecutorTests
             new GdalRasterZonalStatisticsJobExecutor(runner, options, NullLogger<GdalRasterZonalStatisticsJobExecutor>.Instance),
             new GdalMultidimCoverageMetadataJobExecutor(runner, options, NullLogger<GdalMultidimCoverageMetadataJobExecutor>.Instance),
             new PdalPointCloudConvertJobExecutor(runner, options, NullLogger<PdalPointCloudConvertJobExecutor>.Instance),
+        };
+
+        return new GdalDispatchJobExecutor(
+            executors,
             NullLogger<GdalDispatchJobExecutor>.Instance);
     }
 


### PR DESCRIPTION
## Summary

GP Devkit FOUNDATION, P1 (#2122): replace the fat per-process geoprocessing dispatcher constructors with a declarative, self-describing authoring model and a single DI-driven auto-registration loop. This proves the authoring contract end-to-end before the rest of the devkit fans out.

Each per-process executor now self-declares the process id(s) it handles; the dispatchers route by that declaration instead of a hand-maintained positional constructor that named every executor (and, for GDAL, every fan-out id set) explicitly.

**Authoring-model shape chosen: an instance property, not an attribute.** `IProcessExecutor : IJobExecutor` exposes `IReadOnlySet<string> ProcessIds`. A property was the cleaner fit because (a) the GDAL `surface.*` and `raster.statistics/histogram` executors fan a single implementation over several ids computed at construction time — an attribute can't express that cleanly — and (b) the dispatcher builds its routing table from DI-resolved instances with no reflection, keeping it AOT-safe.

## Changes Made

- Add `IProcessExecutor : IJobExecutor` (`ProcessIds`) and `ProcessExecutorRouteTable.Build` — a shared route-table builder with fail-fast duplicate/empty/whitespace-id diagnostics — both in `Honua.Core`.
- All 32 managed per-process executors and all 9 GDAL executors implement `IProcessExecutor` and declare their id(s); the existing `HandledProcessId`/`SupportedProcessIds` constants are retained and reused.
- `GeoprocessingDispatchJobExecutor` and `GdalDispatchJobExecutor` now take `IEnumerable<IProcessExecutor>` and route via `ProcessExecutorRouteTable`; DI registration is a single `Register<T>`/`RegisterGdalExecutor<T>` loop binding each concrete executor and its `IProcessExecutor` projection to one singleton.
- Add `ProcessSchemaJsonGenerator`: emits a JSON Schema (draft 2020-12) for a `ProcessDefinition`'s typed parameter set (the schema surface the later `describe` pillar consumes), derived from the catalog typing so it cannot drift.
- New unit tests for the route-table guards and the JSON-schema generator; updated the dispatcher/conformance tests to the new constructor shape.

## Breaking Changes

None. Routing for every existing process id is unchanged; the dispatcher constructors are internal.

## Behavior preservation / self-review

All 32 managed process ids dispatch identically (enumerated in the issue): geometry.buffer, geometry.clip, geometry.intersect, geometry.project, geometry.area, geometry.union, geometry.centroid, geometry.length, geometry.convex-hull, geometry.dissolve, geometry.simplify, geometry.snap, geometry.make-valid, geometry.difference, analytics.spatial-join-managed, analytics.cluster-managed, analytics.buffer-aggregate-managed, analytics.density-managed, transform.attribute-rename, transform.attribute-cast, transform.computed-field, transform.attribute-filter, transform.spatial-filter, transform.clip, transform.dedup, transform.reproject, source.geojson, source.csv, sink.geojson-file, sink.quarantine, sink.external-postgis, import.dataset. The 9 GDAL ids (gdal.ogr2ogr, gdal.gdalwarp, raster.clip, conversion.raster-reproject, raster.zonal-statistics, pcloud.translate, the surface.* family, raster.statistics/histogram) are unchanged. Proven by the exact-id-set dispatcher tests and the catalog-honesty conformance test, which assert the full routed-id set.

## Gate Impact

- [x] No gate impact (refactor preserving behavior; no API surface or endpoint change)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Verification performed: Release build with `TreatWarningsAsErrors=true` for Honua.Core, Honua.Geoprocessing, Honua.Worker.Gdal, and Honua.Server (0 warnings); `dotnet format --verify-no-changes` clean on changed projects; Honua.Worker.Gdal.Tests (77 passed, 2 GDAL-CLI skips); geoprocessing Fast-tier server unit tests (402 passed) including the dispatcher exact-id-set and catalog-honesty conformance tests; new Core unit tests (9 passed); architecture tests green except the pre-existing `FeatureCatalogDriftTests` trunk drift (an unrelated OGC Features test rename — no geoprocessing content in the diff). Integration tests requiring Docker were not run locally (no Docker daemon in this environment); they run in CI.
