### PR TITLE
feat(geoprocessing): GP Devkit native-profile container-exec fidelity (#2180)

### DIFF
--- a/docker/worker-gdal/README.md
+++ b/docker/worker-gdal/README.md
@@ -76,3 +76,45 @@ assembly (including `Honua.Server`), so the lean serving image's
 package-graph and cold-start budget are completely unaffected. The CLI binaries
 come from the base image layer. The `IGdalCommandRunner` seam also lets the
 executor logic be unit-tested without GDAL installed.
+
+## GP Devkit container-exec fidelity (`--real-worker`, #2180)
+
+The GP Devkit local runner (`honua gp run`) executes the real executor in-process
+for a sub-second loop. For **managed** ops that is full fidelity. For **native**
+(`gdal.*`) ops the in-process path never crosses the image / driver-set / CRS-data /
+arg-handling boundary a production native submit crosses (the job is packaged into
+*this* image and dispatched by Batch) — a `gdal.hillshade` that passes locally
+against a host's GDAL could still fail at that boundary.
+
+`honua gp run … --real-worker` (alias `--container`) closes that cliff: it runs each
+GDAL tool inside **this image** via `DockerGdalCommandRunner` instead of the host
+CLIs. It is **opt-in** and auto-selected only when the image is already present
+locally, so the managed loop is never blocked on a pull (`--in-process` forces the
+fast path). The runner is correct-by-construction:
+
+- Each native executor does all file I/O inside a per-job scratch workspace under
+  `GdalWorker:ScratchRoot` and passes absolute workspace paths to the tool.
+- `DockerGdalCommandRunner` bind-mounts that workspace at the **identical absolute
+  path** (`docker run --rm --network none --user 1001:1001 -v <ws>:<ws> -w <ws>
+  --entrypoint <tool> honua-worker-etl <args…>`), so the executor's absolute paths
+  resolve to the same files inside the container, and outputs land back on the host
+  workspace for read-back. The executor code path is byte-for-byte unchanged — only
+  the `IGdalCommandRunner` implementation differs.
+
+The `docker run` invocation (image ref, mount, working dir, user, entrypoint
+override, arg ordering) is unit-tested offline against a fake container-runtime seam
+(`DockerGdalCommandRunnerTests`); the **end-to-end container run** is
+CI / local-Docker-verified — it needs a Docker daemon and the `honua-worker-etl`
+image (`docker build -f docker/worker-gdal/Dockerfile -t honua-worker-etl .`).
+
+Build the image and run a native op against it:
+
+```sh
+DOCKER_BUILDKIT=1 docker build -f docker/worker-gdal/Dockerfile -t honua-worker-etl .
+honua gp run gdal.ogr2ogr --input in.geojson \
+  --param sourceFormat=GeoJSON --param targetFormat=CSV --out out.csv --real-worker
+```
+
+`gp run`/`gp plan` build the **same** `ExecutionJobSpec` the production submit path
+produces (both project through `GeoprocessingSpecBuilder`), so "plan" is a true
+dry-run of the real native submit spec, not a parallel representation.

--- a/src/Honua.Geoprocessing.Cli/GpCli.cs
+++ b/src/Honua.Geoprocessing.Cli/GpCli.cs
@@ -58,7 +58,7 @@ public static class GpCli
         }
     }
 
-    private static ServiceProvider BuildProvider()
+    private static ServiceProvider BuildProvider(GdalProcessExecutorMode gdalMode = GdalProcessExecutorMode.InProcess)
     {
         // Empty in-memory configuration: AddGeoprocessing binds its option sections
         // from configuration but every option has a valid default, and the
@@ -75,7 +75,11 @@ public static class GpCli
         // Managed geometry/analytics/transform/source/sink executors.
         services.AddGeoprocessing(configuration);
         // Native GDAL executors (Redis-free seam: options + CLI runner + executors only).
-        services.AddGdalProcessExecutors(configuration);
+        // In container mode (--real-worker, #2180) each native gdal.* step runs inside
+        // the real honua-worker-etl image so gp run/plan is a true dry-run of the
+        // native submit path; the managed executor set and the durable spec are
+        // unchanged — only the GDAL command runner differs.
+        services.AddGdalProcessExecutors(configuration, gdalMode);
 
         return services.BuildServiceProvider();
     }
@@ -114,6 +118,9 @@ public static class GpCli
         var processId = args[0];
         string? inputPath = null;
         string? outPath = null;
+        // null = auto: use the container path when the worker image is present locally,
+        // else the fast in-process path. true = force container, false = force in-process.
+        bool? forceContainer = null;
         var inputs = new Dictionary<string, string>(StringComparer.Ordinal);
 
         for (var i = 1; i < args.Length; i++)
@@ -125,6 +132,12 @@ public static class GpCli
                     break;
                 case "--out" or "-o":
                     outPath = NextValue(args, ref i, "--out");
+                    break;
+                case "--container" or "--real-worker":
+                    forceContainer = true;
+                    break;
+                case "--in-process":
+                    forceContainer = false;
                     break;
                 case "--param" or "-p":
                     var kv = NextValue(args, ref i, "--param");
@@ -141,7 +154,8 @@ public static class GpCli
             }
         }
 
-        using var provider = BuildProvider();
+        var gdalMode = await ResolveGdalModeAsync(forceContainer).ConfigureAwait(false);
+        using var provider = BuildProvider(gdalMode);
         var executors = provider.GetServices<IProcessExecutor>();
         var runner = new GeoprocessingLocalRunner(executors);
 
@@ -178,6 +192,7 @@ public static class GpCli
         var result = await runner.RunAsync(processId, inputs).ConfigureAwait(false);
 
         Console.WriteLine($"process : {result.ProcessId}");
+        Console.WriteLine($"runner  : {(gdalMode == GdalProcessExecutorMode.Container ? "container (honua-worker-etl image)" : "in-process")}");
         Console.WriteLine($"status  : {result.Status}");
         Console.WriteLine($"elapsed : {result.Elapsed.TotalMilliseconds:F1} ms");
 
@@ -220,6 +235,46 @@ public static class GpCli
         }
 
         return 0;
+    }
+
+    /// <summary>
+    /// Resolves which GDAL command-runner mode <c>gp run</c> uses for native ops
+    /// (issue #2180), honoring an explicit <c>--real-worker</c>/<c>--in-process</c>
+    /// override and otherwise auto-selecting the container path only when the worker
+    /// image is already present locally (so the managed sub-second loop is never
+    /// blocked on a pull).
+    /// <list type="bullet">
+    /// <item><c>--real-worker</c> (force container): fails fast when the worker image is
+    /// absent so a developer who asked for full fidelity is not silently downgraded.</item>
+    /// <item><c>--in-process</c> (force fast): always the host CLIs.</item>
+    /// <item>default (auto): container when the image is available, else in-process.</item>
+    /// </list>
+    /// </summary>
+    private static async Task<GdalProcessExecutorMode> ResolveGdalModeAsync(bool? forceContainer)
+    {
+        if (forceContainer == false)
+        {
+            return GdalProcessExecutorMode.InProcess;
+        }
+
+        var imageAvailable = await GdalContainerProbe.IsImageAvailableAsync().ConfigureAwait(false);
+
+        if (forceContainer == true)
+        {
+            if (!imageAvailable)
+            {
+                throw new GpCliUsageException(
+                    $"--real-worker requires the '{GdalContainerProbe.DefaultImage}' worker image, which is not " +
+                    "available in the local container runtime. Build it with "
+                    + "'docker build -f docker/worker-gdal/Dockerfile -t honua-worker-etl .', or drop "
+                    + "--real-worker to use the fast in-process path.");
+            }
+
+            return GdalProcessExecutorMode.Container;
+        }
+
+        // Auto: prefer the real-worker fidelity path when the image is already present.
+        return imageAvailable ? GdalProcessExecutorMode.Container : GdalProcessExecutorMode.InProcess;
     }
 
     /// <summary>
@@ -301,12 +356,17 @@ public static class GpCli
         Console.WriteLine();
         Console.WriteLine("Usage:");
         Console.WriteLine("  honua gp list");
