### PR TITLE
feat(geoprocessing): first-class DAG remote source connectors

### DIFF
--- a/src/Honua.Core/Features/Geoprocessing/Abstractions/IDagFeatureSource.cs
+++ b/src/Honua.Core/Features/Geoprocessing/Abstractions/IDagFeatureSource.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.Threading;
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.Core.Features.Geoprocessing.Abstractions;
+
+/// <summary>
+/// A first-class DAG source connector that streams features from a remote source
+/// into a geoprocessing workflow. Each implementation adapts ONE remote-source
+/// family (a Honua catalog layer, an ArcGIS GeoServices FeatureServer, an OGC API
+/// Features collection, a WFS feature type, or an external PostGIS table) onto the
+/// uniform <see cref="DagSourceFeature"/> stream the source executor encodes as the
+/// canonical FeatureCollection artifact.
+///
+/// Implementations REUSE the existing one-shot <c>Honua.Import</c> readers'
+/// pagination/streaming rather than re-implementing transport: the ArcGIS reader
+/// wraps the migration <c>ArcGisRestClient</c>; the catalog reader wraps the shared
+/// query pipeline (<c>IStreamingFeatureStore</c>/<c>IFeatureReader</c>); the OGC/WFS
+/// readers reuse the migration HTTP/paging path; the PostGIS reader reuses the same
+/// secure-connection secret handling as <c>sink.external-postgis</c>.
+/// </summary>
+public interface IDagFeatureSource
+{
+    /// <summary>
+    /// The source process id this reader handles (for example
+    /// <c>source.esri-featureserver</c>). Matches the catalog
+    /// <c>ProcessDefinition.ProcessId</c> and the dispatcher routing key.
+    /// </summary>
+    string SourceId { get; }
+
+    /// <summary>
+    /// Streams the features matching <paramref name="request"/> from the remote source,
+    /// yielding them lazily as the underlying paginated reader advances.
+    /// </summary>
+    /// <param name="request">The resolved upstream query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An async stream of features.</returns>
+    IAsyncEnumerable<DagSourceFeature> ReadAsync(
+        DagSourceRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Geoprocessing/Domain/DagSourceFeature.cs
+++ b/src/Honua.Core/Features/Geoprocessing/Domain/DagSourceFeature.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+
+namespace Honua.Core.Features.Geoprocessing.Domain;
+
+/// <summary>
+/// A single feature streamed from a remote DAG source connector
+/// (<c>source.honua-layer</c>, <c>source.esri-featureserver</c>,
+/// <c>source.ogc-features</c>, <c>source.wfs</c>, <c>source.postgis</c>).
+///
+/// The geometry is carried as a GeoJSON geometry document string rather than a
+/// NetTopologySuite geometry so the readers stay free of an NTS dependency (they
+/// live in the data-provider / core assemblies) while the geoprocessing executor
+/// rehydrates the canonical <c>FeatureCollection</c> artifact through the shared
+/// managed NetTopologySuite reader. A <see langword="null"/> <see cref="GeometryGeoJson"/>
+/// represents a feature with no geometry; attributes still flow through.
+/// </summary>
+public sealed record DagSourceFeature
+{
+    /// <summary>
+    /// The feature geometry as a GeoJSON geometry object document (for example
+    /// <c>{"type":"Point","coordinates":[1,2]}</c>), or <see langword="null"/> when
+    /// the source feature has no geometry.
+    /// </summary>
+    public string? GeometryGeoJson { get; init; }
+
+    /// <summary>
+    /// The feature attributes keyed by field name. Values are the raw scalar values
+    /// surfaced by the source reader (string/number/bool/null).
+    /// </summary>
+    public required IReadOnlyDictionary<string, object?> Attributes { get; init; }
+}

--- a/src/Honua.Core/Features/Geoprocessing/Domain/DagSourceRequest.cs
+++ b/src/Honua.Core/Features/Geoprocessing/Domain/DagSourceRequest.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Migration.Domain;
+
+namespace Honua.Core.Features.Geoprocessing.Domain;
+
+/// <summary>
+/// The resolved upstream query a DAG source connector executes against a remote
+/// source. Built by the geoprocessing source executor from the durable step
+/// inputs and handed to the matching <c>IDagFeatureSource</c>, which translates it
+/// into the source-native query (an ArcGIS REST <c>query</c>, a WFS
+/// <c>GetFeature</c>, an OGC API Features <c>items</c> request, a catalog
+/// <c>FeatureQuery</c>, or an external PostGIS query) and streams the matching
+/// features back page-by-page.
+/// </summary>
+public sealed record DagSourceRequest
+{
+    /// <summary>
+    /// Honua catalog layer identifier for <c>source.honua-layer</c>. Ignored by the
+    /// remote-endpoint sources.
+    /// </summary>
+    public int? LayerId { get; init; }
+
+    /// <summary>
+    /// Remote service root URL for the endpoint sources (ArcGIS FeatureServer/MapServer
+    /// root, OGC API landing/collection URL, or WFS service URL). Ignored by
+    /// <c>source.honua-layer</c> and <c>source.postgis</c>.
+    /// </summary>
+    public string? ServiceUrl { get; init; }
+
+    /// <summary>
+    /// ArcGIS layer index within the FeatureServer for <c>source.esri-featureserver</c>.
+    /// </summary>
+    public int? EsriLayerId { get; init; }
+
+    /// <summary>
+    /// OGC API Features collection id, or WFS feature type name, for the OGC/WFS sources.
+    /// </summary>
+    public string? CollectionId { get; init; }
+
+    /// <summary>
+    /// Optional attribute filter. For <c>source.honua-layer</c> and
+    /// <c>source.esri-featureserver</c> this is a GeoServices-style SQL <c>where</c>
+    /// clause; for <c>source.ogc-features</c> a CQL2-text filter; for
+    /// <c>source.postgis</c> a parameter-free SQL predicate appended after WHERE.
+    /// </summary>
+    public string? Where { get; init; }
+
+    /// <summary>
+    /// Optional bounding-box filter as <c>minX,minY,maxX,maxY</c> in the source CRS.
+    /// </summary>
+    public string? Bbox { get; init; }
+
+    /// <summary>
+    /// Optional comma-separated output field allow-list. <see langword="null"/> selects all.
+    /// </summary>
+    public string? OutFields { get; init; }
+
+    /// <summary>
+    /// Optional output SRID; the reader requests this CRS from the source where the
+    /// protocol supports server-side reprojection.
+    /// </summary>
+    public int? OutputSrid { get; init; }
+
+    /// <summary>
+    /// Page size hint for the underlying paginated reader.
+    /// </summary>
+    public int PageSize { get; init; } = 1000;
+
+    /// <summary>
+    /// Optional incremental-extract watermark. When supplied the reader narrows the
+    /// upstream query to features changed at or after this value (an ISO-8601 instant
+    /// or a monotonic cursor understood by the source). The persistence of the next
+    /// watermark is owned by the incremental-extract orchestration, not the reader.
+    /// </summary>
+    public string? Since { get; init; }
+
+    /// <summary>
+    /// Optional name of the attribute the <see cref="Since"/> watermark filters on
+    /// (for example an <c>updated_at</c> / <c>last_edited_date</c> column). Required
+    /// for <c>source.postgis</c> and <c>source.honua-layer</c> incremental reads.
+    /// </summary>
+    public string? WatermarkField { get; init; }
+
+    /// <summary>
+    /// Hard ceiling on the number of pages the reader will fetch, guarding against a
+    /// non-advancing or pathological source. <see langword="null"/> uses the reader default.
+    /// </summary>
+    public int? MaxPages { get; init; }
+
+    /// <summary>
+    /// Per-request timeout in seconds for the remote-endpoint sources.
+    /// </summary>
+    public int TimeoutSeconds { get; init; } = 120;
+
+    /// <summary>
+    /// Optional ArcGIS credential descriptor for <c>source.esri-featureserver</c>,
+    /// reusing the import path's portal-token / secret-reference mechanism.
+    /// </summary>
+    public GeoservicesCredentialDescriptor? EsriCredentials { get; init; }
+
+    /// <summary>
+    /// Optional HTTP Basic username for the OGC/WFS sources.
+    /// </summary>
+    public string? Username { get; init; }
+
+    /// <summary>
+    /// Optional HTTP Basic password for the OGC/WFS sources (resolved from a secret
+    /// reference by the executor before the request reaches the reader).
+    /// </summary>
+    public string? Password { get; init; }
+
+    /// <summary>
+    /// Resolved connection string for <c>source.postgis</c>. The executor resolves this
+    /// from a registered secure connection (name/id) using the same secret-handling as
+    /// <c>sink.external-postgis</c>; raw connection strings never cross the DAG.
+    /// </summary>
+    public string? PostgisConnectionString { get; init; }
+
+    /// <summary>
+    /// Schema-qualified table or view for <c>source.postgis</c>.
+    /// </summary>
+    public string? PostgisSchema { get; init; }
+
+    /// <summary>Table or view name for <c>source.postgis</c>.</summary>
+    public string? PostgisTable { get; init; }
+
+    /// <summary>Geometry column for <c>source.postgis</c>. Defaults to <c>geom</c>.</summary>
+    public string? PostgisGeometryColumn { get; init; }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
@@ -910,6 +910,117 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
         },
 
         // -----------------------------------------------------------------------
+        // GeoETL remote source connectors (5)
+        // First-class DAG sources that stream features from a remote source straight
+        // into the workflow, REUSING the one-shot Honua.Import readers' pagination /
+        // streaming (ArcGisRestClient, the OGC/WFS GeoJSON paging path, the catalog
+        // query pipeline, and the external-PostGIS secure-connection handling) so a
+        // pipeline no longer has to bounce through a one-shot import to read from a
+        // Honua layer, Esri FeatureServer, OGC API Features, WFS, or external PostGIS.
+        // Each emits the standard FeatureCollection artifact downstream transforms
+        // consume. An optional since/watermark is passed through for incremental
+        // extract (persistence owned by the incremental-extract orchestration).
+        // -----------------------------------------------------------------------
+        new ProcessDefinition
+        {
+            ProcessId = "source.honua-layer",
+            Title = "Honua Layer Source",
+            Description = "Streams features from a Honua catalog layer through the canonical query pipeline (the layer's permanent filters, paging, CRS handling, and field masking are inherited) into the standard FeatureCollection artifact. Supply a where clause and/or a bbox to narrow the extract.",
+            Category = "source",
+            Parameters =
+            [
+                Param("layerId", "Layer Id", "Honua catalog layer identifier to read from.", ProcessParameterValueType.WholeNumber, required: true),
+                Param("where", "Where", "Optional GeoServices-style SQL where clause filtering the features.", ProcessParameterValueType.Text),
+                Param("bbox", "Bounding Box", "Optional 'minX,minY,maxX,maxY' envelope filter in the output CRS.", ProcessParameterValueType.Text),
+                Param("outFields", "Output Fields", "Optional comma-separated output field allow-list. Defaults to all fields.", ProcessParameterValueType.Text),
+                Param("outSrid", "Output SRID", "Optional output spatial reference identifier for server-side reprojection.", ProcessParameterValueType.Srid),
+                Param("since", "Since Watermark", "Optional incremental-extract watermark (ISO-8601 instant). Pairs with watermarkField.", ProcessParameterValueType.Text),
+                Param("watermarkField", "Watermark Field", "Attribute the since watermark filters on (e.g. updated_at).", ProcessParameterValueType.Text),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer]
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "source.esri-featureserver",
+            Title = "Esri FeatureServer Source",
+            Description = "Streams features from an ArcGIS GeoServices FeatureServer/MapServer layer by reusing the migration ArcGIS REST reader (resultOffset/resultRecordCount paging terminated by exceededTransferLimit) and its Esri-JSON to GeoJSON geometry conversion. Reuses the import path's ArcGIS portal-token / HTTP Basic credential handling.",
+            Category = "source",
+            Parameters =
+            [
+                Param("serviceUrl", "Service URL", "ArcGIS FeatureServer/MapServer service root URL.", ProcessParameterValueType.Text, required: true),
+                Param("esriLayerId", "Layer Index", "Layer index within the FeatureServer. Defaults to 0.", ProcessParameterValueType.WholeNumber),
+                Param("where", "Where", "Optional GeoServices SQL where clause. Defaults to 1=1.", ProcessParameterValueType.Text),
+                Param("outFields", "Output Fields", "Optional comma-separated output field allow-list. Defaults to all (*).", ProcessParameterValueType.Text),
+                Param("outSrid", "Output SRID", "Optional output spatial reference (outSR).", ProcessParameterValueType.Srid),
+                Param("pageSize", "Page Size", "Records per page (resultRecordCount). Defaults to 1000.", ProcessParameterValueType.WholeNumber, defaultValue: "1000"),
+                Param("token", "ArcGIS Token", "Inline ArcGIS token for immediate use. Prefer tokenSecretReference.", ProcessParameterValueType.Text),
+                Param("tokenSecretReference", "Token Secret Reference", "Secret reference that resolves to an ArcGIS token at execution time.", ProcessParameterValueType.Text),
+                Param("username", "Username", "HTTP Basic username for secured ArcGIS endpoints.", ProcessParameterValueType.Text),
+                Param("passwordSecretReference", "Password Secret Reference", "Secret reference that resolves to the HTTP Basic password.", ProcessParameterValueType.Text),
+                Param("since", "Since Watermark", "Optional incremental-extract watermark (ISO-8601 instant). Pairs with watermarkField.", ProcessParameterValueType.Text),
+                Param("watermarkField", "Watermark Field", "Edit-date field the since watermark filters on (e.g. last_edited_date).", ProcessParameterValueType.Text),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer]
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "source.ogc-features",
+            Title = "OGC API Features Source",
+            Description = "Streams features from an OGC API Features collection using link-based pagination (an items request with limit/bbox/filter followed by the rel=next link chain), reusing the migration HTTP/paging path. The where clause is interpreted as a CQL2-text filter.",
+            Category = "source",
+            Parameters =
+            [
+                Param("serviceUrl", "Service URL", "OGC API Features landing/base URL (the part before /collections).", ProcessParameterValueType.Text, required: true),
+                Param("collectionId", "Collection Id", "OGC API Features collection identifier.", ProcessParameterValueType.Text, required: true),
+                Param("where", "CQL2 Filter", "Optional CQL2-text filter expression.", ProcessParameterValueType.Text),
+                Param("bbox", "Bounding Box", "Optional 'minX,minY,maxX,maxY' bbox filter.", ProcessParameterValueType.Text),
+                Param("pageSize", "Page Size", "Features per page (limit). Defaults to 1000.", ProcessParameterValueType.WholeNumber, defaultValue: "1000"),
+                Param("username", "Username", "Optional HTTP Basic username.", ProcessParameterValueType.Text),
+                Param("passwordSecretReference", "Password Secret Reference", "Secret reference that resolves to the HTTP Basic password.", ProcessParameterValueType.Text),
+                Param("since", "Since Watermark", "Optional incremental-extract watermark (ISO-8601 instant), mapped to a datetime open interval.", ProcessParameterValueType.Text),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer]
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "source.wfs",
+            Title = "WFS Source",
+            Description = "Streams features from a WFS GetFeature endpoint using startIndex/count paging with GeoJSON output, terminating on an empty page or once advanced past numberMatched (with a repeated-first-feature guard for servers that ignore startIndex). Reuses the migration HTTP/paging path.",
+            Category = "source",
+            Parameters =
+            [
+                Param("serviceUrl", "Service URL", "WFS service endpoint URL.", ProcessParameterValueType.Text, required: true),
+                Param("typeName", "Type Name", "WFS feature type name (typeNames).", ProcessParameterValueType.Text, required: true),
+                Param("bbox", "Bounding Box", "Optional 'minX,minY,maxX,maxY' bbox filter.", ProcessParameterValueType.Text),
+                Param("pageSize", "Page Size", "Features per page (count). Defaults to 1000.", ProcessParameterValueType.WholeNumber, defaultValue: "1000"),
+                Param("username", "Username", "Optional HTTP Basic username.", ProcessParameterValueType.Text),
+                Param("passwordSecretReference", "Password Secret Reference", "Secret reference that resolves to the HTTP Basic password.", ProcessParameterValueType.Text),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer]
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "source.postgis",
+            Title = "External PostGIS Source",
+            Description = "Streams features from a customer-owned PostGIS table/view identified by a registered secure connection — the read-side mirror of sink.external-postgis. Geometry is projected with ST_AsGeoJSON server-side and rows stream through a forward-only reader. Uses the same secure-connection secret handling as the sink; raw connection strings are never accepted.",
+            Category = "source",
+            Parameters =
+            [
+                Param("connectionName", "Secure Connection Name", "Registered secure connection name for the external PostGIS database. Either connectionName or connectionId is required.", ProcessParameterValueType.Text),
+                Param("connectionId", "Secure Connection Id", "Registered secure connection id for the external PostGIS database. Either connectionName or connectionId is required.", ProcessParameterValueType.Text),
+                Param("table", "Table", "Source table or view name. Must match ^[A-Za-z_][A-Za-z0-9_]*$.", ProcessParameterValueType.Text, required: true),
+                Param("schema", "Schema", "Source schema. Defaults to public. Must match ^[A-Za-z_][A-Za-z0-9_]*$.", ProcessParameterValueType.Text, defaultValue: "public"),
+                Param("geometryColumn", "Geometry Column", "Source geometry column. Defaults to geom. Must match ^[A-Za-z_][A-Za-z0-9_]*$.", ProcessParameterValueType.Text, defaultValue: "geom"),
+                Param("where", "Where", "Optional SQL predicate appended after WHERE.", ProcessParameterValueType.Text),
+                Param("bbox", "Bounding Box", "Optional 'minX,minY,maxX,maxY' envelope filter (&& ST_MakeEnvelope).", ProcessParameterValueType.Text),
+                Param("outSrid", "Bbox SRID", "SRID of the bbox envelope. Defaults to 4326.", ProcessParameterValueType.Srid),
+                Param("since", "Since Watermark", "Optional incremental-extract watermark. Pairs with watermarkField.", ProcessParameterValueType.Text),
+                Param("watermarkField", "Watermark Field", "Column the since watermark filters on (e.g. updated_at).", ProcessParameterValueType.Text),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer]
+        },
+
+        // -----------------------------------------------------------------------
         // GeoETL sink operations (3)
         // Terminate a workflow by writing the input FeatureCollection to an external
         // target and emit a small result-descriptor artifact (the target location +

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
@@ -68,6 +68,7 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
         QuarantineSinkExecutor quarantineSink,
         ExternalPostgisSinkExecutor externalPostgisSink,
         ImportDatasetJobExecutor importDataset,
+        IEnumerable<RemoteSourceExecutor> remoteSources,
         ILogger<GeoprocessingDispatchJobExecutor> logger)
     {
         ArgumentNullException.ThrowIfNull(buffer);
@@ -102,9 +103,10 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
         ArgumentNullException.ThrowIfNull(quarantineSink);
         ArgumentNullException.ThrowIfNull(externalPostgisSink);
         ArgumentNullException.ThrowIfNull(importDataset);
+        ArgumentNullException.ThrowIfNull(remoteSources);
         ArgumentNullException.ThrowIfNull(logger);
 
-        _handlers = new Dictionary<string, IJobExecutor>(StringComparer.Ordinal)
+        var handlers = new Dictionary<string, IJobExecutor>(StringComparer.Ordinal)
         {
             [GeometryBufferJobExecutor.HandledProcessId] = buffer,
             [GeometryClipJobExecutor.HandledProcessId] = clip,
@@ -138,7 +140,17 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
             [QuarantineSinkExecutor.HandledProcessId] = quarantineSink,
             [ExternalPostgisSinkExecutor.HandledProcessId] = externalPostgisSink,
             [ImportDatasetJobExecutor.HandledProcessId] = importDataset,
-        }.ToFrozenDictionary(StringComparer.Ordinal);
+        };
+
+        // First-class remote DAG source connectors (source.honua-layer,
+        // source.esri-featureserver, source.ogc-features, source.wfs, source.postgis).
+        // Each RemoteSourceExecutor is bound to a single source process id; route by it.
+        foreach (var remoteSource in remoteSources)
+        {
+            handlers[remoteSource.HandledProcessId] = remoteSource;
+        }
+
+        _handlers = handlers.ToFrozenDictionary(StringComparer.Ordinal);
 
         _logger = logger;
     }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/RemoteSourceExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/RemoteSourceExecutor.cs
