### PR TITLE
feat: stream GeoETL transforms past the 50 MiB artifact cap (#1185)

### DIFF
--- a/docs/internal/contributor/adr/0038-geoetl-pipeline-architecture-and-runtime-boundary.md
+++ b/docs/internal/contributor/adr/0038-geoetl-pipeline-architecture-and-runtime-boundary.md
@@ -79,6 +79,49 @@ child ticket.
   pre-execution. Generic REST/JSON sources with dynamic schemas use a
   documented permissive passthrough mode.
 
+### Streaming feature-artifact contract (ETL scale)
+
+The artifact that flows between DAG steps is a streamed, spillable feature
+contract rather than a whole-collection blob, so pipelines scale past toy
+volumes:
+
+- **Two artifact shapes, both opaque references** stored verbatim on the
+  `ExecutionJobRecord` and projected into the downstream step's `input`:
+  - *Inline* — the legacy `data:application/geo+json;base64,<...>`
+    FeatureCollection data URI, emitted for small outputs (under
+    `FeatureStreamArtifact.DefaultInlineThresholdBytes`, ~1 MiB) so tiny
+    pipelines and OGC API Processes surfaces keep the exact same document.
+  - *Spill* — a `honua-feature-stream:v1;ndjson;path=<abs>;count=<n>;bytes=<n>`
+    reference to a newline-delimited GeoJSON (NDJSON) file under the executor
+    output root, one `Feature` per line. SRID is preserved across the spill
+    boundary via a reserved `__honua_srid` foreign member (GeoJSON has no
+    native SRID), so reproject output keeps its target SRID.
+- **Reads accept either shape** (`FeatureStreamArtifact.TryOpenRead`) and
+  surface an `IAsyncEnumerable<IFeature>`, so a streaming step transparently
+  consumes either an inline or a spilled producer.
+- **Per-feature transforms stream** (`ApplyStream`): attribute-rename,
+  attribute-cast, computed-field, attribute-filter, spatial-filter, clip,
+  reproject — input is processed lazily and output is published incrementally
+  via `FeatureStreamPublisher`, which buffers only up to the inline threshold
+  and then spills, so peak memory is bounded regardless of feature count.
+- **Stateful transforms** (dedup) keep the buffered `Apply` shape but use a
+  `SpillableKeySet` for the seen-key set: each key is reduced to a 128-bit
+  digest and spills to a temp file past an in-memory cap, so dedup stays
+  bounded too. The documented bound is digest-level exactness (collision
+  probability negligible at realistic volumes), output stays first-wins and
+  deterministic. The 4 managed aggregates (cluster/density/spatial-join/
+  buffer-aggregate) inherently buffer the full set and are unchanged.
+- **Sinks stream their input** (external-postgis batched COPY/insert,
+  geojson-file, quarantine) so a large load lands without materializing the
+  collection. The legacy hard `MaxArtifactBytes` (~50 MiB) failure
+  ("Reduce the input feature set") no longer applies to streamable
+  transforms; the cap remains only as the bound on *inline* data-URI inputs.
+- **Boundary**: spill files live under the executor output root, which is the
+  same-node temp directory the file-sink path already uses. Cross-node
+  pipelines (separate worker pods per step) need an object-store-backed spill,
+  tracked as the next streaming-source stream; the current contract matches the
+  existing file-sink/`import.dataset` file-path semantics.
+
 ### Substrate consumption
 
 - GeoETL is a job kind on top of `IJobQueue`. It uses the existing

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/AttributeCastTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/AttributeCastTransformExecutor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Options;
 using NetTopologySuite.Features;
 
@@ -12,7 +13,8 @@ namespace Honua.Geoprocessing.Execution;
 /// type (<c>int</c>, <c>long</c>, <c>double</c>, <c>bool</c>, or <c>string</c>).
 /// A value that cannot be coerced is a row-level data error: per the <c>onError</c>
 /// policy it is dropped (default), set to null, or kept. Ported from the GeoETL
-/// baseline AttributeCastTransform onto the #1185 process/executor contract.
+/// baseline AttributeCastTransform onto the #1185 process/executor contract. Streams:
+/// a per-feature map with no cross-feature state.
 /// </summary>
 internal sealed class AttributeCastTransformExecutor(
     IOptionsMonitor<GeoprocessingExecutorOptions> options)
@@ -22,24 +24,23 @@ internal sealed class AttributeCastTransformExecutor(
 
     protected override string ProcessId => HandledProcessId;
 
-    protected override List<IFeature> Apply(
-        FeatureCollection source,
+    protected override async IAsyncEnumerable<IFeature> ApplyStream(
+        IAsyncEnumerable<IFeature> source,
         StepInputReader inputs,
-        CancellationToken cancellationToken)
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var field = inputs.Require("field");
         var to = inputs.Require("to").ToLowerInvariant();
         var onError = inputs.GetOrDefault("onError", "drop").ToLowerInvariant();
 
-        var output = new List<IFeature>(source.Count);
-        foreach (var feature in source)
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var attributes = feature.Attributes;
             if (attributes is null || !attributes.Exists(field))
             {
-                output.Add(feature);
+                yield return feature;
                 continue;
             }
 
@@ -47,7 +48,7 @@ internal sealed class AttributeCastTransformExecutor(
             if (TryCoerce(raw, to, out var coerced))
             {
                 attributes[field] = coerced!;
-                output.Add(feature);
+                yield return feature;
                 continue;
             }
 
@@ -55,18 +56,16 @@ internal sealed class AttributeCastTransformExecutor(
             {
                 case "null":
                     attributes[field] = null!;
-                    output.Add(feature);
+                    yield return feature;
                     break;
                 case "keep":
-                    output.Add(feature);
+                    yield return feature;
                     break;
                 default:
                     // drop: row-level error, omit the feature from the output.
                     break;
             }
         }
-
-        return output;
     }
 
     private static bool TryCoerce(object? value, string to, out object? result)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/AttributeFilterTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/AttributeFilterTransformExecutor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Options;
 using NetTopologySuite.Features;
 
@@ -13,7 +14,8 @@ namespace Honua.Geoprocessing.Execution;
 /// values: <c>eq</c>, <c>neq</c>, <c>gt</c>, <c>gte</c>, <c>lt</c>, <c>lte</c>,
 /// <c>contains</c>, <c>exists</c>. Numeric operators parse both operands as doubles;
 /// string operators compare ordinally. Ported from the GeoETL baseline
-/// AttributeFilterTransform onto the #1185 process/executor contract.
+/// AttributeFilterTransform onto the #1185 process/executor contract. Streams: a
+/// per-feature filter with no cross-feature state.
 /// </summary>
 internal sealed class AttributeFilterTransformExecutor(
     IOptionsMonitor<GeoprocessingExecutorOptions> options)
@@ -23,26 +25,23 @@ internal sealed class AttributeFilterTransformExecutor(
 
     protected override string ProcessId => HandledProcessId;
 
-    protected override List<IFeature> Apply(
-        FeatureCollection source,
+    protected override async IAsyncEnumerable<IFeature> ApplyStream(
+        IAsyncEnumerable<IFeature> source,
         StepInputReader inputs,
-        CancellationToken cancellationToken)
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var field = inputs.Require("field");
         var op = inputs.GetOrDefault("op", "eq");
         inputs.TryGet("value", out var value);
 
-        var output = new List<IFeature>(source.Count);
-        foreach (var feature in source)
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (Matches(feature, field, op, value))
             {
-                output.Add(feature);
+                yield return feature;
             }
         }
-
-        return output;
     }
 
     private static bool Matches(IFeature feature, string field, string op, string? value)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/AttributeRenameTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/AttributeRenameTransformExecutor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Options;
 using NetTopologySuite.Features;
 
@@ -10,7 +11,8 @@ namespace Honua.Geoprocessing.Execution;
 /// <c>transform.attribute-rename</c> executor. Renames one attribute key to another
 /// on every feature, preserving the value and geometry. Features that do not carry
 /// the <c>from</c> attribute pass through unchanged. Ported from the GeoETL baseline
-/// AttributeRenameTransform onto the #1185 process/executor contract.
+/// AttributeRenameTransform onto the #1185 process/executor contract. Streams: a
+/// per-feature map with no cross-feature state, so it processes the input lazily.
 /// </summary>
 internal sealed class AttributeRenameTransformExecutor(
     IOptionsMonitor<GeoprocessingExecutorOptions> options)
@@ -20,23 +22,22 @@ internal sealed class AttributeRenameTransformExecutor(
 
     protected override string ProcessId => HandledProcessId;
 
-    protected override List<IFeature> Apply(
-        FeatureCollection source,
+    protected override async IAsyncEnumerable<IFeature> ApplyStream(
+        IAsyncEnumerable<IFeature> source,
         StepInputReader inputs,
-        CancellationToken cancellationToken)
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var from = inputs.Require("from");
         var to = inputs.Require("to");
 
-        var output = new List<IFeature>(source.Count);
-        foreach (var feature in source)
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var attributes = feature.Attributes;
             if (attributes is null || !attributes.Exists(from))
             {
-                output.Add(feature);
+                yield return feature;
                 continue;
             }
 
@@ -47,9 +48,7 @@ internal sealed class AttributeRenameTransformExecutor(
                 rebuilt.Add(key, attributes.GetOptionalValue(name));
             }
 
-            output.Add(new Feature(feature.Geometry, rebuilt));
+            yield return new Feature(feature.Geometry, rebuilt);
         }
-
-        return output;
     }
 }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ClipTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ClipTransformExecutor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Options;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
@@ -15,7 +16,8 @@ namespace Honua.Geoprocessing.Execution;
 /// GEOS native dependency. A feature whose clipped geometry is empty is dropped;
 /// the clipped geometry keeps the source feature's SRID and attributes are
 /// preserved. Ported from the GeoETL baseline ClipTransform onto the #1185
-/// process/executor contract.
+/// process/executor contract. Streams: a per-feature map; the region is parsed once
+/// before the stream is consumed.
 /// </summary>
 internal sealed class ClipTransformExecutor(
     IOptionsMonitor<GeoprocessingExecutorOptions> options)
@@ -25,50 +27,56 @@ internal sealed class ClipTransformExecutor(
 
     protected override string ProcessId => HandledProcessId;
 
-    protected override List<IFeature> Apply(
-        FeatureCollection source,
+    protected override async IAsyncEnumerable<IFeature> ApplyStream(
+        IAsyncEnumerable<IFeature> source,
         StepInputReader inputs,
-        CancellationToken cancellationToken)
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var region = SpatialFilterTransformExecutor.ReadRegion(inputs);
 
-        var output = new List<IFeature>(source.Count);
-        foreach (var feature in source)
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var geometry = feature.Geometry;
-            if (geometry is null || geometry.IsEmpty)
+            var clipped = ClipFeature(feature, region);
+            if (clipped is not null)
             {
-                continue;
+                yield return clipped;
             }
+        }
+    }
 
-            // Cheap envelope reject before the overlay for features clearly outside the region.
-            if (!geometry.EnvelopeInternal.Intersects(region.EnvelopeInternal))
-            {
-                continue;
-            }
-
-            NtsGeometry clipped;
-            try
-            {
-                clipped = geometry.Intersection(region);
-            }
-            catch (TopologyException)
-            {
-                // Row-level geometry error: drop the row rather than aborting the run.
-                continue;
-            }
-
-            if (clipped.IsEmpty)
-            {
-                continue;
-            }
-
-            clipped.SRID = geometry.SRID;
-            output.Add(new Feature(clipped, feature.Attributes));
+    private static Feature? ClipFeature(IFeature feature, NtsGeometry region)
+    {
+        var geometry = feature.Geometry;
+        if (geometry is null || geometry.IsEmpty)
+        {
+            return null;
         }
 
-        return output;
+        // Cheap envelope reject before the overlay for features clearly outside the region.
+        if (!geometry.EnvelopeInternal.Intersects(region.EnvelopeInternal))
+        {
+            return null;
+        }
+
+        NtsGeometry clipped;
+        try
+        {
+            clipped = geometry.Intersection(region);
+        }
+        catch (TopologyException)
+        {
+            // Row-level geometry error: drop the row rather than aborting the run.
+            return null;
+        }
+
+        if (clipped.IsEmpty)
+        {
+            return null;
+        }
+
+        clipped.SRID = geometry.SRID;
+        return new Feature(clipped, feature.Attributes);
     }
 }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ComputedFieldTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ComputedFieldTransformExecutor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Options;
 using NetTopologySuite.Features;
 
@@ -14,7 +15,7 @@ namespace Honua.Geoprocessing.Execution;
 /// <c>subtract</c>, <c>multiply</c>, <c>divide</c>, <c>const</c>. Rows whose
 /// arithmetic operands are non-numeric are dropped as row-level data errors.
 /// Ported from the GeoETL baseline ComputedFieldTransform onto the #1185
-/// process/executor contract.
+/// process/executor contract. Streams: a per-feature map with no cross-feature state.
 /// </summary>
 internal sealed class ComputedFieldTransformExecutor(
     IOptionsMonitor<GeoprocessingExecutorOptions> options)
@@ -24,16 +25,15 @@ internal sealed class ComputedFieldTransformExecutor(
 
     protected override string ProcessId => HandledProcessId;
 
-    protected override List<IFeature> Apply(
-        FeatureCollection source,
+    protected override async IAsyncEnumerable<IFeature> ApplyStream(
+        IAsyncEnumerable<IFeature> source,
         StepInputReader inputs,
-        CancellationToken cancellationToken)
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var target = inputs.Require("target");
         var op = inputs.Require("op").ToLowerInvariant();
 
-        var output = new List<IFeature>(source.Count);
-        foreach (var feature in source)
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -49,13 +49,11 @@ internal sealed class ComputedFieldTransformExecutor(
                     attributes.Add(target, value);
                 }
 
-                output.Add(new Feature(feature.Geometry, attributes));
+                yield return new Feature(feature.Geometry, attributes);
             }
 
             // else: row-level data error (non-numeric operand) — drop the row.
         }
-
-        return output;
     }
 
     private static bool TryCompute(

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/CsvSourceExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/CsvSourceExecutor.cs
@@ -91,22 +91,33 @@ internal sealed class CsvSourceExecutor(IOptionsMonitor<GeoprocessingExecutorOpt
         cancellationToken.ThrowIfCancellationRequested();
         await context.ReportProgressAsync(70, "Encoding source artifact", cancellationToken).ConfigureAwait(false);
 
-        var payload = FeatureCollectionArtifact.WriteFeatureCollection(features, HandledProcessId);
-
-        var maxBytes = _options.CurrentValue.MaxArtifactBytes;
-        if (payload.Length > maxBytes)
-        {
-            return JobExecutionResult.Failed(
-                $"{HandledProcessId} artifact size {payload.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}.");
-        }
-
-        var artifactUri = FeatureCollectionArtifact.BuildDataUri(payload);
+        // Publish through the spillable publisher: small results stay inline (back-compat),
+        // large results spill to an NDJSON stream so the legacy 50 MiB cap no longer applies.
+        var published = await FeatureStreamPublisher.PublishAsync(
+            ToAsync(features, cancellationToken),
+            HandledProcessId,
+            inputCount: features.Count,
+            _options.CurrentValue.OutputRootDirectory,
+            job.OperationId,
+            cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
-        await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+        await context.PublishArtifactAsync(published.ArtifactReference, cancellationToken).ConfigureAwait(false);
         await context.ReportProgressAsync(100, $"{HandledProcessId} completed", cancellationToken).ConfigureAwait(false);
 
         return JobExecutionResult.Succeeded();
+    }
+
+    private static async IAsyncEnumerable<IFeature> ToAsync(
+        IReadOnlyList<IFeature> features,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        foreach (var feature in features)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return feature;
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
     }
 
     private static List<IFeature> ParseCsv(string body, char delimiter, CancellationToken cancellationToken)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/DedupTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/DedupTransformExecutor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Extensions.Options;
 using NetTopologySuite.Features;
@@ -14,6 +15,17 @@ namespace Honua.Geoprocessing.Execution;
 /// the geometry (normalized WKT), or both. Pure managed — no native dependency.
 /// Ported from the GeoETL baseline DedupTransform onto the #1185 process/executor
 /// contract.
+///
+/// <para>
+/// <b>Streaming (stateful).</b> Dedup is the one stateful transform: it must remember
+/// which keys it has already emitted. It streams the input and output one feature at a
+/// time, but keeps a "seen keys" set whose memory would otherwise grow with cardinality.
+/// To stay bounded it uses a <see cref="SpillableKeySet"/>, which reduces each key to a
+/// fixed 128-bit digest and spills to a temp file once the in-memory digest count crosses
+/// a cap. Output stays first-wins and deterministic; the documented bound is digest-level
+/// exactness rather than byte-for-byte (collision probability is negligible at any realistic
+/// volume — see <see cref="SpillableKeySet"/>).
+/// </para>
 /// </summary>
 internal sealed class DedupTransformExecutor(
     IOptionsMonitor<GeoprocessingExecutorOptions> options)
@@ -28,27 +40,24 @@ internal sealed class DedupTransformExecutor(
 
     protected override string ProcessId => HandledProcessId;
 
-    protected override List<IFeature> Apply(
-        FeatureCollection source,
+    protected override async IAsyncEnumerable<IFeature> ApplyStream(
+        IAsyncEnumerable<IFeature> source,
         StepInputReader inputs,
-        CancellationToken cancellationToken)
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var (keys, useGeometry) = ReadKeySpec(inputs);
-        var seen = new HashSet<string>(StringComparer.Ordinal);
+        using var seen = new SpillableKeySet();
 
-        var output = new List<IFeature>(source.Count);
-        foreach (var feature in source)
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var key = BuildKey(feature, keys, useGeometry);
             if (seen.Add(key))
             {
-                output.Add(feature);
+                yield return feature;
             }
         }
-
-        return output;
     }
 
     private static string BuildKey(IFeature feature, IReadOnlyList<string> keys, bool useGeometry)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutor.cs
@@ -91,7 +91,11 @@ internal sealed partial class ExternalPostgisSinkExecutor : IJobExecutor
             return JobExecutionResult.Failed($"Invalid {HandledProcessId} inputs: {inputError}");
         }
 
-        if (!FeatureCollectionArtifact.TryParseDataUri(inputUri, out var source, out var parseError, _options.CurrentValue.MaxArtifactBytes))
+        // Open the input as a streamed feature sequence so a >50 MiB load lands via
+        // batched COPY/insert without materializing the whole collection. Spilled NDJSON
+        // streams are unbounded; inline data URIs stay bounded by MaxArtifactBytes.
+        if (!FeatureStreamArtifact.TryOpenRead(
+                inputUri, out var parseError, out var source, _options.CurrentValue.MaxArtifactBytes))
         {
             return JobExecutionResult.Failed($"Invalid {HandledProcessId} inputs: 'input' {parseError}");
         }
@@ -145,7 +149,7 @@ internal sealed partial class ExternalPostgisSinkExecutor : IJobExecutor
             var wkbWriter = new WKBWriter();
             var buffer = new List<IFeature>(batchSize);
 
-            foreach (var feature in source)
+            await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (feature.Geometry is null)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureCollectionTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureCollectionTransformExecutor.cs
@@ -11,12 +11,33 @@ namespace Honua.Geoprocessing.Execution;
 
 /// <summary>
 /// Shared base for the GeoETL <c>transform.*</c> executors. Each transform reads
-/// a <see cref="FeatureCollection"/> from the canonical <c>input</c> data URI
-/// (<see cref="FeatureCollectionArtifact.DataUriPrefix"/>), applies an in-memory
-/// NetTopologySuite transformation that carries feature attributes through, and
-/// publishes a new FeatureCollection data URI. This is the #1185 add-a-capability
-/// shape: the executor is the sole worker-side behavior for a single dotted
-/// process id and surfaces automatically as a <c>process:&lt;id&gt;</c> workflow node.
+/// features from the canonical <c>input</c> artifact, applies a NetTopologySuite
+/// transformation that carries feature attributes through, and publishes a new
+/// feature artifact. This is the #1185 add-a-capability shape: the executor is the
+/// sole worker-side behavior for a single dotted process id and surfaces
+/// automatically as a <c>process:&lt;id&gt;</c> workflow node.
+///
+/// <para>
+/// <b>Streaming (ETL scale).</b> The base now runs a streamed execution path: the
+/// input is opened as a lazy <see cref="IAsyncEnumerable{IFeature}"/> over the
+/// upstream artifact (an inline base64 FeatureCollection <i>or</i> a spilled NDJSON
+/// stream — see <see cref="FeatureStreamArtifact"/>), the transform processes it
+/// chunk-by-chunk, and the output is published through
+/// <see cref="FeatureStreamPublisher"/>, which keeps small results inline (back-compat)
+/// but spills large results to an NDJSON file so peak memory stays bounded and the
+/// legacy 50 MiB artifact cap no longer fails streamable transforms.
+/// </para>
+///
+/// <para>
+/// Transforms that <b>can</b> stream (per-feature maps/filters: attribute-rename,
+/// attribute-cast, computed-field, attribute-filter, spatial-filter, clip, reproject)
+/// override <see cref="ApplyStream"/>. Stateful transforms that need the full set in
+/// memory (e.g. dedup with an in-memory key set) keep the buffered
+/// <see cref="Apply(FeatureCollection, StepInputReader, CancellationToken)"/> path; the
+/// base detects which is implemented and routes accordingly. Both paths publish through
+/// the same spillable publisher, so even buffered transforms emit a streamed artifact
+/// for large outputs rather than failing the cap.
+/// </para>
 /// </summary>
 internal abstract partial class FeatureCollectionTransformExecutor : IJobExecutor
 {
@@ -71,7 +92,10 @@ internal abstract partial class FeatureCollectionTransformExecutor : IJobExecuto
             return JobExecutionResult.Failed($"Invalid {ProcessId} inputs: {inputError}");
         }
 
-        if (!FeatureCollectionArtifact.TryParseDataUri(inputUri, out var source, out var parseError, _options.CurrentValue.MaxArtifactBytes))
+        // Open the input as a lazy feature stream. Spilled NDJSON streams are unbounded;
+        // inline base64 data URIs remain bounded by MaxArtifactBytes for back-compat.
+        if (!FeatureStreamArtifact.TryOpenRead(
+                inputUri, out var parseError, out var inputStream, _options.CurrentValue.MaxArtifactBytes))
         {
             return JobExecutionResult.Failed($"Invalid {ProcessId} inputs: 'input' {parseError}");
         }
@@ -79,10 +103,10 @@ internal abstract partial class FeatureCollectionTransformExecutor : IJobExecuto
         cancellationToken.ThrowIfCancellationRequested();
         await context.ReportProgressAsync(40, $"Applying {ProcessId}", cancellationToken).ConfigureAwait(false);
 
-        List<IFeature> output;
+        FeatureStreamPublisher.PublishResult published;
         try
         {
-            output = Apply(source, inputs, cancellationToken);
+            published = await RunAsync(job, context, inputStream, inputs, cancellationToken).ConfigureAwait(false);
         }
         catch (TransformInputException ex)
         {
@@ -95,40 +119,98 @@ internal abstract partial class FeatureCollectionTransformExecutor : IJobExecuto
         }
 
         cancellationToken.ThrowIfCancellationRequested();
-        await context.ReportProgressAsync(75, $"Encoding {ProcessId} artifact", cancellationToken).ConfigureAwait(false);
-
-        var payload = FeatureCollectionArtifact.WriteFeatureCollection(
-            output,
-            ProcessId,
-            new[] { ("inputCount", (object)source.Count) });
-
-        var maxBytes = _options.CurrentValue.MaxArtifactBytes;
-        if (payload.Length > maxBytes)
-        {
-            return JobExecutionResult.Failed(
-                $"{ProcessId} artifact size {payload.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}. " +
-                "Reduce the input feature set before transforming.");
-        }
-
-        var artifactUri = FeatureCollectionArtifact.BuildDataUri(payload);
-
-        cancellationToken.ThrowIfCancellationRequested();
-        await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+        await context.PublishArtifactAsync(published.ArtifactReference, cancellationToken).ConfigureAwait(false);
         await context.ReportProgressAsync(100, $"{ProcessId} completed", cancellationToken).ConfigureAwait(false);
 
         return JobExecutionResult.Succeeded();
     }
 
