### PR TITLE
feat: select GP Batch job-definition tier by ephemeral need

### DIFF
--- a/src/Honua.Aws/Features/ControlPlane/AwsBatchComputeBackend.cs
+++ b/src/Honua.Aws/Features/ControlPlane/AwsBatchComputeBackend.cs
@@ -23,6 +23,160 @@ internal static class AwsBatchParameterKeys
     public const string GpuCount = "batch.gpu_count";
     public const string RetryAttempts = "batch.retry_attempts";
     public const string ShareIdentifier = "batch.share_identifier";
+
+    /// <summary>
+    /// Per-tier job-definition ARN keys exposed by the honua-iac serverless module's
+    /// fixed job-definition pool (honua-iac#70). The pool mints four job definitions that
+    /// differ only by ephemeral (scratch) storage — the one knob AWS Batch SubmitJob cannot
+    /// override. The runtime selects a tier by the job's ephemeral-storage floor and submits
+    /// against that tier's ARN. The suffix is the tier id (<c>s</c>/<c>m</c>/<c>l</c>/<c>xl</c>):
+    /// <c>batch.job_definition_arn.s</c> = 20 GiB, <c>.m</c> = 50 GiB, <c>.l</c> = 100 GiB,
+    /// <c>.xl</c> = 200 GiB.
+    /// </summary>
+    public const string JobDefinitionArnTierPrefix = JobDefinitionArn + ".";
+
+    /// <summary>
+    /// Optional per-job ephemeral (scratch) storage need, in GiB, used to pick a job-definition
+    /// tier from the pool. Sourced from the GP job's request. Absent or non-positive values fall
+    /// back to the smallest tier (<c>s</c>, 20 GiB).
+    /// </summary>
+    public const string EphemeralGib = "batch.ephemeral_gib";
+}
+
+/// <summary>
+/// Resolves the effective AWS Batch job-definition ARN for a job by selecting a size tier from
+/// the honua-iac job-definition pool (honua-iac#70) by the job's ephemeral-storage need.
+/// </summary>
+/// <remarks>
+/// The pool's four tiers differ only by ephemeral (scratch) storage, the one knob SubmitJob
+/// cannot override: <c>s</c>=20, <c>m</c>=50, <c>l</c>=100, <c>xl</c>=200 GiB. vCPU/memory/
+/// timeout/retry stay SubmitJob overrides and are unaffected by tier selection. The
+/// ephemeral-need ceilings are inclusive and mirror the honua-devops sizing-hint boundaries
+/// exactly (<c>≤20→s</c>, <c>≤50→m</c>, <c>≤100→l</c>, <c>≤200→xl</c>, <c>&gt;200</c> rejected).
+/// </remarks>
+internal static class AwsBatchJobDefinitionTierSelector
+{
+    /// <summary>Smallest tier (Fargate default ephemeral storage of 20 GiB).</summary>
+    internal const string DefaultTier = "s";
+
+    private const int CeilingSmall = 20;
+    private const int CeilingMedium = 50;
+    private const int CeilingLarge = 100;
+    private const int CeilingExtraLarge = 200;
+
+    /// <summary>
+    /// Resolves the job-definition ARN the backend should submit against.
+    /// </summary>
+    /// <remarks>
+    /// Back-compat: when no per-tier keys are configured the single
+    /// <see cref="AwsBatchParameterKeys.JobDefinitionArn"/> is required and returned unchanged,
+    /// preserving existing non-tiered ControlPlane:ExecutionWorkloads configs. When tier keys are
+    /// present, the job's ephemeral need selects the tier and that tier's ARN is returned.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when neither tier keys nor a single ARN are configured, when the ephemeral need
+    /// exceeds the 200 GiB pool ceiling, or when the selected tier's ARN is not configured.
+    /// </exception>
+    public static string ResolveJobDefinitionArn(IReadOnlyDictionary<string, string> parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        if (!HasTierKeys(parameters))
+        {
+            // No tier pool configured: fall back to the single ARN (non-tiered configs).
+            if (parameters.TryGetValue(AwsBatchParameterKeys.JobDefinitionArn, out var single)
+                && !string.IsNullOrWhiteSpace(single))
+            {
+                return single.Trim();
+            }
+
+            throw new InvalidOperationException(
+                $"AWS Batch submission requires parameter '{AwsBatchParameterKeys.JobDefinitionArn}' "
+                + $"or a per-tier '{AwsBatchParameterKeys.JobDefinitionArnTierPrefix}<tier>' pool.");
+        }
+
+        var ephemeralGib = ResolveEphemeralGib(parameters);
+        var tier = MapEphemeralGibToTier(ephemeralGib);
+        var tierKey = AwsBatchParameterKeys.JobDefinitionArnTierPrefix + tier;
+
+        if (parameters.TryGetValue(tierKey, out var arn) && !string.IsNullOrWhiteSpace(arn))
+        {
+            return arn.Trim();
+        }
+
+        throw new InvalidOperationException(
+            $"AWS Batch job needs the '{tier}' job-definition tier (ephemeral {ephemeralGib} GiB) "
+            + $"but parameter '{tierKey}' is not configured.");
+    }
+
+    /// <summary>
+    /// Maps an ephemeral-storage need (GiB) to a pool tier id using inclusive ceilings that mirror
+    /// the honua-devops sizing-hint boundaries: <c>≤20→s</c>, <c>≤50→m</c>, <c>≤100→l</c>,
+    /// <c>≤200→xl</c>. A need above 200 GiB exceeds the Fargate/pool ceiling and is rejected.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the need exceeds 200 GiB.</exception>
+    public static string MapEphemeralGibToTier(int ephemeralGib)
+    {
+        if (ephemeralGib <= CeilingSmall)
+        {
+            return "s";
+        }
+
+        if (ephemeralGib <= CeilingMedium)
+        {
+            return "m";
+        }
+
+        if (ephemeralGib <= CeilingLarge)
+        {
+            return "l";
+        }
+
+        if (ephemeralGib <= CeilingExtraLarge)
+        {
+            return "xl";
+        }
+
+        throw new InvalidOperationException(
+            $"AWS Batch job ephemeral-storage need of {ephemeralGib} GiB exceeds the {CeilingExtraLarge} GiB "
+            + "Fargate/job-definition pool ceiling (largest tier 'xl').");
+    }
+
+    /// <summary>
+    /// True when the parameters carry at least one per-tier job-definition ARN key, signalling the
+    /// tiered honua-iac contract rather than a single-ARN config.
+    /// </summary>
+    private static bool HasTierKeys(IReadOnlyDictionary<string, string> parameters)
+    {
+        foreach (var entry in parameters)
+        {
+            if (entry.Key.StartsWith(AwsBatchParameterKeys.JobDefinitionArnTierPrefix, StringComparison.Ordinal)
+                && !string.IsNullOrWhiteSpace(entry.Value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Reads the job's ephemeral need (GiB) from <see cref="AwsBatchParameterKeys.EphemeralGib"/>.
+    /// Absent, unparseable, or non-positive values default to the smallest tier's 20 GiB so a job
+    /// with no hint lands on <c>s</c>.
+    /// </summary>
+    private static int ResolveEphemeralGib(IReadOnlyDictionary<string, string> parameters)
+    {
+        if (parameters.TryGetValue(AwsBatchParameterKeys.EphemeralGib, out var raw)
+            && !string.IsNullOrWhiteSpace(raw)
+            && int.TryParse(raw.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            && parsed > 0)
+        {
+            return parsed;
+        }
+
+        return CeilingSmall;
+    }
 }
 
 /// <summary>
@@ -233,7 +387,10 @@ internal sealed partial class AwsBatchComputeBackend(
         cancellationToken.ThrowIfCancellationRequested();
 
         var parameters = job.Spec.Parameters;
-        var jobDefinition = GetRequiredParameter(parameters, AwsBatchParameterKeys.JobDefinitionArn);
+        // Select the job-definition tier from the honua-iac pool by the job's ephemeral-storage
+        // need (honua-iac#70); falls back to the single batch.job_definition_arn for non-tiered
+        // configs. vCPU/memory/timeout/retry stay SubmitJob overrides below.
+        var jobDefinition = AwsBatchJobDefinitionTierSelector.ResolveJobDefinitionArn(parameters);
         var jobQueue = GetRequiredParameter(parameters, AwsBatchParameterKeys.JobQueueArn);
         var region = GetOptionalParameter(parameters, AwsBatchParameterKeys.Region);
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/AwsBatchComputeBackendTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/AwsBatchComputeBackendTests.cs
@@ -76,6 +76,72 @@ public sealed class AwsBatchComputeBackendTests
     }
 
     [Fact]
+    public async Task StartAsync_SelectsTierJobDefinitionFromEphemeralHint()
+    {
+        var client = new StubAwsBatchJobClient
+        {
+            NextSubmitResult = new AwsBatchSubmitResult
+            {
+                JobId = "aws-job-tier",
+                JobArn = "arn:aws:batch:us-west-2:123:job/aws-job-tier",
+                JobName = "honua-op-tier"
+            }
+        };
+
+        var backend = CreateBackend(client);
+        var job = CreateJob(parameters: new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [AwsBatchParameterKeys.JobDefinitionArnTierPrefix + "s"] = "arn:aws:batch:us-west-2:123:job-definition/gp-s:1",
+            [AwsBatchParameterKeys.JobDefinitionArnTierPrefix + "m"] = "arn:aws:batch:us-west-2:123:job-definition/gp-m:1",
+            [AwsBatchParameterKeys.JobDefinitionArnTierPrefix + "l"] = "arn:aws:batch:us-west-2:123:job-definition/gp-l:1",
+            [AwsBatchParameterKeys.JobDefinitionArnTierPrefix + "xl"] = "arn:aws:batch:us-west-2:123:job-definition/gp-xl:1",
+            [AwsBatchParameterKeys.EphemeralGib] = "75",
+            [AwsBatchParameterKeys.JobQueueArn] = "arn:aws:batch:us-west-2:123:job-queue/gp",
+            [AwsBatchParameterKeys.Vcpus] = "4",
+            [AwsBatchParameterKeys.MemoryMib] = "8192"
+        });
+
+        var result = await backend.StartAsync(job);
+
+        result.Status.Should().Be(ExecutionJobStatus.Queued);
+        client.LastSubmission.Should().NotBeNull();
+        // 75 GiB falls in the (50,100] band -> 'l' tier.
+        client.LastSubmission!.JobDefinition.Should().Be("arn:aws:batch:us-west-2:123:job-definition/gp-l:1");
+        // vCPU/memory remain SubmitJob overrides regardless of tier selection.
+        client.LastSubmission.Vcpus.Should().Be(4);
+        client.LastSubmission.MemoryMib.Should().Be(8192);
+        // The tier and ephemeral keys are batch.* params and must not leak as env overrides.
+        client.LastSubmission.EnvironmentOverrides.Should()
+            .NotContain(entry => entry.Name.Contains("job_definition_arn") || entry.Name.Contains("ephemeral"));
+    }
+
+    [Fact]
+    public async Task StartAsync_DefaultsToSmallestTier_WhenNoEphemeralHint()
+    {
+        var client = new StubAwsBatchJobClient
+        {
+            NextSubmitResult = new AwsBatchSubmitResult
+            {
+                JobId = "aws-job-tier-default",
+                JobArn = "arn:aws:batch:us-west-2:123:job/aws-job-tier-default",
+                JobName = "honua-op-tier-default"
+            }
+        };
+
+        var backend = CreateBackend(client);
+        var job = CreateJob(parameters: new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [AwsBatchParameterKeys.JobDefinitionArnTierPrefix + "s"] = "arn:aws:batch:us-west-2:123:job-definition/gp-s:1",
+            [AwsBatchParameterKeys.JobDefinitionArnTierPrefix + "xl"] = "arn:aws:batch:us-west-2:123:job-definition/gp-xl:1",
+            [AwsBatchParameterKeys.JobQueueArn] = "arn:aws:batch:us-west-2:123:job-queue/gp"
+        });
+
+        await backend.StartAsync(job);
+
+        client.LastSubmission!.JobDefinition.Should().Be("arn:aws:batch:us-west-2:123:job-definition/gp-s:1");
+    }
+
+    [Fact]
     public async Task StartAsync_ThrowsWhenJobDefinitionMissing()
     {
         var backend = CreateBackend(new StubAwsBatchJobClient());

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/AwsBatchJobDefinitionTierSelectorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/AwsBatchJobDefinitionTierSelectorTests.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Unit tests for the AWS Batch job-definition tier selector. The selector maps a job's
+/// ephemeral-storage need onto the honua-iac job-definition pool (honua-iac#70) and resolves
+/// the selected tier's ARN, while preserving the single-ARN back-compat path.
+/// </summary>
+public sealed class AwsBatchJobDefinitionTierSelectorTests
+{
+    private const string ArnS = "arn:aws:batch:us-west-2:123:job-definition/gp-s:1";
+    private const string ArnM = "arn:aws:batch:us-west-2:123:job-definition/gp-m:1";
+    private const string ArnL = "arn:aws:batch:us-west-2:123:job-definition/gp-l:1";
+    private const string ArnXl = "arn:aws:batch:us-west-2:123:job-definition/gp-xl:1";
+
+    // Inclusive-ceiling boundary cases mirroring the honua-devops sizing hint:
+    // ≤20→s, ≤50→m, ≤100→l, ≤200→xl.
+    [Theory]
+    [InlineData(1, "s")]
+    [InlineData(20, "s")]
+    [InlineData(21, "m")]
+    [InlineData(50, "m")]
+    [InlineData(51, "l")]
+    [InlineData(100, "l")]
+    [InlineData(101, "xl")]
+    [InlineData(200, "xl")]
+    public void MapEphemeralGibToTier_UsesInclusiveCeilings(int ephemeralGib, string expectedTier)
+    {
+        AwsBatchJobDefinitionTierSelector.MapEphemeralGibToTier(ephemeralGib)
+            .Should().Be(expectedTier);
+    }
+
+    [Theory]
+    [InlineData(201)]
+    [InlineData(500)]
+    [InlineData(int.MaxValue)]
+    public void MapEphemeralGibToTier_RejectsAboveCeiling(int ephemeralGib)
+    {
+        var act = () => AwsBatchJobDefinitionTierSelector.MapEphemeralGibToTier(ephemeralGib);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*exceeds*200 GiB*");
+    }
+
+    [Theory]
+    [InlineData("20", ArnS)]
+    [InlineData("21", ArnM)]
+    [InlineData("50", ArnM)]
+    [InlineData("51", ArnL)]
+    [InlineData("100", ArnL)]
+    [InlineData("101", ArnXl)]
+    [InlineData("200", ArnXl)]
+    public void ResolveJobDefinitionArn_SelectsTierArnFromEphemeralHint(string ephemeralGib, string expectedArn)
+    {
+        var parameters = TieredPool();
+        parameters[AwsBatchParameterKeys.EphemeralGib] = ephemeralGib;
+
+        AwsBatchJobDefinitionTierSelector.ResolveJobDefinitionArn(parameters)
+            .Should().Be(expectedArn);
+    }
+
+    [Fact]
+    public void ResolveJobDefinitionArn_DefaultsToSmallestTier_WhenNoEphemeralHint()
+    {
+        var parameters = TieredPool();
+
+        AwsBatchJobDefinitionTierSelector.ResolveJobDefinitionArn(parameters)
+            .Should().Be(ArnS);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("0")]
+    [InlineData("-5")]
+    [InlineData("not-a-number")]
+    public void ResolveJobDefinitionArn_DefaultsToSmallestTier_WhenHintNullOrInvalid(string ephemeralGib)
+    {
+        var parameters = TieredPool();
+        parameters[AwsBatchParameterKeys.EphemeralGib] = ephemeralGib;
+
+        AwsBatchJobDefinitionTierSelector.ResolveJobDefinitionArn(parameters)
+            .Should().Be(ArnS);
+    }
+
+    [Fact]
+    public void ResolveJobDefinitionArn_RejectsWhenEphemeralExceedsCeiling()
+    {
+        var parameters = TieredPool();
+        parameters[AwsBatchParameterKeys.EphemeralGib] = "201";
+
+        var act = () => AwsBatchJobDefinitionTierSelector.ResolveJobDefinitionArn(parameters);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*exceeds*200 GiB*");
+    }
+
+    [Fact]
+    public void ResolveJobDefinitionArn_ThrowsWhenSelectedTierArnMissing()
+    {
+        // Pool missing the 'l' tier; a 100 GiB job needs 'l'.
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [AwsBatchParameterKeys.JobDefinitionArnTierPrefix + "s"] = ArnS,
+            [AwsBatchParameterKeys.JobDefinitionArnTierPrefix + "m"] = ArnM,
+            [AwsBatchParameterKeys.JobDefinitionArnTierPrefix + "xl"] = ArnXl,
+            [AwsBatchParameterKeys.EphemeralGib] = "100"
+        };
+
+        var act = () => AwsBatchJobDefinitionTierSelector.ResolveJobDefinitionArn(parameters);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{AwsBatchParameterKeys.JobDefinitionArnTierPrefix}l*not configured*");
+    }
+
+    [Fact]
+    public void ResolveJobDefinitionArn_UsesSingleArn_WhenNoTierKeysConfigured()
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [AwsBatchParameterKeys.JobDefinitionArn] = ArnS
+        };
+
+        AwsBatchJobDefinitionTierSelector.ResolveJobDefinitionArn(parameters)
+            .Should().Be(ArnS);
+    }
+
+    [Fact]
+    public void ResolveJobDefinitionArn_IgnoresEphemeralHint_OnSingleArnBackCompatPath()
+    {
+        // A non-tiered config with a stray ephemeral hint still returns the single ARN
+        // rather than attempting tier resolution against keys that do not exist.
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [AwsBatchParameterKeys.JobDefinitionArn] = ArnL,
+            [AwsBatchParameterKeys.EphemeralGib] = "100"
+        };
+
+        AwsBatchJobDefinitionTierSelector.ResolveJobDefinitionArn(parameters)
+            .Should().Be(ArnL);
+    }
+
+    [Fact]
+    public void ResolveJobDefinitionArn_PrefersTierKeys_WhenBothSingleAndTierConfigured()
+    {
+        var parameters = TieredPool();
+        parameters[AwsBatchParameterKeys.JobDefinitionArn] = "arn:aws:batch:us-west-2:123:job-definition/legacy:9";
+        parameters[AwsBatchParameterKeys.EphemeralGib] = "100";
+
+        AwsBatchJobDefinitionTierSelector.ResolveJobDefinitionArn(parameters)
+            .Should().Be(ArnL);
+    }
+
+    [Fact]
+    public void ResolveJobDefinitionArn_ThrowsWhenNeitherSingleNorTierConfigured()
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [AwsBatchParameterKeys.JobQueueArn] = "arn:aws:batch:us-west-2:123:job-queue/gp"
+        };
+
+        var act = () => AwsBatchJobDefinitionTierSelector.ResolveJobDefinitionArn(parameters);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{AwsBatchParameterKeys.JobDefinitionArn}*");
+    }
+
+    private static Dictionary<string, string> TieredPool()
+        => new(StringComparer.Ordinal)
+        {
+            [AwsBatchParameterKeys.JobDefinitionArnTierPrefix + "s"] = ArnS,
+            [AwsBatchParameterKeys.JobDefinitionArnTierPrefix + "m"] = ArnM,
+            [AwsBatchParameterKeys.JobDefinitionArnTierPrefix + "l"] = ArnL,
+            [AwsBatchParameterKeys.JobDefinitionArnTierPrefix + "xl"] = ArnXl,
+        };
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2165
Related to #2166

