### PR TITLE
feat: route geoprocessing jobs to AWS Batch via config (#2165)

### DIFF
--- a/docs/operator/geoprocessing-aws-batch.md
+++ b/docs/operator/geoprocessing-aws-batch.md
@@ -1,0 +1,128 @@
+# Routing geoprocessing jobs to AWS Batch (#2165)
+
+By default Honua runs geoprocessing (GP) jobs on the **local / Kubernetes Job**
+baseline workload (`geoprocessing-local`). To run GP jobs on **AWS Batch**
+instead — using the Fargate job-definition pool provisioned by the
+[honua-iac](https://github.com/honua-io) serverless substrate — you supply the
+substrate ARNs to the `geoprocessing-aws-batch` execution workload that already
+ships (gated off) in `appsettings.json`.
+
+This is config-only: no code or redeploy of the GP execution logic is needed.
+
+## How routing works
+
+1. A GP job is submitted (GPServer REST, OGC API Processes, or gRPC).
+2. `GeoprocessingJobService` resolves the GP execution workload from
+   `ControlPlane:ExecutionWorkloads`. If a **fully-configured** AWS Batch
+   workload is present it is preferred over the local baseline; otherwise the
+   job falls back to `geoprocessing-local`.
+3. The workload's `Parameters` are merged onto the job's
+   `ExecutionJobSpec.Parameters`, and the job is handed to the
+   `honua-aws-batch` backend (`AwsBatchComputeBackend`).
+4. The backend selects the job-definition **tier** from the job's ephemeral
+   storage need (`batch.ephemeral_gib` → `s`/`m`/`l`/`xl`) and submits to the
+   queue.
+
+## The activation gate
+
+The committed `geoprocessing-aws-batch` workload has **empty** ARN parameters,
+so it is dropped at startup by the registry's activation gate and GP keeps
+running locally. The workload becomes active only once you provide:
+
+- `batch.job_queue_arn` — the GP job-queue ARN, **and**
+- at least one job-definition ARN — either the single `batch.job_definition_arn`
+  or one or more of the per-tier `batch.job_definition_arn.{s,m,l,xl}` keys.
+
+If those are absent, GP routing cleanly falls back to local with no change to
+existing deploys or tests.
+
+## Substrate outputs → config
+
+The honua-iac serverless module exports these outputs:
+
+| honua-iac output | Honua workload parameter |
+|---|---|
+| `gp_job_queue_arn` | `batch.job_queue_arn` |
+| `gp_job_definition_arns["s"]` | `batch.job_definition_arn.s` |
+| `gp_job_definition_arns["m"]` | `batch.job_definition_arn.m` |
+| `gp_job_definition_arns["l"]` | `batch.job_definition_arn.l` |
+| `gp_job_definition_arns["xl"]` | `batch.job_definition_arn.xl` |
+| deployment region | `batch.region` |
+
+The four tiers differ only by ephemeral (scratch) storage:
+`s` = 20 GiB, `m` = 50 GiB, `l` = 100 GiB, `xl` = 200 GiB. vCPU / memory /
+timeout / retry stay per-submit overrides and are unaffected by tier selection.
+
+> **Tier selection (dependency).** The runtime tier selector that maps
+> `batch.ephemeral_gib` to the right `batch.job_definition_arn.{tier}` lands with
+> [#2181 / `feat/gp-batch-tier-selection`](https://github.com/honua-io/honua-server/pull/2181).
+> Until that PR merges, the backend honors only the **single**
+> `batch.job_definition_arn` key. You can wire AWS Batch today by setting that
+> single key (point it at one job definition); the per-tier keys begin selecting
+> automatically once #2181 is on `trunk`. The parameter-key contract
+> (`batch.job_queue_arn`, `batch.region`, `batch.job_definition_arn`,
+> `batch.job_definition_arn.{s,m,l,xl}`) is identical on both sides.
+
+### appsettings override
+
+```json
+{
+  "ControlPlane": {
+    "ExecutionWorkloads": [
+      {
+        "WorkloadId": "geoprocessing-aws-batch",
+        "Kind": "Geoprocessing",
+        "TargetKind": "AwsBatch",
+        "Backend": "honua-aws-batch",
+        "WorkloadName": "Geoprocessing (AWS Batch)",
+        "Parameters": {
+          "batch.job_queue_arn": "arn:aws:batch:us-east-1:123456789012:job-queue/honua-gp",
+          "batch.region": "us-east-1",
+          "batch.job_definition_arn.s": "arn:aws:batch:us-east-1:123456789012:job-definition/honua-gp-s:1",
+          "batch.job_definition_arn.m": "arn:aws:batch:us-east-1:123456789012:job-definition/honua-gp-m:1",
+          "batch.job_definition_arn.l": "arn:aws:batch:us-east-1:123456789012:job-definition/honua-gp-l:1",
+          "batch.job_definition_arn.xl": "arn:aws:batch:us-east-1:123456789012:job-definition/honua-gp-xl:1"
+        }
+      }
+    ]
+  }
+}
+```
+
+> Do **not** commit account-specific ARNs into the shared `appsettings.json`.
+> Use an environment-specific override file, a mounted secret/config, or
+> environment variables.
+
+### Environment-variable override
+
+The `ExecutionWorkloads` array index of `geoprocessing-aws-batch` depends on
+your effective config (in base `appsettings.json` it is index `1`). Dotted
+parameter keys are exposed through `ParameterEntries` so they survive the
+environment-variable provider:
+
+```bash
+ControlPlane__ExecutionWorkloads__1__Parameters__batch.job_queue_arn="arn:aws:batch:us-east-1:123456789012:job-queue/honua-gp"
+ControlPlane__ExecutionWorkloads__1__Parameters__batch.region="us-east-1"
+ControlPlane__ExecutionWorkloads__1__Parameters__batch.job_definition_arn.s="arn:aws:batch:us-east-1:123456789012:job-definition/honua-gp-s:1"
+# ...m / l / xl
+```
+
+If the environment provider cannot pass dotted keys, use the
+`ParameterEntries` list form instead:
+
+```bash
+ControlPlane__ExecutionWorkloads__1__ParameterEntries__0__Key="batch.job_queue_arn"
+ControlPlane__ExecutionWorkloads__1__ParameterEntries__0__Value="arn:aws:batch:..."
+```
+
+## Verifying it routed
+
+Submit a GP job and confirm the job's spec:
+
+- `Spec.Backend == "honua-aws-batch"`
+- `Spec.TargetKind == AwsBatch`
+- `Spec.Parameters` contains `batch.job_queue_arn` and the tier ARNs
+
+A misconfigured workload (e.g. queue ARN present but no job-definition ARN)
+stays gated off and the job runs locally — check startup logs and the resolved
+`Spec.Backend` to confirm which path was taken.

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -286,7 +286,20 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         }
 
         var definitions = await _workloadRegistry.ListAsync(cancellationToken).ConfigureAwait(false);
-        return definitions.FirstOrDefault(d => d.Kind == ExecutionJobKind.Geoprocessing);
+        var geoprocessingWorkloads = definitions
+            .Where(d => d.Kind == ExecutionJobKind.Geoprocessing)
+            .ToArray();
+
+        // When the operator has supplied a remote (e.g. AWS Batch) GP workload
+        // alongside the always-present local/Kubernetes baseline, prefer the remote
+        // one so a fully-configured substrate routes GP execution off-box. The
+        // registry already drops remote workloads that are missing their required
+        // ARNs (see ExecutionWorkloadGate), so a surviving non-local workload is one
+        // the operator deliberately activated. Falling back to FirstOrDefault keeps
+        // the local-only default behavior when no remote workload is configured.
+        return geoprocessingWorkloads.FirstOrDefault(d =>
+                   !string.Equals(d.Backend, LocalBatchComputeBackend.BackendId, StringComparison.Ordinal))
+               ?? geoprocessingWorkloads.FirstOrDefault();
     }
 
     /// <summary>

--- a/src/Honua.Server/Features/ControlPlane/ConfigurationOperationCatalogs.cs
+++ b/src/Honua.Server/Features/ControlPlane/ConfigurationOperationCatalogs.cs
@@ -77,7 +77,65 @@ internal sealed class ConfigurationExecutionJobDefinitionRegistry(IOptionsMonito
                 RuntimeProfile = definition.RuntimeProfile,
                 Parameters = ConfigurationOperationCatalogHelpers.BuildParameters(definition.Parameters, definition.ParameterEntries)
             })
