### PR TITLE
feat(control-plane): EventBridge-invocable scheduled-tick dispatcher for periodic services

### DIFF
--- a/src/Honua.Core/Features/ControlPlane/Abstractions/ControlPlaneTriggerModeResolver.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/ControlPlaneTriggerModeResolver.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Honua.Core.Features.ControlPlane.Abstractions;
+
+/// <summary>
+/// Resolves the control-plane trigger mode from configuration at composition time, so that the
+/// PERIODIC (bucket-b) background-service registrations scattered across assemblies can all make the
+/// same Poll-vs-Event decision without each one re-binding the typed options.
+/// <para>
+/// The value lives at <c>ControlPlane:TriggerMode</c> (the same key the typed
+/// <c>ControlPlaneTriggerOptions</c> binds, in <c>Honua.Server</c>). Reading the raw string here keeps
+/// the resolver in <c>Honua.Core</c> — where the cross-assembly registrations can reach it — without
+/// depending on the server-internal enum. Anything other than a case-insensitive <c>Event</c> resolves
+/// to <c>Poll</c>, so an unconfigured or on-prem deployment keeps the in-process timers exactly as
+/// before (byte-for-byte).
+/// </para>
+/// </summary>
+public static class ControlPlaneTriggerModeResolver
+{
+    private const string TriggerModeKey = "ControlPlane:TriggerMode";
+    private const string EventModeValue = "Event";
+
+    /// <summary>
+    /// Returns <c>true</c> when <c>ControlPlane:TriggerMode</c> is (case-insensitively) <c>Event</c>.
+    /// In Event mode the in-process periodic timers must NOT be hosted — the ticks are driven by
+    /// EventBridge Scheduler through the scheduled-tick dispatcher instead.
+    /// </summary>
+    /// <param name="configuration">The application configuration.</param>
+    public static bool IsEventMode(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        var value = configuration[TriggerModeKey];
+        return string.Equals(value?.Trim(), EventModeValue, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the in-process periodic timers should be hosted (the default
+    /// <c>Poll</c> mode). Convenience inverse of <see cref="IsEventMode"/> for the
+    /// <c>AddHostedService</c> registration sites.
+    /// </summary>
+    /// <param name="configuration">The application configuration.</param>
+    public static bool ShouldHostInProcessTimers(IConfiguration configuration)
+        => !IsEventMode(configuration);
+}

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/ScheduledTickDispatcher.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/ScheduledTickDispatcher.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.ControlPlane.Abstractions;
+
+/// <summary>
+/// Identifies a single periodic/time-based control-plane maintenance tick. Each kind maps to
+/// exactly one background service's idempotent per-tick body (its <c>TickAsync</c>/sweep/flush
+/// method). The dispatcher routes a kind to the registered <see cref="IScheduledTickHandler"/>
+/// that owns it.
+/// <para>
+/// This is the bucket-(b) PERIODIC half of the control-plane hybrid-trigger design (option C):
+/// on-prem (<c>TriggerMode=Poll</c>) keeps the in-process timers; cloud (<c>TriggerMode=Event</c>)
+/// drops the timers and drives each tick from EventBridge Scheduler -> the scheduled-tick endpoint,
+/// which calls <see cref="IScheduledTickDispatcher.RunTickAsync"/>.
+/// </para>
+/// </summary>
+public enum ScheduledTickKind
+{
+    /// <summary>
+    /// Cron-triggered workflow scheduler evaluation
+    /// (<c>WorkflowSchedulerBackgroundService.TickAsync</c>). Cadence ~1 minute. Idempotent via a
+    /// durable per-occurrence claim plus a durable schedule cursor, so double-fire never duplicates
+    /// a run.
+    /// </summary>
+    WorkflowSchedule,
+
+    /// <summary>
+    /// Execution-job heartbeat/timeout reaping sweep
+    /// (<c>JobReconciliationService.SweepActiveJobsAsync</c>). Cadence ~30s-1min. Idempotent: each
+    /// candidate is re-read and mutated only via optimistic CAS, so a duplicate sweep is a no-op.
+    /// </summary>
+    JobReconciliation,
+
+    /// <summary>
+    /// Scheduled tile-cache expiry/invalidation sweep
+    /// (<c>TileCacheExpiryHostedService.SweepAsync</c>). Cadence minutes. Re-running re-queues
+    /// invalidate jobs whose own pipeline is idempotent.
+    /// </summary>
+    TileCacheExpiry,
+
+    /// <summary>
+    /// Live size-quota / LRU tile-cache eviction sweep
+    /// (<c>TileCacheEvictionService.SweepAsync</c>). Cadence minutes. Re-running re-evaluates the
+    /// current key index against the quota; a no-op when nothing exceeds it.
+    /// </summary>
+    TileCacheEviction,
+
+    /// <summary>
+    /// Geoprocessing workspace cleanup sweep (<c>WorkspaceCleanupService.RunCleanupAsync</c>).
+    /// Cadence minutes-hours. Acts on TTL/expiry state, so re-running finds nothing new.
+    /// </summary>
+    WorkspaceCleanup,
+
+    /// <summary>
+    /// Cloud file-storage expired-file cleanup (<c>FileStorageCleanupService.RunCleanupAsync</c>).
+    /// Cadence hours. Deletes already-expired files; re-running is a no-op. On AWS this tick can be
+    /// replaced by an S3 lifecycle policy, but the tick is retained for on-prem/portability.
+    /// </summary>
+    FileStorageCleanup,
+
+    /// <summary>
+    /// Temporary-file cleanup (<c>TemporaryFileCleanupService.PerformCleanupAsync</c>). Cadence
+    /// ~30 minutes. Deletes expired temp files; re-running is a no-op.
+    /// </summary>
+    TemporaryFileCleanup,
+
+    /// <summary>
+    /// Alert digest flush (<c>DigestFlushBackgroundService.FlushAsync</c>). Cadence minutes.
+    /// Idempotent via an atomic batch claim; a duplicate flush claims a different (or empty) batch.
+    /// </summary>
+    DigestFlush
+}
+
+/// <summary>
+/// A single periodic control-plane tick, exposed so the dispatcher can drive it once on demand
+/// (from EventBridge Scheduler under <c>TriggerMode=Event</c>) without hosting an in-process timer.
+/// <para>
+/// One handler is registered per <see cref="ScheduledTickKind"/>. Implementations live in the
+/// assembly that owns the underlying background service (the service types are <c>internal</c>), and
+/// wrap that service's already-idempotent per-tick body. Hosting the in-process timer and invoking
+/// the tick are independent: in <c>Poll</c> mode the timer runs and the handler is also available;
+/// in <c>Event</c> mode the timer is not hosted and the handler is the only driver.
+/// </para>
+/// </summary>
+public interface IScheduledTickHandler
+{
+    /// <summary>The tick kind this handler owns. Exactly one handler is registered per kind.</summary>
+    ScheduledTickKind Kind { get; }
+
+    /// <summary>
+    /// Runs the underlying service's per-tick body exactly once. Safe to invoke concurrently with,
+    /// or instead of, the in-process timer: the tick bodies are idempotent (claim + cursor, optimistic
+    /// CAS, or expiry-state driven), so a single invocation neither duplicates work nor corrupts state.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RunTickAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Single entrypoint that runs one periodic control-plane tick on demand, routing a
+/// <see cref="ScheduledTickKind"/> to the <see cref="IScheduledTickHandler"/> that owns it.
+/// <para>
+/// This mirrors <see cref="IOperationReconcileDispatcher"/> for the PERIODIC (bucket-b) services:
+/// the in-process timers (<c>Poll</c>) and EventBridge Scheduler (<c>Event</c>) both ultimately
+/// exercise the same idempotent tick body, so a single code path serves on-prem and cloud from one
+/// codebase. The dispatcher carries no coordination of its own; the tick bodies' own idempotency
+/// makes single, duplicate, and concurrent invocation safe.
+/// </para>
+/// </summary>
+public interface IScheduledTickDispatcher
+{
+    /// <summary>
+    /// Runs the tick for the given kind exactly once and returns. Throws
+    /// <see cref="ArgumentOutOfRangeException"/> when no handler is registered for the kind.
+    /// </summary>
+    /// <param name="kind">The tick to run.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RunTickAsync(ScheduledTickKind kind, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Honua.Core.Features.Orchestration.Abstractions;
 using Honua.Geoprocessing.Execution;
 using Honua.Infrastructure.Abstractions;
 using Honua.ControlPlane;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
@@ -48,7 +49,17 @@ internal static class GeoprocessingServiceCollectionExtensions
             && services.Any(d => d.ServiceType == typeof(IArtifactStore)))
         {
             services.AddScoped<IWorkspaceLifecycleService, WorkspaceLifecycleService>();
-            services.AddHostedService<WorkspaceCleanupService>();
+
+            // Workspace cleanup is a PERIODIC tick (bucket-b). Its sweep is idempotent (acts on
+            // TTL/expiry state via a fresh scope), so the scheduled-tick handler is registered in
+            // BOTH modes; the in-process timer is hosted only under TriggerMode=Poll (default,
+            // on-prem), keeping that path byte-for-byte unchanged.
+            services.TryAddSingleton<WorkspaceCleanupService>();
+            services.AddSingleton<IScheduledTickHandler, WorkspaceCleanupScheduledTickHandler>();
+            if (ControlPlaneTriggerModeResolver.ShouldHostInProcessTimers(configuration))
+            {
+                services.AddHostedService(sp => sp.GetRequiredService<WorkspaceCleanupService>());
+            }
         }
 
         // Built-in process catalog (ticket #735)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/WorkspaceCleanupService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/WorkspaceCleanupService.cs
@@ -8,6 +8,22 @@ using Microsoft.Extensions.Options;
 namespace Honua.Geoprocessing;
 
 /// <summary>
+/// Adapts the geoprocessing workspace cleanup sweep to the control-plane scheduled-tick dispatcher so
+/// EventBridge Scheduler can drive one sweep under <c>TriggerMode=Event</c> without hosting the
+/// in-process timer. The sweep acts on TTL/expiry state and creates a fresh scope each call, so a
+/// single invocation is safe.
+/// </summary>
+internal sealed class WorkspaceCleanupScheduledTickHandler(WorkspaceCleanupService service)
+    : Honua.Core.Features.ControlPlane.Abstractions.IScheduledTickHandler
+{
+    public Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind Kind
+        => Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind.WorkspaceCleanup;
+
+    public Task RunTickAsync(CancellationToken cancellationToken = default)
+        => service.RunCleanupAsync(cancellationToken);
+}
+
+/// <summary>
 /// Background service that periodically runs workspace cleanup sweeps.
 /// </summary>
 internal sealed class WorkspaceCleanupService : BackgroundService
@@ -60,7 +76,7 @@ internal sealed class WorkspaceCleanupService : BackgroundService
         WorkspaceCleanupLog.ServiceStopped(_logger);
     }
 
-    private async Task RunCleanupAsync(CancellationToken cancellationToken)
+    internal async Task RunCleanupAsync(CancellationToken cancellationToken)
     {
         using var scope = _serviceScopeFactory.CreateScope();
         var lifecycleService = scope.ServiceProvider.GetRequiredService<IWorkspaceLifecycleService>();

--- a/src/Honua.Hosting/Features/Services/TemporaryFileCleanupService.cs
+++ b/src/Honua.Hosting/Features/Services/TemporaryFileCleanupService.cs
@@ -7,6 +7,21 @@ using Microsoft.Extensions.Options;
 namespace Honua.Infrastructure.Services;
 
 /// <summary>
+/// Adapts the temporary-file cleanup to the control-plane scheduled-tick dispatcher so EventBridge
+/// Scheduler can drive one cleanup under <c>TriggerMode=Event</c> without hosting the in-process
+/// timer. Deletes expired temp files via a fresh scope, so a single invocation is safe.
+/// </summary>
+internal sealed class TemporaryFileCleanupScheduledTickHandler(TemporaryFileCleanupService service)
+    : Honua.Core.Features.ControlPlane.Abstractions.IScheduledTickHandler
+{
+    public Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind Kind
+        => Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind.TemporaryFileCleanup;
+
+    public Task RunTickAsync(CancellationToken cancellationToken = default)
+        => service.PerformCleanupAsync(cancellationToken);
+}
+
+/// <summary>
 /// Background service that periodically cleans up expired temporary files.
 /// </summary>
 internal sealed class TemporaryFileCleanupService : BackgroundService
@@ -66,7 +81,7 @@ internal sealed class TemporaryFileCleanupService : BackgroundService
         TemporaryFileCleanupLog.ServiceStopped(_logger);
     }
 
-    private async Task PerformCleanupAsync(CancellationToken cancellationToken)
+    internal async Task PerformCleanupAsync(CancellationToken cancellationToken)
     {
         using var scope = _serviceScopeFactory.CreateScope();
         var temporaryFileService = scope.ServiceProvider.GetRequiredService<ITemporaryFileService>();

--- a/src/Honua.Io/Features/FileStorage/FileStorageCleanupService.cs
+++ b/src/Honua.Io/Features/FileStorage/FileStorageCleanupService.cs
@@ -8,6 +8,23 @@ using Microsoft.Extensions.Options;
 namespace Honua.FileStorage;
 
 /// <summary>
+/// Adapts the cloud file-storage expired-file cleanup to the control-plane scheduled-tick dispatcher
+/// so EventBridge Scheduler can drive one cleanup under <c>TriggerMode=Event</c> without hosting the
+/// in-process timer. Deletes already-expired files via a fresh scope, so a single invocation is safe.
+/// <para>On AWS this tick can alternatively be replaced by an S3 lifecycle policy (cheaper, no
+/// compute); the tick is retained for on-prem/portability and other storage backends.</para>
+/// </summary>
+internal sealed class FileStorageCleanupScheduledTickHandler(FileStorageCleanupService service)
+    : Honua.Core.Features.ControlPlane.Abstractions.IScheduledTickHandler
+{
+    public Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind Kind
+        => Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind.FileStorageCleanup;
+
+    public Task RunTickAsync(CancellationToken cancellationToken = default)
+        => service.RunCleanupAsync(cancellationToken);
+}
+
+/// <summary>
 /// Background service that periodically cleans up expired temporary files
 /// </summary>
 internal sealed class FileStorageCleanupService : BackgroundService
@@ -64,7 +81,7 @@ internal sealed class FileStorageCleanupService : BackgroundService
         FileStorageLog.CleanupServiceStopped(_logger);
     }
 
-    private async Task RunCleanupAsync(CancellationToken cancellationToken)
+    internal async Task RunCleanupAsync(CancellationToken cancellationToken)
     {
         using var scope = _serviceProvider.CreateScope();
         var fileStorage = scope.ServiceProvider.GetRequiredService<ICloudFileStorage>();

--- a/src/Honua.Jobs/Features/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Jobs/Features/ControlPlane/JobReconciliationService.cs
@@ -7,6 +7,22 @@ using Honua.Core.Features.ControlPlane.Domain;
 namespace Honua.ControlPlane;
 
 /// <summary>
+/// Adapts the execution-job heartbeat/timeout reaping sweep to the control-plane scheduled-tick
+/// dispatcher so EventBridge Scheduler can drive one sweep under <c>TriggerMode=Event</c> without
+/// hosting the in-process timer. The sweep re-reads each candidate and mutates only via optimistic
+/// CAS, so a single invocation is safe and a duplicate is a no-op.
+/// </summary>
+internal sealed class JobReconciliationScheduledTickHandler(JobReconciliationService service)
+    : Honua.Core.Features.ControlPlane.Abstractions.IScheduledTickHandler
+{
+    public Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind Kind
+        => Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind.JobReconciliation;
+
+    public Task RunTickAsync(CancellationToken cancellationToken = default)
+        => service.SweepActiveJobsAsync(cancellationToken);
+}
+
+/// <summary>
 /// Background service that sweeps active execution jobs for expired heartbeats
 /// and timed-out executions, applying retry or terminal-failure policies.
 /// </summary>
@@ -55,7 +71,7 @@ internal sealed partial class JobReconciliationService(
         Log.ReconciliationStopped(logger);
     }
 
-    private async Task SweepActiveJobsAsync(CancellationToken cancellationToken)
+    internal async Task SweepActiveJobsAsync(CancellationToken cancellationToken)
     {
         var activeJobs = await jobStore.ListActiveAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         var now = DateTimeOffset.UtcNow;

--- a/src/Honua.Server/Features/Admin/TileOperations/TileCacheEvictionHostedService.cs
+++ b/src/Honua.Server/Features/Admin/TileOperations/TileCacheEvictionHostedService.cs
@@ -6,6 +6,24 @@ using Microsoft.Extensions.Options;
 namespace Honua.Server.Features.Admin.TileOperations;
 
 /// <summary>
+/// Adapts the live LRU tile-cache eviction sweep to the control-plane scheduled-tick dispatcher so
+/// EventBridge Scheduler can drive one sweep under <c>TriggerMode=Event</c> without hosting the
+/// in-process timer. Routes to <see cref="TileCacheEvictionService.SweepAsync" /> (the same body the
+/// timer calls), no-op when eviction is disabled. Re-running just re-evaluates current state.
+/// </summary>
+internal sealed class TileCacheEvictionScheduledTickHandler(TileCacheEvictionService evictionService)
+    : Honua.Core.Features.ControlPlane.Abstractions.IScheduledTickHandler
+{
+    public Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind Kind
+        => Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind.TileCacheEviction;
+
+    public Task RunTickAsync(CancellationToken cancellationToken = default)
+        => evictionService.IsEnabled
+            ? evictionService.SweepAsync(cancellationToken)
+            : Task.CompletedTask;
+}
+
+/// <summary>
 /// Background service that periodically runs the live size-quota / LRU tile-cache evictor (#1917).
 /// On each tick it asks <see cref="TileCacheEvictionService" /> to snapshot the Redis tile-key index
 /// and evict the least-recently-used tiles that exceed the configured quotas. This is the live

--- a/src/Honua.Server/Features/Admin/TileOperations/TileCacheExpiryHostedService.cs
+++ b/src/Honua.Server/Features/Admin/TileOperations/TileCacheExpiryHostedService.cs
@@ -6,6 +6,21 @@ using Microsoft.Extensions.Options;
 namespace Honua.Server.Features.Admin.TileOperations;
 
 /// <summary>
+/// Adapts the scheduled tile-cache expiry sweep to the control-plane scheduled-tick dispatcher so
+/// EventBridge Scheduler can drive one sweep under <c>TriggerMode=Event</c> without hosting the
+/// in-process timer. The sweep re-queues invalidate jobs whose own pipeline is idempotent.
+/// </summary>
+internal sealed class TileCacheExpiryScheduledTickHandler(TileCacheExpiryHostedService service)
+    : Honua.Core.Features.ControlPlane.Abstractions.IScheduledTickHandler
+{
+    public Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind Kind
+        => Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind.TileCacheExpiry;
+
+    public Task RunTickAsync(CancellationToken cancellationToken = default)
+        => service.SweepAsync(cancellationToken);
+}
+
+/// <summary>
 /// Scheduled tile-cache expiry/invalidation service (#1837). On a configured cadence it dispatches
 /// an <c>invalidate</c> tile operation for each configured target, so cached tiles for a tileset are
 /// periodically refreshed. This is the time-based complement to the per-tileset <c>Cache-Control</c>

--- a/src/Honua.Server/Features/Alerts/AlertDeliveryServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Alerts/AlertDeliveryServiceCollectionExtensions.cs
@@ -2,7 +2,9 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.Alerts.Abstractions;
+using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.Infrastructure.Resilience;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Honua.Alerts;
 
@@ -46,7 +48,17 @@ internal static class AlertDeliveryServiceCollectionExtensions
         services.AddSingleton<IAlertDeliverySink, WebSocketAlertDeliverySink>();
         services.AddSingleton<IAlertDeliverySink, EmailAlertDeliverySink>();
         services.AddSingleton<IAlertDeliverySink>(_ => new UnsupportedAlertDeliverySink(Core.Features.Alerts.Domain.AlertChannelType.Digest));
-        services.AddHostedService<DigestFlushBackgroundService>();
+
+        // Alert digest flush is a PERIODIC tick (bucket-b). The flush claims a batch atomically and
+        // is idempotent, so the scheduled-tick handler is registered in BOTH trigger modes; the
+        // in-process timer is hosted only under TriggerMode=Poll (default, on-prem), keeping that
+        // path byte-for-byte unchanged.
+        services.TryAddSingleton<DigestFlushBackgroundService>();
+        services.AddSingleton<IScheduledTickHandler, DigestFlushScheduledTickHandler>();
+        if (ControlPlaneTriggerModeResolver.ShouldHostInProcessTimers(configuration))
+        {
+            services.AddHostedService(sp => sp.GetRequiredService<DigestFlushBackgroundService>());
+        }
 
 #if HONUA_EXCLUDE_AWS
         RegisterUnsupportedAwsChannels(services);

--- a/src/Honua.Server/Features/Alerts/DigestAlertDeliverySink.cs
+++ b/src/Honua.Server/Features/Alerts/DigestAlertDeliverySink.cs
@@ -14,6 +14,21 @@ using Microsoft.Extensions.Options;
 namespace Honua.Alerts;
 
 /// <summary>
+/// Adapts the alert digest flush to the control-plane scheduled-tick dispatcher so EventBridge
+/// Scheduler can drive one flush under <c>TriggerMode=Event</c> without hosting the in-process timer.
+/// The flush body is idempotent via an atomic batch claim, so a single invocation is safe.
+/// </summary>
+internal sealed class DigestFlushScheduledTickHandler(DigestFlushBackgroundService service)
+    : Honua.Core.Features.ControlPlane.Abstractions.IScheduledTickHandler
+{
+    public Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind Kind
+        => Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind.DigestFlush;
+
+    public Task RunTickAsync(CancellationToken cancellationToken = default)
+        => service.FlushAsync(cancellationToken);
+}
+
+/// <summary>
 /// Background service that batches digest dispatch rows and delivers them to the
 /// configured digest webhook endpoint.
 /// </summary>

--- a/src/Honua.Server/Features/ControlPlane/ControlPlaneTriggerOptions.cs
+++ b/src/Honua.Server/Features/ControlPlane/ControlPlaneTriggerOptions.cs
@@ -54,4 +54,14 @@ internal sealed class ControlPlaneTriggerOptions
     /// no-op in the common case and only re-drives jobs that look stuck.
     /// </summary>
     public TimeSpan StaleThreshold { get; set; } = TimeSpan.FromSeconds(90);
+
+    /// <summary>
+    /// Shared-secret token guarding the internal scheduled-tick endpoint
+    /// (<c>POST /internal/control-plane/scheduled-tick</c>). Under <c>TriggerMode=Event</c> EventBridge
+    /// Scheduler (via the control-plane Lambda) presents this token to drive a PERIODIC tick on
+    /// demand. Bound from <c>ControlPlane:ScheduledTickToken</c> (or the environment); when empty the
+    /// endpoint refuses every request with 503, so an unconfigured deployment can never be driven by
+    /// an unauthenticated caller. Only consulted in Event mode — the endpoint is not mapped under Poll.
+    /// </summary>
+    public string? ScheduledTickToken { get; set; }
 }

--- a/src/Honua.Server/Features/ControlPlane/JobOrchestrationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/ControlPlane/JobOrchestrationServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Server.Features.Admin.Share;
 using Honua.Geoprocessing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using StackExchange.Redis;
 
@@ -14,7 +15,7 @@ namespace Honua.ControlPlane;
 /// Registers durable job orchestration services, separated into API-side and
 /// worker-side concerns to preserve a lean serving runtime. The API image
 /// registers only <see cref="AddJobOrchestration"/>; the worker image
-/// additionally registers <see cref="AddJobWorker"/>.
+/// additionally registers <see cref="AddJobWorker(IServiceCollection, IConfiguration)"/>.
 /// </summary>
 internal static class JobOrchestrationServiceCollectionExtensions
 {
@@ -80,9 +81,19 @@ internal static class JobOrchestrationServiceCollectionExtensions
     /// cancel); the geoprocessing terminal callback stays here because of its
     /// Redis-gated dependency.
     /// </remarks>
+    /// <summary>
+    /// Poll-mode convenience overload (no configuration): hosts the in-process timers, matching the
+    /// pre-Phase-3 behavior. Used by composition tests that drive the worker loop directly. The
+    /// production composition root calls the <see cref="IConfiguration"/> overload so it can honor
+    /// <c>TriggerMode=Event</c>.
+    /// </summary>
     public static IServiceCollection AddJobWorker(this IServiceCollection services)
+        => services.AddJobWorker(new ConfigurationBuilder().Build());
+
+    public static IServiceCollection AddJobWorker(this IServiceCollection services, IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
 
         // Requires orchestration services to be registered first.
         if (!services.Any(d => d.ServiceType == typeof(IJobQueue)))
@@ -99,8 +110,20 @@ internal static class JobOrchestrationServiceCollectionExtensions
         // AddJobOrchestration because it must also fire on API-side operator cancel.)
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobTerminalCallback, GeoprocessingJobTerminalCallback>());
 
+        // JobExecutionService is the always-on queue drainer, not a periodic tick; it stays hosted
+        // in both trigger modes.
         services.AddHostedService<JobExecutionService>();
-        services.AddHostedService<JobReconciliationService>();
+
+        // JobReconciliationService is the PERIODIC heartbeat/timeout reaping sweep (bucket-b). Its
+        // sweep body is idempotent (per-candidate re-read + optimistic CAS), so the scheduled-tick
+        // handler is registered in BOTH modes; the in-process 30s timer is hosted only under
+        // TriggerMode=Poll (default, on-prem), keeping that path byte-for-byte unchanged.
+        services.TryAddSingleton<JobReconciliationService>();
+        services.AddSingleton<IScheduledTickHandler, JobReconciliationScheduledTickHandler>();
+        if (ControlPlaneTriggerModeResolver.ShouldHostInProcessTimers(configuration))
+        {
+            services.AddHostedService(sp => sp.GetRequiredService<JobReconciliationService>());
+        }
 
         return services;
     }

--- a/src/Honua.Server/Features/ControlPlane/ScheduledTickDispatcher.cs
+++ b/src/Honua.Server/Features/ControlPlane/ScheduledTickDispatcher.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Routes a <see cref="ScheduledTickKind"/> to the <see cref="IScheduledTickHandler"/> that owns it
+/// and runs that handler's idempotent per-tick body exactly once.
+/// <para>
+/// This is the PERIODIC (bucket-b) sibling of <see cref="OperationReconcileDispatcher"/>: it adds no
+/// behavior of its own. Handlers are contributed by the assemblies that own the underlying background
+/// services and collected here as <see cref="IEnumerable{T}"/>, so the dispatcher stays a thin map and
+/// the tick services keep their internal visibility. Under <c>TriggerMode=Poll</c> the in-process
+/// timers call the tick bodies directly; under <c>Event</c> EventBridge Scheduler calls
+/// <see cref="RunTickAsync"/> through the scheduled-tick endpoint. The tick bodies' own idempotency
+/// (claim + cursor, optimistic CAS, expiry-state) keeps invocation safe in both.
+/// </para>
+/// </summary>
+internal sealed class ScheduledTickDispatcher : IScheduledTickDispatcher
+{
+    private readonly Dictionary<ScheduledTickKind, IScheduledTickHandler> _handlers;
+
+    public ScheduledTickDispatcher(IEnumerable<IScheduledTickHandler> handlers)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+
+        var map = new Dictionary<ScheduledTickKind, IScheduledTickHandler>();
+        foreach (var handler in handlers)
+        {
+            // Last registration wins per kind; a duplicate kind is a registration mistake but must
+            // not throw at composition time and crash an otherwise healthy host.
+            map[handler.Kind] = handler;
+        }
+
+        _handlers = map;
+    }
+
+    public Task RunTickAsync(ScheduledTickKind kind, CancellationToken cancellationToken = default)
+    {
+        if (!_handlers.TryGetValue(kind, out var handler))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(kind),
+                kind,
+                "No scheduled-tick handler is registered for this kind. The owning feature may be "
+                + "disabled (for example its store/Redis dependency is absent) in this deployment.");
+        }
+
+        return handler.RunTickAsync(cancellationToken);
+    }
+}

--- a/src/Honua.Server/Features/ControlPlane/ScheduledTickEndpoints.cs
+++ b/src/Honua.Server/Features/ControlPlane/ScheduledTickEndpoints.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Internal, token-guarded endpoint that drives one PERIODIC control-plane tick on demand. Under
+/// <c>TriggerMode=Event</c> EventBridge Scheduler (via the control-plane Lambda) POSTs here with the
+/// tick kind so each bucket-(b) maintenance tick runs without an always-on in-process timer.
+/// <para>
+/// Mirrors the token-guard shape of the CloudDemo reset endpoint: a shared-secret header (or
+/// <c>Bearer</c>) compared in fixed time, 401 when absent, 403 when present-but-wrong, 503 when the
+/// server has no token configured. The route is mapped ONLY in Event mode; under Poll (default,
+/// on-prem) it does not exist at all, so the in-process timers remain the sole driver.
+/// </para>
+/// </summary>
+internal static class ScheduledTickEndpoints
+{
+    internal const string RoutePath = "/internal/control-plane/scheduled-tick";
+    internal const string TokenHeader = "X-Honua-Control-Plane-Token";
+
+    /// <summary>
+    /// Maps the scheduled-tick endpoint when, and only when, the control plane is in Event mode.
+    /// In Poll mode this is a no-op, so the surface is never exposed on on-prem deployments.
+    /// </summary>
+    public static IEndpointRouteBuilder MapScheduledTickEndpoints(
+        this IEndpointRouteBuilder endpoints,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        if (!ControlPlaneTriggerModeResolver.IsEventMode(configuration))
+        {
+            // Poll (default, on-prem): the in-process timers drive the ticks; no endpoint is exposed.
+            return endpoints;
+        }
+
+        endpoints.MapPost(RoutePath, HandleScheduledTickAsync)
+            .WithDisplayName("Run Control-Plane Scheduled Tick")
+            .WithTags("ControlPlane")
+            .WithMetadata(new HttpMethodMetadata([HttpMethods.Post]))
+            .AllowAnonymous()
+            .Produces<ScheduledTickResponse>(StatusCodes.Status200OK, "application/json")
+            .Produces<ScheduledTickProblem>(StatusCodes.Status400BadRequest, "application/json")
+            .Produces<ScheduledTickProblem>(StatusCodes.Status401Unauthorized, "application/json")
+            .Produces<ScheduledTickProblem>(StatusCodes.Status403Forbidden, "application/json")
+            .Produces<ScheduledTickProblem>(StatusCodes.Status503ServiceUnavailable, "application/json");
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleScheduledTickAsync(
+        HttpContext context,
+        [FromServices] IOptions<ControlPlaneTriggerOptions> options,
+        [FromServices] IScheduledTickDispatcher dispatcher)
+    {
+        var token = options.Value.ScheduledTickToken;
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return Problem(
+                StatusCodes.Status503ServiceUnavailable,
+                "scheduled_tick_token_not_configured",
+                "Control-plane scheduled-tick token is not configured.");
+        }
+
+        if (!TokenMatches(context.Request, token))
+        {
+            var statusCode = HasPresentedToken(context.Request)
+                ? StatusCodes.Status403Forbidden
+                : StatusCodes.Status401Unauthorized;
+            return Problem(statusCode, "scheduled_tick_token_invalid", "A valid control-plane token is required.");
+        }
+
+        ScheduledTickRequest? request;
+        try
+        {
+            request = await context.Request
+                .ReadFromJsonAsync(ScheduledTickJsonContext.Default.ScheduledTickRequest, context.RequestAborted)
+                .ConfigureAwait(false);
+        }
+        catch (JsonException)
+        {
+            return Problem(StatusCodes.Status400BadRequest, "scheduled_tick_invalid_body", "Request body is not valid JSON.");
+        }
+
+        if (request is null || string.IsNullOrWhiteSpace(request.Kind))
+        {
+            return Problem(StatusCodes.Status400BadRequest, "scheduled_tick_kind_required", "A tick 'kind' is required.");
+        }
+
+        if (!Enum.TryParse<ScheduledTickKind>(request.Kind, ignoreCase: true, out var kind))
+        {
+            return Problem(StatusCodes.Status400BadRequest, "scheduled_tick_kind_unknown", $"Unknown tick kind '{request.Kind}'.");
+        }
+
+        try
+        {
+            await dispatcher.RunTickAsync(kind, context.RequestAborted).ConfigureAwait(false);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // No handler is registered for the kind in this deployment (the owning feature is disabled,
+            // e.g. its store/Redis dependency is absent). Report 503 so the scheduler can retry/log
+            // rather than treating it as a client error.
+            return Problem(
+                StatusCodes.Status503ServiceUnavailable,
+                "scheduled_tick_kind_unavailable",
+                $"No scheduled-tick handler is available for kind '{kind}' in this deployment.");
+        }
+
+        return Results.Json(
+            new ScheduledTickResponse("ran", kind.ToString(), DateTimeOffset.UtcNow),
+            ScheduledTickJsonContext.Default.ScheduledTickResponse,
+            contentType: "application/json");
+    }
+
+    private static IResult Problem(int statusCode, string code, string message)
+        => Results.Json(
+            new ScheduledTickProblem(code, message),
+            ScheduledTickJsonContext.Default.ScheduledTickProblem,
+            statusCode: statusCode,
+            contentType: "application/json");
+
+    private static bool TokenMatches(HttpRequest request, string expectedToken)
+        => Honua.Server.Features.CloudDemo.CloudDemoCredentials.TokenMatches(request, TokenHeader, expectedToken);
+
+    private static bool HasPresentedToken(HttpRequest request)
+        => Honua.Server.Features.CloudDemo.CloudDemoCredentials.HasPresentedToken(request, TokenHeader);
+}
+
+/// <summary>Request body for the scheduled-tick endpoint: the kind of tick to run once.</summary>
+/// <param name="Kind">The <see cref="ScheduledTickKind"/> name (case-insensitive).</param>
+internal sealed record ScheduledTickRequest(
+    [property: JsonPropertyName("kind")] string? Kind);
+
+/// <summary>Success response from the scheduled-tick endpoint.</summary>
+/// <param name="Status">Always <c>ran</c> on success.</param>
+/// <param name="Kind">The tick kind that was run.</param>
+/// <param name="RanAt">When the tick completed.</param>
+internal sealed record ScheduledTickResponse(
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("kind")] string Kind,
+    [property: JsonPropertyName("ranAt")] DateTimeOffset RanAt);
+
+/// <summary>Problem response from the scheduled-tick endpoint.</summary>
+/// <param name="Code">Stable machine-readable error code.</param>
+/// <param name="Message">Human-readable message.</param>
+internal sealed record ScheduledTickProblem(
+    [property: JsonPropertyName("code")] string Code,
+    [property: JsonPropertyName("message")] string Message);
+
+/// <summary>Source-generated JSON context for the scheduled-tick endpoint payloads (AOT-safe).</summary>
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(ScheduledTickRequest))]
+[JsonSerializable(typeof(ScheduledTickResponse))]
+[JsonSerializable(typeof(ScheduledTickProblem))]
+internal sealed partial class ScheduledTickJsonContext : JsonSerializerContext;

