### PR TITLE
feat(geoprocessing): custom-code GP Phase 1 — server control path (Python MVP)

### DIFF
--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeDispatchJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeDispatchJobExecutor.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Geoprocessing.CustomCode;
+
+/// <summary>
+/// The thin server-side dispatch executor for the <c>custom-code</c> runtime
+/// profile. It exists primarily as the worker-side half of the runtime-profile
+/// claim fence: by accepting <em>only</em> the <c>custom-code</c> profile it keeps
+/// the lean managed <c>GeoprocessingDispatchJobExecutor</c> and the native GDAL
+/// worker from ever claiming a custom-code job (mirroring the GDAL worker's
+/// <c>GdalDispatchJobExecutor</c> fence).
+/// </summary>
+/// <remarks>
+/// The heavy work — cloning the pinned commit, installing dependencies, and running
+/// the user entrypoint — happens IN the custom-code Batch container (the harness,
+/// built separately), reached by the param-driven remote-backend submission at
+/// submit time (analogous to how the GP Batch workload is submitted through
+/// <c>AwsBatchComputeBackend</c>). A custom-code job therefore never executes user
+/// code in-process here. If a job carrying this profile is ever claimed locally
+/// (i.e. the deployment failed to configure a custom-code Batch workload so the job
+/// was not routed to a remote backend), this executor fails it loudly rather than
+/// silently no-op'ing or running untrusted code in the server process.
+/// </remarks>
+internal sealed partial class CustomCodeDispatchJobExecutor : IJobExecutor
+{
+    private static readonly IReadOnlySet<string> CustomCodeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { CustomCodeJobContract.RuntimeProfile };
+
+    private readonly ILogger<CustomCodeDispatchJobExecutor> _logger;
+
+    /// <summary>Creates the custom-code dispatch executor.</summary>
+    public CustomCodeDispatchJobExecutor(ILogger<CustomCodeDispatchJobExecutor> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => CustomCodeProfileSet;
+
+    /// <inheritdoc />
+    public Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        // Reaching this point means a custom-code job was claimed by an in-process
+        // worker instead of being dispatched to the custom-code Batch workload. That
+        // is a deployment misconfiguration: custom (untrusted) user code must run in
+        // the isolated Batch container, never in the server process. Fail closed.
+        Log.CustomCodeNotDispatchedToBatch(_logger, job.OperationId);
+        return Task.FromResult(JobExecutionResult.Failed(
+            "Custom-code jobs must be dispatched to the custom-code Batch workload and cannot run in-process. " +
+            "Configure a ControlPlane execution workload with RuntimeProfile='custom-code'."));
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9240, LogLevel.Error,
+            "Custom-code job {OperationId} was claimed in-process but custom-code must run in the Batch container; failing the job")]
+        public static partial void CustomCodeNotDispatchedToBatch(ILogger logger, string operationId);
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeJobContract.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeJobContract.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Geoprocessing.CustomCode;
+
+/// <summary>
+/// The wire contract for a <c>custom-code</c> geoprocessing job — the
+/// <c>customcode.*</c> parameter keys carried on
+/// <see cref="Honua.Core.Features.ControlPlane.Domain.ExecutionJobSpec.Parameters"/>
+/// and the <c>env.*</c> keys the server injects into the Batch container at submit.
+/// </summary>
+/// <remarks>
+/// This is the SERVER half of a contract shared with the user-code harness (which
+/// runs inside the Batch container, built separately) and the iac (which builds the
+/// custom-code Batch job-definition family separately). Both must match these exact
+/// names.
+/// </remarks>
+public static class CustomCodeJobContract
+{
+    /// <summary>
+    /// The <see cref="Honua.Core.Features.ControlPlane.Domain.RuntimeProfiles"/>
+    /// value that fences a custom-code job to the custom-code dispatch executor and
+    /// the custom-code Batch workload. A job carrying this profile is never claimed
+    /// by the lean managed dispatcher or the native GDAL worker.
+    /// </summary>
+    public const string RuntimeProfile = "custom-code";
+
+    /// <summary>The only runtime supported by the MVP.</summary>
+    public const string PythonRuntime = "python";
+
+    // --- caller-supplied customcode.* parameters --------------------------------
+
+    /// <summary>Runtime selector; MVP accepts only <see cref="PythonRuntime"/>.</summary>
+    public const string RuntimeParam = "customcode.runtime";
+
+    /// <summary>HTTPS git repository URL holding the user code (allowlist-checked).</summary>
+    public const string RepoUrlParam = "customcode.repo_url";
+
+    /// <summary>Full 40-hex commit SHA to check out (branches/tags are rejected).</summary>
+    public const string GitRefParam = "customcode.git_ref";
+
+    /// <summary>Entrypoint in <c>module.path:function</c> form.</summary>
+    public const string EntrypointParam = "customcode.entrypoint";
+
+    /// <summary>Relative path to the dependency manifest (e.g. <c>requirements.txt</c>).</summary>
+    public const string DepsManifestParam = "customcode.deps_manifest";
+
+    /// <summary>Opaque user parameters, passed through verbatim to the user code.</summary>
+    public const string ParamsJsonParam = "customcode.params_json";
+
+    /// <summary>
+    /// Declared resource scope as JSON: <c>[{"serviceId":"x","layerId":"y","access":"read|write"}]</c>.
+    /// Validated to be ⊆ what the submitter can reach; the scoped token is bound to
+    /// the intersection of this and the owner snapshot.
+    /// </summary>
+    public const string DeclaredScopeParam = "customcode.declared_scope";
+
+    // --- server-set customcode.* parameters (never caller-supplied) -------------
+
+    /// <summary>
+    /// The per-job S3 output prefix. SERVER-SET only: a caller-supplied value is
+    /// overwritten so user code can never redirect its outputs outside its job's
+    /// isolated prefix.
+    /// </summary>
+    public const string OutputPrefixParam = "customcode.output_prefix";
+
+    // --- injected env.* pass-through (AwsBatchComputeBackend.BuildEnvironmentOverrides) ---
+
+    /// <summary>
+    /// Spec-parameter key that injects the Honua API base URL into the container as
+    /// the <c>HONUA_BASE_URL</c> environment variable.
+    /// </summary>
+    public const string BaseUrlEnvParam = "env.HONUA_BASE_URL";
+
+    /// <summary>
+    /// Spec-parameter key that injects the scoped, job-bound callback token into the
+    /// container as the <c>HONUA_JOB_TOKEN</c> environment variable.
+    /// </summary>
+    public const string JobTokenEnvParam = "env.HONUA_JOB_TOKEN";
+
+    /// <summary>The container environment variable name for the Honua API base URL.</summary>
+    public const string BaseUrlEnvName = "HONUA_BASE_URL";
+
+    /// <summary>The container environment variable name for the scoped job token.</summary>
+    public const string JobTokenEnvName = "HONUA_JOB_TOKEN";
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeOptions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeOptions.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Honua.Geoprocessing.CustomCode;
+
+/// <summary>
+/// The repository-allowlist policy mode applied to a custom-code job's
+/// <c>customcode.repo_url</c> at submit time.
+/// </summary>
+public enum CustomCodeRepoPolicy
+{
+    /// <summary>
+    /// Reject every repository — custom-code submission is disabled. This is the
+    /// fail-closed default when the operator has not opted in by configuring an
+    /// allowlist (or explicitly choosing <see cref="Open"/>).
+    /// </summary>
+    Disabled = 0,
+
+    /// <summary>
+    /// Only repositories whose host is on <see cref="CustomCodeOptions.RepoAllowlist"/>
+    /// may be submitted. This is the recommended posture.
+    /// </summary>
+    OrgAllowlist = 1,
+
+    /// <summary>
+    /// Any HTTPS repository is accepted. Intended for trusted single-tenant
+    /// deployments only — never combine with untrusted submitters.
+    /// </summary>
+    Open = 2,
+}
+
+/// <summary>
+/// Configuration for the custom-code geoprocessing submit path: the repository
+/// allowlist policy, the Honua API base URL injected into user-code containers,
+/// the server-set S3 output-prefix root, and the scoped-token lifetime knobs.
+/// </summary>
+internal sealed class CustomCodeOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Geoprocessing:CustomCode";
+
+    /// <summary>
+    /// Repository-allowlist policy. Defaults to
+    /// <see cref="CustomCodeRepoPolicy.OrgAllowlist"/> — the org-allowlist posture
+    /// the contract specifies as the default; with an empty
+    /// <see cref="RepoAllowlist"/> this rejects every repository (fail-closed).
+    /// </summary>
+    public CustomCodeRepoPolicy RepoPolicy { get; set; } = CustomCodeRepoPolicy.OrgAllowlist;
+
+    /// <summary>
+    /// Allowed repository hosts (e.g. <c>github.com</c>,
+    /// <c>git.internal.example</c>) honored when <see cref="RepoPolicy"/> is
+    /// <see cref="CustomCodeRepoPolicy.OrgAllowlist"/>. Matched case-insensitively
+    /// against the URL host; an entry of the form <c>host/org</c> additionally
+    /// constrains the first path segment.
+    /// </summary>
+    public List<string> RepoAllowlist { get; set; } = [];
+
+    /// <summary>
+    /// The Honua API endpoint injected into the container as <c>HONUA_BASE_URL</c>
+    /// so the user code's SDK callbacks reach this server. Required for custom-code
+    /// submission to a remote Batch workload; must be an absolute HTTPS URL.
+    /// </summary>
+    public string? ApiBaseUrl { get; set; }
+
+    /// <summary>
+    /// The S3 URI prefix root under which each job's server-set
+    /// <c>customcode.output_prefix</c> is allocated (e.g.
+    /// <c>s3://honua-customcode/outputs</c>). The per-job prefix is this root plus
+    /// the job id.
+    /// </summary>
+    public string OutputPrefixRoot { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Maximum wall-clock execution time allowed for a custom-code job, used to
+    /// bound the scoped token's lifetime when the workload declares no explicit
+    /// <c>batch.timeout_seconds</c>.
+    /// </summary>
+    [Range(typeof(TimeSpan), "00:01:00", "1.00:00:00", ErrorMessage = "JobTimeout must be between 1 minute and 24 hours")]
+    public TimeSpan JobTimeout { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Grace period added to the job timeout when computing the scoped token's
+    /// absolute expiry, so the callback credential outlives in-flight requests at
+    /// the moment the job is timing out but never long after.
+    /// </summary>
+    [Range(typeof(TimeSpan), "00:00:30", "01:00:00", ErrorMessage = "TokenGrace must be between 30 seconds and 1 hour")]
+    public TimeSpan TokenGrace { get; set; } = TimeSpan.FromMinutes(5);
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeScopeJson.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeScopeJson.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Geoprocessing.CustomCode;
+
+/// <summary>
+/// Wire shape of one <c>customcode.declared_scope</c> entry:
+/// <c>{"serviceId":"x","layerId":"y","access":"read|write"}</c>.
+/// </summary>
+internal sealed class DeclaredScopeDto
+{
+    /// <summary>Target service identifier (required).</summary>
+    [JsonPropertyName("serviceId")]
+    public string? ServiceId { get; set; }
+
+    /// <summary>Target layer identifier, or null for a service-wide entry.</summary>
+    [JsonPropertyName("layerId")]
+    public string? LayerId { get; set; }
+
+    /// <summary>Requested access (<c>read</c> or <c>write</c>); defaults to read.</summary>
+    [JsonPropertyName("access")]
+    public string? Access { get; set; }
+}
+
+/// <summary>
+/// Source-generated JSON context for parsing the custom-code declared scope,
+/// keeping the submit path reflection-free (AOT-safe).
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(List<DeclaredScopeDto>))]
+internal sealed partial class CustomCodeScopeJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeSubmitCoordinator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeSubmitCoordinator.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+
+namespace Honua.Geoprocessing.CustomCode;
+
+/// <summary>
+/// Encapsulates the custom-code-specific submit work the geoprocessing job service
+/// delegates to: validating the <c>customcode.*</c> parameters, clamping the
+/// declared scope to ⊆ the submitter, pinning the owner snapshot, minting the
+/// scoped job-bound callback token, and injecting it (plus the API base URL and the
+/// server-set output prefix) into the durable spec parameters.
+/// </summary>
+/// <remarks>
+/// The token is the Phase-0 <see cref="IScopedJobTokenIssuer"/> credential: bound to
+/// the JobId, scoped to <c>declared_scope ∩ owner</c>, expiring at the job timeout
+/// plus a grace. It is injected through the existing <c>env.*</c> pass-through so
+/// <c>AwsBatchComputeBackend.BuildEnvironmentOverrides</c> surfaces it to the
+/// container as <c>HONUA_JOB_TOKEN</c> / <c>HONUA_BASE_URL</c>.
+/// </remarks>
+internal sealed class CustomCodeSubmitCoordinator(IScopedJobTokenIssuer tokenIssuer)
+{
+    private readonly IScopedJobTokenIssuer _tokenIssuer = tokenIssuer
+        ?? throw new ArgumentNullException(nameof(tokenIssuer));
+
+    /// <summary>Permission claim type the shared RBAC pipeline reads for scoped grants.</summary>
+    private const string PermissionClaimType = "permission";
+
+    /// <summary>Tenant claim type mirrored from the portal-token grammar.</summary>
+    private const string TenantClaimType = "tenant_id";
+
+    /// <summary>
+    /// Validates the custom-code submission and, on success, mints + injects the
+    /// scoped token. Mutates <paramref name="specParams"/> in place to set the
+    /// server-side output prefix and the injected <c>env.*</c> values, and returns
+    /// the pinned owner snapshot plus the minted token so the caller can persist the
+    /// snapshot and revoke the token on terminal.
+    /// </summary>
+    /// <param name="jobId">The job the token is bound to.</param>
+    /// <param name="principal">The live submitting principal (the owner reach source).</param>
+    /// <param name="specParams">The durable spec parameters to mutate.</param>
+    /// <param name="options">Custom-code policy/config.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The validated result carrying the owner snapshot and issued token.</returns>
+    /// <exception cref="CustomCodeSubmitRejectedException">Thrown when validation fails.</exception>
+    public async Task<CustomCodeSubmitResult> ValidateMintAndInjectAsync(
+        string jobId,
+        ClaimsPrincipal principal,
+        Dictionary<string, string> specParams,
+        CustomCodeOptions options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
+        ArgumentNullException.ThrowIfNull(principal);
+        ArgumentNullException.ThrowIfNull(specParams);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (!CustomCodeSubmitValidator.TryValidate(specParams, options, out var declaredScope, out var paramRejection))
+        {
+            throw new CustomCodeSubmitRejectedException(paramRejection!);
+        }
+
+        if (string.IsNullOrWhiteSpace(options.ApiBaseUrl) ||
+            !Uri.TryCreate(options.ApiBaseUrl, UriKind.Absolute, out var baseUri) ||
+            !string.Equals(baseUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new CustomCodeSubmitRejectedException(
+                "Custom-code submission requires a configured absolute https Geoprocessing:CustomCode:ApiBaseUrl.");
+        }
+
+        // Snapshot the submitter's reach from the LIVE principal and reject any
+        // declared-scope entry the submitter cannot actually reach. The pinned scope
+        // is therefore always ⊆ submitter; the token mint can only attenuate it.
+        var roles = SnapshotRoles(principal);
+        var grants = SnapshotGrants(principal);
+        if (!ScopedJobAttenuation.IsWithinOwner(roles, grants, globalDataEditorRoles: null, declaredScope, out var unreachable))
+        {
+            var target = unreachable is null
+                ? "(unspecified)"
+                : unreachable.LayerId is null
+                    ? unreachable.ServiceId
+                    : string.Concat(unreachable.ServiceId, "/", unreachable.LayerId);
+            throw new CustomCodeSubmitRejectedException(
+                $"Declared scope entry '{target}' exceeds the submitter's permissions and cannot be granted to custom code.");
+        }
+
+        var tenantId = principal.FindFirstValue(TenantClaimType);
+        var principalId = principal.Identity?.Name ?? string.Empty;
+        var ownerScope = new CustomCodeOwnerScope(principalId, tenantId, roles, declaredScope);
+
+        // Server-set the per-job output prefix; never honor a caller-supplied value
+        // so user code cannot redirect its outputs outside its isolated prefix.
+        specParams[CustomCodeJobContract.OutputPrefixParam] = BuildOutputPrefix(options.OutputPrefixRoot, jobId);
+
+        // Mint the scoped, job-bound token. ResourceScope = the validated declared
+        // scope (⊆ owner); the issuer re-intersects with the owner snapshot so the
+        // effective grant can only narrow.
+        var expiresAt = DateTimeOffset.UtcNow + ResolveJobTimeout(specParams, options) + options.TokenGrace;
+        var issuance = await _tokenIssuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: principalId,
+                TenantId: tenantId,
+                Roles: roles,
+                JobId: jobId,
+                ResourceScope: declaredScope,
+                ExpiresAt: expiresAt),
+            cancellationToken).ConfigureAwait(false);
+
+        // Inject the token + base URL via the env.* pass-through.
+        specParams[CustomCodeJobContract.BaseUrlEnvParam] = options.ApiBaseUrl;
+        specParams[CustomCodeJobContract.JobTokenEnvParam] = issuance.Token;
+
+        return new CustomCodeSubmitResult(ownerScope, issuance.Token);
+    }
+
+    private static TimeSpan ResolveJobTimeout(Dictionary<string, string> specParams, CustomCodeOptions options)
+    {
+        // Prefer the workload's declared Batch timeout when present so the token's
+        // lifetime tracks the actual job ceiling; otherwise fall back to the option.
+        if (specParams.TryGetValue("batch.timeout_seconds", out var raw) &&
+            int.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var seconds) &&
+            seconds > 0)
+        {
+            return TimeSpan.FromSeconds(seconds);
+        }
+
+        return options.JobTimeout;
+    }
+
+    private static string BuildOutputPrefix(string root, string jobId)
+    {
+        var trimmedRoot = string.IsNullOrWhiteSpace(root) ? "customcode/outputs" : root.TrimEnd('/');
+        return string.Concat(trimmedRoot, "/", jobId);
+    }
+
+    private static List<string> SnapshotRoles(ClaimsPrincipal principal)
+    {
+        var roles = new List<string>();
+        foreach (var claim in principal.FindAll(ClaimTypes.Role))
+        {
+            if (!string.IsNullOrWhiteSpace(claim.Value))
+            {
+                roles.Add(claim.Value);
+            }
+        }
+
+        foreach (var claim in principal.FindAll("roles"))
+        {
+            if (!string.IsNullOrWhiteSpace(claim.Value) && !roles.Contains(claim.Value))
+            {
+                roles.Add(claim.Value);
+            }
+        }
+
+        return roles;
+    }
+
+    private static List<string> SnapshotGrants(ClaimsPrincipal principal)
+    {
+        var grants = new List<string>();
+        foreach (var claim in principal.FindAll(PermissionClaimType))
+        {
+            if (!string.IsNullOrWhiteSpace(claim.Value))
+            {
+                grants.Add(claim.Value);
+            }
+        }
+
+        return grants;
+    }
+}
+
+/// <summary>
+/// The outcome of a successful custom-code submit gate: the pinned owner snapshot to
+/// persist on the job and the minted scoped token to revoke on terminal.
+/// </summary>
+/// <param name="OwnerScope">The owner snapshot pinned at submit time.</param>
+/// <param name="Token">The minted scoped job-bound callback token (also injected as env.HONUA_JOB_TOKEN).</param>
+internal sealed record CustomCodeSubmitResult(CustomCodeOwnerScope OwnerScope, string Token);
+
+/// <summary>
+/// Raised when a custom-code submission fails validation or scope-clamp. The submit
+/// adapter maps this to the same validation error channel ordinary plan-validation
+/// failures use.
+/// </summary>
+internal sealed class CustomCodeSubmitRejectedException(string message) : Exception(message);

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeSubmitValidator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeSubmitValidator.cs
@@ -1,0 +1,275 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Honua.Core.Features.Authorization.Domain;
+
+namespace Honua.Geoprocessing.CustomCode;
+
+/// <summary>
+/// Pure submit-time validation for a <c>custom-code</c> geoprocessing job. Validates
+/// the <c>customcode.*</c> parameters the caller supplied — runtime, repository URL
+/// (HTTPS + allowlist policy), the git ref (full 40-hex SHA only, never a branch or
+/// tag), the entrypoint shape, and the declared resource scope (parsed from JSON).
+/// </summary>
+/// <remarks>
+/// This type carries no I/O. The <em>scope ⊆ owner</em> check is performed by the
+/// caller through <see cref="ScopedJobAttenuation.IsWithinOwner"/> against the live
+/// submitting principal; this validator only parses and structurally validates the
+/// declared scope so the same JSON contract is enforced in one place.
+/// </remarks>
+internal static partial class CustomCodeSubmitValidator
+{
+    [GeneratedRegex("^[0-9a-f]{40}$", RegexOptions.CultureInvariant)]
+    private static partial Regex FullShaRegex();
+
+    // module.path:function — dotted module path, a single ':' separator, then a
+    // python identifier. Deliberately strict so a shell-injection-shaped entrypoint
+    // is rejected at the door.
+    [GeneratedRegex(@"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*:[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.CultureInvariant)]
+    private static partial Regex EntrypointRegex();
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the submission carries the custom-code
+    /// runtime marker (so the submit path branches into the custom-code gate). A
+    /// submission without it is an ordinary geoprocessing job and is unaffected.
+    /// </summary>
+    public static bool IsCustomCodeSubmission(IReadOnlyDictionary<string, string>? parameters)
+        => parameters is not null
+           && parameters.TryGetValue(CustomCodeJobContract.RuntimeParam, out var runtime)
+           && !string.IsNullOrWhiteSpace(runtime);
+
+    /// <summary>
+    /// Validates the caller-supplied custom-code parameters and parses the declared
+    /// scope. Returns the parsed declared scope on success; on failure sets
+    /// <paramref name="rejection"/> and returns <see langword="null"/>.
+    /// </summary>
+    /// <param name="parameters">The submission parameters (the <c>customcode.*</c> keys).</param>
+    /// <param name="options">The configured repository-allowlist policy.</param>
+    /// <param name="declaredScope">The parsed declared scope when validation succeeds.</param>
+    /// <param name="rejection">A human-readable rejection reason when validation fails.</param>
+    /// <returns><see langword="true"/> when every custom-code parameter is valid.</returns>
+    public static bool TryValidate(
+        IReadOnlyDictionary<string, string> parameters,
+        CustomCodeOptions options,
+        out IReadOnlyList<JobResourceScopeEntry> declaredScope,
+        out string? rejection)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        ArgumentNullException.ThrowIfNull(options);
+        declaredScope = [];
+        rejection = null;
+
+        // runtime — MVP is python-only.
+        var runtime = Get(parameters, CustomCodeJobContract.RuntimeParam);
+        if (!string.Equals(runtime, CustomCodeJobContract.PythonRuntime, StringComparison.Ordinal))
+        {
+            rejection = $"Custom-code runtime must be '{CustomCodeJobContract.PythonRuntime}' (got '{runtime ?? "<none>"}').";
+            return false;
+        }
+
+        // git_ref — full 40-hex commit SHA only. A branch or tag is rejected so the
+        // executed code is pinned to an immutable commit and cannot be moved under us.
+        var gitRef = Get(parameters, CustomCodeJobContract.GitRefParam);
+        if (string.IsNullOrEmpty(gitRef) || !FullShaRegex().IsMatch(gitRef))
+        {
+            rejection = "Custom-code git_ref must be a full 40-character commit SHA (branches and tags are not allowed).";
+            return false;
+        }
+
+        // repo_url — HTTPS + allowlist policy.
+        var repoUrl = Get(parameters, CustomCodeJobContract.RepoUrlParam);
+        if (!TryValidateRepoUrl(repoUrl, options, out rejection))
+        {
+            return false;
+        }
+
+        // entrypoint — module.path:function.
+        var entrypoint = Get(parameters, CustomCodeJobContract.EntrypointParam);
+        if (string.IsNullOrEmpty(entrypoint) || !EntrypointRegex().IsMatch(entrypoint))
+        {
+            rejection = "Custom-code entrypoint must be of the form 'module.path:function'.";
+            return false;
+        }
+
+        // deps_manifest — a relative path (no absolute paths, no traversal).
+        var depsManifest = Get(parameters, CustomCodeJobContract.DepsManifestParam);
+        if (string.IsNullOrEmpty(depsManifest) || !IsSafeRelativePath(depsManifest))
+        {
+            rejection = "Custom-code deps_manifest must be a relative path within the repository (e.g. 'requirements.txt').";
+            return false;
+        }
+
+        // declared_scope — JSON [{serviceId, layerId?, access}].
+        var rawScope = Get(parameters, CustomCodeJobContract.DeclaredScopeParam);
+        if (!TryParseDeclaredScope(rawScope, out declaredScope, out rejection))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryValidateRepoUrl(string? repoUrl, CustomCodeOptions options, out string? rejection)
+    {
+        rejection = null;
+
+        if (string.IsNullOrWhiteSpace(repoUrl) ||
+            !Uri.TryCreate(repoUrl, UriKind.Absolute, out var uri) ||
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            rejection = "Custom-code repo_url must be an absolute https URL.";
+            return false;
+        }
+
+        switch (options.RepoPolicy)
+        {
+            case CustomCodeRepoPolicy.Disabled:
+                rejection = "Custom-code submission is disabled (no repository allowlist is configured).";
+                return false;
+
+            case CustomCodeRepoPolicy.Open:
+                return true;
+
+            case CustomCodeRepoPolicy.OrgAllowlist:
+                if (IsAllowlisted(uri, options.RepoAllowlist))
+                {
+                    return true;
+                }
+
+                rejection = $"Custom-code repo_url host '{uri.Host}' is not on the configured repository allowlist.";
+                return false;
+
+            default:
+                rejection = "Custom-code repository policy is misconfigured.";
+                return false;
+        }
+    }
+
+    private static bool IsAllowlisted(Uri uri, List<string> allowlist)
+    {
+        if (allowlist is null || allowlist.Count == 0)
+        {
+            return false;
+        }
+
+        // The first path segment (the org/owner) is used when an allowlist entry is
+        // of the form "host/org"; otherwise only the host is matched.
+        var firstSegment = uri.AbsolutePath.Trim('/').Split('/', 2, StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } parts
+            ? parts[0]
+            : string.Empty;
+
+        foreach (var rawEntry in allowlist)
+        {
+            if (string.IsNullOrWhiteSpace(rawEntry))
+            {
+                continue;
+            }
+
+            var entry = rawEntry.Trim();
+            var sep = entry.IndexOf('/');
+            if (sep < 0)
+            {
+                if (string.Equals(entry, uri.Host, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            var host = entry[..sep].Trim();
+            var org = entry[(sep + 1)..].Trim();
+            if (string.Equals(host, uri.Host, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(org, firstSegment, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsSafeRelativePath(string path)
+    {
+        if (path.Contains('\0') || path.StartsWith('/') || path.StartsWith('\\'))
+        {
+            return false;
+        }
+
+        // Reject Windows drive-absolute (e.g. C:\) and any parent-traversal segment.
+        if (path.Length >= 2 && char.IsAsciiLetter(path[0]) && path[1] == ':')
+        {
+            return false;
+        }
+
+        var segments = path.Split('/', '\\');
+        foreach (var segment in segments)
+        {
+            if (segment == "..")
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryParseDeclaredScope(
+        string? raw,
+        out IReadOnlyList<JobResourceScopeEntry> declaredScope,
+        out string? rejection)
+    {
+        declaredScope = [];
+        rejection = null;
+
+        // A declared scope is optional: a custom-code job that needs no callback
+        // access declares none and gets a read-nothing token.
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return true;
+        }
+
+        List<DeclaredScopeDto>? dtos;
+        try
+        {
+            dtos = JsonSerializer.Deserialize(raw, CustomCodeScopeJsonContext.Default.ListDeclaredScopeDto);
+        }
+        catch (JsonException)
+        {
+            rejection = "Custom-code declared_scope must be a JSON array of {serviceId, layerId?, access} entries.";
+            return false;
+        }
+
+        if (dtos is null)
+        {
+            return true;
+        }
+
+        var entries = new List<JobResourceScopeEntry>(dtos.Count);
+        foreach (var dto in dtos)
+        {
+            if (string.IsNullOrWhiteSpace(dto.ServiceId))
+            {
+                rejection = "Each custom-code declared_scope entry requires a non-empty serviceId.";
+                return false;
+            }
+
+            var access = string.Equals(dto.Access, "write", StringComparison.OrdinalIgnoreCase)
+                ? JobResourceAccess.Write
+                : JobResourceAccess.Read;
+            var layer = string.IsNullOrWhiteSpace(dto.LayerId) ? null : dto.LayerId!.Trim();
+
+            entries.Add(new JobResourceScopeEntry(dto.ServiceId!.Trim(), layer, access));
+        }
+
+        declaredScope = entries;
+        return true;
+    }
+
+    private static string? Get(IReadOnlyDictionary<string, string> parameters, string key)
+        => parameters.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value.Trim()
+            : null;
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -15,6 +15,7 @@ using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
+using Honua.Geoprocessing.CustomCode;
 using Honua.Infrastructure;
 using Honua.ControlPlane;
 using Microsoft.Extensions.Options;
@@ -42,6 +43,9 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
     private readonly IGeoprocessingResultPackageStore? _resultPackageStore;
     private readonly ILogger<GeoprocessingJobService> _logger;
     private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _executorOptions;
+    private readonly IScopedJobTokenIssuer? _scopedJobTokenIssuer;
+    private readonly IOptionsMonitor<CustomCodeOptions>? _customCodeOptions;
+    private readonly CustomCodeSubmitCoordinator? _customCodeCoordinator;
 
     public GeoprocessingJobService(
         IUniversalProgressStore progressStore,
@@ -57,7 +61,9 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         IExecutionJobDefinitionRegistry? workloadRegistry = null,
         IEnumerable<IBatchComputeBackend>? backends = null,
         IExecutionAdmissionEvaluator? admissionEvaluator = null,
-        IGeoprocessingResultPackageStore? resultPackageStore = null)
+        IGeoprocessingResultPackageStore? resultPackageStore = null,
+        IScopedJobTokenIssuer? scopedJobTokenIssuer = null,
+        IOptionsMonitor<CustomCodeOptions>? customCodeOptions = null)
     {
         _progressStore = progressStore;
         _cancellationNotifiers = cancellationNotifiers.ToArray();
@@ -73,6 +79,11 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         _backends = backends?.ToArray() ?? Array.Empty<IBatchComputeBackend>();
         _admissionEvaluator = admissionEvaluator;
         _resultPackageStore = resultPackageStore;
+        _scopedJobTokenIssuer = scopedJobTokenIssuer;
+        _customCodeOptions = customCodeOptions;
+        _customCodeCoordinator = scopedJobTokenIssuer is null
+            ? null
+            : new CustomCodeSubmitCoordinator(scopedJobTokenIssuer);
     }
 
     private TimeSpan ProgressRetention => _executorOptions.CurrentValue.ResultRetention;
@@ -179,25 +190,19 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
     {
         ValidatePlanStructure(plan);
         EnsurePlanExecutable(plan);
-        EnsurePlanCatalogValid(plan);
-        EnsureApproved(principal, plan);
 
-        // Phase 0 auth spine (Deliverable 1): pin the submitter's owner snapshot
-        // when the job declares a custom-code resource scope. The declared scope is
-        // validated to be ⊆ what the submitter can reach; anything beyond is
-        // rejected here, so the durable snapshot can only ever attenuate (never
-        // widen) a later scoped-job callback token. Behavior is unchanged for
-        // ordinary jobs, which declare no scope and pin no snapshot.
-        var ownerScope = CustomCodeOwnerScopeCapture.TryCapture(
-            principal,
-            protocolMetadata,
-            globalDataEditorRoles: null,
-            out var scopeRejection);
-        if (scopeRejection is not null)
+        // A custom-code job is param-driven (the user code runs in the Batch
+        // container, not against the built-in process catalog), so it carries no
+        // catalog process to validate; the customcode.* parameters are validated by
+        // the custom-code submit gate below instead. Ordinary jobs still go through
+        // the catalog validator.
+        var isCustomCode = CustomCodeSubmitValidator.IsCustomCodeSubmission(protocolMetadata);
+        if (!isCustomCode)
         {
-            GeoprocessingServiceLog.DeclaredScopeRejected(_logger, scopeRejection);
-            throw new GeoprocessingValidationException(scopeRejection);
+            EnsurePlanCatalogValid(plan);
         }
+
+        EnsureApproved(principal, plan);
 
         var jobStore = RequireJobStore();
         var now = DateTimeOffset.UtcNow;
@@ -208,6 +213,34 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         var specParams = protocolMetadata != null
             ? new Dictionary<string, string>(protocolMetadata)
             : new Dictionary<string, string>();
+
+        // Phase 0/1 auth spine: pin the submitter's owner snapshot when the job
+        // declares a custom-code resource scope. The declared scope is validated to
+        // be ⊆ what the submitter can reach; anything beyond is rejected, so the
+        // durable snapshot can only ever attenuate (never widen) the scoped-job
+        // callback token. Behavior is unchanged for ordinary jobs.
+        CustomCodeOwnerScope? ownerScope;
+        string? mintedCustomCodeToken = null;
+        if (isCustomCode)
+        {
+            (ownerScope, mintedCustomCodeToken) = await ValidateMintAndInjectCustomCodeAsync(
+                jobId, principal, specParams, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            // Legacy string-format declared-scope capture (no custom-code runtime
+            // marker) — preserved for the Phase-0 metadata path.
+            ownerScope = CustomCodeOwnerScopeCapture.TryCapture(
+                principal,
+                protocolMetadata,
+                globalDataEditorRoles: null,
+                out var scopeRejection);
+            if (scopeRejection is not null)
+            {
+                GeoprocessingServiceLog.DeclaredScopeRejected(_logger, scopeRejection);
+                throw new GeoprocessingValidationException(scopeRejection);
+            }
+        }
 
         var partitionKey = ResolvePartitionKey(specParams);
         var costWeight = (double)Math.Max(plan.Steps.Count, 1);
@@ -226,8 +259,13 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             }
         }
 
-        var workload = await ResolveWorkloadAsync(cancellationToken).ConfigureAwait(false);
-        var requiredRuntimeProfile = ResolveRequiredRuntimeProfile(plan);
+        var workload = await ResolveWorkloadAsync(isCustomCode, cancellationToken).ConfigureAwait(false);
+        // A custom-code job forces the custom-code runtime profile so the claim
+        // fence routes it to the custom-code Batch workload (and away from the lean
+        // dispatcher and the GDAL worker); otherwise stamp the catalog-required profile.
+        var requiredRuntimeProfile = isCustomCode
+            ? CustomCodeJobContract.RuntimeProfile
+            : ResolveRequiredRuntimeProfile(plan);
         var spec = BuildSpec(plan, specParams, workload, requiredRuntimeProfile);
 
         var jobRecord = new ExecutionJobRecord
@@ -280,6 +318,11 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         }
         catch (Exception) when (!cancellationToken.IsCancellationRequested)
         {
+            // Revoke the scoped callback token so a credential is never left valid
+            // for a job whose submission rolled back (the token must not outlive the
+            // job — Phase-0 invariant #5).
+            await TryRevokeCustomCodeTokenAsync(mintedCustomCodeToken).ConfigureAwait(false);
+
             await ExecutionJobSubmissionHelper.TryRollbackCreatedJobAsync(
                 jobStore,
                 jobId,
@@ -296,7 +339,57 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         return jobRecord;
     }
 
-    private async Task<ExecutionJobDefinition?> ResolveWorkloadAsync(CancellationToken cancellationToken)
+    /// <summary>
+    /// Runs the custom-code submit gate: validates the <c>customcode.*</c>
+    /// parameters, clamps the declared scope to ⊆ the submitter, mints the scoped
+    /// job-bound token, and injects it (plus the API base URL and the server-set
+    /// output prefix) into <paramref name="specParams"/>. Throws
+    /// <see cref="GeoprocessingValidationException"/> on rejection so the adapter
+    /// maps it onto the same validation channel ordinary plan failures use.
+    /// </summary>
+    private async Task<(CustomCodeOwnerScope OwnerScope, string Token)> ValidateMintAndInjectCustomCodeAsync(
+        string jobId,
+        ClaimsPrincipal principal,
+        Dictionary<string, string> specParams,
+        CancellationToken cancellationToken)
+    {
+        if (_customCodeCoordinator is null || _customCodeOptions is null)
+        {
+            throw new GeoprocessingValidationException(
+                "Custom-code geoprocessing is not enabled on this server (no scoped-job token issuer is configured).");
+        }
+
+        try
+        {
+            var result = await _customCodeCoordinator.ValidateMintAndInjectAsync(
+                jobId, principal, specParams, _customCodeOptions.CurrentValue, cancellationToken).ConfigureAwait(false);
+            return (result.OwnerScope, result.Token);
+        }
+        catch (CustomCodeSubmitRejectedException ex)
+        {
+            GeoprocessingServiceLog.DeclaredScopeRejected(_logger, ex.Message);
+            throw new GeoprocessingValidationException(ex.Message);
+        }
+    }
+
+    private async Task TryRevokeCustomCodeTokenAsync(string? token)
+    {
+        if (string.IsNullOrEmpty(token) || _scopedJobTokenIssuer is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _scopedJobTokenIssuer.RevokeAsync(token, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            GeoprocessingServiceLog.CustomCodeTokenRevokeFailed(_logger, ex);
+        }
+    }
+
+    private async Task<ExecutionJobDefinition?> ResolveWorkloadAsync(bool isCustomCode, CancellationToken cancellationToken)
     {
         if (_workloadRegistry == null)
         {
@@ -304,7 +397,23 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         }
 
         var definitions = await _workloadRegistry.ListAsync(cancellationToken).ConfigureAwait(false);
-        return definitions.FirstOrDefault(d => d.Kind == ExecutionJobKind.Geoprocessing);
+
+        if (isCustomCode)
+        {
+            // Route a custom-code job to the workload that declares the custom-code
+            // runtime profile (image = the python custom-code image ref, the Batch
+            // tier/queue params, NO secretsmanager env refs — those are built into
+            // the job-def family by the iac). Falls back to null when not configured
+            // so submission fails cleanly rather than landing on the GP workload.
+            return definitions.FirstOrDefault(d =>
+                d.Kind == ExecutionJobKind.Geoprocessing &&
+                string.Equals(d.RuntimeProfile, CustomCodeJobContract.RuntimeProfile, StringComparison.Ordinal));
+        }
+
+        // An ordinary geoprocessing job must NOT pick up the custom-code workload.
+        return definitions.FirstOrDefault(d =>
+            d.Kind == ExecutionJobKind.Geoprocessing &&
+            !string.Equals(d.RuntimeProfile, CustomCodeJobContract.RuntimeProfile, StringComparison.Ordinal));
     }
 
     /// <summary>

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobTerminalCallback.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobTerminalCallback.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Authorization.Abstractions;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.AnalysisContent;
@@ -10,6 +11,7 @@ using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
+using Honua.Geoprocessing.CustomCode;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -26,7 +28,8 @@ internal sealed partial class GeoprocessingJobTerminalCallback(
     IOptionsMonitor<GeoprocessingExecutorOptions> executorOptions,
     IGeoprocessingResultPackageStore? resultPackageStore,
     IServiceScopeFactory serviceScopeFactory,
-    ILogger<GeoprocessingJobTerminalCallback> logger) : IJobTerminalCallback
+    ILogger<GeoprocessingJobTerminalCallback> logger,
+    IScopedJobTokenIssuer? scopedJobTokenIssuer = null) : IJobTerminalCallback
 {
     private TimeSpan ProgressRetention => executorOptions.CurrentValue.ResultRetention;
 
@@ -36,6 +39,14 @@ internal sealed partial class GeoprocessingJobTerminalCallback(
         {
             return;
         }
+
+        // Revoke the scoped callback token the moment the job reaches a terminal
+        // state so the credential cannot outlive the job (Phase-0 invariant #5).
+        // The token was injected as env.HONUA_JOB_TOKEN at submit; revoking is
+        // idempotent, so a job that minted no token (every non-custom-code job) is a
+        // no-op. Done first and best-effort so a revoke failure never blocks the
+        // terminal progress/result-package sync below.
+        await TryRevokeCustomCodeTokenAsync(job, cancellationToken).ConfigureAwait(false);
 
         // Tracks whether persisting analysis-content artifacts failed. A successful job
         // must not be reported as Completed when its referenced artifacts are missing from
@@ -141,6 +152,30 @@ internal sealed partial class GeoprocessingJobTerminalCallback(
         catch (Exception ex)
         {
             Log.ProgressSyncFailed(logger, job.OperationId, ex);
+        }
+    }
+
+    private async Task TryRevokeCustomCodeTokenAsync(ExecutionJobRecord job, CancellationToken cancellationToken)
+    {
+        if (scopedJobTokenIssuer is null)
+        {
+            return;
+        }
+
+        if (!job.Spec.Parameters.TryGetValue(CustomCodeJobContract.JobTokenEnvParam, out var token) ||
+            string.IsNullOrWhiteSpace(token))
+        {
+            return;
+        }
+
+        try
+        {
+            await scopedJobTokenIssuer.RevokeAsync(token, cancellationToken).ConfigureAwait(false);
+            Log.CustomCodeTokenRevoked(logger, job.OperationId);
+        }
+        catch (Exception ex)
+        {
+            Log.CustomCodeTokenRevokeFailed(logger, job.OperationId, ex);
         }
     }
 
@@ -262,5 +297,11 @@ internal sealed partial class GeoprocessingJobTerminalCallback(
 
         [LoggerMessage(8020, LogLevel.Warning, "Failed to synchronize admin progress for terminal job {OperationId}; admin view may be stale until TTL expiry")]
         public static partial void ProgressSyncFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(8022, LogLevel.Information, "Revoked custom-code scoped job token for terminal job {OperationId}")]
+        public static partial void CustomCodeTokenRevoked(ILogger logger, string operationId);
+
+        [LoggerMessage(8023, LogLevel.Warning, "Failed to revoke custom-code scoped job token for terminal job {OperationId}; it will expire at its absolute TTL")]
+        public static partial void CustomCodeTokenRevokeFailed(ILogger logger, string operationId, Exception exception);
     }
 }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Orchestration.Abstractions;
+using Honua.Geoprocessing.CustomCode;
 using Honua.Geoprocessing.Execution;
 using Honua.Infrastructure.Abstractions;
 using Honua.ControlPlane;
@@ -172,6 +173,24 @@ internal static class GeoprocessingServiceCollectionExtensions
 
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IJobExecutor, GeoprocessingDispatchJobExecutor>());
+
+        // Custom-code geoprocessing (Phase 1). Bind the policy/config and register
+        // the thin custom-code dispatch executor. The executor is fenced to the
+        // "custom-code" runtime profile so neither the lean dispatcher above nor the
+        // native GDAL worker can claim a custom-code job — and, if a custom-code job
+        // is ever claimed in-process (a deployment that forgot to configure the
+        // custom-code Batch workload), it fails closed rather than running untrusted
+        // user code in the server process. The scoped-job token issuer that the
+        // submit path and terminal callback consume is registered by
+        // AddPortalTokenAuthentication in the Honua.Server composition root.
+        services
+            .AddOptions<CustomCodeOptions>()
+            .Bind(configuration.GetSection(CustomCodeOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IJobExecutor, CustomCodeDispatchJobExecutor>());
 
         // Job orchestration substrate (queue, log store — ticket #681) is wired
         // by the Honua.Server composition root via AddJobOrchestration, which

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceLog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceLog.cs
@@ -181,4 +181,9 @@ internal static partial class GeoprocessingServiceLog
     public static partial void DeclaredScopeRejected(
         ILogger logger,
         string reason);
+
+    [LoggerMessage(8031, LogLevel.Warning, "Failed to revoke a custom-code scoped job token during submission rollback")]
+    public static partial void CustomCodeTokenRevokeFailed(
+        ILogger logger,
+        Exception exception);
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeDispatchExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeDispatchExecutorTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Geoprocessing.CustomCode;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing;
+
+/// <summary>
+/// Proves the custom-code dispatch executor is fenced to the <c>custom-code</c>
+/// runtime profile (so neither the lean managed dispatcher nor the native GDAL
+/// worker can claim a custom-code job) and fails closed when claimed in-process.
+/// </summary>
+[Protocol(TestProtocols.GPServer)]
+public sealed class CustomCodeDispatchExecutorTests
+{
+    private readonly CustomCodeDispatchJobExecutor _sut = new(NullLogger<CustomCodeDispatchJobExecutor>.Instance);
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Executor_AcceptsOnlyCustomCodeProfile()
+    {
+        _sut.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        _sut.AcceptedRuntimeProfiles.Should().Equal(CustomCodeJobContract.RuntimeProfile);
+
+        // Claim fence: a managed or native job is NOT claimable by this executor, and
+        // a custom-code job is NOT claimable by a default (managed-only) executor.
+        RuntimeProfiles.CanClaim(_sut.AcceptedRuntimeProfiles, RuntimeProfiles.Managed).Should().BeFalse();
+        RuntimeProfiles.CanClaim(_sut.AcceptedRuntimeProfiles, RuntimeProfiles.Native).Should().BeFalse();
+        RuntimeProfiles.CanClaim(_sut.AcceptedRuntimeProfiles, CustomCodeJobContract.RuntimeProfile).Should().BeTrue();
+        RuntimeProfiles.CanClaim(RuntimeProfiles.DefaultAccepted, CustomCodeJobContract.RuntimeProfile).Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public async Task Executor_ClaimedInProcess_FailsClosed()
+    {
+        var job = new ExecutionJobRecord
+        {
+            OperationId = "gp-cc-1",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.AwsBatch,
+                Backend = "aws-batch",
+                WorkloadName = "customcode",
+                RuntimeProfile = CustomCodeJobContract.RuntimeProfile
+            }
+        };
+
+        var result = await _sut.ExecuteAsync(
+            job, Substitute.For<IJobExecutionContext>(), CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("Batch");
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeSubmitTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeSubmitTests.cs
@@ -1,0 +1,362 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.Geoprocessing;
+using Honua.Geoprocessing.CustomCode;
+using Honua.Infrastructure.Authentication;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing;
+
+/// <summary>
+/// Server-half proof for the custom-code geoprocessing control path (Phase 1): the
+/// submit gate validates the customcode.* contract (SHA-only git ref, https +
+/// repo-allowlist, declared_scope ⊆ owner), mints a scoped job-bound token scoped to
+/// the declared scope, injects it as env.HONUA_JOB_TOKEN, and revokes it on terminal.
+/// </summary>
+[SecurityTest]
+[Protocol(TestProtocols.GPServer)]
+[Operation(Operations.Security)]
+public sealed class CustomCodeSubmitTests
+{
+    private const string ValidSha = "0123456789abcdef0123456789abcdef01234567";
+    private const string RepoUrl = "https://github.com/honua-io/example.git";
+
+    private readonly IExecutionJobStore _jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
+    private readonly IJobQueue _jobQueue = Substitute.For<IJobQueue>();
+    private readonly IUniversalProgressStore _progressStore = Substitute.For<IUniversalProgressStore>();
+    private readonly IJobCancellationNotifier _cancellationNotifier = Substitute.For<IJobCancellationNotifier>();
+    private readonly IOperatorAuthorizationEvaluator _authEvaluator = Substitute.For<IOperatorAuthorizationEvaluator>();
+    private readonly IOperatorApprovalEvaluator _approvalEvaluator = Substitute.For<IOperatorApprovalEvaluator>();
+    private readonly ScopedJobTokenIssuer _issuer = new(new MemoryCache(new MemoryCacheOptions()), NullLogger<ScopedJobTokenIssuer>.Instance);
+
+    public CustomCodeSubmitTests()
+    {
+        _authEvaluator
+            .EvaluateAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<OperatorAuthorizationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(AccessDecision.Allowed()));
+        _approvalEvaluator
+            .Evaluate(Arg.Any<ClaimsPrincipal>(), Arg.Any<OperatorAuthorizationRequest>())
+            .Returns(ApprovalRequirement.NotRequired());
+        _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+    }
+
+    // -----------------------------------------------------------------------
+    // git_ref: full 40-hex SHA only
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_BranchRef_RejectedAtSubmit()
+    {
+        var sut = CreateService();
+        var metadata = CustomCodeMetadata(gitRef: "main");
+
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), metadata);
+
+        await act.Should().ThrowAsync<Exception>()
+            .Where(e => e.Message.Contains("40-character commit SHA"));
+        await _jobStore.DidNotReceive().TryCreateAsync(
+            Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_FullSha_Accepted()
+    {
+        var sut = CreateService();
+        var job = await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), CustomCodeMetadata());
+
+        job.Spec.RuntimeProfile.Should().Be(CustomCodeJobContract.RuntimeProfile);
+    }
+
+    // -----------------------------------------------------------------------
+    // repo_url: https + allowlist policy
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_RepoNotOnAllowlist_Rejected()
+    {
+        var sut = CreateService(options => options.RepoAllowlist = ["git.internal.example"]);
+        var metadata = CustomCodeMetadata(repoUrl: "https://evil.example/x.git");
+
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), metadata);
+
+        await act.Should().ThrowAsync<Exception>()
+            .Where(e => e.Message.Contains("not on the configured repository allowlist"));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_NonHttpsRepo_Rejected()
+    {
+        var sut = CreateService(options => options.RepoPolicy = CustomCodeRepoPolicy.Open);
+        var metadata = CustomCodeMetadata(repoUrl: "http://github.com/honua-io/example.git");
+
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), metadata);
+
+        await act.Should().ThrowAsync<Exception>()
+            .Where(e => e.Message.Contains("https"));
+    }
+
+    // -----------------------------------------------------------------------
+    // declared_scope ⊆ owner
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_DeclaredScopeExceedsOwner_Rejected()
+    {
+        var sut = CreateService();
+        // Owner can only read 'parcels'; declaring write exceeds reach.
+        var metadata = CustomCodeMetadata(
+            declaredScope: """[{"serviceId":"parcels","access":"write"}]""");
+
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), metadata);
+
+        await act.Should().ThrowAsync<Exception>()
+            .Where(e => e.Message.Contains("exceeds the submitter's permissions"));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_DeclaredScopeWithinOwner_PinsSnapshot()
+    {
+        var sut = CreateService();
+        var metadata = CustomCodeMetadata(
+            declaredScope: """[{"serviceId":"parcels","access":"read"}]""");
+
+        var job = await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), metadata);
+
+        job.Audit.CustomCodeOwnerScope.Should().NotBeNull();
+        job.Audit.CustomCodeOwnerScope!.DeclaredScope.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new JobResourceScopeEntry("parcels", null, JobResourceAccess.Read));
+    }
+
+    // -----------------------------------------------------------------------
+    // token mint + injection
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_MintsScopedTokenInjectedAsEnv_BoundToJobAndScope()
+    {
+        var sut = CreateService();
+        var metadata = CustomCodeMetadata(
+            declaredScope: """[{"serviceId":"parcels","layerId":"lots","access":"write"}]""");
+
+        // Owner can write parcels/lots so the declared write is reachable.
+        var job = await sut.SubmitJobAsync(CustomCodePlan(), null, WriterPrincipal(), metadata);
+
+        job.Spec.Parameters.Should().ContainKey(CustomCodeJobContract.JobTokenEnvParam);
+        job.Spec.Parameters.Should().ContainKey(CustomCodeJobContract.BaseUrlEnvParam)
+            .WhoseValue.Should().Be("https://api.honua.test");
+        // Server-set output prefix is present and per-job.
+        job.Spec.Parameters.Should().ContainKey(CustomCodeJobContract.OutputPrefixParam)
+            .WhoseValue.Should().Contain(job.OperationId);
+
+        // The injected token validates ONLY inside this job's context and carries the
+        // declared scope as the frozen grant (ResourceScope = declared_scope).
+        var token = job.Spec.Parameters[CustomCodeJobContract.JobTokenEnvParam];
+        var validation = await _issuer.ValidateAsync(token, job.OperationId, CancellationToken.None);
+        validation.Should().NotBeNull();
+        validation!.JobId.Should().Be(job.OperationId);
+        validation.Principal.HasClaim("permission", "write:parcels/lots").Should().BeTrue();
+
+        // A different job id must NOT validate the token (job-binding).
+        (await _issuer.ValidateAsync(token, "gp-other", CancellationToken.None)).Should().BeNull();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_ServerSetsOutputPrefix_OverridingCaller()
+    {
+        var sut = CreateService();
+        var metadata = CustomCodeMetadata();
+        metadata[CustomCodeJobContract.OutputPrefixParam] = "s3://attacker/loot";
+
+        var job = await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), metadata);
+
+        job.Spec.Parameters[CustomCodeJobContract.OutputPrefixParam].Should().NotContain("attacker");
+        job.Spec.Parameters[CustomCodeJobContract.OutputPrefixParam].Should().Contain(job.OperationId);
+    }
+
+    // -----------------------------------------------------------------------
+    // routing
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_RoutesToCustomCodeWorkload()
+    {
+        var workloadRegistry = Substitute.For<IExecutionJobDefinitionRegistry>();
+        var backend = Substitute.For<IBatchComputeBackend>();
+        backend.BackendName.Returns("aws-batch");
+        backend.TargetKind.Returns(BatchComputeTargetKind.AwsBatch);
+        workloadRegistry.ListAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            // The lean GP workload — must NOT be selected for a custom-code job.
+            new ExecutionJobDefinition
+            {
+                WorkloadId = "gp-remote",
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.AwsBatch,
+                Backend = "aws-batch",
+                WorkloadName = "GP remote",
+                RuntimeProfile = "py311"
+            },
+            new ExecutionJobDefinition
+            {
+                WorkloadId = "customcode-remote",
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.AwsBatch,
+                Backend = "aws-batch",
+                WorkloadName = "Custom-code remote",
+                ArtifactReference = "ecr/honua-customcode-py:latest",
+                RuntimeProfile = CustomCodeJobContract.RuntimeProfile,
+                Parameters = new Dictionary<string, string>
+                {
+                    ["batch.job_definition_arn"] = "arn:aws:batch:us-east-1:1:job-definition/customcode:1",
+                    ["batch.job_queue_arn"] = "arn:aws:batch:us-east-1:1:job-queue/customcode"
+                }
+            }
+        });
+        backend.StartAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<CancellationToken>())
+            .Returns(new BatchComputeSubmissionResult
+            {
+                Status = ExecutionJobStatus.Provisioning,
+                ProviderOperationId = "job-cc-1",
+                Message = "Submitted"
+            });
+
+        var sut = CreateService(workloadRegistry: workloadRegistry, backends: [backend]);
+        var job = await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), CustomCodeMetadata());
+
+        job.Spec.WorkloadId.Should().Be("customcode-remote");
+        job.Spec.RuntimeProfile.Should().Be(CustomCodeJobContract.RuntimeProfile);
+        job.Spec.Parameters.Should().ContainKey("batch.job_definition_arn");
+        // env injection survives onto the spec the backend submits.
+        job.Spec.Parameters.Should().ContainKey(CustomCodeJobContract.JobTokenEnvParam);
+    }
+
+    // -----------------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------------
+
+    private GeoprocessingJobService CreateService(
+        Action<CustomCodeOptions>? configure = null,
+        IExecutionJobDefinitionRegistry? workloadRegistry = null,
+        IEnumerable<IBatchComputeBackend>? backends = null)
+    {
+        var options = new CustomCodeOptions
+        {
+            RepoPolicy = CustomCodeRepoPolicy.OrgAllowlist,
+            RepoAllowlist = ["github.com"],
+            ApiBaseUrl = "https://api.honua.test",
+            OutputPrefixRoot = "s3://honua-customcode/outputs"
+        };
+        configure?.Invoke(options);
+
+        return new GeoprocessingJobService(
+            _progressStore, [_cancellationNotifier],
+            _authEvaluator, _approvalEvaluator,
+            new BuiltInProcessCatalog(),
+            NullLogger<GeoprocessingJobService>.Instance,
+            DefaultExecutorOptions,
+            _jobStore, _jobQueue,
+            workloadRegistry: workloadRegistry,
+            backends: backends,
+            scopedJobTokenIssuer: _issuer,
+            customCodeOptions: new StaticOptionsMonitor<CustomCodeOptions>(options));
+    }
+
+    private static Dictionary<string, string> CustomCodeMetadata(
+        string gitRef = ValidSha,
+        string repoUrl = RepoUrl,
+        string? declaredScope = null)
+    {
+        var metadata = new Dictionary<string, string>
+        {
+            [CustomCodeJobContract.RuntimeParam] = "python",
+            [CustomCodeJobContract.RepoUrlParam] = repoUrl,
+            [CustomCodeJobContract.GitRefParam] = gitRef,
+            [CustomCodeJobContract.EntrypointParam] = "pkg.module:run",
+            [CustomCodeJobContract.DepsManifestParam] = "requirements.txt",
+            [CustomCodeJobContract.ParamsJsonParam] = """{"k":"v"}"""
+        };
+        if (declaredScope is not null)
+        {
+            metadata[CustomCodeJobContract.DeclaredScopeParam] = declaredScope;
+        }
+
+        return metadata;
+    }
+
+    private static AnalysisPlan CustomCodePlan() => new()
+    {
+        PlanId = "cc-plan-1",
+        IntentId = "cc-intent-1",
+        Steps = [new AnalysisPlanStep { StepId = "step-1", Kind = AnalysisPlanStepKind.Geoprocess }]
+    };
+
+    // Owner can READ parcels (read:parcels) but cannot write it.
+    private static ClaimsPrincipal OwnerPrincipal()
+        => new(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Name, "alice"),
+                new Claim(TenantClaimType, "tenant-A"),
+                new Claim("permission", "read:parcels")
+            ],
+            "Test"));
+
+    // Writer can WRITE parcels (service-wide, via the data-editor:parcels role),
+    // which covers the parcels/lots layer. The service-scoped editor role is the
+    // reach grammar the Phase-0 issuer freezes the minted token against.
+    private static ClaimsPrincipal WriterPrincipal()
+        => new(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Name, "bob"),
+                new Claim(TenantClaimType, "tenant-A"),
+                new Claim(ClaimTypes.Role, "data-editor:parcels")
+            ],
+            "Test"));
+
+    private const string TenantClaimType = "tenant_id";
+
+    private static readonly IOptionsMonitor<GeoprocessingExecutorOptions> DefaultExecutorOptions =
+        new StaticOptionsMonitor<GeoprocessingExecutorOptions>(new GeoprocessingExecutorOptions());
+
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue => value;
+        public T Get(string? name) => value;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeTerminalRevokeTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeTerminalRevokeTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Geoprocessing;
+using Honua.Geoprocessing.CustomCode;
+using Honua.Infrastructure.Authentication;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing;
+
+/// <summary>
+/// Proves a custom-code job's scoped callback token is revoked the moment the job
+/// reaches a terminal state (Phase-0 invariant #5: the credential never outlives the
+/// job).
+/// </summary>
+[SecurityTest]
+[Protocol(TestProtocols.GPServer)]
+[Operation(Operations.Security)]
+public sealed class CustomCodeTerminalRevokeTests
+{
+    [UnitTest]
+    public async Task OnTerminal_CustomCodeJob_RevokesScopedToken()
+    {
+        var issuer = new ScopedJobTokenIssuer(new MemoryCache(new MemoryCacheOptions()), NullLogger<ScopedJobTokenIssuer>.Instance);
+        const string jobId = "gp-cc-terminal-1";
+
+        var issuance = await issuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "alice",
+                TenantId: "tenant-A",
+                Roles: ["data-editor:parcels"],
+                JobId: jobId,
+                ResourceScope: [new JobResourceScopeEntry("parcels", null, JobResourceAccess.Write)],
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(30)),
+            CancellationToken.None);
+
+        // Token is valid before terminal.
+        (await issuer.ValidateAsync(issuance.Token, jobId, CancellationToken.None)).Should().NotBeNull();
+
+        var callback = CreateCallback(issuer);
+        var job = TerminalCustomCodeJob(jobId, issuance.Token);
+
+        await callback.OnTerminalAsync(job, CancellationToken.None);
+
+        // After terminal, the token no longer validates — it was revoked.
+        (await issuer.ValidateAsync(issuance.Token, jobId, CancellationToken.None)).Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task OnTerminal_NonCustomCodeJob_NoTokenToRevoke_NoThrow()
+    {
+        var issuer = new ScopedJobTokenIssuer(new MemoryCache(new MemoryCacheOptions()), NullLogger<ScopedJobTokenIssuer>.Instance);
+        var callback = CreateCallback(issuer);
+
+        var job = new ExecutionJobRecord
+        {
+            OperationId = "gp-plain-1",
+            Status = ExecutionJobStatus.Succeeded,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "plain"
+            }
+        };
+
+        var act = async () => await callback.OnTerminalAsync(job, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    private static GeoprocessingJobTerminalCallback CreateCallback(ScopedJobTokenIssuer issuer)
+    {
+        var progressStore = Substitute.For<IUniversalProgressStore>();
+        var processCatalog = Substitute.For<IProcessCatalog>();
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        return new GeoprocessingJobTerminalCallback(
+            progressStore,
+            processCatalog,
+            new StaticOptionsMonitor<GeoprocessingExecutorOptions>(new GeoprocessingExecutorOptions()),
+            resultPackageStore: null,
+            scopeFactory,
+            NullLogger<GeoprocessingJobTerminalCallback>.Instance,
+            issuer);
+    }
+
+    private static ExecutionJobRecord TerminalCustomCodeJob(string jobId, string token) => new()
+    {
+        OperationId = jobId,
+        Status = ExecutionJobStatus.Succeeded,
+        CreatedAt = DateTimeOffset.UtcNow,
+        UpdatedAt = DateTimeOffset.UtcNow,
+        Spec = new ExecutionJobSpec
+        {
+            Kind = ExecutionJobKind.Geoprocessing,
+            TargetKind = BatchComputeTargetKind.AwsBatch,
+            Backend = "aws-batch",
+            WorkloadName = "customcode",
+            RuntimeProfile = CustomCodeJobContract.RuntimeProfile,
+            Parameters = new Dictionary<string, string>
+            {
+                [CustomCodeJobContract.JobTokenEnvParam] = token
+            }
+        }
+    };
+
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue => value;
+        public T Get(string? name) => value;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2186

## Summary
Custom-code GP **Phase 1 — the SERVER control path** (Python MVP), stacked on the
Phase-0 auth spine (#2187, `IScopedJobTokenIssuer`). Adds a `custom-code`
geoprocessing job kind that submits a user-code job to AWS Batch with a scoped,
job-bound callback token injected at submit. The heavy work runs IN the
custom-code Batch container (the harness, built separately); this PR is the THIN
server-side dispatch + auth wiring.

> Stacked on #2187 — base is `feat/scoped-job-token-issuer`. Re-target to `trunk`
> after #2187 lands. Do not force-merge.

## Changes Made
- Add the `customcode.*` wire contract + injected `env.*` keys and a `custom-code`
  RuntimeProfile (`CustomCodeJobContract`).
- Add `CustomCodeDispatchJobExecutor` (Kind=Geoprocessing, accepts only
  `custom-code`) — the worker-side claim fence (mirrors `GdalDispatchJobExecutor`);
  fails closed if claimed in-process so untrusted user code never runs in the server.
- Extend `GeoprocessingJobService.SubmitJobAsync` with a custom-code submit gate:
  full-40-hex-SHA `git_ref` (reject branches/tags), https + repo-allowlist policy
  (`open | org-allowlist`, default `org-allowlist`), `runtime=python`, entrypoint
  shape, and `declared_scope ⊆ owner` (reuse the Phase-0 `IsWithinOwner` check).
- Mint the scoped token from the pinned owner snapshot (`ResourceScope =
  declared_scope`, `ExpiresAt = job timeout + grace`) and inject it + the API base
  URL via the existing `env.*` pass-through as `env.HONUA_JOB_TOKEN` /
  `env.HONUA_BASE_URL`; server-set `customcode.output_prefix` per job.
- Route a custom-code job to the workload declaring `RuntimeProfile=custom-code`
  (image = python custom-code image ref, Batch tier/queue params, no
  secretsmanager refs — built by iac), falling back cleanly if not configured;
  ordinary GP jobs never pick up the custom-code workload.
- Revoke the scoped token on submission rollback and on job-terminal (from the
  geoprocessing terminal callback) so the credential never outlives the job.

## Breaking Changes
None. All new `GeoprocessingJobService` / terminal-callback constructor params are
optional; ordinary geoprocessing jobs are behavior-unchanged.

## Testing
- [x] Unit tests added/updated
- [x] Architecture tests pass

New tests (Operator Eval Harness shard, ADR-0037): SHA-only git_ref validation,
repo-allowlist + https enforcement, `declared_scope ⊆ owner` rejection, scoped
token mint+inject bound to job and scope, server-set output prefix overriding
caller, custom-code workload routing, revoke-on-terminal, and the executor's
custom-code claim fence. 18 custom-code tests pass; 98 GP/scoped-token tests and
117 architecture tests green; no regressions.

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Control plane SDK surface changed

The `customcode.*` param + injected `env.*` contract the harness/iac must match:

**Caller-supplied `customcode.*` (in `ExecutionJobSpec.Parameters`):**
`customcode.runtime=python`, `customcode.repo_url` (https, allowlisted),
`customcode.git_ref` (40-hex SHA), `customcode.entrypoint` (`module.path:function`),
`customcode.deps_manifest` (relative path), `customcode.params_json`,
`customcode.declared_scope` (JSON `[{serviceId, layerId?, access}]`).

**Server-set:** `customcode.output_prefix` (per-job S3 prefix; caller value overwritten).

**Injected container env** (via `env.*` → `AwsBatchComputeBackend.BuildEnvironmentOverrides`):
`HONUA_BASE_URL`, `HONUA_JOB_TOKEN` (scoped, job-bound, `declared_scope ∩ owner`).

**Workload:** an `ExecutionJobDefinition` with `Kind=Geoprocessing`,
`RuntimeProfile=custom-code`, `ArtifactReference` = python custom-code image, and
`batch.job_definition_arn` / `batch.job_queue_arn` (custom-code job-def family).

## Release/Deploy Impact
- [ ] None — no gate impact