-        Console.WriteLine("  honua gp run <processId> [--input <file>] [--param k=v ...] [--out <file>]");
+        Console.WriteLine("  honua gp run <processId> [--input <file>] [--param k=v ...] [--out <file>] [--real-worker]");
         Console.WriteLine();
         Console.WriteLine("Options:");
         Console.WriteLine("  --input, -i <file>  Read a file and bind it (base64) to the process's primary input.");
         Console.WriteLine("  --param, -p k=v     Set a step-0 input (repeatable). Overrides --input for the same key.");
         Console.WriteLine("  --out,   -o <file>  Write the first published artifact's bytes to <file>.");
+        Console.WriteLine("  --real-worker       Run native gdal.* steps inside the real honua-worker-etl");
+        Console.WriteLine("  (--container)       image (docker run) instead of the host GDAL CLIs, so the run");
+        Console.WriteLine("                      crosses the same image/CRS/arg boundary a native submit does.");
+        Console.WriteLine("                      Default: auto (container when the image is present, else in-process).");
+        Console.WriteLine("  --in-process        Force the fast host-CLI path even when the worker image is present.");
         Console.WriteLine();
         Console.WriteLine("Examples:");
         Console.WriteLine("  honua gp run geometry.buffer --param wkb=<base64> --param srid=4326 --param distance=10");

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -332,66 +332,18 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         ExecutionJobDefinition? workload,
         string? requiredRuntimeProfile)
     {
-        specParams[ExecutionJobParameterKeys.GeoprocessingPlanId] = plan.PlanId;
-        var processDefinitions = plan.Steps
-            .Where(step => !string.IsNullOrWhiteSpace(step.ProcessId))
-            .Select(step => step.ProcessId!)
-            .ToArray();
-        if (processDefinitions.Length > 0)
-        {
-            specParams[ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = string.Join(
-                ExecutionJobParameterKeys.MetadataListSeparator,
-                processDefinitions);
-        }
-
-        var outputKinds = plan.Outputs.Select(output => output.ToString()).ToArray();
-        if (outputKinds.Length > 0)
-        {
-            specParams[ExecutionJobParameterKeys.GeoprocessingOutputArtifactKinds] = string.Join(
-                ExecutionJobParameterKeys.MetadataListSeparator,
-                outputKinds);
-        }
-
-        // Project plan step inputs onto the durable spec under a stable prefix so
-        // worker-side executors can read their parameters without reaching back into
-        // the analysis plan. Only `Geoprocess` steps carry semantic inputs in the
-        // first-slice catalog; other kinds are ignored here.
-        for (var stepIndex = 0; stepIndex < plan.Steps.Count; stepIndex++)
-        {
-            var step = plan.Steps[stepIndex];
-            if (step.Kind != AnalysisPlanStepKind.Geoprocess || step.Inputs.Count == 0)
-            {
-                continue;
-            }
-
-            foreach (var input in step.Inputs)
-            {
-                if (string.IsNullOrWhiteSpace(input.Key))
-                {
-                    continue;
-                }
-
-                var key = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}{stepIndex}.{input.Key}";
-                specParams[key] = input.Value ?? string.Empty;
-            }
-        }
-
         if (workload == null)
         {
-            return new ExecutionJobSpec
-            {
-                Kind = ExecutionJobKind.Geoprocessing,
-                TargetKind = BatchComputeTargetKind.KubernetesJob,
-                Backend = LocalBatchComputeBackend.BackendId,
-                WorkloadName = $"geoprocessing:{plan.PlanId}",
-                // Data-driven native-profile stamping: a catalog process that
-                // requires a specialized worker (the gdal.* native family) forces
-                // this profile so the claim fence routes the job to the GDAL worker
-                // and away from the lean dispatcher. Null leaves the job managed/default.
-                RuntimeProfile = requiredRuntimeProfile,
-                Parameters = specParams
-            };
+            // The no-registered-workload case (the default) is built through the shared
+            // spec builder so the durable spec — parameter bag AND envelope — is
+            // identical to the one the GP Devkit local runner produces for the same
+            // plan (issue #2180).
+            return GeoprocessingSpecBuilder.BuildNoWorkloadSpec(plan, specParams, requiredRuntimeProfile);
         }
+
+        // Project the plan's id / process-definitions / output kinds / step inputs onto
+        // the workload-supplied parameter bag through the same shared projection.
+        GeoprocessingSpecBuilder.ProjectPlanParameters(plan, specParams);
 
         foreach (var kv in workload.Parameters)
         {

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingSpecBuilder.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingSpecBuilder.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.ControlPlane;
+
+namespace Honua.Geoprocessing;
+
+/// <summary>
+/// Single source of truth for projecting an <see cref="AnalysisPlan"/> onto the
+/// durable <see cref="ExecutionJobSpec.Parameters"/> bag the worker reads back.
+/// Both the production submit path (<c>GeoprocessingJobService.BuildSpec</c>) and
+/// the GP Devkit local runner (<c>GeoprocessingLocalRunner</c>) build their spec
+/// parameters through this one helper so the spec the local dry-run carries is the
+/// IDENTICAL spec a real submit would produce for the same plan — closing the
+/// "plan is a parallel representation" gap flagged by issue #2180.
+/// </summary>
+internal static class GeoprocessingSpecBuilder
+{
+    /// <summary>
+    /// Projects <paramref name="plan"/>'s id, process-definitions list, output-artifact
+    /// kinds, and per-step inputs into <paramref name="specParams"/> under the canonical
+    /// <c>ExecutionJobParameterKeys</c> keys. Mutates and returns the supplied bag so the
+    /// submit path can layer admission/partition/workload parameters around this core
+    /// projection. The local runner passes a fresh bag and gets exactly the durable
+    /// parameters a worker dispatches on.
+    /// </summary>
+    public static Dictionary<string, string> ProjectPlanParameters(
+        AnalysisPlan plan,
+        Dictionary<string, string> specParams)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(specParams);
+
+        specParams[ExecutionJobParameterKeys.GeoprocessingPlanId] = plan.PlanId;
+
+        var processDefinitions = plan.Steps
+            .Where(step => !string.IsNullOrWhiteSpace(step.ProcessId))
+            .Select(step => step.ProcessId!)
+            .ToArray();
+        if (processDefinitions.Length > 0)
+        {
+            specParams[ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = string.Join(
+                ExecutionJobParameterKeys.MetadataListSeparator,
+                processDefinitions);
+        }
+
+        var outputKinds = plan.Outputs.Select(output => output.ToString()).ToArray();
+        if (outputKinds.Length > 0)
+        {
+            specParams[ExecutionJobParameterKeys.GeoprocessingOutputArtifactKinds] = string.Join(
+                ExecutionJobParameterKeys.MetadataListSeparator,
+                outputKinds);
+        }
+
+        // Project plan step inputs onto the durable spec under a stable prefix so
+        // worker-side executors can read their parameters without reaching back into
+        // the analysis plan. Only `Geoprocess` steps carry semantic inputs in the
+        // first-slice catalog; other kinds are ignored here.
+        for (var stepIndex = 0; stepIndex < plan.Steps.Count; stepIndex++)
+        {
+            var step = plan.Steps[stepIndex];
+            if (step.Kind != AnalysisPlanStepKind.Geoprocess || step.Inputs.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (var input in step.Inputs)
+            {
+                if (string.IsNullOrWhiteSpace(input.Key))
+                {
+                    continue;
+                }
+
+                var key = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}{stepIndex}.{input.Key}";
+                specParams[key] = input.Value ?? string.Empty;
+            }
+        }
+
+        return specParams;
+    }
+
+    /// <summary>
+    /// Builds the <see cref="ExecutionJobSpec"/> for the no-registered-workload case —
+    /// the shape both the production submit path (when no
+    /// <c>ExecutionJobDefinition</c> is registered for the geoprocessing kind, the
+    /// default) and the GP Devkit local runner produce. Centralizing it here makes the
+    /// local dry-run's spec IDENTICAL to a real submit's by construction: same Kind /
+    /// TargetKind / Backend / WorkloadName / RuntimeProfile, and the same parameter bag
+    /// from <see cref="ProjectPlanParameters"/>.
+    /// </summary>
+    /// <param name="plan">The analysis plan to project.</param>
+    /// <param name="specParams">
+    /// The parameter bag to project into (the submit path seeds protocol/admission
+    /// metadata first; the local runner passes a fresh bag).
+    /// </param>
+    /// <param name="requiredRuntimeProfile">
+    /// The data-driven runtime profile (<c>native</c> for a gdal.* step; <c>null</c>
+    /// leaves the job managed/default). Drives the claim fence to the right worker.
+    /// </param>
+    public static ExecutionJobSpec BuildNoWorkloadSpec(
+        AnalysisPlan plan,
+        Dictionary<string, string> specParams,
+        string? requiredRuntimeProfile)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(specParams);
+
+        ProjectPlanParameters(plan, specParams);
+
+        return new ExecutionJobSpec
+        {
+            Kind = ExecutionJobKind.Geoprocessing,
+            TargetKind = BatchComputeTargetKind.KubernetesJob,
+            Backend = LocalBatchComputeBackend.BackendId,
+            WorkloadName = $"geoprocessing:{plan.PlanId}",
+            // Data-driven native-profile stamping: a catalog process that requires a
+            // specialized worker (the gdal.* native family) forces this profile so the
+            // claim fence routes the job to the GDAL worker and away from the lean
+            // dispatcher. Null leaves the job managed/default.
+            RuntimeProfile = requiredRuntimeProfile,
+            Parameters = specParams,
+        };
+    }
+
+    /// <summary>
+    /// Builds a single-step <see cref="AnalysisPlan"/> for a direct
+    /// <c>(processId, step-0 inputs)</c> invocation — the shape the GP Devkit local
+    /// runner / <c>honua gp run</c> drive. The plan is the canonical input the shared
+    /// projection and spec-shape consume, so the local dry-run produces the same spec
+    /// a single-step submit would.
+    /// </summary>
+    /// <param name="processId">Canonical dotted process id (e.g. <c>gdal.hillshade</c>).</param>
+    /// <param name="inputs">Step-0 input name/value pairs.</param>
+    /// <param name="planId">Stable plan id to stamp; the runner supplies its operation id.</param>
+    public static AnalysisPlan SingleStepPlan(
+        string processId,
+        IReadOnlyDictionary<string, string> inputs,
+        string planId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(processId);
+        ArgumentNullException.ThrowIfNull(inputs);
+        ArgumentException.ThrowIfNullOrWhiteSpace(planId);
+
+        var stepInputs = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (name, value) in inputs)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            stepInputs[name] = value ?? string.Empty;
+        }
+
+        return new AnalysisPlan
+        {
+            PlanId = planId,
+            IntentId = planId,
+            Steps =
+            [
+                new AnalysisPlanStep
+                {
+                    StepId = "0",
+                    Kind = AnalysisPlanStepKind.Geoprocess,
+                    ProcessId = processId,
+                    Inputs = stepInputs,
+                },
+            ],
+        };
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/LocalRunner/GeoprocessingLocalRunner.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/LocalRunner/GeoprocessingLocalRunner.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
-using Honua.ControlPlane;
 
 namespace Honua.Geoprocessing.LocalRunner;
 
@@ -125,52 +124,52 @@ public sealed class GeoprocessingLocalRunner
         };
     }
 
