### PR TITLE
Control-plane Phase 2: deploy/metadata/coordinated reconcilers via events

### DIFF
--- a/src/Honua.Server/Features/ControlPlane/ControlPlaneEventHandler.cs
+++ b/src/Honua.Server/Features/ControlPlane/ControlPlaneEventHandler.cs
@@ -2,24 +2,46 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
 
 namespace Honua.ControlPlane;
 
 /// <summary>
-/// Event entrypoint that drives a single execution-job reconcile from an external state-change
-/// event instead of a poll cycle. This is what an AWS Lambda — triggered by an EventBridge
-/// "Batch Job State Change" event — invokes: resolve the provider job id to the durable
-/// operation id, then reconcile that one operation exactly once and exit.
+/// Event entrypoint that drives a single control-plane reconcile from an external state-change
+/// event instead of a poll cycle. This is what an AWS Lambda — triggered by an EventBridge rule —
+/// invokes: resolve the event to the durable operation id, then reconcile that one operation
+/// exactly once and exit.
 /// <para>
-/// The handler is intentionally loop-free and side-effect-light: it never trusts the event
-/// payload as authoritative state. It only selects WHICH operation to reconcile; the reconciler
-/// then re-reads authoritative provider state via the backend's <c>ObserveAsync</c>/<c>DescribeJob</c>
-/// and advances under its own lease + CAS. A malformed, duplicate, or out-of-order event therefore
-/// cannot corrupt state — at worst it triggers a redundant reconcile that the lease/CAS make a no-op.
+/// Phase 1 covers execution jobs (AWS Batch). Phase 2 extends the same loop-free, payload-untrusted
+/// pattern to the deploy/release reconcilers:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <b>Deploy workflows</b> (<see cref="HandleDeployEventAsync"/>): driven by ECS Task State
+///     Change, CodeDeploy DeploymentStateChange, and Lambda-alias events for the
+///     <c>AwsEcsAlbDeployBackend</c> / <c>AwsLambdaGitOpsDeployBackend</c> targets. The event only
+///     selects WHICH deploy operation to reconcile; the reconciler re-reads authoritative provider
+///     state through the backend's <c>ObserveAsync</c> and advances under its own lease + CAS.
+///   </description></item>
+///   <item><description>
+///     <b>Staged releases</b> (metadata-release / coordinated-release) advance one stage per
+///     reconcile. After a stage persists, the reconciler can enqueue a self-continue signal that
+///     <see cref="HandleStagedContinueAsync"/> consumes to drive the next stage immediately, so a
+///     multi-stage release does not have to wait for the coarse backstop between stages. The
+///     data-populate stage completion arrives as a Batch event and reuses the Phase-1
+///     <see cref="HandleExecutionJobEventAsync"/> path.
+///   </description></item>
+/// </list>
+/// <para>
+/// The handler is intentionally loop-free and never trusts the event payload as authoritative
+/// state. A malformed, duplicate, or out-of-order event therefore cannot corrupt state — at worst it
+/// triggers a redundant reconcile that the lease/CAS + terminal guards inside each reconciler make a
+/// no-op.
 /// </para>
 /// </summary>
 internal sealed partial class ControlPlaneEventHandler(
     IExecutionJobStore jobStore,
+    IWorkflowOperationStore workflowStore,
     IOperationReconcileDispatcher dispatcher,
     ILogger<ControlPlaneEventHandler> logger)
 {
@@ -42,7 +64,7 @@ internal sealed partial class ControlPlaneEventHandler(
             return;
         }
 
-        var operationId = await ResolveOperationIdAsync(providerOperationId, cancellationToken).ConfigureAwait(false);
+        var operationId = await ResolveExecutionOperationIdAsync(providerOperationId, cancellationToken).ConfigureAwait(false);
         if (operationId is null)
         {
             Log.UnresolvedExecutionEvent(logger, providerOperationId);
@@ -74,7 +96,110 @@ internal sealed partial class ControlPlaneEventHandler(
             cancellationToken);
     }
 
-    private async Task<string?> ResolveOperationIdAsync(
+    /// <summary>
+    /// Handles a deploy provider state-change event by reconciling the matching deploy workflow once.
+    /// <para>
+    /// The cloud wiring (built by the parallel IaC agent, NOT in this PR) maps the following
+    /// EventBridge events to this handler, passing the provider id the event carries:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description>
+    ///     <b>ECS Task State Change</b> and <b>CodeDeploy DeploymentStateChange</b> for the
+    ///     <c>AwsEcsAlbDeployBackend</c> — the provider id is the CodeDeploy deployment id /
+    ///     ECS service-deployment id recorded as the operation's <c>ProviderOperationId</c>.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <b>Lambda-alias</b> routing-config change events for the
+    ///     <c>AwsLambdaGitOpsDeployBackend</c> — the provider id is the alias/version recorded as
+    ///     the operation's <c>ProviderOperationId</c>.
+    ///   </description></item>
+    /// </list>
+    /// </summary>
+    /// <param name="providerOperationId">
+    /// The deploy provider id carried by the event (CodeDeploy deployment id, ECS service-deployment
+    /// id, or Lambda alias/version). Resolved to the durable operation id via the workflow store.
+    /// If no active deploy operation matches, the event is ignored (terminal or unknown).
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task HandleDeployEventAsync(
+        string providerOperationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(providerOperationId))
+        {
+            return;
+        }
+
+        var operationId = await ResolveWorkflowOperationIdAsync(
+                WorkflowOperationKind.Deploy,
+                providerOperationId,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (operationId is null)
+        {
+            Log.UnresolvedDeployEvent(logger, providerOperationId);
+            return;
+        }
+
+        Log.HandlingDeployEvent(logger, providerOperationId, operationId);
+        await dispatcher
+            .ReconcileOnceAsync(new OperationRef(OperationKind.DeployWorkflow, operationId), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Handles a deploy event that already carries the durable operation id. Reconciles once.
+    /// </summary>
+    public Task HandleDeployOperationAsync(
+        string operationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(operationId))
+        {
+            return Task.CompletedTask;
+        }
+
+        Log.HandlingDeployEvent(logger, "(operation-id)", operationId);
+        return dispatcher.ReconcileOnceAsync(
+            new OperationRef(OperationKind.DeployWorkflow, operationId),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Self-continue entrypoint for a staged release (metadata-release or coordinated-release).
+    /// <para>
+    /// These reconcilers advance exactly one stage per call. Under event mode there is no 5s poll
+    /// loop to re-enter and drive the next stage, so after a stage persists the reconciler enqueues a
+    /// "continue" signal (a custom EventBridge event) that this handler consumes to reconcile the
+    /// same operation again — advancing the next stage. The chain terminates naturally when the
+    /// operation reaches a terminal status, because the reconciler's terminal guard makes any further
+    /// reconcile a no-op. The backstop is the safety net if a continue signal is dropped.
+    /// </para>
+    /// </summary>
+    /// <param name="kind">The staged operation family (MetadataRelease or CoordinatedRelease).</param>
+    /// <param name="operationId">The durable staged-operation id to advance.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public Task HandleStagedContinueAsync(
+        OperationKind kind,
+        string operationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(operationId))
+        {
+            return Task.CompletedTask;
+        }
+
+        if (kind is not (OperationKind.MetadataRelease or OperationKind.CoordinatedRelease))
+        {
+            Log.UnsupportedStagedContinue(logger, kind.ToString(), operationId);
+            return Task.CompletedTask;
+        }
+
+        Log.HandlingStagedContinue(logger, kind.ToString(), operationId);
+        return dispatcher.ReconcileOnceAsync(new OperationRef(kind, operationId), cancellationToken);
+    }
+
+    private async Task<string?> ResolveExecutionOperationIdAsync(
         string providerOperationId,
         CancellationToken cancellationToken)
     {
@@ -90,6 +215,23 @@ internal sealed partial class ControlPlaneEventHandler(
         return null;
     }
 
+    private async Task<string?> ResolveWorkflowOperationIdAsync(
+        WorkflowOperationKind kind,
+        string providerOperationId,
+        CancellationToken cancellationToken)
+    {
+        var active = await workflowStore.ListActiveAsync(kind, cancellationToken).ConfigureAwait(false);
+        foreach (var operation in active)
+        {
+            if (string.Equals(operation.ProviderOperationId, providerOperationId, StringComparison.Ordinal))
+            {
+                return operation.OperationId;
+            }
+        }
+
+        return null;
+    }
+
     private static partial class Log
     {
         [LoggerMessage(9040, LogLevel.Debug, "Handling execution-job state-change event for provider {ProviderOperationId} -> operation {OperationId}")]
@@ -97,5 +239,17 @@ internal sealed partial class ControlPlaneEventHandler(
 
         [LoggerMessage(9041, LogLevel.Debug, "Execution-job state-change event for provider {ProviderOperationId} matched no active operation; ignoring")]
         public static partial void UnresolvedExecutionEvent(ILogger logger, string providerOperationId);
+
+        [LoggerMessage(9046, LogLevel.Debug, "Handling deploy state-change event for provider {ProviderOperationId} -> operation {OperationId}")]
+        public static partial void HandlingDeployEvent(ILogger logger, string providerOperationId, string operationId);
+
+        [LoggerMessage(9047, LogLevel.Debug, "Deploy state-change event for provider {ProviderOperationId} matched no active deploy operation; ignoring")]
+        public static partial void UnresolvedDeployEvent(ILogger logger, string providerOperationId);
+
+        [LoggerMessage(9048, LogLevel.Debug, "Handling staged-release continue signal for {Kind} operation {OperationId}")]
+        public static partial void HandlingStagedContinue(ILogger logger, string kind, string operationId);
+
+        [LoggerMessage(9049, LogLevel.Warning, "Staged-release continue signal for unsupported kind {Kind} (operation {OperationId}); ignoring")]
+        public static partial void UnsupportedStagedContinue(ILogger logger, string kind, string operationId);
     }
 }

--- a/src/Honua.Server/Features/ControlPlane/ControlPlaneTriggerOptions.cs
+++ b/src/Honua.Server/Features/ControlPlane/ControlPlaneTriggerOptions.cs
@@ -4,20 +4,26 @@
 namespace Honua.ControlPlane;
 
 /// <summary>
-/// How the control plane drives execution-job reconciliation.
+/// How the control plane drives reconciliation for every operation family: execution jobs,
+/// deploy workflows, and the staged metadata-release / coordinated-release lifecycles.
 /// </summary>
 internal enum ControlPlaneTriggerMode
 {
     /// <summary>
-    /// On-prem / portable default. The 5-second <c>ExecutionJobReconcilerBackgroundService</c>
-    /// poll loop drives reconciliation exactly as it does today. Byte-for-byte unchanged.
+    /// On-prem / portable default. The 5-second poll loops
+    /// (<c>ExecutionJobReconcilerBackgroundService</c>, <c>DeployWorkflowReconcilerBackgroundService</c>,
+    /// <c>MetadataReleaseReconcilerBackgroundService</c>, <c>CoordinatedReleaseReconcilerBackgroundService</c>)
+    /// drive reconciliation exactly as they do today. Byte-for-byte unchanged.
     /// </summary>
     Poll,
 
     /// <summary>
-    /// Cloud event-driven mode. The 5-second execution-job poll loop is disabled; reconciliation
-    /// is driven by the event handler (an AWS Lambda invoked from an EventBridge "Batch Job State
-    /// Change" event) plus the low-frequency backstop sweep that self-heals dropped/missed events.
+    /// Cloud event-driven mode. The 5-second poll loops are disabled for every operation family;
+    /// reconciliation is driven by the event handler (an AWS Lambda invoked from EventBridge —
+    /// "Batch Job State Change" for execution jobs; ECS Task State Change / CodeDeploy
+    /// DeploymentStateChange / Lambda-alias events for deploys; and custom staged self-continue
+    /// signals for metadata/coordinated releases) plus the low-frequency backstop sweeps that
+    /// self-heal dropped/missed events for both the execution-job store and the workflow store.
     /// </summary>
     Event
 }
@@ -36,22 +42,25 @@ internal sealed class ControlPlaneTriggerOptions
     public const string SectionName = "ControlPlane";
 
     /// <summary>
-    /// Execution-job trigger mode. Defaults to <see cref="ControlPlaneTriggerMode.Poll"/> so an
+    /// Reconcile trigger mode for all operation families (execution jobs, deploys, and the staged
+    /// metadata/coordinated releases). Defaults to <see cref="ControlPlaneTriggerMode.Poll"/> so an
     /// unconfigured on-prem deployment keeps the existing poll behavior.
     /// </summary>
     public ControlPlaneTriggerMode TriggerMode { get; set; } = ControlPlaneTriggerMode.Poll;
 
     /// <summary>
-    /// How often the backstop sweep runs. The backstop ships with Phase 1 in BOTH modes so a
-    /// dropped or missed event self-heals; it is low-frequency on purpose. Works on-prem and can
-    /// also be invoked by EventBridge Scheduler in the cloud.
+    /// How often the backstop sweeps run. Both the execution-job and the workflow-operation
+    /// (deploy/metadata/coordinated) backstops ship in BOTH modes so a dropped or missed event —
+    /// or a lost staged self-continue signal — self-heals; they are low-frequency on purpose. Works
+    /// on-prem and can also be invoked by EventBridge Scheduler in the cloud.
     /// </summary>
     public TimeSpan BackstopInterval { get; set; } = TimeSpan.FromMinutes(2);
 
     /// <summary>
-    /// How stale (by <c>UpdatedAt</c>) a non-terminal execution job must be before the backstop
-    /// reconciles it. Fresh jobs that an event already advanced are skipped, so the backstop is a
-    /// no-op in the common case and only re-drives jobs that look stuck.
+    /// How stale (by <c>UpdatedAt</c>) a non-terminal operation must be before the backstop
+    /// reconciles it. Fresh operations that an event already advanced are skipped, so the backstop is
+    /// a no-op in the common case and only re-drives operations that look stuck. For the staged
+    /// releases this is also the per-stage advance interval when only the backstop is driving them.
     /// </summary>
     public TimeSpan StaleThreshold { get; set; } = TimeSpan.FromSeconds(90);
 }

--- a/src/Honua.Server/Features/ControlPlane/WorkflowOperationBackstopSweepService.cs
+++ b/src/Honua.Server/Features/ControlPlane/WorkflowOperationBackstopSweepService.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Low-frequency backstop sweep for the workflow-store-backed reconcilers: deploy, metadata-release,
+/// and coordinated-release. Phase 2 sibling of <see cref="ExecutionJobBackstopSweepService"/>; ships
+/// in BOTH trigger modes so a dropped or missed event (deploy provider event, or a staged
+/// self-continue signal) self-heals.
+/// <para>
+/// Sweeping all three non-terminal workflow kinds matters most for the staged releases: each
+/// reconcile advances exactly one stage, so a lost continue signal would otherwise wedge a release
+/// mid-flight under event mode. The sweep re-drives any active operation whose <c>UpdatedAt</c> has
+/// gone stale past the threshold, which both completes a missed deploy observation and walks a staged
+/// release forward one stage per cycle until it terminates.
+/// </para>
+/// <para>
+/// Because every reconcile funnels through the dispatcher into the leased + CAS-guarded reconciler, a
+/// backstop reconcile that races a real event (or the poll loop) is a safe no-op: whichever path
+/// already advanced the operation wins, and the late path observes a terminal/unchanged record. The
+/// cadence is deliberately coarse (minutes, not seconds) so it costs almost nothing in the healthy
+/// case yet bounds worst-case latency when events are lost. Works on-prem unchanged and can equally
+/// be invoked by EventBridge Scheduler in the cloud.
+/// </para>
+/// </summary>
+internal sealed partial class WorkflowOperationBackstopSweepService(
+    IWorkflowOperationStore workflowStore,
+    IOperationReconcileDispatcher dispatcher,
+    IOptions<ControlPlaneTriggerOptions> options,
+    ILogger<WorkflowOperationBackstopSweepService> logger) : BackgroundService
+{
+    private static readonly (WorkflowOperationKind StoreKind, OperationKind OperationKind)[] SweptKinds =
+    [
+        (WorkflowOperationKind.Deploy, OperationKind.DeployWorkflow),
+        (WorkflowOperationKind.MetadataRelease, OperationKind.MetadataRelease),
+        (WorkflowOperationKind.CoordinatedRelease, OperationKind.CoordinatedRelease)
+    ];
+
+    private readonly ControlPlaneTriggerOptions _options = options.Value;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var interval = _options.BackstopInterval > TimeSpan.Zero
+            ? _options.BackstopInterval
+            : TimeSpan.FromMinutes(2);
+        var staleThreshold = _options.StaleThreshold > TimeSpan.Zero
+            ? _options.StaleThreshold
+            : TimeSpan.FromSeconds(90);
+
+        Log.BackstopStarted(logger, (int)interval.TotalSeconds, (int)staleThreshold.TotalSeconds);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await SweepOnceAsync(staleThreshold, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                Log.BackstopSweepFailed(logger, ex);
+            }
+
+            try
+            {
+                await Task.Delay(interval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reconciles every active, non-terminal deploy/metadata/coordinated operation whose
+    /// <c>UpdatedAt</c> is older than <paramref name="staleThreshold"/>. Fresh operations are skipped
+    /// so the sweep is a no-op when events (or the poll loop) are keeping records current. Exposed
+    /// internally so tests can drive a single sweep deterministically without the timer loop.
+    /// </summary>
+    internal async Task SweepOnceAsync(TimeSpan staleThreshold, CancellationToken cancellationToken)
+    {
+        var cutoff = DateTimeOffset.UtcNow - staleThreshold;
+
+        foreach (var (storeKind, operationKind) in SweptKinds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // ListActiveAsync already filters terminal operations; the stale-time gate then skips
+            // any operation an event/poll is keeping fresh.
+            var active = await workflowStore.ListActiveAsync(storeKind, cancellationToken).ConfigureAwait(false);
+
+            foreach (var operation in active)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (operation.UpdatedAt > cutoff)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    Log.BackstopReconciling(
+                        logger,
+                        operationKind.ToString(),
+                        operation.OperationId,
+                        (int)(DateTimeOffset.UtcNow - operation.UpdatedAt).TotalSeconds);
+                    await dispatcher
+                        .ReconcileOnceAsync(new OperationRef(operationKind, operation.OperationId), cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Log.BackstopReconcileFailed(logger, operationKind.ToString(), operation.OperationId, ex);
+                }
+            }
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9050, LogLevel.Information, "Started workflow-operation backstop sweep (interval {IntervalSeconds}s, stale threshold {StaleSeconds}s)")]
+        public static partial void BackstopStarted(ILogger logger, int intervalSeconds, int staleSeconds);
+
+        [LoggerMessage(9051, LogLevel.Debug, "Backstop reconciling stale {Kind} operation {OperationId} (stale {StaleSeconds}s)")]
+        public static partial void BackstopReconciling(ILogger logger, string kind, string operationId, int staleSeconds);
+
+        [LoggerMessage(9052, LogLevel.Warning, "Backstop reconcile failed for {Kind} operation {OperationId}")]
+        public static partial void BackstopReconcileFailed(ILogger logger, string kind, string operationId, Exception exception);
+
+        [LoggerMessage(9053, LogLevel.Warning, "Workflow-operation backstop sweep cycle failed")]
+        public static partial void BackstopSweepFailed(ILogger logger, Exception exception);
+    }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -466,23 +466,25 @@ if (connectedRedis != null)
 
     if (!isTestEnvironment)
     {
-        builder.Services.AddHostedService<DeployWorkflowReconcilerBackgroundService>();
-
-        // Execution-job triggering is mode-selected. Poll (default, on-prem/portable): the 5s loop
-        // runs exactly as before. Event (cloud): the 5s loop is disabled; the event handler + the
-        // backstop sweep drive execution-job reconciliation instead.
+        // All reconcile families are mode-selected (Phase 1: execution jobs; Phase 2: deploy +
+        // staged metadata/coordinated releases). Poll (default, on-prem/portable): the 5s loops run
+        // exactly as before. Event (cloud): every 5s loop is disabled; the event handler (deploy
+        // provider events + staged self-continue signals) plus the two backstop sweeps drive
+        // reconciliation instead.
         if (controlPlaneTriggerMode == Honua.ControlPlane.ControlPlaneTriggerMode.Poll)
         {
+            builder.Services.AddHostedService<DeployWorkflowReconcilerBackgroundService>();
             builder.Services.AddHostedService<ExecutionJobReconcilerBackgroundService>();
+            builder.Services.AddHostedService<Honua.ControlPlane.MetadataReleaseReconcilerBackgroundService>();
+            builder.Services.AddHostedService<Honua.ControlPlane.CoordinatedReleaseReconcilerBackgroundService>();
         }
 
-        // The backstop sweep ships with Phase 1 and runs in BOTH modes so a dropped/missed event
-        // (or, under poll, a wedged loop) self-heals. It is low-frequency and is a no-op when the
-        // active jobs are fresh.
+        // The backstop sweeps ship in BOTH modes so a dropped/missed event (or, under poll, a wedged
+        // loop) self-heals. They are low-frequency and are a no-op when the active operations are
+        // fresh. The execution-job backstop covers Batch jobs; the workflow backstop covers the
+        // deploy/metadata/coordinated operations and walks any wedged staged release forward.
         builder.Services.AddHostedService<Honua.ControlPlane.ExecutionJobBackstopSweepService>();
-
-        builder.Services.AddHostedService<Honua.ControlPlane.MetadataReleaseReconcilerBackgroundService>();
-        builder.Services.AddHostedService<Honua.ControlPlane.CoordinatedReleaseReconcilerBackgroundService>();
+        builder.Services.AddHostedService<Honua.ControlPlane.WorkflowOperationBackstopSweepService>();
     }
 
     // Agent-operation approval surface (#1692/#1693): durable proposal store +

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneDeployTriggerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneDeployTriggerTests.cs
@@ -1,0 +1,457 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Phase 2 tests for extending the hybrid-trigger seam to the deploy/release reconcilers:
+/// <list type="bullet">
+///   <item><description>
+///     the deploy event handler resolves a deploy provider id to the durable operation id and
+///     reconciles it once, and is duplicate / out-of-order safe (lease + terminal-guard no-op);
+///   </description></item>
+///   <item><description>
+///     the staged self-continue handler reconciles a metadata/coordinated release once (advancing
+///     one stage) and refuses unsupported kinds;
+///   </description></item>
+///   <item><description>
+///     the workflow-operation backstop sweep covers the deploy/metadata/coordinated staged ops:
+///     it reconciles stale active ops, no-ops fresh ones, and walks a staged release forward.
+///   </description></item>
+/// </list>
+/// </summary>
+public sealed class ControlPlaneDeployTriggerTests
+{
+    // ---- Deploy event handler ----------------------------------------------
+
+    [Fact]
+    public async Task HandleDeployEvent_ResolvesProviderIdAndReconcilesOnce()
+    {
+        var deploy = CreateDeploy("op-deploy", WorkflowOperationStatus.Reconciling, providerOperationId: "codedeploy-d-123");
+        var store = new FakeWorkflowStore(deploy);
+        var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
+        var sut = BuildHandler(store, dispatcher);
+
+        await sut.HandleDeployEventAsync("codedeploy-d-123");
+
+        await dispatcher.Received(1).ReconcileOnceAsync(
+            Arg.Is<OperationRef>(r => r.Kind == OperationKind.DeployWorkflow && r.OperationId == "op-deploy"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleDeployEvent_UnknownProviderId_IsIgnored()
+    {
+        var deploy = CreateDeploy("op-deploy", WorkflowOperationStatus.Reconciling, providerOperationId: "codedeploy-d-123");
+        var store = new FakeWorkflowStore(deploy);
+        var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
+        var sut = BuildHandler(store, dispatcher);
+
+        await sut.HandleDeployEventAsync("not-a-known-deployment");
+
+        await dispatcher.DidNotReceiveWithAnyArgs().ReconcileOnceAsync(default, default);
+    }
+
+    [Fact]
+    public async Task HandleDeployEvent_DuplicateAndOutOfOrderInvocation_AdvancesDeployOnce()
+    {
+        // Real deploy reconciler behind the real dispatcher: prove the lease + terminal-status guard
+        // make a duplicate / out-of-order event a no-op. The backend reports a terminal Succeeded; the
+        // first event advances the durable record, the duplicates re-read a terminal record and bail.
+        var deploy = CreateDeploy("op-dup", WorkflowOperationStatus.Reconciling, providerOperationId: "ecs-dep-dup");
+        var store = new FakeWorkflowStore(deploy);
+        var backend = new FakeDeployBackend(WorkflowOperationStatus.Succeeded);
+        var dispatcher = BuildDeployDispatcher(store, backend);
+        var sut = BuildHandler(store, dispatcher);
+
+        await sut.HandleDeployEventAsync("ecs-dep-dup");
+        await sut.HandleDeployEventAsync("ecs-dep-dup");
+        await sut.HandleDeployOperationAsync("op-dup");
+
+        var stored = await store.GetAsync("op-dup");
+        stored!.Status.Should().Be(WorkflowOperationStatus.Succeeded);
+        store.WriteCount.Should().Be(1, "the terminal guard makes duplicate/out-of-order deploy events a no-op");
+        backend.ObserveCount.Should().Be(1, "only the first event observes the backend; the terminal guard short-circuits the rest");
+    }
+
+    // ---- Staged self-continue handler --------------------------------------
+
+    [Fact]
+    public async Task HandleStagedContinue_MetadataRelease_ReconcilesOnce()
+    {
+        var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
+        var sut = BuildHandler(new FakeWorkflowStore(), dispatcher);
+
+        await sut.HandleStagedContinueAsync(OperationKind.MetadataRelease, "mr-1");
+
+        await dispatcher.Received(1).ReconcileOnceAsync(
+            Arg.Is<OperationRef>(r => r.Kind == OperationKind.MetadataRelease && r.OperationId == "mr-1"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleStagedContinue_CoordinatedRelease_ReconcilesOnce()
+    {
+        var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
+        var sut = BuildHandler(new FakeWorkflowStore(), dispatcher);
+
+        await sut.HandleStagedContinueAsync(OperationKind.CoordinatedRelease, "cr-1");
+
+        await dispatcher.Received(1).ReconcileOnceAsync(
+            Arg.Is<OperationRef>(r => r.Kind == OperationKind.CoordinatedRelease && r.OperationId == "cr-1"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleStagedContinue_UnsupportedKind_IsNoOp()
+    {
+        var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
+        var sut = BuildHandler(new FakeWorkflowStore(), dispatcher);
+
+        // Deploy/execution kinds have their own dedicated event entrypoints; the staged continue is
+        // for the staged releases only.
+        await sut.HandleStagedContinueAsync(OperationKind.DeployWorkflow, "op-deploy");
+
+        await dispatcher.DidNotReceiveWithAnyArgs().ReconcileOnceAsync(default, default);
+    }
+
+    // ---- Workflow-operation backstop sweep ---------------------------------
+
+    [Fact]
+    public async Task WorkflowBackstop_ReconcilesStaleDeployMetadataAndCoordinated()
+    {
+        var stale = DateTimeOffset.UtcNow.AddMinutes(-10);
+        var store = new FakeWorkflowStore(
+            CreateDeploy("op-deploy", WorkflowOperationStatus.Reconciling, "p-deploy", updatedAt: stale),
+            CreateMetadata("op-meta", WorkflowOperationStatus.Reconciling, updatedAt: stale),
+            CreateCoordinated("op-coord", WorkflowOperationStatus.Reconciling, updatedAt: stale));
+        var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
+        var sut = BuildWorkflowBackstop(store, dispatcher, TimeSpan.FromSeconds(90));
+
+        await sut.SweepOnceAsync(TimeSpan.FromSeconds(90), CancellationToken.None);
+
+        await dispatcher.Received(1).ReconcileOnceAsync(
+            Arg.Is<OperationRef>(r => r.Kind == OperationKind.DeployWorkflow && r.OperationId == "op-deploy"), Arg.Any<CancellationToken>());
+        await dispatcher.Received(1).ReconcileOnceAsync(
+            Arg.Is<OperationRef>(r => r.Kind == OperationKind.MetadataRelease && r.OperationId == "op-meta"), Arg.Any<CancellationToken>());
+        await dispatcher.Received(1).ReconcileOnceAsync(
+            Arg.Is<OperationRef>(r => r.Kind == OperationKind.CoordinatedRelease && r.OperationId == "op-coord"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WorkflowBackstop_NoOpsFreshOperations()
+    {
+        var store = new FakeWorkflowStore(
+            CreateDeploy("op-deploy", WorkflowOperationStatus.Reconciling, "p-deploy", updatedAt: DateTimeOffset.UtcNow),
+            CreateMetadata("op-meta", WorkflowOperationStatus.Reconciling, updatedAt: DateTimeOffset.UtcNow));
+        var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
+        var sut = BuildWorkflowBackstop(store, dispatcher, TimeSpan.FromSeconds(90));
+
+        await sut.SweepOnceAsync(TimeSpan.FromSeconds(90), CancellationToken.None);
+
+        await dispatcher.DidNotReceiveWithAnyArgs().ReconcileOnceAsync(default, default);
+    }
+
+    [Fact]
+    public async Task WorkflowBackstop_SkipsTerminalOperations()
+    {
+        // ListActiveAsync filters terminal ops the way the Redis store does, so a Succeeded op is
+        // never surfaced to the sweep.
+        var store = new FakeWorkflowStore(
+            CreateDeploy("op-done", WorkflowOperationStatus.Succeeded, "p-done", updatedAt: DateTimeOffset.UtcNow.AddHours(-1)));
+        var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
+        var sut = BuildWorkflowBackstop(store, dispatcher, TimeSpan.FromSeconds(90));
+
+        await sut.SweepOnceAsync(TimeSpan.FromSeconds(90), CancellationToken.None);
+
+        await dispatcher.DidNotReceiveWithAnyArgs().ReconcileOnceAsync(default, default);
+    }
+
+    [Fact]
+    public async Task WorkflowBackstop_StaleStagedOperation_AdvancesViaRealReconcilerThenSettles()
+    {
+        // A staged metadata release wedged at ScriptMigration: the backstop drives the real
+        // reconciler, which advances exactly one stage to ServicePublication and persists. A second
+        // sweep walks it forward again — proving the backstop covers staged ops and is the safety net
+        // when a self-continue signal is dropped.
+        var stale = DateTimeOffset.UtcNow.AddMinutes(-10);
+        var release = CreateMetadata("op-staged", WorkflowOperationStatus.Reconciling, updatedAt: stale)
+            with
+            {
+                MetadataRelease = MetadataContextAt(MetadataReleaseStage.ScriptMigration)
+            };
+        var store = new FakeWorkflowStore(release);
+        var reconciler = BuildMetadataReconciler(store);
+        var dispatcher = new OperationReconcileDispatcher(
+            Substitute.For<IWorkflowOperationReconciler>(),
+            Substitute.For<IExecutionJobReconciler>(),
+            reconciler,
+            Substitute.For<ICoordinatedReleaseReconciler>());
+        var sut = BuildWorkflowBackstop(store, dispatcher, TimeSpan.FromSeconds(90));
+
+        await sut.SweepOnceAsync(TimeSpan.FromSeconds(90), CancellationToken.None);
+
+        var stored = await store.GetAsync("op-staged");
+        stored!.MetadataRelease!.CurrentStage.Should().Be(
+            MetadataReleaseStage.ServicePublication,
+            "the backstop drove the staged reconciler exactly one stage forward");
+        store.WriteCount.Should().Be(1, "exactly one stage advance persisted per sweep");
+    }
+
+    // ---- Helpers -----------------------------------------------------------
+
+    private static ControlPlaneEventHandler BuildHandler(
+        IWorkflowOperationStore workflowStore,
+        IOperationReconcileDispatcher dispatcher)
+        => new(
+            Substitute.For<IExecutionJobStore>(),
+            workflowStore,
+            dispatcher,
+            NullLogger<ControlPlaneEventHandler>.Instance);
+
+    private static OperationReconcileDispatcher BuildDeployDispatcher(
+        IWorkflowOperationStore store,
+        IDeployBackend backend)
+    {
+        var registry = Substitute.For<IDeployTargetRegistry>();
+        registry.GetAsync("target-1", Arg.Any<CancellationToken>()).Returns(new DeployTargetDefinition
+        {
+            TargetId = "target-1",
+            TargetKind = backend.TargetKind,
+            Backend = backend.BackendName,
+            Environment = "prod",
+            TargetName = "honua-service"
+        });
+
+        var telemetry = Substitute.For<IDeployTelemetrySignalEvaluator>();
+        telemetry.EvaluateAsync(Arg.Any<WorkflowOperationRecord>(), Arg.Any<CancellationToken>())
+            .Returns((DeployTelemetryDecision?)null);
+
+        var reconciler = new DeployWorkflowReconciler(
+            store,
+            registry,
+            [backend],
+            telemetry,
+            NullLogger<DeployWorkflowReconciler>.Instance);
+
+        return new OperationReconcileDispatcher(
+            reconciler,
+            Substitute.For<IExecutionJobReconciler>(),
+            Substitute.For<IMetadataReleaseOperationReconciler>(),
+            Substitute.For<ICoordinatedReleaseReconciler>());
+    }
+
+    private static MetadataReleaseReconciler BuildMetadataReconciler(IWorkflowOperationStore store)
+    {
+        var scriptExecutor = Substitute.For<IMetadataReleaseScriptExecutor>();
+        scriptExecutor.ApplyForwardAsync(Arg.Any<MetadataReleaseExecutionPlan>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        return new MetadataReleaseReconciler(
+            store,
+            Substitute.For<IMetadataReleasePreflightGate>(),
+            scriptExecutor,
+            Substitute.For<IMetadataReleaseDataJobDispatcher>(),
+            Substitute.For<IMetadataReleaseActivator>(),
+            Substitute.For<IMetadataReleaseSmokeChecker>(),
+            NullLogger<MetadataReleaseReconciler>.Instance);
+    }
+
+    private static WorkflowOperationBackstopSweepService BuildWorkflowBackstop(
+        IWorkflowOperationStore store,
+        IOperationReconcileDispatcher dispatcher,
+        TimeSpan staleThreshold)
+        => new(
+            store,
+            dispatcher,
+            Options.Create(new ControlPlaneTriggerOptions { StaleThreshold = staleThreshold }),
+            NullLogger<WorkflowOperationBackstopSweepService>.Instance);
+
+    private static WorkflowOperationRecord CreateDeploy(
+        string operationId,
+        WorkflowOperationStatus status,
+        string? providerOperationId,
+        DateTimeOffset? updatedAt = null) => new()
+        {
+            OperationId = operationId,
+            Kind = WorkflowOperationKind.Deploy,
+            Status = status,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            UpdatedAt = updatedAt ?? DateTimeOffset.UtcNow.AddMinutes(-1),
+            ProviderOperationId = providerOperationId,
+            Deploy = new DeployOperationSpec
+            {
+                TargetId = "target-1",
+                TargetKind = DeployTargetKind.AwsEcs,
+                Backend = "honua-gitops-aws-ecs-alb",
+                Environment = "prod",
+                TargetName = "honua-service",
+                DesiredRevision = "v2"
+            }
+        };
+
+    private static WorkflowOperationRecord CreateMetadata(
+        string operationId,
+        WorkflowOperationStatus status,
+        DateTimeOffset? updatedAt = null) => new()
+        {
+            OperationId = operationId,
+            Kind = WorkflowOperationKind.MetadataRelease,
+            Status = status,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            UpdatedAt = updatedAt ?? DateTimeOffset.UtcNow.AddMinutes(-1),
+            MetadataRelease = MetadataContextAt(MetadataReleaseStage.Preflight)
+        };
+
+    private static MetadataReleaseContext MetadataContextAt(MetadataReleaseStage stage) => new()
+    {
+        PackageId = "pkg-1",
+        DesiredRevision = "rev-2",
+        TargetEnvironment = "prod",
+        CurrentStage = stage,
+        ExecutionPlan = BuildExecutionPlan()
+    };
+
+    private static MetadataReleaseExecutionPlan BuildExecutionPlan() => new()
+    {
+        PackageId = "pkg-1",
+        TargetEnvironment = "prod",
+        ResourceSemanticId = "layer-1",
+        NewFieldName = "added_field",
+        Script = new MetadataReleaseScript
+        {
+            ScriptId = "script-1",
+            ForwardOperations =
+            [
+                new MetadataReleaseScriptOperation
+                {
+                    Kind = MetadataReleaseScriptOperationKind.AddColumn,
+                    ResourceSemanticId = "layer-1",
+                    FieldName = "added_field"
+                }
+            ],
+            InverseOperations = []
+        }
+    };
+
+    private static WorkflowOperationRecord CreateCoordinated(
+        string operationId,
+        WorkflowOperationStatus status,
+        DateTimeOffset? updatedAt = null) => new()
+        {
+            OperationId = operationId,
+            Kind = WorkflowOperationKind.CoordinatedRelease,
+            Status = status,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            UpdatedAt = updatedAt ?? DateTimeOffset.UtcNow.AddMinutes(-1),
+            CoordinatedRelease = new CoordinatedReleaseContext
+            {
+                PackageId = "pkg-coord",
+                TargetEnvironment = "prod",
+                CurrentStep = CoordinatedReleaseStep.Preflight,
+                Container = new CoordinatedReleaseContainerSpec { TargetId = "target-1", DesiredImage = "honua:v2" },
+                MetadataPlan = BuildExecutionPlan()
+            }
+        };
+
+    /// <summary>
+    /// In-memory workflow-operation store. Lease ops always succeed; <see cref="ListActiveAsync"/>
+    /// filters terminal operations exactly like the Redis store, and <see cref="SetAsync"/> counts
+    /// advancing writes so duplicate/out-of-order reconciles are observable.
+    /// </summary>
+    private sealed class FakeWorkflowStore(params WorkflowOperationRecord[] operations) : IWorkflowOperationStore
+    {
+        private readonly Dictionary<string, WorkflowOperationRecord> _ops =
+            operations.ToDictionary(op => op.OperationId, StringComparer.Ordinal);
+
+        public int WriteCount { get; private set; }
+
+        public Task<bool> TryAcquireLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task<bool> RenewLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task ReleaseLeaseAsync(string operationId, string ownerId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<bool> TryCreateAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            if (_ops.ContainsKey(operation.OperationId))
+            {
+                return Task.FromResult(false);
+            }
+
+            _ops[operation.OperationId] = operation;
+            return Task.FromResult(true);
+        }
+
+        public Task<WorkflowOperationRecord?> GetAsync(string operationId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_ops.TryGetValue(operationId, out var op) ? op : null);
+
+        public Task<WorkflowOperationRecord?> GetByMetadataPackageIdAsync(string packageId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_ops.Values.FirstOrDefault(op => op.MetadataRelease?.PackageId == packageId));
+
+        public Task SetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _ops[operation.OperationId] = operation;
+            WriteCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<WorkflowOperationRecord>>(
+                _ops.Values
+                    .Where(op => !IsTerminal(op.Status) && (kind is null || op.Kind == kind))
+                    .OrderByDescending(op => op.UpdatedAt)
+                    .ToArray());
+
+        private static bool IsTerminal(WorkflowOperationStatus status)
+            => status is WorkflowOperationStatus.Succeeded
+                or WorkflowOperationStatus.Failed
+                or WorkflowOperationStatus.RolledBack
+                or WorkflowOperationStatus.ManualInterventionRequired;
+    }
+
+    /// <summary>
+    /// Deploy backend that reports a fixed observation and counts how many times it was observed.
+    /// </summary>
+    private sealed class FakeDeployBackend(WorkflowOperationStatus observedStatus) : IDeployBackend
+    {
+        public int ObserveCount { get; private set; }
+
+        public string BackendName => "honua-gitops-aws-ecs-alb";
+
+        public DeployTargetKind TargetKind => DeployTargetKind.AwsEcs;
+
+        public Task<DeployBackendCapabilities> GetCapabilitiesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new DeployBackendCapabilities { SupportsRollback = true });
+
+        public Task<DeployPlan> PlanAsync(DeployOperationSpec spec, CancellationToken cancellationToken = default)
+            => Task.FromResult(new DeployPlan { IsReadyToSubmit = true });
+
+        public Task<DeploySubmissionResult> StartAsync(WorkflowOperationRecord operation, CancellationToken cancellationToken = default)
+            => Task.FromResult(new DeploySubmissionResult { Status = WorkflowOperationStatus.Submitted });
+
+        public Task<DeployObservation> ObserveAsync(WorkflowOperationRecord operation, CancellationToken cancellationToken = default)
+        {
+            ObserveCount++;
+            return Task.FromResult(new DeployObservation
+            {
+                Status = observedStatus,
+                ProviderOperationId = operation.ProviderOperationId
+            });
+        }
+
+        public Task<DeployObservation> RollbackAsync(WorkflowOperationRecord operation, CancellationToken cancellationToken = default)
+            => Task.FromResult(new DeployObservation { Status = WorkflowOperationStatus.RolledBack });
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneTriggerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneTriggerTests.cs
@@ -29,7 +29,7 @@ public sealed class ControlPlaneTriggerTests
         var job = CreateJob("op-1", ExecutionJobStatus.Running, providerOperationId: "batch-job-abc");
         var store = new VersionedJobStore(job);
         var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
-        var sut = new ControlPlaneEventHandler(store, dispatcher, NullLogger<ControlPlaneEventHandler>.Instance);
+        var sut = new ControlPlaneEventHandler(store, Substitute.For<IWorkflowOperationStore>(), dispatcher, NullLogger<ControlPlaneEventHandler>.Instance);
 
         await sut.HandleExecutionJobEventAsync("batch-job-abc");
 
@@ -44,7 +44,7 @@ public sealed class ControlPlaneTriggerTests
         var job = CreateJob("op-1", ExecutionJobStatus.Running, providerOperationId: "batch-job-abc");
         var store = new VersionedJobStore(job);
         var dispatcher = Substitute.For<IOperationReconcileDispatcher>();
-        var sut = new ControlPlaneEventHandler(store, dispatcher, NullLogger<ControlPlaneEventHandler>.Instance);
+        var sut = new ControlPlaneEventHandler(store, Substitute.For<IWorkflowOperationStore>(), dispatcher, NullLogger<ControlPlaneEventHandler>.Instance);
 
         await sut.HandleExecutionJobEventAsync("not-a-known-job");
 
@@ -62,7 +62,7 @@ public sealed class ControlPlaneTriggerTests
         var progress = new RecordingProgressStore();
         var backend = new CountingBatchBackend(ExecutionJobStatus.Succeeded);
         var dispatcher = BuildDispatcher(store, progress, backend);
-        var sut = new ControlPlaneEventHandler(store, dispatcher, NullLogger<ControlPlaneEventHandler>.Instance);
+        var sut = new ControlPlaneEventHandler(store, Substitute.For<IWorkflowOperationStore>(), dispatcher, NullLogger<ControlPlaneEventHandler>.Instance);
 
         // Fire the same event three times (duplicate delivery) plus a stale "out-of-order" replay.
         await sut.HandleExecutionJobEventAsync("batch-job-dup");
@@ -131,7 +131,7 @@ public sealed class ControlPlaneTriggerTests
         var dispatcher = BuildDispatcher(store, progress, backend);
 
         // Simulate the missed-event self-heal: an event already drove it terminal...
-        var handler = new ControlPlaneEventHandler(store, dispatcher, NullLogger<ControlPlaneEventHandler>.Instance);
+        var handler = new ControlPlaneEventHandler(store, Substitute.For<IWorkflowOperationStore>(), dispatcher, NullLogger<ControlPlaneEventHandler>.Instance);
         await handler.HandleExecutionJobEventAsync("batch-heal");
         var afterEvent = store.WriteCount;
 


### PR DESCRIPTION
Phase 2 of the hybrid control-plane (option C), stacking on the Phase-1 dispatcher seam (feat/control-plane-event-triggers / #2190).

Extends event-driven triggers from the GP job reconcile to the **deploy-workflow, metadata-release, and coordinated-release** reconcilers:
- `ControlPlaneEventHandler` gains handlers that resolve a provider ref → operationId and `ReconcileOnceAsync` the right `OperationKind` (ECS Task State Change / CodeDeploy DeploymentStateChange events; staged metadata/coordinated workflows advance via a self-continue signal).
- New `WorkflowOperationBackstopSweepService` so dropped/missed events for non-ExecutionJob ops self-heal (reconciles stale non-terminal ops).
- `TriggerMode=Poll` (default) preserves the existing 5s deploy/metadata poll loops byte-for-byte; `TriggerMode=Event` disables them and lets events + backstop drive. The per-op lease + read-then-CAS make duplicate/out-of-order delivery safe (unchanged).

IaC EventBridge rules (ECS/CodeDeploy events → Lambda) are the deploy-wiring follow-on (separate PR). On-prem portability preserved (Poll path needs no cloud event infra).

Stacks on #2190. Part of the control-plane C design. Validated locally (under the shared build lock): build green (0 warnings / 0 errors, `-p:NuGetAudit=false`), `dotnet format --verify-no-changes` clean, and the ControlPlane trigger tests pass 17/17 (`ControlPlaneDeployTriggerTests` + updated `ControlPlaneTriggerTests`). ADR-0037 shard mapping intact (ControlPlane source/test dirs → Infra and Security shard, no new mapping needed). Testcontainers `WithRedis` integration tests are environmental and out of scope.
