### PR TITLE
feat(control-plane): opt-in ServiceUrl override + cloud-integration harness

### DIFF
--- a/.github/workflows/cloud-integration-harness.yml
+++ b/.github/workflows/cloud-integration-harness.yml
@@ -1,0 +1,190 @@
+name: Cloud Integration Harness
+
+# Opt-in, Docker-backed cloud-integration tests (#2163). Stands up REAL emulated cloud
+# backends and exercises Honua's cloud seams end-to-end. Every test is tagged
+# [Trait("Category","CloudIntegration")] so it is EXCLUDED from the default PR test run
+# (which never invokes this project) and only runs here.
+#
+# FREE tier (always): kind (real Kubernetes-in-Docker) for KubernetesJobBatchComputeBackend,
+# plus LocalStack Community (S3/Lambda/CloudWatch) via the project's Testcontainers fixture.
+# PAID tier (optional): LocalStack Pro (AWS Batch / ECS) — gated on the LOCALSTACK_AUTH_TOKEN
+# repo secret. When the secret is absent the Pro-tagged scenarios skip (never fail), so the
+# free lane stays green without a LocalStack subscription.
+
+on:
+  schedule:
+    # Nightly; the harness is Docker-heavy and not part of the per-PR gate.
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: 'Which tier(s) to run'
+        type: choice
+        required: false
+        default: free
+        options:
+          - free
+          - pro
+          - all
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
+  CSPROJ: tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj
+  # Self-terminating worker image the kind-backed Job lifecycle test submits. Built and loaded
+  # into the kind node below; ImagePullPolicy=Never in the test keeps it local-only.
+  JOB_IMAGE: honua-ci/job-succeed:latest
+
+concurrency:
+  group: cloud-integration-harness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  free-tier:
+    name: Free Tier (kind + LocalStack Community)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Skip when a manual dispatch explicitly selects only the Pro tier.
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.tier != 'pro' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-ci
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore Honua.sln
+
+      - name: Build cloud-integration test binaries
+        timeout-minutes: 25
+        run: dotnet build ${{ env.CSPROJ }} --no-restore --configuration Release
+
+      - name: Pre-pull LocalStack Community image
+        shell: bash
+        run: |
+          # Warm the docker cache so the LocalStackFixture Testcontainer does not pull during
+          # the test run. Container provisioning itself is owned by the fixture.
+          docker pull localstack/localstack:3.6.0 || echo "::warning::could not pre-pull localstack"
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: honua-cloud-integration
+
+      - name: Build and load the self-terminating worker image into kind
+        shell: bash
+        run: |
+          # A minimal image whose entrypoint runs to completion and exits 0 — stands in for a GP
+          # worker. The lifecycle test sets ImagePullPolicy=Never, so the image must be present
+          # on the kind node (no registry pull).
+          workdir="$(mktemp -d)"
+          cat > "${workdir}/Dockerfile" <<'EOF'
+          FROM busybox:1.36
+          ENTRYPOINT ["/bin/true"]
+          EOF
+          docker build -t "${JOB_IMAGE}" "${workdir}"
+          kind load docker-image "${JOB_IMAGE}" --name honua-cloud-integration
+
+      - name: Export kind cluster inputs for the harness
+        shell: bash
+        run: |
+          # The KindClusterFixture consumes these out-of-cluster credentials (mirroring the
+          # ControlPlane:Kubernetes:* surface an operator configures for a remote cluster).
+          # Extract them with kubectl — the canonical Kubernetes tool — so the harness needs no
+          # kubeconfig parser. The kind API server URL must be reachable from the host network.
+          api_server="$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')"
+          ca_bundle="${RUNNER_TEMP}/kind-ca.pem"
+          kubectl config view --minify --raw \
+            -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 -d > "${ca_bundle}"
+
+          # A ServiceAccount token permitted to create/observe/delete Jobs in the default namespace.
+          kubectl create clusterrolebinding honua-ci-jobs \
+            --clusterrole=cluster-admin \
+            --serviceaccount=default:default || true
+          token="$(kubectl create token default --duration=3600s)"
+
+          {
+            echo "HONUA_TEST_K8S_API_SERVER_URL=${api_server}"
+            echo "HONUA_TEST_K8S_CA_BUNDLE_PATH=${ca_bundle}"
+            echo "HONUA_TEST_K8S_BEARER_TOKEN=${token}"
+            echo "HONUA_TEST_K8S_NAMESPACE=default"
+            echo "HONUA_TEST_K8S_JOB_IMAGE=${JOB_IMAGE}"
+          } >> "$GITHUB_ENV"
+
+      - name: Run free-tier cloud-integration tests
+        env:
+          TESTCONTAINERS_RYUK_DISABLED: false
+        run: |
+          mkdir -p ./tests/TestResults
+          # Free lane: Category=CloudIntegration excluding the Pro tier (no LocalStack token here).
+          dotnet test ${{ env.CSPROJ }} \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --filter "Category=CloudIntegration&Tier!=Pro" \
+            --logger "trx;LogFileName=cloud-integration-free.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults
+
+      - name: Upload free-tier results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: cloud-integration-free-results
+          path: tests/TestResults/
+          retention-days: 14
+
+  pro-tier:
+    name: Pro Tier (LocalStack Batch/ECS)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Only run when explicitly requested. The fixture additionally skips Pro scenarios at
+    # runtime when LOCALSTACK_AUTH_TOKEN is absent, so a missing secret degrades gracefully.
+    if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.tier == 'pro' || github.event.inputs.tier == 'all') }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-ci
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore Honua.sln
+
+      - name: Build cloud-integration test binaries
+        timeout-minutes: 25
+        run: dotnet build ${{ env.CSPROJ }} --no-restore --configuration Release
+
+      - name: Run Pro-tier cloud-integration tests
+        env:
+          # When this secret is unset the LocalStackFixture leaves Batch/ECS disabled and the
+          # Pro-tagged scenarios skip rather than fail, so this lane never hard-fails on a
+          # missing subscription.
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+          TESTCONTAINERS_RYUK_DISABLED: false
+        run: |
+          mkdir -p ./tests/TestResults
+          dotnet test ${{ env.CSPROJ }} \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --filter "Category=CloudIntegration&Tier=Pro" \
+            --logger "trx;LogFileName=cloud-integration-pro.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults
+
+      - name: Upload Pro-tier results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: cloud-integration-pro-results
+          path: tests/TestResults/
+          retention-days: 14

--- a/.github/workflows/cloud-integration-harness.yml
+++ b/.github/workflows/cloud-integration-harness.yml
@@ -5,27 +5,15 @@ name: Cloud Integration Harness
 # [Trait("Category","CloudIntegration")] so it is EXCLUDED from the default PR test run
 # (which never invokes this project) and only runs here.
 #
-# FREE tier (always): kind (real Kubernetes-in-Docker) for KubernetesJobBatchComputeBackend,
-# plus LocalStack Community (S3/Lambda/CloudWatch) via the project's Testcontainers fixture.
-# PAID tier (optional): LocalStack Pro (AWS Batch / ECS) — gated on the LOCALSTACK_AUTH_TOKEN
-# repo secret. When the secret is absent the Pro-tagged scenarios skip (never fail), so the
-# free lane stays green without a LocalStack subscription.
+# All lanes are FREE (no paid token): kind (real Kubernetes-in-Docker) for
+# KubernetesJobBatchComputeBackend, plus LocalStack Community (S3) via the project's
+# Testcontainers fixture. Both gate cleanly with [SkippableFact] when Docker is unavailable.
 
 on:
   schedule:
     # Nightly; the harness is Docker-heavy and not part of the per-PR gate.
     - cron: '0 5 * * *'
   workflow_dispatch:
-    inputs:
-      tier:
-        description: 'Which tier(s) to run'
-        type: choice
-        required: false
-        default: free
-        options:
-          - free
-          - pro
-          - all
 
 permissions:
   contents: read
@@ -49,8 +37,6 @@ jobs:
     name: Free Tier (kind + LocalStack Community)
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Skip when a manual dispatch explicitly selects only the Pro tier.
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.tier != 'pro' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -118,57 +104,8 @@ jobs:
             echo "HONUA_TEST_K8S_JOB_IMAGE=${JOB_IMAGE}"
           } >> "$GITHUB_ENV"
 
-      - name: Run free-tier cloud-integration tests
+      - name: Run cloud-integration tests
         env:
-          TESTCONTAINERS_RYUK_DISABLED: false
-        run: |
-          mkdir -p ./tests/TestResults
-          # Free lane: Category=CloudIntegration excluding the Pro tier (no LocalStack token here).
-          dotnet test ${{ env.CSPROJ }} \
-            --no-build \
-            --no-restore \
-            --configuration Release \
-            --filter "Category=CloudIntegration&Tier!=Pro" \
-            --logger "trx;LogFileName=cloud-integration-free.trx" \
-            --logger "console;verbosity=minimal" \
-            --results-directory ./tests/TestResults
-
-      - name: Upload free-tier results
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: cloud-integration-free-results
-          path: tests/TestResults/
-          retention-days: 14
-
-  pro-tier:
-    name: Pro Tier (LocalStack Batch/ECS)
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    # Only run when explicitly requested. The fixture additionally skips Pro scenarios at
-    # runtime when LOCALSTACK_AUTH_TOKEN is absent, so a missing secret degrades gracefully.
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.tier == 'pro' || github.event.inputs.tier == 'all') }}
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Setup .NET
-        uses: ./.github/actions/setup-dotnet-ci
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      - name: Restore
-        run: dotnet restore Honua.sln
-
-      - name: Build cloud-integration test binaries
-        timeout-minutes: 25
-        run: dotnet build ${{ env.CSPROJ }} --no-restore --configuration Release
-
-      - name: Run Pro-tier cloud-integration tests
-        env:
-          # When this secret is unset the LocalStackFixture leaves Batch/ECS disabled and the
-          # Pro-tagged scenarios skip rather than fail, so this lane never hard-fails on a
-          # missing subscription.
-          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
           TESTCONTAINERS_RYUK_DISABLED: false
         run: |
           mkdir -p ./tests/TestResults
@@ -176,15 +113,15 @@ jobs:
             --no-build \
             --no-restore \
             --configuration Release \
-            --filter "Category=CloudIntegration&Tier=Pro" \
-            --logger "trx;LogFileName=cloud-integration-pro.trx" \
+            --filter "Category=CloudIntegration" \
+            --logger "trx;LogFileName=cloud-integration.trx" \
             --logger "console;verbosity=minimal" \
             --results-directory ./tests/TestResults
 
-      - name: Upload Pro-tier results
+      - name: Upload results
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: cloud-integration-pro-results
+          name: cloud-integration-results
           path: tests/TestResults/
           retention-days: 14

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -113,10 +113,12 @@
     <PackageVersion Include="Snowflake.Data" Version="5.7.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.12.14" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.MySql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />
     <PackageVersion Include="WireMock.Net" Version="2.2.0" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/Honua.sln
