### PR TITLE
feat(geoprocessing): honua gp plan dry-run validate + size/cost estimate (#2126)

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -983,6 +983,7 @@
       "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Eval|FullyQualifiedName~Honua.Server.Tests.Features.Geoprocessing|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Grpc",
       "paths": [
         "src/Honua.Geoprocessing/Features/Geoprocessing/",
+        "src/Honua.Geoprocessing.Cli/",
         "src/Honua.Core/Features/Geoprocessing/",
         "src/Honua.Server/Features/Protocols/Grpc/",
         "src/Honua.Protocols.OgcApi/Processes/",

--- a/Honua.sln
+++ b/Honua.sln
@@ -151,6 +151,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Protocols.SensorThing
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Protocols.SensorThings.Tests", "tests\dotnet\Honua.Protocols.SensorThings.Tests\Honua.Protocols.SensorThings.Tests.csproj", "{09A157E7-67AD-46E1-9495-BD499000592D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Geoprocessing.Cli", "src\Honua.Geoprocessing.Cli\Honua.Geoprocessing.Cli.csproj", "{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -977,6 +979,18 @@ Global
 		{09A157E7-67AD-46E1-9495-BD499000592D}.Release|x64.Build.0 = Release|Any CPU
 		{09A157E7-67AD-46E1-9495-BD499000592D}.Release|x86.ActiveCfg = Release|Any CPU
 		{09A157E7-67AD-46E1-9495-BD499000592D}.Release|x86.Build.0 = Release|Any CPU
+		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Debug|x64.Build.0 = Debug|Any CPU
+		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Debug|x86.Build.0 = Debug|Any CPU
+		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Release|x64.ActiveCfg = Release|Any CPU
+		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Release|x64.Build.0 = Release|Any CPU
+		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Release|x86.ActiveCfg = Release|Any CPU
+		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1045,5 +1059,6 @@ Global
 		{43B1BD9E-AD92-4A52-8DE3-4CE9E7B1BCD8} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
 		{268C7FCA-045F-4DA1-B249-64DCF5E13D11} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{09A157E7-67AD-46E1-9495-BD499000592D} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
+		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/IProcessExecutor.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/IProcessExecutor.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.ControlPlane.Abstractions;
+
+/// <summary>
+/// A self-describing per-process geoprocessing executor. Extends <see cref="IJobExecutor"/>
+/// with a self-declared set of process ids the executor handles, enabling the
+/// geoprocessing/GDAL dispatchers to auto-register and route by <c>processId</c>
+/// without a hand-maintained constructor that names every executor explicitly
+/// (the GP Devkit authoring contract, issue #2122).
+/// </summary>
+/// <remarks>
+/// An instance property (rather than a <c>[GpProcess]</c> attribute) is used so
+/// that executors which fan a single implementation out over several process ids
+/// — for example the GDAL surface and raster-statistics families — can compute
+/// their id set at construction time, and so the dispatcher can build its routing
+/// table from DI-resolved instances with no reflection (AOT-friendly). Each id in
+/// <see cref="ProcessIds"/> must be unique across the registered executor set;
+/// the dispatcher fails fast on a duplicate or empty declaration.
+/// </remarks>
+public interface IProcessExecutor : IJobExecutor
+{
+    /// <summary>
+    /// The non-empty set of canonical dotted process ids this executor handles
+    /// (e.g. <c>geometry.buffer</c>, or the several <c>surface.*</c> ids a single
+    /// GDAL surface executor serves). Comparison is ordinal. Must contain at least
+    /// one id; ids must not be null, empty, or whitespace.
+    /// </summary>
+    IReadOnlySet<string> ProcessIds { get; }
+}

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/ProcessExecutorRouteTable.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/ProcessExecutorRouteTable.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+
+namespace Honua.Core.Features.ControlPlane.Abstractions;
+
+/// <summary>
+/// Builds the per-process-id routing table a geoprocessing dispatcher uses to
+/// fan a claimed job out to the matching <see cref="IProcessExecutor"/>. Shared by
+/// the managed <c>GeoprocessingDispatchJobExecutor</c> and the native
+/// <c>GdalDispatchJobExecutor</c> so both get identical duplicate/empty-id
+/// diagnostics from a single auto-registration loop (issue #2122).
+/// </summary>
+public static class ProcessExecutorRouteTable
+{
+    /// <summary>
+    /// Builds an ordinal <c>processId -&gt; executor</c> map from the registered
+    /// executor set. Throws <see cref="InvalidOperationException"/> when an executor
+    /// declares no ids, declares a null/whitespace id, or when two executors claim
+    /// the same id — surfacing authoring mistakes at composition time rather than
+    /// silently dropping a process at runtime.
+    /// </summary>
+    /// <param name="executors">The DI-resolved per-process executors.</param>
+    /// <returns>A frozen ordinal lookup keyed by process id.</returns>
+    public static FrozenDictionary<string, IProcessExecutor> Build(
+        IEnumerable<IProcessExecutor> executors)
+    {
+        ArgumentNullException.ThrowIfNull(executors);
+
+        var map = new Dictionary<string, IProcessExecutor>(StringComparer.Ordinal);
+
+        foreach (var executor in executors)
+        {
+            ArgumentNullException.ThrowIfNull(executor);
+
+            var ids = executor.ProcessIds;
+            if (ids is null || ids.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Process executor '{executor.GetType().FullName}' declared no process ids; "
+                    + "every IProcessExecutor must handle at least one canonical process id.");
+            }
+
+            foreach (var id in ids)
+            {
+                if (string.IsNullOrWhiteSpace(id))
+                {
+                    throw new InvalidOperationException(
+                        $"Process executor '{executor.GetType().FullName}' declared a null or "
+                        + "whitespace process id; process ids must be non-empty dotted identifiers.");
+                }
+
+                if (map.TryGetValue(id, out var existing))
+                {
+                    throw new InvalidOperationException(
+                        $"Duplicate geoprocessing process id '{id}' declared by both "
+                        + $"'{existing.GetType().FullName}' and '{executor.GetType().FullName}'. "
+                        + "Each process id must be handled by exactly one executor.");
+                }
+
+                map[id] = executor;
+            }
+        }
+
+        return map.ToFrozenDictionary(StringComparer.Ordinal);
+    }
+}

--- a/src/Honua.Core/Features/Geoprocessing/Domain/ProcessSchemaJsonGenerator.cs
+++ b/src/Honua.Core/Features/Geoprocessing/Domain/ProcessSchemaJsonGenerator.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+
+namespace Honua.Core.Features.Geoprocessing.Domain;
+
+/// <summary>
+/// Emits a JSON Schema (draft 2020-12) document for a <see cref="ProcessDefinition"/>'s
+/// typed input parameters, plus a compact output descriptor for the artifact kinds the
+/// process produces. This is the authoring-contract schema surface the GP Devkit
+/// <c>describe</c> command (issue #2124) consumes; it derives entirely from the typed
+/// <see cref="ProcessParameterSpec"/> set rather than a hand-written schema, so the
+/// advertised schema can never drift from the catalog (issue #2122).
+/// </summary>
+/// <remarks>
+/// The document is written with a <see cref="Utf8JsonWriter"/> (no reflection-based
+/// serialization) so it stays AOT-safe.
+/// </remarks>
+public static class ProcessSchemaJsonGenerator
+{
+    private const string SchemaDialect = "https://json-schema.org/draft/2020-12/schema";
+
+    /// <summary>
+    /// Produces the JSON Schema document for the given process definition as a UTF-8
+    /// JSON string. The root object has <c>processId</c>, <c>title</c>,
+    /// <c>description</c>, <c>category</c>, <c>runtimeProfile</c>, an <c>inputs</c>
+    /// JSON Schema object (with <c>properties</c>/<c>required</c>), and an
+    /// <c>outputs</c> array describing the produced artifact kinds.
+    /// </summary>
+    /// <param name="process">The catalog process definition. Must not be null.</param>
+    /// <param name="indented">Whether to pretty-print the output.</param>
+    public static string Generate(ProcessDefinition process, bool indented = true)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = indented }))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("processId", process.ProcessId);
+            writer.WriteString("title", process.Title);
+            writer.WriteString("description", process.Description);
+            writer.WriteString("category", process.Category);
+            writer.WriteString("runtimeProfile", process.RuntimeProfile);
+
+            WriteInputsSchema(writer, process);
+            WriteOutputs(writer, process);
+
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    private static void WriteInputsSchema(Utf8JsonWriter writer, ProcessDefinition process)
+    {
+        writer.WritePropertyName("inputs");
+        writer.WriteStartObject();
+        writer.WriteString("$schema", SchemaDialect);
+        writer.WriteString("type", "object");
+
+        writer.WritePropertyName("properties");
+        writer.WriteStartObject();
+        foreach (var parameter in process.Parameters)
+        {
+            writer.WritePropertyName(parameter.Name);
+            WriteParameterSchema(writer, parameter);
+        }
+
+        writer.WriteEndObject();
+
+        // Required array — only the parameters flagged Required, in declared order.
+        writer.WritePropertyName("required");
+        writer.WriteStartArray();
+        foreach (var parameter in process.Parameters)
+        {
+            if (parameter.Required)
+            {
+                writer.WriteStringValue(parameter.Name);
+            }
+        }
+
+        writer.WriteEndArray();
+
+        // Authoring contract: the parameter set is closed.
+        writer.WriteBoolean("additionalProperties", false);
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteParameterSchema(Utf8JsonWriter writer, ProcessParameterSpec parameter)
+    {
+        writer.WriteStartObject();
+
+        var (jsonType, format) = MapType(parameter.ValueType);
+        writer.WriteString("type", jsonType);
+        if (format is not null)
+        {
+            writer.WriteString("format", format);
+        }
+
+        writer.WriteString("title", parameter.DisplayName);
+        writer.WriteString("description", parameter.Description);
+
+        if (parameter.DefaultValue is not null)
+        {
+            writer.WriteString("default", parameter.DefaultValue);
+        }
+
+        if (parameter.AllowedValues is { Count: > 0 })
+        {
+            writer.WritePropertyName("enum");
+            writer.WriteStartArray();
+            foreach (var allowed in parameter.AllowedValues)
+            {
+                writer.WriteStringValue(allowed);
+            }
+
+            writer.WriteEndArray();
+        }
+
+        // Surface the canonical Honua value type so authoring tools can render a
+        // precise editor (e.g. a WKB picker for Wkb, a layer chooser for LayerId)
+        // beyond the coarse JSON Schema primitive.
+        writer.WriteString("x-honua-value-type", parameter.ValueType.ToString());
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteOutputs(Utf8JsonWriter writer, ProcessDefinition process)
+    {
+        writer.WritePropertyName("outputs");
+        writer.WriteStartArray();
+        foreach (var kind in process.OutputArtifactKinds)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("artifactKind", kind.ToString());
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+    }
+
+    /// <summary>
+    /// Maps a Honua <see cref="ProcessParameterValueType"/> to a JSON Schema
+    /// <c>(type, format)</c> pair. Geometry/array/identifier types are represented by
+    /// their closest JSON Schema primitive plus a descriptive <c>format</c>; the
+    /// precise type is also carried on <c>x-honua-value-type</c>.
+    /// </summary>
+    private static (string Type, string? Format) MapType(ProcessParameterValueType valueType)
+        => valueType switch
+        {
+            ProcessParameterValueType.Text => ("string", null),
+            ProcessParameterValueType.WholeNumber => ("integer", "int32"),
+            ProcessParameterValueType.FloatingPoint => ("number", "double"),
+            ProcessParameterValueType.Flag => ("boolean", null),
+            ProcessParameterValueType.Wkb => ("string", "wkb-base64"),
+            ProcessParameterValueType.WkbArray => ("array", "wkb-base64"),
+            ProcessParameterValueType.Srid => ("integer", "srid"),
+            ProcessParameterValueType.LayerId => ("string", "layer-id"),
+            _ => ("string", null),
+        };
+}

--- a/src/Honua.Geoprocessing.Cli/GpCli.cs
+++ b/src/Honua.Geoprocessing.Cli/GpCli.cs
@@ -10,6 +10,7 @@ using Honua.Worker.Gdal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Honua.Geoprocessing.Cli;
 
@@ -48,6 +49,7 @@ public static class GpCli
             {
                 "list" => RunList(),
                 "run" => await RunRun(rest).ConfigureAwait(false),
+                "plan" => await RunPlan(rest).ConfigureAwait(false),
                 "-h" or "--help" or "help" => PrintUsageAndOk(),
                 _ => Fail($"Unknown command '{verb}'."),
             };
@@ -106,9 +108,187 @@ public static class GpCli
 
     private static async Task<int> RunRun(string[] args)
     {
+        var parsed = ParseProcessArgs(
+            args,
+            "honua gp run <id> --input <file> [--param k=v] [--out <file>]");
+
+        using var provider = BuildProvider();
+        var executors = provider.GetServices<IProcessExecutor>();
+        var runner = new GeoprocessingLocalRunner(executors);
+
+        if (!runner.AvailableProcessIds.Contains(parsed.ProcessId, StringComparer.Ordinal))
+        {
+            throw new GpCliUsageException(
+                $"Process id '{parsed.ProcessId}' is not registered. Run 'honua gp list' to see available processes.");
+        }
+
+        var inputs = new Dictionary<string, string>(parsed.Params, StringComparer.Ordinal);
+        var catalog = provider.GetService<IProcessCatalog>();
+        await BindFileInputAsync(parsed.ProcessId, parsed.InputPath, catalog, inputs).ConfigureAwait(false);
+
+        var result = await runner.RunAsync(parsed.ProcessId, inputs).ConfigureAwait(false);
+
+        Console.WriteLine($"process : {result.ProcessId}");
+        Console.WriteLine($"status  : {result.Status}");
+        Console.WriteLine($"elapsed : {result.Elapsed.TotalMilliseconds:F1} ms");
+
+        foreach (var log in result.Logs)
+        {
+            if (log.Metadata is not null
+                && log.Metadata.TryGetValue("gdal.command", out var command))
+            {
+                Console.WriteLine($"command : {command}");
+            }
+        }
+
+        foreach (var warning in result.Warnings)
+        {
+            Console.WriteLine($"warning : {warning}");
+        }
+
+        if (!result.Succeeded)
+        {
+            Console.Error.WriteLine($"error   : {result.ErrorMessage}");
+            return 1;
+        }
+
+        foreach (var artifact in result.Artifacts)
+        {
+            Console.WriteLine($"artifact: {Summarize(artifact)}");
+        }
+
+        if (parsed.OutPath is not null)
+        {
+            if (result.Artifacts.Count == 0)
+            {
+                Console.Error.WriteLine("error   : run succeeded but produced no artifact to write to --out.");
+                return 1;
+            }
+
+            var bytes = DecodeArtifact(result.Artifacts[0]);
+            await File.WriteAllBytesAsync(parsed.OutPath, bytes).ConfigureAwait(false);
+            Console.WriteLine($"wrote   : {parsed.OutPath} ({bytes.Length} bytes)");
+        }
+
+        return 0;
+    }
+
+    private static async Task<int> RunPlan(string[] args)
+    {
+        var parsed = ParseProcessArgs(
+            args,
+            "honua gp plan <id> --input <file> [--param k=v ...]");
+
+        if (parsed.OutPath is not null)
+        {
+            throw new GpCliUsageException("'plan' does not run the process, so --out is not supported.");
+        }
+
+        using var provider = BuildProvider();
+        var catalog = provider.GetService<IProcessCatalog>()
+            ?? throw new GpCliUsageException("Process catalog is unavailable.");
+        var maxArtifactBytes = provider
+            .GetRequiredService<IOptions<GeoprocessingExecutorOptions>>()
+            .Value.MaxArtifactBytes;
+
+        // Resolve the same inputs `run` would: merge --param then bind --input. We
+        // also capture the raw decoded input size so the estimate has an anchor.
+        var inputs = new Dictionary<string, string>(parsed.Params, StringComparer.Ordinal);
+        var callerInputBytes = await BindFileInputAsync(parsed.ProcessId, parsed.InputPath, catalog, inputs)
+            .ConfigureAwait(false);
+
+        var plan = GpPlanner.Build(parsed.ProcessId, inputs, catalog, maxArtifactBytes, callerInputBytes);
+        if (plan is null)
+        {
+            // Mirror `run`'s "unknown process" usage error rather than a crash.
+            throw new GpCliUsageException(
+                $"Process id '{parsed.ProcessId}' is not registered. Run 'honua gp list' to see available processes.");
+        }
+
+        PrintPlan(plan);
+
+        // Exit non-zero when the plan is invalid so scripts/CI can gate a submit on
+        // a clean plan; a valid plan with only size/cost warnings still exits 0.
+        return plan.IsValid ? 0 : 1;
+    }
+
+    private static void PrintPlan(GpPlan plan)
+    {
+        Console.WriteLine($"process      : {plan.ProcessId}  ({plan.Title})");
+        Console.WriteLine($"category     : {plan.Category}");
+        Console.WriteLine($"runtime      : {plan.RuntimeProfile}");
+        Console.WriteLine($"valid        : {(plan.IsValid ? "yes" : "NO")}");
+        Console.WriteLine();
+
+        Console.WriteLine("steps:");
+        foreach (var step in plan.Steps)
+        {
+            var deps = step.DependsOn.Count == 0 ? "-" : string.Join(", ", step.DependsOn);
+            Console.WriteLine($"  {step.StepId}  {step.ProcessId}  (depends on: {deps})");
+            foreach (var param in step.Parameters)
+            {
+                var req = param.Required ? "required" : "optional";
+                var value = param.DisplayValue ?? "(unset)";
+                var src = param.Source switch
+                {
+                    GpParamSource.Caller => "caller",
+                    GpParamSource.Default => "default",
+                    _ => "unset",
+                };
+                Console.WriteLine($"    - {param.Name} [{param.ValueType}, {req}] = {value}  ({src})");
+            }
+        }
+        Console.WriteLine();
+
+        var outputs = plan.Outputs.Count == 0 ? "-" : string.Join(", ", plan.Outputs);
+        Console.WriteLine($"outputs      : {outputs}");
+        Console.WriteLine();
+
+        var estimate = plan.Estimate;
+        Console.WriteLine("size/cost estimate (HEURISTIC — not a guarantee):");
+        Console.WriteLine($"  input bytes      : {GpPlanner.FormatBytes(estimate.InputBytes)}");
+        Console.WriteLine(estimate.EstimatedOutputBytes is { } outBytes
+            ? $"  est. output      : ~{GpPlanner.FormatBytes(outBytes)}"
+            : "  est. output      : (not estimable offline)");
+        Console.WriteLine($"  cap (MaxArtifactBytes) : {GpPlanner.FormatBytes(estimate.MaxArtifactBytes)}");
+        Console.WriteLine($"  basis            : {estimate.Basis}");
+        Console.WriteLine($"  resource hint    : profile={plan.RuntimeProfile}, long-running={(estimate.LongRunning ? "yes" : "no")}");
+        Console.WriteLine();
+
+        if (plan.Errors.Count > 0)
+        {
+            Console.WriteLine("errors (block submit):");
+            foreach (var error in plan.Errors)
+            {
+                Console.WriteLine($"  ✗ {error}");
+            }
+            Console.WriteLine();
+        }
+
+        if (plan.Warnings.Count > 0)
+        {
+            Console.WriteLine("warnings:");
+            foreach (var warning in plan.Warnings)
+            {
+                Console.WriteLine($"  ! {warning}");
+            }
+            Console.WriteLine();
+        }
+
+        Console.WriteLine(plan.IsValid
+            ? "Plan is valid. Submit with: honua gp run " + plan.ProcessId + " ..."
+            : "Plan is INVALID — fix the errors above before submitting.");
+    }
+
+    /// <summary>
+    /// Parses the shared <c>&lt;processId&gt; [--input f] [--param k=v ...] [--out f]</c>
+    /// argument shape used by both <c>run</c> and <c>plan</c>.
+    /// </summary>
+    private static ProcessArgs ParseProcessArgs(string[] args, string usage)
+    {
         if (args.Length == 0)
         {
-            throw new GpCliUsageException("Missing <processId>. Usage: honua gp run <id> --input <file> [--param k=v] [--out <file>]");
+            throw new GpCliUsageException($"Missing <processId>. Usage: {usage}");
         }
 
         var processId = args[0];
@@ -141,86 +321,53 @@ public static class GpCli
             }
         }
 
-        using var provider = BuildProvider();
-        var executors = provider.GetServices<IProcessExecutor>();
-        var runner = new GeoprocessingLocalRunner(executors);
+        return new ProcessArgs(processId, inputPath, outPath, inputs);
+    }
 