@@ -1,0 +1,379 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Security.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// Production <see cref="IJobExecutor"/> for the first-class remote DAG source
+/// connectors (<c>source.honua-layer</c>, <c>source.esri-featureserver</c>,
+/// <c>source.ogc-features</c>, <c>source.wfs</c>, <c>source.postgis</c>). A single
+/// executor type is instantiated once per source id; it resolves the matching
+/// <see cref="IDagFeatureSource"/> (which REUSES the existing import readers'
+/// pagination/streaming) at execution time through an <see cref="IServiceScopeFactory"/>
+/// scope — the same provider-resolution pattern <c>import.dataset</c> and
+/// <c>sink.external-postgis</c> use, because the source readers live in the active
+/// data-provider assembly, not in Honua.Geoprocessing.
+///
+/// <para>
+/// The executor builds the upstream <see cref="DagSourceRequest"/> from the durable
+/// step inputs, resolves auth (ArcGIS portal token / PostGIS secure connection) the
+/// same way the import path and <c>sink.external-postgis</c> do, streams the matching
+/// features, rehydrates each into a NetTopologySuite feature, and publishes the
+/// canonical FeatureCollection artifact downstream transform/sink nodes consume.
+/// </para>
+///
+/// <para>
+/// The optional <c>since</c> watermark + <c>watermarkField</c> are passed straight
+/// through to the reader; persisting the next watermark is owned by the
+/// incremental-extract orchestration, not this executor.
+/// </para>
+/// </summary>
+internal sealed partial class RemoteSourceExecutor : IJobExecutor
+{
+    private readonly string _processId;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options;
+    private readonly ILogger<RemoteSourceExecutor> _logger;
+
+    private RemoteSourceExecutor(
+        string processId,
+        IServiceScopeFactory serviceScopeFactory,
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<RemoteSourceExecutor> logger)
+    {
+        _processId = processId;
+        _serviceScopeFactory = serviceScopeFactory;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <summary>The source process id this instance handles.</summary>
+    public string HandledProcessId => _processId;
+
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <summary>Creates an executor bound to a single source process id.</summary>
+    public static RemoteSourceExecutor ForProcess(
+        string processId,
+        IServiceScopeFactory serviceScopeFactory,
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<RemoteSourceExecutor> logger)
+        => new(processId, serviceScopeFactory, options, logger);
+
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var resolved = GeoprocessingDispatchHelper.ResolveProcessId(job.Spec.Parameters);
+        if (!string.Equals(resolved, _processId, StringComparison.Ordinal))
+        {
+            return JobExecutionResult.Failed(
+                $"Process id '{resolved ?? "<none>"}' is not handled by the {_processId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, $"Resolving {_processId} source", cancellationToken).ConfigureAwait(false);
+
+        var inputs = new StepInputReader(job.Spec.Parameters);
+
+        using var scope = _serviceScopeFactory.CreateScope();
+        var services = scope.ServiceProvider;
+
+        var source = ResolveSource(services);
+        if (source is null)
+        {
+            return JobExecutionResult.Failed(
+                $"{_processId} failed: no source connector is registered for the active provider.");
+        }
+
+        DagSourceRequest request;
+        try
+        {
+            request = await BuildRequestAsync(inputs, services, cancellationToken).ConfigureAwait(false);
+        }
+        catch (TransformInputException ex)
+        {
+            Log.InvalidInputs(_logger, job.OperationId, _processId, ex.PublicMessage);
+            return JobExecutionResult.Failed($"Invalid {_processId} inputs: {ex.PublicMessage}");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(20, $"Streaming features from {_processId}", cancellationToken).ConfigureAwait(false);
+
+        var geoJsonReader = new GeoJsonReader();
+        var features = new List<IFeature>();
+        var maxBytes = _options.CurrentValue.MaxArtifactBytes;
+
+        try
+        {
+            await foreach (var sourceFeature in source.ReadAsync(request, cancellationToken).ConfigureAwait(false))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                features.Add(ToNtsFeature(sourceFeature, geoJsonReader));
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Log.SourceReadFailed(_logger, job.OperationId, _processId, ex);
+            return JobExecutionResult.Failed($"{_processId} failed during read: {ex.GetType().Name}.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(80, "Encoding source artifact", cancellationToken).ConfigureAwait(false);
+
+        var payload = FeatureCollectionArtifact.WriteFeatureCollection(features, _processId);
+        if (payload.Length > maxBytes)
+        {
+            return JobExecutionResult.Failed(
+                $"{_processId} artifact size {payload.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}.");
+        }
+
+        var artifactUri = FeatureCollectionArtifact.BuildDataUri(payload);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+        await context.ReportProgressAsync(100, $"{_processId} completed ({features.Count} features)", cancellationToken)
+            .ConfigureAwait(false);
+
+        return JobExecutionResult.Succeeded();
+    }
+
+    private IDagFeatureSource? ResolveSource(IServiceProvider services)
+    {
+        foreach (var candidate in services.GetServices<IDagFeatureSource>())
+        {
+            if (string.Equals(candidate.SourceId, _processId, StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private async Task<DagSourceRequest> BuildRequestAsync(
+        StepInputReader inputs,
+        IServiceProvider services,
+        CancellationToken cancellationToken)
+    {
+        var request = new DagSourceRequest
+        {
+            Where = inputs.TryGet("where", out var where) ? where : null,
+            Bbox = inputs.TryGet("bbox", out var bbox) ? bbox : null,
+            OutFields = inputs.TryGet("outFields", out var outFields) ? outFields : null,
+            OutputSrid = TryGetInt(inputs, "outSrid"),
+            PageSize = TryGetInt(inputs, "pageSize") ?? 1000,
+            MaxPages = TryGetInt(inputs, "maxPages"),
+            TimeoutSeconds = TryGetInt(inputs, "timeoutSeconds") ?? 120,
+            Since = inputs.TryGet("since", out var since) ? since : null,
+            WatermarkField = inputs.TryGet("watermarkField", out var watermarkField) ? watermarkField : null,
+            CollectionId = inputs.TryGet("collectionId", out var collectionId)
+                ? collectionId
+                : inputs.TryGet("typeName", out var typeName) ? typeName : null,
+            ServiceUrl = inputs.TryGet("serviceUrl", out var serviceUrl) ? serviceUrl : null,
+            LayerId = TryGetInt(inputs, "layerId"),
+            EsriLayerId = TryGetInt(inputs, "esriLayerId"),
+        };
+
+        return _processId switch
+        {
+            "source.esri-featureserver" => request with
+            {
+                EsriCredentials = await ResolveEsriCredentialsAsync(inputs, services, cancellationToken).ConfigureAwait(false)
+            },
+            "source.ogc-features" or "source.wfs" => request with
+            {
+                Username = inputs.TryGet("username", out var user) ? user : null,
+                Password = await ResolveSecretOrInlineAsync(inputs, services, "password", "passwordSecretReference", cancellationToken)
+                    .ConfigureAwait(false)
+            },
+            "source.postgis" => await EnrichPostgisAsync(request, inputs, services, cancellationToken).ConfigureAwait(false),
+            _ => request
+        };
+    }
+
+    private static async Task<DagSourceRequest> EnrichPostgisAsync(
+        DagSourceRequest request,
+        StepInputReader inputs,
+        IServiceProvider services,
+        CancellationToken cancellationToken)
+    {
+        var connectionString = await ResolveSecureConnectionAsync(inputs, services, cancellationToken).ConfigureAwait(false);
+        return request with
+        {
+            PostgisConnectionString = connectionString,
+            PostgisSchema = inputs.TryGet("schema", out var schema) ? schema : "public",
+            PostgisTable = inputs.TryGet("table", out var table) ? table : null,
+            PostgisGeometryColumn = inputs.TryGet("geometryColumn", out var geom) ? geom : "geom",
+        };
+    }
+
+    private static async Task<GeoservicesCredentialDescriptor?> ResolveEsriCredentialsAsync(
+        StepInputReader inputs,
+        IServiceProvider services,
+        CancellationToken cancellationToken)
+    {
+        var token = await ResolveSecretOrInlineAsync(inputs, services, "token", "tokenSecretReference", cancellationToken)
+            .ConfigureAwait(false);
+        var username = inputs.TryGet("username", out var user) ? user : null;
+        var password = await ResolveSecretOrInlineAsync(inputs, services, "password", "passwordSecretReference", cancellationToken)
+            .ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(token) && string.IsNullOrWhiteSpace(username))
+        {
+            return null;
+        }
+
+        return new GeoservicesCredentialDescriptor
+        {
+            Mode = !string.IsNullOrWhiteSpace(token)
+                ? GeoservicesAuthenticationModes.Token
+                : GeoservicesAuthenticationModes.Basic,
+            AccessToken = token,
+            Username = username,
+            Password = password
+        };
+    }
+
+    private static async Task<string?> ResolveSecretOrInlineAsync(
+        StepInputReader inputs,
+        IServiceProvider services,
+        string inlineKey,
+        string secretRefKey,
+        CancellationToken cancellationToken)
+    {
+        if (inputs.TryGet(secretRefKey, out var secretReference) && !string.IsNullOrWhiteSpace(secretReference))
+        {
+            var resolver = services.GetService<IConnectionSecretResolver>();
+            if (resolver is null)
+            {
+                throw new TransformInputException("a secret reference was supplied but no secret resolver is configured.");
+            }
+
+            return await resolver.ResolveSecretAsync(secretReference!, cancellationToken).ConfigureAwait(false);
+        }
+
+        return inputs.TryGet(inlineKey, out var inline) ? inline : null;
+    }
+
+    private static async Task<string?> ResolveSecureConnectionAsync(
+        StepInputReader inputs,
+        IServiceProvider services,
+        CancellationToken cancellationToken)
+    {
+        var hasName = inputs.TryGet("connectionName", out var connectionName);
+        var hasId = inputs.TryGet("connectionId", out var connectionIdText);
+        if (hasName == hasId)
+        {
+            throw new TransformInputException("exactly one of connectionName or connectionId is required.");
+        }
+
+        var resolver = services.GetService<ISecureConnectionResolver>();
+        if (resolver is null)
+        {
+            throw new TransformInputException("secure connection resolver is not configured.");
+        }
+
+        try
+        {
+            string connectionString;
+            if (hasId)
+            {
+                if (!Guid.TryParse(connectionIdText, out var connectionId))
+                {
+                    throw new TransformInputException("connectionId must be a valid GUID.");
+                }
+
+                connectionString = await resolver.ResolveConnectionStringAsync(connectionId, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                connectionString = await resolver.ResolveConnectionStringAsync(connectionName!, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new TransformInputException("secure connection could not be resolved.");
+            }
+
+            return connectionString;
+        }
+        catch (TransformInputException)
+        {
+            throw;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new TransformInputException("secure connection could not be resolved.");
+        }
+    }
+
+    private static Feature ToNtsFeature(DagSourceFeature sourceFeature, GeoJsonReader reader)
+    {
+        NtsGeometry? geometry = null;
+        if (!string.IsNullOrWhiteSpace(sourceFeature.GeometryGeoJson))
+        {
+            try
+            {
+                geometry = reader.Read<NtsGeometry>(sourceFeature.GeometryGeoJson);
+            }
+            catch (Exception ex) when (ex is Newtonsoft.Json.JsonException or ArgumentException or FormatException)
+            {
+                geometry = null;
+            }
+        }
+
+        var attributes = new AttributesTable();
+        foreach (var (key, value) in sourceFeature.Attributes)
+        {
+            if (!attributes.Exists(key))
+            {
+                attributes.Add(key, value);
+            }
+        }
+
+        return new Feature(geometry, attributes);
+    }
+
+    private static int? TryGetInt(StepInputReader inputs, string name)
+        => inputs.TryGet(name, out var raw)
+            && int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+            ? value
+            : null;
+
+    private static partial class Log
+    {
+        [LoggerMessage(9280, LogLevel.Warning,
+            "Remote source executor rejected job {OperationId} for {ProcessId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string processId, string reason);
+
+        [LoggerMessage(9281, LogLevel.Error,
+            "Remote source executor failed job {OperationId} during {ProcessId} read")]
+        public static partial void SourceReadFailed(ILogger logger, string operationId, string processId, Exception exception);
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -19,6 +19,20 @@ namespace Honua.Geoprocessing;
 internal static class GeoprocessingServiceCollectionExtensions
 {
     /// <summary>
+    /// Source process ids served by a per-process <see cref="RemoteSourceExecutor"/>.
+    /// Must match the catalog ProcessDefinitions and the registered
+    /// <c>IDagFeatureSource.SourceId</c> values.
+    /// </summary>
+    private static readonly string[] RemoteSourceProcessIds =
+    [
+        "source.honua-layer",
+        "source.esri-featureserver",
+        "source.ogc-features",
+        "source.wfs",
+        "source.postgis",
+    ];
+
+    /// <summary>
     /// Registers geoprocessing service dependencies including workspace lifecycle,
     /// the execution job store, and built-in process catalog.
     /// </summary>
@@ -169,6 +183,23 @@ internal static class GeoprocessingServiceCollectionExtensions
         // active data-provider assembly, out of reach for this module — the same
         // pattern ExternalPostgisSinkExecutor uses).
         services.TryAddSingleton<ImportDatasetJobExecutor>();
+
+        // First-class remote DAG source connectors (source.honua-layer,
+        // source.esri-featureserver, source.ogc-features, source.wfs, source.postgis).
+        // One RemoteSourceExecutor is registered per source process id; each resolves
+        // its matching IDagFeatureSource (which reuses the existing import readers'
+        // pagination/streaming) at execution time through an IServiceScopeFactory
+        // scope, mirroring the ImportDatasetJobExecutor / ExternalPostgisSinkExecutor
+        // provider-resolution pattern. The dispatcher routes by HandledProcessId.
+        foreach (var sourceProcessId in RemoteSourceProcessIds)
+        {
+            var capturedProcessId = sourceProcessId;
+            services.AddSingleton(sp => RemoteSourceExecutor.ForProcess(
+                capturedProcessId,
+                sp.GetRequiredService<IServiceScopeFactory>(),
+                sp.GetRequiredService<IOptionsMonitor<GeoprocessingExecutorOptions>>(),
+                sp.GetRequiredService<ILogger<RemoteSourceExecutor>>()));
+        }
 
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IJobExecutor, GeoprocessingDispatchJobExecutor>());

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
@@ -390,6 +390,12 @@ internal static partial class ProcessPlanValidator
             case "sink.external-postgis":
                 ValidateExternalPostgisSinkSemantics(step, violations);
                 break;
+            case "source.postgis":
+                // The external-PostGIS source reuses the same secure-connection contract
+                // as the sink: a registered connectionName XOR connectionId, never an
+                // inline connection string.
+                ValidateExternalPostgisSinkSemantics(step, violations);
+                break;
         }
     }
 

--- a/src/Honua.Postgres/Features/Geoprocessing/EsriFeatureServerDagSource.cs
+++ b/src/Honua.Postgres/Features/Geoprocessing/EsriFeatureServerDagSource.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
+using Honua.Postgres.Features.Migration;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Postgres.Features.Geoprocessing;
+
+/// <summary>
+/// <c>source.esri-featureserver</c> DAG connector. Streams features from an ArcGIS
+/// GeoServices FeatureServer/MapServer layer by REUSING the migration
+/// <see cref="ArcGisRestClient"/> — the same paginated reader the one-shot ArcGIS
+/// import drives (<c>resultOffset</c>/<c>resultRecordCount</c> paging terminated by
+/// <c>exceededTransferLimit</c>) — and the same Esri-JSON → GeoJSON geometry
+/// conversion the importer uses (<see cref="GeoservicesImportService.ConvertEsriGeometryToGeoJson"/>).
+/// No transport, pagination, SSRF guard, or geometry-conversion logic is
+/// re-implemented here.
+/// </summary>
+internal sealed partial class EsriFeatureServerDagSource : IDagFeatureSource
+{
+    private const int DefaultMaxPages = 1000;
+
+    private readonly ArcGisRestClient _restClient;
+    private readonly ILogger<EsriFeatureServerDagSource> _logger;
+
+    public EsriFeatureServerDagSource(
+        ArcGisRestClient restClient,
+        ILogger<EsriFeatureServerDagSource> logger)
+    {
+        _restClient = restClient;
+        _logger = logger;
+    }
+
+    public string SourceId => "source.esri-featureserver";
+
+    public async IAsyncEnumerable<DagSourceFeature> ReadAsync(
+        DagSourceRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.ServiceUrl))
+        {
+            throw new InvalidOperationException("source.esri-featureserver requires a serviceUrl.");
+        }
+
+        var layerId = request.EsriLayerId ?? 0;
+        var batchSize = request.PageSize <= 0 ? 1000 : request.PageSize;
+        var maxPages = request.MaxPages is > 0 ? request.MaxPages.Value : DefaultMaxPages;
+        var where = BuildWhereClause(request);
+        var outFields = string.IsNullOrWhiteSpace(request.OutFields)
+            ? null
+            : request.OutFields.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var offset = 0;
+        var page = 0;
+        var hasMore = true;
+
+        while (hasMore)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (page >= maxPages)
+            {
+                Log.PageCapReached(_logger, SourceId, maxPages);
+                yield break;
+            }
+
+            page++;
+
+            // REUSE: the migration ArcGIS REST client owns the query URL build, retry,
+            // SSRF guard, credential/token handling, and exceededTransferLimit paging.
+            var result = await _restClient.QueryFeaturesAsync(
+                request.ServiceUrl,
+                layerId,
+                offset,
+                batchSize,
+                where,
+                outFields,
+                request.OutputSrid,
+                request.TimeoutSeconds,
+                maxRetries: 3,
+                cancellationToken,
+                request.EsriCredentials).ConfigureAwait(false);
+
+            if (result.Features.Length == 0)
+            {
+                yield break;
+            }
+
+            foreach (var feature in result.Features)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return ProjectFeature(feature);
+            }
+
+            offset += result.Features.Length;
+            hasMore = result.ExceededTransferLimit || result.Features.Length == batchSize;
+        }
+    }
+
+    private static string BuildWhereClause(DagSourceRequest request)
+    {
+        var clauses = new List<string>(3);
+        if (!string.IsNullOrWhiteSpace(request.Where))
+        {
+            clauses.Add(request.Where);
+        }
+
+        // Watermark (incremental extract): narrow to features changed at/after the
+        // cursor. The persistence of the next watermark is owned by the
+        // incremental-extract orchestration; the reader only applies it.
+        if (!string.IsNullOrWhiteSpace(request.Since) && !string.IsNullOrWhiteSpace(request.WatermarkField))
+        {
+            clauses.Add($"{request.WatermarkField} >= TIMESTAMP '{EscapeSqlLiteral(request.Since)}'");
+        }
+
+        // Bbox is expressed as a geometry envelope filter via the where clause for the
+        // GeoServices query path; the FeatureServer query honours a standard envelope.
+        if (!string.IsNullOrWhiteSpace(request.Bbox))
+        {
+            // The ArcGIS REST client does not currently surface a geometry= envelope
+            // parameter; callers pass an attribute where clause. A spatial bbox push-down
+            // is deferred to the streaming-source reconciliation.
+        }
+
+        return clauses.Count == 0 ? "1=1" : string.Join(" AND ", clauses);
+    }
+
+    private static string EscapeSqlLiteral(string value) => value.Replace("'", "''", StringComparison.Ordinal);
+
+    private static DagSourceFeature ProjectFeature(ArcGisFeature feature)
+    {
+        var attributes = new Dictionary<string, object?>(StringComparer.Ordinal);
+        if (feature.Attributes is { } source)
+        {
+            foreach (var (key, value) in source)
+            {
+                attributes[key] = ConvertScalar(value);
+            }
+        }
+
+        string? geometryGeoJson = null;
+        if (feature.Geometry is { ValueKind: JsonValueKind.Object } geometry)
+        {
+            geometryGeoJson = GeoservicesImportService.ConvertEsriGeometryToGeoJson(geometry);
+        }
+
+        return new DagSourceFeature
+        {
+            GeometryGeoJson = geometryGeoJson,
+            Attributes = attributes
+        };
+    }
+
+    private static object? ConvertScalar(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.String => value.GetString(),
+        JsonValueKind.Number => value.TryGetInt64(out var l)
+            ? l
+            : value.GetDouble(),
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        JsonValueKind.Null or JsonValueKind.Undefined => null,
+        _ => value.GetRawText()
+    };
+
+    private static partial class Log
+    {
+        [LoggerMessage(9270, LogLevel.Warning,
+            "DAG source {SourceId} stopped after reaching the page cap of {MaxPages}")]
+        public static partial void PageCapReached(ILogger logger, string sourceId, int maxPages);
+    }
+}

--- a/src/Honua.Postgres/Features/Geoprocessing/ExternalPostgisDagSource.cs
+++ b/src/Honua.Postgres/Features/Geoprocessing/ExternalPostgisDagSource.cs
@@ -1,0 +1,204 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Npgsql;
+
+namespace Honua.Postgres.Features.Geoprocessing;
+
+/// <summary>
+/// <c>source.postgis</c> DAG connector. Streams features from a customer-owned
+/// PostGIS table/view identified by a registered secure connection — the read-side
+/// mirror of <c>sink.external-postgis</c>. The connection string is resolved by the
+/// executor from the same secure-connection secret handling the sink uses (raw
+/// connection strings never cross the DAG); this reader only consumes the resolved
+/// string. Geometry is projected to GeoJSON server-side with <c>ST_AsGeoJSON</c> so
+/// no native client geometry library is needed, and rows stream through a forward-only
+/// reader to keep memory bounded for large extracts. Identifiers are validated against
+/// a strict pattern before interpolation since they cannot be parameterised in SQL.
+/// </summary>
+internal sealed partial class ExternalPostgisDagSource : IDagFeatureSource
+{
+    private readonly NpgsqlDataSource? _injectedDataSource;
+
+    public ExternalPostgisDagSource()
+    {
+    }
+
+    internal ExternalPostgisDagSource(NpgsqlDataSource dataSource)
+    {
+        _injectedDataSource = dataSource;
+    }
+
+    public string SourceId => "source.postgis";
+
+    public async IAsyncEnumerable<DagSourceFeature> ReadAsync(
+        DagSourceRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var schema = Identifier(string.IsNullOrWhiteSpace(request.PostgisSchema) ? "public" : request.PostgisSchema!);
+        var table = Identifier(Require(request.PostgisTable, "table"));
+        var geometryColumn = Identifier(string.IsNullOrWhiteSpace(request.PostgisGeometryColumn) ? "geom" : request.PostgisGeometryColumn!);
+        var sql = BuildSql(schema, table, geometryColumn, request, out var parameters);
+
+        await using var connection = await OpenConnectionAsync(request, cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        foreach (var (name, value) in parameters)
+        {
+            command.Parameters.AddWithValue(name, value);
+        }
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var geometryOrdinal = reader.GetOrdinal("__honua_geom_geojson");
+
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            string? geometryGeoJson = await reader.IsDBNullAsync(geometryOrdinal, cancellationToken).ConfigureAwait(false)
+                ? null
+                : reader.GetString(geometryOrdinal);
+
+            var attributes = new Dictionary<string, object?>(StringComparer.Ordinal);
+            for (var i = 0; i < reader.FieldCount; i++)
+            {
+                if (i == geometryOrdinal)
+                {
+                    continue;
+                }
+
+                var columnName = reader.GetName(i);
+                attributes[columnName] = await reader.IsDBNullAsync(i, cancellationToken).ConfigureAwait(false)
+                    ? null
+                    : reader.GetValue(i);
+            }
+
+            yield return new DagSourceFeature
+            {
+                GeometryGeoJson = geometryGeoJson,
+                Attributes = attributes
+            };
+        }
+    }
+
+    private async Task<NpgsqlConnection> OpenConnectionAsync(DagSourceRequest request, CancellationToken cancellationToken)
+    {
+        if (_injectedDataSource is not null)
+        {
+            return await _injectedDataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        if (string.IsNullOrWhiteSpace(request.PostgisConnectionString))
+        {
+            throw new InvalidOperationException("source.postgis requires a resolved secure connection.");
+        }
+
+        var connection = new NpgsqlConnection(request.PostgisConnectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+
+    private static string BuildSql(
+        string schema,
+        string table,
+        string geometryColumn,
+        DagSourceRequest request,
+        out List<(string Name, object Value)> parameters)
+    {
+        parameters = [];
+        var sql = new StringBuilder();
+
+        // ST_AsGeoJSON projects the geometry server-side so the reader needs no native
+        // geometry library; the alias is filtered out of the attribute projection.
+        sql.Append("SELECT *, ST_AsGeoJSON(\"")
+            .Append(geometryColumn)
+            .Append("\") AS __honua_geom_geojson FROM \"")
+            .Append(schema)
+            .Append("\".\"")
+            .Append(table)
+            .Append('"');
+
+        var predicates = new List<string>(3);
+
+        if (!string.IsNullOrWhiteSpace(request.Where))
+        {
+            // Operator-supplied predicate (validated upstream); appended verbatim.
+            predicates.Add($"({request.Where})");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Since) && !string.IsNullOrWhiteSpace(request.WatermarkField))
+        {
+            var watermarkColumn = Identifier(request.WatermarkField!);
+            predicates.Add($"\"{watermarkColumn}\" >= @__since");
+            parameters.Add(("__since", request.Since!));
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Bbox))
+        {
+            var (minX, minY, maxX, maxY) = ParseBbox(request.Bbox);
+            var srid = request.OutputSrid ?? 4326;
+            predicates.Add(
+                $"\"{geometryColumn}\" && ST_MakeEnvelope("
+                + $"{minX.ToString(CultureInfo.InvariantCulture)},"
+                + $"{minY.ToString(CultureInfo.InvariantCulture)},"
+                + $"{maxX.ToString(CultureInfo.InvariantCulture)},"
+                + $"{maxY.ToString(CultureInfo.InvariantCulture)},"
+                + $"{srid.ToString(CultureInfo.InvariantCulture)})");
+        }
+
+        if (predicates.Count > 0)
+        {
+            sql.Append(" WHERE ").Append(string.Join(" AND ", predicates));
+        }
+
+        return sql.ToString();
+    }
+
+    private static (double MinX, double MinY, double MaxX, double MaxY) ParseBbox(string bbox)
+    {
+        var parts = bbox.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length != 4
+            || !double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var minX)
+            || !double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var minY)
+            || !double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var maxX)
+            || !double.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var maxY))
+        {
+            throw new InvalidOperationException("source.postgis bbox must be 'minX,minY,maxX,maxY'.");
+        }
+
+        return (minX, minY, maxX, maxY);
+    }
+
+    private static string Identifier(string value)
+    {
+        if (!IdentifierRegex().IsMatch(value))
+        {
+            throw new InvalidOperationException(
+                $"identifier '{value}' is invalid; identifiers must match ^[A-Za-z_][A-Za-z0-9_]*$.");
+        }
+
+        return value;
+    }
+
+    private static string Require(string? value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"source.postgis requires a '{name}' option.");
+        }
+
+        return value;
+    }
+
+    [GeneratedRegex("^[A-Za-z_][A-Za-z0-9_]*$")]
+    private static partial Regex IdentifierRegex();
+}

--- a/src/Honua.Postgres/Features/Geoprocessing/GeoJsonPageReader.cs
+++ b/src/Honua.Postgres/Features/Geoprocessing/GeoJsonPageReader.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Migration.Services;
+
+namespace Honua.Postgres.Features.Geoprocessing;
+
+/// <summary>
+/// Shared GeoJSON page-fetch + feature-projection helper for the HTTP DAG source
+/// connectors (<c>source.ogc-features</c>, <c>source.wfs</c>). Reuses the migration
+/// <see cref="MigrationHttpContentReader"/> body-size ceiling so the bounded-buffer
+/// SSRF-mitigation posture matches the import scanners. Parses a GeoJSON
+/// FeatureCollection page and projects each member onto <see cref="DagSourceFeature"/>
+/// (geometry re-serialised as a GeoJSON geometry string, properties flattened to a
+/// scalar attribute map).
+/// </summary>
+internal static class GeoJsonPageReader
+{
+    /// <summary>
+    /// Fetches a GeoJSON document from <paramref name="url"/> and returns the parsed
+    /// page: the projected features, an optional <c>numberMatched</c> total, and the
+    /// raw first-feature text used to detect a non-advancing server.
+    /// </summary>
+    public static async Task<GeoJsonPage> FetchPageAsync(
+        HttpClient httpClient,
+        Uri url,
+        string? basicUsername,
+        string? basicPassword,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Accept.Clear();
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/geo+json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        ApplyBasicAuth(request, basicUsername, basicPassword);
+
+        using var response = await httpClient
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var body = await MigrationHttpContentReader
+            .ReadStringWithLimitAsync(response, MigrationHttpContentReader.DefaultMaxResponseBytes, cancellationToken)
+            .ConfigureAwait(false);
+
+        return ParsePage(body);
+    }
+
+    internal static GeoJsonPage ParsePage(string body)
+    {
+        using var document = JsonDocument.Parse(body);
+        var root = document.RootElement;
+
+        var features = new List<DagSourceFeature>();
+        string? firstFeatureRaw = null;
+        string? nextLink = null;
+        long? numberMatched = null;
+
+        if (root.TryGetProperty("features", out var featureArray)
+            && featureArray.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var feature in featureArray.EnumerateArray())
+            {
+                firstFeatureRaw ??= feature.GetRawText();
+                features.Add(ProjectFeature(feature));
+            }
+        }
+
+        if (root.TryGetProperty("numberMatched", out var matched)
+            && matched.ValueKind == JsonValueKind.Number
+            && matched.TryGetInt64(out var matchedValue))
+        {
+            numberMatched = matchedValue;
+        }
+
+        if (root.TryGetProperty("links", out var links) && links.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var link in links.EnumerateArray())
+            {
+                if (link.TryGetProperty("rel", out var rel)
+                    && rel.ValueKind == JsonValueKind.String
+                    && string.Equals(rel.GetString(), "next", StringComparison.OrdinalIgnoreCase)
+                    && link.TryGetProperty("href", out var href)
+                    && href.ValueKind == JsonValueKind.String)
+                {
+                    nextLink = href.GetString();
+                    break;
+                }
+            }
+        }
+
+        return new GeoJsonPage(features, firstFeatureRaw, nextLink, numberMatched);
+    }
+
+    private static DagSourceFeature ProjectFeature(JsonElement feature)
+    {
+        string? geometryGeoJson = null;
+        if (feature.TryGetProperty("geometry", out var geometry)
+            && geometry.ValueKind == JsonValueKind.Object)
+        {
+            geometryGeoJson = geometry.GetRawText();
+        }
+
+        var attributes = new Dictionary<string, object?>(StringComparer.Ordinal);
+        if (feature.TryGetProperty("properties", out var properties)
+            && properties.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in properties.EnumerateObject())
+            {
+                attributes[property.Name] = ConvertScalar(property.Value);
+            }
+        }
+
+        return new DagSourceFeature
+        {
+            GeometryGeoJson = geometryGeoJson,
+            Attributes = attributes
+        };
+    }
+
+    private static object? ConvertScalar(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.String => value.GetString(),
+        JsonValueKind.Number => value.TryGetInt64(out var l) ? l : value.GetDouble(),
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        JsonValueKind.Null or JsonValueKind.Undefined => null,
+        _ => value.GetRawText()
+    };
+
+    private static void ApplyBasicAuth(HttpRequestMessage request, string? username, string? password)
+    {
+        if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password))
+        {
+            return;
+        }
+
+        var encoded = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{username}:{password}"));
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", encoded);
+    }
+}
+
+/// <summary>A single parsed GeoJSON page from a paginated HTTP source.</summary>
+internal sealed record GeoJsonPage(
+    IReadOnlyList<DagSourceFeature> Features,
+    string? FirstFeatureRaw,
+    string? NextLink,
+    long? NumberMatched);

