### PR TITLE
feat: bridge workflow publish into the metadata-release lifecycle (#2176)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -13229,6 +13229,7 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.WorkflowPackages.WorkflowPackageEndpointsTests.DataWiredWorkflow_ValidatesAndPublishesToScheduleButRejectsSingleJobTargets",
+        "Honua.Server.Tests.Features.WorkflowPackages.WorkflowPackageEndpointsTests.PublishVersion_EmitsWorkflowMetadataReleaseArtifact",
         "Honua.Server.Tests.Features.WorkflowPackages.WorkflowPackageEndpointsTests.PublishVersion_WithDuplicatePublicationId_ReturnsConflict",
         "Honua.Server.Tests.Features.WorkflowPackages.WorkflowPackageEndpointsTests.WorkflowLifecycle_ValidatesDryRunsPublishesTargetsAndStampsJobProvenance"
       ],

--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataReleaseEnums.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataReleaseEnums.cs
@@ -38,6 +38,15 @@ public enum MetadataSemanticArtifactKind
     /// <summary>A Metadata v2 role.</summary>
     [JsonStringEnumMemberName("role")]
     Role,
+
+    /// <summary>
+    /// A published workflow / geoprocessing package version. Workflow artifacts are not
+    /// nodes in the Metadata v2 environment graph; they are emitted directly onto a release
+    /// package by the workflow-package publish path so the GitOps changeset builder can promote
+    /// them. Publishing a workflow is additive and never resolves against a v2 graph snapshot.
+    /// </summary>
+    [JsonStringEnumMemberName("workflow")]
+    Workflow,
 }
 
 /// <summary>

--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataReleaseJsonContext.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataReleaseJsonContext.cs
@@ -26,6 +26,7 @@ namespace Honua.Core.Features.Metadata.Domain.V2;
 [JsonSerializable(typeof(MetadataBoundStorageSummary))]
 [JsonSerializable(typeof(MetadataBoundConnectionSummary))]
 [JsonSerializable(typeof(CreateMetadataReleasePackageRequest))]
+[JsonSerializable(typeof(CreateWorkflowReleasePackageRequest))]
 [JsonSerializable(typeof(MetadataReleasePackage))]
 [JsonSerializable(typeof(MetadataReleasePackageSummary))]
 [JsonSerializable(typeof(MetadataReleasePackageListResponse))]

--- a/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataReleaseModels.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Domain/V2/MetadataReleaseModels.cs
@@ -448,6 +448,57 @@ public sealed record CreateMetadataReleasePackageRequest
 }
 
 /// <summary>
+/// Request to emit a metadata release package for a published workflow / geoprocessing
+/// package version. Unlike <see cref="CreateMetadataReleasePackageRequest"/>, this does not
+/// resolve semantic ids against a Metadata v2 graph snapshot: a workflow is not a graph node,
+/// so the publish path supplies the artifact identity (semantic id, version, content hash)
+/// directly and the service records a single <see cref="MetadataSemanticArtifactKind.Workflow"/>
+/// entry. A workflow publish is additive (<see cref="MetadataReleaseChangeClass.Content"/>).
+/// </summary>
+public sealed record CreateWorkflowReleasePackageRequest
+{
+    /// <summary>Stable semantic identifier for the published workflow (for example <c>workflow.{packageId}</c>).</summary>
+    [JsonPropertyName("semanticId")]
+    public required string SemanticId { get; init; }
+
+    /// <summary>Workflow package identifier.</summary>
+    [JsonPropertyName("packageId")]
+    public required string PackageId { get; init; }
+
+    /// <summary>Published workflow package version.</summary>
+    [JsonPropertyName("packageVersion")]
+    public required int PackageVersion { get; init; }
+
+    /// <summary>Content hash of the published workflow graph; recorded as the desired content-version reference.</summary>
+    [JsonPropertyName("packageHash")]
+    public required string PackageHash { get; init; }
+
+    /// <summary>Workflow publication identifier that produced this release entry.</summary>
+    [JsonPropertyName("publicationId")]
+    public required string PublicationId { get; init; }
+
+    /// <summary>Logical source environment recorded on the package (defaults to the publication origin).</summary>
+    [JsonPropertyName("sourceEnvironment")]
+    public required string SourceEnvironment { get; init; }
+
+    /// <summary>Target environments for downstream GitOps promotion.</summary>
+    [JsonPropertyName("targetEnvironments")]
+    public IReadOnlyList<string> TargetEnvironments { get; init; } = Array.Empty<string>();
+
+    /// <summary>Optional display title.</summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>Optional namespace applied to the package.</summary>
+    [JsonPropertyName("namespace")]
+    public string? Namespace { get; init; }
+
+    /// <summary>Provenance references reused from Console content metadata.</summary>
+    [JsonPropertyName("provenance")]
+    public IReadOnlyList<ConsoleProvenanceRef> Provenance { get; init; } = Array.Empty<ConsoleProvenanceRef>();
+}
+
+/// <summary>
 /// Persisted metadata release package.
 /// </summary>
 public sealed record MetadataReleasePackage