-        if (!runner.AvailableProcessIds.Contains(processId, StringComparer.Ordinal))
+    /// <summary>
+    /// Binds <c>--input &lt;file&gt;</c>: reads the file, base64-encodes its bytes, and
+    /// assigns it to the process's primary file-like input (unless the caller already
+    /// supplied that key via <c>--param</c>). Returns the raw (decoded) byte length of
+    /// the supplied input so the plan size estimate has an anchor — 0 when no file
+    /// input was bound.
+    /// </summary>
+    private static async Task<long> BindFileInputAsync(
+        string processId,
+        string? inputPath,
+        IProcessCatalog? catalog,
+        Dictionary<string, string> inputs)
+    {
+        if (inputPath is null)
+        {
+            return 0;
+        }
+
+        if (!File.Exists(inputPath))
+        {
+            throw new GpCliUsageException($"--input file not found: {inputPath}");
+        }
+
+        var inputKey = ResolveFileInputKey(catalog?.GetProcess(processId));
+        if (inputKey is null)
         {
             throw new GpCliUsageException(
-                $"Process id '{processId}' is not registered. Run 'honua gp list' to see available processes.");
+                $"Process '{processId}' has no file-like input to bind --input to; supply inputs with --param instead.");
         }
 
-        // Bind --input <file>: read the file, base64-encode its bytes, and assign it
-        // to the process's primary file-like input (the first required Wkb/Text/WkbArray
-        // parameter), unless the caller already supplied that input via --param.
-        if (inputPath is not null)
+        var bytes = await File.ReadAllBytesAsync(inputPath).ConfigureAwait(false);
+        if (!inputs.ContainsKey(inputKey))
         {
-            if (!File.Exists(inputPath))
-            {
-                throw new GpCliUsageException($"--input file not found: {inputPath}");
-            }
-
-            var catalog = provider.GetService<IProcessCatalog>();
-            var inputKey = ResolveFileInputKey(catalog?.GetProcess(processId));
-            if (inputKey is null)
-            {
-                throw new GpCliUsageException(
-                    $"Process '{processId}' has no file-like input to bind --input to; supply inputs with --param instead.");
-            }
-
-            if (!inputs.ContainsKey(inputKey))
-            {
-                inputs[inputKey] = Convert.ToBase64String(await File.ReadAllBytesAsync(inputPath).ConfigureAwait(false));
-            }
+            inputs[inputKey] = Convert.ToBase64String(bytes);
         }
 
-        var result = await runner.RunAsync(processId, inputs).ConfigureAwait(false);
-
-        Console.WriteLine($"process : {result.ProcessId}");
-        Console.WriteLine($"status  : {result.Status}");
-        Console.WriteLine($"elapsed : {result.Elapsed.TotalMilliseconds:F1} ms");
-
-        foreach (var log in result.Logs)
-        {
-            if (log.Metadata is not null
-                && log.Metadata.TryGetValue("gdal.command", out var command))
-            {
-                Console.WriteLine($"command : {command}");
-            }
-        }
-
-        foreach (var warning in result.Warnings)
-        {
-            Console.WriteLine($"warning : {warning}");
-        }
-
-        if (!result.Succeeded)
-        {
-            Console.Error.WriteLine($"error   : {result.ErrorMessage}");
-            return 1;
-        }
-
-        foreach (var artifact in result.Artifacts)
-        {
-            Console.WriteLine($"artifact: {Summarize(artifact)}");
-        }
-
-        if (outPath is not null)
-        {
-            if (result.Artifacts.Count == 0)
-            {
-                Console.Error.WriteLine("error   : run succeeded but produced no artifact to write to --out.");
-                return 1;
-            }
-
-            var bytes = DecodeArtifact(result.Artifacts[0]);
-            await File.WriteAllBytesAsync(outPath, bytes).ConfigureAwait(false);
-            Console.WriteLine($"wrote   : {outPath} ({bytes.Length} bytes)");
-        }
-
-        return 0;
+        return bytes.LongLength;
     }
+
+    private readonly record struct ProcessArgs(
+        string ProcessId,
+        string? InputPath,
+        string? OutPath,
+        Dictionary<string, string> Params);
 
     /// <summary>
     /// Resolves the parameter name that <c>--input &lt;file&gt;</c> binds to: the
@@ -301,14 +448,20 @@ public static class GpCli
         Console.WriteLine();
         Console.WriteLine("Usage:");
         Console.WriteLine("  honua gp list");
-        Console.WriteLine("  honua gp run <processId> [--input <file>] [--param k=v ...] [--out <file>]");
+        Console.WriteLine("  honua gp plan <processId> [--input <file>] [--param k=v ...]");
+        Console.WriteLine("  honua gp run  <processId> [--input <file>] [--param k=v ...] [--out <file>]");
         Console.WriteLine();
         Console.WriteLine("Options:");
         Console.WriteLine("  --input, -i <file>  Read a file and bind it (base64) to the process's primary input.");
         Console.WriteLine("  --param, -p k=v     Set a step-0 input (repeatable). Overrides --input for the same key.");
-        Console.WriteLine("  --out,   -o <file>  Write the first published artifact's bytes to <file>.");
+        Console.WriteLine("  --out,   -o <file>  Write the first published artifact's bytes to <file> (run only).");
+        Console.WriteLine();
+        Console.WriteLine("Commands:");
+        Console.WriteLine("  plan  Dry-run: validate params + DAG and estimate output size/cost WITHOUT executing.");
+        Console.WriteLine("  run   Execute the process and emit its artifact(s).");
         Console.WriteLine();
         Console.WriteLine("Examples:");
+        Console.WriteLine("  honua gp plan geometry.buffer --param wkb=<base64> --param srid=4326 --param distance=10");
         Console.WriteLine("  honua gp run geometry.buffer --param wkb=<base64> --param srid=4326 --param distance=10");
         Console.WriteLine("  honua gp run gdal.ogr2ogr --input in.geojson --param sourceFormat=GeoJSON --param targetFormat=CSV --out out.csv");
     }

--- a/src/Honua.Geoprocessing.Cli/GpCli.cs
+++ b/src/Honua.Geoprocessing.Cli/GpCli.cs
@@ -1,0 +1,321 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Geoprocessing;
+using Honua.Geoprocessing.LocalRunner;
+using Honua.Worker.Gdal;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Geoprocessing.Cli;
+
+/// <summary>
+/// The <c>honua gp</c> dev tool (GP Devkit, issue #2123): a headless, Redis-free
+/// geoprocessing dev loop. It builds the SAME managed + native GDAL
+/// <see cref="IProcessExecutor"/> set the serving/worker hosts register, then drives
+/// a single process directly through <see cref="GeoprocessingLocalRunner"/> — with
+/// NO Redis, NO job store, NO queue, and NO control plane — so the inner-loop GP
+/// edit/run cycle is sub-second and works fully offline. It is a dev tool only and is
+/// deliberately kept out of the AOT-published server surface.
+/// </summary>
+public static class GpCli
+{
+    /// <summary>
+    /// Parses argv and dispatches to the <c>list</c> or <c>run</c> verb.
+    /// </summary>
+    /// <param name="args">Process arguments (the verb plus its options).</param>
+    /// <returns>A process exit code: 0 success, non-zero on usage error or a failed run.</returns>
+    public static async Task<int> RunAsync(string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length == 0)
+        {
+            PrintUsage();
+            return 2;
+        }
+
+        var verb = args[0];
+        var rest = args[1..];
+
+        try
+        {
+            return verb switch
+            {
+                "list" => RunList(),
+                "run" => await RunRun(rest).ConfigureAwait(false),
+                "-h" or "--help" or "help" => PrintUsageAndOk(),
+                _ => Fail($"Unknown command '{verb}'."),
+            };
+        }
+        catch (GpCliUsageException ex)
+        {
+            return Fail(ex.Message);
+        }
+    }
+
+    private static ServiceProvider BuildProvider()
+    {
+        // Empty in-memory configuration: AddGeoprocessing binds its option sections
+        // from configuration but every option has a valid default, and the
+        // Redis-conditional durable-store registrations are skipped because no
+        // IConnectionMultiplexer is present. The result is the full managed +
+        // native executor set with zero external dependencies.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection()
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.AddSimpleConsole(o => o.SingleLine = true).SetMinimumLevel(LogLevel.Warning));
+
+        // Managed geometry/analytics/transform/source/sink executors.
+        services.AddGeoprocessing(configuration);
+        // Native GDAL executors (Redis-free seam: options + CLI runner + executors only).
+        services.AddGdalProcessExecutors(configuration);
+
+        return services.BuildServiceProvider();
+    }
+
+    private static int RunList()
+    {
+        using var provider = BuildProvider();
+        var executors = provider.GetServices<IProcessExecutor>();
+        var runner = new GeoprocessingLocalRunner(executors);
+        var catalog = provider.GetService<IProcessCatalog>();
+
+        Console.WriteLine("Available geoprocessing processes:");
+        foreach (var id in runner.AvailableProcessIds)
+        {
+            var def = catalog?.GetProcess(id);
+            if (def is not null)
+            {
+                Console.WriteLine($"  {id,-32} {def.Title}");
+            }
+            else
+            {
+                Console.WriteLine($"  {id}");
+            }
+        }
+
+        return 0;
+    }
+
+    private static async Task<int> RunRun(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            throw new GpCliUsageException("Missing <processId>. Usage: honua gp run <id> --input <file> [--param k=v] [--out <file>]");
+        }
+
+        var processId = args[0];
+        string? inputPath = null;
+        string? outPath = null;
+        var inputs = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        for (var i = 1; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--input" or "-i":
+                    inputPath = NextValue(args, ref i, "--input");
+                    break;
+                case "--out" or "-o":
+                    outPath = NextValue(args, ref i, "--out");
+                    break;
+                case "--param" or "-p":
+                    var kv = NextValue(args, ref i, "--param");
+                    var eq = kv.IndexOf('=', StringComparison.Ordinal);
+                    if (eq <= 0)
+                    {
+                        throw new GpCliUsageException($"Invalid --param '{kv}'; expected key=value.");
+                    }
+
+                    inputs[kv[..eq]] = kv[(eq + 1)..];
+                    break;
+                default:
+                    throw new GpCliUsageException($"Unknown option '{args[i]}'.");
+            }
+        }
+
+        using var provider = BuildProvider();
+        var executors = provider.GetServices<IProcessExecutor>();
+        var runner = new GeoprocessingLocalRunner(executors);
+
+        if (!runner.AvailableProcessIds.Contains(processId, StringComparer.Ordinal))
+        {
+            throw new GpCliUsageException(
+                $"Process id '{processId}' is not registered. Run 'honua gp list' to see available processes.");
+        }
+
+        // Bind --input <file>: read the file, base64-encode its bytes, and assign it
+        // to the process's primary file-like input (the first required Wkb/Text/WkbArray
+        // parameter), unless the caller already supplied that input via --param.
+        if (inputPath is not null)
+        {
+            if (!File.Exists(inputPath))
+            {
+                throw new GpCliUsageException($"--input file not found: {inputPath}");
+            }
+
+            var catalog = provider.GetService<IProcessCatalog>();
+            var inputKey = ResolveFileInputKey(catalog?.GetProcess(processId));
+            if (inputKey is null)
+            {
+                throw new GpCliUsageException(
+                    $"Process '{processId}' has no file-like input to bind --input to; supply inputs with --param instead.");
+            }
+
+            if (!inputs.ContainsKey(inputKey))
+            {
+                inputs[inputKey] = Convert.ToBase64String(await File.ReadAllBytesAsync(inputPath).ConfigureAwait(false));
+            }
+        }
+
+        var result = await runner.RunAsync(processId, inputs).ConfigureAwait(false);
+
+        Console.WriteLine($"process : {result.ProcessId}");
+        Console.WriteLine($"status  : {result.Status}");
+        Console.WriteLine($"elapsed : {result.Elapsed.TotalMilliseconds:F1} ms");
+
+        foreach (var log in result.Logs)
+        {
+            if (log.Metadata is not null
+                && log.Metadata.TryGetValue("gdal.command", out var command))
+            {
+                Console.WriteLine($"command : {command}");
+            }
+        }
+
+        foreach (var warning in result.Warnings)
+        {
+            Console.WriteLine($"warning : {warning}");
+        }
+
+        if (!result.Succeeded)
+        {
+            Console.Error.WriteLine($"error   : {result.ErrorMessage}");
+            return 1;
+        }
+
+        foreach (var artifact in result.Artifacts)
+        {
+            Console.WriteLine($"artifact: {Summarize(artifact)}");
+        }
+
+        if (outPath is not null)
+        {
+            if (result.Artifacts.Count == 0)
+            {
+                Console.Error.WriteLine("error   : run succeeded but produced no artifact to write to --out.");
+                return 1;
+            }
+
+            var bytes = DecodeArtifact(result.Artifacts[0]);
+            await File.WriteAllBytesAsync(outPath, bytes).ConfigureAwait(false);
+            Console.WriteLine($"wrote   : {outPath} ({bytes.Length} bytes)");
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Resolves the parameter name that <c>--input &lt;file&gt;</c> binds to: the
+    /// first required file-like (<c>Wkb</c>/<c>WkbArray</c>/<c>Text</c>) parameter the
+    /// process declares, or <c>null</c> when the process has none.
+    /// </summary>
+    private static string? ResolveFileInputKey(ProcessDefinition? definition)
+    {
+        if (definition is null)
+        {
+            return null;
+        }
+
+        foreach (var parameter in definition.Parameters)
+        {
+            if (parameter.Required
+                && parameter.ValueType is ProcessParameterValueType.Wkb
+                    or ProcessParameterValueType.WkbArray
+                    or ProcessParameterValueType.Text)
+            {
+                return parameter.Name;
+            }
+        }
+
+        return null;
+    }
+
+    private static byte[] DecodeArtifact(string artifact)
+    {
+        // Executors publish artifacts as base64 data URIs (data:<media>;base64,<payload>).
+        var comma = artifact.IndexOf(',', StringComparison.Ordinal);
+        if (artifact.StartsWith("data:", StringComparison.Ordinal) && comma > 0)
+        {
+            return Convert.FromBase64String(artifact[(comma + 1)..]);
+        }
+
+        // Non-data-URI artifact references (e.g. file/object paths) are returned as text.
+        return System.Text.Encoding.UTF8.GetBytes(artifact);
+    }
+
+    private static string Summarize(string artifact)
+    {
+        if (artifact.Length <= 80)
+        {
+            return artifact;
+        }
+
+        return artifact[..77] + "...";
+    }
+
+    private static string NextValue(string[] args, ref int index, string option)
+    {
+        if (index + 1 >= args.Length)
+        {
+            throw new GpCliUsageException($"Option '{option}' requires a value.");
+        }
+
+        return args[++index];
+    }
+
+    private static int PrintUsageAndOk()
+    {
+        PrintUsage();
+        return 0;
+    }
+
+    private static int Fail(string message)
+    {
+        Console.Error.WriteLine(message);
+        Console.Error.WriteLine();
+        PrintUsage();
+        return 2;
+    }
+
+    private static void PrintUsage()
+    {
+        Console.WriteLine("honua gp — headless, Redis-free geoprocessing dev runner (GP Devkit)");
+        Console.WriteLine();
+        Console.WriteLine("Usage:");
+        Console.WriteLine("  honua gp list");
+        Console.WriteLine("  honua gp run <processId> [--input <file>] [--param k=v ...] [--out <file>]");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --input, -i <file>  Read a file and bind it (base64) to the process's primary input.");
+        Console.WriteLine("  --param, -p k=v     Set a step-0 input (repeatable). Overrides --input for the same key.");
+        Console.WriteLine("  --out,   -o <file>  Write the first published artifact's bytes to <file>.");
+        Console.WriteLine();
+        Console.WriteLine("Examples:");
+        Console.WriteLine("  honua gp run geometry.buffer --param wkb=<base64> --param srid=4326 --param distance=10");
+        Console.WriteLine("  honua gp run gdal.ogr2ogr --input in.geojson --param sourceFormat=GeoJSON --param targetFormat=CSV --out out.csv");
+    }
+}
+
+/// <summary>
+/// Signals a CLI usage error that should print the message plus usage and exit
+/// non-zero, distinct from an executor-reported run failure.
+/// </summary>
+internal sealed class GpCliUsageException(string message) : Exception(message);

--- a/src/Honua.Geoprocessing.Cli/Honua.Geoprocessing.Cli.csproj
+++ b/src/Honua.Geoprocessing.Cli/Honua.Geoprocessing.Cli.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Honua.Geoprocessing.Cli</RootNamespace>
+    <AssemblyName>honua-gp</AssemblyName>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <InvariantGlobalization>true</InvariantGlobalization>
+
+    <!--
+      GP Devkit dev tool (#2123). Packaged as a local dotnet tool (`honua gp`) for
+      a sub-second, Redis-free geoprocessing dev loop. It is DELIBERATELY kept out
+      of the AOT-published server surface: nothing in Honua.Server references this
+      project, so the AOT publish (which targets only Honua.Server's transitive
+      ProjectReferences) never pulls it in. The tool itself is NOT AOT-published.
+    -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>honua-gp</ToolCommandName>
+    <IsPackable>false</IsPackable>
+    <PublishAot>false</PublishAot>
+
+    <!-- Console front-end intentionally writes to stdout/stderr. -->
+    <NoWarn>$(NoWarn);CA1303;CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Reuses the SAME managed IProcessExecutor set the serving host registers
+      (via the internal AddGeoprocessing seam) plus the native GDAL executors
+      (via the Redis-free AddGdalProcessExecutors seam), so `gp run` drives the
+      real executor code path with no Redis/queue/job-store/control-plane.
+    -->
+    <ProjectReference Include="..\Honua.Geoprocessing\Honua.Geoprocessing.csproj" />
+    <ProjectReference Include="..\Honua.Worker.Gdal\Honua.Worker.Gdal.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Honua.Geoprocessing.Cli/Program.cs
+++ b/src/Honua.Geoprocessing.Cli/Program.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Geoprocessing.Cli;
+
+return await GpCli.RunAsync(args).ConfigureAwait(false);

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/AnalysisPlanGraphValidator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/AnalysisPlanGraphValidator.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.Geoprocessing;
+
+/// <summary>
+/// Structural (dependency-graph) validation for an <see cref="AnalysisPlan"/>.
+/// Enforces that every step has a unique, non-empty identifier, that each
+/// declared dependency refers to a real step (no dangling references and no
+/// self-dependencies), and that the resulting dependency graph is acyclic.
+///
+/// <para>
+/// The executor assumes a topological ordering of steps, so a cycle or a
+/// dangling reference would deadlock (or misorder) the run; this validator is
+/// the single fail-fast gate that rejects such plans before submission. It is
+/// shared by the durable submit/validate/dry-run paths
+/// (<see cref="GeoprocessingJobService"/>) and the headless GP Devkit
+/// <c>honua gp plan</c> dry-run path so both reject the exact same malformed
+/// graphs with the exact same message.
+/// </para>
+/// </summary>
+internal static class AnalysisPlanGraphValidator
+{
+    /// <summary>
+    /// Validates the plan's step dependency graph, throwing
+    /// <see cref="GeoprocessingValidationException"/> on the first structural
+    /// defect (empty/duplicate stepId, dangling or self dependency, or a cycle).
+    /// An empty plan is treated as structurally valid here; callers enforce the
+    /// "at least one step" rule separately where it applies.
+    /// </summary>
+    /// <param name="plan">The plan whose step graph is validated.</param>
+    /// <exception cref="GeoprocessingValidationException">
+    /// Thrown when the step graph is malformed.
+    /// </exception>
+    public static void Validate(AnalysisPlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        // Proto-level enum validation happens in the conversion layer. The remaining
+        // domain-level invariant is that the step dependency graph be acyclic and that
+        // every dependency refer to a real step — the executor assumes topological
+        // ordering, so a cycle or dangling reference deadlocks the run.
+        if (plan.Steps.Count == 0)
+        {
+            return;
+        }
+
+        var stepIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var step in plan.Steps)
+        {
+            if (string.IsNullOrWhiteSpace(step.StepId))
+            {
+                throw new GeoprocessingValidationException("Every step requires a non-empty stepId.");
+            }
+
+            if (!stepIds.Add(step.StepId))
+            {
+                throw new GeoprocessingValidationException(
+                    $"Duplicate step identifier '{step.StepId}'.");
+            }
+        }
+
+        foreach (var step in plan.Steps)
+        {
+            foreach (var dep in step.DependsOn)
+            {
+                if (!stepIds.Contains(dep))
+                {
+                    throw new GeoprocessingValidationException(
+                        $"Step '{step.StepId}' depends on unknown step '{dep}'.");
+                }
+
+                if (string.Equals(dep, step.StepId, StringComparison.Ordinal))
+                {
+                    throw new GeoprocessingValidationException(
+                        $"Step '{step.StepId}' cannot depend on itself.");
+                }
+            }
+        }
+
+        // Kahn's algorithm: iteratively remove nodes with zero in-degree; if any remain,
+        // the remaining subgraph contains a cycle.
+        var inDegree = plan.Steps.ToDictionary(s => s.StepId, _ => 0, StringComparer.Ordinal);
+        var edges = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var step in plan.Steps)
+        {
+            edges[step.StepId] = new List<string>();
+        }
+
+        foreach (var step in plan.Steps)
+        {
+            foreach (var dep in step.DependsOn)
+            {
+                edges[dep].Add(step.StepId);
+                inDegree[step.StepId]++;
+            }
+        }
+
+        var ready = new Queue<string>(inDegree.Where(p => p.Value == 0).Select(p => p.Key));
+        var visited = 0;
+        while (ready.Count > 0)
+        {
+            var current = ready.Dequeue();
+            visited++;
+            foreach (var next in edges[current])
+            {
+                if (--inDegree[next] == 0)
+                {
+                    ready.Enqueue(next);
+                }
+            }
+        }
+
+        if (visited != plan.Steps.Count)
+        {
+            throw new GeoprocessingValidationException(
+                "Plan step dependency graph contains a cycle.");
+        }
+    }
+
+    /// <summary>
+    /// Returns the steps of <paramref name="plan"/> in a deterministic topological
+    /// order (dependencies before dependents). Ties are broken by ordinal stepId so
+    /// the same plan always yields the same execution order in the plan preview.
+    /// Assumes <see cref="Validate(AnalysisPlan)"/> has already accepted the plan;
+    /// callers that have not validated should call it first.
+    /// </summary>
+    /// <param name="plan">The (already structurally valid) plan to order.</param>
+    /// <returns>The plan's steps in topological execution order.</returns>
+    public static IReadOnlyList<AnalysisPlanStep> TopologicalOrder(AnalysisPlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        if (plan.Steps.Count <= 1)
+        {
+            return plan.Steps;
+        }
+
+        var byId = plan.Steps.ToDictionary(s => s.StepId, StringComparer.Ordinal);
+        var inDegree = plan.Steps.ToDictionary(s => s.StepId, _ => 0, StringComparer.Ordinal);
+        var edges = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var step in plan.Steps)
+        {
+            edges[step.StepId] = new List<string>();
+        }
+
+        foreach (var step in plan.Steps)
+        {
+            foreach (var dep in step.DependsOn)
+            {
+                edges[dep].Add(step.StepId);
+                inDegree[step.StepId]++;
+            }
+        }
+
+        // Deterministic Kahn: a min-ordered ready set keyed by stepId breaks ties so
+        // independent steps always emit in the same (ordinal) order.
+        var ready = new SortedSet<string>(
+            inDegree.Where(p => p.Value == 0).Select(p => p.Key),
+            StringComparer.Ordinal);
+
+        var ordered = new List<AnalysisPlanStep>(plan.Steps.Count);
+        while (ready.Count > 0)
+        {
+            var current = ready.Min!;
+            ready.Remove(current);
+            ordered.Add(byId[current]);
+            foreach (var next in edges[current])
+            {
+                if (--inDegree[next] == 0)
+                {
+                    ready.Add(next);
+                }
+            }
+        }
+
+        // A cycle would leave steps unvisited; fall back to declared order rather
+        // than dropping steps (Validate is expected to have rejected cycles already).
+        return ordered.Count == plan.Steps.Count ? ordered : plan.Steps;
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/CsvSourceExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/CsvSourceExecutor.cs
@@ -29,7 +29,7 @@ namespace Honua.Geoprocessing.Execution;
 /// delimiter auto-detection and file-path streaming belong to a later streaming-source
 /// stream.
 /// </remarks>