--- a/src/Honua.Postgres/Features/Geoprocessing/HonuaLayerDagSource.cs
+++ b/src/Honua.Postgres/Features/Geoprocessing/HonuaLayerDagSource.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace Honua.Postgres.Features.Geoprocessing;
+
+/// <summary>
+/// <c>source.honua-layer</c> DAG connector. Streams features from a Honua catalog
+/// layer by REUSING the canonical query pipeline
+/// (<see cref="IStreamingFeatureStore.StreamFeaturesAsync"/>) rather than touching
+/// SQL directly, so the layer's permanent filters, paging, CRS handling, and field
+/// masking are inherited. The where/bbox/since inputs are translated into a
+/// <see cref="FeatureQuery"/>; the streamed WKB geometry is converted to GeoJSON
+/// through the shared managed NetTopologySuite reader/writer (no native dependency).
+/// </summary>
+internal sealed class HonuaLayerDagSource : IDagFeatureSource
+{
+    private readonly IStreamingFeatureStore _streamingStore;
+
+    public HonuaLayerDagSource(IStreamingFeatureStore streamingStore)
+    {
+        _streamingStore = streamingStore;
+    }
+
+    public string SourceId => "source.honua-layer";
+
+    public async IAsyncEnumerable<DagSourceFeature> ReadAsync(
+        DagSourceRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.LayerId is not { } layerId)
+        {
+            throw new InvalidOperationException("source.honua-layer requires a layerId.");
+        }
+
+        var query = BuildQuery(request);
+
+        // Per-feature WKB -> GeoJSON conversion via the shared managed NTS reader/writer.
+        var wkbReader = new WKBReader();
+        var geoJsonWriter = new GeoJsonWriter();
+
+        await foreach (var feature in _streamingStore
+            .StreamFeaturesAsync(layerId, query, cancellationToken)
+            .ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            string? geometryGeoJson = null;
+            if (feature.Geometry is { Length: > 0 } wkb)
+            {
+                var geometry = wkbReader.Read(wkb);
+                if (geometry is not null && !geometry.IsEmpty)
+                {
+                    geometryGeoJson = geoJsonWriter.Write(geometry);
+                }
+            }
+
+            yield return new DagSourceFeature
+            {
+                GeometryGeoJson = geometryGeoJson,
+                Attributes = feature.Attributes
+            };
+        }
+    }
+
+    private static FeatureQuery BuildQuery(DagSourceRequest request)
+    {
+        var where = BuildWhereClause(request);
+
+        ImmutableArray<string>? outFields = string.IsNullOrWhiteSpace(request.OutFields)
+            ? null
+            : request.OutFields
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToImmutableArray();
+
+        return new FeatureQuery
+        {
+            Where = where,
+            OutFields = outFields,
+            OutputSrid = request.OutputSrid,
+            SpatialFilter = BuildSpatialFilter(request),
+            IncludeZ = true,
+            IncludeM = false
+        };
+    }
+
+    private static string? BuildWhereClause(DagSourceRequest request)
+    {
+        var clauses = new List<string>(2);
+        if (!string.IsNullOrWhiteSpace(request.Where))
+        {
+            clauses.Add(request.Where);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Since) && !string.IsNullOrWhiteSpace(request.WatermarkField))
+        {
+            clauses.Add($"{request.WatermarkField} >= TIMESTAMP '{request.Since!.Replace("'", "''", StringComparison.Ordinal)}'");
+        }
+
+        return clauses.Count == 0 ? null : string.Join(" AND ", clauses);
+    }
+
+    private static SpatialFilter? BuildSpatialFilter(DagSourceRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Bbox))
+        {
+            return null;
+        }
+
+        var parts = request.Bbox.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length != 4
+            || !double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var minX)
+            || !double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var minY)
+            || !double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var maxX)
+            || !double.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var maxY))
+        {
+            throw new InvalidOperationException("source.honua-layer bbox must be 'minX,minY,maxX,maxY'.");
+        }
+
+        var srid = request.OutputSrid ?? 4326;
+        var factory = new GeometryFactory(new PrecisionModel(), srid);
+        var envelope = factory.ToGeometry(new Envelope(minX, maxX, minY, maxY));
+        var wkb = new WKBWriter().Write(envelope);
+        return SpatialFilter.Create(wkb, SpatialRelationship.Intersects, srid, isSimpleEnvelope: true);
+    }
+}

