### PR TITLE
feat(scene): serve I3S per-field attribute files for identify parity (#1811)

### DIFF
--- a/src/Honua.Protocols.Scene/I3s/I3sSceneServerEndpoints.cs
+++ b/src/Honua.Protocols.Scene/I3s/I3sSceneServerEndpoints.cs
@@ -46,6 +46,15 @@ internal static partial class I3sSceneServerEndpoints
     /// </summary>
     private const string I3sGeometryContentType = "application/octet-stream";
 
+    /// <summary>
+    /// Content type for the I3S per-field attribute binary file
+    /// (<c>nodes/{id}/attributes/{fieldKey}/0</c>). Like the geometry buffer the
+    /// I3S spec leaves the attribute media type unspecified and ArcGIS serves it
+    /// as an opaque byte stream, so we follow the same
+    /// <c>application/octet-stream</c> convention.
+    /// </summary>
+    private const string I3sAttributeContentType = "application/octet-stream";
+
     public static IEndpointRouteBuilder MapI3sSceneServerEndpoints(this IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
@@ -212,6 +221,41 @@ internal static partial class I3sSceneServerEndpoints
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 
+        // Node attribute binary resource (#1811): the per-field attribute file an
+        // ArcGIS SceneLayer client reads to satisfy identify. The OBJECTID field
+        // (f_0/Oid32) is materialised from the served node geometry's feature
+        // section so attribute order matches geometry order; user-attribute value
+        // decode (EXT_structural_metadata property tables) stays deferred and its
+        // fields answer a deterministic 404. Mapped at both the GeoServices and
+        // legacy /scenes paths for parity with the geometry route.
+        endpoints.MapGet(
+                "/rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/attributes/{fieldKey}/{attributeId:int}",
+                HandleGetNodeAttribute)
+            .WithName("GetGeoServicesSceneNodeAttribute")
+            .WithDisplayName("Get GeoServices SceneServer Node Attribute")
+            .WithSummary("Get the Esri I3S node attribute binary file at the GeoServices path")
+            .WithDescription("Returns the I3S per-field attribute binary file (count header + value array) for one attributeStorageInfo field of a served scene node, keyed on the node geometry's feature ids so an ArcGIS / I3S client can identify a picked feature. Enterprise edition.")
+            .WithTags(ScenesTag)
+            .Produces(StatusCodes.Status200OK, contentType: I3sAttributeContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status500InternalServerError);
+
+        endpoints.MapGet(
+                "/scenes/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/attributes/{fieldKey}/{attributeId:int}",
+                HandleGetNodeAttribute)
+            .WithName("GetI3sSceneNodeAttribute")
+            .WithDisplayName("Get I3S Scene Node Attribute")
+            .WithSummary("Get the Esri I3S node attribute binary file for a hosted scene")
+            .WithDescription("Alias of /rest/services/{sceneId}/SceneServer/layers/{layerId}/nodes/{nodeId}/attributes/{fieldKey}/{attributeId}. Returns the I3S per-field attribute binary file used by ArcGIS identify. Enterprise edition.")
+            .WithTags(ScenesTag)
+            .Produces(StatusCodes.Status200OK, contentType: I3sAttributeContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status500InternalServerError);
+
         return endpoints;
     }
 
@@ -327,6 +371,101 @@ internal static partial class I3sSceneServerEndpoints
         }
 
         return Results.Bytes(transcoded.Buffer, I3sGeometryContentType);