--- a/src/Honua.Core/Features/Metadata/Abstractions/IMetadataReleaseService.cs
+++ b/src/Honua.Core/Features/Metadata/Abstractions/IMetadataReleaseService.cs
@@ -34,6 +34,19 @@ public interface IMetadataReleaseService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Emits and persists a metadata release package for a published workflow / geoprocessing
+    /// package version. The workflow is recorded as a single
+    /// <see cref="Domain.V2.MetadataSemanticArtifactKind.Workflow"/> entry without resolving it
+    /// against a Metadata v2 graph snapshot, so the downstream GitOps changeset builder can promote
+    /// the published workflow. A workflow publish is additive
+    /// (<see cref="Domain.V2.MetadataReleaseChangeClass.Content"/>).
+    /// </summary>
+    Task<MetadataReleasePackage> CreateWorkflowReleasePackageAsync(
+        CreateWorkflowReleasePackageRequest request,
+        string createdBy,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns a persisted metadata release package.
     /// </summary>
     Task<MetadataReleasePackage?> GetReleasePackageAsync(

--- a/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
+++ b/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
@@ -250,6 +250,132 @@ public sealed class MetadataReleaseService(
     }
 
     /// <inheritdoc />
+    public async Task<MetadataReleasePackage> CreateWorkflowReleasePackageAsync(
+        CreateWorkflowReleasePackageRequest request,
+        string createdBy,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.SemanticId))
+        {
+            throw new ArgumentException("Workflow semantic id is required.", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.PackageId))
+        {
+            throw new ArgumentException("Workflow package id is required.", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.PackageHash))
+        {
+            throw new ArgumentException("Workflow package hash is required.", nameof(request));
+        }
+
+        ValidateEnvironment(request.SourceEnvironment);
+        var targetEnvironments = NormalizeRequiredList(
+            request.TargetEnvironments,
+            nameof(request.TargetEnvironments),
+            MaxBindingEnvironments);
+        var provenance = NormalizeOptionalList(request.Provenance, nameof(request.Provenance));
+
+        using var activity = ActivitySource.StartActivity("honua.metadata.release.workflow.create", ActivityKind.Internal);
+        activity?.SetTag("metadata.source_environment", request.SourceEnvironment);
+        activity?.SetTag("metadata.target_environment.count", targetEnvironments.Count);
+        activity?.SetTag("metadata.workflow.package_id", request.PackageId);
+        activity?.SetTag("metadata.workflow.package_version", request.PackageVersion);
+
+        var semanticId = request.SemanticId.Trim();
+        var now = _timeProvider.GetUtcNow();
+
+        // A workflow is not a Metadata v2 graph node, so we cannot project a target binding from
+        // a snapshot. Record the entry as Missing in every target so the GitOps changeset builder
+        // treats it as an additive promotion rather than an update of an existing graph artifact.
+        var targetStates = targetEnvironments
+            .Select(environment => new MetadataReleaseTargetState
+            {
+                Environment = environment,
+                CurrentMetadataRevision = null,
+                CurrentContentVersionId = null,
+                BindingState = MetadataEnvironmentBindingState.Missing,
+            })
+            .ToArray();
+
+        var entry = new MetadataReleaseEntry
+        {
+            SemanticId = semanticId,
+            ArtifactKind = MetadataSemanticArtifactKind.Workflow,
+            ResourceType = null,
+            SourceField = null,
+            DesiredMetadataRevision = request.PackageVersion,
+            DesiredContentVersionId = request.PackageHash.Trim(),
+            DesiredProvenance = provenance,
+            // A workflow publish ships a new content version of the workflow graph; classify it as
+            // a Content (additive) change, never a destructive Delete/Binding mutation.
+            ChangeClass = MetadataReleaseChangeClass.Content,
+            TargetStates = targetStates,
+            DependentSemanticIds = Array.Empty<string>(),
+            Status = MetadataReleaseEntryStatus.Ready,
+        };
+
+        var packageId = Guid.NewGuid();
+        var packageKey = BuildWorkflowPackageKey(request, now, packageId);
+        var metadata = new MetadataV2ObjectMetadata
+        {
+            Id = packageId.ToString("D"),
+            Name = packageKey,
+            Namespace = string.IsNullOrWhiteSpace(request.Namespace) ? null : request.Namespace.Trim(),
+            Title = string.IsNullOrWhiteSpace(request.Title)
+                ? $"Workflow {request.PackageId} v{request.PackageVersion.ToString(CultureInfo.InvariantCulture)}"
+                : request.Title.Trim(),
+            Description = $"Published workflow package {request.PackageId} version {request.PackageVersion.ToString(CultureInfo.InvariantCulture)}.",
+            CreatedAt = now,
+            UpdatedAt = now,
+            Generation = 1,
+            Labels = new Dictionary<string, string>
+            {
+                ["sourceEnvironment"] = request.SourceEnvironment,
+                ["workflowPackageId"] = request.PackageId,
+                ["workflowPackageVersion"] = request.PackageVersion.ToString(CultureInfo.InvariantCulture),
+                ["workflowPublicationId"] = request.PublicationId,
+            },
+            Annotations = new Dictionary<string, string>
+            {
+                ["metadata.honua.io/workflowPackageHash"] = request.PackageHash.Trim(),
+            },
+        };
+
+        var package = new MetadataReleasePackage
+        {
+            PackageId = packageId,
+            Metadata = metadata,
+            SourceEnvironment = request.SourceEnvironment.Trim(),
+            // Workflow release packages do not derive from a Metadata v2 revision; record the
+            // package version as the source revision and the content hash as the source etag so
+            // the package remains self-describing for the GitOps changeset builder.
+            SourceRevision = request.PackageVersion,
+            SourceEtag = request.PackageHash.Trim(),
+            TargetEnvironments = targetEnvironments,
+            Entries = [entry],
+            Status = MetadataReleasePackageStatus.Ready,
+            CreatedBy = string.IsNullOrWhiteSpace(createdBy) ? "system" : createdBy.Trim(),
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        var stored = await packageStore.CreateAsync(package, cancellationToken).ConfigureAwait(false);
+        activity?.SetTag("metadata.package_id", stored.PackageId);
+        MetadataReleaseServiceLog.WorkflowPackageEmitted(
+            logger,
+            stored.PackageId,
+            request.PackageId,
+            request.PackageVersion,
+            request.PublicationId,
+            stored.TargetEnvironments.Count);
+        return stored;
+    }
+
+    /// <inheritdoc />
     public Task<MetadataReleasePackage?> GetReleasePackageAsync(
         Guid packageId,
         CancellationToken cancellationToken = default)
@@ -928,6 +1054,36 @@ public sealed class MetadataReleaseService(
         return string.Concat(result, "-", timestamp, "-", nonce);
     }
 
+    private static string BuildWorkflowPackageKey(
+        CreateWorkflowReleasePackageRequest request,
+        DateTimeOffset now,
+        Guid packageId)
+    {
+        var basis = $"workflow-{request.PackageId}-v{request.PackageVersion.ToString(CultureInfo.InvariantCulture)}";
+        var builder = new StringBuilder(basis.Length + 26);
+        foreach (var ch in basis.Trim().ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                builder.Append(ch);
+            }
+            else if (builder.Length > 0 && builder[^1] != '-')
+            {
+                builder.Append('-');
+            }
+        }
+
+        var result = builder.ToString().Trim('-');
+        if (string.IsNullOrEmpty(result))
+        {
+            result = "workflow-release";
+        }
+
+        var timestamp = now.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
+        var nonce = packageId.ToString("N")[..8];
+        return string.Concat(result, "-", timestamp, "-", nonce);
+    }
+
     private sealed record ResolvedSemanticArtifact(
         string SemanticId,
         MetadataSemanticArtifactKind Kind,
@@ -989,6 +1145,18 @@ internal static partial class MetadataReleaseServiceLog
         ILogger logger,
         Guid packageId,
         int entryCount);