-    private static ExecutionJobRecord BuildJobRecord(
+    /// <summary>
+    /// Builds the execution-job record the executor runs against. The durable
+    /// <see cref="ExecutionJobSpec"/> is constructed through the SAME
+    /// <see cref="GeoprocessingSpecBuilder"/> the production submit path
+    /// (<c>GeoprocessingJobService.BuildSpec</c>) uses for the no-registered-workload
+    /// case, from an equivalent single-step <c>AnalysisPlan</c> — so the spec a
+    /// <c>gp run</c>/<c>gp plan</c> dry-run carries is byte-for-byte the spec a real
+    /// single-step submit would produce for the same <c>(processId, inputs)</c>
+    /// (issue #2180): same parameter bag (process-definitions, step-0 inputs, plan id),
+    /// same Kind / TargetKind / Backend / WorkloadName, and the same data-driven
+    /// <see cref="ExecutionJobSpec.RuntimeProfile"/> — <c>native</c> for a gdal.*
+    /// executor, <c>null</c> (managed/default) otherwise. This makes "plan" a true dry
+    /// run of the real spec, not a parallel representation.
+    /// </summary>
+    internal static ExecutionJobRecord BuildJobRecord(
         string processId,
         IReadOnlyDictionary<string, string> inputs,
         IProcessExecutor executor)
     {
-        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            // The canonical process-id key the dispatch helper / executors resolve.
-            [ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId,
-            // protocolProcessId is the fallback key several executors also accept.
-            ["protocolProcessId"] = processId,
-        };
-
-        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
-        foreach (var (name, value) in inputs)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                continue;
-            }
-
-            parameters[prefix + name] = value ?? string.Empty;
-        }
-
-        // Stamp the runtime profile the executor accepts so a native (GDAL) executor's
-        // own profile guard, if any, is satisfied; managed executors ignore it.
-        var runtimeProfile = executor.AcceptedRuntimeProfiles.Contains(RuntimeProfiles.Native)
+        // The local runner has no process catalog to consult, so the required runtime
+        // profile is derived from the resolved executor's accepted set instead — a
+        // native (GDAL) executor accepts the native profile, which the submit path's
+        // catalog lookup would stamp as the same `native` value; a managed executor
+        // leaves the profile null/default, exactly as the submit path does.
+        var requiredRuntimeProfile = executor.AcceptedRuntimeProfiles.Contains(RuntimeProfiles.Native)
             ? RuntimeProfiles.Native
-            : RuntimeProfiles.Managed;
+            : null;
+
+        var operationId = "local-" + Guid.NewGuid().ToString("N");
+
+        // The local runner is a single-step (processId + step-0 inputs) invocation;
+        // model it as the canonical single-step plan the shared spec builder consumes.
+        var plan = GeoprocessingSpecBuilder.SingleStepPlan(processId, inputs, planId: operationId);
+        var spec = GeoprocessingSpecBuilder.BuildNoWorkloadSpec(
+            plan,
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            requiredRuntimeProfile);
 
         var now = DateTimeOffset.UtcNow;
         return new ExecutionJobRecord
         {
-            OperationId = "local-" + Guid.NewGuid().ToString("N"),
+            OperationId = operationId,
             Status = ExecutionJobStatus.Running,
             CreatedAt = now,
             UpdatedAt = now,
-            Spec = new ExecutionJobSpec
-            {
-                Kind = ExecutionJobKind.Geoprocessing,
-                TargetKind = BatchComputeTargetKind.KubernetesJob,
-                Backend = "local",
-                WorkloadName = "gp-local:" + processId,
-                RuntimeProfile = runtimeProfile,
-                Parameters = parameters,
-            },
+            Spec = spec,
         };
     }
 }

