### PR TITLE
feat(control-plane): AWS Lambda host for event-driven reconcile (TriggerMode=Event)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -725,6 +725,19 @@ jobs:
             --logger "console;verbosity=minimal" \
             --results-directory ./tests/TestResults
 
+      - name: Run .NET Tests (Control-plane Lambda)
+        # Thin event-deserialization + forwarder unit tests for the cloud
+        # control-plane reconcile Lambda host (Honua.ControlPlane.Lambda). No
+        # service dependencies; runs in seconds.
+        timeout-minutes: 3
+        run: |
+          dotnet test tests/dotnet/Honua.ControlPlane.Lambda.Tests/Honua.ControlPlane.Lambda.Tests.csproj \
+            --no-restore \
+            --configuration Release \
+            --logger "trx;LogFileName=control-plane-lambda-tests.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults
+
       - name: Run .NET Tests (Server Fast Tier)
         # Per ADR-0037 the Fast tier runs across every test project on every
         # PR, including Honua.Server.Tests. Filtering by Tier=Fast keeps this

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,9 @@
     <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.2" />
     <PackageVersion Include="Aspire.Npgsql" Version="13.2.2" />
     <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.2.2" />
+    <PackageVersion Include="Amazon.Lambda.Core" Version="2.5.1" />
+    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.13.0" />
+    <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
     <PackageVersion Include="AWSSDK.Batch" Version="4.0.8.8" />
     <PackageVersion Include="AWSSDK.BedrockRuntime" Version="4.0.21.1" />
     <PackageVersion Include="AWSSDK.CloudWatch" Version="4.0.11.2" />