+            .Where(ExecutionWorkloadGate.IsActivatable)
             .ToArray();
+}
+
+/// <summary>
+/// Activation gate for configuration-declared execution workloads.
+/// </summary>
+/// <remarks>
+/// An AWS Batch workload is only usable once the operator supplies the substrate
+/// ARNs the <c>AwsBatchComputeBackend</c> requires at submit time: the job-queue ARN
+/// plus at least one job-definition ARN (either the single
+/// <c>batch.job_definition_arn</c> or one of the per-tier
+/// <c>batch.job_definition_arn.{s,m,l,xl}</c> keys). A workload row committed with
+/// empty placeholder ARNs (so the entry is discoverable in base appsettings) is
+/// therefore dropped here until those parameters are provided through an environment
+/// or appsettings override — which means submit routing cleanly falls back to the
+/// local/Kubernetes baseline workload and existing deploys (and tests) are unaffected.
+/// The parameter keys are matched as literal contract strings rather than via
+/// <c>AwsBatchParameterKeys</c> so this gate does not take a hard dependency on the
+/// optionally-excluded <c>Honua.Aws</c> assembly (HonuaIncludeAws / HONUA_EXCLUDE_AWS).
+/// </remarks>
+internal static class ExecutionWorkloadGate
+{
+    private const string JobQueueArnKey = "batch.job_queue_arn";
+    private const string JobDefinitionArnKey = "batch.job_definition_arn";
+    private const string JobDefinitionArnTierPrefix = JobDefinitionArnKey + ".";
+
+    public static bool IsActivatable(ExecutionJobDefinition definition)
+    {
+        if (definition.TargetKind != BatchComputeTargetKind.AwsBatch)
+        {
+            return true;
+        }
+
+        return HasValue(definition.Parameters, JobQueueArnKey)
+            && HasAnyJobDefinitionArn(definition.Parameters);
+    }
+
+    private static bool HasAnyJobDefinitionArn(IReadOnlyDictionary<string, string> parameters)
+    {
+        if (HasValue(parameters, JobDefinitionArnKey))
+        {
+            return true;
+        }
+
+        foreach (var entry in parameters)
+        {
+            if (entry.Key.StartsWith(JobDefinitionArnTierPrefix, StringComparison.Ordinal)
+                && !string.IsNullOrWhiteSpace(entry.Value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasValue(IReadOnlyDictionary<string, string> parameters, string key)
+        => parameters.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value);
 }
 
 internal static class ConfigurationOperationCatalogHelpers

--- a/src/Honua.Server/appsettings.json
+++ b/src/Honua.Server/appsettings.json
@@ -221,5 +221,31 @@
         "ContentSecurityPolicy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-ancestors 'none'; base-uri 'self'"
       }
     }
+  },
+  "ControlPlane": {
+    "ExecutionWorkloads": [
+      {
+        "WorkloadId": "geoprocessing-local",
+        "Kind": "Geoprocessing",
+        "TargetKind": "KubernetesJob",
+        "Backend": "local",
+        "WorkloadName": "Geoprocessing (local baseline)"
+      },
+      {
+        "WorkloadId": "geoprocessing-aws-batch",
+        "Kind": "Geoprocessing",
+        "TargetKind": "AwsBatch",
+        "Backend": "honua-aws-batch",
+        "WorkloadName": "Geoprocessing (AWS Batch)",
+        "Parameters": {
+          "batch.job_queue_arn": "",
+          "batch.region": "",
+          "batch.job_definition_arn.s": "",
+          "batch.job_definition_arn.m": "",
+          "batch.job_definition_arn.l": "",
+          "batch.job_definition_arn.xl": ""
+        }
+      }
+    ]
   }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -442,6 +442,130 @@ public sealed class GeoprocessingJobServiceTests
             Arg.Any<CancellationToken>());
     }
 
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_WithLocalAndBatchWorkloads_PrefersBatchAndCarriesTierParams()
+    {
+        // Both the always-present local baseline AND a fully-configured AWS Batch GP
+        // workload are registered. The service must prefer the Batch workload and
+        // route the job to the honua-aws-batch backend, carrying the queue + tier ARNs.
+        var workloadRegistry = Substitute.For<IExecutionJobDefinitionRegistry>();
+        var batchBackend = Substitute.For<IBatchComputeBackend>();
+        batchBackend.BackendName.Returns("honua-aws-batch");
+        batchBackend.TargetKind.Returns(BatchComputeTargetKind.AwsBatch);
+        workloadRegistry.ListAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new ExecutionJobDefinition
+            {
+                WorkloadId = "geoprocessing-local",
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "Geoprocessing (local baseline)"
+            },
+            new ExecutionJobDefinition
+            {
+                WorkloadId = "geoprocessing-aws-batch",
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.AwsBatch,
+                Backend = "honua-aws-batch",
+                WorkloadName = "Geoprocessing (AWS Batch)",
+                Parameters = new Dictionary<string, string>
+                {
+                    ["batch.job_queue_arn"] = "arn:aws:batch:us-east-1:123:job-queue/honua-gp",
+                    ["batch.region"] = "us-east-1",
+                    ["batch.job_definition_arn.s"] = "arn:aws:batch:us-east-1:123:job-definition/honua-gp-s:1",
+                    ["batch.job_definition_arn.m"] = "arn:aws:batch:us-east-1:123:job-definition/honua-gp-m:1",
+                    ["batch.job_definition_arn.l"] = "arn:aws:batch:us-east-1:123:job-definition/honua-gp-l:1",
+                    ["batch.job_definition_arn.xl"] = "arn:aws:batch:us-east-1:123:job-definition/honua-gp-xl:1"
+                }
+            }
+        });
+        batchBackend.StartAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<CancellationToken>())
+            .Returns(new BatchComputeSubmissionResult
+            {
+                Status = ExecutionJobStatus.Provisioning,
+                ProviderOperationId = "job-batch-789",
+                Message = "Submitted to AWS Batch"
+            });
+        _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var sut = new GeoprocessingJobService(
+            _progressStore,
+            [_cancellationNotifier],
+            _authEvaluator,
+            _approvalEvaluator,
+            new BuiltInProcessCatalog(),
+            NullLogger<GeoprocessingJobService>.Instance,
+            DefaultExecutorOptions,
+            _jobStore,
+            _jobQueue,
+            workloadRegistry: workloadRegistry,
+            backends: [batchBackend]);
+
+        var job = await sut.SubmitJobAsync(CreateValidPlan(), null, CreatePrincipal());
+
+        job.Spec.WorkloadId.Should().Be("geoprocessing-aws-batch");
+        job.Spec.Backend.Should().Be("honua-aws-batch");
+        job.Spec.TargetKind.Should().Be(BatchComputeTargetKind.AwsBatch);
+        job.Spec.Parameters.Should().ContainKey("batch.job_queue_arn")
+            .WhoseValue.Should().Be("arn:aws:batch:us-east-1:123:job-queue/honua-gp");
+        job.Spec.Parameters.Should().ContainKey("batch.region").WhoseValue.Should().Be("us-east-1");
+        job.Spec.Parameters.Should().ContainKey("batch.job_definition_arn.s");
+        job.Spec.Parameters.Should().ContainKey("batch.job_definition_arn.xl");
+        await batchBackend.Received().StartAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<CancellationToken>());
+        await _jobQueue.DidNotReceive().EnqueueAsync(
+            Arg.Any<string>(),
+            Arg.Any<OperationPriority>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_WithOnlyLocalWorkload_FallsBackToLocalBackend()
+    {
+        // Without an activated remote workload (the AWS Batch row gated off / absent),
+        // GP must keep routing to the local baseline backend — no regression.
+        var workloadRegistry = Substitute.For<IExecutionJobDefinitionRegistry>();
+        workloadRegistry.ListAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new ExecutionJobDefinition
+            {
+                WorkloadId = "geoprocessing-local",
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "Geoprocessing (local baseline)"
+            }
+        });
+        _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var sut = new GeoprocessingJobService(
+            _progressStore,
+            [_cancellationNotifier],
+            _authEvaluator,
+            _approvalEvaluator,
+            new BuiltInProcessCatalog(),
+            NullLogger<GeoprocessingJobService>.Instance,
+            DefaultExecutorOptions,
+            _jobStore,
+            _jobQueue,
+            workloadRegistry: workloadRegistry);
+
+        var job = await sut.SubmitJobAsync(CreateValidPlan(), null, CreatePrincipal());
+
+        job.Spec.Backend.Should().Be("local");
+        job.Spec.WorkloadId.Should().Be("geoprocessing-local");
+        await _jobQueue.Received().EnqueueAsync(
+            job.OperationId,
+            Arg.Any<OperationPriority>(),
+            Arg.Any<CancellationToken>());
+    }
+
     // -----------------------------------------------------------------------
     // GetJobAsync
     // -----------------------------------------------------------------------

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ConfigurationOperationCatalogsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ConfigurationOperationCatalogsTests.cs
@@ -89,6 +89,133 @@ public sealed class ConfigurationOperationCatalogsTests
         workload.Parameters.Should().Contain(new KeyValuePair<string, string>("image.uri", "123456789012.dkr.ecr.us-east-1.amazonaws.com/honua-gp:py311"));
     }
 