--- a/src/Honua.Server/Features/FileStorage/FileStorageServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/FileStorage/FileStorageServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Infrastructure.Helpers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace Honua.FileStorage;
@@ -96,12 +97,41 @@ public static class FileStorageServiceCollectionExtensions
 
         // Register cleanup background service
         var enableCleanup = section.GetValue("EnableAutomaticCleanup", true);
-        if (enableCleanup)
-        {
-            services.AddHostedService<FileStorageCleanupService>();
-        }
+        RegisterFileStorageCleanup(
+            services,
+            enableCleanup,
+            Honua.Core.Features.ControlPlane.Abstractions.ControlPlaneTriggerModeResolver
+                .ShouldHostInProcessTimers(configuration));
 
         return services;
+    }
+
+    /// <summary>
+    /// Registers the file-storage cleanup as a PERIODIC control-plane tick (bucket-b). The cleanup
+    /// deletes already-expired files via a fresh scope and is idempotent, so the scheduled-tick
+    /// handler is registered in BOTH trigger modes; the in-process timer is hosted only when
+    /// <paramref name="hostInProcessTimer"/> is set (TriggerMode=Poll, default/on-prem), keeping that
+    /// path byte-for-byte unchanged. On AWS this tick can alternatively be replaced by an S3 lifecycle
+    /// policy (cheaper); the tick is kept for on-prem/portability.
+    /// </summary>
+    private static void RegisterFileStorageCleanup(
+        IServiceCollection services,
+        bool enableCleanup,
+        bool hostInProcessTimer)
+    {
+        if (!enableCleanup)
+        {
+            return;
+        }
+
+        services.TryAddSingleton<FileStorageCleanupService>();
+        services.AddSingleton<
+            Honua.Core.Features.ControlPlane.Abstractions.IScheduledTickHandler,
+            FileStorageCleanupScheduledTickHandler>();
+        if (hostInProcessTimer)
+        {
+            services.AddHostedService(sp => sp.GetRequiredService<FileStorageCleanupService>());
+        }
     }
 
     /// <summary>