--- a/Honua.sln
+++ b/Honua.sln
@@ -151,6 +151,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Protocols.SensorThing
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Protocols.SensorThings.Tests", "tests\dotnet\Honua.Protocols.SensorThings.Tests\Honua.Protocols.SensorThings.Tests.csproj", "{09A157E7-67AD-46E1-9495-BD499000592D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.ControlPlane.Lambda", "src\Honua.ControlPlane.Lambda\Honua.ControlPlane.Lambda.csproj", "{C6BCF7FB-E329-4820-BC94-7D3939F747A7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.ControlPlane.Lambda.Tests", "tests\dotnet\Honua.ControlPlane.Lambda.Tests\Honua.ControlPlane.Lambda.Tests.csproj", "{014DB146-0395-4086-BD8C-155FFF3AA9EB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -977,6 +981,30 @@ Global
 		{09A157E7-67AD-46E1-9495-BD499000592D}.Release|x64.Build.0 = Release|Any CPU
 		{09A157E7-67AD-46E1-9495-BD499000592D}.Release|x86.ActiveCfg = Release|Any CPU
 		{09A157E7-67AD-46E1-9495-BD499000592D}.Release|x86.Build.0 = Release|Any CPU
+		{C6BCF7FB-E329-4820-BC94-7D3939F747A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6BCF7FB-E329-4820-BC94-7D3939F747A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6BCF7FB-E329-4820-BC94-7D3939F747A7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C6BCF7FB-E329-4820-BC94-7D3939F747A7}.Debug|x64.Build.0 = Debug|Any CPU
+		{C6BCF7FB-E329-4820-BC94-7D3939F747A7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C6BCF7FB-E329-4820-BC94-7D3939F747A7}.Debug|x86.Build.0 = Debug|Any CPU
+		{C6BCF7FB-E329-4820-BC94-7D3939F747A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6BCF7FB-E329-4820-BC94-7D3939F747A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6BCF7FB-E329-4820-BC94-7D3939F747A7}.Release|x64.ActiveCfg = Release|Any CPU
+		{C6BCF7FB-E329-4820-BC94-7D3939F747A7}.Release|x64.Build.0 = Release|Any CPU
+		{C6BCF7FB-E329-4820-BC94-7D3939F747A7}.Release|x86.ActiveCfg = Release|Any CPU
+		{C6BCF7FB-E329-4820-BC94-7D3939F747A7}.Release|x86.Build.0 = Release|Any CPU
+		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Debug|x64.Build.0 = Debug|Any CPU
+		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Debug|x86.Build.0 = Debug|Any CPU
+		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Release|x64.ActiveCfg = Release|Any CPU
+		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Release|x64.Build.0 = Release|Any CPU
+		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Release|x86.ActiveCfg = Release|Any CPU
+		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1045,5 +1073,7 @@ Global
 		{43B1BD9E-AD92-4A52-8DE3-4CE9E7B1BCD8} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
 		{268C7FCA-045F-4DA1-B249-64DCF5E13D11} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{09A157E7-67AD-46E1-9495-BD499000592D} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
+		{C6BCF7FB-E329-4820-BC94-7D3939F747A7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{014DB146-0395-4086-BD8C-155FFF3AA9EB} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
 	EndGlobalSection
 EndGlobal

--- a/docker/Dockerfile.controlplane-lambda
+++ b/docker/Dockerfile.controlplane-lambda
@@ -1,0 +1,92 @@
+# syntax=docker/dockerfile:1.7
+# Cloud control-plane reconcile Lambda image (TriggerMode=Event).
+#
+# This image packages TWO cooperating processes so a single Lambda function can be invoked
+# directly by EventBridge (a "Batch Job State Change" event) or EventBridge Scheduler (the
+# backstop tick) and reconcile exactly one control-plane operation per invocation:
+#
+#   1. The full Honua.Server host (AOT, self-contained) — the fully-wired reconcile graph
+#      (dispatcher + typed reconcilers + durable stores + batch/deploy backends). It exposes the
+#      internal control-plane routes (/internal/control-plane/...) and is fronted by the AWS Lambda
+#      Web Adapter so it can also serve as the normal API image. It is the ONE faithful composition
+#      of the reconcile graph; the thin entrypoint deliberately does not re-compose it.
+#   2. The thin Honua.ControlPlane.Lambda custom-runtime bootstrap (AOT) — deserializes the
+#      EventBridge event, extracts detail.jobId, and forwards a single reconcile/backstop request to
+#      the co-located host over loopback HTTP, then exits.
+#
+# Handler selection is via HONUA_CONTROL_PLANE_LAMBDA_HANDLER (batch-event | backstop); the iac sets
+# it per EventBridge target. ControlPlane__TriggerMode=Event disables the in-process poll/backstop
+# timers so there is no always-on control-plane host.
+#
+# PACKAGING NOTE: the simplest alternative is to skip the custom-runtime bootstrap entirely and have
+# EventBridge post directly to the server's /internal/control-plane routes through the Lambda Web
+# Adapter (an EventBridge API destination or Function URL with an input transformer). This image
+# supports the direct EventBridge -> Lambda invoke model; the honua-iac module wires the function and
+# its IAM/EventBridge/Scheduler resources behind the enable_control_plane_events gate.
+
+ARG DOTNET_SDK_IMAGE=mcr.microsoft.com/dotnet/sdk:10.0
+WORKDIR /src
+
+FROM ${DOTNET_SDK_IMAGE} AS build
+WORKDIR /src
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends clang lld zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+ARG TARGETARCH
+ARG CONFIGURATION=Release
+RUN --mount=type=cache,target=/root/.nuget/packages \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) RUNTIME_ID="linux-x64" ; ILC_SINGLE_THREADED="false" ;; \
+      arm64) RUNTIME_ID="linux-arm64" ; ILC_SINGLE_THREADED="true" ;; \
+      *) echo "Unsupported TARGETARCH=${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    dotnet publish src/Honua.Server/Honua.Server.csproj \
+      --configuration "$CONFIGURATION" --runtime "$RUNTIME_ID" --self-contained true \
+      --output /app/server \
+      -p:RuntimeIdentifier="$RUNTIME_ID" -p:PublishAot=true -p:DebugType=None -p:DebugSymbols=false \
+      -p:StripSymbols=true -p:OptimizationPreference=Speed -p:IlcOptimizationPreference=Speed \
+      -p:IlcSingleThreaded="$ILC_SINGLE_THREADED" \
+      -p:HonuaSkipOracleForAotVerification=true -p:HonuaSkipSnowflakeForAotVerification=true && \
+    dotnet publish src/Honua.ControlPlane.Lambda/Honua.ControlPlane.Lambda.csproj \
+      --configuration "$CONFIGURATION" --runtime "$RUNTIME_ID" --self-contained true \
+      --output /app/bootstrap \
+      -p:RuntimeIdentifier="$RUNTIME_ID" -p:PublishAot=true -p:DebugType=None -p:DebugSymbols=false \
+      -p:StripSymbols=true && \
+    # The Lambda custom runtime requires the entrypoint binary to be named "bootstrap".
+    cp /app/bootstrap/Honua.ControlPlane.Lambda /app/bootstrap/bootstrap && \
+    chmod +x /app/bootstrap/bootstrap && \
+    rm -rf /app/server/BlazorDebugProxy /app/server/wwwroot && \
+    find /app -type f \( -name '*.pdb' -o -name '*.dbg' \) -delete
+
+FROM public.ecr.aws/lambda/provided:al2 AS runtime
+
+# Lambda Web Adapter so the co-located full host can serve the internal reconcile routes.
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
+
+WORKDIR ${LAMBDA_TASK_ROOT}
+COPY --from=build /app/server ${LAMBDA_TASK_ROOT}/server
+COPY --from=build /app/bootstrap/bootstrap ${LAMBDA_TASK_ROOT}/bootstrap
+COPY docker/scripts/controlplane-lambda-entrypoint.sh ${LAMBDA_TASK_ROOT}/entrypoint.sh
+
+RUN yum install -y krb5-libs libicu fontconfig freetype && \
+    yum clean all && \
+    chmod +x ${LAMBDA_TASK_ROOT}/server/Honua.Server \
+             ${LAMBDA_TASK_ROOT}/bootstrap \
+             ${LAMBDA_TASK_ROOT}/entrypoint.sh
+
+ENV PORT=8080 \
+    AWS_LWA_PORT=8080 \
+    ASPNETCORE_ENVIRONMENT=Production \
+    ControlPlane__TriggerMode=Event \
+    HONUA_CONTROL_PLANE_LAMBDA_HANDLER=batch-event \
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    DOTNET_EnableDiagnostics=0
+
+# The entrypoint starts the full host in the background (serving the internal reconcile routes via
+# LWA) and then execs the thin custom-runtime bootstrap, which handles each EventBridge invocation.
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker/scripts/controlplane-lambda-entrypoint.sh
+++ b/docker/scripts/controlplane-lambda-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Control-plane reconcile Lambda entrypoint.
+#
+# Starts the full Honua.Server host in the background — fronted by the AWS Lambda Web Adapter, it
+# serves the internal /internal/control-plane reconcile routes on the loopback port — then execs the
+# thin custom-runtime bootstrap, which deserializes each EventBridge invocation and forwards a single
+# reconcile/backstop request to the host. The host carries the fully-wired reconcile graph; the
+# bootstrap stays graph-free for a fast cold start.
+set -eu
+
+PORT="${AWS_LWA_PORT:-${PORT:-8080}}"
+
+# Launch the full host (LWA reads $AWS_LWA_PORT). It runs with ControlPlane__TriggerMode=Event, so its
+# in-process poll/backstop timers are disabled and it only serves the on-demand reconcile routes.
+"${LAMBDA_TASK_ROOT}/server/Honua.Server" &
+SERVER_PID=$!
+
+# Wait for the host to accept connections before handing invocations to the bootstrap. Bounded so a
+# wedged host fails the invocation rather than hanging until the Lambda timeout.
+i=0
+until curl -fsS "http://127.0.0.1:${PORT}/healthz/live" >/dev/null 2>&1; do
+  i=$((i + 1))
+  if [ "$i" -ge 60 ]; then
+    echo "control-plane host did not become ready on port ${PORT}" >&2
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "control-plane host exited during startup" >&2
+    break
+  fi
+  sleep 0.5
+done
+
+# Hand control to the custom-runtime bootstrap (the Lambda runtime client loop).
+exec "${LAMBDA_TASK_ROOT}/bootstrap"

--- a/src/Honua.ControlPlane.Lambda/BatchEventParser.cs
+++ b/src/Honua.ControlPlane.Lambda/BatchEventParser.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.ControlPlane.Lambda;
+
+/// <summary>
+/// Pure parsing of an EventBridge "Batch Job State Change" event into the AWS Batch provider job id
+/// (<c>detail.jobId</c>) that the control-plane reconcile entrypoint forwards. Kept side-effect-free
+/// and dependency-free so the deserialization contract (sample event JSON → provider id) is fully
+/// unit-testable without the Lambda runtime.
+/// </summary>
+internal static class BatchEventParser
+{
+    /// <summary>The expected <c>source</c> of a Batch state-change event.</summary>
+    internal const string ExpectedSource = "aws.batch";
+
+    /// <summary>The expected <c>detail-type</c> of a Batch state-change event.</summary>
+    internal const string ExpectedDetailType = "Batch Job State Change";
+
+    /// <summary>
+    /// Extracts the AWS Batch provider job id (<c>detail.jobId</c>) from a deserialized event.
+    /// Returns <see langword="null"/> when the event is not a Batch state-change event or carries no
+    /// job id; callers treat a null result as "nothing to reconcile" and exit cleanly.
+    /// </summary>
+    public static string? ExtractProviderOperationId(BatchJobStateChangeEvent? evt)
+    {
+        if (evt?.Detail is null)
+        {
+            return null;
+        }
+
+        // Defensive: only act on the event type we expect. EventBridge rule matching already filters
+        // to source=aws.batch + detail-type="Batch Job State Change", but a malformed or mis-routed
+        // payload must not be coerced into a reconcile.
+        if (!string.IsNullOrEmpty(evt.Source)
+            && !string.Equals(evt.Source, ExpectedSource, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrEmpty(evt.DetailType)
+            && !string.Equals(evt.DetailType, ExpectedDetailType, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var jobId = evt.Detail.JobId;
+        return string.IsNullOrWhiteSpace(jobId) ? null : jobId;
+    }
+
+    /// <summary>
+    /// Deserializes raw EventBridge event JSON and extracts the provider job id. Returns
+    /// <see langword="null"/> for empty, malformed, or non-matching payloads (never throws on
+    /// malformed JSON), so a bad event becomes a clean no-op rather than a Lambda error.
+    /// </summary>
+    public static string? ExtractProviderOperationId(string? eventJson)
+    {
+        if (string.IsNullOrWhiteSpace(eventJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            var evt = JsonSerializer.Deserialize(
+                eventJson,
+                ControlPlaneLambdaJsonContext.Default.BatchJobStateChangeEvent);
+            return ExtractProviderOperationId(evt);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Honua.ControlPlane.Lambda/BatchJobStateChangeEvent.cs
+++ b/src/Honua.ControlPlane.Lambda/BatchJobStateChangeEvent.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.ControlPlane.Lambda;
+
+/// <summary>
+/// Minimal projection of an Amazon EventBridge "Batch Job State Change" event. Only the fields the
+/// reconcile entrypoint needs are modeled; AWS may add properties over time, and System.Text.Json
+/// ignores unknown members by default (per the AWS guidance to tolerate unknown properties).
+/// <para>
+/// The authoritative job selector is <see cref="BatchJobStateChangeDetail.JobId"/> (<c>detail.jobId</c>),
+/// which is the AWS Batch provider job id. The control-plane event handler resolves that to the durable
+/// operation id and reconciles once — the event payload is never trusted as authoritative state.
+/// </para>
+/// </summary>
+internal sealed class BatchJobStateChangeEvent
+{
+    /// <summary>Event source. For AWS Batch state-change events this is <c>aws.batch</c>.</summary>
+    [JsonPropertyName("source")]
+    public string? Source { get; set; }
+
+    /// <summary>Event type. For these events this is <c>Batch Job State Change</c>.</summary>
+    [JsonPropertyName("detail-type")]
+    public string? DetailType { get; set; }
+
+    /// <summary>The Batch job description carried in the event.</summary>
+    [JsonPropertyName("detail")]
+    public BatchJobStateChangeDetail? Detail { get; set; }
+}
+
+/// <summary>
+/// The <c>detail</c> object of a Batch Job State Change event. Carries the provider job id and the
+/// reported status (the status is informational only; the reconciler re-reads authoritative state).
+/// </summary>
+internal sealed class BatchJobStateChangeDetail
+{
+    /// <summary>The AWS Batch job id — the provider operation id the handler resolves.</summary>
+    [JsonPropertyName("jobId")]
+    public string? JobId { get; set; }
+
+    /// <summary>The AWS Batch job ARN.</summary>
+    [JsonPropertyName("jobArn")]
+    public string? JobArn { get; set; }
+
+    /// <summary>The job name.</summary>
+    [JsonPropertyName("jobName")]
+    public string? JobName { get; set; }
+
+    /// <summary>The reported job status (e.g. RUNNING, SUCCEEDED, FAILED). Informational only.</summary>
+    [JsonPropertyName("status")]
+    public string? Status { get; set; }
+}

--- a/src/Honua.ControlPlane.Lambda/ControlPlaneLambdaJsonContext.cs
+++ b/src/Honua.ControlPlane.Lambda/ControlPlaneLambdaJsonContext.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.ControlPlane.Lambda;
+
+/// <summary>
+/// Source-generated JSON context for the EventBridge event types this Lambda deserializes. Keeps the
+/// entrypoint AOT-safe (no reflection-based serialization) and is wired into the Lambda runtime via
+/// <c>SourceGeneratorLambdaJsonSerializer</c>.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNameCaseInsensitive = false,
+    GenerationMode = JsonSourceGenerationMode.Default)]
+[JsonSerializable(typeof(BatchJobStateChangeEvent))]
+[JsonSerializable(typeof(BatchJobStateChangeDetail))]
+[JsonSerializable(typeof(BackstopTickEvent))]
+internal sealed partial class ControlPlaneLambdaJsonContext : JsonSerializerContext
+{
+}
+
+/// <summary>
+/// Opaque payload type for the EventBridge Scheduler backstop tick. Its contents are ignored — the
+/// handler simply sweeps once — but a concrete (non-Stream) deserialization target keeps the Lambda
+/// bootstrap overload resolution unambiguous and AOT-safe.
+/// </summary>
+internal sealed class BackstopTickEvent
+{
+}

--- a/src/Honua.ControlPlane.Lambda/Function.cs
+++ b/src/Honua.ControlPlane.Lambda/Function.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace Honua.ControlPlane.Lambda;
+
+/// <summary>
+/// Thin AWS Lambda entrypoint for the cloud (event-driven) control-plane reconcile. Two handlers,
+/// selected by the <c>HONUA_CONTROL_PLANE_LAMBDA_HANDLER</c> environment variable so a single image
+/// serves both EventBridge targets:
+/// <list type="bullet">
+/// <item><c>batch-event</c>: deserializes an EventBridge "Batch Job State Change" event, extracts
+/// <c>detail.jobId</c>, and drives one execution-job reconcile, then exits.</item>
+/// <item><c>backstop</c>: invoked by EventBridge Scheduler on a coarse timer; runs one backstop
+/// sweep (reconcile stale non-terminal ops) and exits.</item>
+/// </list>
+/// Each invocation cold-starts (or warm-reuses), reconciles exactly once via the in-process
+/// Honua.Server host (LWA), and returns — there is no always-on control-plane host.
+/// </summary>
+internal static class Function
+{
+    internal const string HandlerEnvVar = "HONUA_CONTROL_PLANE_LAMBDA_HANDLER";
+    internal const string BatchEventHandler = "batch-event";
+    internal const string BackstopHandler = "backstop";
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(GetTimeoutSeconds()),
+    };
+
+    public static async Task Main()
+    {
+        var env = ReadEnvironment();
+        var handlerMode = env.GetValueOrDefault(HandlerEnvVar) ?? BatchEventHandler;
+        var forwarder = new ReconcileForwarder(HttpClient, ReconcileForwarderOptions.FromEnvironment(env));
+        var serializer = new SourceGeneratorLambdaJsonSerializer<ControlPlaneLambdaJsonContext>();
+
+        if (string.Equals(handlerMode, BackstopHandler, StringComparison.OrdinalIgnoreCase))
+        {
+            // The Scheduler tick payload is opaque and ignored; the handler simply sweeps once.
+            Func<BackstopTickEvent, ILambdaContext, Task> backstop = async (_, context) =>
+            {
+                context.Logger.LogInformation("Control-plane backstop sweep tick");
+                using var cts = context.CreateDeadlineTokenSource();
+                await forwarder.RunBackstopAsync(cts.Token).ConfigureAwait(false);
+            };
+
+            using var backstopBootstrap = LambdaBootstrapBuilder
+                .Create(backstop, serializer)
+                .Build();
+            await backstopBootstrap.RunAsync().ConfigureAwait(false);
+            return;
+        }
+
+        Func<BatchJobStateChangeEvent, ILambdaContext, Task> batchEvent = async (evt, context) =>
+        {
+            var providerOperationId = BatchEventParser.ExtractProviderOperationId(evt);
+            if (string.IsNullOrWhiteSpace(providerOperationId))
+            {
+                context.Logger.LogInformation("Batch event carried no actionable jobId; nothing to reconcile");
+                return;
+            }
+
+            context.Logger.LogInformation($"Reconciling execution job for Batch jobId {providerOperationId}");
+            using var cts = context.CreateDeadlineTokenSource();
+            await forwarder.ReconcileBatchEventAsync(providerOperationId, cts.Token).ConfigureAwait(false);
+        };
+
+        using var bootstrap = LambdaBootstrapBuilder
+            .Create(batchEvent, serializer)
+            .Build();
+        await bootstrap.RunAsync().ConfigureAwait(false);
+    }
+
+    private static int GetTimeoutSeconds()
+    {
+        var raw = Environment.GetEnvironmentVariable("HONUA_CONTROL_PLANE_RECONCILE_TIMEOUT_SECONDS");
+        return int.TryParse(raw, out var seconds) && seconds > 0 ? seconds : 60;
+    }
+
+    private static Dictionary<string, string?> ReadEnvironment()
+    {
+        var result = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        {
+            if (entry.Key is string key)
+            {
+                result[key] = entry.Value as string;
+            }
+        }
+
+        return result;
+    }
+}
+
+/// <summary>Helper extension to derive a cancellation token from a Lambda invocation's deadline.</summary>
+internal static class LambdaContextExtensions
+{
+    /// <summary>
+    /// Creates a linked <see cref="CancellationTokenSource"/> that trips shortly before the Lambda
+    /// deadline so a reconcile that overruns is cancelled cleanly rather than killed mid-flight by the
+    /// runtime. The caller owns the returned source and must dispose it.
+    /// </summary>
+    public static CancellationTokenSource CreateDeadlineTokenSource(this ILambdaContext context)
+    {
+        var remaining = context.RemainingTime;
+        if (remaining <= TimeSpan.Zero)
+        {
+            var cancelled = new CancellationTokenSource();
+            cancelled.Cancel();
+            return cancelled;
+        }
+
+        // Leave a small margin so the HTTP call is abandoned before the hard Lambda timeout.
+        var budget = remaining - TimeSpan.FromMilliseconds(500);
+        if (budget <= TimeSpan.Zero)
+        {
+            budget = remaining;
+        }
+
+        return new CancellationTokenSource(budget);
+    }
+}

--- a/src/Honua.ControlPlane.Lambda/Honua.ControlPlane.Lambda.csproj
+++ b/src/Honua.ControlPlane.Lambda/Honua.ControlPlane.Lambda.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <!--
+      AOT-published, self-contained custom-runtime Lambda. This mirrors the AOT
+      posture of the serving image (Honua.Server). The entrypoint is intentionally
+      thin: it parses the EventBridge "Batch Job State Change" event (and the
+      Scheduler backstop tick), then forwards a single reconcile/sweep request to
+      the in-process Honua.Server host (running under the AWS Lambda Web Adapter)
+      over loopback HTTP. It deliberately does NOT ProjectReference Honua.Server:
+      the reconcile dispatcher's typed reconcilers transitively need most of the
+      server's infrastructure graph, so the one faithful composition is the
+      server's own. Keeping this project graph-free keeps the AOT surface tiny and
+      the cold start fast.
+    -->
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+    <StripSymbols>true</StripSymbols>
+    <OptimizationPreference>Speed</OptimizationPreference>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <RootNamespace>Honua.ControlPlane.Lambda</RootNamespace>
+    <AssemblyName>Honua.ControlPlane.Lambda</AssemblyName>
+    <!-- The Lambda custom-runtime bootstrap must be named "bootstrap" in the image. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Honua.ControlPlane.Lambda.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" />
+  </ItemGroup>
+
+</Project>

--- a/src/Honua.ControlPlane.Lambda/ReconcileForwarder.cs
+++ b/src/Honua.ControlPlane.Lambda/ReconcileForwarder.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.ControlPlane.Lambda;
+
+/// <summary>
+/// Forwards a single reconcile / backstop request to the in-process Honua.Server host running under
+/// the AWS Lambda Web Adapter, over the loopback HTTP port the adapter exposes. This is the seam that
+/// lets the thin event entrypoint reuse the server's fully-wired reconcile graph without re-composing
+/// the deep reconciler + store + backend dependency tree in this project.
+/// </summary>
+internal sealed class ReconcileForwarder(HttpClient httpClient, ReconcileForwarderOptions options)
+{
+    private const string BatchEventPath = "/internal/control-plane/events/batch-job-state-change";
+    private const string BackstopPath = "/internal/control-plane/backstop/sweep";
+
+    /// <summary>
+    /// Posts a Batch state-change reconcile for one provider job id. No-op when the id is null/blank
+    /// (a malformed or terminal event resolves to no active job).
+    /// </summary>
+    public async Task ReconcileBatchEventAsync(string? providerOperationId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(providerOperationId))
+        {
+            return;
+        }
+
+        var uri = $"{options.BaseAddress.TrimEnd('/')}{BatchEventPath}?providerOperationId={Uri.EscapeDataString(providerOperationId)}";
+        await PostAsync(uri, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Posts a single backstop sweep request.</summary>
+    public async Task RunBackstopAsync(CancellationToken cancellationToken)
+    {
+        var uri = $"{options.BaseAddress.TrimEnd('/')}{BackstopPath}";
+        await PostAsync(uri, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task PostAsync(string uri, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, uri);
+        if (!string.IsNullOrEmpty(options.EventToken))
+        {
+            request.Headers.TryAddWithoutValidation("X-Honua-ControlPlane-Token", options.EventToken);
+        }
+
+        using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+}
+
+/// <summary>Configuration for <see cref="ReconcileForwarder"/>, sourced from Lambda env vars.</summary>
+internal sealed class ReconcileForwarderOptions
+{
+    /// <summary>Loopback base address of the LWA-fronted host. Defaults to the adapter's port.</summary>
+    public required string BaseAddress { get; init; }
+
+    /// <summary>Optional shared secret sent as the control-plane event token header.</summary>
+    public string? EventToken { get; init; }
+
+    /// <summary>
+    /// Builds options from the Lambda environment: <c>AWS_LWA_PORT</c>/<c>PORT</c> (default 8080) for
+    /// the loopback address and <c>HONUA_CONTROL_PLANE_EVENT_TOKEN</c> for the shared secret.
+    /// </summary>
+    public static ReconcileForwarderOptions FromEnvironment(IReadOnlyDictionary<string, string?> env)
+    {
+        var port = FirstNonEmpty(env, "AWS_LWA_PORT", "PORT") ?? "8080";
+        return new ReconcileForwarderOptions
+        {
+            BaseAddress = $"http://127.0.0.1:{port}",
+            EventToken = FirstNonEmpty(env, "HONUA_CONTROL_PLANE_EVENT_TOKEN"),
+        };
+    }
+
+    private static string? FirstNonEmpty(IReadOnlyDictionary<string, string?> env, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (env.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Honua.Server/Features/ControlPlane/ControlPlaneEventEndpoints.cs
+++ b/src/Honua.Server/Features/ControlPlane/ControlPlaneEventEndpoints.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Internal HTTP entrypoints that drive a single execution-job reconcile / backstop sweep from an
+/// out-of-band trigger instead of the in-process poll loop. These are the cloud (event-driven)
+/// surface: an AWS Lambda invoked by EventBridge ("Batch Job State Change") or EventBridge Scheduler
+/// (the backstop timer) posts to these routes, the full Honua.Server host (running under the AWS
+/// Lambda Web Adapter) resolves the already-wired <see cref="ControlPlaneEventHandler"/> /
+/// <see cref="ExecutionJobBackstopSweepService"/>, reconciles once, and returns.
+/// <para>
+/// Hosting the reconcile on the FULL server graph (rather than re-composing the deep reconciler +
+/// store + backend dependency tree in a standalone Lambda) is deliberate: the dispatcher's typed
+/// reconcilers transitively need most of the server's infrastructure (durable stores, batch/deploy
+/// backends, metadata + data-plane services), so the one faithful composition is the server's own.
+/// The thin <c>Honua.ControlPlane.Lambda</c> entrypoint only parses the EventBridge event into a
+/// provider job id and posts here; this keeps a single source of truth for the reconcile graph and
+/// is AOT-trivial (query-string binding, no request-body JSON contract to source-generate).
+/// </para>
+/// <para>
+/// The routes are mapped only when <c>ControlPlane:TriggerMode = Event</c> and are protected by a
+/// shared-secret header (<c>X-Honua-ControlPlane-Token</c>) when a token is configured, because they
+/// are an internal control surface reachable only from the EventBridge-invoked Lambda inside the
+/// deployment's trust boundary, not a public API.
+/// </para>
+/// </summary>
+internal static class ControlPlaneEventEndpoints
+{
+    /// <summary>Header carrying the shared secret that authorizes an event/backstop invocation.</summary>
+    internal const string TokenHeader = "X-Honua-ControlPlane-Token";
+
+    internal sealed class ControlPlaneEventEndpointsLog;
+
+    /// <summary>
+    /// Maps the internal control-plane event + backstop routes. No-op unless the configured
+    /// <see cref="ControlPlaneTriggerOptions.TriggerMode"/> is <see cref="ControlPlaneTriggerMode.Event"/>,
+    /// so on-prem (poll) deployments never expose this surface.
+    /// </summary>
+    public static void MapControlPlaneEventEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var options = endpoints.ServiceProvider
+            .GetRequiredService<IOptions<ControlPlaneTriggerOptions>>().Value;
+        if (options.TriggerMode != ControlPlaneTriggerMode.Event)
+        {
+            return;
+        }
+
+        var group = endpoints.MapGroup("/internal/control-plane")
+            .WithTags("ControlPlane", "Internal")
+            .ExcludeFromDescription();
+
+        group.MapPost("/events/batch-job-state-change", HandleBatchJobStateChangeAsync)
+            .WithDisplayName("Control-plane Batch job state-change reconcile");
+
+        group.MapPost("/backstop/sweep", HandleBackstopSweepAsync)
+            .WithDisplayName("Control-plane backstop sweep");
+    }
+
+    /// <summary>
+    /// Reconciles the execution-job operation referenced by an AWS Batch state-change event once.
+    /// The Lambda has already extracted <c>detail.jobId</c> (the AWS Batch provider id) and passes it
+    /// as the <c>providerOperationId</c> query parameter.
+    /// </summary>
+    private static async Task<IResult> HandleBatchJobStateChangeAsync(
+        [FromQuery] string? providerOperationId,
+        [FromServices] ControlPlaneEventHandler handler,
+        [FromServices] IConfiguration configuration,
+        HttpRequest httpRequest,
+        CancellationToken cancellationToken)
+    {
+        if (!IsAuthorized(httpRequest, configuration))
+        {
+            return Results.Unauthorized();
+        }
+
+        await handler
+            .HandleExecutionJobEventAsync(providerOperationId ?? string.Empty, cancellationToken)
+            .ConfigureAwait(false);
+
+        return Results.Ok();
+    }
+
+    /// <summary>
+    /// Runs one backstop sweep (reconcile every stale non-terminal execution job) and returns.
+    /// EventBridge Scheduler posts here on a coarse timer so dropped/missed events self-heal.
+    /// </summary>
+    private static async Task<IResult> HandleBackstopSweepAsync(
+        [FromServices] ExecutionJobBackstopSweepService backstop,
+        [FromServices] IOptions<ControlPlaneTriggerOptions> options,
+        [FromServices] IConfiguration configuration,
+        HttpRequest httpRequest,
+        CancellationToken cancellationToken)
+    {
+        if (!IsAuthorized(httpRequest, configuration))
+        {
+            return Results.Unauthorized();
+        }
+
+        var staleThreshold = options.Value.StaleThreshold > TimeSpan.Zero
+            ? options.Value.StaleThreshold
+            : TimeSpan.FromSeconds(90);
+
+        await backstop.SweepOnceAsync(staleThreshold, cancellationToken).ConfigureAwait(false);
+        return Results.Ok();
+    }
+
+    private static bool IsAuthorized(HttpRequest httpRequest, IConfiguration configuration)
+    {
+        var expected = configuration["ControlPlane:EventToken"]
+            ?? configuration["HONUA_CONTROL_PLANE_EVENT_TOKEN"];
+
+        // No token configured => the surface is reachable only inside the deployment trust boundary
+        // (private VPC, EventBridge-invoked Lambda). When a token IS configured it is required and
+        // compared in fixed time.
+        if (string.IsNullOrEmpty(expected))
+        {
+            return true;
+        }
+
+        if (!httpRequest.Headers.TryGetValue(TokenHeader, out var provided) || provided.Count != 1)
+        {
+            return false;
+        }
+
+        return System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(
+            System.Text.Encoding.UTF8.GetBytes(provided.ToString()),
+            System.Text.Encoding.UTF8.GetBytes(expected));
+    }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -406,59 +406,14 @@ builder.Services.AddHonuaBatchAndDeployBackends();
 
 if (connectedRedis != null)
 {
-    builder.Services.AddSingleton<IWorkflowOperationStore, RedisWorkflowOperationStore>();
-    builder.Services.AddSingleton<IWorkflowOperationReconciler, DeployWorkflowReconciler>();
-    builder.Services.AddSingleton<IExecutionJobReconciler, ExecutionJobReconciler>();
-
-    // Additive metadata-release layer-evolution lifecycle: create service, stage-action services,
-    // reconciler, and its background loop. Sibling to the deploy reconciler; processes only
-    // WorkflowOperationKind.MetadataRelease.
-    builder.Services.AddSingleton<Honua.ControlPlane.MetadataReleaseControlService>();
-    builder.Services.AddSingleton<
-        Honua.Core.Features.ControlPlane.Abstractions.IMetadataReleasePreflightGate,
-        Honua.ControlPlane.MetadataReleasePreflightGate>();
-    builder.Services.AddSingleton<
-        Honua.Core.Features.ControlPlane.Abstractions.IMetadataReleaseScriptExecutor,
-        Honua.ControlPlane.MetadataReleaseScriptExecutor>();
-    builder.Services.AddSingleton<
-        Honua.Core.Features.ControlPlane.Abstractions.IMetadataReleaseDataJobDispatcher,
-        Honua.ControlPlane.MetadataReleaseDataJobDispatcher>();
-    builder.Services.AddSingleton<
-        Honua.Core.Features.ControlPlane.Abstractions.IMetadataReleaseActivator,
-        Honua.ControlPlane.MetadataReleaseActivator>();
-    builder.Services.AddSingleton<
-        Honua.Core.Features.ControlPlane.Abstractions.IMetadataReleaseSmokeChecker,
-        Honua.ControlPlane.MetadataReleaseSmokeChecker>();
-    builder.Services.AddSingleton<
-        Honua.Core.Features.ControlPlane.Abstractions.IMetadataReleaseOperationReconciler,
-        Honua.ControlPlane.MetadataReleaseReconciler>();
-
-    // Coordinated platform-upgrade release lifecycle (Demo C): conducts a container rollout, an
-    // additive DB script migration, and a metadata-v2 activation as one ordered, gated,
-    // rollback-able operation. Composes the deploy and metadata-release services via thin step
-    // executors rather than a parallel lifecycle.
-    builder.Services.AddSingleton<Honua.ControlPlane.CoordinatedReleaseControlService>();
-    builder.Services.AddSingleton<
-        Honua.Core.Features.ControlPlane.Abstractions.ICoordinatedContainerStepExecutor,
-        Honua.ControlPlane.CoordinatedContainerStepExecutor>();
-    builder.Services.AddSingleton<
-        Honua.Core.Features.ControlPlane.Abstractions.ICoordinatedMetadataStepExecutor,
-        Honua.ControlPlane.CoordinatedMetadataStepExecutor>();
-    builder.Services.AddSingleton<
-        Honua.Core.Features.ControlPlane.Abstractions.ICoordinatedReleaseReconciler,
-        Honua.ControlPlane.CoordinatedReleaseReconciler>();
-
-    // Control-plane hybrid-trigger seam (design option C).
+    // Control-plane reconcile graph (stores, four typed reconcilers, dispatcher seam, event handler,
+    // trigger options). Shared with the cloud event entrypoint (Honua.ControlPlane.Lambda) via
+    // ControlPlaneReconcileRegistration so both wire the exact same graph from one source of truth.
     // Phase 0: one dispatcher routes a reconcile-once request to the typed reconciler that owns the
     // operation kind. Both the poll loops and the Phase 1 event handler call this single method.
     // Phase 1: the event handler is the cloud (EventBridge -> Lambda) entrypoint, and the backstop
     // sweep self-heals dropped events; the TriggerMode flag chooses poll (on-prem) vs event (cloud).
-    builder.Services.Configure<Honua.ControlPlane.ControlPlaneTriggerOptions>(
-        builder.Configuration.GetSection(Honua.ControlPlane.ControlPlaneTriggerOptions.SectionName));
-    builder.Services.AddSingleton<
-        Honua.Core.Features.ControlPlane.Abstractions.IOperationReconcileDispatcher,
-        Honua.ControlPlane.OperationReconcileDispatcher>();
-    builder.Services.AddSingleton<Honua.ControlPlane.ControlPlaneEventHandler>();
+    builder.Services.AddHonuaControlPlaneReconcilers(builder.Configuration);
 
     var controlPlaneTriggerMode = builder.Configuration
         .GetSection(Honua.ControlPlane.ControlPlaneTriggerOptions.SectionName)
@@ -474,12 +429,15 @@ if (connectedRedis != null)
         if (controlPlaneTriggerMode == Honua.ControlPlane.ControlPlaneTriggerMode.Poll)
         {
             builder.Services.AddHostedService<ExecutionJobReconcilerBackgroundService>();
-        }
 
-        // The backstop sweep ships with Phase 1 and runs in BOTH modes so a dropped/missed event
-        // (or, under poll, a wedged loop) self-heals. It is low-frequency and is a no-op when the
-        // active jobs are fresh.
-        builder.Services.AddHostedService<Honua.ControlPlane.ExecutionJobBackstopSweepService>();
+            // The in-process backstop timer self-heals a wedged poll loop. In Event mode the timer is
+            // NOT hosted: EventBridge Scheduler drives the same SweepOnceAsync via the internal HTTP
+            // entrypoint (ControlPlaneEventEndpoints), so the host has no always-on control-plane timer.
+            // The backstop service itself is registered as a resolvable singleton in both modes by
+            // AddHonuaControlPlaneReconcilers, so the endpoint can drive it on demand.
+            builder.Services.AddHostedService(
+                sp => sp.GetRequiredService<Honua.ControlPlane.ExecutionJobBackstopSweepService>());
+        }
 
         builder.Services.AddHostedService<Honua.ControlPlane.MetadataReleaseReconcilerBackgroundService>();
         builder.Services.AddHostedService<Honua.ControlPlane.CoordinatedReleaseReconcilerBackgroundService>();
@@ -1320,6 +1278,10 @@ app.MapMetadataReleaseControlEndpoints();
 app.MapCoordinatedReleaseControlEndpoints();
 app.MapMetadataPrevalidationEndpoints();
 app.MapDeployControlEndpoints();
+
+// Cloud event-driven control-plane surface (TriggerMode=Event only): the EventBridge-invoked
+// reconcile Lambda + EventBridge Scheduler backstop post here. No-op under poll (on-prem).
+app.MapControlPlaneEventEndpoints();
 
 // Console approval surface for agent-proposed operations (#1694).
 app.MapProposalEndpoints();

--- a/src/Honua.Server/Startup/ControlPlaneReconcileRegistration.cs
+++ b/src/Honua.Server/Startup/ControlPlaneReconcileRegistration.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Startup;
+
+/// <summary>
+/// Shared registration for the control-plane reconcile graph: the durable Redis-backed operation
+/// stores, the four typed reconcilers (deploy workflow, execution job, metadata release, coordinated
+/// release), the single <see cref="IOperationReconcileDispatcher"/> seam, the event handler, and the
+/// trigger options.
+/// <para>
+/// This is the ONE source of truth for the reconcile-side composition so the long-running server host
+/// (<c>Program.cs</c>) and the cloud event surface (<c>ControlPlaneEventEndpoints</c>, driven by the
+/// <c>Honua.ControlPlane.Lambda</c> entrypoint) wire the exact same graph. It deliberately registers only
+/// the reconcile services; the long-running host adds the poll/backstop <c>BackgroundService</c>s and the
+/// agent-approval gateway separately because those are host-lifecycle concerns, not part of a single
+/// cold-start-reconcile-exit Lambda invocation.
+/// </para>
+/// </summary>
+internal static class ControlPlaneReconcileRegistration
+{
+    /// <summary>
+    /// Registers the control-plane reconcile graph (stores, reconcilers, dispatcher, event handler,
+    /// trigger options). Requires that the batch + deploy backends (<c>AddHonuaBatchAndDeployBackends</c>),
+    /// the Redis multiplexer, and the control-plane HTTP clients are already registered.
+    /// </summary>
+    public static IServiceCollection AddHonuaControlPlaneReconcilers(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddSingleton<IWorkflowOperationStore, RedisWorkflowOperationStore>();
+        services.AddSingleton<IWorkflowOperationReconciler, DeployWorkflowReconciler>();
+        services.AddSingleton<IExecutionJobReconciler, ExecutionJobReconciler>();
+
+        // Additive metadata-release layer-evolution lifecycle: create service, stage-action services,
+        // reconciler, and its background loop. Sibling to the deploy reconciler; processes only
+        // WorkflowOperationKind.MetadataRelease.
+        services.AddSingleton<MetadataReleaseControlService>();
+        services.AddSingleton<IMetadataReleasePreflightGate, MetadataReleasePreflightGate>();
+        services.AddSingleton<IMetadataReleaseScriptExecutor, MetadataReleaseScriptExecutor>();
+        services.AddSingleton<IMetadataReleaseDataJobDispatcher, MetadataReleaseDataJobDispatcher>();
+        services.AddSingleton<IMetadataReleaseActivator, MetadataReleaseActivator>();
+        services.AddSingleton<IMetadataReleaseSmokeChecker, MetadataReleaseSmokeChecker>();
+        services.AddSingleton<IMetadataReleaseOperationReconciler, MetadataReleaseReconciler>();
+
+        // Coordinated platform-upgrade release lifecycle (Demo C): conducts a container rollout, an
+        // additive DB script migration, and a metadata-v2 activation as one ordered, gated,
+        // rollback-able operation. Composes the deploy and metadata-release services via thin step
+        // executors rather than a parallel lifecycle.
+        services.AddSingleton<CoordinatedReleaseControlService>();
+        services.AddSingleton<ICoordinatedContainerStepExecutor, CoordinatedContainerStepExecutor>();
+        services.AddSingleton<ICoordinatedMetadataStepExecutor, CoordinatedMetadataStepExecutor>();
+        services.AddSingleton<ICoordinatedReleaseReconciler, CoordinatedReleaseReconciler>();
+
+        // Control-plane hybrid-trigger seam (design option C).
+        // Phase 0: one dispatcher routes a reconcile-once request to the typed reconciler that owns the
+        // operation kind. Both the poll loops and the Phase 1 event handler call this single method.
+        // Phase 1: the event handler is the cloud (EventBridge -> Lambda) entrypoint, and the backstop
+        // sweep self-heals dropped events; the TriggerMode flag chooses poll (on-prem) vs event (cloud).
+        services.Configure<ControlPlaneTriggerOptions>(
+            configuration.GetSection(ControlPlaneTriggerOptions.SectionName));
+        services.AddSingleton<IOperationReconcileDispatcher, OperationReconcileDispatcher>();
+        services.AddSingleton<ControlPlaneEventHandler>();
+
+        // The backstop sweep is registered as a resolvable singleton so the EventBridge-Scheduler
+        // entrypoint (ControlPlaneEventEndpoints) can drive a single sweep on demand. The long-running
+        // host additionally registers it as a hosted timer in Poll mode (see Program.cs); in Event mode
+        // the scheduler drives SweepOnceAsync instead, so the timer is not hosted.
+        services.AddSingleton<ExecutionJobBackstopSweepService>();
+
+        return services;
+    }
+}

--- a/tests/dotnet/Honua.ControlPlane.Lambda.Tests/BatchEventParserTests.cs
+++ b/tests/dotnet/Honua.ControlPlane.Lambda.Tests/BatchEventParserTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane.Lambda;
+using Xunit;
+
+namespace Honua.ControlPlane.Lambda.Tests;
+
+/// <summary>
+/// Tests the event-deserialization contract: a canonical EventBridge "Batch Job State Change" event
+/// JSON deserializes to the provider job id (<c>detail.jobId</c>) that the reconcile entrypoint
+/// forwards, and malformed / non-matching / terminal payloads resolve to a clean no-op (null).
+/// </summary>
+public sealed class BatchEventParserTests
+{
+    // A representative AWS Batch "Batch Job State Change" EventBridge event (trimmed to the shape the
+    // parser depends on, with extra detail fields present to prove unknown members are tolerated).
+    private const string SampleBatchStateChangeEvent = """
+    {
+      "version": "0",
+      "id": "c8f9c4b5-1f5b-4c2a-9b1e-1a2b3c4d5e6f",
+      "detail-type": "Batch Job State Change",
+      "source": "aws.batch",
+      "account": "123456789012",
+      "time": "2026-06-21T12:34:56Z",
+      "region": "us-east-1",
+      "resources": [
+        "arn:aws:batch:us-east-1:123456789012:job/26c7b4e8-1234-4abc-9def-0123456789ab"
+      ],
+      "detail": {
+        "jobArn": "arn:aws:batch:us-east-1:123456789012:job/26c7b4e8-1234-4abc-9def-0123456789ab",
+        "jobName": "honua-gp-export",
+        "jobId": "26c7b4e8-1234-4abc-9def-0123456789ab",
+        "jobQueue": "arn:aws:batch:us-east-1:123456789012:job-queue/honua",
+        "status": "SUCCEEDED",
+        "createdAt": 1750000000000,
+        "container": { "image": "honua/worker:latest" }
+      }
+    }
+    """;
+
+    [Fact]
+    public void ExtractProviderOperationId_FromSampleBatchEventJson_ReturnsDetailJobId()
+    {
+        var providerId = BatchEventParser.ExtractProviderOperationId(SampleBatchStateChangeEvent);
+
+        providerId.Should().Be("26c7b4e8-1234-4abc-9def-0123456789ab");
+    }
+
+    [Fact]
+    public void ExtractProviderOperationId_NullOrBlankJson_ReturnsNull()
+    {
+        BatchEventParser.ExtractProviderOperationId((string?)null).Should().BeNull();
+        BatchEventParser.ExtractProviderOperationId("   ").Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractProviderOperationId_MalformedJson_ReturnsNullAndDoesNotThrow()
+    {
+        BatchEventParser.ExtractProviderOperationId("{ not json").Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractProviderOperationId_WrongDetailType_ReturnsNull()
+    {
+        const string wrongType = """
+        { "source": "aws.batch", "detail-type": "EC2 Instance State-change Notification",
+          "detail": { "jobId": "should-be-ignored" } }
+        """;
+
+        BatchEventParser.ExtractProviderOperationId(wrongType).Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractProviderOperationId_WrongSource_ReturnsNull()
+    {
+        const string wrongSource = """
+        { "source": "aws.ec2", "detail-type": "Batch Job State Change",
+          "detail": { "jobId": "should-be-ignored" } }
+        """;
+
+        BatchEventParser.ExtractProviderOperationId(wrongSource).Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractProviderOperationId_MissingDetailOrJobId_ReturnsNull()
+    {
+        BatchEventParser.ExtractProviderOperationId(
+            """{ "source": "aws.batch", "detail-type": "Batch Job State Change" }""")
+            .Should().BeNull();
+
+        BatchEventParser.ExtractProviderOperationId(
+            """{ "source": "aws.batch", "detail-type": "Batch Job State Change", "detail": { "status": "RUNNING" } }""")
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractProviderOperationId_FromTypedEvent_ReturnsJobId()
+    {
+        var evt = new BatchJobStateChangeEvent
+        {
+            Source = BatchEventParser.ExpectedSource,
+            DetailType = BatchEventParser.ExpectedDetailType,
+            Detail = new BatchJobStateChangeDetail { JobId = "batch-job-xyz", Status = "RUNNING" },
+        };
+
+        BatchEventParser.ExtractProviderOperationId(evt).Should().Be("batch-job-xyz");
+    }
+}

--- a/tests/dotnet/Honua.ControlPlane.Lambda.Tests/Honua.ControlPlane.Lambda.Tests.csproj
+++ b/tests/dotnet/Honua.ControlPlane.Lambda.Tests/Honua.ControlPlane.Lambda.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591;CA1861</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Honua.ControlPlane.Lambda\Honua.ControlPlane.Lambda.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/dotnet/Honua.ControlPlane.Lambda.Tests/ReconcileForwarderTests.cs
+++ b/tests/dotnet/Honua.ControlPlane.Lambda.Tests/ReconcileForwarderTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http;
+using FluentAssertions;
+using Honua.ControlPlane.Lambda;
+using Xunit;
+
+namespace Honua.ControlPlane.Lambda.Tests;
+
+/// <summary>
+/// Tests that the forwarder targets the in-process host's internal reconcile routes with the provider
+/// id and shared-secret header, and no-ops when there is nothing to reconcile.
+/// </summary>
+public sealed class ReconcileForwarderTests
+{
+    [Fact]
+    public async Task ReconcileBatchEventAsync_PostsProviderIdAndTokenHeader()
+    {
+        var handler = new RecordingHandler();
+        var forwarder = new ReconcileForwarder(
+            new HttpClient(handler),
+            new ReconcileForwarderOptions { BaseAddress = "http://127.0.0.1:8080", EventToken = "secret-token" });
+
+        await forwarder.ReconcileBatchEventAsync("batch-job-abc", CancellationToken.None);
+
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.AbsolutePath.Should().Be("/internal/control-plane/events/batch-job-state-change");
+        handler.LastRequest.RequestUri.Query.Should().Contain("providerOperationId=batch-job-abc");
+        handler.LastRequest.Headers.GetValues("X-Honua-ControlPlane-Token").Should().ContainSingle()
+            .Which.Should().Be("secret-token");
+    }
+
+    [Fact]
+    public async Task ReconcileBatchEventAsync_BlankProviderId_DoesNotPost()
+    {
+        var handler = new RecordingHandler();
+        var forwarder = new ReconcileForwarder(
+            new HttpClient(handler),
+            new ReconcileForwarderOptions { BaseAddress = "http://127.0.0.1:8080" });
+
+        await forwarder.ReconcileBatchEventAsync(" ", CancellationToken.None);
+
+        handler.LastRequest.Should().BeNull("a blank provider id resolves to no active job");
+    }
+
+    [Fact]
+    public async Task RunBackstopAsync_PostsToBackstopRoute()
+    {
+        var handler = new RecordingHandler();
+        var forwarder = new ReconcileForwarder(
+            new HttpClient(handler),
+            new ReconcileForwarderOptions { BaseAddress = "http://127.0.0.1:8080" });
+
+        await forwarder.RunBackstopAsync(CancellationToken.None);
+
+        handler.LastRequest!.RequestUri!.AbsolutePath.Should().Be("/internal/control-plane/backstop/sweep");
+        handler.LastRequest.Headers.Contains("X-Honua-ControlPlane-Token").Should().BeFalse();
+    }
+
+    [Fact]
+    public void FromEnvironment_UsesLwaPortAndToken()
+    {
+        var options = ReconcileForwarderOptions.FromEnvironment(new Dictionary<string, string?>
+        {
+            ["AWS_LWA_PORT"] = "9000",
+            ["HONUA_CONTROL_PLANE_EVENT_TOKEN"] = "tok",
+        });
+
+        options.BaseAddress.Should().Be("http://127.0.0.1:9000");
+        options.EventToken.Should().Be("tok");
+    }
+
+    [Fact]
+    public void FromEnvironment_DefaultsPortTo8080()
+    {
+        var options = ReconcileForwarderOptions.FromEnvironment(new Dictionary<string, string?>());
+
+        options.BaseAddress.Should().Be("http://127.0.0.1:8080");
+        options.EventToken.Should().BeNull();
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to the control-plane hybrid-trigger Phase 1 (follow-on to #2190).

## Summary
Adds the cloud Lambda entrypoint host for the control-plane hybrid trigger so `ControlPlane:TriggerMode=Event` is actually deployable in cloud with no always-on control-plane host. Stacks on the `feat/control-plane-event-triggers` branch (#2190): that PR added the dispatcher seam, the GP event handler, the backstop sweep, and the `TriggerMode` flag but had no Lambda host or HTTP surface to invoke them. This PR hosts them.

Two event entrypoints are wired:
- a **Batch-event handler** that deserializes an EventBridge "Batch Job State Change" event, extracts `detail.jobId` (the AWS Batch provider id), and drives one execution-job reconcile; and
- a **backstop handler** invoked by EventBridge Scheduler on a ~2-minute timer that runs one backstop sweep.

Design note: the reconcile dispatcher's typed reconcilers transitively need most of the server's infrastructure graph (durable stores, batch/deploy backends, metadata + data-plane services), so the one faithful composition is the server's own. The new thin `Honua.ControlPlane.Lambda` custom-runtime entrypoint therefore parses the EventBridge event and forwards a single reconcile/backstop request to the in-process Honua.Server host (running under the AWS Lambda Web Adapter, the same way the API already deploys to Lambda) over loopback HTTP. The host carries the fully-wired graph via a new shared registration extension so the long-running host and the cloud entrypoint wire the exact same reconcile services from one source of truth.

## Changes Made
- New `src/Honua.ControlPlane.Lambda` AOT custom-runtime project (Amazon.Lambda.RuntimeSupport + source-generated serializer): two handlers selected by `HONUA_CONTROL_PLANE_LAMBDA_HANDLER` (`batch-event` | `backstop`); thin `BatchEventParser` (deserialize event → `detail.jobId`) and `ReconcileForwarder` (post to the host's internal routes).
- New internal HTTP surface on the host (`ControlPlaneEventEndpoints`): `POST /internal/control-plane/events/batch-job-state-change` and `/backstop/sweep`, mapped only when `TriggerMode=Event`, token-guarded (`X-Honua-ControlPlane-Token`).
- New `ControlPlaneReconcileRegistration.AddHonuaControlPlaneReconcilers` extracted from `Program.cs` as the single source of truth for the reconcile graph; `Program.cs` now calls it. In Event mode the in-process backstop timer is not hosted (the Scheduler drives the same `SweepOnceAsync`); the backstop service is also registered as a resolvable singleton.
- `docker/Dockerfile.controlplane-lambda` + entrypoint script: builds the server (AOT) and the thin bootstrap into one image; the host serves the internal routes via LWA, the bootstrap handles each EventBridge invocation.
- `Amazon.Lambda.Core` / `Amazon.Lambda.RuntimeSupport` / `Amazon.Lambda.Serialization.SystemTextJson` added to `Directory.Packages.props`; projects added to `Honua.sln`; CI step added to run the new unit tests.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

12 unit tests cover the event-deserialization contract (sample Batch State Change event JSON → the right provider id; malformed/wrong-source/wrong-type/missing → clean no-op) and the forwarder (route/query/token/no-op). `dotnet test` on the new project: Passed 12, Failed 0.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires infrastructure changes
- [x] Requires environment variable or secret changes

Pairs with honua-iac PR #75 (gated EventBridge + Scheduler + IAM wiring). The deployed image must contain the new Lambda handler entrypoints; the iac `control_plane_events_image` variable points the reconcile/backstop Lambdas at that image.

## Breaking Changes
None. Poll (on-prem) mode is byte-for-byte unchanged; the new surface is inert unless `TriggerMode=Event`.

---

## Pre-PR Checklist
- [x] Ran the affected build + unit tests and all checks passed
- [x] Commit messages follow conventional format
- [x] PR title matches main commit message
- [x] Tests added for new functionality