--- a/src/Honua.Worker.Gdal/Execution/DockerGdalCommandRunner.cs
+++ b/src/Honua.Worker.Gdal/Execution/DockerGdalCommandRunner.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Opt-in container-exec <see cref="IGdalCommandRunner"/> (issue #2180) that runs
+/// each GDAL/OGR tool inside the real <c>honua-worker-etl</c> image via
+/// <c>docker run</c>, instead of shelling out to the host's in-process GDAL CLIs
+/// (<see cref="ProcessGdalCommandRunner"/>).
+///
+/// <para>
+/// <b>Why this exists.</b> The GP Devkit local runner runs the real native executor
+/// in-process for a sub-second loop, but the in-process path never crosses the
+/// image / driver-set / CRS-data / arg-handling boundary a production native submit
+/// crosses (the job is packaged into the GDAL worker container and dispatched by
+/// AWS Batch). A <c>gdal.hillshade</c> that passes <c>gp run</c> against a host's
+/// GDAL could still fail at that boundary. Running the tool inside the SAME image
+/// Batch packages closes that fidelity cliff while keeping <c>gp plan</c>/<c>gp run</c>
+/// a true dry-run of the native submit path.
+/// </para>
+///
+/// <para>
+/// <b>How it stays correct-by-construction.</b> Every native executor does ALL of its
+/// file I/O inside a per-job scratch workspace under <c>GdalWorkerOptions.ScratchRoot</c>
+/// and passes that workspace as the tool's working directory, with absolute
+/// workspace paths in the argument vector (e.g. <c>gdaldem hillshade …
+/// /scratch/&lt;op&gt;/input.tif /scratch/&lt;op&gt;/output.tif</c>). This runner bind-mounts
+/// the host workspace into the container at the <em>identical absolute path</em>
+/// (<c>-v &lt;workspace&gt;:&lt;workspace&gt;</c>, <c>-w &lt;workspace&gt;</c>), so those absolute
+/// paths resolve to the same files inside the container; the tool reads the inputs
+/// the executor materialized and writes its outputs back onto the host workspace
+/// where the executor then reads them. The executor code path is therefore byte-for-
+/// byte unchanged — only the <see cref="IGdalCommandRunner"/> implementation differs.
+/// </para>
+/// </summary>
+internal sealed partial class DockerGdalCommandRunner(
+    IDockerCommandInvoker invoker,
+    IOptions<GdalContainerExecutionOptions> options,
+    ILogger<DockerGdalCommandRunner> logger) : IGdalCommandRunner
+{
+    /// <inheritdoc />
+    public Task<GdalCommandResult> RunAsync(
+        string tool,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tool);
+        ArgumentNullException.ThrowIfNull(arguments);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
+
+        var opts = options.Value;
+        var dockerArgs = BuildDockerRunArguments(opts, tool, arguments, workingDirectory);
+
+        Log.DispatchingToContainer(logger, tool, opts.Image, workingDirectory);
+        return invoker.RunAsync(opts.DockerExecutable, dockerArgs, cancellationToken);
+    }
+
+    /// <summary>
+    /// Builds the full <c>docker run …</c> argument vector for one GDAL tool
+    /// invocation. Pure and deterministic so it can be asserted offline (the docker
+    /// invocation is the load-bearing, correct-by-construction part of this runner).
+    ///
+    /// <para>The layout is:</para>
+    /// <code>
+    /// run --rm --network &lt;net&gt; --user &lt;uid:gid&gt;
+    ///     -v &lt;workspace&gt;:&lt;workspace&gt; -w &lt;workspace&gt;
+    ///     --entrypoint &lt;tool&gt; &lt;image&gt; &lt;...toolArgs&gt;
+    /// </code>
+    /// <list type="bullet">
+    /// <item><c>--rm</c>: the container is single-shot per tool invocation; nothing
+    /// persists outside the bind-mounted workspace.</item>
+    /// <item><c>--network</c>: hermetic by default (<c>none</c>) — every op runs purely
+    /// on the bind-mounted scratch files.</item>
+    /// <item><c>--user</c>: pins uid:gid so files the tool writes into the host-owned
+    /// workspace are owned consistently and stay readable by the host runner.</item>
+    /// <item><c>-v &lt;workspace&gt;:&lt;workspace&gt;</c> + <c>-w &lt;workspace&gt;</c>: the
+    /// identical-path bind mount that makes the executor's absolute workspace paths
+    /// resolve inside the container.</item>
+    /// <item><c>--entrypoint &lt;tool&gt;</c>: overrides the image's
+    /// <c>dotnet Honua.Worker.Gdal.dll</c> entrypoint so we invoke the raw GDAL CLI
+    /// (<c>gdalwarp</c>/<c>ogr2ogr</c>/<c>gdaldem</c>/…) the image ships on PATH —
+    /// the same binaries the in-container worker shells out to.</item>
+    /// </list>
+    /// </summary>
+    public static IReadOnlyList<string> BuildDockerRunArguments(
+        GdalContainerExecutionOptions options,
+        string tool,
+        IReadOnlyList<string> toolArguments,
+        string workspace)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tool);
+        ArgumentNullException.ThrowIfNull(toolArguments);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspace);
+
+        var args = new List<string>(toolArguments.Count + 14)
+        {
+            "run",
+            "--rm",
+        };
+
+        if (!string.IsNullOrWhiteSpace(options.Network))
+        {
+            args.Add("--network");
+            args.Add(options.Network);
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.User))
+        {
+            args.Add("--user");
+            args.Add(options.User);
+        }
+
+        // Identical-path bind mount: the executor's absolute workspace paths must
+        // resolve to the same files inside the container.
+        args.Add("-v");
+        args.Add($"{workspace}:{workspace}");
+        args.Add("-w");
+        args.Add(workspace);
+
+        // Override the image entrypoint (dotnet Honua.Worker.Gdal.dll) so the raw
+        // GDAL tool on the image PATH is what runs.
+        args.Add("--entrypoint");
+        args.Add(tool);
+
+        args.Add(options.Image);
+        args.AddRange(toolArguments);
+
+        return args;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9273, LogLevel.Information,
+            "Dispatching GDAL tool {Tool} to container image {Image} (workspace {Workspace})")]
+        public static partial void DispatchingToContainer(ILogger logger, string tool, string image, string workspace);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalContainerExecutionOptions.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalContainerExecutionOptions.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Configuration for the opt-in container-exec GDAL command runner
+/// (<see cref="DockerGdalCommandRunner"/>, issue #2180). When the GP Devkit local
+/// runner runs in <c>--real-worker</c> mode, native-profile (<c>gdal.*</c>) steps
+/// are executed by shelling each GDAL/OGR tool out into a fresh
+/// <c>docker run</c> of the real <c>honua-worker-etl</c> image — the SAME image
+/// Batch packages — instead of the host's in-process GDAL CLIs. This exercises the
+/// image / CRS data / driver set / arg handling at the container boundary a
+/// production native submit would actually cross, closing the fidelity cliff
+/// where an op that passes <c>gp run</c> locally could still fail at the image
+/// boundary it never touched.
+/// </summary>
+internal sealed class GdalContainerExecutionOptions
+{
+    /// <summary>
+    /// Default container image reference for the heavyweight GDAL/ETL worker. Matches
+    /// the local build tag produced by <c>docker/worker-gdal/Dockerfile</c>
+    /// (<c>docker build -t honua-worker-etl .</c>).
+    /// </summary>
+    public const string DefaultImage = "honua-worker-etl";
+
+    /// <summary>
+    /// The container image to run each GDAL tool inside. Defaults to the local
+    /// <see cref="DefaultImage"/> tag; override to pin a published/digest-pinned ref.
+    /// </summary>
+    public string Image { get; set; } = DefaultImage;
+
+    /// <summary>
+    /// The container runtime CLI used to launch the image. Defaults to <c>docker</c>;
+    /// override to <c>podman</c> or an absolute path on hosts where it is not on PATH.
+    /// </summary>
+    public string DockerExecutable { get; set; } = "docker";
+
+    /// <summary>
+    /// The uid:gid the container process runs as. Defaults to <c>1001:1001</c> — the
+    /// non-root <c>honua</c> user the worker image declares — so artifacts the GDAL
+    /// tool writes into the bind-mounted scratch workspace are owned consistently and
+    /// remain readable by the host runner after the container exits.
+    /// </summary>
+    public string User { get; set; } = "1001:1001";
+
+    /// <summary>
+    /// The container network mode. Defaults to <c>none</c>: every GP Devkit native op
+    /// operates purely on the bind-mounted scratch workspace (base64 inputs are
+    /// materialized to files before the tool runs, outputs are read back after), so no
+    /// network is required and disabling it keeps the local dry-run hermetic.
+    /// </summary>
+    public string Network { get; set; } = "none";
+}