+
+    [LoggerMessage(
+        EventId = 116305,
+        Level = LogLevel.Information,
+        Message = "Metadata release package {PackageId} emitted for workflow package {WorkflowPackageId} v{WorkflowPackageVersion} (publication {PublicationId}) targeting {TargetEnvironmentCount} environments.")]
+    public static partial void WorkflowPackageEmitted(
+        ILogger logger,
+        Guid packageId,
+        string workflowPackageId,
+        int workflowPackageVersion,
+        string publicationId,
+        int targetEnvironmentCount);
 
     [LoggerMessage(
         EventId = 116304,

--- a/src/Honua.Server/Features/Admin/MetadataReleaseEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/MetadataReleaseEndpoints.cs
@@ -289,6 +289,7 @@ internal static class MetadataReleaseEndpoints
             "catalog" => MetadataSemanticArtifactKind.Catalog,
             "policy" => MetadataSemanticArtifactKind.Policy,
             "role" => MetadataSemanticArtifactKind.Role,
+            "workflow" => MetadataSemanticArtifactKind.Workflow,
             _ => null,
         };
 

--- a/src/Honua.Server/Features/WorkflowPackages/WorkflowPackageLog.cs
+++ b/src/Honua.Server/Features/WorkflowPackages/WorkflowPackageLog.cs
@@ -39,4 +39,20 @@ internal static partial class WorkflowPackageLog
         int version,
         string publicationId,
         string runId);
