### PR TITLE
feat(geoprocessing): honua gp publish — push authored workflows to the WorkflowPackage store (#2176)

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -1000,6 +1000,24 @@
       ]
     },
     {
+      "name": "GP Devkit CLI",
+      "_comment": "GP Devkit (#2123/#2176) honua-gp dev tool. Its offline unit tests live in their OWN assembly (Honua.Geoprocessing.Cli.Tests) rather than the Honua.Server.Tests monolith, so the shard targets that csproj via `csproj`. Filters on the assembly's root namespace so every CLI test class is auto-covered. Paths claim the CLI src tree and its test tree so a publish/runner change targets this shard instead of tripping the unmapped-source run_all net for src/Honua.Geoprocessing.Cli/.",
+      "shard_name": "GP Devkit CLI",
+      "artifact_suffix": "gp-devkit-cli",
+      "log_name": "server-tests-gp-devkit-cli",
+      "timeout_minutes": 15,
+      "test_timeout_minutes": 10,
+      "max_cpu_count": "",
+      "upload_operator_eval_report": false,
+      "upload_odata_evidence": false,
+      "csproj": "tests/dotnet/Honua.Geoprocessing.Cli.Tests/Honua.Geoprocessing.Cli.Tests.csproj",
+      "filter": "FullyQualifiedName~Honua.Geoprocessing.Cli.Tests",
+      "paths": [
+        "src/Honua.Geoprocessing.Cli/",
+        "tests/dotnet/Honua.Geoprocessing.Cli.Tests/"
+      ]
+    },
+    {
       "name": "MCP",
       "shard_name": "MCP",
       "artifact_suffix": "mcp",

--- a/Honua.sln
+++ b/Honua.sln
@@ -153,6 +153,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Protocols.SensorThing
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Geoprocessing.Cli", "src\Honua.Geoprocessing.Cli\Honua.Geoprocessing.Cli.csproj", "{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Geoprocessing.Cli.Tests", "tests\dotnet\Honua.Geoprocessing.Cli.Tests\Honua.Geoprocessing.Cli.Tests.csproj", "{1D6DCC0C-878C-4937-806F-54F2AF0398ED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -991,6 +993,18 @@ Global
 		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Release|x64.Build.0 = Release|Any CPU
 		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Release|x86.ActiveCfg = Release|Any CPU
 		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC}.Release|x86.Build.0 = Release|Any CPU
+		{1D6DCC0C-878C-4937-806F-54F2AF0398ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D6DCC0C-878C-4937-806F-54F2AF0398ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D6DCC0C-878C-4937-806F-54F2AF0398ED}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1D6DCC0C-878C-4937-806F-54F2AF0398ED}.Debug|x64.Build.0 = Debug|Any CPU
+		{1D6DCC0C-878C-4937-806F-54F2AF0398ED}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1D6DCC0C-878C-4937-806F-54F2AF0398ED}.Debug|x86.Build.0 = Debug|Any CPU
+		{1D6DCC0C-878C-4937-806F-54F2AF0398ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D6DCC0C-878C-4937-806F-54F2AF0398ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D6DCC0C-878C-4937-806F-54F2AF0398ED}.Release|x64.ActiveCfg = Release|Any CPU
+		{1D6DCC0C-878C-4937-806F-54F2AF0398ED}.Release|x64.Build.0 = Release|Any CPU
+		{1D6DCC0C-878C-4937-806F-54F2AF0398ED}.Release|x86.ActiveCfg = Release|Any CPU
+		{1D6DCC0C-878C-4937-806F-54F2AF0398ED}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1060,5 +1074,6 @@ Global
 		{268C7FCA-045F-4DA1-B249-64DCF5E13D11} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{09A157E7-67AD-46E1-9495-BD499000592D} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
 		{EA6AA0CA-B050-4A9D-BCB6-3BADC64F02BC} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{1D6DCC0C-878C-4937-806F-54F2AF0398ED} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
 	EndGlobalSection
 EndGlobal

--- a/samples/gp/buffer-and-area/workflow.json
+++ b/samples/gp/buffer-and-area/workflow.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": "workflow-package.v1",
+  "workerProfile": "managed",
+  "nodes": [
+    {
+      "nodeId": "buffer",
+      "nodeTypeId": "process:geometry.buffer",
+      "parameters": {
+        "distance": "100",
+        "srid": "4326"
+      }
+    },
+    {
+      "nodeId": "area",
+      "nodeTypeId": "process:geometry.area",
+      "parameters": {
+        "srid": "4326"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "sourceNodeId": "buffer",
+      "targetNodeId": "area",
+      "kind": "Data"
+    }
+  ],
+  "editorMetadata": {
+    "authoredVia": "honua-gp-devkit",
+    "summary": "Buffer an input geometry by 100m, then compute the buffered area. A locally-authored workflow fixture that 'honua gp publish buffer-and-area' pushes to the WorkflowPackage store."
+  }
+}

--- a/src/Honua.Geoprocessing.Cli/GpCli.cs
+++ b/src/Honua.Geoprocessing.Cli/GpCli.cs
@@ -5,6 +5,7 @@ using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Geoprocessing;
+using Honua.Geoprocessing.Cli.Publish;
 using Honua.Geoprocessing.LocalRunner;
 using Honua.Worker.Gdal;
 using Microsoft.Extensions.Configuration;
@@ -48,6 +49,7 @@ public static class GpCli
             {
                 "list" => RunList(),
                 "run" => await RunRun(rest).ConfigureAwait(false),
+                "publish" => await RunPublish(rest).ConfigureAwait(false),
                 "-h" or "--help" or "help" => PrintUsageAndOk(),
                 _ => Fail($"Unknown command '{verb}'."),
             };
@@ -222,6 +224,38 @@ public static class GpCli
         return 0;
     }
 
+    private static async Task<int> RunPublish(string[] args)
+    {
+        using var provider = BuildProvider();
+        var executors = provider.GetServices<IProcessExecutor>();
+        var runner = new GeoprocessingLocalRunner(executors);
+        var processIds = runner.AvailableProcessIds.ToHashSet(StringComparer.Ordinal);
+        var catalog = provider.GetService<IProcessCatalog>();
+
+        return await GpPublishCommand.RunAsync(
+            args,
+            processIds,
+            catalog,
+            CreatePublishClient,
+            Console.Out,
+            Console.Error).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Default REST-client factory for the publish verb: a real <see cref="HttpClient"/> rooted at
+    /// the <c>--server</c> base URL, authenticated with the admin API key (or a bearer token).
+    /// </summary>
+    private static WorkflowPackagePublishClient CreatePublishClient(GpPublishOptions options)
+    {
+        if (!Uri.TryCreate(options.Server, UriKind.Absolute, out var baseAddress))
+        {
+            throw new GpCliUsageException($"Invalid --server URL: '{options.Server}'.");
+        }
+
+        var http = new HttpClient { BaseAddress = baseAddress };
+        return new WorkflowPackagePublishClient(http, options.ApiKey, options.BearerToken);
+    }
+
     /// <summary>
     /// Resolves the parameter name that <c>--input &lt;file&gt;</c> binds to: the
     /// first required file-like (<c>Wkb</c>/<c>WkbArray</c>/<c>Text</c>) parameter the
@@ -302,15 +336,28 @@ public static class GpCli
         Console.WriteLine("Usage:");
         Console.WriteLine("  honua gp list");
         Console.WriteLine("  honua gp run <processId> [--input <file>] [--param k=v ...] [--out <file>]");
+        Console.WriteLine("  honua gp publish <id> [--server <url>] [--api-key <key>] [--message <m>] [--dry-run] [--publish]");
         Console.WriteLine();
-        Console.WriteLine("Options:");
+        Console.WriteLine("Run options:");
         Console.WriteLine("  --input, -i <file>  Read a file and bind it (base64) to the process's primary input.");
         Console.WriteLine("  --param, -p k=v     Set a step-0 input (repeatable). Overrides --input for the same key.");
         Console.WriteLine("  --out,   -o <file>  Write the first published artifact's bytes to <file>.");
         Console.WriteLine();
+        Console.WriteLine("Publish options:");
+        Console.WriteLine("  --server, -s <url>  Console REST server root. Default http://localhost:8080.");
+        Console.WriteLine("  --api-key, -k <key> Admin API key (X-API-Key). Defaults to $HONUA_ADMIN_PASSWORD.");
+        Console.WriteLine("  --bearer <token>    Bearer token instead of an API key.");
+        Console.WriteLine("  --message, -m <m>   Author message stamped on the package.");
+        Console.WriteLine("  --file, -f <json>   Publish an explicit WorkflowGraph JSON file.");
+        Console.WriteLine("  --as-process-node   Wrap a single registered process as a one-node workflow package.");
+        Console.WriteLine("  --dry-run           Validate + dry-run only; never create a publication.");
+        Console.WriteLine("  --publish           Also publish the created version to a process endpoint.");
+        Console.WriteLine();
         Console.WriteLine("Examples:");
         Console.WriteLine("  honua gp run geometry.buffer --param wkb=<base64> --param srid=4326 --param distance=10");
         Console.WriteLine("  honua gp run gdal.ogr2ogr --input in.geojson --param sourceFormat=GeoJSON --param targetFormat=CSV --out out.csv");
+        Console.WriteLine("  honua gp publish my-flow --file workflow.json --dry-run");
+        Console.WriteLine("  honua gp publish geometry.buffer --as-process-node --publish --api-key <key>");
     }
 }
 