## Summary
honua-iac#70 replaced the single `batch.job_definition_arn` AWS-Batch workload parameter with a fixed **pool of four size tiers** (`batch.job_definition_arn.{s,m,l,xl}`) that differ only by ephemeral (scratch) storage — the one knob AWS Batch `SubmitJob` cannot override (`s`=20, `m`=50, `l`=100, `xl`=200 GiB). This is the server leg of that design correction: the runtime now selects a job-definition tier by a GP job's ephemeral-storage need and submits against that tier's ARN, so GP-on-Batch keeps working against the tiered honua-iac contract. Non-tiered configs that still set a single `batch.job_definition_arn` keep working unchanged.

## Changes Made
- Add `AwsBatchJobDefinitionTierSelector` (`Honua.Aws`): resolves the effective job-definition ARN by the job's ephemeral need. Reads `batch.ephemeral_gib` from the job spec params (defaults to the smallest tier `s` when absent/non-positive/unparseable) and maps need → tier with inclusive ceilings mirroring the honua-devops sizing-hint boundaries: `≤20→s, ≤50→m, ≤100→l, ≤200→xl, >200→reject` (clear error at the 200 GiB Fargate/pool ceiling). Resolves the selected tier to its `batch.job_definition_arn.<tier>` ARN with a clear error if that tier key is missing.
- `AwsBatchComputeBackend.StartAsync` now resolves the job-definition ARN via the selector instead of reading `batch.job_definition_arn` directly. `vCPU`/`memory`/`timeout`/`retry` remain `SubmitJob` overrides, unchanged.
- Back-compat preserved: when no per-tier keys are present, the single `batch.job_definition_arn` is still required and used.
- Add `batch.job_definition_arn.<tier>` (tier-prefix) and `batch.ephemeral_gib` parameter-key constants.
- Tests: selector boundary cases (null/0/20/21/50/51/100/101/200/>200→reject), tier→ARN resolution, default-to-`s`, single-ARN back-compat, prefer-tier-when-both, missing-tier error; backend tier-selection `SubmitJob` assertions (vCPU/memory still overridden; tier/ephemeral keys not leaked as env overrides).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] None — no docs or contract impact

The server now consumes the tiered `batch.job_definition_arn.{s,m,l,xl}` + `batch.ephemeral_gib` contract from honua-iac#70.

## Release/Deploy Impact
- [x] Requires infrastructure changes
- [ ] None — standard merge-and-release flow

Pairs with honua-iac#70 (the tier pool) and the honua-devops adapter sizing hint. Environments still configured with a single `batch.job_definition_arn` are unaffected.

## Breaking Changes
None — single-ARN configs keep working; tier selection only activates when per-tier keys are present.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
