### PR TITLE
feat(customcode): .NET custom-code GP runtime (Phase 2)

### DIFF
--- a/docker/worker-customcode-dotnet/Dockerfile
+++ b/docker/worker-customcode-dotnet/Dockerfile
@@ -1,0 +1,138 @@
+# syntax=docker/dockerfile:1.7
+#
+# Honua custom-code GP worker (DOTNET runtime) — Phase 2.
+#
+# The .NET sibling of docker/worker-customcode-python. This image is the SANDBOXED
+# unit that runs inside a per-job AWS Batch container: it clones a user's GP tool at a
+# PINNED git SHA, builds the user's .csproj against a WARM NuGet cache, runs it under a
+# SCOPED Honua SDK client, and uploads the tool's output artifacts to the job's S3
+# output prefix.
+#
+# It is SEPARATE from docker/worker-gdal (the .NET native ETL worker, which runs the
+# durable job loop and ships no git). Here we want a .NET SDK (needed to `dotnet build`
+# the user's project at job time) on a GDAL-full base, plus git/ca-certs, with the
+# common .NET geo deps (NetTopologySuite) + the Honua .NET SDK pre-warmed in the NuGet
+# cache so the common tool needs no network restore.
+#
+# The ENTRYPOINT is the harness (Honua.CustomCode.Harness), which:
+#   clone pinned SHA -> verify HEAD == SHA -> dotnet build the user .csproj ->
+#   build a SCOPED Honua client -> STRIP the IMDS/credential + token env vars ->
+#   activate the user's IGeoprocessingTool -> ExecuteAsync(context) -> upload artifacts.
+# See ./harness/.
+
+# --- build stage: publish the harness + warm the NuGet cache + sanity-build sample ---
+# Pinned .NET SDK (do NOT use a floating tag).
+ARG DOTNET_SDK_IMAGE=mcr.microsoft.com/dotnet/sdk:10.0
+FROM ${DOTNET_SDK_IMAGE} AS build
+WORKDIR /src
+
+# Copy the harness solution + build infra first for better layer caching.
+COPY docker/worker-customcode-dotnet/harness/ ./harness/
+
+WORKDIR /src/harness
+
+# Publish the harness host (framework-dependent; NOT AOT — it loads user assemblies
+# dynamically). NuGetAudit is off (offline restore from nuget.org only).
+RUN dotnet publish src/Honua.CustomCode.Harness/Honua.CustomCode.Harness.csproj \
+      --configuration Release \
+      -p:NuGetAudit=false \
+      --output /opt/harness
+
+# IN-BUILD SANITY CHECK (correct-by-construction): restore + build the sample tool.
+# This proves the SDK contract resolves, the geometry stack restores, and a real
+# IGeoprocessingTool compiles — failing the image build early if anything regresses.
+RUN dotnet build samples/BufferTool/BufferTool.csproj \
+      --configuration Release \
+      -p:NuGetAudit=false \
+      --output /tmp/sample-build \
+ && test -f /tmp/sample-build/BufferTool.dll
+
+# --- runtime stage: GDAL-full base + the .NET SDK + git + the warm cache --------------
+# Pinned GDAL "ubuntu-full" base (matches the python image's base family). It ships the
+# full GDAL driver set; .NET tools that shell out to gdal* or P/Invoke GDAL get it here.
+ARG GDAL_BASE_IMAGE=ghcr.io/osgeo/gdal:ubuntu-full-3.12.4
+FROM ${GDAL_BASE_IMAGE} AS runtime
+
+ARG DOTNET_SDK_CHANNEL=10.0
+# Pin the geo + SDK package versions so the warm cache matches the harness solution.
+ARG NETTOPOLOGYSUITE_VERSION=2.6.0
+ARG HONUA_SDK_DOTNET_VERSION=0.1.4
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_NOLOGO=1 \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \
+    NUGET_XMLDOC_MODE=skip
+
+# git (clone user code), ca-certificates (TLS to git host + Honua API), and the deps the
+# dotnet-install script needs. The .NET SDK is required at runtime to `dotnet build` the
+# user's .csproj at job time (this is why we install the SDK, not just the runtime).
+# hadolint ignore=DL3008
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      git \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install the pinned .NET SDK onto the GDAL (Ubuntu) base via the official script.
+ENV DOTNET_ROOT=/usr/share/dotnet
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+ && chmod +x /tmp/dotnet-install.sh \
+ && /tmp/dotnet-install.sh --channel "${DOTNET_SDK_CHANNEL}" --install-dir "${DOTNET_ROOT}" \
+ && ln -s "${DOTNET_ROOT}/dotnet" /usr/bin/dotnet \
+ && rm -f /tmp/dotnet-install.sh
+
+# The published harness host.
+COPY --from=build /opt/harness /opt/harness
+
+# Pre-warm the NuGet cache (NetTopologySuite + GeoJSON IO + the Honua .NET SDK) so the
+# common user tool builds with NO network restore at job time. We do this by restoring a
+# tiny throwaway project that references the common packages into the shared global
+# packages folder, then deleting the project (the populated cache layer is what we keep).
+ENV NUGET_PACKAGES=/opt/nuget/packages
+RUN mkdir -p /tmp/warm \
+ && cat > /tmp/warm/warm.csproj <<EOF
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NetTopologySuite" Version="${NETTOPOLOGYSUITE_VERSION}" />
+    <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />
+    <PackageReference Include="Honua.Sdk" Version="${HONUA_SDK_DOTNET_VERSION}" />
+  </ItemGroup>
+</Project>
+EOF
+RUN --mount=type=secret,id=github_actor \
+    --mount=type=secret,id=github_token \
+    sh -c 'cd /tmp/warm && dotnet restore -p:NuGetAudit=false || true' \
+ && rm -rf /tmp/warm
+
+# Non-root user (uid 1001, matching docker/worker-gdal + the python image). The per-job
+# scratch tree is owned by the worker so clone + build + output writes succeed.
+RUN groupadd --gid 1001 --system honua \
+ && useradd --uid 1001 --gid 1001 --system --no-create-home --shell /usr/sbin/nologin honua \
+ && mkdir -p /work/src /work/build /work/out \
+ && chown -R 1001:1001 /work /opt/nuget
+
+WORKDIR /work
+
+ENV HONUA_CUSTOMCODE_SOURCE_ROOT=/work/src \
+    HONUA_CUSTOMCODE_BUILD_OUTPUT=/work/build \
+    HONUA_CUSTOMCODE_WORKDIR=/work/out \
+    GDAL_NUM_THREADS=ALL_CPUS
+
+LABEL org.opencontainers.image.title="honua-worker-customcode-dotnet" \
+      org.opencontainers.image.description="Honua custom-code GP worker (.NET runtime): runs user IGeoprocessingTool implementations at a pinned git SHA under a scoped Honua SDK client." \
+      org.opencontainers.image.licenses="Elastic-2.0" \
+      honua.runtime.profile="customcode-dotnet" \
+      security.non-root="true" \
+      security.user="1001"
+
+USER 1001:1001
+
+# The harness reads CUSTOMCODE_* / HONUA_* from the Batch container env (or a
+# CUSTOMCODE_JOB_SPEC file). See harness/src/Honua.CustomCode.Harness/JobSpec.cs.
+ENTRYPOINT ["dotnet", "/opt/harness/Honua.CustomCode.Harness.dll"]

--- a/docker/worker-customcode-dotnet/README.md
+++ b/docker/worker-customcode-dotnet/README.md
@@ -1,0 +1,143 @@
+# honua-worker-customcode-dotnet (Phase 2)
+
+The **.NET custom-code GP runtime** — the symmetric sibling of
+[`docker/worker-customcode-python`](../worker-customcode-python/README.md) (Phase 1).
+This image is the sandboxed unit that runs inside a per-job AWS Batch container: it
+clones a user's GP tool at a **pinned git SHA**, **builds the user's `.csproj`** against
+a warm NuGet cache, runs the tool's `IGeoprocessingTool` under a **scoped Honua SDK
+client**, and uploads the tool's output artifacts to the job's S3 output prefix.
+
+It is **separate** from `docker/worker-gdal` — that image is the .NET native ETL worker
+that runs the durable job loop and ships no git. This image is the opposite: a .NET
+**SDK** (needed to compile the user project at job time) on a GDAL-full base, with the
+common .NET geo stack + the Honua .NET SDK baked into the NuGet cache.
+
+## Image contents
+
+- **Base:** `ghcr.io/osgeo/gdal:ubuntu-full-3.12.4` (pinned) — the full GDAL driver set
+  for tools that shell out to or P/Invoke GDAL.
+- Added: the **.NET 10 SDK** (pinned channel), `git`, `ca-certificates`.
+- Pre-warmed NuGet cache (no per-job restore for the common case): **NetTopologySuite**,
+  `NetTopologySuite.IO.GeoJSON`, and **`Honua.Sdk`** (the .NET SDK umbrella).
+- The harness host `Honua.CustomCode.Harness` is published to `/opt/harness`; the
+  `ENTRYPOINT` runs `dotnet /opt/harness/Honua.CustomCode.Harness.dll`.
+- Runs as non-root `uid 1001` (matching `worker-gdal` + the python image). Scratch tree
+  `/work` (`src` / `build` / `out`).
+
+> Docker build is **CI/local-Docker verified** — it is not built in the agent
+> environment (no daemon). The Dockerfile is correct-by-construction: a pinned, verified
+> base + SDK, and an **in-build sanity check** that `dotnet build`s the sample
+> `IGeoprocessingTool` (`samples/BufferTool`) and asserts the output assembly exists,
+> failing the image build early if the SDK contract or geometry stack regresses.
+
+## The contract (job inputs)
+
+Identical to the python runtime (one contract, two runtimes). The Batch container
+receives the auth spine as **env vars** (standard Batch secret injection, so the token
+is strippable):
+
+- `HONUA_BASE_URL`
+- `HONUA_JOB_TOKEN` — the scoped, job-bound bearer token (from the server)
+
+The `customcode.*` parameters are resolved in this order (see
+`harness/src/Honua.CustomCode.Harness/JobSpec.cs`):
+
+1. A mounted job-spec file if `CUSTOMCODE_JOB_SPEC` points at a readable JSON file
+   (preferred for large `params_json`). The auth spine is *never* read from this file.
+2. Otherwise discrete `CUSTOMCODE_*` env vars.
+
+| Spec key | Env var | Notes |
+|---|---|---|
+| `runtime` | `CUSTOMCODE_RUNTIME` | `dotnet` |
+| `repo_url` | `CUSTOMCODE_REPO_URL` | https/ssh git URL |
+| `git_ref` | `CUSTOMCODE_GIT_REF` | **40-hex SHA**, validated |
+| `entrypoint` | `CUSTOMCODE_ENTRYPOINT` | **`Assembly::Namespace.Type`** |
+| `deps_manifest` | `CUSTOMCODE_DEPS_MANIFEST` | the user's **`.csproj`**, repo-relative |
+| `params_json` | `CUSTOMCODE_PARAMS_JSON` | inline JSON or `@/path` |
+| `output_prefix` | `CUSTOMCODE_OUTPUT_PREFIX` | `s3://bucket/prefix` |
+| `declared_scope` | `CUSTOMCODE_DECLARED_SCOPE` | advisory scope list |
+| `output_max_bytes` | `CUSTOMCODE_OUTPUT_MAX_BYTES` | default 1 GiB |
+
+The only runtime-shaped differences from python are the **entrypoint** form
+(`Assembly::Namespace.Type` instead of `module:func`) and the **deps manifest** (the
+user `.csproj` instead of `requirements.txt`).
+
+## Harness flow
+
+1. **Load + validate inputs.** `git_ref` must be a 40-hex SHA; `output_prefix` must be
+   `s3://…`; `entrypoint` must be `Assembly::Namespace.Type`.
+2. **Clone pinned source.** `git init` + `fetch --depth 1 <sha>` +
+   `checkout --detach <sha>`, then **assert `git rev-parse HEAD == <sha>`** — fail hard
+   on mismatch.
+3. **Build the user project.** `dotnet build <deps_manifest> -c Release` against the warm
+   cache (the SDK + geometry stack are already baked in, so the common tool needs no
+   network restore). The manifest is resolved relative to the source root and must stay
+   inside it (no `..` escapes).
+4. **Build the scoped client, then strip credentials.** Construct the scoped Honua client
+   (`AddHonua(o => { o.BaseAddress = HONUA_BASE_URL; o.BearerTokenProvider = _ =>
+   Task.FromResult(HONUA_JOB_TOKEN); })`), **then delete** `HONUA_JOB_TOKEN`,
+   `AWS_CONTAINER_CREDENTIALS_*`, `ECS_CONTAINER_METADATA_URI*`, and any static AWS keys
+   from the environment **before activating user code** — so the tool can neither read the
+   raw token nor assume the Batch task role. An invariant check
+   (`AssertCredentialsStripped`) runs after the scrub.
+5. **Activate + run.** Load the `Assembly::Namespace.Type` entrypoint from the build
+   output via a dedicated `AssemblyLoadContext`, verify it implements
+   `IGeoprocessingTool`, activate it, build a `GpContext`, call
+   `ExecuteAsync(context, ct)`.
+6. **Upload + report.** Upload registered artifacts to `output_prefix`, enforce the
+   output-size cap, and map the returned `GpResult` to an exit code: `0` success,
+   `1` tool failure, `2` harness/setup error, `3` cancelled (the same code contract as
+   the python harness).
+
+## The `IGeoprocessingTool` contract
+
+A tool ships an assembly with a public type implementing `IGeoprocessingTool` and a
+public parameterless constructor:
+
+```csharp
+using Honua.CustomCode.Sdk;
+
+public sealed class BufferTool : IGeoprocessingTool
+{
+    public async Task<GpResult> ExecuteAsync(GpContext context, CancellationToken ct)
+    {
+        var distance = context.Params.GetProperty("distance").GetDouble(); // parsed params_json
+        context.Log.Info("starting");                                       // job logs
+        context.Progress.Report(50.0, "buffering");                         // coarse progress
+        ct.ThrowIfCancellationRequested();                                  // cooperative cancel
+        var outPath = Path.Combine(context.WorkDirectory, "out.geojson");   // writable scratch
+        await File.WriteAllTextAsync(outPath, "...", ct);
+        context.Output.AddArtifact("out.geojson", outPath);                 // staged for S3 upload
+        // context.Client -> pre-authed scoped Honua client (raw token never exposed)
+        // context.Inputs -> resolved input artifacts (name -> local path)
+        return GpResult.Succeeded("done");                                  // or GpResult.Failed("why")
+    }
+}
+```
+
+`context` exposes: `.Params` (`JsonElement`), `.Inputs`, `.Client` (scoped Honua client,
+typed as `object` so the SDK contract stays small/stable — cast to the client you need),
+`.Output.AddArtifact(name, path)`, `.Progress.Report(pct, phase)`, `.Log.Info/Warn(...)`,
+`.WorkDirectory`. Cancellation is the `CancellationToken` argument to `ExecuteAsync`.
+
+A trivial sample lives in [`harness/samples/BufferTool`](harness/samples/BufferTool/BufferTool.cs)
+(entrypoint `BufferTool::Honua.CustomCode.Samples.BufferTool`): buffers a WKT geometry
+with NetTopologySuite and writes GeoJSON.
+
+The contract types live in the SDK-facing package
+[`Honua.CustomCode.Sdk`](harness/src/Honua.CustomCode.Sdk/) — the only package a tool
+author references.
+
+## Tests (offline)
+
+`harness/tests/Honua.CustomCode.Harness.Tests/` unit-tests the git-ref validation
+(rejects non-SHA), the dotnet entrypoint shape (`Assembly::Namespace.Type`, rejects the
+python `module:func` form), the IMDS/token strip (vars gone after client build, observed
+by the tool at execute time), context construction + artifact sink + size cap,
+`GpResult` shape, entrypoint type-loading + contract enforcement, and the full flow with
+a fake git/build/SDK-client/uploader. Run:
+
+```bash
+cd docker/worker-customcode-dotnet/harness
+dotnet test Honua.CustomCode.slnx --configuration Release -p:NuGetAudit=false
+```

--- a/docker/worker-customcode-dotnet/harness/.gitignore
+++ b/docker/worker-customcode-dotnet/harness/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+[Bb]in/
+[Oo]bj/
+*.user
+TestResults/

