### PR TITLE
feat(customcode): first-class GDAL interop in the Python GP runtime

### DIFF
--- a/docker/worker-customcode-python/Dockerfile
+++ b/docker/worker-customcode-python/Dockerfile
@@ -72,7 +72,12 @@ RUN python3 -m pip install --no-cache-dir --break-system-packages \
 
 # Correctness check: the SDK + geo bindings + the harness must import, and the
 # console script must be on PATH. Fails the build early if a wheel didn't link.
-RUN python3 -c "import honua_sdk, rasterio, geopandas, shapely, pyproj, fiona, boto3; import osgeo.gdal" \
+# The GDAL interop check imports the FULL osgeo binding set (gdal/ogr/osr) AND
+# rasterio, and asserts a driver count > 0 — proving in-process raster/vector GDAL
+# is available to user tools (not just the gdal* CLIs). rasterio/osgeo link against
+# the GDAL-full base, so this fails fast on any ABI/wheel mismatch.
+RUN python3 -c "import honua_sdk, rasterio, geopandas, shapely, pyproj, fiona, boto3" \
+ && python3 -c "from osgeo import gdal, ogr, osr; gdal.AllRegister(); assert gdal.GetDriverCount() > 0, 'no GDAL raster drivers'; assert ogr.GetDriverCount() > 0, 'no OGR vector drivers'; import rasterio; assert len(rasterio.drivers.raster_driver_extensions()) > 0" \
  && python3 -c "import honua_customcode_harness as h; assert hasattr(h, 'run')" \
  && command -v honua-customcode-harness
 

--- a/docker/worker-customcode-python/README.md
+++ b/docker/worker-customcode-python/README.md
@@ -16,6 +16,23 @@ on a GDAL-full base with the geospatial stack + `honua-sdk` baked in.
 - Added: `git`, `python3-pip`, `ca-certificates`, build toolchain.
 - Pre-installed (no per-job restore for the common case): `rasterio`,
   `geopandas`, `shapely`, `pyproj`, `fiona`, `boto3`, and **`honua-sdk==0.1.4`**.
+
+### First-class GDAL interop
+
+A raster/vector GP tool processes data **with GDAL directly, in-process** — the
+SDK is data-transport only, not a raster library. This image gives user code the
+full GDAL Python interop surface:
+
+- `osgeo.gdal` / `osgeo.ogr` / `osgeo.osr` — the GDAL/OGR/OSR Python C-bindings
+  (from the GDAL-full base), for direct dataset/driver/CRS work.
+- `rasterio` (+ `fiona`, `geopandas`, `pyproj`, `shapely`) — the higher-level geo
+  stack, linking against the **same** base `libgdal`.
+
+The in-build sanity check imports the full binding set and asserts
+`gdal.GetDriverCount() > 0` / `ogr.GetDriverCount() > 0`, so the image fails to
+build if the raster/vector interop ever regresses. See the raster sample below
+and [`docs/customcode/raster-gp-pattern.md`](../../docs/customcode/raster-gp-pattern.md)
+for the SDK-as-transport / GDAL-as-engine pattern.
 - The harness package `honua_customcode_harness` is installed; the
   `honua-customcode-harness` console script is the `ENTRYPOINT`.
 - Runs as non-root `uid 1001` (matching `worker-gdal`). Scratch tree `/work`.
@@ -102,8 +119,15 @@ def execute(context: GpContext) -> GpResult:
 `.output.add_artifact(name, path)`, `.progress.report(pct, phase)`,
 `.log.info/warn(...)`, `.cancellation`, `.workdir`.
 
-A trivial sample lives in [`harness/samples/buffer_tool.py`](harness/samples/buffer_tool.py)
-(entrypoint `buffer_tool:execute`): buffers a WKT geometry and writes GeoJSON.
+Two samples live under [`harness/samples/`](harness/samples/):
+
+- [`buffer_tool.py`](harness/samples/buffer_tool.py) (entrypoint
+  `buffer_tool:execute`): buffers a WKT geometry and writes GeoJSON (vector).
+- [`raster_ndvi_tool.py`](harness/samples/raster_ndvi_tool.py) (entrypoint
+  `raster_ndvi_tool:execute`): the **raster** sample — synthesizes a 2-band
+  GeoTIFF with `osgeo.gdal`, reads it with `rasterio`, computes NDVI band math,
+  and writes an LZW-compressed Float32 GeoTIFF. This proves the in-image
+  raster-processing path (GDAL is the engine, the SDK is transport).
 
 ## Tests (offline)
 

