### PR TITLE
feat(geoprocessing): close custom-code params->env contract seam (#2191)

### DIFF
--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeJobContract.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeJobContract.cs
@@ -83,4 +83,62 @@ public static class CustomCodeJobContract
 
     /// <summary>The container environment variable name for the scoped job token.</summary>
     public const string JobTokenEnvName = "HONUA_JOB_TOKEN";
+
+    // --- customcode.* -> env.CUSTOMCODE_* job-input pass-through ----------------
+    //
+    // The harness (docker/worker-customcode-python/harness, built on the
+    // feat/customcode-python-image branch) reads each job input from a discrete
+    // CUSTOMCODE_<UPPER> environment variable (the spec key uppercased). The
+    // server therefore re-emits every caller/server-set customcode.* parameter as
+    // an env.CUSTOMCODE_<UPPER> key so AwsBatchComputeBackend.BuildEnvironmentOverrides
+    // surfaces it to the Batch container under the exact name the harness reads.
+    // The auth spine (HONUA_BASE_URL/HONUA_JOB_TOKEN) is injected separately and is
+    // intentionally NOT part of this body map — it follows the standard secret path.
+    //
+    // CONTRACT GUARD: CustomCodeJobContractDriftTests pins ParameterToEnv against the
+    // harness's checked-in jobspec field map so this seam cannot silently drift.
+
+    /// <summary>Container env var carrying <see cref="RuntimeParam"/> (<c>customcode.runtime</c>).</summary>
+    public const string RuntimeEnvName = "CUSTOMCODE_RUNTIME";
+
+    /// <summary>Container env var carrying <see cref="RepoUrlParam"/> (<c>customcode.repo_url</c>).</summary>
+    public const string RepoUrlEnvName = "CUSTOMCODE_REPO_URL";
+
+    /// <summary>Container env var carrying <see cref="GitRefParam"/> (<c>customcode.git_ref</c>).</summary>
+    public const string GitRefEnvName = "CUSTOMCODE_GIT_REF";
+
+    /// <summary>Container env var carrying <see cref="EntrypointParam"/> (<c>customcode.entrypoint</c>).</summary>
+    public const string EntrypointEnvName = "CUSTOMCODE_ENTRYPOINT";
+
+    /// <summary>Container env var carrying <see cref="DepsManifestParam"/> (<c>customcode.deps_manifest</c>).</summary>
+    public const string DepsManifestEnvName = "CUSTOMCODE_DEPS_MANIFEST";
+
+    /// <summary>Container env var carrying <see cref="ParamsJsonParam"/> (<c>customcode.params_json</c>).</summary>
+    public const string ParamsJsonEnvName = "CUSTOMCODE_PARAMS_JSON";
+
+    /// <summary>Container env var carrying <see cref="OutputPrefixParam"/> (<c>customcode.output_prefix</c>).</summary>
+    public const string OutputPrefixEnvName = "CUSTOMCODE_OUTPUT_PREFIX";
+
+    /// <summary>Container env var carrying <see cref="DeclaredScopeParam"/> (<c>customcode.declared_scope</c>).</summary>
+    public const string DeclaredScopeEnvName = "CUSTOMCODE_DECLARED_SCOPE";
+
+    /// <summary>
+    /// The pinned, ordered <c>customcode.*</c> spec-parameter to container
+    /// environment-variable name map. Every entry here is re-emitted as an
+    /// <c>env.&lt;value&gt;</c> spec parameter at submit so the Batch pass-through
+    /// surfaces it to the harness. Keep this in lockstep with the harness's
+    /// jobspec field mapping; the drift test enforces it.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> ParameterToEnv { get; } =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [RuntimeParam] = RuntimeEnvName,
+            [RepoUrlParam] = RepoUrlEnvName,
+            [GitRefParam] = GitRefEnvName,
+            [EntrypointParam] = EntrypointEnvName,
+            [DepsManifestParam] = DepsManifestEnvName,
+            [ParamsJsonParam] = ParamsJsonEnvName,
+            [OutputPrefixParam] = OutputPrefixEnvName,
+            [DeclaredScopeParam] = DeclaredScopeEnvName,
+        };
 }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeSubmitCoordinator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeSubmitCoordinator.cs
