### PR TITLE
feat(auth): custom-code geoprocessing auth spine (Phase 0) — scoped, attenuated, job-bound token issuer

### DIFF
--- a/src/Honua.Core/Features/Authorization/Abstractions/IScopedJobTokenIssuer.cs
+++ b/src/Honua.Core/Features/Authorization/Abstractions/IScopedJobTokenIssuer.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using Honua.Core.Features.Authorization.Domain;
+
+namespace Honua.Core.Features.Authorization.Abstractions;
+
+/// <summary>
+/// Issues and validates opaque, job-bound, attenuated callback tokens for
+/// custom-code geoprocessing (the Phase 0 auth spine). A scoped job token lets
+/// future user-supplied geoprocessing code call back into Honua through the SDK
+/// with authority that is <em>strictly ≤ the submitter's</em> — never more.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a <em>separate</em> issuer from <see cref="IPortalTokenIssuer"/>: it
+/// mirrors that mint pattern (opaque entropy + distributed-cache-backed record,
+/// re-hydrating a <see cref="ClaimsPrincipal"/>) but adds a frozen
+/// <see cref="ScopedJobTokenRequest.ResourceScope"/> and a hard binding to a
+/// single <see cref="ScopedJobTokenRequest.JobId"/>. The ArcGIS portal token is
+/// never overloaded to carry this attenuation.
+/// </para>
+/// <para>
+/// The hydrated principal carries <em>only</em> the frozen intersection of the
+/// owner's grants and the resource scope, expressed with the same role/permission
+/// claim grammar the shared RBAC pipeline already enforces. Authorization is
+/// therefore never forked: the same service-scoped-role and per-operation
+/// permission checks every other request flows through enforce the attenuation.
+/// </para>
+/// </remarks>
+public interface IScopedJobTokenIssuer
+{
+    /// <summary>
+    /// Mints an opaque scoped-job token. The effective authority of the token is
+    /// computed and <em>frozen server-side at this call</em> as the intersection
+    /// of the owner snapshot's roles/grants and the requested
+    /// <see cref="ScopedJobTokenRequest.ResourceScope"/>; nothing presented later
+    /// can widen it.
+    /// </summary>
+    /// <param name="request">The mint request describing the pinned owner snapshot, job, scope, and expiry.</param>
+    /// <param name="cancellationToken">Token used to abort the issuance.</param>
+    /// <returns>The issued opaque token and its absolute expiry.</returns>
+    Task<ScopedJobTokenIssuance> IssueAsync(
+        ScopedJobTokenRequest request,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Validates an opaque scoped-job token presented within a job context and, on
+    /// success, returns the hydrated attenuated principal. The token validates
+    /// <em>only</em> when <paramref name="jobId"/> exactly matches the job the
+    /// token was bound to (invariant #4); a mismatch, an unknown/expired token, or
+    /// a revoked record returns <see langword="null"/>.
+    /// </summary>
+    /// <param name="token">The opaque token value supplied by the SDK callback.</param>
+    /// <param name="jobId">The active job context the token is presented within.</param>
+    /// <param name="cancellationToken">Token used to abort the lookup.</param>
+    /// <returns>The validated attenuated session, or <see langword="null"/> when unusable.</returns>
+    Task<ScopedJobTokenValidation?> ValidateAsync(
+        string token,
+        string jobId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Revokes a scoped-job token by deleting its backing record. Called when a job
+    /// reaches a terminal state so the callback credential cannot outlive the job
+    /// (invariant #5). Idempotent: revoking an already-absent token is a no-op.
+    /// </summary>
+    /// <param name="token">The opaque token value to revoke.</param>
+    /// <param name="cancellationToken">Token used to abort the removal.</param>
+    Task RevokeAsync(string token, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Inputs required to mint a scoped-job token. Every authority-bearing field is
+/// taken from the pinned owner snapshot — never from a value the future job
+/// supplies.
+/// </summary>
+/// <param name="PrincipalId">Stable identifier of the submitting principal (surfaced on the hydrated principal).</param>
+/// <param name="TenantId">
+/// Tenant captured from the submitter's <c>tenant_id</c> claim at submit time, or
+/// <see langword="null"/> for the tenant-less default. This is the only source of
+/// the hydrated principal's tenant — it is never widened by a callback-supplied
+/// value (invariant #2).
+/// </param>
+/// <param name="Roles">Snapshot of the submitter's roles, used to compute the owner's reachable grants.</param>
+/// <param name="JobId">The job this token is bound to; the token is honored only inside that job's context (invariant #4).</param>
+/// <param name="ResourceScope">The requested resource scope; the effective grant is the intersection of this and the owner's reachable grants (invariant #1).</param>
+/// <param name="ExpiresAt">Absolute expiry; set to the job timeout plus a small grace (invariant #5).</param>
+public sealed record ScopedJobTokenRequest(
+    string PrincipalId,
+    string? TenantId,
+    IReadOnlyList<string> Roles,
+    string JobId,
+    IReadOnlyList<JobResourceScopeEntry> ResourceScope,
+    DateTimeOffset ExpiresAt);
+
+/// <summary>
+/// Result of minting a scoped-job token.
+/// </summary>
+/// <param name="Token">The opaque token to hand to the job's callback context.</param>
+/// <param name="ExpiresAt">Absolute expiry of the token.</param>
+public sealed record ScopedJobTokenIssuance(string Token, DateTimeOffset ExpiresAt);
+
+/// <summary>
+/// A validated scoped-job session: the hydrated, attenuated principal and the
+/// token expiry.
+/// </summary>
+/// <param name="Principal">
+/// The hydrated <see cref="ClaimsPrincipal"/> carrying only the frozen
+/// intersection grants and the pinned tenant. Its authority flows through the
+/// existing shared RBAC pipeline unchanged (invariant #6).
+/// </param>
+/// <param name="JobId">The job the token is bound to (echoed for callers that audit the binding).</param>
+/// <param name="ExpiresAt">Absolute expiry of the token.</param>
+public sealed record ScopedJobTokenValidation(
+    ClaimsPrincipal Principal,
+    string JobId,
+    DateTimeOffset ExpiresAt);

--- a/src/Honua.Core/Features/Authorization/Domain/JobResourceScope.cs
+++ b/src/Honua.Core/Features/Authorization/Domain/JobResourceScope.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Authorization.Domain;
+
+/// <summary>
+/// The access level a <see cref="JobResourceScopeEntry"/> grants over its target
+/// resource. Read is the floor: a <see cref="JobResourceAccess.Write"/> entry also
+/// confers read, while a <see cref="JobResourceAccess.Read"/> entry never confers
+/// write (custom-code auth spine invariant #3 — read-only unless write declared).
+/// </summary>
+public enum JobResourceAccess
+{
+    /// <summary>
+    /// Read-only access (query/metadata) to the scoped resource. This is the
+    /// default when an entry does not explicitly declare write.
+    /// </summary>
+    Read = 0,
+
+    /// <summary>
+    /// Read and write (insert/update/delete) access to the scoped resource.
+    /// </summary>
+    Write = 1,
+}
+
+/// <summary>
+/// A single resource-scope grant for a custom-code geoprocessing job: the
+/// <c>(serviceId, layerId?, access)</c> tuple identifying one service (or one
+/// layer within it) the job's SDK callbacks may reach, and at what access level.
+/// </summary>
+/// <remarks>
+/// A null <see cref="LayerId"/> denotes a service-wide entry that covers every
+/// layer of the named service; a non-null <see cref="LayerId"/> narrows the entry
+/// to that single layer. This mirrors the existing layer-scoped write-key grant
+/// grammar (<c>write:{service}</c> vs <c>write:{service}/{layer}</c>) so the scope
+/// flows through the same shared RBAC pipeline rather than a parallel ACL model.
+/// </remarks>
+/// <param name="ServiceId">The target service identifier (required).</param>
+/// <param name="LayerId">The target layer identifier, or <see langword="null"/> for a service-wide entry.</param>
+/// <param name="Access">The access level granted over the target.</param>
+public sealed record JobResourceScopeEntry(
+    string ServiceId,
+    string? LayerId,
+    JobResourceAccess Access);
+
+/// <summary>
+/// The durable owner snapshot pinned at submit time for a custom-code
+/// geoprocessing job. It captures exactly the authorization facts the scoped-job
+/// token issuer needs to attenuate a callback token to <em>≤ the submitter's</em>
+/// permissions: the submitter's principal id, tenant, role snapshot, and the
+/// (already validated, ⊆ submitter) scope the job declared it needs.
+/// </summary>
+/// <remarks>
+/// This snapshot is the <em>sole</em> source of truth the mint reads — nothing
+/// user-supplied at callback time can widen it. <see cref="TenantId"/> in
+/// particular is captured here from the live principal's <c>tenant_id</c> claim
+/// and is never re-derived from a caller-supplied value, so cross-tenant access
+/// is structurally impossible (invariant #2).
+/// </remarks>
+/// <param name="PrincipalId">Stable identifier of the submitting principal.</param>
+/// <param name="TenantId">Tenant the submitter belonged to, or <see langword="null"/> for the tenant-less default.</param>
+/// <param name="Roles">Snapshot of the submitter's roles at submit time.</param>
+/// <param name="DeclaredScope">
+/// The resource scope the job declared it needs, already clamped to ⊆ what the
+/// submitter could reach at submit time. Empty when the job declared no scope
+/// (the behavior-preserving default for non-custom-code jobs).
+/// </param>
+public sealed record CustomCodeOwnerScope(
+    string PrincipalId,
+    string? TenantId,
+    IReadOnlyList<string> Roles,
+    IReadOnlyList<JobResourceScopeEntry> DeclaredScope);

--- a/src/Honua.Core/Features/Authorization/Domain/ScopedJobAttenuation.cs
+++ b/src/Honua.Core/Features/Authorization/Domain/ScopedJobAttenuation.cs
@@ -1,0 +1,398 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Authorization.Domain;
+
+/// <summary>
+/// Pure, server-side attenuation math for the custom-code geoprocessing auth spine
+/// (Phase 0). Computes the <em>intersection</em> of an owner's reachable grants and
+/// a requested resource scope, and projects that intersection onto the role and
+/// permission claims the shared RBAC pipeline already enforces.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This type carries no I/O and no <c>HttpContext</c> dependency so it is safe to
+/// call from any layer (submit-time clamp in the geoprocessing service and
+/// mint-time freeze in the issuer share this one implementation). It is the single
+/// place the narrow-only invariant is computed; both callers MUST route through it
+/// so the rule cannot drift between the two sites.
+/// </para>
+/// <para>
+/// Owner reachability is derived from the same claim grammar the live pipeline
+/// reads: the <c>admin</c> role (full authority), configured global data-editor
+/// roles, service-scoped <c>data-editor:{service}</c> roles (service-wide write),
+/// and per-resource <c>read:</c>/<c>write:</c> permission grants. A scope entry is
+/// only retained when the owner could actually reach it at the requested access
+/// level — anything else is dropped (clamped away), never widened.
+/// </para>
+/// </remarks>
+public static class ScopedJobAttenuation
+{
+    /// <summary>The conventional full-authority role.</summary>
+    public const string AdminRole = "admin";
+
+    /// <summary>Prefix for service-scoped data-editor roles (mirrors <c>RbacOptions.DataEditorServicePrefix</c> default).</summary>
+    public const string ServiceEditorRolePrefix = "data-editor:";
+
+    /// <summary>Permission-grant prefix for write access (mirrors the layer-scoped write-key grammar).</summary>
+    public const string WriteGrantPrefix = "write:";
+
+    /// <summary>Permission-grant prefix for read access (the read counterpart of <see cref="WriteGrantPrefix"/>).</summary>
+    public const string ReadGrantPrefix = "read:";
+
+    /// <summary>
+    /// Computes the effective (intersected) scope: every requested entry the owner
+    /// could actually reach at the requested access level, clamped to the owner's
+    /// reachable access. An entry the owner could only read but the request asked
+    /// to write is downgraded to read; an entry the owner could not reach at all is
+    /// dropped. The result can therefore never exceed either input.
+    /// </summary>
+    /// <param name="ownerRoles">The owner's role snapshot.</param>
+    /// <param name="ownerGrants">
+    /// The owner's per-resource permission grants (<c>read:{svc}[/{layer}]</c> /
+    /// <c>write:{svc}[/{layer}]</c>), or <see langword="null"/>/empty when the owner
+    /// carries no fine-grained grants.
+    /// </param>
+    /// <param name="globalDataEditorRoles">
+    /// Roles that confer write to every service (the configured global data-editor
+    /// roles), or <see langword="null"/> when none are configured.
+    /// </param>
+    /// <param name="requestedScope">The scope the job declared / requested.</param>
+    /// <returns>The intersected, access-clamped scope (possibly empty).</returns>
+    public static IReadOnlyList<JobResourceScopeEntry> Intersect(
+        IReadOnlyList<string>? ownerRoles,
+        IReadOnlyList<string>? ownerGrants,
+        IReadOnlyList<string>? globalDataEditorRoles,
+        IReadOnlyList<JobResourceScopeEntry>? requestedScope)
+    {
+        if (requestedScope is null || requestedScope.Count == 0)
+        {
+            return [];
+        }
+
+        var reach = OwnerReach.From(ownerRoles, ownerGrants, globalDataEditorRoles);
+
+        var effective = new List<JobResourceScopeEntry>(requestedScope.Count);
+        foreach (var entry in requestedScope)
+        {
+            if (entry is null || string.IsNullOrWhiteSpace(entry.ServiceId))
+            {
+                continue;
+            }
+
+            var service = entry.ServiceId.Trim();
+            var layer = string.IsNullOrWhiteSpace(entry.LayerId) ? null : entry.LayerId!.Trim();
+
+            var reachable = reach.MaxAccess(service, layer);
+            if (reachable is null)
+            {
+                // Owner cannot reach this resource at all — drop it (narrow-only).
+                continue;
+            }
+
+            // Clamp the requested access down to what the owner could reach. A
+            // requested Write against a read-only-reachable resource degrades to Read.
+            var granted = entry.Access == JobResourceAccess.Write && reachable == JobResourceAccess.Write
+                ? JobResourceAccess.Write
+                : JobResourceAccess.Read;
+
+            effective.Add(new JobResourceScopeEntry(service, layer, granted));
+        }
+
+        return effective;
+    }
+
+    /// <summary>
+    /// Determines whether a requested scope is wholly reachable by the owner — i.e.
+    /// the intersection equals the request (every entry retained at the requested
+    /// access). Used by the submit-time validation to reject (rather than silently
+    /// clamp) a declared scope that exceeds the submitter.
+    /// </summary>
+    /// <param name="ownerRoles">The owner's role snapshot.</param>
+    /// <param name="ownerGrants">The owner's per-resource permission grants.</param>
+    /// <param name="globalDataEditorRoles">Roles conferring write to every service.</param>
+    /// <param name="requestedScope">The declared scope to test.</param>
+    /// <param name="firstUnreachable">The first entry the owner cannot fully reach, when the method returns <see langword="false"/>.</param>
+    /// <returns><see langword="true"/> when every entry is reachable at its requested access.</returns>
+    public static bool IsWithinOwner(
+        IReadOnlyList<string>? ownerRoles,
+        IReadOnlyList<string>? ownerGrants,
+        IReadOnlyList<string>? globalDataEditorRoles,
+        IReadOnlyList<JobResourceScopeEntry>? requestedScope,
+        out JobResourceScopeEntry? firstUnreachable)
+    {
+        firstUnreachable = null;
+        if (requestedScope is null || requestedScope.Count == 0)
+        {
+            return true;
+        }
+
+        var reach = OwnerReach.From(ownerRoles, ownerGrants, globalDataEditorRoles);
+        foreach (var entry in requestedScope)
+        {
+            if (entry is null || string.IsNullOrWhiteSpace(entry.ServiceId))
+            {
+                firstUnreachable = entry;
+                return false;
+            }
+
+            var service = entry.ServiceId.Trim();
+            var layer = string.IsNullOrWhiteSpace(entry.LayerId) ? null : entry.LayerId!.Trim();
+            var reachable = reach.MaxAccess(service, layer);
+
+            if (reachable is null ||
+                (entry.Access == JobResourceAccess.Write && reachable != JobResourceAccess.Write))
+            {
+                firstUnreachable = entry;
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Projects an effective scope onto the role and permission claim values the
+    /// shared RBAC pipeline enforces. The returned values are what the issuer pins
+    /// onto the hydrated principal: <c>data-editor:{service}</c> roles for
+    /// service-wide write entries, and <c>read:</c>/<c>write:</c> permission grants
+    /// for every entry. Because only the intersected scope is projected, the
+    /// hydrated principal can never out-grant the intersection.
+    /// </summary>
+    /// <param name="effectiveScope">The already-intersected scope.</param>
+    /// <returns>The role and permission claim values to pin onto the principal.</returns>
+    public static ScopedJobClaims ToClaims(IReadOnlyList<JobResourceScopeEntry> effectiveScope)
+    {
+        var roles = new List<string>();
+        var permissions = new List<string>();
+
+        if (effectiveScope is null)
+        {
+            return new ScopedJobClaims(roles, permissions);
+        }
+
+        foreach (var entry in effectiveScope)
+        {
+            if (entry is null || string.IsNullOrWhiteSpace(entry.ServiceId))
+            {
+                continue;
+            }
+
+            var service = entry.ServiceId.Trim();
+            var layer = string.IsNullOrWhiteSpace(entry.LayerId) ? null : entry.LayerId!.Trim();
+            var target = layer is null ? service : string.Concat(service, "/", layer);
+
+            // Always project a read grant; reads are the access floor.
+            permissions.Add(string.Concat(ReadGrantPrefix, target));
+
+            if (entry.Access == JobResourceAccess.Write)
+            {
+                permissions.Add(string.Concat(WriteGrantPrefix, target));
+
+                // A service-wide write entry also satisfies the service-scoped
+                // data-editor role gate; a layer-specific write does not widen to
+                // the whole service, so only the scoped permission grant is added.
+                if (layer is null)
+                {
+                    roles.Add(string.Concat(ServiceEditorRolePrefix, service));
+                }
+            }
+        }
+
+        return new ScopedJobClaims(roles, permissions);
+    }
+
+    /// <summary>
+    /// Pre-indexed view of an owner's reachable access for fast per-entry checks.
+    /// </summary>
+    private sealed class OwnerReach
+    {
+        private readonly bool _isAdminOrGlobalEditor;
+        // service (lower) -> max access for the whole service
+        private readonly Dictionary<string, JobResourceAccess> _serviceAccess = new(StringComparer.OrdinalIgnoreCase);
+        // "service/layer" (lower) -> max access for that layer
+        private readonly Dictionary<string, JobResourceAccess> _layerAccess = new(StringComparer.OrdinalIgnoreCase);
+
+        private OwnerReach(bool isAdminOrGlobalEditor)
+        {
+            _isAdminOrGlobalEditor = isAdminOrGlobalEditor;
+        }
+
+        public static OwnerReach From(
+            IReadOnlyList<string>? roles,
+            IReadOnlyList<string>? grants,
+            IReadOnlyList<string>? globalDataEditorRoles)
+        {
+            var admin = false;
+
+            HashSet<string>? globalEditors = null;
+            if (globalDataEditorRoles is { Count: > 0 })
+            {
+                globalEditors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var r in globalDataEditorRoles)
+                {
+                    if (!string.IsNullOrWhiteSpace(r))
+                    {
+                        globalEditors.Add(r.Trim());
+                    }
+                }
+            }
+
+            var serviceWideWriteRoles = new List<string>();
+            if (roles is not null)
+            {
+                foreach (var raw in roles)
+                {
+                    if (string.IsNullOrWhiteSpace(raw))
+                    {
+                        continue;
+                    }
+
+                    var role = raw.Trim();
+
+                    if (string.Equals(role, AdminRole, StringComparison.OrdinalIgnoreCase) ||
+                        (globalEditors is not null && globalEditors.Contains(role)))
+                    {
+                        admin = true;
+                        continue;
+                    }
+
+                    if (role.StartsWith(ServiceEditorRolePrefix, StringComparison.OrdinalIgnoreCase) &&
+                        role.Length > ServiceEditorRolePrefix.Length)
+                    {
+                        var svc = role[ServiceEditorRolePrefix.Length..].Trim();
+                        if (svc.Length > 0)
+                        {
+                            serviceWideWriteRoles.Add(svc);
+                        }
+                    }
+                }
+            }
+
+            var reach = new OwnerReach(admin);
+
+            foreach (var svc in serviceWideWriteRoles)
+            {
+                reach.AddServiceAccess(svc, JobResourceAccess.Write);
+            }
+
+            if (grants is not null)
+            {
+                foreach (var raw in grants)
+                {
+                    if (string.IsNullOrWhiteSpace(raw))
+                    {
+                        continue;
+                    }
+
+                    var grant = raw.Trim();
+                    JobResourceAccess access;
+                    string target;
+                    if (grant.StartsWith(WriteGrantPrefix, StringComparison.OrdinalIgnoreCase) &&
+                        grant.Length > WriteGrantPrefix.Length)
+                    {
+                        access = JobResourceAccess.Write;
+                        target = grant[WriteGrantPrefix.Length..].Trim();
+                    }
+                    else if (grant.StartsWith(ReadGrantPrefix, StringComparison.OrdinalIgnoreCase) &&
+                        grant.Length > ReadGrantPrefix.Length)
+                    {
+                        access = JobResourceAccess.Read;
+                        target = grant[ReadGrantPrefix.Length..].Trim();
+                    }
+                    else
+                    {
+                        continue;
+                    }
+
+                    if (target.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    var sep = target.IndexOf('/');
+                    if (sep < 0)
+                    {
+                        reach.AddServiceAccess(target, access);
+                    }
+                    else
+                    {
+                        var svc = target[..sep].Trim();
+                        var layer = target[(sep + 1)..].Trim();
+                        if (svc.Length > 0 && layer.Length > 0)
+                        {
+                            reach.AddLayerAccess(svc, layer, access);
+                        }
+                    }
+                }
+            }
+
+            return reach;
+        }
+
+        private void AddServiceAccess(string service, JobResourceAccess access)
+        {
+            if (!_serviceAccess.TryGetValue(service, out var existing) || access > existing)
+            {
+                _serviceAccess[service] = access;
+            }
+        }
+
+        private void AddLayerAccess(string service, string layer, JobResourceAccess access)
+        {
+            var key = string.Concat(service, "/", layer);
+            if (!_layerAccess.TryGetValue(key, out var existing) || access > existing)
+            {
+                _layerAccess[key] = access;
+            }
+        }
+
+        /// <summary>
+        /// Returns the maximum access the owner can reach for the
+        /// <c>(service, layer)</c> target, or <see langword="null"/> when the owner
+        /// cannot reach it at all.
+        /// </summary>
+        public JobResourceAccess? MaxAccess(string service, string? layer)
+        {
+            if (_isAdminOrGlobalEditor)
+            {
+                return JobResourceAccess.Write;
+            }
+
+            JobResourceAccess? best = null;
+
+            if (_serviceAccess.TryGetValue(service, out var svcAccess))
+            {
+                best = Max(best, svcAccess);
+            }
+
+            if (layer is null)
+            {
+                // A service-wide request is only reachable by a service-wide grant
+                // (a single-layer grant does not cover the whole service).
+                return best;
+            }
+
+            var layerKey = string.Concat(service, "/", layer);
+            if (_layerAccess.TryGetValue(layerKey, out var layerAccess))
+            {
+                best = Max(best, layerAccess);
+            }
+
+            return best;
+        }
+
+        private static JobResourceAccess Max(JobResourceAccess? current, JobResourceAccess candidate)
+            => current is null || candidate > current ? candidate : current.Value;
+    }
+}
+
+/// <summary>
+/// The role and permission claim values an attenuated scoped-job principal carries,
+/// produced by <see cref="ScopedJobAttenuation.ToClaims"/>.
+/// </summary>
+/// <param name="Roles">Service-scoped <c>data-editor:{service}</c> roles for service-wide write entries.</param>
+/// <param name="Permissions">Per-resource <c>read:</c>/<c>write:</c> permission grants for every entry.</param>
+public sealed record ScopedJobClaims(
+    IReadOnlyList<string> Roles,
+    IReadOnlyList<string> Permissions);

--- a/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
+++ b/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Authorization.Domain;
+
 namespace Honua.Core.Features.ControlPlane.Domain;
 
 /// <summary>
@@ -374,6 +376,16 @@ public sealed record OperationAuditInfo
     /// Machine-readable reason codes from the approval evaluation.
     /// </summary>
     public IReadOnlyList<string> ApprovalReasonCodes { get; init; } = [];
+
+    /// <summary>
+    /// Durable owner snapshot pinned at submit time for custom-code geoprocessing
+    /// jobs (Phase 0 auth spine). Captures the submitter's tenant, role snapshot,
+    /// and the already-validated (⊆ submitter) declared resource scope so a
+    /// scoped-job callback token can be attenuated to ≤ the submitter's
+    /// permissions. <see langword="null"/> for ordinary (non-custom-code) jobs,
+    /// which carry no declared scope — preserving existing behavior.
+    /// </summary>
+    public CustomCodeOwnerScope? CustomCodeOwnerScope { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCodeOwnerScopeCapture.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCodeOwnerScopeCapture.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using Honua.Core.Features.Authorization.Domain;
+
+namespace Honua.Geoprocessing;
+
+/// <summary>
+/// Captures the durable owner snapshot pinned on a custom-code geoprocessing job at
+/// submit time (Phase 0 auth spine, Deliverable 1). The snapshot records the
+/// submitter's identity, tenant, role snapshot, and the validated declared scope so
+/// a later scoped-job callback token can be attenuated to ≤ the submitter.
+/// </summary>
+/// <remarks>
+/// This is intentionally minimal and behavior-preserving: a job that declares no
+/// scope (every non-custom-code job today) yields a <see langword="null"/> snapshot
+/// and the submit path is unchanged. A job that <em>does</em> declare scope is
+/// validated against what the submitter could actually reach — anything the
+/// submitter could not reach causes a rejection, so the pinned scope is always
+/// ⊆ submitter.
+/// </remarks>
+internal static class CustomCodeOwnerScopeCapture
+{
+    /// <summary>
+    /// Protocol-metadata key carrying a custom-code job's declared resource scope.
+    /// The value is a list of <c>access:service[/layer]</c> entries separated by
+    /// <see cref="EntrySeparator"/>, where <c>access</c> is <c>read</c> or
+    /// <c>write</c> (e.g. <c>write:parcels/lots;read:zoning</c>).
+    /// </summary>
+    public const string DeclaredScopeMetadataKey = "honua.customcode.declared_scope";
+
+    /// <summary>Permission claim type the shared RBAC pipeline reads for scoped grants.</summary>
+    public const string PermissionClaimType = "permission";
+
+    /// <summary>Tenant claim type mirrored from the portal-token grammar.</summary>
+    public const string TenantClaimType = "tenant_id";
+
+    private const char EntrySeparator = ';';
+    private const char AccessSeparator = ':';
+    private const char LayerSeparator = '/';
+
+    /// <summary>
+    /// Builds the owner snapshot for a submission, or returns <see langword="null"/>
+    /// when the job declares no custom-code scope (the behavior-preserving default).
+    /// </summary>
+    /// <param name="principal">The live submitting principal.</param>
+    /// <param name="protocolMetadata">The submission's protocol metadata, which may carry a declared scope.</param>
+    /// <param name="globalDataEditorRoles">Configured roles that confer write to every service, when known.</param>
+    /// <param name="rejection">A human-readable rejection reason when the declared scope exceeds the submitter.</param>
+    /// <returns>The pinned snapshot, or <see langword="null"/> when no scope was declared.</returns>
+    public static CustomCodeOwnerScope? TryCapture(
+        ClaimsPrincipal principal,
+        IReadOnlyDictionary<string, string>? protocolMetadata,
+        IReadOnlyList<string>? globalDataEditorRoles,
+        out string? rejection)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+        rejection = null;
+
+        if (protocolMetadata is null ||
+            !protocolMetadata.TryGetValue(DeclaredScopeMetadataKey, out var raw) ||
+            string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        var declared = ParseDeclaredScope(raw);
+        var roles = SnapshotRoles(principal);
+        var grants = SnapshotGrants(principal);
+
+        // Reject anything the submitter could not actually reach at the requested
+        // access. The snapshot must be ⊆ submitter; we reject (rather than silently
+        // clamp) so a caller asking for more than it has gets a clear signal.
+        if (!ScopedJobAttenuation.IsWithinOwner(roles, grants, globalDataEditorRoles, declared, out var unreachable))
+        {
+            var target = unreachable is null
+                ? "(unspecified)"
+                : unreachable.LayerId is null
+                    ? unreachable.ServiceId
+                    : string.Concat(unreachable.ServiceId, "/", unreachable.LayerId);
+            rejection =
+                $"Declared scope entry '{target}' exceeds the submitter's permissions and cannot be granted to custom code.";
+            return null;
+        }
+
+        var tenantId = principal.FindFirstValue(TenantClaimType);
+        var principalId = principal.Identity?.Name ?? string.Empty;
+
+        return new CustomCodeOwnerScope(principalId, tenantId, roles, declared);
+    }
+
+    private static List<JobResourceScopeEntry> ParseDeclaredScope(string raw)
+    {
+        var entries = new List<JobResourceScopeEntry>();
+        foreach (var part in raw.Split(EntrySeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var accessSep = part.IndexOf(AccessSeparator);
+            if (accessSep <= 0 || accessSep >= part.Length - 1)
+            {
+                // No access prefix: treat as read-only (the access floor).
+                AddEntry(entries, JobResourceAccess.Read, part);
+                continue;
+            }
+
+            var accessToken = part[..accessSep].Trim();
+            var target = part[(accessSep + 1)..].Trim();
+            var access = string.Equals(accessToken, "write", StringComparison.OrdinalIgnoreCase)
+                ? JobResourceAccess.Write
+                : JobResourceAccess.Read;
+            AddEntry(entries, access, target);
+        }
+
+        return entries;
+    }
+
+    private static void AddEntry(List<JobResourceScopeEntry> entries, JobResourceAccess access, string target)
+    {
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            return;
+        }
+
+        var sep = target.IndexOf(LayerSeparator);
+        if (sep < 0)
+        {
+            entries.Add(new JobResourceScopeEntry(target.Trim(), null, access));
+            return;
+        }
+
+        var service = target[..sep].Trim();
+        var layer = target[(sep + 1)..].Trim();
+        if (service.Length == 0)
+        {
+            return;
+        }
+
+        entries.Add(new JobResourceScopeEntry(service, layer.Length == 0 ? null : layer, access));
+    }
+
+    private static List<string> SnapshotRoles(ClaimsPrincipal principal)
+    {
+        var roles = new List<string>();
+        foreach (var claim in principal.FindAll(ClaimTypes.Role))
+        {
+            if (!string.IsNullOrWhiteSpace(claim.Value))
+            {
+                roles.Add(claim.Value);
+            }
+        }
+
+        // Also capture the configurable "roles" claim type the RBAC pipeline reads,
+        // so a snapshot is faithful regardless of which claim type carried the role.
+        foreach (var claim in principal.FindAll("roles"))
+        {
+            if (!string.IsNullOrWhiteSpace(claim.Value) && !roles.Contains(claim.Value))
+            {
+                roles.Add(claim.Value);
+            }
+        }
+
+        return roles;
+    }
+
+    private static List<string> SnapshotGrants(ClaimsPrincipal principal)
+    {
+        var grants = new List<string>();
+        foreach (var claim in principal.FindAll(PermissionClaimType))
+        {
+            if (!string.IsNullOrWhiteSpace(claim.Value))
+            {
+                grants.Add(claim.Value);
+            }
+        }
+
+        return grants;
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -182,6 +182,23 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         EnsurePlanCatalogValid(plan);
         EnsureApproved(principal, plan);
 
+        // Phase 0 auth spine (Deliverable 1): pin the submitter's owner snapshot
+        // when the job declares a custom-code resource scope. The declared scope is
+        // validated to be ⊆ what the submitter can reach; anything beyond is
+        // rejected here, so the durable snapshot can only ever attenuate (never
+        // widen) a later scoped-job callback token. Behavior is unchanged for
+        // ordinary jobs, which declare no scope and pin no snapshot.
+        var ownerScope = CustomCodeOwnerScopeCapture.TryCapture(
+            principal,
+            protocolMetadata,
+            globalDataEditorRoles: null,
+            out var scopeRejection);
+        if (scopeRejection is not null)
+        {
+            GeoprocessingServiceLog.DeclaredScopeRejected(_logger, scopeRejection);
+            throw new GeoprocessingValidationException(scopeRejection);
+        }
+
         var jobStore = RequireJobStore();
         var now = DateTimeOffset.UtcNow;
         var resolvedKey = string.IsNullOrWhiteSpace(idempotencyKey) ? null : idempotencyKey;
@@ -225,7 +242,8 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             {
                 IdempotencyKey = resolvedKey,
                 RequestedBy = principal.Identity?.Name,
-                RequestFingerprint = requestFingerprint
+                RequestFingerprint = requestFingerprint,
+                CustomCodeOwnerScope = ownerScope
             },
             Spec = spec
         };

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceLog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceLog.cs
@@ -176,4 +176,9 @@ internal static partial class GeoprocessingServiceLog
     public static partial void JobOwnershipDenied(
         ILogger logger,
         string jobId);
+
+    [LoggerMessage(8030, LogLevel.Warning, "Custom-code declared scope rejected: {Reason}")]
+    public static partial void DeclaredScopeRejected(
+        ILogger logger,
+        string reason);
 }

--- a/src/Honua.Hosting/Features/Authentication/PortalTokenAuthenticationExtensions.cs
+++ b/src/Honua.Hosting/Features/Authentication/PortalTokenAuthenticationExtensions.cs
@@ -53,6 +53,7 @@ public static class PortalTokenAuthenticationExtensions
             .ValidateOnStart();
 
         services.TryAddSingletonPortalTokenIssuer();
+        services.TryAddSingletonScopedJobTokenIssuer();
         services.TryAddPortalCredentialVerifier();
         services.TryAddPortalAccessProjection(configuration);
         services.TryAddPortalOAuthBridge();
@@ -84,6 +85,19 @@ public static class PortalTokenAuthenticationExtensions
         if (!services.Any(d => d.ServiceType == typeof(IPortalTokenIssuer)))
         {
             services.AddSingleton<IPortalTokenIssuer, PortalTokenIssuer>();
+        }
+    }
+
+    /// <summary>
+    /// Registers the custom-code geoprocessing scoped-job token issuer (Phase 0
+    /// auth spine). A separate singleton from the portal-token issuer so the ArcGIS
+    /// portal token is never overloaded to carry job-bound attenuation.
+    /// </summary>
+    private static void TryAddSingletonScopedJobTokenIssuer(this IServiceCollection services)
+    {
+        if (!services.Any(d => d.ServiceType == typeof(IScopedJobTokenIssuer)))
+        {
+            services.AddSingleton<IScopedJobTokenIssuer, ScopedJobTokenIssuer>();
         }
     }
 

--- a/src/Honua.Hosting/Features/Authentication/ScopedJobTokenIssuer.cs
+++ b/src/Honua.Hosting/Features/Authentication/ScopedJobTokenIssuer.cs
@@ -1,0 +1,318 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Infrastructure.Logging;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Honua.Infrastructure.Authentication;
+
+/// <summary>
+/// Distributed-cache backed <see cref="IScopedJobTokenIssuer"/> for the custom-code
+/// geoprocessing auth spine (Phase 0). Mirrors <see cref="PortalTokenIssuer"/>'s
+/// mint pattern — opaque entropy plus a redis-authoritative record re-hydrated into
+/// a <see cref="ClaimsPrincipal"/> — but the stored record additionally carries the
+/// bound <c>JobId</c> and the <em>frozen, already-intersected</em> resource scope.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The attenuation is computed once, here, at mint time: the issuer intersects the
+/// pinned owner snapshot's roles/grants with the requested scope
+/// (<see cref="ScopedJobAttenuation.Intersect"/>) and stores only the resulting
+/// role/permission claim grammar. Nothing presented at callback time can widen the
+/// stored scope — the token value carries no claims of its own, and validation
+/// projects exactly the stored, frozen grant set.
+/// </para>
+/// <para>
+/// The hydrated principal uses the same role/<c>permission</c>/<c>tenant_id</c>
+/// claim grammar the shared RBAC pipeline already enforces, so authorization is
+/// never forked: the same service-scoped-role and per-operation permission checks
+/// every other request flows through enforce the intersection.
+/// </para>
+/// </remarks>
+internal sealed partial class ScopedJobTokenIssuer(
+    IMemoryCache memoryCache,
+    ILogger<ScopedJobTokenIssuer> logger,
+    IDistributedCache? distributedCache = null) : IScopedJobTokenIssuer
+{
+    internal const string AuthSchemeName = "ScopedJobToken";
+    internal const string AuthTypeClaimValue = "scoped-job-token";
+    internal const string TenantClaimType = "tenant_id";
+    internal const string JobIdClaimType = "honua_job_id";
+    internal const string PermissionClaimType = "permission";
+    internal const string RolesClaimType = "roles";
+    private const string TokenKeyPrefix = "scoped-job-auth:token:";
+
+    private readonly IMemoryCache _memoryCache = memoryCache;
+    private readonly ILogger<ScopedJobTokenIssuer> _logger = logger;
+    private readonly IDistributedCache? _distributedCache = distributedCache;
+
+    /// <inheritdoc />
+    public async Task<ScopedJobTokenIssuance> IssueAsync(
+        ScopedJobTokenRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (string.IsNullOrWhiteSpace(request.JobId))
+        {
+            throw new ArgumentException("A scoped-job token must be bound to a job id.", nameof(request));
+        }
+
+        // Freeze the attenuation server-side: the effective grant is the
+        // intersection of the pinned owner's reachable scope and the requested
+        // resource scope. The owner snapshot is the SOLE input — nothing the future
+        // job supplies participates here.
+        var effectiveScope = ScopedJobAttenuation.Intersect(
+            request.Roles,
+            ownerGrants: null,
+            globalDataEditorRoles: null,
+            request.ResourceScope);
+        var claims = ScopedJobAttenuation.ToClaims(effectiveScope);
+
+        var token = CreateTokenValue();
+        var record = new ScopedJobTokenRecord
+        {
+            PrincipalId = request.PrincipalId,
+            // TenantId is taken from the pinned snapshot only; it is never
+            // re-derived from a callback-supplied value (invariant #2).
+            TenantId = request.TenantId,
+            JobId = request.JobId.Trim(),
+            Roles = claims.Roles.ToArray(),
+            Permissions = claims.Permissions.ToArray(),
+            ExpiresAt = request.ExpiresAt,
+        };
+
+        await SetAsync(
+            TokenKeyPrefix + token,
+            record,
+            request.ExpiresAt,
+            ScopedJobTokenJsonContext.Default.ScopedJobTokenRecord,
+            cancellationToken).ConfigureAwait(false);
+
+        ScopedJobTokenLog.TokenIssued(_logger, record.JobId, claims.Roles.Count, claims.Permissions.Count);
+        return new ScopedJobTokenIssuance(token, request.ExpiresAt);
+    }
+
+    /// <inheritdoc />
+    public async Task<ScopedJobTokenValidation?> ValidateAsync(
+        string token,
+        string jobId,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(jobId))
+        {
+            return null;
+        }
+
+        var record = await GetAsync(token, cancellationToken).ConfigureAwait(false);
+        if (record is null)
+        {
+            return null;
+        }
+
+        // Job-binding (invariant #4): the token is honored ONLY inside the exact
+        // job context it was minted for. An ordinal compare prevents a token from a
+        // sibling job being replayed in this job's callback context.
+        if (!string.Equals(record.JobId, jobId.Trim(), StringComparison.Ordinal))
+        {
+            ScopedJobTokenLog.JobBindingMismatch(_logger, record.JobId, LogValueRedactor.Hash(token));
+            return null;
+        }
+
+        var principal = ProjectPrincipal(record);
+        return new ScopedJobTokenValidation(principal, record.JobId, record.ExpiresAt);
+    }
+
+    /// <inheritdoc />
+    public Task RevokeAsync(string token, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return Task.CompletedTask;
+        }
+
+        return RemoveAsync(TokenKeyPrefix + token, cancellationToken);
+    }
+
+    private static string CreateTokenValue()
+    {
+        // 256 bits of entropy, matching PortalTokenIssuer / AdminAuthSessionStore.
+        return Convert.ToHexString(RandomNumberGenerator.GetBytes(32)).ToLowerInvariant();
+    }
+
+    private static ClaimsPrincipal ProjectPrincipal(ScopedJobTokenRecord record)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.Name, record.PrincipalId),
+            new(ClaimTypes.NameIdentifier, record.PrincipalId),
+            new("auth_type", AuthTypeClaimValue),
+            new(JobIdClaimType, record.JobId),
+        };
+
+        if (!string.IsNullOrWhiteSpace(record.TenantId))
+        {
+            claims.Add(new Claim(TenantClaimType, record.TenantId!));
+        }
+
+        foreach (var role in record.Roles)
+        {
+            if (!string.IsNullOrWhiteSpace(role))
+            {
+                // Project both the canonical Role claim (so IsInRole and the shared
+                // role enumeration both see it) and the configurable "roles" claim
+                // the RBAC pipeline also reads.
+                claims.Add(new Claim(ClaimTypes.Role, role));
+                claims.Add(new Claim(RolesClaimType, role));
+            }
+        }
+
+        foreach (var permission in record.Permissions)
+        {
+            if (!string.IsNullOrWhiteSpace(permission))
+            {
+                claims.Add(new Claim(PermissionClaimType, permission));
+            }
+        }
+
+        var identity = new ClaimsIdentity(
+            claims,
+            AuthSchemeName,
+            ClaimTypes.Name,
+            ClaimTypes.Role);
+        return new ClaimsPrincipal(identity);
+    }
+
+    private async Task SetAsync<T>(
+        string key,
+        T value,
+        DateTimeOffset expiresAt,
+        JsonTypeInfo<T> typeInfo,
+        CancellationToken cancellationToken)
+    {
+        var payload = JsonSerializer.SerializeToUtf8Bytes(value, typeInfo);
+        if (_distributedCache is null)
+        {
+            _memoryCache.Set(key, payload, expiresAt);
+            return;
+        }
+
+        try
+        {
+            await _distributedCache.SetAsync(
+                key,
+                payload,
+                new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpiration = expiresAt
+                },
+                cancellationToken).ConfigureAwait(false);
+            _memoryCache.Set(key, payload, expiresAt);
+        }
+        catch (Exception ex)
+        {
+            _memoryCache.Remove(key);
+            ScopedJobTokenLog.DistributedCachePersistFailed(_logger, LogValueRedactor.Hash(key), ex);
+            // Surface persistence failures so the caller does not believe a token
+            // was issued when another replica will not see it.
+            throw;
+        }
+    }
+
+    private async Task<ScopedJobTokenRecord?> GetAsync(string token, CancellationToken cancellationToken)
+    {
+        var key = TokenKeyPrefix + token;
+        byte[]? payload = null;
+
+        if (_distributedCache is not null)
+        {
+            try
+            {
+                payload = await _distributedCache.GetAsync(key, cancellationToken).ConfigureAwait(false);
+                if (payload is null)
+                {
+                    _memoryCache.Remove(key);
+                    return null;
+                }
+            }
+            catch (Exception ex)
+            {
+                _memoryCache.Remove(key);
+                ScopedJobTokenLog.DistributedCacheReadFailed(_logger, LogValueRedactor.Hash(key), ex);
+                return null;
+            }
+        }
+        else if (!_memoryCache.TryGetValue(key, out payload) || payload is null)
+        {
+            return null;
+        }
+
+        var value = JsonSerializer.Deserialize(payload, ScopedJobTokenJsonContext.Default.ScopedJobTokenRecord);
+        if (value is null)
+        {
+            await RemoveAsync(key, cancellationToken).ConfigureAwait(false);
+            return null;
+        }
+
+        if (value.ExpiresAt <= DateTimeOffset.UtcNow)
+        {
+            await RemoveAsync(key, cancellationToken).ConfigureAwait(false);
+            return null;
+        }
+
+        _memoryCache.Set(key, payload, value.ExpiresAt);
+        return value;
+    }
+
+    private async Task RemoveAsync(string key, CancellationToken cancellationToken)
+    {
+        _memoryCache.Remove(key);
+
+        if (_distributedCache is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _distributedCache.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            ScopedJobTokenLog.DistributedCacheRemoveFailed(_logger, LogValueRedactor.Hash(key), ex);
+        }
+    }
+}
+
+/// <summary>
+/// Distributed-cache record backing a scoped-job token. Carries the frozen,
+/// already-intersected role/permission grants plus the bound job id; the token
+/// value itself is an opaque cache key with no embedded claims.
+/// </summary>
+internal sealed class ScopedJobTokenRecord
+{
+    public required string PrincipalId { get; init; }
+
+    public string? TenantId { get; init; }
+
+    public required string JobId { get; init; }
+
+    public required string[] Roles { get; init; }
+
+    public required string[] Permissions { get; init; }
+
+    public required DateTimeOffset ExpiresAt { get; init; }
+}
+
+[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(ScopedJobTokenRecord))]
+internal sealed partial class ScopedJobTokenJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Hosting/Features/Authentication/ScopedJobTokenLog.cs
+++ b/src/Honua.Hosting/Features/Authentication/ScopedJobTokenLog.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Authentication;
+
+/// <summary>
+/// Source-generated log messages for the scoped-job token issuer (custom-code auth
+/// spine, Phase 0). Tokens are never written verbatim; an 8-character SHA-256
+/// prefix is emitted instead so issuance and validation events can be correlated
+/// without leaking the secret value to log sinks.
+/// </summary>
+internal static partial class ScopedJobTokenLog
+{
+    [LoggerMessage(EventId = 7050, Level = LogLevel.Information,
+        Message = "Scoped-job token issued for job {JobId} with frozen attenuation roles={RoleCount} permissions={PermissionCount}.")]
+    public static partial void TokenIssued(ILogger logger, string jobId, int roleCount, int permissionCount);
+
+    [LoggerMessage(EventId = 7051, Level = LogLevel.Warning,
+        Message = "Scoped-job token validation rejected: token {TokenHash} was minted for job {BoundJobId} but presented in a different job context.")]
+    public static partial void JobBindingMismatch(ILogger logger, string boundJobId, string tokenHash);
+
+    [LoggerMessage(EventId = 7052, Level = LogLevel.Warning,
+        Message = "Scoped-job token store could not persist distributed cache entry {KeyHash}.")]
+    public static partial void DistributedCachePersistFailed(ILogger logger, string keyHash, Exception exception);
+
+    [LoggerMessage(EventId = 7053, Level = LogLevel.Warning,
+        Message = "Scoped-job token store could not read distributed cache entry {KeyHash}.")]
+    public static partial void DistributedCacheReadFailed(ILogger logger, string keyHash, Exception exception);
+
+    [LoggerMessage(EventId = 7054, Level = LogLevel.Warning,
+        Message = "Scoped-job token store could not remove distributed cache entry {KeyHash}.")]
+    public static partial void DistributedCacheRemoveFailed(ILogger logger, string keyHash, Exception exception);
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeOwnerScopeCaptureTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeOwnerScopeCaptureTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Geoprocessing;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Geoprocessing;
+
+/// <summary>
+/// Unit tests for the submit-time owner-snapshot capture (Phase 0 auth spine,
+/// Deliverable 1): it pins the submitter's tenant/roles/declared scope, validates
+/// the declared scope is ⊆ the submitter, and preserves existing behavior for jobs
+/// that declare no scope.
+/// </summary>
+[SecurityTest]
+[Protocol(TestProtocols.FeatureServer)]
+[Operation(Operations.Security)]
+public sealed class CustomCodeOwnerScopeCaptureTests
+{
+    [UnitTest]
+    public void TryCapture_NoDeclaredScope_ReturnsNull_PreservesBehavior()
+    {
+        var principal = Principal("alice", tenant: "tenant-A", roles: ["data-editor:parcels"]);
+
+        var snapshot = CustomCodeOwnerScopeCapture.TryCapture(
+            principal,
+            protocolMetadata: new Dictionary<string, string>(),
+            globalDataEditorRoles: null,
+            out var rejection);
+
+        snapshot.Should().BeNull();
+        rejection.Should().BeNull();
+    }
+
+    [UnitTest]
+    public void TryCapture_DeclaredScopeWithinOwner_PinsSnapshot()
+    {
+        var principal = Principal(
+            "alice",
+            tenant: "tenant-A",
+            roles: ["data-editor:parcels"],
+            permissions: ["read:zoning"]);
+
+        var metadata = new Dictionary<string, string>
+        {
+            [CustomCodeOwnerScopeCapture.DeclaredScopeMetadataKey] = "write:parcels;read:zoning",
+        };
+
+        var snapshot = CustomCodeOwnerScopeCapture.TryCapture(
+            principal, metadata, globalDataEditorRoles: null, out var rejection);
+
+        rejection.Should().BeNull();
+        snapshot.Should().NotBeNull();
+        snapshot!.PrincipalId.Should().Be("alice");
+        snapshot.TenantId.Should().Be("tenant-A");
+        snapshot.Roles.Should().Contain("data-editor:parcels");
+        snapshot.DeclaredScope.Should().HaveCount(2);
+        snapshot.DeclaredScope.Should().Contain(e =>
+            e.ServiceId == "parcels" && e.LayerId == null && e.Access == JobResourceAccess.Write);
+        snapshot.DeclaredScope.Should().Contain(e =>
+            e.ServiceId == "zoning" && e.Access == JobResourceAccess.Read);
+    }
+
+    [UnitTest]
+    public void TryCapture_DeclaredScopeExceedsOwner_Rejects()
+    {
+        // Submitter can only reach 'parcels'; declaring 'secret' exceeds them.
+        var principal = Principal("alice", tenant: null, roles: ["data-editor:parcels"]);
+
+        var metadata = new Dictionary<string, string>
+        {
+            [CustomCodeOwnerScopeCapture.DeclaredScopeMetadataKey] = "write:parcels;write:secret",
+        };
+
+        var snapshot = CustomCodeOwnerScopeCapture.TryCapture(
+            principal, metadata, globalDataEditorRoles: null, out var rejection);
+
+        snapshot.Should().BeNull();
+        rejection.Should().NotBeNull();
+        rejection.Should().Contain("secret");
+    }
+
+    [UnitTest]
+    public void TryCapture_WriteDeclaredAgainstReadOnlyOwner_Rejects()
+    {
+        // Submitter can only read 'zoning'; declaring write exceeds them.
+        var principal = Principal("alice", tenant: null, roles: [], permissions: ["read:zoning"]);
+
+        var metadata = new Dictionary<string, string>
+        {
+            [CustomCodeOwnerScopeCapture.DeclaredScopeMetadataKey] = "write:zoning",
+        };
+
+        var snapshot = CustomCodeOwnerScopeCapture.TryCapture(
+            principal, metadata, globalDataEditorRoles: null, out var rejection);
+
+        snapshot.Should().BeNull();
+        rejection.Should().NotBeNull();
+    }
+
+    [UnitTest]
+    public void TryCapture_TenantPinnedFromClaim_NotFromMetadata()
+    {
+        // Even if metadata tried to carry a tenant, the snapshot tenant comes only
+        // from the principal's claim (non-forgeable, invariant #2).
+        var principal = Principal("alice", tenant: "tenant-REAL", roles: ["data-editor:parcels"]);
+
+        var metadata = new Dictionary<string, string>
+        {
+            [CustomCodeOwnerScopeCapture.DeclaredScopeMetadataKey] = "read:parcels",
+            ["tenant_id"] = "tenant-FORGED",
+        };
+
+        var snapshot = CustomCodeOwnerScopeCapture.TryCapture(
+            principal, metadata, globalDataEditorRoles: null, out _);
+
+        snapshot.Should().NotBeNull();
+        snapshot!.TenantId.Should().Be("tenant-REAL");
+    }
+
+    private static ClaimsPrincipal Principal(
+        string name,
+        string? tenant,
+        string[] roles,
+        string[]? permissions = null)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.Name, name) };
+        if (!string.IsNullOrEmpty(tenant))
+        {
+            claims.Add(new Claim("tenant_id", tenant));
+        }
+
+        foreach (var role in roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        foreach (var permission in permissions ?? [])
+        {
+            claims.Add(new Claim("permission", permission));
+        }
+
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ScopedJobAttenuationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ScopedJobAttenuationTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Infrastructure.Authentication;
+
+/// <summary>
+/// Unit tests for the pure attenuation math that computes and freezes the
+/// narrow-only intersection at the heart of the custom-code auth spine. These prove
+/// the intersection can only narrow, before any token or pipeline is involved.
+/// </summary>
+[SecurityTest]
+[Protocol(TestProtocols.FeatureServer)]
+[Operation(Operations.Security)]
+public sealed class ScopedJobAttenuationTests
+{
+    [UnitTest]
+    public void Intersect_DropsResourcesOwnerCannotReach()
+    {
+        var effective = ScopedJobAttenuation.Intersect(
+            ownerRoles: ["data-editor:parcels"],
+            ownerGrants: null,
+            globalDataEditorRoles: null,
+            requestedScope:
+            [
+                new JobResourceScopeEntry("parcels", null, JobResourceAccess.Write),
+                new JobResourceScopeEntry("zoning", null, JobResourceAccess.Write),
+            ]);
+
+        effective.Should().ContainSingle();
+        effective[0].ServiceId.Should().Be("parcels");
+        effective[0].Access.Should().Be(JobResourceAccess.Write);
+    }
+
+    [UnitTest]
+    public void Intersect_ClampsRequestedWriteDownToOwnerReadAccess()
+    {
+        var effective = ScopedJobAttenuation.Intersect(
+            ownerRoles: [],
+            ownerGrants: ["read:zoning"],
+            globalDataEditorRoles: null,
+            requestedScope: [new JobResourceScopeEntry("zoning", null, JobResourceAccess.Write)]);
+
+        effective.Should().ContainSingle();
+        effective[0].Access.Should().Be(JobResourceAccess.Read);
+    }
+
+    [UnitTest]
+    public void Intersect_AdminOwner_StillBoundedByRequestedScope()
+    {
+        var effective = ScopedJobAttenuation.Intersect(
+            ownerRoles: ["admin"],
+            ownerGrants: null,
+            globalDataEditorRoles: null,
+            requestedScope: [new JobResourceScopeEntry("parcels", "lots", JobResourceAccess.Read)]);
+
+        // Admin can reach everything, but the scope ceiling is a single read-only layer.
+        effective.Should().ContainSingle();
+        effective[0].ServiceId.Should().Be("parcels");
+        effective[0].LayerId.Should().Be("lots");
+        effective[0].Access.Should().Be(JobResourceAccess.Read);
+    }
+
+    [UnitTest]
+    public void Intersect_ServiceWideRequestNotSatisfiedByLayerGrant()
+    {
+        // A single-layer grant must NOT widen to a service-wide entry.
+        var effective = ScopedJobAttenuation.Intersect(
+            ownerRoles: [],
+            ownerGrants: ["write:parcels/lots"],
+            globalDataEditorRoles: null,
+            requestedScope: [new JobResourceScopeEntry("parcels", null, JobResourceAccess.Write)]);
+
+        effective.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public void Intersect_GlobalDataEditorRole_ReachesAnyService()
+    {
+        var effective = ScopedJobAttenuation.Intersect(
+            ownerRoles: ["gis-editors"],
+            ownerGrants: null,
+            globalDataEditorRoles: ["gis-editors"],
+            requestedScope: [new JobResourceScopeEntry("anything", null, JobResourceAccess.Write)]);
+
+        effective.Should().ContainSingle();
+        effective[0].Access.Should().Be(JobResourceAccess.Write);
+    }
+
+    [UnitTest]
+    public void IsWithinOwner_FlagsFirstUnreachableEntry()
+    {
+        var within = ScopedJobAttenuation.IsWithinOwner(
+            ownerRoles: ["data-editor:parcels"],
+            ownerGrants: null,
+            globalDataEditorRoles: null,
+            requestedScope:
+            [
+                new JobResourceScopeEntry("parcels", null, JobResourceAccess.Write),
+                new JobResourceScopeEntry("zoning", null, JobResourceAccess.Read),
+            ],
+            out var unreachable);
+
+        within.Should().BeFalse();
+        unreachable.Should().NotBeNull();
+        unreachable!.ServiceId.Should().Be("zoning");
+    }
+
+    [UnitTest]
+    public void IsWithinOwner_WriteRequestAgainstReadOwner_IsNotWithin()
+    {
+        var within = ScopedJobAttenuation.IsWithinOwner(
+            ownerRoles: [],
+            ownerGrants: ["read:zoning"],
+            globalDataEditorRoles: null,
+            requestedScope: [new JobResourceScopeEntry("zoning", null, JobResourceAccess.Write)],
+            out var unreachable);
+
+        within.Should().BeFalse();
+        unreachable!.ServiceId.Should().Be("zoning");
+    }
+
+    [UnitTest]
+    public void IsWithinOwner_ExactReach_IsWithin()
+    {
+        var within = ScopedJobAttenuation.IsWithinOwner(
+            ownerRoles: ["data-editor:parcels"],
+            ownerGrants: ["read:zoning"],
+            globalDataEditorRoles: null,
+            requestedScope:
+            [
+                new JobResourceScopeEntry("parcels", "lots", JobResourceAccess.Write),
+                new JobResourceScopeEntry("zoning", null, JobResourceAccess.Read),
+            ],
+            out var unreachable);
+
+        within.Should().BeTrue();
+        unreachable.Should().BeNull();
+    }
+
+    [UnitTest]
+    public void ToClaims_ServiceWideWrite_ProjectsRoleAndBothGrants()
+    {
+        var claims = ScopedJobAttenuation.ToClaims(
+            [new JobResourceScopeEntry("parcels", null, JobResourceAccess.Write)]);
+
+        claims.Roles.Should().Contain("data-editor:parcels");
+        claims.Permissions.Should().Contain(["read:parcels", "write:parcels"]);
+    }
+
+    [UnitTest]
+    public void ToClaims_LayerWrite_DoesNotProjectServiceRole()
+    {
+        var claims = ScopedJobAttenuation.ToClaims(
+            [new JobResourceScopeEntry("parcels", "lots", JobResourceAccess.Write)]);
+
+        // A layer-specific write must not grant the whole-service editor role.
+        claims.Roles.Should().BeEmpty();
+        claims.Permissions.Should().Contain(["read:parcels/lots", "write:parcels/lots"]);
+    }
+
+    [UnitTest]
+    public void ToClaims_ReadEntry_ProjectsReadGrantOnly()
+    {
+        var claims = ScopedJobAttenuation.ToClaims(
+            [new JobResourceScopeEntry("zoning", null, JobResourceAccess.Read)]);
+
+        claims.Roles.Should().BeEmpty();
+        claims.Permissions.Should().ContainSingle().Which.Should().Be("read:zoning");
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ScopedJobTokenIssuerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ScopedJobTokenIssuerTests.cs
@@ -1,0 +1,308 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Infrastructure.Authentication;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Infrastructure.Authentication;
+
+/// <summary>
+/// Security proof for the custom-code geoprocessing scoped-job token issuer (Phase 0
+/// auth spine). Each invariant — narrow-only attenuation, non-forgeable tenant,
+/// read-only-unless-write, job-binding, revocation, and expiry — is exercised
+/// against the real issuer so the hydrated principal can never out-grant the
+/// submitter or reach another tenant.
+/// </summary>
+[SecurityTest]
+[Protocol(TestProtocols.FeatureServer)]
+[Operation(Operations.Security)]
+public sealed class ScopedJobTokenIssuerTests
+{
+    private const string PermissionClaimType = "permission";
+    private const string TenantClaimType = "tenant_id";
+
+    [UnitTest]
+    public async Task IssueAsync_WriteScopeWithinOwner_HydratesAttenuatedPrincipalBoundToJob()
+    {
+        var issuer = CreateIssuer();
+        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(30);
+
+        var issuance = await issuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "alice",
+                TenantId: "tenant-A",
+                Roles: ["data-editor:parcels"],
+                JobId: "gp-job-1",
+                ResourceScope: [new JobResourceScopeEntry("parcels", null, JobResourceAccess.Write)],
+                ExpiresAt: expiresAt),
+            CancellationToken.None);
+
+        issuance.Token.Should().NotBeNullOrWhiteSpace();
+        issuance.ExpiresAt.Should().Be(expiresAt);
+
+        var validation = await issuer.ValidateAsync(issuance.Token, "gp-job-1", CancellationToken.None);
+
+        validation.Should().NotBeNull();
+        validation!.Principal.Identity!.IsAuthenticated.Should().BeTrue();
+        validation.Principal.FindFirstValue(ClaimTypes.Name).Should().Be("alice");
+        validation.JobId.Should().Be("gp-job-1");
+        validation.Principal.FindFirstValue(TenantClaimType).Should().Be("tenant-A");
+
+        // Service-wide write was reachable, so the service-scoped editor role and
+        // both read+write permission grants are projected.
+        validation.Principal.IsInRole("data-editor:parcels").Should().BeTrue();
+        PermissionsOf(validation.Principal).Should().Contain(["read:parcels", "write:parcels"]);
+    }
+
+    [UnitTest]
+    public async Task IssueAsync_RequestExceedsOwner_AttenuatesToOwnerGrantsOnly()
+    {
+        // Owner can only reach 'parcels' (write). The request also asks for 'zoning'
+        // (which the owner cannot reach) — the resulting principal must carry NO
+        // authority over 'zoning' (narrow-only invariant #1).
+        var issuer = CreateIssuer();
+
+        var issuance = await issuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "alice",
+                TenantId: null,
+                Roles: ["data-editor:parcels"],
+                JobId: "gp-job-2",
+                ResourceScope:
+                [
+                    new JobResourceScopeEntry("parcels", null, JobResourceAccess.Write),
+                    new JobResourceScopeEntry("zoning", null, JobResourceAccess.Write),
+                ],
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)),
+            CancellationToken.None);
+
+        var validation = await issuer.ValidateAsync(issuance.Token, "gp-job-2", CancellationToken.None);
+
+        validation.Should().NotBeNull();
+        var permissions = PermissionsOf(validation!.Principal);
+        permissions.Should().Contain(["read:parcels", "write:parcels"]);
+        // The out-of-owner resource is entirely absent — neither read nor write.
+        permissions.Should().NotContain(p => p.Contains("zoning", StringComparison.OrdinalIgnoreCase));
+        validation.Principal.IsInRole("data-editor:zoning").Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task IssueAsync_ResourceScopeNarrowerThanOwner_GrantsOnlyTheScope()
+    {
+        // Owner is admin (can reach everything) but the ResourceScope is narrowed to
+        // a single read-only layer. The token must grant ONLY that, never more —
+        // the scope is the ceiling even when the owner is broader.
+        var issuer = CreateIssuer();
+
+        var issuance = await issuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "root",
+                TenantId: "tenant-A",
+                Roles: ["admin"],
+                JobId: "gp-job-3",
+                ResourceScope: [new JobResourceScopeEntry("parcels", "lots", JobResourceAccess.Read)],
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)),
+            CancellationToken.None);
+
+        var validation = await issuer.ValidateAsync(issuance.Token, "gp-job-3", CancellationToken.None);
+
+        validation.Should().NotBeNull();
+        // Even though the owner is admin, the principal is NOT admin: it carries only
+        // the scoped read grant.
+        validation!.Principal.IsInRole("admin").Should().BeFalse();
+        var permissions = PermissionsOf(validation.Principal);
+        permissions.Should().Contain("read:parcels/lots");
+        permissions.Should().NotContain(p => p.StartsWith("write:", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [UnitTest]
+    public async Task IssueAsync_TenantComesFromSnapshotOnly_IsNonForgeable()
+    {
+        // The hydrated tenant always equals the snapshot tenant. There is no input
+        // path for a callback to supply a tenant — the only tenant source is the
+        // pinned snapshot (invariant #2).
+        var issuer = CreateIssuer();
+
+        var issuance = await issuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "alice",
+                TenantId: "tenant-A",
+                Roles: ["data-editor:parcels"],
+                JobId: "gp-job-4",
+                ResourceScope: [new JobResourceScopeEntry("parcels", null, JobResourceAccess.Read)],
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)),
+            CancellationToken.None);
+
+        var validation = await issuer.ValidateAsync(issuance.Token, "gp-job-4", CancellationToken.None);
+
+        validation.Should().NotBeNull();
+        validation!.Principal.FindAll(TenantClaimType).Should().ContainSingle()
+            .Which.Value.Should().Be("tenant-A");
+    }
+
+    [UnitTest]
+    public async Task IssueAsync_ReadOnlyScope_YieldsNoWriteAuthority()
+    {
+        // A scope entry without write yields read-only for that resource (invariant #3).
+        var issuer = CreateIssuer();
+
+        var issuance = await issuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "alice",
+                TenantId: null,
+                Roles: ["data-editor:parcels"], // owner COULD write, but scope is read-only
+                JobId: "gp-job-5",
+                ResourceScope: [new JobResourceScopeEntry("parcels", null, JobResourceAccess.Read)],
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)),
+            CancellationToken.None);
+
+        var validation = await issuer.ValidateAsync(issuance.Token, "gp-job-5", CancellationToken.None);
+
+        validation.Should().NotBeNull();
+        var permissions = PermissionsOf(validation!.Principal);
+        permissions.Should().Contain("read:parcels");
+        permissions.Should().NotContain("write:parcels");
+        validation.Principal.IsInRole("data-editor:parcels").Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task IssueAsync_RequestedWriteAgainstReadOnlyOwner_ClampsToRead()
+    {
+        // Owner has only a read grant on 'zoning'; the request asks for write.
+        // The effective grant clamps down to read (cannot widen owner authority).
+        var issuer = CreateIssuer();
+
+        var issuance = await issuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "carol",
+                TenantId: null,
+                Roles: [],
+                JobId: "gp-job-6",
+                ResourceScope: [new JobResourceScopeEntry("zoning", null, JobResourceAccess.Write)],
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)),
+            CancellationToken.None);
+
+        var validation = await issuer.ValidateAsync(issuance.Token, "gp-job-6", CancellationToken.None);
+
+        validation.Should().NotBeNull();
+        // Owner had no reach on zoning (no role/grant), so nothing is granted at all.
+        PermissionsOf(validation!.Principal).Should().NotContain(p => p.Contains("zoning", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [UnitTest]
+    public async Task ValidateAsync_WrongJobContext_ReturnsNull()
+    {
+        // Job-binding (invariant #4): a token minted for one job is rejected in
+        // another job's context.
+        var issuer = CreateIssuer();
+
+        var issuance = await issuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "alice",
+                TenantId: null,
+                Roles: ["data-editor:parcels"],
+                JobId: "gp-job-7",
+                ResourceScope: [new JobResourceScopeEntry("parcels", null, JobResourceAccess.Read)],
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)),
+            CancellationToken.None);
+
+        var sameJob = await issuer.ValidateAsync(issuance.Token, "gp-job-7", CancellationToken.None);
+        var otherJob = await issuer.ValidateAsync(issuance.Token, "gp-job-DIFFERENT", CancellationToken.None);
+
+        sameJob.Should().NotBeNull();
+        otherJob.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task RevokeAsync_RemovesToken_SubsequentValidationFails()
+    {
+        // Revocation (invariant #5): deleting the record invalidates the token.
+        var issuer = CreateIssuer();
+
+        var issuance = await issuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "alice",
+                TenantId: null,
+                Roles: ["data-editor:parcels"],
+                JobId: "gp-job-8",
+                ResourceScope: [new JobResourceScopeEntry("parcels", null, JobResourceAccess.Read)],
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)),
+            CancellationToken.None);
+
+        (await issuer.ValidateAsync(issuance.Token, "gp-job-8", CancellationToken.None)).Should().NotBeNull();
+
+        await issuer.RevokeAsync(issuance.Token, CancellationToken.None);
+
+        (await issuer.ValidateAsync(issuance.Token, "gp-job-8", CancellationToken.None)).Should().BeNull();
+        // Revoking an already-absent token is a no-op.
+        await issuer.Invoking(i => i.RevokeAsync(issuance.Token, CancellationToken.None))
+            .Should().NotThrowAsync();
+    }
+
+    [UnitTest]
+    public async Task ValidateAsync_ExpiredToken_ReturnsNull()
+    {
+        // Short-lived (invariant #5): an expired token never validates.
+        var issuer = CreateIssuer();
+
+        var issuance = await issuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "alice",
+                TenantId: null,
+                Roles: ["data-editor:parcels"],
+                JobId: "gp-job-9",
+                ResourceScope: [new JobResourceScopeEntry("parcels", null, JobResourceAccess.Read)],
+                ExpiresAt: DateTimeOffset.UtcNow.AddMilliseconds(-1)),
+            CancellationToken.None);
+
+        var validation = await issuer.ValidateAsync(issuance.Token, "gp-job-9", CancellationToken.None);
+
+        validation.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task ValidateAsync_UnknownToken_ReturnsNull()
+    {
+        var issuer = CreateIssuer();
+
+        var validation = await issuer.ValidateAsync(
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "gp-job-10",
+            CancellationToken.None);
+
+        validation.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task IssueAsync_RejectsMissingJobBinding()
+    {
+        var issuer = CreateIssuer();
+
+        await issuer.Invoking(i => i.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "alice",
+                TenantId: null,
+                Roles: ["admin"],
+                JobId: "   ",
+                ResourceScope: [new JobResourceScopeEntry("parcels", null, JobResourceAccess.Read)],
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)),
+            CancellationToken.None))
+            .Should().ThrowAsync<ArgumentException>();
+    }
+
+    private static List<string> PermissionsOf(ClaimsPrincipal principal)
+        => principal.FindAll(PermissionClaimType).Select(c => c.Value).ToList();
+
+    private static ScopedJobTokenIssuer CreateIssuer()
+    {
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        return new ScopedJobTokenIssuer(memoryCache, NullLogger<ScopedJobTokenIssuer>.Instance);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ScopedJobTokenPipelineTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ScopedJobTokenPipelineTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Infrastructure.Authentication;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Infrastructure.Authentication;
+
+/// <summary>
+/// End-to-end proof of invariant #6: a hydrated scoped-job principal is authorized
+/// by the EXISTING shared RBAC pipeline (<see cref="ServiceDataEditorAuthorization"/>)
+/// unchanged. The mint freezes the intersection as <c>data-editor:{service}</c>
+/// roles, and the same service-scoped-role check every other request flows through
+/// grants in-scope access and denies out-of-scope access — authorization is never
+/// forked.
+/// </summary>
+[SecurityTest]
+[Protocol(TestProtocols.FeatureServer)]
+[Operation(Operations.Security)]
+public sealed class ScopedJobTokenPipelineTests
+{
+    [UnitTest]
+    public async Task HydratedPrincipal_FlowsThroughServiceDataEditorPipeline_EnforcesAttenuation()
+    {
+        var issuer = CreateIssuer();
+
+        // Submitter could write 'parcels' (and nothing else). Scope requests parcels.
+        var issuance = await issuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "alice",
+                TenantId: "tenant-A",
+                Roles: ["data-editor:parcels"],
+                JobId: "gp-pipeline-1",
+                ResourceScope: [new JobResourceScopeEntry("parcels", null, JobResourceAccess.Write)],
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)),
+            CancellationToken.None);
+
+        var validation = await issuer.ValidateAsync(issuance.Token, "gp-pipeline-1", CancellationToken.None);
+        validation.Should().NotBeNull();
+
+        var context = CreateContext(validation!.Principal);
+
+        // In-scope: the existing pipeline GRANTS write to 'parcels' via the frozen
+        // service-scoped editor role.
+        var inScope = await ServiceDataEditorAuthorization.EvaluateServiceAccessAsync(
+            context, "parcels", CancellationToken.None);
+        inScope.IsAllowed.Should().BeTrue("the frozen data-editor:parcels role authorizes the in-scope service");
+
+        // Out-of-scope: the SAME pipeline DENIES 'zoning' — the token confers no
+        // authority the submitter did not have and the scope did not include.
+        var outOfScope = await ServiceDataEditorAuthorization.EvaluateServiceAccessAsync(
+            context, "zoning", CancellationToken.None);
+        outOfScope.IsAllowed.Should().BeFalse("no grant exists for the out-of-scope service");
+    }
+
+    [UnitTest]
+    public async Task HydratedReadOnlyPrincipal_IsNotAuthorizedAsServiceEditor()
+    {
+        var issuer = CreateIssuer();
+
+        // Read-only scope: even though the submitter could write, the scope is read.
+        var issuance = await issuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "alice",
+                TenantId: null,
+                Roles: ["data-editor:parcels"],
+                JobId: "gp-pipeline-2",
+                ResourceScope: [new JobResourceScopeEntry("parcels", null, JobResourceAccess.Read)],
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)),
+            CancellationToken.None);
+
+        var validation = await issuer.ValidateAsync(issuance.Token, "gp-pipeline-2", CancellationToken.None);
+        var context = CreateContext(validation!.Principal);
+
+        // The read-only principal carries NO data-editor role, so the write-oriented
+        // service-editor gate denies it (invariant #3 enforced by the shared pipeline).
+        var decision = await ServiceDataEditorAuthorization.EvaluateServiceAccessAsync(
+            context, "parcels", CancellationToken.None);
+        decision.IsAllowed.Should().BeFalse("a read-only scope confers no service-editor (write) authority");
+    }
+
+    private static DefaultHttpContext CreateContext(System.Security.Claims.ClaimsPrincipal principal)
+    {
+        var services = new ServiceCollection();
+        services.Configure<RbacOptions>(_ => { });
+
+        return new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+            User = principal
+        };
+    }
+
+    private static ScopedJobTokenIssuer CreateIssuer()
+        => new(new MemoryCache(new MemoryCacheOptions()), NullLogger<ScopedJobTokenIssuer>.Instance);
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
<!-- Phase 0 of the custom-code geoprocessing design pass; no standalone tracking issue filed yet. -->
Related to #1883

