### PR TITLE
feat(control-plane): hybrid-trigger dispatcher seam + GP event handler/backstop + TriggerMode flag

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -958,6 +958,8 @@
         "src/Honua.Core/Features/Styling/",
         "src/Honua.Postgres/Features/Styling/",
         "src/Honua.Server/Features/Infrastructure/",
+        "src/Honua.Server/Features/ControlPlane/",
+        "src/Honua.Core/Features/ControlPlane/",
         "src/Honua.Protocols.GeoServices/Catalog/",
         "tests/dotnet/Honua.Server.Tests/Features/Authorization/",
         "tests/dotnet/Honua.Server.Tests/Features/Caching/",

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/OperationReconcileDispatcher.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/OperationReconcileDispatcher.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.ControlPlane.Abstractions;
+
+/// <summary>
+/// Identifies the family of control-plane operation that a reconcile request targets.
+/// The dispatcher uses this to route an <see cref="OperationRef"/> to the matching
+/// typed reconciler's idempotent reconcile-once method.
+/// </summary>
+public enum OperationKind
+{
+    /// <summary>
+    /// Deploy/rollback workflow operations reconciled by
+    /// <see cref="IWorkflowOperationReconciler"/>.
+    /// </summary>
+    DeployWorkflow,
+
+    /// <summary>
+    /// Run-to-completion execution jobs (geoprocessing, ETL) reconciled by
+    /// <see cref="IExecutionJobReconciler"/>.
+    /// </summary>
+    ExecutionJob,
+
+    /// <summary>
+    /// Additive metadata-release workflow operations reconciled by
+    /// <see cref="IMetadataReleaseOperationReconciler"/>.
+    /// </summary>
+    MetadataRelease,
+
+    /// <summary>
+    /// Coordinated platform-upgrade releases reconciled by
+    /// <see cref="ICoordinatedReleaseReconciler"/>.
+    /// </summary>
+    CoordinatedRelease
+}
+
+/// <summary>
+/// A protocol-neutral reference to a single control-plane operation, sufficient for the
+/// dispatcher to route a reconcile request to the correct typed reconciler without the
+/// caller knowing which reconciler implements the work.
+/// </summary>
+/// <param name="Kind">The operation family that owns this operation.</param>
+/// <param name="OperationId">The stable durable operation identifier.</param>
+public readonly record struct OperationRef(OperationKind Kind, string OperationId);
+
+/// <summary>
+/// Single entrypoint that reconciles one control-plane operation exactly once, routing to
+/// the typed reconciler that owns the operation's <see cref="OperationKind"/>.
+/// <para>
+/// This is the seam shared by both trigger styles: the background poll loops and the
+/// event handler / backstop sweep all funnel through <see cref="ReconcileOnceAsync"/> so a
+/// single idempotent reconcile path serves poll-driven (on-prem) and event-driven (cloud)
+/// deployments from one codebase. The per-operation lease + read-then-CAS + terminal guards
+/// inside each reconciler make duplicate, concurrent, and out-of-order invocation safe, so
+/// the dispatcher itself carries no extra coordination.
+/// </para>
+/// </summary>
+public interface IOperationReconcileDispatcher
+{
+    /// <summary>
+    /// Reconciles the referenced operation once and returns. Routing is by
+    /// <see cref="OperationRef.Kind"/>; an empty operation id is a no-op.
+    /// </summary>
+    /// <param name="op">The operation to reconcile.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ReconcileOnceAsync(OperationRef op, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Server/Features/ControlPlane/ControlPlaneEventHandler.cs
+++ b/src/Honua.Server/Features/ControlPlane/ControlPlaneEventHandler.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Event entrypoint that drives a single execution-job reconcile from an external state-change
+/// event instead of a poll cycle. This is what an AWS Lambda — triggered by an EventBridge
+/// "Batch Job State Change" event — invokes: resolve the provider job id to the durable
+/// operation id, then reconcile that one operation exactly once and exit.
+/// <para>
+/// The handler is intentionally loop-free and side-effect-light: it never trusts the event
+/// payload as authoritative state. It only selects WHICH operation to reconcile; the reconciler
+/// then re-reads authoritative provider state via the backend's <c>ObserveAsync</c>/<c>DescribeJob</c>
+/// and advances under its own lease + CAS. A malformed, duplicate, or out-of-order event therefore
+/// cannot corrupt state — at worst it triggers a redundant reconcile that the lease/CAS make a no-op.
+/// </para>
+/// </summary>
+internal sealed partial class ControlPlaneEventHandler(
+    IExecutionJobStore jobStore,
+    IOperationReconcileDispatcher dispatcher,
+    ILogger<ControlPlaneEventHandler> logger)
+{
+    /// <summary>
+    /// Handles a batch execution-job state-change event by reconciling the matching operation once.
+    /// </summary>
+    /// <param name="providerOperationId">
+    /// The provider/backend job id carried by the event (for AWS Batch this is
+    /// <c>detail.jobId</c>). Resolved to the durable operation id via the execution-job store.
+    /// If no active job matches, the event is treated as already-handled (terminal or unknown)
+    /// and ignored.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task HandleExecutionJobEventAsync(
+        string providerOperationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(providerOperationId))
+        {
+            return;
+        }
+
+        var operationId = await ResolveOperationIdAsync(providerOperationId, cancellationToken).ConfigureAwait(false);
+        if (operationId is null)
+        {
+            Log.UnresolvedExecutionEvent(logger, providerOperationId);
+            return;
+        }
+
+        Log.HandlingExecutionEvent(logger, providerOperationId, operationId);
+        await dispatcher
+            .ReconcileOnceAsync(new OperationRef(OperationKind.ExecutionJob, operationId), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Handles an event that already carries the durable operation id (for callers that mapped the
+    /// provider id upstream). Reconciles the operation once.
+    /// </summary>
+    public Task HandleExecutionJobOperationAsync(
+        string operationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(operationId))
+        {
+            return Task.CompletedTask;
+        }
+
+        Log.HandlingExecutionEvent(logger, "(operation-id)", operationId);
+        return dispatcher.ReconcileOnceAsync(
+            new OperationRef(OperationKind.ExecutionJob, operationId),
+            cancellationToken);
+    }
+
+    private async Task<string?> ResolveOperationIdAsync(
+        string providerOperationId,
+        CancellationToken cancellationToken)
+    {
+        var active = await jobStore.ListActiveAsync(kind: null, cancellationToken).ConfigureAwait(false);
+        foreach (var job in active)
+        {
+            if (string.Equals(job.ProviderOperationId, providerOperationId, StringComparison.Ordinal))
+            {
+                return job.OperationId;
+            }
+        }
+
+        return null;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9040, LogLevel.Debug, "Handling execution-job state-change event for provider {ProviderOperationId} -> operation {OperationId}")]
+        public static partial void HandlingExecutionEvent(ILogger logger, string providerOperationId, string operationId);
+
+        [LoggerMessage(9041, LogLevel.Debug, "Execution-job state-change event for provider {ProviderOperationId} matched no active operation; ignoring")]
+        public static partial void UnresolvedExecutionEvent(ILogger logger, string providerOperationId);
+    }
+}