--- a/src/Honua.Postgres/Features/Geoprocessing/OgcFeaturesDagSource.cs
+++ b/src/Honua.Postgres/Features/Geoprocessing/OgcFeaturesDagSource.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Postgres.Features.Geoprocessing;
+
+/// <summary>
+/// <c>source.ogc-features</c> DAG connector. Streams features from an OGC API
+/// Features collection using the same link-based pagination the one-shot OGC API
+/// Features import uses: an initial <c>items</c> request with <c>limit</c> (plus
+/// optional <c>bbox</c>/<c>filter</c>/<c>datetime</c>) followed by the chain of
+/// <c>rel="next"</c> links until exhausted. Page fetch + GeoJSON projection are reused
+/// from <see cref="GeoJsonPageReader"/> (bounded-buffer body read).
+/// </summary>
+internal sealed partial class OgcFeaturesDagSource : IDagFeatureSource
+{
+    private const int DefaultMaxPages = 1000;
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<OgcFeaturesDagSource> _logger;
+
+    public OgcFeaturesDagSource(HttpClient httpClient, ILogger<OgcFeaturesDagSource> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public string SourceId => "source.ogc-features";
+
+    public async IAsyncEnumerable<DagSourceFeature> ReadAsync(
+        DagSourceRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.ServiceUrl))
+        {
+            throw new InvalidOperationException("source.ogc-features requires a serviceUrl.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.CollectionId))
+        {
+            throw new InvalidOperationException("source.ogc-features requires a collectionId.");
+        }
+
+        var maxPages = request.MaxPages is > 0 ? request.MaxPages.Value : DefaultMaxPages;
+        Uri? nextUri = BuildItemsUri(request);
+        string? previousFirstFeatureRaw = null;
+        var page = 0;
+
+        while (nextUri is not null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (page >= maxPages)
+            {
+                Log.PageCapReached(_logger, SourceId, maxPages);
+                yield break;
+            }
+
+            page++;
+            var fetched = await GeoJsonPageReader
+                .FetchPageAsync(_httpClient, nextUri, request.Username, request.Password, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (fetched.Features.Count == 0)
+            {
+                yield break;
+            }
+
+            // Guard against a non-advancing server returning the same first page.
+            if (page > 1 && fetched.FirstFeatureRaw is not null
+                && string.Equals(fetched.FirstFeatureRaw, previousFirstFeatureRaw, StringComparison.Ordinal))
+            {
+                yield break;
+            }
+
+            previousFirstFeatureRaw = fetched.FirstFeatureRaw;
+
+            foreach (var feature in fetched.Features)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return feature;
+            }
+
+            nextUri = string.IsNullOrWhiteSpace(fetched.NextLink)
+                ? null
+                : new Uri(nextUri, fetched.NextLink);
+        }
+    }
+
+    private static Uri BuildItemsUri(DagSourceRequest request)
+    {
+        var trimmed = request.ServiceUrl!.TrimEnd('/');
+        var itemsUrl = $"{trimmed}/collections/{Uri.EscapeDataString(request.CollectionId!)}/items";
+        var builder = new UriBuilder(itemsUrl);
+
+        var query = new List<string>
+        {
+            $"limit={(request.PageSize <= 0 ? 1000 : request.PageSize).ToString(CultureInfo.InvariantCulture)}"
+        };
+
+        if (!string.IsNullOrWhiteSpace(request.Bbox))
+        {
+            query.Add($"bbox={Uri.EscapeDataString(request.Bbox)}");
+        }
+
+        // Where is interpreted as a CQL2-text filter on the OGC API Features path.
+        if (!string.IsNullOrWhiteSpace(request.Where))
+        {
+            query.Add($"filter={Uri.EscapeDataString(request.Where)}");
+            query.Add("filter-lang=cql2-text");
+        }
+
+        // Watermark (incremental extract) maps to the standard datetime open-interval.
+        if (!string.IsNullOrWhiteSpace(request.Since))
+        {
+            query.Add($"datetime={Uri.EscapeDataString(request.Since)}/..");
+        }
+
+        builder.Query = string.Join("&", query);
+        return builder.Uri;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9271, LogLevel.Warning,
+            "DAG source {SourceId} stopped after reaching the page cap of {MaxPages}")]
+        public static partial void PageCapReached(ILogger logger, string sourceId, int maxPages);
+    }
+}

