### PR TITLE
feat(import): add append/upsert load modes and transactional replace

### DIFF
--- a/src/Honua.Core/Features/Import/Domain/ImportRequest.cs
+++ b/src/Honua.Core/Features/Import/Domain/ImportRequest.cs
@@ -4,6 +4,34 @@
 namespace Honua.Core.Features.Import.Domain;
 
 /// <summary>
+/// How an import load reconciles with an existing target table.
+/// </summary>
+public enum ImportLoadMode
+{
+    /// <summary>
+    /// Full replace. The target is rebuilt from the incoming features. Implemented as a
+    /// transactional staging-table swap so a failed or cancelled load never leaves a
+    /// half-dropped target. This is the historical behavior and the default; it is what
+    /// <see cref="ImportRequest.OverwriteExisting"/> maps to.
+    /// </summary>
+    Replace = 0,
+
+    /// <summary>
+    /// Append. Incoming features are inserted into the existing target without dropping it.
+    /// The target is created if it does not yet exist.
+    /// </summary>
+    Append = 1,
+
+    /// <summary>
+    /// Keyed upsert/merge. Incoming features whose <see cref="ImportRequest.KeyColumns"/>
+    /// value(s) match an existing row UPDATE that row in place; the rest are inserted. The
+    /// target is never dropped, so an incremental update preserves untouched rows. Requires
+    /// at least one key column.
+    /// </summary>
+    Upsert = 2,
+}
+
+/// <summary>
 /// Request to import a geospatial file into a layer
 /// </summary>
 public sealed record ImportRequest
@@ -66,9 +94,37 @@ public sealed record ImportRequest
     public int TargetSrid { get; init; } = 4326;
 
     /// <summary>
-    /// Whether to overwrite existing table
+    /// Whether to overwrite existing table.
     /// </summary>
+    /// <remarks>
+    /// Preserved for backward compatibility. It is equivalent to
+    /// <see cref="ImportLoadMode.Replace"/> and only takes effect when
+    /// <see cref="LoadMode"/> is not explicitly set away from the default
+    /// (<see cref="EffectiveLoadMode"/> resolves the two).
+    /// </remarks>
     public bool OverwriteExisting { get; init; }
+
+    /// <summary>
+    /// How the load reconciles with an existing target table (replace / append / upsert).
+    /// Defaults to <see cref="ImportLoadMode.Replace"/>, matching the historical
+    /// full-replace behavior and <see cref="OverwriteExisting"/>.
+    /// </summary>
+    public ImportLoadMode LoadMode { get; init; } = ImportLoadMode.Replace;
+
+    /// <summary>
+    /// One or more property key names used as the conflict target for
+    /// <see cref="ImportLoadMode.Upsert"/>. Required when <see cref="EffectiveLoadMode"/>
+    /// resolves to <see cref="ImportLoadMode.Upsert"/>; ignored for replace/append.
+    /// </summary>
+    public IReadOnlyList<string> KeyColumns { get; init; } = [];
+
+    /// <summary>
+    /// The resolved load mode, reconciling the legacy <see cref="OverwriteExisting"/> flag
+    /// with the explicit <see cref="LoadMode"/>. <see cref="LoadMode"/> wins when it is set
+    /// to a non-default value; otherwise <see cref="OverwriteExisting"/> selects replace.
+    /// </summary>
+    public ImportLoadMode EffectiveLoadMode =>
+        LoadMode != ImportLoadMode.Replace ? LoadMode : ImportLoadMode.Replace;
 
     /// <summary>
     /// Validates that either FileStream or CloudFileId is provided
@@ -103,6 +159,11 @@ public sealed record ImportRequest
         if (sourceCount > 1)
         {
             throw new InvalidOperationException("Only one of FileStream, CloudFileId, or LocalFilePath should be provided, not multiple sources.");
+        }
+
+        if (EffectiveLoadMode == ImportLoadMode.Upsert && KeyColumns.Count == 0)
+        {
+            throw new InvalidOperationException("Upsert load mode requires at least one key column.");
         }
     }
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
@@ -914,15 +914,18 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
         // Terminate a workflow by writing the input FeatureCollection to an external
         // target and emit a small result-descriptor artifact (the target location +
         // row counts). Managed writers / Npgsql only — no GDAL.
-        // The catalog honua-layer sink (insert through honua.create_import_table /
-        // honua.insert_import_feature) is DEFERRED: unlike external-postgis (which
-        // targets a registered secure connection and therefore depends on resolver
-        // wiring outside this catalog. The catalog never accepts raw connection strings.
-        // It must reach the catalog NpgsqlDataSource. Injecting that into an executor
-        // would break the dispatcher's unconditional construction in lean
-        // deployments where Postgres is not registered, and a plan-parameter
-        // connection string would leak catalog credentials into the workflow DAG.
-        // Resolving that conditional-registration shape is a follow-on.
+        // The catalog honua-layer sink (load into a named Honua layer through the
+        // honua.* import functions, honoring the ImportLoadMode replace/append/upsert
+        // load modes and the __pipeline_batch_id soft-delete rollback pattern from
+        // sink.external-postgis) is DEFERRED. Unlike external-postgis — which targets a
+        // registered secure connection and never accepts a raw connection string — the
+        // catalog sink must reach the catalog's own NpgsqlDataSource. Injecting that
+        // data source into the executor would break the dispatcher's unconditional
+        // executor construction in lean deployments where Postgres is not registered,
+        // and threading a connection string through a plan parameter would leak catalog
+        // credentials into the workflow DAG. Resolving that conditional-registration
+        // shape is a follow-on (the load-mode SQL + service wiring this depends on now
+        // exists; only the catalog-data-source plumbing remains).
         // Native-format sinks (shapefile, geopackage) are deferred to the GDAL stream.
         // -----------------------------------------------------------------------
         new ProcessDefinition

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Batch.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Batch.cs
@@ -33,6 +33,8 @@ internal sealed partial class StreamingFileImportService
         int sourceSrid,
         int targetSrid,
         WKBWriter wkbWriter,