@@ -162,10 +192,10 @@ public static class FileStorageServiceCollectionExtensions
                 throw new InvalidOperationException($"Unknown storage provider: {options.Provider}");
         }
 
-        if (options.EnableAutomaticCleanup)
-        {
-            services.AddHostedService<FileStorageCleanupService>();
-        }
+        // This Action-based overload has no IConfiguration to read the trigger mode from; it is the
+        // programmatic/test composition path, which is always poll-style (in-process timer hosted).
+        // The IConfiguration overload above is the production path that honors TriggerMode=Event.
+        RegisterFileStorageCleanup(services, options.EnableAutomaticCleanup, hostInProcessTimer: true);
 
         return services;
     }

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -145,7 +145,7 @@ internal static class FeatureRegistrationExtensions
         // wired — i.e. under the same DevGrant/license Redis entitlement that enables GP
         // (honua-server#1827/#1787). On a Redis-less profile this is a no-op, so the lean
         // API-only and Community editions never start an unconditional worker.
-        services.AddJobWorker();
+        services.AddJobWorker(configuration);
         services.AddAnalysisContent(configuration);
         services.AddTemporalHistory();
         services.AddAnalysisReporting(configuration);

--- a/src/Honua.Server/Features/Orchestration/OrchestrationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Orchestration/OrchestrationServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.Orchestration.Abstractions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using StackExchange.Redis;
 