--- a/src/Honua.Geoprocessing.Cli/Honua.Geoprocessing.Cli.csproj
+++ b/src/Honua.Geoprocessing.Cli/Honua.Geoprocessing.Cli.csproj
@@ -36,4 +36,9 @@
     <ProjectReference Include="..\Honua.Worker.Gdal\Honua.Worker.Gdal.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- The publish-command pipeline is internal; the offline unit tests exercise it directly. -->
+    <InternalsVisibleTo Include="Honua.Geoprocessing.Cli.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Honua.Geoprocessing.Cli/Publish/GpPublishCommand.cs
+++ b/src/Honua.Geoprocessing.Cli/Publish/GpPublishCommand.cs
@@ -1,0 +1,352 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.WorkflowPackages.Domain;
+
+namespace Honua.Geoprocessing.Cli.Publish;
+
+/// <summary>
+/// Parsed options for the <c>honua gp publish</c> verb.
+/// </summary>
+internal sealed record GpPublishOptions
+{
+    /// <summary>The workflow or process id to publish.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Server root URL. Defaults to the local quickstart (<c>http://localhost:8080</c>).</summary>
+    public string Server { get; init; } = "http://localhost:8080";
+
+    /// <summary>Admin API key sent as <c>X-API-Key</c>.</summary>
+    public string? ApiKey { get; init; }
+
+    /// <summary>Bearer token sent as <c>Authorization: Bearer</c>.</summary>
+    public string? BearerToken { get; init; }
+
+    /// <summary>Author message stamped onto the package metadata.</summary>
+    public string? Message { get; init; }
+
+    /// <summary>Validate + dry-run only; never create a publication.</summary>
+    public bool DryRun { get; init; }
+
+    /// <summary>Also publish the created version to a process-endpoint target.</summary>
+    public bool Publish { get; init; }
+
+    /// <summary>Explicit workflow graph JSON file, overriding fixture/process resolution.</summary>
+    public string? File { get; init; }
+
+    /// <summary>Wrap a single registered process into a one-node graph.</summary>
+    public bool AsProcessNode { get; init; }
+
+    /// <summary>Override the package name (defaults to the id).</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Override the package namespace.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>Fixture root holding <c>&lt;id&gt;/workflow.json</c>. Defaults to <c>samples/gp</c>.</summary>
+    public string FixtureRoot { get; init; } = Path.Combine("samples", "gp");
+}
+
+/// <summary>
+/// Implements the <c>honua gp publish</c> verb: it builds the WorkflowPackage/WorkflowGraph
+/// payload a locally-authored workflow maps to and drives the Console workflow-package REST
+/// surface (save → version → validate → dry-run → optional publish), mirroring the Console UI.
+/// </summary>
+/// <remarks>
+/// This bridges the devkit's local loop to the GitOps cross-env path: publishing creates an
+/// immutable, versioned package in the store. It does NOT deploy across environments — the
+/// publish → metadata-release → GitOps release path promotes the package between environments.
+/// </remarks>
+internal static class GpPublishCommand
+{
+    /// <summary>
+    /// Parses the publish args, resolves the id to a graph, and drives the REST sequence.
+    /// </summary>
+    /// <param name="args">The verb's options (everything after <c>publish</c>).</param>
+    /// <param name="processIds">Registered process ids, used to detect code processes.</param>
+    /// <param name="catalog">Process catalog, used to seed default parameters for process nodes.</param>
+    /// <param name="clientFactory">
+    /// Factory producing the REST client for an <c>(server, apiKey, bearer)</c> tuple. Injected so
+    /// offline tests can supply a faked transport; production uses the default factory.
+    /// </param>
+    /// <param name="output">Standard output sink.</param>
+    /// <param name="error">Error output sink.</param>
+    public static async Task<int> RunAsync(
+        string[] args,
+        IReadOnlySet<string> processIds,
+        IProcessCatalog? catalog,
+        Func<GpPublishOptions, WorkflowPackagePublishClient> clientFactory,
+        TextWriter output,
+        TextWriter error)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(processIds);
+        ArgumentNullException.ThrowIfNull(clientFactory);
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(error);
+
+        var options = ParseOptions(args);
+
+        var source = new GpWorkflowSource(catalog, processIds)
+            .Resolve(options.Id, options.File, options.AsProcessNode, options.Name, options.FixtureRoot);
+
+        if (!source.CanPublish)
+        {
+            // Honest non-publish path. A code process is an expected, non-error outcome
+            // (exit 0) — it simply deploys via the server image; an unknown id is an error.
+            output.WriteLine($"id      : {options.Id}");
+            output.WriteLine($"kind    : {source.Kind}");
+            output.WriteLine($"result  : not published");
+            output.WriteLine($"reason  : {source.Reason}");
+            return string.Equals(source.Kind, "code process", StringComparison.Ordinal) ? 0 : 2;
+        }
+
+        var graph = source.Graph!;
+        var saveRequest = new SaveWorkflowPackageRequestDto
+        {
+            PackageId = options.Id,
+            Name = source.Name ?? options.Id,
+            Namespace = options.Namespace,
+            Description = options.Message,
+            Graph = graph,
+            Metadata = BuildMetadata(options, source)
+        };
+
+        var client = clientFactory(options);
+
+        GpPublishResult result;
+        try
+        {
+            if (options.DryRun)
+            {
+                result = await client.DryRunOnlyAsync(saveRequest).ConfigureAwait(false);
+            }
+            else
+            {
+                PublishWorkflowPackageRequestDto? publishRequest = options.Publish
+                    ? BuildPublishRequest(source)
+                    : null;
+
+                result = await client.SaveVersionAndPublishAsync(
+                        saveRequest,
+                        validate: true,
+                        dryRun: false,
+                        publish: options.Publish,
+                        publishRequest,
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (GpPublishHttpException ex)
+        {
+            error.WriteLine($"error   : {ex.Message}");
+            return 1;
+        }
+
+        WriteResult(output, options, source, result);
+        return 0;
+    }
+
+    private static Dictionary<string, string> BuildMetadata(GpPublishOptions options, GpPublishSource source)
+    {
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["authoredVia"] = "honua-gp-devkit",
+            ["sourceKind"] = source.Kind
+        };
+
+        if (!string.IsNullOrWhiteSpace(options.Message))
+        {
+            metadata["message"] = options.Message;
+        }
+
+        if (!string.IsNullOrWhiteSpace(source.ProcessId))
+        {
+            metadata["processId"] = source.ProcessId;
+        }
+
+        return metadata;
+    }
+
+    private static PublishWorkflowPackageRequestDto BuildPublishRequest(GpPublishSource source)
+        => new()
+        {
+            // The devkit publishes single authored workflows as process-style endpoints — the
+            // target a locally-authored process/workflow most naturally maps to.
+            Target = WorkflowPublicationTarget.ProcessEndpoint,
+            ProcessId = source.ProcessId,
+            Enabled = true
+        };
+
+    private static void WriteResult(
+        TextWriter output,
+        GpPublishOptions options,
+        GpPublishSource source,
+        GpPublishResult result)
+    {
+        output.WriteLine($"id        : {options.Id}");
+        output.WriteLine($"kind      : {source.Kind}");
+        output.WriteLine($"server    : {options.Server.TrimEnd('/')}");
+        output.WriteLine($"package   : {result.Package.PackageId}");
+        output.WriteLine($"nodes     : {source.Graph!.Nodes.Count}");
+
+        if (result.Version is not null)
+        {
+            output.WriteLine($"version   : {result.Version.Version}");
+            output.WriteLine($"hash      : {result.Version.PackageHash}");
+        }
+
+        if (result.Validation is not null)
+        {
+            output.WriteLine($"validate  : {(result.Validation.IsValid ? "valid" : "INVALID")}");
+            foreach (var failure in result.Validation.Failures)
+            {
+                output.WriteLine($"  - {failure.Code}: {failure.Message}");
+            }
+
+            foreach (var warning in result.Validation.Warnings)
+            {
+                output.WriteLine($"  ! {warning}");
+            }
+        }
+
+        if (result.DryRun is not null)
+        {
+            output.WriteLine(
+                $"dry-run   : ~{result.DryRun.EstimatedDurationSeconds}s, "
+                + $"cost {result.DryRun.EstimatedCostWeight:F1}, "
+                + $"{result.DryRun.OutputSchemas.Count} output(s)");
+        }
+
+        if (result.Publication is not null)
+        {
+            output.WriteLine($"published : {result.Publication.PublicationId} -> {result.Publication.Target}");
+            if (!string.IsNullOrWhiteSpace(result.Publication.EndpointPath))
+            {
+                output.WriteLine($"endpoint  : {result.Publication.EndpointPath}");
+            }
+        }
+
+        output.WriteLine();
+        if (options.DryRun)
+        {
+            output.WriteLine(
+                "result    : validated + dry-ran a draft version. Nothing was published. "
+                + "Re-run without --dry-run to create a publishable version.");
+        }
+        else if (result.Publication is not null)
+        {
+            output.WriteLine(
+                "result    : package version published. Next: a metadata release picks up the "
+                + "published package and the GitOps release path promotes it across environments "
+                + "(this command only published the package; it does NOT deploy across envs).");
+        }
+        else
+        {
+            output.WriteLine(
+                "result    : immutable package version created and ready to publish. Next: publish it "
+                + "(re-run with --publish, or use the Console), then a metadata release + the GitOps "
+                + "cross-env path promotes it across environments (publishing does NOT deploy across envs).");
+        }
+    }
+
+    /// <summary>
+    /// Parses the publish verb's options. Exposed to tests.
+    /// </summary>
+    internal static GpPublishOptions ParseOptions(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            throw new GpCliUsageException(
+                "Missing <id>. Usage: honua gp publish <id> [--server <url>] [--api-key <key>] "
+                + "[--message <m>] [--dry-run] [--publish] [--as-process-node] [--file <workflow.json>]");
+        }
+
+        var id = args[0];
+        if (id.StartsWith('-'))
+        {
+            throw new GpCliUsageException("The first argument to 'publish' must be a workflow or process id.");
+        }
+
+        string server = "http://localhost:8080";
+        string? apiKey = Environment.GetEnvironmentVariable("HONUA_ADMIN_PASSWORD");
+        string? bearer = null;
+        string? message = null;
+        var dryRun = false;
+        var publish = false;
+        string? file = null;
+        var asProcessNode = false;
+        string? name = null;
+        string? ns = null;
+
+        for (var i = 1; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--server" or "-s":
+                    server = NextValue(args, ref i, "--server");
+                    break;
+                case "--api-key" or "-k":
+                    apiKey = NextValue(args, ref i, "--api-key");
+                    break;
+                case "--bearer" or "--token":
+                    bearer = NextValue(args, ref i, "--bearer");
+                    break;
+                case "--message" or "-m":
+                    message = NextValue(args, ref i, "--message");
+                    break;
+                case "--dry-run":
+                    dryRun = true;
+                    break;
+                case "--publish":
+                    publish = true;
+                    break;
+                case "--file" or "-f":
+                    file = NextValue(args, ref i, "--file");
+                    break;
+                case "--as-process-node":
+                    asProcessNode = true;
+                    break;
+                case "--name":
+                    name = NextValue(args, ref i, "--name");
+                    break;
+                case "--namespace":
+                    ns = NextValue(args, ref i, "--namespace");
+                    break;
+                default:
+                    throw new GpCliUsageException($"Unknown option '{args[i]}'.");
+            }
+        }
+
+        if (dryRun && publish)
+        {
+            throw new GpCliUsageException("--dry-run and --publish are mutually exclusive.");
+        }
+
+        return new GpPublishOptions
+        {
+            Id = id,
+            Server = server,
+            ApiKey = apiKey,
+            BearerToken = bearer,
+            Message = message,
+            DryRun = dryRun,
+            Publish = publish,
+            File = file,
+            AsProcessNode = asProcessNode,
+            Name = name,
+            Namespace = ns
+        };
+    }
+
+    private static string NextValue(string[] args, ref int index, string option)
+    {
+        if (index + 1 >= args.Length)
+        {
+            throw new GpCliUsageException($"Option '{option}' requires a value.");
+        }
+
+        return args[++index];
+    }
+}