--- a/src/Honua.Worker.Gdal/Execution/IDockerCommandInvoker.cs
+++ b/src/Honua.Worker.Gdal/Execution/IDockerCommandInvoker.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Seam over launching the container runtime (<c>docker</c> / <c>podman</c>) as a
+/// child process. <see cref="DockerGdalCommandRunner"/> builds the full
+/// <c>docker run …</c> argument vector (image, mounts, user, network, entrypoint
+/// tool, tool args) and hands it to this invoker, which actually starts the
+/// process. Splitting the argv-construction from the process launch lets the
+/// argv — the load-bearing, correct-by-construction part (image ref, mount path,
+/// uid, entrypoint) — be asserted by an offline unit test with a fake invoker on a
+/// host that has no Docker daemon, while the real <see cref="ProcessDockerCommandInvoker"/>
+/// runs the container in CI / on a local Docker box.
+/// </summary>
+internal interface IDockerCommandInvoker
+{
+    /// <summary>
+    /// Runs the container runtime executable with the supplied argument vector.
+    /// </summary>
+    /// <param name="executable">The container runtime, e.g. <c>docker</c>.</param>
+    /// <param name="arguments">
+    /// The full argument vector after the executable — typically
+    /// <c>["run", "--rm", …, image, tool, …toolArgs]</c>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token; kills the process when triggered.</param>
+    Task<GdalCommandResult> RunAsync(
+        string executable,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Probes whether the named container image is present locally (so the GP Devkit
+    /// runner can auto-enable container mode only when the image is already pulled,
+    /// rather than blocking the sub-second loop on a pull). Returns <c>false</c> when
+    /// the container runtime is unavailable or the image is absent.
+    /// </summary>
+    /// <param name="executable">The container runtime, e.g. <c>docker</c>.</param>
+    /// <param name="image">The image reference to probe.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<bool> ImageExistsAsync(
+        string executable,
+        string image,
+        CancellationToken cancellationToken);
+}

--- a/src/Honua.Worker.Gdal/Execution/ProcessDockerCommandInvoker.cs
+++ b/src/Honua.Worker.Gdal/Execution/ProcessDockerCommandInvoker.cs
@@ -1,0 +1,171 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Production <see cref="IDockerCommandInvoker"/> that launches the container
+/// runtime (<c>docker</c> / <c>podman</c>) as a child process. Mirrors the child-
+/// process management of <see cref="ProcessGdalCommandRunner"/> (no shell, captured
+/// stdout/stderr, kill-on-cancel). It is exercised end-to-end only where a Docker
+/// daemon is present (CI / local-Docker dev box); the argv it receives is the part
+/// verified offline by <see cref="DockerGdalCommandRunner"/>'s unit tests.
+/// </summary>
+internal sealed partial class ProcessDockerCommandInvoker(ILogger<ProcessDockerCommandInvoker> logger)
+    : IDockerCommandInvoker
+{
+    /// <inheritdoc />
+    public async Task<GdalCommandResult> RunAsync(
+        string executable,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executable);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        Log.RunningContainer(logger, executable, string.Join(' ', arguments));
+
+        var (exitCode, stdout, stderr) = await RunProcessAsync(
+            executable, arguments, throwIfStartFails: true, cancellationToken).ConfigureAwait(false);
+
+        Log.ContainerCompleted(logger, executable, exitCode);
+        return new GdalCommandResult
+        {
+            ExitCode = exitCode,
+            StandardOutput = stdout,
+            StandardError = stderr,
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ImageExistsAsync(
+        string executable,
+        string image,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executable);
+        ArgumentException.ThrowIfNullOrWhiteSpace(image);
+
+        // `docker image inspect <ref>` exits 0 when the image is present locally and
+        // non-zero (with no daemon access, or image absent) otherwise. Any launch
+        // failure (no Docker installed) is treated as "not available" so auto-mode
+        // silently falls back to the in-process path instead of throwing.
+        try
+        {
+            var (exitCode, _, _) = await RunProcessAsync(
+                executable,
+                new[] { "image", "inspect", image },
+                throwIfStartFails: false,
+                cancellationToken).ConfigureAwait(false);
+            return exitCode == 0;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.ImageProbeFailed(logger, image, ex.Message);
+            return false;
+        }
+    }
+
+    private static async Task<(int ExitCode, string StandardOutput, string StandardError)> RunProcessAsync(
+        string executable,
+        IReadOnlyList<string> arguments,
+        bool throwIfStartFails,
+        CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = new Process { StartInfo = startInfo };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                stdout.AppendLine(e.Data);
+            }
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                stderr.AppendLine(e.Data);
+            }
+        };
+
+        if (!process.Start())
+        {
+            if (throwIfStartFails)
+            {
+                throw new InvalidOperationException($"Failed to start container runtime '{executable}'.");
+            }
+
+            return (-1, "", "");
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            TryKill(process);
+            throw;
+        }
+
+        // Ensure async stream readers flush before the buffers are read.
+        await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+
+        return (process.ExitCode, stdout.ToString(), stderr.ToString());
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Process already exited between the check and the kill.
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // Permission/race killing the process; nothing more we can do.
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9270, LogLevel.Information, "Running container {Executable} {Arguments}")]
+        public static partial void RunningContainer(ILogger logger, string executable, string arguments);
+
+        [LoggerMessage(9271, LogLevel.Information, "Container {Executable} exited with code {ExitCode}")]
+        public static partial void ContainerCompleted(ILogger logger, string executable, int exitCode);
+
+        [LoggerMessage(9272, LogLevel.Debug, "Container image probe for {Image} failed: {Reason}")]
+        public static partial void ImageProbeFailed(ILogger logger, string image, string reason);
+    }
+}

