### PR TITLE
feat(orchestration): add event/CDC + incremental-extract ETL triggers

### DIFF
--- a/src/Honua.Core/Features/Migration/Watermark/ISourceWatermarkStore.cs
+++ b/src/Honua.Core/Features/Migration/Watermark/ISourceWatermarkStore.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Migration.Watermark;
+
+/// <summary>
+/// Durable store for per-pipeline+source high-water marks used by incremental ("changed-since")
+/// extraction. The watermark is read before a pull to bound the scan, and advanced only on a
+/// successful pull so a failed or interrupted run resumes from the last durable mark rather than
+/// re-scanning from scratch.
+/// </summary>
+public interface ISourceWatermarkStore
+{
+    /// <summary>
+    /// Reads the persisted watermark for the pipeline+source, or <c>null</c> when none exists
+    /// (first extraction → full pull).
+    /// </summary>
+    Task<SourceWatermark?> GetAsync(
+        string pipelineId,
+        string sourceId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Advances the watermark monotonically. Implementations must never move a timestamp-based
+    /// watermark backwards so concurrent replicas and out-of-order completions cannot cause a
+    /// later run to re-pull already-extracted records. Returns the effective stored watermark.
+    /// </summary>
+    Task<SourceWatermark> AdvanceAsync(
+        SourceWatermark watermark,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears the watermark for the pipeline+source so the next run performs a full re-scan.
+    /// </summary>
+    Task ClearAsync(
+        string pipelineId,
+        string sourceId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Migration/Watermark/SourceWatermark.cs
+++ b/src/Honua.Core/Features/Migration/Watermark/SourceWatermark.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Migration.Watermark;
+
+/// <summary>
+/// Kind of high-water mark a remote pull source advances for incremental ("changed-since")
+/// extraction. The kind selects how the persisted <see cref="SourceWatermark.Value"/> is
+/// translated into a source-specific filter (Esri <c>lastEditDate</c>, OGC/WFS temporal,
+/// or file mtime) and how it is compared/advanced.
+/// </summary>
+public enum WatermarkKind
+{
+    /// <summary>
+    /// Edit timestamp high-water mark. The persisted value is a UTC instant (round-trip
+    /// "O" format). Esri sources translate it into a <c>lastEditDate &gt; value</c> predicate
+    /// over the layer's edit-tracking field; OGC/WFS sources translate it into a temporal
+    /// <c>datetime</c> / <c>after</c> filter.
+    /// </summary>
+    EditTimestamp,
+
+    /// <summary>
+    /// File modified-time high-water mark for file/object pull sources. The persisted value is
+    /// a UTC instant (round-trip "O" format); only files whose mtime is strictly greater are
+    /// re-pulled.
+    /// </summary>
+    FileModifiedTime
+}
+
+/// <summary>
+/// Durable high-water mark for one pipeline+source pair. A scheduled run reads the watermark,
+/// pulls only records that changed after it, then advances the mark on success. Recovery
+/// resumes from the persisted mark rather than re-scanning the whole source.
+/// </summary>
+public sealed record SourceWatermark
+{
+    /// <summary>
+    /// Pipeline (workflow / import job) that owns the watermark.
+    /// </summary>
+    public required string PipelineId { get; init; }
+
+    /// <summary>
+    /// Stable identifier of the source within the pipeline (e.g. the source layer/collection
+    /// URL or file path). Lets one pipeline track several sources independently.
+    /// </summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>
+    /// Watermark kind, selecting the source-specific translation/compare semantics.
+    /// </summary>
+    public required WatermarkKind Kind { get; init; }
+
+    /// <summary>
+    /// Opaque high-water value. For <see cref="WatermarkKind.EditTimestamp"/> and
+    /// <see cref="WatermarkKind.FileModifiedTime"/> this is a UTC instant in round-trip
+    /// "O" format. <c>null</c> means "never extracted" — the first run performs a full pull
+    /// and then seeds the mark.
+    /// </summary>
+    public string? Value { get; init; }
+
+    /// <summary>
+    /// When the watermark was last advanced.
+    /// </summary>
+    public DateTimeOffset? UpdatedAt { get; init; }
+
+    /// <summary>
+    /// Parses <see cref="Value"/> as a UTC instant for timestamp-based watermark kinds, or
+    /// <c>null</c> when unset/unparseable (treated as "no lower bound", i.e. full pull).
+    /// </summary>
+    public DateTimeOffset? AsTimestamp()
+    {
+        if (string.IsNullOrWhiteSpace(Value))
+        {
+            return null;
+        }
+
+        return DateTimeOffset.TryParse(
+            Value,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.RoundtripKind,
+            out var parsed)
+            ? parsed.ToUniversalTime()
+            : null;
+    }
+
+    /// <summary>
+    /// Encodes a UTC instant into the canonical round-trip watermark value.
+    /// </summary>
+    public static string Encode(DateTimeOffset instant)
+        => instant.ToUniversalTime().ToString("O", System.Globalization.CultureInfo.InvariantCulture);
+}

--- a/src/Honua.Core/Features/Migration/Watermark/WatermarkExtractPlanner.cs
+++ b/src/Honua.Core/Features/Migration/Watermark/WatermarkExtractPlanner.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Migration.Watermark;
+
+/// <summary>
+/// Translates a persisted <see cref="SourceWatermark"/> into the source-specific filter a
+/// remote pull source applies to fetch only records that changed since the high-water mark.
+/// Pure and AOT-safe (no reflection): each method maps a watermark into a small, serialisable
+/// instruction the corresponding import adapter (Esri FeatureServer, OGC API Features / WFS,
+/// file/object pull) applies before pulling.
+/// </summary>
+public static class WatermarkExtractPlanner
+{
+    /// <summary>
+    /// Builds the Esri FeatureServer incremental query for a layer that exposes edit tracking.
+    /// When the watermark is unset (first run) a full pull is planned; otherwise a
+    /// <c>{editField} &gt; {epochMs}</c> where-clause restricts the pull to edited features.
+    /// Esri encodes <c>lastEditDate</c> as epoch milliseconds, so the watermark instant is
+    /// converted to epoch-ms for the predicate.
+    /// </summary>
+    /// <param name="watermark">Current watermark, or <c>null</c> for first run.</param>
+    /// <param name="editField">
+    /// Edit-tracking field from the layer's <c>editFieldsInfo</c> (e.g. <c>last_edited_date</c>).
+    /// Required when an incremental pull is wanted; if null/blank a full pull is planned.
+    /// </param>
+    public static EsriIncrementalQuery PlanEsri(SourceWatermark? watermark, string? editField)
+    {
+        var since = watermark?.Kind == WatermarkKind.EditTimestamp ? watermark.AsTimestamp() : null;
+        if (since is null || string.IsNullOrWhiteSpace(editField))
+        {
+            return new EsriIncrementalQuery
+            {
+                IsIncremental = false,
+                WhereClause = "1=1"
+            };
+        }
+
+        var epochMs = since.Value.ToUnixTimeMilliseconds();
+        var where = string.Create(
+            System.Globalization.CultureInfo.InvariantCulture,
+            $"{editField} > {epochMs}");
+        return new EsriIncrementalQuery
+        {
+            IsIncremental = true,
+            WhereClause = where,
+            SinceEpochMilliseconds = epochMs
+        };
+    }
+
+    /// <summary>
+    /// Builds the OGC API Features / WFS temporal filter for an incremental pull. When the
+    /// watermark is set, returns a half-open <c>datetime</c> interval starting just after the
+    /// high-water mark (OGC datetime intervals are inclusive, so the mark is nudged forward by
+    /// one millisecond to avoid re-pulling the boundary record). A null watermark plans a full
+    /// pull.
+    /// </summary>
+    public static OgcTemporalFilter PlanOgc(SourceWatermark? watermark, string? datetimeField = null)
+    {
+        var since = watermark?.Kind == WatermarkKind.EditTimestamp ? watermark.AsTimestamp() : null;
+        if (since is null)
+        {
+            return new OgcTemporalFilter { IsIncremental = false };
+        }
+
+        var lowerBound = since.Value.AddMilliseconds(1);
+        var datetime = string.Create(
+            System.Globalization.CultureInfo.InvariantCulture,
+            $"{lowerBound.ToUniversalTime():O}/..");
+        return new OgcTemporalFilter
+        {
+            IsIncremental = true,
+            DatetimeParameter = datetime,
+            DatetimeField = datetimeField
+        };
+    }
+
+    /// <summary>
+    /// Decides whether a file/object should be pulled given the current file-mtime watermark.
+    /// Only files modified strictly after the mark are re-pulled; a null watermark pulls every
+    /// file (full scan).
+    /// </summary>
+    public static bool ShouldPullFile(SourceWatermark? watermark, DateTimeOffset fileModifiedAt)
+    {
+        var since = watermark?.Kind == WatermarkKind.FileModifiedTime ? watermark.AsTimestamp() : null;
+        return since is null || fileModifiedAt.ToUniversalTime() > since.Value;
+    }
+
+    /// <summary>
+    /// Computes the watermark to persist after a successful incremental pull, given the maximum
+    /// edit/modified timestamp observed across the pulled records. The watermark only advances
+    /// (never rewinds): if the batch produced no newer records the prior watermark is retained.
+    /// </summary>
+    public static SourceWatermark Advance(
+        SourceWatermark current,
+        DateTimeOffset? maxObservedTimestamp,
+        DateTimeOffset now)
+    {
+        var existing = current.AsTimestamp();
+        if (maxObservedTimestamp is null)
+        {
+            return current with { UpdatedAt = now };
+        }
+
+        var observed = maxObservedTimestamp.Value.ToUniversalTime();
+        if (existing is { } prior && observed <= prior)
+        {
+            return current with { UpdatedAt = now };
+        }
+
+        return current with
+        {
+            Value = SourceWatermark.Encode(observed),
+            UpdatedAt = now
+        };
+    }
+}
+
+/// <summary>
+/// Esri FeatureServer incremental query instruction derived from a watermark.
+/// </summary>
+public readonly record struct EsriIncrementalQuery
+{
+    /// <summary>
+    /// Whether the pull is incremental (changed-since) or a full scan.
+    /// </summary>
+    public required bool IsIncremental { get; init; }
+
+    /// <summary>
+    /// Where-clause to send as the FeatureServer <c>where</c> parameter.
+    /// </summary>
+    public required string WhereClause { get; init; }
+
+    /// <summary>
+    /// Lower-bound edit time as epoch milliseconds, when incremental.
+    /// </summary>
+    public long? SinceEpochMilliseconds { get; init; }
+}
+
+/// <summary>
+/// OGC API Features / WFS temporal filter instruction derived from a watermark.
+/// </summary>
+public readonly record struct OgcTemporalFilter
+{
+    /// <summary>
+    /// Whether the pull is incremental (changed-since) or a full scan.
+    /// </summary>
+    public required bool IsIncremental { get; init; }
+
+    /// <summary>
+    /// Value for the OGC API Features <c>datetime</c> query parameter (half-open interval),
+    /// when incremental.
+    /// </summary>
+    public string? DatetimeParameter { get; init; }
+
+    /// <summary>
+    /// Optional source temporal field the filter applies to (for WFS temporal predicates).
+    /// </summary>
+    public string? DatetimeField { get; init; }
+}

--- a/src/Honua.Core/Features/Orchestration/Abstractions/IChangeFeedGenerationProbe.cs
+++ b/src/Honua.Core/Features/Orchestration/Abstractions/IChangeFeedGenerationProbe.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Orchestration.Abstractions;
+
+/// <summary>
+/// Probes the feature change-feed for the highest generation observed across a set of watched
+/// layers since a base generation. The change feed (<c>feature_changes</c> / the monotonic
+/// <c>sync_generation</c> sequence) already powers replica sync; this probe reuses it as an
+/// event/CDC trigger source for the workflow scheduler.
+/// </summary>
+/// <remarks>
+/// The probe is intentionally a narrow read over the change tracker so the event-trigger
+/// background service stays decoupled from the scoped feature-store services and remains
+/// unit-testable with an in-memory fake.
+/// </remarks>
+public interface IChangeFeedGenerationProbe
+{
+    /// <summary>
+    /// Returns the highest change generation observed for any of the <paramref name="watchedLayerIds"/>
+    /// strictly after <paramref name="sinceGeneration"/>, or <c>null</c> when no watched layer has
+    /// advanced past the base generation. The returned generation is the marker the scheduler
+    /// fires on and persists as the durable change-feed cursor.
+    /// </summary>
+    /// <param name="sinceGeneration">Base generation (exclusive) to look for advances past.</param>
+    /// <param name="watchedLayerIds">Layer ids the trigger watches. Must be non-empty.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<long?> GetLatestGenerationAsync(
+        long sinceGeneration,
+        IReadOnlyList<int> watchedLayerIds,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Orchestration/Abstractions/IObjectStoreTriggerProbe.cs
+++ b/src/Honua.Core/Features/Orchestration/Abstractions/IObjectStoreTriggerProbe.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Orchestration.Domain;
+
+namespace Honua.Core.Features.Orchestration.Abstractions;
+
+/// <summary>
+/// Probes a watched object store for new objects under a prefix. The baseline
+/// implementation polls a configured store and reports the newest object marker
+/// (key + last-modified) so the scheduler can fire when the marker advances past the
+/// durable object-store cursor. The contract is intentionally push-friendly: an
+/// S3/event-driven implementation can surface the same <see cref="ObjectStoreProbeResult"/>
+/// without changing the scheduler dispatch.
+/// </summary>
+public interface IObjectStoreTriggerProbe
+{
+    /// <summary>
+    /// Returns the newest object currently visible under the configured store and prefix,
+    /// or <c>null</c> when the store/prefix is empty or the store id is not registered.
+    /// </summary>
+    Task<ObjectStoreProbeResult?> ProbeNewestAsync(
+        ObjectStoreTriggerConfig config,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Marker identifying the newest object observed under a watched prefix. The
+/// <see cref="Marker"/> is a monotonic, lexicographically-comparable string so the
+/// scheduler can compare it against the durable cursor without store-specific knowledge.
+/// </summary>
+public readonly record struct ObjectStoreProbeResult
+{
+    /// <summary>
+    /// Opaque key of the newest object (e.g. an S3 key or relative file path).
+    /// </summary>
+    public required string Key { get; init; }
+
+    /// <summary>
+    /// Last-modified time of the newest object.
+    /// </summary>
+    public required DateTimeOffset LastModified { get; init; }
+
+    /// <summary>
+    /// Monotonic, comparable marker for the newest object. New objects must produce a marker
+    /// that sorts strictly after every previously-observed object's marker. Composed from the
+    /// last-modified timestamp and key so ties (same mtime) remain deterministic.
+    /// </summary>
+    public string Marker => string.Create(
+        System.Globalization.CultureInfo.InvariantCulture,
+        $"{LastModified.ToUniversalTime():O}|{Key}");
+}

--- a/src/Honua.Core/Features/Orchestration/Abstractions/IWorkflowDefinitionStore.cs
+++ b/src/Honua.Core/Features/Orchestration/Abstractions/IWorkflowDefinitionStore.cs
@@ -94,4 +94,57 @@ public interface IWorkflowDefinitionStore
         string workflowId,
         DateTimeOffset fireTime,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns event-triggered workflow definitions whose trigger is enabled and is of a kind
+    /// the scheduler evaluates per tick (change-feed, object-store). Cron definitions are
+    /// returned by <see cref="ListScheduledAsync"/> instead.
+    /// </summary>
+    Task<IReadOnlyList<WorkflowDefinition>> ListEventTriggeredAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads the durable string-valued trigger cursor for the workflow under the given
+    /// <paramref name="cursorKind"/> (e.g. the last-fired change-feed generation or the last
+    /// object-store marker). Returns <c>null</c> when the workflow has never fired for that kind.
+    /// </summary>
+    Task<string?> GetTriggerCursorAsync(
+        string workflowId,
+        string cursorKind,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the durable string-valued trigger cursor for the workflow. Unlike the cron cursor
+    /// (which is a monotonic timestamp), the event-trigger cursor stores an opaque comparable
+    /// marker so generation numbers and object-store markers share one mechanism. Callers must
+    /// only set a marker that sorts strictly after the previous one to preserve at-most-once
+    /// semantics across replicas.
+    /// </summary>
+    Task SetTriggerCursorAsync(
+        string workflowId,
+        string cursorKind,
+        string marker,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically claims a single event-trigger firing identified by an opaque marker so only
+    /// one replica creates the corresponding run. Reuses the same distributed fire-claim
+    /// semantics as <see cref="TryClaimScheduleFireAsync"/>.
+    /// </summary>
+    /// <returns>True when this caller claimed the firing; false when another replica already has.</returns>
+    Task<bool> TryClaimTriggerFireAsync(
+        string workflowId,
+        string cursorKind,
+        string marker,
+        TimeSpan retention,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Releases a previously-won event-trigger firing claim so another tick can retry it after a
+    /// transient run-creation failure.
+    /// </summary>
+    Task ReleaseTriggerClaimAsync(
+        string workflowId,
+        string cursorKind,
+        string marker,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Honua.Core/Features/Orchestration/Domain/OrchestrationEnums.cs
+++ b/src/Honua.Core/Features/Orchestration/Domain/OrchestrationEnums.cs
@@ -104,7 +104,20 @@ public enum WorkflowTriggerKind
     /// <summary>
     /// Run was created by the cron scheduler.
     /// </summary>
-    Cron
+    Cron,
+
+    /// <summary>
+    /// Run was created because a watched Honua layer's change-feed generation advanced
+    /// (event/CDC trigger). The changed-feature delta is surfaced to the run as input
+    /// metadata where the pipeline can consume it.
+    /// </summary>
+    ChangeFeed,
+
+    /// <summary>
+    /// Run was created because a new object landed under a watched object-store prefix
+    /// ("drop a file → pipeline runs" ETL).
+    /// </summary>
+    ObjectStore
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Orchestration/Domain/WorkflowDefinitionValidator.cs
+++ b/src/Honua.Core/Features/Orchestration/Domain/WorkflowDefinitionValidator.cs
@@ -142,6 +142,38 @@ public static class WorkflowDefinitionValidator
             }
         }
 
+        if (definition.Trigger is { Kind: WorkflowTriggerKind.ChangeFeed } changeFeed)
+        {
+            if (changeFeed.WatchedLayerIds.Count == 0)
+            {
+                failures.Add("Change-feed trigger requires at least one watched layer id.");
+            }
+            else if (changeFeed.WatchedLayerIds.Any(id => id < 0))
+            {
+                failures.Add("Change-feed trigger watched layer ids must be non-negative.");
+            }
+        }
+
+        if (definition.Trigger is { Kind: WorkflowTriggerKind.ObjectStore } objectStore)
+        {
+            if (objectStore.ObjectStore is null)
+            {
+                failures.Add("Object-store trigger requires an object-store configuration.");
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(objectStore.ObjectStore.StoreId))
+                {
+                    failures.Add("Object-store trigger requires a non-empty store id.");
+                }
+
+                if (objectStore.ObjectStore.PollInterval is { } interval && interval <= TimeSpan.Zero)
+                {
+                    failures.Add("Object-store trigger poll interval must be positive when specified.");
+                }
+            }
+        }
+
         return failures;
     }
 

--- a/src/Honua.Core/Features/Orchestration/Domain/WorkflowTrigger.cs
+++ b/src/Honua.Core/Features/Orchestration/Domain/WorkflowTrigger.cs
@@ -25,7 +25,48 @@ public sealed record WorkflowTrigger
     public string? TimeZone { get; init; }
 
     /// <summary>
+    /// Layer identifiers watched by a <see cref="WorkflowTriggerKind.ChangeFeed"/> trigger.
+    /// When any of these layers' change generation advances past the durable change-feed
+    /// cursor, the workflow fires once for the new generation. Required (non-empty) for
+    /// change-feed triggers.
+    /// </summary>
+    public IReadOnlyList<int> WatchedLayerIds { get; init; } = [];
+
+    /// <summary>
+    /// Configuration for a <see cref="WorkflowTriggerKind.ObjectStore"/> trigger. Required for
+    /// object-store triggers.
+    /// </summary>
+    public ObjectStoreTriggerConfig? ObjectStore { get; init; }
+
+    /// <summary>
     /// Whether the trigger is currently enabled. Disabled triggers are skipped by the scheduler.
     /// </summary>
     public bool Enabled { get; init; } = true;
+}
+
+/// <summary>
+/// Configuration for an object-store / file-watcher trigger. A new object landing under
+/// the watched prefix fires the workflow. The baseline implementation is poll-based; the
+/// shape is designed so an S3/event push can replace the poll later without changing the
+/// trigger contract.
+/// </summary>
+public sealed record ObjectStoreTriggerConfig
+{
+    /// <summary>
+    /// Logical object-store identifier resolved by the probe registry (e.g. a configured
+    /// bucket/container/local-root binding). Required.
+    /// </summary>
+    public required string StoreId { get; init; }
+
+    /// <summary>
+    /// Key prefix under <see cref="StoreId"/> that is watched for new objects. Empty watches
+    /// the whole store.
+    /// </summary>
+    public string Prefix { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional minimum interval between polls of the store. Null lets the scheduler poll on
+    /// every tick.
+    /// </summary>
+    public TimeSpan? PollInterval { get; init; }
 }

--- a/src/Honua.Server/Features/Orchestration/ChangeTrackerGenerationProbe.cs
+++ b/src/Honua.Server/Features/Orchestration/ChangeTrackerGenerationProbe.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.Orchestration.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Features.Orchestration;
+
+/// <summary>
+/// Adapts the scoped <see cref="IChangeTracker"/> into the singleton-friendly
+/// <see cref="IChangeFeedGenerationProbe"/> the event-trigger background service consumes.
+/// Resolves a fresh <see cref="IChangeTracker"/> per probe from a request-style scope so the
+/// background loop never captures a scoped service on the root provider.
+/// </summary>
+internal sealed class ChangeTrackerGenerationProbe(IServiceScopeFactory scopeFactory) : IChangeFeedGenerationProbe
+{
+    public async Task<long?> GetLatestGenerationAsync(
+        long sinceGeneration,
+        IReadOnlyList<int> watchedLayerIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(watchedLayerIds);
+        if (watchedLayerIds.Count == 0)
+        {
+            return null;
+        }
+
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var tracker = scope.ServiceProvider.GetService<IChangeTracker>();
+        if (tracker is null)
+        {
+            // Read-only / non-Postgres providers register no change tracker; the change-feed
+            // trigger is a no-op there rather than a hard failure.
+            return null;
+        }
+
+        var layerIds = watchedLayerIds as int[] ?? watchedLayerIds.ToArray();
+        var changes = await tracker
+            .GetChangesSinceAsync(sinceGeneration, layerIds, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (changes.Count == 0)
+        {
+            return null;
+        }
+
+        var maxGeneration = sinceGeneration;
+        foreach (var change in changes)
+        {
+            if (change.Generation > maxGeneration)
+            {
+                maxGeneration = change.Generation;
+            }
+        }
+
+        return maxGeneration > sinceGeneration ? maxGeneration : null;
+    }
+}

--- a/src/Honua.Server/Features/Orchestration/FileSystemObjectStoreTriggerProbe.cs
+++ b/src/Honua.Server/Features/Orchestration/FileSystemObjectStoreTriggerProbe.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Orchestration.Abstractions;
+using Honua.Core.Features.Orchestration.Domain;
+
+namespace Honua.Server.Features.Orchestration;
+
+/// <summary>
+/// Poll-based baseline <see cref="IObjectStoreTriggerProbe"/> backed by local/mounted file
+/// system roots. Each configured <see cref="ObjectStoreTriggerConfig.StoreId"/> maps to a root
+/// directory; the probe lists files under the watched prefix and reports the newest one (by the
+/// monotonic last-modified + key marker). An object-store/S3 push implementation can later return
+/// the same <see cref="ObjectStoreProbeResult"/> without changing the scheduler dispatch.
+/// </summary>
+/// <remarks>
+/// The file-system root is the natural baseline for "drop a file → pipeline runs" on a mounted
+/// volume (NFS/EFS/local), and keeps the baseline dependency-free and AOT-safe.
+/// </remarks>
+internal sealed class FileSystemObjectStoreTriggerProbe : IObjectStoreTriggerProbe
+{
+    private readonly Dictionary<string, string> _roots;
+
+    public FileSystemObjectStoreTriggerProbe(IReadOnlyDictionary<string, string> roots)
+    {
+        ArgumentNullException.ThrowIfNull(roots);
+        _roots = new Dictionary<string, string>(roots, StringComparer.Ordinal);
+    }
+
+    public Task<ObjectStoreProbeResult?> ProbeNewestAsync(
+        ObjectStoreTriggerConfig config,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_roots.TryGetValue(config.StoreId, out var root) || string.IsNullOrWhiteSpace(root))
+        {
+            return Task.FromResult<ObjectStoreProbeResult?>(null);
+        }
+
+        var searchRoot = root;
+        if (!string.IsNullOrEmpty(config.Prefix))
+        {
+            // Prefix is interpreted as a relative sub-path under the store root. Reject any
+            // attempt to escape the root so a malformed prefix cannot read outside the store.
+            var combined = Path.GetFullPath(Path.Combine(root, config.Prefix));
+            var normalizedRoot = Path.GetFullPath(root);
+            if (!combined.StartsWith(normalizedRoot, StringComparison.Ordinal))
+            {
+                return Task.FromResult<ObjectStoreProbeResult?>(null);
+            }
+
+            searchRoot = combined;
+        }
+
+        if (!Directory.Exists(searchRoot))
+        {
+            return Task.FromResult<ObjectStoreProbeResult?>(null);
+        }
+
+        ObjectStoreProbeResult? newest = null;
+        foreach (var path in Directory.EnumerateFiles(searchRoot, "*", SearchOption.AllDirectories))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            DateTimeOffset lastModified;
+            try
+            {
+                lastModified = File.GetLastWriteTimeUtc(path);
+            }
+            catch (IOException)
+            {
+                // File vanished between enumeration and stat; skip it.
+                continue;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                continue;
+            }
+
+            var key = Path.GetRelativePath(root, path).Replace(Path.DirectorySeparatorChar, '/');
+            var candidate = new ObjectStoreProbeResult
+            {
+                Key = key,
+                LastModified = lastModified
+            };
+
+            if (newest is null || string.CompareOrdinal(candidate.Marker, newest.Value.Marker) > 0)
+            {
+                newest = candidate;
+            }
+        }
+
+        return Task.FromResult(newest);
+    }
+}

--- a/src/Honua.Server/Features/Orchestration/OrchestrationLog.cs
+++ b/src/Honua.Server/Features/Orchestration/OrchestrationLog.cs
@@ -151,4 +151,16 @@ internal static partial class OrchestrationLog
         ILogger logger,
         string runId,
         Exception exception);
+
+    [LoggerMessage(8123, LogLevel.Information, "Started orchestration event-trigger background service")]
+    public static partial void EventTriggerBackgroundServiceStarted(ILogger logger);
+
+    [LoggerMessage(8124, LogLevel.Warning, "Orchestration event-trigger tick failed")]
+    public static partial void EventTriggerTickFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(8125, LogLevel.Information, "Change-feed trigger fired workflow {WorkflowId} at generation {Generation}")]
+    public static partial void ChangeFeedTriggerFired(ILogger logger, string workflowId, long generation);
+
+    [LoggerMessage(8126, LogLevel.Information, "Object-store trigger fired workflow {WorkflowId} for object {ObjectKey}")]
+    public static partial void ObjectStoreTriggerFired(ILogger logger, string workflowId, string objectKey);
 }

--- a/src/Honua.Server/Features/Orchestration/OrchestrationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Orchestration/OrchestrationServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Migration.Watermark;
 using Honua.Core.Features.Orchestration.Abstractions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using StackExchange.Redis;
 
@@ -38,7 +40,40 @@ internal static class OrchestrationServiceCollectionExtensions
         services.TryAddSingleton<IWorkflowCancellationCoordinator>(sp =>
             sp.GetRequiredService<WorkflowOrchestrationEngine>());
 
+        // Durable per-pipeline+source high-water marks for incremental ("changed-since") extract.
+        services.TryAddSingleton<ISourceWatermarkStore>(sp =>
+            new RedisSourceWatermarkStore(sp.GetRequiredService<IConnectionMultiplexer>()));
+
+        // Event/CDC trigger probes. The change-feed probe adapts the scoped IChangeTracker; the
+        // object-store probe is a poll-based file-system baseline whose StoreId->root bindings come
+        // from configuration (Orchestration:ObjectStoreTriggers:Roots:<storeId> = <path>). Bindings
+        // are read manually (no reflection binder) to stay AOT-safe.
+        services.TryAddSingleton<IChangeFeedGenerationProbe, ChangeTrackerGenerationProbe>();
+        services.TryAddSingleton<IObjectStoreTriggerProbe>(sp =>
+            new FileSystemObjectStoreTriggerProbe(
+                ReadObjectStoreRoots(sp.GetService<IConfiguration>())));
+
         return services;
+    }
+
+    private static Dictionary<string, string> ReadObjectStoreRoots(IConfiguration? configuration)
+    {
+        var roots = new Dictionary<string, string>(StringComparer.Ordinal);
+        var section = configuration?.GetSection("Orchestration:ObjectStoreTriggers:Roots");
+        if (section is null || !section.Exists())
+        {
+            return roots;
+        }
+
+        foreach (var child in section.GetChildren())
+        {
+            if (!string.IsNullOrWhiteSpace(child.Key) && !string.IsNullOrWhiteSpace(child.Value))
+            {
+                roots[child.Key] = child.Value!;
+            }
+        }
+
+        return roots;
     }
 
     public static IServiceCollection AddOrchestrationBackgroundServices(this IServiceCollection services)
@@ -55,6 +90,7 @@ internal static class OrchestrationServiceCollectionExtensions
 
         services.AddHostedService<WorkflowOrchestrationBackgroundService>();
         services.AddHostedService<WorkflowSchedulerBackgroundService>();
+        services.AddHostedService<WorkflowEventTriggerBackgroundService>();
         return services;
     }
 }

