### PR TITLE
feat(customcode): add GDAL C# bindings for first-class .NET GDAL interop

### DIFF
--- a/docker/worker-customcode-dotnet/Dockerfile
+++ b/docker/worker-customcode-dotnet/Dockerfile
@@ -38,7 +38,7 @@ RUN dotnet publish src/Honua.CustomCode.Harness/Honua.CustomCode.Harness.csproj 
       -p:NuGetAudit=false \
       --output /opt/harness
 
-# IN-BUILD SANITY CHECK (correct-by-construction): restore + build the sample tool.
+# IN-BUILD SANITY CHECK (correct-by-construction): restore + build the sample tools.
 # This proves the SDK contract resolves, the geometry stack restores, and a real
 # IGeoprocessingTool compiles — failing the image build early if anything regresses.
 RUN dotnet build samples/BufferTool/BufferTool.csproj \
@@ -46,6 +46,53 @@ RUN dotnet build samples/BufferTool/BufferTool.csproj \
       -p:NuGetAudit=false \
       --output /tmp/sample-build \
  && test -f /tmp/sample-build/BufferTool.dll
+
+# GDAL INTEROP SANITY CHECK: build the raster sample (which references the GDAL C#
+# bindings MaxRev.Gdal.Core + MaxRev.Gdal.LinuxRuntime.Minimal) AND execute a tiny
+# probe that calls GdalBase.ConfigureAll() and asserts a driver count > 0 — proving
+# the self-contained native GDAL loads and OSGeo.GDAL interop works in-process, not
+# just that it compiles. Fails the image build early on any binding/native regression.
+RUN dotnet build samples/RasterTool/RasterTool.csproj \
+      --configuration Release \
+      -p:NuGetAudit=false \
+      --output /tmp/raster-build \
+ && test -f /tmp/raster-build/RasterTool.dll
+RUN mkdir -p /tmp/gdalprobe \
+ && cat > /tmp/gdalprobe/Probe.csproj <<EOF
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MaxRev.Gdal.Core" Version="3.12.4.520" />
+    <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.12.4.520" />
+  </ItemGroup>
+</Project>
+EOF
+RUN cat > /tmp/gdalprobe/Program.cs <<EOF
+using MaxRev.Gdal.Core;
+using OSGeo.GDAL;
+
+GdalBase.ConfigureAll();
+var drivers = Gdal.GetDriverCount();
+Console.WriteLine($"GDAL {Gdal.VersionInfo("RELEASE_NAME")} drivers={drivers}");
+if (drivers <= 0)
+{
+    Console.Error.WriteLine("FATAL: GDAL registered no drivers");
+    return 1;
+}
+if (Gdal.GetDriverByName("GTiff") is null)
+{
+    Console.Error.WriteLine("FATAL: GTiff driver missing");
+    return 1;
+}
+return 0;
+EOF
+RUN cd /tmp/gdalprobe && dotnet run -c Release -p:NuGetAudit=false
 
 # --- runtime stage: GDAL-full base + the .NET SDK + git + the warm cache --------------
 # Pinned GDAL "ubuntu-full" base (matches the python image's base family). It ships the
@@ -57,6 +104,10 @@ ARG DOTNET_SDK_CHANNEL=10.0
 # Pin the geo + SDK package versions so the warm cache matches the harness solution.
 ARG NETTOPOLOGYSUITE_VERSION=2.6.0
 ARG HONUA_SDK_DOTNET_VERSION=0.1.4
+# GDAL C# bindings (in-process raster/vector interop). MaxRev bundles its own
+# self-contained native GDAL (no ABI dependence on the base libgdal); 3.12.4.520
+# bundles native GDAL 3.12.4, matching the GDAL-full base image tag.
+ARG MAXREV_GDAL_VERSION=3.12.4.520
 
 ENV DEBIAN_FRONTEND=noninteractive \
     DOTNET_CLI_TELEMETRY_OPTOUT=1 \
@@ -91,17 +142,22 @@ COPY --from=build /opt/harness /opt/harness
 # tiny throwaway project that references the common packages into the shared global
 # packages folder, then deleting the project (the populated cache layer is what we keep).
 ENV NUGET_PACKAGES=/opt/nuget/packages