--- a/src/Honua.Postgres/Features/Geoprocessing/WfsDagSource.cs
+++ b/src/Honua.Postgres/Features/Geoprocessing/WfsDagSource.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Postgres.Features.Geoprocessing;
+
+/// <summary>
+/// <c>source.wfs</c> DAG connector. Streams features from a WFS <c>GetFeature</c>
+/// endpoint using the same <c>startIndex</c>/<c>count</c> paging the one-shot WFS
+/// import uses (GeoJSON output, terminate on an empty page, <c>numberMatched</c>
+/// advance check, and a repeated-first-feature guard for servers that ignore
+/// <c>startIndex</c>). Page fetch + GeoJSON projection are reused from
+/// <see cref="GeoJsonPageReader"/>.
+/// </summary>
+internal sealed partial class WfsDagSource : IDagFeatureSource
+{
+    private const int DefaultMaxPages = 1000;
+    private const string DefaultVersion = "2.0.0";
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<WfsDagSource> _logger;
+
+    public WfsDagSource(HttpClient httpClient, ILogger<WfsDagSource> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public string SourceId => "source.wfs";
+
+    public async IAsyncEnumerable<DagSourceFeature> ReadAsync(
+        DagSourceRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.ServiceUrl))
+        {
+            throw new InvalidOperationException("source.wfs requires a serviceUrl.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.CollectionId))
+        {
+            throw new InvalidOperationException("source.wfs requires a typeName (collectionId).");
+        }
+
+        var pageSize = request.PageSize <= 0 ? 1000 : request.PageSize;
+        var maxPages = request.MaxPages is > 0 ? request.MaxPages.Value : DefaultMaxPages;
+
+        var startIndex = 0;
+        var page = 0;
+        string? previousFirstFeatureRaw = null;
+        var hasMore = true;
+
+        while (hasMore)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (page >= maxPages)
+            {
+                Log.PageCapReached(_logger, SourceId, maxPages);
+                yield break;
+            }
+
+            page++;
+            var url = BuildGetFeatureUri(request, startIndex, pageSize);
+            var fetched = await GeoJsonPageReader
+                .FetchPageAsync(_httpClient, url, request.Username, request.Password, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (fetched.Features.Count == 0)
+            {
+                yield break;
+            }
+
+            if (page > 1 && fetched.FirstFeatureRaw is not null
+                && string.Equals(fetched.FirstFeatureRaw, previousFirstFeatureRaw, StringComparison.Ordinal))
+            {
+                // The server ignores startIndex (returns the same page); stop to avoid duplicates.
+                yield break;
+            }
+
+            previousFirstFeatureRaw = fetched.FirstFeatureRaw;
+
+            foreach (var feature in fetched.Features)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return feature;
+            }
+
+            startIndex += fetched.Features.Count;
+
+            // Do not infer "done" from a short page (many WFS servers cap below the
+            // requested count). Advance until an empty page, or past numberMatched.
+            hasMore = fetched.NumberMatched is null || startIndex < fetched.NumberMatched.Value;
+        }
+    }
+
+    private static Uri BuildGetFeatureUri(DagSourceRequest request, int startIndex, int count)
+    {
+        var version = DefaultVersion;
+        var builder = new UriBuilder(request.ServiceUrl!);
+
+        var query = new List<string>
+        {
+            "service=WFS",
+            $"version={version}",
+            "request=GetFeature",
+            $"typeNames={Uri.EscapeDataString(request.CollectionId!)}",
+            "outputFormat=application/json",
+            $"count={count.ToString(CultureInfo.InvariantCulture)}",
+            $"startIndex={startIndex.ToString(CultureInfo.InvariantCulture)}"
+        };
+
+        if (!string.IsNullOrWhiteSpace(request.Bbox))
+        {
+            query.Add($"bbox={Uri.EscapeDataString(request.Bbox)}");
+        }
+
+        builder.Query = string.Join("&", query);
+        return builder.Uri;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9272, LogLevel.Warning,
+            "DAG source {SourceId} stopped after reaching the page cap of {MaxPages}")]
+        public static partial void PageCapReached(ILogger logger, string sourceId, int maxPages);
+    }
+}

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Geometry.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Geometry.cs
@@ -19,7 +19,7 @@ namespace Honua.Postgres.Features.Migration;
 
 internal sealed partial class GeoservicesImportService
 {
-    private static string? ConvertEsriGeometryToGeoJson(JsonElement geometry)
+    internal static string? ConvertEsriGeometryToGeoJson(JsonElement geometry)
     {
         // Esri JSON geometry format is similar to GeoJSON but not identical
         // This converts common geometry types to GeoJSON

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -41,7 +41,9 @@ using Honua.Postgres.Features.AnalysisContent;
 using Honua.Postgres.Features.AuditLog;
 using Honua.Postgres.Features.Attachments;
 using Honua.Postgres.Features.FeatureStore;
+using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Postgres.Features.Geometry;
+using Honua.Postgres.Features.Geoprocessing;
 using Honua.Postgres.Features.GeometryService;
 using Honua.Postgres.Features.HealthCheck;
 using Honua.Postgres.Features.Migration;
@@ -580,6 +582,49 @@ internal static class ServiceCollectionExtensions
                 serviceProvider.GetRequiredService<ILogger<OgcWfsImportService>>(),
                 serviceProvider.GetService<PostgresSchemaConfiguration>());
         });