@@ -113,6 +113,21 @@ internal sealed class CustomCodeSubmitCoordinator(IScopedJobTokenIssuer tokenIss
         specParams[CustomCodeJobContract.BaseUrlEnvParam] = options.ApiBaseUrl;
         specParams[CustomCodeJobContract.JobTokenEnvParam] = issuance.Token;
 
+        // Re-emit every customcode.* job input as an env.CUSTOMCODE_* parameter so the
+        // Batch pass-through (AwsBatchComputeBackend.BuildEnvironmentOverrides) surfaces
+        // it to the container under the exact name the harness reads. Without this the
+        // customcode.* keys stay on the durable spec but never reach the container — the
+        // pass-through only forwards env.* keys — and the harness would fail closed with
+        // "Required job input is missing". The server-set output_prefix is already in
+        // specParams at this point, so it is forwarded with the clamped value.
+        foreach (var (paramKey, envName) in CustomCodeJobContract.ParameterToEnv)
+        {
+            if (specParams.TryGetValue(paramKey, out var value) && !string.IsNullOrWhiteSpace(value))
+            {
+                specParams["env." + envName] = value;
+            }
+        }
+
         return new CustomCodeSubmitResult(ownerScope, issuance.Token);
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeJobContractDriftTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeJobContractDriftTests.cs
@@ -1,0 +1,236 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Geoprocessing.CustomCode;
+using Honua.Infrastructure.Authentication;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Features.Geoprocessing;
+
+/// <summary>
+/// Contract drift guard for the custom-code params seam (honua-server#2191): the SERVER
+/// re-emits every <c>customcode.*</c> job-input parameter as an
+/// <c>env.CUSTOMCODE_*</c> spec parameter at submit, and the IMAGE/HARNESS
+/// (<c>docker/worker-customcode-python/harness</c>, built on
+/// <c>feat/customcode-python-image</c>) reads each input from the matching
+/// <c>CUSTOMCODE_*</c> container environment variable. The two halves were built in
+/// parallel, so this test pins the param→env mapping against a checked-in snapshot of
+/// the harness's jobspec field map. If the harness renames an env var (or the server
+/// stops emitting one), this fails — the same drift discipline as the AWS-adapter
+/// contract test (#108).
+/// </summary>
+[Protocol(TestProtocols.GPServer)]
+public sealed class CustomCodeJobContractDriftTests
+{
+    private const string ValidSha = "0123456789abcdef0123456789abcdef01234567";
+    private const string FixtureFileName = "customcode-harness-jobspec-contract.json";
+
+    /// <summary>
+    /// The server's pinned <c>customcode.* → CUSTOMCODE_*</c> env-name map must equal,
+    /// key for key, the harness's <c>CUSTOMCODE_* → spec-key</c> map (inverted). This is
+    /// the load-bearing seam assertion: any divergence means the server emits an env var
+    /// the harness does not read, or omits one it requires.
+    /// </summary>
+    [UnitTest]
+    [Operation(Operations.Create)]
+    public void ServerParameterToEnvMap_MatchesHarnessJobSpecContractFixture()
+    {
+        var fixture = LoadHarnessContractFixture();
+
+        // Harness fixture: CUSTOMCODE_<ENV> -> <spec_key>. The server param key is
+        // "customcode.<spec_key>"; the server env name is the CUSTOMCODE_<ENV> key.
+        // Build the expected server map (customcode.<spec_key> -> CUSTOMCODE_<ENV>).
+        var expected = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (envName, specKey) in fixture.BodyEnvToSpecKey)
+        {
+            expected["customcode." + specKey] = envName;
+        }
+
+        CustomCodeJobContract.ParameterToEnv
+            .Should()
+            .BeEquivalentTo(
+                expected,
+                "the server's customcode.* -> env.CUSTOMCODE_* emission must match the "
+                + $"harness's {FixtureFileName} field map ({fixture.HarnessFile} @ "
+                + $"{fixture.HarnessCommit}); a mismatch silently breaks the params seam");
+
+        // The CUSTOMCODE_<ENV> name must be the spec key uppercased — the exact rule the
+        // harness uses (env.get("CUSTOMCODE_" + key.upper())). Pin it so a future server
+        // env-name typo can't pass the map-equality check above against a drifted fixture.
+        foreach (var (envName, specKey) in fixture.BodyEnvToSpecKey)
+        {
+            envName.Should().Be(
+                "CUSTOMCODE_" + specKey.ToUpperInvariant(),
+                "the harness derives the env var as CUSTOMCODE_<spec-key-upper>");
+        }
+    }
+
+    /// <summary>
+    /// The auth spine env names are env-only and intentionally NOT in the body map;
+    /// pin them so they are not accidentally folded into the customcode.* pass-through
+    /// (which would route the scoped token through the wrong, non-secret path).
+    /// </summary>
+    [UnitTest]
+    [Operation(Operations.Create)]
+    public void AuthSpineEnvNames_AreSeparateFromBodyMap_AndPinnedToHarness()
+    {
+        var fixture = LoadHarnessContractFixture();
+
+        fixture.AuthSpineEnv.Should().Contain(CustomCodeJobContract.BaseUrlEnvName);
+        fixture.AuthSpineEnv.Should().Contain(CustomCodeJobContract.JobTokenEnvName);
+
+        CustomCodeJobContract.ParameterToEnv.Values
+            .Should().NotContain(CustomCodeJobContract.BaseUrlEnvName);
+        CustomCodeJobContract.ParameterToEnv.Values
+            .Should().NotContain(CustomCodeJobContract.JobTokenEnvName);
+    }
+
+    /// <summary>
+    /// End-to-end through the coordinator: after a successful submit the durable spec
+    /// carries an <c>env.CUSTOMCODE_*</c> parameter for every supplied customcode.* input
+    /// (so AwsBatchComputeBackend.BuildEnvironmentOverrides — which forwards ONLY env.*
+    /// keys — surfaces them to the container as CUSTOMCODE_*). This is the regression
+    /// guard for the original seam break: bare customcode.* keys never reached the
+    /// container, so the harness failed closed with "Required job input is missing".
+    /// </summary>
+    [UnitTest]
+    [Operation(Operations.Create)]
+    public async Task Coordinator_EmitsEveryCustomCodeInputAsEnvPassThrough()
+    {
+        var issuer = new ScopedJobTokenIssuer(
+            new MemoryCache(new MemoryCacheOptions()),
+            NullLogger<ScopedJobTokenIssuer>.Instance);
+        var coordinator = new CustomCodeSubmitCoordinator(issuer);
+
+        var options = new CustomCodeOptions
+        {
+            RepoPolicy = CustomCodeRepoPolicy.OrgAllowlist,
+            RepoAllowlist = ["github.com"],
+            ApiBaseUrl = "https://api.honua.test",
+            OutputPrefixRoot = "s3://honua-customcode/outputs"
+        };
+
+        var specParams = new Dictionary<string, string>
+        {
+            [CustomCodeJobContract.RuntimeParam] = "python",
+            [CustomCodeJobContract.RepoUrlParam] = "https://github.com/honua-io/example.git",
+            [CustomCodeJobContract.GitRefParam] = ValidSha,
+            [CustomCodeJobContract.EntrypointParam] = "pkg.module:run",
+            [CustomCodeJobContract.DepsManifestParam] = "requirements.txt",
+            [CustomCodeJobContract.ParamsJsonParam] = """{"k":"v"}""",
+            [CustomCodeJobContract.DeclaredScopeParam] = """[{"serviceId":"parcels","access":"read"}]"""
+        };
+
+        await coordinator.ValidateMintAndInjectAsync(
+            "gp-cc-seam-1", OwnerPrincipal(), specParams, options, CancellationToken.None);
+
+        // Every supplied customcode.* input is now mirrored to env.CUSTOMCODE_* with the
+        // SAME value (output_prefix is server-set, so its env mirrors the clamped value).
+        foreach (var (paramKey, envName) in CustomCodeJobContract.ParameterToEnv)
+        {
+            specParams.Should().ContainKey(paramKey, "test supplied/derived every input");
+            var passThroughKey = "env." + envName;
+            specParams.Should().ContainKey(passThroughKey,
+                $"'{paramKey}' must be re-emitted as '{passThroughKey}' so the Batch pass-through forwards it");
+            specParams[passThroughKey].Should().Be(specParams[paramKey],
+                "the env pass-through must carry the exact customcode.* value");
+        }
+
+        // The server-set output prefix flows through to its env var too.
+        specParams.Should().ContainKey("env." + CustomCodeJobContract.OutputPrefixEnvName)
+            .WhoseValue.Should().Contain("gp-cc-seam-1");
+
+        // Auth spine present and env-only.
+        specParams.Should().ContainKey(CustomCodeJobContract.BaseUrlEnvParam);
+        specParams.Should().ContainKey(CustomCodeJobContract.JobTokenEnvParam);
+    }
+
+    /// <summary>
+    /// An optional, unsupplied customcode.* input must NOT be emitted as an empty env
+    /// var — the harness treats a present-but-empty CUSTOMCODE_* the same as a supplied
+    /// value, so emitting an empty declared_scope would change harness behavior.
+    /// </summary>
+    [UnitTest]
+    [Operation(Operations.Create)]
+    public async Task Coordinator_OmitsEnvForUnsuppliedOptionalInput()
+    {
+        var issuer = new ScopedJobTokenIssuer(
+            new MemoryCache(new MemoryCacheOptions()),
+            NullLogger<ScopedJobTokenIssuer>.Instance);
+        var coordinator = new CustomCodeSubmitCoordinator(issuer);
+
+        var options = new CustomCodeOptions
+        {
+            RepoPolicy = CustomCodeRepoPolicy.OrgAllowlist,
+            RepoAllowlist = ["github.com"],
+            ApiBaseUrl = "https://api.honua.test",
+            OutputPrefixRoot = "s3://honua-customcode/outputs"
+        };
+
+        // No declared_scope supplied.
+        var specParams = new Dictionary<string, string>
+        {
+            [CustomCodeJobContract.RuntimeParam] = "python",
+            [CustomCodeJobContract.RepoUrlParam] = "https://github.com/honua-io/example.git",
+            [CustomCodeJobContract.GitRefParam] = ValidSha,
+            [CustomCodeJobContract.EntrypointParam] = "pkg.module:run",
+            [CustomCodeJobContract.DepsManifestParam] = "requirements.txt"
+        };
+
+        await coordinator.ValidateMintAndInjectAsync(
+            "gp-cc-seam-2", OwnerPrincipal(), specParams, options, CancellationToken.None);
+
+        specParams.Should().NotContainKey("env." + CustomCodeJobContract.DeclaredScopeEnvName);
+        specParams.Should().NotContainKey("env." + CustomCodeJobContract.ParamsJsonEnvName);
+    }
+
+    private static ClaimsPrincipal OwnerPrincipal()
+        => new(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Name, "alice"),
+                new Claim("tenant_id", "tenant-A"),
+                new Claim("permission", "read:parcels")
+            ],
+            "Test"));
+
+    private static HarnessContractFixture LoadHarnessContractFixture()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Features", "Geoprocessing", FixtureFileName);
+        File.Exists(path).Should().BeTrue($"the checked-in harness contract fixture must be copied to the test output: {path}");
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        var root = doc.RootElement;
+
+        var bodyMap = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var prop in root.GetProperty("body_env_to_spec_key").EnumerateObject())
+        {
+            bodyMap[prop.Name] = prop.Value.GetString()!;
+        }
+
+        var authSpine = new List<string>();
+        foreach (var item in root.GetProperty("auth_spine_env").EnumerateArray())
+        {
+            authSpine.Add(item.GetString()!);
+        }
+
+        return new HarnessContractFixture(
+            BodyEnvToSpecKey: bodyMap,
+            AuthSpineEnv: authSpine,
+            HarnessFile: root.GetProperty("harness_file").GetString()!,
+            HarnessCommit: root.GetProperty("harness_commit").GetString()!);
+    }
+
+    private sealed record HarnessContractFixture(
+        IReadOnlyDictionary<string, string> BodyEnvToSpecKey,
+        IReadOnlyList<string> AuthSpineEnv,
+        string HarnessFile,
+        string HarnessCommit);
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/customcode-harness-jobspec-contract.json
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/customcode-harness-jobspec-contract.json
@@ -1,0 +1,29 @@
+{
+  "_comment": "CHECKED-IN CONTRACT FIXTURE — the harness (image) half of the custom-code params seam (honua-server#2191). Pins the CUSTOMCODE_* container environment-variable names the Python harness reads, so the server's customcode.*->env.CUSTOMCODE_* emission cannot silently drift. Same drift-guard discipline as the AWS-adapter contract test (#108). When the harness changes its env contract, this fixture and the harness MUST change together.",
+  "_source": "honua-io/honua-server docker/worker-customcode-python/harness/honua_customcode_harness/jobspec.py @ feat/customcode-python-image (3e0c2b773f5cc1ae48e80bcffd124544ad356ac0). The harness resolves each spec field from CUSTOMCODE_<KEY-UPPER> when CUSTOMCODE_JOB_SPEC is absent (load_job_spec), and ALWAYS reads the auth spine HONUA_BASE_URL/HONUA_JOB_TOKEN from the environment only (never from the spec body).",
+  "harness_branch": "feat/customcode-python-image",
+  "harness_commit": "3e0c2b773f5cc1ae48e80bcffd124544ad356ac0",
+  "harness_file": "docker/worker-customcode-python/harness/honua_customcode_harness/jobspec.py",
+
+  "body_env_to_spec_key": {
+    "CUSTOMCODE_RUNTIME": "runtime",
+    "CUSTOMCODE_REPO_URL": "repo_url",
+    "CUSTOMCODE_GIT_REF": "git_ref",
+    "CUSTOMCODE_ENTRYPOINT": "entrypoint",
+    "CUSTOMCODE_DEPS_MANIFEST": "deps_manifest",
+    "CUSTOMCODE_PARAMS_JSON": "params_json",
+    "CUSTOMCODE_OUTPUT_PREFIX": "output_prefix",
+    "CUSTOMCODE_DECLARED_SCOPE": "declared_scope"
+  },
+
+  "_auth_spine_comment": "Injected separately by the server (env.HONUA_BASE_URL/env.HONUA_JOB_TOKEN) and read env-only by the harness; intentionally NOT part of the customcode.* body map.",
+  "auth_spine_env": [
+    "HONUA_BASE_URL",
+    "HONUA_JOB_TOKEN"
+  ],
+
+  "_harness_only_comment": "Optional harness input with a built-in default (1 GiB). The server has no customcode.output_max_bytes parameter today, so it is not emitted and the harness default applies. Listed here so the parity test treats its absence as intentional, not drift.",
+  "harness_only_optional_env": [
+    "CUSTOMCODE_OUTPUT_MAX_BYTES"
+  ]
+}