--- a/src/Honua.Geoprocessing.Cli/Publish/GpPublishJson.cs
+++ b/src/Honua.Geoprocessing.Cli/Publish/GpPublishJson.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Honua.Geoprocessing.Cli.Publish;
+
+/// <summary>
+/// JSON options matching the Console workflow-package endpoints' source-generated context
+/// (<c>WorkflowPackagesJsonContext</c>): camelCase property names and string enum values.
+/// The devkit tool is reflection-friendly (it is never AOT-published), so a plain
+/// <see cref="JsonSerializerOptions"/> is used rather than a source-generated context.
+/// </summary>
+internal static class GpPublishJson
+{
+    /// <summary>
+    /// Shared, immutable serializer options mirroring the server's wire policy.
+    /// </summary>
+    public static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter() }
+    };
+}

--- a/src/Honua.Geoprocessing.Cli/Publish/GpPublishWireModels.cs
+++ b/src/Honua.Geoprocessing.Cli/Publish/GpPublishWireModels.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.WorkflowPackages.Domain;
+
+namespace Honua.Geoprocessing.Cli.Publish;
+
+// These records mirror the Console REST wire contract for the workflow-package
+// endpoints (src/Honua.Server/Features/WorkflowPackages/WorkflowPackageEndpointModels.cs).
+// The server-side request records are `internal` to Honua.Server, so the devkit cannot
+// reference them directly; we re-declare the exact same shape here and (de)serialize with
+// the same camelCase + string-enum policy the server's source-generated JSON context uses.
+// They carry the public Honua.Core domain types (WorkflowGraph, WorkflowSchedule, ...) so
+// the graph payload itself is the canonical model — only the request envelope is mirrored.
+
+/// <summary>
+/// Mirror of the server's <c>SaveWorkflowPackageRequest</c> body for
+/// <c>POST /api/v{n}/console/workflow-packages</c>.
+/// </summary>
+internal sealed record SaveWorkflowPackageRequestDto
+{
+    /// <summary>Stable package identifier; null lets the server assign one.</summary>
+    public string? PackageId { get; init; }
+
+    /// <summary>Human-readable package name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Optional package description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Optional logical namespace for Console authoring.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>The mutable draft graph to save.</summary>
+    public required WorkflowGraph Graph { get; init; }
+
+    /// <summary>Opaque metadata carried with the package draft.</summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
+}
+
+/// <summary>
+/// Mirror of the server's <c>PublishWorkflowPackageRequest</c> body for
+/// <c>POST /api/v{n}/console/workflow-packages/{id}/versions/{v}/publish</c>.
+/// </summary>
+internal sealed record PublishWorkflowPackageRequestDto
+{
+    /// <summary>Optional stable publication identifier.</summary>
+    public string? PublicationId { get; init; }
+
+    /// <summary>Publication target (Job, Schedule, or ProcessEndpoint).</summary>
+    public required WorkflowPublicationTarget Target { get; init; }
+
+    /// <summary>Process identifier when the target is a process endpoint.</summary>
+    public string? ProcessId { get; init; }
+
+    /// <summary>Schedule when the target is a schedule.</summary>
+    public WorkflowSchedule? Schedule { get; init; }
+
+    /// <summary>Whether the publication is enabled.</summary>
+    public bool Enabled { get; init; } = true;
+}
+
+/// <summary>
+/// Mirror of the generic <c>ApiResponse&lt;T&gt;</c> envelope the Console endpoints return.
+/// </summary>
+/// <typeparam name="T">The response payload type.</typeparam>
+internal sealed record ApiResponseDto<T>
+{
+    /// <summary>Whether the request succeeded.</summary>
+    public bool Success { get; init; }
+
+    /// <summary>The response payload.</summary>
+    public T? Data { get; init; }
+
+    /// <summary>Optional response message.</summary>
+    public string? Message { get; init; }
+}