@@ -41,9 +43,12 @@ internal static class OrchestrationServiceCollectionExtensions
         return services;
     }
 
-    public static IServiceCollection AddOrchestrationBackgroundServices(this IServiceCollection services)
+    public static IServiceCollection AddOrchestrationBackgroundServices(
+        this IServiceCollection services,
+        IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
 
         // Background services depend on the same Redis-backed stores the engine needs.
         // Only start them when AddOrchestration actually registered the engine — otherwise
@@ -54,7 +59,19 @@ internal static class OrchestrationServiceCollectionExtensions
         }
 
         services.AddHostedService<WorkflowOrchestrationBackgroundService>();
-        services.AddHostedService<WorkflowSchedulerBackgroundService>();
+
+        // Cron scheduler tick: a single shared singleton instance so the in-memory compiled-cron
+        // cache survives across ticks whether the in-process timer or the scheduled-tick dispatcher
+        // drives it. The IScheduledTickHandler is registered in BOTH trigger modes so EventBridge
+        // Scheduler can drive the tick under TriggerMode=Event; the in-process timer is hosted only
+        // under TriggerMode=Poll (default, on-prem), keeping that path byte-for-byte unchanged.
+        services.TryAddSingleton<WorkflowSchedulerBackgroundService>();
+        services.AddSingleton<IScheduledTickHandler, WorkflowSchedulerScheduledTickHandler>();
+        if (ControlPlaneTriggerModeResolver.ShouldHostInProcessTimers(configuration))
+        {
+            services.AddHostedService(sp => sp.GetRequiredService<WorkflowSchedulerBackgroundService>());
+        }
+
         return services;
     }
 }