+    [Fact]
+    public async Task ExecutionJobRegistry_DropsAwsBatchWorkload_WhenSubstrateArnsAreEmpty()
+    {
+        // The committed placeholder AWS Batch GP workload ships with empty ARN
+        // parameters so it is discoverable; the activation gate must drop it until an
+        // operator override supplies the substrate ARNs, leaving local to win routing.
+        var registry = new ConfigurationExecutionJobDefinitionRegistry(
+            new TestControlPlaneOptionsMonitor(new ControlPlaneOptions
+            {
+                ExecutionWorkloads =
+                [
+                    new ExecutionWorkloadOptions
+                    {
+                        WorkloadId = "geoprocessing-local",
+                        TargetKind = global::Honua.Core.Features.ControlPlane.Domain.BatchComputeTargetKind.KubernetesJob,
+                        Backend = "local",
+                        WorkloadName = "Geoprocessing (local baseline)"
+                    },
+                    new ExecutionWorkloadOptions
+                    {
+                        WorkloadId = "geoprocessing-aws-batch",
+                        TargetKind = global::Honua.Core.Features.ControlPlane.Domain.BatchComputeTargetKind.AwsBatch,
+                        Backend = "honua-aws-batch",
+                        WorkloadName = "Geoprocessing (AWS Batch)",
+                        Parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            ["batch.job_queue_arn"] = string.Empty,
+                            ["batch.region"] = string.Empty,
+                            ["batch.job_definition_arn.s"] = string.Empty,
+                            ["batch.job_definition_arn.xl"] = string.Empty
+                        }
+                    }
+                ]
+            }));
+
+        var definitions = await registry.ListAsync();
+
+        definitions.Should().ContainSingle()
+            .Which.WorkloadId.Should().Be("geoprocessing-local");
+    }
+
+    [Fact]
+    public async Task ExecutionJobRegistry_KeepsAwsBatchWorkload_WhenQueueAndTierArnPresent()
+    {
+        var registry = new ConfigurationExecutionJobDefinitionRegistry(
+            new TestControlPlaneOptionsMonitor(new ControlPlaneOptions
+            {
+                ExecutionWorkloads =
+                [
+                    new ExecutionWorkloadOptions
+                    {
+                        WorkloadId = "geoprocessing-aws-batch",
+                        TargetKind = global::Honua.Core.Features.ControlPlane.Domain.BatchComputeTargetKind.AwsBatch,
+                        Backend = "honua-aws-batch",
+                        WorkloadName = "Geoprocessing (AWS Batch)",
+                        Parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            ["batch.job_queue_arn"] = "arn:aws:batch:us-east-1:123:job-queue/honua-gp",
+                            ["batch.job_definition_arn.s"] = "arn:aws:batch:us-east-1:123:job-definition/honua-gp-s:1"
+                        }
+                    }
+                ]
+            }));
+
+        var workload = await registry.GetAsync("geoprocessing-aws-batch");
+
+        workload.Should().NotBeNull();
+        workload!.Backend.Should().Be("honua-aws-batch");
+    }
+
+    [Fact]
+    public async Task ExecutionJobRegistry_DropsAwsBatchWorkload_WhenQueuePresentButNoJobDefinition()
+    {
+        var registry = new ConfigurationExecutionJobDefinitionRegistry(
+            new TestControlPlaneOptionsMonitor(new ControlPlaneOptions
+            {
+                ExecutionWorkloads =
+                [
+                    new ExecutionWorkloadOptions
+                    {
+                        WorkloadId = "geoprocessing-aws-batch",
+                        TargetKind = global::Honua.Core.Features.ControlPlane.Domain.BatchComputeTargetKind.AwsBatch,
+                        Backend = "honua-aws-batch",
+                        WorkloadName = "Geoprocessing (AWS Batch)",
+                        Parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            ["batch.job_queue_arn"] = "arn:aws:batch:us-east-1:123:job-queue/honua-gp"
+                        }
+                    }
+                ]
+            }));
+
+        var definitions = await registry.ListAsync();
+
+        definitions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecutionJobRegistry_KeepsAwsBatchWorkload_WhenSingleNonTieredArnPresent()
+    {
+        // Back-compat: a non-tiered config with the single batch.job_definition_arn key
+        // (the pre-tier-selection wiring path) must stay active.
+        var registry = new ConfigurationExecutionJobDefinitionRegistry(
+            new TestControlPlaneOptionsMonitor(new ControlPlaneOptions
+            {
+                ExecutionWorkloads =
+                [
+                    new ExecutionWorkloadOptions
+                    {
+                        WorkloadId = "geoprocessing-aws-batch",
+                        TargetKind = global::Honua.Core.Features.ControlPlane.Domain.BatchComputeTargetKind.AwsBatch,
+                        Backend = "honua-aws-batch",
+                        WorkloadName = "Geoprocessing (AWS Batch)",
+                        Parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            ["batch.job_queue_arn"] = "arn:aws:batch:us-east-1:123:job-queue/honua-gp",
+                            ["batch.job_definition_arn"] = "arn:aws:batch:us-east-1:123:job-definition/honua-gp:1"
+                        }
+                    }
+                ]
+            }));
+
+        var workload = await registry.GetAsync("geoprocessing-aws-batch");
+
+        workload.Should().NotBeNull();
+    }
+
     private sealed class TestControlPlaneOptionsMonitor(ControlPlaneOptions currentValue) : IOptionsMonitor<ControlPlaneOptions>
     {
         public ControlPlaneOptions CurrentValue => currentValue;


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2165

## Summary
Wires GP job execution onto AWS Batch. An independent review found the entire
GP-on-Batch stack dormant: no committed deploy config declared a GP AWS Batch
`ExecutionWorkload`, so `GeoprocessingJobService.BuildSpec` always fell back to
the `local`/`KubernetesJob` baseline and the real `AwsBatchComputeBackend`
(`honua-aws-batch`, already DI-registered) never fired for GP. This closes the
config seam — config-only, gated, and behavior-preserving for the local default.

## Changes Made
- Add a config-driven, gated `geoprocessing-aws-batch` `ExecutionWorkload` to base
  `appsettings.json` (`Backend=honua-aws-batch`, `TargetKind=AwsBatch`) carrying
  `batch.job_queue_arn` / `batch.region` / per-tier
  `batch.job_definition_arn.{s,m,l,xl}` placeholder params (no real ARNs committed).
- Gate it in `ConfigurationExecutionJobDefinitionRegistry` (`ExecutionWorkloadGate`):
  an AWS Batch workload is dropped until the operator supplies the substrate ARNs
  (queue ARN + at least one job-definition ARN, single or tiered). Until then the
  placeholder stays inert and GP cleanly falls back to local — existing deploys and
  tests are unaffected. Keys are matched as literal contract strings so the gate
  takes no hard dependency on the optionally-excluded `Honua.Aws` assembly
  (`HonuaIncludeAws` / `HONUA_EXCLUDE_AWS`).
- Prefer a non-local GP workload in `GeoprocessingJobService.ResolveWorkloadAsync`
  so a fully-configured Batch workload wins routing; local remains the default when
  no remote workload is activated.
- Add `docs/operator/geoprocessing-aws-batch.md` mapping the honua-iac substrate
  outputs (`gp_job_queue_arn`, `gp_job_definition_arns{s,m,l,xl}`, region) onto the
  one `ControlPlane:ExecutionWorkloads` row, with appsettings and env-var override
  forms.

## End-to-end param verification
Submit GP job -> `ResolveWorkloadAsync` picks the Batch workload -> `BuildSpec`
merges `workload.Parameters` onto `ExecutionJobSpec.Parameters` -> the job routes to
`honua-aws-batch` (`(BackendName, TargetKind)` = `("honua-aws-batch", AwsBatch)`) ->
`AwsBatchComputeBackend.StartAsync` reads `batch.job_queue_arn` / `batch.region` /
`batch.job_definition_arn`. Parameter keys line up with `AwsBatchParameterKeys`.

## Dependency on tier-selection (#2181)
The runtime tier selector that maps `batch.ephemeral_gib` to
`batch.job_definition_arn.{tier}` lands with `feat/gp-batch-tier-selection` (#2181),
not yet on trunk. Until it merges, `AwsBatchComputeBackend` honors only the single
`batch.job_definition_arn` key (operators can wire Batch today via that single key).
The parameter-key contract (`batch.job_queue_arn`, `batch.region`,
`batch.job_definition_arn`, `batch.job_definition_arn.{s,m,l,xl}`) is identical on
both sides, so this PR and #2181 compose without rework.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

GP routing: with Batch ARNs present a GP job routes to `honua-aws-batch` and carries
the queue/tier params; without them it falls back to local (no enqueue change to the
local queue). Gate: drops empty-ARN and queue-only workloads, keeps single-ARN and
tiered. Targeted suite green (`ConfigurationOperationCatalogsTests` +
`GeoprocessingJobServiceTests`: 82 passed). Architecture tests: 117 passed. Release
build clean (0 warnings, 0 errors); `dotnet format --verify-no-changes` clean.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] Requires environment variable or secret changes
- [x] Requires infrastructure changes

To activate, an operator drops the honua-iac substrate ARNs into
`ControlPlane:ExecutionWorkloads` (see the new operator doc). No change required for
existing deploys, which keep running GP locally.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