--- a/src/Honua.Server/Features/Orchestration/OrchestrationTelemetry.cs
+++ b/src/Honua.Server/Features/Orchestration/OrchestrationTelemetry.cs
@@ -18,6 +18,7 @@ internal static class OrchestrationTelemetry
         public const string ExecuteStep = "honua.orchestration.execute_step";
         public const string ResolveBindings = "honua.orchestration.resolve_bindings";
         public const string SchedulerTick = "honua.orchestration.scheduler_tick";
+        public const string EventTriggerTick = "honua.orchestration.event_trigger_tick";
     }
 
     internal static class Tags

--- a/src/Honua.Server/Features/Orchestration/RedisSourceWatermarkStore.cs
+++ b/src/Honua.Server/Features/Orchestration/RedisSourceWatermarkStore.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Migration.Watermark;
+using StackExchange.Redis;
+
+namespace Honua.Server.Features.Orchestration;
+
+/// <summary>
+/// Redis-backed durable store for per-pipeline+source high-water marks. Advancing a
+/// timestamp-based watermark is monotonic: a competing replica or an out-of-order completion
+/// can never rewind the mark past a value already persisted, so a later run cannot re-pull
+/// records an earlier run already extracted. The mark is stored as a single string value so an
+/// optimistic compare-and-set guards concurrent advances without per-field null ambiguity.
+/// </summary>
+internal sealed class RedisSourceWatermarkStore(IConnectionMultiplexer redis) : ISourceWatermarkStore
+{
+    private const string WatermarkKeyPrefix = "orchestration:watermark:";
+
+    private readonly IDatabase _database = redis.GetDatabase();
+
+    public async Task<SourceWatermark?> GetAsync(
+        string pipelineId,
+        string sourceId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pipelineId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceId);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var payload = await _database.StringGetAsync(GetKey(pipelineId, sourceId)).ConfigureAwait(false);
+        return payload.HasValue ? Deserialize(pipelineId, sourceId, payload!) : null;
+    }
+
+    public async Task<SourceWatermark> AdvanceAsync(
+        SourceWatermark watermark,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(watermark);
+        ArgumentException.ThrowIfNullOrWhiteSpace(watermark.PipelineId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(watermark.SourceId);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var key = GetKey(watermark.PipelineId, watermark.SourceId);
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var current = await _database.StringGetAsync(key).ConfigureAwait(false);
+            var existing = current.HasValue
+                ? Deserialize(watermark.PipelineId, watermark.SourceId, current!)
+                : null;
+
+            // Monotonic guard: never move a timestamp watermark backwards.
+            var effective = MergeMonotonic(existing, watermark);
+            var serialized = Serialize(effective);
+
+            if (!current.HasValue)
+            {
+                // Create only if still absent; a racing creator forces a re-read.
+                if (await _database.StringSetAsync(key, serialized, when: When.NotExists).ConfigureAwait(false))
+                {
+                    return effective;
+                }
+
+                continue;
+            }
+
+            // Compare-and-set against the exact bytes we read so a concurrent advance cannot be
+            // clobbered; on contention we re-read and re-apply the monotonic merge.
+            var transaction = _database.CreateTransaction();
+            transaction.AddCondition(Condition.StringEqual(key, current));
+            _ = transaction.StringSetAsync(key, serialized);
+            if (await transaction.ExecuteAsync().ConfigureAwait(false))
+            {
+                return effective;
+            }
+        }
+    }
+
+    public async Task ClearAsync(
+        string pipelineId,
+        string sourceId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pipelineId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceId);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await _database.KeyDeleteAsync(GetKey(pipelineId, sourceId)).ConfigureAwait(false);
+    }
+
+    private static SourceWatermark MergeMonotonic(SourceWatermark? existing, SourceWatermark requested)
+    {
+        if (existing is null)
+        {
+            return requested;
+        }
+
+        var existingTimestamp = existing.AsTimestamp();
+        var requestedTimestamp = requested.AsTimestamp();
+
+        // Both timestamp-based: only advance when strictly newer; otherwise keep the persisted
+        // mark (refreshing UpdatedAt so callers can observe the touch).
+        if (existingTimestamp is { } prior && requestedTimestamp is { } next && next <= prior)
+        {
+            return existing with { UpdatedAt = requested.UpdatedAt };
+        }
+
+        return requested;
+    }
+
+    private static string Serialize(SourceWatermark watermark)
+        => JsonSerializer.Serialize(
+            new WatermarkPayload(watermark.Kind, watermark.Value, watermark.UpdatedAt),
+            WatermarkJsonContext.Default.WatermarkPayload);
+
+    private static SourceWatermark Deserialize(string pipelineId, string sourceId, string payload)
+    {
+        WatermarkPayload? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize(payload, WatermarkJsonContext.Default.WatermarkPayload);
+        }
+        catch (JsonException)
+        {
+            parsed = null;
+        }
+
+        return new SourceWatermark
+        {
+            PipelineId = pipelineId,
+            SourceId = sourceId,
+            Kind = parsed?.Kind ?? WatermarkKind.EditTimestamp,
+            Value = string.IsNullOrEmpty(parsed?.Value) ? null : parsed.Value,
+            UpdatedAt = parsed?.UpdatedAt
+        };
+    }
+
+    private static RedisKey GetKey(string pipelineId, string sourceId)
+        => string.Concat(WatermarkKeyPrefix, pipelineId, ":", sourceId);
+
+    internal sealed record WatermarkPayload(
+        WatermarkKind Kind,
+        string? Value,
+        DateTimeOffset? UpdatedAt);
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(RedisSourceWatermarkStore.WatermarkPayload))]
+internal sealed partial class WatermarkJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Orchestration/RedisWorkflowDefinitionStore.cs
+++ b/src/Honua.Server/Features/Orchestration/RedisWorkflowDefinitionStore.cs
@@ -18,6 +18,8 @@ internal sealed class RedisWorkflowDefinitionStore(IConnectionMultiplexer redis)
     private const string ScheduleClaimKeyPrefix = "orchestration:schedule:claim:";
     private const string ScheduleCursorKeyPrefix = "orchestration:schedule:cursor:";
     private const string SchedulePendingCursorKeyPrefix = "orchestration:schedule:pending-cursor:";