--- a/docker/worker-customcode-dotnet/harness/Directory.Build.props
+++ b/docker/worker-customcode-dotnet/harness/Directory.Build.props
@@ -1,0 +1,22 @@
+<Project>
+
+  <!--
+    Build props for the .NET custom-code harness solution. This tree is SEPARATE
+    from the main Honua.sln (like the Python harness under
+    docker/worker-customcode-python/harness) — it is built only in the image (and
+    in CI/agent offline checks), never as part of the AOT serving build.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Audit is opt-out here: the offline build has no audit feed. -->
+    <NuGetAudit>false</NuGetAudit>
+    <Deterministic>true</Deterministic>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+</Project>

--- a/docker/worker-customcode-dotnet/harness/Directory.Packages.props
+++ b/docker/worker-customcode-dotnet/harness/Directory.Packages.props
@@ -1,0 +1,22 @@
+<Project>
+
+  <!-- Central package versions for the .NET custom-code harness solution. -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Geometry stack (sample tool + pre-warmed image cache). -->
+    <PackageVersion Include="NetTopologySuite" Version="2.6.0" />
+    <PackageVersion Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Test stack. -->
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="FluentAssertions" Version="7.2.2" />
+  </ItemGroup>
+
+</Project>

--- a/docker/worker-customcode-dotnet/harness/Honua.CustomCode.slnx
+++ b/docker/worker-customcode-dotnet/harness/Honua.CustomCode.slnx
@@ -1,0 +1,12 @@
+<Solution>
+  <Folder Name="/samples/">
+    <Project Path="samples/BufferTool/BufferTool.csproj" />
+  </Folder>
+  <Folder Name="/src/">
+    <Project Path="src/Honua.CustomCode.Harness/Honua.CustomCode.Harness.csproj" />
+    <Project Path="src/Honua.CustomCode.Sdk/Honua.CustomCode.Sdk.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Honua.CustomCode.Harness.Tests/Honua.CustomCode.Harness.Tests.csproj" />
+  </Folder>
+</Solution>