--- a/tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj
+++ b/tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj
@@ -67,6 +67,9 @@
     <None Update="TestData/Sld/*.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Features/Geoprocessing/customcode-harness-jobspec-contract.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Closes #2191.

Verifies and closes the custom-code params→env contract seam between the server control path (#2189, `feat/customcode-server`) and the Python harness (#2188, `feat/customcode-python-image`), which were built in parallel. **The seam was broken** and this PR fixes it plus adds a drift guard.

The harness reads each job input from a discrete `CUSTOMCODE_*` container env var (or a `CUSTOMCODE_JOB_SPEC` file), and always reads the auth spine `HONUA_BASE_URL`/`HONUA_JOB_TOKEN` env-only. The server emitted the body inputs as bare `customcode.*` keys on `ExecutionJobSpec.Parameters`, but `AwsBatchComputeBackend.BuildEnvironmentOverrides` forwards **only** `env.*` keys to the Batch container — so the `customcode.*` inputs never reached the harness. Every custom-code job would have failed closed at the harness with "Required job input is missing". The auth spine was already wired (`env.HONUA_BASE_URL`/`env.HONUA_JOB_TOKEN`); the body inputs were not.

## Changes Made

- `CustomCodeSubmitCoordinator.ValidateMintAndInjectAsync` now re-emits every supplied `customcode.*` input as an `env.CUSTOMCODE_*` parameter so the existing Batch pass-through surfaces it under the exact name the harness reads. The server-set `output_prefix` is forwarded with its clamped value; unsupplied optional inputs are omitted (not emitted empty) so harness behavior is unchanged.
- `CustomCodeJobContract` gains the pinned `customcode.* → CUSTOMCODE_*` map (`ParameterToEnv`) and the `CUSTOMCODE_*` env-name constants. The auth spine stays separate and env-only.
- Contract drift guard (same discipline as the #108 AWS-adapter drift test): a checked-in fixture (`customcode-harness-jobspec-contract.json`) snapshots the harness's jobspec field map, referencing the harness file + commit on `feat/customcode-python-image`. `CustomCodeJobContractDriftTests` asserts the server's `ParameterToEnv` matches it key-for-key, that env names are `CUSTOMCODE_<spec-key-upper>`, that the auth spine stays out of the body map, and — end to end through the coordinator — that every input is mirrored to `env.CUSTOMCODE_*` with the correct value.

Key mapping (server param → container env var read by the harness):
`customcode.runtime`→`CUSTOMCODE_RUNTIME`, `repo_url`→`CUSTOMCODE_REPO_URL`, `git_ref`→`CUSTOMCODE_GIT_REF`, `entrypoint`→`CUSTOMCODE_ENTRYPOINT`, `deps_manifest`→`CUSTOMCODE_DEPS_MANIFEST`, `params_json`→`CUSTOMCODE_PARAMS_JSON`, `output_prefix`→`CUSTOMCODE_OUTPUT_PREFIX`, `declared_scope`→`CUSTOMCODE_DECLARED_SCOPE`. Auth spine injected separately: `env.HONUA_BASE_URL`/`env.HONUA_JOB_TOKEN`.

`params_json` (potentially large) rides the discrete `CUSTOMCODE_PARAMS_JSON` env var the harness accepts as inline JSON; the server has no spec-file mount path, so the env pass-through is the only route it can emit, and the harness fully supports it. The harness-only `CUSTOMCODE_OUTPUT_MAX_BYTES` has a built-in default and is intentionally not emitted (recorded in the fixture as harness-only optional).

This PR stacks on `feat/customcode-server`.

## Breaking Changes

None.

## Gate Impact

- [x] No gate impact / internal only

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Release build (warnings-as-errors) green; `dotnet format --verify-no-changes` clean on changed files; custom-code suite 22/22 (incl. 4 new drift tests) and AwsBatch backend 46/46 pass. Test paths land in the Geoprocessing shard per ADR-0037 (`ci-shards.json` already claims `src/Honua.Geoprocessing/Features/Geoprocessing/` and `tests/.../Features/Geoprocessing/`). AOT-safe (no reflection added; map is a plain static dictionary, fixture parsed with `JsonDocument` in test code only).