--- a/src/Honua.Server/Features/ControlPlane/ControlPlaneTriggerOptions.cs
+++ b/src/Honua.Server/Features/ControlPlane/ControlPlaneTriggerOptions.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// How the control plane drives execution-job reconciliation.
+/// </summary>
+internal enum ControlPlaneTriggerMode
+{
+    /// <summary>
+    /// On-prem / portable default. The 5-second <c>ExecutionJobReconcilerBackgroundService</c>
+    /// poll loop drives reconciliation exactly as it does today. Byte-for-byte unchanged.
+    /// </summary>
+    Poll,
+
+    /// <summary>
+    /// Cloud event-driven mode. The 5-second execution-job poll loop is disabled; reconciliation
+    /// is driven by the event handler (an AWS Lambda invoked from an EventBridge "Batch Job State
+    /// Change" event) plus the low-frequency backstop sweep that self-heals dropped/missed events.
+    /// </summary>
+    Event
+}
+
+/// <summary>
+/// Configuration for control-plane reconcile triggering. Bound from the <c>ControlPlane</c>
+/// configuration section; the trigger seam lets cloud deployments go event-driven while on-prem
+/// stays poll-driven from one codebase (control-plane hybrid-trigger design, option C).
+/// </summary>
+internal sealed class ControlPlaneTriggerOptions
+{
+    /// <summary>
+    /// Configuration section name. Reuses the existing <c>ControlPlane</c> section so the trigger
+    /// keys sit alongside the catalogs (for example <c>ControlPlane:TriggerMode</c>).
+    /// </summary>
+    public const string SectionName = "ControlPlane";
+
+    /// <summary>
+    /// Execution-job trigger mode. Defaults to <see cref="ControlPlaneTriggerMode.Poll"/> so an
+    /// unconfigured on-prem deployment keeps the existing poll behavior.
+    /// </summary>
+    public ControlPlaneTriggerMode TriggerMode { get; set; } = ControlPlaneTriggerMode.Poll;
+
+    /// <summary>
+    /// How often the backstop sweep runs. The backstop ships with Phase 1 in BOTH modes so a
+    /// dropped or missed event self-heals; it is low-frequency on purpose. Works on-prem and can
+    /// also be invoked by EventBridge Scheduler in the cloud.
+    /// </summary>
+    public TimeSpan BackstopInterval { get; set; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// How stale (by <c>UpdatedAt</c>) a non-terminal execution job must be before the backstop
+    /// reconciles it. Fresh jobs that an event already advanced are skipped, so the backstop is a
+    /// no-op in the common case and only re-drives jobs that look stuck.
+    /// </summary>
+    public TimeSpan StaleThreshold { get; set; } = TimeSpan.FromSeconds(90);
+}

--- a/src/Honua.Server/Features/ControlPlane/ExecutionJobBackstopSweepService.cs
+++ b/src/Honua.Server/Features/ControlPlane/ExecutionJobBackstopSweepService.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Low-frequency backstop sweep for execution-job reconciliation. Ships with Phase 1 in BOTH
+/// trigger modes: it re-drives any active execution job whose <c>UpdatedAt</c> has gone stale past
+/// the configured threshold, so a dropped or missed state-change event self-heals.
+/// <para>
+/// Because every reconcile funnels through the dispatcher into the leased + CAS-guarded reconciler,
+/// a backstop reconcile that races a real event (or the poll loop) is a safe no-op: whichever path
+/// already advanced the job wins the CAS, and the late path observes a terminal/unchanged record.
+/// The cadence is deliberately coarse (minutes, not seconds) so it costs almost nothing in the
+/// healthy case yet bounds worst-case latency when events are lost.
+/// </para>
+/// This works on-prem unchanged and can equally be invoked by EventBridge Scheduler in the cloud.
+/// </summary>
+internal sealed partial class ExecutionJobBackstopSweepService(
+    IExecutionJobStore jobStore,
+    IOperationReconcileDispatcher dispatcher,
+    IOptions<ControlPlaneTriggerOptions> options,
+    ILogger<ExecutionJobBackstopSweepService> logger) : BackgroundService
+{
+    private readonly ControlPlaneTriggerOptions _options = options.Value;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var interval = _options.BackstopInterval > TimeSpan.Zero
+            ? _options.BackstopInterval
+            : TimeSpan.FromMinutes(2);
+        var staleThreshold = _options.StaleThreshold > TimeSpan.Zero
+            ? _options.StaleThreshold
+            : TimeSpan.FromSeconds(90);
+
+        Log.BackstopStarted(logger, (int)interval.TotalSeconds, (int)staleThreshold.TotalSeconds);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await SweepOnceAsync(staleThreshold, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                Log.BackstopSweepFailed(logger, ex);
+            }
+
+            try
+            {
+                await Task.Delay(interval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reconciles every active, non-terminal execution job whose <c>UpdatedAt</c> is older than
+    /// <paramref name="staleThreshold"/>. Fresh jobs are skipped so the sweep is a no-op when events
+    /// (or the poll loop) are keeping records current. Exposed internally so tests can drive a single
+    /// sweep deterministically without the timer loop.
+    /// </summary>
+    internal async Task SweepOnceAsync(TimeSpan staleThreshold, CancellationToken cancellationToken)
+    {
+        var active = await jobStore.ListActiveAsync(kind: null, cancellationToken).ConfigureAwait(false);
+        var cutoff = DateTimeOffset.UtcNow - staleThreshold;
+
+        foreach (var job in active)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (IsTerminal(job.Status) || job.UpdatedAt > cutoff)
+            {
+                continue;
+            }
+
+            try
+            {
+                Log.BackstopReconciling(logger, job.OperationId, (int)(DateTimeOffset.UtcNow - job.UpdatedAt).TotalSeconds);
+                await dispatcher
+                    .ReconcileOnceAsync(new OperationRef(OperationKind.ExecutionJob, job.OperationId), cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.BackstopReconcileFailed(logger, job.OperationId, ex);
+            }
+        }
+    }
+
+    private static bool IsTerminal(ExecutionJobStatus status)
+        => status is ExecutionJobStatus.Succeeded
+            or ExecutionJobStatus.Failed
+            or ExecutionJobStatus.Cancelled;
+
+    private static partial class Log
+    {
+        [LoggerMessage(9042, LogLevel.Information, "Started execution-job backstop sweep (interval {IntervalSeconds}s, stale threshold {StaleSeconds}s)")]
+        public static partial void BackstopStarted(ILogger logger, int intervalSeconds, int staleSeconds);
+
+        [LoggerMessage(9043, LogLevel.Debug, "Backstop reconciling stale execution job {OperationId} (stale {StaleSeconds}s)")]
+        public static partial void BackstopReconciling(ILogger logger, string operationId, int staleSeconds);
+
+        [LoggerMessage(9044, LogLevel.Warning, "Backstop reconcile failed for execution job {OperationId}")]
+        public static partial void BackstopReconcileFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9045, LogLevel.Warning, "Execution-job backstop sweep cycle failed")]
+        public static partial void BackstopSweepFailed(ILogger logger, Exception exception);
+    }
+}

--- a/src/Honua.Server/Features/ControlPlane/OperationReconcileDispatcher.cs
+++ b/src/Honua.Server/Features/ControlPlane/OperationReconcileDispatcher.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Routes an <see cref="OperationRef"/> to the typed reconciler that owns its
+/// <see cref="OperationKind"/>, calling that reconciler's idempotent reconcile-once method.
+/// <para>
+/// This is the Phase 0 dispatcher seam: it adds no behavior of its own. The background poll
+/// loops and the Phase 1 event handler / backstop sweep both call
+/// <see cref="ReconcileOnceAsync"/> so a single reconcile path is exercised regardless of what
+/// triggers it. The reconcilers' own lease + CAS + terminal guards keep duplicate and
+/// out-of-order invocation safe; the dispatcher deliberately stays a thin switch.
+/// </para>
+/// </summary>
+internal sealed class OperationReconcileDispatcher(
+    IWorkflowOperationReconciler deployReconciler,
+    IExecutionJobReconciler executionJobReconciler,
+    IMetadataReleaseOperationReconciler metadataReleaseReconciler,
+    ICoordinatedReleaseReconciler coordinatedReleaseReconciler) : IOperationReconcileDispatcher
+{
+    public Task ReconcileOnceAsync(OperationRef op, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(op.OperationId))
+        {
+            return Task.CompletedTask;
+        }
+
+        return op.Kind switch
+        {
+            OperationKind.DeployWorkflow
+                => deployReconciler.ReconcileWorkflowOperationAsync(op.OperationId, cancellationToken),
+            OperationKind.ExecutionJob
+                => executionJobReconciler.ReconcileExecutionJobAsync(op.OperationId, cancellationToken),
+            OperationKind.MetadataRelease
+                => metadataReleaseReconciler.ReconcileMetadataReleaseAsync(op.OperationId, cancellationToken),
+            OperationKind.CoordinatedRelease
+                => coordinatedReleaseReconciler.ReconcileCoordinatedReleaseAsync(op.OperationId, cancellationToken),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(op),
+                op.Kind,
+                "Unknown control-plane operation kind; no reconciler is registered for this kind.")
+        };
+    }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -448,10 +448,39 @@ if (connectedRedis != null)
         Honua.Core.Features.ControlPlane.Abstractions.ICoordinatedReleaseReconciler,
         Honua.ControlPlane.CoordinatedReleaseReconciler>();
 