## Summary
Builds **Phase 0 — the AUTH SPINE** for the custom-code geoprocessing feature: a scoped, attenuated, job-bound token issuer that lets future user-supplied GP code call back into Honua via the SDK with authority **STRICTLY ≤ the submitter's permissions**. This is security-critical net-new code derived from the custom-code design pass. It is a *separate* issuer alongside `IPortalTokenIssuer` (the ArcGIS portal token is never overloaded). This PR is Phase 0 only — the worker images/harness/job-kind/iac are Phase 1 and depend on this.

The attenuation is computed and **frozen server-side at mint time** from a durable owner snapshot pinned at submit; nothing presented at callback time can widen it. The hydrated principal carries only the frozen intersection using the same role/`permission`/`tenant_id` claim grammar the existing shared RBAC pipeline already enforces — authorization is never forked.

## Changes Made
- **`IScopedJobTokenIssuer` + `ScopedJobTokenIssuer`** (Core abstraction / Hosting impl): opaque-entropy, redis-backed issuer mirroring `PortalTokenIssuer`; the stored record additionally carries the bound `JobId` and the frozen, already-intersected resource scope. `IssueAsync`/`ValidateAsync(token, jobId)`/`RevokeAsync`. Registered as a singleton alongside the portal-token issuer.
- **`ScopedJobAttenuation`** (Core, pure/AOT-safe): the single place the narrow-only intersection is computed. Effective grant = `(owner roles/grants) ∩ (ResourceScope)`, clamped to the owner's reachable access, projected onto `data-editor:{service}` roles + `read:`/`write:` permission grants. Admin/global-editor reach is consumed at mint but never re-emitted.
- **`OperationAuditInfo.CustomCodeOwnerScope` + `CustomCodeOwnerScopeCapture`** (Deliverable 1): pins the submitter's `PrincipalId`/`TenantId`/`Roles`/`DeclaredScope` at submit from the live `ClaimsPrincipal`, and **rejects any declared scope that exceeds the submitter**. Behavior-preserving for non-custom-code jobs (no declared scope → no snapshot). Carried on the durable `ExecutionJobRecord` (already source-gen serialized → AOT-safe).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

34 auth tests pass (29 new + 5 portal-token regression): narrow-only attenuation, non-forgeable tenant, read-only-unless-write, job-binding, revocation, expiry, and end-to-end enforcement through the existing `ServiceDataEditorAuthorization` pipeline. Full `Honua.Architecture.Tests` (117) green; 74 `GeoprocessingJobServiceTests` + 418 fast geoprocessing tests green (no submit-path regression). Release build is warnings-as-errors clean; `dotnet format --verify-no-changes` clean on all changed files.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [ ] None — no docs or contract impact

Adds `OperationAuditInfo.CustomCodeOwnerScope` to the durable control-plane record (additive, nullable, source-gen serialized).

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — all additions are net-new or additive nullable fields; existing portal-token and job-submit paths are unchanged.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