+
+    [LoggerMessage(118507, LogLevel.Information, "Workflow package {PackageId} version {Version} publication {PublicationId} emitted metadata release package {ReleasePackageId}")]
+    public static partial void WorkflowReleaseArtifactEmitted(
+        ILogger logger,
+        string packageId,
+        int version,
+        string publicationId,
+        Guid releasePackageId);
+
+    [LoggerMessage(118508, LogLevel.Warning, "Workflow package {PackageId} version {Version} publication {PublicationId} failed to emit a metadata release package; the publication is saved and the artifact can be re-emitted")]
+    public static partial void WorkflowReleaseArtifactFailed(
+        ILogger logger,
+        string packageId,
+        int version,
+        string publicationId,
+        Exception exception);
 }

--- a/src/Honua.Server/Features/WorkflowPackages/WorkflowPackageService.cs
+++ b/src/Honua.Server/Features/WorkflowPackages/WorkflowPackageService.cs
@@ -7,6 +7,8 @@ using System.Security.Cryptography;
 using System.Text;
 using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Orchestration.Abstractions;
 using Honua.Core.Features.Orchestration.Domain;
 using Honua.Core.Features.WorkflowPackages.Abstractions;
@@ -23,8 +25,22 @@ internal sealed class WorkflowPackageService(
     TimeProvider clock,
     ILogger<WorkflowPackageService> logger,
     IWorkflowDefinitionStore? workflowDefinitionStore = null,
-    WorkflowOrchestrationEngine? orchestrationEngine = null)
+    WorkflowOrchestrationEngine? orchestrationEngine = null,
+    IMetadataReleaseService? metadataReleaseService = null)
 {
+    /// <summary>
+    /// Default source environment recorded on the metadata release package emitted when a
+    /// workflow version is published. Workflow packages are environment-agnostic at authoring
+    /// time; the GitOps changeset builder promotes the artifact into concrete environments.
+    /// </summary>
+    private const string WorkflowReleaseSourceEnvironment = "console";
+
+    /// <summary>
+    /// Default target environment for the emitted release package. Promotion to additional
+    /// environments is governed downstream by the GitOps release/approval path.
+    /// </summary>
+    private const string WorkflowReleaseTargetEnvironment = "production";
+
     public Task<IReadOnlyList<WorkflowPackage>> ListPackagesAsync(CancellationToken cancellationToken)
         => store.ListPackagesAsync(cancellationToken);
 
@@ -293,7 +309,66 @@ internal sealed class WorkflowPackageService(
 
         var saved = await store.SavePublicationAsync(publication, cancellationToken).ConfigureAwait(false);
         WorkflowPackageLog.PackagePublished(logger, packageId, version, publicationId, request.Target.ToString());
+
+        await EmitMetadataReleaseArtifactAsync(saved, principal, cancellationToken).ConfigureAwait(false);
         return saved;
+    }
+
+    /// <summary>
+    /// Bridges a published workflow version into the metadata-release lifecycle by recording a
+    /// Workflow-kind release-package entry. This is the publish→metadata-release→GitOps bridge:
+    /// the emitted package becomes a real release-package entry that the release lifecycle and the
+    /// downstream GitOps changeset builder can promote. The emission is best-effort — a workflow
+    /// publication is already durably saved, so a metadata-release failure must not fail the publish
+    /// (the artifact can be re-emitted), and the dependency is optional so existing wiring/tests that
+    /// do not supply <see cref="IMetadataReleaseService"/> keep working.
+    /// </summary>
+    private async Task EmitMetadataReleaseArtifactAsync(
+        WorkflowPublication publication,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken)
+    {
+        if (metadataReleaseService is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var releaseRequest = new CreateWorkflowReleasePackageRequest
+            {
+                SemanticId = $"workflow.{Slug(publication.PackageId)}",
+                PackageId = publication.PackageId,
+                PackageVersion = publication.PackageVersion,
+                PackageHash = publication.PackageHash,
+                PublicationId = publication.PublicationId,
+                SourceEnvironment = WorkflowReleaseSourceEnvironment,
+                TargetEnvironments = [WorkflowReleaseTargetEnvironment],
+                Title = $"Workflow {publication.PackageId} v{publication.PackageVersion.ToString(CultureInfo.InvariantCulture)}",
+            };
+
+            var releasePackage = await metadataReleaseService
+                .CreateWorkflowReleasePackageAsync(releaseRequest, ResolveActor(principal) ?? "system", cancellationToken)
+                .ConfigureAwait(false);
+
+            WorkflowPackageLog.WorkflowReleaseArtifactEmitted(
+                logger,
+                publication.PackageId,
+                publication.PackageVersion,
+                publication.PublicationId,
+                releasePackage.PackageId);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // The publication is already persisted; surface the failure for observability but do
+            // not roll the publish back. The release artifact can be re-emitted out of band.
+            WorkflowPackageLog.WorkflowReleaseArtifactFailed(
+                logger,
+                publication.PackageId,
+                publication.PackageVersion,
+                publication.PublicationId,
+                ex);
+        }
     }
 
     public Task<IReadOnlyList<WorkflowPublication>> ListPublicationsAsync(

--- a/src/Honua.Server/Features/WorkflowPackages/WorkflowPackageServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/WorkflowPackages/WorkflowPackageServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.WorkflowPackages.Abstractions;
+using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Orchestration.Abstractions;
 using Honua.Geoprocessing;
 using Honua.Server.Features.Orchestration;
@@ -30,7 +31,8 @@ internal static class WorkflowPackageServiceCollectionExtensions
             sp.GetRequiredService<TimeProvider>(),
             sp.GetRequiredService<ILogger<WorkflowPackageService>>(),
             sp.GetService<IWorkflowDefinitionStore>(),
-            sp.GetService<WorkflowOrchestrationEngine>()));
+            sp.GetService<WorkflowOrchestrationEngine>(),
+            sp.GetService<IMetadataReleaseService>()));
 
         return services;
     }

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataReleaseServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataReleaseServiceTests.cs
@@ -387,6 +387,125 @@ public sealed class MetadataReleaseServiceTests
         json.Should().NotContain("super-secret-password");
     }
 