+    // Control-plane hybrid-trigger seam (design option C).
+    // Phase 0: one dispatcher routes a reconcile-once request to the typed reconciler that owns the
+    // operation kind. Both the poll loops and the Phase 1 event handler call this single method.
+    // Phase 1: the event handler is the cloud (EventBridge -> Lambda) entrypoint, and the backstop
+    // sweep self-heals dropped events; the TriggerMode flag chooses poll (on-prem) vs event (cloud).
+    builder.Services.Configure<Honua.ControlPlane.ControlPlaneTriggerOptions>(
+        builder.Configuration.GetSection(Honua.ControlPlane.ControlPlaneTriggerOptions.SectionName));
+    builder.Services.AddSingleton<
+        Honua.Core.Features.ControlPlane.Abstractions.IOperationReconcileDispatcher,
+        Honua.ControlPlane.OperationReconcileDispatcher>();
+    builder.Services.AddSingleton<Honua.ControlPlane.ControlPlaneEventHandler>();
+
+    var controlPlaneTriggerMode = builder.Configuration
+        .GetSection(Honua.ControlPlane.ControlPlaneTriggerOptions.SectionName)
+        .GetValue<Honua.ControlPlane.ControlPlaneTriggerMode>("TriggerMode", Honua.ControlPlane.ControlPlaneTriggerMode.Poll);
+
     if (!isTestEnvironment)
     {
         builder.Services.AddHostedService<DeployWorkflowReconcilerBackgroundService>();
-        builder.Services.AddHostedService<ExecutionJobReconcilerBackgroundService>();
+
+        // Execution-job triggering is mode-selected. Poll (default, on-prem/portable): the 5s loop
+        // runs exactly as before. Event (cloud): the 5s loop is disabled; the event handler + the
+        // backstop sweep drive execution-job reconciliation instead.
+        if (controlPlaneTriggerMode == Honua.ControlPlane.ControlPlaneTriggerMode.Poll)
+        {
+            builder.Services.AddHostedService<ExecutionJobReconcilerBackgroundService>();
+        }
+
+        // The backstop sweep ships with Phase 1 and runs in BOTH modes so a dropped/missed event
+        // (or, under poll, a wedged loop) self-heals. It is low-frequency and is a no-op when the
+        // active jobs are fresh.
+        builder.Services.AddHostedService<Honua.ControlPlane.ExecutionJobBackstopSweepService>();
+
         builder.Services.AddHostedService<Honua.ControlPlane.MetadataReleaseReconcilerBackgroundService>();
         builder.Services.AddHostedService<Honua.ControlPlane.CoordinatedReleaseReconcilerBackgroundService>();
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneTriggerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneTriggerTests.cs
@@ -1,0 +1,327 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Phase 1 tests for the hybrid-trigger seam: the event handler reconciles one operation once and
+/// is safe under duplicate/out-of-order invocation (lease/CAS no-op), and the backstop sweep
+/// reconciles stale operations while no-opping fresh ones. Both drive the same dispatcher path that
+/// the poll loop uses.
+/// </summary>
+public sealed class ControlPlaneTriggerTests
+{
+    // ---- Event handler -----------------------------------------------------
+
+    [Fact]
+    public async Task HandleExecutionJobEvent_ResolvesProviderIdAndReconcilesOnce()
+    {
+        var job = CreateJob("op-1", ExecutionJobStatus.Running, providerOperationId: "batch-job-abc");
+        var store = new VersionedJobStore(job);
+        var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
+        var sut = new ControlPlaneEventHandler(store, dispatcher, NullLogger<ControlPlaneEventHandler>.Instance);
+
+        await sut.HandleExecutionJobEventAsync("batch-job-abc");
+
+        await dispatcher.Received(1).ReconcileOnceAsync(
+            Arg.Is<OperationRef>(r => r.Kind == OperationKind.ExecutionJob && r.OperationId == "op-1"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleExecutionJobEvent_UnknownProviderId_IsIgnored()
+    {
+        var job = CreateJob("op-1", ExecutionJobStatus.Running, providerOperationId: "batch-job-abc");
+        var store = new VersionedJobStore(job);
+        var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
+        var sut = new ControlPlaneEventHandler(store, dispatcher, NullLogger<ControlPlaneEventHandler>.Instance);
+
+        await sut.HandleExecutionJobEventAsync("not-a-known-job");
+
+        await dispatcher.DidNotReceiveWithAnyArgs().ReconcileOnceAsync(default, default);
+    }
+
+    [Fact]
+    public async Task HandleExecutionJobEvent_DuplicateAndOutOfOrderInvocation_AdvancesJobOnce()
+    {
+        // Real reconciler behind the real dispatcher: prove the lease/CAS + terminal guards make a
+        // duplicate / out-of-order event a no-op. The backend reports a terminal Succeeded; the first
+        // event advances the durable record, the duplicates re-read a terminal record and bail.
+        var job = CreateJob("op-dup", ExecutionJobStatus.Running, providerOperationId: "batch-job-dup");
+        var store = new VersionedJobStore(job);
+        var progress = new RecordingProgressStore();
+        var backend = new CountingBatchBackend(ExecutionJobStatus.Succeeded);
+        var dispatcher = BuildDispatcher(store, progress, backend);
+        var sut = new ControlPlaneEventHandler(store, dispatcher, NullLogger<ControlPlaneEventHandler>.Instance);
+
+        // Fire the same event three times (duplicate delivery) plus a stale "out-of-order" replay.
+        await sut.HandleExecutionJobEventAsync("batch-job-dup");
+        await sut.HandleExecutionJobEventAsync("batch-job-dup");
+        await sut.HandleExecutionJobOperationAsync("op-dup");
+
+        var stored = await store.GetAsync("op-dup");
+        stored!.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        // Exactly one durable advancing write: the terminal-guard short-circuits the later calls
+        // before any further CAS, so the version advanced exactly once.
+        store.WriteCount.Should().Be(1, "the terminal guard makes duplicate/out-of-order events a no-op");
+    }
+
+    // ---- Backstop sweep ----------------------------------------------------
+
+    [Fact]
+    public async Task Backstop_ReconcilesStaleNonTerminalOperation()
+    {
+        var stale = CreateJob("op-stale", ExecutionJobStatus.Running, providerOperationId: "p-stale", updatedAt: DateTimeOffset.UtcNow.AddMinutes(-10));
+        var store = new VersionedJobStore(stale);
+        var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
+        var sut = BuildBackstop(store, dispatcher, staleThreshold: TimeSpan.FromSeconds(90));
+
+        await sut.SweepOnceAsync(TimeSpan.FromSeconds(90), CancellationToken.None);
+
+        await dispatcher.Received(1).ReconcileOnceAsync(
+            Arg.Is<OperationRef>(r => r.Kind == OperationKind.ExecutionJob && r.OperationId == "op-stale"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Backstop_NoOpsFreshOperation()
+    {
+        var fresh = CreateJob("op-fresh", ExecutionJobStatus.Running, providerOperationId: "p-fresh", updatedAt: DateTimeOffset.UtcNow);
+        var store = new VersionedJobStore(fresh);
+        var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
+        var sut = BuildBackstop(store, dispatcher, staleThreshold: TimeSpan.FromSeconds(90));
+
+        await sut.SweepOnceAsync(TimeSpan.FromSeconds(90), CancellationToken.None);
+
+        await dispatcher.DidNotReceiveWithAnyArgs().ReconcileOnceAsync(default, default);
+    }
+
+    [Fact]
+    public async Task Backstop_SkipsTerminalOperation()
+    {
+        var terminal = CreateJob("op-done", ExecutionJobStatus.Succeeded, providerOperationId: "p-done", updatedAt: DateTimeOffset.UtcNow.AddHours(-1));
+        var store = new VersionedJobStore(terminal);
+        var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
+        var sut = BuildBackstop(store, dispatcher, staleThreshold: TimeSpan.FromSeconds(90));
+
+        await sut.SweepOnceAsync(TimeSpan.FromSeconds(90), CancellationToken.None);
+
+        await dispatcher.DidNotReceiveWithAnyArgs().ReconcileOnceAsync(default, default);
+    }
+
+    [Fact]
+    public async Task Backstop_StaleOperationAlreadyAdvancedByEvent_IsCasNoOp()
+    {
+        // The backstop and a prior event both reconcile the same stale job. With the real reconciler,
+        // the backstop re-reads a now-terminal record and makes no further durable write.
+        var stale = CreateJob("op-heal", ExecutionJobStatus.Running, providerOperationId: "batch-heal", updatedAt: DateTimeOffset.UtcNow.AddMinutes(-10));
+        var store = new VersionedJobStore(stale);
+        var progress = new RecordingProgressStore();
+        var backend = new CountingBatchBackend(ExecutionJobStatus.Succeeded);
+        var dispatcher = BuildDispatcher(store, progress, backend);
+
+        // Simulate the missed-event self-heal: an event already drove it terminal...
+        var handler = new ControlPlaneEventHandler(store, dispatcher, NullLogger<ControlPlaneEventHandler>.Instance);
+        await handler.HandleExecutionJobEventAsync("batch-heal");
+        var afterEvent = store.WriteCount;
+
+        // ...then the backstop sweeps the (now terminal) job; the terminal guard makes it a no-op.
+        var sut = BuildBackstop(store, dispatcher, staleThreshold: TimeSpan.FromSeconds(90));
+        await sut.SweepOnceAsync(TimeSpan.FromSeconds(90), CancellationToken.None);
+
+        afterEvent.Should().Be(1);
+        store.WriteCount.Should().Be(1, "the backstop is a no-op once an event has advanced the job to terminal");
+        (await store.GetAsync("op-heal"))!.Status.Should().Be(ExecutionJobStatus.Succeeded);
+    }
+
+    // ---- Helpers -----------------------------------------------------------
+
+    private static OperationReconcileDispatcher BuildDispatcher(
+        IExecutionJobStore store,
+        IUniversalProgressStore progress,
+        IBatchComputeBackend backend)
+    {
+        var reconciler = new ExecutionJobReconciler(
+            store,
+            [backend],
+            progress,
+            NullLogger<ExecutionJobReconciler>.Instance);
+
+        return new OperationReconcileDispatcher(
+            Substitute.For<IWorkflowOperationReconciler>(),
+            reconciler,
+            Substitute.For<IMetadataReleaseOperationReconciler>(),
+            Substitute.For<ICoordinatedReleaseReconciler>());
+    }
+
+    private static ExecutionJobBackstopSweepService BuildBackstop(
+        IExecutionJobStore store,
+        IOperationReconcileDispatcher dispatcher,
+        TimeSpan staleThreshold)
+        => new(
+            store,
+            dispatcher,
+            Options.Create(new ControlPlaneTriggerOptions { StaleThreshold = staleThreshold }),
+            NullLogger<ExecutionJobBackstopSweepService>.Instance);
+
+    private static ExecutionJobRecord CreateJob(
+        string operationId,
+        ExecutionJobStatus status,
+        string? providerOperationId,
+        DateTimeOffset? updatedAt = null) => new()
+        {
+            OperationId = operationId,
+            Status = status,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            UpdatedAt = updatedAt ?? DateTimeOffset.UtcNow.AddMinutes(-1),
+            ProviderOperationId = providerOperationId,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.AwsBatch,
+                Backend = "aws-batch",
+                WorkloadId = "plan-remote",
+                WorkloadName = "Geoprocessing",
+                Parameters = new Dictionary<string, string>
+                {
+                    [ExecutionJobParameterKeys.GeoprocessingPlanId] = "plan-remote"
+                }
+            }
+        };
+
+    /// <summary>
+    /// In-memory execution-job store that enforces optimistic-concurrency CAS via the record
+    /// <see cref="ExecutionJobRecord.Version"/> token, so duplicate/out-of-order reconciles exercise
+    /// the same conflict path the Redis store would. Counts successful advancing writes.
+    /// </summary>
+    private sealed class VersionedJobStore(params ExecutionJobRecord[] jobs) : IExecutionJobStore
+    {
+        private readonly Dictionary<string, ExecutionJobRecord> _jobs =
+            jobs.ToDictionary(job => job.OperationId, StringComparer.Ordinal);
+
+        public int WriteCount { get; private set; }
+
+        public Task<bool> TryAcquireLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task<bool> RenewLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task ReleaseLeaseAsync(string operationId, string ownerId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<bool> TryCreateAsync(ExecutionJobRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            if (_jobs.ContainsKey(operation.OperationId))
+            {
+                return Task.FromResult(false);
+            }
+
+            _jobs[operation.OperationId] = operation;
+            return Task.FromResult(true);
+        }
+
+        public Task<ExecutionJobRecord?> GetAsync(string operationId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_jobs.TryGetValue(operationId, out var job) ? job : null);
+
+        public Task SetAsync(ExecutionJobRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _jobs[operation.OperationId] = operation with { Version = operation.Version + 1 };
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> TrySetAsync(ExecutionJobRecord job, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            if (!_jobs.TryGetValue(job.OperationId, out var current) || current.Version != job.Version)
+            {
+                return Task.FromResult(false);
+            }
+
+            _jobs[job.OperationId] = job with { Version = job.Version + 1 };
+            WriteCount++;
+            return Task.FromResult(true);
+        }
+
+        public Task<ExecutionJobPage> QueryAsync(ExecutionJobQuery query, CancellationToken cancellationToken = default)
+            => Task.FromResult(new ExecutionJobPage { Items = _jobs.Values.ToArray() });
+
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(_jobs.Values.ToArray());
+    }
+
+    /// <summary>
+    /// Batch backend that reports a fixed observation and counts how many times it was observed.
+    /// </summary>
+    private sealed class CountingBatchBackend(ExecutionJobStatus observedStatus) : IBatchComputeBackend
+    {
+        public int ObserveCount { get; private set; }
+
+        public string BackendName => "aws-batch";
+
+        public BatchComputeTargetKind TargetKind => BatchComputeTargetKind.AwsBatch;
+
+        public Task<BatchComputeBackendCapabilities> GetCapabilitiesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new BatchComputeBackendCapabilities { SupportsProgressPolling = true });
+
+        public Task<BatchComputeSubmissionResult> StartAsync(ExecutionJobRecord job, CancellationToken cancellationToken = default)
+            => Task.FromResult(new BatchComputeSubmissionResult { Status = ExecutionJobStatus.Provisioning });
+
+        public Task<BatchComputeObservation> ObserveAsync(ExecutionJobRecord job, CancellationToken cancellationToken = default)
+        {
+            ObserveCount++;
+            return Task.FromResult(new BatchComputeObservation
+            {
+                Status = observedStatus,
+                ProviderOperationId = job.ProviderOperationId,
+                PercentComplete = 100
+            });
+        }
+
+        public Task<BatchComputeObservation> CancelAsync(ExecutionJobRecord job, CancellationToken cancellationToken = default)
+            => Task.FromResult(new BatchComputeObservation { Status = ExecutionJobStatus.Cancelled });
+    }
+
+    private sealed class RecordingProgressStore : IUniversalProgressStore
+    {
+        private readonly Dictionary<string, IOperationProgress> _progress = new(StringComparer.Ordinal);
+
+        public Task SetProgressAsync(string operationId, IOperationProgress progress, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _progress[operationId] = progress;
+            return Task.CompletedTask;
+        }
+
+        public Task<ProgressCompareAndSetResult> TrySetProgressAsync(string operationId, IOperationProgress progress, OperationStatus expectedStatus, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(ProgressCompareAndSetResult.Updated);
+
+        public Task<TProgress?> GetProgressAsync<TProgress>(string operationId, CancellationToken cancellationToken = default)
+            where TProgress : class, IOperationProgress
+            => Task.FromResult(_progress.TryGetValue(operationId, out var progress) ? progress as TProgress : null);
+
+        public Task<IOperationProgress?> GetProgressAsync(string operationId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_progress.TryGetValue(operationId, out var progress) ? progress : null);
+
+        public Task DeleteProgressAsync(string operationId, CancellationToken cancellationToken = default)
+        {
+            _progress.Remove(operationId);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<string>> GetActiveOperationIdsAsync(OperationType? operationType = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>(_progress.Keys.ToArray());
+
+        public Task<IReadOnlyList<TProgress>> GetActiveOperationsAsync<TProgress>(OperationType operationType, CancellationToken cancellationToken = default)
+            where TProgress : class, IOperationProgress
+            => Task.FromResult<IReadOnlyList<TProgress>>(_progress.Values.OfType<TProgress>().ToArray());
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/OperationReconcileDispatcherTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/OperationReconcileDispatcherTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Phase 0 dispatcher-seam tests: the dispatcher routes each operation kind to the matching typed
+/// reconciler's reconcile-once method and does nothing else (no extra coordination, no behavior).
+/// </summary>
+public sealed class OperationReconcileDispatcherTests
+{
+    [Fact]
+    public async Task ReconcileOnceAsync_ExecutionJob_RoutesToExecutionJobReconciler()
+    {
+        var deploy = Substitute.For<IWorkflowOperationReconciler>();
+        var execution = Substitute.For<IExecutionJobReconciler>();
+        var metadata = Substitute.For<IMetadataReleaseOperationReconciler>();
+        var coordinated = Substitute.For<ICoordinatedReleaseReconciler>();
+        var sut = new OperationReconcileDispatcher(deploy, execution, metadata, coordinated);
+
+        await sut.ReconcileOnceAsync(new OperationRef(OperationKind.ExecutionJob, "job-1"));
+
+        await execution.Received(1).ReconcileExecutionJobAsync("job-1", Arg.Any<CancellationToken>());
+        await deploy.DidNotReceiveWithAnyArgs().ReconcileWorkflowOperationAsync(default!, default);
+        await metadata.DidNotReceiveWithAnyArgs().ReconcileMetadataReleaseAsync(default!, default);
+        await coordinated.DidNotReceiveWithAnyArgs().ReconcileCoordinatedReleaseAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task ReconcileOnceAsync_DeployWorkflow_RoutesToDeployReconciler()
+    {
+        var deploy = Substitute.For<IWorkflowOperationReconciler>();
+        var sut = new OperationReconcileDispatcher(
+            deploy,
+            Substitute.For<IExecutionJobReconciler>(),
+            Substitute.For<IMetadataReleaseOperationReconciler>(),
+            Substitute.For<ICoordinatedReleaseReconciler>());
+
+        await sut.ReconcileOnceAsync(new OperationRef(OperationKind.DeployWorkflow, "deploy-1"));
+
+        await deploy.Received(1).ReconcileWorkflowOperationAsync("deploy-1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReconcileOnceAsync_MetadataRelease_RoutesToMetadataReleaseReconciler()
+    {
+        var metadata = Substitute.For<IMetadataReleaseOperationReconciler>();
+        var sut = new OperationReconcileDispatcher(
+            Substitute.For<IWorkflowOperationReconciler>(),
+            Substitute.For<IExecutionJobReconciler>(),
+            metadata,
+            Substitute.For<ICoordinatedReleaseReconciler>());
+
+        await sut.ReconcileOnceAsync(new OperationRef(OperationKind.MetadataRelease, "mr-1"));
+
+        await metadata.Received(1).ReconcileMetadataReleaseAsync("mr-1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReconcileOnceAsync_CoordinatedRelease_RoutesToCoordinatedReconciler()
+    {
+        var coordinated = Substitute.For<ICoordinatedReleaseReconciler>();
+        var sut = new OperationReconcileDispatcher(
+            Substitute.For<IWorkflowOperationReconciler>(),
+            Substitute.For<IExecutionJobReconciler>(),
+            Substitute.For<IMetadataReleaseOperationReconciler>(),
+            coordinated);
+
+        await sut.ReconcileOnceAsync(new OperationRef(OperationKind.CoordinatedRelease, "cr-1"));
+
+        await coordinated.Received(1).ReconcileCoordinatedReleaseAsync("cr-1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReconcileOnceAsync_EmptyOperationId_IsNoOp()
+    {
+        var execution = Substitute.For<IExecutionJobReconciler>();
+        var sut = new OperationReconcileDispatcher(
+            Substitute.For<IWorkflowOperationReconciler>(),
+            execution,
+            Substitute.For<IMetadataReleaseOperationReconciler>(),
+            Substitute.For<ICoordinatedReleaseReconciler>());
+
+        await sut.ReconcileOnceAsync(new OperationRef(OperationKind.ExecutionJob, "   "));
+
+        await execution.DidNotReceiveWithAnyArgs().ReconcileExecutionJobAsync(default!, default);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to control-plane hybrid-trigger design (option C). The reconcile loop a review flagged as "won't scale" is the GP execution-job poll.

## Summary
Implements the server-side of the control-plane hybrid-trigger design (option C): Phase 0 introduces a single dispatcher seam over the existing typed reconcilers (pure refactor, zero behavior change), and Phase 1 lets the GP job-status reconcile be driven by a Batch state-change EVENT plus a backstop sweep, behind a `TriggerMode` flag — with poll remaining the on-prem/portable default. One codebase serves cloud (event-driven) and on-prem (poll) unchanged.

## Changes Made
- **Phase 0 — dispatcher seam (no behavior change):** `IOperationReconcileDispatcher.ReconcileOnceAsync(OperationRef op, ct)` in `Honua.Core/Features/ControlPlane/Abstractions`, where `OperationRef = (OperationKind Kind, string OperationId)`. The impl switches on `Kind` and calls the existing typed reconciler's idempotent reconcile-once method (`IWorkflowOperationReconciler` / `IExecutionJobReconciler` / `IMetadataReleaseOperationReconciler` / `ICoordinatedReleaseReconciler`). The existing `BackgroundService` poll loops are left running unchanged.
- **Phase 1 — event handler:** `ControlPlaneEventHandler.HandleExecutionJobEventAsync(providerOperationId)` resolves the provider/batch job id to the durable `operationId` (via `IExecutionJobStore.ListActiveAsync` matching `ProviderOperationId`) and calls `ReconcileOnceAsync((ExecutionJob, operationId))` once-and-exit. Loop-free; never trusts the event payload as state (the reconciler re-reads authoritative provider state via the backend's `ObserveAsync`/`DescribeJob`), so duplicate/out-of-order/malformed events are lease/CAS no-ops.
- **Phase 1 — backstop sweep (ships with this PR):** `ExecutionJobBackstopSweepService`, a low-frequency (~2 min) `BackgroundService` that reconciles any active non-terminal job whose `UpdatedAt` is older than `StaleThreshold`, so a dropped/missed event self-heals. Runs in BOTH modes; a no-op when active jobs are fresh. Works on-prem and is equally invocable by EventBridge Scheduler in the cloud.
- **Phase 1 — TriggerMode flag:** `ControlPlane:TriggerMode = Poll | Event` (default **Poll**). `Poll` keeps the existing 5s `ExecutionJobReconcilerBackgroundService`. `Event` disables that 5s loop for execution-jobs (event handler + backstop drive it instead); the backstop runs either way. `StaleThreshold` and `BackstopInterval` are configurable.
- **CI:** mapped `src/Honua.Server/Features/ControlPlane/` and `src/Honua.Core/Features/ControlPlane/` to the Infra-and-Security shard in `.github/ci-shards.json` (ADR-0037). Router + coverage validators pass.

### Follow-on (intentionally NOT in this PR — cloud deploy step)
IaC EventBridge rule + Lambda packaging. The rule is an EventBridge **"Batch Job State Change"** event; the Lambda passes `detail.jobId` (the AWS Batch provider id) into `ControlPlaneEventHandler.HandleExecutionJobEventAsync`, which maps `detail.jobId → ProviderOperationId → operationId` and reconciles once. This PR delivers the server-side logic + the proof that event-or-poll both drive the same reconcile.

## Testing
- [x] Unit tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

New tests (`OperationReconcileDispatcherTests`, `ControlPlaneTriggerTests`, 12 total, all green): dispatcher routes each kind to the right reconciler and no-ops empty ids; the event handler reconciles one op once, ignores unknown provider ids, and is a CAS/terminal no-op under duplicate + out-of-order invocation (asserted with the real reconciler + version-CAS store); the backstop reconciles a stale op, no-ops fresh and terminal ops, and is a no-op once an event already advanced a stale job. The 534 non-Docker ControlPlane tests stay green (TriggerMode=Poll path is byte-for-byte unchanged); the 13 `WithRedis` failures are environmental (no Docker daemon).

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Control plane SDK surface changed

New public Core abstraction (`IOperationReconcileDispatcher`, `OperationRef`, `OperationKind`); all documented. Reconciler implementations + options remain `internal`.

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

(Default `TriggerMode=Poll` means no config or infra change is required to adopt this PR. Going event-driven is a later, opt-in cloud deploy step — see follow-on above.)

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Tests added for new functionality