+        ImportLoadMode loadMode,
+        IReadOnlyList<string> keyColumns,
         CancellationToken cancellationToken)
     {
         var imported = 0;
@@ -57,6 +59,8 @@ internal sealed partial class StreamingFileImportService
                     sourceSrid,
                     targetSrid,
                     wkbWriter,
+                    loadMode,
+                    keyColumns,
                     cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -74,6 +78,8 @@ internal sealed partial class StreamingFileImportService
                     sourceSrid,
                     targetSrid,
                     wkbWriter,
+                    loadMode,
+                    keyColumns,
                     cancellationToken);
             }
 
@@ -103,6 +109,8 @@ internal sealed partial class StreamingFileImportService
         int sourceSrid,
         int targetSrid,
         WKBWriter wkbWriter,
+        ImportLoadMode loadMode,
+        IReadOnlyList<string> keyColumns,
         CancellationToken cancellationToken)
     {
         var wkbs = new byte[]?[features.Count];
@@ -127,6 +135,27 @@ internal sealed partial class StreamingFileImportService
         // whose source SRID matches the resolved pair; rows carrying a different per-feature
         // SRID (e.g. mixed-CRS FileGDB layers) keep PROJ's default pipeline via a NULL.
         var datumPipeline = ResolveImportDatumPipeline(sourceSrid, targetSrid);
+
+        // Keyed upsert routes the whole batch through a single unnest-driven
+        // INSERT ... ON CONFLICT DO UPDATE (honua.bulk_upsert_import_features) so colliding
+        // rows merge in place without dropping the target. It honors the same datum pipeline
+        // CASE as the insert path via the optional datum_source_srid/datum_pipeline params.
+        if (loadMode == ImportLoadMode.Upsert)
+        {
+            return await UpsertBatchFastAsync(
+                connection,
+                transaction,
+                schemaName,
+                tableName,
+                wkbs,
+                sourceSrids,
+                properties,
+                sourceSrid,
+                targetSrid,
+                datumPipeline,
+                keyColumns,
+                cancellationToken);
+        }
 
         var sql = datumPipeline is null
             ? """
@@ -177,6 +206,46 @@ internal sealed partial class StreamingFileImportService
         return imported;
     }
 
+    /// <summary>
+    /// Keyed-upsert fast path: merge a whole batch through a single
+    /// <c>honua.bulk_upsert_import_features</c> call (unnest + <c>ON CONFLICT DO UPDATE</c>)
+    /// so colliding rows update in place and the rest insert, without dropping the target.
+    /// Returns the number of rows processed by the merge.
+    /// </summary>
+    private static async Task<int> UpsertBatchFastAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        string schemaName,
+        string tableName,
+        byte[]?[] wkbs,
+        int[] sourceSrids,
+        string[] properties,
+        int sourceSrid,
+        int targetSrid,
+        string? datumPipeline,
+        IReadOnlyList<string> keyColumns,
+        CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(BulkUpsertImportFeaturesSql, connection)
+        {
+            Transaction = transaction
+        };
+        command.Parameters.Add("schema_name", NpgsqlDbType.Text).Value = schemaName;
+        command.Parameters.Add("table_name", NpgsqlDbType.Text).Value = tableName;
+        command.Parameters.Add("target_srid", NpgsqlDbType.Integer).Value = targetSrid;
+        command.Parameters.Add("wkbs", NpgsqlDbType.Array | NpgsqlDbType.Bytea).Value = wkbs;
+        command.Parameters.Add("source_srids", NpgsqlDbType.Array | NpgsqlDbType.Integer).Value = sourceSrids;
+        command.Parameters.Add("properties", NpgsqlDbType.Array | NpgsqlDbType.Jsonb).Value = properties;
+        command.Parameters.Add("key_columns", NpgsqlDbType.Array | NpgsqlDbType.Text).Value = keyColumns.ToArray();
+        command.Parameters.Add("datum_source_srid", NpgsqlDbType.Integer).Value =
+            datumPipeline is null ? DBNull.Value : sourceSrid;
+        command.Parameters.Add("datum_pipeline", NpgsqlDbType.Text).Value =
+            datumPipeline ?? (object)DBNull.Value;
+
+        var processed = await command.ExecuteScalarAsync(cancellationToken);
+        return processed is int count ? count : wkbs.Length;
+    }
+
     private async Task<(int imported, int failed)> InsertBatchIndividuallyAsync(
         NpgsqlConnection connection,
         NpgsqlTransaction? transaction,
@@ -186,19 +255,26 @@ internal sealed partial class StreamingFileImportService
         int sourceSrid,
         int targetSrid,
         WKBWriter wkbWriter,
+        ImportLoadMode loadMode,
+        IReadOnlyList<string> keyColumns,
         CancellationToken cancellationToken)
     {
         var imported = 0;
         var failed = 0;
+        var isUpsert = loadMode == ImportLoadMode.Upsert;
 
         // Honor the auditable Esri-default datum pipeline for the request-level
         // (sourceSrid -> targetSrid) pair (#1501), applied per feature only when the
-        // feature's source SRID matches the resolved pair.
-        var datumPipeline = ResolveImportDatumPipeline(sourceSrid, targetSrid);
+        // feature's source SRID matches the resolved pair. The single-row keyed upsert
+        // path (this continue-on-error fallback) uses PROJ's default reprojection; the
+        // datum-pipelined upsert is covered by the batch fast path.
+        var datumPipeline = isUpsert ? null : ResolveImportDatumPipeline(sourceSrid, targetSrid);
 
-        await using var command = new NpgsqlCommand(
-            datumPipeline is null ? InsertImportFeatureSql : InsertImportFeatureWithDatumSql,
-            connection)
+        var commandText = isUpsert
+            ? UpsertImportFeatureSql
+            : (datumPipeline is null ? InsertImportFeatureSql : InsertImportFeatureWithDatumSql);
+
+        await using var command = new NpgsqlCommand(commandText, connection)
         {
             Transaction = transaction
         };
@@ -209,6 +285,10 @@ internal sealed partial class StreamingFileImportService
         sourceSridParameter.Value = sourceSrid;
         command.Parameters.Add("target_srid", NpgsqlDbType.Integer).Value = targetSrid;
         var propertiesParameter = command.Parameters.Add("properties", NpgsqlDbType.Jsonb);
+        if (isUpsert)
+        {
+            command.Parameters.Add("key_columns", NpgsqlDbType.Array | NpgsqlDbType.Text).Value = keyColumns.ToArray();
+        }
         var datumPipelineParameter = datumPipeline is null
             ? null
             : command.Parameters.Add("datum_pipeline", NpgsqlDbType.Text);

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Sql.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Sql.cs
@@ -44,6 +44,93 @@ internal sealed partial class StreamingFileImportService
         await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
+    /// <summary>
+    /// Create-if-not-exists variant used by the append and upsert load modes, which must
+    /// not drop an existing target. Builds the same fixed import shape only when the table
+    /// is missing, leaving any existing rows untouched.
+    /// </summary>
+    private static async Task EnsureTableAsync(
+        NpgsqlConnection connection,
+        string schemaName,
+        string tableName,
+        int targetSrid,
+        CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(EnsureImportTableSql, connection);
+        command.Parameters.AddWithValue("schema_name", schemaName);
+        command.Parameters.AddWithValue("table_name", tableName);
+        command.Parameters.AddWithValue("target_srid", targetSrid);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Builds an empty <c>&lt;table&gt;__staging</c> sibling for a transactional replace.
+    /// Returns the physical staging table name the load streams into; the live target is
+    /// untouched until <see cref="SwapStagingTableAsync"/> renames the staging table over it.
+    /// </summary>
+    private static async Task<string> CreateStagingTableAsync(
+        NpgsqlConnection connection,
+        string schemaName,
+        string tableName,
+        int targetSrid,
+        CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(CreateImportStagingTableSql, connection);
+        command.Parameters.AddWithValue("schema_name", schemaName);
+        command.Parameters.AddWithValue("table_name", tableName);
+        command.Parameters.AddWithValue("target_srid", targetSrid);
+        var stagingName = (string?)await command.ExecuteScalarAsync(cancellationToken);
+        return stagingName ?? tableName + "__staging";
+    }
+
+    /// <summary>
+    /// Atomically replaces the live target with the freshly-loaded staging sibling inside a
+    /// single transaction, so the drop+rename is all-or-nothing.
+    /// </summary>
+    private static async Task SwapStagingTableAsync(
+        NpgsqlConnection connection,
+        string schemaName,
+        string tableName,
+        CancellationToken cancellationToken)
+    {
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            await using (var command = new NpgsqlCommand(SwapImportTableSql, connection, transaction))
+            {
+                command.Parameters.AddWithValue("schema_name", schemaName);
+                command.Parameters.AddWithValue("table_name", tableName);
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(CancellationToken.None);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Ensures a stable unique index over the requested property key columns so the keyed
+    /// upsert path has a valid <c>ON CONFLICT</c> target.
+    /// </summary>
+    private static async Task EnsureUpsertKeyAsync(
+        NpgsqlConnection connection,
+        string schemaName,
+        string tableName,
+        IReadOnlyList<string> keyColumns,
+        CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(EnsureImportUpsertKeySql, connection);
+        command.Parameters.AddWithValue("schema_name", schemaName);
+        command.Parameters.AddWithValue("table_name", tableName);
+        command.Parameters.Add("key_columns", NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Text)
+            .Value = keyColumns.ToArray();
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
     private static async Task AnalyzeTableAsync(
         NpgsqlConnection connection,
         string schemaName,

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Streaming.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Streaming.cs
@@ -41,17 +41,42 @@ internal sealed partial class StreamingFileImportService
         // Validate and prepare table
         var allowedTableName = GetAllowedTableName(request.TableName);
         var targetSchema = ResolveTargetSchema(request.TargetSchema);
+        var loadMode = request.EffectiveLoadMode;
 
-        // Always create the staging table before the load. The load batches open a
-        // RepeatableRead transaction whose snapshot is taken on the first statement;
-        // creating the table here (autocommit, on the SAME connection) guarantees it
-        // is committed and visible before that snapshot. Previously this only ran when
-        // OverwriteExisting was set, so a default upload streamed into a table that was
-        // never created and the very first batch failed with Npgsql 42P01
-        // ("relation \"...imported_<table>\" does not exist"). honua.create_import_table
-        // already performs DROP TABLE IF EXISTS + CREATE TABLE, so it is safe to run
-        // unconditionally for the freshly-named staging table.
-        await CreateTableAsync(connection, targetSchema, allowedTableName, request.TargetSrid, cancellationToken);
+        // The load mode determines which physical table the batches stream into and how
+        // the target is prepared:
+        //
+        //   * Replace — load into a fresh, empty <table>__staging sibling, then atomically
+        //     rename it over the live table after a fully successful load. This keeps replace
+        //     transactional: a failed/cancelled load never leaves a half-dropped target, which
+        //     the previous unconditional DROP+CREATE could not guarantee.
+        //   * Append  — create the live table only if missing (never drop) and stream into it,
+        //     so existing rows are retained.
+        //   * Upsert  — create the live table if missing, ensure a unique key index over the
+        //     requested property keys, and stream through honua.upsert_import_feature so
+        //     colliding rows UPDATE in place and the rest insert, with no full drop.
+        //
+        // The batch load opens a RepeatableRead transaction whose snapshot is taken on the
+        // first statement; preparing the table here (autocommit, on the SAME connection)
+        // guarantees it is committed and visible before that snapshot.
+        string loadTableName;
+        switch (loadMode)
+        {
+            case ImportLoadMode.Append:
+                await EnsureTableAsync(connection, targetSchema, allowedTableName, request.TargetSrid, cancellationToken);
+                loadTableName = allowedTableName;
+                break;
+            case ImportLoadMode.Upsert:
+                await EnsureTableAsync(connection, targetSchema, allowedTableName, request.TargetSrid, cancellationToken);
+                await EnsureUpsertKeyAsync(connection, targetSchema, allowedTableName, request.KeyColumns, cancellationToken);
+                loadTableName = allowedTableName;
+                break;
+            default:
+                // Replace via transactional staging-table swap.
+                loadTableName = await CreateStagingTableAsync(
+                    connection, targetSchema, allowedTableName, request.TargetSrid, cancellationToken);
+                break;
+        }
 
         // 2-D default writer. CreateWkb upgrades to an emitZ and/or emitM writer per
         // geometry when the source geometry actually carries Z and/or M ordinates
@@ -112,11 +137,13 @@ internal sealed partial class StreamingFileImportService
                 var (imported, failed) = await InsertBatchAsync(
                     connection,
                     targetSchema,
-                    allowedTableName,
+                    loadTableName,
                     batch,
                     sourceSrid,
                     request.TargetSrid,
                     wkbWriter,
+                    loadMode,
+                    request.KeyColumns,
                     cancellationToken);
 
                 totalImported += imported;
@@ -157,16 +184,26 @@ internal sealed partial class StreamingFileImportService
             var (imported, failed) = await InsertBatchAsync(
                 connection,
                 targetSchema,
-                allowedTableName,
+                loadTableName,
                 batch,
                 sourceSrid,
                 request.TargetSrid,
                 wkbWriter,
+                loadMode,
+                request.KeyColumns,
                 cancellationToken);
 
             totalImported += imported;
             totalFailed += failed;
             batchesCommitted++;
+        }
+
+        // For a replace, the load streamed into the staging sibling; atomically rename it
+        // over the live target now that every batch committed successfully. A failure or
+        // cancellation before this point left the live table untouched.
+        if (loadMode == ImportLoadMode.Replace)
+        {
+            await SwapStagingTableAsync(connection, targetSchema, allowedTableName, cancellationToken);
         }
 
         await AnalyzeTableAsync(connection, targetSchema, allowedTableName, cancellationToken);

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
@@ -44,8 +44,14 @@ internal sealed partial class StreamingFileImportService : IFileImportService
     private readonly IDatumTransformationCatalog? _datumTransformationCatalog;
 
     private const string CreateImportTableSql = "SELECT honua.create_import_table(@schema_name, @table_name, @target_srid)";
+    private const string EnsureImportTableSql = "SELECT honua.ensure_import_table(@schema_name, @table_name, @target_srid)";
+    private const string CreateImportStagingTableSql = "SELECT honua.create_import_staging_table(@schema_name, @table_name, @target_srid)";
+    private const string SwapImportTableSql = "SELECT honua.swap_import_table(@schema_name, @table_name)";
+    private const string EnsureImportUpsertKeySql = "SELECT honua.ensure_import_upsert_key(@schema_name, @table_name, @key_columns)";
     private const string InsertImportFeatureSql = "SELECT honua.insert_import_feature(@schema_name, @table_name, @wkb, @source_srid, @target_srid, @properties)";
     private const string InsertImportFeatureWithDatumSql = "SELECT honua.insert_import_feature(@schema_name, @table_name, @wkb, @source_srid, @target_srid, @properties, @datum_pipeline)";
+    private const string UpsertImportFeatureSql = "SELECT honua.upsert_import_feature(@schema_name, @table_name, @wkb, @source_srid, @target_srid, @properties, @key_columns)";
+    private const string BulkUpsertImportFeaturesSql = "SELECT processed_count FROM honua.bulk_upsert_import_features(@schema_name, @table_name, @wkbs, @source_srids, @target_srid, @properties, @key_columns, @datum_source_srid, @datum_pipeline)";
     private const int CrsDetectionHeaderSize = 8192;
     private const long DefaultMaxArchiveEntryBytes = 500L * 1024 * 1024;
     private const long DefaultMaxArchiveExtractedBytes = 1024L * 1024 * 1024;

--- a/src/Honua.Server/Migrations/070_AddImportLoadModes.sql
+++ b/src/Honua.Server/Migrations/070_AddImportLoadModes.sql
@@ -1,0 +1,335 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Import load-mode helpers (#ETL-load-modes). The original import path was
+-- full-replace only: honua.create_import_table unconditionally DROP+CREATEs and
+-- honua.insert_import_feature does a plain INSERT, so there was no way to add to
+-- or incrementally update an existing target. This migration adds the SQL needed
+-- for the three load modes the application now exposes:
+--
+--   * replace  — transactional staging-table-swap so a failed load never leaves a
+--                half-dropped target (honua.create_import_staging_table builds an
+--                empty sibling, the load streams into it, honua.swap_import_table
+--                atomically renames it over the live table inside one transaction).
+--   * append   — plain INSERT into the existing table (reuses insert_import_feature).
+--   * upsert   — keyed ON CONFLICT (key) DO UPDATE through a stable unique index
+--                over one or more property keys.
+--
+-- All DDL stays inside plpgsql function bodies so application SQL text remains
+-- static and identifiers are handled with format(%I) rather than interpolation.
+
+CREATE SCHEMA IF NOT EXISTS honua;
+CREATE SCHEMA IF NOT EXISTS honua_data;
+
+-- Validates a single identifier with the same rules the create path enforces.
+CREATE OR REPLACE FUNCTION honua.assert_import_identifier(value text, label text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF value IS NULL OR length(trim(value)) = 0 THEN
+        RAISE EXCEPTION '% cannot be null or empty', label;
+    END IF;
+
+    IF length(value) > 63 THEN
+        RAISE EXCEPTION '% exceeds PostgreSQL identifier limit of 63 characters', label;
+    END IF;
+
+    IF value !~ '^[a-zA-Z_][a-zA-Z0-9_]*$' THEN
+        RAISE EXCEPTION '% must start with a letter or underscore and contain only letters, digits, and underscores', label;
+    END IF;
+END;
+$$;
+
+-- Create-if-not-exists variant of create_import_table for the append/upsert load
+-- modes, which must NOT drop an existing target. Builds the same fixed import shape
+-- (id SERIAL PK, geometry, properties JSONB) only when the table is missing, leaving
+-- any existing rows untouched.
+CREATE OR REPLACE FUNCTION honua.ensure_import_table(
+    schema_name text,
+    table_name text,
+    target_srid integer DEFAULT 4326)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM honua.assert_import_identifier(schema_name, 'Schema name');
+    PERFORM honua.assert_import_identifier(table_name, 'Table name');
+
+    IF target_srid IS NULL OR target_srid <= 0 THEN
+        RAISE EXCEPTION 'Target SRID must be a positive integer';
+    END IF;
+
+    EXECUTE format('CREATE SCHEMA IF NOT EXISTS %I', schema_name);
+    EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS %I.%I (id SERIAL PRIMARY KEY, geometry GEOMETRY(Geometry, %s), properties JSONB, created_at TIMESTAMPTZ DEFAULT NOW())',
+        schema_name, table_name, target_srid);
+    EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.%I USING GIST (geometry)', 'idx_' || table_name || '_geometry', schema_name, table_name);
+    EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.%I USING GIN (properties)', 'idx_' || table_name || '_properties', schema_name, table_name);
+END;
+$$;
+
+-- Builds an EMPTY staging sibling for a transactional replace. The staging table
+-- has the same fixed import shape (id SERIAL PK, geometry, properties JSONB) and a
+-- predictable name (<table>__staging) so the load can stream into it and the swap
+-- can rename it over the live table. Unlike create_import_table this does NOT touch
+-- the live target — the live table is only replaced atomically by swap_import_table
+-- after the load fully succeeds, so a failed/cancelled load leaves the live table
+-- intact.
+CREATE OR REPLACE FUNCTION honua.create_import_staging_table(
+    schema_name text,
+    table_name text,
+    target_srid integer DEFAULT 4326)
+RETURNS text
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    staging_name text;
+BEGIN
+    PERFORM honua.assert_import_identifier(schema_name, 'Schema name');
+    PERFORM honua.assert_import_identifier(table_name, 'Table name');
+
+    IF target_srid IS NULL OR target_srid <= 0 THEN
+        RAISE EXCEPTION 'Target SRID must be a positive integer';
+    END IF;
+
+    staging_name := table_name || '__staging';
+    IF length(staging_name) > 63 THEN
+        RAISE EXCEPTION 'Staging table name exceeds PostgreSQL identifier limit of 63 characters';
+    END IF;
+
+    EXECUTE format('CREATE SCHEMA IF NOT EXISTS %I', schema_name);
+    -- A leftover staging table from a previously-crashed load is safe to drop: it
+    -- is never the live target and only ever holds in-flight, not-yet-swapped rows.
+    EXECUTE format('DROP TABLE IF EXISTS %I.%I', schema_name, staging_name);
+    EXECUTE format(
+        'CREATE TABLE %I.%I (id SERIAL PRIMARY KEY, geometry GEOMETRY(Geometry, %s), properties JSONB, created_at TIMESTAMPTZ DEFAULT NOW())',
+        schema_name, staging_name, target_srid);
+    EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.%I USING GIST (geometry)', 'idx_' || staging_name || '_geometry', schema_name, staging_name);
+    EXECUTE format('CREATE INDEX IF NOT EXISTS %I ON %I.%I USING GIN (properties)', 'idx_' || staging_name || '_properties', schema_name, staging_name);
+
+    RETURN staging_name;
+END;
+$$;
+
+-- Atomically replaces the live target table with a freshly-loaded staging sibling.
+-- Run inside the caller's transaction so the drop+rename is all-or-nothing: callers
+-- BEGIN, load into <table>__staging, then call this; on commit the old table is gone
+-- and the staging table has taken its name. A rollback leaves the live table intact.
+CREATE OR REPLACE FUNCTION honua.swap_import_table(
+    schema_name text,
+    table_name text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    staging_name text;
+BEGIN
+    PERFORM honua.assert_import_identifier(schema_name, 'Schema name');
+    PERFORM honua.assert_import_identifier(table_name, 'Table name');
+
+    staging_name := table_name || '__staging';
+
+    EXECUTE format('DROP TABLE IF EXISTS %I.%I CASCADE', schema_name, table_name);
+    EXECUTE format('ALTER TABLE %I.%I RENAME TO %I', schema_name, staging_name, table_name);
+
+    -- Rename the staging indexes onto the canonical names so a later load (which
+    -- references idx_<table>_geometry / idx_<table>_properties) does not collide.
+    EXECUTE format('ALTER INDEX IF EXISTS %I.%I RENAME TO %I',
+        schema_name, 'idx_' || staging_name || '_geometry', 'idx_' || table_name || '_geometry');
+    EXECUTE format('ALTER INDEX IF EXISTS %I.%I RENAME TO %I',
+        schema_name, 'idx_' || staging_name || '_properties', 'idx_' || table_name || '_properties');
+END;
+$$;
+
+-- Ensures a stable unique index over one or more JSONB property keys so the keyed
+-- upsert path has a valid ON CONFLICT target. The index is expression-based over
+-- properties->>'<key>' for each key column, matching the way insert_import_feature
+-- stores attributes. Idempotent: re-running with the same keys is a no-op.
+CREATE OR REPLACE FUNCTION honua.ensure_import_upsert_key(
+    schema_name text,
+    table_name text,
+    key_columns text[])
+RETURNS text
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    index_name text;
+    key_expression text;
+    key text;
+BEGIN
+    PERFORM honua.assert_import_identifier(schema_name, 'Schema name');
+    PERFORM honua.assert_import_identifier(table_name, 'Table name');
+
+    IF key_columns IS NULL OR array_length(key_columns, 1) IS NULL THEN
+        RAISE EXCEPTION 'Upsert load mode requires at least one key column';
+    END IF;
+
+    key_expression := '';
+    FOREACH key IN ARRAY key_columns
+    LOOP
+        IF key IS NULL OR length(trim(key)) = 0 THEN
+            RAISE EXCEPTION 'Upsert key column cannot be null or empty';
+        END IF;
+
+        IF length(key_expression) > 0 THEN
+            key_expression := key_expression || ', ';
+        END IF;
+
+        -- %L safely quotes the key as a literal inside the expression index body.
+        key_expression := key_expression || format('(properties->>%L)', key);
+    END LOOP;
+
+    index_name := 'uq_' || table_name || '_import_key';
+    IF length(index_name) > 63 THEN
+        index_name := 'uq_import_key_' || md5(table_name);
+    END IF;
+
+    EXECUTE format(
+        'CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.%I (%s)',
+        index_name, schema_name, table_name, key_expression);
+
+    RETURN index_name;
+END;
+$$;
+
+-- Keyed upsert: insert a feature, or UPDATE the existing row whose property key(s)
+-- collide, WITHOUT dropping the table. The ON CONFLICT target is the expression
+-- index built by ensure_import_upsert_key over the same property keys. Geometry and
+-- properties of the conflicting row are refreshed from the incoming feature.
+CREATE OR REPLACE FUNCTION honua.upsert_import_feature(
+    schema_name text,
+    table_name text,
+    wkb bytea,
+    source_srid integer,
+    target_srid integer,
+    properties jsonb,
+    key_columns text[])
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    conflict_expression text;
+    key text;
+BEGIN
+    IF key_columns IS NULL OR array_length(key_columns, 1) IS NULL THEN
+        RAISE EXCEPTION 'Upsert load mode requires at least one key column';
+    END IF;
+
+    conflict_expression := '';
+    FOREACH key IN ARRAY key_columns
+    LOOP
+        IF length(conflict_expression) > 0 THEN
+            conflict_expression := conflict_expression || ', ';
+        END IF;
+
+        conflict_expression := conflict_expression || format('(properties->>%L)', key);
+    END LOOP;
+
+    EXECUTE format(
+        'INSERT INTO %I.%I (geometry, properties) ' ||
+        'VALUES (ST_Transform(ST_GeomFromWKB($1, $2), $3), $4) ' ||
+        'ON CONFLICT (%s) DO UPDATE SET ' ||
+        'geometry = EXCLUDED.geometry, properties = EXCLUDED.properties',
+        schema_name, table_name, conflict_expression)
+    USING wkb, source_srid, target_srid, properties;
+END;
+$$;
+
+-- Batch keyed upsert mirroring honua.bulk_insert_import_features: a single
+-- unnest-driven INSERT ... ON CONFLICT (...) DO UPDATE so the streaming fast path
+-- can merge a whole batch without dropping the target. The ON CONFLICT target is the
+-- same expression list (properties->>'<key>', ...) the unique index in
+-- honua.ensure_import_upsert_key is built over, so a batch row whose key(s) collide
+-- with an existing row refreshes that row's geometry/properties; the rest insert.
+-- Keeping the DDL/SQL text inside the function body keeps application SQL static and
+-- lets identifiers be handled with format(%I)/key literals with format(%L).
+CREATE OR REPLACE FUNCTION honua.bulk_upsert_import_features(
+    schema_name text,
+    table_name text,
+    wkb_array bytea[],
+    source_srid_array integer[],
+    target_srid integer,
+    properties_array jsonb[],
+    key_columns text[],
+    datum_source_srid integer DEFAULT NULL,
+    datum_transformation_pipeline text DEFAULT NULL)
+RETURNS TABLE(processed_count integer, failed_count integer)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    max_i integer;
+    processed integer := 0;
+    conflict_expression text;   -- over the live table's "properties" column (ON CONFLICT target)
+    distinct_expression text;   -- the same keys over the unnest alias "props" (DISTINCT ON)
+    geometry_expression text;   -- ST_Transform shape, optionally datum-pipelined
+    key text;
+BEGIN
+    max_i := array_length(wkb_array, 1);
+
+    IF max_i IS NULL THEN
+        RETURN QUERY SELECT 0, 0;
+        RETURN;
+    END IF;
+
+    IF array_length(source_srid_array, 1) != max_i OR
+       array_length(properties_array, 1) != max_i THEN
+        RAISE EXCEPTION 'Input arrays must have the same length';
+    END IF;
+
+    IF key_columns IS NULL OR array_length(key_columns, 1) IS NULL THEN
+        RAISE EXCEPTION 'Upsert load mode requires at least one key column';
+    END IF;
+
+    conflict_expression := '';
+    distinct_expression := '';
+    FOREACH key IN ARRAY key_columns
+    LOOP
+        IF key IS NULL OR length(trim(key)) = 0 THEN
+            RAISE EXCEPTION 'Upsert key column cannot be null or empty';
+        END IF;
+
+        IF length(conflict_expression) > 0 THEN
+            conflict_expression := conflict_expression || ', ';
+            distinct_expression := distinct_expression || ', ';
+        END IF;
+
+        conflict_expression := conflict_expression || format('(properties->>%L)', key);
+        distinct_expression := distinct_expression || format('(props->>%L)', key);
+    END LOOP;
+
+    -- Mirror the insert fast-path geometry expression: rows whose source SRID matches the
+    -- resolved (datum_source_srid -> target_srid) pair get the explicit Esri-parity
+    -- 3-argument ST_Transform; everything else keeps PROJ's default 2-argument transform.
+    -- %L safely quotes the pipeline literal; a NULL pipeline collapses to the bare form.
+    IF datum_transformation_pipeline IS NULL OR length(datum_transformation_pipeline) = 0 THEN
+        geometry_expression :=
+            format('CASE WHEN wkb IS NOT NULL AND srid > 0 THEN ST_Transform(ST_GeomFromWKB(wkb, srid), %s) ELSE NULL END', target_srid);
+    ELSE
+        geometry_expression := format(
+            'CASE WHEN wkb IS NULL OR srid <= 0 THEN NULL ' ||
+            'WHEN srid = %s THEN ST_Transform(ST_GeomFromWKB(wkb, srid), %L, %s) ' ||
+            'ELSE ST_Transform(ST_GeomFromWKB(wkb, srid), %s) END',
+            datum_source_srid, datum_transformation_pipeline, target_srid, target_srid);
+    END IF;
+
+    -- DISTINCT ON keeps one row per key tuple within the batch so a single statement
+    -- cannot try to update the same conflict target twice (Postgres raises "ON CONFLICT
+    -- DO UPDATE command cannot affect row a second time" otherwise).
+    EXECUTE format(
+        'INSERT INTO %I.%I (geometry, properties) ' ||
+        'SELECT DISTINCT ON (%s) %s, props ' ||
+        'FROM unnest($1, $2, $3) AS t(wkb, srid, props) ' ||
+        'ON CONFLICT (%s) DO UPDATE SET ' ||
+        '       geometry = EXCLUDED.geometry, properties = EXCLUDED.properties',
+        schema_name, table_name,
+        distinct_expression,
+        geometry_expression,
+        conflict_expression)
+    USING wkb_array, source_srid_array, properties_array;
+
+    GET DIAGNOSTICS processed = ROW_COUNT;
+
+    RETURN QUERY SELECT processed, 0;
+END;
+$$;

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/ImportRequestTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/ImportRequestTests.cs
@@ -104,4 +104,86 @@ public sealed class ImportRequestTests
 
         request.UsesLocalFile.Should().BeFalse();
     }
+
+    [Fact]
+    public void LoadMode_DefaultsToReplace()
+    {
+        var request = new ImportRequest
+        {
+            FileName = "data.geojson",
+            TableName = "table"
+        };
+
+        request.LoadMode.Should().Be(ImportLoadMode.Replace);
+        request.EffectiveLoadMode.Should().Be(ImportLoadMode.Replace);
+    }
+
+    [Theory]
+    [InlineData(ImportLoadMode.Append)]
+    [InlineData(ImportLoadMode.Upsert)]
+    public void EffectiveLoadMode_WhenLoadModeSet_HonorsExplicitMode(ImportLoadMode mode)
+    {
+        var request = new ImportRequest
+        {
+            FileName = "data.geojson",
+            TableName = "table",
+            LoadMode = mode,
+            KeyColumns = mode == ImportLoadMode.Upsert ? ["id"] : []
+        };
+
+        request.EffectiveLoadMode.Should().Be(mode);
+    }
+
+    [Fact]
+    public void Validate_WhenUpsertWithoutKeyColumns_Throws()
+    {
+        using var stream = new MemoryStream();
+        var request = new ImportRequest
+        {
+            FileName = "data.geojson",
+            TableName = "table",
+            FileStream = stream,
+            LoadMode = ImportLoadMode.Upsert
+        };
+
+        Action act = () => request.Validate();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Upsert load mode requires at least one key column*");
+    }
+
+    [Fact]
+    public void Validate_WhenUpsertWithKeyColumns_DoesNotThrow()
+    {
+        using var stream = new MemoryStream();
+        var request = new ImportRequest
+        {
+            FileName = "data.geojson",
+            TableName = "table",
+            FileStream = stream,
+            LoadMode = ImportLoadMode.Upsert,
+            KeyColumns = ["id"]
+        };
+
+        Action act = () => request.Validate();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Validate_WhenAppendWithoutKeyColumns_DoesNotThrow()
+    {
+        using var stream = new MemoryStream();
+        var request = new ImportRequest
+        {
+            FileName = "data.geojson",
+            TableName = "table",
+            FileStream = stream,
+            LoadMode = ImportLoadMode.Append
+        };
+
+        Action act = () => request.Validate();
+
+        act.Should().NotThrow();
+    }
 }


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to ETL load-mode work (no tracking issue filed).

## Summary
The streaming file-import path was full-replace only: `honua.create_import_table` unconditionally DROP+CREATEs the target and `honua.insert_import_feature` does a plain INSERT, so there was no way to add to or incrementally update an existing imported layer. This PR adds three load modes to the import path:

- **replace** (default, historical behavior) — now implemented as a transactional staging-table swap so a failed or cancelled load never leaves a half-dropped target.
- **append** — inserts into the existing target (created if missing), retaining existing rows.
- **upsert/merge** — keyed `INSERT ... ON CONFLICT (key) DO UPDATE` over one or more JSONB property keys, so colliding rows update in place and the rest insert, with no drop.

The `sink.honua-layer` GeoETL DAG sink remains deferred (the load-mode SQL + service wiring it depends on now exist; only the catalog-NpgsqlDataSource conditional-registration plumbing remains) — see the rationale in `BuiltInProcessCatalog.cs`.

## Changes Made
- Added `ImportLoadMode` enum (Replace/Append/Upsert) and `LoadMode`/`KeyColumns`/`EffectiveLoadMode` to `ImportRequest`, with upsert key-column validation.
- New migration `070_AddImportLoadModes.sql`: `ensure_import_table` (create-if-missing), `create_import_staging_table` + `swap_import_table` (transactional replace), `ensure_import_upsert_key` (expression unique index over property keys), `upsert_import_feature` + `bulk_upsert_import_features` (keyed ON CONFLICT DO UPDATE, DISTINCT ON to dedupe within a batch, datum-pipeline parity).
- Wired the load mode through `StreamingFileImportService` streaming/batch/sql partials: replace loads into a `<table>__staging` sibling and atomically swaps; append/upsert ensure the live table; upsert routes the batch through `bulk_upsert_import_features` and the continue-on-error fallback through `upsert_import_feature`.
- Added pure unit tests for load-mode defaulting, `EffectiveLoadMode` resolution, and upsert key-column validation.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

PostGIS/Testcontainers integration coverage for the SQL helpers is Docker-gated; the Release warnings-as-errors build verifies the new SQL/service wiring and the pure-unit load-mode validation tests pass.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires database migration

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran the equivalent of `scripts/ci/pre-pr-check.sh` (Release warnings-as-errors build, `dotnet format --verify-no-changes`, affected unit tests) and all checks passed
- [x] Commit messages follow conventional format
- [x] PR title matches main commit message
- [x] Tests added for new functionality