+# The RuntimeIdentifier pulls the linux-x64 native GDAL runtime asset into the warm
+# cache too, so a raster tool builds with NO network restore at job time.
 RUN mkdir -p /tmp/warm \
  && cat > /tmp/warm/warm.csproj <<EOF
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NetTopologySuite" Version="${NETTOPOLOGYSUITE_VERSION}" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />
     <PackageReference Include="Honua.Sdk" Version="${HONUA_SDK_DOTNET_VERSION}" />
+    <PackageReference Include="MaxRev.Gdal.Core" Version="${MAXREV_GDAL_VERSION}" />
+    <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="${MAXREV_GDAL_VERSION}" />
   </ItemGroup>
 </Project>
 EOF

--- a/docker/worker-customcode-dotnet/README.md
+++ b/docker/worker-customcode-dotnet/README.md
@@ -18,7 +18,42 @@ common .NET geo stack + the Honua .NET SDK baked into the NuGet cache.
   for tools that shell out to or P/Invoke GDAL.
 - Added: the **.NET 10 SDK** (pinned channel), `git`, `ca-certificates`.
 - Pre-warmed NuGet cache (no per-job restore for the common case): **NetTopologySuite**,
-  `NetTopologySuite.IO.GeoJSON`, and **`Honua.Sdk`** (the .NET SDK umbrella).
+  `NetTopologySuite.IO.GeoJSON`, **`Honua.Sdk`** (the .NET SDK umbrella), and the **GDAL
+  C# bindings** (`MaxRev.Gdal.Core` + `MaxRev.Gdal.LinuxRuntime.Minimal`).
+
+### First-class GDAL interop
+
+A raster/vector GP tool processes data **with GDAL directly, in-process** — the SDK is
+data-transport only, not a raster library. The base image ships the `gdal*` CLIs, but a
+.NET tool cannot do in-process raster/vector GDAL work without the **C# bindings**, so
+this image pre-warms them so a tool can simply:
+
+```csharp
+using MaxRev.Gdal.Core;
+using OSGeo.GDAL;   // raster
+using OSGeo.OGR;    // vector
+using OSGeo.OSR;    // CRS
+
+GdalBase.ConfigureAll();          // once, before using GDAL (registers all drivers)
+using var ds = Gdal.Open(path, Access.GA_ReadOnly);
+```
+
+- **Binding:** `MaxRev.Gdal.Core` + `MaxRev.Gdal.LinuxRuntime.Minimal`, pinned to
+  **`3.12.4.520`** (bundles native GDAL **3.12.4**). MaxRev bundles its **own
+  self-contained native GDAL**, so there is **no ABI dependence** on the base image's
+  `libgdal` — and the pinned version **matches** the base's GDAL (3.12.4) so the
+  in-process binding and the `gdal*` CLIs agree on driver behavior.
+- **Init:** a tool calls `GdalBase.ConfigureAll()` once (it wires the bundled native
+  GDAL + PROJ data and calls `Gdal.AllRegister()`). The `RasterTool` sample does this
+  behind a one-time guard; document this in your own tool if you copy the pattern.
+- **Sanity:** the image build compiles the `RasterTool` sample AND runs a probe that
+  calls `GdalBase.ConfigureAll()` and asserts `Gdal.GetDriverCount() > 0` (and that the
+  `GTiff` driver resolves) — so the image fails to build if the native binding ever
+  regresses.
+
+See the raster sample below and
+[`docs/customcode/raster-gp-pattern.md`](../../docs/customcode/raster-gp-pattern.md) for
+the SDK-as-transport / GDAL-as-engine pattern.
 - The harness host `Honua.CustomCode.Harness` is published to `/opt/harness`; the
   `ENTRYPOINT` runs `dotnet /opt/harness/Honua.CustomCode.Harness.dll`.
 - Runs as non-root `uid 1001` (matching `worker-gdal` + the python image). Scratch tree
@@ -120,9 +155,17 @@ typed as `object` so the SDK contract stays small/stable — cast to the client 
 `.Output.AddArtifact(name, path)`, `.Progress.Report(pct, phase)`, `.Log.Info/Warn(...)`,
 `.WorkDirectory`. Cancellation is the `CancellationToken` argument to `ExecuteAsync`.
 