--- a/src/Honua.Server/Features/Orchestration/WorkflowSchedulerBackgroundService.cs
+++ b/src/Honua.Server/Features/Orchestration/WorkflowSchedulerBackgroundService.cs
@@ -9,6 +9,23 @@ using Microsoft.Extensions.Hosting;
 namespace Honua.Server.Features.Orchestration;
 
 /// <summary>
+/// Adapts the cron workflow-scheduler tick to the control-plane scheduled-tick dispatcher so
+/// EventBridge Scheduler can drive one evaluation under <c>TriggerMode=Event</c> without hosting the
+/// in-process timer. Wraps the SAME singleton <see cref="WorkflowSchedulerBackgroundService" /> the
+/// timer would host, so the in-memory compiled-cron cache survives across ticks. The tick is
+/// idempotent via a durable per-occurrence claim plus a durable schedule cursor.
+/// </summary>
+internal sealed class WorkflowSchedulerScheduledTickHandler(WorkflowSchedulerBackgroundService service)
+    : Honua.Core.Features.ControlPlane.Abstractions.IScheduledTickHandler
+{
+    public Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind Kind
+        => Honua.Core.Features.ControlPlane.Abstractions.ScheduledTickKind.WorkflowSchedule;
+
+    public Task RunTickAsync(CancellationToken cancellationToken = default)
+        => service.TickAsync(cancellationToken);
+}
+
+/// <summary>
 /// Background worker that evaluates cron-triggered workflow definitions and creates
 /// workflow runs when their schedule fires. Runs one tick per minute, producing at most
 /// one run per definition per tick.

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -460,6 +460,15 @@ if (connectedRedis != null)
         Honua.ControlPlane.OperationReconcileDispatcher>();
     builder.Services.AddSingleton<Honua.ControlPlane.ControlPlaneEventHandler>();
 