--- a/src/Honua.Geoprocessing.Cli/Publish/GpWorkflowSource.cs
+++ b/src/Honua.Geoprocessing.Cli/Publish/GpWorkflowSource.cs
@@ -1,0 +1,233 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.WorkflowPackages.Domain;
+
+namespace Honua.Geoprocessing.Cli.Publish;
+
+/// <summary>
+/// Outcome of resolving a <c>honua gp publish &lt;id&gt;</c> identifier into a publishable
+/// <see cref="WorkflowGraph"/>, including the publish/skip semantics for the id kind.
+/// </summary>
+internal sealed record GpPublishSource
+{
+    /// <summary>Whether a publishable graph was produced.</summary>
+    public bool CanPublish { get; init; }
+
+    /// <summary>The graph to push to the package store, when <see cref="CanPublish"/> is true.</summary>
+    public WorkflowGraph? Graph { get; init; }
+
+    /// <summary>Human-readable package name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>How the id resolved (authored workflow, fixture, or wrapped code process).</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>
+    /// When <see cref="CanPublish"/> is false, the honest reason the id does not map to a
+    /// publishable data artifact (e.g. a built-in code process that deploys via the image).
+    /// </summary>
+    public string? Reason { get; init; }
+
+    /// <summary>The process id when the source wrapped a single registered process.</summary>
+    public string? ProcessId { get; init; }
+}
+
+/// <summary>
+/// Resolves a <c>honua gp publish</c> identifier into a <see cref="WorkflowGraph"/>, enforcing
+/// the process-vs-workflow publish semantics.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Honua geoprocessing <b>processes</b> (e.g. <c>geometry.buffer</c>) are CODE: they are
+/// registered <c>IProcessExecutor</c>s compiled into the server image and discovered through
+/// the <see cref="IProcessCatalog"/>. They are not data artifacts and therefore do not, on
+/// their own, deploy through the versioned WorkflowPackage store — a code process ships with
+/// the server image and is promoted by rebuilding/releasing that image, not by publishing a
+/// package. So <c>gp publish &lt;processId&gt;</c> is, by default, a no-op that prints that
+/// guidance.
+/// </para>
+/// <para>
+/// Authored <b>workflows</b> (a <see cref="WorkflowGraph"/> of nodes/edges, exactly what the
+/// Console map-builder produces) ARE the data artifact the package store versions and the
+/// GitOps cross-env release path promotes. A workflow is resolved from a local fixture at
+/// <c>samples/gp/&lt;id&gt;/workflow.json</c> or from an explicit <c>--file</c>.
+/// </para>
+/// <para>
+/// As a convenience that mirrors dragging a single process onto the Console canvas, a single
+/// registered process can be wrapped into a one-node graph with <c>--as-process-node</c>, which
+/// makes the code process publishable as a package targeting a process endpoint.
+/// </para>
+/// </remarks>
+internal sealed class GpWorkflowSource(IProcessCatalog? catalog, IReadOnlySet<string> registeredProcessIds)
+{
+    private static readonly JsonSerializerOptions GraphReadOptions = GpPublishJson.Options;
+
+    /// <summary>
+    /// Resolves <paramref name="id"/> to a publishable graph or an honest skip reason.
+    /// </summary>
+    /// <param name="id">A workflow id or a registered process id.</param>
+    /// <param name="filePath">An explicit graph JSON file, overriding fixture/process resolution.</param>
+    /// <param name="asProcessNode">Wrap a single registered process into a one-node graph.</param>
+    /// <param name="name">An explicit package name; defaults to the id.</param>
+    /// <param name="fixtureRoot">Root directory holding <c>&lt;id&gt;/workflow.json</c> fixtures.</param>
+    public GpPublishSource Resolve(
+        string id,
+        string? filePath,
+        bool asProcessNode,
+        string? name,
+        string fixtureRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+
+        // 1. Explicit graph file wins: this is a hand-authored or exported workflow artifact.
+        if (filePath is not null)
+        {
+            var graph = ReadGraphFile(filePath);
+            return new GpPublishSource
+            {
+                CanPublish = true,
+                Graph = graph,
+                Name = name ?? id,
+                Kind = "workflow (file)"
+            };
+        }
+
+        // 2. Local workflow fixture: samples/gp/<id>/workflow.json.
+        var fixturePath = Path.Combine(fixtureRoot, id, "workflow.json");
+        if (File.Exists(fixturePath))
+        {
+            var graph = ReadGraphFile(fixturePath);
+            return new GpPublishSource
+            {
+                CanPublish = true,
+                Graph = graph,
+                Name = name ?? id,
+                Kind = "workflow (fixture)"
+            };
+        }
+
+        // 3. A registered code process. By default this is NOT publishable as a package;
+        //    it deploys via the server image. With --as-process-node we wrap it as a
+        //    one-node graph the same way the Console drops a single process onto the canvas.
+        if (registeredProcessIds.Contains(id))
+        {
+            if (!asProcessNode)
+            {
+                return new GpPublishSource
+                {
+                    CanPublish = false,
+                    Kind = "code process",
+                    ProcessId = id,
+                    Reason =
+                        $"'{id}' is a built-in geoprocessing process: it is CODE that ships with the "
+                        + "server image, not a data workflow, so it deploys by releasing a new server "
+                        + "image rather than through the WorkflowPackage store. To publish it as a "
+                        + "single-node workflow package (a process-endpoint wrapper, like dropping it "
+                        + "onto the Console canvas), re-run with --as-process-node. To publish an "
+                        + "authored multi-step workflow, add samples/gp/" + id + "/workflow.json or "
+                        + "pass --file <workflow.json>."
+                };
+            }
+
+            var graph = BuildSingleProcessGraph(id);
+            return new GpPublishSource
+            {
+                CanPublish = true,
+                Graph = graph,
+                Name = name ?? id,
+                Kind = "workflow (process node)",
+                ProcessId = id
+            };
+        }
+
+        // 4. Unknown id with no fixture and no file.
+        return new GpPublishSource
+        {
+            CanPublish = false,
+            Kind = "unknown",
+            Reason =
+                $"No publishable workflow found for '{id}'. Expected a fixture at "
+                + $"samples/gp/{id}/workflow.json, an explicit --file <workflow.json>, or a registered "
+                + "process id used with --as-process-node. Run 'honua gp list' to see registered processes."
+        };
+    }
+
+    /// <summary>
+    /// Wraps a single registered process into a one-node <see cref="WorkflowGraph"/> whose node
+    /// type is <c>process:&lt;id&gt;</c> — the same node-type convention the server's workflow
+    /// node registry uses for geoprocessing processes.
+    /// </summary>
+    internal WorkflowGraph BuildSingleProcessGraph(string processId)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal);
+        var definition = catalog?.GetProcess(processId);
+        if (definition is not null)
+        {
+            // Seed default-valued parameters so the published node carries the process's declared
+            // defaults; required-without-default parameters are left for the run-time caller to bind.
+            foreach (var parameter in definition.Parameters)
+            {
+                if (parameter.DefaultValue is not null)
+                {
+                    parameters[parameter.Name] = parameter.DefaultValue;
+                }
+            }
+        }
+
+        var node = new WorkflowNode
+        {
+            NodeId = "n1",
+            NodeTypeId = ProcessNodeTypePrefix + processId,
+            Parameters = parameters,
+            WorkerProfile = ResolveWorkerProfile(definition)
+        };
+
+        return new WorkflowGraph
+        {
+            SchemaVersion = "workflow-package.v1",
+            Nodes = [node],
+            Edges = [],
+            WorkerProfile = ResolveWorkerProfile(definition)
+        };
+    }
+
+    /// <summary>
+    /// Node-type prefix for geoprocessing process nodes. Kept in sync with the server's
+    /// <c>ProcessCatalogWorkflowNodeProvider.NodeTypePrefix</c>.
+    /// </summary>
+    internal const string ProcessNodeTypePrefix = "process:";
+
+    private static string ResolveWorkerProfile(ProcessDefinition? definition)
+        => definition is { RuntimeProfile.Length: > 0 } ? definition.RuntimeProfile : "managed";
+
+    private static WorkflowGraph ReadGraphFile(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new GpCliUsageException($"Workflow graph file not found: {path}");
+        }
+
+        WorkflowGraph? graph;
+        try
+        {
+            var json = File.ReadAllText(path);
+            graph = JsonSerializer.Deserialize<WorkflowGraph>(json, GraphReadOptions);
+        }
+        catch (JsonException ex)
+        {
+            throw new GpCliUsageException($"Failed to parse workflow graph '{path}': {ex.Message}");
+        }
+
+        if (graph is null || graph.Nodes is null)
+        {
+            throw new GpCliUsageException(
+                $"Workflow graph '{path}' is empty or missing a 'nodes' array.");
+        }
+
+        return graph;
+    }
+}