-A trivial sample lives in [`harness/samples/BufferTool`](harness/samples/BufferTool/BufferTool.cs)
-(entrypoint `BufferTool::Honua.CustomCode.Samples.BufferTool`): buffers a WKT geometry
-with NetTopologySuite and writes GeoJSON.
+Two samples live under [`harness/samples/`](harness/samples/):
+
+- [`BufferTool`](harness/samples/BufferTool/BufferTool.cs) (entrypoint
+  `BufferTool::Honua.CustomCode.Samples.BufferTool`): buffers a WKT geometry with
+  NetTopologySuite and writes GeoJSON (vector).
+- [`RasterTool`](harness/samples/RasterTool/RasterTool.cs) (entrypoint
+  `RasterTool::Honua.CustomCode.Samples.RasterTool`): the **raster** sample, proving
+  in-process GDAL interop. It synthesizes a 2-band GeoTIFF with `OSGeo.GDAL`, reads the
+  bands, computes NDVI band math, and writes an LZW-compressed Float32 GeoTIFF — the
+  .NET mirror of the Python `raster_ndvi_tool.py` sample (GDAL is the engine, the SDK is
+  transport).
 
 The contract types live in the SDK-facing package
 [`Honua.CustomCode.Sdk`](harness/src/Honua.CustomCode.Sdk/) — the only package a tool

--- a/docker/worker-customcode-dotnet/harness/Directory.Packages.props
+++ b/docker/worker-customcode-dotnet/harness/Directory.Packages.props
@@ -12,6 +12,22 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      GDAL C# bindings for first-class in-process raster/vector GDAL interop
+      (OSGeo.GDAL / OSGeo.OGR / OSGeo.OSR). MaxRev.Gdal.* is the maintained
+      cross-platform binding that bundles its OWN self-contained native GDAL — so
+      there is no ABI risk against the base image's libgdal. The pinned
+      3.12.4.520 build bundles native GDAL 3.12.4, which also MATCHES the GDAL-full
+      base image (ghcr.io/osgeo/gdal:ubuntu-full-3.12.4) so the in-process binding
+      and the gdal* CLIs agree on driver behavior. LinuxRuntime.Minimal carries the
+      native payload for linux-x64. Init via GdalBase.ConfigureAll() (see the
+      RasterInfo sample + the README).
+    -->
+    <PackageVersion Include="MaxRev.Gdal.Core" Version="3.12.4.520" />
+    <PackageVersion Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.12.4.520" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Test stack. -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/docker/worker-customcode-dotnet/harness/Honua.CustomCode.slnx
+++ b/docker/worker-customcode-dotnet/harness/Honua.CustomCode.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/samples/">
     <Project Path="samples/BufferTool/BufferTool.csproj" />
+    <Project Path="samples/RasterTool/RasterTool.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Honua.CustomCode.Harness/Honua.CustomCode.Harness.csproj" />

