### PR TITLE
feat(etl): native PROJ datum-shift reproject + OGR import reader for honua-worker-etl

### DIFF
--- a/docker/worker-gdal/Dockerfile
+++ b/docker/worker-gdal/Dockerfile
@@ -19,7 +19,13 @@ ARG DOTNET_SDK_IMAGE=mcr.microsoft.com/dotnet/sdk:10.0
 # omits the NetCDF/HDF5 drivers required by the multidimensional coverage
 # reader (ADR-0039 Path B). Verified: gdalmdiminfo reports "not recognized as
 # being in a supported file format" against NetCDF4 on the small image.
-ARG GDAL_BASE_IMAGE=ghcr.io/osgeo/gdal:ubuntu-full-latest
+#
+# PINNED to a concrete patch tag (not `-latest`) so the worker's driver universe —
+# PROJ datum-shift grids, native FileGDB (OpenFileGDB), GML app-schema, netCDF /
+# GRIB / HDF — is reproducible across builds. PROJ ships with this base; the
+# native vector reproject (transform.reproject on the native profile) and the OGR
+# import reader (source.ogr) depend on its transformation pipelines.
+ARG GDAL_BASE_IMAGE=ghcr.io/osgeo/gdal:ubuntu-full-3.12.4
 # Pinned .NET runtime version installed onto the GDAL (Ubuntu) base.
 ARG DOTNET_RUNTIME_VERSION=10.0
 
@@ -100,7 +106,14 @@ RUN command -v gdalwarp && command -v ogr2ogr && command -v gdalmdiminfo \
  && gdalinfo --formats | grep -qi GRIB \
  && command -v pdal \
  && pdal --drivers | grep -qi readers.las \
- && pdal --drivers | grep -qi filters.reprojection
+ && pdal --drivers | grep -qi filters.reprojection \
+ # PROJ datum-shift support for native vector reproject (transform.reproject on
+ # the native profile): projsync/proj.db must be present so PROJ can apply
+ # datum/grid shifts (e.g. NAD 27 -> WGS 84). The full base ships PROJ.
+ && command -v projinfo \
+ # OGR import-reader (source.ogr) format breadth the managed readers cannot serve.
+ && ogr2ogr --formats | grep -qi OpenFileGDB \
+ && ogr2ogr --formats | grep -qi GML
 
 # Non-root runtime user.
 RUN groupadd --gid 1001 --system honua \

--- a/docker/worker-gdal/README.md
+++ b/docker/worker-gdal/README.md
@@ -6,15 +6,31 @@ It is the GDAL-equipped counterpart to the lean serving image (`/Dockerfile`).
 
 ## What it is
 
-- Built on a **GDAL base image** (`ghcr.io/osgeo/gdal`) with the .NET runtime
-  layered on. The GDAL CLI tools (`gdalwarp`, `ogr2ogr`, …) are on `PATH`.
+- Built on a **GDAL base image** (`ghcr.io/osgeo/gdal:ubuntu-full-3.12.4`, pinned)
+  with the .NET runtime layered on. The GDAL CLI tools (`gdalwarp`, `ogr2ogr`, …)
+  and PROJ (datum-shift grids) are on `PATH`.
 - Runs the **same** durable job-execution loop (`JobExecutionService` /
   `JobReconciliationService` / `RedisJobQueue`) that the serving image hosts —
   it does **not** fork a parallel runtime. The entrypoint is
   `Honua.Worker.Gdal.dll`, a headless .NET Generic Host.
-- Registers **only native-profile executors** (`GdalDispatchJobExecutor` →
-  `gdal.ogr2ogr`, `gdal.gdalwarp`). Each overrides
-  `AcceptedRuntimeProfiles` to `{ "native" }`.
+- Registers **only native-profile executors** (`GdalDispatchJobExecutor`). Each
+  overrides `AcceptedRuntimeProfiles` to `{ "native" }`. Native processes:
+  - `gdal.gdalwarp` — raster reprojection (PROJ).
+  - `gdal.ogr2ogr` — vector format conversion.
+  - `transform.reproject` — **native vector reproject with full PROJ datum/grid
+    shifts** (e.g. NAD 27 → WGS 84). The heavyweight counterpart to the managed
+    `transform.reproject`, which serves only the in-memory fast paths (identity,
+    Web Mercator aliases, WGS 84 ↔ Web Mercator) and rejects datum shifts. The
+    submit path escalates a reproject job to the native profile when its SRID
+    pair is not a managed fast path (`ManagedReprojectFastPath`), so the claim
+    fence routes it here.
+  - `source.ogr` — **GDAL/OGR-backed import reader** for the broad format
+    universe the managed `source.geojson` / `source.csv` readers cannot serve
+    (native FileGDB / OpenFileGDB, GML app-schema, KML, MapInfo TAB, ESRI
+    Shapefile, GeoPackage, FlatGeobuf), canonicalizing to a GeoJSON
+    FeatureCollection. Multi-file datasets arrive as a base64 ZIP.
+  - `pcloud.translate` — LAZ/COPC decompress + reproject (PDAL).
+  - `surface.*` / `raster.*` / `coverage.multidim.metadata` raster families.
 
 ## How heavy jobs route here (and never to the lean image)
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
@@ -1019,6 +1019,20 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
             OutputArtifactKinds = [ArtifactKind.FeatureLayer],
             RuntimeProfile = RuntimeProfiles.Native
         },