--- a/src/Honua.Worker.Gdal/GdalContainerProbe.cs
+++ b/src/Honua.Worker.Gdal/GdalContainerProbe.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal;
+
+/// <summary>
+/// Public probe the GP Devkit CLI uses to decide whether the container-exec
+/// fidelity path (<see cref="GdalProcessExecutorMode.Container"/>, issue #2180) can
+/// run on this host — i.e. whether the worker image is already present locally —
+/// without forcing the CLI to reach into the worker assembly's internal
+/// container-runtime seam.
+/// </summary>
+public static class GdalContainerProbe
+{
+    /// <summary>
+    /// The default container image reference the probe checks for and the
+    /// container-exec runner runs. Matches the local build tag produced by
+    /// <c>docker/worker-gdal/Dockerfile</c>.
+    /// </summary>
+    public static string DefaultImage => GdalContainerExecutionOptions.DefaultImage;
+
+    /// <summary>
+    /// Returns whether the named worker image is present in the local container
+    /// runtime. Returns <c>false</c> (never throws) when no container runtime is
+    /// installed or the image has not been pulled/built — so the CLI's auto-mode can
+    /// fall back to the fast in-process path silently.
+    /// </summary>
+    /// <param name="image">Image reference; defaults to <see cref="DefaultImage"/>.</param>
+    /// <param name="dockerExecutable">Container runtime; defaults to <c>docker</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static async Task<bool> IsImageAvailableAsync(
+        string? image = null,
+        string dockerExecutable = "docker",
+        CancellationToken cancellationToken = default)
+    {
+        var invoker = new ProcessDockerCommandInvoker(NullLogger<ProcessDockerCommandInvoker>.Instance);
+        return await invoker.ImageExistsAsync(
+            dockerExecutable,
+            string.IsNullOrWhiteSpace(image) ? GdalContainerExecutionOptions.DefaultImage : image,
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Honua.Worker.Gdal/GdalProcessExecutorMode.cs
+++ b/src/Honua.Worker.Gdal/GdalProcessExecutorMode.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Worker.Gdal;
+
+/// <summary>
+/// Selects how the native GDAL <c>IProcessExecutor</c> set reaches the GDAL/OGR CLI
+/// tools when registered through
+/// <see cref="GdalWorkerServiceCollectionExtensions.AddGdalProcessExecutors(Microsoft.Extensions.DependencyInjection.IServiceCollection, Microsoft.Extensions.Configuration.IConfiguration, GdalProcessExecutorMode)"/>
+/// (GP Devkit native-profile fidelity, issue #2180).
+/// </summary>
+public enum GdalProcessExecutorMode
+{
+    /// <summary>
+    /// Default fast path: shell each GDAL tool out to the host's in-process GDAL CLIs.
+    /// Keeps the GP Devkit dev loop sub-second; requires GDAL on the host PATH for
+    /// native ops (managed ops never touch it).
+    /// </summary>
+    InProcess = 0,
+
+    /// <summary>
+    /// Opt-in fidelity path (<c>--real-worker</c>): run each GDAL tool inside the real
+    /// <c>honua-worker-etl</c> container image via <c>docker run</c>, so the image /
+    /// CRS-data / driver-set / arg-handling boundary a production native submit crosses
+    /// is exercised locally. Requires a container runtime and the worker image.
+    /// </summary>
+    Container = 1,
+}

--- a/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
+++ b/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
@@ -107,6 +107,32 @@ public static class GdalWorkerServiceCollectionExtensions
     public static IServiceCollection AddGdalProcessExecutors(
         this IServiceCollection services,
         IConfiguration configuration)
+        => services.AddGdalProcessExecutors(configuration, GdalProcessExecutorMode.InProcess);
+
+    /// <summary>
+    /// Registers the native GDAL <see cref="IProcessExecutor"/> set with an explicit
+    /// command-runner mode (issue #2180).
+    /// <list type="bullet">
+    /// <item><see cref="GdalProcessExecutorMode.InProcess"/> — the default fast path:
+    /// each GDAL tool is shelled out via <see cref="ProcessGdalCommandRunner"/> against
+    /// the host's GDAL CLIs, keeping the GP Devkit sub-second loop on managed ops.</item>
+    /// <item><see cref="GdalProcessExecutorMode.Container"/> — the opt-in
+    /// <c>--real-worker</c> fidelity path: each GDAL tool runs inside the real
+    /// <c>honua-worker-etl</c> image via <see cref="DockerGdalCommandRunner"/>, so the
+    /// image / CRS data / driver-set / arg-handling boundary a production native submit
+    /// crosses is actually exercised locally.</item>
+    /// </list>
+    /// Both modes register the IDENTICAL executor set and read the IDENTICAL durable
+    /// spec — only the <see cref="IGdalCommandRunner"/> implementation differs, so the
+    /// managed fast path is unaffected and the spec a job carries is the same.
+    /// </summary>
+    /// <param name="services">Service collection.</param>
+    /// <param name="configuration">Host configuration; binds the <c>GdalWorker</c> section.</param>
+    /// <param name="mode">Which command-runner implementation to register.</param>
+    public static IServiceCollection AddGdalProcessExecutors(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        GdalProcessExecutorMode mode)
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
@@ -117,7 +143,22 @@ public static class GdalWorkerServiceCollectionExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
-        services.TryAddSingleton<IGdalCommandRunner, ProcessGdalCommandRunner>();
+        if (mode == GdalProcessExecutorMode.Container)
+        {
+            // Container-exec fidelity path: bind the GdalContainer options and run each
+            // GDAL tool inside the real worker image. The in-process runner is NOT
+            // registered, so the same executor code path shells out via docker instead.
+            services
+                .AddOptions<GdalContainerExecutionOptions>()
+                .Bind(configuration.GetSection("GdalContainer"));
+            services.TryAddSingleton<IDockerCommandInvoker, ProcessDockerCommandInvoker>();
+            services.TryAddSingleton<IGdalCommandRunner, DockerGdalCommandRunner>();
+        }
+        else
+        {
+            services.TryAddSingleton<IGdalCommandRunner, ProcessGdalCommandRunner>();
+        }
+
         RegisterGdalExecutor<GdalVectorConvertJobExecutor>(services);
         RegisterGdalExecutor<GdalRasterReprojectJobExecutor>(services);
         RegisterGdalExecutor<GdalSurfaceJobExecutor>(services);

--- a/tests/dotnet/Honua.Architecture.Tests/ModuleDependencyPolicyTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/ModuleDependencyPolicyTests.cs
@@ -559,13 +559,18 @@ public sealed class ModuleDependencyPolicyTests
     /// </summary>
     private static ModuleRole ClassifyByCsprojName(string projectName)
     {
-        // Tooling first: test projects and the test-kit are not part of the
-        // runtime topology. This guard must precede the family-prefix checks
-        // below, otherwise e.g. "Honua.Protocols.GeoServices.Tests" would match
-        // the "Honua.Protocols." prefix and be misclassified as a runtime
-        // Protocols consumer (and its test-only Postgres reference would trip
-        // the matrix). Unclassified consumers may reference anything.
+        // Tooling first: test projects, the test-kit, and packaged dev-tool CLIs are
+        // not part of the runtime topology. This guard must precede the family-prefix
+        // checks below, otherwise e.g. "Honua.Protocols.GeoServices.Tests" would match
+        // the "Honua.Protocols." prefix and be misclassified as a runtime Protocols
+        // consumer (and its test-only Postgres reference would trip the matrix), and
+        // the GP Devkit dev tool "Honua.Geoprocessing.Cli" would match the
+        // "Honua.Geoprocessing." prefix and be wrongly held to the runtime matrix even
+        // though it is a `dotnet tool`-packaged, AOT-excluded developer convenience
+        // (issues #2123 / #2180) that the lean server never references. Unclassified
+        // consumers may reference anything.
         if (projectName.EndsWith(".Tests", StringComparison.Ordinal) ||
+            projectName.EndsWith(".Cli", StringComparison.Ordinal) ||
             projectName.Equals("Honua.TestKit", StringComparison.Ordinal))
         {
             return ModuleRole.Unclassified;

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/LocalRunner/GeoprocessingLocalRunnerSpecEquivalenceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/LocalRunner/GeoprocessingLocalRunnerSpecEquivalenceTests.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Geoprocessing;
+using Honua.Geoprocessing.LocalRunner;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.LocalRunner;
+
+/// <summary>
+/// Proves the GP Devkit native-profile fidelity contract (issue #2180): the
+/// <see cref="ExecutionJobSpec"/> the local runner builds for a single
+/// <c>(processId, inputs)</c> invocation is IDENTICAL to the spec the production
+/// submit path (<c>GeoprocessingJobService.BuildSpec</c> → the no-registered-workload
+/// case) produces for the equivalent single-step plan — so <c>gp run</c>/<c>gp plan</c>
+/// is a true dry-run of the real submit spec, not a parallel representation.
+///
+/// <para>
+/// Both paths route through the single source of truth
+/// (<see cref="GeoprocessingSpecBuilder"/>): the submit path calls
+/// <see cref="GeoprocessingSpecBuilder.BuildNoWorkloadSpec"/> for the no-workload case,
+/// and the local runner's <see cref="GeoprocessingLocalRunner.BuildJobRecord"/> models
+/// its invocation as the same single-step plan and calls the same builder. These tests
+/// pin that equivalence so a future divergence (a parameter key, the runtime-profile
+/// stamp, or an envelope field drifting on one path) fails loudly.
+/// </para>
+/// </summary>
+public sealed class GeoprocessingLocalRunnerSpecEquivalenceTests
+{
+    [UnitTest]
+    public void BuildJobRecord_NativeProcess_MatchesSubmitPathSpec()
+    {
+        const string processId = "gdal.hillshade";
+        var inputs = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["source"] = "ZmFrZS1yYXN0ZXI=",
+            ["azimuth"] = "315",
+            ["altitude"] = "45",
+        };
+
+        var runnerSpec = GeoprocessingLocalRunner
+            .BuildJobRecord(processId, inputs, new NativeFakeExecutor(processId))
+            .Spec;
+
+        // The submit path's no-registered-workload branch builds its spec through the
+        // same shared builder from the equivalent single-step plan, stamping `native`
+        // for a gdal.* step (catalog-driven in prod; executor-accepted-set-driven here,
+        // which resolves to the same value).
+        var plan = GeoprocessingSpecBuilder.SingleStepPlan(processId, inputs, planId: runnerSpec.WorkloadName.Split(':')[^1]);
+        var submitSpec = GeoprocessingSpecBuilder.BuildNoWorkloadSpec(
+            plan,
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            requiredRuntimeProfile: RuntimeProfiles.Native);
+
+        AssertSpecsEquivalent(runnerSpec, submitSpec, expectedProfile: RuntimeProfiles.Native);
+    }
+
+    [UnitTest]
+    public void BuildJobRecord_ManagedProcess_MatchesSubmitPathSpec_AndLeavesProfileNull()
+    {
+        const string processId = "geometry.buffer";
+        var inputs = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["wkb"] = "AQEAAAAAAAAAAAAAAAAAAAAAAAAA",
+            ["srid"] = "4326",
+            ["distance"] = "10",
+        };
+
+        var runnerSpec = GeoprocessingLocalRunner
+            .BuildJobRecord(processId, inputs, new ManagedFakeExecutor(processId))
+            .Spec;
+
+        var plan = GeoprocessingSpecBuilder.SingleStepPlan(processId, inputs, planId: runnerSpec.WorkloadName.Split(':')[^1]);
+        var submitSpec = GeoprocessingSpecBuilder.BuildNoWorkloadSpec(
+            plan,
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            requiredRuntimeProfile: null);
+
+        // A managed op leaves RuntimeProfile null/default exactly as the submit path
+        // does (it only stamps a non-managed profile), so the lean dispatcher claims it.
+        runnerSpec.RuntimeProfile.Should().BeNull();
+        AssertSpecsEquivalent(runnerSpec, submitSpec, expectedProfile: null);
+    }
+
+    [UnitTest]
+    public void BuildJobRecord_ProjectsCanonicalDurableKeys_TheWorkerResolvesProcessIdFrom()
+    {
+        const string processId = "gdal.ogr2ogr";
+        var inputs = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["source"] = "Zm9v",
+            ["sourceFormat"] = "GeoJSON",
+            ["targetFormat"] = "CSV",
+        };
+
+        var spec = GeoprocessingLocalRunner
+            .BuildJobRecord(processId, inputs, new NativeFakeExecutor(processId))
+            .Spec;
+
+        // The canonical process-definitions key the dispatcher/executors resolve on.
+        spec.Parameters[ExecutionJobParameterKeys.GeoprocessingProcessDefinitions]
+            .Should().Be(processId);
+
+        // Step-0 inputs under the canonical prefix.
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+        spec.Parameters[prefix + "source"].Should().Be("Zm9v");
+        spec.Parameters[prefix + "sourceFormat"].Should().Be("GeoJSON");
+        spec.Parameters[prefix + "targetFormat"].Should().Be("CSV");
+
+        // The local runner no longer emits the legacy `protocolProcessId` fallback —
+        // prod's spec relies on process_definitions, and so does the dry-run, keeping
+        // the two specs identical.
+        spec.Parameters.Should().NotContainKey("protocolProcessId");
+    }
+
+    private static void AssertSpecsEquivalent(
+        ExecutionJobSpec runnerSpec,
+        ExecutionJobSpec submitSpec,
+        string? expectedProfile)
+    {
+        runnerSpec.Kind.Should().Be(submitSpec.Kind);
+        runnerSpec.TargetKind.Should().Be(submitSpec.TargetKind);
+        runnerSpec.Backend.Should().Be(submitSpec.Backend);
+        runnerSpec.WorkloadName.Should().Be(submitSpec.WorkloadName);
+        runnerSpec.RuntimeProfile.Should().Be(expectedProfile);
+        runnerSpec.RuntimeProfile.Should().Be(submitSpec.RuntimeProfile);
+
+        // The durable parameter bag — the only payload a worker dispatches on — must
+        // match key-for-key and value-for-value.
+        runnerSpec.Parameters.Should().BeEquivalentTo(submitSpec.Parameters);
+    }
+
+    private sealed class NativeFakeExecutor(string processId) : IProcessExecutor
+    {
+        private static readonly IReadOnlySet<string> Native =
+            new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+        public IReadOnlySet<string> ProcessIds { get; } =
+            new HashSet<string>(StringComparer.Ordinal) { processId };
+
+        public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+        public IReadOnlySet<string> AcceptedRuntimeProfiles => Native;
+
+        public Task<JobExecutionResult> ExecuteAsync(
+            ExecutionJobRecord job,
+            IJobExecutionContext context,
+            CancellationToken cancellationToken)
+            => Task.FromResult(JobExecutionResult.Succeeded());
+    }
+
+    private sealed class ManagedFakeExecutor(string processId) : IProcessExecutor
+    {
+        public IReadOnlySet<string> ProcessIds { get; } =
+            new HashSet<string>(StringComparer.Ordinal) { processId };
+
+        public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+        // Managed executors fall back to the managed-only default accepted set.
+        public IReadOnlySet<string> AcceptedRuntimeProfiles => RuntimeProfiles.DefaultAccepted;
+
+        public Task<JobExecutionResult> ExecuteAsync(
+            ExecutionJobRecord job,
+            IJobExecutionContext context,
+            CancellationToken cancellationToken)
+            => Task.FromResult(JobExecutionResult.Succeeded());
+    }
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/DockerGdalCommandRunnerTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/DockerGdalCommandRunnerTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Offline coverage for the opt-in container-exec GDAL command runner
+/// (<see cref="DockerGdalCommandRunner"/>, issue #2180). Docker is NOT available on a
+/// lean CI agent, so these tests verify the load-bearing, correct-by-construction part
+/// of the runner — the exact <c>docker run …</c> argument vector it builds (image ref,
+/// identical-path bind mount, working dir, user, network, entrypoint-override, tool
+/// args) — and that it delegates to the container-runtime seam. The end-to-end run
+/// against a real container is CI/local-Docker-verified (it needs the
+/// <c>honua-worker-etl</c> image and a Docker daemon).
+/// </summary>
+public sealed class DockerGdalCommandRunnerTests
+{
+    [UnitTest]
+    public void BuildDockerRunArguments_BindMountsWorkspaceAtIdenticalPath_AndOverridesEntrypoint()
+    {
+        var options = new GdalContainerExecutionOptions();
+        const string workspace = "/tmp/honua-gdal-worker/op-123";
+        var toolArgs = new[] { "hillshade", "-of", "GTiff", "/tmp/honua-gdal-worker/op-123/input.tif", "/tmp/honua-gdal-worker/op-123/output.tif" };
+
+        var args = DockerGdalCommandRunner.BuildDockerRunArguments(options, "gdaldem", toolArgs, workspace);
+
+        // docker run --rm --network none --user 1001:1001 -v <ws>:<ws> -w <ws>
+        //   --entrypoint gdaldem honua-worker-etl <toolArgs...>
+        args.Should().ContainInOrder("run", "--rm");
+        args.Should().ContainInOrder("--network", "none");
+        args.Should().ContainInOrder("--user", "1001:1001");
+
+        // The identical-path bind mount is what makes the executor's absolute workspace
+        // paths (in toolArgs) resolve to the same files inside the container.
+        args.Should().ContainInOrder("-v", $"{workspace}:{workspace}");
+        args.Should().ContainInOrder("-w", workspace);
+
+        // Entrypoint override → the raw GDAL CLI on the image PATH, not the worker dll.
+        args.Should().ContainInOrder("--entrypoint", "gdaldem");
+
+        // Image precedes the tool args; tool args follow verbatim in order.
+        var imageIndex = args.ToList().IndexOf(GdalContainerExecutionOptions.DefaultImage);
+        imageIndex.Should().BeGreaterThan(0);
+        args.Skip(imageIndex + 1).Should().Equal(toolArgs);
+
+        // The image must come AFTER --entrypoint (docker run flag ordering) and the tool
+        // args after the image, so the container runs `gdaldem <args>`.
+        args.ToList().IndexOf("--entrypoint").Should().BeLessThan(imageIndex);
+    }
+
+    [UnitTest]
+    public void BuildDockerRunArguments_HonorsCustomImageNetworkAndUser()
+    {
+        var options = new GdalContainerExecutionOptions
+        {
+            Image = "ghcr.io/honua-io/honua-worker-etl@sha256:abc",
+            Network = "bridge",
+            User = "0:0",
+        };
+
+        var args = DockerGdalCommandRunner.BuildDockerRunArguments(
+            options, "ogr2ogr", new[] { "-f", "CSV", "/w/out.csv", "/w/in.geojson" }, "/w");
+
+        args.Should().Contain("ghcr.io/honua-io/honua-worker-etl@sha256:abc");
+        args.Should().ContainInOrder("--network", "bridge");
+        args.Should().ContainInOrder("--user", "0:0");
+    }
+
+    [UnitTest]
+    public async Task RunAsync_DelegatesTheBuiltArgvToTheContainerInvoker()
+    {
+        var invoker = new FakeDockerCommandInvoker(_ => new GdalCommandResult { ExitCode = 0 });
+        var runner = new DockerGdalCommandRunner(
+            invoker,
+            Options.Create(new GdalContainerExecutionOptions()),
+            NullLogger<DockerGdalCommandRunner>.Instance);
+
+        var result = await runner.RunAsync(
+            "gdalwarp",
+            new[] { "-t_srs", "EPSG:3857", "/scratch/op/in.tif", "/scratch/op/out.tif" },
+            "/scratch/op",
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        invoker.Invocations.Should().ContainSingle();
+
+        var invocation = invoker.Invocations[0];
+        invocation.Executable.Should().Be("docker");
+        invocation.Arguments.Should().ContainInOrder("run", "--rm");
+        invocation.Arguments.Should().ContainInOrder("-v", "/scratch/op:/scratch/op");
+        invocation.Arguments.Should().ContainInOrder("--entrypoint", "gdalwarp");
+        invocation.Arguments.Should().ContainInOrder(GdalContainerExecutionOptions.DefaultImage, "-t_srs", "EPSG:3857");
+    }
+
+    private sealed class FakeDockerCommandInvoker(Func<IReadOnlyList<string>, GdalCommandResult> behavior)
+        : IDockerCommandInvoker
+    {
+        public List<(string Executable, IReadOnlyList<string> Arguments)> Invocations { get; } = [];
+
+        public Task<GdalCommandResult> RunAsync(
+            string executable,
+            IReadOnlyList<string> arguments,
+            CancellationToken cancellationToken)
+        {
+            Invocations.Add((executable, arguments));
+            return Task.FromResult(behavior(arguments));
+        }
+
+        public Task<bool> ImageExistsAsync(string executable, string image, CancellationToken cancellationToken)
+            => Task.FromResult(true);
+    }
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalProcessExecutorModeRegistrationTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalProcessExecutorModeRegistrationTests.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Verifies the mode gating of the native GDAL executor registration seam
+/// (<see cref="GdalWorkerServiceCollectionExtensions.AddGdalProcessExecutors(IServiceCollection, IConfiguration, GdalProcessExecutorMode)"/>,
+/// issue #2180): the default / <see cref="GdalProcessExecutorMode.InProcess"/> mode
+/// keeps the fast host-CLI runner (no regression to the sub-second managed loop),
+/// while <see cref="GdalProcessExecutorMode.Container"/> swaps in the container-exec
+/// runner — registering the IDENTICAL executor set either way, so only the
+/// <see cref="IGdalCommandRunner"/> implementation differs.
+/// </summary>
+public sealed class GdalProcessExecutorModeRegistrationTests
+{
+    [UnitTest]
+    public void AddGdalProcessExecutors_DefaultMode_RegistersInProcessRunner()
+    {
+        using var provider = BuildProvider(static (services, config) =>
+            services.AddGdalProcessExecutors(config));
+
+        provider.GetRequiredService<IGdalCommandRunner>().Should().BeOfType<ProcessGdalCommandRunner>();
+    }
+
+    [UnitTest]
+    public void AddGdalProcessExecutors_InProcessMode_RegistersInProcessRunner()
+    {
+        using var provider = BuildProvider(static (services, config) =>
+            services.AddGdalProcessExecutors(config, GdalProcessExecutorMode.InProcess));
+
+        provider.GetRequiredService<IGdalCommandRunner>().Should().BeOfType<ProcessGdalCommandRunner>();
+    }
+
+    [UnitTest]
+    public void AddGdalProcessExecutors_ContainerMode_RegistersDockerRunner_AndInvoker()
+    {
+        using var provider = BuildProvider(static (services, config) =>
+            services.AddGdalProcessExecutors(config, GdalProcessExecutorMode.Container));
+
+        provider.GetRequiredService<IGdalCommandRunner>().Should().BeOfType<DockerGdalCommandRunner>();
+        provider.GetRequiredService<IDockerCommandInvoker>().Should().BeOfType<ProcessDockerCommandInvoker>();
+    }
+
+    [UnitTest]
+    public void AddGdalProcessExecutors_BothModes_RegisterIdenticalExecutorSet()
+    {
+        using var inProcess = BuildProvider(static (services, config) =>
+            services.AddGdalProcessExecutors(config, GdalProcessExecutorMode.InProcess));
+        using var container = BuildProvider(static (services, config) =>
+            services.AddGdalProcessExecutors(config, GdalProcessExecutorMode.Container));
+
+        // The executor set is the same regardless of how GDAL is reached.
+        var inProcessExecutorTypes = ExecutorTypeNames(inProcess);
+        var containerExecutorTypes = ExecutorTypeNames(container);
+
+        containerExecutorTypes.Should().BeEquivalentTo(inProcessExecutorTypes);
+        containerExecutorTypes.Should().NotBeEmpty();
+    }
+
+    [UnitTest]
+    public void AddGdalProcessExecutors_ContainerMode_BindsImageFromConfiguration()
+    {
+        const string customImage = "ghcr.io/honua-io/honua-worker-etl:pinned";
+        using var provider = BuildProvider(
+            static (services, config) => services.AddGdalProcessExecutors(config, GdalProcessExecutorMode.Container),
+            new Dictionary<string, string?> { ["GdalContainer:Image"] = customImage });
+
+        var options = provider
+            .GetRequiredService<IOptions<GdalContainerExecutionOptions>>()
+            .Value;
+
+        options.Image.Should().Be(customImage);
+    }
+
+    private static string[] ExecutorTypeNames(IServiceProvider provider)
+        => provider
+            .GetServices<IProcessExecutor>()
+            .Select(e => e.GetType().FullName!)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+    private static ServiceProvider BuildProvider(
+        Action<IServiceCollection, IConfiguration> register,
+        IDictionary<string, string?>? configValues = null)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configValues ?? new Dictionary<string, string?>())
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        register(services, configuration);
+
+        return services.BuildServiceProvider();
+    }
+}


### PR DESCRIPTION
## Summary

GP Devkit native-profile fidelity (#2180). The P2 local runner runs the real executor in-process — full fidelity for **managed** ops, but for **native** (`gdal.*`) ops the in-process path never crosses the image / CRS-data / driver-set / arg-handling boundary a production native submit crosses (the job is packaged into the GDAL worker container and dispatched by Batch). A `gdal.hillshade` that passes `gp run` locally could still fail at that boundary.

This adds an **opt-in** container-exec mode that runs each native `gdal.*` step inside the **real `honua-worker-etl` image** via `docker run`, and makes `gp run`/`gp plan` emit the **identical `ExecutionJobSpec`** the prod submit path produces — so "plan" is a true dry-run of the real native spec, not a parallel representation. The fast in-process managed loop is unchanged.

**Stacks on the P2 devkit branch** (`feat/gp-devkit-p2-runner-cli`, unmerged) — base this PR against it / land after P2.

## Changes Made

- Add `DockerGdalCommandRunner` (opt-in `IGdalCommandRunner`): runs each GDAL tool inside the `honua-worker-etl` image via `docker run` instead of the host CLIs. Correct-by-construction — every executor does all file I/O in a per-job scratch workspace and passes absolute workspace paths to the tool, so the runner bind-mounts that workspace at the **identical absolute path** (`-v <ws>:<ws> -w <ws>`) and overrides the image entrypoint to the raw tool; the executor code path is byte-for-byte unchanged.
- Add `GdalProcessExecutorMode` (InProcess default / Container) on the `AddGdalProcessExecutors` seam; container mode swaps the runner but registers the identical executor set.
- Wire `honua gp run --real-worker` (alias `--container`, plus `--in-process`): auto-selects the container path only when the image is present locally (`GdalContainerProbe`) so the sub-second managed loop is never blocked on a pull.
- Split the docker launch behind `IDockerCommandInvoker` so the `docker run` argv (image ref, mount, working dir, user, entrypoint override, arg order) is unit-tested offline against a fake.
- Extract `GeoprocessingSpecBuilder` as the single source of truth for projecting an `AnalysisPlan` onto the durable `ExecutionJobSpec`. Both `GeoprocessingJobService.BuildSpec` (no-workload case) and the local runner build their spec through it from an equivalent single-step plan → identical spec (parameter bag, Kind/TargetKind/Backend/WorkloadName, data-driven RuntimeProfile: `native` for `gdal.*`, `null` for managed). Runner no longer emits the legacy `protocolProcessId` fallback.
- Classify the `Honua.Geoprocessing.Cli` dev tool as tooling in the module-dependency policy (it is a `dotnet tool`-packaged, AOT-excluded developer convenience the lean server never references) — also clears a pre-existing matrix violation.

## Breaking Changes

None. In-process is the default; container mode is opt-in. Managed-profile fast path unchanged.

## Docker correct-by-construction note

Docker is not available in the build env, so the container-exec path is made correct-by-construction and verified by the docker invocation it builds (`DockerGdalCommandRunnerTests`): `docker run --rm --network none --user 1001:1001 -v <ws>:<ws> -w <ws> --entrypoint <tool> honua-worker-etl <args…>`. The **end-to-end container run** is **CI / local-Docker-verified** — it needs a Docker daemon + the `honua-worker-etl` image (`docker build -f docker/worker-gdal/Dockerfile -t honua-worker-etl .`).

## Gate Impact

- [x] No gate impact (dev-tool / local-runner fidelity; lean serving image + AOT surface unaffected — `Honua.Server` does not reference the CLI)

## Testing

- [x] Ran the affected build (Release, warnings-as-errors) and unit tests; all green
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

`dotnet build` (Release, `TreatWarningsAsErrors`): Worker.Gdal + Geoprocessing + CLI — **0 warnings, 0 errors**. `dotnet format --verify-no-changes`: clean. Tests: **Worker.Gdal 10/10**, **Server.Tests 7/7** (3 new spec-equivalence + 4 existing local-runner), **Architecture 3/3** (ModuleDependencyPolicy + GeoprocessingIsolation). Container end-to-end run is CI/local-Docker-verified (no daemon in build env).

Closes #2180