--- a/docker/worker-customcode-dotnet/harness/NuGet.config
+++ b/docker/worker-customcode-dotnet/harness/NuGet.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!--
+    The offline harness/test build uses ONLY nuget.org (the geometry + test stack).
+    The real Honua .NET SDK (compiled in behind the HONUA_SDK constant for the image
+    build) restores from the GitHub Packages feed configured in the image build; it is
+    intentionally NOT referenced by the offline build so this tree builds with no
+    private feed/credentials.
+  -->
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/docker/worker-customcode-dotnet/harness/samples/BufferTool/BufferTool.cs
+++ b/docker/worker-customcode-dotnet/harness/samples/BufferTool/BufferTool.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.CustomCode.Sdk;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace Honua.CustomCode.Samples;
+
+/// <summary>
+/// Sample custom-code GP tool: buffer an input WKT geometry and write GeoJSON. This is
+/// the .NET mirror of the Python sample <c>buffer_tool.py</c>. A real tool would pull
+/// features via <see cref="GpContext.Client"/> and/or read staged
+/// <see cref="GpContext.Inputs"/>; here we accept a WKT geometry + a buffer distance in
+/// <see cref="GpContext.Params"/> and emit a buffered polygon as a GeoJSON artifact.
+/// </summary>
+/// <remarks>
+/// Entrypoint spec for this tool: <c>"BufferTool::Honua.CustomCode.Samples.BufferTool"</c>.
+/// Expected <c>params_json</c>:
+/// <c>{"wkt": "POINT (1 1)", "distance": 0.5, "out_name": "buffered.geojson"}</c>.
+/// </remarks>
+public sealed class BufferTool : IGeoprocessingTool
+{
+    /// <inheritdoc />
+    public Task<GpResult> ExecuteAsync(GpContext context, CancellationToken cancellationToken)
+    {
+        if (!context.Params.TryGetProperty("wkt", out var wktElement) ||
+            wktElement.ValueKind != JsonValueKind.String ||
+            wktElement.GetString() is not { Length: > 0 } wkt)
+        {
+            return Task.FromResult(GpResult.Failed("params.wkt is required (a WKT geometry)."));
+        }
+
+        var distance = context.Params.TryGetProperty("distance", out var d) && d.ValueKind == JsonValueKind.Number
+            ? d.GetDouble()
+            : 0.0;
+        var outName = context.Params.TryGetProperty("out_name", out var n) && n.ValueKind == JsonValueKind.String
+            ? n.GetString()!
+            : "buffered.geojson";
+
+        context.Log.Info($"buffering '{wkt}' by {distance}");
+        context.Progress.Report(10.0, "parsing input");
+
+        Geometry geometry;
+        try
+        {
+            geometry = new WKTReader().Read(wkt);
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(GpResult.Failed($"failed to parse WKT: {ex.Message}"));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        context.Progress.Report(50.0, "buffering");
+
+        var buffered = geometry.Buffer(distance);
+
+        var geometryJson = new GeoJsonWriter().Write(buffered);
+        using var doc = JsonDocument.Parse(geometryJson);
+        var feature = new
+        {
+            type = "Feature",
+            geometry = doc.RootElement,
+            properties = new { source_wkt = wkt, distance },
+        };
+
+        var outPath = Path.Combine(context.WorkDirectory, outName);
+        File.WriteAllText(outPath, JsonSerializer.Serialize(feature));
+        context.Progress.Report(90.0, "writing output");
+
+        context.Output.AddArtifact(outName, outPath);
+        context.Log.Info($"wrote {outName} ({new FileInfo(outPath).Length} bytes)");
+        context.Progress.Report(100.0, "done");
+
+        return Task.FromResult(GpResult.Succeeded($"buffered geometry written to {outName}"));
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/samples/BufferTool/BufferTool.csproj
+++ b/docker/worker-customcode-dotnet/harness/samples/BufferTool/BufferTool.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Sample .NET custom-code GP tool. A trivial transform that demonstrates the
+    IGeoprocessingTool contract: it buffers a WKT geometry with NetTopologySuite
+    and writes the result as GeoJSON. A real tool would pull features via
+    context.Client and/or read staged context.Inputs.
+
+    Entrypoint for this tool: "BufferTool::Honua.CustomCode.Samples.BufferTool".
+
+    In the image the common deps (NetTopologySuite + the Honua .NET SDK) are
+    pre-warmed in the NuGet cache so this builds with no network restore.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+    <AssemblyName>BufferTool</AssemblyName>
+    <RootNamespace>Honua.CustomCode.Samples</RootNamespace>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- The tool references only the SDK contract. -->
+    <ProjectReference Include="..\..\src\Honua.CustomCode.Sdk\Honua.CustomCode.Sdk.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- NetTopologySuite (+ GeoJSON IO) is pre-warmed in the image cache. -->
+    <PackageReference Include="NetTopologySuite" />
+    <PackageReference Include="NetTopologySuite.IO.GeoJSON" />
+  </ItemGroup>
+
+</Project>

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/ArtifactUploader.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/ArtifactUploader.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.CustomCode.Sdk;
+
+namespace Honua.CustomCode.Harness;
+
+/// <summary>The result of uploading one artifact.</summary>
+/// <param name="Name">The artifact name.</param>
+/// <param name="Uri">The destination S3 URI.</param>
+/// <param name="SizeBytes">The uploaded size in bytes.</param>
+public sealed record UploadResult(string Name, string Uri, long SizeBytes);
+
+/// <summary>
+/// Uploads staged artifacts to the job's S3 <c>output_prefix</c>. This runs AFTER user
+/// code returns and AFTER the credential scrub, so it uses an injected upload callback
+/// (in production a dedicated upload credential the strip step does not remove). The
+/// callback is injectable so the orchestrator stays testable offline. Mirrors the
+/// Python harness's <c>upload.py</c>.
+/// </summary>
+public sealed class ArtifactUploader
+{
+    private readonly string _bucket;
+    private readonly string _prefix;
+    private readonly Action<string, string, string> _put;
+
+    /// <summary>Creates an uploader for an <c>s3://bucket/prefix</c> destination.</summary>
+    /// <param name="outputPrefix">The job's <c>s3://bucket/prefix</c> output prefix.</param>
+    /// <param name="put">An injectable <c>(bucket, key, localPath)</c> put callback; defaults to a real S3 put.</param>
+    public ArtifactUploader(string outputPrefix, Action<string, string, string>? put = null)
+    {
+        if (!Uri.TryCreate(outputPrefix, UriKind.Absolute, out var uri) ||
+            !string.Equals(uri.Scheme, "s3", StringComparison.Ordinal) ||
+            string.IsNullOrEmpty(uri.Host))
+        {
+            throw new ArgumentException($"output_prefix must be s3://bucket/prefix, got '{outputPrefix}'.", nameof(outputPrefix));
+        }
+
+        _bucket = uri.Host;
+        _prefix = uri.AbsolutePath.TrimStart('/');
+        _put = put ?? DefaultS3Put;
+    }
+
+    /// <summary>Upload each artifact under <c>s3://bucket/prefix/&lt;name&gt;</c>.</summary>
+    /// <param name="artifacts">The artifacts to upload.</param>
+    /// <returns>The per-artifact upload results.</returns>
+    public IReadOnlyList<UploadResult> Upload(IEnumerable<Artifact> artifacts)
+    {
+        var results = new List<UploadResult>();
+        foreach (var artifact in artifacts)
+        {
+            var key = KeyFor(artifact.Name);
+            _put(_bucket, key, artifact.Path);
+            results.Add(new UploadResult(artifact.Name, $"s3://{_bucket}/{key}", artifact.SizeBytes));
+        }
+
+        return results;
+    }
+
+    private string KeyFor(string name)
+        => string.IsNullOrEmpty(_prefix) ? name : $"{_prefix.TrimEnd('/')}/{name}";
+
+    private static void DefaultS3Put(string bucket, string key, string path)
+    {
+        // The real S3 put is wired in the image where the AWS SDK + upload credential
+        // are present. Kept out of the offline harness build so the host stays
+        // dependency-light and fully testable with an injected fake.
+        throw new NotSupportedException(
+            "No S3 put callback was provided. The image wires the AWS SDK put at runtime.");
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/CredentialSandbox.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/CredentialSandbox.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.CustomCode.Harness;
+
+/// <summary>
+/// Credential-stripping + scoped Honua client construction. The harness builds the
+/// scoped client from <c>HONUA_JOB_TOKEN</c> and then SCRUBS the process environment
+/// <em>before</em> activating user code, so a tool cannot read the raw scoped token nor
+/// reach the ECS/Batch task role via the container credential provider or IMDS.
+/// </summary>
+/// <remarks>
+/// This is the .NET mirror of the Python harness's <c>sandbox.py</c>. The only
+/// capability the tool keeps to talk to Honua is the pre-authed scoped client whose
+/// token is least-privilege and job-bound. AWS SDK calls the user makes then fall back
+/// to whatever (if anything) the operator left in place — by default nothing.
+/// </remarks>
+public static class CredentialSandbox
+{
+    /// <summary>
+    /// Env vars that hand out ambient cloud credentials or the scoped token. These are
+    /// deleted after the scoped client is built and BEFORE user code is activated.
+    /// </summary>
+    public static readonly IReadOnlySet<string> StrippedEnvVars = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "HONUA_JOB_TOKEN",
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+        "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+        "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+        "ECS_CONTAINER_METADATA_URI",
+        "ECS_CONTAINER_METADATA_URI_V4",
+        "ECS_CONTAINER_METADATA_FILE",
+        // Static keys, if ever injected, must not leak to user code either.
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+    };
+
+    /// <summary>
+    /// Delete ambient-credential + token env vars in place. Returns the names actually
+    /// removed (useful for logging/asserting). Operates on the process environment by
+    /// default; an injected <paramref name="env"/> is used for tests.
+    /// </summary>
+    /// <param name="env">An optional in-memory environment (for tests).</param>
+    /// <returns>The sorted names that were removed.</returns>
+    public static IReadOnlyList<string> StripCredentialEnv(IDictionary<string, string?>? env = null)
+    {
+        var removed = new List<string>();
+        foreach (var name in StrippedEnvVars)
+        {
+            if (env is null)
+            {
+                if (Environment.GetEnvironmentVariable(name) is not null)
+                {
+                    Environment.SetEnvironmentVariable(name, null);
+                    removed.Add(name);
+                }
+            }
+            else if (env.Remove(name))
+            {
+                removed.Add(name);
+            }
+        }
+
+        removed.Sort(StringComparer.Ordinal);
+        return removed;
+    }
+
+    /// <summary>
+    /// Throw if any stripped var is still present (post-scrub invariant check).
+    /// </summary>
+    /// <param name="env">An optional in-memory environment (for tests).</param>
+    /// <exception cref="InvalidOperationException">When a credential var still remains.</exception>
+    public static void AssertCredentialsStripped(IDictionary<string, string?>? env = null)
+    {
+        var leaked = StrippedEnvVars
+            .Where(name => env is null
+                ? Environment.GetEnvironmentVariable(name) is not null
+                : env.ContainsKey(name))
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        if (leaked.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"credential env not fully stripped: {string.Join(", ", leaked)}");
+        }
+    }
+
+    /// <summary>
+    /// Construct the scoped Honua client from the job-bound bearer token. The default
+    /// factory wires the real Honua SDK (<c>AddHonua(o =&gt; o.BaseAddress = ...;
+    /// o.BearerTokenProvider = _ =&gt; Task.FromResult(token))</c>); tests inject a fake.
+    /// </summary>
+    /// <param name="baseUrl">The Honua API base URL.</param>
+    /// <param name="jobToken">The scoped, job-bound bearer token.</param>
+    /// <param name="clientFactory">An injectable factory (for tests). Defaults to the real SDK wiring.</param>
+    /// <returns>The constructed scoped client (opaque to the harness).</returns>
+    public static object BuildScopedClient(
+        string baseUrl,
+        string jobToken,
+        Func<string, string, object>? clientFactory = null)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new ArgumentException("baseUrl is required to build the scoped client.", nameof(baseUrl));
+        }
+
+        if (string.IsNullOrWhiteSpace(jobToken))
+        {
+            throw new ArgumentException("jobToken is required to build the scoped client.", nameof(jobToken));
+        }
+
+        clientFactory ??= ScopedHonuaClientFactory.Create;
+        return clientFactory(baseUrl, jobToken);
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/EntrypointLoader.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/EntrypointLoader.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Reflection;
+using System.Runtime.Loader;
+using Honua.CustomCode.Sdk;
+
+namespace Honua.CustomCode.Harness;
+
+/// <summary>Raised when the tool entrypoint cannot be loaded, resolved, or activated.</summary>
+public sealed class EntrypointException(string message) : Exception(message);
+
+/// <summary>
+/// Loads a user tool's <see cref="IGeoprocessingTool"/> from a built assembly. The
+/// entrypoint is <c>"Assembly::Namespace.Type"</c>: the assembly is loaded (with its
+/// dependencies resolved against the build output directory), the type is resolved,
+/// verified to implement <see cref="IGeoprocessingTool"/>, and activated via its public
+/// parameterless constructor. The .NET analogue of the Python harness's
+/// <c>loader.py</c> (which imports <c>module:func</c>).
+/// </summary>
+public sealed class EntrypointLoader
+{
+    private readonly Func<string, Assembly>? _assemblyLoader;
+
+    /// <summary>Creates a loader.</summary>
+    /// <param name="assemblyLoader">An injectable assembly loader keyed by assembly simple name (for tests).</param>
+    public EntrypointLoader(Func<string, Assembly>? assemblyLoader = null)
+    {
+        _assemblyLoader = assemblyLoader;
+    }
+
+    /// <summary>
+    /// Resolve and activate the <see cref="IGeoprocessingTool"/> named by
+    /// <paramref name="entrypoint"/> from <paramref name="buildOutputDirectory"/>.
+    /// </summary>
+    /// <param name="buildOutputDirectory">The directory holding the built user assembly + its deps.</param>
+    /// <param name="entrypoint">The <c>"Assembly::Namespace.Type"</c> entrypoint.</param>
+    /// <returns>The activated tool instance.</returns>
+    /// <exception cref="EntrypointException">On any load/resolve/activation failure.</exception>
+    public IGeoprocessingTool Load(string buildOutputDirectory, string entrypoint)
+    {
+        var parts = entrypoint.Split("::", 2);
+        if (parts.Length != 2 || parts[0].Length == 0 || parts[1].Length == 0)
+        {
+            throw new EntrypointException($"entrypoint '{entrypoint}' must be 'Assembly::Namespace.Type'.");
+        }
+
+        var assemblyName = parts[0];
+        var typeName = parts[1];
+
+        Assembly assembly;
+        try
+        {
+            assembly = _assemblyLoader is not null
+                ? _assemblyLoader(assemblyName)
+                : LoadFromDirectory(buildOutputDirectory, assemblyName);
+        }
+        catch (Exception ex) when (ex is not EntrypointException)
+        {
+            throw new EntrypointException($"failed to load assembly '{assemblyName}': {ex.Message}");
+        }
+
+        var type = assembly.GetType(typeName, throwOnError: false)
+            ?? assembly.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal))
+            ?? throw new EntrypointException($"assembly '{assemblyName}' has no type '{typeName}'.");
+
+        if (!typeof(IGeoprocessingTool).IsAssignableFrom(type))
+        {
+            throw new EntrypointException(
+                $"type '{typeName}' does not implement {nameof(IGeoprocessingTool)}.");
+        }
+
+        if (type.IsAbstract || type.GetConstructor(Type.EmptyTypes) is null)
+        {
+            throw new EntrypointException(
+                $"type '{typeName}' must be a concrete type with a public parameterless constructor.");
+        }
+
+        try
+        {
+            return (IGeoprocessingTool)Activator.CreateInstance(type)!;
+        }
+        catch (Exception ex)
+        {
+            throw new EntrypointException($"failed to activate '{typeName}': {ex.Message}");
+        }
+    }
+
+    private static Assembly LoadFromDirectory(string buildOutputDirectory, string assemblyName)
+    {
+        var path = Path.Combine(buildOutputDirectory, assemblyName + ".dll");
+        if (!File.Exists(path))
+        {
+            throw new EntrypointException($"built assembly not found: {path}");
+        }
+
+        // A dedicated load context resolves the user assembly's dependencies from the
+        // build output directory (where dotnet build copied them) without polluting the
+        // harness's default context.
+        var context = new UserAssemblyLoadContext(buildOutputDirectory);
+        return context.LoadFromAssemblyPath(path);
+    }
+
+    private sealed class UserAssemblyLoadContext(string probeDirectory) : AssemblyLoadContext
+    {
+        private readonly AssemblyDependencyResolver _resolver = new(probeDirectory);
+        private readonly string _probeDirectory = probeDirectory;
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            var resolved = _resolver.ResolveAssemblyToPath(assemblyName);
+            if (resolved is not null)
+            {
+                return LoadFromAssemblyPath(resolved);
+            }
+
+            // Fall back to a sibling DLL in the build output (deps copied next to the tool).
+            if (assemblyName.Name is { } name)
+            {
+                var candidate = Path.Combine(_probeDirectory, name + ".dll");
+                if (File.Exists(candidate))
+                {
+                    return LoadFromAssemblyPath(candidate);
+                }
+            }
+
+            // Returning null defers to the default context so the SHARED contract
+            // assembly (Honua.CustomCode.Sdk) loaded by the harness is reused — the tool
+            // and harness must agree on the same IGeoprocessingTool type identity.
+            return null;
+        }
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/Harness.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/Harness.cs
@@ -1,0 +1,230 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.CustomCode.Sdk;
+
+namespace Honua.CustomCode.Harness;
+
+/// <summary>
+/// The .NET custom-code harness orchestrator. Runs one job end-to-end and returns a
+/// process exit code. This is the symmetric counterpart of the Python harness's
+/// <c>run()</c> — same steps, same exit-code contract:
+/// <list type="bullet">
+/// <item>0 = succeeded</item>
+/// <item>1 = tool returned/raised failure</item>
+/// <item>2 = harness/setup error (bad inputs, clone/verify/build failure)</item>
+/// <item>3 = job cancelled</item>
+/// </list>
+/// Most collaborators are injectable so the whole flow is testable offline.
+/// </summary>
+public sealed class Harness
+{
+    /// <summary>Exit code: the tool succeeded.</summary>
+    public const int ExitOk = 0;
+
+    /// <summary>Exit code: the tool returned or raised a failure.</summary>
+    public const int ExitToolFailed = 1;
+
+    /// <summary>Exit code: a harness/setup error (bad inputs, clone/verify/build failure).</summary>
+    public const int ExitHarnessError = 2;
+
+    /// <summary>Exit code: the job was cancelled.</summary>
+    public const int ExitCancelled = 3;
+
+    private readonly HarnessOptions _options;
+
+    /// <summary>Creates a harness with the given (mostly injectable) options.</summary>
+    /// <param name="options">The harness collaborators + directories.</param>
+    public Harness(HarnessOptions? options = null)
+    {
+        _options = options ?? new HarnessOptions();
+    }
+
+    /// <summary>Run one custom-code job end-to-end.</summary>
+    /// <param name="env">The job environment (defaults to the process environment).</param>
+    /// <param name="cancellationToken">Cooperative cancellation for the whole run.</param>
+    /// <returns>The terminal process exit code.</returns>
+    public async Task<int> RunAsync(
+        IReadOnlyDictionary<string, string?>? env = null,
+        CancellationToken cancellationToken = default)
+    {
+        var log = _options.Logger ?? new HarnessLogger();
+
+        // --- 1. Inputs ------------------------------------------------------
+        JobSpec spec;
+        try
+        {
+            spec = JobSpec.Load(env);
+        }
+        catch (JobSpecException ex)
+        {
+            log.Warn($"invalid job inputs: {ex.Message}");
+            return ExitHarnessError;
+        }
+
+        // --- 2. Pinned source ----------------------------------------------
+        try
+        {
+            log.Info($"cloning {spec.RepoUrl} @ {spec.GitRef}");
+            _options.SourceFetch.ClonePinned(spec.RepoUrl, spec.GitRef, _options.SourceRoot);
+        }
+        catch (SourceFetchException ex)
+        {
+            log.Warn($"source fetch failed: {ex.Message}");
+            return ExitHarnessError;
+        }
+
+        // --- 3. Build the user project (NTS + SDK already warm-cached) ------
+        UserBuildResult build;
+        try
+        {
+            log.Info($"building {spec.DepsManifest}");
+            build = _options.ProjectBuilder.Build(_options.SourceRoot, spec.DepsManifest, _options.BuildOutput);
+        }
+        catch (UserBuildException ex)
+        {
+            log.Warn($"user project build failed: {ex.Message}");
+            return ExitHarnessError;
+        }
+
+        // --- 4. Scoped client, THEN scrub credentials ----------------------
+        object? client;
+        try
+        {
+            client = CredentialSandbox.BuildScopedClient(spec.BaseUrl, spec.JobToken, _options.ClientFactory);
+        }
+        catch (Exception ex)
+        {
+            log.Warn($"failed to construct scoped client: {ex.Message}");
+            return ExitHarnessError;
+        }
+
+        if (_options.StripEnvironment)
+        {
+            var removed = CredentialSandbox.StripCredentialEnv(_options.MutableEnv);
+            log.Info($"stripped credential env before user code: {string.Join(", ", removed)}");
+            // Invariant: nothing sensitive may remain visible to the tool.
+            CredentialSandbox.AssertCredentialsStripped(_options.MutableEnv);
+        }
+
+        // --- 5. Load + activate the entrypoint, then run -------------------
+        Directory.CreateDirectory(_options.WorkDir);
+        var output = new OutputSink(spec.OutputMaxBytes);
+        var context = new GpContext(
+            spec.Params,
+            new Dictionary<string, string>(),
+            client,
+            output,
+            new LoggingProgressReporter(log),
+            log,
+            _options.WorkDir);
+
+        IGeoprocessingTool tool;
+        try
+        {
+            tool = _options.EntrypointLoader.Load(build.OutputDirectory, spec.Entrypoint);
+        }
+        catch (EntrypointException ex)
+        {
+            log.Warn($"entrypoint load failed: {ex.Message}");
+            return ExitHarnessError;
+        }
+
+        GpResult result;
+        try
+        {
+            result = await tool.ExecuteAsync(context, cancellationToken).ConfigureAwait(false)
+                     ?? GpResult.Succeeded();
+        }
+        catch (OperationCanceledException)
+        {
+            log.Warn("job cancelled");
+            return ExitCancelled;
+        }
+        catch (Exception ex)
+        {
+            log.Warn("tool raised an unhandled exception:");
+            log.Warn(ex.ToString());
+            return ExitToolFailed;
+        }
+        finally
+        {
+            (client as IDisposable)?.Dispose();
+        }
+
+        if (!result.Ok)
+        {
+            log.Warn($"tool reported failure: {result.Message}");
+            return ExitToolFailed;
+        }
+
+        // --- 6. Upload artifacts -------------------------------------------
+        try
+        {
+            var uploader = _options.UploaderFactory is { } factory
+                ? factory(spec.OutputPrefix)
+                : new ArtifactUploader(spec.OutputPrefix);
+            foreach (var uploaded in uploader.Upload(output.Artifacts))
+            {
+                log.Info($"uploaded {uploaded.Name} -> {uploaded.Uri} ({uploaded.SizeBytes} bytes)");
+            }
+        }
+        catch (OutputSizeExceededException ex)
+        {
+            log.Warn($"output cap exceeded: {ex.Message}");
+            return ExitToolFailed;
+        }
+        catch (Exception ex)
+        {
+            log.Warn($"artifact upload failed: {ex.Message}");
+            return ExitHarnessError;
+        }
+
+        log.Info($"job succeeded: {result.Message ?? "ok"}");
+        return ExitOk;
+    }
+}
+
+/// <summary>
+/// The injectable collaborators + directories for a <see cref="Harness"/> run. In
+/// production the defaults wire to git, the .NET SDK, the real scoped Honua client, and
+/// S3; tests inject fakes for every seam.
+/// </summary>
+public sealed class HarnessOptions
+{
+    /// <summary>The directory the user source is cloned into.</summary>
+    public string SourceRoot { get; set; } = "/work/src";
+
+    /// <summary>The directory the user project is built into.</summary>
+    public string BuildOutput { get; set; } = "/work/build";
+
+    /// <summary>The writable scratch directory handed to the tool.</summary>
+    public string WorkDir { get; set; } = "/work/out";
+
+    /// <summary>The git clone/verify collaborator.</summary>
+    public SourceFetch SourceFetch { get; set; } = new();
+
+    /// <summary>The user-project restore/build collaborator.</summary>
+    public UserProjectBuilder ProjectBuilder { get; set; } = new();
+
+    /// <summary>The entrypoint type loader/activator.</summary>
+    public EntrypointLoader EntrypointLoader { get; set; } = new();
+
+    /// <summary>An optional scoped-client factory override (tests inject a fake).</summary>
+    public Func<string, string, object>? ClientFactory { get; set; }
+
+    /// <summary>An optional uploader factory override (tests inject a fake).</summary>
+    public Func<string, ArtifactUploader>? UploaderFactory { get; set; }
+
+    /// <summary>An optional logger override.</summary>
+    public IGpLogger? Logger { get; set; }
+
+    /// <summary>Whether to strip the credential environment before user code (default true).</summary>
+    public bool StripEnvironment { get; set; } = true;
+
+    /// <summary>
+    /// An optional in-memory environment the strip step operates on (tests). When null,
+    /// the strip step mutates the real process environment.
+    /// </summary>
+    public IDictionary<string, string?>? MutableEnv { get; set; }
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/HarnessLog.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/HarnessLog.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.CustomCode.Sdk;
+
+namespace Honua.CustomCode.Harness;
+
+/// <summary>
+/// Tiny stderr logger so tool output is interleaved into job logs. Intentionally
+/// dependency-free so a tool's own logging setup cannot suppress harness/job lines.
+/// Mirrors the Python harness's <c>_StdLogger</c>.
+/// </summary>
+public sealed class HarnessLogger(TextWriter? writer = null) : IGpLogger
+{
+    private readonly TextWriter _writer = writer ?? Console.Error;
+
+    /// <inheritdoc />
+    public void Info(string message) => _writer.WriteLine($"[tool] INFO  {message}");
+
+    /// <inheritdoc />
+    public void Warn(string message) => _writer.WriteLine($"[tool] WARN  {message}");
+}
+
+/// <summary>A progress reporter that logs each report. Mirrors the Python default.</summary>
+public sealed class LoggingProgressReporter(IGpLogger log) : IProgressReporter
+{
+    private readonly IGpLogger _log = log;
+
+    /// <inheritdoc />
+    public void Report(double percent, string phase)
+    {
+        var clamped = Math.Clamp(percent, 0.0, 100.0);
+        _log.Info($"progress {clamped.ToString("F1", CultureInfo.InvariantCulture),5}% — {phase}");
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/Honua.CustomCode.Harness.csproj
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/Honua.CustomCode.Harness.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    The .NET custom-code GP harness — the image ENTRYPOINT. A small console host
+    that clones user code at a pinned git SHA, builds the user's .csproj against a
+    warm NuGet cache, strips the IMDS/token environment, activates the user's
+    IGeoprocessingTool, runs it under a scoped Honua client, uploads artifacts,
+    and exits with a terminal code.
+
+    This host is its OWN process — it is NOT the AOT serving host. It loads a
+    user-built assembly via AssemblyLoadContext (reflection), so it is
+    deliberately NOT compiled AOT.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+    <RootNamespace>Honua.CustomCode.Harness</RootNamespace>
+    <AssemblyName>Honua.CustomCode.Harness</AssemblyName>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+    <!-- The harness loads user assemblies dynamically; AOT/trimming do not apply. -->
+    <PublishAot>false</PublishAot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Honua.CustomCode.Sdk\Honua.CustomCode.Sdk.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/JobSpec.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/JobSpec.cs
@@ -1,0 +1,366 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Honua.CustomCode.Harness;
+
+/// <summary>Raised when the job inputs are missing or malformed.</summary>
+public sealed class JobSpecException(string message) : Exception(message);
+
+/// <summary>
+/// Validated, fully-resolved job inputs (the harness half of the contract). Mirrors
+/// the Python harness's <c>JobSpec</c> exactly — the same env vars and spec-file
+/// precedence — so a single contract serves both runtimes.
+/// </summary>
+/// <remarks>
+/// THE CONTRACT (image/harness half). The Batch container receives the job parameters
+/// in one of two interchangeable ways, resolved in this order:
+/// <list type="number">
+/// <item>A mounted job-spec file — if <c>CUSTOMCODE_JOB_SPEC</c> points at a readable
+/// JSON file, every field is read from it (preferred for large params/deps).</item>
+/// <item>Discrete <c>CUSTOMCODE_*</c> environment variables otherwise.</item>
+/// </list>
+/// In BOTH modes the auth spine is always env-only and never in the spec file:
+/// <c>HONUA_BASE_URL</c> and <c>HONUA_JOB_TOKEN</c> are read from the environment so the
+/// scoped token follows the standard Batch secret-injection path and is strippable.
+/// <para>
+/// Field mapping (env var -&gt; spec key):
+/// <c>CUSTOMCODE_RUNTIME</c> -&gt; runtime (e.g. "dotnet");
+/// <c>CUSTOMCODE_REPO_URL</c> -&gt; repo_url;
+/// <c>CUSTOMCODE_GIT_REF</c> -&gt; git_ref (40-hex SHA, validated);
+/// <c>CUSTOMCODE_ENTRYPOINT</c> -&gt; entrypoint ("Assembly::Namespace.Type");
+/// <c>CUSTOMCODE_DEPS_MANIFEST</c> -&gt; deps_manifest (the user .csproj, repo-relative);
+/// <c>CUSTOMCODE_PARAMS_JSON</c> -&gt; params_json (inline JSON OR @path);
+/// <c>CUSTOMCODE_OUTPUT_PREFIX</c> -&gt; output_prefix (s3://bucket/prefix);
+/// <c>CUSTOMCODE_DECLARED_SCOPE</c> -&gt; declared_scope (advisory; comma/space list);
+/// <c>CUSTOMCODE_OUTPUT_MAX_BYTES</c> -&gt; output_max_bytes (int; default 1 GiB).
+/// </para>
+/// </remarks>
+public sealed class JobSpec
+{
+    /// <summary>The default output cap when the job declares none (1 GiB).</summary>
+    public const long DefaultOutputMaxBytes = 1L * 1024 * 1024 * 1024;
+
+    // A git_ref MUST be a fully-pinned 40-hex commit SHA. The server resolves to a
+    // pinned SHA before dispatch; the harness re-validates as defense-in-depth.
+    private static readonly Regex GitShaRegex = new("^[0-9a-f]{40}$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    // .NET entrypoint: Assembly::Namespace.Type. Matches the server-side validator.
+    private static readonly Regex EntrypointRegex =
+        new(@"^[A-Za-z_][A-Za-z0-9_]*::[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private JobSpec(
+        string runtime,
+        string repoUrl,
+        string gitRef,
+        string entrypoint,
+        string depsManifest,
+        JsonElement parameters,
+        string outputPrefix,
+        IReadOnlyList<string> declaredScope,
+        long outputMaxBytes,
+        string baseUrl,
+        string jobToken)
+    {
+        Runtime = runtime;
+        RepoUrl = repoUrl;
+        GitRef = gitRef;
+        Entrypoint = entrypoint;
+        DepsManifest = depsManifest;
+        Params = parameters;
+        OutputPrefix = outputPrefix;
+        DeclaredScope = declaredScope;
+        OutputMaxBytes = outputMaxBytes;
+        BaseUrl = baseUrl;
+        JobToken = jobToken;
+    }
+
+    /// <summary>The runtime selector ("dotnet").</summary>
+    public string Runtime { get; }
+
+    /// <summary>The HTTPS git repository URL holding the user code.</summary>
+    public string RepoUrl { get; }
+
+    /// <summary>The pinned 40-hex commit SHA to check out.</summary>
+    public string GitRef { get; }
+
+    /// <summary>The entrypoint, "Assembly::Namespace.Type".</summary>
+    public string Entrypoint { get; }
+
+    /// <summary>The repo-relative path to the user's <c>.csproj</c>.</summary>
+    public string DepsManifest { get; }
+
+    /// <summary>The parsed <c>params_json</c> (tool-defined schema).</summary>
+    public JsonElement Params { get; }
+
+    /// <summary>The server-set per-job S3 output prefix.</summary>
+    public string OutputPrefix { get; }
+
+    /// <summary>The advisory declared scope (informational on the harness side).</summary>
+    public IReadOnlyList<string> DeclaredScope { get; }
+
+    /// <summary>The per-job output-size cap in bytes.</summary>
+    public long OutputMaxBytes { get; }
+
+    /// <summary>The Honua API base URL (from <c>HONUA_BASE_URL</c>).</summary>
+    public string BaseUrl { get; }
+
+    /// <summary>The scoped, job-bound bearer token (from <c>HONUA_JOB_TOKEN</c>).</summary>
+    public string JobToken { get; }
+
+    /// <summary>The assembly simple name from the entrypoint ("Asm" in "Asm::Type").</summary>
+    public string EntrypointAssembly => Entrypoint.Split("::", 2)[0];
+
+    /// <summary>The CLR type name from the entrypoint ("Type" in "Asm::Type").</summary>
+    public string EntrypointType => Entrypoint.Split("::", 2)[1];
+
+    /// <summary>Returns true iff <paramref name="value"/> is a fully-pinned 40-hex SHA.</summary>
+    /// <param name="value">The candidate ref.</param>
+    public static bool IsValidGitSha(string? value) => !string.IsNullOrEmpty(value) && GitShaRegex.IsMatch(value);
+
+    /// <summary>Resolve and validate the job inputs from a spec file or env vars.</summary>
+    /// <param name="env">The environment to read (defaults to the process environment).</param>
+    /// <returns>The validated job spec.</returns>
+    /// <exception cref="JobSpecException">When any required input is missing or malformed.</exception>
+    public static JobSpec Load(IReadOnlyDictionary<string, string?>? env = null)
+    {
+        env ??= ReadProcessEnv();
+
+        Func<string, string?> field;
+        if (TryGet(env, "CUSTOMCODE_JOB_SPEC") is { } specPath)
+        {
+            var source = LoadSpecFile(specPath);
+            field = key => source.TryGetValue(key, out var v) ? v : null;
+        }
+        else
+        {
+            // Spec keys map 1:1 to CUSTOMCODE_<UPPER> env vars.
+            field = key => TryGet(env, "CUSTOMCODE_" + key.ToUpperInvariant());
+        }
+
+        var runtime = field("runtime") ?? "dotnet";
+        var repoUrl = field("repo_url");
+        var gitRef = field("git_ref");
+        var entrypoint = field("entrypoint");
+        var depsManifest = field("deps_manifest");
+        var outputPrefix = field("output_prefix");
+
+        // The auth spine is ALWAYS env-only — never sourced from the spec file.
+        var baseUrl = TryGet(env, "HONUA_BASE_URL");
+        var jobToken = TryGet(env, "HONUA_JOB_TOKEN");
+
+        Require(repoUrl, "repo_url / CUSTOMCODE_REPO_URL");
+        Require(gitRef, "git_ref / CUSTOMCODE_GIT_REF");
+        Require(entrypoint, "entrypoint / CUSTOMCODE_ENTRYPOINT");
+        Require(depsManifest, "deps_manifest / CUSTOMCODE_DEPS_MANIFEST");
+        Require(outputPrefix, "output_prefix / CUSTOMCODE_OUTPUT_PREFIX");
+        Require(baseUrl, "HONUA_BASE_URL");
+        Require(jobToken, "HONUA_JOB_TOKEN");
+
+        if (!IsValidGitSha(gitRef))
+        {
+            throw new JobSpecException(
+                $"git_ref must be a 40-character hex commit SHA (got '{gitRef}'). " +
+                "Branches, tags, and abbreviated SHAs are rejected.");
+        }
+
+        if (!EntrypointRegex.IsMatch(entrypoint!))
+        {
+            throw new JobSpecException(
+                $"entrypoint must be 'Assembly::Namespace.Type' (got '{entrypoint}').");
+        }
+
+        if (!IsSafeRelativePath(depsManifest!))
+        {
+            throw new JobSpecException(
+                $"deps_manifest must be a relative path within the repository (got '{depsManifest}').");
+        }
+
+        if (!StartsWithAny(repoUrl!, "https://", "git@", "ssh://", "http://"))
+        {
+            throw new JobSpecException($"repo_url has an unsupported scheme: '{repoUrl}'.");
+        }
+
+        if (!outputPrefix!.StartsWith("s3://", StringComparison.Ordinal))
+        {
+            throw new JobSpecException($"output_prefix must be an s3:// URI, got '{outputPrefix}'.");
+        }
+
+        return new JobSpec(
+            runtime,
+            repoUrl!,
+            gitRef!,
+            entrypoint!,
+            depsManifest!,
+            CoerceParams(field("params_json")),
+            outputPrefix,
+            CoerceScope(field("declared_scope")),
+            CoerceMaxBytes(field("output_max_bytes")),
+            baseUrl!,
+            jobToken!);
+    }
+
+    private static IReadOnlyDictionary<string, string?> ReadProcessEnv()
+    {
+        var map = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (System.Collections.DictionaryEntry kv in Environment.GetEnvironmentVariables())
+        {
+            map[(string)kv.Key] = kv.Value as string;
+        }
+
+        return map;
+    }
+
+    private static IReadOnlyDictionary<string, string?> LoadSpecFile(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new JobSpecException($"CUSTOMCODE_JOB_SPEC points at a missing file: {path}");
+        }
+
+        JsonElement root;
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(path));
+            root = doc.RootElement.Clone();
+        }
+        catch (Exception ex) when (ex is JsonException or IOException)
+        {
+            throw new JobSpecException($"Failed to read/parse job spec {path}: {ex.Message}");
+        }
+
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new JobSpecException("Job spec file must contain a JSON object.");
+        }
+
+        var map = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (var prop in root.EnumerateObject())
+        {
+            // params_json may be an embedded object; keep it as raw JSON text so the
+            // common coercion path handles it like an inline JSON string.
+            map[prop.Name] = prop.Value.ValueKind switch
+            {
+                JsonValueKind.String => prop.Value.GetString(),
+                JsonValueKind.Null => null,
+                _ => prop.Value.GetRawText(),
+            };
+        }
+
+        return map;
+    }
+
+    private static JsonElement CoerceParams(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw))
+        {
+            return ParseEmptyObject();
+        }
+
+        var text = raw;
+        if (text.StartsWith('@'))
+        {
+            var paramsPath = text[1..];
+            if (!File.Exists(paramsPath))
+            {
+                throw new JobSpecException($"params_json @file is missing: {paramsPath}");
+            }
+
+            text = File.ReadAllText(paramsPath);
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                throw new JobSpecException("params_json must decode to a JSON object.");
+            }
+
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException ex)
+        {
+            throw new JobSpecException($"params_json is not valid JSON: {ex.Message}");
+        }
+    }
+
+    private static JsonElement ParseEmptyObject()
+    {
+        using var doc = JsonDocument.Parse("{}");
+        return doc.RootElement.Clone();
+    }
+
+    private static IReadOnlyList<string> CoerceScope(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return [];
+        }
+
+        return raw
+            .Split([',', ' ', '\t', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToArray();
+    }
+
+    private static long CoerceMaxBytes(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw))
+        {
+            return DefaultOutputMaxBytes;
+        }
+
+        if (!long.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+        {
+            throw new JobSpecException($"output_max_bytes must be an integer, got '{raw}'.");
+        }
+
+        if (value <= 0)
+        {
+            throw new JobSpecException("output_max_bytes must be positive.");
+        }
+
+        return value;
+    }
+
+    private static bool IsSafeRelativePath(string path)
+    {
+        if (path.Contains('\0') || path.StartsWith('/') || path.StartsWith('\\'))
+        {
+            return false;
+        }
+
+        if (path.Length >= 2 && char.IsAsciiLetter(path[0]) && path[1] == ':')
+        {
+            return false;
+        }
+
+        foreach (var segment in path.Split('/', '\\'))
+        {
+            if (segment == "..")
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool StartsWithAny(string value, params string[] prefixes)
+        => prefixes.Any(p => value.StartsWith(p, StringComparison.Ordinal));
+
+    private static string? TryGet(IReadOnlyDictionary<string, string?> env, string key)
+        => env.TryGetValue(key, out var v) && !string.IsNullOrWhiteSpace(v) ? v.Trim() : null;
+
+    private static void Require(string? value, string label)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new JobSpecException($"Required job input is missing: {label}.");
+        }
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/OutputSink.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/OutputSink.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.CustomCode.Sdk;
+
+namespace Honua.CustomCode.Harness;
+
+/// <summary>Raised when staged artifacts exceed the job's output-size cap.</summary>
+public sealed class OutputSizeExceededException(string message) : Exception(message);
+
+/// <summary>
+/// Collects artifacts a tool wants persisted to the job's output prefix and enforces
+/// the per-job output-size cap eagerly. The harness uploads after the tool returns.
+/// Mirrors the Python harness's <c>OutputSink</c>.
+/// </summary>
+public sealed class OutputSink : IOutputSink
+{
+    private readonly long _maxTotalBytes;
+    private readonly List<Artifact> _artifacts = [];
+    private long _totalBytes;
+
+    /// <summary>Creates a sink with a positive total-size cap.</summary>
+    /// <param name="maxTotalBytes">The maximum total bytes across all artifacts.</param>
+    public OutputSink(long maxTotalBytes)
+    {
+        if (maxTotalBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxTotalBytes), "maxTotalBytes must be positive.");
+        }
+
+        _maxTotalBytes = maxTotalBytes;
+    }
+
+    /// <summary>The registered artifacts, in registration order.</summary>
+    public IReadOnlyList<Artifact> Artifacts => _artifacts;
+
+    /// <summary>The total staged bytes so far.</summary>
+    public long TotalBytes => _totalBytes;
+
+    /// <inheritdoc />
+    public Artifact AddArtifact(string name, string path)
+    {
+        if (string.IsNullOrEmpty(name) || name.Contains('/') || name.Contains('\\') || name is "." or "..")
+        {
+            throw new ArgumentException($"Artifact name '{name}' must be a simple file name.", nameof(name));
+        }
+
+        var resolved = Path.GetFullPath(path);
+        if (!File.Exists(resolved))
+        {
+            throw new FileNotFoundException($"Artifact '{name}' path does not exist: {resolved}");
+        }
+
+        var size = new FileInfo(resolved).Length;
+        var projected = _totalBytes + size;
+        if (projected > _maxTotalBytes)
+        {
+            throw new OutputSizeExceededException(
+                $"Adding artifact '{name}' ({size} bytes) would exceed the output cap of " +
+                $"{_maxTotalBytes} bytes (already staged {_totalBytes} bytes).");
+        }
+
+        var artifact = new Artifact(name, resolved, size);
+        _artifacts.Add(artifact);
+        _totalBytes = projected;
+        return artifact;
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/Program.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/Program.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.CustomCode.Harness;
+
+// The image ENTRYPOINT. Reads CUSTOMCODE_* / HONUA_* from the Batch container env (or
+// a CUSTOMCODE_JOB_SPEC file), runs one custom-code job, and exits with the terminal
+// code. SIGTERM/SIGINT request cooperative cancellation so an in-flight tool can stop.
+using var cts = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) =>
+{
+    e.Cancel = true;
+    cts.Cancel();
+};
+AppDomain.CurrentDomain.ProcessExit += (_, _) => cts.Cancel();
+
+// Honor SIGTERM (Batch sends it on cancel/timeout) as cooperative cancellation.
+System.Runtime.InteropServices.PosixSignalRegistration.Create(
+    System.Runtime.InteropServices.PosixSignal.SIGTERM,
+    ctx =>
+    {
+        ctx.Cancel = true;
+        cts.Cancel();
+    });
+
+var options = new HarnessOptions
+{
+    SourceRoot = Environment.GetEnvironmentVariable("HONUA_CUSTOMCODE_SOURCE_ROOT") ?? "/work/src",
+    BuildOutput = Environment.GetEnvironmentVariable("HONUA_CUSTOMCODE_BUILD_OUTPUT") ?? "/work/build",
+    WorkDir = Environment.GetEnvironmentVariable("HONUA_CUSTOMCODE_WORKDIR") ?? "/work/out",
+};
+
+var harness = new Harness(options);
+return await harness.RunAsync(cancellationToken: cts.Token).ConfigureAwait(false);

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/ScopedHonuaClientFactory.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/ScopedHonuaClientFactory.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Http.Headers;
+
+namespace Honua.CustomCode.Harness;
+
+/// <summary>
+/// Builds the SCOPED Honua client the tool sees as <see cref="Sdk.GpContext.Client"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The production wiring is the .NET mirror of the Python harness's
+/// <c>HonuaClient(base_url, StaticAuthProvider({"Authorization": f"Bearer {token}"}))</c>:
+/// register the Honua SDK clients into a DI container with
+/// <c>AddHonua(o =&gt; { o.BaseAddress = baseUrl; o.BearerTokenProvider = _ =&gt;
+/// Task.FromResult&lt;string?&gt;(token); })</c> so every request carries the scoped,
+/// job-bound bearer token and nothing else.
+/// </para>
+/// <para>
+/// The real <c>AddHonua</c> wiring is compiled in behind the <c>HONUA_SDK</c> constant
+/// (set in the Docker build, where the SDK package restores from the warm NuGet cache).
+/// In the offline harness/test build the SDK package is absent, so this factory returns
+/// a least-privilege fallback client: a bare <see cref="HttpClient"/> with the scoped
+/// bearer header pre-set and the base address pinned. Either way the harness only ever
+/// hands the tool a client that carries the scoped token — never the raw token string —
+/// and the strip step removes the token env right after this runs.
+/// </para>
+/// </remarks>
+public static class ScopedHonuaClientFactory
+{
+    /// <summary>Create the scoped client for <paramref name="baseUrl"/> + <paramref name="jobToken"/>.</summary>
+    /// <param name="baseUrl">The Honua API base URL.</param>
+    /// <param name="jobToken">The scoped, job-bound bearer token.</param>
+    /// <returns>The scoped client (opaque to the harness; the tool casts it).</returns>
+    public static object Create(string baseUrl, string jobToken)
+    {
+#if HONUA_SDK
+        return CreateWithSdk(baseUrl, jobToken);
+#else
+        return CreateFallback(baseUrl, jobToken);
+#endif
+    }
+
+#if HONUA_SDK
+    private static object CreateWithSdk(string baseUrl, string jobToken)
+    {
+        // The image restores Honua.Sdk into the warm NuGet cache; AddHonua wires every
+        // enabled client over an HttpClient whose Authorization header is set from the
+        // scoped BearerTokenProvider before each request.
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        Honua.Sdk.Extensions.ServiceCollectionExtensions.AddHonua(services, o =>
+        {
+            o.BaseAddress = new Uri(baseUrl, UriKind.Absolute);
+            o.BearerTokenProvider = _ => Task.FromResult<string?>(jobToken);
+        });
+        return services
+            .Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions
+            .BuildServiceProvider();
+    }
+#endif
+
+    private static object CreateFallback(string baseUrl, string jobToken)
+    {
+        var http = new HttpClient
+        {
+            BaseAddress = new Uri(baseUrl, UriKind.Absolute),
+        };
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jobToken);
+        return http;
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/SourceFetch.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/SourceFetch.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+
+namespace Honua.CustomCode.Harness;
+
+/// <summary>Raised when cloning/checkout/verification of user code fails.</summary>
+public sealed class SourceFetchException(string message) : Exception(message);
+
+/// <summary>The outcome of running a process: exit code + captured stdout/stderr.</summary>
+/// <param name="ExitCode">The process exit code.</param>
+/// <param name="StdOut">Captured standard output.</param>
+/// <param name="StdErr">Captured standard error.</param>
+public sealed record ProcessResult(int ExitCode, string StdOut, string StdErr);
+
+/// <summary>
+/// Clone + pin user code at an exact git SHA, then verify the checkout. The harness
+/// only ever runs code at a fully-pinned 40-hex SHA; after fetching we
+/// <c>git rev-parse HEAD</c> and assert it equals the requested SHA. Mirrors the
+/// Python harness's <c>sourcefetch.py</c>.
+/// </summary>
+public sealed class SourceFetch
+{
+    private readonly Func<IReadOnlyList<string>, string?, ProcessResult> _runner;
+
+    /// <summary>Creates a source fetcher.</summary>
+    /// <param name="gitRunner">An injectable git runner (for tests); defaults to invoking the real git binary.</param>
+    public SourceFetch(Func<IReadOnlyList<string>, string?, ProcessResult>? gitRunner = null)
+    {
+        _runner = gitRunner ?? RunGit;
+    }
+
+    /// <summary>
+    /// Clone <paramref name="repoUrl"/> and check out exactly <paramref name="gitRef"/>
+    /// (a 40-hex SHA), then assert <c>rev-parse HEAD == sha</c>.
+    /// </summary>
+    /// <param name="repoUrl">The git repository URL.</param>
+    /// <param name="gitRef">The pinned 40-hex commit SHA.</param>
+    /// <param name="destination">The destination directory.</param>
+    /// <returns>The destination directory.</returns>
+    /// <exception cref="SourceFetchException">On any clone/checkout/verify failure.</exception>
+    public string ClonePinned(string repoUrl, string gitRef, string destination)
+    {
+        if (!JobSpec.IsValidGitSha(gitRef))
+        {
+            // Defense-in-depth: never pass an unvalidated ref to git.
+            throw new SourceFetchException($"refusing to fetch non-SHA git_ref '{gitRef}' (must be 40-hex).");
+        }
+
+        Directory.CreateDirectory(destination);
+        Git(destination, "init", "--quiet");
+        Git(destination, "remote", "add", "origin", repoUrl);
+
+        try
+        {
+            // A direct fetch of the SHA keeps the download minimal.
+            Git(destination, "fetch", "--depth", "1", "origin", gitRef);
+        }
+        catch (SourceFetchException)
+        {
+            // Some hosts disable uploadpack.allowReachableSHA1InWant; fall back to a
+            // shallow clone of the default branch + a deeper fetch by SHA.
+            Git(destination, "fetch", "--depth", "1", "origin");
+            Git(destination, "fetch", "--depth", "50", "origin");
+        }
+
+        Git(destination, "checkout", "--quiet", "--detach", gitRef);
+
+        var head = Git(destination, "rev-parse", "HEAD").Trim();
+        if (!string.Equals(head, gitRef, StringComparison.Ordinal))
+        {
+            throw new SourceFetchException(
+                $"checkout verification failed: HEAD is '{head}' but expected '{gitRef}'.");
+        }
+
+        return destination;
+    }
+
+    private string Git(string cwd, params string[] args)
+    {
+        var result = _runner(args, cwd);
+        if (result.ExitCode != 0)
+        {
+            throw new SourceFetchException(
+                $"git {string.Join(' ', args)} failed ({result.ExitCode}): {result.StdErr.Trim()}");
+        }
+
+        return result.StdOut ?? string.Empty;
+    }
+
+    private static ProcessResult RunGit(IReadOnlyList<string> args, string? cwd)
+    {
+        var psi = new ProcessStartInfo("git")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = cwd ?? string.Empty,
+        };
+        foreach (var arg in args)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(psi)
+            ?? throw new SourceFetchException("failed to start git.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return new ProcessResult(process.ExitCode, stdout, stderr);
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/UserProjectBuilder.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Harness/UserProjectBuilder.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+
+namespace Honua.CustomCode.Harness;
+
+/// <summary>Raised when restoring/building the user's project fails.</summary>
+public sealed class UserBuildException(string message) : Exception(message);
+
+/// <summary>The result of building a user project.</summary>
+/// <param name="ProjectPath">The resolved absolute path of the user's <c>.csproj</c>.</param>
+/// <param name="OutputDirectory">The directory holding the built assemblies.</param>
+public sealed record UserBuildResult(string ProjectPath, string OutputDirectory);
+
+/// <summary>
+/// Restores + builds the user's <c>.csproj</c> against the warm NuGet cache baked into
+/// the image (NetTopologySuite + the Honua .NET SDK), so the common tool needs no
+/// network restore. This is the .NET analogue of the Python harness's
+/// <c>deps.py</c> (which <c>pip install -r requirements.txt</c>) — for .NET the
+/// "deps manifest" IS the user project, and the runtime compile produces the assembly
+/// the entrypoint loader activates.
+/// </summary>
+public sealed class UserProjectBuilder
+{
+    private readonly Func<IReadOnlyList<string>, string?, ProcessResult> _runner;
+
+    /// <summary>Creates a project builder.</summary>
+    /// <param name="dotnetRunner">An injectable <c>dotnet</c> runner (for tests); defaults to invoking the real SDK.</param>
+    public UserProjectBuilder(Func<IReadOnlyList<string>, string?, ProcessResult>? dotnetRunner = null)
+    {
+        _runner = dotnetRunner ?? RunDotnet;
+    }
+
+    /// <summary>
+    /// Resolve <paramref name="depsManifest"/> relative to <paramref name="sourceRoot"/>
+    /// (no <c>..</c> escapes), then <c>dotnet build -c Release</c> it into
+    /// <paramref name="outputDirectory"/>. Returns the built output directory.
+    /// </summary>
+    /// <param name="sourceRoot">The cloned source root.</param>
+    /// <param name="depsManifest">The repo-relative path to the user's <c>.csproj</c>.</param>
+    /// <param name="outputDirectory">The directory to emit the build into.</param>
+    /// <returns>The resolved project path + the build output directory.</returns>
+    /// <exception cref="UserBuildException">On a path-escape, a missing project, or a failed build.</exception>
+    public UserBuildResult Build(string sourceRoot, string depsManifest, string outputDirectory)
+    {
+        var root = Path.GetFullPath(sourceRoot);
+        var project = Path.GetFullPath(Path.Combine(root, depsManifest));
+
+        // Defense-in-depth: the project must stay within the cloned source root.
+        var rootWithSep = root.EndsWith(Path.DirectorySeparatorChar) ? root : root + Path.DirectorySeparatorChar;
+        if (!project.StartsWith(rootWithSep, StringComparison.Ordinal))
+        {
+            throw new UserBuildException($"deps_manifest '{depsManifest}' escapes the source root.");
+        }
+
+        if (!File.Exists(project))
+        {
+            throw new UserBuildException($"deps_manifest project not found: {project}");
+        }
+
+        Directory.CreateDirectory(outputDirectory);
+
+        // --offline so the warm cache is authoritative for the common case and a tool
+        // cannot silently pull arbitrary packages at job time; if a tool genuinely needs
+        // an extra package the operator widens the cache, not the network at runtime.
+        var args = new List<string>
+        {
+            "build",
+            project,
+            "--configuration", "Release",
+            "--nologo",
+            "--output", outputDirectory,
+            "-p:TreatWarningsAsErrors=false",
+            "-p:NuGetAudit=false",
+        };
+
+        var result = _runner(args, root);
+        if (result.ExitCode != 0)
+        {
+            var tail = (result.StdErr + "\n" + result.StdOut).Trim();
+            if (tail.Length > 4000)
+            {
+                tail = tail[^4000..];
+            }
+
+            throw new UserBuildException($"dotnet build {project} failed ({result.ExitCode}): {tail}");
+        }
+
+        return new UserBuildResult(project, outputDirectory);
+    }
+
+    private static ProcessResult RunDotnet(IReadOnlyList<string> args, string? cwd)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = cwd ?? string.Empty,
+        };
+        foreach (var arg in args)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(psi)
+            ?? throw new UserBuildException("failed to start dotnet.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return new ProcessResult(process.ExitCode, stdout, stderr);
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Sdk/GpContext.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Sdk/GpContext.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.CustomCode.Sdk;
+
+/// <summary>
+/// The object passed to a tool's <see cref="IGeoprocessingTool.ExecuteAsync"/>. This
+/// is the .NET mirror of the Python harness's <c>GpContext</c>.
+/// </summary>
+/// <remarks>
+/// Stability note: this is the SDK-facing API. Keep it additive — adding members is
+/// fine; renaming/removing breaks tools pinned to an image.
+/// </remarks>
+public sealed class GpContext
+{
+    /// <summary>Creates a context. The harness constructs this; tools receive it.</summary>
+    /// <param name="parameters">Parsed <c>params_json</c> as a <see cref="JsonElement"/>.</param>
+    /// <param name="inputs">Resolved input artifacts (name -&gt; local path).</param>
+    /// <param name="client">A pre-authenticated, scoped Honua client (see <see cref="Client"/>).</param>
+    /// <param name="output">Sink to register artifacts for upload.</param>
+    /// <param name="progress">Coarse progress reporter.</param>
+    /// <param name="log">Job logger.</param>
+    /// <param name="workDirectory">A writable scratch directory the tool owns for the job.</param>
+    public GpContext(
+        JsonElement parameters,
+        IReadOnlyDictionary<string, string> inputs,
+        object? client,
+        IOutputSink output,
+        IProgressReporter progress,
+        IGpLogger log,
+        string workDirectory)
+    {
+        Params = parameters;
+        Inputs = inputs ?? throw new ArgumentNullException(nameof(inputs));
+        Client = client;
+        Output = output ?? throw new ArgumentNullException(nameof(output));
+        Progress = progress ?? throw new ArgumentNullException(nameof(progress));
+        Log = log ?? throw new ArgumentNullException(nameof(log));
+        WorkDirectory = string.IsNullOrWhiteSpace(workDirectory)
+            ? throw new ArgumentException("workDirectory is required.", nameof(workDirectory))
+            : workDirectory;
+    }
+
+    /// <summary>The parsed <c>params_json</c> (a tool-defined schema), as a <see cref="JsonElement"/>.</summary>
+    public JsonElement Params { get; }
+
+    /// <summary>
+    /// Resolved input artifacts (name -&gt; local path). For Phase 2 this is whatever
+    /// the server pre-staged; tools that need server data pull it via <see cref="Client"/>.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Inputs { get; }
+
+    /// <summary>
+    /// A pre-authenticated, <em>scoped</em> Honua client. Its bearer token is job-bound
+    /// and least-privilege; the raw token is never exposed to tool code. Exposed as
+    /// <see cref="object"/> so the SDK contract does not drag the whole Honua SDK graph
+    /// through this stable package — a tool casts it to the client type it needs. May be
+    /// <see langword="null"/> when no callback access was granted.
+    /// </summary>
+    public object? Client { get; }
+
+    /// <summary>Sink to register artifacts for upload to the job's output prefix.</summary>
+    public IOutputSink Output { get; }
+
+    /// <summary>Coarse progress reporter.</summary>
+    public IProgressReporter Progress { get; }
+
+    /// <summary>Job logger.</summary>
+    public IGpLogger Log { get; }
+
+    /// <summary>A writable scratch directory the tool owns for the job.</summary>
+    public string WorkDirectory { get; }
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Sdk/GpResult.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Sdk/GpResult.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.CustomCode.Sdk;
+
+/// <summary>Terminal status of a custom-code GP tool run.</summary>
+public enum GpStatus
+{
+    /// <summary>The tool completed successfully.</summary>
+    Succeeded,
+
+    /// <summary>The tool failed; <see cref="GpResult.Message"/> carries the reason.</summary>
+    Failed,
+}
+
+/// <summary>
+/// The terminal result a tool returns from
+/// <see cref="IGeoprocessingTool.ExecuteAsync"/>. Construct via
+/// <see cref="Succeeded"/> / <see cref="Failed"/> rather than the constructor so the
+/// status label stays canonical. This is the .NET mirror of the Python harness's
+/// <c>GpResult</c>.
+/// </summary>
+public sealed class GpResult
+{
+    private GpResult(GpStatus status, string? message)
+    {
+        Status = status;
+        Message = message;
+    }
+
+    /// <summary>The terminal status.</summary>
+    public GpStatus Status { get; }
+
+    /// <summary>An optional success message, or the failure reason when failed.</summary>
+    public string? Message { get; }
+
+    /// <summary><see langword="true"/> when <see cref="Status"/> is <see cref="GpStatus.Succeeded"/>.</summary>
+    public bool Ok => Status == GpStatus.Succeeded;
+
+    /// <summary>Build a succeeded result, optionally with a message.</summary>
+    /// <param name="message">An optional success message.</param>
+    public static GpResult Succeeded(string? message = null) => new(GpStatus.Succeeded, message);
+
+    /// <summary>Build a failed result with a required non-empty reason.</summary>
+    /// <param name="message">The failure reason (must be non-empty).</param>
+    public static GpResult Failed(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            throw new ArgumentException("GpResult.Failed requires a non-empty message.", nameof(message));
+        }
+
+        return new GpResult(GpStatus.Failed, message);
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Sdk/Honua.CustomCode.Sdk.csproj
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Sdk/Honua.CustomCode.Sdk.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    The SDK-facing contract for .NET custom-code GP tools. This is the ONLY
+    package a tool author references: it defines IGeoprocessingTool, GpContext,
+    GpResult, and the sink/progress/log surfaces. Keep it additive — renaming or
+    removing members breaks tools pinned to an image.
+
+    It is deliberately dependency-light (it does NOT reference the Honua SDK):
+    GpContext.Client is exposed as object so a tool can be authored and tested
+    without dragging the whole SDK graph through this contract, and so this
+    package stays small and stable. The harness sets Client to a real, scoped
+    Honua client at runtime; the sample casts as needed.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
+    <PackageId>Honua.CustomCode.Sdk</PackageId>
+    <Description>Honua custom-code GP .NET SDK — the IGeoprocessingTool contract a user tool implements.</Description>
+    <PackageLicenseExpression>Elastic-2.0</PackageLicenseExpression>
+  </PropertyGroup>
+
+</Project>

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Sdk/IGeoprocessingTool.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Sdk/IGeoprocessingTool.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.CustomCode.Sdk;
+
+/// <summary>
+/// The contract a .NET custom-code GP tool implements — the symmetric counterpart of
+/// the Python harness's <c>def execute(context) -&gt; GpResult</c>.
+/// </summary>
+/// <remarks>
+/// A user tool ships an assembly exposing a public type implementing this interface
+/// with a public parameterless constructor. The image entrypoint identifies it as
+/// <c>"MyAsm::My.Namespace.MyTool"</c> (assembly simple name, <c>::</c>, CLR type).
+/// The harness clones the user code at a pinned git SHA, builds the user's
+/// <c>.csproj</c> against a warm NuGet cache, strips the IMDS/token environment before
+/// activating the type, builds a <see cref="GpContext"/> with a scoped Honua client,
+/// calls <see cref="ExecuteAsync"/>, uploads the registered artifacts, and maps the
+/// returned <see cref="GpResult"/> to a process exit code.
+/// </remarks>
+public interface IGeoprocessingTool
+{
+    /// <summary>
+    /// Run the tool. Register output files via <see cref="GpContext.Output"/>, report
+    /// coarse progress via <see cref="GpContext.Progress"/>, log via
+    /// <see cref="GpContext.Log"/>, and observe <paramref name="cancellationToken"/> at
+    /// loop boundaries for cooperative cancellation.
+    /// </summary>
+    /// <param name="context">The job context (params, inputs, scoped client, sinks, scratch dir).</param>
+    /// <param name="cancellationToken">Flipped by the harness when the job is cancelled.</param>
+    /// <returns>The terminal result (<see cref="GpResult.Succeeded"/> / <see cref="GpResult.Failed"/>).</returns>
+    Task<GpResult> ExecuteAsync(GpContext context, CancellationToken cancellationToken);
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Sdk/IOutputSink.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Sdk/IOutputSink.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.CustomCode.Sdk;
+
+/// <summary>A named output file the tool wants uploaded to the job's output prefix.</summary>
+/// <param name="Name">A simple file name (no path separators).</param>
+/// <param name="Path">The absolute local path of the file on disk.</param>
+/// <param name="SizeBytes">The file size in bytes.</param>
+public sealed record Artifact(string Name, string Path, long SizeBytes);
+
+/// <summary>
+/// Collects artifacts a tool wants persisted to the job's S3 output prefix. The
+/// harness performs the actual upload after the tool returns; this sink only records
+/// intent and enforces the per-job output-size cap eagerly so a runaway tool fails
+/// fast. Mirrors the Python harness's <c>OutputSink</c>.
+/// </summary>
+public interface IOutputSink
+{
+    /// <summary>
+    /// Register a file on disk for upload under <paramref name="name"/>. Throws if the
+    /// file is missing, the name is not a simple file name, or adding it would exceed
+    /// the configured output-size cap.
+    /// </summary>
+    /// <param name="name">A simple file name (no <c>/</c>, <c>\\</c>, <c>.</c>, or <c>..</c>).</param>
+    /// <param name="path">The path of the file on disk.</param>
+    /// <returns>The registered artifact.</returns>
+    Artifact AddArtifact(string name, string path);
+}

--- a/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Sdk/IProgressReporter.cs
+++ b/docker/worker-customcode-dotnet/harness/src/Honua.CustomCode.Sdk/IProgressReporter.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.CustomCode.Sdk;
+
+/// <summary>Reports coarse progress back to the job. The default impl logs.</summary>
+public interface IProgressReporter
+{
+    /// <summary>Report coarse progress.</summary>
+    /// <param name="percent">A percentage in <c>[0, 100]</c> (clamped by the harness).</param>
+    /// <param name="phase">A short human-readable phase label.</param>
+    void Report(double percent, string phase);
+}
+
+/// <summary>
+/// Structured-ish logger surface for tools. Lines are captured as job logs. Kept
+/// dependency-free so a tool's own logging setup cannot suppress harness/job lines.
+/// </summary>
+public interface IGpLogger
+{
+    /// <summary>Log an informational line.</summary>
+    /// <param name="message">The message.</param>
+    void Info(string message);
+
+    /// <summary>Log a warning line.</summary>
+    /// <param name="message">The message.</param>
+    void Warn(string message);
+}

--- a/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/ContextAndResultTests.cs
+++ b/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/ContextAndResultTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.CustomCode.Harness;
+using Honua.CustomCode.Sdk;
+using Xunit;
+
+namespace Honua.CustomCode.Harness.Tests;
+
+public sealed class ContextAndResultTests
+{
+    [Fact]
+    public void GpResult_Succeeded_IsOk()
+    {
+        var r = GpResult.Succeeded("done");
+        r.Ok.Should().BeTrue();
+        r.Status.Should().Be(GpStatus.Succeeded);
+        r.Message.Should().Be("done");
+    }
+
+    [Fact]
+    public void GpResult_Failed_RequiresMessage()
+    {
+        GpResult.Failed("boom").Ok.Should().BeFalse();
+        var act = () => GpResult.Failed("");
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void OutputSink_AddArtifact_StagesFile_AndEnforcesCap()
+    {
+        var dir = Directory.CreateTempSubdirectory("ccnet-sink");
+        try
+        {
+            var path = Path.Combine(dir.FullName, "out.txt");
+            File.WriteAllText(path, new string('x', 100));
+
+            var sink = new OutputSink(maxTotalBytes: 150);
+            var artifact = sink.AddArtifact("out.txt", path);
+
+            artifact.Name.Should().Be("out.txt");
+            artifact.SizeBytes.Should().Be(100);
+            sink.TotalBytes.Should().Be(100);
+            sink.Artifacts.Should().ContainSingle();
+
+            // A second 100-byte file would push past the 150-byte cap.
+            var path2 = Path.Combine(dir.FullName, "out2.txt");
+            File.WriteAllText(path2, new string('y', 100));
+            var act = () => sink.AddArtifact("out2.txt", path2);
+            act.Should().Throw<OutputSizeExceededException>();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("nested/name")]
+    [InlineData(".")]
+    public void OutputSink_RejectsNonSimpleNames(string name)
+    {
+        var dir = Directory.CreateTempSubdirectory("ccnet-sink");
+        try
+        {
+            var path = Path.Combine(dir.FullName, "f.txt");
+            File.WriteAllText(path, "x");
+            var sink = new OutputSink(1000);
+            var act = () => sink.AddArtifact(name, path);
+            act.Should().Throw<ArgumentException>();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void OutputSink_MissingFile_Throws()
+    {
+        var sink = new OutputSink(1000);
+        var act = () => sink.AddArtifact("missing.txt", "/no/such/file.txt");
+        act.Should().Throw<FileNotFoundException>();
+    }
+
+    [Fact]
+    public void ArtifactUploader_UploadsEachArtifact_UnderPrefix()
+    {
+        var dir = Directory.CreateTempSubdirectory("ccnet-up");
+        try
+        {
+            var path = Path.Combine(dir.FullName, "a.txt");
+            File.WriteAllText(path, "hello");
+            var puts = new List<(string Bucket, string Key, string Path)>();
+
+            var uploader = new ArtifactUploader("s3://my-bucket/outputs/job-1", (b, k, p) => puts.Add((b, k, p)));
+            var results = uploader.Upload([new Artifact("a.txt", path, 5)]);
+
+            puts.Should().ContainSingle();
+            puts[0].Bucket.Should().Be("my-bucket");
+            puts[0].Key.Should().Be("outputs/job-1/a.txt");
+            results.Should().ContainSingle()
+                .Which.Uri.Should().Be("s3://my-bucket/outputs/job-1/a.txt");
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/CredentialSandboxTests.cs
+++ b/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/CredentialSandboxTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.CustomCode.Harness;
+using Xunit;
+
+namespace Honua.CustomCode.Harness.Tests;
+
+public sealed class CredentialSandboxTests
+{
+    [Fact]
+    public void StripCredentialEnv_RemovesTokenAndImdsVars()
+    {
+        var env = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["HONUA_JOB_TOKEN"] = "scoped",
+            ["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"] = "/v2/credentials/abc",
+            ["ECS_CONTAINER_METADATA_URI_V4"] = "http://169.254.170.2/v4",
+            ["AWS_ACCESS_KEY_ID"] = "AKIA...",
+            ["HONUA_BASE_URL"] = "https://api.honua.test", // must be kept
+            ["PATH"] = "/usr/bin",                          // must be kept
+        };
+
+        var removed = CredentialSandbox.StripCredentialEnv(env);
+
+        removed.Should().Contain(new[]
+        {
+            "HONUA_JOB_TOKEN",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+            "ECS_CONTAINER_METADATA_URI_V4",
+            "AWS_ACCESS_KEY_ID",
+        });
+        env.Should().NotContainKeys("HONUA_JOB_TOKEN", "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "ECS_CONTAINER_METADATA_URI_V4", "AWS_ACCESS_KEY_ID");
+        env.Should().ContainKey("HONUA_BASE_URL");
+        env.Should().ContainKey("PATH");
+    }
+
+    [Fact]
+    public void AssertCredentialsStripped_Throws_WhenTokenRemains()
+    {
+        var env = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["HONUA_JOB_TOKEN"] = "still-here",
+        };
+
+        var act = () => CredentialSandbox.AssertCredentialsStripped(env);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*credential env not fully stripped*");
+    }
+
+    [Fact]
+    public void AssertCredentialsStripped_Passes_WhenClean()
+    {
+        var env = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["HONUA_BASE_URL"] = "https://api.honua.test",
+        };
+
+        var act = () => CredentialSandbox.AssertCredentialsStripped(env);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BuildScopedClient_UsesInjectedFactory_AndRequiresBaseUrlAndToken()
+    {
+        var built = false;
+        var client = CredentialSandbox.BuildScopedClient("https://api.honua.test", "scoped", (url, token) =>
+        {
+            built = true;
+            url.Should().Be("https://api.honua.test");
+            token.Should().Be("scoped");
+            return new object();
+        });
+
+        built.Should().BeTrue();
+        client.Should().NotBeNull();
+
+        var noToken = () => CredentialSandbox.BuildScopedClient("https://api.honua.test", "", (_, _) => new object());
+        noToken.Should().Throw<ArgumentException>();
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/EntrypointLoaderTests.cs
+++ b/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/EntrypointLoaderTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Reflection;
+using FluentAssertions;
+using Honua.CustomCode.Harness;
+using Honua.CustomCode.Sdk;
+using Xunit;
+
+namespace Honua.CustomCode.Harness.Tests;
+
+/// <summary>A valid tool type used for entrypoint type-loading tests.</summary>
+public sealed class FakeBufferTool : IGeoprocessingTool
+{
+    public Task<GpResult> ExecuteAsync(GpContext context, CancellationToken cancellationToken)
+        => Task.FromResult(GpResult.Succeeded("ok"));
+}
+
+/// <summary>A type that does NOT implement the contract.</summary>
+public sealed class NotATool
+{
+}
+
+public sealed class EntrypointLoaderTests
+{
+    private static Assembly ThisAssembly => typeof(EntrypointLoaderTests).Assembly;
+
+    [Fact]
+    public void Load_ResolvesAndActivates_ValidToolType()
+    {
+        var loader = new EntrypointLoader(_ => ThisAssembly);
+
+        var tool = loader.Load("ignored", $"FakeAsm::{typeof(FakeBufferTool).FullName}");
+
+        tool.Should().BeOfType<FakeBufferTool>();
+    }
+
+    [Fact]
+    public void Load_TypeNotImplementingContract_Throws()
+    {
+        var loader = new EntrypointLoader(_ => ThisAssembly);
+
+        var act = () => loader.Load("ignored", $"FakeAsm::{typeof(NotATool).FullName}");
+
+        act.Should().Throw<EntrypointException>().WithMessage("*does not implement IGeoprocessingTool*");
+    }
+
+    [Fact]
+    public void Load_MissingType_Throws()
+    {
+        var loader = new EntrypointLoader(_ => ThisAssembly);
+
+        var act = () => loader.Load("ignored", "FakeAsm::No.Such.Type");
+
+        act.Should().Throw<EntrypointException>().WithMessage("*has no type*");
+    }
+
+    [Theory]
+    [InlineData("NoSeparator")]
+    [InlineData("Asm::")]
+    [InlineData("::Type")]
+    public void Load_MalformedEntrypoint_Throws(string entrypoint)
+    {
+        var loader = new EntrypointLoader(_ => ThisAssembly);
+
+        var act = () => loader.Load("ignored", entrypoint);
+
+        act.Should().Throw<EntrypointException>();
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/HarnessEndToEndTests.cs
+++ b/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/HarnessEndToEndTests.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.CustomCode.Harness;
+using Honua.CustomCode.Sdk;
+using Xunit;
+
+namespace Honua.CustomCode.Harness.Tests;
+
+// Tool types used by the E2E tests are TOP-LEVEL (not nested) so their CLR full names
+// are dotted (Namespace.Type), matching the "Assembly::Namespace.Type" entrypoint form
+// the harness validates and loads.
+public sealed class ProbeTool : IGeoprocessingTool
+{
+    // Set by the test before the run; the tool records what it observed.
+    public static IDictionary<string, string?>? ObservedEnv;
+    public static object? ObservedClient;
+    public static bool? TokenPresentAtExecute;
+    public static string? ArtifactToWrite;
+
+    public Task<GpResult> ExecuteAsync(GpContext context, CancellationToken cancellationToken)
+    {
+        ObservedClient = context.Client;
+        // At execute time the credential env must already be scrubbed.
+        TokenPresentAtExecute = ObservedEnv is not null && ObservedEnv.ContainsKey("HONUA_JOB_TOKEN");
+
+        if (ArtifactToWrite is not null)
+        {
+            var path = Path.Combine(context.WorkDirectory, ArtifactToWrite);
+            File.WriteAllText(path, "result-bytes");
+            context.Output.AddArtifact(ArtifactToWrite, path);
+        }
+
+        context.Progress.Report(100.0, "done");
+        return Task.FromResult(GpResult.Succeeded("probe ok"));
+    }
+}
+
+public sealed class FailingTool : IGeoprocessingTool
+{
+    public Task<GpResult> ExecuteAsync(GpContext context, CancellationToken cancellationToken)
+        => Task.FromResult(GpResult.Failed("nope"));
+}
+
+public sealed class ThrowingTool : IGeoprocessingTool
+{
+    public Task<GpResult> ExecuteAsync(GpContext context, CancellationToken cancellationToken)
+        => throw new InvalidOperationException("boom");
+}
+
+public sealed class CancellingTool : IGeoprocessingTool
+{
+    public Task<GpResult> ExecuteAsync(GpContext context, CancellationToken cancellationToken)
+        => throw new OperationCanceledException();
+}
+
+public sealed class HarnessEndToEndTests
+{
+    private const string ValidSha = "0123456789abcdef0123456789abcdef01234567";
+
+    private static HarnessOptions BuildOptions(
+        IDictionary<string, string?> env,
+        out List<(string Bucket, string Key, string Path)> uploads)
+    {
+        var workRoot = Directory.CreateTempSubdirectory("ccnet-e2e");
+        var capturedUploads = new List<(string, string, string)>();
+        uploads = capturedUploads;
+
+        // Stage the user .csproj so UserProjectBuilder's real path/existence checks pass;
+        // the injected dotnet runner below stubs the actual compile.
+        var sourceRoot = Path.Combine(workRoot.FullName, "src");
+        Directory.CreateDirectory(Path.Combine(sourceRoot, "tool"));
+        File.WriteAllText(Path.Combine(sourceRoot, "tool", "MyTool.csproj"), "<Project />");
+
+        return new HarnessOptions
+        {
+            SourceRoot = Path.Combine(workRoot.FullName, "src"),
+            BuildOutput = Path.Combine(workRoot.FullName, "build"),
+            WorkDir = Path.Combine(workRoot.FullName, "out"),
+            // Fake git: succeed, and report HEAD == requested SHA.
+            SourceFetch = new SourceFetch((args, _) =>
+                args is ["rev-parse", "HEAD"] ? new ProcessResult(0, ValidSha, "") : new ProcessResult(0, "", "")),
+            // Fake build: just succeed (the loader is also injected, so no real assembly is needed).
+            ProjectBuilder = new UserProjectBuilder((_, _) => new ProcessResult(0, "build ok", "")),
+            // The entrypoint loader resolves tool types from THIS test assembly.
+            EntrypointLoader = new EntrypointLoader(_ => typeof(HarnessEndToEndTests).Assembly),
+            // Fake scoped-client factory: records that it was called with the token.
+            ClientFactory = (_, token) => new TestScopedClient(token),
+            // Fake uploader records puts.
+            UploaderFactory = prefix => new ArtifactUploader(prefix, (b, k, p) => capturedUploads.Add((b, k, p))),
+            MutableEnv = env,
+            StripEnvironment = true,
+        };
+    }
+
+    private sealed class TestScopedClient(string token)
+    {
+        public string Token { get; } = token;
+    }
+
+    private static Dictionary<string, string?> JobEnv() => new(StringComparer.Ordinal)
+    {
+        ["CUSTOMCODE_RUNTIME"] = "dotnet",
+        ["CUSTOMCODE_REPO_URL"] = "https://github.com/honua-io/example.git",
+        ["CUSTOMCODE_GIT_REF"] = ValidSha,
+        ["CUSTOMCODE_ENTRYPOINT"] = "MyTool::My.Namespace.BufferTool",
+        ["CUSTOMCODE_DEPS_MANIFEST"] = "tool/MyTool.csproj",
+        ["CUSTOMCODE_PARAMS_JSON"] = """{"wkt":"POINT (1 1)"}""",
+        ["CUSTOMCODE_OUTPUT_PREFIX"] = "s3://bucket/outputs/job-1",
+        ["HONUA_BASE_URL"] = "https://api.honua.test",
+        ["HONUA_JOB_TOKEN"] = "scoped-token",
+        ["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"] = "/v2/credentials/abc",
+    };
+
+    [Fact]
+    public async Task Run_HappyPath_StripsCredsBeforeTool_BuildsClient_UploadsArtifact_ReturnsOk()
+    {
+        var env = JobEnv();
+        ProbeTool.ObservedEnv = env;
+        ProbeTool.TokenPresentAtExecute = null;
+        ProbeTool.ObservedClient = null;
+        ProbeTool.ArtifactToWrite = "out.geojson";
+
+        var options = BuildOptions(env, out var uploads);
+        // Point the entrypoint at the probe tool living in this test assembly.
+        env["CUSTOMCODE_ENTRYPOINT"] = $"TestAsm::{typeof(ProbeTool).FullName}";
+
+        var harness = new Harness(options);
+        var exit = await harness.RunAsync(env);
+
+        exit.Should().Be(Harness.ExitOk);
+
+        // The scoped client was constructed from the token (and handed to the tool).
+        ProbeTool.ObservedClient.Should().BeOfType<TestScopedClient>()
+            .Which.Token.Should().Be("scoped-token");
+
+        // The credential env was scrubbed BEFORE the tool ran.
+        ProbeTool.TokenPresentAtExecute.Should().BeFalse();
+        env.Should().NotContainKey("HONUA_JOB_TOKEN");
+        env.Should().NotContainKey("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI");
+        env.Should().ContainKey("HONUA_BASE_URL"); // non-credential env preserved.
+
+        // The artifact was uploaded under the per-job prefix.
+        uploads.Should().ContainSingle();
+        uploads[0].Key.Should().Be("outputs/job-1/out.geojson");
+    }
+
+    [Fact]
+    public async Task Run_BadInputs_ReturnsHarnessError()
+    {
+        var env = JobEnv();
+        env["CUSTOMCODE_GIT_REF"] = "main"; // not a SHA
+        var options = BuildOptions(env, out _);
+
+        var exit = await new Harness(options).RunAsync(env);
+
+        exit.Should().Be(Harness.ExitHarnessError);
+    }
+
+    [Fact]
+    public async Task Run_ToolReportsFailure_ReturnsToolFailed()
+    {
+        var env = JobEnv();
+        env["CUSTOMCODE_ENTRYPOINT"] = $"TestAsm::{typeof(FailingTool).FullName}";
+        var options = BuildOptions(env, out _);
+        options.EntrypointLoader = new EntrypointLoader(_ => typeof(HarnessEndToEndTests).Assembly);
+
+        var exit = await new Harness(options).RunAsync(env);
+
+        exit.Should().Be(Harness.ExitToolFailed);
+    }
+
+    [Fact]
+    public async Task Run_ToolThrows_ReturnsToolFailed()
+    {
+        var env = JobEnv();
+        env["CUSTOMCODE_ENTRYPOINT"] = $"TestAsm::{typeof(ThrowingTool).FullName}";
+        var options = BuildOptions(env, out _);
+        options.EntrypointLoader = new EntrypointLoader(_ => typeof(HarnessEndToEndTests).Assembly);
+
+        var exit = await new Harness(options).RunAsync(env);
+
+        exit.Should().Be(Harness.ExitToolFailed);
+    }
+
+    [Fact]
+    public async Task Run_Cancelled_ReturnsCancelled()
+    {
+        var env = JobEnv();
+        env["CUSTOMCODE_ENTRYPOINT"] = $"TestAsm::{typeof(CancellingTool).FullName}";
+        var options = BuildOptions(env, out _);
+        options.EntrypointLoader = new EntrypointLoader(_ => typeof(HarnessEndToEndTests).Assembly);
+
+        var exit = await new Harness(options).RunAsync(env);
+
+        exit.Should().Be(Harness.ExitCancelled);
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/Honua.CustomCode.Harness.Tests.csproj
+++ b/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/Honua.CustomCode.Harness.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <!-- Tests need no XML docs; relax warnings-as-errors noise from missing docs. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.CustomCode.Harness\Honua.CustomCode.Harness.csproj" />
+    <ProjectReference Include="..\..\src\Honua.CustomCode.Sdk\Honua.CustomCode.Sdk.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/JobSpecTests.cs
+++ b/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/JobSpecTests.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.CustomCode.Harness;
+using Xunit;
+
+namespace Honua.CustomCode.Harness.Tests;
+
+public sealed class JobSpecTests
+{
+    private const string ValidSha = "0123456789abcdef0123456789abcdef01234567";
+
+    private static Dictionary<string, string?> BaseEnv() => new(StringComparer.Ordinal)
+    {
+        ["CUSTOMCODE_RUNTIME"] = "dotnet",
+        ["CUSTOMCODE_REPO_URL"] = "https://github.com/honua-io/example.git",
+        ["CUSTOMCODE_GIT_REF"] = ValidSha,
+        ["CUSTOMCODE_ENTRYPOINT"] = "MyTool::My.Namespace.BufferTool",
+        ["CUSTOMCODE_DEPS_MANIFEST"] = "tool/MyTool.csproj",
+        ["CUSTOMCODE_PARAMS_JSON"] = """{"k":"v"}""",
+        ["CUSTOMCODE_OUTPUT_PREFIX"] = "s3://bucket/outputs/job-1",
+        ["HONUA_BASE_URL"] = "https://api.honua.test",
+        ["HONUA_JOB_TOKEN"] = "scoped-token",
+    };
+
+    [Fact]
+    public void Load_FullSha_Accepted_ParsesEntrypointParts()
+    {
+        var spec = JobSpec.Load(BaseEnv());
+
+        spec.Runtime.Should().Be("dotnet");
+        spec.GitRef.Should().Be(ValidSha);
+        spec.EntrypointAssembly.Should().Be("MyTool");
+        spec.EntrypointType.Should().Be("My.Namespace.BufferTool");
+        spec.OutputMaxBytes.Should().Be(JobSpec.DefaultOutputMaxBytes);
+        spec.Params.GetProperty("k").GetString().Should().Be("v");
+    }
+
+    [Theory]
+    [InlineData("main")]
+    [InlineData("0123456789abcdef")] // abbreviated
+    [InlineData("0123456789ABCDEF0123456789ABCDEF01234567")] // uppercase
+    [InlineData("v1.2.3")]
+    public void Load_NonShaGitRef_Rejected(string gitRef)
+    {
+        var env = BaseEnv();
+        env["CUSTOMCODE_GIT_REF"] = gitRef;
+
+        var act = () => JobSpec.Load(env);
+
+        act.Should().Throw<JobSpecException>().WithMessage("*40-character hex commit SHA*");
+    }
+
+    [Theory]
+    [InlineData("pkg.module:run")]   // python form
+    [InlineData("MyTool::")]          // missing type
+    [InlineData("::Type")]            // missing assembly
+    [InlineData("My Tool::Type")]     // space
+    [InlineData("MyTool::My-Type")]   // invalid type char
+    public void Load_BadDotnetEntrypoint_Rejected(string entrypoint)
+    {
+        var env = BaseEnv();
+        env["CUSTOMCODE_ENTRYPOINT"] = entrypoint;
+
+        var act = () => JobSpec.Load(env);
+
+        act.Should().Throw<JobSpecException>().WithMessage("*Assembly::Namespace.Type*");
+    }
+
+    [Fact]
+    public void Load_DepsManifestTraversal_Rejected()
+    {
+        var env = BaseEnv();
+        env["CUSTOMCODE_DEPS_MANIFEST"] = "../../etc/evil.csproj";
+
+        var act = () => JobSpec.Load(env);
+
+        act.Should().Throw<JobSpecException>().WithMessage("*relative path within the repository*");
+    }
+
+    [Fact]
+    public void Load_NonS3OutputPrefix_Rejected()
+    {
+        var env = BaseEnv();
+        env["CUSTOMCODE_OUTPUT_PREFIX"] = "file:///tmp/out";
+
+        var act = () => JobSpec.Load(env);
+
+        act.Should().Throw<JobSpecException>().WithMessage("*s3://*");
+    }
+
+    [Fact]
+    public void Load_MissingToken_Rejected()
+    {
+        var env = BaseEnv();
+        env.Remove("HONUA_JOB_TOKEN");
+
+        var act = () => JobSpec.Load(env);
+
+        act.Should().Throw<JobSpecException>().WithMessage("*HONUA_JOB_TOKEN*");
+    }
+
+    [Fact]
+    public void Load_EmptyParams_DefaultsToEmptyObject()
+    {
+        var env = BaseEnv();
+        env.Remove("CUSTOMCODE_PARAMS_JSON");
+
+        var spec = JobSpec.Load(env);
+
+        spec.Params.ValueKind.Should().Be(JsonValueKind.Object);
+        spec.Params.EnumerateObject().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Load_JobSpecFile_ReadsFields_ButAuthStaysEnvOnly()
+    {
+        var dir = Directory.CreateTempSubdirectory("ccnet-spec");
+        try
+        {
+            var specPath = Path.Combine(dir.FullName, "spec.json");
+            File.WriteAllText(specPath, JsonSerializer.Serialize(new Dictionary<string, object>
+            {
+                ["runtime"] = "dotnet",
+                ["repo_url"] = "https://github.com/honua-io/example.git",
+                ["git_ref"] = ValidSha,
+                ["entrypoint"] = "MyTool::My.Namespace.BufferTool",
+                ["deps_manifest"] = "tool/MyTool.csproj",
+                ["output_prefix"] = "s3://bucket/outputs/job-1",
+            }));
+
+            var env = new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["CUSTOMCODE_JOB_SPEC"] = specPath,
+                // Auth spine is ALWAYS env-only.
+                ["HONUA_BASE_URL"] = "https://api.honua.test",
+                ["HONUA_JOB_TOKEN"] = "scoped-token",
+            };
+
+            var spec = JobSpec.Load(env);
+
+            spec.RepoUrl.Should().Be("https://github.com/honua-io/example.git");
+            spec.JobToken.Should().Be("scoped-token");
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Load_JobSpecFile_MissingAuthEnv_Rejected()
+    {
+        var dir = Directory.CreateTempSubdirectory("ccnet-spec");
+        try
+        {
+            var specPath = Path.Combine(dir.FullName, "spec.json");
+            // The token is (incorrectly) placed in the spec file — it must NOT be honored.
+            File.WriteAllText(specPath, JsonSerializer.Serialize(new Dictionary<string, object>
+            {
+                ["repo_url"] = "https://github.com/honua-io/example.git",
+                ["git_ref"] = ValidSha,
+                ["entrypoint"] = "MyTool::My.Namespace.BufferTool",
+                ["deps_manifest"] = "tool/MyTool.csproj",
+                ["output_prefix"] = "s3://bucket/outputs/job-1",
+                ["HONUA_JOB_TOKEN"] = "smuggled",
+            }));
+
+            var env = new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["CUSTOMCODE_JOB_SPEC"] = specPath,
+                ["HONUA_BASE_URL"] = "https://api.honua.test",
+            };
+
+            var act = () => JobSpec.Load(env);
+
+            act.Should().Throw<JobSpecException>().WithMessage("*HONUA_JOB_TOKEN*");
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/SourceFetchTests.cs
+++ b/docker/worker-customcode-dotnet/harness/tests/Honua.CustomCode.Harness.Tests/SourceFetchTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.CustomCode.Harness;
+using Xunit;
+
+namespace Honua.CustomCode.Harness.Tests;
+
+public sealed class SourceFetchTests
+{
+    private const string ValidSha = "0123456789abcdef0123456789abcdef01234567";
+
+    [Fact]
+    public void ClonePinned_NonSha_RefusedBeforeGit()
+    {
+        var called = false;
+        var fetch = new SourceFetch((_, _) => { called = true; return new ProcessResult(0, "", ""); });
+
+        var act = () => fetch.ClonePinned("https://github.com/x/y.git", "main", "/tmp/ccnet-x");
+
+        act.Should().Throw<SourceFetchException>().WithMessage("*must be 40-hex*");
+        called.Should().BeFalse("git must never be invoked with an unvalidated ref");
+    }
+
+    [Fact]
+    public void ClonePinned_VerifiesHeadEqualsSha()
+    {
+        var dir = Directory.CreateTempSubdirectory("ccnet-fetch");
+        try
+        {
+            // Fake git: every command succeeds; rev-parse returns the requested SHA.
+            ProcessResult Runner(IReadOnlyList<string> args, string? cwd)
+                => args is ["rev-parse", "HEAD"]
+                    ? new ProcessResult(0, ValidSha + "\n", "")
+                    : new ProcessResult(0, "", "");
+
+            var fetch = new SourceFetch(Runner);
+            var result = fetch.ClonePinned("https://github.com/x/y.git", ValidSha, dir.FullName);
+
+            result.Should().Be(dir.FullName);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ClonePinned_HeadMismatch_Throws()
+    {
+        var dir = Directory.CreateTempSubdirectory("ccnet-fetch");
+        try
+        {
+            ProcessResult Runner(IReadOnlyList<string> args, string? cwd)
+                => args is ["rev-parse", "HEAD"]
+                    ? new ProcessResult(0, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n", "")
+                    : new ProcessResult(0, "", "");
+
+            var fetch = new SourceFetch(Runner);
+            var act = () => fetch.ClonePinned("https://github.com/x/y.git", ValidSha, dir.FullName);
+
+            act.Should().Throw<SourceFetchException>().WithMessage("*checkout verification failed*");
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ClonePinned_FallsBackWhenDirectShaFetchFails()
+    {
+        var dir = Directory.CreateTempSubdirectory("ccnet-fetch");
+        try
+        {
+            var fetchedByShaDirectly = false;
+            var fellBack = false;
+
+            ProcessResult Runner(IReadOnlyList<string> args, string? cwd)
+            {
+                if (args.Count >= 5 && args[0] == "fetch" && args[^1] == ValidSha)
+                {
+                    fetchedByShaDirectly = true;
+                    return new ProcessResult(128, "", "server does not allow request for unadvertised object");
+                }
+
+                if (args is ["fetch", "--depth", "50", "origin"])
+                {
+                    fellBack = true;
+                }
+
+                return args is ["rev-parse", "HEAD"]
+                    ? new ProcessResult(0, ValidSha, "")
+                    : new ProcessResult(0, "", "");
+            }
+
+            var fetch = new SourceFetch(Runner);
+            fetch.ClonePinned("https://github.com/x/y.git", ValidSha, dir.FullName);
+
+            fetchedByShaDirectly.Should().BeTrue();
+            fellBack.Should().BeTrue();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeJobContract.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeJobContract.cs
@@ -25,12 +25,28 @@ public static class CustomCodeJobContract
     /// </summary>
     public const string RuntimeProfile = "custom-code";
 
-    /// <summary>The only runtime supported by the MVP.</summary>
+    /// <summary>The Python custom-code runtime (Phase 1).</summary>
     public const string PythonRuntime = "python";
+
+    /// <summary>The .NET custom-code runtime (Phase 2).</summary>
+    public const string DotnetRuntime = "dotnet";
+
+    /// <summary>
+    /// The runtimes the custom-code submit gate accepts. The runtime selects only
+    /// the per-job container image (resolved by the iac job-definition family — the
+    /// runtime value flows through the spec parameters to the Batch container); every
+    /// security control (SHA-only pin, repo allowlist, scope ⊆ owner, scoped-token
+    /// mint/inject/revoke) and the routing fence are runtime-agnostic.
+    /// </summary>
+    public static readonly IReadOnlySet<string> SupportedRuntimes =
+        new HashSet<string>(StringComparer.Ordinal) { PythonRuntime, DotnetRuntime };
 
     // --- caller-supplied customcode.* parameters --------------------------------
 
-    /// <summary>Runtime selector; MVP accepts only <see cref="PythonRuntime"/>.</summary>
+    /// <summary>
+    /// Runtime selector; accepts <see cref="PythonRuntime"/> or
+    /// <see cref="DotnetRuntime"/> (see <see cref="SupportedRuntimes"/>).
+    /// </summary>
     public const string RuntimeParam = "customcode.runtime";
 
     /// <summary>HTTPS git repository URL holding the user code (allowlist-checked).</summary>

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeSubmitValidator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeSubmitValidator.cs
@@ -24,11 +24,20 @@ internal static partial class CustomCodeSubmitValidator
     [GeneratedRegex("^[0-9a-f]{40}$", RegexOptions.CultureInvariant)]
     private static partial Regex FullShaRegex();
 
-    // module.path:function — dotted module path, a single ':' separator, then a
-    // python identifier. Deliberately strict so a shell-injection-shaped entrypoint
-    // is rejected at the door.
+    // PYTHON entrypoint: module.path:function — dotted module path, a single ':'
+    // separator, then a python identifier. Deliberately strict so a
+    // shell-injection-shaped entrypoint is rejected at the door.
     [GeneratedRegex(@"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*:[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.CultureInvariant)]
-    private static partial Regex EntrypointRegex();
+    private static partial Regex PythonEntrypointRegex();
+
+    // .NET entrypoint: Assembly::Namespace.Type — an assembly simple name, a '::'
+    // separator, then a dotted CLR type name. The assembly and each type segment are
+    // CLR-style identifiers (letters/digits/underscore, may start with '_'); the
+    // strictness keeps a shell-injection-shaped entrypoint out just like the python
+    // form. The harness resolves "MyAsm::My.Namespace.MyTool" to a built assembly +
+    // type implementing IGeoprocessingTool.
+    [GeneratedRegex(@"^[A-Za-z_][A-Za-z0-9_]*::[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$", RegexOptions.CultureInvariant)]
+    private static partial Regex DotnetEntrypointRegex();
 
     /// <summary>
     /// Returns <see langword="true"/> when the submission carries the custom-code
@@ -61,11 +70,14 @@ internal static partial class CustomCodeSubmitValidator
         declaredScope = [];
         rejection = null;
 
-        // runtime — MVP is python-only.
+        // runtime — 'python' (Phase 1) or 'dotnet' (Phase 2). The runtime selects the
+        // per-job image; the controls below and the routing fence are runtime-agnostic.
         var runtime = Get(parameters, CustomCodeJobContract.RuntimeParam);
-        if (!string.Equals(runtime, CustomCodeJobContract.PythonRuntime, StringComparison.Ordinal))
+        if (runtime is null || !CustomCodeJobContract.SupportedRuntimes.Contains(runtime))
         {
-            rejection = $"Custom-code runtime must be '{CustomCodeJobContract.PythonRuntime}' (got '{runtime ?? "<none>"}').";
+            rejection =
+                $"Custom-code runtime must be '{CustomCodeJobContract.PythonRuntime}' or " +
+                $"'{CustomCodeJobContract.DotnetRuntime}' (got '{runtime ?? "<none>"}').";
             return false;
         }
 
@@ -85,19 +97,23 @@ internal static partial class CustomCodeSubmitValidator
             return false;
         }
 
-        // entrypoint — module.path:function.
+        // entrypoint — shape depends on the runtime: python wants 'module.path:function';
+        // .NET wants 'Assembly::Namespace.Type' (assembly::CLR-type).
         var entrypoint = Get(parameters, CustomCodeJobContract.EntrypointParam);
-        if (string.IsNullOrEmpty(entrypoint) || !EntrypointRegex().IsMatch(entrypoint))
+        if (!TryValidateEntrypoint(entrypoint, runtime, out rejection))
         {
-            rejection = "Custom-code entrypoint must be of the form 'module.path:function'.";
             return false;
         }
 
-        // deps_manifest — a relative path (no absolute paths, no traversal).
+        // deps_manifest — a relative path (no absolute paths, no traversal). For
+        // python this is a requirements file; for .NET it is the user's .csproj (both
+        // are repo-relative and resolved by the runtime's harness).
         var depsManifest = Get(parameters, CustomCodeJobContract.DepsManifestParam);
         if (string.IsNullOrEmpty(depsManifest) || !IsSafeRelativePath(depsManifest))
         {
-            rejection = "Custom-code deps_manifest must be a relative path within the repository (e.g. 'requirements.txt').";
+            rejection = string.Equals(runtime, CustomCodeJobContract.DotnetRuntime, StringComparison.Ordinal)
+                ? "Custom-code deps_manifest must be a relative path within the repository (e.g. 'tool/MyTool.csproj')."
+                : "Custom-code deps_manifest must be a relative path within the repository (e.g. 'requirements.txt').";
             return false;
         }
 
@@ -105,6 +121,31 @@ internal static partial class CustomCodeSubmitValidator
         var rawScope = Get(parameters, CustomCodeJobContract.DeclaredScopeParam);
         if (!TryParseDeclaredScope(rawScope, out declaredScope, out rejection))
         {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryValidateEntrypoint(string? entrypoint, string runtime, out string? rejection)
+    {
+        rejection = null;
+
+        if (string.Equals(runtime, CustomCodeJobContract.DotnetRuntime, StringComparison.Ordinal))
+        {
+            if (string.IsNullOrEmpty(entrypoint) || !DotnetEntrypointRegex().IsMatch(entrypoint))
+            {
+                rejection = "Custom-code entrypoint for the 'dotnet' runtime must be of the form 'Assembly::Namespace.Type'.";
+                return false;
+            }
+
+            return true;
+        }
+
+        // Default to the python form.
+        if (string.IsNullOrEmpty(entrypoint) || !PythonEntrypointRegex().IsMatch(entrypoint))
+        {
+            rejection = "Custom-code entrypoint for the 'python' runtime must be of the form 'module.path:function'.";
             return false;
         }
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -401,9 +401,11 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         if (isCustomCode)
         {
             // Route a custom-code job to the workload that declares the custom-code
-            // runtime profile (image = the python custom-code image ref, the Batch
-            // tier/queue params, NO secretsmanager env refs — those are built into
-            // the job-def family by the iac). Falls back to null when not configured
+            // runtime profile (the Batch tier/queue params, NO secretsmanager env
+            // refs — those are built into the job-def family by the iac). The runtime
+            // selector (customcode.runtime = python|dotnet) flows through the spec
+            // parameters and the iac job-def family resolves it to the matching image;
+            // the routing fence itself is runtime-agnostic. Falls back to null when not configured
             // so submission fails cleanly rather than landing on the GP workload.
             return definitions.FirstOrDefault(d =>
                 d.Kind == ExecutionJobKind.Geoprocessing &&

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeSubmitTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeSubmitTests.cs
@@ -267,6 +267,127 @@ public sealed class CustomCodeSubmitTests
     }
 
     // -----------------------------------------------------------------------
+    // runtime = dotnet (Phase 2)
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_DotnetRuntime_Accepted()
+    {
+        var sut = CreateService();
+        var metadata = DotnetCustomCodeMetadata();
+
+        var job = await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), metadata);
+
+        // dotnet routes through the same custom-code runtime profile as python; the
+        // runtime selector flows through verbatim for the iac to resolve to an image.
+        job.Spec.RuntimeProfile.Should().Be(CustomCodeJobContract.RuntimeProfile);
+        job.Spec.Parameters.Should().ContainKey(CustomCodeJobContract.RuntimeParam)
+            .WhoseValue.Should().Be(CustomCodeJobContract.DotnetRuntime);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_DotnetRuntime_RoutesToCustomCodeWorkload()
+    {
+        var workloadRegistry = Substitute.For<IExecutionJobDefinitionRegistry>();
+        var backend = Substitute.For<IBatchComputeBackend>();
+        backend.BackendName.Returns("aws-batch");
+        backend.TargetKind.Returns(BatchComputeTargetKind.AwsBatch);
+        workloadRegistry.ListAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new ExecutionJobDefinition
+            {
+                WorkloadId = "gp-remote",
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.AwsBatch,
+                Backend = "aws-batch",
+                WorkloadName = "GP remote",
+                RuntimeProfile = "py311"
+            },
+            new ExecutionJobDefinition
+            {
+                WorkloadId = "customcode-remote",
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.AwsBatch,
+                Backend = "aws-batch",
+                WorkloadName = "Custom-code remote",
+                ArtifactReference = "ecr/honua-customcode:latest",
+                RuntimeProfile = CustomCodeJobContract.RuntimeProfile,
+                Parameters = new Dictionary<string, string>
+                {
+                    ["batch.job_definition_arn"] = "arn:aws:batch:us-east-1:1:job-definition/customcode:1",
+                    ["batch.job_queue_arn"] = "arn:aws:batch:us-east-1:1:job-queue/customcode"
+                }
+            }
+        });
+        backend.StartAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<CancellationToken>())
+            .Returns(new BatchComputeSubmissionResult
+            {
+                Status = ExecutionJobStatus.Provisioning,
+                ProviderOperationId = "job-cc-dotnet-1",
+                Message = "Submitted"
+            });
+
+        var sut = CreateService(workloadRegistry: workloadRegistry, backends: [backend]);
+        var job = await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), DotnetCustomCodeMetadata());
+
+        job.Spec.WorkloadId.Should().Be("customcode-remote");
+        job.Spec.RuntimeProfile.Should().Be(CustomCodeJobContract.RuntimeProfile);
+        job.Spec.Parameters.Should().ContainKey(CustomCodeJobContract.RuntimeParam)
+            .WhoseValue.Should().Be(CustomCodeJobContract.DotnetRuntime);
+        job.Spec.Parameters.Should().ContainKey(CustomCodeJobContract.JobTokenEnvParam);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_DotnetRuntime_PythonStyleEntrypoint_Rejected()
+    {
+        var sut = CreateService();
+        // A 'module:func' (python) entrypoint is invalid for the dotnet runtime.
+        var metadata = DotnetCustomCodeMetadata(entrypoint: "pkg.module:run");
+
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), metadata);
+
+        await act.Should().ThrowAsync<Exception>()
+            .Where(e => e.Message.Contains("Assembly::Namespace.Type"));
+        await _jobStore.DidNotReceive().TryCreateAsync(
+            Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_UnknownRuntime_Rejected()
+    {
+        var sut = CreateService();
+        var metadata = DotnetCustomCodeMetadata();
+        metadata[CustomCodeJobContract.RuntimeParam] = "ruby";
+
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), metadata);
+
+        await act.Should().ThrowAsync<Exception>()
+            .Where(e => e.Message.Contains("runtime must be"));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_DotnetRuntime_BranchRef_RejectedAtSubmit()
+    {
+        var sut = CreateService();
+        var metadata = DotnetCustomCodeMetadata(gitRef: "main");
+
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), metadata);
+
+        await act.Should().ThrowAsync<Exception>()
+            .Where(e => e.Message.Contains("40-character commit SHA"));
+    }
+
+    // -----------------------------------------------------------------------
     // helpers
     // -----------------------------------------------------------------------
 
@@ -309,6 +430,29 @@ public sealed class CustomCodeSubmitTests
             [CustomCodeJobContract.GitRefParam] = gitRef,
             [CustomCodeJobContract.EntrypointParam] = "pkg.module:run",
             [CustomCodeJobContract.DepsManifestParam] = "requirements.txt",
+            [CustomCodeJobContract.ParamsJsonParam] = """{"k":"v"}"""
+        };
+        if (declaredScope is not null)
+        {
+            metadata[CustomCodeJobContract.DeclaredScopeParam] = declaredScope;
+        }
+
+        return metadata;
+    }
+
+    private static Dictionary<string, string> DotnetCustomCodeMetadata(
+        string gitRef = ValidSha,
+        string repoUrl = RepoUrl,
+        string entrypoint = "MyTool::My.Namespace.BufferTool",
+        string? declaredScope = null)
+    {
+        var metadata = new Dictionary<string, string>
+        {
+            [CustomCodeJobContract.RuntimeParam] = CustomCodeJobContract.DotnetRuntime,
+            [CustomCodeJobContract.RepoUrlParam] = repoUrl,
+            [CustomCodeJobContract.GitRefParam] = gitRef,
+            [CustomCodeJobContract.EntrypointParam] = entrypoint,
+            [CustomCodeJobContract.DepsManifestParam] = "tool/MyTool.csproj",
             [CustomCodeJobContract.ParamsJsonParam] = """{"k":"v"}"""
         };
         if (declaredScope is not null)


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2188
Related to #2189

## Summary
Custom-code GP **Phase 2** — the **.NET runtime**, mirroring the Python MVP (Phase 1).
Adds a `worker-customcode-dotnet` image + harness and the symmetric `IGeoprocessingTool`
contract, plus the small server change to accept `customcode.runtime = "dotnet"`.

This PR **stacks on the custom-code server branch** (`feat/customcode-server`, #2189),
which carries the runtime-agnostic control path (submit validation, scoped-token
mint/inject/revoke, the custom-code workload fence). It is the .NET sibling of the Python
image/harness on `feat/customcode-python-image` (#2188).

## Changes Made
- **Server:** `customcode.runtime` now accepts `"python"` or `"dotnet"`
  (`CustomCodeJobContract.SupportedRuntimes`). All security (SHA-only pin, repo
  allowlist, scope ⊆ owner, scoped-token mint/inject/revoke) and the `custom-code`
  routing fence are unchanged and runtime-agnostic — the runtime selector flows through
  the spec parameters and the iac job-def family (#73) resolves it to the matching image.
  Entrypoint validation is runtime-aware: python keeps `module.path:function`, dotnet
  requires `Assembly::Namespace.Type`.
- **Image:** `docker/worker-customcode-dotnet/Dockerfile` — GDAL-full base + the .NET 10
  SDK (to `dotnet build` the user `.csproj` at job time) + git + ca-certs, non-root
  uid 1001, a warm NuGet cache (NetTopologySuite + `Honua.Sdk`), and an in-build sanity
  build of the sample tool. ENTRYPOINT = the .NET harness.
- **Harness:** `Honua.CustomCode.Harness` console host — clone pinned SHA → verify HEAD →
  `dotnet build` the user project against the warm cache → build the scoped Honua client
  → **strip the IMDS/credential + token env before activating user code** → load +
  activate the `IGeoprocessingTool` entrypoint → `ExecuteAsync` → upload artifacts. Same
  `CUSTOMCODE_*` / `CUSTOMCODE_JOB_SPEC` + `HONUA_BASE_URL` / `HONUA_JOB_TOKEN` job-spec
  contract and exit-code contract (0/1/2/3) as the Python harness.
- **Contract + sample:** `Honua.CustomCode.Sdk` defines `IGeoprocessingTool`,
  `GpContext` (Params/Inputs/Client/Output/Progress/Log/WorkDirectory), and `GpResult`.
  A sample `BufferTool` buffers a WKT geometry with NetTopologySuite and writes GeoJSON.
  README documents the contract + runtime flow.

## Testing
- [x] Unit tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed
- Server: 23 custom-code submit/route/revoke tests green (incl. new dotnet runtime
  accept/route + reject-bad-entrypoint + unknown-runtime cases).
- Harness: 43 offline tests green — git-ref validation, dotnet entrypoint shape,
  IMDS-strip (token env gone after client build, observed by the tool at execute time),
  context/sink/GpResult, entrypoint type-loading + contract enforcement, full flow with
  fakes. Build green with `-p:NuGetAudit=false`.
- Docker not runnable in CI agent; the Dockerfile is correct-by-construction with an
  in-build restore + sample build sanity check.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [x] Documentation updated

## Release/Deploy Impact
- [x] Requires infrastructure changes

## Breaking Changes
None — `customcode.runtime` gains `"dotnet"` additively; `"python"` is unchanged.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