+    private const string TriggerCursorKeyPrefix = "orchestration:trigger:cursor:";
+    private const string TriggerClaimKeyPrefix = "orchestration:trigger:claim:";
 
     private readonly IDatabase _database = redis.GetDatabase();
 
@@ -122,7 +124,120 @@ internal sealed class RedisWorkflowDefinitionStore(IConnectionMultiplexer redis)
         // scan-based cleanup is required.
         await _database.KeyDeleteAsync(GetScheduleCursorKey(workflowId)).ConfigureAwait(false);
         await _database.KeyDeleteAsync(GetSchedulePendingCursorKey(workflowId)).ConfigureAwait(false);
+
+        // Clear event-trigger cursors (change-feed generation, object-store marker) so a
+        // recreate of the same id does not inherit a stale firing position. Per-firing claim
+        // keys carry a short TTL and key off the marker, so they cannot suppress fresh firings.
+        await _database.KeyDeleteAsync(GetTriggerCursorKey(workflowId, ChangeFeedCursorKind)).ConfigureAwait(false);
+        await _database.KeyDeleteAsync(GetTriggerCursorKey(workflowId, ObjectStoreCursorKind)).ConfigureAwait(false);
         return removed;
+    }
+
+    /// <summary>Cursor kind discriminator for the change-feed trigger.</summary>
+    internal const string ChangeFeedCursorKind = "change-feed";
+
+    /// <summary>Cursor kind discriminator for the object-store trigger.</summary>
+    internal const string ObjectStoreCursorKind = "object-store";
+
+    public async Task<IReadOnlyList<WorkflowDefinition>> ListEventTriggeredAsync(CancellationToken cancellationToken = default)
+    {
+        var all = await ListAsync(cancellationToken).ConfigureAwait(false);
+        return all
+            .Where(def => def.Trigger is { Enabled: true } trigger
+                          && trigger.Kind is WorkflowTriggerKind.ChangeFeed or WorkflowTriggerKind.ObjectStore)
+            .ToArray();
+    }
+
+    public async Task<string?> GetTriggerCursorAsync(
+        string workflowId,
+        string cursorKind,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cursorKind);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var payload = await _database.StringGetAsync(GetTriggerCursorKey(workflowId, cursorKind)).ConfigureAwait(false);
+        return payload.HasValue ? payload.ToString() : null;
+    }
+
+    public async Task SetTriggerCursorAsync(
+        string workflowId,
+        string cursorKind,
+        string marker,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cursorKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(marker);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var key = GetTriggerCursorKey(workflowId, cursorKind);
+
+        // Move forward only: a late/competing replica must never rewind the cursor past a
+        // firing already enumerated locally. Ordinal compare matches the marker contract
+        // (round-trip timestamps and zero-padded generations both sort lexicographically).
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var current = await _database.StringGetAsync(key).ConfigureAwait(false);
+            if (!current.HasValue)
+            {
+                if (await _database.StringSetAsync(key, marker, when: When.NotExists).ConfigureAwait(false))
+                {
+                    return;
+                }
+
+                continue;
+            }
+
+            if (string.CompareOrdinal(current.ToString(), marker) >= 0)
+            {
+                return;
+            }
+
+            var transaction = _database.CreateTransaction();
+            transaction.AddCondition(Condition.StringEqual(key, current));
+            _ = transaction.StringSetAsync(key, marker);
+            if (await transaction.ExecuteAsync().ConfigureAwait(false))
+            {
+                return;
+            }
+        }
+    }
+
+    public async Task<bool> TryClaimTriggerFireAsync(
+        string workflowId,
+        string cursorKind,
+        string marker,
+        TimeSpan retention,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cursorKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(marker);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var ttl = retention > TimeSpan.Zero ? retention : TimeSpan.FromHours(24);
+        return await _database.StringSetAsync(
+            GetTriggerClaimKey(workflowId, cursorKind, marker),
+            Environment.MachineName,
+            ttl,
+            when: When.NotExists).ConfigureAwait(false);
+    }
+
+    public async Task ReleaseTriggerClaimAsync(
+        string workflowId,
+        string cursorKind,
+        string marker,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cursorKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(marker);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await _database.KeyDeleteAsync(GetTriggerClaimKey(workflowId, cursorKind, marker)).ConfigureAwait(false);
     }
 
     public async Task<bool> TryClaimScheduleFireAsync(
@@ -298,4 +413,18 @@ internal sealed class RedisWorkflowDefinitionStore(IConnectionMultiplexer redis)
 
     private static string GetSchedulePendingCursorKey(string workflowId)
         => SchedulePendingCursorKeyPrefix + workflowId;
+
+    private static string GetTriggerCursorKey(string workflowId, string cursorKind)
+        => string.Concat(TriggerCursorKeyPrefix, cursorKind, ":", workflowId);
+
+    private static string GetTriggerClaimKey(string workflowId, string cursorKind, string marker)
+    {
+        // Hash the marker so arbitrarily long object-store keys never produce an oversized
+        // Redis key. The marker is also stored as the cursor for ordering; the claim key only
+        // needs to be unique per (workflow, kind, marker).
+        var hash = System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes(marker));
+        var encoded = Convert.ToHexStringLower(hash);
+        return string.Concat(TriggerClaimKeyPrefix, cursorKind, ":", workflowId, ":", encoded);
+    }
 }