+    // Phase 3: the PERIODIC (bucket-b) scheduled-tick dispatcher routes a tick kind to the handler
+    // that owns the matching background service's idempotent tick body. Handlers are contributed by
+    // the owning assemblies (registered alongside each service above). Under TriggerMode=Poll the
+    // in-process timers drive the ticks; under Event the timers are not hosted and EventBridge
+    // Scheduler -> the scheduled-tick endpoint drives them through this dispatcher.
+    builder.Services.AddSingleton<
+        Honua.Core.Features.ControlPlane.Abstractions.IScheduledTickDispatcher,
+        Honua.ControlPlane.ScheduledTickDispatcher>();
+
     var controlPlaneTriggerMode = builder.Configuration
         .GetSection(Honua.ControlPlane.ControlPlaneTriggerOptions.SectionName)
         .GetValue<Honua.ControlPlane.ControlPlaneTriggerMode>("TriggerMode", Honua.ControlPlane.ControlPlaneTriggerMode.Poll);
@@ -642,7 +651,21 @@ builder.Services.Configure<Honua.Infrastructure.Services.TemporaryFileOptions>(
 builder.Services.AddSingleton<Honua.Infrastructure.Services.FileSystemTemporaryFileService>();
 builder.Services.AddSingleton<Honua.Infrastructure.Services.ITemporaryFileService,
     Honua.Infrastructure.Services.CloudBackedTemporaryFileService>();
-builder.Services.AddHostedService<Honua.Infrastructure.Services.TemporaryFileCleanupService>();
+
+// Temporary-file cleanup is a PERIODIC tick (bucket-b). Its cleanup deletes expired temp files via a
+// fresh scope and is idempotent, so the scheduled-tick handler is registered in BOTH trigger modes;
+// the in-process 30-minute timer is hosted only under TriggerMode=Poll (default, on-prem), keeping
+// that path byte-for-byte unchanged.
+builder.Services.TryAddSingleton<Honua.Infrastructure.Services.TemporaryFileCleanupService>();
+builder.Services.AddSingleton<
+    Honua.Core.Features.ControlPlane.Abstractions.IScheduledTickHandler,
+    Honua.Infrastructure.Services.TemporaryFileCleanupScheduledTickHandler>();
+if (Honua.Core.Features.ControlPlane.Abstractions.ControlPlaneTriggerModeResolver
+    .ShouldHostInProcessTimers(builder.Configuration))
+{
+    builder.Services.AddHostedService(sp =>
+        sp.GetRequiredService<Honua.Infrastructure.Services.TemporaryFileCleanupService>());
+}
 
 // Register shared validation services
 builder.Services.AddValidationServices();
@@ -655,7 +678,7 @@ builder.Services.AddOperationsToolset();
 builder.Services.AddAdminRealtime();
 if (!isTestEnvironment)
 {
-    builder.Services.AddOrchestrationBackgroundServices();
+    builder.Services.AddOrchestrationBackgroundServices(builder.Configuration);
 }
 
 builder.Services.AddSingleton<Honua.Protocols.GeoServices.FeatureServer.DistributedReplicaStore>(sp =>
@@ -1318,6 +1341,10 @@ app.MapMetadataReleaseEndpoints();
 app.MapMetadataReleaseOperationEndpoints();
 app.MapMetadataReleaseControlEndpoints();
 app.MapCoordinatedReleaseControlEndpoints();
+
+// Phase 3: internal, token-guarded scheduled-tick endpoint for EventBridge Scheduler. Mapped only
+// when ControlPlane:TriggerMode=Event; a no-op (route absent) under Poll (default, on-prem).
+app.MapScheduledTickEndpoints(builder.Configuration);
 app.MapMetadataPrevalidationEndpoints();
 app.MapDeployControlEndpoints();
 

--- a/src/Honua.Server/Startup/ImportExportTileOperationsRegistration.cs
+++ b/src/Honua.Server/Startup/ImportExportTileOperationsRegistration.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Migration.Domain;
 using Honua.Core.Features.FileImport.Domain;
 using Honua.Core.Features.Migration.Services;
 using Honua.Core.Features.FileImport.Services;
+using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Server.Features.Admin.TileOperations;
 using Honua.Io.Export;
@@ -121,7 +122,17 @@ internal static class ImportExportTileOperationsRegistration
         // per-tileset Cache-Control TTL (#1794). Disabled unless TileCacheExpiry:Enabled is set.
         services.Configure<TileCacheExpiryOptions>(
             configuration.GetSection(TileCacheExpiryOptions.SectionName));
-        services.AddHostedService<TileCacheExpiryHostedService>();
+
+        // Scheduled tile-cache expiry is a PERIODIC tick (bucket-b). The sweep re-queues invalidate
+        // jobs whose own pipeline is idempotent, so the scheduled-tick handler is registered in BOTH
+        // trigger modes; the in-process timer is hosted only under TriggerMode=Poll (default,
+        // on-prem), keeping that path byte-for-byte unchanged.
+        services.TryAddSingleton<TileCacheExpiryHostedService>();
+        services.AddSingleton<IScheduledTickHandler, TileCacheExpiryScheduledTickHandler>();
+        if (ControlPlaneTriggerModeResolver.ShouldHostInProcessTimers(configuration))
+        {
+            services.AddHostedService(sp => sp.GetRequiredService<TileCacheExpiryHostedService>());
+        }
 
         // Live size-quota / LRU tile-cache evictor (#1917). The pure LRU policy and quota options
         // landed in #1837; this binds them to a live Redis tile-key index on the hot serve path.
@@ -150,7 +161,17 @@ internal static class ImportExportTileOperationsRegistration
         services.Configure<TileCacheEvictionSweepOptions>(
             configuration.GetSection(TileCacheEvictionSweepOptions.SectionName));
         services.AddSingleton<TileCacheEvictionService>();
-        services.AddHostedService<TileCacheEvictionHostedService>();
+
+        // Live LRU tile-cache eviction is a PERIODIC tick (bucket-b). The sweep re-evaluates the
+        // current key index against the quota (no-op when nothing exceeds it), so the scheduled-tick
+        // handler is registered in BOTH trigger modes; the in-process timer is hosted only under
+        // TriggerMode=Poll (default, on-prem), keeping that path byte-for-byte unchanged. The handler
+        // routes to TileCacheEvictionService.SweepAsync (the same body the timer calls).
+        services.AddSingleton<IScheduledTickHandler, TileCacheEvictionScheduledTickHandler>();
+        if (ControlPlaneTriggerModeResolver.ShouldHostInProcessTimers(configuration))
+        {
+            services.AddHostedService<TileCacheEvictionHostedService>();
+        }
 
         // Batch-dispatched tile-cache / PMTiles execution jobs (issue #1697).
         // The worker-side executor is registered unconditionally so any worker host

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ScheduledTickDispatcherTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ScheduledTickDispatcherTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Abstractions;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Phase 3 dispatcher-seam tests: the scheduled-tick dispatcher routes each tick kind to the handler
+/// that owns it and runs that handler's tick exactly once, and does nothing else (no extra
+/// coordination). Mirrors <see cref="OperationReconcileDispatcherTests"/> for the PERIODIC services.
+/// </summary>
+public sealed class ScheduledTickDispatcherTests
+{
+    private sealed class RecordingHandler(ScheduledTickKind kind) : IScheduledTickHandler
+    {
+        public ScheduledTickKind Kind { get; } = kind;
+
+        public int RunCount { get; private set; }
+
+        public CancellationToken LastToken { get; private set; }
+
+        public Task RunTickAsync(CancellationToken cancellationToken = default)
+        {
+            RunCount++;
+            LastToken = cancellationToken;
+            return Task.CompletedTask;
+        }
+    }
+
+    private static (ScheduledTickDispatcher Dispatcher, IReadOnlyDictionary<ScheduledTickKind, RecordingHandler> Handlers)
+        BuildDispatcherForAllKinds()
+    {
+        var handlers = Enum.GetValues<ScheduledTickKind>()
+            .ToDictionary(kind => kind, kind => new RecordingHandler(kind));
+        var dispatcher = new ScheduledTickDispatcher(handlers.Values);
+        return (dispatcher, handlers);
+    }
+
+    [Theory]
+    [InlineData(ScheduledTickKind.WorkflowSchedule)]
+    [InlineData(ScheduledTickKind.JobReconciliation)]
+    [InlineData(ScheduledTickKind.TileCacheExpiry)]
+    [InlineData(ScheduledTickKind.TileCacheEviction)]
+    [InlineData(ScheduledTickKind.WorkspaceCleanup)]
+    [InlineData(ScheduledTickKind.FileStorageCleanup)]
+    [InlineData(ScheduledTickKind.TemporaryFileCleanup)]
+    [InlineData(ScheduledTickKind.DigestFlush)]
+    public async Task RunTickAsync_RoutesToTheMatchingHandlerOnly(ScheduledTickKind kind)
+    {
+        var (dispatcher, handlers) = BuildDispatcherForAllKinds();
+
+        await dispatcher.RunTickAsync(kind);
+
+        handlers[kind].RunCount.Should().Be(1, "the dispatcher routes the tick to the handler that owns its kind");
+        foreach (var (otherKind, handler) in handlers)
+        {
+            if (otherKind == kind)
+            {
+                continue;
+            }
+
+            handler.RunCount.Should().Be(0, "no other handler should be invoked for kind {0}", kind);
+        }
+    }
+
+    [Fact]
+    public async Task RunTickAsync_RunsTheTickExactlyOncePerInvocation()
+    {
+        var (dispatcher, handlers) = BuildDispatcherForAllKinds();
+
+        await dispatcher.RunTickAsync(ScheduledTickKind.DigestFlush);
+        await dispatcher.RunTickAsync(ScheduledTickKind.DigestFlush);
+
+        handlers[ScheduledTickKind.DigestFlush].RunCount
+            .Should().Be(2, "each invocation runs the tick once — the dispatcher adds no batching or dedupe of its own");
+    }
+
+    [Fact]
+    public async Task RunTickAsync_ForwardsTheCancellationToken()
+    {
+        var (dispatcher, handlers) = BuildDispatcherForAllKinds();
+        using var cts = new CancellationTokenSource();
+
+        await dispatcher.RunTickAsync(ScheduledTickKind.WorkflowSchedule, cts.Token);
+
+        handlers[ScheduledTickKind.WorkflowSchedule].LastToken
+            .Should().Be(cts.Token, "the dispatcher forwards the caller's token to the tick body");
+    }
+
+    [Fact]
+    public async Task RunTickAsync_UnregisteredKind_Throws()
+    {
+        // Only the WorkflowSchedule handler is registered (e.g. every other feature is disabled in
+        // this deployment). Driving an unregistered kind must surface a clear error so the scheduler
+        // can retry/log rather than silently no-op.
+        var dispatcher = new ScheduledTickDispatcher(
+            [new RecordingHandler(ScheduledTickKind.WorkflowSchedule)]);
+
+        var act = async () => await dispatcher.RunTickAsync(ScheduledTickKind.DigestFlush);
+
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Constructor_DuplicateKind_DoesNotThrow()
+    {
+        // A duplicate registration for one kind is a registration mistake, but it must not crash
+        // composition of an otherwise healthy host; last-registered wins.
+        var act = () => new ScheduledTickDispatcher(
+        [
+            new RecordingHandler(ScheduledTickKind.DigestFlush),
+            new RecordingHandler(ScheduledTickKind.DigestFlush)
+        ]);
+
+        act.Should().NotThrow();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ScheduledTickTriggerModeTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ScheduledTickTriggerModeTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Phase 3 trigger-mode tests for the PERIODIC (bucket-b) services. Under <c>TriggerMode=Poll</c> the
+/// in-process timers are hosted as before; under <c>Event</c> none of them are hosted, but the
+/// scheduled-tick handlers + dispatcher are registered so EventBridge Scheduler can drive each tick.
+/// These exercise <see cref="ControlPlaneTriggerModeResolver"/> (the shared gate every registration
+/// site uses) and the dispatcher's resolution of the registered handler set.
+/// </summary>
+public sealed class ScheduledTickTriggerModeTests
+{
+    private static IConfiguration Configuration(string? triggerMode)
+    {
+        var values = new Dictionary<string, string?>();
+        if (triggerMode is not null)
+        {
+            values["ControlPlane:TriggerMode"] = triggerMode;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    [Fact]
+    public void Resolver_Unconfigured_DefaultsToPoll_HostsInProcessTimers()
+    {
+        var configuration = Configuration(triggerMode: null);
+
+        ControlPlaneTriggerModeResolver.IsEventMode(configuration).Should().BeFalse();
+        ControlPlaneTriggerModeResolver.ShouldHostInProcessTimers(configuration).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("Poll")]
+    [InlineData("poll")]
+    [InlineData("not-a-mode")]
+    public void Resolver_NonEvent_HostsInProcessTimers(string mode)
+    {
+        var configuration = Configuration(mode);
+
+        ControlPlaneTriggerModeResolver.IsEventMode(configuration).Should().BeFalse();
+        ControlPlaneTriggerModeResolver.ShouldHostInProcessTimers(configuration).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("Event")]
+    [InlineData("event")]
+    [InlineData("EVENT")]
+    public void Resolver_Event_DoesNotHostInProcessTimers(string mode)
+    {
+        var configuration = Configuration(mode);
+
+        ControlPlaneTriggerModeResolver.IsEventMode(configuration).Should().BeTrue();
+        ControlPlaneTriggerModeResolver.ShouldHostInProcessTimers(configuration).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Poll_HostsTimer_AndRegistersHandler_ForSharedRegistrationShape()
+    {
+        // Reproduce the exact registration shape every PERIODIC site uses: a shared singleton service,
+        // an always-registered scheduled-tick handler, and a Poll-gated hosted-service that resolves
+        // the SAME singleton. Under Poll the timer is hosted and the handler is present.
+        var services = new ServiceCollection();
+        RegisterLikeProductionSite(services, Configuration("Poll"));
+
+        var hostedDescriptors = services
+            .Where(d => d.ServiceType == typeof(IHostedService))
+            .ToList();
+        hostedDescriptors.Should().ContainSingle("Poll mode hosts the in-process timer");
+
+        services.Should().Contain(d => d.ServiceType == typeof(IScheduledTickHandler),
+            "the scheduled-tick handler is registered in BOTH modes");
+    }
+
+    [Fact]
+    public void Event_HostsNoTimer_ButRegistersHandlerAndDispatcherDrivesIt()
+    {
+        var services = new ServiceCollection();
+        RegisterLikeProductionSite(services, Configuration("Event"));
+
+        services.Should().NotContain(d => d.ServiceType == typeof(IHostedService),
+            "Event mode hosts none of the in-process timers");
+        services.Should().Contain(d => d.ServiceType == typeof(IScheduledTickHandler),
+            "Event mode still registers the handler so the dispatcher can drive the tick");
+
+        // The dispatcher, resolving the registered handler set, drives the tick on demand — the
+        // Event-mode replacement for the in-process timer.
+        services.AddSingleton<IScheduledTickDispatcher, ScheduledTickDispatcher>();
+        using var provider = services.BuildServiceProvider();
+        var dispatcher = provider.GetRequiredService<IScheduledTickDispatcher>();
+        var handler = (CountingTickHandler)provider.GetServices<IScheduledTickHandler>().Single();
+
+        var act = async () => await dispatcher.RunTickAsync(handler.Kind);
+        act.Should().NotThrowAsync();
+    }
+
+    /// <summary>
+    /// Mirrors the Poll-gated registration pattern used at every PERIODIC site: shared singleton +
+    /// always-on handler + conditionally-hosted timer keyed off the trigger mode.
+    /// </summary>
+    private static void RegisterLikeProductionSite(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSingleton<CountingTickHandler>();
+        services.AddSingleton<IScheduledTickHandler>(sp => sp.GetRequiredService<CountingTickHandler>());
+        if (ControlPlaneTriggerModeResolver.ShouldHostInProcessTimers(configuration))
+        {
+            services.AddSingleton<IHostedService, FakeTimerHostedService>();
+        }
+    }
+
+    private sealed class CountingTickHandler : IScheduledTickHandler
+    {
+        public ScheduledTickKind Kind => ScheduledTickKind.DigestFlush;
+
+        public Task RunTickAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class FakeTimerHostedService : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 of the control-plane hybrid trigger (design option C). Converts the PERIODIC / time-based background services from always-on in-process timers to ticks invocable once by EventBridge Scheduler under `ControlPlane:TriggerMode=Event`, behind the same TriggerMode flag, keeping the in-process timer as the on-prem (`Poll`, default) fallback byte-for-byte.

Mirrors the `IOperationReconcileDispatcher` (#2190) seam for the bucket-(b) periodic services and adds a token-guarded scheduled-tick endpoint in the `ControlPlaneEventEndpoints` (#2198) spirit (#2198 is not on this branch, so the token-guard mirrors the CloudDemo reset endpoint).

Pairs with honua-iac `feat/control-plane-scheduled-ticks` (EventBridge Scheduler rules + scheduled-tick Lambda).

## Changes Made

- Core: `IScheduledTickDispatcher` + `ScheduledTickKind` + `IScheduledTickHandler` (routes a tick kind to the handler that owns the matching service's idempotent per-tick body); `ControlPlaneTriggerModeResolver` (shared Poll-vs-Event gate from `ControlPlane:TriggerMode`).
- Server: `ScheduledTickDispatcher` (thin switch over the registered handler set) + token-guarded `POST /internal/control-plane/scheduled-tick`, mapped ONLY in Event mode; new `ControlPlane:ScheduledTickToken` option.
- Converted services (each tick already idempotent — verified): `WorkflowSchedulerBackgroundService` (`TickAsync`; durable claim+cursor), `JobReconciliationService` (`SweepActiveJobsAsync`; re-read + optimistic CAS), `TileCacheExpiry`/`TileCacheEviction` (`SweepAsync`), `WorkspaceCleanup`/`FileStorageCleanup`/`TemporaryFileCleanup` (`RunCleanup`/`PerformCleanup`), `DigestFlushBackgroundService` (`FlushAsync`; atomic batch claim).
- Each owning assembly registers a thin `IScheduledTickHandler` wrapping the existing tick method (promoted `private`->`internal` where needed) + a shared singleton; the in-process timer is hosted only under Poll, the handler in both modes.
- `FileStorageCleanup` can alternatively be served by an S3 lifecycle policy (noted); the tick is retained for on-prem/portability.

## Breaking Changes

None. Default `TriggerMode=Poll` keeps every in-process timer hosted exactly as before.

## Gate Impact

- [x] No gate impact / additive (control-plane hybrid trigger, off by default)

## Testing

- [x] Ran the equivalent of `scripts/ci/pre-pr-check.sh`: Release build with `TreatWarningsAsErrors=true -p:NuGetAudit=false` (green, 0 warnings), `dotnet format --verify-no-changes` on changed files (clean), and the ControlPlane suite (33 passed, 0 failed: new `ScheduledTickDispatcherTests` + `ScheduledTickTriggerModeTests` + existing dispatcher/trigger tests). Docker/Testcontainers integration shards not run locally (environmental).

Related to #2190, #2198 (control-plane hybrid-trigger umbrella).