--- a/docker/worker-customcode-python/harness/samples/raster_ndvi_tool.py
+++ b/docker/worker-customcode-python/harness/samples/raster_ndvi_tool.py
@@ -1,0 +1,114 @@
+"""Sample custom-code raster GP tool: GDAL/rasterio in-process raster processing.
+
+This is the raster counterpart of ``buffer_tool.py``. It PROVES the in-image
+raster-processing path: a GP tool processes a GeoTIFF *with GDAL* (here via the
+``rasterio``/``osgeo`` bindings that link against the GDAL-full base image), not
+via the Honua SDK. The SDK is data-transport only — a real tool would fetch the
+input coverage to a local file (or a ``/vsi`` handle) with ``context.client`` and
+upload/register the output GeoTIFF. Here we keep the data path trivial so the
+sample is self-contained and offline.
+
+What it does (a trivial band-math op — NDVI = (NIR - RED) / (NIR + RED)):
+
+1. Resolve a 2-band (RED, NIR) input GeoTIFF. If ``params.input`` names a staged
+   input artifact (see ``context.inputs``) use it; otherwise synthesize a tiny
+   2-band GeoTIFF with ``osgeo.gdal`` so the sample runs with no inputs.
+2. Read the bands with ``rasterio``, compute NDVI as float32 band math.
+3. Write a single-band Float32 GeoTIFF (LZW-compressed) preserving the CRS +
+   transform, and register it as the output artifact.
+
+Entrypoint spec for this tool: ``raster_ndvi_tool:execute``.
+
+Expected ``params_json`` (all optional)::
+
+    {"input": "scene.tif", "out_name": "ndvi.tif", "size": 64}
+"""
+
+from __future__ import annotations
+
+from honua_customcode_harness import GpContext, GpResult
+
+
+def _synthesize_scene(path: str, size: int) -> None:
+    """Write a tiny 2-band (RED, NIR) Float32 GeoTIFF using ``osgeo.gdal``.
+
+    Demonstrates the *direct* GDAL C-binding path (``osgeo.gdal``), distinct from
+    the higher-level ``rasterio`` read below — both link the same base libgdal.
+    """
+    import numpy as np
+    from osgeo import gdal, osr
+
+    gdal.UseExceptions()
+    driver = gdal.GetDriverByName("GTiff")
+    ds = driver.Create(path, size, size, 2, gdal.GDT_Float32)
+
+    # A real-ish geotransform + CRS (UTM 33N) so reproject/warp would be valid.
+    ds.SetGeoTransform((500000.0, 10.0, 0.0, 4600000.0, 0.0, -10.0))
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(32633)
+    ds.SetProjection(srs.ExportToWkt())
+
+    rng = np.random.default_rng(42)
+    red = rng.uniform(0.05, 0.4, size=(size, size)).astype("float32")
+    nir = rng.uniform(0.3, 0.9, size=(size, size)).astype("float32")
+    ds.GetRasterBand(1).WriteArray(red)
+    ds.GetRasterBand(2).WriteArray(nir)
+    ds.FlushCache()
+    ds = None  # noqa: F841 — close the dataset (GDAL idiom).
+
+
+def execute(context: GpContext) -> GpResult:
+    params = context.params
+    out_name = str(params.get("out_name", "ndvi.tif"))
+    size = int(params.get("size", 64))
+
+    context.log.info("raster NDVI tool starting (GDAL/rasterio in-process)")
+    context.progress.report(5.0, "resolving input")
+
+    try:
+        import numpy as np
+        import rasterio
+    except ImportError as exc:  # pragma: no cover - baked into the image
+        return GpResult.failed(f"raster stack not available in this runtime: {exc}")
+
+    # Resolve the input: a staged input artifact, else synthesize one.
+    input_key = params.get("input")
+    if input_key and input_key in context.inputs:
+        input_path = str(context.inputs[input_key])
+        context.log.info(f"using staged input {input_key!r} -> {input_path}")
+    else:
+        input_path = str(context.workdir / "scene.tif")
+        context.log.info("no input staged; synthesizing a 2-band scene with osgeo.gdal")
+        _synthesize_scene(input_path, size)
+
+    context.cancellation.raise_if_cancelled()
+    context.progress.report(40.0, "reading bands")
+
+    with rasterio.open(input_path) as src:
+        if src.count < 2:
+            return GpResult.failed(
+                f"input must have >= 2 bands (RED, NIR); got {src.count}."
+            )
+        red = src.read(1).astype("float32")
+        nir = src.read(2).astype("float32")
+        profile = src.profile
+
+    context.progress.report(70.0, "computing NDVI")
+    denom = nir + red
+    # Avoid divide-by-zero; NDVI is in [-1, 1].
+    ndvi = np.where(denom == 0, 0.0, (nir - red) / denom).astype("float32")
+
+    profile.update(count=1, dtype="float32", compress="lzw")
+    out_path = context.workdir / out_name
+    with rasterio.open(out_path, "w", **profile) as dst:
+        dst.write(ndvi, 1)
+
+    context.progress.report(90.0, "registering output")
+    context.output.add_artifact(out_name, out_path)
+    context.log.info(
+        f"wrote {out_name} ({out_path.stat().st_size} bytes), "
+        f"NDVI range [{float(ndvi.min()):.3f}, {float(ndvi.max()):.3f}]"
+    )
+    context.progress.report(100.0, "done")
+
+    return GpResult.succeeded(f"NDVI GeoTIFF written to {out_name}")