-internal sealed class CsvSourceExecutor(IOptionsMonitor<GeoprocessingExecutorOptions> options) : IJobExecutor
+internal sealed class CsvSourceExecutor(IOptionsMonitor<GeoprocessingExecutorOptions> options) : IProcessExecutor
 {
     internal const string HandledProcessId = "source.csv";
 
@@ -44,6 +44,13 @@ internal sealed class CsvSourceExecutor(IOptionsMonitor<GeoprocessingExecutorOpt
         new[] { "lat", "latitude", "y" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options = options;
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutor.cs
@@ -26,7 +26,7 @@ namespace Honua.Geoprocessing.Execution;
 /// interpolation since they cannot be parameterized in DDL/DML. Every row's attributes JSONB
 /// carries a reserved <c>__pipeline_batch_id</c> key for soft-delete rollback.
 /// </summary>
-internal sealed partial class ExternalPostgisSinkExecutor : IJobExecutor
+internal sealed partial class ExternalPostgisSinkExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "sink.external-postgis";
 
@@ -63,6 +63,13 @@ internal sealed partial class ExternalPostgisSinkExecutor : IJobExecutor
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ExternalPostgisSinkExecutor>.Instance;
         _secureConnectionResolver = secureConnectionResolver;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureCollectionTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureCollectionTransformExecutor.cs
@@ -18,10 +18,11 @@ namespace Honua.Geoprocessing.Execution;
 /// shape: the executor is the sole worker-side behavior for a single dotted
 /// process id and surfaces automatically as a <c>process:&lt;id&gt;</c> workflow node.
 /// </summary>
-internal abstract partial class FeatureCollectionTransformExecutor : IJobExecutor
+internal abstract partial class FeatureCollectionTransformExecutor : IProcessExecutor
 {
     private protected readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options;
     private readonly ILogger _logger;
+    private IReadOnlySet<string>? _processIds;
 
     protected FeatureCollectionTransformExecutor(
         IOptionsMonitor<GeoprocessingExecutorOptions> options,
@@ -43,6 +44,10 @@ internal abstract partial class FeatureCollectionTransformExecutor : IJobExecuto
     /// The single dotted process id this executor handles (e.g. <c>transform.reproject</c>).
     /// </summary>
     protected abstract string ProcessId { get; }
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds =>
+        _processIds ??= new HashSet<string>(StringComparer.Ordinal) { ProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonFileSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonFileSinkExecutor.cs
@@ -20,7 +20,7 @@ namespace Honua.Geoprocessing.Execution;
 /// null geometry are written (GeoJSON permits a null geometry member) but counted as
 /// rejected so the result reflects them.
 /// </summary>
-internal sealed partial class GeoJsonFileSinkExecutor : IJobExecutor
+internal sealed partial class GeoJsonFileSinkExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "sink.geojson-file";
 
@@ -40,6 +40,13 @@ internal sealed partial class GeoJsonFileSinkExecutor : IJobExecutor
         : this(options, Microsoft.Extensions.Logging.Abstractions.NullLogger<GeoJsonFileSinkExecutor>.Instance)
     {
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonSourceExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonSourceExecutor.cs
@@ -22,11 +22,18 @@ namespace Honua.Geoprocessing.Execution;
 /// this executor accepts an <c>inline</c> GeoJSON document or an <c>input</c> data URI.
 /// File-path streaming for very large inputs belongs to a later streaming-source stream.
 /// </remarks>
-internal sealed class GeoJsonSourceExecutor(IOptionsMonitor<GeoprocessingExecutorOptions> options) : IJobExecutor
+internal sealed class GeoJsonSourceExecutor(IOptionsMonitor<GeoprocessingExecutorOptions> options) : IProcessExecutor
 {
     internal const string HandledProcessId = "source.geojson";
 
     private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options = options;
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryAreaJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryAreaJobExecutor.cs
@@ -28,7 +28,7 @@ namespace Honua.Geoprocessing.Execution;
 /// geodesic path is tracked as a follow-on slice alongside the geodesic
 /// buffer / length executors.
 /// </summary>
-internal sealed partial class GeometryAreaJobExecutor : IJobExecutor
+internal sealed partial class GeometryAreaJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog entry
@@ -48,6 +48,13 @@ internal sealed partial class GeometryAreaJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryBufferJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryBufferJobExecutor.cs
@@ -26,7 +26,7 @@ namespace Honua.Geoprocessing.Execution;
 /// terminally with a clean classification — the dispatcher is intentionally
 /// narrow until additional executors land.
 /// </summary>
-internal sealed partial class GeometryBufferJobExecutor : IJobExecutor
+internal sealed partial class GeometryBufferJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog entry in
@@ -44,6 +44,13 @@ internal sealed partial class GeometryBufferJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryCentroidJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryCentroidJobExecutor.cs
@@ -24,7 +24,7 @@ namespace Honua.Geoprocessing.Execution;
 /// of the input geometry type, matching the long-standing GeoServices and
 /// PostGIS <c>ST_Centroid</c> semantics.
 /// </summary>
-internal sealed partial class GeometryCentroidJobExecutor : IJobExecutor
+internal sealed partial class GeometryCentroidJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -42,6 +42,13 @@ internal sealed partial class GeometryCentroidJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryClipJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryClipJobExecutor.cs
@@ -23,7 +23,7 @@ namespace Honua.Geoprocessing.Execution;
 /// is used (not the polygon itself), so this executor materializes the
 /// clip envelope and intersects the target with it.
 /// </summary>
-internal sealed partial class GeometryClipJobExecutor : IJobExecutor
+internal sealed partial class GeometryClipJobExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "geometry.clip";
 
@@ -37,6 +37,13 @@ internal sealed partial class GeometryClipJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryConvexHullJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryConvexHullJobExecutor.cs
@@ -27,7 +27,7 @@ namespace Honua.Geoprocessing.Execution;
 /// hull over all member vertices, which is the canonical "hull of the
 /// union" behavior used by PostGIS <c>ST_ConvexHull</c>.
 /// </summary>
-internal sealed partial class GeometryConvexHullJobExecutor : IJobExecutor
+internal sealed partial class GeometryConvexHullJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -45,6 +45,13 @@ internal sealed partial class GeometryConvexHullJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryDifferenceJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryDifferenceJobExecutor.cs
@@ -25,7 +25,7 @@ namespace Honua.Geoprocessing.Execution;
 /// <see cref="GeometryIntersectJobExecutor"/>: both geometries must share the
 /// supplied SRID; reprojection is handled by <see cref="GeometryProjectJobExecutor"/>.
 /// </summary>
-internal sealed partial class GeometryDifferenceJobExecutor : IJobExecutor
+internal sealed partial class GeometryDifferenceJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -43,6 +43,13 @@ internal sealed partial class GeometryDifferenceJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryDissolveJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryDissolveJobExecutor.cs
@@ -30,7 +30,7 @@ namespace Honua.Geoprocessing.Execution;
 /// through the dissolve artifact shape so downstream consumers can rely
 /// on the FeatureCollection envelope.
 /// </summary>
-internal sealed partial class GeometryDissolveJobExecutor : IJobExecutor
+internal sealed partial class GeometryDissolveJobExecutor : IProcessExecutor
 {
     private const string FeatureCollectionDataUriPrefix = "data:application/geo+json;base64,";
     private const string DefaultGroupKey = "__all__";
@@ -51,6 +51,13 @@ internal sealed partial class GeometryDissolveJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryIntersectJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryIntersectJobExecutor.cs
@@ -19,7 +19,7 @@ namespace Honua.Geoprocessing.Execution;
 /// intersector geometry. Both geometries must share the supplied SRID;
 /// reprojection is handled by <see cref="GeometryProjectJobExecutor"/>.
 /// </summary>
-internal sealed partial class GeometryIntersectJobExecutor : IJobExecutor
+internal sealed partial class GeometryIntersectJobExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "geometry.intersect";
 
@@ -33,6 +33,13 @@ internal sealed partial class GeometryIntersectJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryLengthJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryLengthJobExecutor.cs
@@ -27,7 +27,7 @@ namespace Honua.Geoprocessing.Execution;
 /// <see cref="Geometry.Length"/> for line geometries; for polygons NTS
 /// returns the perimeter, which is consistent with the catalog description.
 /// </summary>
-internal sealed partial class GeometryLengthJobExecutor : IJobExecutor
+internal sealed partial class GeometryLengthJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -47,6 +47,13 @@ internal sealed partial class GeometryLengthJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryMakeValidJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryMakeValidJobExecutor.cs
@@ -27,7 +27,7 @@ namespace Honua.Geoprocessing.Execution;
 /// <c>data:application/geo+json;base64,</c> envelope, matching the rest of the
 /// deterministic single-geometry <c>geometry.*</c> family.
 /// </summary>
-internal sealed partial class GeometryMakeValidJobExecutor : IJobExecutor
+internal sealed partial class GeometryMakeValidJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -45,6 +45,13 @@ internal sealed partial class GeometryMakeValidJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryProjectJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryProjectJobExecutor.cs
@@ -24,7 +24,7 @@ namespace Honua.Geoprocessing.Execution;
 /// first-slice executor remains deterministic without a PostGIS round-trip;
 /// those pairs are tracked as a follow-on.
 /// </summary>
-internal sealed partial class GeometryProjectJobExecutor : IJobExecutor
+internal sealed partial class GeometryProjectJobExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "geometry.project";
 
@@ -41,6 +41,13 @@ internal sealed partial class GeometryProjectJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometrySimplifyJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometrySimplifyJobExecutor.cs
@@ -29,7 +29,7 @@ namespace Honua.Geoprocessing.Execution;
 /// <c>ST_Simplify</c> and can produce invalid geometries on near-tolerance
 /// vertices, which is why preservation is the default.
 /// </summary>
-internal sealed partial class GeometrySimplifyJobExecutor : IJobExecutor
+internal sealed partial class GeometrySimplifyJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -47,6 +47,13 @@ internal sealed partial class GeometrySimplifyJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometrySnapJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometrySnapJobExecutor.cs
@@ -28,7 +28,7 @@ namespace Honua.Geoprocessing.Execution;
 /// polygons. The reference geometry is consumed for vertex
 /// reference only; only the input geometry's coordinates are mutated.
 /// </summary>
-internal sealed partial class GeometrySnapJobExecutor : IJobExecutor
+internal sealed partial class GeometrySnapJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog
@@ -46,6 +46,13 @@ internal sealed partial class GeometrySnapJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryUnionJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeometryUnionJobExecutor.cs
@@ -28,7 +28,7 @@ namespace Honua.Geoprocessing.Execution;
 /// All inputs must share the supplied SRID; reprojection is handled by
 /// <see cref="GeometryProjectJobExecutor"/>.
 /// </summary>
-internal sealed partial class GeometryUnionJobExecutor : IJobExecutor
+internal sealed partial class GeometryUnionJobExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "geometry.union";
 
@@ -42,6 +42,13 @@ internal sealed partial class GeometryUnionJobExecutor : IJobExecutor
         _options = options;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
@@ -32,114 +32,25 @@ namespace Honua.Geoprocessing.Execution;
 /// </summary>
 internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
 {
-    private readonly FrozenDictionary<string, IJobExecutor> _handlers;
+    private readonly FrozenDictionary<string, IProcessExecutor> _handlers;
     private readonly ILogger<GeoprocessingDispatchJobExecutor> _logger;
 
+    /// <summary>
+    /// Composes the dispatcher over the auto-registered per-process executors
+    /// (issue #2122). Each <see cref="IProcessExecutor"/> self-declares the process
+    /// ids it handles through <see cref="IProcessExecutor.ProcessIds"/>, so the
+    /// routing table is built from a single DI scan instead of a hand-maintained
+    /// constructor naming every executor. Duplicate or empty ids fail fast at
+    /// composition time via <see cref="ProcessExecutorRouteTable.Build"/>.
+    /// </summary>
     public GeoprocessingDispatchJobExecutor(
-        GeometryBufferJobExecutor buffer,
-        GeometryClipJobExecutor clip,
-        GeometryIntersectJobExecutor intersect,
-        GeometryProjectJobExecutor project,
-        GeometryAreaJobExecutor area,
-        GeometryUnionJobExecutor union,
-        GeometryCentroidJobExecutor centroid,
-        GeometryLengthJobExecutor length,
-        GeometryConvexHullJobExecutor convexHull,
-        GeometryDissolveJobExecutor dissolve,
-        GeometrySimplifyJobExecutor simplify,
-        GeometrySnapJobExecutor snap,
-        GeometryMakeValidJobExecutor makeValid,
-        GeometryDifferenceJobExecutor difference,
-        ManagedSpatialJoinExecutor spatialJoinManaged,
-        ManagedClusterExecutor clusterManaged,
-        ManagedBufferAggregateExecutor bufferAggregateManaged,
-        ManagedDensityExecutor densityManaged,
-        AttributeRenameTransformExecutor attributeRename,
-        AttributeCastTransformExecutor attributeCast,
-        ComputedFieldTransformExecutor computedField,
-        AttributeFilterTransformExecutor attributeFilter,
-        SpatialFilterTransformExecutor spatialFilter,
-        ClipTransformExecutor clip2,
-        DedupTransformExecutor dedup,
-        ReprojectTransformExecutor reproject,
-        GeoJsonSourceExecutor geoJsonSource,
-        CsvSourceExecutor csvSource,
-        GeoJsonFileSinkExecutor geoJsonFileSink,
-        QuarantineSinkExecutor quarantineSink,
-        ExternalPostgisSinkExecutor externalPostgisSink,
-        ImportDatasetJobExecutor importDataset,
+        IEnumerable<IProcessExecutor> executors,
         ILogger<GeoprocessingDispatchJobExecutor> logger)
     {
-        ArgumentNullException.ThrowIfNull(buffer);
-        ArgumentNullException.ThrowIfNull(clip);
-        ArgumentNullException.ThrowIfNull(intersect);
-        ArgumentNullException.ThrowIfNull(project);
-        ArgumentNullException.ThrowIfNull(area);
-        ArgumentNullException.ThrowIfNull(union);
-        ArgumentNullException.ThrowIfNull(centroid);
-        ArgumentNullException.ThrowIfNull(length);
-        ArgumentNullException.ThrowIfNull(convexHull);
-        ArgumentNullException.ThrowIfNull(dissolve);
-        ArgumentNullException.ThrowIfNull(simplify);
-        ArgumentNullException.ThrowIfNull(snap);
-        ArgumentNullException.ThrowIfNull(makeValid);
-        ArgumentNullException.ThrowIfNull(difference);
-        ArgumentNullException.ThrowIfNull(spatialJoinManaged);
-        ArgumentNullException.ThrowIfNull(clusterManaged);
-        ArgumentNullException.ThrowIfNull(bufferAggregateManaged);
-        ArgumentNullException.ThrowIfNull(densityManaged);
-        ArgumentNullException.ThrowIfNull(attributeRename);
-        ArgumentNullException.ThrowIfNull(attributeCast);
-        ArgumentNullException.ThrowIfNull(computedField);
-        ArgumentNullException.ThrowIfNull(attributeFilter);
-        ArgumentNullException.ThrowIfNull(spatialFilter);
-        ArgumentNullException.ThrowIfNull(clip2);
-        ArgumentNullException.ThrowIfNull(dedup);
-        ArgumentNullException.ThrowIfNull(reproject);
-        ArgumentNullException.ThrowIfNull(geoJsonSource);
-        ArgumentNullException.ThrowIfNull(csvSource);
-        ArgumentNullException.ThrowIfNull(geoJsonFileSink);
-        ArgumentNullException.ThrowIfNull(quarantineSink);
-        ArgumentNullException.ThrowIfNull(externalPostgisSink);
-        ArgumentNullException.ThrowIfNull(importDataset);
+        ArgumentNullException.ThrowIfNull(executors);
         ArgumentNullException.ThrowIfNull(logger);
 
-        _handlers = new Dictionary<string, IJobExecutor>(StringComparer.Ordinal)
-        {
-            [GeometryBufferJobExecutor.HandledProcessId] = buffer,
-            [GeometryClipJobExecutor.HandledProcessId] = clip,
-            [GeometryIntersectJobExecutor.HandledProcessId] = intersect,
-            [GeometryProjectJobExecutor.HandledProcessId] = project,
-            [GeometryAreaJobExecutor.HandledProcessId] = area,
-            [GeometryUnionJobExecutor.HandledProcessId] = union,
-            [GeometryCentroidJobExecutor.HandledProcessId] = centroid,
-            [GeometryLengthJobExecutor.HandledProcessId] = length,
-            [GeometryConvexHullJobExecutor.HandledProcessId] = convexHull,
-            [GeometryDissolveJobExecutor.HandledProcessId] = dissolve,
-            [GeometrySimplifyJobExecutor.HandledProcessId] = simplify,
-            [GeometrySnapJobExecutor.HandledProcessId] = snap,
-            [GeometryMakeValidJobExecutor.HandledProcessId] = makeValid,
-            [GeometryDifferenceJobExecutor.HandledProcessId] = difference,
-            [ManagedSpatialJoinExecutor.HandledProcessId] = spatialJoinManaged,
-            [ManagedClusterExecutor.HandledProcessId] = clusterManaged,
-            [ManagedBufferAggregateExecutor.HandledProcessId] = bufferAggregateManaged,
-            [ManagedDensityExecutor.HandledProcessId] = densityManaged,
-            [AttributeRenameTransformExecutor.HandledProcessId] = attributeRename,
-            [AttributeCastTransformExecutor.HandledProcessId] = attributeCast,
-            [ComputedFieldTransformExecutor.HandledProcessId] = computedField,
-            [AttributeFilterTransformExecutor.HandledProcessId] = attributeFilter,
-            [SpatialFilterTransformExecutor.HandledProcessId] = spatialFilter,
-            [ClipTransformExecutor.HandledProcessId] = clip2,
-            [DedupTransformExecutor.HandledProcessId] = dedup,
-            [ReprojectTransformExecutor.HandledProcessId] = reproject,
-            [GeoJsonSourceExecutor.HandledProcessId] = geoJsonSource,
-            [CsvSourceExecutor.HandledProcessId] = csvSource,
-            [GeoJsonFileSinkExecutor.HandledProcessId] = geoJsonFileSink,
-            [QuarantineSinkExecutor.HandledProcessId] = quarantineSink,
-            [ExternalPostgisSinkExecutor.HandledProcessId] = externalPostgisSink,
-            [ImportDatasetJobExecutor.HandledProcessId] = importDataset,
-        }.ToFrozenDictionary(StringComparer.Ordinal);
-
+        _handlers = ProcessExecutorRouteTable.Build(executors);
         _logger = logger;
     }
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ImportDatasetJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ImportDatasetJobExecutor.cs
@@ -58,7 +58,7 @@ namespace Honua.Geoprocessing.Execution;
 /// rather than checkpointing each row; finer-grained resume is deferred.
 /// </para>
 /// </summary>
-internal sealed partial class ImportDatasetJobExecutor : IJobExecutor
+internal sealed partial class ImportDatasetJobExecutor : IProcessExecutor
 {
     /// <summary>
     /// The single process id this executor handles. Matches the catalog entry
@@ -84,6 +84,13 @@ internal sealed partial class ImportDatasetJobExecutor : IJobExecutor
         _serviceScopeFactory = serviceScopeFactory;
         _logger = logger;
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/QuarantineSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/QuarantineSinkExecutor.cs
@@ -19,7 +19,7 @@ namespace Honua.Geoprocessing.Execution;
 /// rejected rows route here instead of aborting the run. Reconciled from the GeoETL
 /// baseline QuarantineSinkConnector onto the #1185 process/executor contract.
 /// </summary>
-internal sealed partial class QuarantineSinkExecutor : IJobExecutor
+internal sealed partial class QuarantineSinkExecutor : IProcessExecutor
 {
     internal const string HandledProcessId = "sink.quarantine";
 
@@ -41,6 +41,13 @@ internal sealed partial class QuarantineSinkExecutor : IJobExecutor
         : this(options, Microsoft.Extensions.Logging.Abstractions.NullLogger<QuarantineSinkExecutor>.Instance)
     {
     }
+
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
 
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -1048,88 +1048,11 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
     }
 
     private static void ValidatePlanStructure(AnalysisPlan plan)
-    {
-        // Proto-level enum validation happens in the conversion layer. The remaining
-        // domain-level invariant is that the step dependency graph be acyclic and that
-        // every dependency refer to a real step — the executor assumes topological
-        // ordering, so a cycle or dangling reference deadlocks the run.
-        if (plan.Steps.Count == 0)
-        {
-            return;
-        }
-
-        var stepIds = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var step in plan.Steps)
-        {
-            if (string.IsNullOrWhiteSpace(step.StepId))
-            {
-                throw new GeoprocessingValidationException("Every step requires a non-empty stepId.");
-            }
-
-            if (!stepIds.Add(step.StepId))
-            {
-                throw new GeoprocessingValidationException(
-                    $"Duplicate step identifier '{step.StepId}'.");
-            }
-        }
-
-        foreach (var step in plan.Steps)
-        {
-            foreach (var dep in step.DependsOn)
-            {
-                if (!stepIds.Contains(dep))
-                {
-                    throw new GeoprocessingValidationException(
-                        $"Step '{step.StepId}' depends on unknown step '{dep}'.");
-                }
-
-                if (string.Equals(dep, step.StepId, StringComparison.Ordinal))
-                {
-                    throw new GeoprocessingValidationException(
-                        $"Step '{step.StepId}' cannot depend on itself.");
-                }
-            }
-        }
-
-        // Kahn's algorithm: iteratively remove nodes with zero in-degree; if any remain,
-        // the remaining subgraph contains a cycle.
-        var inDegree = plan.Steps.ToDictionary(s => s.StepId, _ => 0, StringComparer.Ordinal);
-        var edges = new Dictionary<string, List<string>>(StringComparer.Ordinal);
-        foreach (var step in plan.Steps)
-        {
-            edges[step.StepId] = new List<string>();
-        }
-
-        foreach (var step in plan.Steps)
-        {
-            foreach (var dep in step.DependsOn)
-            {
-                edges[dep].Add(step.StepId);
-                inDegree[step.StepId]++;
-            }
-        }
-
-        var ready = new Queue<string>(inDegree.Where(p => p.Value == 0).Select(p => p.Key));
-        var visited = 0;
-        while (ready.Count > 0)
-        {
-            var current = ready.Dequeue();
-            visited++;
-            foreach (var next in edges[current])
-            {
-                if (--inDegree[next] == 0)
-                {
-                    ready.Enqueue(next);
-                }
-            }
-        }
-
-        if (visited != plan.Steps.Count)
-        {
-            throw new GeoprocessingValidationException(
-                "Plan step dependency graph contains a cycle.");
-        }
-    }
+        // Structural (dependency-graph) validation is shared with the headless
+        // GP Devkit `honua gp plan` dry-run path via AnalysisPlanGraphValidator so
+        // both reject the same malformed graphs (dangling/self deps, cycles) with
+        // the same message.
+        => AnalysisPlanGraphValidator.Validate(plan);
 
     private static void EnsurePlanExecutable(AnalysisPlan plan)
     {

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Orchestration.Abstractions;
 using Honua.Geoprocessing.Execution;
+using Honua.Geoprocessing.LocalRunner;
 using Honua.Infrastructure.Abstractions;
 using Honua.ControlPlane;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -115,6 +116,12 @@ internal static class GeoprocessingServiceCollectionExtensions
 
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IJobExecutor, GeoprocessingDispatchJobExecutor>());
+
+        // Headless single-process runner (GP Devkit, #2123): invokes one managed
+        // IProcessExecutor directly with no Redis/queue/job-store, reusing the same
+        // executor instances registered above. Consumed by the dev `honua gp` CLI.
+        services.TryAddSingleton(sp =>
+            new GeoprocessingLocalRunner(sp.GetServices<IProcessExecutor>()));
 
         // Job orchestration substrate (queue, log store — ticket #681) is wired
         // by the Honua.Server composition root via AddJobOrchestration, which

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -93,82 +93,25 @@ internal static class GeoprocessingServiceCollectionExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
-        // Built-in production executors (ticket #1031). Slice 1 introduced the
-        // first concrete executor (geometry.buffer); slice 2 added geometry.clip,
-        // geometry.intersect, and geometry.project; slice 3 added geometry.area
-        // (per-feature measure) and geometry.union (collection aggregation);
-        // slice 4 added geometry.centroid, geometry.length, and
-        // geometry.convex-hull — rounding out the deterministic single-feature
-        // vector set; slice 5 lands the migration-priority shape transforms
-        // geometry.dissolve (group-aware aggregate), geometry.simplify
-        // (Douglas-Peucker), and geometry.snap (vertex conditioning) so the
-        // workspace covers the common parity targets before later slices
-        // tackle the heavyweight raster / surface families. The worker host
-        // keys executors by ExecutionJobKind, so the per-process executors
-        // are composed behind GeoprocessingDispatchJobExecutor — the single
-        // IJobExecutor registered for ExecutionJobKind.Geoprocessing — which
-        // routes claimed jobs to the matching handler.
-        services.TryAddSingleton<GeometryBufferJobExecutor>();
-        services.TryAddSingleton<GeometryClipJobExecutor>();
-        services.TryAddSingleton<GeometryIntersectJobExecutor>();
-        services.TryAddSingleton<GeometryProjectJobExecutor>();
-        services.TryAddSingleton<GeometryAreaJobExecutor>();
-        services.TryAddSingleton<GeometryUnionJobExecutor>();
-        services.TryAddSingleton<GeometryCentroidJobExecutor>();
-        services.TryAddSingleton<GeometryLengthJobExecutor>();
-        services.TryAddSingleton<GeometryConvexHullJobExecutor>();
-        services.TryAddSingleton<GeometryDissolveJobExecutor>();
-        services.TryAddSingleton<GeometrySimplifyJobExecutor>();
-        services.TryAddSingleton<GeometrySnapJobExecutor>();
-
-        // Catalog-honesty reconciliation onto #1185: geometry.make-valid and
-        // geometry.difference were advertised in the catalog (and flagged
-        // synchronous / first-slice automated) on trunk but had no executor, so
-        // a job submission could never reach them. Add the managed NTS executors
-        // (GeometryFixer / Geometry.Difference) so the advertised set is honest.
-        services.TryAddSingleton<GeometryMakeValidJobExecutor>();
-        services.TryAddSingleton<GeometryDifferenceJobExecutor>();
-
-        // Managed spatial-join (analytics.spatial-join-managed) — a job-dispatchable
-        // counterpart to trunk's analytics.spatial-join, which runs only through the
-        // synchronous PostGIS SpatialAnalytics protocol and is not job-routed. NTS
-        // STRtree aggregate join over two inline FeatureCollections; no Postgres.
-        services.TryAddSingleton<ManagedSpatialJoinExecutor>();
-
-        // Managed analytics counterparts for cluster / buffer-aggregate / density
-        // (#1260). Each is the workflow/codemod-reachable counterpart to the
-        // matching analytics.* PostGIS-protocol path: NTS over an inline
-        // FeatureCollection, no Postgres dependency, so the lean dispatcher can
-        // construct them unconditionally.
-        services.TryAddSingleton<ManagedClusterExecutor>();
-        services.TryAddSingleton<ManagedBufferAggregateExecutor>();
-        services.TryAddSingleton<ManagedDensityExecutor>();
-
-        // GeoETL transform executors reconciled from feat/geoetl-baseline onto the
-        // #1185 add-a-capability contract. Each reads/writes a FeatureCollection
-        // data URI and is composed behind GeoprocessingDispatchJobExecutor.
-        services.TryAddSingleton<AttributeRenameTransformExecutor>();
-        services.TryAddSingleton<AttributeCastTransformExecutor>();
-        services.TryAddSingleton<ComputedFieldTransformExecutor>();
-        services.TryAddSingleton<AttributeFilterTransformExecutor>();
-        services.TryAddSingleton<SpatialFilterTransformExecutor>();
-        services.TryAddSingleton<ClipTransformExecutor>();
-        services.TryAddSingleton<DedupTransformExecutor>();
-        services.TryAddSingleton<ReprojectTransformExecutor>();
-        services.TryAddSingleton<GeoJsonSourceExecutor>();
-        services.TryAddSingleton<CsvSourceExecutor>();
-        services.TryAddSingleton<GeoJsonFileSinkExecutor>();
-        services.TryAddSingleton<QuarantineSinkExecutor>();
-        services.TryAddSingleton<ExternalPostgisSinkExecutor>();
-
-        // Import-dataset orchestration executor (#1630). Owns the full durable
-        // import pipeline (fetch -> validate+chunk -> import -> flatten -> tile ->
-        // extent+MVT refresh -> provenance) by composing the existing provider
-        // services, which it resolves at execution time through an
-        // IServiceScopeFactory scope (the provider implementations live in the
-        // active data-provider assembly, out of reach for this module — the same
-        // pattern ExternalPostgisSinkExecutor uses).
-        services.TryAddSingleton<ImportDatasetJobExecutor>();
+        // Built-in production executors (ticket #1031; GP Devkit authoring
+        // contract #2122). Each per-process executor implements IProcessExecutor
+        // and self-declares the process id(s) it handles, so they are registered
+        // through a single auto-registration scan rather than ~31 hand-maintained
+        // lines, and GeoprocessingDispatchJobExecutor — the single IJobExecutor
+        // registered for ExecutionJobKind.Geoprocessing — builds its routing table
+        // by enumerating IProcessExecutor and keying by ProcessIds.
+        //
+        // The executor families composed behind the dispatcher:
+        //  - geometry.* deterministic single-feature / aggregate vector ops
+        //    (buffer/clip/intersect/project/area/union/centroid/length/
+        //     convex-hull/dissolve/simplify/snap), plus the catalog-honesty
+        //    reconciliation of geometry.make-valid + geometry.difference (#1185);
+        //  - analytics.*-managed NTS counterparts to the PostGIS-protocol analytics
+        //    paths (spatial-join/cluster/buffer-aggregate/density, #1260);
+        //  - transform.* / source.* / sink.* GeoETL executors (feat/geoetl-baseline
+        //    reconciled onto the #1185 add-a-capability contract);
+        //  - import.dataset durable import orchestration (#1630).
+        AddProcessExecutors(services);
 
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IJobExecutor, GeoprocessingDispatchJobExecutor>());
@@ -179,5 +122,70 @@ internal static class GeoprocessingServiceCollectionExtensions
         // Honua.Server.Features.Admin.Share (out of reach for this assembly).
 
         return services;
+    }
+
+    /// <summary>
+    /// Auto-registers every built-in <see cref="IProcessExecutor"/> (GP Devkit
+    /// authoring contract #2122). Each executor is registered as its concrete type
+    /// (so call sites that resolve a specific executor keep working) and is also
+    /// surfaced into the enumerable <see cref="IProcessExecutor"/> set the
+    /// <see cref="GeoprocessingDispatchJobExecutor"/> enumerates — both bound to the
+    /// SAME singleton instance via a resolving factory, so there is exactly one of
+    /// each. No reflection scan is used, keeping the registration AOT-safe; adding a
+    /// new managed process is a one-line <c>Register&lt;T&gt;</c> call here plus its
+    /// catalog entry.
+    /// </summary>
+    private static void AddProcessExecutors(IServiceCollection services)
+    {
+        Register<GeometryBufferJobExecutor>(services);
+        Register<GeometryClipJobExecutor>(services);
+        Register<GeometryIntersectJobExecutor>(services);
+        Register<GeometryProjectJobExecutor>(services);
+        Register<GeometryAreaJobExecutor>(services);
+        Register<GeometryUnionJobExecutor>(services);
+        Register<GeometryCentroidJobExecutor>(services);
+        Register<GeometryLengthJobExecutor>(services);
+        Register<GeometryConvexHullJobExecutor>(services);
+        Register<GeometryDissolveJobExecutor>(services);
+        Register<GeometrySimplifyJobExecutor>(services);
+        Register<GeometrySnapJobExecutor>(services);
+        Register<GeometryMakeValidJobExecutor>(services);
+        Register<GeometryDifferenceJobExecutor>(services);
+        Register<ManagedSpatialJoinExecutor>(services);
+        Register<ManagedClusterExecutor>(services);
+        Register<ManagedBufferAggregateExecutor>(services);
+        Register<ManagedDensityExecutor>(services);
+        Register<AttributeRenameTransformExecutor>(services);
+        Register<AttributeCastTransformExecutor>(services);
+        Register<ComputedFieldTransformExecutor>(services);
+        Register<AttributeFilterTransformExecutor>(services);
+        Register<SpatialFilterTransformExecutor>(services);
+        Register<ClipTransformExecutor>(services);
+        Register<DedupTransformExecutor>(services);
+        Register<ReprojectTransformExecutor>(services);
+        Register<GeoJsonSourceExecutor>(services);
+        Register<CsvSourceExecutor>(services);
+        Register<GeoJsonFileSinkExecutor>(services);
+        Register<QuarantineSinkExecutor>(services);
+        Register<ExternalPostgisSinkExecutor>(services);
+        Register<ImportDatasetJobExecutor>(services);
+    }
+
+    private static void Register<TExecutor>(IServiceCollection services)
+        where TExecutor : class, IProcessExecutor
+    {
+        services.TryAddSingleton<TExecutor>();
+
+        // Surface the same singleton into the IProcessExecutor enumerable the
+        // dispatcher consumes. Guard against a double-add so a repeated
+        // AddGeoprocessing call cannot register a duplicate id (which would trip
+        // the route-table duplicate-id guard at composition time).
+        if (!services.Any(d =>
+                d.ServiceType == typeof(IProcessExecutor)
+                && d.ImplementationFactory is not null
+                && d.ImplementationFactory.Method.ReturnType == typeof(TExecutor)))
+        {
+            services.AddSingleton<IProcessExecutor>(sp => sp.GetRequiredService<TExecutor>());
+        }
     }
 }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GpPlan.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GpPlan.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.Geoprocessing;
+
+/// <summary>
+/// The immutable, machine-shaped result of <c>honua gp plan</c> (GP Devkit P5,
+/// issue #2126): the validated, ordered dry-run plan for a single process plus a
+/// best-effort output-size / cost estimate. Produced WITHOUT executing the
+/// process (no Redis, no job store, no executor invocation), so it can be shown
+/// to the operator before submit and is the same magnitude a future devops-agent
+/// step would size serverless Batch resources from.
+/// </summary>
+internal sealed record GpPlan
+{
+    /// <summary>Canonical dotted process id the plan targets.</summary>
+    public required string ProcessId { get; init; }
+
+    /// <summary>Human-readable process title from the catalog.</summary>
+    public required string Title { get; init; }
+
+    /// <summary>Top-level process category (e.g. <c>geometry</c>, <c>raster</c>).</summary>
+    public required string Category { get; init; }
+
+    /// <summary>
+    /// The runtime profile the job would run under (<c>managed</c> or
+    /// <c>native</c>), read from the catalog — the routing/resource hint a
+    /// serverless sizing step consumes.
+    /// </summary>
+    public required string RuntimeProfile { get; init; }
+
+    /// <summary>Whether the plan passed validation and could be submitted as-is.</summary>
+    public bool IsValid => Errors.Count == 0;
+
+    /// <summary>Validation errors that block submission (param + structural).</summary>
+    public required IReadOnlyList<string> Errors { get; init; }
+
+    /// <summary>Non-fatal advisories (e.g. size/cost cautions) for the operator.</summary>
+    public required IReadOnlyList<string> Warnings { get; init; }
+
+    /// <summary>The ordered steps the plan would execute.</summary>
+    public required IReadOnlyList<GpPlanStep> Steps { get; init; }
+
+    /// <summary>Declared output artifact kinds for the process.</summary>
+    public required IReadOnlyList<ArtifactKind> Outputs { get; init; }
+
+    /// <summary>The output-size / cost estimate (always a heuristic).</summary>
+    public required GpSizeEstimate Estimate { get; init; }
+}
+
+/// <summary>One resolved step in a <see cref="GpPlan"/>.</summary>
+internal sealed record GpPlanStep
+{
+    /// <summary>Step identifier within the plan DAG.</summary>
+    public required string StepId { get; init; }
+
+    /// <summary>The process id this step runs.</summary>
+    public required string ProcessId { get; init; }
+
+    /// <summary>Step identifiers that must complete before this one.</summary>
+    public required IReadOnlyList<string> DependsOn { get; init; }
+
+    /// <summary>
+    /// The resolved parameters for this step, in declaration order, each with a
+    /// note on whether the value came from the caller or a catalog default.
+    /// </summary>
+    public required IReadOnlyList<GpResolvedParam> Parameters { get; init; }
+}
+
+/// <summary>A single resolved parameter shown in the plan preview.</summary>
+internal sealed record GpResolvedParam
+{
+    /// <summary>Parameter name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Declared value type from the schema.</summary>
+    public required ProcessParameterValueType ValueType { get; init; }
+
+    /// <summary>Whether the parameter is declared-required.</summary>
+    public required bool Required { get; init; }
+
+    /// <summary>
+    /// The resolved, display-safe value (large/binary values are abbreviated),
+    /// or <c>null</c> when the parameter is unset and has no default.
+    /// </summary>
+    public required string? DisplayValue { get; init; }
+
+    /// <summary>Where the value came from: caller, default, or unset.</summary>
+    public required GpParamSource Source { get; init; }
+}
+
+/// <summary>Provenance of a resolved parameter value.</summary>
+internal enum GpParamSource
+{
+    /// <summary>Supplied by the caller (<c>--param</c> or bound <c>--input</c>).</summary>
+    Caller,
+
+    /// <summary>Filled from the catalog default value.</summary>
+    Default,
+
+    /// <summary>Not supplied and no default available.</summary>
+    Unset,
+}
+
+/// <summary>
+/// A best-effort output-size and cost estimate. Every field is a HEURISTIC,
+/// never a guarantee — the actual artifact size depends on geometry complexity,
+/// compression, and the operation's real selectivity, none of which are known
+/// without running. The estimate exists to warn the operator BEFORE submit that
+/// a run is likely to exceed the 50 MiB <c>MaxArtifactBytes</c> cap (the real
+/// failure mode — the job FAILS at that cap today) or to be long-running.
+/// </summary>
+internal sealed record GpSizeEstimate
+{
+    /// <summary>Total caller-supplied input payload size, in bytes.</summary>
+    public required long InputBytes { get; init; }
+
+    /// <summary>
+    /// Heuristic estimated output payload size, in bytes. <c>null</c> when no
+    /// file-like input was supplied to anchor the estimate.
+    /// </summary>
+    public required long? EstimatedOutputBytes { get; init; }
+
+    /// <summary>The configured <c>MaxArtifactBytes</c> cap the estimate is judged against.</summary>
+    public required long MaxArtifactBytes { get; init; }
+
+    /// <summary>
+    /// A short human-readable explanation of how the output estimate was derived
+    /// (the multiplier and its basis), so the operator can judge its trust.
+    /// </summary>
+    public required string Basis { get; init; }
+
+    /// <summary>True when the estimated output is likely to exceed the cap.</summary>
+    public bool ExceedsCap =>
+        EstimatedOutputBytes is { } bytes && bytes > MaxArtifactBytes;
+
+    /// <summary>
+    /// True when the operation is flagged as potentially long-running / cost
+    /// sensitive (e.g. a native raster/surface op over many tiles), so the
+    /// operator and a serverless sizing step can budget for it.
+    /// </summary>
+    public required bool LongRunning { get; init; }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GpPlanner.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GpPlanner.cs
@@ -1,0 +1,233 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.Geoprocessing;
+
+/// <summary>
+/// Builds the dry-run <see cref="GpPlan"/> for <c>honua gp plan</c> (GP Devkit
+/// P5, issue #2126): resolves caller params against a process's typed schema,
+/// runs the SAME catalog parameter validation (<see cref="ProcessPlanValidator"/>)
+/// and structural DAG validation (<see cref="AnalysisPlanGraphValidator"/>) the
+/// durable submit/validate path runs — WITHOUT executing anything — and attaches
+/// a best-effort output-size / cost estimate judged against the configured
+/// <see cref="GeoprocessingExecutorOptions.MaxArtifactBytes"/> cap.
+///
+/// <para>
+/// The estimate is the resource hint a future devops-agent serverless-sizing
+/// step would size Batch from, so the plan deliberately surfaces the input /
+/// output magnitude and a long-running flag alongside the validation result.
+/// </para>
+/// </summary>
+internal static class GpPlanner
+{
+    /// <summary>
+    /// Produces the plan for <paramref name="processId"/> against the resolved
+    /// <paramref name="resolvedInputs"/> (already-merged <c>--param</c> +
+    /// bound <c>--input</c> values). Returns <c>null</c> when the process id is
+    /// unknown so the caller can emit a usage error listing valid ids.
+    /// </summary>
+    /// <param name="processId">Canonical dotted process id.</param>
+    /// <param name="resolvedInputs">Resolved step-0 input name/value pairs.</param>
+    /// <param name="catalog">The process catalog to validate against.</param>
+    /// <param name="maxArtifactBytes">The configured per-artifact byte cap.</param>
+    /// <param name="callerInputBytes">
+    /// Total raw bytes the caller actually supplied as a file-like input (the
+    /// decoded length of <c>--input</c>), used to anchor the size estimate.
+    /// </param>
+    /// <returns>The dry-run plan, or <c>null</c> when the process is not registered.</returns>
+    public static GpPlan? Build(
+        string processId,
+        IReadOnlyDictionary<string, string> resolvedInputs,
+        IProcessCatalog catalog,
+        long maxArtifactBytes,
+        long callerInputBytes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(processId);
+        ArgumentNullException.ThrowIfNull(resolvedInputs);
+        ArgumentNullException.ThrowIfNull(catalog);
+
+        var definition = catalog.GetProcess(processId);
+        if (definition is null)
+        {
+            return null;
+        }
+
+        // A single-process plan: the GP Devkit CLI drives ONE process at a time,
+        // but we still build a real AnalysisPlan and run the shared structural
+        // validation so a future multi-step authoring path reuses the same gate.
+        var plan = new AnalysisPlan
+        {
+            PlanId = $"gp-plan-{processId}",
+            IntentId = "gp-cli",
+            Steps =
+            [
+                new AnalysisPlanStep
+                {
+                    StepId = "step-0",
+                    Kind = AnalysisPlanStepKind.Geoprocess,
+                    ProcessId = processId,
+                    Inputs = new Dictionary<string, string>(resolvedInputs, StringComparer.Ordinal),
+                    DependsOn = [],
+                },
+            ],
+            Outputs = definition.OutputArtifactKinds,
+        };
+
+        var errors = new List<string>();
+
+        // Structural / DAG validation — the same Kahn topological check the durable
+        // submit path runs. Surfaces dangling deps, self-deps, and cycles.
+        try
+        {
+            AnalysisPlanGraphValidator.Validate(plan);
+        }
+        catch (GeoprocessingValidationException ex)
+        {
+            errors.Add(ex.Message);
+        }
+
+        // Typed-schema parameter validation — the same ProcessPlanValidator the
+        // durable validate/submit path runs (required/unknown params, per-type
+        // parsing, per-process semantic rules).
+        var (violations, validatorWarnings) = ProcessPlanValidator.Validate(plan, catalog);
+        foreach (var violation in violations)
+        {
+            errors.Add($"{violation.Code}: {violation.Message}");
+        }
+
+        var warnings = new List<string>(validatorWarnings);
+
+        var steps = new[]
+        {
+            new GpPlanStep
+            {
+                StepId = plan.Steps[0].StepId,
+                ProcessId = processId,
+                DependsOn = plan.Steps[0].DependsOn,
+                Parameters = ResolveParameters(definition, resolvedInputs),
+            },
+        };
+
+        var estimate = GpSizeEstimator.Estimate(definition, callerInputBytes, maxArtifactBytes);
+        AppendEstimateWarnings(estimate, warnings);
+
+        return new GpPlan
+        {
+            ProcessId = processId,
+            Title = definition.Title,
+            Category = definition.Category,
+            RuntimeProfile = RuntimeProfiles.Normalize(definition.RuntimeProfile),
+            Errors = errors,
+            Warnings = warnings,
+            Steps = steps,
+            Outputs = definition.OutputArtifactKinds,
+            Estimate = estimate,
+        };
+    }
+
+    private static GpResolvedParam[] ResolveParameters(
+        ProcessDefinition definition,
+        IReadOnlyDictionary<string, string> resolvedInputs)
+    {
+        var resolved = new List<GpResolvedParam>(definition.Parameters.Count);
+        foreach (var spec in definition.Parameters)
+        {
+            string? displayValue;
+            GpParamSource source;
+
+            if (resolvedInputs.TryGetValue(spec.Name, out var supplied))
+            {
+                displayValue = Abbreviate(supplied, spec.ValueType);
+                source = GpParamSource.Caller;
+            }
+            else if (spec.DefaultValue is not null)
+            {
+                displayValue = Abbreviate(spec.DefaultValue, spec.ValueType);
+                source = GpParamSource.Default;
+            }
+            else
+            {
+                displayValue = null;
+                source = GpParamSource.Unset;
+            }
+
+            resolved.Add(new GpResolvedParam
+            {
+                Name = spec.Name,
+                ValueType = spec.ValueType,
+                Required = spec.Required,
+                DisplayValue = displayValue,
+                Source = source,
+            });
+        }
+
+        return resolved.ToArray();
+    }
+
+    private static void AppendEstimateWarnings(GpSizeEstimate estimate, List<string> warnings)
+    {
+        if (estimate.ExceedsCap && estimate.EstimatedOutputBytes is { } outputBytes)
+        {
+            warnings.Add(
+                $"Estimated output (~{FormatBytes(outputBytes)}) is likely to exceed the " +
+                $"{FormatBytes(estimate.MaxArtifactBytes)} MaxArtifactBytes cap — the job FAILS at that cap today. " +
+                "This is a heuristic estimate, not a guarantee; reduce the input or raise " +
+                "Geoprocessing:Executors:MaxArtifactBytes before submitting.");
+        }
+        else if (estimate.InputBytes > estimate.MaxArtifactBytes)
+        {
+            // Even when the output estimate stays under the cap, an input already
+            // larger than the cap is a strong signal the run is at risk.
+            warnings.Add(
+                $"Input payload (~{FormatBytes(estimate.InputBytes)}) already exceeds the " +
+                $"{FormatBytes(estimate.MaxArtifactBytes)} MaxArtifactBytes cap; the output is likely to as well.");
+        }
+
+        if (estimate.LongRunning)
+        {
+            warnings.Add(
+                "This operation is raster/surface-class and may be long-running and cost-sensitive " +
+                "over a large or multi-tile input; budget compute accordingly.");
+        }
+    }
+
+    /// <summary>
+    /// Abbreviates a display value so large base64/WKB blobs do not flood the
+    /// plan preview; short scalar values are shown verbatim.
+    /// </summary>
+    private static string Abbreviate(string value, ProcessParameterValueType valueType)
+    {
+        var isBinary = valueType is ProcessParameterValueType.Wkb or ProcessParameterValueType.WkbArray;
+        if (isBinary || value.Length > 64)
+        {
+            return $"<{value.Length} chars>";
+        }
+
+        return value;
+    }
+
+    internal static string FormatBytes(long bytes)
+    {
+        if (bytes < 1024)
+        {
+            return $"{bytes} B";
+        }
+
+        double value = bytes;
+        string[] units = ["KiB", "MiB", "GiB", "TiB"];
+        var unitIndex = -1;
+        do
+        {
+            value /= 1024d;
+            unitIndex++;
+        }
+        while (value >= 1024d && unitIndex < units.Length - 1);
+
+        return string.Create(CultureInfo.InvariantCulture, $"{value:0.##} {units[unitIndex]}");
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GpSizeEstimator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GpSizeEstimator.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.Geoprocessing;
+
+/// <summary>
+/// Best-effort, deliberately-honest output-size / cost heuristic for
+/// <c>honua gp plan</c> (GP Devkit P5, issue #2126). Given the caller's input
+/// payload size and the process's declared category / output kind, it estimates
+/// the output magnitude so the operator can be WARNED before submit when a run
+/// is likely to blow the 50 MiB <see cref="GeoprocessingExecutorOptions.MaxArtifactBytes"/>
+/// cap (the real failure mode — the job FAILS at that cap today).
+///
+/// <para>
+/// HONEST LIMITS: this is a rough multiplier on the input bytes, NOT a guarantee.
+/// It cannot know geometry vertex complexity, output compression (e.g. a COG /
+/// GeoTIFF that compresses well, or a GeoJSON that balloons), the operation's
+/// real selectivity (a tight clip vs. a wide buffer), or the live feature count
+/// behind a layer reference. A scalar result (area/length/count) is always tiny;
+/// a feature/raster op roughly tracks its input. Treat the number as an order of
+/// magnitude, surfaced precisely so a serverless sizing step can budget Batch.
+/// </para>
+/// </summary>
+internal static class GpSizeEstimator
+{
+    /// <summary>
+    /// Produces the heuristic estimate for <paramref name="definition"/> against a
+    /// caller input of <paramref name="callerInputBytes"/> raw bytes, judged
+    /// against <paramref name="maxArtifactBytes"/>.
+    /// </summary>
+    /// <param name="definition">The process whose output magnitude is estimated.</param>
+    /// <param name="callerInputBytes">
+    /// Raw size, in bytes, of the file-like input the caller supplied (the decoded
+    /// length of <c>--input</c>). Zero when no file-like input was bound.
+    /// </param>
+    /// <param name="maxArtifactBytes">The configured per-artifact byte cap.</param>
+    /// <returns>The heuristic size / cost estimate.</returns>
+    public static GpSizeEstimate Estimate(
+        ProcessDefinition definition,
+        long callerInputBytes,
+        long maxArtifactBytes)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        var primaryOutput = definition.OutputArtifactKinds.Count > 0
+            ? definition.OutputArtifactKinds[0]
+            : ArtifactKind.File;
+
+        var isRasterClass = IsRasterClass(definition);
+        var longRunning = isRasterClass;
+
+        // A scalar/report output (area, length, count, statistics) is a handful of
+        // bytes regardless of input size — never a cap risk.
+        if (primaryOutput is ArtifactKind.Scalar or ArtifactKind.Report)
+        {
+            return new GpSizeEstimate
+            {
+                InputBytes = callerInputBytes,
+                EstimatedOutputBytes = callerInputBytes > 0 ? ScalarOutputBytes : null,
+                MaxArtifactBytes = maxArtifactBytes,
+                Basis = "scalar/report output is constant-size regardless of input",
+                LongRunning = longRunning,
+            };
+        }
+
+        // With no file-like input to anchor on (e.g. a layer-scoped analytics op
+        // whose live feature count is unknown offline), we cannot size the output
+        // honestly — report no estimate rather than a fabricated one.
+        if (callerInputBytes <= 0)
+        {
+            return new GpSizeEstimate
+            {
+                InputBytes = 0,
+                EstimatedOutputBytes = null,
+                MaxArtifactBytes = maxArtifactBytes,
+                Basis = "no file-like input supplied; output magnitude cannot be estimated offline",
+                LongRunning = longRunning,
+            };
+        }
+
+        var (multiplier, basis) = OutputMultiplier(definition, primaryOutput, isRasterClass);
+
+        // Guard the multiply against overflow on absurd inputs.
+        var scaled = (double)callerInputBytes * multiplier;
+        var estimatedOutput = scaled >= long.MaxValue ? long.MaxValue : (long)scaled;
+
+        return new GpSizeEstimate
+        {
+            InputBytes = callerInputBytes,
+            EstimatedOutputBytes = estimatedOutput,
+            MaxArtifactBytes = maxArtifactBytes,
+            Basis = basis,
+            LongRunning = longRunning,
+        };
+    }
+
+    // A scalar artifact (a GeoJSON Feature carrying one number, or a small JSON
+    // stats document) is on the order of a few hundred bytes.
+    private const long ScalarOutputBytes = 512;
+
+    private static bool IsRasterClass(ProcessDefinition definition)
+    {
+        if (definition.OutputArtifactKinds.Contains(ArtifactKind.Raster))
+        {
+            return true;
+        }
+
+        return definition.Category is "raster" or "surface"
+            || definition.ProcessId.StartsWith("raster.", StringComparison.Ordinal)
+            || definition.ProcessId.StartsWith("surface.", StringComparison.Ordinal)
+            || definition.ProcessId.StartsWith("conversion.raster", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Picks the per-operation output multiplier and a one-line basis. The
+    /// multipliers are coarse by design: shrinking ops (simplify, dissolve, dedup,
+    /// clip) come in below 1x; growing ops (buffer densification, WKB→GeoJSON
+    /// text expansion) come in above 1x; format conversions hover near 1x.
+    /// </summary>
+    private static (double Multiplier, string Basis) OutputMultiplier(
+        ProcessDefinition definition,
+        ArtifactKind primaryOutput,
+        bool isRasterClass)
+    {
+        var id = definition.ProcessId;
+
+        // Raster/surface: output pixel count tracks the input raster; reprojection
+        // and resampling can inflate, derived surfaces stay ~1x the source grid.
+        if (isRasterClass)
+        {
+            if (id.Contains("reproject", StringComparison.Ordinal)
+                || id.Contains("resample", StringComparison.Ordinal))
+            {
+                return (1.5, "raster reproject/resample roughly tracks input pixels, with headroom for grid inflation");
+            }
+
+            return (1.0, "raster/surface output roughly tracks the input pixel count");
+        }
+
+        // Geometry / feature text expansion: a WKB→GeoJSON or feature-layer output
+        // is text and runs noticeably larger than compact binary input.
+        var producesFeatureText = primaryOutput is ArtifactKind.FeatureLayer or ArtifactKind.File;
+
+        // Shrinking operations: fewer/​smaller features than the input.
+        if (id.Contains("simplify", StringComparison.Ordinal)
+            || id.Contains("dissolve", StringComparison.Ordinal)
+            || id.Contains("dedup", StringComparison.Ordinal)
+            || id.Contains("clip", StringComparison.Ordinal)
+            || id.Contains("union", StringComparison.Ordinal)
+            || id.Contains("difference", StringComparison.Ordinal)
+            || id.Contains("filter", StringComparison.Ordinal))
+        {
+            // Still text-expanded relative to WKB input, but the op removes data,
+            // so net it sits around parity rather than growing.
+            return (1.0, "generalization/filter op removes data but text-expands geometry; ~parity with input");
+        }
+
+        // Buffer densifies geometry (more vertices) and emits polygons from points/
+        // lines — the canonical growth case.
+        if (id.Contains("buffer", StringComparison.Ordinal))
+        {
+            return (5.0, "buffer densifies geometry and emits polygon output; estimate ~5x the input bytes (heuristic)");
+        }
+
+        if (producesFeatureText)
+        {
+            return (4.0, "feature/geometry text output (GeoJSON) typically expands compact binary input ~3-5x (heuristic)");
+        }
+
+        // Tables / other file outputs: assume near parity.
+        return (1.5, "tabular/file output assumed near input size with modest formatting overhead (heuristic)");
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/LocalRunner/GeoprocessingLocalRunner.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/LocalRunner/GeoprocessingLocalRunner.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.ControlPlane;
+
+namespace Honua.Geoprocessing.LocalRunner;
+
+/// <summary>
+/// Headless, single-process geoprocessing runner (GP Devkit, issue #2123). Invokes
+/// exactly ONE registered <see cref="IProcessExecutor"/> directly against in-memory
+/// inputs — with NO Redis, NO durable job store, NO queue, and NO control plane.
+///
+/// <para>
+/// It reuses the real executor path: it builds the same durable
+/// <see cref="ExecutionJobSpec.Parameters"/> bag the production submit path projects
+/// (the <c>geoprocessing.process_definitions</c> id key plus
+/// <c>geoprocessing.step.0.&lt;name&gt;</c> step inputs), constructs a minimal
+/// in-memory <see cref="IJobExecutionContext"/>, runs the executor, and returns the
+/// captured artifact reference(s), structured logs, warnings, status, and wall-clock
+/// timing. Validation and artifact-size-cap failures surface as a failed result with
+/// the executor's own classified message — exactly as they would in production.
+/// </para>
+///
+/// <para>
+/// The runner is intentionally agnostic to the executor family: the same code path
+/// drives the managed NTS geometry/transform/analytics executors and the native
+/// GDAL-backed executors (whose CLI command is surfaced into the captured logs). It
+/// performs no native work itself, so a managed op runs fully offline; a GDAL op runs
+/// offline too when its CLI runner seam is faked.
+/// </para>
+/// </summary>
+public sealed class GeoprocessingLocalRunner
+{
+    private readonly IReadOnlyDictionary<string, IProcessExecutor> _executorsById;
+
+    /// <summary>
+    /// Creates a runner over the supplied executor set. Typically resolved from DI as
+    /// <c>IEnumerable&lt;IProcessExecutor&gt;</c> (the same registrations the worker host
+    /// uses), but any explicit set works for tests and the dev CLI.
+    /// </summary>
+    /// <param name="executors">The per-process executors the runner can invoke.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when two executors declare the same process id (the same fail-fast
+    /// contract the production dispatchers enforce).
+    /// </exception>
+    public GeoprocessingLocalRunner(IEnumerable<IProcessExecutor> executors)
+    {
+        ArgumentNullException.ThrowIfNull(executors);
+        _executorsById = ProcessExecutorRouteTable.Build(executors);
+    }
+
+    /// <summary>
+    /// The set of process ids this runner can invoke, ordinally sorted.
+    /// </summary>
+    public IReadOnlyList<string> AvailableProcessIds =>
+        _executorsById.Keys.OrderBy(id => id, StringComparer.Ordinal).ToArray();
+
+    /// <summary>
+    /// Runs a single process against the supplied step-0 inputs.
+    /// </summary>
+    /// <param name="processId">Canonical dotted process id (e.g. <c>geometry.buffer</c>).</param>
+    /// <param name="inputs">
+    /// Step-0 input name/value pairs (e.g. <c>wkb</c>, <c>srid</c>, <c>distance</c>),
+    /// projected under the canonical <c>geoprocessing.step.0.&lt;name&gt;</c> keys the
+    /// executors read. Values are opaque strings, matching the durable spec contract.
+    /// </param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>The structured outcome of the run.</returns>
+    public async Task<LocalRunResult> RunAsync(
+        string processId,
+        IReadOnlyDictionary<string, string> inputs,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(processId);
+        ArgumentNullException.ThrowIfNull(inputs);
+
+        if (!_executorsById.TryGetValue(processId, out var executor))
+        {
+            var supported = string.Join(", ", AvailableProcessIds);
+            return LocalRunResult.UnknownProcess(processId, supported);
+        }
+
+        var record = BuildJobRecord(processId, inputs, executor);
+        var context = new LocalJobExecutionContext(record.OperationId);
+
+        var stopwatch = Stopwatch.StartNew();
+        JobExecutionResult result;
+        try
+        {
+            result = await executor.ExecuteAsync(record, context, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            return new LocalRunResult
+            {
+                ProcessId = processId,
+                Status = ExecutionJobStatus.Failed,
+                ErrorMessage = $"Executor threw {ex.GetType().Name}: {ex.Message}",
+                Artifacts = context.Artifacts,
+                Logs = context.Logs,
+                Warnings = [],
+                Elapsed = stopwatch.Elapsed,
+            };
+        }
+
+        stopwatch.Stop();
+
+        return new LocalRunResult
+        {
+            ProcessId = processId,
+            Status = result.Status,
+            ErrorMessage = result.ErrorMessage,
+            Artifacts = context.Artifacts,
+            Logs = context.Logs,
+            Warnings = result.Warnings,
+            Elapsed = stopwatch.Elapsed,
+        };
+    }
+
+    private static ExecutionJobRecord BuildJobRecord(
+        string processId,
+        IReadOnlyDictionary<string, string> inputs,
+        IProcessExecutor executor)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // The canonical process-id key the dispatch helper / executors resolve.
+            [ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId,
+            // protocolProcessId is the fallback key several executors also accept.
+            ["protocolProcessId"] = processId,
+        };
+
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+        foreach (var (name, value) in inputs)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            parameters[prefix + name] = value ?? string.Empty;
+        }
+
+        // Stamp the runtime profile the executor accepts so a native (GDAL) executor's
+        // own profile guard, if any, is satisfied; managed executors ignore it.
+        var runtimeProfile = executor.AcceptedRuntimeProfiles.Contains(RuntimeProfiles.Native)
+            ? RuntimeProfiles.Native
+            : RuntimeProfiles.Managed;
+
+        var now = DateTimeOffset.UtcNow;
+        return new ExecutionJobRecord
+        {
+            OperationId = "local-" + Guid.NewGuid().ToString("N"),
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = now,
+            UpdatedAt = now,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "gp-local:" + processId,
+                RuntimeProfile = runtimeProfile,
+                Parameters = parameters,
+            },
+        };
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/LocalRunner/LocalJobExecutionContext.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/LocalRunner/LocalJobExecutionContext.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Geoprocessing.LocalRunner;
+
+/// <summary>
+/// In-memory <see cref="IJobExecutionContext"/> for the headless
+/// <see cref="GeoprocessingLocalRunner"/> (issue #2123). Records every progress
+/// update, structured log entry, and published artifact reference in order so the
+/// runner can surface them to the caller. It performs no I/O and reaches no Redis,
+/// job store, or control plane — the runner is fully self-contained.
+/// </summary>
+internal sealed class LocalJobExecutionContext(string operationId) : IJobExecutionContext
+{
+    private readonly List<ExecutionLogEntry> _logs = [];
+    private readonly List<string> _artifacts = [];
+
+    /// <inheritdoc />
+    public string OperationId { get; } = operationId;
+
+    /// <summary>Structured log entries appended during execution, in order.</summary>
+    public IReadOnlyList<ExecutionLogEntry> Logs => _logs;
+
+    /// <summary>Artifact references published during execution, in order.</summary>
+    public IReadOnlyList<string> Artifacts => _artifacts;
+
+    /// <inheritdoc />
+    public Task ReportProgressAsync(
+        double? percentComplete,
+        string? phase,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task AppendLogAsync(ExecutionLogEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        _logs.Add(entry);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task PublishArtifactAsync(string artifactReference, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactReference);
+        _artifacts.Add(artifactReference);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/LocalRunner/LocalRunResult.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/LocalRunner/LocalRunResult.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Geoprocessing.LocalRunner;
+
+/// <summary>
+/// Structured outcome of a single <see cref="GeoprocessingLocalRunner"/> invocation
+/// (issue #2123): terminal status, the published artifact reference(s), the structured
+/// logs the executor emitted (including, for GDAL ops, the actual CLI command), any
+/// warnings, an error message on failure, and wall-clock timing.
+/// </summary>
+public sealed record LocalRunResult
+{
+    /// <summary>The process id that was invoked.</summary>
+    public required string ProcessId { get; init; }
+
+    /// <summary>Terminal status reported by the executor.</summary>
+    public required ExecutionJobStatus Status { get; init; }
+
+    /// <summary>Whether the run succeeded.</summary>
+    public bool Succeeded => Status == ExecutionJobStatus.Succeeded;
+
+    /// <summary>Classified error message when the run failed; otherwise <c>null</c>.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Artifact references the executor published, in order.</summary>
+    public IReadOnlyList<string> Artifacts { get; init; } = [];
+
+    /// <summary>Structured log entries emitted during execution, in order.</summary>
+    public IReadOnlyList<ExecutionLogEntry> Logs { get; init; } = [];
+
+    /// <summary>Warnings collected during execution.</summary>
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+
+    /// <summary>Wall-clock duration of the executor invocation.</summary>
+    public TimeSpan Elapsed { get; init; }
+
+    /// <summary>
+    /// Builds the failed result returned when the requested process id is not
+    /// registered with the runner.
+    /// </summary>
+    /// <param name="processId">The unknown process id.</param>
+    /// <param name="supportedProcessIds">Comma-separated list of available ids.</param>
+    public static LocalRunResult UnknownProcess(string processId, string supportedProcessIds) => new()
+    {
+        ProcessId = processId,
+        Status = ExecutionJobStatus.Failed,
+        ErrorMessage =
+            $"Process id '{processId}' is not registered with the local runner. "
+            + $"Available process ids: {supportedProcessIds}.",
+    };
+}

--- a/src/Honua.Geoprocessing/Honua.Geoprocessing.csproj
+++ b/src/Honua.Geoprocessing/Honua.Geoprocessing.csproj
@@ -53,6 +53,10 @@
     <InternalsVisibleTo Include="Honua.Protocols.GeoServices" />
     <InternalsVisibleTo Include="Honua.Protocols.GeoServices.Tests" />
     <InternalsVisibleTo Include="Honua.Ai.Tests" />
+    <!-- GP Devkit dev CLI (#2123): consumes the internal AddGeoprocessing
+         registration to resolve the managed IProcessExecutor set Redis-free.
+         Grant matches the CLI's AssemblyName (honua-gp), not its project name. -->
+    <InternalsVisibleTo Include="honua-gp" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/src/Honua.Worker.Gdal/Execution/GdalCommandLog.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalCommandLog.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Emits the GDAL/OGR command a native executor is about to run as a structured log
+/// entry on the shared <see cref="IJobExecutionContext"/>. Surfacing the command makes
+/// every native run reproducible from the job's logs (operator diagnosis) and is the
+/// seam the GP Devkit headless runner reads to report the actual CLI command for a
+/// GDAL op (issue #2123). The per-job scratch workspace path is redacted to a stable
+/// placeholder so the log does not leak the worker filesystem layout, matching the
+/// cross-cutting rule already enforced by <see cref="GdalErrorSanitizer"/>.
+/// </summary>
+internal static class GdalCommandLog
+{
+    /// <summary>Metadata key carrying the GDAL/OGR tool name on the command log entry.</summary>
+    public const string ToolMetadataKey = "gdal.tool";
+
+    /// <summary>Metadata key carrying the full sanitized command line on the command log entry.</summary>
+    public const string CommandMetadataKey = "gdal.command";
+
+    /// <summary>
+    /// Appends an informational log entry describing the command (tool + arguments,
+    /// with the scratch workspace redacted). Never throws on a null/empty workspace.
+    /// </summary>
+    public static Task LogCommandAsync(
+        IJobExecutionContext context,
+        string tool,
+        IReadOnlyList<string> arguments,
+        string workspace,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var command = BuildSanitizedCommand(tool, arguments, workspace);
+
+        var entry = new ExecutionLogEntry
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Level = ExecutionLogLevel.Info,
+            Message = $"Running GDAL command: {command}",
+            Phase = "execute",
+            Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [ToolMetadataKey] = tool,
+                [CommandMetadataKey] = command,
+            },
+        };
+
+        return context.AppendLogAsync(entry, cancellationToken);
+    }
+
+    /// <summary>
+    /// Builds the sanitized, single-line command string (<c>tool arg arg ...</c>) with
+    /// the per-job scratch workspace path replaced by a stable placeholder.
+    /// </summary>
+    public static string BuildSanitizedCommand(
+        string tool,
+        IReadOnlyList<string> arguments,
+        string workspace)
+    {
+        var parts = new List<string>(arguments.Count + 1) { tool };
+        foreach (var argument in arguments)
+        {
+            parts.Add(Redact(argument, workspace));
+        }
+
+        return string.Join(' ', parts);
+    }
+
+    private static string Redact(string value, string workspace)
+    {
+        if (string.IsNullOrEmpty(value) || string.IsNullOrEmpty(workspace))
+        {
+            return value;
+        }
+
+        return value.Replace(workspace, "<scratch>", StringComparison.Ordinal);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalDispatchJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalDispatchJobExecutor.cs
@@ -26,60 +26,26 @@ internal sealed partial class GdalDispatchJobExecutor : IJobExecutor
     private static readonly IReadOnlySet<string> NativeProfileSet =
         new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
 
-    private readonly FrozenDictionary<string, IJobExecutor> _handlers;
+    private readonly FrozenDictionary<string, IProcessExecutor> _handlers;
     private readonly ILogger<GdalDispatchJobExecutor> _logger;
 
     /// <summary>
-    /// Composes the dispatcher over the registered GDAL-backed executors.
+    /// Composes the dispatcher over the auto-registered GDAL-backed executors
+    /// (issue #2122). Each <see cref="IProcessExecutor"/> self-declares the process
+    /// ids it handles through <see cref="IProcessExecutor.ProcessIds"/> — including
+    /// the <c>surface.*</c> and <c>raster.statistics/histogram</c> families that fan
+    /// a single executor over several ids — so the O(1) routing table is built from
+    /// a single DI scan via <see cref="ProcessExecutorRouteTable.Build"/> instead of
+    /// a hand-maintained constructor naming every executor and its id set.
     /// </summary>
     public GdalDispatchJobExecutor(
-        GdalVectorConvertJobExecutor vectorConvert,
-        GdalRasterReprojectJobExecutor rasterReproject,
-        GdalSurfaceJobExecutor surface,
-        GdalRasterClipJobExecutor rasterClip,
-        GdalRasterReprojectCatalogJobExecutor rasterReprojectCatalog,
-        GdalRasterStatisticsJobExecutor rasterStatistics,
-        GdalRasterZonalStatisticsJobExecutor rasterZonalStatistics,
-        GdalMultidimCoverageMetadataJobExecutor multidimCoverageMetadata,
-        PdalPointCloudConvertJobExecutor pointCloudConvert,
+        IEnumerable<IProcessExecutor> executors,
         ILogger<GdalDispatchJobExecutor> logger)
     {
-        ArgumentNullException.ThrowIfNull(vectorConvert);
-        ArgumentNullException.ThrowIfNull(rasterReproject);
-        ArgumentNullException.ThrowIfNull(surface);
-        ArgumentNullException.ThrowIfNull(rasterClip);
-        ArgumentNullException.ThrowIfNull(rasterReprojectCatalog);
-        ArgumentNullException.ThrowIfNull(rasterStatistics);
-        ArgumentNullException.ThrowIfNull(rasterZonalStatistics);
-        ArgumentNullException.ThrowIfNull(multidimCoverageMetadata);
-        ArgumentNullException.ThrowIfNull(pointCloudConvert);
+        ArgumentNullException.ThrowIfNull(executors);
         ArgumentNullException.ThrowIfNull(logger);
 
-        var handlers = new Dictionary<string, IJobExecutor>(StringComparer.Ordinal)
-        {
-            [GdalVectorConvertJobExecutor.HandledProcessId] = vectorConvert,
-            [GdalRasterReprojectJobExecutor.HandledProcessId] = rasterReproject,
-            [GdalRasterClipJobExecutor.HandledProcessId] = rasterClip,
-            [GdalRasterReprojectCatalogJobExecutor.HandledProcessId] = rasterReprojectCatalog,
-            [GdalRasterZonalStatisticsJobExecutor.HandledProcessId] = rasterZonalStatistics,
-            [GdalMultidimCoverageMetadataJobExecutor.HandledProcessId] = multidimCoverageMetadata,
-            [PdalPointCloudConvertJobExecutor.HandledProcessId] = pointCloudConvert,
-        };
-
-        // surface.* and raster.statistics/histogram each fan out a single executor
-        // over several process ids; copy them into the dispatcher's flat handler map
-        // so the routing decision stays O(1) per call.
-        foreach (var processId in GdalSurfaceJobExecutor.SupportedProcessIds)
-        {
-            handlers[processId] = surface;
-        }
-        foreach (var processId in GdalRasterStatisticsJobExecutor.SupportedProcessIds)
-        {
-            handlers[processId] = rasterStatistics;
-        }
-
-        _handlers = handlers.ToFrozenDictionary(StringComparer.Ordinal);
-
+        _handlers = ProcessExecutorRouteTable.Build(executors);
         _logger = logger;
     }
 

--- a/src/Honua.Worker.Gdal/Execution/GdalMultidimCoverageMetadataJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalMultidimCoverageMetadataJobExecutor.cs
@@ -110,6 +110,8 @@ internal sealed partial class GdalMultidimCoverageMetadataJobExecutor(
 
             var args = new List<string> { vsiPath };
 
+            await GdalCommandLog.LogCommandAsync(context, "gdalmdiminfo", args, workspace, cancellationToken).ConfigureAwait(false);
+
             using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 

--- a/src/Honua.Worker.Gdal/Execution/GdalMultidimCoverageMetadataJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalMultidimCoverageMetadataJobExecutor.cs
@@ -30,7 +30,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalMultidimCoverageMetadataJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalMultidimCoverageMetadataJobExecutor> logger) : IJobExecutor
+    ILogger<GdalMultidimCoverageMetadataJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "coverage.multidim.metadata";
@@ -41,6 +41,13 @@ internal sealed partial class GdalMultidimCoverageMetadataJobExecutor(
         new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterClipJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterClipJobExecutor.cs
@@ -146,6 +146,8 @@ internal sealed partial class GdalRasterClipJobExecutor(
                 outputPath,
             };
 
+            await GdalCommandLog.LogCommandAsync(context, "gdalwarp", args, workspace, cancellationToken).ConfigureAwait(false);
+
             using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterClipJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterClipJobExecutor.cs
@@ -25,7 +25,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalRasterClipJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalRasterClipJobExecutor> logger) : IJobExecutor
+    ILogger<GdalRasterClipJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "raster.clip";
@@ -36,6 +36,13 @@ internal sealed partial class GdalRasterClipJobExecutor(
         new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectCatalogJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectCatalogJobExecutor.cs
@@ -133,6 +133,8 @@ internal sealed partial class GdalRasterReprojectCatalogJobExecutor(
                 outputPath,
             };
 
+            await GdalCommandLog.LogCommandAsync(context, "gdalwarp", args, workspace, cancellationToken).ConfigureAwait(false);
+
             using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectCatalogJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectCatalogJobExecutor.cs
@@ -22,7 +22,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalRasterReprojectCatalogJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalRasterReprojectCatalogJobExecutor> logger) : IJobExecutor
+    ILogger<GdalRasterReprojectCatalogJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "raster.reproject";
@@ -49,6 +49,13 @@ internal sealed partial class GdalRasterReprojectCatalogJobExecutor(
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectJobExecutor.cs
@@ -24,7 +24,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalRasterReprojectJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalRasterReprojectJobExecutor> logger) : IJobExecutor
+    ILogger<GdalRasterReprojectJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "gdal.gdalwarp";
@@ -35,6 +35,13 @@ internal sealed partial class GdalRasterReprojectJobExecutor(
         new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectJobExecutor.cs
@@ -112,6 +112,8 @@ internal sealed partial class GdalRasterReprojectJobExecutor(
             args.Add(inputPath);
             args.Add(outputPath);
 
+            await GdalCommandLog.LogCommandAsync(context, "gdalwarp", args, workspace, cancellationToken).ConfigureAwait(false);
+
             using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterStatisticsJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterStatisticsJobExecutor.cs
@@ -100,6 +100,8 @@ internal sealed partial class GdalRasterStatisticsJobExecutor(
             }
             args.Add(inputPath);
 
+            await GdalCommandLog.LogCommandAsync(context, "gdalinfo", args, workspace, cancellationToken).ConfigureAwait(false);
+
             using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterStatisticsJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterStatisticsJobExecutor.cs
@@ -22,7 +22,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalRasterStatisticsJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalRasterStatisticsJobExecutor> logger) : IJobExecutor
+    ILogger<GdalRasterStatisticsJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>Process id for per-band statistics.</summary>
     public const string StatisticsProcessId = "raster.statistics";
@@ -38,6 +38,9 @@ internal sealed partial class GdalRasterStatisticsJobExecutor(
 
     private static readonly IReadOnlySet<string> NativeProfileSet =
         new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds => SupportedProcessIds;
 
     /// <inheritdoc />
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterZonalStatisticsJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterZonalStatisticsJobExecutor.cs
@@ -210,6 +210,8 @@ internal sealed partial class GdalRasterZonalStatisticsJobExecutor(
                 // Each gdalwarp/gdalinfo call gets its own CTS so a multi-zone
                 // job whose cumulative runtime exceeds the per-tool ceiling is
                 // not aborted unless an individual invocation actually hangs.
+                await GdalCommandLog.LogCommandAsync(context, "gdalwarp", clipArgs, workspace, cancellationToken).ConfigureAwait(false);
+
                 GdalCommandResult clipResult;
                 using (var clipTimeoutCts = new CancellationTokenSource(opts.ToolTimeout))
                 using (var clipLinked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, clipTimeoutCts.Token))
@@ -233,6 +235,8 @@ internal sealed partial class GdalRasterZonalStatisticsJobExecutor(
                 }
 
                 var infoArgs = new List<string> { "-json", "-stats", clippedPath };
+                await GdalCommandLog.LogCommandAsync(context, "gdalinfo", infoArgs, workspace, cancellationToken).ConfigureAwait(false);
+
                 GdalCommandResult infoResult;
                 using (var infoTimeoutCts = new CancellationTokenSource(opts.ToolTimeout))
                 using (var infoLinked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, infoTimeoutCts.Token))

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterZonalStatisticsJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterZonalStatisticsJobExecutor.cs
@@ -27,7 +27,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalRasterZonalStatisticsJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalRasterZonalStatisticsJobExecutor> logger) : IJobExecutor
+    ILogger<GdalRasterZonalStatisticsJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "raster.zonal-statistics";
@@ -46,6 +46,13 @@ internal sealed partial class GdalRasterZonalStatisticsJobExecutor(
         }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/Execution/GdalSurfaceJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalSurfaceJobExecutor.cs
@@ -25,7 +25,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalSurfaceJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalSurfaceJobExecutor> logger) : IJobExecutor
+    ILogger<GdalSurfaceJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>Process id for slope.</summary>
     public const string SlopeProcessId = "surface.slope";
@@ -62,6 +62,9 @@ internal sealed partial class GdalSurfaceJobExecutor(
 
     /// <summary>Process ids this executor routes.</summary>
     public static IReadOnlyCollection<string> SupportedProcessIds => HandledProcessIds;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds => HandledProcessIds;
 
     /// <inheritdoc />
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;

--- a/src/Honua.Worker.Gdal/Execution/GdalSurfaceJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalSurfaceJobExecutor.cs
@@ -130,6 +130,8 @@ internal sealed partial class GdalSurfaceJobExecutor(
             args.Add(inputPath);
             args.Add(outputPath);
 
+            await GdalCommandLog.LogCommandAsync(context, "gdaldem", args, workspace, cancellationToken).ConfigureAwait(false);
+
             using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 

--- a/src/Honua.Worker.Gdal/Execution/GdalVectorConvertJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalVectorConvertJobExecutor.cs
@@ -24,7 +24,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class GdalVectorConvertJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<GdalVectorConvertJobExecutor> logger) : IJobExecutor
+    ILogger<GdalVectorConvertJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "gdal.ogr2ogr";
@@ -43,6 +43,13 @@ internal sealed partial class GdalVectorConvertJobExecutor(
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/Execution/GdalVectorConvertJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalVectorConvertJobExecutor.cs
@@ -126,6 +126,8 @@ internal sealed partial class GdalVectorConvertJobExecutor(
                 inputPath,
             };
 
+            await GdalCommandLog.LogCommandAsync(context, "ogr2ogr", args, workspace, cancellationToken).ConfigureAwait(false);
+
             using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 

--- a/src/Honua.Worker.Gdal/Execution/PdalPointCloudConvertJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/PdalPointCloudConvertJobExecutor.cs
@@ -43,7 +43,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class PdalPointCloudConvertJobExecutor(
     IGdalCommandRunner runner,
     IOptionsMonitor<GdalWorkerOptions> options,
-    ILogger<PdalPointCloudConvertJobExecutor> logger) : IJobExecutor
+    ILogger<PdalPointCloudConvertJobExecutor> logger) : IProcessExecutor
 {
     /// <summary>The canonical process id this executor handles.</summary>
     public const string HandledProcessId = "pcloud.translate";
@@ -61,6 +61,13 @@ internal sealed partial class PdalPointCloudConvertJobExecutor(
         new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
 
     /// <inheritdoc />
+    /// <summary>
+    /// The single process id this executor handles, surfaced through
+    /// <see cref="IProcessExecutor"/> so the GDAL dispatcher auto-registers it (#2122).
+    /// </summary>
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
     public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
 
     /// <inheritdoc />

--- a/src/Honua.Worker.Gdal/Execution/PdalPointCloudConvertJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/PdalPointCloudConvertJobExecutor.cs
@@ -138,6 +138,8 @@ internal sealed partial class PdalPointCloudConvertJobExecutor(
 
             var args = BuildTranslateArguments(inputPath, outputPath, reproject ? sourceSrs : null);
 
+            await GdalCommandLog.LogCommandAsync(context, "pdal", args, workspace, cancellationToken).ConfigureAwait(false);
+
             using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 

--- a/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
+++ b/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
@@ -76,17 +76,47 @@ public static class GdalWorkerServiceCollectionExtensions
         // ships; the worker does not introduce its own BackgroundService.
         services.AddGdalWorkerExecutionLoop();
 
-        // GDAL executor options.
+        // GDAL executor options, CLI runner, and the native-profile executor set.
+        // The per-process executors implement IProcessExecutor and self-declare their
+        // process id(s) (GP Devkit authoring contract #2122), so GdalDispatchJobExecutor
+        // builds its routing table by enumerating IProcessExecutor instead of a
+        // hand-maintained ctor. Shared with the Redis-free AddGdalProcessExecutors seam.
+        services.AddGdalProcessExecutors(configuration);
+
+        // Register the native dispatcher as the single IJobExecutor for the
+        // Geoprocessing kind in this host. It declares AcceptedRuntimeProfiles =
+        // { "native" }, so JobExecutionService passes that profile set to the
+        // queue claim filter and the worker only claims native-profile jobs.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IJobExecutor, GdalDispatchJobExecutor>());
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers ONLY the native GDAL <see cref="IProcessExecutor"/> set plus its
+    /// dependencies — the <c>GdalWorkerOptions</c>, the <see cref="IGdalCommandRunner"/>
+    /// CLI runner, and each per-process executor — with NO Redis connection, queue,
+    /// job store, or hosted execution loop. This is the Redis-free seam the GP Devkit
+    /// headless runner / <c>honua gp</c> dev CLI consume (issue #2123) so a developer
+    /// can run a single native op directly without the durable substrate
+    /// <see cref="AddGdalWorker"/> wires for the worker host.
+    /// </summary>
+    /// <param name="services">Service collection.</param>
+    /// <param name="configuration">Host configuration; binds the <c>GdalWorker</c> section.</param>
+    public static IServiceCollection AddGdalProcessExecutors(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
         services
             .AddOptions<GdalWorkerOptions>()
             .Bind(configuration.GetSection(GdalWorkerOptions.SectionName))
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
-        // GDAL CLI runner + native-profile executors. The per-process executors
-        // implement IProcessExecutor and self-declare their process id(s) (GP Devkit
-        // authoring contract #2122), so GdalDispatchJobExecutor builds its routing
-        // table by enumerating IProcessExecutor instead of a hand-maintained ctor.
         services.TryAddSingleton<IGdalCommandRunner, ProcessGdalCommandRunner>();
         RegisterGdalExecutor<GdalVectorConvertJobExecutor>(services);
         RegisterGdalExecutor<GdalRasterReprojectJobExecutor>(services);
@@ -97,13 +127,6 @@ public static class GdalWorkerServiceCollectionExtensions
         RegisterGdalExecutor<GdalRasterZonalStatisticsJobExecutor>(services);
         RegisterGdalExecutor<GdalMultidimCoverageMetadataJobExecutor>(services);
         RegisterGdalExecutor<PdalPointCloudConvertJobExecutor>(services);
-
-        // Register the native dispatcher as the single IJobExecutor for the
-        // Geoprocessing kind in this host. It declares AcceptedRuntimeProfiles =
-        // { "native" }, so JobExecutionService passes that profile set to the
-        // queue claim filter and the worker only claims native-profile jobs.
-        services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<IJobExecutor, GdalDispatchJobExecutor>());
 
         return services;
     }

--- a/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
+++ b/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
@@ -83,17 +83,20 @@ public static class GdalWorkerServiceCollectionExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
-        // GDAL CLI runner + native-profile executors.
+        // GDAL CLI runner + native-profile executors. The per-process executors
+        // implement IProcessExecutor and self-declare their process id(s) (GP Devkit
+        // authoring contract #2122), so GdalDispatchJobExecutor builds its routing
+        // table by enumerating IProcessExecutor instead of a hand-maintained ctor.
         services.TryAddSingleton<IGdalCommandRunner, ProcessGdalCommandRunner>();
-        services.TryAddSingleton<GdalVectorConvertJobExecutor>();
-        services.TryAddSingleton<GdalRasterReprojectJobExecutor>();
-        services.TryAddSingleton<GdalSurfaceJobExecutor>();
-        services.TryAddSingleton<GdalRasterClipJobExecutor>();
-        services.TryAddSingleton<GdalRasterReprojectCatalogJobExecutor>();
-        services.TryAddSingleton<GdalRasterStatisticsJobExecutor>();
-        services.TryAddSingleton<GdalRasterZonalStatisticsJobExecutor>();
-        services.TryAddSingleton<GdalMultidimCoverageMetadataJobExecutor>();
-        services.TryAddSingleton<PdalPointCloudConvertJobExecutor>();
+        RegisterGdalExecutor<GdalVectorConvertJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterReprojectJobExecutor>(services);
+        RegisterGdalExecutor<GdalSurfaceJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterClipJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterReprojectCatalogJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterStatisticsJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterZonalStatisticsJobExecutor>(services);
+        RegisterGdalExecutor<GdalMultidimCoverageMetadataJobExecutor>(services);
+        RegisterGdalExecutor<PdalPointCloudConvertJobExecutor>(services);
 
         // Register the native dispatcher as the single IJobExecutor for the
         // Geoprocessing kind in this host. It declares AcceptedRuntimeProfiles =
@@ -122,5 +125,25 @@ public static class GdalWorkerServiceCollectionExtensions
         services.AddHostedService<JobReconciliationService>();
 
         return services;
+    }
+
+    /// <summary>
+    /// Registers a GDAL <see cref="IProcessExecutor"/> as its concrete type and
+    /// surfaces the same singleton into the enumerable <see cref="IProcessExecutor"/>
+    /// set <see cref="GdalDispatchJobExecutor"/> consumes — both bound to one
+    /// instance via a resolving factory (GP Devkit authoring contract #2122).
+    /// </summary>
+    private static void RegisterGdalExecutor<TExecutor>(IServiceCollection services)
+        where TExecutor : class, IProcessExecutor
+    {
+        services.TryAddSingleton<TExecutor>();
+
+        if (!services.Any(d =>
+                d.ServiceType == typeof(IProcessExecutor)
+                && d.ImplementationFactory is not null
+                && d.ImplementationFactory.Method.ReturnType == typeof(TExecutor)))
+        {
+            services.AddSingleton<IProcessExecutor>(sp => sp.GetRequiredService<TExecutor>());
+        }
     }
 }

--- a/tests/dotnet/Honua.Core.Tests/Features/ControlPlane/ProcessExecutorRouteTableTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/ControlPlane/ProcessExecutorRouteTableTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.ControlPlane;
+
+/// <summary>
+/// Unit tests for <see cref="ProcessExecutorRouteTable"/> — the shared
+/// auto-registration routing-table builder used by the managed and GDAL
+/// geoprocessing dispatchers (GP Devkit authoring contract #2122). Pins the
+/// fail-fast diagnostics that protect the authoring contract from a duplicate or
+/// empty process-id declaration.
+/// </summary>
+public sealed class ProcessExecutorRouteTableTests
+{
+    private sealed class FakeProcessExecutor(params string[] ids) : IProcessExecutor
+    {
+        public IReadOnlySet<string> ProcessIds { get; } =
+            new HashSet<string>(ids, StringComparer.Ordinal);
+
+        public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+        public Task<JobExecutionResult> ExecuteAsync(
+            ExecutionJobRecord job,
+            IJobExecutionContext context,
+            CancellationToken cancellationToken)
+            => Task.FromResult(JobExecutionResult.Succeeded());
+    }
+
+    [UnitTest]
+    public void Build_MapsEachDeclaredIdToItsExecutor()
+    {
+        var a = new FakeProcessExecutor("geometry.buffer");
+        var b = new FakeProcessExecutor("surface.slope", "surface.aspect");
+
+        var table = ProcessExecutorRouteTable.Build(new IProcessExecutor[] { a, b });
+
+        table.Should().HaveCount(3);
+        table["geometry.buffer"].Should().BeSameAs(a);
+        table["surface.slope"].Should().BeSameAs(b);
+        table["surface.aspect"].Should().BeSameAs(b);
+    }
+
+    [UnitTest]
+    public void Build_DuplicateIdAcrossExecutors_Throws()
+    {
+        var a = new FakeProcessExecutor("geometry.buffer");
+        var b = new FakeProcessExecutor("geometry.buffer");
+
+        var act = () => ProcessExecutorRouteTable.Build(new IProcessExecutor[] { a, b });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*geometry.buffer*");
+    }
+
+    [UnitTest]
+    public void Build_ExecutorWithNoIds_Throws()
+    {
+        var empty = new FakeProcessExecutor();
+
+        var act = () => ProcessExecutorRouteTable.Build(new IProcessExecutor[] { empty });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*no process ids*");
+    }
+
+    [UnitTest]
+    public void Build_ExecutorWithWhitespaceId_Throws()
+    {
+        var bad = new FakeProcessExecutor("  ");
+
+        var act = () => ProcessExecutorRouteTable.Build(new IProcessExecutor[] { bad });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*whitespace process id*");
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Geoprocessing/ProcessSchemaJsonGeneratorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Geoprocessing/ProcessSchemaJsonGeneratorTests.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Core.Tests.Features.Geoprocessing;
+
+/// <summary>
+/// Unit tests for <see cref="ProcessSchemaJsonGenerator"/> — the GP Devkit authoring
+/// contract's JSON Schema emission derived from a process's typed parameter set
+/// (issues #2122 / #2124). Pins the JSON Schema shape <c>describe</c> consumes so the
+/// advertised schema cannot silently drift from the catalog typing.
+/// </summary>
+[Protocol(ProtocolNames.TestQuality)]
+public sealed class ProcessSchemaJsonGeneratorTests
+{
+    private static ProcessDefinition SampleProcess() => new()
+    {
+        ProcessId = "geometry.buffer",
+        Title = "Buffer",
+        Description = "Buffers a geometry by a distance.",
+        Category = "geometry",
+        RuntimeProfile = "managed",
+        Parameters = new[]
+        {
+            new ProcessParameterSpec
+            {
+                Name = "wkb",
+                DisplayName = "Geometry (WKB)",
+                Description = "Input geometry as base64 WKB.",
+                ValueType = ProcessParameterValueType.Wkb,
+                Required = true,
+            },
+            new ProcessParameterSpec
+            {
+                Name = "srid",
+                DisplayName = "SRID",
+                Description = "Spatial reference identifier.",
+                ValueType = ProcessParameterValueType.Srid,
+                Required = true,
+            },
+            new ProcessParameterSpec
+            {
+                Name = "distance",
+                DisplayName = "Distance",
+                Description = "Buffer distance in CRS units.",
+                ValueType = ProcessParameterValueType.FloatingPoint,
+                Required = true,
+            },
+            new ProcessParameterSpec
+            {
+                Name = "geodesic",
+                DisplayName = "Geodesic",
+                Description = "Whether to buffer geodesically.",
+                ValueType = ProcessParameterValueType.Flag,
+                Required = false,
+                DefaultValue = "false",
+            },
+            new ProcessParameterSpec
+            {
+                Name = "method",
+                DisplayName = "Method",
+                Description = "Join method.",
+                ValueType = ProcessParameterValueType.Text,
+                Required = false,
+                AllowedValues = new[] { "round", "mitre", "bevel" },
+            },
+        },
+        OutputArtifactKinds = new[] { ArtifactKind.FeatureLayer },
+    };
+
+    [UnitTest]
+    public void Generate_ProducesValidJsonWithProcessMetadata()
+    {
+        var json = ProcessSchemaJsonGenerator.Generate(SampleProcess());
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        root.GetProperty("processId").GetString().Should().Be("geometry.buffer");
+        root.GetProperty("title").GetString().Should().Be("Buffer");
+        root.GetProperty("category").GetString().Should().Be("geometry");
+        root.GetProperty("runtimeProfile").GetString().Should().Be("managed");
+    }
+
+    [UnitTest]
+    public void Generate_RequiredArrayContainsOnlyRequiredParameters()
+    {
+        var json = ProcessSchemaJsonGenerator.Generate(SampleProcess());
+
+        using var doc = JsonDocument.Parse(json);
+        var inputs = doc.RootElement.GetProperty("inputs");
+
+        inputs.GetProperty("type").GetString().Should().Be("object");
+        inputs.GetProperty("additionalProperties").GetBoolean().Should().BeFalse();
+
+        var required = inputs.GetProperty("required")
+            .EnumerateArray()
+            .Select(e => e.GetString())
+            .ToArray();
+
+        required.Should().BeEquivalentTo("wkb", "srid", "distance");
+        required.Should().NotContain("geodesic");
+        required.Should().NotContain("method");
+    }
+
+    [UnitTest]
+    public void Generate_MapsValueTypesToJsonSchemaTypesAndFormats()
+    {
+        var json = ProcessSchemaJsonGenerator.Generate(SampleProcess());
+
+        using var doc = JsonDocument.Parse(json);
+        var props = doc.RootElement.GetProperty("inputs").GetProperty("properties");
+
+        var wkb = props.GetProperty("wkb");
+        wkb.GetProperty("type").GetString().Should().Be("string");
+        wkb.GetProperty("format").GetString().Should().Be("wkb-base64");
+        wkb.GetProperty("x-honua-value-type").GetString().Should().Be("Wkb");
+
+        props.GetProperty("srid").GetProperty("type").GetString().Should().Be("integer");
+        props.GetProperty("srid").GetProperty("format").GetString().Should().Be("srid");
+
+        props.GetProperty("distance").GetProperty("type").GetString().Should().Be("number");
+        props.GetProperty("geodesic").GetProperty("type").GetString().Should().Be("boolean");
+        props.GetProperty("geodesic").GetProperty("default").GetString().Should().Be("false");
+    }
+
+    [UnitTest]
+    public void Generate_EmitsEnumForAllowedValues()
+    {
+        var json = ProcessSchemaJsonGenerator.Generate(SampleProcess());
+
+        using var doc = JsonDocument.Parse(json);
+        var method = doc.RootElement.GetProperty("inputs").GetProperty("properties").GetProperty("method");
+
+        var values = method.GetProperty("enum").EnumerateArray().Select(e => e.GetString()).ToArray();
+        values.Should().BeEquivalentTo("round", "mitre", "bevel");
+    }
+
+    [UnitTest]
+    public void Generate_EmitsOutputArtifactKinds()
+    {
+        var json = ProcessSchemaJsonGenerator.Generate(SampleProcess());
+
+        using var doc = JsonDocument.Parse(json);
+        var outputs = doc.RootElement.GetProperty("outputs").EnumerateArray().ToArray();
+
+        outputs.Should().HaveCount(1);
+        outputs[0].GetProperty("artifactKind").GetString().Should().Be("FeatureLayer");
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Geoprocessing;
 using Honua.Geoprocessing.Execution;
@@ -313,7 +314,8 @@ public sealed class CatalogExecutableConformanceTests
         var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
         monitor.CurrentValue.Returns(options);
 
-        var dispatcher = new GeoprocessingDispatchJobExecutor(
+        IProcessExecutor[] executors =
+        {
             new GeometryBufferJobExecutor(monitor, NullLogger<GeometryBufferJobExecutor>.Instance),
             new GeometryClipJobExecutor(monitor, NullLogger<GeometryClipJobExecutor>.Instance),
             new GeometryIntersectJobExecutor(monitor, NullLogger<GeometryIntersectJobExecutor>.Instance),
@@ -348,6 +350,10 @@ public sealed class CatalogExecutableConformanceTests
             new ImportDatasetJobExecutor(
                 Substitute.For<IServiceScopeFactory>(),
                 NullLogger<ImportDatasetJobExecutor>.Instance),
+        };
+
+        var dispatcher = new GeoprocessingDispatchJobExecutor(
+            executors,
             NullLogger<GeoprocessingDispatchJobExecutor>.Instance);
 
         return dispatcher.SupportedProcessIds;

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
@@ -136,7 +136,12 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
         monitor.CurrentValue.Returns(options);
 
-        return new GeoprocessingDispatchJobExecutor(
+        // Auto-registration contract (#2122): the dispatcher routes by enumerating
+        // the IProcessExecutor set and keying on each executor's self-declared
+        // ProcessIds, so the test composes the same executor instances as a flat
+        // list instead of the former positional constructor.
+        IProcessExecutor[] executors =
+        {
             new GeometryBufferJobExecutor(monitor, NullLogger<GeometryBufferJobExecutor>.Instance),
             new GeometryClipJobExecutor(monitor, NullLogger<GeometryClipJobExecutor>.Instance),
             new GeometryIntersectJobExecutor(monitor, NullLogger<GeometryIntersectJobExecutor>.Instance),
@@ -171,6 +176,10 @@ public sealed class GeoprocessingDispatchJobExecutorTests
             new ImportDatasetJobExecutor(
                 Substitute.For<IServiceScopeFactory>(),
                 NullLogger<ImportDatasetJobExecutor>.Instance),
+        };
+
+        return new GeoprocessingDispatchJobExecutor(
+            executors,
             NullLogger<GeoprocessingDispatchJobExecutor>.Instance);
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GpPlanTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GpPlanTests.cs
@@ -1,0 +1,261 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Geoprocessing;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Geoprocessing;
+
+/// <summary>
+/// Unit coverage for the headless <c>honua gp plan</c> dry-run path (GP Devkit
+/// P5, issue #2126): proves the planner validates a process's params against the
+/// typed catalog schema and the shared DAG structural gate WITHOUT executing,
+/// and that the size/cost estimate warns before submit when an output is likely
+/// to blow the <see cref="GeoprocessingExecutorOptions.MaxArtifactBytes"/> cap.
+/// Fully offline — no Redis, no job store, no executor invocation.
+/// </summary>
+public sealed class GpPlanTests
+{
+    private const long DefaultCap = 50L * 1024L * 1024L;
+
+    // POINT(0 0) — the same WKB the durable-runtime buffer tests use.
+    private const string PointWkbBase64 = "AQEAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    private static BuiltInProcessCatalog Catalog() => new();
+
+    [UnitTest]
+    public void Build_ValidBufferParams_ProducesValidPlanWithResolvedParamsAndOutputs()
+    {
+        var inputs = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["wkb"] = PointWkbBase64,
+            ["srid"] = "4326",
+            ["distance"] = "10",
+        };
+
+        var plan = GpPlanner.Build("geometry.buffer", inputs, Catalog(), DefaultCap, callerInputBytes: 0);
+
+        plan.Should().NotBeNull();
+        plan!.IsValid.Should().BeTrue(because: string.Join("; ", plan.Errors));
+        plan.Errors.Should().BeEmpty();
+        plan.ProcessId.Should().Be("geometry.buffer");
+        plan.RuntimeProfile.Should().Be(RuntimeProfiles.Managed);
+        plan.Outputs.Should().Contain(ArtifactKind.FeatureLayer);
+
+        // The plan previews the single ordered step with all resolved params, and
+        // fills the optional 'geodesic' flag from its catalog default.
+        plan.Steps.Should().ContainSingle();
+        var step = plan.Steps[0];
+        step.ProcessId.Should().Be("geometry.buffer");
+        step.DependsOn.Should().BeEmpty();
+
+        var geodesic = step.Parameters.Single(p => p.Name == "geodesic");
+        geodesic.Source.Should().Be(GpParamSource.Default);
+        geodesic.DisplayValue.Should().Be("false");
+
+        var distance = step.Parameters.Single(p => p.Name == "distance");
+        distance.Source.Should().Be(GpParamSource.Caller);
+        distance.DisplayValue.Should().Be("10");
+    }
+
+    [UnitTest]
+    public void Build_UnknownProcessId_ReturnsNull()
+    {
+        var plan = GpPlanner.Build(
+            "geometry.does-not-exist",
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            Catalog(),
+            DefaultCap,
+            callerInputBytes: 0);
+
+        plan.Should().BeNull();
+    }
+
+    [UnitTest]
+    public void Build_MissingAndInvalidParams_ReportsValidationErrorsWithoutExecuting()
+    {
+        // Omit required 'distance'; supply a non-numeric 'srid'. Both must surface
+        // as catalog validation errors — the same ProcessPlanValidator the durable
+        // submit path runs — and the plan must be marked invalid.
+        var inputs = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["wkb"] = PointWkbBase64,
+            ["srid"] = "not-a-number",
+        };
+
+        var plan = GpPlanner.Build("geometry.buffer", inputs, Catalog(), DefaultCap, callerInputBytes: 0);
+
+        plan.Should().NotBeNull();
+        plan!.IsValid.Should().BeFalse();
+        plan.Errors.Should().Contain(e => e.Contains("MISSING_REQUIRED_PARAMETER") && e.Contains("distance"));
+        plan.Errors.Should().Contain(e => e.Contains("INVALID_PARAMETER_VALUE") && e.Contains("srid"));
+    }
+
+    [UnitTest]
+    public void Build_UnknownParameter_IsRejected()
+    {
+        var inputs = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["wkb"] = PointWkbBase64,
+            ["srid"] = "4326",
+            ["distance"] = "10",
+            ["bogus"] = "x",
+        };
+
+        var plan = GpPlanner.Build("geometry.buffer", inputs, Catalog(), DefaultCap, callerInputBytes: 0);
+
+        plan!.IsValid.Should().BeFalse();
+        plan.Errors.Should().Contain(e => e.Contains("UNKNOWN_PARAMETER") && e.Contains("bogus"));
+    }
+
+    [UnitTest]
+    public void GraphValidator_PlanWithCycle_IsRejected()
+    {
+        // The CLI plan path delegates structural validation to the SAME shared
+        // AnalysisPlanGraphValidator the durable submit path uses; a cycle must be
+        // caught here, mirroring GeoprocessingJobService.ValidatePlanStructure.
+        var plan = new AnalysisPlan
+        {
+            PlanId = "p",
+            IntentId = "i",
+            Steps =
+            [
+                Step("a", dependsOn: ["b"]),
+                Step("b", dependsOn: ["a"]),
+            ],
+        };
+
+        var act = () => AnalysisPlanGraphValidator.Validate(plan);
+
+        act.Should().Throw<Exception>().Where(e => e.Message.Contains("cycle"));
+    }
+
+    [UnitTest]
+    public void GraphValidator_PlanWithDanglingDependency_IsRejected()
+    {
+        var plan = new AnalysisPlan
+        {
+            PlanId = "p",
+            IntentId = "i",
+            Steps =
+            [
+                Step("a", dependsOn: ["ghost"]),
+            ],
+        };
+
+        var act = () => AnalysisPlanGraphValidator.Validate(plan);
+
+        act.Should().Throw<Exception>().Where(e => e.Message.Contains("unknown step") && e.Message.Contains("ghost"));
+    }
+
+    [UnitTest]
+    public void GraphValidator_AcyclicPlan_OrdersDependenciesBeforeDependents()
+    {
+        var plan = new AnalysisPlan
+        {
+            PlanId = "p",
+            IntentId = "i",
+            Steps =
+            [
+                Step("c", dependsOn: ["a", "b"]),
+                Step("b", dependsOn: ["a"]),
+                Step("a"),
+            ],
+        };
+
+        AnalysisPlanGraphValidator.Validate(plan);
+        var ordered = AnalysisPlanGraphValidator.TopologicalOrder(plan).Select(s => s.StepId).ToArray();
+
+        ordered.Should().Equal("a", "b", "c");
+    }
+
+    [UnitTest]
+    public void Build_LargeInputBuffer_EstimatesOverCapAndWarns()
+    {
+        // 12 MiB of input × the buffer ~5x growth heuristic crosses the 50 MiB cap.
+        const long twelveMiB = 12L * 1024L * 1024L;
+        var inputs = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["wkb"] = PointWkbBase64,
+            ["srid"] = "4326",
+            ["distance"] = "10",
+        };
+
+        var plan = GpPlanner.Build("geometry.buffer", inputs, Catalog(), DefaultCap, callerInputBytes: twelveMiB);
+
+        plan.Should().NotBeNull();
+        // Params are valid; the only signal is a size warning, so the plan stays valid.
+        plan!.IsValid.Should().BeTrue();
+        plan.Estimate.InputBytes.Should().Be(twelveMiB);
+        plan.Estimate.EstimatedOutputBytes.Should().BeGreaterThan(DefaultCap);
+        plan.Estimate.ExceedsCap.Should().BeTrue();
+        plan.Warnings.Should().Contain(w => w.Contains("MaxArtifactBytes") && w.Contains("exceed"));
+        plan.Warnings.Should().Contain(w => w.Contains("heuristic"));
+    }
+
+    [UnitTest]
+    public void Build_SmallInputBuffer_StaysUnderCapWithNoSizeWarning()
+    {
+        const long oneMiB = 1L * 1024L * 1024L;
+        var inputs = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["wkb"] = PointWkbBase64,
+            ["srid"] = "4326",
+            ["distance"] = "10",
+        };
+
+        var plan = GpPlanner.Build("geometry.buffer", inputs, Catalog(), DefaultCap, callerInputBytes: oneMiB);
+
+        plan!.Estimate.ExceedsCap.Should().BeFalse();
+        plan.Warnings.Should().NotContain(w => w.Contains("exceed"));
+    }
+
+    [UnitTest]
+    public void Estimate_ScalarOutputProcess_IsNeverACapRisk()
+    {
+        // geometry.area emits a scalar; even a huge input cannot blow the cap.
+        var definition = Catalog().GetProcess("geometry.area");
+        definition.Should().NotBeNull();
+        definition!.OutputArtifactKinds.Should().Contain(ArtifactKind.Scalar);
+
+        var estimate = GpSizeEstimator.Estimate(definition, callerInputBytes: 500L * 1024L * 1024L, DefaultCap);
+
+        estimate.ExceedsCap.Should().BeFalse();
+        estimate.EstimatedOutputBytes.Should().BeLessThan(DefaultCap);
+    }
+
+    [UnitTest]
+    public void Estimate_RasterClassProcess_FlagsLongRunning()
+    {
+        var definition = Catalog().GetProcess("raster.reproject");
+        definition.Should().NotBeNull();
+        definition!.RuntimeProfile.Should().Be(RuntimeProfiles.Native);
+
+        var estimate = GpSizeEstimator.Estimate(definition, callerInputBytes: 1024, DefaultCap);
+
+        estimate.LongRunning.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Estimate_NoFileInput_DoesNotFabricateAnOutputSize()
+    {
+        var definition = Catalog().GetProcess("geometry.buffer")!;
+
+        var estimate = GpSizeEstimator.Estimate(definition, callerInputBytes: 0, DefaultCap);
+
+        estimate.EstimatedOutputBytes.Should().BeNull();
+        estimate.ExceedsCap.Should().BeFalse();
+    }
+
+    private static AnalysisPlanStep Step(string id, string[]? dependsOn = null) => new()
+    {
+        StepId = id,
+        Kind = AnalysisPlanStepKind.Geoprocess,
+        ProcessId = "geometry.buffer",
+        Inputs = new Dictionary<string, string>(StringComparer.Ordinal),
+        DependsOn = dependsOn ?? [],
+    };
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/LocalRunner/GeoprocessingLocalRunnerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/LocalRunner/GeoprocessingLocalRunnerTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Geoprocessing;
+using Honua.Geoprocessing.Execution;
+using Honua.Geoprocessing.LocalRunner;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.LocalRunner;
+
+/// <summary>
+/// Unit coverage for the headless <see cref="GeoprocessingLocalRunner"/> (GP Devkit,
+/// issue #2123) against a managed geometry op. Proves the runner drives a real
+/// <see cref="IProcessExecutor"/> with no Redis/queue/job-store, projecting step-0
+/// inputs into the durable parameter contract and surfacing the published artifact,
+/// structured logs, status, and wall-clock timing. The GDAL-op path (the actual CLI
+/// command surfaced for a native op) is covered offline in
+/// <c>Honua.Worker.Gdal.Tests.GeoprocessingLocalRunnerGdalTests</c> against a fake
+/// GDAL command runner.
+/// </summary>
+public sealed class GeoprocessingLocalRunnerTests
+{
+    // POINT(0 0) — the same WKB the durable-runtime buffer tests use.
+    private const string PointWkbBase64 = "AQEAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    [UnitTest]
+    public async Task RunAsync_GeometryBuffer_RunsManagedOpAndReturnsArtifact()
+    {
+        var runner = new GeoprocessingLocalRunner([CreateBufferExecutor()]);
+
+        var result = await runner.RunAsync(
+            GeometryBufferJobExecutor.HandledProcessId,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["wkb"] = PointWkbBase64,
+                ["srid"] = "4326",
+                ["distance"] = "10",
+            });
+
+        result.Succeeded.Should().BeTrue(result.ErrorMessage);
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        result.ProcessId.Should().Be(GeometryBufferJobExecutor.HandledProcessId);
+        result.Artifacts.Should().ContainSingle();
+        result.Artifacts[0].Should().StartWith("data:application/geo+json;base64,");
+        result.Elapsed.Should().BeGreaterThanOrEqualTo(TimeSpan.Zero);
+
+        // The buffered feature stamps the requested distance; decode and assert so
+        // the test proves the runner returned the real op's artifact, not a stub.
+        var json = DecodeDataUri(result.Artifacts[0]);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("type").GetString().Should().Be("Feature");
+        doc.RootElement
+            .GetProperty("properties")
+            .GetProperty("bufferDistance")
+            .GetDouble()
+            .Should().BeApproximately(10d, 1e-9);
+    }
+
+    [UnitTest]
+    public async Task RunAsync_UnknownProcessId_FailsWithoutInvokingAnyExecutor()
+    {
+        var runner = new GeoprocessingLocalRunner([CreateBufferExecutor()]);
+
+        var result = await runner.RunAsync(
+            "geometry.does-not-exist",
+            new Dictionary<string, string>(StringComparer.Ordinal));
+
+        result.Succeeded.Should().BeFalse();
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("geometry.does-not-exist");
+        result.ErrorMessage.Should().Contain(GeometryBufferJobExecutor.HandledProcessId);
+        result.Artifacts.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public void AvailableProcessIds_ReflectsRegisteredExecutors()
+    {
+        var runner = new GeoprocessingLocalRunner([CreateBufferExecutor()]);
+
+        runner.AvailableProcessIds.Should().Contain(GeometryBufferJobExecutor.HandledProcessId);
+    }
+
+    [UnitTest]
+    public async Task RunAsync_InvalidInputs_SurfacesExecutorClassifiedFailure()
+    {
+        var runner = new GeoprocessingLocalRunner([CreateBufferExecutor()]);
+
+        // Omit the required 'wkb' input; the executor's own validation must classify it.
+        var result = await runner.RunAsync(
+            GeometryBufferJobExecutor.HandledProcessId,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["srid"] = "4326",
+                ["distance"] = "10",
+            });
+
+        result.Succeeded.Should().BeFalse();
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("wkb");
+        result.Artifacts.Should().BeEmpty();
+    }
+
+    private static GeometryBufferJobExecutor CreateBufferExecutor()
+    {
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = 50L * 1024L * 1024L,
+            ResultRetention = TimeSpan.FromDays(7),
+        });
+        return new GeometryBufferJobExecutor(monitor, NullLogger<GeometryBufferJobExecutor>.Instance);
+    }
+
+    private static string DecodeDataUri(string dataUri)
+    {
+        var comma = dataUri.IndexOf(',', StringComparison.Ordinal);
+        var base64 = dataUri[(comma + 1)..];
+        return System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+    }
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterExecutorTests.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.TestKit.Attributes;
 using Honua.Worker.Gdal.Execution;
@@ -718,7 +719,8 @@ public sealed class GdalRasterExecutorTests
     {
         var runner = FakeGdalCommandRunner.Failing(1, "n/a");
         var options = GdalJobFactory.Options(Path.Combine(Path.GetTempPath(), "honua-gdal-dispatch-test"));
-        return new GdalDispatchJobExecutor(
+        IProcessExecutor[] executors =
+        {
             new GdalVectorConvertJobExecutor(runner, options, NullLogger<GdalVectorConvertJobExecutor>.Instance),
             new GdalRasterReprojectJobExecutor(runner, options, NullLogger<GdalRasterReprojectJobExecutor>.Instance),
             new GdalSurfaceJobExecutor(runner, options, NullLogger<GdalSurfaceJobExecutor>.Instance),
@@ -728,6 +730,10 @@ public sealed class GdalRasterExecutorTests
             new GdalRasterZonalStatisticsJobExecutor(runner, options, NullLogger<GdalRasterZonalStatisticsJobExecutor>.Instance),
             new GdalMultidimCoverageMetadataJobExecutor(runner, options, NullLogger<GdalMultidimCoverageMetadataJobExecutor>.Instance),
             new PdalPointCloudConvertJobExecutor(runner, options, NullLogger<PdalPointCloudConvertJobExecutor>.Instance),
+        };
+
+        return new GdalDispatchJobExecutor(
+            executors,
             NullLogger<GdalDispatchJobExecutor>.Instance);
     }
 

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalWorkerExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalWorkerExecutorTests.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -78,7 +79,8 @@ public sealed class GdalWorkerExecutorTests
     {
         var runner = FakeGdalCommandRunner.Failing(1, "n/a");
         var options = GdalJobFactory.Options(Path.Combine(Path.GetTempPath(), "honua-gdal-dispatch-test"));
-        return new GdalDispatchJobExecutor(
+        IProcessExecutor[] executors =
+        {
             new GdalVectorConvertJobExecutor(runner, options, NullLogger<GdalVectorConvertJobExecutor>.Instance),
             new GdalRasterReprojectJobExecutor(runner, options, NullLogger<GdalRasterReprojectJobExecutor>.Instance),
             new GdalSurfaceJobExecutor(runner, options, NullLogger<GdalSurfaceJobExecutor>.Instance),
@@ -88,6 +90,10 @@ public sealed class GdalWorkerExecutorTests
             new GdalRasterZonalStatisticsJobExecutor(runner, options, NullLogger<GdalRasterZonalStatisticsJobExecutor>.Instance),
             new GdalMultidimCoverageMetadataJobExecutor(runner, options, NullLogger<GdalMultidimCoverageMetadataJobExecutor>.Instance),
             new PdalPointCloudConvertJobExecutor(runner, options, NullLogger<PdalPointCloudConvertJobExecutor>.Instance),
+        };
+
+        return new GdalDispatchJobExecutor(
+            executors,
             NullLogger<GdalDispatchJobExecutor>.Instance);
     }
 

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GeoprocessingLocalRunnerGdalTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GeoprocessingLocalRunnerGdalTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Geoprocessing.LocalRunner;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Offline coverage for the headless <see cref="GeoprocessingLocalRunner"/> (GP Devkit,
+/// issue #2123) driving a native GDAL op. The runner invokes the real
+/// <c>gdal.ogr2ogr</c> executor with no Redis/queue/job-store; a
+/// <see cref="FakeGdalCommandRunner"/> stands in for the <c>ogr2ogr</c> CLI so the run
+/// is fully offline. This proves the GP Devkit contract for native ops: the run
+/// returns the published artifact AND the structured logs that carry the actual GDAL
+/// command line a developer would otherwise have to reconstruct by hand.
+/// </summary>
+public sealed class GeoprocessingLocalRunnerGdalTests
+{
+    private const string ScratchSuite = "honua-gdal-local-runner-test";
+
+    private static readonly byte[] ConvertedBytes = Encoding.UTF8.GetBytes("id,wkt\n1,POINT(1 2)\n");
+
+    [UnitTest]
+    public async Task RunAsync_GdalVectorConvert_ReturnsArtifactAndSurfacesActualCommand()
+    {
+        var scratch = GdalCli.NewScratch(ScratchSuite);
+        try
+        {
+            // ogr2ogr's arg order is `-f CSV <output> <input>`: the output path is the
+            // second-to-last argument, so the fake writes its bytes there.
+            var gdalRunner = FakeGdalCommandRunner.Succeeding(ConvertedBytes, outputArgIndexFromEnd: 1);
+            var executor = new GdalVectorConvertJobExecutor(
+                gdalRunner,
+                GdalJobFactory.Options(scratch),
+                NullLogger<GdalVectorConvertJobExecutor>.Instance);
+
+            var runner = new GeoprocessingLocalRunner([executor]);
+
+            var result = await runner.RunAsync(
+                GdalVectorConvertJobExecutor.HandledProcessId,
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["source"] = Convert.ToBase64String(Encoding.UTF8.GetBytes(
+                        """{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":{"name":"a"}}]}""")),
+                    ["sourceFormat"] = "GeoJSON",
+                    ["targetFormat"] = "CSV",
+                });
+
+            result.Succeeded.Should().BeTrue(result.ErrorMessage);
+            result.ProcessId.Should().Be(GdalVectorConvertJobExecutor.HandledProcessId);
+            result.Artifacts.Should().ContainSingle();
+            result.Artifacts[0].Should().StartWith("data:text/csv;base64,");
+
+            // The runner ran the real executor: the fake CLI was invoked once with ogr2ogr.
+            gdalRunner.Invocations.Should().ContainSingle();
+            gdalRunner.Invocations[0].Tool.Should().Be("ogr2ogr");
+
+            // The GP Devkit contract for GDAL ops: the actual command line is surfaced
+            // through the structured logs (with the scratch workspace redacted).
+            var commandEntry = result.Logs.Should().ContainSingle(
+                e => e.Metadata != null && e.Metadata.ContainsKey(GdalCommandLog.CommandMetadataKey)).Subject;
+            commandEntry.Metadata![GdalCommandLog.ToolMetadataKey].Should().Be("ogr2ogr");
+            commandEntry.Metadata[GdalCommandLog.CommandMetadataKey].Should().StartWith("ogr2ogr ");
+            commandEntry.Metadata[GdalCommandLog.CommandMetadataKey].Should().NotContain(scratch);
+            commandEntry.Metadata[GdalCommandLog.CommandMetadataKey].Should().Contain("<scratch>");
+        }
+        finally
+        {
+            GdalCli.CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task RunAsync_GdalCommandFails_SurfacesFailedResult()
+    {
+        var scratch = GdalCli.NewScratch(ScratchSuite);
+        try
+        {
+            var gdalRunner = FakeGdalCommandRunner.Failing(1, "ERROR 1: ogr2ogr blew up");
+            var executor = new GdalVectorConvertJobExecutor(
+                gdalRunner,
+                GdalJobFactory.Options(scratch),
+                NullLogger<GdalVectorConvertJobExecutor>.Instance);
+
+            var runner = new GeoprocessingLocalRunner([executor]);
+
+            var result = await runner.RunAsync(
+                GdalVectorConvertJobExecutor.HandledProcessId,
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["source"] = Convert.ToBase64String(Encoding.UTF8.GetBytes(
+                        """{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":{"name":"a"}}]}""")),
+                    ["sourceFormat"] = "GeoJSON",
+                    ["targetFormat"] = "CSV",
+                });
+
+            result.Succeeded.Should().BeFalse();
+            result.Status.Should().Be(Honua.Core.Features.ControlPlane.Domain.ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().NotBeNullOrEmpty();
+            result.Artifacts.Should().BeEmpty();
+        }
+        finally
+        {
+            GdalCli.CleanupScratch(scratch);
+        }
+    }
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/Honua.Worker.Gdal.Tests.csproj
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/Honua.Worker.Gdal.Tests.csproj
@@ -9,6 +9,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Honua.Worker.Gdal\Honua.Worker.Gdal.csproj" />
+    <!-- GP Devkit (#2123): the headless GeoprocessingLocalRunner lives in
+         Honua.Geoprocessing; the GDAL-op runner test drives it over the native
+         GDAL executor with a fake CLI runner. -->
+    <ProjectReference Include="..\..\..\src\Honua.Geoprocessing\Honua.Geoprocessing.csproj" />
     <ProjectReference Include="..\Honua.TestKit\Honua.TestKit.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2126

## Summary
Adds GP Devkit P5: the `honua gp plan <id> --input <file> [--param k=v ...]` verb — a headless, Redis-free dry-run that validates a process's parameters against its typed catalog schema and the shared step-graph (DAG) structural gate **without executing**, then estimates the output magnitude and **warns before submit** when a run is likely to exceed the 50 MiB `MaxArtifactBytes` cap (the real failure mode — a job FAILS at that cap today). Stacks on PR #2171 (P2 runner + `honua gp` CLI).

The plan output is also the resource hint a future devops-agent serverless-sizing step would size Batch from, so it surfaces the input/output magnitude, runtime profile, and a long-running flag alongside the validation result.

## Changes Made
- Extracted the Kahn topological/DAG validation out of `GeoprocessingJobService.ValidatePlanStructure` into a shared `AnalysisPlanGraphValidator` so the durable submit/validate/dry-run path and the new CLI plan path reject the same malformed graphs (cycles, dangling/self deps) with the same message — true reuse, not a copy.
- `GpPlanner.Build` constructs a single-process `AnalysisPlan`, runs `ProcessPlanValidator` (typed param schema + per-process semantics) and `AnalysisPlanGraphValidator`, resolves each parameter (caller / catalog-default / unset), and attaches a `GpSizeEstimate`.
- `GpSizeEstimator`: an **honest heuristic** output-size multiplier keyed on category and output kind — scalar/report is constant-size (never a cap risk), raster/surface tracks input pixels and flags long-running, reproject/resample carries grid-inflation headroom, buffer densifies (~5x), generalization/filter sits ~parity, feature/GeoJSON text expands ~3-5x. Judged against the configured cap; explicitly **not** a guarantee (no compression/vertex-complexity/selectivity knowledge offline).
- `gp plan` prints the ordered steps, resolved params with provenance, declared outputs, the estimate (labelled `HEURISTIC`), a `resource hint` (profile + long-running), and errors/warnings. Exits non-zero on an invalid plan so a submit can be gated on a clean plan; a valid plan with only a size warning still exits 0.
- The planner core lives in `Honua.Geoprocessing` (no GDAL/CLI deps) so the geoprocessing test shard unit-tests it offline and `Honua.Server` stays AOT-clean without referencing the dev-only CLI (which transitively pulls `Honua.Worker.Gdal`).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

12 offline unit tests (`GpPlanTests`, no Redis/no Docker): valid plan with resolved params + defaults; missing/invalid/unknown param rejection (same `ProcessPlanValidator`); cycle + dangling-dependency rejection via the shared `AnalysisPlanGraphValidator`; deterministic topological order; over-cap size estimate producing a warning; small-input no-warning; scalar-output never-a-risk; raster long-running flag; no-file-input does-not-fabricate-an-estimate. All 12 pass; the 78 existing geoprocessing job-service/local-runner tests still pass after the validator extraction. `dotnet format --verify-no-changes` clean on all changed files.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

> Stacks on PR #2171 (`feat/gp-devkit-p2-runner-cli`). The CLI project is already mapped to the Operator Eval Harness shard in `.github/ci-shards.json`; the new source/test files fall under already-mapped paths (`src/Honua.Geoprocessing/Features/Geoprocessing/`, `tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/`), so no shard-map change was needed. No NuGet packages added (no lockfile regen).
