### PR TITLE
feat(geoprocessing): custom-code repo-signing policy (per-tenant allowlist + signed-only)

### DIFF
--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeCommitSignatureVerifier.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeCommitSignatureVerifier.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Geoprocessing.CustomCode;
+
+/// <summary>
+/// The outcome of verifying the signature on a pinned custom-code commit. This is the
+/// seam the <see cref="CustomCodeRepoPolicy.SignedOnly"/> gate evaluates: a commit is
+/// admitted only when <see cref="IsSignatureValid"/> is <see langword="true"/>
+/// <em>and</em> <see cref="SignerKeyId"/> is on the configured
+/// <see cref="CustomCodeOptions.TrustedSignerKeys"/>.
+/// </summary>
+/// <param name="IsSignatureValid">
+/// <see langword="true"/> only when the verifier cryptographically confirmed a valid
+/// signature over the commit object. <see langword="false"/> when the signature is
+/// absent, malformed, cryptographically invalid, or could not be verified at all (the
+/// verifier could not reach the provider) — the gate treats every
+/// <see langword="false"/> the same: fail closed.
+/// </param>
+/// <param name="SignerKeyId">
+/// The identifier of the key that produced the signature (GPG long key-id /
+/// fingerprint, or sigstore identity) when <see cref="IsSignatureValid"/> is
+/// <see langword="true"/>; otherwise <see langword="null"/>.
+/// </param>
+/// <param name="Detail">
+/// A short, non-sensitive human-readable reason suitable for surfacing in the
+/// rejection message (e.g. <c>"commit is not signed"</c>,
+/// <c>"signature could not be verified (provider unreachable)"</c>). Never carry
+/// secrets, tokens, or raw provider responses here.
+/// </param>
+public sealed record CommitSignatureResult(bool IsSignatureValid, string? SignerKeyId, string? Detail)
+{
+    /// <summary>
+    /// A canonical "could not verify" result used by verifiers that cannot reach the
+    /// provider or have no implementation for the repo host. Fails closed under
+    /// <see cref="CustomCodeRepoPolicy.SignedOnly"/>.
+    /// </summary>
+    /// <param name="detail">The non-sensitive reason verification was not possible.</param>
+    /// <returns>An invalid-signature result carrying <paramref name="detail"/>.</returns>
+    public static CommitSignatureResult Unverifiable(string detail)
+        => new(IsSignatureValid: false, SignerKeyId: null, Detail: detail);
+}
+
+/// <summary>
+/// Verifies that a pinned custom-code commit carries a trusted, valid signature. This
+/// is a deliberate seam: the concrete verifier may call the git provider's API (e.g.
+/// GitHub's <c>verification</c> object on the commit), shell out to a sigstore/GPG
+/// verifier, or consult an internal attestation store. The submit gate depends only
+/// on this abstraction so the verification mechanism can evolve without touching the
+/// policy. A verifier MUST fail closed: when it cannot establish a valid signature for
+/// any reason it returns a result whose <see cref="CommitSignatureResult.IsSignatureValid"/>
+/// is <see langword="false"/> (use <see cref="CommitSignatureResult.Unverifiable"/>).
+/// </summary>
+public interface ICustomCodeCommitSignatureVerifier
+{
+    /// <summary>
+    /// Verifies the signature on the commit identified by <paramref name="commitSha"/>
+    /// in the repository at <paramref name="repoUrl"/>.
+    /// </summary>
+    /// <param name="repoUrl">The validated absolute HTTPS repository URL.</param>
+    /// <param name="commitSha">The validated full 40-hex commit SHA being pinned.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The verification outcome. Implementations must never throw for an
+    /// unverifiable commit — return <see cref="CommitSignatureResult.Unverifiable"/>
+    /// instead so the gate fails closed deterministically.
+    /// </returns>
+    ValueTask<CommitSignatureResult> VerifyAsync(
+        Uri repoUrl,
+        string commitSha,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// The default verifier registered when no provider-backed verifier is configured. It
+/// performs no network I/O and always reports the commit as unverifiable, so a
+/// deployment that selects <see cref="CustomCodeRepoPolicy.SignedOnly"/> without
+/// wiring a real verifier rejects every submission (fail-closed) rather than silently
+/// admitting unsigned code. This keeps signed-only honest by construction: opting into
+/// the strongest posture without a verifier is a no-op that blocks, never a bypass.
+/// </summary>
+internal sealed class UnverifiableCommitSignatureVerifier : ICustomCodeCommitSignatureVerifier
+{
+    /// <summary>The shared singleton instance (the verifier is stateless).</summary>
+    public static readonly UnverifiableCommitSignatureVerifier Instance = new();
+
+    /// <inheritdoc />
+    public ValueTask<CommitSignatureResult> VerifyAsync(
+        Uri repoUrl,
+        string commitSha,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(repoUrl);
+        ArgumentException.ThrowIfNullOrWhiteSpace(commitSha);
+
+        return ValueTask.FromResult(CommitSignatureResult.Unverifiable(
+            "no commit-signature verifier is configured; signed-only rejects unverifiable commits"));
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeOptions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeOptions.cs
@@ -29,6 +29,16 @@ public enum CustomCodeRepoPolicy
     /// deployments only — never combine with untrusted submitters.
     /// </summary>
     Open = 2,
+
+    /// <summary>
+    /// The strongest posture (Phase 3 supply-chain hardening). The repository must
+    /// satisfy the org-allowlist <em>and</em> the pinned commit must carry a verified
+    /// signature (GPG/sigstore) by a trusted key. A commit whose signature is absent,
+    /// invalid, by an untrusted key, or simply <em>unverifiable</em> (the configured
+    /// verifier cannot reach the provider) is rejected — the gate fails closed. The
+    /// per-tenant allowlist (when configured) is enforced in addition.
+    /// </summary>
+    SignedOnly = 3,
 }
 
 /// <summary>
@@ -45,18 +55,46 @@ internal sealed class CustomCodeOptions
     /// Repository-allowlist policy. Defaults to
     /// <see cref="CustomCodeRepoPolicy.OrgAllowlist"/> — the org-allowlist posture
     /// the contract specifies as the default; with an empty
-    /// <see cref="RepoAllowlist"/> this rejects every repository (fail-closed).
+    /// <see cref="RepoAllowlist"/> this rejects every repository (fail-closed). The
+    /// MVP default is unchanged; <see cref="CustomCodeRepoPolicy.SignedOnly"/> is the
+    /// opt-in Phase 3 supply-chain posture.
     /// </summary>
     public CustomCodeRepoPolicy RepoPolicy { get; set; } = CustomCodeRepoPolicy.OrgAllowlist;
 
     /// <summary>
     /// Allowed repository hosts (e.g. <c>github.com</c>,
     /// <c>git.internal.example</c>) honored when <see cref="RepoPolicy"/> is
-    /// <see cref="CustomCodeRepoPolicy.OrgAllowlist"/>. Matched case-insensitively
+    /// <see cref="CustomCodeRepoPolicy.OrgAllowlist"/> or
+    /// <see cref="CustomCodeRepoPolicy.SignedOnly"/>. Matched case-insensitively
     /// against the URL host; an entry of the form <c>host/org</c> additionally
     /// constrains the first path segment.
     /// </summary>
     public List<string> RepoAllowlist { get; set; } = [];
+
+    /// <summary>
+    /// Optional per-tenant repository allowlist (Phase 3). Keyed by the submitting
+    /// principal's <c>tenant_id</c>; the value is a list of allowlist entries in the
+    /// same <c>host</c> or <c>host/org</c> grammar as <see cref="RepoAllowlist"/>.
+    /// When a tenant has an entry here, the submitted repo_url must match the
+    /// tenant's list <em>in addition to</em> the org-wide allowlist — both gates must
+    /// pass, so a tenant list can only narrow what the org allows, never widen it.
+    /// A tenant absent from this map is unconstrained by the per-tenant gate and
+    /// falls through to the org allowlist alone (behavior-preserving default).
+    /// Enforced under <see cref="CustomCodeRepoPolicy.OrgAllowlist"/> and
+    /// <see cref="CustomCodeRepoPolicy.SignedOnly"/>.
+    /// </summary>
+    public Dictionary<string, List<string>> TenantRepoAllowlist { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Trusted signing-key identifiers (e.g. GPG long key-ids / fingerprints, or
+    /// sigstore identities) accepted when <see cref="RepoPolicy"/> is
+    /// <see cref="CustomCodeRepoPolicy.SignedOnly"/>. A verified commit signature
+    /// whose signer is not on this list is rejected. When empty under
+    /// <see cref="CustomCodeRepoPolicy.SignedOnly"/> the gate fails closed (no key is
+    /// trusted, so every submission is rejected) — configure at least one key to use
+    /// signed-only.
+    /// </summary>
+    public List<string> TrustedSignerKeys { get; set; } = [];
 
     /// <summary>
     /// The Honua API endpoint injected into the container as <c>HONUA_BASE_URL</c>

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeSubmitCoordinator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeSubmitCoordinator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Linq;
 using System.Security.Claims;
 using Honua.Core.Features.Authorization.Abstractions;
 using Honua.Core.Features.Authorization.Domain;
@@ -21,10 +22,18 @@ namespace Honua.Geoprocessing.CustomCode;
 /// <c>AwsBatchComputeBackend.BuildEnvironmentOverrides</c> surfaces it to the
 /// container as <c>HONUA_JOB_TOKEN</c> / <c>HONUA_BASE_URL</c>.
 /// </remarks>
-internal sealed class CustomCodeSubmitCoordinator(IScopedJobTokenIssuer tokenIssuer)
+internal sealed class CustomCodeSubmitCoordinator(
+    IScopedJobTokenIssuer tokenIssuer,
+    ICustomCodeCommitSignatureVerifier? signatureVerifier = null)
 {
     private readonly IScopedJobTokenIssuer _tokenIssuer = tokenIssuer
         ?? throw new ArgumentNullException(nameof(tokenIssuer));
+
+    // The commit-signature verifier consulted only under the signed-only posture.
+    // Defaults to the fail-closed verifier so signed-only without a configured
+    // verifier rejects every submission rather than admitting unsigned code.
+    private readonly ICustomCodeCommitSignatureVerifier _signatureVerifier =
+        signatureVerifier ?? UnverifiableCommitSignatureVerifier.Instance;
 
     /// <summary>Permission claim type the shared RBAC pipeline reads for scoped grants.</summary>
     private const string PermissionClaimType = "permission";
@@ -58,9 +67,27 @@ internal sealed class CustomCodeSubmitCoordinator(IScopedJobTokenIssuer tokenIss
         ArgumentNullException.ThrowIfNull(specParams);
         ArgumentNullException.ThrowIfNull(options);
 
-        if (!CustomCodeSubmitValidator.TryValidate(specParams, options, out var declaredScope, out var paramRejection))
+        var tenantId = principal.FindFirstValue(TenantClaimType);
+
+        if (!CustomCodeSubmitValidator.TryValidate(
+                specParams,
+                options,
+                tenantId,
+                out var declaredScope,
+                out var repoUri,
+                out var commitSha,
+                out var requiresSignatureVerification,
+                out var paramRejection))
         {
             throw new CustomCodeSubmitRejectedException(paramRejection!);
+        }
+
+        // Signed-only posture: the pinned commit must carry a valid signature by a
+        // trusted key. Run the verification seam and fail closed on anything that is
+        // not a verified, trusted signature. This is the supply-chain (T4) gate.
+        if (requiresSignatureVerification)
+        {
+            await EnsureCommitTrustedAsync(repoUri!, commitSha!, options, cancellationToken).ConfigureAwait(false);
         }
 
         if (string.IsNullOrWhiteSpace(options.ApiBaseUrl) ||
@@ -87,7 +114,6 @@ internal sealed class CustomCodeSubmitCoordinator(IScopedJobTokenIssuer tokenIss
                 $"Declared scope entry '{target}' exceeds the submitter's permissions and cannot be granted to custom code.");
         }
 
-        var tenantId = principal.FindFirstValue(TenantClaimType);
         var principalId = principal.Identity?.Name ?? string.Empty;
         var ownerScope = new CustomCodeOwnerScope(principalId, tenantId, roles, declaredScope);
 
@@ -114,6 +140,45 @@ internal sealed class CustomCodeSubmitCoordinator(IScopedJobTokenIssuer tokenIss
         specParams[CustomCodeJobContract.JobTokenEnvParam] = issuance.Token;
 
         return new CustomCodeSubmitResult(ownerScope, issuance.Token);
+    }
+
+    /// <summary>
+    /// Runs the commit-signature verification seam for the signed-only posture and
+    /// throws <see cref="CustomCodeSubmitRejectedException"/> unless the pinned commit
+    /// carries a cryptographically valid signature whose signer is on the configured
+    /// <see cref="CustomCodeOptions.TrustedSignerKeys"/>. Fails closed on an absent,
+    /// invalid, untrusted, or unverifiable signature.
+    /// </summary>
+    private async Task EnsureCommitTrustedAsync(
+        Uri repoUri,
+        string commitSha,
+        CustomCodeOptions options,
+        CancellationToken cancellationToken)
+    {
+        // No trusted key configured ⇒ nothing can be trusted ⇒ reject (fail closed).
+        if (options.TrustedSignerKeys is not { Count: > 0 })
+        {
+            throw new CustomCodeSubmitRejectedException(
+                "Custom-code signed-only policy is enabled but no trusted signer keys are configured; every submission is rejected.");
+        }
+
+        var result = await _signatureVerifier
+            .VerifyAsync(repoUri, commitSha, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!result.IsSignatureValid)
+        {
+            var detail = string.IsNullOrWhiteSpace(result.Detail) ? "the commit signature is missing or invalid" : result.Detail;
+            throw new CustomCodeSubmitRejectedException(
+                $"Custom-code commit '{commitSha}' was rejected by the signed-only policy: {detail}.");
+        }
+
+        if (string.IsNullOrWhiteSpace(result.SignerKeyId) ||
+            !options.TrustedSignerKeys.Any(k => string.Equals(k, result.SignerKeyId, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new CustomCodeSubmitRejectedException(
+                $"Custom-code commit '{commitSha}' is signed by a key that is not on the configured trusted-signer list.");
+        }
     }
 
     private static TimeSpan ResolveJobTimeout(Dictionary<string, string> specParams, CustomCodeOptions options)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeSubmitValidator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCode/CustomCodeSubmitValidator.cs
@@ -45,20 +45,41 @@ internal static partial class CustomCodeSubmitValidator
     /// scope. Returns the parsed declared scope on success; on failure sets
     /// <paramref name="rejection"/> and returns <see langword="null"/>.
     /// </summary>
+    /// <remarks>
+    /// This is the <em>pure</em>, I/O-free half of the submit gate: runtime, SHA-pin,
+    /// repo URL + org/per-tenant allowlist, entrypoint, manifest, and declared scope.
+    /// The <see cref="CustomCodeRepoPolicy.SignedOnly"/> posture additionally requires
+    /// an out-of-band commit-signature check; that check is asynchronous (it may call
+    /// the git provider) and is performed by the caller against
+    /// <see cref="ICustomCodeCommitSignatureVerifier"/>. <paramref name="requiresSignatureVerification"/>
+    /// reports whether the caller must run it; the validated URL and SHA are returned
+    /// so the caller need not re-parse them.
+    /// </remarks>
     /// <param name="parameters">The submission parameters (the <c>customcode.*</c> keys).</param>
-    /// <param name="options">The configured repository-allowlist policy.</param>
+    /// <param name="options">The configured repository-allowlist/signing policy.</param>
+    /// <param name="tenantId">The submitting principal's tenant id, for the per-tenant allowlist (may be null).</param>
     /// <param name="declaredScope">The parsed declared scope when validation succeeds.</param>
+    /// <param name="repoUri">The validated repository URI when validation succeeds.</param>
+    /// <param name="commitSha">The validated full commit SHA when validation succeeds.</param>
+    /// <param name="requiresSignatureVerification"><see langword="true"/> when the caller must run the commit-signature verifier (signed-only).</param>
     /// <param name="rejection">A human-readable rejection reason when validation fails.</param>
     /// <returns><see langword="true"/> when every custom-code parameter is valid.</returns>
     public static bool TryValidate(
         IReadOnlyDictionary<string, string> parameters,
         CustomCodeOptions options,
+        string? tenantId,
         out IReadOnlyList<JobResourceScopeEntry> declaredScope,
+        out Uri? repoUri,
+        out string? commitSha,
+        out bool requiresSignatureVerification,
         out string? rejection)
     {
         ArgumentNullException.ThrowIfNull(parameters);
         ArgumentNullException.ThrowIfNull(options);
         declaredScope = [];
+        repoUri = null;
+        commitSha = null;
+        requiresSignatureVerification = false;
         rejection = null;
 
         // runtime — MVP is python-only.
@@ -78,9 +99,11 @@ internal static partial class CustomCodeSubmitValidator
             return false;
         }
 
-        // repo_url — HTTPS + allowlist policy.
+        commitSha = gitRef;
+
+        // repo_url — HTTPS + org/per-tenant allowlist + signing policy.
         var repoUrl = Get(parameters, CustomCodeJobContract.RepoUrlParam);
-        if (!TryValidateRepoUrl(repoUrl, options, out rejection))
+        if (!TryValidateRepoUrl(repoUrl, options, tenantId, out repoUri, out requiresSignatureVerification, out rejection))
         {
             return false;
         }
@@ -111,9 +134,17 @@ internal static partial class CustomCodeSubmitValidator
         return true;
     }
 
-    private static bool TryValidateRepoUrl(string? repoUrl, CustomCodeOptions options, out string? rejection)
+    private static bool TryValidateRepoUrl(
+        string? repoUrl,
+        CustomCodeOptions options,
+        string? tenantId,
+        out Uri? repoUri,
+        out bool requiresSignatureVerification,
+        out string? rejection)
     {
         rejection = null;
+        repoUri = null;
+        requiresSignatureVerification = false;
 
         if (string.IsNullOrWhiteSpace(repoUrl) ||
             !Uri.TryCreate(repoUrl, UriKind.Absolute, out var uri) ||
@@ -123,6 +154,8 @@ internal static partial class CustomCodeSubmitValidator
             return false;
         }
 
+        repoUri = uri;
+
         switch (options.RepoPolicy)
         {
             case CustomCodeRepoPolicy.Disabled:
@@ -130,21 +163,57 @@ internal static partial class CustomCodeSubmitValidator
                 return false;
 
             case CustomCodeRepoPolicy.Open:
+                // Open accepts any host and does not consult the per-tenant allowlist;
+                // it is the trusted-single-tenant escape hatch.
                 return true;
 
             case CustomCodeRepoPolicy.OrgAllowlist:
-                if (IsAllowlisted(uri, options.RepoAllowlist))
+                return TryEnforceAllowlists(uri, options, tenantId, out rejection);
+
+            case CustomCodeRepoPolicy.SignedOnly:
+                // Signed-only is org-allowlist PLUS a commit-signature requirement. The
+                // allowlist gate runs here (pure); the caller runs the async signature
+                // check against the verifier when this flag is set.
+                if (!TryEnforceAllowlists(uri, options, tenantId, out rejection))
                 {
-                    return true;
+                    return false;
                 }
 
-                rejection = $"Custom-code repo_url host '{uri.Host}' is not on the configured repository allowlist.";
-                return false;
+                requiresSignatureVerification = true;
+                return true;
 
             default:
                 rejection = "Custom-code repository policy is misconfigured.";
                 return false;
         }
+    }
+
+    /// <summary>
+    /// Enforces the org-wide allowlist and, when the tenant has a per-tenant list, that
+    /// list <em>in addition</em> (both must pass). A tenant absent from the per-tenant
+    /// map is constrained by the org list alone.
+    /// </summary>
+    private static bool TryEnforceAllowlists(Uri uri, CustomCodeOptions options, string? tenantId, out string? rejection)
+    {
+        rejection = null;
+
+        if (!IsAllowlisted(uri, options.RepoAllowlist))
+        {
+            rejection = $"Custom-code repo_url host '{uri.Host}' is not on the configured repository allowlist.";
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(tenantId) &&
+            options.TenantRepoAllowlist is { Count: > 0 } &&
+            options.TenantRepoAllowlist.TryGetValue(tenantId, out var tenantList) &&
+            tenantList is { Count: > 0 } &&
+            !IsAllowlisted(uri, tenantList))
+        {
+            rejection = $"Custom-code repo_url host '{uri.Host}' is not on tenant '{tenantId}''s repository allowlist.";
+            return false;
+        }
+
+        return true;
     }
 
     private static bool IsAllowlisted(Uri uri, List<string> allowlist)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -63,7 +63,8 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         IExecutionAdmissionEvaluator? admissionEvaluator = null,
         IGeoprocessingResultPackageStore? resultPackageStore = null,
         IScopedJobTokenIssuer? scopedJobTokenIssuer = null,
-        IOptionsMonitor<CustomCodeOptions>? customCodeOptions = null)
+        IOptionsMonitor<CustomCodeOptions>? customCodeOptions = null,
+        ICustomCodeCommitSignatureVerifier? customCodeSignatureVerifier = null)
     {
         _progressStore = progressStore;
         _cancellationNotifiers = cancellationNotifiers.ToArray();
@@ -83,7 +84,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         _customCodeOptions = customCodeOptions;
         _customCodeCoordinator = scopedJobTokenIssuer is null
             ? null
-            : new CustomCodeSubmitCoordinator(scopedJobTokenIssuer);
+            : new CustomCodeSubmitCoordinator(scopedJobTokenIssuer, customCodeSignatureVerifier);
     }
 
     private TimeSpan ProgressRetention => _executorOptions.CurrentValue.ResultRetention;

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -189,6 +189,15 @@ internal static class GeoprocessingServiceCollectionExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
+        // Commit-signature verification seam for the signed-only repo-trust posture
+        // (Phase 3 supply-chain hardening). The default is the fail-closed verifier:
+        // a deployment that selects signed-only without registering a provider-backed
+        // verifier rejects every submission rather than admitting unsigned code. A
+        // real verifier (e.g. a GitHub commit-verification adapter) replaces this by
+        // registering ICustomCodeCommitSignatureVerifier before this call.
+        services.TryAddSingleton<ICustomCodeCommitSignatureVerifier>(
+            UnverifiableCommitSignatureVerifier.Instance);
+
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IJobExecutor, CustomCodeDispatchJobExecutor>());
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeSubmitTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeSubmitTests.cs
@@ -267,13 +267,181 @@ public sealed class CustomCodeSubmitTests
     }
 
     // -----------------------------------------------------------------------
+    // Phase 3: per-tenant repository allowlist
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_RepoOnOrgButNotTenantAllowlist_Rejected()
+    {
+        // Org allows github.com; tenant-A is additionally constrained to a specific
+        // org path, so a bare github.com/honua-io repo for tenant-A is rejected.
+        var sut = CreateService(options =>
+        {
+            options.RepoAllowlist = ["github.com"];
+            options.TenantRepoAllowlist["tenant-A"] = ["github.com/trusted-org"];
+        });
+
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), CustomCodeMetadata());
+
+        await act.Should().ThrowAsync<Exception>()
+            .Where(e => e.Message.Contains("tenant 'tenant-A'"));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_RepoOnTenantAllowlist_Accepted()
+    {
+        var sut = CreateService(options =>
+        {
+            options.RepoAllowlist = ["github.com"];
+            options.TenantRepoAllowlist["tenant-A"] = ["github.com/honua-io"];
+        });
+
+        var job = await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), CustomCodeMetadata());
+
+        job.Spec.RuntimeProfile.Should().Be(CustomCodeJobContract.RuntimeProfile);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_TenantWithoutListFallsThroughToOrgAllowlist()
+    {
+        // A tenant absent from the per-tenant map is constrained by the org list
+        // alone — behavior-preserving for tenants the operator has not scoped.
+        var sut = CreateService(options =>
+        {
+            options.RepoAllowlist = ["github.com"];
+            options.TenantRepoAllowlist["tenant-OTHER"] = ["github.com/nobody"];
+        });
+
+        var job = await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), CustomCodeMetadata());
+
+        job.Spec.RuntimeProfile.Should().Be(CustomCodeJobContract.RuntimeProfile);
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 3: signed-only commit-signature policy
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_SignedOnly_UnsignedCommit_Rejected()
+    {
+        var verifier = new StubSignatureVerifier(CommitSignatureResult.Unverifiable("commit is not signed"));
+        var sut = CreateService(
+            options =>
+            {
+                options.RepoPolicy = CustomCodeRepoPolicy.SignedOnly;
+                options.TrustedSignerKeys = ["ABCD1234"];
+            },
+            signatureVerifier: verifier);
+
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), CustomCodeMetadata());
+
+        await act.Should().ThrowAsync<Exception>()
+            .Where(e => e.Message.Contains("signed-only policy") && e.Message.Contains("not signed"));
+        verifier.LastSha.Should().Be(ValidSha);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_SignedOnly_WronglySignedCommit_Rejected()
+    {
+        // Valid signature, but by an untrusted key.
+        var verifier = new StubSignatureVerifier(new CommitSignatureResult(IsSignatureValid: true, SignerKeyId: "DEADBEEF", Detail: null));
+        var sut = CreateService(
+            options =>
+            {
+                options.RepoPolicy = CustomCodeRepoPolicy.SignedOnly;
+                options.TrustedSignerKeys = ["ABCD1234"];
+            },
+            signatureVerifier: verifier);
+
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), CustomCodeMetadata());
+
+        await act.Should().ThrowAsync<Exception>()
+            .Where(e => e.Message.Contains("not on the configured trusted-signer list"));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_SignedOnly_TrustedSignedCommit_Accepted()
+    {
+        var verifier = new StubSignatureVerifier(new CommitSignatureResult(IsSignatureValid: true, SignerKeyId: "abcd1234", Detail: null));
+        var sut = CreateService(
+            options =>
+            {
+                options.RepoPolicy = CustomCodeRepoPolicy.SignedOnly;
+                options.RepoAllowlist = ["github.com"];
+                options.TrustedSignerKeys = ["ABCD1234"]; // case-insensitive match
+            },
+            signatureVerifier: verifier);
+
+        var job = await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), CustomCodeMetadata());
+
+        job.Spec.RuntimeProfile.Should().Be(CustomCodeJobContract.RuntimeProfile);
+        verifier.LastRepo!.Host.Should().Be("github.com");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_SignedOnly_NoTrustedKeysConfigured_FailsClosed()
+    {
+        // Signed-only with an empty trusted-key list rejects everything, regardless of
+        // verifier outcome — the verifier is never consulted.
+        var verifier = new StubSignatureVerifier(new CommitSignatureResult(IsSignatureValid: true, SignerKeyId: "ABCD1234", Detail: null));
+        var sut = CreateService(
+            options =>
+            {
+                options.RepoPolicy = CustomCodeRepoPolicy.SignedOnly;
+                options.TrustedSignerKeys = [];
+            },
+            signatureVerifier: verifier);
+
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), CustomCodeMetadata());
+
+        await act.Should().ThrowAsync<Exception>()
+            .Where(e => e.Message.Contains("no trusted signer keys are configured"));
+        verifier.LastSha.Should().BeNull();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_SignedOnly_DefaultVerifier_FailsClosed()
+    {
+        // No verifier registered (the DI default is the fail-closed verifier): even
+        // with trusted keys configured, every signed-only submission is rejected
+        // because the default verifier reports the commit unverifiable.
+        var sut = CreateService(options =>
+        {
+            options.RepoPolicy = CustomCodeRepoPolicy.SignedOnly;
+            options.TrustedSignerKeys = ["ABCD1234"];
+        });
+
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), CustomCodeMetadata());
+
+        await act.Should().ThrowAsync<Exception>()
+            .Where(e => e.Message.Contains("no commit-signature verifier is configured"));
+    }
+
+    // -----------------------------------------------------------------------
     // helpers
     // -----------------------------------------------------------------------
 
     private GeoprocessingJobService CreateService(
         Action<CustomCodeOptions>? configure = null,
         IExecutionJobDefinitionRegistry? workloadRegistry = null,
-        IEnumerable<IBatchComputeBackend>? backends = null)
+        IEnumerable<IBatchComputeBackend>? backends = null,
+        ICustomCodeCommitSignatureVerifier? signatureVerifier = null)
     {
         var options = new CustomCodeOptions
         {
@@ -294,7 +462,22 @@ public sealed class CustomCodeSubmitTests
             workloadRegistry: workloadRegistry,
             backends: backends,
             scopedJobTokenIssuer: _issuer,
-            customCodeOptions: new StaticOptionsMonitor<CustomCodeOptions>(options));
+            customCodeOptions: new StaticOptionsMonitor<CustomCodeOptions>(options),
+            customCodeSignatureVerifier: signatureVerifier);
+    }
+
+    /// <summary>A test verifier that returns a fixed signature outcome.</summary>
+    private sealed class StubSignatureVerifier(CommitSignatureResult result) : ICustomCodeCommitSignatureVerifier
+    {
+        public Uri? LastRepo { get; private set; }
+        public string? LastSha { get; private set; }
+
+        public ValueTask<CommitSignatureResult> VerifyAsync(Uri repoUrl, string commitSha, CancellationToken cancellationToken)
+        {
+            LastRepo = repoUrl;
+            LastSha = commitSha;
+            return ValueTask.FromResult(result);
+        }
     }
 
     private static Dictionary<string, string> CustomCodeMetadata(


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2189

## Summary
Phase 3 (Beta) supply-chain hardening for the custom-code geoprocessing submit gate. Extends the repo-trust policy beyond the MVP org-allowlist with (a) a per-tenant repository allowlist and (b) an optional commit-signature requirement, via a new policy knob `open | org-allowlist | signed-only`. The MVP default (`OrgAllowlist`) and the existing SHA-pin behavior are unchanged; everything new is opt-in by config.

This is the server half; the egress-isolation half lands in honua-iac (separate PR).

## Changes Made
- Added `CustomCodeRepoPolicy.SignedOnly`: org-allowlist **plus** a verified commit signature by a trusted key. Fails closed on absent / invalid / untrusted / unverifiable signatures.
- Added per-tenant repository allowlist (`CustomCodeOptions.TenantRepoAllowlist`), enforced **in addition** to the org allowlist under both `OrgAllowlist` and `SignedOnly` (a tenant list can only narrow, never widen, what the org allows; tenants absent from the map fall through to the org list).
- Added the commit-signature verification seam `ICustomCodeCommitSignatureVerifier` + `CommitSignatureResult`, with a fail-closed default verifier (`UnverifiableCommitSignatureVerifier`) registered via `TryAddSingleton`. Selecting signed-only without wiring a provider-backed verifier rejects every submission rather than admitting unsigned code.
- Added `CustomCodeOptions.TrustedSignerKeys`; empty under signed-only fails closed.
- Kept the pure validator I/O-free: it performs URL/SHA/allowlist checks and reports whether an async signature check is required; the coordinator runs the verifier and matches the signer against the trusted-key list.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Custom-code suite: 26/26 green (`--filter FullyQualifiedName~CustomCode`). New tests cover: signed-only rejects unsigned / wrongly-signed (untrusted key) / unverifiable (default verifier) commits and accepts a trusted-signed commit (case-insensitive key match); empty-trusted-keys fails closed; per-tenant allowlist enforced and falls through to the org list for unscoped tenants; existing org-allowlist + SHA-pin paths unchanged. Release build green with `-p:TreatWarningsAsErrors=true -p:NuGetAudit=false`; `dotnet format --verify-no-changes` clean.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] None — no docs or contract impact

The wire contract (`customcode.*` params) is unchanged; new behavior is server-side config only.

## Release/Deploy Impact
None — all new behavior is gated behind `Geoprocessing:CustomCode` config; the MVP default posture is unchanged.

## Breaking Changes
None.

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