+    [UnitTest]
+    public async Task CreateWorkflowReleasePackageAsync_EmitsAdditiveWorkflowEntry()
+    {
+        // No Metadata v2 graphs are required: a workflow is not a graph node, so the publish
+        // path supplies the artifact identity directly.
+        var service = CreateService();
+
+        var package = await service.CreateWorkflowReleasePackageAsync(
+            new CreateWorkflowReleasePackageRequest
+            {
+                SemanticId = "workflow.parcels-pipeline",
+                PackageId = "pkg-parcels-pipeline",
+                PackageVersion = 3,
+                PackageHash = "abc123hash",
+                PublicationId = "wfp-001",
+                SourceEnvironment = "console",
+                TargetEnvironments = ["production"],
+            },
+            "user-1");
+
+        package.Status.Should().Be(MetadataReleasePackageStatus.Ready);
+        package.SourceEnvironment.Should().Be("console");
+        package.SourceRevision.Should().Be(3);
+        package.SourceEtag.Should().Be("abc123hash");
+        package.TargetEnvironments.Should().ContainSingle().Which.Should().Be("production");
+
+        var entry = package.Entries.Should().ContainSingle().Subject;
+        entry.SemanticId.Should().Be("workflow.parcels-pipeline");
+        entry.ArtifactKind.Should().Be(MetadataSemanticArtifactKind.Workflow);
+        entry.ChangeClass.Should().Be(MetadataReleaseChangeClass.Content);
+        entry.DesiredMetadataRevision.Should().Be(3);
+        entry.DesiredContentVersionId.Should().Be("abc123hash");
+        entry.Status.Should().Be(MetadataReleaseEntryStatus.Ready);
+        entry.TargetStates.Should().ContainSingle()
+            .Which.BindingState.Should().Be(MetadataEnvironmentBindingState.Missing);
+        entry.ResourceType.Should().BeNull();
+
+        package.Metadata.Labels.Should().Contain(new KeyValuePair<string, string>("workflowPackageId", "pkg-parcels-pipeline"));
+        package.Metadata.Labels.Should().Contain(new KeyValuePair<string, string>("workflowPublicationId", "wfp-001"));
+    }
+
+    [UnitTest]
+    public async Task CreateWorkflowReleasePackageAsync_RoundTripsWorkflowKindThroughGitOpsManifest()
+    {
+        var service = CreateService();
+
+        var package = await service.CreateWorkflowReleasePackageAsync(
+            new CreateWorkflowReleasePackageRequest
+            {
+                SemanticId = "workflow.parcels-pipeline",
+                PackageId = "pkg-parcels-pipeline",
+                PackageVersion = 5,
+                PackageHash = "deadbeef",
+                PublicationId = "wfp-002",
+                SourceEnvironment = "console",
+                TargetEnvironments = ["production"],
+            },
+            "user-1");
+
+        var manifest = await service.GetGitOpsManifestAsync(package.PackageId);
+
+        manifest.Should().NotBeNull();
+        manifest!.Spec.Entries.Should().ContainSingle(entry =>
+            entry.SemanticId == "workflow.parcels-pipeline" &&
+            entry.ArtifactKind == MetadataSemanticArtifactKind.Workflow &&
+            entry.ChangeClass == MetadataReleaseChangeClass.Content &&
+            entry.DesiredMetadataRevision == 5 &&
+            entry.DesiredContentVersionId == "deadbeef");
+
+        // The new enum member must serialize/deserialize as "workflow" via the source-generated
+        // (AOT-safe) JSON context so the downstream GitOps changeset builder can consume it.
+        var json = JsonSerializer.Serialize(
+            manifest,
+            MetadataReleaseJsonContext.Default.GitOpsMetadataReleaseManifest);
+        json.Should().Contain("\"workflow\"");
+
+        var roundTripped = JsonSerializer.Deserialize(
+            json,
+            MetadataReleaseJsonContext.Default.GitOpsMetadataReleaseManifest);
+        roundTripped!.Spec.Entries.Should().ContainSingle()
+            .Which.ArtifactKind.Should().Be(MetadataSemanticArtifactKind.Workflow);
+    }
+
+    [UnitTest]
+    public async Task CreateWorkflowReleasePackageAsync_WithBlankIdentity_ThrowsValidationError()
+    {
+        var service = CreateService();
+
+        var blankSemanticId = await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.CreateWorkflowReleasePackageAsync(
+                new CreateWorkflowReleasePackageRequest
+                {
+                    SemanticId = "  ",
+                    PackageId = "pkg-1",
+                    PackageVersion = 1,
+                    PackageHash = "hash",
+                    PublicationId = "wfp-1",
+                    SourceEnvironment = "console",
+                    TargetEnvironments = ["production"],
+                },
+                "user-1"));
+        blankSemanticId.Message.Should().Contain("Workflow semantic id is required.");
+
+        var blankHash = await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.CreateWorkflowReleasePackageAsync(
+                new CreateWorkflowReleasePackageRequest
+                {
+                    SemanticId = "workflow.x",
+                    PackageId = "pkg-1",
+                    PackageVersion = 1,
+                    PackageHash = "  ",
+                    PublicationId = "wfp-1",
+                    SourceEnvironment = "console",
+                    TargetEnvironments = ["production"],
+                },
+                "user-1"));
+        blankHash.Message.Should().Contain("Workflow package hash is required.");
+    }
+
     private static MetadataReleaseService CreateService(params MetadataV2Graph[] graphs)
     {
         var reader = new StaticEnvironmentReader(graphs);

--- a/tests/dotnet/Honua.Server.Tests/Features/WorkflowPackages/WorkflowPackageEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/WorkflowPackages/WorkflowPackageEndpointsTests.cs
@@ -11,6 +11,8 @@ using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -37,6 +39,7 @@ public sealed class WorkflowPackageEndpointsTests : IAsyncLifetime
     private readonly InMemoryExecutionJobStore _jobStore = new();
     private readonly InMemoryProgressStore _progressStore = new();
     private readonly RecordingJobQueue _jobQueue = new();
+    private readonly RecordingMetadataReleaseService _releaseService = new();
     private readonly WebAppFixture _fixture;
     private HttpClient _client = null!;
 
@@ -49,9 +52,13 @@ public sealed class WorkflowPackageEndpointsTests : IAsyncLifetime
                 services.RemoveAll<IExecutionJobStore>();
                 services.RemoveAll<IJobQueue>();
                 services.RemoveAll<IUniversalProgressStore>();
+                services.RemoveAll<IMetadataReleaseService>();
                 services.AddSingleton<IExecutionJobStore>(_jobStore);
                 services.AddSingleton<IUniversalProgressStore>(_progressStore);
                 services.AddSingleton<IJobQueue>(_jobQueue);
+                // Capture the publish→metadata-release bridge deterministically without requiring an
+                // active Metadata v2 snapshot in the test environment (#2176).
+                services.AddSingleton<IMetadataReleaseService>(_releaseService);
             })
             .ConfigureWebHost(builder =>
             {
@@ -390,6 +397,38 @@ public sealed class WorkflowPackageEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("POST /api/v1/console/workflow-packages/{packageId}/versions/{packageVersion}/publish")]
+    public async Task PublishVersion_EmitsWorkflowMetadataReleaseArtifact()
+    {
+        var packageId = await CreatePackageAsync("release-bridge", CreateAreaGraph());
+        var version = await CreateVersionAsync(packageId);
+
+        await PublishAsync(packageId, version.Version, new
+        {
+            publicationId = "pub-release-bridge",
+            target = "Job",
+            enabled = true
+        });
+
+        // The publish path must bridge into the metadata-release lifecycle by emitting a
+        // Workflow-kind release-package entry that the GitOps changeset builder can promote (#2176).
+        _releaseService.Requests.Should().ContainSingle();
+        var emitted = _releaseService.Requests[0];
+        emitted.PackageId.Should().Be(packageId);
+        emitted.PackageVersion.Should().Be(version.Version);
+        emitted.PackageHash.Should().Be(version.PackageHash);
+        emitted.PublicationId.Should().Be("pub-release-bridge");
+        emitted.SemanticId.Should().StartWith("workflow.");
+        emitted.TargetEnvironments.Should().NotBeEmpty();
+
+        var package = _releaseService.LastPackage;
+        package.Should().NotBeNull();
+        package!.Entries.Should().ContainSingle()
+            .Which.ArtifactKind.Should().Be(MetadataSemanticArtifactKind.Workflow);
+        package.Entries[0].ChangeClass.Should().Be(MetadataReleaseChangeClass.Content);
+    }
+
+    [IntegrationTest]
     [Endpoint("POST /api/v1/console/workflow-publications/{publicationId}/runs")]
     public async Task RunPublication_WithReservedProvenanceOverride_PreservesStampedProvenance()
     {
@@ -588,6 +627,90 @@ public sealed class WorkflowPackageEndpointsTests : IAsyncLifetime
 
     private static async Task<JsonDocument> ReadJsonAsync(HttpResponseMessage response)
         => JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+    /// <summary>
+    /// Records workflow release-package emissions from the publish path so the publish→
+    /// metadata-release bridge can be asserted without an active Metadata v2 snapshot (#2176).
+    /// All other release-service operations are unused by these tests.
+    /// </summary>
+    private sealed class RecordingMetadataReleaseService : IMetadataReleaseService
+    {
+        public List<CreateWorkflowReleasePackageRequest> Requests { get; } = new();
+
+        public MetadataReleasePackage? LastPackage { get; private set; }
+
+        public Task<MetadataReleasePackage> CreateWorkflowReleasePackageAsync(
+            CreateWorkflowReleasePackageRequest request,
+            string createdBy,
+            CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            var now = DateTimeOffset.UtcNow;
+            var package = new MetadataReleasePackage
+            {
+                PackageId = Guid.NewGuid(),
+                Metadata = new MetadataV2ObjectMetadata
+                {
+                    Id = Guid.NewGuid().ToString("D"),
+                    Name = $"workflow-{request.PackageId}",
+                },
+                SourceEnvironment = request.SourceEnvironment,
+                SourceRevision = request.PackageVersion,
+                SourceEtag = request.PackageHash,
+                TargetEnvironments = request.TargetEnvironments,
+                Entries =
+                [
+                    new MetadataReleaseEntry
+                    {
+                        SemanticId = request.SemanticId,
+                        ArtifactKind = MetadataSemanticArtifactKind.Workflow,
+                        DesiredMetadataRevision = request.PackageVersion,
+                        DesiredContentVersionId = request.PackageHash,
+                        ChangeClass = MetadataReleaseChangeClass.Content,
+                        Status = MetadataReleaseEntryStatus.Ready,
+                    },
+                ],
+                Status = MetadataReleasePackageStatus.Ready,
+                CreatedBy = createdBy,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            LastPackage = package;
+            return Task.FromResult(package);
+        }
+
+        public Task<MetadataSemanticInventoryResponse?> GetSemanticInventoryAsync(
+            string environment,
+            MetadataSemanticInventoryFilter filter,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<MetadataEnvironmentBindingsResponse> GetEnvironmentBindingsAsync(
+            MetadataEnvironmentBindingsRequest request,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<MetadataReleasePackage> CreateReleasePackageAsync(
+            CreateMetadataReleasePackageRequest request,
+            string createdBy,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<MetadataReleasePackage?> GetReleasePackageAsync(
+            Guid packageId,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<MetadataReleasePackageListResponse> ListReleasePackagesAsync(
+            MetadataReleasePackageListFilter filter,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<GitOpsMetadataReleaseManifest?> GetGitOpsManifestAsync(
+            Guid packageId,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+    }
 
     private sealed class InMemoryExecutionJobStore : IExecutionJobStore
     {


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2176

## Summary
An independent review found the publish->metadata-release->GitOps bridge for
workflow/geoprocessing packages was comment-only: `WorkflowPackageService.PublishVersionAsync`
wrote only to the package + workflow-definition stores and emitted nothing toward
metadata-release, the release model could not represent a workflow (the
`MetadataSemanticArtifactKind` enum had no Workflow member, and release entries
are `required` over that enum), and the `gp publish` CLI told users a metadata
release picks up the package and the GitOps path promotes it — which no code
implemented. This PR makes that claim true on the server side: a published
workflow version now becomes a real metadata release-package entry that the
release lifecycle and the downstream honua-devops GitOps changeset builder can
consume.

## Changes Made
- Add a `Workflow` member to `MetadataSemanticArtifactKind` (serialized as
  `"workflow"` via the source-generated, AOT-safe `JsonStringEnumConverter`).
  All exhaustive uses stay correct: the compatibility analyzer's
  `TargetArtifactExists` expression switch already has a safe `_ => false`
  default (a workflow is never a v2 graph artifact), the `sourceArtifact.Kind`
  statement switch is a no-op for non-graph kinds, and the admin
  artifactKind-filter parser (`MetadataReleaseEndpoints`) now accepts `workflow`.
- Add `CreateWorkflowReleasePackageRequest` and
  `IMetadataReleaseService.CreateWorkflowReleasePackageAsync` (+ implementation).
  A workflow is not a Metadata v2 graph node, so this path does NOT resolve the
  artifact against a snapshot: the publish path supplies id/version/hash and the
  service records one `Workflow`-kind entry classified as additive
  (`MetadataReleaseChangeClass.Content`), `Missing` in every target environment,
  via the real `IMetadataReleasePackageStore`. It round-trips through the
  existing GitOps manifest export unchanged.
- `WorkflowPackageService.PublishVersionAsync` emits that release artifact after
  the publication is saved (wired through DI as an optional dependency). The
  emission is best-effort: a metadata-release failure logs a warning but never
  rolls back an already-durable publication, and the optional dependency keeps
  existing construction/tests working.
- Tests + regenerated `feature-catalog.json` for the new proving test.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

`Honua.Core.Tests` metadata suite 208/208 green (3 new workflow-release tests:
additive entry, GitOps-manifest enum round-trip, validation). `Honua.Architecture.Tests`
117/117 green after regenerating the feature catalog. Release build with
`TreatWarningsAsErrors=true` green for `Honua.Core` and `Honua.Server`;
`dotnet format --verify-no-changes` clean. The new workflow-publish integration
test compiles and follows the existing fixture; it runs in CI (Docker/Testcontainers
not available locally).

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Control plane SDK surface changed
<!-- New MetadataSemanticArtifactKind member + IMetadataReleaseService method. -->

## Release/Deploy Impact
- [ ] None — standard merge-and-release flow
<!-- The honua-devops MetadataReleaseChangeSetBuilder already accepts the
     Workflow kind: artifact kind is sanitized free text with no allowlist, so a
     "workflow" entry is not rejected — no coordinated honua-devops change is
     required to avoid rejection. -->

## Breaking Changes
None. The enum is additive; all existing kinds and switches keep working.

## CLI reconciliation (feat/gp-devkit-p9-publish)
The `gp publish` next-steps prose lives on the unmerged `feat/gp-devkit-p9-publish`
branch, not trunk, so it is not edited here. Once this bridge and that branch
both land, the printed claim ("a metadata release picks up the published package
and the GitOps release path promotes it") becomes accurate on the server side.
One softening to apply on that branch when it lands: promotion is NOT automatic —
the emitted release package is a draft/ready proposal that still flows through
the governed GitOps/approval path (honua-devops emits `submitImmediately=false`,
plan + pr-first). The CLI wording should say a release package is emitted for
promotion through the GitOps/approval path, not imply auto-promotion.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