--- a/src/Honua.Server/Features/Orchestration/WorkflowEventTriggerBackgroundService.cs
+++ b/src/Honua.Server/Features/Orchestration/WorkflowEventTriggerBackgroundService.cs
@@ -1,0 +1,332 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using Honua.Core.Features.Orchestration.Abstractions;
+using Honua.Core.Features.Orchestration.Domain;
+using Microsoft.Extensions.Hosting;
+
+namespace Honua.Server.Features.Orchestration;
+
+/// <summary>
+/// Background worker that evaluates event/CDC-triggered workflow definitions and creates runs
+/// when a watched source advances:
+/// <list type="bullet">
+///   <item>change-feed (<see cref="WorkflowTriggerKind.ChangeFeed"/>): a watched layer's
+///   <c>feature_changes</c> generation advances past the durable change-feed cursor;</item>
+///   <item>object-store (<see cref="WorkflowTriggerKind.ObjectStore"/>): a new object lands under
+///   a watched prefix, advancing the object marker past the durable object-store cursor.</item>
+/// </list>
+/// HA safety mirrors the cron scheduler: the firing marker is atomically claimed via the durable
+/// fire-claim before a run is created, so replicas and restarts never double-fire a given marker.
+/// </summary>
+internal sealed class WorkflowEventTriggerBackgroundService(
+    IWorkflowDefinitionStore definitionStore,
+    WorkflowOrchestrationEngine engine,
+    IChangeFeedGenerationProbe changeFeedProbe,
+    IObjectStoreTriggerProbe objectStoreProbe,
+    TimeProvider clock,
+    ILogger<WorkflowEventTriggerBackgroundService> logger) : BackgroundService
+{
+    private static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan TriggerClaimRetention = TimeSpan.FromHours(24);
+
+    // Tracks the last poll time per object-store workflow so a configured PollInterval can throttle
+    // store probes without throttling change-feed evaluation. In-memory only; a missed poll simply
+    // fires on the next tick.
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _lastObjectStorePoll = new(StringComparer.Ordinal);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        OrchestrationLog.EventTriggerBackgroundServiceStarted(logger);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await TickAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                OrchestrationLog.EventTriggerTickFailed(logger, ex);
+            }
+
+            try
+            {
+                await Task.Delay(TickInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    internal async Task TickAsync(CancellationToken cancellationToken)
+    {
+        using var activity = Honua.ServiceDefaults.HonuaTelemetry.ActivitySource.StartActivity(
+            OrchestrationTelemetry.Activities.EventTriggerTick,
+            System.Diagnostics.ActivityKind.Internal);
+
+        var definitions = await definitionStore.ListEventTriggeredAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var definition in definitions)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var trigger = definition.Trigger;
+            if (trigger is null || !trigger.Enabled)
+            {
+                continue;
+            }
+
+            try
+            {
+                switch (trigger.Kind)
+                {
+                    case WorkflowTriggerKind.ChangeFeed:
+                        await EvaluateChangeFeedAsync(definition, trigger, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case WorkflowTriggerKind.ObjectStore:
+                        await EvaluateObjectStoreAsync(definition, trigger, cancellationToken).ConfigureAwait(false);
+                        break;
+                    default:
+                        // Cron/Manual are handled elsewhere; ignore.
+                        break;
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                OrchestrationLog.EventTriggerTickFailed(logger, ex);
+            }
+        }
+    }
+
+    private async Task EvaluateChangeFeedAsync(
+        WorkflowDefinition definition,
+        WorkflowTrigger trigger,
+        CancellationToken cancellationToken)
+    {
+        if (trigger.WatchedLayerIds.Count == 0)
+        {
+            return;
+        }
+
+        var cursorMarker = await definitionStore
+            .GetTriggerCursorAsync(definition.WorkflowId, RedisWorkflowDefinitionStore.ChangeFeedCursorKind, cancellationToken)
+            .ConfigureAwait(false);
+        var sinceGeneration = ParseGeneration(cursorMarker);
+
+        var latest = await changeFeedProbe
+            .GetLatestGenerationAsync(sinceGeneration, trigger.WatchedLayerIds, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (latest is not { } generation || generation <= sinceGeneration)
+        {
+            // No watched layer advanced past the cursor — do not fire.
+            return;
+        }
+
+        var marker = EncodeGeneration(generation);
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["trigger.kind"] = nameof(WorkflowTriggerKind.ChangeFeed),
+            ["trigger.change_feed.generation"] = generation.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ["trigger.change_feed.since_generation"] = sinceGeneration.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ["trigger.change_feed.watched_layers"] = string.Join(',', trigger.WatchedLayerIds)
+        };
+
+        var fired = await FireAsync(
+            definition,
+            RedisWorkflowDefinitionStore.ChangeFeedCursorKind,
+            marker,
+            metadata,
+            cancellationToken).ConfigureAwait(false);
+
+        if (fired)
+        {
+            OrchestrationLog.ChangeFeedTriggerFired(logger, definition.WorkflowId, generation);
+        }
+    }
+
+    private async Task EvaluateObjectStoreAsync(
+        WorkflowDefinition definition,
+        WorkflowTrigger trigger,
+        CancellationToken cancellationToken)
+    {
+        if (trigger.ObjectStore is not { } config || string.IsNullOrWhiteSpace(config.StoreId))
+        {
+            return;
+        }
+
+        // Honour the per-trigger poll interval so high-frequency ticks do not hammer the store.
+        if (config.PollInterval is { } interval && interval > TimeSpan.Zero)
+        {
+            var now = clock.GetUtcNow();
+            if (_lastObjectStorePoll.TryGetValue(definition.WorkflowId, out var lastPoll)
+                && now - lastPoll < interval)
+            {
+                return;
+            }
+
+            _lastObjectStorePoll[definition.WorkflowId] = now;
+        }
+
+        var newest = await objectStoreProbe.ProbeNewestAsync(config, cancellationToken).ConfigureAwait(false);
+        if (newest is not { } result)
+        {
+            // Empty store/prefix — nothing to fire.
+            return;
+        }
+
+        var cursorMarker = await definitionStore
+            .GetTriggerCursorAsync(definition.WorkflowId, RedisWorkflowDefinitionStore.ObjectStoreCursorKind, cancellationToken)
+            .ConfigureAwait(false);
+
+        // First observation seeds the cursor without firing so an already-present backlog of objects
+        // does not stampede a run on first deployment. Only objects that land after the seed fire.
+        if (cursorMarker is null)
+        {
+            await definitionStore
+                .SetTriggerCursorAsync(definition.WorkflowId, RedisWorkflowDefinitionStore.ObjectStoreCursorKind, result.Marker, cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        if (string.CompareOrdinal(result.Marker, cursorMarker) <= 0)
+        {
+            // No new object landed past the cursor — do not fire.
+            return;
+        }
+
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["trigger.kind"] = nameof(WorkflowTriggerKind.ObjectStore),
+            ["trigger.object_store.store_id"] = config.StoreId,
+            ["trigger.object_store.prefix"] = config.Prefix,
+            ["trigger.object_store.key"] = result.Key,
+            ["trigger.object_store.last_modified"] = result.LastModified.ToUniversalTime().ToString("O", System.Globalization.CultureInfo.InvariantCulture)
+        };
+
+        var fired = await FireAsync(
+            definition,
+            RedisWorkflowDefinitionStore.ObjectStoreCursorKind,
+            result.Marker,
+            metadata,
+            cancellationToken).ConfigureAwait(false);
+
+        if (fired)
+        {
+            OrchestrationLog.ObjectStoreTriggerFired(logger, definition.WorkflowId, result.Key);
+        }
+    }
+
+    /// <summary>
+    /// Atomically claims the firing marker, creates the run, and advances the durable cursor.
+    /// Returns true only when this caller created the run. A lost claim (another replica won) or a
+    /// not-advanced marker yields false. Transient run-creation failures release the claim and leave
+    /// the cursor untouched so the next tick retries the same marker.
+    /// </summary>
+    private async Task<bool> FireAsync(
+        WorkflowDefinition definition,
+        string cursorKind,
+        string marker,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken cancellationToken)
+    {
+        var claimed = await definitionStore
+            .TryClaimTriggerFireAsync(definition.WorkflowId, cursorKind, marker, TriggerClaimRetention, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!claimed)
+        {
+            // Another replica already claimed this marker. Only advance our cursor once that
+            // replica has durably committed the firing (its cursor reflects the marker). If the
+            // winner is still mid-flight — or crashed and released the claim before committing —
+            // we leave our cursor where it is so the marker can be re-claimed and retried by a
+            // future tick, preserving at-least-one-eventually semantics on a persistent advance.
+            var durableCursor = await definitionStore
+                .GetTriggerCursorAsync(definition.WorkflowId, cursorKind, cancellationToken)
+                .ConfigureAwait(false);
+            if (durableCursor is not null && string.CompareOrdinal(durableCursor, marker) >= 0)
+            {
+                await definitionStore
+                    .SetTriggerCursorAsync(definition.WorkflowId, cursorKind, marker, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            return false;
+        }
+
+        try
+        {
+            var principal = OrchestrationSystemPrincipal.Create(null);
+            var triggerKind = cursorKind == RedisWorkflowDefinitionStore.ChangeFeedCursorKind
+                ? WorkflowTriggerKind.ChangeFeed
+                : WorkflowTriggerKind.ObjectStore;
+
+            await engine
+                .CreateRunAsync(definition, triggerKind, principal, metadata, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (WorkflowDefinitionValidationException ex)
+        {
+            // Permanent failure: the definition can never fire. Advance the cursor so we stop
+            // retrying a marker that will always fail validation.
+            OrchestrationLog.EventTriggerTickFailed(logger, ex);
+            await definitionStore
+                .SetTriggerCursorAsync(definition.WorkflowId, cursorKind, marker, cancellationToken)
+                .ConfigureAwait(false);
+            return false;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            await TryReleaseClaimAsync(definition.WorkflowId, cursorKind, marker).ConfigureAwait(false);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Transient: release the claim and leave the cursor so the next tick retries the marker.
+            OrchestrationLog.EventTriggerTickFailed(logger, ex);
+            await TryReleaseClaimAsync(definition.WorkflowId, cursorKind, marker).ConfigureAwait(false);
+            return false;
+        }
+
+        // Run created: advance the durable cursor past the fired marker so it is never replayed.
+        await definitionStore
+            .SetTriggerCursorAsync(definition.WorkflowId, cursorKind, marker, cancellationToken)
+            .ConfigureAwait(false);
+        return true;
+    }
+
+    private async Task TryReleaseClaimAsync(string workflowId, string cursorKind, string marker)
+    {
+        try
+        {
+            await definitionStore
+                .ReleaseTriggerClaimAsync(workflowId, cursorKind, marker, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            OrchestrationLog.EventTriggerTickFailed(logger, ex);
+        }
+    }
+
+    private static long ParseGeneration(string? marker)
+        => long.TryParse(marker, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var value)
+            ? value
+            : 0L;
+
+    // Zero-padded so the change-feed generation cursor compares correctly with the ordinal
+    // string compare used by the shared trigger-cursor mechanism.
+    private static string EncodeGeneration(long generation)
+        => generation.ToString("D19", System.Globalization.CultureInfo.InvariantCulture);
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Migration/WatermarkExtractPlannerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Migration/WatermarkExtractPlannerTests.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Migration.Watermark;
+
+namespace Honua.Core.Tests.Features.Migration;
+
+public sealed class WatermarkExtractPlannerTests
+{
+    private static SourceWatermark TimestampWatermark(DateTimeOffset instant) => new()
+    {
+        PipelineId = "p",
+        SourceId = "s",
+        Kind = WatermarkKind.EditTimestamp,
+        Value = SourceWatermark.Encode(instant)
+    };
+
+    [Fact]
+    public void PlanEsri_NullWatermark_PlansFullPull()
+    {
+        var query = WatermarkExtractPlanner.PlanEsri(watermark: null, editField: "last_edited_date");
+
+        query.IsIncremental.Should().BeFalse();
+        query.WhereClause.Should().Be("1=1");
+        query.SinceEpochMilliseconds.Should().BeNull();
+    }
+
+    [Fact]
+    public void PlanEsri_WithWatermark_PlansChangedSincePredicate()
+    {
+        var since = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var query = WatermarkExtractPlanner.PlanEsri(TimestampWatermark(since), "last_edited_date");
+
+        query.IsIncremental.Should().BeTrue();
+        query.SinceEpochMilliseconds.Should().Be(since.ToUnixTimeMilliseconds());
+        query.WhereClause.Should().Be($"last_edited_date > {since.ToUnixTimeMilliseconds()}");
+    }
+
+    [Fact]
+    public void PlanEsri_MissingEditField_FallsBackToFullPull()
+    {
+        var since = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var query = WatermarkExtractPlanner.PlanEsri(TimestampWatermark(since), editField: null);
+
+        query.IsIncremental.Should().BeFalse();
+        query.WhereClause.Should().Be("1=1");
+    }
+
+    [Fact]
+    public void PlanOgc_WithWatermark_PlansHalfOpenIntervalAfterMark()
+    {
+        var since = new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        var filter = WatermarkExtractPlanner.PlanOgc(TimestampWatermark(since), datetimeField: "updated");
+
+        filter.IsIncremental.Should().BeTrue();
+        filter.DatetimeField.Should().Be("updated");
+        // Lower bound nudged forward 1ms so the boundary record is not re-pulled, interval open-ended.
+        filter.DatetimeParameter.Should().StartWith(
+            since.AddMilliseconds(1).ToUniversalTime().ToString("O", System.Globalization.CultureInfo.InvariantCulture));
+        filter.DatetimeParameter.Should().EndWith("/..");
+    }
+
+    [Fact]
+    public void PlanOgc_NullWatermark_PlansFullPull()
+    {
+        var filter = WatermarkExtractPlanner.PlanOgc(watermark: null);
+
+        filter.IsIncremental.Should().BeFalse();
+        filter.DatetimeParameter.Should().BeNull();
+    }
+
+    [Fact]
+    public void ShouldPullFile_NullWatermark_PullsEveryFile()
+    {
+        WatermarkExtractPlanner.ShouldPullFile(watermark: null, DateTimeOffset.UnixEpoch)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldPullFile_OnlyPullsFilesNewerThanMark()
+    {
+        var mark = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var watermark = new SourceWatermark
+        {
+            PipelineId = "p",
+            SourceId = "s",
+            Kind = WatermarkKind.FileModifiedTime,
+            Value = SourceWatermark.Encode(mark)
+        };
+
+        WatermarkExtractPlanner.ShouldPullFile(watermark, mark.AddSeconds(1)).Should().BeTrue();
+        WatermarkExtractPlanner.ShouldPullFile(watermark, mark).Should().BeFalse();
+        WatermarkExtractPlanner.ShouldPullFile(watermark, mark.AddSeconds(-1)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Advance_OnlyMovesForward_NeverRewinds()
+    {
+        var now = new DateTimeOffset(2026, 6, 10, 0, 0, 0, TimeSpan.Zero);
+        var current = TimestampWatermark(new DateTimeOffset(2026, 6, 5, 0, 0, 0, TimeSpan.Zero));
+
+        // Newer observed timestamp advances the mark.
+        var advanced = WatermarkExtractPlanner.Advance(current, new DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero), now);
+        advanced.AsTimestamp().Should().Be(new DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero));
+        advanced.UpdatedAt.Should().Be(now);
+
+        // Older observed timestamp must NOT rewind the mark.
+        var notRewound = WatermarkExtractPlanner.Advance(advanced, new DateTimeOffset(2026, 6, 6, 0, 0, 0, TimeSpan.Zero), now);
+        notRewound.AsTimestamp().Should().Be(new DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero));
+
+        // No observed records retains the mark but refreshes UpdatedAt.
+        var noRecords = WatermarkExtractPlanner.Advance(advanced, maxObservedTimestamp: null, now);
+        noRecords.AsTimestamp().Should().Be(new DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void SourceWatermark_RoundTripsTimestampThroughEncode()
+    {
+        var instant = new DateTimeOffset(2026, 6, 1, 9, 30, 15, TimeSpan.Zero);
+        var watermark = TimestampWatermark(instant);
+
+        watermark.AsTimestamp().Should().Be(instant);
+    }
+
+    [Fact]
+    public void SourceWatermark_NullOrUnparseableValue_TreatedAsNoLowerBound()
+    {
+        var watermark = new SourceWatermark
+        {
+            PipelineId = "p",
+            SourceId = "s",
+            Kind = WatermarkKind.EditTimestamp,
+            Value = null
+        };
+
+        watermark.AsTimestamp().Should().BeNull();
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Orchestration/WorkflowDefinitionValidatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Orchestration/WorkflowDefinitionValidatorTests.cs
@@ -226,6 +226,100 @@ public sealed class WorkflowDefinitionValidatorTests
         Assert.Contains(failures, f => f.Contains("dependency cycle", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void Validate_AcceptsChangeFeedTrigger_WithWatchedLayers()
+    {
+        var definition = BuildDefinition(("a", Empty)) with
+        {
+            Trigger = new WorkflowTrigger
+            {
+                Kind = WorkflowTriggerKind.ChangeFeed,
+                WatchedLayerIds = [1, 2]
+            }
+        };
+
+        Assert.Empty(WorkflowDefinitionValidator.Validate(definition));
+    }
+
+    [Fact]
+    public void Validate_RejectsChangeFeedTrigger_WithoutWatchedLayers()
+    {
+        var definition = BuildDefinition(("a", Empty)) with
+        {
+            Trigger = new WorkflowTrigger { Kind = WorkflowTriggerKind.ChangeFeed }
+        };
+
+        var failures = WorkflowDefinitionValidator.Validate(definition);
+
+        Assert.Contains(failures, f => f.Contains("at least one watched layer", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_RejectsChangeFeedTrigger_WithNegativeLayerId()
+    {
+        var definition = BuildDefinition(("a", Empty)) with
+        {
+            Trigger = new WorkflowTrigger
+            {
+                Kind = WorkflowTriggerKind.ChangeFeed,
+                WatchedLayerIds = [-1]
+            }
+        };
+
+        var failures = WorkflowDefinitionValidator.Validate(definition);
+
+        Assert.Contains(failures, f => f.Contains("non-negative", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_AcceptsObjectStoreTrigger_WithStoreId()
+    {
+        var definition = BuildDefinition(("a", Empty)) with
+        {
+            Trigger = new WorkflowTrigger
+            {
+                Kind = WorkflowTriggerKind.ObjectStore,
+                ObjectStore = new ObjectStoreTriggerConfig { StoreId = "drop", Prefix = "in/" }
+            }
+        };
+
+        Assert.Empty(WorkflowDefinitionValidator.Validate(definition));
+    }
+
+    [Fact]
+    public void Validate_RejectsObjectStoreTrigger_WithoutConfig()
+    {
+        var definition = BuildDefinition(("a", Empty)) with
+        {
+            Trigger = new WorkflowTrigger { Kind = WorkflowTriggerKind.ObjectStore }
+        };
+
+        var failures = WorkflowDefinitionValidator.Validate(definition);
+
+        Assert.Contains(failures, f => f.Contains("object-store configuration", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_RejectsObjectStoreTrigger_WithNonPositivePollInterval()
+    {
+        var definition = BuildDefinition(("a", Empty)) with
+        {
+            Trigger = new WorkflowTrigger
+            {
+                Kind = WorkflowTriggerKind.ObjectStore,
+                ObjectStore = new ObjectStoreTriggerConfig
+                {
+                    StoreId = "drop",
+                    PollInterval = TimeSpan.Zero
+                }
+            }
+        };
+
+        var failures = WorkflowDefinitionValidator.Validate(definition);
+
+        Assert.Contains(failures, f => f.Contains("poll interval must be positive", StringComparison.Ordinal));
+    }
+
     private static WorkflowDefinition BuildDefinition(params (string StepId, string[] DependsOn)[] steps)
     {
         var now = DateTimeOffset.UtcNow;

--- a/tests/dotnet/Honua.Server.Tests/Features/Orchestration/FakeOrchestrationFixtures.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Orchestration/FakeOrchestrationFixtures.cs
@@ -86,6 +86,8 @@ internal sealed class FakeWorkflowDefinitionStore : IWorkflowDefinitionStore
     private readonly ConcurrentDictionary<string, byte> _scheduleClaims = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, DateTimeOffset> _scheduleCursors = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, DateTimeOffset> _pendingScheduleCursors = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, string> _triggerCursors = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, byte> _triggerClaims = new(StringComparer.Ordinal);
 
     public Task<WorkflowDefinition?> GetAsync(string workflowId, CancellationToken cancellationToken = default)
         => Task.FromResult(_definitions.TryGetValue(workflowId, out var d) ? d : null);
@@ -208,6 +210,43 @@ internal sealed class FakeWorkflowDefinitionStore : IWorkflowDefinitionStore
     /// </summary>
     public void SeedScheduleCursor(string workflowId, DateTimeOffset cursor)
         => _scheduleCursors[workflowId] = cursor.ToUniversalTime();
+
+    public Task<IReadOnlyList<WorkflowDefinition>> ListEventTriggeredAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<WorkflowDefinition>>(
+            _definitions.Values
+                .Where(def => def.Trigger is { Enabled: true } trigger
+                              && trigger.Kind is WorkflowTriggerKind.ChangeFeed or WorkflowTriggerKind.ObjectStore)
+                .ToArray());
+
+    public Task<string?> GetTriggerCursorAsync(string workflowId, string cursorKind, CancellationToken cancellationToken = default)
+        => Task.FromResult(_triggerCursors.TryGetValue(TriggerKey(workflowId, cursorKind), out var marker) ? marker : null);
+
+    public Task SetTriggerCursorAsync(string workflowId, string cursorKind, string marker, CancellationToken cancellationToken = default)
+    {
+        _triggerCursors.AddOrUpdate(
+            TriggerKey(workflowId, cursorKind),
+            _ => marker,
+            (_, existing) => string.CompareOrdinal(existing, marker) >= 0 ? existing : marker);
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> TryClaimTriggerFireAsync(string workflowId, string cursorKind, string marker, TimeSpan retention, CancellationToken cancellationToken = default)
+    {
+        _ = retention;
+        return Task.FromResult(_triggerClaims.TryAdd(TriggerClaimKey(workflowId, cursorKind, marker), 0));
+    }
+
+    public Task ReleaseTriggerClaimAsync(string workflowId, string cursorKind, string marker, CancellationToken cancellationToken = default)
+    {
+        _triggerClaims.TryRemove(TriggerClaimKey(workflowId, cursorKind, marker), out _);
+        return Task.CompletedTask;
+    }
+
+    private static string TriggerKey(string workflowId, string cursorKind)
+        => string.Concat(cursorKind, ":", workflowId);
+
+    private static string TriggerClaimKey(string workflowId, string cursorKind, string marker)
+        => string.Concat(cursorKind, ":", workflowId, ":", marker);
 }
 
 internal sealed class FakeProgressStore : IUniversalProgressStore

--- a/tests/dotnet/Honua.Server.Tests/Features/Orchestration/FileSystemObjectStoreTriggerProbeTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Orchestration/FileSystemObjectStoreTriggerProbeTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Orchestration.Domain;
+using Honua.Server.Features.Orchestration;
+
+namespace Honua.Server.Tests.Features.Orchestration;
+
+public sealed class FileSystemObjectStoreTriggerProbeTests : IDisposable
+{
+    private readonly string _root;
+
+    public FileSystemObjectStoreTriggerProbeTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "honua-objstore-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private FileSystemObjectStoreTriggerProbe BuildProbe()
+        => new(new Dictionary<string, string>(StringComparer.Ordinal) { ["drop"] = _root });
+
+    private string Write(string relativePath, DateTimeOffset modified)
+    {
+        var full = Path.Combine(_root, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, "x");
+        File.SetLastWriteTimeUtc(full, modified.UtcDateTime);
+        return full;
+    }
+
+    [Fact]
+    public async Task ProbeNewestAsync_EmptyStore_ReturnsNull()
+    {
+        var result = await BuildProbe().ProbeNewestAsync(new ObjectStoreTriggerConfig { StoreId = "drop" });
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ProbeNewestAsync_UnregisteredStore_ReturnsNull()
+    {
+        var result = await BuildProbe().ProbeNewestAsync(new ObjectStoreTriggerConfig { StoreId = "missing" });
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ProbeNewestAsync_ReturnsNewestObjectByMarker()
+    {
+        Write("in/a.csv", new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero));
+        Write("in/b.csv", new DateTimeOffset(2026, 6, 3, 0, 0, 0, TimeSpan.Zero));
+        Write("in/c.csv", new DateTimeOffset(2026, 6, 2, 0, 0, 0, TimeSpan.Zero));
+
+        var result = await BuildProbe().ProbeNewestAsync(
+            new ObjectStoreTriggerConfig { StoreId = "drop", Prefix = "in" });
+
+        Assert.NotNull(result);
+        Assert.Equal("in/b.csv", result.Value.Key);
+    }
+
+    [Fact]
+    public async Task ProbeNewestAsync_NewObject_AdvancesMarker()
+    {
+        Write("in/a.csv", new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero));
+        var first = await BuildProbe().ProbeNewestAsync(
+            new ObjectStoreTriggerConfig { StoreId = "drop", Prefix = "in" });
+        Assert.NotNull(first);
+
+        Write("in/z.csv", new DateTimeOffset(2026, 6, 5, 0, 0, 0, TimeSpan.Zero));
+        var second = await BuildProbe().ProbeNewestAsync(
+            new ObjectStoreTriggerConfig { StoreId = "drop", Prefix = "in" });
+
+        Assert.NotNull(second);
+        // The newest marker must strictly advance when a newer object lands.
+        Assert.True(string.CompareOrdinal(second.Value.Marker, first.Value.Marker) > 0);
+        Assert.Equal("in/z.csv", second.Value.Key);
+    }
+
+    [Fact]
+    public async Task ProbeNewestAsync_PrefixEscapeAttempt_ReturnsNull()
+    {
+        var result = await BuildProbe().ProbeNewestAsync(
+            new ObjectStoreTriggerConfig { StoreId = "drop", Prefix = "../../etc" });
+
+        Assert.Null(result);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Orchestration/RedisSourceWatermarkStoreTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Orchestration/RedisSourceWatermarkStoreTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Migration.Watermark;
+using Honua.Server.Features.Orchestration;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using StackExchange.Redis;
+
+namespace Honua.Server.Tests.Features.Orchestration;
+
+/// <summary>
+/// Redis integration tests for the durable per-pipeline+source watermark store backing
+/// incremental ("changed-since") extraction.
+/// </summary>
+[Collection("Redis")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Import)]
+[Operation(Operations.TestInfrastructure)]
+public sealed class RedisSourceWatermarkStoreTests
+{
+    private readonly RedisFixture _redis;
+
+    public RedisSourceWatermarkStoreTests(RedisFixture redis)
+    {
+        _redis = redis;
+    }
+
+    private static SourceWatermark Mark(string pipeline, string source, DateTimeOffset? at, DateTimeOffset updated) => new()
+    {
+        PipelineId = pipeline,
+        SourceId = source,
+        Kind = WatermarkKind.EditTimestamp,
+        Value = at is { } v ? SourceWatermark.Encode(v) : null,
+        UpdatedAt = updated
+    };
+
+    [IntegrationTest]
+    public async Task Get_WhenNeverExtracted_ReturnsNull()
+    {
+        using var multiplexer = ConnectionMultiplexer.Connect(_redis.ConnectionString);
+        var store = new RedisSourceWatermarkStore(multiplexer);
+        var pipeline = $"wf-{Guid.NewGuid():N}";
+
+        var result = await store.GetAsync(pipeline, "src");
+
+        result.Should().BeNull();
+    }
+
+    [IntegrationTest]
+    public async Task Advance_PersistsAndReadsBackWatermark()
+    {
+        using var multiplexer = ConnectionMultiplexer.Connect(_redis.ConnectionString);
+        var store = new RedisSourceWatermarkStore(multiplexer);
+        var pipeline = $"wf-{Guid.NewGuid():N}";
+        var at = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+
+        await store.AdvanceAsync(Mark(pipeline, "src", at, at));
+
+        var stored = await store.GetAsync(pipeline, "src");
+        stored.Should().NotBeNull();
+        stored!.AsTimestamp().Should().Be(at);
+        stored.Kind.Should().Be(WatermarkKind.EditTimestamp);
+    }
+
+    [IntegrationTest]
+    public async Task Advance_IsMonotonic_NeverRewinds()
+    {
+        using var multiplexer = ConnectionMultiplexer.Connect(_redis.ConnectionString);
+        var store = new RedisSourceWatermarkStore(multiplexer);
+        var pipeline = $"wf-{Guid.NewGuid():N}";
+        var later = new DateTimeOffset(2026, 6, 10, 0, 0, 0, TimeSpan.Zero);
+        var earlier = new DateTimeOffset(2026, 6, 5, 0, 0, 0, TimeSpan.Zero);
+
+        await store.AdvanceAsync(Mark(pipeline, "src", later, later));
+
+        // A competing/out-of-order completion tries to set an earlier mark — must be ignored.
+        var effective = await store.AdvanceAsync(Mark(pipeline, "src", earlier, earlier));
+        effective.AsTimestamp().Should().Be(later);
+
+        var stored = await store.GetAsync(pipeline, "src");
+        stored!.AsTimestamp().Should().Be(later);
+    }
+
+    [IntegrationTest]
+    public async Task Advance_ResumesFromPersistedMark_AfterReopen()
+    {
+        var pipeline = $"wf-{Guid.NewGuid():N}";
+        var at = new DateTimeOffset(2026, 6, 7, 12, 0, 0, TimeSpan.Zero);
+
+        using (var multiplexerA = ConnectionMultiplexer.Connect(_redis.ConnectionString))
+        {
+            var storeA = new RedisSourceWatermarkStore(multiplexerA);
+            await storeA.AdvanceAsync(Mark(pipeline, "src", at, at));
+        }
+
+        // Simulate process restart: a fresh connection/store must resume from the durable mark.
+        using var multiplexerB = ConnectionMultiplexer.Connect(_redis.ConnectionString);
+        var storeB = new RedisSourceWatermarkStore(multiplexerB);
+        var resumed = await storeB.GetAsync(pipeline, "src");
+
+        resumed.Should().NotBeNull();
+        resumed!.AsTimestamp().Should().Be(at);
+    }
+
+    [IntegrationTest]
+    public async Task Clear_RemovesWatermark_NextPullIsFullScan()
+    {
+        using var multiplexer = ConnectionMultiplexer.Connect(_redis.ConnectionString);
+        var store = new RedisSourceWatermarkStore(multiplexer);
+        var pipeline = $"wf-{Guid.NewGuid():N}";
+        var at = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+
+        await store.AdvanceAsync(Mark(pipeline, "src", at, at));
+        await store.ClearAsync(pipeline, "src");
+
+        (await store.GetAsync(pipeline, "src")).Should().BeNull();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Orchestration/WorkflowEventTriggerBackgroundServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Orchestration/WorkflowEventTriggerBackgroundServiceTests.cs
@@ -1,0 +1,344 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Orchestration.Abstractions;
+using Honua.Core.Features.Orchestration.Domain;
+using Honua.Server.Features.Orchestration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Features.Orchestration;
+
+public sealed class WorkflowEventTriggerBackgroundServiceTests
+{
+    private static readonly DateTimeOffset Start = new(2026, 4, 16, 12, 0, 0, TimeSpan.Zero);
+
+    // ---------------- Change-feed trigger ----------------
+
+    [Fact]
+    public async Task TickAsync_ChangeFeed_FiresRun_WhenGenerationAdvances()
+    {
+        var harness = new EventTriggerHarness(Start);
+        var definition = BuildChangeFeedDefinition("wf-cdc", watchedLayers: [7]);
+        await harness.Definitions.TryCreateAsync(definition);
+
+        harness.ChangeFeed.LatestGeneration = 42;
+
+        await harness.Service.TickAsync(CancellationToken.None);
+
+        var runs = await harness.RunStore.ListActiveAsync();
+        Assert.Single(runs);
+        Assert.Equal(WorkflowTriggerKind.ChangeFeed, runs[0].TriggerKind);
+        Assert.Equal("42", runs[0].Metadata["trigger.change_feed.generation"]);
+    }
+
+    [Fact]
+    public async Task TickAsync_ChangeFeed_DoesNotFire_WhenNoGenerationAdvance()
+    {
+        var harness = new EventTriggerHarness(Start);
+        var definition = BuildChangeFeedDefinition("wf-cdc", watchedLayers: [7]);
+        await harness.Definitions.TryCreateAsync(definition);
+
+        // Probe reports no advance (null).
+        harness.ChangeFeed.LatestGeneration = null;
+
+        await harness.Service.TickAsync(CancellationToken.None);
+
+        Assert.Empty(await harness.RunStore.ListActiveAsync());
+    }
+
+    [Fact]
+    public async Task TickAsync_ChangeFeed_DoesNotRefire_WhenGenerationUnchanged()
+    {
+        var harness = new EventTriggerHarness(Start);
+        var definition = BuildChangeFeedDefinition("wf-cdc", watchedLayers: [7]);
+        await harness.Definitions.TryCreateAsync(definition);
+
+        harness.ChangeFeed.LatestGeneration = 42;
+        await harness.Service.TickAsync(CancellationToken.None);
+        Assert.Single(harness.RunStore.Snapshot);
+
+        // Same generation on the next tick must not fire again. The probe is invoked with the
+        // advanced cursor (since=42), so it reports no further advance.
+        harness.ChangeFeed.LatestGeneration = 42;
+        await harness.Service.TickAsync(CancellationToken.None);
+
+        Assert.Single(harness.RunStore.Snapshot);
+    }
+
+    [Fact]
+    public async Task TickAsync_ChangeFeed_FiresAgain_OnFurtherAdvance()
+    {
+        var harness = new EventTriggerHarness(Start);
+        var definition = BuildChangeFeedDefinition("wf-cdc", watchedLayers: [7]);
+        await harness.Definitions.TryCreateAsync(definition);
+
+        harness.ChangeFeed.LatestGeneration = 42;
+        await harness.Service.TickAsync(CancellationToken.None);
+
+        harness.ChangeFeed.LatestGeneration = 50;
+        await harness.Service.TickAsync(CancellationToken.None);
+
+        Assert.Equal(2, harness.RunStore.Snapshot.Count);
+        var generations = harness.RunStore.Snapshot
+            .Select(r => r.Metadata["trigger.change_feed.generation"])
+            .ToArray();
+        Assert.Contains("42", generations);
+        Assert.Contains("50", generations);
+    }
+
+    [Fact]
+    public async Task TickAsync_ChangeFeed_HaSingleFire_AcrossTwoReplicas()
+    {
+        // Two replicas share one durable definition store (the HA fire-claim lives there).
+        var definitionStore = new FakeWorkflowDefinitionStore();
+        var runStore = new FakeWorkflowRunStore();
+        var definition = BuildChangeFeedDefinition("wf-cdc", watchedLayers: [7]);
+        await definitionStore.TryCreateAsync(definition);
+
+        var replicaA = BuildReplica(definitionStore, runStore, latestGeneration: 99);
+        var replicaB = BuildReplica(definitionStore, runStore, latestGeneration: 99);
+
+        // Both replicas tick for the same generation; only one may create a run.
+        await Task.WhenAll(
+            replicaA.TickAsync(CancellationToken.None),
+            replicaB.TickAsync(CancellationToken.None));
+
+        Assert.Single(runStore.Snapshot);
+    }
+
+    [Fact]
+    public async Task TickAsync_ChangeFeed_SkipsDisabledTrigger()
+    {
+        var harness = new EventTriggerHarness(Start);
+        var definition = BuildChangeFeedDefinition("wf-cdc", watchedLayers: [7]) with
+        {
+            Trigger = new WorkflowTrigger
+            {
+                Kind = WorkflowTriggerKind.ChangeFeed,
+                WatchedLayerIds = [7],
+                Enabled = false
+            }
+        };
+        Assert.False(definition.Trigger!.Enabled);
+        await harness.Definitions.TryCreateAsync(definition);
+
+        harness.ChangeFeed.LatestGeneration = 42;
+        await harness.Service.TickAsync(CancellationToken.None);
+
+        Assert.Empty(await harness.RunStore.ListActiveAsync());
+    }
+
+    [Fact]
+    public async Task TickAsync_ChangeFeed_RetriesSameGeneration_OnTransientCreateFailure()
+    {
+        var harness = new EventTriggerHarness(Start);
+        var definition = BuildChangeFeedDefinition("wf-cdc", watchedLayers: [7]);
+        await harness.Definitions.TryCreateAsync(definition);
+
+        harness.ChangeFeed.LatestGeneration = 42;
+        harness.RunStore.NextTryCreateFailure = new InvalidOperationException("transient blip");
+
+        await harness.Service.TickAsync(CancellationToken.None);
+        Assert.Empty(harness.RunStore.Snapshot);
+
+        // The cursor must not have advanced; the claim is released so the next tick retries.
+        var cursor = await harness.Definitions.GetTriggerCursorAsync(
+            definition.WorkflowId, RedisWorkflowDefinitionStore.ChangeFeedCursorKind);
+        Assert.Null(cursor);
+
+        await harness.Service.TickAsync(CancellationToken.None);
+        Assert.Single(harness.RunStore.Snapshot);
+    }
+
+    // ---------------- Object-store trigger ----------------
+
+    [Fact]
+    public async Task TickAsync_ObjectStore_FiresRun_WhenNewObjectLandsAfterSeed()
+    {
+        var harness = new EventTriggerHarness(Start);
+        var definition = BuildObjectStoreDefinition("wf-obj", storeId: "drop", prefix: "in/");
+        await harness.Definitions.TryCreateAsync(definition);
+
+        // First tick seeds the cursor with the existing newest object — no fire (avoids backlog stampede).
+        harness.ObjectStore.Newest = new ObjectStoreProbeResult
+        {
+            Key = "in/a.csv",
+            LastModified = Start
+        };
+        await harness.Service.TickAsync(CancellationToken.None);
+        Assert.Empty(harness.RunStore.Snapshot);
+
+        // A new object lands after the seed → fire.
+        harness.ObjectStore.Newest = new ObjectStoreProbeResult
+        {
+            Key = "in/b.csv",
+            LastModified = Start.AddMinutes(1)
+        };
+        await harness.Service.TickAsync(CancellationToken.None);
+
+        var run = Assert.Single(harness.RunStore.Snapshot);
+        Assert.Equal(WorkflowTriggerKind.ObjectStore, run.TriggerKind);
+        Assert.Equal("in/b.csv", run.Metadata["trigger.object_store.key"]);
+    }
+
+    [Fact]
+    public async Task TickAsync_ObjectStore_DoesNotFire_WhenNoNewObject()
+    {
+        var harness = new EventTriggerHarness(Start);
+        var definition = BuildObjectStoreDefinition("wf-obj", storeId: "drop", prefix: "in/");
+        await harness.Definitions.TryCreateAsync(definition);
+
+        var existing = new ObjectStoreProbeResult { Key = "in/a.csv", LastModified = Start };
+        harness.ObjectStore.Newest = existing;
+        await harness.Service.TickAsync(CancellationToken.None); // seed
+
+        // Same newest object on the next tick → no fire.
+        harness.ObjectStore.Newest = existing;
+        await harness.Service.TickAsync(CancellationToken.None);
+
+        Assert.Empty(harness.RunStore.Snapshot);
+    }
+
+    [Fact]
+    public async Task TickAsync_ObjectStore_DoesNotFire_WhenStoreEmpty()
+    {
+        var harness = new EventTriggerHarness(Start);
+        var definition = BuildObjectStoreDefinition("wf-obj", storeId: "drop", prefix: "in/");
+        await harness.Definitions.TryCreateAsync(definition);
+
+        harness.ObjectStore.Newest = null; // empty store/prefix
+        await harness.Service.TickAsync(CancellationToken.None);
+
+        Assert.Empty(harness.RunStore.Snapshot);
+    }
+
+    // ---------------- Helpers ----------------
+
+    private static WorkflowEventTriggerBackgroundService BuildReplica(
+        FakeWorkflowDefinitionStore definitions,
+        FakeWorkflowRunStore runStore,
+        long? latestGeneration)
+    {
+        var clock = new TestClock(Start);
+        var engine = new WorkflowOrchestrationEngine(
+            runStore, definitions, new FakeWorkflowJobExecutor(), new FakeProgressStore(), clock,
+            NullLogger<WorkflowOrchestrationEngine>.Instance);
+        return new WorkflowEventTriggerBackgroundService(
+            definitions,
+            engine,
+            new FakeChangeFeedProbe { LatestGeneration = latestGeneration },
+            new FakeObjectStoreProbe(),
+            clock,
+            NullLogger<WorkflowEventTriggerBackgroundService>.Instance);
+    }
+
+    private static WorkflowDefinition BuildChangeFeedDefinition(string id, IReadOnlyList<int> watchedLayers)
+        => BuildBaseDefinition(id) with
+        {
+            Trigger = new WorkflowTrigger
+            {
+                Kind = WorkflowTriggerKind.ChangeFeed,
+                WatchedLayerIds = watchedLayers,
+                Enabled = true
+            }
+        };
+
+    private static WorkflowDefinition BuildObjectStoreDefinition(string id, string storeId, string prefix)
+        => BuildBaseDefinition(id) with
+        {
+            Trigger = new WorkflowTrigger
+            {
+                Kind = WorkflowTriggerKind.ObjectStore,
+                ObjectStore = new ObjectStoreTriggerConfig
+                {
+                    StoreId = storeId,
+                    Prefix = prefix
+                },
+                Enabled = true
+            }
+        };
+
+    private static WorkflowDefinition BuildBaseDefinition(string id) => new()
+    {
+        WorkflowId = id,
+        Name = "event-triggered",
+        Steps = new[]
+        {
+            new WorkflowStepDefinition
+            {
+                StepId = "a",
+                Plan = new AnalysisPlan
+                {
+                    PlanId = "plan-a",
+                    IntentId = "intent-a",
+                    Steps = new[]
+                    {
+                        new AnalysisPlanStep
+                        {
+                            StepId = "ap",
+                            Kind = AnalysisPlanStepKind.Geoprocess,
+                            ProcessId = "noop"
+                        }
+                    }
+                }
+            }
+        },
+        CreatedAt = Start,
+        UpdatedAt = Start
+    };
+
+    private sealed class EventTriggerHarness
+    {
+        public EventTriggerHarness(DateTimeOffset start)
+        {
+            RunStore = new FakeWorkflowRunStore();
+            Definitions = new FakeWorkflowDefinitionStore();
+            ChangeFeed = new FakeChangeFeedProbe();
+            ObjectStore = new FakeObjectStoreProbe();
+            Clock = new TestClock(start);
+            Engine = new WorkflowOrchestrationEngine(
+                RunStore, Definitions, new FakeWorkflowJobExecutor(), new FakeProgressStore(), Clock,
+                NullLogger<WorkflowOrchestrationEngine>.Instance);
+            Service = new WorkflowEventTriggerBackgroundService(
+                Definitions, Engine, ChangeFeed, ObjectStore, Clock,
+                NullLogger<WorkflowEventTriggerBackgroundService>.Instance);
+        }
+
+        public FakeWorkflowRunStore RunStore { get; }
+        public FakeWorkflowDefinitionStore Definitions { get; }
+        public FakeChangeFeedProbe ChangeFeed { get; }
+        public FakeObjectStoreProbe ObjectStore { get; }
+        public TestClock Clock { get; }
+        public WorkflowOrchestrationEngine Engine { get; }
+        public WorkflowEventTriggerBackgroundService Service { get; }
+    }
+
+    private sealed class FakeChangeFeedProbe : IChangeFeedGenerationProbe
+    {
+        public long? LatestGeneration { get; set; }
+
+        public Task<long?> GetLatestGenerationAsync(
+            long sinceGeneration,
+            IReadOnlyList<int> watchedLayerIds,
+            CancellationToken cancellationToken = default)
+        {
+            if (LatestGeneration is { } latest && latest > sinceGeneration)
+            {
+                return Task.FromResult<long?>(latest);
+            }
+
+            return Task.FromResult<long?>(null);
+        }
+    }
+
+    private sealed class FakeObjectStoreProbe : IObjectStoreTriggerProbe
+    {
+        public ObjectStoreProbeResult? Newest { get; set; }
+
+        public Task<ObjectStoreProbeResult?> ProbeNewestAsync(
+            ObjectStoreTriggerConfig config,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Newest);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
No tracking issue — net-new ETL trigger capability.

## Summary
ETL workflow triggers were Manual + Cron only. This adds event/CDC and incremental-extract capability to the orchestration scheduler while leaving Manual + Cron unchanged:

- **Change-feed (CDC) trigger** wires the existing `IChangeTracker` / `feature_changes` generation cursor into the workflow scheduler as a new trigger kind. A workflow fires when a watched layer's change generation advances past a durable cursor, reusing the same distributed fire-claim the cron scheduler uses (HA-safe, no duplicate fires across replicas).
- **Watermark / incremental ("changed-since") extract** persists a per-pipeline+source high-water mark and translates it into source-specific pull filters (Esri `lastEditDate` epoch-ms predicate, OGC/WFS half-open temporal `datetime`, file mtime). The mark advances only on success and is monotonic, so a failed/interrupted run resumes from the last durable mark instead of re-scanning.
- **Object-store / file-watcher trigger** fires when a new object lands under a watched prefix. The baseline is a poll-based file-system probe whose result shape (`ObjectStoreProbeResult` monotonic marker) lets an S3/event push replace the poll later without changing scheduler dispatch.

## Changes Made
- Added `WorkflowTriggerKind.ChangeFeed` and `WorkflowTriggerKind.ObjectStore`; extended `WorkflowTrigger` (`WatchedLayerIds`, `ObjectStoreTriggerConfig`) and `WorkflowDefinitionValidator` with per-kind validation.
- Added durable event-trigger cursor + fire-claim methods to `IWorkflowDefinitionStore` and implemented them in `RedisWorkflowDefinitionStore` (move-forward-only cursor, hashed per-marker claim keys with TTL).
- Added `IChangeFeedGenerationProbe` (Core) + `ChangeTrackerGenerationProbe` (Server, scope-resolves the scoped `IChangeTracker`).
- Added `IObjectStoreTriggerProbe` + `FileSystemObjectStoreTriggerProbe` poll baseline (prefix-escape guarded).
- Added `WorkflowEventTriggerBackgroundService`: per-tick evaluation of change-feed + object-store triggers with claim → create-run → advance-cursor, transient-failure release/retry, and first-observation seed for object-store (no backlog stampede).
- Added watermark feature: `SourceWatermark`, `WatermarkKind`, `ISourceWatermarkStore`, `WatermarkExtractPlanner` (Core) + monotonic Redis-backed `RedisSourceWatermarkStore` (Server, optimistic CAS, source-gen JSON).
- DI: registered probes, watermark store, and the new hosted service; object-store roots read AOT-safely from `Orchestration:ObjectStoreTriggers:Roots:<storeId>`.
- Tests: validator (new kinds), `WatermarkExtractPlanner`, event-trigger background service (fires-on-advance / not-otherwise / HA-single-fire / transient-retry / object-store seed+fire), file-system probe, Redis watermark store (persist/monotonic/resume/clear).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Tests added for new functionality