--- a/docs/customcode/raster-gp-pattern.md
+++ b/docs/customcode/raster-gp-pattern.md
@@ -1,0 +1,118 @@
+# Raster/vector geoprocessing in custom-code GP tools
+
+**TL;DR — GDAL is the engine, the Honua SDK is transport.** A custom-code GP tool
+processes raster/vector data *with GDAL directly, in-process*, on local files. It uses
+the Honua SDK only to fetch input coverages to a local file (or a `/vsi` handle) and to
+upload/register the output GeoTIFF. The SDK is deliberately **not** a raster library —
+there is no need for it to be one.
+
+This pattern is identical across both custom-code runtimes:
+
+| | Python runtime | .NET runtime |
+|---|---|---|
+| Image | [`docker/worker-customcode-python`](../../docker/worker-customcode-python/README.md) | [`docker/worker-customcode-dotnet`](../../docker/worker-customcode-dotnet/README.md) |
+| GDAL interop | `osgeo.gdal` / `osgeo.ogr` / `osgeo.osr` + `rasterio` (GDAL-full base) | `OSGeo.GDAL` / `OSGeo.OGR` / `OSGeo.OSR` via `MaxRev.Gdal.Core` (+ `LinuxRuntime.Minimal`) |
+| Init | implicit on import (`gdal.UseExceptions()` recommended) | `GdalBase.ConfigureAll()` once before use |
+| Raster sample | `samples/raster_ndvi_tool.py` | `samples/RasterTool/RasterTool.cs` |
+| Vector sample | `samples/buffer_tool.py` | `samples/BufferTool/BufferTool.cs` |
+
+Both images are built on the **`ghcr.io/osgeo/gdal:ubuntu-full-3.12.4`** base, so the
+full GDAL driver set is present. In-build sanity checks assert the bindings load and a
+driver count `> 0`, so the images fail to build if raster/vector interop ever regresses.
+
+## The three roles
+
+1. **Honua SDK → input.** Fetch the input coverage to a local file (or open a GDAL
+   `/vsi*` handle, e.g. `/vsicurl/…`, `/vsis3/…`). This is the *transport* step.
+2. **GDAL → processing.** Open the local file / `/vsi` handle with GDAL (`rasterio` or
+   `osgeo.gdal` in Python; `OSGeo.GDAL` in .NET), do the raster/vector work (reproject,
+   warp, band math, raster algebra, vector ops), and write a local GeoTIFF. This is the
+   *engine* step — GDAL does all raster I/O and geodesy.
+3. **Honua SDK → output.** Register the output GeoTIFF as a job artifact (the harness
+   uploads it to the job's S3 output prefix) and/or register it as a coverage via the
+   SDK. The *transport* step again.
+
+The harness already gives a tool a writable scratch `workdir`/`WorkDirectory`, a scoped
+`client`/`Client` (the SDK), an `inputs`/`Inputs` map of staged input artifacts, and an
+`output`/`Output` artifact sink. The tool's only job is steps 1→3.
+
+## Python
+
+```python
+from honua_customcode_harness import GpContext, GpResult
+
+
+def execute(context: GpContext) -> GpResult:
+    import rasterio
+    from rasterio.warp import calculate_default_transform, reproject, Resampling
+
+    # 1. SDK is transport: resolve a staged input (or fetch via context.client).
+    src_path = str(context.inputs["scene"])      # local file the harness staged
+
+    # 2. GDAL is the engine: reproject to EPSG:4326 with rasterio (== GDAL warp).
+    dst_path = context.workdir / "reprojected.tif"
+    with rasterio.open(src_path) as src:
+        transform, w, h = calculate_default_transform(
+            src.crs, "EPSG:4326", src.width, src.height, *src.bounds)
+        profile = src.profile
+        profile.update(crs="EPSG:4326", transform=transform, width=w, height=h)
+        with rasterio.open(dst_path, "w", **profile) as dst:
+            for b in range(1, src.count + 1):
+                reproject(
+                    source=rasterio.band(src, b),
+                    destination=rasterio.band(dst, b),
+                    src_transform=src.transform, src_crs=src.crs,
+                    dst_transform=transform, dst_crs="EPSG:4326",
+                    resampling=Resampling.bilinear)
+
+    # 3. SDK is transport: register the output GeoTIFF for upload.
+    context.output.add_artifact("reprojected.tif", dst_path)
+    return GpResult.succeeded("reprojected to EPSG:4326")
+```
+
+The low-level `osgeo.gdal`/`ogr`/`osr` bindings are equally available for direct
+dataset/driver/CRS work (see `samples/raster_ndvi_tool.py`, which synthesizes a scene
+with `osgeo.gdal` and computes NDVI band math with `rasterio`).
+
+## .NET
+
+```csharp
+using Honua.CustomCode.Sdk;
+using MaxRev.Gdal.Core;
+using OSGeo.GDAL;
+
+public sealed class ReprojectTool : IGeoprocessingTool
+{
+    public Task<GpResult> ExecuteAsync(GpContext context, CancellationToken ct)
+    {
+        GdalBase.ConfigureAll();                       // once, before using GDAL
+
+        // 1. SDK is transport: the harness staged the input locally.
+        var srcPath = context.Inputs["scene"];
+
+        // 2. GDAL is the engine: warp to EPSG:4326 with the GDAL utilities API.
+        var dstPath = Path.Combine(context.WorkDirectory, "reprojected.tif");
+        using var src = Gdal.Open(srcPath, Access.GA_ReadOnly);
+        var options = new GDALWarpAppOptions(["-t_srs", "EPSG:4326", "-r", "bilinear"]);
+        using var dst = Gdal.Warp(dstPath, [src], options, null, null);
+        dst.FlushCache();
+
+        // 3. SDK is transport: register the output GeoTIFF for upload.
+        context.Output.AddArtifact("reprojected.tif", dstPath);
+        return Task.FromResult(GpResult.Succeeded("reprojected to EPSG:4326"));
+    }
+}
+```
+
+`OSGeo.OGR` (vector) and `OSGeo.OSR` (CRS) are available the same way. See
+`samples/RasterTool/RasterTool.cs`, which creates a 2-band GeoTIFF with `OSGeo.GDAL` and
+computes NDVI band math in-process.
+
+## Why the SDK is not a raster library
+
+GDAL already is the cross-language raster/vector engine (drivers, reprojection, warping,
+algebra, format I/O) and is present in-process in both runtimes. Re-exposing any of that
+through the Honua SDK would duplicate GDAL behind a thinner, lossy surface. The SDK's job
+is the data path — authenticated fetch/upload/register of coverages — which complements,
+and does not duplicate, the SDK's raster agents (coverage download/upload/metadata). Keep
+the boundary crisp: **SDK moves bytes, GDAL processes pixels.**


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2188

## Summary
Confirms and hardens **first-class GDAL interop** in the Python custom-code GP
runtime so a raster/vector GP tool processes data with GDAL **directly,
in-process** — the Honua SDK is data-transport only, not a raster library. This
complements (does not duplicate) the SDK raster agents (coverage
download/upload/metadata).

Stacked on `feat/customcode-python-image` (PR #2188, Phase 1).

The image already shipped `osgeo.gdal`/`ogr`/`osr` + `rasterio` on the GDAL-full
base; this PR proves it with a tighter in-build check, adds a raster sample, and
documents the SDK-as-transport / GDAL-as-engine pattern.

## Changes Made
- Tighten the in-build sanity check to import the full `osgeo` binding set
  (`gdal`/`ogr`/`osr`) **and** `rasterio`, and assert raster + vector driver
  counts `> 0` — fails the image build if GDAL interop ever regresses.
- Add raster sample `harness/samples/raster_ndvi_tool.py`: synthesizes a 2-band
  GeoTIFF with `osgeo.gdal`, reads it with `rasterio`, computes NDVI band math,
  writes an LZW-compressed Float32 GeoTIFF — proving the in-image raster path.
- Document the GDAL-interop surface in the image README.
- Add `docs/customcode/raster-gp-pattern.md` (shared with the .NET PR): SDK moves
  bytes, GDAL processes pixels.

## Testing
- [x] Manual testing performed

Sample byte-compiles; the Dockerfile's Python import/driver-count check is valid
Python syntax. The Docker image build itself is **CI/local-Docker verified** (no
daemon in the agent env) — the in-build import + driver-count check is the
correctness gate.

## Gate Impact
- [x] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