+        new ProcessDefinition
+        {
+            ProcessId = "source.ogr",
+            Title = "OGR Source (GDAL)",
+            Description = "GDAL/OGR-backed import reader executed out-of-process by the heavyweight worker via the ogr2ogr CLI. The native counterpart to the managed source.geojson / source.csv readers (hand-rolled NetTopologySuite parsers limited to GeoJSON and CSV): source.ogr canonicalizes the FULL OGR driver universe — native File Geodatabase (OpenFileGDB), GML / GML application schemas, KML, MapInfo TAB, ESRI Shapefile, GeoPackage, FlatGeobuf, and (where the worker image's drivers are compiled in) database-spatial sources — into the standard GeoJSON FeatureCollection artifact every workflow DAG starts from. Multi-file datasets (Shapefile sidecars, FileGDB directories) are supplied as a base64 ZIP and unpacked in an isolated scratch workspace. Routed to the native worker profile — NOT executable in the GDAL-free serving image.",
+            Category = "source",
+            Parameters =
+            [
+                Param("source", "Source Dataset", "Source dataset as base64-encoded bytes in the source format. Multi-file datasets (Shapefile, FileGDB) are supplied as a base64-encoded ZIP archive, which the worker unpacks before opening with OGR.", ProcessParameterValueType.Text, required: true),
+                Param("sourceFormat", "Source Format", "Source OGR driver hint used to choose the input file extension when the payload is a single file. Allowed values include: GeoJSON, GML, KML, GPKG, FlatGeobuf, MapInfo File, CSV, ESRI Shapefile, OpenFileGDB. Defaults to GeoJSON. ZIP-packaged datasets are detected by content and the hint is advisory.", ProcessParameterValueType.Text, defaultValue: "GeoJSON"),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
 
         // -----------------------------------------------------------------------
         // Point-cloud conversion (1)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ManagedReprojectFastPath.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ManagedReprojectFastPath.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// Single source of truth for the SRID pairs the lean, GDAL-free
+/// <c>transform.reproject</c> path (<see cref="ReprojectTransformExecutor"/>) can
+/// serve in-memory via the shared <c>CoordinateTransformer</c>: identity, the Web
+/// Mercator aliases, and WGS 84 (4326) ↔ Web Mercator. Every OTHER pair is a
+/// datum/grid shift that requires PROJ's transformation pipelines and is therefore
+/// routed to the heavyweight native worker (<c>GdalVectorReprojectJobExecutor</c>
+/// via <c>ogr2ogr -s_srs/-t_srs</c>).
+///
+/// The geoprocessing submit path (<c>GeoprocessingJobService.ResolveRequiredRuntimeProfile</c>)
+/// consults <see cref="RequiresNativeWorker(int, int)"/> to ESCALATE such a job to
+/// the native runtime profile BEFORE it is queued, so the claim fence hands the job
+/// to the GDAL worker rather than the lean dispatcher rejecting it at execution time.
+/// Centralizing the predicate here keeps the managed executor's accept-set and the
+/// submit-path escalation provably in lock-step: a pair is native iff it is NOT a
+/// managed fast-path, with no second copy of the rule to drift.
+/// </summary>
+internal static class ManagedReprojectFastPath
+{
+    /// <summary>
+    /// The Web Mercator SRID and its common authority aliases. Reprojecting between
+    /// any two of these is a no-op datum-wise (same WGS 84 datum, same projection
+    /// math) and is served on the managed path.
+    /// </summary>
+    private static readonly HashSet<int> WebMercatorAliases =
+        new() { 3857, 900913, 102100, 102113, 3785 };
+
+    /// <summary>
+    /// Returns <c>true</c> when reprojecting from <paramref name="fromSrid"/> to
+    /// <paramref name="toSrid"/> is one of the managed in-memory fast paths: identity
+    /// (same SRID), Web-Mercator-alias ↔ Web-Mercator-alias, or WGS 84 (4326) ↔ Web
+    /// Mercator. These need no datum shift, so the lean executor handles them.
+    /// </summary>
+    public static bool IsManagedFastPath(int fromSrid, int toSrid)
+    {
+        if (fromSrid == toSrid)
+        {
+            return true;
+        }
+
+        if (WebMercatorAliases.Contains(fromSrid) && WebMercatorAliases.Contains(toSrid))
+        {
+            return true;
+        }
+
+        if (fromSrid == 4326 && WebMercatorAliases.Contains(toSrid))
+        {
+            return true;
+        }
+
+        return WebMercatorAliases.Contains(fromSrid) && toSrid == 4326;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the SRID pair is NOT a managed fast path and therefore
+    /// requires the native PROJ-backed worker (a datum/grid shift). The inverse of
+    /// <see cref="IsManagedFastPath(int, int)"/>.
+    /// </summary>
+    public static bool RequiresNativeWorker(int fromSrid, int toSrid)
+        => !IsManagedFastPath(fromSrid, toSrid);
+
+    /// <summary>
+    /// Returns <c>true</c> when the managed transform can copy geometries through
+    /// unchanged: identity or any Web-Mercator-alias ↔ Web-Mercator-alias pair (same
+    /// projected coordinate space, so no per-coordinate transform is required). A
+    /// 4326 ↔ Web Mercator pair is a managed fast path but NOT a passthrough — it
+    /// still runs the in-memory coordinate transform.
+    /// </summary>
+    public static bool IsPassthrough(int fromSrid, int toSrid)
+        => fromSrid == toSrid
+            || (WebMercatorAliases.Contains(fromSrid) && WebMercatorAliases.Contains(toSrid));
+
+    /// <summary>
+    /// Parses a positive-integer SRID step input. Returns <c>false</c> (with
+    /// <paramref name="srid"/> = 0) when the value is missing, non-numeric, or not a
+    /// positive integer — matching the managed executor's <c>ReadSrid</c> contract so
+    /// the submit path and the executor agree on what a valid SRID input is.
+    /// </summary>
+    public static bool TryParseSrid(string? raw, out int srid)
+    {
+        if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out srid) || srid <= 0)
+        {
+            srid = 0;
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ReprojectTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ReprojectTransformExecutor.cs
@@ -27,10 +27,12 @@ internal sealed class ReprojectTransformExecutor(
 {
     internal const string HandledProcessId = "transform.reproject";
 
-    private static readonly HashSet<int> WebMercatorAliases =
-        new() { 3857, 900913, 102100, 102113, 3785 };
-
     protected override string ProcessId => HandledProcessId;
+
+    // NOTE: managed accept-set vs. native-escalation are kept in lock-step by the
+    // shared ManagedReprojectFastPath predicate. This executor rejects any pair the
+    // submit path should have escalated to the native worker; the submit path
+    // escalates exactly the pairs this executor rejects.
 
     protected override List<IFeature> Apply(
         FeatureCollection source,
@@ -40,7 +42,7 @@ internal sealed class ReprojectTransformExecutor(
         var fromSrid = ReadSrid(inputs, "fromSrid");
         var toSrid = ReadSrid(inputs, "toSrid");
 
-        if (!IsTransformSupported(fromSrid, toSrid))
+        if (!ManagedReprojectFastPath.IsManagedFastPath(fromSrid, toSrid))
         {
             throw new TransformInputException(
                 $"reproject from SRID {fromSrid} to {toSrid} is not supported by the managed transform path. " +
@@ -48,8 +50,7 @@ internal sealed class ReprojectTransformExecutor(
                 "WGS 84 (4326) ↔ Web Mercator. Datum-shift pairs require the native worker profile.");
         }
 
-        var passthrough = fromSrid == toSrid
-            || (WebMercatorAliases.Contains(fromSrid) && WebMercatorAliases.Contains(toSrid));
+        var passthrough = ManagedReprojectFastPath.IsPassthrough(fromSrid, toSrid);
 
         var output = new List<IFeature>(source.Count);
         foreach (var feature in source)
@@ -79,26 +80,6 @@ internal sealed class ReprojectTransformExecutor(
         }
 
         return output;
-    }
-
-    private static bool IsTransformSupported(int fromSrid, int toSrid)
-    {
-        if (fromSrid == toSrid)
-        {
-            return true;
-        }
-
-        if (WebMercatorAliases.Contains(fromSrid) && WebMercatorAliases.Contains(toSrid))
-        {
-            return true;
-        }
-
-        if (fromSrid == 4326 && WebMercatorAliases.Contains(toSrid))
-        {
-            return true;
-        }
-
-        return WebMercatorAliases.Contains(fromSrid) && toSrid == 4326;
     }
 
     private static int ReadSrid(StepInputReader inputs, string key)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -15,6 +15,7 @@ using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
+using Honua.Geoprocessing.Execution;
 using Honua.Infrastructure;
 using Honua.ControlPlane;
 using Microsoft.Extensions.Options;
@@ -321,9 +322,53 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             {
                 return profile;
             }
+
+            // Dynamic escalation: a few catalog processes are managed for their
+            // in-memory fast paths but require the native PROJ-backed worker for
+            // datum-shift inputs. The catalog RuntimeProfile is a STATIC per-process
+            // declaration that cannot express "managed for some inputs, native for
+            // others", so inspect the step inputs here. transform.reproject escalates
+            // to native when the from/to SRID pair is not a managed fast path (i.e. a
+            // datum/grid shift): the GDAL worker's GdalVectorReprojectJobExecutor
+            // handles the SAME transform.reproject process id under the native profile.
+            if (RequiresNativeRuntimeEscalation(step))
+            {
+                return RuntimeProfiles.Native;
+            }
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when an otherwise-managed <paramref name="step"/> carries
+    /// inputs that force it onto the native worker profile. Currently this covers
+    /// <c>transform.reproject</c> jobs whose <c>fromSrid</c>/<c>toSrid</c> pair is a
+    /// datum/grid shift the lean executor cannot serve (see
+    /// <see cref="ManagedReprojectFastPath"/>). When the SRID inputs are missing or
+    /// unparseable, escalation is declined so the managed executor produces the
+    /// canonical input-validation error rather than silently routing native.
+    /// </summary>
+    private static bool RequiresNativeRuntimeEscalation(AnalysisPlanStep step)
+    {
+        if (!string.Equals(step.ProcessId, ReprojectTransformExecutor.HandledProcessId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!step.Inputs.TryGetValue("fromSrid", out var fromRaw)
+            || !step.Inputs.TryGetValue("toSrid", out var toRaw))
+        {
+            return false;
+        }
+
+        if (!ManagedReprojectFastPath.TryParseSrid(fromRaw, out var fromSrid)
+            || !ManagedReprojectFastPath.TryParseSrid(toRaw, out var toSrid))
+        {
+            return false;
+        }
+
+        return ManagedReprojectFastPath.RequiresNativeWorker(fromSrid, toSrid);
     }
 
     private static ExecutionJobSpec BuildSpec(

--- a/src/Honua.Worker.Gdal/Execution/GdalDispatchJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalDispatchJobExecutor.cs
@@ -34,6 +34,8 @@ internal sealed partial class GdalDispatchJobExecutor : IJobExecutor
     /// </summary>
     public GdalDispatchJobExecutor(
         GdalVectorConvertJobExecutor vectorConvert,
+        GdalVectorReprojectJobExecutor vectorReproject,
+        GdalVectorSourceReadJobExecutor vectorSourceRead,
         GdalRasterReprojectJobExecutor rasterReproject,
         GdalSurfaceJobExecutor surface,
         GdalRasterClipJobExecutor rasterClip,
@@ -45,6 +47,8 @@ internal sealed partial class GdalDispatchJobExecutor : IJobExecutor
         ILogger<GdalDispatchJobExecutor> logger)
     {
         ArgumentNullException.ThrowIfNull(vectorConvert);
+        ArgumentNullException.ThrowIfNull(vectorReproject);
+        ArgumentNullException.ThrowIfNull(vectorSourceRead);
         ArgumentNullException.ThrowIfNull(rasterReproject);
         ArgumentNullException.ThrowIfNull(surface);
         ArgumentNullException.ThrowIfNull(rasterClip);
@@ -58,6 +62,8 @@ internal sealed partial class GdalDispatchJobExecutor : IJobExecutor
         var handlers = new Dictionary<string, IJobExecutor>(StringComparer.Ordinal)
         {
             [GdalVectorConvertJobExecutor.HandledProcessId] = vectorConvert,
+            [GdalVectorReprojectJobExecutor.HandledProcessId] = vectorReproject,
+            [GdalVectorSourceReadJobExecutor.HandledProcessId] = vectorSourceRead,
             [GdalRasterReprojectJobExecutor.HandledProcessId] = rasterReproject,
             [GdalRasterClipJobExecutor.HandledProcessId] = rasterClip,
             [GdalRasterReprojectCatalogJobExecutor.HandledProcessId] = rasterReprojectCatalog,

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterReprojectJobExecutor.cs
@@ -68,7 +68,7 @@ internal sealed partial class GdalRasterReprojectJobExecutor(
             return JobExecutionResult.Failed("Invalid reprojection inputs: missing required input 'targetSrs'.");
         }
 
-        if (!IsValidSrsToken(targetSrs))
+        if (!GdalSrsToken.IsValid(targetSrs))
         {
             return JobExecutionResult.Failed(
                 $"Invalid reprojection inputs: 'targetSrs' value '{targetSrs}' is not an accepted CRS token " +
@@ -94,14 +94,14 @@ internal sealed partial class GdalRasterReprojectJobExecutor(
             await context.ReportProgressAsync(40, "Running gdalwarp reprojection", cancellationToken).ConfigureAwait(false);
 
             var args = new List<string> { "-overwrite", "-of", "GTiff" };
-            if (!string.IsNullOrWhiteSpace(sourceSrs) && IsValidSrsToken(sourceSrs))
+            if (!string.IsNullOrWhiteSpace(sourceSrs) && GdalSrsToken.IsValid(sourceSrs))
             {
                 args.Add("-s_srs");
-                args.Add(NormalizeSrs(sourceSrs));
+                args.Add(GdalSrsToken.Normalize(sourceSrs));
             }
 
             args.Add("-t_srs");
-            args.Add(NormalizeSrs(targetSrs));
+            args.Add(GdalSrsToken.Normalize(targetSrs));
             args.Add(inputPath);
             args.Add(outputPath);
 
@@ -160,47 +160,6 @@ internal sealed partial class GdalRasterReprojectJobExecutor(
         {
             GdalScratch.TryCleanup(workspace, logger);
         }
-    }
-
-    /// <summary>
-    /// Validates a CRS token to a conservative allow-shape before passing it to
-    /// the CLI. Accepts a bare positive integer (EPSG code) or an
-    /// <c>AUTHORITY:CODE</c> token. This blocks shell-influencing values and
-    /// arbitrary PROJ strings while covering the common reprojection cases.
-    /// </summary>
-    private static bool IsValidSrsToken(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return false;
-        }
-
-        var token = value.Trim();
-        if (int.TryParse(token, out var epsg) && epsg > 0)
-        {
-            return true;
-        }
-
-        var parts = token.Split(':', 2);
-        if (parts.Length != 2)
-        {
-            return false;
-        }
-
-        var authority = parts[0];
-        var code = parts[1];
-        if (authority.Length is 0 or > 16 || !authority.All(char.IsLetterOrDigit))
-        {
-            return false;
-        }
-
-        return code.Length is > 0 and <= 16 && code.All(char.IsLetterOrDigit);
-    }
-
-    private static string NormalizeSrs(string value)
-    {
-        var token = value.Trim();
-        return int.TryParse(token, out _) ? $"EPSG:{token}" : token;
     }
 
     private static partial class Log

--- a/src/Honua.Worker.Gdal/Execution/GdalSrsToken.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalSrsToken.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Shared CRS-token validation and normalization for the native-profile GDAL
+/// executors that pass a spatial-reference token to the CLI (<c>gdalwarp</c>,
+/// <c>ogr2ogr</c>). Centralized so every executor enforces the same conservative
+/// allow-shape — a bare positive integer (EPSG code) or a short
+/// <c>AUTHORITY:CODE</c> token — before a value reaches an argument list. This
+/// blocks shell-influencing values and arbitrary PROJ strings while covering the
+/// reprojection and datum-shift cases (EPSG codes, ESRI / IGNF datum authorities).
+/// </summary>
+internal static class GdalSrsToken
+{
+    /// <summary>
+    /// Validates a CRS token to the conservative allow-shape. Accepts a bare
+    /// positive integer (EPSG code) or an <c>AUTHORITY:CODE</c> token whose
+    /// authority and code are alphanumeric and bounded in length.
+    /// </summary>
+    /// <param name="value">The raw CRS token from the durable spec.</param>
+    /// <returns><c>true</c> when the token is safe to pass to the CLI.</returns>
+    public static bool IsValid(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var token = value.Trim();
+        if (int.TryParse(token, out var epsg) && epsg > 0)
+        {
+            return true;
+        }
+
+        var parts = token.Split(':', 2);
+        if (parts.Length != 2)
+        {
+            return false;
+        }
+
+        var authority = parts[0];
+        var code = parts[1];
+        if (authority.Length is 0 or > 16 || !authority.All(char.IsLetterOrDigit))
+        {
+            return false;
+        }
+
+        return code.Length is > 0 and <= 16 && code.All(char.IsLetterOrDigit);
+    }
+
+    /// <summary>
+    /// Normalizes a validated CRS token for the CLI: a bare integer is widened to
+    /// the <c>EPSG:&lt;code&gt;</c> form; an <c>AUTHORITY:CODE</c> token is passed
+    /// through trimmed. Callers must validate with <see cref="IsValid(string?)"/>
+    /// first.
+    /// </summary>
+    /// <param name="value">A token already accepted by <see cref="IsValid(string?)"/>.</param>
+    /// <returns>The normalized CLI-ready CRS token.</returns>
+    public static string Normalize(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        var token = value.Trim();
+        return int.TryParse(token, out _) ? $"EPSG:{token}" : token;
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalVectorReprojectJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalVectorReprojectJobExecutor.cs
@@ -1,0 +1,290 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IJobExecutor"/> for the <c>transform.reproject</c>
+/// process when the SRID pair requires a full PROJ datum/grid shift.
+///
+/// This is the heavyweight counterpart to the lean managed
+/// <c>ReprojectTransformExecutor</c>, which deliberately serves ONLY the in-memory
+/// fast paths (identity, Web Mercator aliases, and WGS 84 (4326) ↔ Web Mercator)
+/// and rejects every datum-shift pair (e.g. NAD 27 (4267) → WGS 84 (4326)) because
+/// those need PROJ's transformation pipelines and datum-shift grids. The
+/// geoprocessing submit path escalates such a job to the native runtime profile
+/// (see <c>NativeReprojectEscalation</c>), and the claim fence routes it here.
+///
+/// The durable spec carries the SAME canonical step inputs the managed executor
+/// reads — <c>input</c> (a <c>data:application/geo+json;base64,</c> FeatureCollection
+/// URI), <c>fromSrid</c>, and <c>toSrid</c> — so a job authored for the managed path
+/// is shaped identically for the native path. The executor runs <c>ogr2ogr</c> with
+/// <c>-s_srs</c>/<c>-t_srs</c> in an isolated scratch workspace (PROJ selects the
+/// authoritative pipeline, applying the datum/grid shift) and publishes the
+/// reprojected FeatureCollection as a canonical geo+json data-URI artifact, matching
+/// the managed executor's output envelope so downstream workflow nodes are agnostic
+/// to which profile produced the artifact.
+/// </summary>
+internal sealed partial class GdalVectorReprojectJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalVectorReprojectJobExecutor> logger) : IJobExecutor
+{
+    /// <summary>The canonical process id this executor handles.</summary>
+    public const string HandledProcessId = "transform.reproject";
+
+    /// <summary>
+    /// Content type of the FeatureCollection artifact published on success. Matches
+    /// the managed <c>FeatureCollectionArtifact.DataUriPrefix</c> so the native and
+    /// managed paths emit an identical envelope.
+    /// </summary>
+    private const string GeoJsonContentType = "application/geo+json";
+
+    private const string GeoJsonDataUriPrefix = "data:application/geo+json;base64,";
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing reprojection inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        if (!TryReadSrid(parameters, "fromSrid", out var fromSrid, out var fromError))
+        {
+            return JobExecutionResult.Failed($"Invalid reprojection inputs: {fromError}");
+        }
+
+        if (!TryReadSrid(parameters, "toSrid", out var toSrid, out var toError))
+        {
+            return JobExecutionResult.Failed($"Invalid reprojection inputs: {toError}");
+        }
+
+        if (!GdalJobInputReader.TryGetInput(parameters, "input", out var inputUri)
+            || string.IsNullOrWhiteSpace(inputUri))
+        {
+            return JobExecutionResult.Failed("Invalid reprojection inputs: missing required input 'input'.");
+        }
+
+        if (!TryDecodeGeoJsonDataUri(inputUri, opts.MaxArtifactBytes, out var sourceBytes, out var decodeError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, decodeError);
+            return JobExecutionResult.Failed($"Invalid reprojection inputs: 'input' {decodeError}");
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            var inputPath = Path.Combine(workspace, "input.geojson");
+            var outputPath = Path.Combine(workspace, "output.geojson");
+            await File.WriteAllBytesAsync(inputPath, sourceBytes, cancellationToken).ConfigureAwait(false);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running ogr2ogr datum-shift reprojection", cancellationToken).ConfigureAwait(false);
+
+            // -s_srs / -t_srs both EPSG codes: PROJ selects the authoritative
+            // transformation pipeline (including a datum/grid shift) for the pair.
+            var args = new List<string>
+            {
+                "-f",
+                "GeoJSON",
+                "-s_srs",
+                $"EPSG:{fromSrid.ToString(CultureInfo.InvariantCulture)}",
+                "-t_srs",
+                $"EPSG:{toSrid.ToString(CultureInfo.InvariantCulture)}",
+                outputPath,
+                inputPath,
+            };
+
+            using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            GdalCommandResult result;
+            try
+            {
+                result = await runner.RunAsync("ogr2ogr", args, workspace, linked.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                Log.ToolTimedOut(logger, job.OperationId, opts.ToolTimeout);
+                return JobExecutionResult.Failed($"ogr2ogr timed out after {opts.ToolTimeout}.");
+            }
+
+            if (!result.Succeeded)
+            {
+                Log.ToolFailed(logger, job.OperationId, result.ExitCode, GdalErrorSanitizer.TruncateForLog(result.StandardError));
+                return JobExecutionResult.Failed(
+                    $"ogr2ogr exited with code {result.ExitCode}: {GdalErrorSanitizer.Sanitize(result.StandardError, workspace)}");
+            }
+
+            if (!File.Exists(outputPath))
+            {
+                return JobExecutionResult.Failed(
+                    "ogr2ogr reported success but produced no reprojected FeatureCollection.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(80, "Encoding reprojected feature artifact", cancellationToken).ConfigureAwait(false);
+
+            var outputBytes = await File.ReadAllBytesAsync(outputPath, cancellationToken).ConfigureAwait(false);
+            if (outputBytes.Length == 0)
+            {
+                return JobExecutionResult.Failed("ogr2ogr produced an empty reprojected FeatureCollection.");
+            }
+
+            if (outputBytes.Length > opts.MaxArtifactBytes)
+            {
+                Log.ArtifactTooLarge(logger, job.OperationId, outputBytes.Length, opts.MaxArtifactBytes);
+                return JobExecutionResult.Failed(
+                    $"Reprojected FeatureCollection size {outputBytes.Length} bytes exceeds configured " +
+                    $"MaxArtifactBytes={opts.MaxArtifactBytes}.");
+            }
+
+            var artifactUri = GdalDataUri.Build(GeoJsonContentType, outputBytes);
+            await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+            await context.ReportProgressAsync(100, "Reprojection completed", cancellationToken).ConfigureAwait(false);
+
+            Log.ReprojectionCompleted(logger, job.OperationId, fromSrid, toSrid, outputBytes.Length);
+            return JobExecutionResult.Succeeded();
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    private static bool TryReadSrid(
+        IReadOnlyDictionary<string, string> parameters,
+        string name,
+        out int srid,
+        out string error)
+    {
+        srid = 0;
+        error = "";
+
+        if (!GdalJobInputReader.TryGetInput(parameters, name, out var raw)
+            || string.IsNullOrWhiteSpace(raw))
+        {
+            error = $"missing required input '{name}'";
+            return false;
+        }
+
+        if (!int.TryParse(raw.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out srid) || srid <= 0)
+        {
+            error = $"input '{name}' value '{raw}' is not a positive EPSG SRID";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryDecodeGeoJsonDataUri(
+        string value,
+        long maxBytes,
+        out byte[] bytes,
+        out string error)
+    {
+        bytes = [];
+        error = "";
+
+        if (!value.StartsWith(GeoJsonDataUriPrefix, StringComparison.Ordinal))
+        {
+            error = $"must be a '{GeoJsonDataUriPrefix}' data URI";
+            return false;
+        }
+
+        var payload = value[GeoJsonDataUriPrefix.Length..];
+
+        // Conservative upper-bound size guard before decoding, mirroring
+        // GdalJobInputReader.TryGetBase64Input: base64 packs 4 chars into 3 bytes.
+        if ((long)payload.Length / 4 * 3 > maxBytes)
+        {
+            error = $"payload size exceeds configured MaxArtifactBytes={maxBytes}";
+            return false;
+        }
+
+        try
+        {
+            bytes = Convert.FromBase64String(payload);
+        }
+        catch (FormatException)
+        {
+            error = "payload is not valid base64";
+            bytes = [];
+            return false;
+        }
+
+        if (bytes.Length == 0)
+        {
+            error = "payload decoded to zero bytes";
+            bytes = [];
+            return false;
+        }
+
+        if (bytes.Length > maxBytes)
+        {
+            error = $"payload size {bytes.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}";
+            bytes = [];
+            return false;
+        }
+
+        return true;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9240, LogLevel.Warning,
+            "GDAL vector reproject executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9241, LogLevel.Warning,
+            "GDAL vector reproject executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9242, LogLevel.Error,
+            "GDAL vector reproject executor failed job {OperationId}: ogr2ogr exit {ExitCode}: {Error}")]
+        public static partial void ToolFailed(ILogger logger, string operationId, int exitCode, string error);
+
+        [LoggerMessage(9243, LogLevel.Error,
+            "GDAL vector reproject executor timed out job {OperationId} after {Timeout}")]
+        public static partial void ToolTimedOut(ILogger logger, string operationId, TimeSpan timeout);
+
+        [LoggerMessage(9244, LogLevel.Warning,
+            "GDAL vector reproject executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+
+        [LoggerMessage(9245, LogLevel.Information,
+            "GDAL vector reproject executor completed job {OperationId}: fromSrid={FromSrid}, toSrid={ToSrid}, bytes={Bytes}")]
+        public static partial void ReprojectionCompleted(ILogger logger, string operationId, int fromSrid, int toSrid, long bytes);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalVectorSourceReadJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalVectorSourceReadJobExecutor.cs
@@ -1,0 +1,298 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using System.IO.Compression;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IJobExecutor"/> for the <c>source.ogr</c> process: a
+/// GDAL/OGR-backed import reader that canonicalizes a broad-format source dataset
+/// into the standard GeoJSON FeatureCollection artifact every workflow DAG starts
+/// from.
+///
+/// This is the heavyweight counterpart to the lean managed <c>source.geojson</c> /
+/// <c>source.csv</c> readers, which are hand-rolled NetTopologySuite parsers covering
+/// only GeoJSON and CSV. <c>source.ogr</c> reaches the FULL OGR driver universe the
+/// managed readers cannot — native File Geodatabase (OpenFileGDB), GML / GML
+/// application schemas, KML, MapInfo TAB, ESRI Shapefile, GeoPackage, FlatGeobuf, and
+/// (where the worker image's drivers are compiled in) database-spatial sources — and
+/// converts them to GeoJSON via <c>ogr2ogr -f GeoJSON</c> in an isolated scratch
+/// workspace.
+///
+/// It runs only inside the GDAL worker image (it overrides
+/// <see cref="AcceptedRuntimeProfiles"/> to <c>{ "native" }</c>, so the substrate
+/// claim fence keeps the lean managed worker from ever claiming it). The source
+/// dataset arrives as a base64 step input; some formats (Shapefile, FileGDB) are
+/// multi-file directories shipped as a base64 ZIP, so the executor unzips a
+/// <c>.zip</c> payload into the workspace and points OGR at the extracted dataset via
+/// GDAL's <c>/vsizip/</c>-free directory open. The canonicalized FeatureCollection is
+/// published as a <c>data:application/geo+json;base64,</c> artifact, matching the
+/// managed sources so downstream nodes are agnostic to which reader produced it.
+/// </summary>
+internal sealed partial class GdalVectorSourceReadJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalVectorSourceReadJobExecutor> logger) : IJobExecutor
+{
+    /// <summary>The canonical process id this executor handles.</summary>
+    public const string HandledProcessId = "source.ogr";
+
+    private const string GeoJsonContentType = "application/geo+json";
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    // Source-format hint -> input file extension. The hint selects the on-disk
+    // extension OGR uses to choose the driver; OGR is otherwise content-sniffing.
+    // ZIP-packaged multi-file datasets (Shapefile, FileGDB) are detected by the
+    // ".zip" magic on the decoded bytes and extracted, regardless of the hint.
+    private static readonly FrozenDictionary<string, string> SourceExtensions =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["GeoJSON"] = ".geojson",
+            ["GML"] = ".gml",
+            ["KML"] = ".kml",
+            ["GPKG"] = ".gpkg",
+            ["FlatGeobuf"] = ".fgb",
+            ["MapInfo File"] = ".tab",
+            ["CSV"] = ".csv",
+            ["ESRI Shapefile"] = ".shp",
+            ["OpenFileGDB"] = ".gdb",
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing source inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        if (!GdalJobInputReader.TryGetInput(parameters, "sourceFormat", out var sourceFormat)
+            || string.IsNullOrWhiteSpace(sourceFormat))
+        {
+            sourceFormat = "GeoJSON";
+        }
+
+        if (!GdalJobInputReader.TryGetBase64Input(parameters, "source", opts.MaxArtifactBytes, out var sourceBytes, out var inputError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, inputError);
+            return JobExecutionResult.Failed($"Invalid source inputs: {inputError}");
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            string ogrSourcePath;
+            if (IsZipArchive(sourceBytes))
+            {
+                ogrSourcePath = ExtractZipSource(sourceBytes, workspace, sourceFormat);
+                if (ogrSourcePath.Length == 0)
+                {
+                    return JobExecutionResult.Failed(
+                        "Source ZIP archive did not contain a recognizable OGR dataset (.shp/.gdb/.gml/...).");
+                }
+            }
+            else
+            {
+                var extension = SourceExtensions.TryGetValue(sourceFormat, out var ext) ? ext : ".dat";
+                ogrSourcePath = Path.Combine(workspace, "input" + extension);
+                await File.WriteAllBytesAsync(ogrSourcePath, sourceBytes, cancellationToken).ConfigureAwait(false);
+            }
+
+            var outputPath = Path.Combine(workspace, "output.geojson");
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running ogr2ogr source canonicalization", cancellationToken).ConfigureAwait(false);
+
+            var args = new List<string>
+            {
+                "-f",
+                "GeoJSON",
+                outputPath,
+                ogrSourcePath,
+            };
+
+            using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            GdalCommandResult result;
+            try
+            {
+                result = await runner.RunAsync("ogr2ogr", args, workspace, linked.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                Log.ToolTimedOut(logger, job.OperationId, opts.ToolTimeout);
+                return JobExecutionResult.Failed($"ogr2ogr timed out after {opts.ToolTimeout}.");
+            }
+
+            if (!result.Succeeded)
+            {
+                Log.ToolFailed(logger, job.OperationId, result.ExitCode, GdalErrorSanitizer.TruncateForLog(result.StandardError));
+                return JobExecutionResult.Failed(
+                    $"ogr2ogr exited with code {result.ExitCode}: {GdalErrorSanitizer.Sanitize(result.StandardError, workspace)}");
+            }
+
+            if (!File.Exists(outputPath))
+            {
+                return JobExecutionResult.Failed(
+                    "ogr2ogr reported success but produced no FeatureCollection; verify the source dataset and format hint.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(80, "Encoding source artifact", cancellationToken).ConfigureAwait(false);
+
+            var outputBytes = await File.ReadAllBytesAsync(outputPath, cancellationToken).ConfigureAwait(false);
+            if (outputBytes.Length == 0)
+            {
+                return JobExecutionResult.Failed("ogr2ogr produced an empty FeatureCollection.");
+            }
+
+            if (outputBytes.Length > opts.MaxArtifactBytes)
+            {
+                Log.ArtifactTooLarge(logger, job.OperationId, outputBytes.Length, opts.MaxArtifactBytes);
+                return JobExecutionResult.Failed(
+                    $"Source FeatureCollection size {outputBytes.Length} bytes exceeds configured " +
+                    $"MaxArtifactBytes={opts.MaxArtifactBytes}.");
+            }
+
+            var artifactUri = GdalDataUri.Build(GeoJsonContentType, outputBytes);
+            await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+            await context.ReportProgressAsync(100, "Source read completed", cancellationToken).ConfigureAwait(false);
+
+            Log.SourceReadCompleted(logger, job.OperationId, sourceFormat, outputBytes.Length);
+            return JobExecutionResult.Succeeded();
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    // ZIP local-file-header magic: 'P' 'K' 0x03 0x04.
+    private static bool IsZipArchive(byte[] bytes)
+        => bytes.Length >= 4 && bytes[0] == 0x50 && bytes[1] == 0x4B && bytes[2] == 0x03 && bytes[3] == 0x04;
+
+    /// <summary>
+    /// Extracts a ZIP-packaged multi-file dataset into a sandboxed sub-directory of
+    /// the scratch workspace and returns the OGR-openable dataset path (the
+    /// containing directory for a <c>.gdb</c> FileGDB, or the single <c>.shp</c>/
+    /// recognized vector file otherwise). Entry paths are validated to stay within
+    /// the extraction root (no zip-slip). Returns an empty string when no
+    /// recognizable dataset is found.
+    /// </summary>
+    private static string ExtractZipSource(byte[] zipBytes, string workspace, string sourceFormat)
+    {
+        var extractRoot = Path.Combine(workspace, "src");
+        Directory.CreateDirectory(extractRoot);
+        var fullExtractRoot = Path.GetFullPath(extractRoot) + Path.DirectorySeparatorChar;
+
+        using (var stream = new MemoryStream(zipBytes, writable: false))
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Read))
+        {
+            foreach (var entry in archive.Entries)
+            {
+                // Directory entries have empty names.
+                if (entry.FullName.EndsWith('/') || entry.FullName.EndsWith('\\'))
+                {
+                    continue;
+                }
+
+                var destinationPath = Path.GetFullPath(Path.Combine(extractRoot, entry.FullName));
+                if (!destinationPath.StartsWith(fullExtractRoot, StringComparison.Ordinal))
+                {
+                    // Zip-slip: entry escapes the extraction root — skip it.
+                    continue;
+                }
+
+                Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+                entry.ExtractToFile(destinationPath, overwrite: true);
+            }
+        }
+
+        // A FileGDB is a directory ending in .gdb; OGR opens the directory.
+        var gdb = Directory
+            .EnumerateDirectories(extractRoot, "*.gdb", SearchOption.AllDirectories)
+            .FirstOrDefault();
+        if (gdb is not null)
+        {
+            return gdb;
+        }
+
+        // Otherwise find the first recognized single-file vector dataset. Prefer the
+        // hinted extension, then fall back to the common single-file vector formats.
+        var preferred = SourceExtensions.TryGetValue(sourceFormat, out var ext) ? ext : null;
+        var candidates = new[] { preferred, ".shp", ".gml", ".kml", ".gpkg", ".fgb", ".tab", ".geojson", ".json" }
+            .Where(e => e is not null)
+            .Cast<string>()
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var candidate in candidates)
+        {
+            var match = Directory
+                .EnumerateFiles(extractRoot, "*" + candidate, SearchOption.AllDirectories)
+                .FirstOrDefault();
+            if (match is not null)
+            {
+                return match;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9250, LogLevel.Warning,
+            "GDAL source read executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9251, LogLevel.Warning,
+            "GDAL source read executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9252, LogLevel.Error,
+            "GDAL source read executor failed job {OperationId}: ogr2ogr exit {ExitCode}: {Error}")]
+        public static partial void ToolFailed(ILogger logger, string operationId, int exitCode, string error);
+
+        [LoggerMessage(9253, LogLevel.Error,
+            "GDAL source read executor timed out job {OperationId} after {Timeout}")]
+        public static partial void ToolTimedOut(ILogger logger, string operationId, TimeSpan timeout);
+
+        [LoggerMessage(9254, LogLevel.Warning,
+            "GDAL source read executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+
+        [LoggerMessage(9255, LogLevel.Information,
+            "GDAL source read executor completed job {OperationId}: sourceFormat={SourceFormat}, bytes={Bytes}")]
+        public static partial void SourceReadCompleted(ILogger logger, string operationId, string sourceFormat, long bytes);
+    }
+}

--- a/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
+++ b/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
@@ -86,6 +86,8 @@ public static class GdalWorkerServiceCollectionExtensions
         // GDAL CLI runner + native-profile executors.
         services.TryAddSingleton<IGdalCommandRunner, ProcessGdalCommandRunner>();
         services.TryAddSingleton<GdalVectorConvertJobExecutor>();
+        services.TryAddSingleton<GdalVectorReprojectJobExecutor>();
+        services.TryAddSingleton<GdalVectorSourceReadJobExecutor>();
         services.TryAddSingleton<GdalRasterReprojectJobExecutor>();
         services.TryAddSingleton<GdalSurfaceJobExecutor>();
         services.TryAddSingleton<GdalRasterClipJobExecutor>();

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -145,6 +145,12 @@ public sealed class CatalogExecutableConformanceTests
         // NOT in the lean dispatcher handler map).
         "gdal.gdalwarp",
         "gdal.ogr2ogr",
+        // GDAL/OGR-backed import reader (GdalVectorSourceReadJobExecutor): the
+        // native counterpart to the managed source.geojson / source.csv readers,
+        // canonicalizing the broader OGR format universe (FileGDB, GML, KML, TAB,
+        // Shapefile, GeoPackage, FlatGeobuf) into the standard FeatureCollection
+        // artifact. Declares RuntimeProfile = native; no lean-dispatcher executor.
+        "source.ogr",
     };
 
     [UnitTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -215,6 +215,73 @@ public sealed class GeoprocessingJobServiceTests
     [UnitTest]
     [Operation(Operations.Create)]
     [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_ManagedReprojectFastPath_LeavesRuntimeProfileUnstamped()
+    {
+        _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // 4326 -> 3857 is a managed in-memory fast path: no datum shift, so the job
+        // stays on the lean profile and the managed ReprojectTransformExecutor serves
+        // it. The submit path must NOT escalate this to native.
+        var plan = CreateReprojectPlan(fromSrid: "4326", toSrid: "3857");
+
+        var job = await _sut.SubmitJobAsync(plan, null, CreatePrincipal());
+
+        job.Spec.RuntimeProfile.Should().BeNull();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_DatumShiftReproject_EscalatesToNativeRuntimeProfile()
+    {
+        _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // NAD 27 (4267) -> WGS 84 (4326) is a datum shift the managed path rejects.
+        // Even though transform.reproject declares the managed catalog profile, the
+        // submit path inspects the SRID inputs and ESCALATES the job to native so the
+        // claim fence routes it to the PROJ-backed GdalVectorReprojectJobExecutor.
+        var plan = CreateReprojectPlan(fromSrid: "4267", toSrid: "4326");
+
+        var job = await _sut.SubmitJobAsync(plan, null, CreatePrincipal());
+
+        job.Spec.RuntimeProfile.Should().Be(RuntimeProfiles.Native);
+    }
+
+    private static AnalysisPlan CreateReprojectPlan(string fromSrid, string toSrid)
+    {
+        // A minimal canonical geo+json data URI satisfying transform.reproject's
+        // required 'input'. The submit path's escalation reads only the SRID inputs.
+        const string emptyFeatureCollection =
+            "data:application/geo+json;base64," +
+            "eyJ0eXBlIjoiRmVhdHVyZUNvbGxlY3Rpb24iLCJmZWF0dXJlcyI6W119"; // {"type":"FeatureCollection","features":[]}
+
+        return new AnalysisPlan
+        {
+            PlanId = "plan-reproject",
+            IntentId = "intent-reproject",
+            Steps =
+            [
+                new AnalysisPlanStep
+                {
+                    StepId = "step-1",
+                    Kind = AnalysisPlanStepKind.Geoprocess,
+                    ProcessId = "transform.reproject",
+                    Inputs = new Dictionary<string, string>
+                    {
+                        ["input"] = emptyFeatureCollection,
+                        ["fromSrid"] = fromSrid,
+                        ["toSrid"] = toSrid
+                    }
+                }
+            ]
+        };
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
     public async Task SubmitJob_WithValidPlan_EnqueuesJob()
     {
         _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
@@ -36,7 +36,7 @@ public sealed class ProcessCatalogTests
     [UnitTest]
     [Operation(Operations.Query)]
     [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
-    public void Catalog_ListProcesses_ReturnsExactly57BuiltIns()
+    public void Catalog_ListProcesses_ReturnsExactly60BuiltIns()
     {
         var all = _catalog.ListProcesses();
 
@@ -49,8 +49,10 @@ public sealed class ProcessCatalogTests
         // gdal.ogr2ogr) reconciled from feat/gdal-heavy-worker + 1 durable
         // import pipeline (import.dataset) added by #1630 + 1 native-profile
         // point-cloud translate (pcloud.translate, LAZ/COPC decompress +
-        // projected-CRS reproject) added by #1854.
-        all.Should().HaveCount(59);
+        // projected-CRS reproject) added by #1854 + 1 native-profile GDAL/OGR
+        // import reader (source.ogr, broad-format FeatureCollection canonicalization)
+        // added for the honua-worker-etl format breadth (ADR-0038 roadmap F).
+        all.Should().HaveCount(60);
         all.Select(p => p.ProcessId).Should().OnlyHaveUniqueItems();
     }
 

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterExecutorTests.cs
@@ -675,6 +675,12 @@ public sealed class GdalRasterExecutorTests
             "pcloud.translate",
             // Existing native-routed ids must still be present.
             "gdal.gdalwarp", "gdal.ogr2ogr",
+            // Native vector reproject (datum/grid shift via ogr2ogr -s_srs/-t_srs):
+            // the heavyweight counterpart to the managed transform.reproject, routed
+            // here when the SRID pair is escalated to the native profile.
+            "transform.reproject",
+            // GDAL/OGR-backed import reader (broad format universe → GeoJSON).
+            "source.ogr",
         };
 
         dispatcher.SupportedProcessIds.Should().BeEquivalentTo(allIds);
@@ -720,6 +726,8 @@ public sealed class GdalRasterExecutorTests
         var options = GdalJobFactory.Options(Path.Combine(Path.GetTempPath(), "honua-gdal-dispatch-test"));
         return new GdalDispatchJobExecutor(
             new GdalVectorConvertJobExecutor(runner, options, NullLogger<GdalVectorConvertJobExecutor>.Instance),
+            new GdalVectorReprojectJobExecutor(runner, options, NullLogger<GdalVectorReprojectJobExecutor>.Instance),
+            new GdalVectorSourceReadJobExecutor(runner, options, NullLogger<GdalVectorSourceReadJobExecutor>.Instance),
             new GdalRasterReprojectJobExecutor(runner, options, NullLogger<GdalRasterReprojectJobExecutor>.Instance),
             new GdalSurfaceJobExecutor(runner, options, NullLogger<GdalSurfaceJobExecutor>.Instance),
             new GdalRasterClipJobExecutor(runner, options, NullLogger<GdalRasterClipJobExecutor>.Instance),

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalWorkerExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalWorkerExecutorTests.cs
@@ -80,6 +80,8 @@ public sealed class GdalWorkerExecutorTests
         var options = GdalJobFactory.Options(Path.Combine(Path.GetTempPath(), "honua-gdal-dispatch-test"));
         return new GdalDispatchJobExecutor(
             new GdalVectorConvertJobExecutor(runner, options, NullLogger<GdalVectorConvertJobExecutor>.Instance),
+            new GdalVectorReprojectJobExecutor(runner, options, NullLogger<GdalVectorReprojectJobExecutor>.Instance),
+            new GdalVectorSourceReadJobExecutor(runner, options, NullLogger<GdalVectorSourceReadJobExecutor>.Instance),
             new GdalRasterReprojectJobExecutor(runner, options, NullLogger<GdalRasterReprojectJobExecutor>.Instance),
             new GdalSurfaceJobExecutor(runner, options, NullLogger<GdalSurfaceJobExecutor>.Instance),
             new GdalRasterClipJobExecutor(runner, options, NullLogger<GdalRasterClipJobExecutor>.Instance),
@@ -300,8 +302,211 @@ public sealed class GdalWorkerExecutorTests
     }
 
     // -------------------------------------------------------------------------
+    // Vector reproject (ogr2ogr datum shift) — fake runner + routing
+    // -------------------------------------------------------------------------
+
+    [UnitTest]
+    public void VectorReproject_DeclaresNativeProfile_AndHandlesTransformReproject()
+    {
+        var executor = NewVectorReprojectExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        executor.AcceptedRuntimeProfiles.Should().NotContain(RuntimeProfiles.Managed);
+        // The native reproject executor handles the SAME process id as the managed
+        // executor — escalation routes by RuntimeProfile, not by a distinct id.
+        GdalVectorReprojectJobExecutor.HandledProcessId.Should().Be("transform.reproject");
+    }
+
+    [UnitTest]
+    public async Task VectorReproject_Succeeds_PublishesGeoJsonArtifact_AndPassesBothSrs()
+    {
+        var reprojected = Encoding.UTF8.GetBytes(PointGeoJson);
+        // ogr2ogr arg order is "-f GeoJSON -s_srs .. -t_srs .. <output> <input>", so
+        // the output path is the second-to-last argument.
+        var runner = FakeGdalCommandRunner.Succeeding(reprojected, outputArgIndexFromEnd: 1);
+        var executor = NewVectorReprojectExecutor(runner, out var scratch);
+
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalVectorReprojectJobExecutor.HandledProcessId,
+                ("input", "data:application/geo+json;base64," + Base64(PointGeoJson)),
+                ("fromSrid", "4267"),
+                ("toSrid", "4326"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Should().ContainSingle();
+            context.Artifacts[0].Should().StartWith("data:application/geo+json;base64,");
+
+            // PROJ selects the datum-shift pipeline from the explicit s_srs/t_srs pair.
+            var args = runner.Invocations.Single().Arguments;
+            args.Should().ContainInOrder("-s_srs", "EPSG:4267");
+            args.Should().ContainInOrder("-t_srs", "EPSG:4326");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task VectorReproject_RejectsNonGeoJsonDataUri()
+    {
+        var executor = NewVectorReprojectExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalVectorReprojectJobExecutor.HandledProcessId,
+                ("input", "not-a-data-uri"),
+                ("fromSrid", "4267"),
+                ("toSrid", "4326"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("data URI");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // OGR source read (ogr2ogr canonicalization) — fake runner + routing
+    // -------------------------------------------------------------------------
+
+    [UnitTest]
+    public void SourceRead_DeclaresNativeProfile_AndHandlesSourceOgr()
+    {
+        var executor = NewSourceReadExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        GdalVectorSourceReadJobExecutor.HandledProcessId.Should().Be("source.ogr");
+    }
+
+    [UnitTest]
+    public async Task SourceRead_Succeeds_CanonicalizesToGeoJsonArtifact()
+    {
+        var canonical = Encoding.UTF8.GetBytes(PointGeoJson);
+        var runner = FakeGdalCommandRunner.Succeeding(canonical, outputArgIndexFromEnd: 1);
+        var executor = NewSourceReadExecutor(runner, out var scratch);
+
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalVectorSourceReadJobExecutor.HandledProcessId,
+                ("source", Base64(PointGeoJson)),
+                ("sourceFormat", "GeoJSON"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Should().ContainSingle();
+            context.Artifacts[0].Should().StartWith("data:application/geo+json;base64,");
+            runner.Invocations.Single().Arguments.Should().ContainInOrder("-f", "GeoJSON");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Real GDAL CLI — datum-shift reprojection proof when ogr2ogr is available
+    // -------------------------------------------------------------------------
+
+    [GdalCliFact("ogr2ogr")]
+    [Protocol(ProtocolNames.TestQuality)]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task VectorReproject_WithRealOgr2Ogr_AppliesNad27ToWgs84DatumShift()
+    {
+        var scratch = NewScratch();
+        var executor = new GdalVectorReprojectJobExecutor(
+            new ProcessGdalCommandRunner(NullLogger<ProcessGdalCommandRunner>.Instance),
+            GdalJobFactory.Options(scratch),
+            NullLogger<GdalVectorReprojectJobExecutor>.Instance);
+
+        try
+        {
+            // A point near Meades Ranch, Kansas — the NAD 27 origin region where the
+            // NAD27→WGS84 datum shift is on the order of tens of metres (well above any
+            // rounding). NAD 27 = EPSG:4267, WGS 84 = EPSG:4326. The managed fast path
+            // REJECTS this pair; only the PROJ-backed worker performs the grid shift.
+            const double srcLon = -98.5;
+            const double srcLat = 39.0;
+            var nad27Point =
+                "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":" +
+                "{\"type\":\"Point\",\"coordinates\":[" +
+                srcLon.ToString(System.Globalization.CultureInfo.InvariantCulture) + "," +
+                srcLat.ToString(System.Globalization.CultureInfo.InvariantCulture) +
+                "]},\"properties\":{}}]}";
+
+            var job = GdalJobFactory.Job(
+                GdalVectorReprojectJobExecutor.HandledProcessId,
+                ("input", "data:application/geo+json;base64," + Base64(nad27Point)),
+                ("fromSrid", "4267"),
+                ("toSrid", "4326"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Should().ContainSingle();
+
+            var outGeoJson = Encoding.UTF8.GetString(GdalCli.DecodeDataUri(context.Artifacts[0]));
+            var (outLon, outLat) = FirstPointCoordinates(outGeoJson);
+
+            // The datum shift must move the coordinate — but only slightly (the NAD27
+            // vs WGS84 horizontal difference is sub-kilometre). A passthrough/identity
+            // bug would leave the coordinate exactly unchanged; a wrong CRS would move
+            // it kilometres. Assert a non-zero shift bounded to a realistic envelope.
+            var deltaLon = Math.Abs(outLon - srcLon);
+            var deltaLat = Math.Abs(outLat - srcLat);
+            (deltaLon + deltaLat).Should().BeGreaterThan(1e-6,
+                "NAD27→WGS84 is a real datum shift, not an identity transform");
+            deltaLon.Should().BeLessThan(0.01, "the horizontal datum shift is sub-kilometre, not a CRS mistake");
+            deltaLat.Should().BeLessThan(0.01, "the horizontal datum shift is sub-kilometre, not a CRS mistake");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static (double Lon, double Lat) FirstPointCoordinates(string geoJson)
+    {
+        using var doc = System.Text.Json.JsonDocument.Parse(geoJson);
+        var coords = doc.RootElement
+            .GetProperty("features")[0]
+            .GetProperty("geometry")
+            .GetProperty("coordinates");
+        return (coords[0].GetDouble(), coords[1].GetDouble());
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    private static GdalVectorReprojectJobExecutor NewVectorReprojectExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = NewScratch();
+        return new GdalVectorReprojectJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalVectorReprojectJobExecutor>.Instance);
+    }
+
+    private static GdalVectorSourceReadJobExecutor NewSourceReadExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = NewScratch();
+        return new GdalVectorSourceReadJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalVectorSourceReadJobExecutor>.Instance);
+    }
 
     private static GdalVectorConvertJobExecutor NewVectorExecutor(IGdalCommandRunner runner, out string scratch)
     {


### PR DESCRIPTION
## Summary

Completes the `honua-worker-etl` native-image gap (ADR-0038 roadmap F): unlocks PROJ
datum-shift reprojection and GDAL/OGR format breadth, routed to the heavyweight worker
via the runtime-profile claim fence, while the lean serving image stays GDAL-free
(ADR-0034).

Related to honua-server ADR-0038 (GeoETL pipeline / runtime boundary).

## Changes Made

- Added `GdalVectorReprojectJobExecutor` (`transform.reproject`, native profile): full PROJ datum/grid-shift reprojection via `ogr2ogr -s_srs/-t_srs`, emitting the same canonical geo+json data-URI artifact as the managed executor.
- Added `ManagedReprojectFastPath` as the single source of truth for the managed fast-path SRID pairs (identity, Web Mercator aliases, 4326 ↔ Web Mercator); the managed `ReprojectTransformExecutor` now consumes it (dropping its private duplicate).
- Submit path (`GeoprocessingJobService.ResolveRequiredRuntimeProfile`) **escalates** a reproject job to the native profile when its SRID pair is not a managed fast path (a datum shift); managed fast paths stay unstamped and never touch the worker.
- Added `GdalVectorSourceReadJobExecutor` (`source.ogr`, native profile): GDAL/OGR import reader canonicalizing the broad format universe (OpenFileGDB, GML, KML, MapInfo TAB, Shapefile, GeoPackage, FlatGeobuf) to GeoJSON; multi-file datasets arrive as a base64 ZIP (zip-slip protected). New native catalog entry.
- Added `GdalSrsToken` (shared CRS-token validation/normalization for the CLI executors).
- Wired both executors into `GdalDispatchJobExecutor` + DI; both declare `AcceptedRuntimeProfiles = { native }`.
- Image (`docker/worker-gdal`, titled `honua-worker-etl`): pinned the GDAL base to `ubuntu-full-3.12.4`; extended the build-time guard to assert PROJ (`projinfo`) and the OpenFileGDB/GML OGR drivers.

## Breaking Changes

None. Managed reproject fast paths (4326 ↔ 3857) are unchanged; the worker image and native processes are opt-in via the runtime-profile fence.

## Gate Impact

- [x] No gate impact (additive native-profile executors; lean image stays GDAL-free)

## Testing

- [x] Ran the affected build (Release, warnings-as-errors, `-p:NuGetAudit=false`) and tests
- Datum-shift proof: `VectorReproject_WithRealOgr2Ogr_AppliesNad27ToWgs84DatumShift` (NAD27→WGS84), env-gated on `ogr2ogr` (ADR-0037). PROJ-verified expected shift (dLon≈0.00036, dLat≈0.000015) bounds the assertion.
- Submit-path escalation: datum shift → native, managed fast path → unstamped.
- Worker dispatcher routing + input-validation; catalog conformance + count updated for `source.ogr`.
- Architecture tests (117), fast Geoprocessing tests (415), catalog/source/workflow tests (137) all green.

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