--- a/docker/worker-customcode-dotnet/harness/samples/RasterTool/RasterTool.cs
+++ b/docker/worker-customcode-dotnet/harness/samples/RasterTool/RasterTool.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.CustomCode.Sdk;
+using MaxRev.Gdal.Core;
+using OSGeo.GDAL;
+using OSGeo.OSR;
+
+namespace Honua.CustomCode.Samples;
+
+/// <summary>
+/// Sample custom-code RASTER GP tool: process a GeoTIFF in-process with the GDAL C#
+/// bindings (<c>OSGeo.GDAL</c>/<c>OSGeo.OGR</c>/<c>OSGeo.OSR</c>). This is the raster
+/// counterpart of <see cref="BufferTool"/> (vector) and the .NET mirror of the Python
+/// <c>raster_ndvi_tool.py</c> sample — it proves first-class, in-process GDAL interop in
+/// the .NET runtime.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Honua SDK is data-transport only: a real tool would fetch the input coverage to a
+/// local file (or a <c>/vsi</c> handle) via <see cref="GpContext.Client"/> and
+/// upload/register the output GeoTIFF. GDAL is the raster engine. Here the data path is
+/// trivial/self-contained: if no input is staged we synthesize a 2-band (RED, NIR)
+/// GeoTIFF with GDAL, then compute NDVI band math and write a single-band Float32
+/// GeoTIFF.
+/// </para>
+/// <para>
+/// Entrypoint spec for this tool: <c>"RasterTool::Honua.CustomCode.Samples.RasterTool"</c>.
+/// Expected <c>params_json</c> (all optional):
+/// <c>{"input": "scene.tif", "out_name": "ndvi.tif", "size": 64}</c>.
+/// </para>
+/// </remarks>
+public sealed class RasterTool : IGeoprocessingTool
+{
+    private static int _initialized;
+
+    /// <inheritdoc />
+    public Task<GpResult> ExecuteAsync(GpContext context, CancellationToken cancellationToken)
+    {
+        // One-time GDAL init. GdalBase.ConfigureAll() wires the bundled native GDAL +
+        // PROJ data and registers all drivers (it calls Gdal.AllRegister internally).
+        // Idempotent-guard so repeated tool invocations in one process do not re-register.
+        if (Interlocked.Exchange(ref _initialized, 1) == 0)
+        {
+            GdalBase.ConfigureAll();
+        }
+
+        if (Gdal.GetDriverCount() <= 0)
+        {
+            return Task.FromResult(GpResult.Failed("GDAL initialized but registered no drivers."));
+        }
+
+        var outName = context.Params.TryGetProperty("out_name", out var n) &&
+                      n.ValueKind == System.Text.Json.JsonValueKind.String
+            ? n.GetString()!
+            : "ndvi.tif";
+        var size = context.Params.TryGetProperty("size", out var s) &&
+                   s.ValueKind == System.Text.Json.JsonValueKind.Number
+            ? Math.Clamp(s.GetInt32(), 2, 4096)
+            : 64;
+
+        context.Log.Info($"raster NDVI tool starting (GDAL {Gdal.VersionInfo("RELEASE_NAME")}, in-process)");
+        context.Progress.Report(5.0, "resolving input");
+
+        // Resolve the input: a staged input artifact, else synthesize a 2-band scene.
+        string inputPath;
+        if (context.Params.TryGetProperty("input", out var inEl) &&
+            inEl.ValueKind == System.Text.Json.JsonValueKind.String &&
+            inEl.GetString() is { Length: > 0 } inputKey &&
+            context.Inputs.TryGetValue(inputKey, out var staged))
+        {
+            inputPath = staged;
+            context.Log.Info($"using staged input '{inputKey}' -> {inputPath}");
+        }
+        else
+        {
+            inputPath = Path.Combine(context.WorkDirectory, "scene.tif");
+            context.Log.Info("no input staged; synthesizing a 2-band scene with OSGeo.GDAL");
+            SynthesizeScene(inputPath, size);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        context.Progress.Report(40.0, "reading bands");
+
+        using var src = Gdal.Open(inputPath, Access.GA_ReadOnly)
+            ?? throw new InvalidOperationException($"GDAL could not open {inputPath}.");
+        if (src.RasterCount < 2)
+        {
+            return Task.FromResult(GpResult.Failed(
+                $"input must have >= 2 bands (RED, NIR); got {src.RasterCount}."));
+        }
+
+        var width = src.RasterXSize;
+        var height = src.RasterYSize;
+        var count = width * height;
+        var red = new float[count];
+        var nir = new float[count];
+        src.GetRasterBand(1).ReadRaster(0, 0, width, height, red, width, height, 0, 0);
+        src.GetRasterBand(2).ReadRaster(0, 0, width, height, nir, width, height, 0, 0);
+
+        context.Progress.Report(70.0, "computing NDVI");
+        var ndvi = new float[count];
+        for (var i = 0; i < count; i++)
+        {
+            var denom = nir[i] + red[i];
+            ndvi[i] = denom == 0f ? 0f : (nir[i] - red[i]) / denom;
+        }
+
+        // Write a single-band Float32 GeoTIFF, preserving CRS + geotransform, LZW-compressed.
+        var transform = new double[6];
+        src.GetGeoTransform(transform);
+        var projection = src.GetProjectionRef();
+
+        var outPath = Path.Combine(context.WorkDirectory, outName);
+        var driver = Gdal.GetDriverByName("GTiff");
+        using (var dst = driver.Create(outPath, width, height, 1, DataType.GDT_Float32,
+                   ["COMPRESS=LZW"]))
+        {
+            dst.SetGeoTransform(transform);
+            if (!string.IsNullOrEmpty(projection))
+            {
+                dst.SetProjection(projection);
+            }
+
+            dst.GetRasterBand(1).WriteRaster(0, 0, width, height, ndvi, width, height, 0, 0);
+            dst.FlushCache();
+        }
+
+        context.Progress.Report(90.0, "registering output");
+        context.Output.AddArtifact(outName, outPath);
+
+        float min = ndvi[0], max = ndvi[0];
+        foreach (var v in ndvi)
+        {
+            if (v < min) min = v;
+            if (v > max) max = v;
+        }
+
+        context.Log.Info(
+            $"wrote {outName} ({new FileInfo(outPath).Length} bytes), NDVI range [{min:F3}, {max:F3}]");
+        context.Progress.Report(100.0, "done");
+
+        return Task.FromResult(GpResult.Succeeded($"NDVI GeoTIFF written to {outName}"));
+    }
+
+    /// <summary>
+    /// Write a tiny 2-band (RED, NIR) Float32 GeoTIFF using <c>OSGeo.GDAL</c> + a real-ish
+    /// UTM 33N CRS/geotransform, so the sample runs with no staged inputs.
+    /// </summary>
+    private static void SynthesizeScene(string path, int size)
+    {
+        var driver = Gdal.GetDriverByName("GTiff");
+        using var ds = driver.Create(path, size, size, 2, DataType.GDT_Float32, null);
+        ds.SetGeoTransform([500000.0, 10.0, 0.0, 4600000.0, 0.0, -10.0]);
+
+        using var srs = new SpatialReference(string.Empty);
+        srs.ImportFromEPSG(32633);
+        srs.ExportToWkt(out var wkt, null);
+        ds.SetProjection(wkt);
+
+        var rng = new Random(42);
+        var count = size * size;
+        var red = new float[count];
+        var nir = new float[count];
+        for (var i = 0; i < count; i++)
+        {
+            red[i] = (float)(0.05 + (rng.NextDouble() * 0.35));
+            nir[i] = (float)(0.3 + (rng.NextDouble() * 0.6));
+        }
+
+        ds.GetRasterBand(1).WriteRaster(0, 0, size, size, red, size, size, 0, 0);
+        ds.GetRasterBand(2).WriteRaster(0, 0, size, size, nir, size, size, 0, 0);
+        ds.FlushCache();
+    }
+}

--- a/docker/worker-customcode-dotnet/harness/samples/RasterTool/RasterTool.csproj
+++ b/docker/worker-customcode-dotnet/harness/samples/RasterTool/RasterTool.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Sample .NET custom-code RASTER GP tool. The raster counterpart of the vector
+    BufferTool: it processes a GeoTIFF IN-PROCESS with the GDAL C# bindings
+    (OSGeo.GDAL / OSGeo.OGR / OSGeo.OSR) — proving first-class GDAL interop in the
+    .NET runtime, on par with the Python rasterio sample. The Honua SDK is
+    data-transport only (a real tool fetches the input coverage to a local file
+    and uploads the output GeoTIFF); GDAL is the raster engine.
+
+    Entrypoint for this tool: "RasterTool::Honua.CustomCode.Samples.RasterTool".
+
+    MaxRev.Gdal.* bundles its own self-contained native GDAL (no ABI dependence on
+    the base image's libgdal); the pinned version matches the base GDAL (3.12.4).
+    Both packages are pre-warmed in the image NuGet cache so this builds with no
+    network restore.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+    <AssemblyName>RasterTool</AssemblyName>
+    <RootNamespace>Honua.CustomCode.Samples</RootNamespace>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+    <!-- Pull the native runtime asset for the build/run RID. -->
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(OS)' != 'Windows_NT'">linux-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- The tool references only the SDK contract. -->
+    <ProjectReference Include="..\..\src\Honua.CustomCode.Sdk\Honua.CustomCode.Sdk.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- GDAL C# bindings + the self-contained linux-x64 native runtime, pre-warmed. -->
+    <PackageReference Include="MaxRev.Gdal.Core" />
+    <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" />
+  </ItemGroup>
+
+</Project>

--- a/docs/customcode/raster-gp-pattern.md
+++ b/docs/customcode/raster-gp-pattern.md
@@ -1,0 +1,118 @@
+# Raster/vector geoprocessing in custom-code GP tools
+
+**TL;DR — GDAL is the engine, the Honua SDK is transport.** A custom-code GP tool
+processes raster/vector data *with GDAL directly, in-process*, on local files. It uses
+the Honua SDK only to fetch input coverages to a local file (or a `/vsi` handle) and to
+upload/register the output GeoTIFF. The SDK is deliberately **not** a raster library —
+there is no need for it to be one.
+
+This pattern is identical across both custom-code runtimes:
+
+| | Python runtime | .NET runtime |
+|---|---|---|
+| Image | [`docker/worker-customcode-python`](../../docker/worker-customcode-python/README.md) | [`docker/worker-customcode-dotnet`](../../docker/worker-customcode-dotnet/README.md) |
+| GDAL interop | `osgeo.gdal` / `osgeo.ogr` / `osgeo.osr` + `rasterio` (GDAL-full base) | `OSGeo.GDAL` / `OSGeo.OGR` / `OSGeo.OSR` via `MaxRev.Gdal.Core` (+ `LinuxRuntime.Minimal`) |
+| Init | implicit on import (`gdal.UseExceptions()` recommended) | `GdalBase.ConfigureAll()` once before use |
+| Raster sample | `samples/raster_ndvi_tool.py` | `samples/RasterTool/RasterTool.cs` |
+| Vector sample | `samples/buffer_tool.py` | `samples/BufferTool/BufferTool.cs` |
+
+Both images are built on the **`ghcr.io/osgeo/gdal:ubuntu-full-3.12.4`** base, so the
+full GDAL driver set is present. In-build sanity checks assert the bindings load and a
+driver count `> 0`, so the images fail to build if raster/vector interop ever regresses.
+
+## The three roles
+
+1. **Honua SDK → input.** Fetch the input coverage to a local file (or open a GDAL
+   `/vsi*` handle, e.g. `/vsicurl/…`, `/vsis3/…`). This is the *transport* step.
+2. **GDAL → processing.** Open the local file / `/vsi` handle with GDAL (`rasterio` or
+   `osgeo.gdal` in Python; `OSGeo.GDAL` in .NET), do the raster/vector work (reproject,
+   warp, band math, raster algebra, vector ops), and write a local GeoTIFF. This is the
+   *engine* step — GDAL does all raster I/O and geodesy.
+3. **Honua SDK → output.** Register the output GeoTIFF as a job artifact (the harness
+   uploads it to the job's S3 output prefix) and/or register it as a coverage via the
+   SDK. The *transport* step again.
+
+The harness already gives a tool a writable scratch `workdir`/`WorkDirectory`, a scoped
+`client`/`Client` (the SDK), an `inputs`/`Inputs` map of staged input artifacts, and an
+`output`/`Output` artifact sink. The tool's only job is steps 1→3.
+
+## Python
+
+```python
+from honua_customcode_harness import GpContext, GpResult
+
+
+def execute(context: GpContext) -> GpResult:
+    import rasterio
+    from rasterio.warp import calculate_default_transform, reproject, Resampling
+
+    # 1. SDK is transport: resolve a staged input (or fetch via context.client).
+    src_path = str(context.inputs["scene"])      # local file the harness staged
+
+    # 2. GDAL is the engine: reproject to EPSG:4326 with rasterio (== GDAL warp).
+    dst_path = context.workdir / "reprojected.tif"
+    with rasterio.open(src_path) as src:
+        transform, w, h = calculate_default_transform(
+            src.crs, "EPSG:4326", src.width, src.height, *src.bounds)
+        profile = src.profile
+        profile.update(crs="EPSG:4326", transform=transform, width=w, height=h)
+        with rasterio.open(dst_path, "w", **profile) as dst:
+            for b in range(1, src.count + 1):
+                reproject(
+                    source=rasterio.band(src, b),
+                    destination=rasterio.band(dst, b),
+                    src_transform=src.transform, src_crs=src.crs,
+                    dst_transform=transform, dst_crs="EPSG:4326",
+                    resampling=Resampling.bilinear)
+
+    # 3. SDK is transport: register the output GeoTIFF for upload.
+    context.output.add_artifact("reprojected.tif", dst_path)
+    return GpResult.succeeded("reprojected to EPSG:4326")
+```
+
+The low-level `osgeo.gdal`/`ogr`/`osr` bindings are equally available for direct
+dataset/driver/CRS work (see `samples/raster_ndvi_tool.py`, which synthesizes a scene
+with `osgeo.gdal` and computes NDVI band math with `rasterio`).
+
+## .NET
+
+```csharp
+using Honua.CustomCode.Sdk;
+using MaxRev.Gdal.Core;
+using OSGeo.GDAL;
+
+public sealed class ReprojectTool : IGeoprocessingTool
+{
+    public Task<GpResult> ExecuteAsync(GpContext context, CancellationToken ct)
+    {
+        GdalBase.ConfigureAll();                       // once, before using GDAL
+
+        // 1. SDK is transport: the harness staged the input locally.
+        var srcPath = context.Inputs["scene"];
+
+        // 2. GDAL is the engine: warp to EPSG:4326 with the GDAL utilities API.
+        var dstPath = Path.Combine(context.WorkDirectory, "reprojected.tif");
+        using var src = Gdal.Open(srcPath, Access.GA_ReadOnly);
+        var options = new GDALWarpAppOptions(["-t_srs", "EPSG:4326", "-r", "bilinear"]);
+        using var dst = Gdal.Warp(dstPath, [src], options, null, null);
+        dst.FlushCache();
+
+        // 3. SDK is transport: register the output GeoTIFF for upload.
+        context.Output.AddArtifact("reprojected.tif", dstPath);
+        return Task.FromResult(GpResult.Succeeded("reprojected to EPSG:4326"));
+    }
+}
+```
+
+`OSGeo.OGR` (vector) and `OSGeo.OSR` (CRS) are available the same way. See
+`samples/RasterTool/RasterTool.cs`, which creates a 2-band GeoTIFF with `OSGeo.GDAL` and
+computes NDVI band math in-process.
+
+## Why the SDK is not a raster library
+
+GDAL already is the cross-language raster/vector engine (drivers, reprojection, warping,
+algebra, format I/O) and is present in-process in both runtimes. Re-exposing any of that
+through the Honua SDK would duplicate GDAL behind a thinner, lossy surface. The SDK's job
+is the data path — authenticated fetch/upload/register of coverages — which complements,
+and does not duplicate, the SDK's raster agents (coverage download/upload/metadata). Keep
+the boundary crisp: **SDK moves bytes, GDAL processes pixels.**


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2196

## Summary
Adds the **GDAL C# bindings** to the .NET custom-code GP runtime so a tool can do
**in-process raster/vector GDAL interop** (`using OSGeo.GDAL; using OSGeo.OGR;
using OSGeo.OSR;`) — closing the real gap on the .NET side. The image already had
the GDAL CLIs (GDAL-full base) + NetTopologySuite, but a .NET GP tool could not do
in-process GDAL work without the C# bindings. GDAL is the raster engine; the Honua
SDK stays data-transport only.

Stacked on `feat/customcode-dotnet` (PR #2196, Phase 2). Parity with the Python
runtime's `osgeo`/`rasterio` interop.

## Changes Made
- Add `MaxRev.Gdal.Core` + `MaxRev.Gdal.LinuxRuntime.Minimal`, pinned
  **3.12.4.520**. MaxRev bundles its **own self-contained native GDAL** (no ABI
  dependence on the base `libgdal`); the pin bundles native **GDAL 3.12.4**,
  matching the GDAL-full base image (`ubuntu-full-3.12.4`) so the binding and the
  `gdal*` CLIs agree on driver behavior.
- Pre-warm both packages (with a `linux-x64` RID for the native asset) in the
  image NuGet cache so a raster tool builds with **no network restore** at job time.
- Add raster sample `harness/samples/RasterTool`: `GdalBase.ConfigureAll()` init,
  then open/create a GeoTIFF with `OSGeo.GDAL`, compute NDVI band math, write a
  GeoTIFF — the .NET mirror of the Python `rasterio` sample.
- Add an in-build GDAL sanity check: build the raster sample **and** run a probe
  that asserts `GdalBase.ConfigureAll()` registers drivers (count `> 0`, `GTiff`
  present), proving the native binding loads in-process.
- Document the GDAL-interop surface + init in the image README; add shared
  `docs/customcode/raster-gp-pattern.md`.

## Changes Made (verification)
- `RasterTool` compiles clean (0 warn / 0 err, `TreatWarningsAsErrors=true`)
  against the real MaxRev 3.12.4.520 bindings; full `Honua.CustomCode.slnx` builds.
- A runtime probe confirmed the native binding: `GdalBase.ConfigureAll()`
  registered **210 drivers** (incl. `GTiff`), reported **GDAL 3.12.4** (matching
  the base), and `Gdal.Warp` reprojected a synthetic scene — so the Dockerfile's
  in-build probe will pass. Image build itself is CI/local-Docker verified.

## Testing
- [x] Manual testing performed

## Gate Impact
- [x] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