+
+        // First-class DAG remote source connectors (feat/etl-remote-source-connectors).
+        // Each IDagFeatureSource streams features into a geoprocessing workflow by reusing
+        // an existing one-shot import reader's pagination/streaming rather than bouncing
+        // through a one-shot import. The geoprocessing RemoteSourceExecutor resolves these
+        // at execution time through an IServiceScopeFactory scope.
+        //   - source.esri-featureserver wraps the migration ArcGisRestClient (registered above);
+        //   - source.honua-layer wraps the canonical IStreamingFeatureStore query pipeline;
+        //   - source.postgis mirrors the sink.external-postgis secure-connection handling;
+        //   - source.ogc-features / source.wfs reuse the migration bounded-buffer GeoJSON path.
+        services.AddScoped<IDagFeatureSource, EsriFeatureServerDagSource>(serviceProvider =>
+            new EsriFeatureServerDagSource(
+                serviceProvider.GetRequiredService<ArcGisRestClient>(),
+                serviceProvider.GetRequiredService<ILogger<EsriFeatureServerDagSource>>()));
+        services.AddScoped<IDagFeatureSource, HonuaLayerDagSource>(serviceProvider =>
+            new HonuaLayerDagSource(
+                serviceProvider.GetRequiredService<IStreamingFeatureStore>()));
+        services.AddScoped<IDagFeatureSource, ExternalPostgisDagSource>(_ =>
+            new ExternalPostgisDagSource());
+
+        services.AddResilientHttpClient<OgcFeaturesDagSource>(
+            "dag-source-ogc-features",
+            HttpResiliencePolicies.SlowServiceDefaults,
+            configureClient: client =>
+            {
+                client.DefaultRequestHeaders.Add("User-Agent", "HonuaServer/1.0");
+                client.Timeout = TimeSpan.FromMinutes(10);
+            },
+            configureHandler: static () => OgcApiFeaturesImportService.CreatePinnedDnsHttpMessageHandler());
+        services.AddScoped<IDagFeatureSource>(serviceProvider =>
+            serviceProvider.GetRequiredService<OgcFeaturesDagSource>());
+
+        services.AddResilientHttpClient<WfsDagSource>(
+            "dag-source-wfs",
+            HttpResiliencePolicies.SlowServiceDefaults,
+            configureClient: client =>
+            {
+                client.DefaultRequestHeaders.Add("User-Agent", "HonuaServer/1.0");
+                client.Timeout = TimeSpan.FromMinutes(5);
+            },
+            configureHandler: static () => OgcServiceMigrationScanner.CreatePinnedDnsHttpMessageHandler());
+        services.AddScoped<IDagFeatureSource>(serviceProvider =>
+            serviceProvider.GetRequiredService<WfsDagSource>());
 
         // Register OGC WMTS tile-cache export service (#1016 slice 4). Reuses the OGC service
         // migration scanner for inventory/manifest resolution; the dedicated HTTP client is

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Geoprocessing/DagSourceReaderTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Geoprocessing/DagSourceReaderTests.cs
@@ -1,0 +1,344 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
+using Honua.Postgres.Features.Geoprocessing;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NSubstitute;
+
+namespace Honua.Postgres.Tests.Features.Geoprocessing;
+
+/// <summary>
+/// In-memory unit coverage for the first-class DAG remote source connectors. Each
+/// reader is exercised against a faked transport (HttpMessageHandler / streaming
+/// feature store) so the upstream-query build, pagination/streaming, and GeoJSON
+/// projection are verified without Docker or a live remote service.
+/// </summary>
+public sealed class DagSourceReaderTests
+{
+    // -------------------------------------------------------------------------
+    // source.esri-featureserver — wraps ArcGisRestClient paging + Esri->GeoJSON
+    // -------------------------------------------------------------------------
+
+    [UnitTest]
+    public async Task EsriFeatureServer_PaginatesUntilTransferLimitClears_AndConvertsGeometry()
+    {
+        var page1 = """
+        {"features":[
+          {"attributes":{"OBJECTID":1,"name":"a"},"geometry":{"x":10.0,"y":20.0}},
+          {"attributes":{"OBJECTID":2,"name":"b"},"geometry":{"x":30.0,"y":40.0}}
+        ],"exceededTransferLimit":true,"spatialReference":{"wkid":4326}}
+        """;
+        var page2 = """
+        {"features":[
+          {"attributes":{"OBJECTID":3,"name":"c"},"geometry":{"x":50.0,"y":60.0}}
+        ],"exceededTransferLimit":false,"spatialReference":{"wkid":4326}}
+        """;
+        var page3Empty = """{"features":[],"exceededTransferLimit":false}""";
+
+        var capturedUrls = new List<string>();
+        var handler = new SequencedJsonHandler(capturedUrls, page1, page2, page3Empty);
+        var reader = new EsriFeatureServerDagSource(
+            BuildArcGisClient(handler),
+            NullLogger<EsriFeatureServerDagSource>.Instance);
+
+        var request = new DagSourceRequest
+        {
+            ServiceUrl = "https://example.com/arcgis/rest/services/Sample/FeatureServer",
+            EsriLayerId = 0,
+            Where = "status = 'active'",
+            PageSize = 2,
+            OutputSrid = 4326
+        };
+
+        var features = await CollectAsync(reader.ReadAsync(request));
+
+        features.Should().HaveCount(3);
+        // Geometry round-trips to GeoJSON points through the reused Esri->GeoJSON converter.
+        var firstGeometry = new GeoJsonReader().Read<Geometry>(features[0].GeometryGeoJson!) as Point;
+        firstGeometry!.X.Should().BeApproximately(10.0, 1e-9);
+        firstGeometry.Y.Should().BeApproximately(20.0, 1e-9);
+        features[0].Attributes["name"].Should().Be("a");
+
+        // The where clause + paging offsets were pushed into the upstream query URL.
+        capturedUrls.Should().Contain(u => u.Contains("where=status", StringComparison.Ordinal));
+        capturedUrls.Should().Contain(u => u.Contains("resultOffset=0", StringComparison.Ordinal));
+        capturedUrls.Should().Contain(u => u.Contains("resultOffset=2", StringComparison.Ordinal));
+    }
+
+    [UnitTest]
+    public async Task EsriFeatureServer_SinceWatermark_AddsTemporalPredicate()
+    {
+        var page = """{"features":[],"exceededTransferLimit":false}""";
+        var capturedUrls = new List<string>();
+        var handler = new SequencedJsonHandler(capturedUrls, page);
+        var reader = new EsriFeatureServerDagSource(
+            BuildArcGisClient(handler),
+            NullLogger<EsriFeatureServerDagSource>.Instance);
+
+        var request = new DagSourceRequest
+        {
+            ServiceUrl = "https://example.com/arcgis/rest/services/Sample/FeatureServer",
+            Since = "2026-01-01T00:00:00Z",
+            WatermarkField = "last_edited_date"
+        };
+
+        _ = await CollectAsync(reader.ReadAsync(request));
+
+        capturedUrls.Should().ContainSingle()
+            .Which.Should().Contain("last_edited_date");
+    }
+
+    // -------------------------------------------------------------------------
+    // source.ogc-features — link-based pagination + bbox/filter query build
+    // -------------------------------------------------------------------------
+
+    [UnitTest]
+    public async Task OgcFeatures_FollowsNextLinks_AndPushesBboxAndFilter()
+    {
+        var page1 = """
+        {"type":"FeatureCollection","features":[
+          {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":{"id":1}}
+        ],"links":[{"rel":"next","href":"https://example.com/page2"}]}
+        """;
+        var page2 = """
+        {"type":"FeatureCollection","features":[
+          {"type":"Feature","geometry":{"type":"Point","coordinates":[3,4]},"properties":{"id":2}}
+        ],"links":[]}
+        """;
+
+        var capturedUrls = new List<string>();
+        var handler = new SequencedJsonHandler(capturedUrls, page1, page2);
+        var reader = new OgcFeaturesDagSource(new HttpClient(handler), NullLogger<OgcFeaturesDagSource>.Instance);
+
+        var request = new DagSourceRequest
+        {
+            ServiceUrl = "https://example.com/ogc",
+            CollectionId = "buildings",
+            Bbox = "0,0,10,10",
+            Where = "height>5",
+            PageSize = 1
+        };
+
+        var features = await CollectAsync(reader.ReadAsync(request));
+
+        features.Should().HaveCount(2);
+        features[1].Attributes["id"].Should().Be(2L);
+        capturedUrls[0].Should().Contain("bbox=0");
+        capturedUrls[0].Should().Contain("filter=");
+        capturedUrls[0].Should().Contain("limit=1");
+        capturedUrls[1].Should().Be("https://example.com/page2");
+    }
+
+    // -------------------------------------------------------------------------
+    // source.wfs — startIndex/count paging, terminate on empty page
+    // -------------------------------------------------------------------------
+
+    [UnitTest]
+    public async Task Wfs_PagesByStartIndex_UntilEmptyPage()
+    {
+        var page1 = """
+        {"type":"FeatureCollection","features":[
+          {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":{"gid":1}}
+        ]}
+        """;
+        var page2 = """
+        {"type":"FeatureCollection","features":[
+          {"type":"Feature","geometry":{"type":"Point","coordinates":[2,2]},"properties":{"gid":2}}
+        ]}
+        """;
+        var empty = """{"type":"FeatureCollection","features":[]}""";
+
+        var capturedUrls = new List<string>();
+        var handler = new SequencedJsonHandler(capturedUrls, page1, page2, empty);
+        var reader = new WfsDagSource(new HttpClient(handler), NullLogger<WfsDagSource>.Instance);
+
+        var request = new DagSourceRequest
+        {
+            ServiceUrl = "https://example.com/wfs",
+            CollectionId = "topp:states",
+            PageSize = 1
+        };
+
+        var features = await CollectAsync(reader.ReadAsync(request));
+
+        features.Should().HaveCount(2);
+        capturedUrls[0].Should().Contain("startIndex=0");
+        capturedUrls[0].Should().Contain("typeNames=topp");
+        capturedUrls[1].Should().Contain("startIndex=1");
+    }
+
+    [UnitTest]
+    public async Task Wfs_StopsWhenServerIgnoresStartIndex()
+    {
+        // Same page returned regardless of startIndex => the reader must stop after the
+        // repeated-first-feature is detected, not stream unbounded duplicates.
+        var samePage = """
+        {"type":"FeatureCollection","features":[
+          {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":{"gid":1}}
+        ]}
+        """;
+
+        var handler = new RepeatingJsonHandler(samePage);
+        var reader = new WfsDagSource(new HttpClient(handler), NullLogger<WfsDagSource>.Instance);
+
+        var request = new DagSourceRequest
+        {
+            ServiceUrl = "https://example.com/wfs",
+            CollectionId = "topp:states",
+            PageSize = 1
+        };
+
+        var features = await CollectAsync(reader.ReadAsync(request));
+
+        // First page yields 1; second page is detected as a repeat and stops the stream.
+        features.Should().HaveCount(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // source.honua-layer — wraps the canonical streaming feature store
+    // -------------------------------------------------------------------------
+
+    [UnitTest]
+    public async Task HonuaLayer_StreamsFromCatalog_AndBuildsBboxSpatialFilter()
+    {
+        var factory = new GeometryFactory(new PrecisionModel(), 4326);
+        var wkb = new WKBWriter().Write(factory.CreatePoint(new Coordinate(5, 6)));
+        var stored = new Feature
+        {
+            Id = 1,
+            Geometry = wkb,
+            Attributes = ImmutableDictionary<string, object?>.Empty.Add("name", "x")
+        };
+
+        FeatureQuery? capturedQuery = null;
+        var store = Substitute.For<IStreamingFeatureStore>();
+        store.StreamFeaturesAsync(Arg.Any<int>(), Arg.Do<FeatureQuery>(q => capturedQuery = q), Arg.Any<CancellationToken>())
+            .Returns(_ => ToAsync(stored));
+
+        var reader = new HonuaLayerDagSource(store);
+        var request = new DagSourceRequest
+        {
+            LayerId = 42,
+            Where = "name = 'x'",
+            Bbox = "0,0,10,10",
+            OutputSrid = 4326
+        };
+
+        var features = await CollectAsync(reader.ReadAsync(request));
+
+        features.Should().HaveCount(1);
+        var geometry = new GeoJsonReader().Read<Geometry>(features[0].GeometryGeoJson!) as Point;
+        geometry!.X.Should().BeApproximately(5, 1e-9);
+        features[0].Attributes["name"].Should().Be("x");
+
+        capturedQuery.Should().NotBeNull();
+        var query = capturedQuery!.Value;
+        query.Where.Should().Be("name = 'x'");
+        query.SpatialFilter.Should().NotBeNull();
+        query.SpatialFilter!.Value.IsSimpleEnvelope.Should().BeTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // GeoJSON page projection (shared by OGC/WFS)
+    // -------------------------------------------------------------------------
+
+    [UnitTest]
+    public void GeoJsonPageReader_ParsesNumberMatchedAndNextLink()
+    {
+        var body = """
+        {"type":"FeatureCollection","numberMatched":99,"features":[
+          {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":{"a":1}}
+        ],"links":[{"rel":"next","href":"https://example.com/n"}]}
+        """;
+
+        var page = GeoJsonPageReader.ParsePage(body);
+
+        page.Features.Should().HaveCount(1);
+        page.NumberMatched.Should().Be(99);
+        page.NextLink.Should().Be("https://example.com/n");
+        page.Features[0].Attributes["a"].Should().Be(1L);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static ArcGisRestClient BuildArcGisClient(HttpMessageHandler handler)
+        => new(
+            new HttpClient(handler),
+            NullLogger<ArcGisRestClient>.Instance,
+            // Resolve any host to a public address so the SSRF guard admits the test host.
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("8.8.8.8") }));
+
+    private static async Task<List<DagSourceFeature>> CollectAsync(IAsyncEnumerable<DagSourceFeature> stream)
+    {
+        var result = new List<DagSourceFeature>();
+        await foreach (var item in stream)
+        {
+            result.Add(item);
+        }
+
+        return result;
+    }
+
+    private static async IAsyncEnumerable<Feature> ToAsync(params Feature[] features)
+    {
+        foreach (var feature in features)
+        {
+            yield return feature;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    private sealed class SequencedJsonHandler : HttpMessageHandler
+    {
+        private readonly List<string> _capturedUrls;
+        private readonly Queue<string> _bodies;
+
+        public SequencedJsonHandler(List<string> capturedUrls, params string[] bodies)
+        {
+            _capturedUrls = capturedUrls;
+            _bodies = new Queue<string>(bodies);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            _capturedUrls.Add(request.RequestUri!.ToString());
+            var body = _bodies.Count > 0 ? _bodies.Dequeue() : """{"features":[]}""";
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class RepeatingJsonHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+
+        public RepeatingJsonHandler(string body) => _body = body;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json")
+            });
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -84,6 +84,13 @@ public sealed class CatalogExecutableConformanceTests
         // GeoETL sources.
         "source.geojson",
         "source.csv",
+        // First-class remote DAG source connectors: each runs through the dispatcher
+        // via a per-process RemoteSourceExecutor that reuses an existing import reader.
+        "source.honua-layer",
+        "source.esri-featureserver",
+        "source.ogc-features",
+        "source.wfs",
+        "source.postgis",
         // GeoETL sinks.
         "sink.geojson-file",
         "sink.quarantine",
@@ -348,8 +355,31 @@ public sealed class CatalogExecutableConformanceTests
             new ImportDatasetJobExecutor(
                 Substitute.For<IServiceScopeFactory>(),
                 NullLogger<ImportDatasetJobExecutor>.Instance),
+            BuildRemoteSourceExecutors(monitor),
             NullLogger<GeoprocessingDispatchJobExecutor>.Instance);
 
         return dispatcher.SupportedProcessIds;
+    }
+
+    private static RemoteSourceExecutor[] BuildRemoteSourceExecutors(
+        IOptionsMonitor<GeoprocessingExecutorOptions> monitor)
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        string[] sourceIds =
+        [
+            "source.honua-layer",
+            "source.esri-featureserver",
+            "source.ogc-features",
+            "source.wfs",
+            "source.postgis",
+        ];
+
+        return sourceIds
+            .Select(id => RemoteSourceExecutor.ForProcess(
+                id,
+                scopeFactory,
+                monitor,
+                NullLogger<RemoteSourceExecutor>.Instance))
+            .ToArray();
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
@@ -171,6 +171,7 @@ public sealed class GeoprocessingDispatchJobExecutorTests
             new ImportDatasetJobExecutor(
                 Substitute.For<IServiceScopeFactory>(),
                 NullLogger<ImportDatasetJobExecutor>.Instance),
+            Array.Empty<RemoteSourceExecutor>(),
             NullLogger<GeoprocessingDispatchJobExecutor>.Instance);
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/RemoteSourceExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/RemoteSourceExecutorTests.cs
@@ -1,0 +1,201 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Geoprocessing;
+using Honua.Geoprocessing.Execution;
+using Honua.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Unit coverage for the <see cref="RemoteSourceExecutor"/> wiring: it resolves the
+/// matching <see cref="IDagFeatureSource"/> from a scope, builds the upstream
+/// <see cref="DagSourceRequest"/> from the durable step inputs (including the
+/// since/watermark pass-through), streams the source features, and publishes the
+/// canonical FeatureCollection artifact. The source reader is faked so no transport runs.
+/// </summary>
+public sealed class RemoteSourceExecutorTests
+{
+    private const string DataUriPrefix = "data:application/geo+json;base64,";
+
+    [UnitTest]
+    public async Task RemoteSource_StreamsFeatures_AndPublishesFeatureCollection()
+    {
+        var fake = new FakeDagFeatureSource("source.ogc-features",
+        [
+            new DagSourceFeature
+            {
+                GeometryGeoJson = """{"type":"Point","coordinates":[1,2]}""",
+                Attributes = new Dictionary<string, object?> { ["name"] = "a" }
+            },
+            new DagSourceFeature
+            {
+                GeometryGeoJson = null,
+                Attributes = new Dictionary<string, object?> { ["name"] = "b" }
+            }
+        ]);
+
+        var (status, uri, captured) = await RunAsync(
+            fake,
+            ("serviceUrl", "https://example.com/ogc"),
+            ("collectionId", "buildings"),
+            ("bbox", "0,0,10,10"),
+            ("since", "2026-01-01T00:00:00Z"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+
+        var features = ReadFeatures(uri!);
+        features.Should().HaveCount(2);
+        features[0].Attributes.GetOptionalValue("name").Should().Be("a");
+        features[1].Geometry.Should().BeNull();
+
+        // The executor built the upstream request from the step inputs and passed the
+        // watermark through unchanged.
+        captured.Should().NotBeNull();
+        captured!.ServiceUrl.Should().Be("https://example.com/ogc");
+        captured.CollectionId.Should().Be("buildings");
+        captured.Bbox.Should().Be("0,0,10,10");
+        captured.Since.Should().Be("2026-01-01T00:00:00Z");
+    }
+
+    [UnitTest]
+    public async Task RemoteSource_NoRegisteredSource_FailsCleanly()
+    {
+        // Register a source with a different id so resolution finds no match.
+        var fake = new FakeDagFeatureSource("source.wfs", []);
+        var executor = BuildExecutor("source.ogc-features", fake);
+
+        var (status, _, _) = await RunExecutorAsync(executor, "source.ogc-features");
+        status.Should().Be(ExecutionJobStatus.Failed);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static RemoteSourceExecutor BuildExecutor(string processId, IDagFeatureSource source)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(source);
+        var provider = services.BuildServiceProvider();
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = 50L * 1024L * 1024L,
+            ResultRetention = TimeSpan.FromDays(7)
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+
+        return RemoteSourceExecutor.ForProcess(
+            processId,
+            scopeFactory,
+            monitor,
+            NullLogger<RemoteSourceExecutor>.Instance);
+    }
+
+    private static async Task<(ExecutionJobStatus Status, string? Uri, DagSourceRequest? Captured)> RunAsync(
+        FakeDagFeatureSource source,
+        params (string Name, string Value)[] inputs)
+    {
+        var executor = BuildExecutor(source.SourceId, source);
+        var (status, uri, _) = await RunExecutorAsync(executor, source.SourceId, inputs);
+        return (status, uri, source.LastRequest);
+    }
+
+    private static async Task<(ExecutionJobStatus Status, string? Uri, object? Unused)> RunExecutorAsync(
+        RemoteSourceExecutor executor,
+        string processId,
+        params (string Name, string Value)[] inputs)
+    {
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-test");
+        string? publishedUri = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedUri = call.ArgAt<string>(0));
+
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId,
+            ["protocolProcessId"] = processId,
+        };
+
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+        foreach (var (name, value) in inputs)
+        {
+            parameters[prefix + name] = value;
+        }
+
+        var record = new ExecutionJobRecord
+        {
+            OperationId = "op-test",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:test",
+                Parameters = parameters
+            }
+        };
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+        return (result.Status, publishedUri, null);
+    }
+
+    private static List<IFeature> ReadFeatures(string dataUri)
+    {
+        var bytes = Convert.FromBase64String(dataUri[DataUriPrefix.Length..]);
+        var json = Encoding.UTF8.GetString(bytes);
+        return new GeoJsonReader().Read<FeatureCollection>(json).ToList();
+    }
+
+    private sealed class FakeDagFeatureSource : IDagFeatureSource
+    {
+        private readonly IReadOnlyList<DagSourceFeature> _features;
+
+        public FakeDagFeatureSource(string sourceId, IReadOnlyList<DagSourceFeature> features)
+        {
+            SourceId = sourceId;
+            _features = features;
+        }
+
+        public string SourceId { get; }
+
+        public DagSourceRequest? LastRequest { get; private set; }
+
+        public async IAsyncEnumerable<DagSourceFeature> ReadAsync(
+            DagSourceRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            LastRequest = request;
+            foreach (var feature in _features)
+            {
+                yield return feature;
+            }
+
+            await Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #418

## Summary
DAG `source.*` nodes were limited to inline GeoJSON/CSV, so a geoprocessing pipeline could not read from a Honua layer, Esri FeatureServer, OGC API Features, WFS, or external PostGIS as a first-class DAG source — it had to bounce through a one-shot `Honua.Import`. This PR adds five first-class DAG **source connectors** that stream features straight into the workflow, **reusing the existing one-shot import readers' pagination/streaming** rather than reimplementing transport.

New source process ids: `source.honua-layer`, `source.esri-featureserver`, `source.ogc-features`, `source.wfs`, `source.postgis`. Each emits the standard FeatureCollection artifact downstream transform/sink nodes already consume.

## Changes Made
- Added a public `IDagFeatureSource` abstraction + `DagSourceRequest`/`DagSourceFeature` domain in `Honua.Core` (`Features/Geoprocessing`).
- Implemented five readers in `Honua.Postgres` (`Features/Geoprocessing`), each reusing an existing import reader:
  - `EsriFeatureServerDagSource` wraps the migration `ArcGisRestClient` (resultOffset/resultRecordCount paging terminated by `exceededTransferLimit`) and reuses its Esri-JSON → GeoJSON conversion (`GeoservicesImportService.ConvertEsriGeometryToGeoJson`, made `internal`).
  - `HonuaLayerDagSource` wraps the canonical `IStreamingFeatureStore` query pipeline (the layer's permanent filters, paging, CRS, field masking are inherited); where + bbox become a `FeatureQuery`.
  - `OgcFeaturesDagSource` / `WfsDagSource` reuse a shared `GeoJsonPageReader` over the migration bounded-buffer `MigrationHttpContentReader`; OGC follows `rel=next` links, WFS pages by `startIndex`/`count` with a repeated-first-feature guard.
  - `ExternalPostgisDagSource` is the read-side mirror of `sink.external-postgis`, reusing the same secure-connection secret handling (`ST_AsGeoJSON` server-side projection, forward-only streaming, strict identifier validation).
- Added the `RemoteSourceExecutor` in `Honua.Geoprocessing` (one instance per source id) that resolves the matching `IDagFeatureSource` through an `IServiceScopeFactory` scope (the `import.dataset` / `sink.external-postgis` provider-resolution pattern), builds the upstream request from the durable step inputs, resolves auth (ArcGIS portal token / OGC-WFS basic / PostGIS secure connection), streams features, and publishes the FeatureCollection artifact.
- Added the five `ProcessDefinition`s to `BuiltInProcessCatalog`; routed them through `GeoprocessingDispatchJobExecutor`; registered readers + executors in the Postgres / Geoprocessing DI; added the `source.postgis` secure-connection semantic check to `ProcessPlanValidator`.
- **Watermark hook:** every reader accepts an optional `since` + `watermarkField` that is passed straight through to narrow the upstream query (Esri/PostGIS temporal predicate, OGC `datetime` open interval, catalog where clause). Persisting the next watermark is left to the incremental-extract orchestration.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

`DagSourceReaderTests` (Honua.Postgres.Tests, 7 tests) cover Esri pagination + Esri→GeoJSON conversion, the since-watermark predicate, OGC next-link following with bbox/filter push-down, WFS startIndex paging + the ignore-startIndex guard, the honua-layer FeatureQuery/bbox spatial filter, and the shared GeoJSON page projection — all against faked transports/streaming stores (no Docker). `RemoteSourceExecutorTests` (Honua.Server.Tests) cover the executor wiring, watermark pass-through, and unregistered-source failure. `CatalogExecutableConformanceTests` confirms all five new source ids have dispatcher executors. Build is green with `-p:TreatWarningsAsErrors=true`.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