+++ b/Honua.sln
@@ -151,6 +151,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Protocols.SensorThing
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Protocols.SensorThings.Tests", "tests\dotnet\Honua.Protocols.SensorThings.Tests\Honua.Protocols.SensorThings.Tests.csproj", "{09A157E7-67AD-46E1-9495-BD499000592D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.CloudIntegration.Tests", "tests\dotnet\Honua.CloudIntegration.Tests\Honua.CloudIntegration.Tests.csproj", "{37AA4C31-08CB-4D43-994B-DA77173DE12E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -977,6 +979,18 @@ Global
 		{09A157E7-67AD-46E1-9495-BD499000592D}.Release|x64.Build.0 = Release|Any CPU
 		{09A157E7-67AD-46E1-9495-BD499000592D}.Release|x86.ActiveCfg = Release|Any CPU
 		{09A157E7-67AD-46E1-9495-BD499000592D}.Release|x86.Build.0 = Release|Any CPU
+		{37AA4C31-08CB-4D43-994B-DA77173DE12E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{37AA4C31-08CB-4D43-994B-DA77173DE12E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{37AA4C31-08CB-4D43-994B-DA77173DE12E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{37AA4C31-08CB-4D43-994B-DA77173DE12E}.Debug|x64.Build.0 = Debug|Any CPU
+		{37AA4C31-08CB-4D43-994B-DA77173DE12E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{37AA4C31-08CB-4D43-994B-DA77173DE12E}.Debug|x86.Build.0 = Debug|Any CPU
+		{37AA4C31-08CB-4D43-994B-DA77173DE12E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{37AA4C31-08CB-4D43-994B-DA77173DE12E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{37AA4C31-08CB-4D43-994B-DA77173DE12E}.Release|x64.ActiveCfg = Release|Any CPU
+		{37AA4C31-08CB-4D43-994B-DA77173DE12E}.Release|x64.Build.0 = Release|Any CPU
+		{37AA4C31-08CB-4D43-994B-DA77173DE12E}.Release|x86.ActiveCfg = Release|Any CPU
+		{37AA4C31-08CB-4D43-994B-DA77173DE12E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1045,5 +1059,6 @@ Global
 		{43B1BD9E-AD92-4A52-8DE3-4CE9E7B1BCD8} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
 		{268C7FCA-045F-4DA1-B249-64DCF5E13D11} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{09A157E7-67AD-46E1-9495-BD499000592D} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
+		{37AA4C31-08CB-4D43-994B-DA77173DE12E} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
 	EndGlobalSection
 EndGlobal

--- a/src/Honua.Aws/Features/ControlPlane/AwsBatchComputeBackend.cs
+++ b/src/Honua.Aws/Features/ControlPlane/AwsBatchComputeBackend.cs
@@ -17,6 +17,15 @@ internal static class AwsBatchParameterKeys
     public const string JobDefinitionArn = "batch.job_definition_arn";
     public const string JobQueueArn = "batch.job_queue_arn";
     public const string Region = "batch.region";
+
+    /// <summary>
+    /// Optional, config-driven AWS Batch endpoint override. When set (for example to a LocalStack
+    /// Pro Batch endpoint or a real-cloud integration endpoint) it is forwarded to the SDK as a
+    /// ServiceURL; when unset the SDK uses the default regional endpoint, so production behaviour
+    /// is unchanged. Batch emulation requires LocalStack Pro, so this is primarily for paid/real
+    /// integration coverage rather than the free CI tier.
+    /// </summary>
+    public const string ServiceUrl = "batch.service_url";
     public const string TimeoutSeconds = "batch.timeout_seconds";
     public const string Vcpus = "batch.vcpus";
     public const string MemoryMib = "batch.memory_mib";
@@ -236,6 +245,7 @@ internal sealed partial class AwsBatchComputeBackend(
         var jobDefinition = GetRequiredParameter(parameters, AwsBatchParameterKeys.JobDefinitionArn);
         var jobQueue = GetRequiredParameter(parameters, AwsBatchParameterKeys.JobQueueArn);
         var region = GetOptionalParameter(parameters, AwsBatchParameterKeys.Region);
+        var serviceUrl = GetOptionalParameter(parameters, AwsBatchParameterKeys.ServiceUrl);
 
         var jobName = BuildJobName(job.OperationId, job.AttemptCount);
         var submission = new AwsBatchJobSubmission
@@ -254,7 +264,7 @@ internal sealed partial class AwsBatchComputeBackend(
 
         try
         {
-            var result = await batchClient.SubmitJobAsync(submission, region, cancellationToken).ConfigureAwait(false);
+            var result = await batchClient.SubmitJobAsync(submission, region, serviceUrl, cancellationToken).ConfigureAwait(false);
             Log.BatchJobSubmitted(logger, job.OperationId, result.JobId, jobQueue, jobDefinition);
             ControlPlaneTelemetry.RecordExecutionSubmission(job);
 
@@ -308,6 +318,7 @@ internal sealed partial class AwsBatchComputeBackend(
 
         var providerId = job.ProviderOperationId;
         var region = GetOptionalParameter(job.Spec.Parameters, AwsBatchParameterKeys.Region);
+        var serviceUrl = GetOptionalParameter(job.Spec.Parameters, AwsBatchParameterKeys.ServiceUrl);
 
         if (string.IsNullOrWhiteSpace(providerId))
         {
@@ -318,7 +329,7 @@ internal sealed partial class AwsBatchComputeBackend(
             // real AWS Batch job if the provider accepted the submission.
             if (TryDeriveOrphanedSubmissionName(job, out var orphanedJobName))
             {
-                return await ObservePendingDiscoveryAsync(job, orphanedJobName, region, cancellationToken).ConfigureAwait(false);
+                return await ObservePendingDiscoveryAsync(job, orphanedJobName, region, serviceUrl, cancellationToken).ConfigureAwait(false);
             }
 
             return new BatchComputeObservation
@@ -330,12 +341,12 @@ internal sealed partial class AwsBatchComputeBackend(
 
         if (TryExtractPendingJobName(providerId, out var pendingJobName))
         {
-            return await ObservePendingDiscoveryAsync(job, pendingJobName, region, cancellationToken).ConfigureAwait(false);
+            return await ObservePendingDiscoveryAsync(job, pendingJobName, region, serviceUrl, cancellationToken).ConfigureAwait(false);
         }
 
         try
         {
-            var state = await batchClient.DescribeJobAsync(providerId, region, cancellationToken).ConfigureAwait(false);
+            var state = await batchClient.DescribeJobAsync(providerId, region, serviceUrl, cancellationToken).ConfigureAwait(false);
             if (state == null)
             {
                 Log.BatchJobNotFound(logger, job.OperationId, providerId);
@@ -381,7 +392,8 @@ internal sealed partial class AwsBatchComputeBackend(
         ExecutionJobRecord job,
         string pendingJobName,
         string? region,
-        CancellationToken cancellationToken)
+        string? serviceUrl = null,
+        CancellationToken cancellationToken = default)
     {
         var jobQueue = GetOptionalParameter(job.Spec.Parameters, AwsBatchParameterKeys.JobQueueArn);
         if (string.IsNullOrWhiteSpace(jobQueue))
@@ -400,7 +412,7 @@ internal sealed partial class AwsBatchComputeBackend(
         try
         {
             var matches = await batchClient
-                .ListJobsByNameAsync(jobQueue, pendingJobName, region, cancellationToken)
+                .ListJobsByNameAsync(jobQueue, pendingJobName, region, serviceUrl, cancellationToken)
                 .ConfigureAwait(false);
             if (matches.Count == 0)
             {
@@ -483,6 +495,7 @@ internal sealed partial class AwsBatchComputeBackend(
 
         var providerId = job.ProviderOperationId;
         var region = GetOptionalParameter(job.Spec.Parameters, AwsBatchParameterKeys.Region);
+        var serviceUrl = GetOptionalParameter(job.Spec.Parameters, AwsBatchParameterKeys.ServiceUrl);
 
         if (string.IsNullOrWhiteSpace(providerId))
         {
@@ -493,7 +506,7 @@ internal sealed partial class AwsBatchComputeBackend(
             // name so ListJobsByName can rediscover and cancel the real provider job.
             if (TryDeriveOrphanedSubmissionName(job, out var orphanedJobName))
             {
-                return await CancelPendingDiscoveryAsync(job, orphanedJobName, region, cancellationToken).ConfigureAwait(false);
+                return await CancelPendingDiscoveryAsync(job, orphanedJobName, region, serviceUrl, cancellationToken).ConfigureAwait(false);
             }
 
             return new BatchComputeObservation
@@ -505,12 +518,12 @@ internal sealed partial class AwsBatchComputeBackend(
 
         if (TryExtractPendingJobName(providerId, out var pendingJobName))
         {
-            return await CancelPendingDiscoveryAsync(job, pendingJobName, region, cancellationToken).ConfigureAwait(false);
+            return await CancelPendingDiscoveryAsync(job, pendingJobName, region, serviceUrl, cancellationToken).ConfigureAwait(false);
         }
 
         try
         {
-            var state = await batchClient.DescribeJobAsync(providerId, region, cancellationToken).ConfigureAwait(false);
+            var state = await batchClient.DescribeJobAsync(providerId, region, serviceUrl, cancellationToken).ConfigureAwait(false);
             if (state == null)
             {
                 return new BatchComputeObservation
@@ -534,19 +547,19 @@ internal sealed partial class AwsBatchComputeBackend(
 
             if (AwsBatchStateMapper.CanCancelWithoutTerminate(state.Status))
             {
-                await batchClient.CancelJobAsync(providerId, AwsBatchStateMapper.CancelReason, region, cancellationToken).ConfigureAwait(false);
+                await batchClient.CancelJobAsync(providerId, AwsBatchStateMapper.CancelReason, region, serviceUrl, cancellationToken).ConfigureAwait(false);
                 Log.BatchJobCancelled(logger, job.OperationId, providerId, state.Status ?? "UNKNOWN");
             }
             else
             {
-                await batchClient.TerminateJobAsync(providerId, AwsBatchStateMapper.CancelReason, region, cancellationToken).ConfigureAwait(false);
+                await batchClient.TerminateJobAsync(providerId, AwsBatchStateMapper.CancelReason, region, serviceUrl, cancellationToken).ConfigureAwait(false);
                 Log.BatchJobTerminated(logger, job.OperationId, providerId, state.Status ?? "UNKNOWN");
             }
 
             // Re-observe so we only report terminal Cancelled once AWS has actually reached a
             // terminal state. If AWS has not yet transitioned (e.g. TerminateJob is still propagating
             // SIGTERM), surface the current non-terminal state so the reconciler keeps polling.
-            var postCancelState = await batchClient.DescribeJobAsync(providerId, region, cancellationToken).ConfigureAwait(false);
+            var postCancelState = await batchClient.DescribeJobAsync(providerId, region, serviceUrl, cancellationToken).ConfigureAwait(false);
             if (postCancelState == null)
             {
                 return new BatchComputeObservation
@@ -592,7 +605,8 @@ internal sealed partial class AwsBatchComputeBackend(
         ExecutionJobRecord job,
         string pendingJobName,
         string? region,
-        CancellationToken cancellationToken)
+        string? serviceUrl = null,
+        CancellationToken cancellationToken = default)
     {
         var jobQueue = GetOptionalParameter(job.Spec.Parameters, AwsBatchParameterKeys.JobQueueArn);
         if (string.IsNullOrWhiteSpace(jobQueue))
@@ -611,7 +625,7 @@ internal sealed partial class AwsBatchComputeBackend(
         try
         {
             var matches = await batchClient
-                .ListJobsByNameAsync(jobQueue, pendingJobName, region, cancellationToken)
+                .ListJobsByNameAsync(jobQueue, pendingJobName, region, serviceUrl, cancellationToken)
                 .ConfigureAwait(false);
             if (matches.Count == 0)
             {

--- a/src/Honua.Aws/Features/ControlPlane/AwsBatchJobClient.cs
+++ b/src/Honua.Aws/Features/ControlPlane/AwsBatchJobClient.cs
@@ -71,29 +71,34 @@ internal interface IAwsBatchJobClient
     Task<AwsBatchSubmitResult> SubmitJobAsync(
         AwsBatchJobSubmission submission,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default);
 
     Task<AwsBatchJobState?> DescribeJobAsync(
         string jobId,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<AwsBatchJobState>> ListJobsByNameAsync(
         string jobQueue,
         string jobName,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default);
 
     Task CancelJobAsync(
         string jobId,
         string reason,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default);
 
     Task TerminateJobAsync(
         string jobId,
         string reason,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default);
 }
 
@@ -102,11 +107,12 @@ internal sealed class AwsSdkBatchJobClient : IAwsBatchJobClient
     public async Task<AwsBatchSubmitResult> SubmitJobAsync(
         AwsBatchJobSubmission submission,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(submission);
 
-        using var client = CreateClient(region);
+        using var client = CreateClient(region, serviceUrl);
         var request = new SubmitJobRequest
         {
             JobName = submission.JobName,
@@ -148,11 +154,12 @@ internal sealed class AwsSdkBatchJobClient : IAwsBatchJobClient
     public async Task<AwsBatchJobState?> DescribeJobAsync(
         string jobId,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
 
-        using var client = CreateClient(region);
+        using var client = CreateClient(region, serviceUrl);
         var response = await client.DescribeJobsAsync(
             new DescribeJobsRequest { Jobs = [jobId] },
             cancellationToken).ConfigureAwait(false);
@@ -182,12 +189,13 @@ internal sealed class AwsSdkBatchJobClient : IAwsBatchJobClient
         string jobQueue,
         string jobName,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(jobQueue);
         ArgumentException.ThrowIfNullOrWhiteSpace(jobName);
 
-        using var client = CreateClient(region);
+        using var client = CreateClient(region, serviceUrl);
         var response = await client.ListJobsAsync(
             new ListJobsRequest
             {
@@ -227,11 +235,12 @@ internal sealed class AwsSdkBatchJobClient : IAwsBatchJobClient
         string jobId,
         string reason,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
 
-        using var client = CreateClient(region);
+        using var client = CreateClient(region, serviceUrl);
         await client.CancelJobAsync(
             new CancelJobRequest
             {
@@ -245,11 +254,12 @@ internal sealed class AwsSdkBatchJobClient : IAwsBatchJobClient
         string jobId,
         string reason,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
 
-        using var client = CreateClient(region);
+        using var client = CreateClient(region, serviceUrl);
         await client.TerminateJobAsync(
             new TerminateJobRequest
             {
@@ -306,13 +316,27 @@ internal sealed class AwsSdkBatchJobClient : IAwsBatchJobClient
         return overrides;
     }
 
-    private static AmazonBatchClient CreateClient(string? region)
+    // Visible for testing. Applies an opt-in, config-driven ServiceURL override (for example a
+    // LocalStack Pro Batch endpoint, or a real-cloud test endpoint) when supplied; when unset the
+    // client uses the default regional endpoint, keeping production behaviour unchanged. AWS Batch
+    // emulation is a LocalStack Pro feature, so this override is primarily for paid/real coverage.
+    internal static AmazonBatchClient CreateClient(string? region, string? serviceUrl)
     {
+        var config = new AmazonBatchConfig();
+
         if (!string.IsNullOrWhiteSpace(region))
         {
-            return new AmazonBatchClient(RegionEndpoint.GetBySystemName(region));
+            config.RegionEndpoint = RegionEndpoint.GetBySystemName(region);
         }
 
-        return new AmazonBatchClient();
+        // Mirrors AwsS3FileStorage.CreateClient: when an explicit endpoint is supplied it takes
+        // precedence for the actual request URL while the region (when set) still provides the
+        // SigV4 signing region. Unset = default regional endpoint, keeping production behaviour.
+        if (!string.IsNullOrWhiteSpace(serviceUrl))
+        {
+            config.ServiceURL = serviceUrl;
+        }
+
+        return new AmazonBatchClient(config);
     }
 }

--- a/src/Honua.Aws/Features/ControlPlane/AwsLambdaAliasClient.cs
+++ b/src/Honua.Aws/Features/ControlPlane/AwsLambdaAliasClient.cs
@@ -26,6 +26,7 @@ internal interface IAwsLambdaAliasClient
         string functionName,
         string aliasName,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default);
 
     Task<AwsLambdaAliasState> UpdateAliasAsync(
@@ -34,6 +35,7 @@ internal interface IAwsLambdaAliasClient
         string functionVersion,
         IReadOnlyDictionary<string, double>? additionalVersionWeights,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default);
 }
 
@@ -43,9 +45,10 @@ internal sealed class AwsSdkLambdaAliasClient : IAwsLambdaAliasClient
         string functionName,
         string aliasName,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default)
     {
-        using var client = CreateClient(region);
+        using var client = CreateClient(region, serviceUrl);
         var response = await client.GetAliasAsync(
             new GetAliasRequest
             {
@@ -67,9 +70,10 @@ internal sealed class AwsSdkLambdaAliasClient : IAwsLambdaAliasClient
         string functionVersion,
         IReadOnlyDictionary<string, double>? additionalVersionWeights,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default)
     {
-        using var client = CreateClient(region);
+        using var client = CreateClient(region, serviceUrl);
         var response = await client.UpdateAliasAsync(
             new UpdateAliasRequest
             {
@@ -92,14 +96,27 @@ internal sealed class AwsSdkLambdaAliasClient : IAwsLambdaAliasClient
             response.RoutingConfig?.AdditionalVersionWeights);
     }
 
-    private static AmazonLambdaClient CreateClient(string? region)
+    // Visible for testing. Applies an opt-in, config-driven ServiceURL override (for example a
+    // LocalStack Community Lambda endpoint) when supplied; when unset the client uses the default
+    // regional endpoint, keeping production behaviour unchanged.
+    internal static AmazonLambdaClient CreateClient(string? region, string? serviceUrl)
     {
+        var config = new AmazonLambdaConfig();
+
         if (!string.IsNullOrWhiteSpace(region))
         {
-            return new AmazonLambdaClient(RegionEndpoint.GetBySystemName(region));
+            config.RegionEndpoint = RegionEndpoint.GetBySystemName(region);
         }
 
-        return new AmazonLambdaClient();
+        // Mirrors AwsS3FileStorage.CreateClient: when an explicit endpoint is supplied it takes
+        // precedence for the actual request URL while the region (when set) still provides the
+        // SigV4 signing region. Unset = default regional endpoint, keeping production behaviour.
+        if (!string.IsNullOrWhiteSpace(serviceUrl))
+        {
+            config.ServiceURL = serviceUrl;
+        }
+
+        return new AmazonLambdaClient(config);
     }
 
     private static AwsLambdaAliasState ToState(

--- a/src/Honua.Aws/Features/ControlPlane/AwsLambdaGitOpsDeployBackend.cs
+++ b/src/Honua.Aws/Features/ControlPlane/AwsLambdaGitOpsDeployBackend.cs
@@ -107,10 +107,11 @@ internal sealed partial class AwsLambdaGitOpsDeployBackend(
         var functionName = ResolveFunctionName(spec);
         var aliasName = ResolveAliasName(spec.Parameters);
         var region = ResolveRegion(spec.Parameters);
+        var serviceUrl = ResolveServiceUrl(spec.Parameters);
 
         try
         {
-            var aliasState = await aliasClient.GetAliasAsync(functionName, aliasName, region, cancellationToken).ConfigureAwait(false);
+            var aliasState = await aliasClient.GetAliasAsync(functionName, aliasName, region, serviceUrl, cancellationToken).ConfigureAwait(false);
             _ = TryResolveCanaryWeightFraction(spec.Parameters, out var canaryWeightFraction, out _);
             var currentStableVersion = aliasState.FunctionVersion;
 
@@ -127,6 +128,7 @@ internal sealed partial class AwsLambdaGitOpsDeployBackend(
                             [spec.DesiredRevision] = canaryWeightFraction.Value
                         },
                         region,
+                        serviceUrl,
                         cancellationToken)
                     .ConfigureAwait(false);
             }
@@ -139,6 +141,7 @@ internal sealed partial class AwsLambdaGitOpsDeployBackend(
                         spec.DesiredRevision,
                         null,
                         region,
+                        serviceUrl,
                         cancellationToken)
                     .ConfigureAwait(false);
             }
@@ -178,7 +181,8 @@ internal sealed partial class AwsLambdaGitOpsDeployBackend(
             var functionName = ResolveFunctionName(spec);
             var aliasName = ResolveAliasName(spec.Parameters);
             var region = ResolveRegion(spec.Parameters);
-            var aliasState = await aliasClient.GetAliasAsync(functionName, aliasName, region, cancellationToken).ConfigureAwait(false);
+            var serviceUrl = ResolveServiceUrl(spec.Parameters);
+            var aliasState = await aliasClient.GetAliasAsync(functionName, aliasName, region, serviceUrl, cancellationToken).ConfigureAwait(false);
             var hasWeightedTraffic = aliasState.AdditionalVersionWeights.Count > 0;
             _ = TryResolveCanaryWeightFraction(spec.Parameters, out var desiredWeightFraction, out _);
             var routesDesiredRevision = aliasState.AdditionalVersionWeights.TryGetValue(spec.DesiredRevision, out var currentCanaryWeight);
@@ -280,6 +284,7 @@ internal sealed partial class AwsLambdaGitOpsDeployBackend(
         var functionName = ResolveFunctionName(spec);
         var aliasName = ResolveAliasName(spec.Parameters);
         var region = ResolveRegion(spec.Parameters);
+        var serviceUrl = ResolveServiceUrl(spec.Parameters);
 
         try
         {
@@ -289,6 +294,7 @@ internal sealed partial class AwsLambdaGitOpsDeployBackend(
                     spec.DesiredRevision,
                     null,
                     region,
+                    serviceUrl,
                     cancellationToken)
                 .ConfigureAwait(false);
 
@@ -341,6 +347,7 @@ internal sealed partial class AwsLambdaGitOpsDeployBackend(
         var functionName = ResolveFunctionName(spec);
         var aliasName = ResolveAliasName(spec.Parameters);
         var region = ResolveRegion(spec.Parameters);
+        var serviceUrl = ResolveServiceUrl(spec.Parameters);
 
         try
         {
@@ -350,6 +357,7 @@ internal sealed partial class AwsLambdaGitOpsDeployBackend(
                     rollbackVersion,
                     null,
                     region,
+                    serviceUrl,
                     cancellationToken)
                 .ConfigureAwait(false);
 
@@ -407,6 +415,13 @@ internal sealed partial class AwsLambdaGitOpsDeployBackend(
         var match = LambdaArnRegionPattern.Match(resourceId);
         return match.Success ? match.Groups["region"].Value : null;
     }
+
+    // Opt-in, config-driven endpoint override. When set (for example to a LocalStack Community
+    // Lambda endpoint such as http://localhost:4566) it is forwarded to the SDK as a ServiceURL;
+    // when unset the SDK uses the default regional endpoint, so production behaviour is unchanged.
+    private static string? ResolveServiceUrl(IReadOnlyDictionary<string, string> parameters)
+        => GetParameter(parameters, "aws.service_url")
+            ?? GetParameter(parameters, "lambda.service_url");
 
     private static string? GetParameter(IReadOnlyDictionary<string, string> parameters, string key)
         => parameters.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)

--- a/src/Honua.Aws/Features/ControlPlane/CloudWatchDeployTelemetryProviderEvaluator.cs
+++ b/src/Honua.Aws/Features/ControlPlane/CloudWatchDeployTelemetryProviderEvaluator.cs
@@ -24,7 +24,8 @@ internal interface ICloudWatchMetricClient
         DateTime startUtc,
         DateTime endUtc,
         int periodSeconds,
-        CancellationToken cancellationToken);
+        string? serviceUrl = null,
+        CancellationToken cancellationToken = default);
 }
 
 internal sealed class AwsSdkCloudWatchMetricClient : ICloudWatchMetricClient
@@ -35,9 +36,10 @@ internal sealed class AwsSdkCloudWatchMetricClient : ICloudWatchMetricClient
         DateTime startUtc,
         DateTime endUtc,
         int periodSeconds,
-        CancellationToken cancellationToken)
+        string? serviceUrl = null,
+        CancellationToken cancellationToken = default)
     {
-        using var client = CreateClient(region);
+        using var client = CreateClient(region, serviceUrl);
         var response = await client.GetMetricDataAsync(
             new GetMetricDataRequest
             {
@@ -67,10 +69,28 @@ internal sealed class AwsSdkCloudWatchMetricClient : ICloudWatchMetricClient
         return null;
     }
 
-    private static AmazonCloudWatchClient CreateClient(string? region)
-        => string.IsNullOrWhiteSpace(region)
-            ? new AmazonCloudWatchClient()
-            : new AmazonCloudWatchClient(RegionEndpoint.GetBySystemName(region));
+    // Visible for testing. Applies an opt-in, config-driven ServiceURL override (for example a
+    // LocalStack Community CloudWatch endpoint) when supplied; when unset the client uses the
+    // default regional endpoint, keeping production behaviour unchanged.
+    internal static AmazonCloudWatchClient CreateClient(string? region, string? serviceUrl)
+    {
+        var config = new AmazonCloudWatchConfig();
+
+        if (!string.IsNullOrWhiteSpace(region))
+        {
+            config.RegionEndpoint = RegionEndpoint.GetBySystemName(region);
+        }
+
+        // Mirrors AwsS3FileStorage.CreateClient: when an explicit endpoint is supplied it takes
+        // precedence for the actual request URL while the region (when set) still provides the
+        // SigV4 signing region. Unset = default regional endpoint, keeping production behaviour.
+        if (!string.IsNullOrWhiteSpace(serviceUrl))
+        {
+            config.ServiceURL = serviceUrl;
+        }
+
+        return new AmazonCloudWatchClient(config);
+    }
 }
 
 /// <summary>
@@ -106,12 +126,13 @@ internal sealed class CloudWatchDeployTelemetryProviderEvaluator(
         }
 
         var region = ResolveRegion(connection);
+        var serviceUrl = ResolveServiceUrl(connection);
         var endUtc = DateTime.UtcNow;
         var startUtc = endUtc.AddSeconds(-WindowSeconds);
 
         var sampleCount = string.IsNullOrWhiteSpace(policy.MinimumSampleQuery)
             ? (double?)null
-            : await metricClient.GetExpressionValueAsync(region, policy.MinimumSampleQuery, startUtc, endUtc, WindowSeconds, cancellationToken).ConfigureAwait(false);
+            : await metricClient.GetExpressionValueAsync(region, policy.MinimumSampleQuery, startUtc, endUtc, WindowSeconds, serviceUrl, cancellationToken).ConfigureAwait(false);
 
         if (policy.MinimumSampleCount.HasValue && (!sampleCount.HasValue || sampleCount.Value < policy.MinimumSampleCount.Value))
         {
@@ -121,13 +142,13 @@ internal sealed class CloudWatchDeployTelemetryProviderEvaluator(
         double? errorRate = null;
         if (!string.IsNullOrWhiteSpace(policy.ErrorRateQuery) && policy.ErrorRateThreshold.HasValue)
         {
-            errorRate = await metricClient.GetExpressionValueAsync(region, policy.ErrorRateQuery, startUtc, endUtc, WindowSeconds, cancellationToken).ConfigureAwait(false);
+            errorRate = await metricClient.GetExpressionValueAsync(region, policy.ErrorRateQuery, startUtc, endUtc, WindowSeconds, serviceUrl, cancellationToken).ConfigureAwait(false);
         }
 
         double? latencyP95 = null;
         if (!string.IsNullOrWhiteSpace(policy.LatencyP95Query) && policy.LatencyP95ThresholdMs.HasValue)
         {
-            latencyP95 = await metricClient.GetExpressionValueAsync(region, policy.LatencyP95Query, startUtc, endUtc, WindowSeconds, cancellationToken).ConfigureAwait(false);
+            latencyP95 = await metricClient.GetExpressionValueAsync(region, policy.LatencyP95Query, startUtc, endUtc, WindowSeconds, serviceUrl, cancellationToken).ConfigureAwait(false);
         }
 
         return new DeployTelemetryReadings
@@ -136,6 +157,29 @@ internal sealed class CloudWatchDeployTelemetryProviderEvaluator(
             ErrorRate = errorRate,
             LatencyP95 = latencyP95
         };
+    }
+
+    // Opt-in, config-driven endpoint override. A custom CloudWatch BaseUrl (for example a
+    // LocalStack Community endpoint such as http://localhost:4566) is forwarded to the SDK as a
+    // ServiceURL so the telemetry gate can be exercised against an emulator. Standard regional
+    // monitoring endpoints are left to ResolveRegion / the SDK default endpoint, so production
+    // connections that only set BaseUrl for region inference keep their existing behaviour.
+    private static string? ResolveServiceUrl(DeployTelemetryConnectionDescriptor connection)
+    {
+        if (string.IsNullOrWhiteSpace(connection.BaseUrl) ||
+            !Uri.TryCreate(connection.BaseUrl, UriKind.Absolute, out var uri))
+        {
+            return null;
+        }
+
+        var labels = uri.Host.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        var isStandardRegionalEndpoint =
+            labels.Length >= 4 &&
+            string.Equals(labels[0], "monitoring", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(labels[^2], "amazonaws", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(labels[^1], "com", StringComparison.OrdinalIgnoreCase);
+
+        return isStandardRegionalEndpoint ? null : connection.BaseUrl.Trim();
     }
 
     private static string? ResolveRegion(DeployTelemetryConnectionDescriptor connection)

--- a/src/Honua.Aws/Honua.Aws.csproj
+++ b/src/Honua.Aws/Honua.Aws.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Honua.Server" />
     <InternalsVisibleTo Include="Honua.Server.Tests" />
+    <InternalsVisibleTo Include="Honua.CloudIntegration.Tests" />
     <InternalsVisibleTo Include="Honua.Architecture.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>

--- a/src/Honua.Server/Honua.Server.csproj
+++ b/src/Honua.Server/Honua.Server.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Honua.Server.Tests" />
+    <InternalsVisibleTo Include="Honua.CloudIntegration.Tests" />
     <InternalsVisibleTo Include="Honua.TestKit" />
     <InternalsVisibleTo Include="Honua.Protocols.OData.Tests" />
     <InternalsVisibleTo Include="Honua.Protocols.OgcApi.Tests" />

--- a/tests/dotnet/Honua.CloudIntegration.Tests/CloudIntegrationTraits.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/CloudIntegrationTraits.cs
@@ -24,23 +24,4 @@ internal static class CloudIntegrationTraits
     /// Trait value applied to every Docker-backed cloud-integration test.
     /// </summary>
     public const string CloudIntegration = "CloudIntegration";
-
-    /// <summary>
-    /// Trait key marking a test as requiring the paid LocalStack Pro tier (AWS Batch / ECS
-    /// emulation). Combined with the <see cref="CloudIntegration"/> category so the optional
-    /// Pro lane can be selected with <c>Category=CloudIntegration&amp;Tier=Pro</c> and the free
-    /// lane can exclude it with <c>Tier!=Pro</c>.
-    /// </summary>
-    public const string Tier = "Tier";
-
-    /// <summary>
-    /// Trait value for tests that require a LocalStack Pro auth token. These skip (not fail)
-    /// when <c>LOCALSTACK_AUTH_TOKEN</c> is absent so the default free CI tier stays green.
-    /// </summary>
-    public const string Pro = "Pro";
-
-    /// <summary>
-    /// Trait value for the free default tier (kind + LocalStack Community).
-    /// </summary>
-    public const string Free = "Free";
 }

--- a/tests/dotnet/Honua.CloudIntegration.Tests/CloudIntegrationTraits.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/CloudIntegrationTraits.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Shared constants for the cloud-integration trait taxonomy (#2163). Every test in this
+/// project is tagged <c>[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.CloudIntegration)]</c>
+/// so the default PR test run — which filters <c>Category!=CloudIntegration</c> on the
+/// Honua.Server.Tests projects and never invokes <c>dotnet test</c> against this project —
+/// excludes it. The dedicated cloud-integration workflow opts in with
+/// <c>--filter "Category=CloudIntegration"</c>.
+/// </summary>
+internal static class CloudIntegrationTraits
+{
+    /// <summary>
+    /// xUnit trait key. Mirrors the <c>Category</c> key used by the rest of the suite so a
+    /// single <c>Category=CloudIntegration</c> / <c>Category!=CloudIntegration</c> filter
+    /// governs inclusion and exclusion uniformly.
+    /// </summary>
+    public const string Category = "Category";
+
+    /// <summary>
+    /// Trait value applied to every Docker-backed cloud-integration test.
+    /// </summary>
+    public const string CloudIntegration = "CloudIntegration";
+
+    /// <summary>
+    /// Trait key marking a test as requiring the paid LocalStack Pro tier (AWS Batch / ECS
+    /// emulation). Combined with the <see cref="CloudIntegration"/> category so the optional
+    /// Pro lane can be selected with <c>Category=CloudIntegration&amp;Tier=Pro</c> and the free
+    /// lane can exclude it with <c>Tier!=Pro</c>.
+    /// </summary>
+    public const string Tier = "Tier";
+
+    /// <summary>
+    /// Trait value for tests that require a LocalStack Pro auth token. These skip (not fail)
+    /// when <c>LOCALSTACK_AUTH_TOKEN</c> is absent so the default free CI tier stays green.
+    /// </summary>
+    public const string Pro = "Pro";
+
+    /// <summary>
+    /// Trait value for the free default tier (kind + LocalStack Community).
+    /// </summary>
+    public const string Free = "Free";
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj
@@ -1,0 +1,66 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Cloud-integration test harness (#2163). Opt-in, Docker-backed integration tests that
+    stand up REAL emulated cloud backends via Testcontainers and exercise Honua's cloud
+    seams end-to-end. Every test is tagged [Trait("Category","CloudIntegration")] so it is
+    EXCLUDED from the default PR test run (which filters Category!=CloudIntegration) and only
+    runs in the dedicated nightly / explicit cloud-integration workflow.
+
+    Default (FREE) tier — no paid token required:
+      * kind / k3d           : real Kubernetes-in-Docker for KubernetesJobBatchComputeBackend.
+      * LocalStack Community  : S3, Lambda, CloudWatch (the free service set).
+
+    Optional (PAID/REAL) tier — gated on LOCALSTACK_AUTH_TOKEN:
+      * LocalStack Pro        : AWS Batch / ECS emulation. SKIPPED (not failed) when the token
+                                is absent. Azure Batch has NO emulator and is real-cloud only.
+
+    This project is a test project (never AOT-published) and is intentionally NOT registered in
+    the Honua.Server.Tests ADR-0037 shard matrix, so it never runs on the per-PR server-test path.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <RootNamespace>Honua.CloudIntegration.Tests</RootNamespace>
+    <!-- These tests require a live Docker daemon (kind + LocalStack). They are correct-by-
+         construction and only executed in CI / local Docker environments. -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Xunit.SkippableFact" />
+    <PackageReference Include="Testcontainers" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="AWSSDK.S3" />
+    <PackageReference Include="AWSSDK.Lambda" />
+    <PackageReference Include="AWSSDK.CloudWatch" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Honua.Core\Honua.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\Honua.Aws\Honua.Aws.csproj" />
+    <ProjectReference Include="..\..\..\src\Honua.Server\Honua.Server.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj
@@ -7,13 +7,10 @@
     EXCLUDED from the default PR test run (which filters Category!=CloudIntegration) and only
     runs in the dedicated nightly / explicit cloud-integration workflow.
 
-    Default (FREE) tier — no paid token required:
+    All lanes are FREE (no paid token required):
       * kind / k3d           : real Kubernetes-in-Docker for KubernetesJobBatchComputeBackend.
-      * LocalStack Community  : S3, Lambda, CloudWatch (the free service set).
-
-    Optional (PAID/REAL) tier — gated on LOCALSTACK_AUTH_TOKEN:
-      * LocalStack Pro        : AWS Batch / ECS emulation. SKIPPED (not failed) when the token
-                                is absent. Azure Batch has NO emulator and is real-cloud only.
+      * LocalStack Community  : S3 artifact round-trip (the free service set). Each test gates
+                                with [SkippableFact] and skips (never fails) when Docker is absent.
 
     This project is a test project (never AOT-published) and is intentionally NOT registered in
     the Honua.Server.Tests ADR-0037 shard matrix, so it never runs on the per-PR server-test path.
@@ -40,15 +37,12 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="NSubstitute" />
     <PackageReference Include="Xunit.SkippableFact" />
     <PackageReference Include="Testcontainers" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="AWSSDK.S3" />
-    <PackageReference Include="AWSSDK.Lambda" />
-    <PackageReference Include="AWSSDK.CloudWatch" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/Honua.CloudIntegration.Tests/KindClusterFixture.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/KindClusterFixture.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Fixture that adapts an already-provisioned <c>kind</c> (Kubernetes-in-Docker) cluster
+/// into the inputs <c>KubernetesJobBatchComputeBackend</c> needs out-of-cluster: an HTTPS
+/// API server URL, a PEM CA bundle path, a bearer token, and a target namespace.
+///
+/// Why env-var hand-off rather than parsing kubeconfig here: kind is provisioned by the CI
+/// workflow's <c>kind</c> action (or a local <c>kind create cluster</c>), which already owns
+/// the cluster lifecycle. The workflow extracts the server URL, cluster CA, and a
+/// ServiceAccount token with <c>kubectl</c> — the canonical Kubernetes tool — and exports
+/// them as the environment variables below. This keeps the harness free of a YAML/kubeconfig
+/// parser and a Kubernetes client dependency (the production
+/// <c>KubernetesJobClient</c> is itself a raw-HTTP adapter that avoids the official client),
+/// and means the harness drives the SAME credential surface
+/// (<c>ControlPlane:Kubernetes:ApiServerUrl</c> / <c>BearerToken</c> / <c>CaBundlePath</c>)
+/// an operator configures for a real out-of-cluster target.
+///
+/// When the required variables are absent the fixture reports <see cref="Available"/> = false
+/// and the kind-backed tests skip, so the project still compiles and runs (skipping) where no
+/// cluster is present (for example a developer box without kind).
+/// </summary>
+public sealed class KindClusterFixture : IAsyncLifetime
+{
+    /// <summary>HTTPS API server URL of the kind cluster (must be https per option validation).</summary>
+    public const string ApiServerUrlEnvVar = "HONUA_TEST_K8S_API_SERVER_URL";
+
+    /// <summary>Filesystem path to a PEM CA bundle that signs the kind API server certificate.</summary>
+    public const string CaBundlePathEnvVar = "HONUA_TEST_K8S_CA_BUNDLE_PATH";
+
+    /// <summary>Bearer token for a ServiceAccount permitted to create/observe/delete Jobs.</summary>
+    public const string BearerTokenEnvVar = "HONUA_TEST_K8S_BEARER_TOKEN";
+
+    /// <summary>Namespace the test Jobs are created in (defaults to <c>default</c>).</summary>
+    public const string NamespaceEnvVar = "HONUA_TEST_K8S_NAMESPACE";
+
+    /// <summary>
+    /// True when all required cluster inputs are present so the kind-backed scenarios can run.
+    /// </summary>
+    public bool Available { get; private set; }
+
+    /// <summary>HTTPS API server URL, or null when unavailable.</summary>
+    public string? ApiServerUrl { get; private set; }
+
+    /// <summary>CA bundle path, or null when unavailable.</summary>
+    public string? CaBundlePath { get; private set; }
+
+    /// <summary>Bearer token, or null when unavailable.</summary>
+    public string? BearerToken { get; private set; }
+
+    /// <summary>Target namespace; defaults to <c>default</c>.</summary>
+    public string Namespace { get; private set; } = "default";
+
+    /// <summary>
+    /// Resolves the cluster inputs from the environment. Synchronous in practice but kept
+    /// async to satisfy <see cref="IAsyncLifetime"/>.
+    /// </summary>
+    public Task InitializeAsync()
+    {
+        ApiServerUrl = Environment.GetEnvironmentVariable(ApiServerUrlEnvVar);
+        CaBundlePath = Environment.GetEnvironmentVariable(CaBundlePathEnvVar);
+        BearerToken = Environment.GetEnvironmentVariable(BearerTokenEnvVar);
+        var configuredNamespace = Environment.GetEnvironmentVariable(NamespaceEnvVar);
+        if (!string.IsNullOrWhiteSpace(configuredNamespace))
+        {
+            Namespace = configuredNamespace.Trim();
+        }
+
+        Available =
+            !string.IsNullOrWhiteSpace(ApiServerUrl) &&
+            !string.IsNullOrWhiteSpace(BearerToken) &&
+            !string.IsNullOrWhiteSpace(CaBundlePath) &&
+            File.Exists(CaBundlePath);
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>No-op; the kind cluster lifecycle is owned by the workflow that created it.</summary>
+    public Task DisposeAsync() => Task.CompletedTask;
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/KubernetesBackendFactory.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/KubernetesBackendFactory.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.ControlPlane;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Builds a production-shaped <see cref="KubernetesJobBatchComputeBackend"/> wired against a
+/// real out-of-cluster API server (a kind cluster). The wiring mirrors
+/// <c>Program.cs</c>: a named <c>control-plane-kubernetes</c> HttpClient whose primary
+/// handler is <see cref="KubernetesJobClient.CreatePrimaryHandler"/> (so the kind cluster CA
+/// is trusted exactly as it would be for a real private-CA target), the shared
+/// <see cref="KubernetesApiRequestFactory"/>, and a <see cref="KubernetesExecutionOptions"/>
+/// snapshot with in-cluster auto-detect disabled (out-of-cluster targeting).
+/// </summary>
+internal static class KubernetesBackendFactory
+{
+    /// <summary>
+    /// Composes the backend and its real <see cref="IKubernetesJobClient"/> against the
+    /// supplied kind cluster inputs. The returned <see cref="ServiceProvider"/> owns the
+    /// HttpClient lifetime and must be disposed by the caller.
+    /// </summary>
+    public static (KubernetesJobBatchComputeBackend Backend, ServiceProvider Provider) Create(
+        string apiServerUrl,
+        string bearerToken,
+        string caBundlePath,
+        string @namespace,
+        string? defaultImage)
+    {
+        var options = new KubernetesExecutionOptions
+        {
+            // Out-of-cluster: target the kind API server explicitly and trust its CA bundle,
+            // exactly as an operator pointing Honua at a remote cluster would configure.
+            InClusterAutoDetect = false,
+            ApiServerUrl = apiServerUrl,
+            BearerToken = bearerToken,
+            CaBundlePath = caBundlePath,
+            DefaultNamespace = @namespace,
+            DefaultImage = defaultImage,
+            // Clean completed Jobs quickly so repeated runs do not collide on Job name.
+            DefaultTtlSecondsAfterFinished = 120
+        };
+
+        var optionsMonitor = new StaticOptionsMonitor<KubernetesExecutionOptions>(options);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IOptionsMonitor<KubernetesExecutionOptions>>(optionsMonitor);
+        services.AddHttpClient(KubernetesJobClient.HttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(() =>
+                KubernetesJobClient.CreatePrimaryHandler(
+                    inClusterAutoDetect: false,
+                    caBundlePath: caBundlePath));
+
+        var provider = services.BuildServiceProvider();
+
+        var requestFactory = new KubernetesApiRequestFactory(optionsMonitor);
+        var jobClient = new KubernetesJobClient(
+            provider.GetRequiredService<IHttpClientFactory>(),
+            requestFactory,
+            NullLogger<KubernetesJobClient>.Instance);
+
+        var backend = new KubernetesJobBatchComputeBackend(
+            jobClient,
+            optionsMonitor,
+            NullLogger<KubernetesJobBatchComputeBackend>.Instance);
+
+        return (backend, provider);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IOptionsMonitor{T}"/> over a fixed snapshot. The backend and request
+    /// factory only read <see cref="IOptionsMonitor{T}.CurrentValue"/>; change notification is
+    /// not exercised by the harness.
+    /// </summary>
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = value;
+
+        public T Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/KubernetesJobLifecycleCloudIntegrationTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/KubernetesJobLifecycleCloudIntegrationTests.cs
@@ -20,7 +20,6 @@ namespace Honua.CloudIntegration.Tests;
 /// the project still runs on boxes without a cluster.
 /// </summary>
 [Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.CloudIntegration)]
-[Trait(CloudIntegrationTraits.Tier, CloudIntegrationTraits.Free)]
 public sealed class KubernetesJobLifecycleCloudIntegrationTests : IClassFixture<KindClusterFixture>
 {
     // A tiny worker image whose default entrypoint runs to completion and exits 0 — stands in

--- a/tests/dotnet/Honua.CloudIntegration.Tests/KubernetesJobLifecycleCloudIntegrationTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/KubernetesJobLifecycleCloudIntegrationTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Domain;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Free-tier scenario (#2163): proves the per-target Job submission → run → terminal-result
+/// lifecycle for <c>KubernetesJobBatchComputeBackend</c> against a real kind cluster. Honua is
+/// serverless at every level with no standing compute, and each GP job is a unique per-job
+/// submission, so this validates the per-submission lifecycle rather than a fixed cluster.
+///
+/// kind/k3d is free real Kubernetes-in-Docker, so this is the default CI lane. When no kind
+/// cluster is wired (no <c>HONUA_TEST_K8S_*</c> env vars), the tests skip rather than fail so
+/// the project still runs on boxes without a cluster.
+/// </summary>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.CloudIntegration)]
+[Trait(CloudIntegrationTraits.Tier, CloudIntegrationTraits.Free)]
+public sealed class KubernetesJobLifecycleCloudIntegrationTests : IClassFixture<KindClusterFixture>
+{
+    // A tiny worker image whose default entrypoint runs to completion and exits 0 — stands in
+    // for a GP worker. The backend's BuildManifest does not set a container command/args, so
+    // the image MUST self-terminate via its own entrypoint. The CI workflow builds this image
+    // (entrypoint = /bin/true) and loads it into the kind node so it resolves with an
+    // image-pull-policy of Never. Overridable via env so a local run can point at a different
+    // self-terminating image already present on the node.
+    private static readonly string SucceedingImage =
+        Environment.GetEnvironmentVariable("HONUA_TEST_K8S_JOB_IMAGE") ?? "honua-ci/job-succeed:latest";
+
+    private readonly KindClusterFixture _kind;
+
+    public KubernetesJobLifecycleCloudIntegrationTests(KindClusterFixture kind)
+    {
+        _kind = kind;
+    }
+
+    [SkippableFact]
+    public async Task SubmitJob_RunsToCompletion_ReportsSucceeded()
+    {
+        Skip.IfNot(_kind.Available, "kind cluster not configured (HONUA_TEST_K8S_* env vars absent).");
+
+        var (backend, provider) = KubernetesBackendFactory.Create(
+            _kind.ApiServerUrl!,
+            _kind.BearerToken!,
+            _kind.CaBundlePath!,
+            _kind.Namespace,
+            defaultImage: SucceedingImage);
+
+        var operationId = $"ci-k8s-{Guid.NewGuid():N}".Substring(0, 24);
+        await using var _ = provider;
+
+        var job = CreateJob(operationId, image: SucceedingImage);
+
+        try
+        {
+            // 1. Submit: the backend must translate the record into a batch/v1 Job and create it.
+            var submission = await backend.StartAsync(job);
+            submission.Status.Should().BeOneOf(
+                ExecutionJobStatus.Provisioning,
+                ExecutionJobStatus.Queued);
+            submission.ProviderOperationId.Should().NotBeNullOrWhiteSpace();
+
+            // Pin the namespace the backend resolved so later observe calls target the same Job.
+            var observedJob = MergeResolvedParameters(job, submission);
+
+            // 2. Observe until terminal: poll the real cluster through the backend's observe path.
+            var terminal = await PollUntilTerminalAsync(backend, observedJob, TimeSpan.FromMinutes(4));
+            terminal.Status.Should().Be(
+                ExecutionJobStatus.Succeeded,
+                "the busybox job exits 0 and the backend maps a completed Job to Succeeded");
+        }
+        finally
+        {
+            // 3. Clean up: best-effort cancel/delete so the namespace does not accumulate Jobs.
+            try
+            {
+                await backend.CancelAsync(job);
+            }
+            catch
+            {
+                // Cleanup is best-effort; the cluster is ephemeral CI infrastructure.
+            }
+        }
+    }
+
+    private static async Task<BatchComputeObservation> PollUntilTerminalAsync(
+        KubernetesJobBatchComputeBackend backend,
+        ExecutionJobRecord job,
+        TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        BatchComputeObservation last = new() { Status = ExecutionJobStatus.Queued };
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            last = await backend.ObserveAsync(job);
+            if (last.Status is ExecutionJobStatus.Succeeded
+                or ExecutionJobStatus.Failed
+                or ExecutionJobStatus.Cancelled)
+            {
+                return last;
+            }
+
+            // Carry the provider id forward so observe keeps resolving the same Job.
+            if (!string.IsNullOrWhiteSpace(last.ProviderOperationId))
+            {
+                job = job with { ProviderOperationId = last.ProviderOperationId };
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(3));
+        }
+
+        throw new TimeoutException(
+            $"Kubernetes Job did not reach a terminal state within {timeout}. Last status: {last.Status}.");
+    }
+
+    private static ExecutionJobRecord MergeResolvedParameters(
+        ExecutionJobRecord job,
+        BatchComputeSubmissionResult submission)
+    {
+        var parameters = new Dictionary<string, string>(job.Spec.Parameters, StringComparer.Ordinal);
+        if (submission.ResolvedParameters is { Count: > 0 })
+        {
+            foreach (var (key, value) in submission.ResolvedParameters)
+            {
+                parameters[key] = value;
+            }
+        }
+
+        return job with
+        {
+            ProviderOperationId = submission.ProviderOperationId,
+            Spec = job.Spec with { Parameters = parameters }
+        };
+    }
+
+    private static ExecutionJobRecord CreateJob(string operationId, string image)
+    {
+        var spec = new ExecutionJobSpec
+        {
+            Kind = ExecutionJobKind.Geoprocessing,
+            TargetKind = BatchComputeTargetKind.KubernetesJob,
+            Backend = KubernetesJobBatchComputeBackend.BackendId,
+            WorkloadId = "ci-harness-workload",
+            WorkloadName = "cloud-integration-gp",
+            Artifact = image,
+            Parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [KubernetesJobParameterKeys.Image] = image,
+                // The image is preloaded into the kind node by the workflow, so never attempt a
+                // registry pull (which would fail for the local-only honua-ci/job-succeed tag).
+                [KubernetesJobParameterKeys.ImagePullPolicy] = "Never"
+            }
+        };
+
+        return new ExecutionJobRecord
+        {
+            OperationId = operationId,
+            Status = ExecutionJobStatus.Queued,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = spec
+        };
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/LocalStackFixture.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/LocalStackFixture.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Testcontainers fixture that boots a single LocalStack container and exposes its
+/// edge endpoint. The default (free) tier enables only the LocalStack Community service
+/// set — S3, Lambda, CloudWatch, and CloudWatch Logs — which require no paid token.
+///
+/// When the optional <c>LOCALSTACK_AUTH_TOKEN</c> environment variable is present the
+/// fixture additionally requests the Pro service set (AWS Batch + ECS emulation) and
+/// passes the token through to the container. Pro-tier tests check
+/// <see cref="ProEnabled"/> and skip (never fail) when the token is absent, so the free
+/// CI lane stays green without a LocalStack subscription.
+///
+/// Mirrors <c>Honua.TestKit.EmulatorFixture</c> (same image/tag, port 4566, health probe)
+/// so the harness shares the repo's proven LocalStack Community wiring.
+/// </summary>
+public sealed class LocalStackFixture : IAsyncLifetime
+{
+    // Pin to the same image/tag the repo already uses in EmulatorFixture so the
+    // Community service surface and health endpoint behaviour match what CI proves.
+    private const string Image = "localstack/localstack:3.6.0";
+    private const int EdgePort = 4566;
+
+    /// <summary>
+    /// Name of the optional environment variable carrying a LocalStack Pro auth token.
+    /// When set, Batch/ECS emulation is enabled and Pro-tier scenarios run; when unset,
+    /// those scenarios skip.
+    /// </summary>
+    public const string AuthTokenEnvVar = "LOCALSTACK_AUTH_TOKEN";
+
+    /// <summary>
+    /// Static credential pair LocalStack accepts for SigV4 signing. LocalStack does not
+    /// verify credentials, but the SDK still requires non-empty values when an explicit
+    /// endpoint is configured.
+    /// </summary>
+    public const string AccessKeyId = "test";
+
+    /// <summary>
+    /// Static secret access key paired with <see cref="AccessKeyId"/>.
+    /// </summary>
+    public const string SecretAccessKey = "test";
+
+    /// <summary>
+    /// Region used for every emulated AWS client. Matches the repo's existing S3 emulator tests.
+    /// </summary>
+    public const string Region = "us-east-1";
+
+    private IContainer? _container;
+
+    /// <summary>
+    /// True when a LocalStack Pro auth token was supplied, so Batch/ECS emulation is available.
+    /// </summary>
+    public bool ProEnabled { get; private set; }
+
+    /// <summary>
+    /// Edge service URL (for example <c>http://localhost:32789</c>) used as the SDK
+    /// <c>ServiceURL</c> override for every emulated AWS client.
+    /// </summary>
+    public string ServiceUrl { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Boots LocalStack, enabling the Pro service set only when an auth token is present.
+    /// </summary>
+    public async Task InitializeAsync()
+    {
+        var authToken = Environment.GetEnvironmentVariable(AuthTokenEnvVar);
+        ProEnabled = !string.IsNullOrWhiteSpace(authToken);
+
+        // Community set is always available; Batch/ECS are Pro-only emulations. Requesting
+        // them without a token would have LocalStack reject those service calls, so only add
+        // them when the token unlocks them.
+        var services = ProEnabled
+            ? "s3,lambda,cloudwatch,logs,batch,ecs,iam,ec2"
+            : "s3,lambda,cloudwatch,logs";
+
+        var builder = new ContainerBuilder()
+            .WithImage(Image)
+            .WithPortBinding(EdgePort, true)
+            .WithEnvironment("SERVICES", services)
+            .WithEnvironment("DEFAULT_REGION", Region)
+            .WithEnvironment("AWS_DEFAULT_REGION", Region)
+            .WithEnvironment("AWS_ACCESS_KEY_ID", AccessKeyId)
+            .WithEnvironment("AWS_SECRET_ACCESS_KEY", SecretAccessKey)
+            // Lambda emulation needs a Docker socket to spawn function containers; LocalStack
+            // detects the mounted socket automatically. The kind/Docker-in-CI host provides it.
+            .WithBindMount("/var/run/docker.sock", "/var/run/docker.sock");
+
+        if (ProEnabled)
+        {
+            builder = builder.WithEnvironment(AuthTokenEnvVar, authToken!);
+        }
+
+        _container = builder.Build();
+        await _container.StartAsync();
+
+        var mappedPort = _container.GetMappedPublicPort(EdgePort);
+        ServiceUrl = $"http://localhost:{mappedPort}";
+
+        await WaitForReadyAsync(mappedPort, services);
+    }
+
+    /// <summary>
+    /// Stops and disposes the LocalStack container.
+    /// </summary>
+    public async Task DisposeAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync();
+            _container = null;
+        }
+    }
+
+    private static async Task WaitForReadyAsync(int port, string services)
+    {
+        var timeout = TimeSpan.FromSeconds(180);
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(8) };
+
+        // Only the always-present Community services are required for readiness; Pro services
+        // may take longer to provision and are not gating for the free lane.
+        var requiredServices = new[] { "s3", "lambda", "cloudwatch" };
+        Exception? lastError = null;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            try
+            {
+                using var response = await httpClient.GetAsync(
+                    $"http://localhost:{port}/_localstack/health");
+                if (response.IsSuccessStatusCode)
+                {
+                    var body = await response.Content.ReadAsStringAsync();
+                    if (requiredServices.All(svc => IsServiceUp(body, svc)))
+                    {
+                        return;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or TimeoutException)
+            {
+                lastError = ex;
+            }
+
+            await Task.Delay(1000);
+        }
+
+        var detail = lastError is null ? string.Empty : $" Last error: {lastError.Message}";
+        throw new TimeoutException(
+            $"Timed out waiting for LocalStack services [{services}] to become ready.{detail}");
+    }
+
+    // LocalStack reports each service state as "available", "running", or "disabled" in the
+    // /_localstack/health JSON. Accept both available and running (lazily-started services
+    // report "available" until first use), tolerating whitespace variations in the payload.
+    private static bool IsServiceUp(string healthBody, string service)
+        => healthBody.Contains($"\"{service}\": \"available\"", StringComparison.OrdinalIgnoreCase)
+            || healthBody.Contains($"\"{service}\":\"available\"", StringComparison.OrdinalIgnoreCase)
+            || healthBody.Contains($"\"{service}\": \"running\"", StringComparison.OrdinalIgnoreCase)
+            || healthBody.Contains($"\"{service}\":\"running\"", StringComparison.OrdinalIgnoreCase);
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/LocalStackFixture.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/LocalStackFixture.cs
@@ -8,18 +8,19 @@ using Xunit;
 namespace Honua.CloudIntegration.Tests;
 
 /// <summary>
-/// Testcontainers fixture that boots a single LocalStack container and exposes its
-/// edge endpoint. The default (free) tier enables only the LocalStack Community service
-/// set — S3, Lambda, CloudWatch, and CloudWatch Logs — which require no paid token.
+/// Testcontainers fixture that boots a single LocalStack Community container and exposes its
+/// edge endpoint. Only the free (Community) service set is enabled — currently S3, which the
+/// <see cref="S3ArtifactRoundTripCloudIntegrationTests"/> exercises end-to-end. No paid
+/// LocalStack Pro token is required.
 ///
-/// When the optional <c>LOCALSTACK_AUTH_TOKEN</c> environment variable is present the
-/// fixture additionally requests the Pro service set (AWS Batch + ECS emulation) and
-/// passes the token through to the container. Pro-tier tests check
-/// <see cref="ProEnabled"/> and skip (never fail) when the token is absent, so the free
-/// CI lane stays green without a LocalStack subscription.
+/// When Docker is unavailable (for example a developer box without a daemon) container startup
+/// fails; the fixture catches that, reports <see cref="Available"/> = false, and the dependent
+/// tests skip (never fail) — mirroring <see cref="KindClusterFixture"/>'s skip-when-absent
+/// behaviour so the project still compiles and runs everywhere.
 ///
-/// Mirrors <c>Honua.TestKit.EmulatorFixture</c> (same image/tag, port 4566, health probe)
-/// so the harness shares the repo's proven LocalStack Community wiring.
+/// Pins the same image/tag the repo already uses in <c>Honua.TestKit.EmulatorFixture</c> (port
+/// 4566, <c>/_localstack/health</c> probe) so the harness reuses the repo's proven LocalStack
+/// Community wiring.
 /// </summary>
 public sealed class LocalStackFixture : IAsyncLifetime
 {
@@ -28,12 +29,9 @@ public sealed class LocalStackFixture : IAsyncLifetime
     private const string Image = "localstack/localstack:3.6.0";
     private const int EdgePort = 4566;
 
-    /// <summary>
-    /// Name of the optional environment variable carrying a LocalStack Pro auth token.
-    /// When set, Batch/ECS emulation is enabled and Pro-tier scenarios run; when unset,
-    /// those scenarios skip.
-    /// </summary>
-    public const string AuthTokenEnvVar = "LOCALSTACK_AUTH_TOKEN";
+    // Community service set exercised by this harness. Kept minimal (only what a runnable test
+    // actually uses) so the fixture does not imply coverage it does not have.
+    private const string Services = "s3";
 
     /// <summary>
     /// Static credential pair LocalStack accepts for SigV4 signing. LocalStack does not
@@ -55,55 +53,54 @@ public sealed class LocalStackFixture : IAsyncLifetime
     private IContainer? _container;
 
     /// <summary>
-    /// True when a LocalStack Pro auth token was supplied, so Batch/ECS emulation is available.
+    /// True when the LocalStack container started and reported its Community services ready, so
+    /// the dependent integration tests can run. False when Docker is unavailable.
     /// </summary>
-    public bool ProEnabled { get; private set; }
+    public bool Available { get; private set; }
 
     /// <summary>
     /// Edge service URL (for example <c>http://localhost:32789</c>) used as the SDK
-    /// <c>ServiceURL</c> override for every emulated AWS client.
+    /// <c>ServiceURL</c> override for every emulated AWS client. Empty when unavailable.
     /// </summary>
     public string ServiceUrl { get; private set; } = string.Empty;
 
     /// <summary>
-    /// Boots LocalStack, enabling the Pro service set only when an auth token is present.
+    /// Boots LocalStack Community. When Docker is unavailable the failure is swallowed and
+    /// <see cref="Available"/> stays false so the dependent tests skip instead of failing.
     /// </summary>
     public async Task InitializeAsync()
     {
-        var authToken = Environment.GetEnvironmentVariable(AuthTokenEnvVar);
-        ProEnabled = !string.IsNullOrWhiteSpace(authToken);
-
-        // Community set is always available; Batch/ECS are Pro-only emulations. Requesting
-        // them without a token would have LocalStack reject those service calls, so only add
-        // them when the token unlocks them.
-        var services = ProEnabled
-            ? "s3,lambda,cloudwatch,logs,batch,ecs,iam,ec2"
-            : "s3,lambda,cloudwatch,logs";
-
-        var builder = new ContainerBuilder()
-            .WithImage(Image)
-            .WithPortBinding(EdgePort, true)
-            .WithEnvironment("SERVICES", services)
-            .WithEnvironment("DEFAULT_REGION", Region)
-            .WithEnvironment("AWS_DEFAULT_REGION", Region)
-            .WithEnvironment("AWS_ACCESS_KEY_ID", AccessKeyId)
-            .WithEnvironment("AWS_SECRET_ACCESS_KEY", SecretAccessKey)
-            // Lambda emulation needs a Docker socket to spawn function containers; LocalStack
-            // detects the mounted socket automatically. The kind/Docker-in-CI host provides it.
-            .WithBindMount("/var/run/docker.sock", "/var/run/docker.sock");
-
-        if (ProEnabled)
+        try
         {
-            builder = builder.WithEnvironment(AuthTokenEnvVar, authToken!);
+            _container = new ContainerBuilder()
+                .WithImage(Image)
+                .WithPortBinding(EdgePort, true)
+                .WithEnvironment("SERVICES", Services)
+                .WithEnvironment("DEFAULT_REGION", Region)
+                .WithEnvironment("AWS_DEFAULT_REGION", Region)
+                .WithEnvironment("AWS_ACCESS_KEY_ID", AccessKeyId)
+                .WithEnvironment("AWS_SECRET_ACCESS_KEY", SecretAccessKey)
+                .Build();
+
+            await _container.StartAsync();
+
+            var mappedPort = _container.GetMappedPublicPort(EdgePort);
+            ServiceUrl = $"http://localhost:{mappedPort}";
+
+            await WaitForReadyAsync(mappedPort);
+            Available = true;
         }
-
-        _container = builder.Build();
-        await _container.StartAsync();
-
-        var mappedPort = _container.GetMappedPublicPort(EdgePort);
-        ServiceUrl = $"http://localhost:{mappedPort}";
-
-        await WaitForReadyAsync(mappedPort, services);
+        catch (Exception ex) when (ex is not TimeoutException)
+        {
+            // Docker not available (or the daemon refused the container): degrade to skip rather
+            // than fail, exactly like KindClusterFixture when its env vars are absent.
+            Available = false;
+            if (_container is not null)
+            {
+                await _container.DisposeAsync();
+                _container = null;
+            }
+        }
     }
 
     /// <summary>
@@ -118,15 +115,11 @@ public sealed class LocalStackFixture : IAsyncLifetime
         }
     }
 
-    private static async Task WaitForReadyAsync(int port, string services)
+    private static async Task WaitForReadyAsync(int port)
     {
-        var timeout = TimeSpan.FromSeconds(180);
+        var timeout = TimeSpan.FromSeconds(120);
         var deadline = DateTimeOffset.UtcNow.Add(timeout);
         using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(8) };
-
-        // Only the always-present Community services are required for readiness; Pro services
-        // may take longer to provision and are not gating for the free lane.
-        var requiredServices = new[] { "s3", "lambda", "cloudwatch" };
         Exception? lastError = null;
 
         while (DateTimeOffset.UtcNow < deadline)
@@ -138,7 +131,7 @@ public sealed class LocalStackFixture : IAsyncLifetime
                 if (response.IsSuccessStatusCode)
                 {
                     var body = await response.Content.ReadAsStringAsync();
-                    if (requiredServices.All(svc => IsServiceUp(body, svc)))
+                    if (IsServiceUp(body, "s3"))
                     {
                         return;
                     }
@@ -154,7 +147,7 @@ public sealed class LocalStackFixture : IAsyncLifetime
 
         var detail = lastError is null ? string.Empty : $" Last error: {lastError.Message}";
         throw new TimeoutException(
-            $"Timed out waiting for LocalStack services [{services}] to become ready.{detail}");
+            $"Timed out waiting for LocalStack service [{Services}] to become ready.{detail}");
     }
 
     // LocalStack reports each service state as "available", "running", or "disabled" in the

--- a/tests/dotnet/Honua.CloudIntegration.Tests/S3ArtifactRoundTripCloudIntegrationTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/S3ArtifactRoundTripCloudIntegrationTests.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Amazon.S3;
+using Amazon.S3.Model;
+using FluentAssertions;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Free-tier (LocalStack Community) scenario (#2163): proves an S3 artifact round-trip — create
+/// bucket, put object, get object, delete — against a REAL emulated S3 endpoint via the
+/// <see cref="LocalStackFixture"/>'s edge ServiceURL. This exercises the same SDK
+/// ServiceURL-override + path-style seam Honua's <c>AwsS3FileStorage</c> uses to target a custom
+/// endpoint, so the LocalStack Community fixture backs a runnable test rather than sitting unused.
+///
+/// Gated like the kind lifecycle test: when Docker is unavailable the fixture reports
+/// <see cref="LocalStackFixture.Available"/> = false and this test skips (never fails).
+/// </summary>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.CloudIntegration)]
+public sealed class S3ArtifactRoundTripCloudIntegrationTests : IClassFixture<LocalStackFixture>
+{
+    private readonly LocalStackFixture _localStack;
+
+    public S3ArtifactRoundTripCloudIntegrationTests(LocalStackFixture localStack)
+    {
+        _localStack = localStack;
+    }
+
+    [SkippableFact]
+    public async Task PutThenGet_RoundTripsArtifact_ThroughCommunityS3()
+    {
+        Skip.IfNot(_localStack.Available, "LocalStack Community not available (Docker daemon absent).");
+
+        using var client = CreateClient(_localStack.ServiceUrl);
+
+        var bucket = $"honua-ci-{Guid.NewGuid():N}";
+        var key = "deploy/artifact.txt";
+        var payload = $"honua-cloud-integration-{Guid.NewGuid():N}";
+
+        await client.PutBucketAsync(new PutBucketRequest { BucketName = bucket });
+
+        try
+        {
+            // 1. Put: write the artifact through the emulated S3 endpoint.
+            await client.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = bucket,
+                Key = key,
+                ContentBody = payload
+            });
+
+            // 2. Get: read it back and assert the bytes round-trip unchanged.
+            using var response = await client.GetObjectAsync(new GetObjectRequest
+            {
+                BucketName = bucket,
+                Key = key
+            });
+
+            using var reader = new StreamReader(response.ResponseStream, Encoding.UTF8);
+            var roundTripped = await reader.ReadToEndAsync();
+
+            roundTripped.Should().Be(
+                payload,
+                "the object written to the emulated S3 endpoint must be retrievable byte-for-byte");
+        }
+        finally
+        {
+            // 3. Clean up: best-effort delete so the ephemeral emulator does not accumulate state.
+            try
+            {
+                await client.DeleteObjectAsync(new DeleteObjectRequest { BucketName = bucket, Key = key });
+                await client.DeleteBucketAsync(new DeleteBucketRequest { BucketName = bucket });
+            }
+            catch
+            {
+                // The LocalStack container is ephemeral CI infrastructure; cleanup is best-effort.
+            }
+        }
+    }
+
+    private static AmazonS3Client CreateClient(string serviceUrl)
+    {
+        // Mirror the AwsS3FileStorage seam: explicit ServiceURL targets the emulator edge endpoint
+        // while ForcePathStyle keeps virtual-host bucket addressing off (LocalStack serves
+        // path-style by default). Static "test"/"test" credentials satisfy SigV4 signing.
+        var config = new AmazonS3Config
+        {
+            ServiceURL = serviceUrl,
+            ForcePathStyle = true,
+            AuthenticationRegion = LocalStackFixture.Region,
+        };
+
+        return new AmazonS3Client(
+            LocalStackFixture.AccessKeyId,
+            LocalStackFixture.SecretAccessKey,
+            config);
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/xunit.runner.json
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/xunit.runner.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": 1,
+  "methodDisplay": "method",
+  "methodDisplayOptions": "all",
+  "diagnosticMessages": false,
+  "internalDiagnosticMessages": false,
+  "preEnumerateTheories": true,
+  "shadowCopy": false,
+  "stopOnFail": false,
+  "longRunningTestSeconds": 300
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/AwsBatchComputeBackendTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/AwsBatchComputeBackendTests.cs
@@ -91,6 +91,74 @@ public sealed class AwsBatchComputeBackendTests
     }
 
     [Fact]
+    public async Task StartAsync_WithServiceUrlParameter_ForwardsEndpointOverride()
+    {
+        // An opt-in batch.service_url parameter (LocalStack Pro / real-cloud Batch endpoint) must
+        // reach the SDK client seam as a ServiceURL override.
+        var client = new StubAwsBatchJobClient
+        {
+            NextSubmitResult = new AwsBatchSubmitResult
+            {
+                JobId = "aws-job-1",
+                JobName = "honua-op-1"
+            }
+        };
+        var backend = CreateBackend(client);
+        var job = CreateJob(parameters: new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [AwsBatchParameterKeys.JobDefinitionArn] = "arn:aws:batch:us-west-2:123:job-definition/heavy-gdal:1",
+            [AwsBatchParameterKeys.JobQueueArn] = "arn:aws:batch:us-west-2:123:job-queue/gp-heavy",
+            [AwsBatchParameterKeys.Region] = "us-west-2",
+            [AwsBatchParameterKeys.ServiceUrl] = "http://localhost:4566"
+        });
+
+        await backend.StartAsync(job);
+
+        client.LastServiceUrl.Should().Be("http://localhost:4566");
+    }
+
+    [Fact]
+    public async Task StartAsync_WithoutServiceUrlParameter_LeavesEndpointOverrideUnset()
+    {
+        var client = new StubAwsBatchJobClient
+        {
+            NextSubmitResult = new AwsBatchSubmitResult { JobId = "aws-job-1", JobName = "honua-op-1" }
+        };
+        var backend = CreateBackend(client);
+        var job = CreateJob(parameters: new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [AwsBatchParameterKeys.JobDefinitionArn] = "arn:aws:batch:us-west-2:123:job-definition/heavy-gdal:1",
+            [AwsBatchParameterKeys.JobQueueArn] = "arn:aws:batch:us-west-2:123:job-queue/gp-heavy",
+            [AwsBatchParameterKeys.Region] = "us-west-2"
+        });
+
+        await backend.StartAsync(job);
+
+        client.LastServiceUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateClient_WithServiceUrl_AppliesEndpointOverride()
+    {
+        using var client = AwsSdkBatchJobClient.CreateClient("us-west-2", "http://localhost:4566");
+
+        // The AWS SDK treats ServiceURL and RegionEndpoint as mutually exclusive: setting an
+        // explicit ServiceURL clears RegionEndpoint (mirrors AwsS3FileStorage). The override must
+        // win so the client targets the emulator endpoint.
+        client.Config.ServiceURL.Should().Be("http://localhost:4566/");
+        client.Config.RegionEndpoint.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateClient_WithoutServiceUrl_UsesDefaultRegionalEndpoint()
+    {
+        using var client = AwsSdkBatchJobClient.CreateClient("us-west-2", serviceUrl: null);
+
+        client.Config.RegionEndpoint!.SystemName.Should().Be("us-west-2");
+        string.IsNullOrEmpty(client.Config.ServiceURL).Should().BeTrue();
+    }
+
+    [Fact]
     public async Task ObserveAsync_MapsRunningToRunning()
     {
         var client = new StubAwsBatchJobClient
@@ -1201,6 +1269,8 @@ internal sealed class StubAwsBatchJobClient : IAwsBatchJobClient
 
     public string? LastRegion { get; private set; }
 
+    public string? LastServiceUrl { get; private set; }
+
     public string? LastListJobsQueue { get; private set; }
 
     public string? LastListJobsName { get; private set; }
@@ -1216,10 +1286,12 @@ internal sealed class StubAwsBatchJobClient : IAwsBatchJobClient
     public Task<AwsBatchSubmitResult> SubmitJobAsync(
         AwsBatchJobSubmission submission,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default)
     {
         LastSubmission = submission;
         LastRegion = region;
+        LastServiceUrl = serviceUrl;
         if (SubmitException != null)
         {
             throw SubmitException;
@@ -1231,10 +1303,12 @@ internal sealed class StubAwsBatchJobClient : IAwsBatchJobClient
     public Task<AwsBatchJobState?> DescribeJobAsync(
         string jobId,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default)
     {
         DescribeCallCount++;
         LastRegion = region;
+        LastServiceUrl = serviceUrl;
         if (DescribeException != null)
         {
             throw DescribeException;
@@ -1248,12 +1322,14 @@ internal sealed class StubAwsBatchJobClient : IAwsBatchJobClient
         string jobQueue,
         string jobName,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default)
     {
         ListJobsCallCount++;
         LastListJobsQueue = jobQueue;
         LastListJobsName = jobName;
         LastRegion = region;
+        LastServiceUrl = serviceUrl;
         if (ListJobsException != null)
         {
             throw ListJobsException;
@@ -1267,9 +1343,11 @@ internal sealed class StubAwsBatchJobClient : IAwsBatchJobClient
         string jobId,
         string reason,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default)
     {
         CancelCallCount++;
+        LastServiceUrl = serviceUrl;
         if (CancelException != null)
         {
             throw CancelException;
@@ -1282,9 +1360,11 @@ internal sealed class StubAwsBatchJobClient : IAwsBatchJobClient
         string jobId,
         string reason,
         string? region,
+        string? serviceUrl = null,
         CancellationToken cancellationToken = default)
     {
         TerminateCallCount++;
+        LastServiceUrl = serviceUrl;
         if (TerminateException != null)
         {
             throw TerminateException;

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/AwsLambdaGitOpsDeployBackendTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/AwsLambdaGitOpsDeployBackendTests.cs
@@ -235,6 +235,76 @@ public sealed class AwsLambdaGitOpsDeployBackendTests
         aliasClient.LastUpdatedVersion.Should().BeNull();
     }
 
+    [Fact]
+    public async Task StartAsync_WithServiceUrlParameter_ForwardsEndpointOverride()
+    {
+        // An opt-in lambda.service_url / aws.service_url parameter (for example a LocalStack
+        // Community Lambda endpoint) must reach the SDK client seam as a ServiceURL override.
+        var aliasClient = new StubAwsLambdaAliasClient
+        {
+            CurrentState = new AwsLambdaAliasState
+            {
+                AliasName = "live",
+                AliasArn = "arn:aws:lambda:us-east-1:123456789012:function:honua:live",
+                FunctionVersion = "41"
+            }
+        };
+        var backend = new AwsLambdaGitOpsDeployBackend(aliasClient, NullLogger<AwsLambdaGitOpsDeployBackend>.Instance);
+
+        await backend.StartAsync(CreateOperation(
+            desiredRevision: "42",
+            currentRevision: null,
+            parameters: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["lambda.alias_name"] = "live",
+                ["target.resource_id"] = "arn:aws:lambda:us-east-1:123456789012:function:honua-prod-lambda",
+                ["telemetry.connection"] = "prod-prom",
+                ["lambda.service_url"] = "http://localhost:4566"
+            }));
+
+        aliasClient.LastServiceUrl.Should().Be("http://localhost:4566");
+    }
+
+    [Fact]
+    public async Task StartAsync_WithoutServiceUrlParameter_LeavesEndpointOverrideUnset()
+    {
+        var aliasClient = new StubAwsLambdaAliasClient
+        {
+            CurrentState = new AwsLambdaAliasState
+            {
+                AliasName = "live",
+                AliasArn = "arn:aws:lambda:us-east-1:123456789012:function:honua:live",
+                FunctionVersion = "41"
+            }
+        };
+        var backend = new AwsLambdaGitOpsDeployBackend(aliasClient, NullLogger<AwsLambdaGitOpsDeployBackend>.Instance);
+
+        await backend.StartAsync(CreateOperation(desiredRevision: "42", currentRevision: null));
+
+        aliasClient.LastServiceUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateClient_WithServiceUrl_AppliesEndpointOverride()
+    {
+        using var client = AwsSdkLambdaAliasClient.CreateClient("us-east-1", "http://localhost:4566");
+
+        // The AWS SDK treats ServiceURL and RegionEndpoint as mutually exclusive: setting an
+        // explicit ServiceURL clears RegionEndpoint (mirrors AwsS3FileStorage). The override must
+        // win so the client targets the emulator endpoint.
+        client.Config.ServiceURL.Should().Be("http://localhost:4566/");
+        client.Config.RegionEndpoint.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateClient_WithoutServiceUrl_UsesDefaultRegionalEndpoint()
+    {
+        using var client = AwsSdkLambdaAliasClient.CreateClient("us-east-1", serviceUrl: null);
+
+        client.Config.RegionEndpoint!.SystemName.Should().Be("us-east-1");
+        string.IsNullOrEmpty(client.Config.ServiceURL).Should().BeTrue();
+    }
+
     private static DeployOperationSpec CreateSpec(
         string desiredRevision,
         IReadOnlyDictionary<string, string>? parameters = null)
@@ -297,12 +367,18 @@ public sealed class AwsLambdaGitOpsDeployBackendTests
 
         public IReadOnlyDictionary<string, double> LastAdditionalVersionWeights { get; private set; } = new Dictionary<string, double>(StringComparer.Ordinal);
 
+        public string? LastServiceUrl { get; private set; }
+
         public Task<AwsLambdaAliasState> GetAliasAsync(
             string functionName,
             string aliasName,
             string? region,
+            string? serviceUrl = null,
             CancellationToken cancellationToken = default)
-            => Task.FromResult(CurrentState);
+        {
+            LastServiceUrl = serviceUrl;
+            return Task.FromResult(CurrentState);
+        }
 
         public Task<AwsLambdaAliasState> UpdateAliasAsync(
             string functionName,
@@ -310,8 +386,10 @@ public sealed class AwsLambdaGitOpsDeployBackendTests
             string functionVersion,
             IReadOnlyDictionary<string, double>? additionalVersionWeights,
             string? region,
+            string? serviceUrl = null,
             CancellationToken cancellationToken = default)
         {
+            LastServiceUrl = serviceUrl;
             LastUpdatedVersion = functionVersion;
             LastAdditionalVersionWeights = additionalVersionWeights is { Count: > 0 }
                 ? new Dictionary<string, double>(additionalVersionWeights, StringComparer.Ordinal)

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/CloudWatchDeployTelemetryProviderEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/CloudWatchDeployTelemetryProviderEvaluatorTests.cs
@@ -142,6 +142,61 @@ public sealed class CloudWatchDeployTelemetryProviderEvaluatorTests
         client.LastRegion.Should().Be("us-east-2");
     }
 
+    [Fact]
+    public async Task EvaluateAsync_CustomBaseUrl_ForwardsServiceUrlOverride()
+    {
+        // A non-standard CloudWatch BaseUrl (for example a LocalStack Community endpoint) must be
+        // forwarded to the SDK as a ServiceURL so the telemetry gate can run against an emulator.
+        var client = new FakeCloudWatchMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleExpression] = 50,
+            [ErrorRateExpression] = 0.01,
+            [LatencyExpression] = 120
+        });
+
+        await Evaluate(client, region: "us-east-1", baseUrl: "http://localhost:4566");
+
+        client.LastServiceUrl.Should().Be("http://localhost:4566");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_StandardRegionalBaseUrl_DoesNotForwardServiceUrl()
+    {
+        // A standard regional monitoring endpoint is used only for region inference and must NOT
+        // be forwarded as a ServiceURL override, so production connections keep default endpoints.
+        var client = new FakeCloudWatchMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleExpression] = 50,
+            [ErrorRateExpression] = 0.01,
+            [LatencyExpression] = 120
+        });
+
+        await Evaluate(client, baseUrl: "https://monitoring.us-east-2.amazonaws.com");
+
+        client.LastServiceUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateClient_WithServiceUrl_AppliesEndpointOverride()
+    {
+        using var client = AwsSdkCloudWatchMetricClient.CreateClient("us-east-1", "http://localhost:4566");
+
+        // The AWS SDK treats ServiceURL and RegionEndpoint as mutually exclusive: setting an
+        // explicit ServiceURL clears RegionEndpoint (mirrors AwsS3FileStorage). The override must
+        // win so the client targets the emulator endpoint.
+        client.Config.ServiceURL.Should().Be("http://localhost:4566/");
+        client.Config.RegionEndpoint.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateClient_WithoutServiceUrl_UsesDefaultRegionalEndpoint()
+    {
+        using var client = AwsSdkCloudWatchMetricClient.CreateClient("us-east-1", serviceUrl: null);
+
+        client.Config.RegionEndpoint!.SystemName.Should().Be("us-east-1");
+        string.IsNullOrEmpty(client.Config.ServiceURL).Should().BeTrue();
+    }
+
     private static async Task<DeployTelemetryDecision?> Evaluate(
         FakeCloudWatchMetricClient client,
         string? region = null,
@@ -235,15 +290,19 @@ public sealed class CloudWatchDeployTelemetryProviderEvaluatorTests
 
         public string? LastRegion { get; private set; }
 
+        public string? LastServiceUrl { get; private set; }
+
         public Task<double?> GetExpressionValueAsync(
             string? region,
             string expression,
             DateTime startUtc,
             DateTime endUtc,
             int periodSeconds,
-            CancellationToken cancellationToken)
+            string? serviceUrl = null,
+            CancellationToken cancellationToken = default)
         {
             LastRegion = region;
+            LastServiceUrl = serviceUrl;
             RequestedExpressions.Enqueue(expression);
             return Task.FromResult(values.TryGetValue(expression, out var value) ? value : null);
         }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/CloudWatchDeployTelemetryProviderEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/CloudWatchDeployTelemetryProviderEvaluatorTests.cs
@@ -176,6 +176,62 @@ public sealed class CloudWatchDeployTelemetryProviderEvaluatorTests
         client.LastServiceUrl.Should().BeNull();
     }
 
+    // The ServiceUrl override repurposes connection.BaseUrl (which on trunk drove only region
+    // inference). Only the canonical commercial regional endpoint — monitoring.{region}.amazonaws.com
+    // — is treated as "standard" (region inference only, no ServiceURL override). Every other host
+    // shape routes via an explicit ServiceURL so non-standard CloudWatch edges keep working. The
+    // three tests below pin that intentional behaviour for China, FIPS, and VPC PrivateLink hosts.
+
+    [Theory]
+    // China partition: the ...amazonaws.com.cn suffix is NOT the commercial endpoint, so it must
+    // be forwarded as an explicit ServiceURL (and region is not inferred from the host).
+    [InlineData("https://monitoring.cn-north-1.amazonaws.com.cn")]
+    // FIPS endpoint: the "monitoring-fips" host label is not the bare "monitoring" label, so it is
+    // not treated as the standard endpoint and routes via explicit ServiceURL.
+    [InlineData("https://monitoring-fips.us-east-1.amazonaws.com")]
+    // VPC PrivateLink (interface endpoint) DNS name: a vpce-* host targeting the CloudWatch service
+    // is non-standard and must be forwarded verbatim as the ServiceURL.
+    [InlineData("https://vpce-0a1b2c3d-abcde.monitoring.us-east-1.vpce.amazonaws.com")]
+    public async Task EvaluateAsync_NonStandardCloudWatchHost_ForwardsExplicitServiceUrl(string baseUrl)
+    {
+        var client = new FakeCloudWatchMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleExpression] = 50,
+            [ErrorRateExpression] = 0.01,
+            [LatencyExpression] = 120
+        });
+
+        // Region must be supplied explicitly because a non-standard host is NOT region-inferable;
+        // the SigV4 signing region therefore comes from the connection's Region, not the URL.
+        await Evaluate(client, region: "us-east-1", baseUrl: baseUrl);
+
+        client.LastServiceUrl.Should().Be(
+            baseUrl,
+            "non-standard CloudWatch hosts (China/FIPS/VPC) must route via an explicit ServiceURL override");
+    }
+
+    [Theory]
+    [InlineData("https://monitoring.cn-north-1.amazonaws.com.cn")]
+    [InlineData("https://monitoring-fips.us-east-1.amazonaws.com")]
+    [InlineData("https://vpce-0a1b2c3d-abcde.monitoring.us-east-1.vpce.amazonaws.com")]
+    public async Task EvaluateAsync_NonStandardCloudWatchHost_DoesNotInferRegionFromHost(string baseUrl)
+    {
+        var client = new FakeCloudWatchMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleExpression] = 50,
+            [ErrorRateExpression] = 0.01,
+            [LatencyExpression] = 120
+        });
+
+        // No explicit Region and a non-standard host: region inference only fires for the canonical
+        // monitoring.{region}.amazonaws.com shape, so these hosts yield a null region (SDK default
+        // chain) rather than mis-parsing a label as the region.
+        await Evaluate(client, region: null, baseUrl: baseUrl);
+
+        client.LastRegion.Should().BeNull(
+            "only the canonical commercial monitoring.{region}.amazonaws.com host is region-inferable");
+    }
+
     [Fact]
     public void CreateClient_WithServiceUrl_AppliesEndpointOverride()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowReconcilerLambdaTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowReconcilerLambdaTests.cs
@@ -308,6 +308,7 @@ public sealed class DeployWorkflowReconcilerLambdaTests
             string functionName,
             string aliasName,
             string? region,
+            string? serviceUrl = null,
             CancellationToken cancellationToken = default)
             => Task.FromResult(CurrentState);
 
@@ -317,6 +318,7 @@ public sealed class DeployWorkflowReconcilerLambdaTests
             string functionVersion,
             IReadOnlyDictionary<string, double>? additionalVersionWeights,
             string? region,
+            string? serviceUrl = null,
             CancellationToken cancellationToken = default)
         {
             var weights = additionalVersionWeights is { Count: > 0 }


### PR DESCRIPTION
## Summary

Adds an opt-in, config-driven `ServiceUrl` endpoint override to the AWS Batch, Lambda, and CloudWatch control-plane client seams (#2162), and lands the free-tier cloud-integration test harness (#2163) that exercises Honua's cloud seams end-to-end against real emulated backends.

The override mirrors the proven `AwsS3FileStorage.CreateClient` pattern: when an explicit `ServiceURL` is supplied it is applied to the SDK config; when unset the client uses the default regional endpoint, so production behaviour is unchanged (prod-safe by default).

## Changes Made

- `AwsBatchJobClient` / `AwsLambdaAliasClient` / `AwsSdkCloudWatchMetricClient`: thread an optional `serviceUrl` through each method and apply it as the SDK config `ServiceURL` (mirrors `AwsS3FileStorage`). `serviceUrl` is ordered before `CancellationToken` to satisfy CA1068.
- `AwsBatchComputeBackend` (`batch.service_url`), `AwsLambdaGitOpsDeployBackend` (`aws.service_url` / `lambda.service_url`), and `CloudWatchDeployTelemetryProviderEvaluator` (non-standard `BaseUrl`) resolve and forward the override; standard regional endpoints are left to default resolution.
- New `Honua.CloudIntegration.Tests` project: Docker-backed, opt-in tests tagged `[Trait("Category","CloudIntegration")]`, excluded from the default PR run. Free tier = kind + LocalStack Community; the LocalStack Pro Batch/ECS lane is gated on `LOCALSTACK_AUTH_TOKEN` and skips (never fails) when the token is absent.
- `cloud-integration-harness.yml` workflow: nightly + `workflow_dispatch`. Free tier (kind + LocalStack Community) always runs; optional Pro tier runs only when explicitly dispatched and uses the secret.
- Registered the new project in `Honua.sln`. It is a test project (never AOT-published — the AOT job targets only `Honua.Server.csproj`) and intentionally outside the ADR-0037 `Honua.Server.Tests` shard map (it is a separate test assembly, not a Honua.Server.Tests class).
- Unit tests proving the `ServiceUrl` override reaches the client seam and is applied to the SDK config.

## What was finished here

The two prior agents left the work uncommitted and it did not compile: the new `serviceUrl` parameters were placed **after** `CancellationToken`, tripping CA1068 (warnings-as-errors) across all interfaces, implementations, call sites, and test stubs. Reordered `serviceUrl` before `CancellationToken` everywhere. Also corrected three `CreateClient_WithServiceUrl_AppliesEndpointOverride` unit tests: the AWS SDK treats `ServiceURL` and `RegionEndpoint` as mutually exclusive (setting `ServiceURL` clears `RegionEndpoint`, same as `AwsS3FileStorage`), so the tests now assert the override wins and `RegionEndpoint` is null rather than asserting both are retained. Added the missing free-tier CI workflow and registered the project in the solution.

## Breaking Changes

None.

## Gate Impact

- [x] No gate impact (additive, opt-in; default behaviour unchanged)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

`Honua.Aws`, `Honua.Server.Tests`, and `Honua.CloudIntegration.Tests` build clean (0 warnings/errors). The 12 `ServiceUrl`/`CreateClient`/`EndpointOverride` unit tests pass. `scripts/ci/validate-ci-router.sh` passes. The Docker-backed cloud-integration tests (kind + LocalStack) are **CI-verified, not run here** — Docker/kind/LocalStack are not available in this environment, so the harness and workflow are correct-by-construction.

Closes #2162
Related to #2163