+    }
+
+    private static async Task<IResult> HandleGetNodeAttribute(
+        string sceneId,
+        int layerId,
+        int nodeId,
+        string fieldKey,
+        int attributeId,
+        HttpContext context,
+        [FromServices] ISceneDatasetRegistry registry,
+        [FromServices] ILicenseStatusProvider licenseStatusProvider,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(sceneId))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Scene identifier is required.");
+        }
+
+        var edition = licenseStatusProvider.GetCurrentStatus().Edition;
+        if (edition < HonuaEdition.Enterprise)
+        {
+            return StandardErrorHelpers.CreateForbidden(
+                context,
+                $"I3S scene serving requires the Enterprise edition. Current edition: {edition}.");
+        }
+
+        if (layerId != I3sSceneServiceBuilder.LayerId)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Scene layer was not found.");
+        }
+
+        // This slice serves the single attribute resource (id 0) of the single
+        // whole-scene node (id 0); any other index is an honest 404 (multi-node
+        // paging is the deferred #1809 lane).
+        if (attributeId != 0)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Node attribute was not found.");
+        }
+
+        var scene = await registry.FindAsync(sceneId, cancellationToken).ConfigureAwait(false);
+        if (scene is null)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Scene was not found.");
+        }
+
+        if (scene.AccessPolicy is { } accessPolicy)
+        {
+            var deniedResult = AccessPolicyHelpers.RequireAccess(
+                context,
+                layerPolicy: accessPolicy,
+                servicePolicy: null,
+                scope: AccessScope.Read);
+            if (deniedResult is not null)
+            {
+                return deniedResult;
+            }
+        }
+
+        // The served field set is the layer descriptor's attributeStorageInfo, so
+        // an attribute request can only resolve a field the descriptor advertises.
+        var extent = await ResolveExtentAsync(context, scene, cancellationToken).ConfigureAwait(false);
+        var datasetType = await ResolveDatasetTypeAsync(context, scene, cancellationToken).ConfigureAwait(false);
+        var layer = I3sSceneServiceBuilder.BuildLayer(scene, extent, datasetType, advertiseNodePages: false);
+        var field = layer.AttributeStorageInfo?
+            .FirstOrDefault(a => string.Equals(a.Key, fieldKey, StringComparison.Ordinal));
+        if (field is null)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Scene attribute field was not found.");
+        }
+
+        // The attribute file is keyed on the same feature section the served node
+        // geometry carries, so the geometry provider is the single source. A null
+        // provider/geometry surfaces as a 404 rather than an empty attribute file.
+        var provider = context.RequestServices.GetService<ISceneNodeGeometryProvider>();
+        if (provider is null)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Node attributes are not available for this scene.");
+        }
+
+        var geometry = await provider.GetNodeGeometryAsync(scene, nodeId, cancellationToken).ConfigureAwait(false);
+        if (geometry is not { } transcoded)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, "Node attributes are not available for this scene.");
+        }
+
+        var attributeBuffer = I3sAttributeBufferBuilder.Build(transcoded, field);
+        if (attributeBuffer is null)
+        {
+            // The field is advertised but not yet materialisable from the served
+            // geometry (a user-attribute field needing the deferred property-table
+            // decode), so the resource honestly 404s rather than fabricating values.
+            return StandardErrorHelpers.CreateNotFound(context, "Node attribute values are not available for this field.");
+        }
+
+        return Results.Bytes(attributeBuffer, I3sAttributeContentType);
     }
 
     private static async Task<IResult> HandleAsync(

--- a/src/Honua.Protocols.Scene/I3s/I3sSceneServiceBuilder.cs
+++ b/src/Honua.Protocols.Scene/I3s/I3sSceneServiceBuilder.cs
@@ -162,8 +162,10 @@ internal static class I3sSceneServiceBuilder
 
     /// <summary>
     /// Per-attribute storage layout describing the default <c>OBJECTID</c> key
-    /// every served 3D Object node carries. Descriptive only — no attribute
-    /// resource is fetchable on this slice.
+    /// (<c>f_0</c>, <c>Oid32</c>) every served 3D Object node carries. The
+    /// <c>f_0</c> attribute file is fetchable at
+    /// <c>nodes/{id}/attributes/f_0/0</c> (#1811, identify parity); user-attribute
+    /// fields are descriptive only until the deferred property-table decode lands.
     /// </summary>
     private static readonly IReadOnlyList<I3sAttributeStorageInfo> DefaultAttributeStorageInfo =
     [

--- a/src/Honua.Scene/Conversion/I3sAttributeBufferBuilder.cs
+++ b/src/Honua.Scene/Conversion/I3sAttributeBufferBuilder.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using Honua.Core.Features.Scene.Conversion;
+
+namespace Honua.Scene;
+
+/// <summary>
+/// Builds the I3S per-field attribute binary file served at
+/// <c>nodes/{nodeId}/attributes/{fieldKey}/0</c> (#1811). This file is what an
+/// ArcGIS SceneLayer client reads to satisfy <c>identify</c> — it pairs the
+/// served node geometry's feature ids with the layer's
+/// <c>attributeStorageInfo</c> so a picked feature resolves to its attribute
+/// values.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The attribute values are derived <b>honestly from the geometry that is
+/// actually served</b>: the transcoded geometry buffer carries a feature section
+/// (per-feature <c>id</c> + vertex range) emitted by
+/// <see cref="I3sGeometryTranscoder"/>, so the attribute file is read back from
+/// that same buffer rather than from a parallel data path. This guarantees the
+/// attribute order matches the geometry's feature order, which is exactly the
+/// invariant an I3S client relies on when mapping a picked vertex's feature id to
+/// an attribute row.
+/// </para>
+/// <para>
+/// <b>Scope (#1811 increment).</b> The synthetic <c>OBJECTID</c> field (<c>f_0</c>,
+/// <c>Oid32</c>) every served 3D Object node carries is materialised here as a
+/// fixed-width attribute file: an 8-byte-aligned header (<c>count</c> +
+/// reserved, little-endian UInt32) followed by <c>count</c> little-endian Int32
+/// object ids, matching the <c>attributeStorageInfo</c> ordering
+/// <c>["attributeValues"]</c> and value type <c>Oid32</c>. Per-value user
+/// attribute fields (strings, numerics) require decoding the baked glTF
+/// <c>EXT_structural_metadata</c> property tables — that decode stays the
+/// deferred hard-lane work, so those fields return <see langword="null"/> here
+/// (the endpoint answers a deterministic 404 rather than fabricating values).
+/// </para>
+/// </remarks>
+public static class I3sAttributeBufferBuilder
+{
+    /// <summary>
+    /// The descriptor's default key for the synthetic <c>OBJECTID</c> field every
+    /// served 3D Object node carries.
+    /// </summary>
+    public const string ObjectIdFieldKey = "f_0";
+
+    /// <summary>The I3S Oid32 value type advertised for the OBJECTID field.</summary>
+    public const string Oid32ValueType = "Oid32";
+
+    /// <summary>
+    /// Header bytes for a fixed-width attribute file: <c>count</c> (UInt32) plus a
+    /// reserved UInt32 so the value array starts on an 8-byte boundary, matching
+    /// the alignment ArcGIS uses for fixed-size attribute resources.
+    /// </summary>
+    public const int HeaderBytes = 8;
+
+    /// <summary>Bytes per <c>Oid32</c> value (one little-endian Int32).</summary>
+    public const int Oid32ValueBytes = 4;
+
+    /// <summary>
+    /// Builds the binary attribute file for one attribute-storage field of a
+    /// served scene node, or <see langword="null"/> when the field cannot be
+    /// materialised from the served geometry (so the endpoint can answer an
+    /// honest 404 instead of fabricating values).
+    /// </summary>
+    /// <param name="geometry">
+    /// The node geometry already transcoded for the node's
+    /// <c>geometries/0</c> resource. Its feature section supplies the per-feature
+    /// ids the attribute file is keyed on.
+    /// </param>
+    /// <param name="field">The attribute-storage descriptor for the requested field.</param>
+    /// <returns>
+    /// The attribute file bytes, or <see langword="null"/> when the field is not a
+    /// servable fixed-width <c>OBJECTID</c> field.
+    /// </returns>
+    public static byte[]? Build(I3sTranscodedGeometry geometry, I3sAttributeStorageInfo field)
+    {
+        ArgumentNullException.ThrowIfNull(field);
+
+        // Only the synthetic OBJECTID (Oid32) field is materialisable from the
+        // served geometry today; user-attribute fields need the deferred
+        // EXT_structural_metadata property-table decode.
+        if (!string.Equals(field.Key, ObjectIdFieldKey, StringComparison.Ordinal)
+            || !string.Equals(field.AttributeValues?.ValueType, Oid32ValueType, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var ids = ReadFeatureIds(geometry);
+        return PackOid32(ids);
+    }
+
+    /// <summary>
+    /// Reads the per-feature object ids out of the transcoded geometry's trailing
+    /// feature section using the buffer layout published by
+    /// <see cref="I3sGeometryTranscoder"/> (so the binary format stays
+    /// single-sourced with the transcoder that writes it).
+    /// </summary>
+    private static int[] ReadFeatureIds(I3sTranscodedGeometry geometry)
+    {
+        var buffer = geometry.Buffer;
+        var featureCount = geometry.FeatureCount;
+        var ids = new int[featureCount];
+
+        var featureSectionOffset = I3sGeometryTranscoder.HeaderBytes
+            + (geometry.VertexCount * I3sGeometryTranscoder.VertexStrideBytes);
+
+        var span = buffer.AsSpan();
+        for (var i = 0; i < featureCount; i++)
+        {
+            var recordOffset = featureSectionOffset + (i * I3sGeometryTranscoder.FeatureRecordBytes);
+            var id = BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(recordOffset, 8));
+            // Oid32 narrows the 64-bit feature id to the 32-bit object-id space
+            // Esri identify uses; hosted scene object ids fit in 32 bits.
+            ids[i] = unchecked((int)id);
+        }
+
+        return ids;
+    }
+
+    private static byte[] PackOid32(int[] ids)
+    {
+        var buffer = new byte[HeaderBytes + (ids.Length * Oid32ValueBytes)];
+        var span = buffer.AsSpan();
+
+        BinaryPrimitives.WriteUInt32LittleEndian(span[..4], (uint)ids.Length);
+        // span[4..8] reserved (zero) for 8-byte value-array alignment.
+
+        var offset = HeaderBytes;
+        foreach (var id in ids)
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(span.Slice(offset, Oid32ValueBytes), id);
+            offset += Oid32ValueBytes;
+        }
+
+        return buffer;
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sAttributeBufferBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sAttributeBufferBuilderTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using Honua.Core.Features.Scene.Conversion;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Scene;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.Conversion;
+
+/// <summary>
+/// Unit tests for the I3S per-field attribute binary builder (#1811): the
+/// <c>nodes/{id}/attributes/f_0/0</c> file that an ArcGIS SceneLayer client reads
+/// to satisfy identify. The OBJECTID values must be derived from — and aligned
+/// with — the served node geometry's feature section.
+/// </summary>
+public sealed class I3sAttributeBufferBuilderTests
+{
+    [UnitTest]
+    public void Build_ObjectIdField_EmitsCountHeaderAndFeatureIdValues()
+    {
+        var geometry = TranscodeThreeFeatures();
+        var field = ObjectIdField();
+
+        var bytes = I3sAttributeBufferBuilder.Build(geometry, field);
+
+        bytes.Should().NotBeNull();
+        var span = bytes!.AsSpan();
+
+        var expectedLength = I3sAttributeBufferBuilder.HeaderBytes
+            + (geometry.FeatureCount * I3sAttributeBufferBuilder.Oid32ValueBytes);
+        bytes.Length.Should().Be(expectedLength);
+
+        var count = BinaryPrimitives.ReadUInt32LittleEndian(span[..4]);
+        count.Should().Be((uint)geometry.FeatureCount);
+
+        // Values must equal the source feature ids in feature order, so a picked
+        // feature resolves to the same OBJECTID the geometry feature section maps.
+        var id0 = BinaryPrimitives.ReadInt32LittleEndian(span.Slice(I3sAttributeBufferBuilder.HeaderBytes, 4));
+        var id1 = BinaryPrimitives.ReadInt32LittleEndian(span.Slice(I3sAttributeBufferBuilder.HeaderBytes + 4, 4));
+        var id2 = BinaryPrimitives.ReadInt32LittleEndian(span.Slice(I3sAttributeBufferBuilder.HeaderBytes + 8, 4));
+        id0.Should().Be(11);
+        id1.Should().Be(22);
+        id2.Should().Be(33);
+    }
+
+    [UnitTest]
+    public void Build_NonObjectIdField_ReturnsNull()
+    {
+        // A user-attribute field is advertised but its values need the deferred
+        // EXT_structural_metadata decode, so the builder declines to fabricate it.
+        var geometry = TranscodeThreeFeatures();
+        var field = new I3sAttributeStorageInfo
+        {
+            Key = "f_1",
+            Name = "HEIGHT",
+            Ordering = ["attributeValues"],
+            AttributeValues = new I3sAttributeValues { ValueType = "Float64", ValuesPerElement = 1 },
+        };
+
+        var bytes = I3sAttributeBufferBuilder.Build(geometry, field);
+
+        bytes.Should().BeNull();
+    }
+
+    [UnitTest]
+    public void Build_ObjectIdKeyButWrongValueType_ReturnsNull()
+    {
+        var geometry = TranscodeThreeFeatures();
+        var field = new I3sAttributeStorageInfo
+        {
+            Key = I3sAttributeBufferBuilder.ObjectIdFieldKey,
+            Name = "OBJECTID",
+            Ordering = ["attributeValues"],
+            AttributeValues = new I3sAttributeValues { ValueType = "String", ValuesPerElement = 1 },
+        };
+
+        I3sAttributeBufferBuilder.Build(geometry, field).Should().BeNull();
+    }
+
+    private static I3sTranscodedGeometry TranscodeThreeFeatures()
+    {
+        var features = new[]
+        {
+            Square(11, -122.4200, 37.7700),
+            Square(22, -122.4190, 37.7700),
+            Square(33, -122.4180, 37.7700),
+        };
+        return I3sGeometryTranscoder.Transcode(features);
+    }
+
+    private static SceneFeature Square(long id, double lon, double lat) => new()
+    {
+        Id = id,
+        Geometry = new SceneFeatureGeometry
+        {
+            Kind = SceneGeometryKind.Polygon,
+            Vertices = new[]
+            {
+                new SceneVertex(lon, lat, 10.0),
+                new SceneVertex(lon + 0.0001, lat, 10.0),
+                new SceneVertex(lon + 0.0001, lat + 0.0001, 10.0),
+                new SceneVertex(lon, lat + 0.0001, 10.0),
+            },
+        },
+    };
+
+    private static I3sAttributeStorageInfo ObjectIdField() => new()
+    {
+        Key = I3sAttributeBufferBuilder.ObjectIdFieldKey,
+        Name = "OBJECTID",
+        Ordering = ["attributeValues"],
+        AttributeValues = new I3sAttributeValues
+        {
+            ValueType = I3sAttributeBufferBuilder.Oid32ValueType,
+            ValuesPerElement = 1,
+        },
+    };
+}

--- a/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs
@@ -584,6 +584,105 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/attributes/{fieldKey}/{attributeId:int}")]
+    public async Task GetNodeAttribute_EnterpriseEdition_ReturnsObjectIdAttributeFile()
+    {
+        // #1811: the attributes route serves the per-field OBJECTID binary file an
+        // ArcGIS SceneLayer client reads for identify. The values are the served
+        // geometry's feature ids (the stub transcodes one feature with Id=1).
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/rest/services/{SceneId}/SceneServer/layers/0/nodes/0/attributes/f_0/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/octet-stream");
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        var count = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(0, 4));
+        count.Should().Be(1u); // single fixture feature
+        var objectId = BinaryPrimitives.ReadInt32LittleEndian(bytes.AsSpan(8, 4));
+        objectId.Should().Be(1);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /scenes/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/attributes/{fieldKey}/{attributeId:int}")]
+    public async Task GetNodeAttribute_AtScenesAlias_ReturnsObjectIdAttributeFile()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/scenes/{SceneId}/SceneServer/layers/0/nodes/0/attributes/f_0/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/octet-stream");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/attributes/{fieldKey}/{attributeId:int}")]
+    public async Task GetNodeAttribute_CommunityEdition_Returns403()
+    {
+        var response = await _communityFixture.Client.GetAsync(
+            $"/rest/services/{SceneId}/SceneServer/layers/0/nodes/0/attributes/f_0/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/attributes/{fieldKey}/{attributeId:int}")]
+    public async Task GetNodeAttribute_UnknownField_Returns404()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/rest/services/{SceneId}/SceneServer/layers/0/nodes/0/attributes/f_99/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/attributes/{fieldKey}/{attributeId:int}")]
+    public async Task GetNodeAttribute_UnknownAttributeId_Returns404()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/rest/services/{SceneId}/SceneServer/layers/0/nodes/0/attributes/f_0/7");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/attributes/{fieldKey}/{attributeId:int}")]
+    public async Task GetNodeAttribute_UnknownLayerId_Returns404()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/rest/services/{SceneId}/SceneServer/layers/7/nodes/0/attributes/f_0/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/attributes/{fieldKey}/{attributeId:int}")]
+    public async Task GetNodeAttribute_SceneWithNoTranscodableGeometry_Returns404()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/rest/services/{NoGeometrySceneId}/SceneServer/layers/0/nodes/0/attributes/f_0/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{sceneId}/SceneServer/layers/{layerId:int}/nodes/{nodeId:int}/attributes/{fieldKey}/{attributeId:int}")]
+    public async Task GetNodeAttribute_ProtectedScene_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _enterpriseFixture.Client.GetAsync(
+            $"/rest/services/{ProtectedSceneId}/SceneServer/layers/0/nodes/0/attributes/f_0/0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
     /// <summary>
     /// In-memory <see cref="ISceneNodeGeometryProvider"/> that transcodes a
     /// single fixture square with the real <see cref="I3sGeometryTranscoder"/>,


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1811
Related to #1810

## Summary
Lands the remaining unfinished slice of the 3D/Scene parity group: serving the
I3S **per-field attribute binary file** (`nodes/{nodeId}/attributes/{fieldKey}/0`)
that an ArcGIS SceneLayer client reads to satisfy `identify`. This was the core
gap blocking identify parity for hosted Honua scenes (#1811).

During verification the other three issues in the group were found to be
**already implemented on `trunk`** and are not re-done here (see per-issue status
below); evidence has been posted to each issue.

Per-issue status:
- **#1811 (attribute files + statistics):** advanced here — the advertised
  `OBJECTID` (`f_0`/`Oid32`) attribute file is now fetchable; `statistics/f_n`
  already resolved on trunk. User-attribute value decode (glTF
  `EXT_structural_metadata` property tables) remains the deferred hard-lane work,
  so this is a slice — `Related to`, issue stays open.
- **#1810 (glTF→I3S geometry transcoder + serving):** the transcoder and
  `nodes/{id}/geometries/0` serving already landed on trunk; texture binary
  serving (`textures/0`) is genuinely deferred (no UV/texture data is produced
  yet to serve honestly) — `Related to`, stays open.
- **#1877 (FeatureServer 3D queries + true curves):** already implemented on
  trunk (`returnZ`/`returnM` EWKB read + `hasZ`/`hasM` advertisement; true-curve
  input densification). Lossless curve *output* re-emission is documented as a
  deferred sidecar-storage design. Evidence commented on the issue.
- **#1879 (ImageServer sensor/DEM height mensuration):** already implemented on
  trunk (DEM-backed `esriMensurationHeightFromBaseAndTop` + sensor metadata
  model). Shadow/photogrammetric height stays `501` (rare). Evidence commented
  on the issue.

## Changes Made
- Add `I3sAttributeBufferBuilder` (Honua.Scene) that materialises the
  `OBJECTID`/`Oid32` attribute file (8-byte count header + Int32 value array)
  from the served node geometry's feature section, so attribute order aligns with
  geometry order — the invariant I3S identify relies on.
- Map `nodes/{nodeId}/attributes/{fieldKey}/{attributeId}` at both the
  `/rest/services` GeoServices path and the legacy `/scenes` alias, reusing the
  geometry route's Enterprise gate and scene access-policy enforcement.
- Decline user-attribute fields with an honest `404` (deferred property-table
  decode) rather than fabricating values.
- Update the descriptor `attributeStorageInfo` doc to note `f_0` is now fetchable.
- Add unit tests (buffer builder) and integration tests (happy path, alias,
  edition gate, unknown field/attribute/layer, no-geometry scene, protected-scene
  auth).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

<!--
Note: the shared multi-agent build lock was saturated, so the full
`scripts/ci/pre-pr-check.sh` (full-solution Release build) was not run to
completion here. Verified locally instead: Release warnings-as-errors builds of
the changed source projects (Honua.Scene, Honua.Protocols.Scene) and both
affected test projects all pass with 0 warnings/0 errors; `dotnet format
--verify-no-changes` passes on every changed project; the new attribute-builder
unit tests pass (3/3). Integration tests compile clean and run under the
aggregate CI gate.
-->