--- a/src/Honua.Geoprocessing.Cli/Publish/WorkflowPackagePublishClient.cs
+++ b/src/Honua.Geoprocessing.Cli/Publish/WorkflowPackagePublishClient.cs
@@ -1,0 +1,291 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Honua.Core.Features.WorkflowPackages.Domain;
+
+namespace Honua.Geoprocessing.Cli.Publish;
+
+/// <summary>
+/// Raised when a Console workflow-package REST call returns a non-success status.
+/// </summary>
+internal sealed class GpPublishHttpException(string message) : Exception(message);
+
+/// <summary>
+/// Aggregated result of the <c>save → version → validate → dry-run → (publish)</c> sequence
+/// the devkit drives against the Console workflow-package REST surface.
+/// </summary>
+internal sealed record GpPublishResult
+{
+    /// <summary>The saved (or replaced) package draft.</summary>
+    public required WorkflowPackage Package { get; init; }
+
+    /// <summary>The immutable version created from the draft, when one was created.</summary>
+    public WorkflowPackageVersion? Version { get; init; }
+
+    /// <summary>The validate result, when validate was requested.</summary>
+    public WorkflowPackageValidationResult? Validation { get; init; }
+
+    /// <summary>The bounded dry-run result, when dry-run was requested.</summary>
+    public WorkflowDryRunResult? DryRun { get; init; }
+
+    /// <summary>The publication, when the version was published to a target.</summary>
+    public WorkflowPublication? Publication { get; init; }
+}
+
+/// <summary>
+/// Thin REST client that drives the Console workflow-package endpoints exactly as the Console UI
+/// does. It honors an admin API key (default) or a bearer token, and serializes with the same
+/// camelCase + string-enum policy the server uses.
+/// </summary>
+/// <remarks>
+/// The <see cref="HttpClient"/> is injected so offline unit tests can supply a faked
+/// <see cref="HttpMessageHandler"/> and assert the call sequence, payload mapping, and auth header
+/// without a live server.
+/// </remarks>
+internal sealed class WorkflowPackagePublishClient
+{
+    private const string ApiKeyHeader = "X-API-Key";
+
+    private readonly HttpClient _http;
+
+    /// <summary>
+    /// Creates a client over an already-configured <see cref="HttpClient"/> whose
+    /// <see cref="HttpClient.BaseAddress"/> is the server root (e.g. <c>http://localhost:8080</c>).
+    /// </summary>
+    /// <param name="http">The transport; the caller owns its lifetime.</param>
+    /// <param name="apiKey">Admin API key sent as <c>X-API-Key</c>. Mutually exclusive with a bearer token.</param>
+    /// <param name="bearerToken">Bearer token sent as <c>Authorization: Bearer</c>. Mutually exclusive with the API key.</param>
+    public WorkflowPackagePublishClient(HttpClient http, string? apiKey = null, string? bearerToken = null)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+
+        if (!string.IsNullOrWhiteSpace(bearerToken))
+        {
+            _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+        }
+        else if (!string.IsNullOrWhiteSpace(apiKey))
+        {
+            _http.DefaultRequestHeaders.Remove(ApiKeyHeader);
+            _http.DefaultRequestHeaders.Add(ApiKeyHeader, apiKey);
+        }
+    }
+
+    /// <summary>Base path for the Console workflow-package surface (API version 1.0).</summary>
+    internal const string BasePath = "/api/v1/console/workflow-packages";
+
+    /// <summary>
+    /// Saves the package draft (creating or replacing it), creates an immutable version, and then
+    /// optionally validates, dry-runs, and publishes. The sequence mirrors the Console authoring flow.
+    /// </summary>
+    /// <param name="request">The package save body carrying the graph payload.</param>
+    /// <param name="validate">Call the version validate endpoint.</param>
+    /// <param name="dryRun">Call the version dry-run endpoint.</param>
+    /// <param name="publish">Publish the created version to <paramref name="publishRequest"/>'s target.</param>
+    /// <param name="publishRequest">Publication target body; required when <paramref name="publish"/> is true.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task<GpPublishResult> SaveVersionAndPublishAsync(
+        SaveWorkflowPackageRequestDto request,
+        bool validate,
+        bool dryRun,
+        bool publish,
+        PublishWorkflowPackageRequestDto? publishRequest,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var package = await SavePackageAsync(request, cancellationToken).ConfigureAwait(false);
+        var version = await CreateVersionAsync(package.PackageId, cancellationToken).ConfigureAwait(false);
+
+        WorkflowPackageValidationResult? validation = null;
+        if (validate)
+        {
+            validation = await ValidateVersionAsync(package.PackageId, version.Version, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        WorkflowDryRunResult? dryRunResult = null;
+        if (dryRun)
+        {
+            dryRunResult = await DryRunVersionAsync(package.PackageId, version.Version, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        WorkflowPublication? publication = null;
+        if (publish)
+        {
+            ArgumentNullException.ThrowIfNull(publishRequest);
+            publication = await PublishVersionAsync(
+                    package.PackageId,
+                    version.Version,
+                    publishRequest,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return new GpPublishResult
+        {
+            Package = package,
+            Version = version,
+            Validation = validation,
+            DryRun = dryRunResult,
+            Publication = publication
+        };
+    }
+
+    /// <summary>
+    /// Validates and dry-runs a draft graph WITHOUT publishing: it still saves a draft and
+    /// creates an immutable version (the validate/dry-run endpoints operate on a version), then
+    /// reports validation + dry-run. No publication is created.
+    /// </summary>
+    public async Task<GpPublishResult> DryRunOnlyAsync(
+        SaveWorkflowPackageRequestDto request,
+        CancellationToken cancellationToken = default)
+        => await SaveVersionAndPublishAsync(
+                request,
+                validate: true,
+                dryRun: true,
+                publish: false,
+                publishRequest: null,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+    private async Task<WorkflowPackage> SavePackageAsync(
+        SaveWorkflowPackageRequestDto request,
+        CancellationToken cancellationToken)
+    {
+        using var content = JsonContent.Create(request, options: GpPublishJson.Options);
+        using var response = await _http.PostAsync(BasePath, content, cancellationToken).ConfigureAwait(false);
+        return await ReadDataAsync<WorkflowPackage>(response, "save package", cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<WorkflowPackageVersion> CreateVersionAsync(string packageId, CancellationToken cancellationToken)
+    {
+        var path = $"{BasePath}/{Uri.EscapeDataString(packageId)}/versions";
+        using var response = await _http.PostAsync(path, content: null, cancellationToken).ConfigureAwait(false);
+        return await ReadDataAsync<WorkflowPackageVersion>(response, "create version", cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<WorkflowPackageValidationResult> ValidateVersionAsync(
+        string packageId,
+        int version,
+        CancellationToken cancellationToken)
+    {
+        var path = $"{BasePath}/{Uri.EscapeDataString(packageId)}/versions/{version}/validate";
+        using var response = await _http.PostAsync(path, content: null, cancellationToken).ConfigureAwait(false);
+        return await ReadDataAsync<WorkflowPackageValidationResult>(response, "validate version", cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<WorkflowDryRunResult> DryRunVersionAsync(
+        string packageId,
+        int version,
+        CancellationToken cancellationToken)
+    {
+        var path = $"{BasePath}/{Uri.EscapeDataString(packageId)}/versions/{version}/dry-run";
+        using var response = await _http.PostAsync(path, content: null, cancellationToken).ConfigureAwait(false);
+        return await ReadDataAsync<WorkflowDryRunResult>(response, "dry-run version", cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<WorkflowPublication> PublishVersionAsync(
+        string packageId,
+        int version,
+        PublishWorkflowPackageRequestDto request,
+        CancellationToken cancellationToken)
+    {
+        var path = $"{BasePath}/{Uri.EscapeDataString(packageId)}/versions/{version}/publish";
+        using var content = JsonContent.Create(request, options: GpPublishJson.Options);
+        using var response = await _http.PostAsync(path, content, cancellationToken).ConfigureAwait(false);
+        return await ReadDataAsync<WorkflowPublication>(response, "publish version", cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task<T> ReadDataAsync<T>(
+        HttpResponseMessage response,
+        string operation,
+        CancellationToken cancellationToken)
+    {
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var detail = ExtractMessage(body) ?? body;
+            throw new GpPublishHttpException(
+                $"Failed to {operation}: {(int)response.StatusCode} {response.StatusCode}. {Trim(detail)}");
+        }
+
+        ApiResponseDto<T>? envelope;
+        try
+        {
+            envelope = System.Text.Json.JsonSerializer.Deserialize<ApiResponseDto<T>>(body, GpPublishJson.Options);
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            throw new GpPublishHttpException($"Failed to {operation}: could not parse server response ({ex.Message}).");
+        }
+
+        if (envelope is null || !envelope.Success || envelope.Data is null)
+        {
+            throw new GpPublishHttpException(
+                $"Failed to {operation}: server reported failure. {Trim(envelope?.Message)}");
+        }
+
+        return envelope.Data;
+    }
+
+    private static string? ExtractMessage(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = System.Text.Json.JsonDocument.Parse(body);
+            var root = document.RootElement;
+            if (root.ValueKind == System.Text.Json.JsonValueKind.Object)
+            {
+                if (root.TryGetProperty("message", out var message) &&
+                    message.ValueKind == System.Text.Json.JsonValueKind.String)
+                {
+                    return message.GetString();
+                }
+
+                if (root.TryGetProperty("detail", out var detail) &&
+                    detail.ValueKind == System.Text.Json.JsonValueKind.String)
+                {
+                    return detail.GetString();
+                }
+            }
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            // Non-JSON error body (e.g. a plain 401 challenge); fall through to raw text.
+        }
+
+        return null;
+    }
+
+    private static string Trim(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var collapsed = value.Trim();
+        return collapsed.Length <= 400 ? collapsed : collapsed[..397] + "...";
+    }
+
+    /// <summary>
+    /// Indicates whether a status is one the publish flow treats as an auth failure, for
+    /// clearer messaging in the command layer.
+    /// </summary>
+    internal static bool IsAuthFailure(HttpStatusCode status)
+        => status is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden;
+}

--- a/tests/dotnet/Honua.Architecture.Tests/ModuleDependencyPolicyTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/ModuleDependencyPolicyTests.cs
@@ -571,6 +571,23 @@ public sealed class ModuleDependencyPolicyTests
             return ModuleRole.Unclassified;
         }
 
+        // Dev-tool CLIs (e.g. the GP Devkit's `honua-gp`, project
+        // Honua.Geoprocessing.Cli) are tooling, not runtime topology. They are
+        // packaged as local dotnet tools (PackAsTool) and are DELIBERATELY kept
+        // out of the AOT-published server surface — nothing in Honua.Server
+        // references them, so the AOT publish never pulls them in. Like tests /
+        // samples / benchmarks, they may reference whatever runtime module they
+        // drive (the GP CLI re-uses the real Honua.Geoprocessing + Honua.Worker.Gdal
+        // executor set), so they fall through to the default tooling policy
+        // rather than the runtime dependency-direction matrix. This guard must
+        // precede the family-prefix checks below, otherwise "Honua.Geoprocessing.Cli"
+        // would match the "Honua.Geoprocessing." prefix and be misclassified as a
+        // runtime Geoprocessing consumer.
+        if (projectName.EndsWith(".Cli", StringComparison.Ordinal))
+        {
+            return ModuleRole.Unclassified;
+        }
+
         // Tier 1: Abstractions — must come before Core because of the prefix.
         if (projectName.Equals("Honua.Core.Abstractions", StringComparison.Ordinal))
         {

--- a/tests/dotnet/Honua.Geoprocessing.Cli.Tests/GpPublishCommandTests.cs
+++ b/tests/dotnet/Honua.Geoprocessing.Cli.Tests/GpPublishCommandTests.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Geoprocessing.Cli.Publish;
+using Xunit;
+
+namespace Honua.Geoprocessing.Cli.Tests;
+
+public sealed class GpPublishCommandTests : IDisposable
+{
+    private readonly string _fixtureRoot = Path.Combine(
+        Path.GetTempPath(),
+        "gp-publish-cmd-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_fixtureRoot))
+        {
+            Directory.Delete(_fixtureRoot, recursive: true);
+        }
+    }
+
+    private const string PackageJson = """{"packageId":"my-flow","name":"My Flow","graph":{"schemaVersion":"workflow-package.v1","nodes":[]},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"}""";
+    private const string VersionJson = """{"packageId":"my-flow","version":7,"schemaVersion":"workflow-package.v1","packageHash":"hash-7","graph":{"schemaVersion":"workflow-package.v1","nodes":[]},"validation":{"isValid":true},"createdAt":"2026-01-01T00:00:00Z"}""";
+    private const string ValidationJson = """{"isValid":true,"packageHash":"hash-7"}""";
+    private const string DryRunJson = """{"validation":{"isValid":true},"estimatedDurationSeconds":4,"estimatedCostWeight":2.0,"packageHash":"hash-7"}""";
+    private const string PublicationJson = """{"publicationId":"pub-9","packageId":"my-flow","packageVersion":7,"packageHash":"hash-7","target":"ProcessEndpoint","endpointPath":"/rest/.../GPServer","eligibility":{"isValid":true},"createdAt":"2026-01-01T00:00:00Z"}""";
+
+    private sealed class StubCatalog(params ProcessDefinition[] processes) : IProcessCatalog
+    {
+        public ProcessDefinition? GetProcess(string processId)
+            => processes.FirstOrDefault(p => p.ProcessId == processId);
+
+        public IReadOnlyList<ProcessDefinition> ListProcesses() => processes;
+
+        public IReadOnlyList<ProcessDefinition> GetProcessesByCategory(string category)
+            => processes.Where(p => p.Category == category).ToArray();
+    }
+
+    private static ProcessDefinition BufferProcess()
+        => new()
+        {
+            ProcessId = "geometry.buffer",
+            Title = "Buffer",
+            Description = "Buffer",
+            Category = "geometry",
+            Parameters = [],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer]
+        };
+
+    private void WriteFixture(string id, string json)
+    {
+        Directory.CreateDirectory(Path.Combine(_fixtureRoot, id));
+        File.WriteAllText(Path.Combine(_fixtureRoot, id, "workflow.json"), json);
+    }
+
+    private async Task<(int Exit, string Out, string Err, RecordingHttpMessageHandler? Handler)> RunAsync(
+        string[] args,
+        Action<RecordingHttpMessageHandler>? configure = null)
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var processIds = new HashSet<string>(StringComparer.Ordinal) { "geometry.buffer" };
+        var catalog = new StubCatalog(BufferProcess());
+        RecordingHttpMessageHandler? handler = null;
+
+        WorkflowPackagePublishClient Factory(GpPublishOptions options)
+        {
+            handler = new RecordingHttpMessageHandler();
+            configure?.Invoke(handler);
+            var http = new HttpClient(handler) { BaseAddress = new Uri(options.Server) };
+            return new WorkflowPackagePublishClient(http, options.ApiKey, options.BearerToken);
+        }
+
+        // Append the temp fixture root via the public option by injecting it through args is not
+        // supported, so we resolve it directly: tests that need fixtures pass --file instead, and
+        // the fixtureRoot default is exercised by GpWorkflowSourceTests. For command tests we use
+        // --file or a registered process id.
+        var exit = await GpPublishCommand.RunAsync(args, processIds, catalog, Factory, output, error);
+        return (exit, output.ToString(), error.ToString(), handler);
+    }
+
+    [Fact]
+    public async Task Run_CodeProcessWithoutWrapFlag_PrintsImageGuidance_AndExitsZero()
+    {
+        var (exit, output, _, handler) = await RunAsync(["geometry.buffer"]);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("not published", output, StringComparison.Ordinal);
+        Assert.Contains("server image", output, StringComparison.Ordinal);
+        // No HTTP calls were made for a non-publishable code process.
+        Assert.Null(handler);
+    }
+
+    [Fact]
+    public async Task Run_UnknownId_ExitsTwo()
+    {
+        var (exit, output, _, handler) = await RunAsync(["totally-unknown"]);
+
+        Assert.Equal(2, exit);
+        Assert.Contains("not published", output, StringComparison.Ordinal);
+        Assert.Null(handler);
+    }
+
+    [Fact]
+    public async Task Run_ProcessNode_Publish_DrivesFullSequence_AndReportsNextStep()
+    {
+        var (exit, output, _, handler) = await RunAsync(
+            ["geometry.buffer", "--as-process-node", "--publish", "--api-key", "k"],
+            h => h
+                .RespondCreated("/workflow-packages", PackageJson)
+                .RespondCreated("/versions", VersionJson)
+                .RespondOk("/validate", ValidationJson)
+                .RespondOk("/publish", PublicationJson));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("version   : 7", output, StringComparison.Ordinal);
+        Assert.Contains("hash      : hash-7", output, StringComparison.Ordinal);
+        Assert.Contains("published : pub-9", output, StringComparison.Ordinal);
+        Assert.Contains("GitOps", output, StringComparison.Ordinal);
+        Assert.Contains("does NOT deploy across envs", output, StringComparison.Ordinal);
+
+        Assert.NotNull(handler);
+        Assert.Equal("k", handler!.Requests[0].ApiKeyHeader);
+        Assert.EndsWith("/publish", handler.Requests[^1].Path, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Run_DryRun_DoesNotPublish_AndSaysNothingWasPublished()
+    {
+        var (exit, output, _, handler) = await RunAsync(
+            ["geometry.buffer", "--as-process-node", "--dry-run"],
+            h => h
+                .RespondCreated("/workflow-packages", PackageJson)
+                .RespondCreated("/versions", VersionJson)
+                .RespondOk("/validate", ValidationJson)
+                .RespondOk("/dry-run", DryRunJson));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("dry-run", output, StringComparison.Ordinal);
+        Assert.Contains("Nothing was published", output, StringComparison.Ordinal);
+        Assert.NotNull(handler);
+        Assert.DoesNotContain(handler!.Requests, r => r.Path.EndsWith("/publish", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Run_HttpError_PrintsError_AndExitsOne()
+    {
+        var (exit, _, err, _) = await RunAsync(
+            ["geometry.buffer", "--as-process-node"],
+            h => h.Respond("/workflow-packages", System.Net.HttpStatusCode.Forbidden, "{\"message\":\"forbidden\"}"));
+
+        Assert.Equal(1, exit);
+        Assert.Contains("error", err, StringComparison.Ordinal);
+        Assert.Contains("403", err, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ParseOptions_DefaultsServerToLocalQuickstart()
+    {
+        var options = GpPublishCommand.ParseOptions(["my-flow"]);
+
+        Assert.Equal("my-flow", options.Id);
+        Assert.Equal("http://localhost:8080", options.Server);
+    }
+
+    [Fact]
+    public void ParseOptions_DryRunAndPublish_AreMutuallyExclusive()
+    {
+        Assert.Throws<GpCliUsageException>(() =>
+            GpPublishCommand.ParseOptions(["my-flow", "--dry-run", "--publish"]));
+    }
+
+    [Fact]
+    public void ParseOptions_ReadsServerApiKeyAndFlags()
+    {
+        var options = GpPublishCommand.ParseOptions(
+            ["my-flow", "--server", "http://h:9", "--api-key", "abc", "--message", "msg", "--publish", "--as-process-node"]);
+
+        Assert.Equal("http://h:9", options.Server);
+        Assert.Equal("abc", options.ApiKey);
+        Assert.Equal("msg", options.Message);
+        Assert.True(options.Publish);
+        Assert.True(options.AsProcessNode);
+    }
+
+    [Fact]
+    public void ParseOptions_MissingId_Throws()
+    {
+        Assert.Throws<GpCliUsageException>(() => GpPublishCommand.ParseOptions([]));
+    }
+}

--- a/tests/dotnet/Honua.Geoprocessing.Cli.Tests/GpWorkflowSourceTests.cs
+++ b/tests/dotnet/Honua.Geoprocessing.Cli.Tests/GpWorkflowSourceTests.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Geoprocessing.Cli.Publish;
+using Xunit;
+
+namespace Honua.Geoprocessing.Cli.Tests;
+
+public sealed class GpWorkflowSourceTests : IDisposable
+{
+    private readonly string _fixtureRoot = Path.Combine(
+        Path.GetTempPath(),
+        "gp-publish-tests-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_fixtureRoot))
+        {
+            Directory.Delete(_fixtureRoot, recursive: true);
+        }
+    }
+
+    private sealed class StubCatalog(params ProcessDefinition[] processes) : IProcessCatalog
+    {
+        private readonly Dictionary<string, ProcessDefinition> _byId =
+            processes.ToDictionary(p => p.ProcessId, StringComparer.Ordinal);
+
+        public ProcessDefinition? GetProcess(string processId)
+            => _byId.GetValueOrDefault(processId);
+
+        public IReadOnlyList<ProcessDefinition> ListProcesses() => processes;
+
+        public IReadOnlyList<ProcessDefinition> GetProcessesByCategory(string category)
+            => processes.Where(p => p.Category == category).ToArray();
+    }
+
+    private static ProcessDefinition BufferProcess()
+        => new()
+        {
+            ProcessId = "geometry.buffer",
+            Title = "Buffer",
+            Description = "Buffer a geometry",
+            Category = "geometry",
+            Parameters =
+            [
+                new ProcessParameterSpec
+                {
+                    Name = "distance",
+                    DisplayName = "Distance",
+                    Description = "Buffer distance",
+                    ValueType = ProcessParameterValueType.FloatingPoint,
+                    Required = true,
+                    DefaultValue = "10"
+                },
+                new ProcessParameterSpec
+                {
+                    Name = "wkb",
+                    DisplayName = "Geometry",
+                    Description = "Input geometry",
+                    ValueType = ProcessParameterValueType.Wkb,
+                    Required = true
+                }
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer],
+            RuntimeProfile = "managed"
+        };
+
+    private GpWorkflowSource CreateSource(params string[] registeredIds)
+        => new(new StubCatalog(BufferProcess()), registeredIds.ToHashSet(StringComparer.Ordinal));
+
+    [Fact]
+    public void Resolve_CodeProcessWithoutWrapFlag_IsNotPublishable_AndExplainsImageDeploy()
+    {
+        var source = CreateSource("geometry.buffer");
+
+        var result = source.Resolve("geometry.buffer", filePath: null, asProcessNode: false, name: null, _fixtureRoot);
+
+        Assert.False(result.CanPublish);
+        Assert.Equal("code process", result.Kind);
+        Assert.Equal("geometry.buffer", result.ProcessId);
+        Assert.Contains("server image", result.Reason, StringComparison.Ordinal);
+        Assert.Contains("--as-process-node", result.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Resolve_CodeProcessWithWrapFlag_BuildsSingleProcessNodeGraph()
+    {
+        var source = CreateSource("geometry.buffer");
+
+        var result = source.Resolve("geometry.buffer", filePath: null, asProcessNode: true, name: null, _fixtureRoot);
+
+        Assert.True(result.CanPublish);
+        Assert.Equal("workflow (process node)", result.Kind);
+        var node = Assert.Single(result.Graph!.Nodes);
+        Assert.Equal("process:geometry.buffer", node.NodeTypeId);
+        // Default-valued parameters are seeded; required-without-default are not.
+        Assert.Equal("10", node.Parameters["distance"]);
+        Assert.False(node.Parameters.ContainsKey("wkb"));
+    }
+
+    [Fact]
+    public void Resolve_WorkflowFixture_IsPublishable()
+    {
+        Directory.CreateDirectory(Path.Combine(_fixtureRoot, "my-flow"));
+        File.WriteAllText(
+            Path.Combine(_fixtureRoot, "my-flow", "workflow.json"),
+            """{"schemaVersion":"workflow-package.v1","nodes":[{"nodeId":"n1","nodeTypeId":"process:geometry.buffer"}]}""");
+
+        var source = CreateSource("geometry.buffer");
+
+        var result = source.Resolve("my-flow", filePath: null, asProcessNode: false, name: null, _fixtureRoot);
+
+        Assert.True(result.CanPublish);
+        Assert.Equal("workflow (fixture)", result.Kind);
+        Assert.Single(result.Graph!.Nodes);
+    }
+
+    [Fact]
+    public void Resolve_ExplicitFile_OverridesFixtureAndProcess()
+    {
+        var path = Path.Combine(_fixtureRoot, "explicit.json");
+        Directory.CreateDirectory(_fixtureRoot);
+        File.WriteAllText(
+            path,
+            """{"schemaVersion":"workflow-package.v1","nodes":[{"nodeId":"a","nodeTypeId":"process:geometry.area"},{"nodeId":"b","nodeTypeId":"process:geometry.buffer"}]}""");
+
+        var source = CreateSource("geometry.buffer");
+
+        var result = source.Resolve("geometry.buffer", filePath: path, asProcessNode: false, name: "named", _fixtureRoot);
+
+        Assert.True(result.CanPublish);
+        Assert.Equal("workflow (file)", result.Kind);
+        Assert.Equal("named", result.Name);
+        Assert.Equal(2, result.Graph!.Nodes.Count);
+    }
+
+    [Fact]
+    public void Resolve_UnknownId_IsNotPublishable_AndIsAnError()
+    {
+        var source = CreateSource("geometry.buffer");
+
+        var result = source.Resolve("does-not-exist", filePath: null, asProcessNode: false, name: null, _fixtureRoot);
+
+        Assert.False(result.CanPublish);
+        Assert.Equal("unknown", result.Kind);
+        Assert.Contains("does-not-exist", result.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Resolve_MissingFile_ThrowsUsageException()
+    {
+        var source = CreateSource("geometry.buffer");
+
+        Assert.Throws<GpCliUsageException>(() =>
+            source.Resolve("x", filePath: Path.Combine(_fixtureRoot, "nope.json"), asProcessNode: false, name: null, _fixtureRoot));
+    }
+}

--- a/tests/dotnet/Honua.Geoprocessing.Cli.Tests/Honua.Geoprocessing.Cli.Tests.csproj
+++ b/tests/dotnet/Honua.Geoprocessing.Cli.Tests/Honua.Geoprocessing.Cli.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591;CA1861;CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Honua.Geoprocessing.Cli\Honua.Geoprocessing.Cli.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/dotnet/Honua.Geoprocessing.Cli.Tests/RecordingHttpMessageHandler.cs
+++ b/tests/dotnet/Honua.Geoprocessing.Cli.Tests/RecordingHttpMessageHandler.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+
+namespace Honua.Geoprocessing.Cli.Tests;
+
+/// <summary>
+/// A faked <see cref="HttpMessageHandler"/> that records every request (method, path, captured
+/// auth headers, and body) and replies with queued canned responses keyed by path suffix. Lets the
+/// publish-flow tests assert the call sequence, payload mapping, and auth header fully offline.
+/// </summary>
+internal sealed class RecordingHttpMessageHandler : HttpMessageHandler
+{
+    private readonly List<(string Suffix, HttpStatusCode Status, string Body)> _responses = [];
+
+    public List<RecordedRequest> Requests { get; } = [];
+
+    /// <summary>Queues a 200 response with an <c>ApiResponse</c>-shaped JSON body for the path suffix.</summary>
+    public RecordingHttpMessageHandler RespondOk(string suffix, string dataJson)
+    {
+        _responses.Add((suffix, HttpStatusCode.OK, $"{{\"success\":true,\"data\":{dataJson}}}"));
+        return this;
+    }
+
+    /// <summary>Queues a 201 response with an <c>ApiResponse</c>-shaped JSON body for the path suffix.</summary>
+    public RecordingHttpMessageHandler RespondCreated(string suffix, string dataJson)
+    {
+        _responses.Add((suffix, HttpStatusCode.Created, $"{{\"success\":true,\"data\":{dataJson}}}"));
+        return this;
+    }
+
+    /// <summary>Queues a raw status + body response for the path suffix (e.g. an auth failure).</summary>
+    public RecordingHttpMessageHandler Respond(string suffix, HttpStatusCode status, string body)
+    {
+        _responses.Add((suffix, status, body));
+        return this;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var path = request.RequestUri!.AbsolutePath;
+        string? body = null;
+        if (request.Content is not null)
+        {
+            body = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        request.Headers.TryGetValues("X-API-Key", out var apiKeyValues);
+
+        Requests.Add(new RecordedRequest(
+            request.Method.Method,
+            path,
+            apiKeyValues is null ? null : string.Join(",", apiKeyValues),
+            request.Headers.Authorization?.ToString(),
+            body));
+
+        var match = _responses.FirstOrDefault(r => path.EndsWith(r.Suffix, StringComparison.Ordinal));
+        if (match.Suffix is null)
+        {
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent($"{{\"success\":false,\"message\":\"no canned response for {path}\"}}")
+            };
+        }
+
+        return new HttpResponseMessage(match.Status)
+        {
+            Content = new StringContent(match.Body)
+        };
+    }
+}
+
+/// <summary>A single recorded outbound request.</summary>
+internal sealed record RecordedRequest(
+    string Method,
+    string Path,
+    string? ApiKeyHeader,
+    string? AuthorizationHeader,
+    string? Body);

--- a/tests/dotnet/Honua.Geoprocessing.Cli.Tests/WorkflowPackagePublishClientTests.cs
+++ b/tests/dotnet/Honua.Geoprocessing.Cli.Tests/WorkflowPackagePublishClientTests.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using Honua.Core.Features.WorkflowPackages.Domain;
+using Honua.Geoprocessing.Cli.Publish;
+using Xunit;
+
+namespace Honua.Geoprocessing.Cli.Tests;
+
+public sealed class WorkflowPackagePublishClientTests
+{
+    private const string PackageJson = """{"packageId":"my-flow","name":"My Flow","graph":{"schemaVersion":"workflow-package.v1","nodes":[]},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"}""";
+    private const string VersionJson = """{"packageId":"my-flow","version":3,"schemaVersion":"workflow-package.v1","packageHash":"abc123","graph":{"schemaVersion":"workflow-package.v1","nodes":[]},"validation":{"isValid":true},"createdAt":"2026-01-01T00:00:00Z"}""";
+    private const string ValidationJson = """{"isValid":true,"packageHash":"abc123"}""";
+    private const string DryRunJson = """{"validation":{"isValid":true},"estimatedDurationSeconds":5,"estimatedCostWeight":1.5,"packageHash":"abc123"}""";
+    private const string PublicationJson = """{"publicationId":"pub-1","packageId":"my-flow","packageVersion":3,"packageHash":"abc123","target":"ProcessEndpoint","eligibility":{"isValid":true},"createdAt":"2026-01-01T00:00:00Z"}""";
+
+    private static SaveWorkflowPackageRequestDto SampleRequest()
+        => new()
+        {
+            PackageId = "my-flow",
+            Name = "My Flow",
+            Graph = new WorkflowGraph { Nodes = [] }
+        };
+
+    private static (WorkflowPackagePublishClient Client, RecordingHttpMessageHandler Handler) CreateClient(
+        Action<RecordingHttpMessageHandler> configure,
+        string? apiKey = "secret-key",
+        string? bearer = null)
+    {
+        var handler = new RecordingHttpMessageHandler();
+        configure(handler);
+        var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:8080") };
+        return (new WorkflowPackagePublishClient(http, apiKey, bearer), handler);
+    }
+
+    [Fact]
+    public async Task SaveVersionAndPublish_WithoutPublish_CallsSaveThenVersionThenValidate()
+    {
+        var (client, handler) = CreateClient(h => h
+            .RespondCreated("/workflow-packages", PackageJson)
+            .RespondCreated("/versions", VersionJson)
+            .RespondOk("/validate", ValidationJson));
+
+        var result = await client.SaveVersionAndPublishAsync(
+            SampleRequest(), validate: true, dryRun: false, publish: false, publishRequest: null);
+
+        // Exact call sequence: save -> create version -> validate.
+        Assert.Collection(
+            handler.Requests,
+            r => Assert.Equal(("POST", "/api/v1/console/workflow-packages"), (r.Method, r.Path)),
+            r => Assert.Equal(("POST", "/api/v1/console/workflow-packages/my-flow/versions"), (r.Method, r.Path)),
+            r => Assert.Equal(("POST", "/api/v1/console/workflow-packages/my-flow/versions/3/validate"), (r.Method, r.Path)));
+
+        Assert.Equal("my-flow", result.Package.PackageId);
+        Assert.Equal(3, result.Version!.Version);
+        Assert.Equal("abc123", result.Version.PackageHash);
+        Assert.True(result.Validation!.IsValid);
+        Assert.Null(result.Publication);
+    }
+
+    [Fact]
+    public async Task DryRunOnly_DoesNotCallPublishEndpoint()
+    {
+        var (client, handler) = CreateClient(h => h
+            .RespondCreated("/workflow-packages", PackageJson)
+            .RespondCreated("/versions", VersionJson)
+            .RespondOk("/validate", ValidationJson)
+            .RespondOk("/dry-run", DryRunJson));
+
+        var result = await client.DryRunOnlyAsync(SampleRequest());
+
+        Assert.NotNull(result.Validation);
+        Assert.NotNull(result.DryRun);
+        Assert.Null(result.Publication);
+        // No request path ends with /publish.
+        Assert.DoesNotContain(handler.Requests, r => r.Path.EndsWith("/publish", StringComparison.Ordinal));
+        // Dry-run endpoint WAS hit.
+        Assert.Contains(handler.Requests, r => r.Path.EndsWith("/dry-run", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task SaveVersionAndPublish_WithPublish_CallsPublishEndpointLast()
+    {
+        var (client, handler) = CreateClient(h => h
+            .RespondCreated("/workflow-packages", PackageJson)
+            .RespondCreated("/versions", VersionJson)
+            .RespondOk("/validate", ValidationJson)
+            .RespondOk("/publish", PublicationJson));
+
+        var publishRequest = new PublishWorkflowPackageRequestDto
+        {
+            Target = WorkflowPublicationTarget.ProcessEndpoint,
+            ProcessId = "geometry.buffer"
+        };
+
+        var result = await client.SaveVersionAndPublishAsync(
+            SampleRequest(), validate: true, dryRun: false, publish: true, publishRequest);
+
+        Assert.NotNull(result.Publication);
+        Assert.Equal("pub-1", result.Publication!.PublicationId);
+        Assert.Equal(
+            "/api/v1/console/workflow-packages/my-flow/versions/3/publish",
+            handler.Requests[^1].Path);
+    }
+
+    [Fact]
+    public async Task SaveRequest_SerializesGraphAndProcessNode_WithCamelCaseAndStringEnums()
+    {
+        var (client, handler) = CreateClient(h => h
+            .RespondCreated("/workflow-packages", PackageJson)
+            .RespondCreated("/versions", VersionJson)
+            .RespondOk("/validate", ValidationJson));
+
+        var request = new SaveWorkflowPackageRequestDto
+        {
+            PackageId = "my-flow",
+            Name = "My Flow",
+            Graph = new WorkflowGraph
+            {
+                Nodes =
+                [
+                    new WorkflowNode { NodeId = "n1", NodeTypeId = "process:geometry.buffer" }
+                ],
+                Edges =
+                [
+                    new WorkflowEdge
+                    {
+                        SourceNodeId = "n1",
+                        TargetNodeId = "n2",
+                        Kind = WorkflowEdgeKind.Control
+                    }
+                ]
+            }
+        };
+
+        await client.SaveVersionAndPublishAsync(
+            request, validate: true, dryRun: false, publish: false, publishRequest: null);
+
+        var saveBody = handler.Requests[0].Body!;
+        // camelCase property names.
+        Assert.Contains("\"packageId\":\"my-flow\"", saveBody, StringComparison.Ordinal);
+        Assert.Contains("\"nodeTypeId\":\"process:geometry.buffer\"", saveBody, StringComparison.Ordinal);
+        Assert.Contains("\"schemaVersion\":\"workflow-package.v1\"", saveBody, StringComparison.Ordinal);
+        // Enum serialized as the string name, not a number.
+        Assert.Contains("\"kind\":\"Control\"", saveBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"kind\":1", saveBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApiKey_IsSentAsXApiKeyHeader()
+    {
+        var (client, handler) = CreateClient(
+            h => h.RespondCreated("/workflow-packages", PackageJson).RespondCreated("/versions", VersionJson),
+            apiKey: "secret-key");
+
+        await client.SaveVersionAndPublishAsync(
+            SampleRequest(), validate: false, dryRun: false, publish: false, publishRequest: null);
+
+        Assert.Equal("secret-key", handler.Requests[0].ApiKeyHeader);
+        Assert.Null(handler.Requests[0].AuthorizationHeader);
+    }
+
+    [Fact]
+    public async Task BearerToken_IsSentAsAuthorizationHeader_AndTakesPrecedenceOverApiKey()
+    {
+        var (client, handler) = CreateClient(
+            h => h.RespondCreated("/workflow-packages", PackageJson).RespondCreated("/versions", VersionJson),
+            apiKey: "secret-key",
+            bearer: "tok-123");
+
+        await client.SaveVersionAndPublishAsync(
+            SampleRequest(), validate: false, dryRun: false, publish: false, publishRequest: null);
+
+        Assert.Equal("Bearer tok-123", handler.Requests[0].AuthorizationHeader);
+        Assert.Null(handler.Requests[0].ApiKeyHeader);
+    }
+
+    [Fact]
+    public async Task NonSuccessStatus_RaisesHttpException_WithServerMessage()
+    {
+        var (client, _) = CreateClient(h => h
+            .Respond("/workflow-packages", HttpStatusCode.Unauthorized, "{\"message\":\"Admin authorization required.\"}"));
+
+        var ex = await Assert.ThrowsAsync<GpPublishHttpException>(() =>
+            client.SaveVersionAndPublishAsync(
+                SampleRequest(), validate: false, dryRun: false, publish: false, publishRequest: null));
+
+        Assert.Contains("401", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("Admin authorization required", ex.Message, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## GP Devkit P9 — `honua gp publish` (Closes #2176)

A CLI bridge that pushes a locally-authored workflow into the versioned **WorkflowPackage store** via the Console REST surface, closing the loop between the devkit's local run/test loop (P2) and the GitOps cross-env release path.

> **Stacks on #2171** (`feat/gp-devkit-p2-runner-cli`). Base is the P2 branch; retarget to `trunk` once #2171 merges.

### Publish semantics — process vs workflow
The single most important scope decision (per the issue's scope check):

- A built-in geoprocessing **process** (e.g. `geometry.buffer`) is **CODE** that ships in the server image, not a data artifact. `gp publish <processId>` prints that guidance and **exits 0 without publishing** — code processes deploy by releasing a new server image, not through the package store.
- An authored **workflow** (a `WorkflowGraph` of nodes/edges, what the Console map-builder produces) **is** the data artifact the store versions. Resolved from `samples/gp/<id>/workflow.json` or an explicit `--file <workflow.json>`.
- `--as-process-node` wraps a single registered process into a one-node (`process:<id>`) graph — mirroring dropping a process onto the Console canvas — so it can publish as a process-endpoint package.

### Call sequence (mirrors the Console UI against the real request models)
`POST /workflow-packages` (save) → `POST /{id}/versions` (immutable version) → `/validate` → (`/dry-run`) → optional `/publish`.

- `--dry-run` validates + dry-runs **without** creating a publication.
- Auth: admin `X-API-Key` (default `$HONUA_ADMIN_PASSWORD`) or `--bearer`.
- `--server` defaults to the local quickstart `http://localhost:8080`.
- Output is honest: reports package id / version / hash and the **next step** — publish only writes a package; the metadata-release + GitOps path promotes it across environments. It does **not** deploy across envs.

### CI / AOT
- Nothing in `Honua.Server` references the CLI — AOT publish surface unchanged.
- Tests live in their own `Honua.Geoprocessing.Cli.Tests` assembly with a dedicated ADR-0037 shard (`GP Devkit CLI`); `validate-ci-router.sh` passes.
- The `honua-gp` dev-tool CLI is classified as **Unclassified tooling** in the ADR-0047 module-dependency test (like tests/samples/benchmarks) — it is `PackAsTool` dev tooling outside the runtime topology, so its reuse of the real `Honua.Geoprocessing` + `Honua.Worker.Gdal` executor set is not a runtime matrix edge. (This also clears a pre-existing violation the P2 CLI introduced.)

### Tests — 22 offline unit tests, no live server
Faked `HttpMessageHandler` asserts: payload mapping (process/workflow → WorkflowPackage/WorkflowGraph, camelCase + string enums), the save→version→validate→dry-run→publish sequence, dry-run-doesn't-publish, the `X-API-Key`/bearer header, and the code-process-vs-workflow semantics.

```
Passed!  - Failed: 0, Passed: 22  (Honua.Geoprocessing.Cli.Tests)
Passed!  - Failed: 0, Passed: 25  (Honua.Architecture.Tests)
```

### Demo (offline)
```
$ honua gp publish geometry.buffer
kind    : code process
result  : not published
reason  : '...' is CODE that ships with the server image ... re-run with --as-process-node ...   [exit 0]

$ honua gp publish buffer-and-area --dry-run    # resolves samples/gp/buffer-and-area/workflow.json,
                                                  # builds payload, calls the live console endpoint
```