+    private async Task<FeatureStreamPublisher.PublishResult> RunAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        IAsyncEnumerable<IFeature> inputStream,
+        StepInputReader inputs,
+        CancellationToken cancellationToken)
+    {
+        var outputRoot = _options.CurrentValue.OutputRootDirectory;
+
+        // Streaming path: per-feature transforms process the input chunk-by-chunk and the
+        // publisher spills large outputs. The full set is never held in memory.
+        var streamed = ApplyStream(inputStream, inputs, cancellationToken);
+        if (streamed is not null)
+        {
+            return await FeatureStreamPublisher.PublishAsync(
+                streamed,
+                ProcessId,
+                inputCount: -1,
+                outputRoot,
+                job.OperationId,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        // Buffered path: stateful transforms (dedup) need the full collection. We still
+        // drain the input incrementally and publish through the spillable publisher, so
+        // large outputs stream out rather than failing the legacy artifact cap.
+        var source = new FeatureCollection();
+        await foreach (var feature in inputStream.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            source.Add(feature);
+        }
+
+        await context.ReportProgressAsync(60, $"Encoding {ProcessId} artifact", cancellationToken).ConfigureAwait(false);
+
+        var output = Apply(source, inputs, cancellationToken);
+        return await FeatureStreamPublisher.PublishAsync(
+            ToAsync(output, cancellationToken),
+            ProcessId,
+            inputCount: source.Count,
+            outputRoot,
+            job.OperationId,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async IAsyncEnumerable<IFeature> ToAsync(
+        IReadOnlyList<IFeature> features,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        foreach (var feature in features)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return feature;
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+    }
+
     /// <summary>
-    /// Applies the transform's algorithm to the parsed input feature set.
-    /// Implementations return the output features, preserving attributes. Throw
-    /// <see cref="TransformInputException"/> for caller-supplied parameter errors
-    /// so they surface as a classified <c>Invalid ... inputs</c> failure.
+    /// Streaming transform entry point. Per-feature transforms (maps/filters) override this
+    /// to process the input <see cref="IAsyncEnumerable{IFeature}"/> lazily and yield output
+    /// features one at a time, so the full feature set is never materialized. The default
+    /// returns <c>null</c>, signalling the base to fall back to the buffered
+    /// <see cref="Apply(FeatureCollection, StepInputReader, CancellationToken)"/> path
+    /// (for stateful transforms that genuinely need the whole collection). Throw
+    /// <see cref="TransformInputException"/> for caller-supplied parameter errors.
     /// </summary>
-    protected abstract List<IFeature> Apply(
+    protected virtual IAsyncEnumerable<IFeature>? ApplyStream(
+        IAsyncEnumerable<IFeature> source,
+        StepInputReader inputs,
+        CancellationToken cancellationToken) => null;
+
+    /// <summary>
+    /// Applies the transform's algorithm to the fully buffered input feature set.
+    /// Implementations return the output features, preserving attributes. Used by stateful
+    /// transforms that cannot stream; per-feature transforms should override
+    /// <see cref="ApplyStream"/> instead. The default throws — a concrete executor must
+    /// implement at least one of the two paths. Throw <see cref="TransformInputException"/>
+    /// for caller-supplied parameter errors so they surface as a classified
+    /// <c>Invalid ... inputs</c> failure.
+    /// </summary>
+    protected virtual List<IFeature> Apply(
         FeatureCollection source,
         StepInputReader inputs,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken)
+        => throw new NotSupportedException(
+            $"{ProcessId} implements neither {nameof(ApplyStream)} nor {nameof(Apply)}.");
 
     private static partial class Log
     {

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureStreamArtifact.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureStreamArtifact.cs
@@ -1,0 +1,433 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// Streaming in/out contract for the GeoETL transform, source, and sink executors.
+/// Replaces the whole-collection base64 data-URI (<see cref="FeatureCollectionArtifact"/>)
+/// for large feature sets: a step reads features incrementally from an upstream
+/// artifact and writes them incrementally to a spillable backing store, so the full
+/// set is never materialized in memory and the hard 50 MiB artifact-cap failure no
+/// longer applies to streamable transforms.
+///
+/// <para>
+/// Two artifact shapes flow through the DAG, both opaque strings that the workflow
+/// runtime stores verbatim and projects into the downstream step's <c>input</c>:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <b>Inline (back-compat fast path)</b> — a
+///     <c>data:application/geo+json;base64,&lt;...&gt;</c> data URI carrying the whole
+///     FeatureCollection. Emitted for small outputs so tiny pipelines keep their
+///     existing artifact bytes and downstream consumers (OGC API Processes surfaces)
+///     see the same document.
+///   </description></item>
+///   <item><description>
+///     <b>Spill (streamed)</b> — a <c>honua-feature-stream:v1;ndjson;path=&lt;abs&gt;;count=&lt;n&gt;;bytes=&lt;n&gt;</c>
+///     reference pointing at a newline-delimited GeoJSON (NDJSON) file under the
+///     executor output root. One GeoJSON <c>Feature</c> per line, read and written a
+///     line at a time so memory stays bounded regardless of feature count.
+///   </description></item>
+/// </list>
+///
+/// <para>
+/// Reads accept either shape so a streaming step can consume the output of a
+/// pre-existing inline producer and vice versa. Uses the managed NetTopologySuite
+/// GeoJSON reader/writer per feature — no native dependency, AOT-safe.
+/// </para>
+/// </summary>
+internal static class FeatureStreamArtifact
+{
+    /// <summary>
+    /// Reference scheme prefix for a spilled NDJSON feature stream. The remainder is a
+    /// <c>;</c>-delimited key/value list (<c>ndjson;path=...;count=...;bytes=...</c>).
+    /// </summary>
+    public const string StreamReferencePrefix = "honua-feature-stream:v1;";
+
+    /// <summary>
+    /// Foreign-member key used to carry a feature's geometry SRID through the NDJSON line.
+    /// GeoJSON has no native SRID, and the NTS reader/writer resets it to the factory default
+    /// on round-trip, so reprojected geometries would otherwise lose their target SRID across
+    /// the spill boundary. We stash it as a reserved property on write and restore it (then
+    /// strip the property) on read, so streaming preserves SRID fidelity end-to-end.
+    /// </summary>
+    private const string SridMemberKey = "__honua_srid";
+
+    /// <summary>
+    /// Default ceiling, in decoded bytes, under which an output is published inline as
+    /// a base64 FeatureCollection data URI (back-compat) instead of spilling to a file.
+    /// Outputs at or above this size spill, so small pipelines keep their existing
+    /// artifact shape while large ones stream. 1 MiB keeps inline artifacts comfortably
+    /// under the legacy 50 MiB cap with headroom for base64 expansion.
+    /// </summary>
+    public const long DefaultInlineThresholdBytes = 1L * 1024L * 1024L;
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="reference"/> is a spilled NDJSON stream
+    /// reference rather than an inline data URI.
+    /// </summary>
+    public static bool IsStreamReference(string? reference)
+        => reference is not null && reference.StartsWith(StreamReferencePrefix, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Opens an incremental feature stream over an upstream artifact reference. Accepts
+    /// both the spilled NDJSON reference and the inline base64 FeatureCollection data
+    /// URI, so a streaming step transparently consumes either producer. The returned
+    /// sequence is lazy: features are decoded one at a time as the consumer pulls them.
+    /// </summary>
+    /// <param name="reference">The upstream artifact reference (stream ref or data URI).</param>
+    /// <param name="error">A classified error when the reference cannot be opened.</param>
+    /// <param name="stream">The lazy feature sequence on success.</param>
+    /// <param name="maxInlineDecodedBytes">
+    /// Ceiling applied only to inline data-URI inputs (mirrors
+    /// <see cref="FeatureCollectionArtifact.TryParseDataUri"/>). Spilled streams are
+    /// unbounded — that is the whole point — so the ceiling does not apply to them.
+    /// </param>
+    public static bool TryOpenRead(
+        string? reference,
+        out string error,
+        out IAsyncEnumerable<IFeature> stream,
+        long maxInlineDecodedBytes = long.MaxValue)
+    {
+        error = "";
+        stream = AsyncEnumerable.Empty<IFeature>();
+
+        if (string.IsNullOrWhiteSpace(reference))
+        {
+            error = "value is missing or empty";
+            return false;
+        }
+
+        if (IsStreamReference(reference))
+        {
+            if (!TryParseStreamReference(reference, out var descriptor, out error))
+            {
+                return false;
+            }
+
+            if (!File.Exists(descriptor.Path))
+            {
+                error = "feature stream backing file no longer exists";
+                return false;
+            }
+
+            stream = ReadNdjsonFileAsync(descriptor.Path);
+            return true;
+        }
+
+        // Inline back-compat path: decode the whole FeatureCollection up front (it is
+        // bounded by maxInlineDecodedBytes) and yield its features. Small collections
+        // never spilled, so this keeps tiny pipelines working unchanged.
+        if (!FeatureCollectionArtifact.TryParseDataUri(reference, out var collection, out error, maxInlineDecodedBytes))
+        {
+            return false;
+        }
+
+        stream = ToAsync(collection);
+        return true;
+    }
+
+    /// <summary>
+    /// Parses a spilled NDJSON stream reference into its descriptor fields.
+    /// </summary>
+    public static bool TryParseStreamReference(
+        string reference,
+        out StreamDescriptor descriptor,
+        out string error)
+    {
+        descriptor = default;
+        error = "";
+
+        if (!IsStreamReference(reference))
+        {
+            error = $"value must be a '{StreamReferencePrefix}' stream reference";
+            return false;
+        }
+
+        var body = reference[StreamReferencePrefix.Length..];
+        var parts = body.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        string? path = null;
+        long count = 0;
+        long bytes = 0;
+        var format = "";
+
+        foreach (var part in parts)
+        {
+            var eq = part.IndexOf('=', StringComparison.Ordinal);
+            if (eq < 0)
+            {
+                // Bare token is the format marker (e.g. "ndjson").
+                format = part;
+                continue;
+            }
+
+            var key = part[..eq];
+            var value = part[(eq + 1)..];
+            switch (key)
+            {
+                case "path":
+                    path = Uri.UnescapeDataString(value);
+                    break;
+                case "count":
+                    long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out count);
+                    break;
+                case "bytes":
+                    long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out bytes);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        if (!string.Equals(format, "ndjson", StringComparison.Ordinal))
+        {
+            error = $"unsupported feature stream format '{format}' (expected 'ndjson')";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            error = "feature stream reference is missing a 'path'";
+            return false;
+        }
+
+        descriptor = new StreamDescriptor(path!, count, bytes);
+        return true;
+    }
+
+    /// <summary>
+    /// Builds a spilled NDJSON stream reference for a backing file. The path is URI-escaped
+    /// so it survives the <c>;</c>-delimited reference grammar even on Windows.
+    /// </summary>
+    public static string BuildStreamReference(string path, long count, long bytes)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        var escaped = Uri.EscapeDataString(path);
+        return $"{StreamReferencePrefix}ndjson;path={escaped};count={count.ToString(CultureInfo.InvariantCulture)};bytes={bytes.ToString(CultureInfo.InvariantCulture)}";
+    }
+
+    /// <summary>
+    /// Allocates a fresh, collision-free backing file path under the executor output
+    /// root for a spilled stream. The caller owns the file lifetime.
+    /// </summary>
+    public static string AllocateSpillPath(string outputRootDirectory, string operationId, string processId)
+    {
+        ArgumentNullException.ThrowIfNull(outputRootDirectory);
+
+        var streamRoot = Path.Combine(outputRootDirectory, "streams");
+        Directory.CreateDirectory(streamRoot);
+
+        var safeProcess = SanitizeForFileName(processId);
+        var safeOperation = SanitizeForFileName(operationId);
+        var unique = Guid.NewGuid().ToString("N");
+        return Path.Combine(streamRoot, $"{safeOperation}.{safeProcess}.{unique}.ndjson");
+    }
+
+    /// <summary>
+    /// Streams a sequence of features to an NDJSON backing file one line at a time, then
+    /// returns a spill reference describing it. Memory stays bounded: a single feature is
+    /// serialized at a time and the writer flushes as the buffer fills.
+    /// </summary>
+    public static async Task<string> WriteStreamAsync(
+        string path,
+        IAsyncEnumerable<IFeature> features,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(features);
+
+        var writer = new GeoJsonWriter();
+        long count = 0;
+        long bytes = 0;
+
+        await using (var fileStream = new FileStream(
+            path, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1 << 16, useAsync: true))
+        await using (var textWriter = new StreamWriter(fileStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+        {
+            await foreach (var feature in features.WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var line = SerializeLine(writer, feature);
+                await textWriter.WriteLineAsync(line.AsMemory(), cancellationToken).ConfigureAwait(false);
+                count++;
+                // '\n' line terminator is one byte; the line itself is single-byte-per-char
+                // for ASCII but may be multi-byte for UTF-8 — Encoding.UTF8 gives the true count.
+                bytes += Encoding.UTF8.GetByteCount(line) + 1;
+            }
+
+            await textWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return BuildStreamReference(path, count, bytes);
+    }
+
+    /// <summary>
+    /// Serializes one feature to an NDJSON line, stamping its geometry SRID as a reserved
+    /// foreign member so the spill round-trip preserves SRID fidelity (GeoJSON otherwise
+    /// drops it). Shared by the bulk writer and the publisher's incremental spill writer.
+    /// </summary>
+    public static string SerializeLine(GeoJsonWriter writer, IFeature feature)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(feature);
+
+        var srid = feature.Geometry?.SRID ?? 0;
+        if (srid == 0)
+        {
+            return writer.Write(feature);
+        }
+
+        // Carry the SRID on a copy of the attributes so the source feature is not mutated.
+        var attributes = new AttributesTable();
+        if (feature.Attributes is { } source)
+        {
+            foreach (var name in source.GetNames())
+            {
+                attributes.Add(name, source.GetOptionalValue(name));
+            }
+        }
+
+        attributes.Add(SridMemberKey, srid);
+        return writer.Write(new Feature(feature.Geometry, attributes));
+    }
+
+    /// <summary>
+    /// Parses one NDJSON line back to a feature, restoring the geometry SRID stashed by
+    /// <see cref="SerializeLine"/> and stripping the reserved member so it never leaks
+    /// downstream.
+    /// </summary>
+    public static IFeature? DeserializeLine(GeoJsonReader reader, string line)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        var feature = reader.Read<Feature>(line);
+        if (feature is null)
+        {
+            return null;
+        }
+
+        var attributes = feature.Attributes;
+        if (attributes is null || !attributes.Exists(SridMemberKey))
+        {
+            return feature;
+        }
+
+        var rawSrid = attributes.GetOptionalValue(SridMemberKey);
+        if (feature.Geometry is not null
+            && rawSrid is not null
+            && int.TryParse(
+                Convert.ToString(rawSrid, CultureInfo.InvariantCulture),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var srid))
+        {
+            feature.Geometry.SRID = srid;
+        }
+
+        var rebuilt = new AttributesTable();
+        foreach (var name in attributes.GetNames())
+        {
+            if (!string.Equals(name, SridMemberKey, StringComparison.Ordinal))
+            {
+                rebuilt.Add(name, attributes.GetOptionalValue(name));
+            }
+        }
+
+        return new Feature(feature.Geometry, rebuilt);
+    }
+
+    /// <summary>
+    /// Reads an NDJSON backing file as a lazy feature sequence, one line (one feature) at
+    /// a time. Memory stays bounded by the largest single feature, never the whole file.
+    /// </summary>
+    public static async IAsyncEnumerable<IFeature> ReadNdjsonFileAsync(
+        string path,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        var reader = new GeoJsonReader();
+        await using var fileStream = new FileStream(
+            path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1 << 16, useAsync: true);
+        using var textReader = new StreamReader(fileStream, Encoding.UTF8);
+
+        while (await textReader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { } line)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var feature = DeserializeLine(reader, line);
+            if (feature is not null)
+            {
+                yield return feature;
+            }
+        }
+    }
+
+    private static async IAsyncEnumerable<IFeature> ToAsync(
+        FeatureCollection collection,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var feature in collection)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return feature;
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+    }
+
+    private static string SanitizeForFileName(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "x";
+        }
+
+        var builder = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            builder.Append(char.IsLetterOrDigit(ch) || ch is '-' or '_' ? ch : '_');
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Describes a spilled NDJSON feature stream: the backing file path and the
+    /// feature/byte counts recorded when it was written.
+    /// </summary>
+    internal readonly record struct StreamDescriptor(string Path, long Count, long Bytes);
+}
+
+/// <summary>
+/// Minimal async-enumerable helpers so the streaming artifact contract does not pull in
+/// System.Linq.Async. Keeps the dependency surface AOT-friendly.
+/// </summary>
+internal static class AsyncEnumerable
+{
+    public static IAsyncEnumerable<T> Empty<T>() => EmptyAsyncEnumerable<T>.Instance;
+
+    private sealed class EmptyAsyncEnumerable<T> : IAsyncEnumerable<T>, IAsyncEnumerator<T>
+    {
+        public static readonly EmptyAsyncEnumerable<T> Instance = new();
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) => this;
+
+        public T Current => default!;
+
+        public ValueTask<bool> MoveNextAsync() => ValueTask.FromResult(false);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureStreamPublisher.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureStreamPublisher.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using NetTopologySuite.Features;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// Materializes a transform's output feature stream into a DAG artifact, choosing the
+/// inline base64 data URI for small results (back-compat) and spilling to an NDJSON file
+/// for large ones (streaming, no hard cap). The decision is made by buffering only up to
+/// <see cref="FeatureStreamArtifact.DefaultInlineThresholdBytes"/>: as soon as the buffered
+/// payload crosses the threshold the publisher flips to spill mode, flushes the buffer to
+/// the backing file, and writes the rest of the stream incrementally — so peak memory is
+/// bounded by the inline threshold regardless of how many features flow through.
+/// </summary>
+internal static class FeatureStreamPublisher
+{
+    /// <summary>
+    /// The outcome of publishing a feature stream: the artifact reference to publish plus
+    /// the input/output feature counts for provenance.
+    /// </summary>
+    internal readonly record struct PublishResult(string ArtifactReference, long OutputCount);
+
+    /// <summary>
+    /// Consumes <paramref name="features"/> and produces a DAG artifact reference.
+    /// </summary>
+    /// <param name="features">The transform output stream (lazy).</param>
+    /// <param name="processId">Process id stamped on inline FeatureCollection artifacts.</param>
+    /// <param name="inputCount">Upstream feature count for inline provenance members.</param>
+    /// <param name="outputRootDirectory">Root under which spill files are created.</param>
+    /// <param name="operationId">Owning job id, used to name the spill file.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <param name="inlineThresholdBytes">
+    /// Buffered-payload ceiling under which the output is published inline. At or above it
+    /// the publisher spills. Defaults to <see cref="FeatureStreamArtifact.DefaultInlineThresholdBytes"/>.
+    /// </param>
+    public static async Task<PublishResult> PublishAsync(
+        IAsyncEnumerable<IFeature> features,
+        string processId,
+        long inputCount,
+        string outputRootDirectory,
+        string operationId,
+        CancellationToken cancellationToken,
+        long inlineThresholdBytes = FeatureStreamArtifact.DefaultInlineThresholdBytes)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+        ArgumentNullException.ThrowIfNull(processId);
+        ArgumentNullException.ThrowIfNull(outputRootDirectory);
+
+        var buffer = new List<IFeature>();
+        long approxBytes = 0;
+        var spilled = false;
+        string? spillPath = null;
+
+        await using var spillWriter = new NdjsonSpillWriter();
+
+        await foreach (var feature in features.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!spilled)
+            {
+                buffer.Add(feature);
+                approxBytes += EstimateFeatureBytes(feature);
+
+                if (approxBytes >= inlineThresholdBytes)
+                {
+                    // Crossed the inline ceiling: flip to spill mode, flush the buffered
+                    // prefix to the backing file, and stream the remainder from here.
+                    spilled = true;
+                    spillPath = FeatureStreamArtifact.AllocateSpillPath(outputRootDirectory, operationId, processId);
+                    await spillWriter.OpenAsync(spillPath, cancellationToken).ConfigureAwait(false);
+                    foreach (var buffered in buffer)
+                    {
+                        await spillWriter.WriteAsync(buffered, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    buffer.Clear();
+                    buffer.TrimExcess();
+                }
+
+                continue;
+            }
+
+            await spillWriter.WriteAsync(feature, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (spilled)
+        {
+            var (count, bytes) = await spillWriter.CompleteAsync(cancellationToken).ConfigureAwait(false);
+            var reference = FeatureStreamArtifact.BuildStreamReference(spillPath!, count, bytes);
+            return new PublishResult(reference, count);
+        }
+
+        // Small result: keep the legacy inline base64 FeatureCollection artifact so tiny
+        // pipelines and OGC API Processes surfaces see exactly the same document as before.
+        // Preserve the legacy inline artifact shape: stamp inputCount only when the caller
+        // knew it (the buffered path). Streaming callers pass -1 (unknown without draining),
+        // in which case the member is omitted rather than written as a sentinel.
+        var extraMembers = inputCount >= 0
+            ? new[] { ("inputCount", (object)inputCount) }
+            : null;
+        var payload = FeatureCollectionArtifact.WriteFeatureCollection(buffer, processId, extraMembers);
+        var artifactUri = FeatureCollectionArtifact.BuildDataUri(payload);
+        return new PublishResult(artifactUri, buffer.Count);
+    }
+
+    private static long EstimateFeatureBytes(IFeature feature)
+    {
+        // Cheap, allocation-free upper-ish estimate so the publisher can decide spill
+        // without serializing every feature twice. Geometry coordinate count dominates;
+        // each coordinate is ~40 GeoJSON bytes, attributes add a flat per-feature constant.
+        long estimate = 64;
+        var geometry = feature.Geometry;
+        if (geometry is not null)
+        {
+            estimate += (long)geometry.NumPoints * 40L;
+        }
+
+        var attributes = feature.Attributes;
+        if (attributes is not null)
+        {
+            estimate += attributes.Count * 24L;
+        }
+
+        return estimate;
+    }
+
+    /// <summary>
+    /// Incremental NDJSON writer used by the publisher once it flips to spill mode. Keeps a
+    /// single feature in flight at a time; the underlying file stream flushes as its buffer
+    /// fills. Mirrors <see cref="FeatureStreamArtifact.WriteStreamAsync"/> but lets the
+    /// publisher feed features one at a time as it decides to spill.
+    /// </summary>
+    private sealed class NdjsonSpillWriter : IAsyncDisposable
+    {
+        private readonly NetTopologySuite.IO.GeoJsonWriter _writer = new();
+        private FileStream? _fileStream;
+        private StreamWriter? _textWriter;
+        private long _count;
+        private long _bytes;
+
+        public async Task OpenAsync(string path, CancellationToken cancellationToken)
+        {
+            _ = cancellationToken;
+            _fileStream = new FileStream(
+                path, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1 << 16, useAsync: true);
+            _textWriter = new StreamWriter(
+                _fileStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        public async Task WriteAsync(IFeature feature, CancellationToken cancellationToken)
+        {
+            var line = FeatureStreamArtifact.SerializeLine(_writer, feature);
+            await _textWriter!.WriteLineAsync(line.AsMemory(), cancellationToken).ConfigureAwait(false);
+            _count++;
+            _bytes += System.Text.Encoding.UTF8.GetByteCount(line) + 1;
+        }
+
+        public async Task<(long Count, long Bytes)> CompleteAsync(CancellationToken cancellationToken)
+        {
+            if (_textWriter is not null)
+            {
+                await _textWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return (_count, _bytes);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_textWriter is not null)
+            {
+                await _textWriter.DisposeAsync().ConfigureAwait(false);
+            }
+
+            if (_fileStream is not null)
+            {
+                await _fileStream.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonFileSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonFileSinkExecutor.cs
@@ -81,7 +81,10 @@ internal sealed partial class GeoJsonFileSinkExecutor : IJobExecutor
             return JobExecutionResult.Failed($"Invalid {HandledProcessId} inputs: {pathResolutionError}");
         }
 
-        if (!FeatureCollectionArtifact.TryParseDataUri(inputUri, out var source, out var parseError, _options.CurrentValue.MaxArtifactBytes))
+        // Stream the input so a >50 MiB sink writes incrementally to the output file
+        // without buffering the whole collection. Spilled NDJSON streams are unbounded.
+        if (!FeatureStreamArtifact.TryOpenRead(
+                inputUri, out var parseError, out var source, _options.CurrentValue.MaxArtifactBytes))
         {
             return JobExecutionResult.Failed($"Invalid {HandledProcessId} inputs: 'input' {parseError}");
         }
@@ -111,7 +114,7 @@ internal sealed partial class GeoJsonFileSinkExecutor : IJobExecutor
                 await jsonWriter.WritePropertyNameAsync("features", cancellationToken).ConfigureAwait(false);
                 await jsonWriter.WriteStartArrayAsync(cancellationToken).ConfigureAwait(false);
 
-                foreach (var feature in source)
+                await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     var concrete = feature as Feature ?? new Feature(feature.Geometry, feature.Attributes);

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonSourceExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonSourceExecutor.cs
@@ -75,23 +75,33 @@ internal sealed class GeoJsonSourceExecutor(IOptionsMonitor<GeoprocessingExecuto
         cancellationToken.ThrowIfCancellationRequested();
         await context.ReportProgressAsync(70, "Encoding source artifact", cancellationToken).ConfigureAwait(false);
 
-        var payload = FeatureCollectionArtifact.WriteFeatureCollection(
-            collection.ToList(),
-            HandledProcessId);
-
-        var maxBytes = _options.CurrentValue.MaxArtifactBytes;
-        if (payload.Length > maxBytes)
-        {
-            return JobExecutionResult.Failed(
-                $"{HandledProcessId} artifact size {payload.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}.");
-        }
-
-        var artifactUri = FeatureCollectionArtifact.BuildDataUri(payload);
+        // Publish through the spillable publisher: small sources stay inline (back-compat),
+        // large sources spill to an NDJSON stream so downstream transforms read incrementally
+        // and the legacy 50 MiB cap no longer fails a large source feed.
+        var published = await FeatureStreamPublisher.PublishAsync(
+            ToAsync(collection, cancellationToken),
+            HandledProcessId,
+            inputCount: collection.Count,
+            _options.CurrentValue.OutputRootDirectory,
+            job.OperationId,
+            cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
-        await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+        await context.PublishArtifactAsync(published.ArtifactReference, cancellationToken).ConfigureAwait(false);
         await context.ReportProgressAsync(100, $"{HandledProcessId} completed", cancellationToken).ConfigureAwait(false);
 
         return JobExecutionResult.Succeeded();
+    }
+
+    private static async IAsyncEnumerable<IFeature> ToAsync(
+        FeatureCollection collection,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        foreach (var feature in collection)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return feature;
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
     }
 }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/QuarantineSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/QuarantineSinkExecutor.cs
@@ -82,7 +82,10 @@ internal sealed partial class QuarantineSinkExecutor : IJobExecutor
             return JobExecutionResult.Failed($"Invalid {HandledProcessId} inputs: {pathResolutionError}");
         }
 
-        if (!FeatureCollectionArtifact.TryParseDataUri(inputUri, out var source, out var parseError, _options.CurrentValue.MaxArtifactBytes))
+        // Stream the input so a large dead-letter set writes incrementally without
+        // buffering the whole collection. Spilled NDJSON streams are unbounded.
+        if (!FeatureStreamArtifact.TryOpenRead(
+                inputUri, out var parseError, out var source, _options.CurrentValue.MaxArtifactBytes))
         {
             return JobExecutionResult.Failed($"Invalid {HandledProcessId} inputs: 'input' {parseError}");
         }
@@ -114,7 +117,7 @@ internal sealed partial class QuarantineSinkExecutor : IJobExecutor
                 await jsonWriter.WritePropertyNameAsync("features", cancellationToken).ConfigureAwait(false);
                 await jsonWriter.WriteStartArrayAsync(cancellationToken).ConfigureAwait(false);
 
-                foreach (var feature in source)
+                await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     var tagged = Tag(feature, batchId, reasonField);

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ReprojectTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ReprojectTransformExecutor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using Honua.Infrastructure.Rendering;
 using Microsoft.Extensions.Options;
 using NetTopologySuite.Features;
@@ -19,7 +20,9 @@ namespace Honua.Geoprocessing.Execution;
 /// matching <c>geometry.project</c>. Attributes are carried through. Reconciled from
 /// the GeoETL baseline ReprojectTransform onto the #1185 process/executor contract;
 /// the managed math is replaced by the shared CoordinateTransformer so this transform
-/// and geometry.project stay bit-for-bit aligned.
+/// and geometry.project stay bit-for-bit aligned. Streams: a per-feature map; SRIDs
+/// are validated once before the stream is consumed (the validation surfaces on the
+/// first pull as a classified <c>Invalid ... inputs</c> failure).
 /// </summary>
 internal sealed class ReprojectTransformExecutor(
     IOptionsMonitor<GeoprocessingExecutorOptions> options)
@@ -32,10 +35,10 @@ internal sealed class ReprojectTransformExecutor(
 
     protected override string ProcessId => HandledProcessId;
 
-    protected override List<IFeature> Apply(
-        FeatureCollection source,
+    protected override async IAsyncEnumerable<IFeature> ApplyStream(
+        IAsyncEnumerable<IFeature> source,
         StepInputReader inputs,
-        CancellationToken cancellationToken)
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var fromSrid = ReadSrid(inputs, "fromSrid");
         var toSrid = ReadSrid(inputs, "toSrid");
@@ -51,15 +54,14 @@ internal sealed class ReprojectTransformExecutor(
         var passthrough = fromSrid == toSrid
             || (WebMercatorAliases.Contains(fromSrid) && WebMercatorAliases.Contains(toSrid));
 
-        var output = new List<IFeature>(source.Count);
-        foreach (var feature in source)
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var geometry = feature.Geometry;
             if (geometry is null || geometry.IsEmpty)
             {
-                output.Add(feature);
+                yield return feature;
                 continue;
             }
 
@@ -75,10 +77,8 @@ internal sealed class ReprojectTransformExecutor(
             }
 
             projected.SRID = toSrid;
-            output.Add(new Feature(projected, feature.Attributes));
+            yield return new Feature(projected, feature.Attributes);
         }
-
-        return output;
     }
 
     private static bool IsTransformSupported(int fromSrid, int toSrid)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/SpatialFilterTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/SpatialFilterTransformExecutor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Options;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
@@ -15,7 +16,8 @@ namespace Honua.Geoprocessing.Execution;
 /// geometry satisfies a spatial predicate against a bounding box or an arbitrary
 /// WKT region, dropping the rest. Pure managed NetTopologySuite — no GEOS native
 /// dependency. Ported from the GeoETL baseline SpatialFilterTransform onto the
-/// #1185 process/executor contract.
+/// #1185 process/executor contract. Streams: a per-feature filter; the region is
+/// parsed once before the stream is consumed.
 /// </summary>
 internal sealed class SpatialFilterTransformExecutor(
     IOptionsMonitor<GeoprocessingExecutorOptions> options)
@@ -25,16 +27,15 @@ internal sealed class SpatialFilterTransformExecutor(
 
     protected override string ProcessId => HandledProcessId;
 
-    protected override List<IFeature> Apply(
-        FeatureCollection source,
+    protected override async IAsyncEnumerable<IFeature> ApplyStream(
+        IAsyncEnumerable<IFeature> source,
         StepInputReader inputs,
-        CancellationToken cancellationToken)
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var region = ReadRegion(inputs);
         var predicate = ReadPredicate(inputs);
 
-        var output = new List<IFeature>(source.Count);
-        foreach (var feature in source)
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -46,11 +47,9 @@ internal sealed class SpatialFilterTransformExecutor(
 
             if (Matches(geometry, region, predicate))
             {
-                output.Add(feature);
+                yield return feature;
             }
         }
-
-        return output;
     }
 
     private static bool Matches(NtsGeometry geometry, NtsGeometry region, SpatialPredicate predicate) =>

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/SpillableKeySet.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/SpillableKeySet.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// Bounded-memory "have I seen this key?" set for the streaming dedup transform. Each
+/// caller key (which can be a long normalized-WKT string) is reduced to a fixed 16-byte
+/// SHA-256 digest, so per-key memory is constant regardless of key length. The digests
+/// live in an in-memory <see cref="HashSet{T}"/> until they cross
+/// <see cref="_inMemoryDigestLimit"/>, at which point the set spills to a temp file and
+/// continues with a bounded recent-window cache plus on-disk membership checks — peak
+/// memory stays bounded by the window, not by the cardinality of the input.
+///
+/// <para>
+/// Collision note: a 128-bit digest makes an accidental false-positive (two distinct keys
+/// hashing equal, which would wrongly drop a feature) astronomically unlikely for any
+/// realistic ETL volume (~10^18 keys for a 1% chance). This is the documented bound: dedup
+/// is exact up to the 128-bit digest, not byte-for-byte, in exchange for constant per-key
+/// memory and a spill ceiling. Determinism is preserved: the same input always produces the
+/// same first-wins output.
+/// </para>
+/// </summary>
+internal sealed class SpillableKeySet : IDisposable
+{
+    private readonly HashSet<Digest> _inMemory = new();
+    private readonly long _inMemoryDigestLimit;
+    private readonly int _windowLimit;
+
+    // Once spilled, recent digests are kept in a bounded window for fast negative checks;
+    // the authoritative membership is the on-disk sorted-append file scanned per probe miss.
+    private readonly LinkedList<Digest> _windowOrder = new();
+    private readonly HashSet<Digest> _window = new();
+    private FileStream? _spillFile;
+    private string? _spillPath;
+    private bool _spilled;
+
+    public SpillableKeySet(long inMemoryDigestLimit = 2_000_000, int windowLimit = 1_000_000)
+    {
+        _inMemoryDigestLimit = inMemoryDigestLimit;
+        _windowLimit = windowLimit;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> the first time a key is seen (caller should emit the feature),
+    /// <c>false</c> for a duplicate (caller should drop it).
+    /// </summary>
+    public bool Add(string key)
+    {
+        var digest = Digest.From(key);
+
+        if (!_spilled)
+        {
+            var added = _inMemory.Add(digest);
+            if (added && _inMemory.Count >= _inMemoryDigestLimit)
+            {
+                SpillInMemoryToDisk();
+            }
+
+            return added;
+        }
+
+        // Spilled mode: check the recent window first (cheap), then scan the spill file.
+        if (_window.Contains(digest))
+        {
+            return false;
+        }
+
+        if (ExistsOnDisk(digest))
+        {
+            return false;
+        }
+
+        AppendToDisk(digest);
+        AddToWindow(digest);
+        return true;
+    }
+
+    private void SpillInMemoryToDisk()
+    {
+        _spillPath = Path.Combine(Path.GetTempPath(), $"honua-dedup-{Guid.NewGuid():N}.keys");
+        _spillFile = new FileStream(_spillPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+
+        Span<byte> scratch = stackalloc byte[Digest.Size];
+        foreach (var digest in _inMemory)
+        {
+            digest.WriteTo(scratch);
+            _spillFile.Write(scratch);
+            AddToWindow(digest);
+        }
+
+        _spillFile.Flush();
+        _inMemory.Clear();
+        _inMemory.TrimExcess();
+        _spilled = true;
+    }
+
+    private bool ExistsOnDisk(Digest digest)
+    {
+        if (_spillFile is null)
+        {
+            return false;
+        }
+
+        _spillFile.Flush();
+        _spillFile.Seek(0, SeekOrigin.Begin);
+
+        Span<byte> buffer = stackalloc byte[Digest.Size];
+        int read;
+        while ((read = ReadFull(_spillFile, buffer)) == Digest.Size)
+        {
+            if (Digest.From(buffer).Equals(digest))
+            {
+                return true;
+            }
+        }
+
+        _ = read;
+        return false;
+    }
+
+    private void AppendToDisk(Digest digest)
+    {
+        if (_spillFile is null)
+        {
+            return;
+        }
+
+        _spillFile.Seek(0, SeekOrigin.End);
+        Span<byte> scratch = stackalloc byte[Digest.Size];
+        digest.WriteTo(scratch);
+        _spillFile.Write(scratch);
+        _spillFile.Flush();
+    }
+
+    private void AddToWindow(Digest digest)
+    {
+        if (_window.Add(digest))
+        {
+            _windowOrder.AddLast(digest);
+            if (_window.Count > _windowLimit)
+            {
+                var oldest = _windowOrder.First!.Value;
+                _windowOrder.RemoveFirst();
+                _window.Remove(oldest);
+            }
+        }
+    }
+
+    private static int ReadFull(Stream stream, Span<byte> buffer)
+    {
+        var total = 0;
+        while (total < buffer.Length)
+        {
+            var read = stream.Read(buffer[total..]);
+            if (read == 0)
+            {
+                break;
+            }
+
+            total += read;
+        }
+
+        return total;
+    }
+
+    public void Dispose()
+    {
+        _spillFile?.Dispose();
+        if (_spillPath is not null && File.Exists(_spillPath))
+        {
+            try
+            {
+                File.Delete(_spillPath);
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup of the temp spill file.
+            }
+        }
+    }
+
+    private readonly struct Digest : IEquatable<Digest>
+    {
+        public const int Size = 16;
+
+        private readonly ulong _hi;
+        private readonly ulong _lo;
+
+        private Digest(ulong hi, ulong lo)
+        {
+            _hi = hi;
+            _lo = lo;
+        }
+
+        public static Digest From(string key)
+        {
+            Span<byte> hash = stackalloc byte[32];
+            SHA256.HashData(Encoding.UTF8.GetBytes(key), hash);
+            return From(hash);
+        }
+
+        public static Digest From(ReadOnlySpan<byte> bytes)
+            => new(
+                BinaryPrimitives.ReadUInt64LittleEndian(bytes[..8]),
+                BinaryPrimitives.ReadUInt64LittleEndian(bytes.Slice(8, 8)));
+
+        public void WriteTo(Span<byte> destination)
+        {
+            BinaryPrimitives.WriteUInt64LittleEndian(destination[..8], _hi);
+            BinaryPrimitives.WriteUInt64LittleEndian(destination.Slice(8, 8), _lo);
+        }
+
+        public bool Equals(Digest other) => _hi == other._hi && _lo == other._lo;
+
+        public override bool Equals(object? obj) => obj is Digest other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(_hi, _lo);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/StreamingTransformExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/StreamingTransformExecutorTests.cs
@@ -1,0 +1,481 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Geoprocessing;
+using Honua.Geoprocessing.Execution;
+using Honua.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Streaming-execution coverage for the GeoETL transform path (ETL scale gap). Proves the
+/// transforms no longer materialize the whole FeatureCollection in memory and no longer
+/// fail the legacy 50 MiB artifact cap: a pipeline over a &gt;50 MiB (decoded) feature set
+/// completes and its output is correct; per-feature transforms stream the input to a
+/// spilled NDJSON artifact; dedup spills its seen-key set; and the spill backing file
+/// stays bounded relative to the inline path.
+/// </summary>
+public sealed class StreamingTransformExecutorTests : IDisposable
+{
+    private const string DataUriPrefix = "data:application/geo+json;base64,";
+
+    private readonly string _outputRoot =
+        Path.Combine(Path.GetTempPath(), "honua-stream-tests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_outputRoot))
+            {
+                Directory.Delete(_outputRoot, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup of the per-test spill root.
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Headline proof: a >50 MiB (decoded) pipeline completes and is correct.
+    // -------------------------------------------------------------------------
+
+    [UnitTest]
+    public async Task Pipeline_Over50MiBDecoded_CompletesAndIsCorrect()
+    {
+        // Build a source whose decoded GeoJSON is comfortably over the legacy 50 MiB cap.
+        // ~140k features of LineStrings + padded attributes lands well past 50 MiB; on the
+        // old path the very first transform failed with "Reduce the input feature set".
+        const int featureCount = 140_000;
+        var sourceRef = await BuildSpilledSourceAsync(featureCount, includeDuplicates: true);
+        DecodedByteSize(sourceRef).Should().BeGreaterThan(50L * 1024L * 1024L,
+            "the proof requires a source larger than the legacy 50 MiB artifact cap");
+
+        var options = Options();
+
+        // Step 1: attribute-filter keeps the "keep=true" half.
+        var filtered = await RunStreamAsync(
+            new AttributeFilterTransformExecutor(options),
+            AttributeFilterTransformExecutor.HandledProcessId,
+            ("input", sourceRef),
+            ("field", "keep"),
+            ("op", "eq"),
+            ("value", "true"));
+        filtered.Status.Should().Be(ExecutionJobStatus.Succeeded);
+
+        // Step 2: reproject 4326 -> 3857 (per-feature map).
+        var reprojected = await RunStreamAsync(
+            new ReprojectTransformExecutor(options),
+            ReprojectTransformExecutor.HandledProcessId,
+            ("input", filtered.Reference!),
+            ("fromSrid", "4326"),
+            ("toSrid", "3857"));
+        reprojected.Status.Should().Be(ExecutionJobStatus.Succeeded);
+
+        // Step 3: dedup on the "gid" attribute (stateful, spillable).
+        var deduped = await RunStreamAsync(
+            new DedupTransformExecutor(options),
+            DedupTransformExecutor.HandledProcessId,
+            ("input", reprojected.Reference!),
+            ("keys", "gid"));
+        deduped.Status.Should().Be(ExecutionJobStatus.Succeeded);
+
+        // The large intermediate/output artifacts are spilled streams, not inline data URIs.
+        FeatureStreamArtifact.IsStreamReference(reprojected.Reference).Should().BeTrue(
+            "a >50 MiB output must spill rather than inline");
+
+        // Correctness: every output feature passes the filter, carries the 3857 SRID, and
+        // each gid appears exactly once. Count via the stream so we never buffer the output.
+        var (count, distinctGids, allKept, allReprojected) = await SummarizeStreamAsync(deduped.Reference!);
+        count.Should().Be(distinctGids, "dedup leaves one feature per gid");
+        allKept.Should().BeTrue("the filter dropped every keep=false feature");
+        allReprojected.Should().BeTrue("reproject stamped every geometry with SRID 3857");
+        // featureCount/2 are keep=true; duplicates collapse to the distinct gid count.
+        count.Should().BeGreaterThan(0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Streaming correctness for per-feature transforms over a spilled input.
+    // -------------------------------------------------------------------------
+
+    [UnitTest]
+    public async Task StreamingFilter_OverSpilledInput_DropsNonMatching()
+    {
+        var sourceRef = await BuildSpilledSourceAsync(60_000, includeDuplicates: false);
+        FeatureStreamArtifact.IsStreamReference(sourceRef).Should().BeTrue();
+
+        var result = await RunStreamAsync(
+            new AttributeFilterTransformExecutor(Options()),
+            AttributeFilterTransformExecutor.HandledProcessId,
+            ("input", sourceRef),
+            ("field", "keep"),
+            ("op", "eq"),
+            ("value", "true"));
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        var (count, _, allKept, _) = await SummarizeStreamAsync(result.Reference!);
+        count.Should().Be(30_000, "exactly half the features carry keep=true");
+        allKept.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public async Task StreamingReproject_OverSpilledInput_StampsTargetSrid()
+    {
+        var sourceRef = await BuildSpilledSourceAsync(60_000, includeDuplicates: false);
+
+        var result = await RunStreamAsync(
+            new ReprojectTransformExecutor(Options()),
+            ReprojectTransformExecutor.HandledProcessId,
+            ("input", sourceRef),
+            ("fromSrid", "4326"),
+            ("toSrid", "3857"));
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        var (count, _, _, allReprojected) = await SummarizeStreamAsync(result.Reference!);
+        count.Should().Be(60_000);
+        allReprojected.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public async Task StreamingMap_AttributeRename_OverSpilledInput_RenamesEveryFeature()
+    {
+        var sourceRef = await BuildSpilledSourceAsync(60_000, includeDuplicates: false);
+
+        var result = await RunStreamAsync(
+            new AttributeRenameTransformExecutor(Options()),
+            AttributeRenameTransformExecutor.HandledProcessId,
+            ("input", sourceRef),
+            ("from", "gid"),
+            ("to", "renamed_gid"));
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+
+        long total = 0;
+        var allRenamed = true;
+        await foreach (var feature in OpenStream(result.Reference!))
+        {
+            total++;
+            if (!feature.Attributes.Exists("renamed_gid") || feature.Attributes.Exists("gid"))
+            {
+                allRenamed = false;
+            }
+        }
+
+        total.Should().Be(60_000);
+        allRenamed.Should().BeTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // Dedup spill correctness.
+    // -------------------------------------------------------------------------
+
+    [UnitTest]
+    public async Task StreamingDedup_OverSpilledInputWithDuplicates_KeepsFirstPerKey()
+    {
+        // 80k features, each gid present exactly twice -> 40k distinct, first-wins.
+        var sourceRef = await BuildSpilledSourceAsync(80_000, includeDuplicates: true);
+
+        var result = await RunStreamAsync(
+            new DedupTransformExecutor(Options()),
+            DedupTransformExecutor.HandledProcessId,
+            ("input", sourceRef),
+            ("keys", "gid"));
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        long total = 0;
+        await foreach (var feature in OpenStream(result.Reference!))
+        {
+            total++;
+            var gid = Convert.ToString(feature.Attributes.GetOptionalValue("gid"), CultureInfo.InvariantCulture)!;
+            seen.Add(gid).Should().BeTrue("dedup must emit each gid at most once");
+        }
+
+        total.Should().Be(40_000, "80k features with each gid duplicated collapse to 40k distinct");
+    }
+
+    [UnitTest]
+    public async Task SpillableKeySet_BeyondInMemoryLimit_StaysExact()
+    {
+        // Drive the spillable key set past its in-memory cap so the on-disk path is exercised.
+        using var keys = new SpillableKeySet(inMemoryDigestLimit: 1_000, windowLimit: 500);
+
+        var firstSeen = 0;
+        for (var i = 0; i < 5_000; i++)
+        {
+            if (keys.Add($"key-{i.ToString(CultureInfo.InvariantCulture)}"))
+            {
+                firstSeen++;
+            }
+        }
+
+        firstSeen.Should().Be(5_000, "every distinct key is seen for the first time exactly once");
+
+        // Re-adding any previously seen key must report a duplicate even after the spill.
+        keys.Add("key-0").Should().BeFalse();
+        keys.Add("key-4999").Should().BeFalse();
+        keys.Add("key-2500").Should().BeFalse();
+        keys.Add("brand-new").Should().BeTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // Artifact contract: inline fast-path for small, spill for large.
+    // -------------------------------------------------------------------------
+
+    [UnitTest]
+    public async Task SmallOutput_StaysInline_ForBackCompat()
+    {
+        var input = BuildInlineUri(
+            Feature(Point(0, 0), ("keep", "true"), ("gid", "1")),
+            Feature(Point(1, 1), ("keep", "true"), ("gid", "2")));
+
+        var result = await RunStreamAsync(
+            new AttributeRenameTransformExecutor(Options()),
+            AttributeRenameTransformExecutor.HandledProcessId,
+            ("input", input),
+            ("from", "gid"),
+            ("to", "id"));
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        FeatureStreamArtifact.IsStreamReference(result.Reference).Should().BeFalse(
+            "a tiny output keeps the legacy inline base64 data URI");
+        result.Reference!.Should().StartWith(DataUriPrefix);
+    }
+
+    [UnitTest]
+    public async Task StreamRead_AcceptsBothInlineAndSpilledProducers()
+    {
+        // A spilled producer feeding an inline-sized downstream and vice versa both round-trip.
+        var spilledRef = await BuildSpilledSourceAsync(60_000, includeDuplicates: false);
+        FeatureStreamArtifact.TryOpenRead(spilledRef, out var spillError, out var spillStream).Should().BeTrue(spillError);
+        (await CountAsync(spillStream)).Should().Be(60_000);
+
+        var inlineRef = BuildInlineUri(Feature(Point(0, 0), ("gid", "1")));
+        FeatureStreamArtifact.TryOpenRead(inlineRef, out var inlineError, out var inlineStream).Should().BeTrue(inlineError);
+        (await CountAsync(inlineStream)).Should().Be(1);
+    }
+
+    [UnitTest]
+    public async Task LargeOutput_SpillFileStaysBounded_RelativeToFeatureCount()
+    {
+        // The spill backing file holds NDJSON, so it is on the order of the decoded payload,
+        // not an in-memory base64 blob. The point of the assertion is that we CAN produce an
+        // artifact whose decoded content far exceeds the 50 MiB cap without an OOM/cap failure.
+        var result = await RunStreamAsync(
+            new AttributeRenameTransformExecutor(Options()),
+            AttributeRenameTransformExecutor.HandledProcessId,
+            ("input", await BuildSpilledSourceAsync(140_000, includeDuplicates: false)),
+            ("from", "gid"),
+            ("to", "id"));
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        FeatureStreamArtifact.IsStreamReference(result.Reference).Should().BeTrue();
+        FeatureStreamArtifact.TryParseStreamReference(result.Reference!, out var descriptor, out var err)
+            .Should().BeTrue(err);
+        descriptor.Count.Should().Be(140_000);
+        descriptor.Bytes.Should().BeGreaterThan(50L * 1024L * 1024L);
+        File.Exists(descriptor.Path).Should().BeTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private IOptionsMonitor<GeoprocessingExecutorOptions> Options(long maxArtifactBytes = 50L * 1024L * 1024L)
+    {
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = maxArtifactBytes,
+            OutputRootDirectory = _outputRoot,
+            ResultRetention = TimeSpan.FromDays(7)
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+        return monitor;
+    }
+
+    /// <summary>
+    /// Writes a large synthetic feature set directly to a spilled NDJSON artifact (bypassing
+    /// the in-memory inline encode), so a transform under test reads it as a real stream. Each
+    /// feature carries a "keep" flag (alternating true/false), a "gid", and a padded "pad"
+    /// attribute so the decoded payload crosses the 50 MiB cap at the configured counts.
+    /// </summary>
+    private async Task<string> BuildSpilledSourceAsync(int featureCount, bool includeDuplicates)
+    {
+        Directory.CreateDirectory(_outputRoot);
+        var path = FeatureStreamArtifact.AllocateSpillPath(_outputRoot, "op-source", "source.synthetic");
+        return await FeatureStreamArtifact.WriteStreamAsync(path, Generate(featureCount, includeDuplicates), CancellationToken.None);
+    }
+
+    private static async IAsyncEnumerable<IFeature> Generate(int featureCount, bool includeDuplicates)
+    {
+        var factory = NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory(4326);
+        var pad = new string('p', 256);
+        for (var i = 0; i < featureCount; i++)
+        {
+            var x = i % 90;
+            var y = (i / 90) % 90;
+            var line = factory.CreateLineString(new[]
+            {
+                new Coordinate(x, y),
+                new Coordinate(x + 0.1, y + 0.1),
+                new Coordinate(x + 0.2, y),
+            });
+
+            // When duplicates are requested, each gid repeats once (gid = i/2) so dedup halves.
+            var gid = includeDuplicates ? (i / 2) : i;
+            var table = new AttributesTable
+            {
+                { "gid", gid.ToString(CultureInfo.InvariantCulture) },
+                { "keep", (i % 2 == 0) ? "true" : "false" },
+                { "pad", pad },
+            };
+
+            yield return new Feature(line, table);
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+    }
+
+    private static long DecodedByteSize(string reference)
+    {
+        if (FeatureStreamArtifact.TryParseStreamReference(reference, out var descriptor, out _))
+        {
+            return descriptor.Bytes;
+        }
+
+        return Convert.FromBase64String(reference[DataUriPrefix.Length..]).LongLength;
+    }
+
+    private IAsyncEnumerable<IFeature> OpenStream(string reference)
+    {
+        FeatureStreamArtifact.TryOpenRead(reference, out var error, out var stream).Should().BeTrue(error);
+        return stream;
+    }
+
+    private static async Task<long> CountAsync(IAsyncEnumerable<IFeature> stream)
+    {
+        long count = 0;
+        await foreach (var _ in stream)
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private async Task<(long Count, long DistinctGids, bool AllKept, bool AllReprojected)> SummarizeStreamAsync(string reference)
+    {
+        long count = 0;
+        var gids = new HashSet<string>(StringComparer.Ordinal);
+        var allKept = true;
+        var allReprojected = true;
+
+        await foreach (var feature in OpenStream(reference))
+        {
+            count++;
+            var gid = Convert.ToString(feature.Attributes.GetOptionalValue("gid"), CultureInfo.InvariantCulture);
+            if (gid is not null)
+            {
+                gids.Add(gid);
+            }
+
+            if (!string.Equals(
+                    Convert.ToString(feature.Attributes.GetOptionalValue("keep"), CultureInfo.InvariantCulture),
+                    "true",
+                    StringComparison.Ordinal))
+            {
+                allKept = false;
+            }
+
+            if (feature.Geometry is null || feature.Geometry.SRID != 3857)
+            {
+                allReprojected = false;
+            }
+        }
+
+        return (count, gids.Count, allKept, allReprojected);
+    }
+
+    private static Point Point(double x, double y)
+        => NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory(4326).CreatePoint(new Coordinate(x, y));
+
+    private static Feature Feature(Geometry geometry, params (string Name, object Value)[] attributes)
+    {
+        var table = new AttributesTable();
+        foreach (var (name, value) in attributes)
+        {
+            table.Add(name, value);
+        }
+
+        return new Feature(geometry, table);
+    }
+
+    private static string BuildInlineUri(params IFeature[] features)
+    {
+        var collection = new FeatureCollection();
+        foreach (var feature in features)
+        {
+            collection.Add(feature);
+        }
+
+        var json = new GeoJsonWriter().Write(collection);
+        return DataUriPrefix + Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
+    }
+
+    private async Task<(ExecutionJobStatus Status, string? Reference)> RunStreamAsync(
+        IJobExecutor executor,
+        string processId,
+        params (string Name, string Value)[] inputs)
+    {
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-" + Guid.NewGuid().ToString("N"));
+        string? publishedRef = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedRef = call.ArgAt<string>(0));
+
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId,
+            ["protocolProcessId"] = processId,
+        };
+
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+        foreach (var (name, value) in inputs)
+        {
+            parameters[prefix + name] = value;
+        }
+
+        var record = new ExecutionJobRecord
+        {
+            OperationId = (string)context.OperationId,
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:test",
+                Parameters = parameters
+            }
+        };
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+        return (result.Status, publishedRef);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1185

## Summary
Closes the #1 ETL scale gap in the GeoETL DAG transform path. Previously every
`transform.*` step materialized the WHOLE FeatureCollection in memory as a
base64 GeoJSON data URI, hard-capped at 50 MiB decoded — above which the job
FAILED with "Reduce the input feature set". This replaces the whole-collection
artifact with a streamed, spillable feature contract so pipelines scale past toy
volumes while keeping the small-inline fast path for back-compat.

## Changes Made
- **New streamed artifact contract** (`FeatureStreamArtifact`): two opaque,
  verbatim-stored artifact shapes that the DAG runtime projects into the next
  step's `input` — *inline* base64 FeatureCollection data URI for small outputs
  (back-compat, unchanged document) and *spill* `honua-feature-stream:v1;ndjson;...`
  references to a per-step NDJSON file (one Feature per line). Reads accept either
  shape and yield `IAsyncEnumerable<IFeature>`. SRID is preserved across the spill
  boundary via a reserved `__honua_srid` member (GeoJSON has no native SRID).
- **Spillable output publisher** (`FeatureStreamPublisher`): buffers only up to a
  ~1 MiB inline threshold, then flips to NDJSON spill, so peak memory is bounded
  regardless of feature count. Removes the hard 50 MiB failure for streamable
  transforms; the cap remains only on inline data-URI inputs.
- **Streaming transforms** (`ApplyStream`): attribute-rename, attribute-cast,
  computed-field, attribute-filter, spatial-filter, clip, reproject now process
  the input stream chunk-by-chunk and emit incrementally.
- **Stateful dedup**: streams with a `SpillableKeySet` (per-key 128-bit digest,
  spills to a temp file past an in-memory cap) so the seen-key set stays bounded;
  output is first-wins and deterministic. The 4 managed aggregates
  (cluster/density/spatial-join/buffer-aggregate) keep the buffered path (they
  inherently need the full set) but still spill large outputs.
- **Streaming sinks**: external-postgis (batched COPY/insert staging-table load),
  geojson-file, and quarantine now read their input as a stream rather than a
  buffered collection. Sources (geojson, csv) publish via the spillable publisher.
- ADR-0038 updated with the streaming feature-artifact contract section.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

New `StreamingTransformExecutorTests`: a >50 MiB (decoded) filter->reproject->dedup
pipeline completes and is correct (was: failed at the first step); streaming
filter/map/reproject correctness over spilled input; dedup spill correctness;
`SpillableKeySet` exactness past its in-memory cap; inline fast-path for small
outputs; spill for large outputs; read accepts both producer shapes.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. Small pipelines keep the exact inline base64 artifact. The streamed/spill
artifact is a new opaque reference shape consumed transparently by downstream
steps. Cross-node (separate worker pod per step) spill is same-node today,
matching the existing file-sink/`import.dataset` file-path semantics; an
object-store-backed spill is a follow-up.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
