### PR TITLE
docs(gp): soften gp publish prose to GitOps approval-gated promotion

### DIFF
--- a/src/Honua.Geoprocessing.Cli/Publish/GpPublishCommand.cs
+++ b/src/Honua.Geoprocessing.Cli/Publish/GpPublishCommand.cs
@@ -55,8 +55,9 @@ internal sealed record GpPublishOptions
 /// </summary>
 /// <remarks>
 /// This bridges the devkit's local loop to the GitOps cross-env path: publishing creates an
-/// immutable, versioned package in the store. It does NOT deploy across environments — the
-/// publish → metadata-release → GitOps release path promotes the package between environments.
+/// immutable, versioned package in the store and emits a metadata release package for promotion
+/// through the GitOps approval path. It does NOT deploy across environments and does NOT auto-promote
+/// — promotion is governed/approval-gated (honua-devops is plan + PR-first, submitImmediately=false).
 /// </remarks>
 internal static class GpPublishCommand
 {
@@ -238,16 +239,17 @@ internal static class GpPublishCommand
         else if (result.Publication is not null)
         {
             output.WriteLine(
-                "result    : package version published. Next: a metadata release picks up the "
-                + "published package and the GitOps release path promotes it across environments "
-                + "(this command only published the package; it does NOT deploy across envs).");
+                "result    : package version published. Next: it emits a metadata release package "
+                + "for promotion through the GitOps approval path (governed/approval-gated, not "
+                + "auto-promoted) (this command only published the package; it does NOT deploy across envs).");
         }
         else
         {
             output.WriteLine(
                 "result    : immutable package version created and ready to publish. Next: publish it "
-                + "(re-run with --publish, or use the Console), then a metadata release + the GitOps "
-                + "cross-env path promotes it across environments (publishing does NOT deploy across envs).");
+                + "(re-run with --publish, or use the Console) to emit a metadata release package for "
+                + "promotion through the GitOps approval path (governed/approval-gated, not auto-promoted) "
+                + "(publishing does NOT deploy across envs).");
         }
     }
 


### PR DESCRIPTION
Closes #2185

## Summary

The `gp publish` next-steps prose implied the published package is auto-promoted across environments via GitOps. With the publish→release bridge wired (#2184), `gp publish` does emit a metadata release package — but promotion is governed/approval-gated (honua-devops is plan + PR-first, `submitImmediately=false`), not automatic. This rewords the prose to be accurate, with no implication of auto-promotion.

Stacks on `feat/gp-devkit-p9-publish` (base of this PR).

## Changes Made

- Reword the two printed next-steps result lines in `GpPublishCommand.cs` (the published branch and the created-not-yet-published branch) to say the package is emitted "for promotion through the GitOps approval path (governed/approval-gated, not auto-promoted)".
- Update the matching `<remarks>` XML doc on `GpPublishCommand` for the same accuracy.
- Preserve the existing `does NOT deploy across envs` phrasing (asserted by `GpPublishCommandTests`).

## Breaking Changes

None. CLI output prose only.

## Gate Impact

- [x] No gate impact (prose-only change to CLI next-steps output).

## Testing

- [x] `dotnet build src/Honua.Geoprocessing.Cli` Release with `TreatWarningsAsErrors=true` — green.
- [x] `dotnet format src/Honua.Geoprocessing.Cli --verify-no-changes` — clean.
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
