### PR TITLE
feat(orchestration,geoetl): workflow branching + ForEach and sink.honua-layer (#2146, #2210)

### DIFF
--- a/src/Honua.Core/Features/Geoprocessing/Abstractions/IHonuaLayerSink.cs
+++ b/src/Honua.Core/Features/Geoprocessing/Abstractions/IHonuaLayerSink.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Geoprocessing.Abstractions;
+
+/// <summary>
+/// How a <see cref="IHonuaLayerSink"/> reconciles an incoming feature batch against the
+/// rows already in the destination table. Mirrors the import-path load modes (#2209).
+/// </summary>
+public enum HonuaLayerLoadMode
+{
+    /// <summary>Insert the incoming rows alongside whatever is already present.</summary>
+    Append,
+
+    /// <summary>Remove every existing row in the destination table, then insert the incoming rows.</summary>
+    Replace,
+
+    /// <summary>
+    /// Delete existing rows whose key-field attribute values match an incoming row, then
+    /// insert the incoming rows — an idempotent reload keyed on
+    /// <see cref="HonuaLayerSinkRequest.KeyFields"/>.
+    /// </summary>
+    Upsert,
+}
+
+/// <summary>
+/// One feature to load: its geometry encoded as well-known binary plus a JSON object of
+/// attributes. The attributes JSON already carries the reserved
+/// <c>__pipeline_batch_id</c> key the rollback pattern relies on, so the sink stays free
+/// of geometry-library and feature-model dependencies.
+/// </summary>
+/// <param name="WellKnownBinary">The feature geometry encoded as WKB.</param>
+/// <param name="AttributesJson">The feature attributes as a JSON object string (including the batch-id key).</param>
+public sealed record HonuaLayerSinkRow(byte[] WellKnownBinary, string AttributesJson);
+
+/// <summary>
+/// The destination description and load policy for a <see cref="IHonuaLayerSink"/> load.
+/// </summary>
+/// <param name="Schema">Destination schema (validated identifier).</param>
+/// <param name="Table">Destination table / layer name (validated identifier).</param>
+/// <param name="GeometryColumn">Destination geometry column (validated identifier).</param>
+/// <param name="TargetSrid">SRID applied to the destination geometry column.</param>
+/// <param name="LoadMode">How the incoming rows reconcile with existing rows.</param>
+/// <param name="BatchId">The run batch id tagged on every row for soft-delete rollback.</param>
+/// <param name="KeyFields">
+/// Attribute names that identify a row for <see cref="HonuaLayerLoadMode.Upsert"/>;
+/// ignored for the other modes.
+/// </param>
+public sealed record HonuaLayerSinkRequest(
+    string Schema,
+    string Table,
+    string GeometryColumn,
+    int TargetSrid,
+    HonuaLayerLoadMode LoadMode,
+    string BatchId,
+    IReadOnlyList<string> KeyFields);
+
+/// <summary>
+/// The result of a <see cref="IHonuaLayerSink"/> load.
+/// </summary>
+/// <param name="FeaturesWritten">The number of rows inserted into the destination table.</param>
+/// <param name="Schema">The destination schema that was written.</param>
+/// <param name="Table">The destination table that was written.</param>
+/// <param name="BatchId">The batch id tagged on the written rows (for rollback).</param>
+public sealed record HonuaLayerSinkOutcome(
+    long FeaturesWritten,
+    string Schema,
+    string Table,
+    string BatchId);
+
+/// <summary>
+/// Optional capability that loads an upstream feature artifact into a named layer in the
+/// Honua <em>catalog</em> database. It is the deliberate seam that lets the
+/// <c>sink.honua-layer</c> DAG node reach the catalog's own database without coupling the
+/// geoprocessing dispatcher — which is constructed unconditionally, including in lean,
+/// Postgres-free deployments — to the catalog <c>NpgsqlDataSource</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The implementation lives with the catalog provider (it depends on the catalog data
+/// source) and is registered <em>only</em> when that database is present. In a lean
+/// deployment the capability is simply absent: the <c>sink.honua-layer</c> executor
+/// resolves it as <see langword="null"/> and fails the node closed with a clear
+/// "unavailable in this deployment" message instead of forcing a Postgres dependency on
+/// the dispatcher or leaking a catalog connection string through plan parameters.
+/// </para>
+/// <para>
+/// Rows are pre-encoded (WKB + attributes JSON) by the executor so this abstraction never
+/// references a geometry or feature-model type; the attributes JSON carries the reserved
+/// <c>__pipeline_batch_id</c> key so a completed load can be rolled back by batch id.
+/// </para>
+/// </remarks>
+public interface IHonuaLayerSink
+{
+    /// <summary>
+    /// Loads the supplied rows into the destination described by <paramref name="request"/>
+    /// using its load mode, within a single transaction so a failure leaves the catalog
+    /// table unchanged.
+    /// </summary>
+    /// <param name="request">The destination and load policy.</param>
+    /// <param name="rows">The pre-encoded feature rows to load.</param>
+    /// <param name="cancellationToken">Token used to abort the load.</param>
+    /// <returns>The load outcome (rows written, destination, batch id).</returns>
+    Task<HonuaLayerSinkOutcome> LoadAsync(
+        HonuaLayerSinkRequest request,
+        IReadOnlyList<HonuaLayerSinkRow> rows,
+        CancellationToken cancellationToken);
+}

--- a/src/Honua.Core/Features/Orchestration/Domain/WorkflowDefinitionExpander.cs
+++ b/src/Honua.Core/Features/Orchestration/Domain/WorkflowDefinitionExpander.cs
@@ -1,0 +1,203 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.Core.Features.Orchestration.Domain;
+
+/// <summary>
+/// Deterministically unrolls a <see cref="WorkflowDefinition"/> containing
+/// <see cref="WorkflowForEachSpec"/> steps into a flat definition of concrete steps —
+/// one per iteration item — so the durable orchestration engine reconciles a plain DAG.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The transform is pure and deterministic: the same input always yields the same
+/// expanded step-set in the same order. The engine therefore applies it both when a run
+/// is created (to materialise the run's step states) and on every reconcile tick (after
+/// reloading the stored definition); because both sides expand identically, the step-set
+/// consistency guard holds and no extra durable state is needed.
+/// </para>
+/// <para>
+/// A ForEach step <c>F</c> over items <c>[a, b]</c> unrolls into sub-steps
+/// <c>F::0</c> and <c>F::1</c>, each carrying a copy of the template's plan with the
+/// item value substituted for <see cref="WorkflowForEachSpec.ItemPlaceholder"/>. A step
+/// that depends on <c>F</c> fans in to depend on every sub-step, so its execution waits
+/// for all iterations and the run aggregates the per-item outputs. Acyclicity is
+/// preserved: the unroll only duplicates nodes along existing edges, so an acyclic
+/// source graph stays acyclic.
+/// </para>
+/// </remarks>
+public static class WorkflowDefinitionExpander
+{
+    /// <summary>The reserved separator joining a ForEach step id with its iteration index.</summary>
+    public const string IterationSeparator = "::";
+
+    /// <summary>
+    /// Returns an expanded copy of <paramref name="definition"/> with every ForEach step
+    /// unrolled into concrete per-item steps. A definition with no ForEach steps is
+    /// returned unchanged.
+    /// </summary>
+    /// <param name="definition">The (already validated) definition to expand.</param>
+    /// <returns>The flat, fully-unrolled definition.</returns>
+    public static WorkflowDefinition Expand(WorkflowDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        if (!definition.Steps.Any(static s => s.ForEach is not null))
+        {
+            return definition;
+        }
+
+        // Map every source step id to the concrete step ids it expands into. Non-ForEach
+        // steps map to themselves; ForEach steps map to their ordered per-item instances.
+        var expandedIds = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var step in definition.Steps)
+        {
+            if (step.ForEach is { } forEach)
+            {
+                var count = Math.Min(forEach.Items.Count, WorkflowForEachSpec.HardIterationLimit);
+                var ids = new List<string>(count);
+                for (var i = 0; i < count; i++)
+                {
+                    ids.Add(IterationStepId(step.StepId, i));
+                }
+
+                expandedIds[step.StepId] = ids;
+            }
+            else
+            {
+                expandedIds[step.StepId] = [step.StepId];
+            }
+        }
+
+        var expandedSteps = new List<WorkflowStepDefinition>(definition.Steps.Count);
+        foreach (var step in definition.Steps)
+        {
+            if (step.ForEach is { } forEach)
+            {
+                var count = Math.Min(forEach.Items.Count, WorkflowForEachSpec.HardIterationLimit);
+                for (var i = 0; i < count; i++)
+                {
+                    expandedSteps.Add(BuildIterationStep(step, forEach, i, expandedIds));
+                }
+            }
+            else
+            {
+                expandedSteps.Add(step with
+                {
+                    DependsOn = RemapDependencies(step.DependsOn, expandedIds),
+                    InputBindings = RemapBindings(step.InputBindings, expandedIds)
+                });
+            }
+        }
+
+        return definition with { Steps = expandedSteps };
+    }
+
+    private static WorkflowStepDefinition BuildIterationStep(
+        WorkflowStepDefinition template,
+        WorkflowForEachSpec forEach,
+        int index,
+        IReadOnlyDictionary<string, List<string>> expandedIds)
+    {
+        var item = forEach.Items[index];
+        var stepId = IterationStepId(template.StepId, index);
+
+        return template with
+        {
+            StepId = stepId,
+            ForEach = null,
+            Plan = SubstituteItem(template.Plan, forEach.ItemPlaceholder, item, index),
+            DependsOn = RemapDependencies(template.DependsOn, expandedIds),
+            InputBindings = RemapBindings(template.InputBindings, expandedIds)
+        };
+    }
+
+    private static string IterationStepId(string baseStepId, int index)
+        => string.Concat(baseStepId, IterationSeparator, index.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+    private static IReadOnlyList<string> RemapDependencies(
+        IReadOnlyList<string> dependsOn,
+        IReadOnlyDictionary<string, List<string>> expandedIds)
+    {
+        if (dependsOn.Count == 0)
+        {
+            return [];
+        }
+
+        var remapped = new List<string>(dependsOn.Count);
+        foreach (var dependency in dependsOn)
+        {
+            if (expandedIds.TryGetValue(dependency, out var ids))
+            {
+                remapped.AddRange(ids);
+            }
+            else
+            {
+                remapped.Add(dependency);
+            }
+        }
+
+        return remapped;
+    }
+
+    private static IReadOnlyList<StepInputBinding> RemapBindings(
+        IReadOnlyList<StepInputBinding> bindings,
+        IReadOnlyDictionary<string, List<string>> expandedIds)
+    {
+        if (bindings.Count == 0)
+        {
+            return [];
+        }
+
+        var remapped = new List<StepInputBinding>(bindings.Count);
+        foreach (var binding in bindings)
+        {
+            // Binding from a ForEach source is rejected at validation; if a single-instance
+            // source was remapped (non-ForEach maps to itself) we keep it, otherwise we bind
+            // from the first instance defensively so the transform stays total.
+            var sourceId = expandedIds.TryGetValue(binding.SourceStepId, out var ids) && ids.Count > 0
+                ? ids[0]
+                : binding.SourceStepId;
+            remapped.Add(binding with { SourceStepId = sourceId });
+        }
+
+        return remapped;
+    }
+
+    private static AnalysisPlan SubstituteItem(AnalysisPlan plan, string placeholder, string item, int index)
+    {
+        var suffixedPlanId = string.Concat(plan.PlanId, IterationSeparator, index.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        if (string.IsNullOrEmpty(placeholder) || plan.Steps.Count == 0)
+        {
+            return plan with { PlanId = suffixedPlanId };
+        }
+
+        var steps = new AnalysisPlanStep[plan.Steps.Count];
+        for (var s = 0; s < plan.Steps.Count; s++)
+        {
+            var step = plan.Steps[s];
+            if (step.Inputs.Count == 0)
+            {
+                steps[s] = step;
+                continue;
+            }
+
+            Dictionary<string, string>? substituted = null;
+            foreach (var pair in step.Inputs)
+            {
+                if (pair.Value.Contains(placeholder, StringComparison.Ordinal))
+                {
+                    substituted ??= new Dictionary<string, string>(step.Inputs, StringComparer.Ordinal);
+                    substituted[pair.Key] = pair.Value.Replace(placeholder, item, StringComparison.Ordinal);
+                }
+            }
+
+            steps[s] = substituted is null ? step : step with { Inputs = substituted };
+        }
+
+        return plan with { PlanId = suffixedPlanId, Steps = steps };
+    }
+}

--- a/src/Honua.Core/Features/Orchestration/Domain/WorkflowDefinitionExpander.cs
+++ b/src/Honua.Core/Features/Orchestration/Domain/WorkflowDefinitionExpander.cs
@@ -117,7 +117,7 @@ public static class WorkflowDefinitionExpander
     private static string IterationStepId(string baseStepId, int index)
         => string.Concat(baseStepId, IterationSeparator, index.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
-    private static IReadOnlyList<string> RemapDependencies(
+    private static List<string> RemapDependencies(
         IReadOnlyList<string> dependsOn,
         IReadOnlyDictionary<string, List<string>> expandedIds)
     {
@@ -142,7 +142,7 @@ public static class WorkflowDefinitionExpander
         return remapped;
     }
 
-    private static IReadOnlyList<StepInputBinding> RemapBindings(
+    private static List<StepInputBinding> RemapBindings(
         IReadOnlyList<StepInputBinding> bindings,
         IReadOnlyDictionary<string, List<string>> expandedIds)
     {

--- a/src/Honua.Core/Features/Orchestration/Domain/WorkflowDefinitionValidator.cs
+++ b/src/Honua.Core/Features/Orchestration/Domain/WorkflowDefinitionValidator.cs
@@ -68,7 +68,21 @@ public static class WorkflowDefinitionValidator
             {
                 failures.Add($"Step '{step.StepId}' retry policy must allow at least one attempt.");
             }
+
+            if (!string.IsNullOrWhiteSpace(step.StepId) &&
+                step.StepId.Contains(WorkflowDefinitionExpander.IterationSeparator, StringComparison.Ordinal))
+            {
+                failures.Add($"Step '{step.StepId}' identifier must not contain the reserved iteration separator '{WorkflowDefinitionExpander.IterationSeparator}'.");
+            }
+
+            ValidateForEach(step, failures);
         }
+
+        var forEachStepIds = new HashSet<string>(
+            definition.Steps
+                .Where(s => s.ForEach is not null && !string.IsNullOrWhiteSpace(s.StepId))
+                .Select(s => s.StepId),
+            StringComparer.Ordinal);
 
         foreach (var step in definition.Steps)
         {
@@ -77,6 +91,10 @@ public static class WorkflowDefinitionValidator
                 if (!stepIds.Contains(dependency))
                 {
                     failures.Add($"Step '{step.StepId}' depends on unknown step '{dependency}'.");
+                }
+                else if (step.ForEach is not null && forEachStepIds.Contains(dependency))
+                {
+                    failures.Add($"ForEach step '{step.StepId}' may not depend on ForEach step '{dependency}'; nested iteration is not supported.");
                 }
             }
 
@@ -91,6 +109,10 @@ public static class WorkflowDefinitionValidator
                 {
                     failures.Add($"Step '{step.StepId}' binding references source step '{binding.SourceStepId}' which is not declared in DependsOn. Binding sources must be explicit dependencies so execution ordering and cycle detection cover all data edges.");
                 }
+                else if (forEachStepIds.Contains(binding.SourceStepId))
+                {
+                    failures.Add($"Step '{step.StepId}' binding may not read from ForEach step '{binding.SourceStepId}'; binding from an iteration's aggregate output is not supported.");
+                }
 
                 if (string.IsNullOrWhiteSpace(binding.TargetInputKey))
                 {
@@ -102,6 +124,8 @@ public static class WorkflowDefinitionValidator
                     failures.Add($"Step '{step.StepId}' binding is missing an artifact selector.");
                 }
             }
+
+            ValidateCondition(step, stepIds, forEachStepIds, failures);
         }
 
         // Cycle detection requires unique step identifiers; skip when duplicates were flagged
@@ -143,6 +167,75 @@ public static class WorkflowDefinitionValidator
         }
 
         return failures;
+    }
+
+    private static void ValidateForEach(WorkflowStepDefinition step, List<string> failures)
+    {
+        if (step.ForEach is not { } forEach)
+        {
+            return;
+        }
+
+        if (forEach.Items.Count == 0)
+        {
+            failures.Add($"Step '{step.StepId}' ForEach must declare at least one item.");
+        }
+
+        if (forEach.Items.Count > WorkflowForEachSpec.HardIterationLimit)
+        {
+            failures.Add($"Step '{step.StepId}' ForEach declares {forEach.Items.Count} items, exceeding the hard limit of {WorkflowForEachSpec.HardIterationLimit}.");
+        }
+
+        if (forEach.MaxIterations is { } max)
+        {
+            if (max < 1)
+            {
+                failures.Add($"Step '{step.StepId}' ForEach MaxIterations must be at least 1.");
+            }
+            else if (forEach.Items.Count > max)
+            {
+                failures.Add($"Step '{step.StepId}' ForEach declares {forEach.Items.Count} items but MaxIterations is {max}.");
+            }
+        }
+
+        if (string.IsNullOrEmpty(forEach.ItemPlaceholder))
+        {
+            failures.Add($"Step '{step.StepId}' ForEach item placeholder must be non-empty.");
+        }
+    }
+
+    private static void ValidateCondition(
+        WorkflowStepDefinition step,
+        HashSet<string> stepIds,
+        HashSet<string> forEachStepIds,
+        List<string> failures)
+    {
+        if (step.Condition is not { } condition)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(condition.SourceStepId) || !stepIds.Contains(condition.SourceStepId))
+        {
+            failures.Add($"Step '{step.StepId}' condition references unknown source step '{condition.SourceStepId}'.");
+        }
+        else
+        {
+            if (!step.DependsOn.Contains(condition.SourceStepId, StringComparer.Ordinal))
+            {
+                failures.Add($"Step '{step.StepId}' condition references source step '{condition.SourceStepId}' which is not declared in DependsOn. Condition sources must be explicit dependencies so they are terminal before the branch is evaluated.");
+            }
+
+            if (forEachStepIds.Contains(condition.SourceStepId))
+            {
+                failures.Add($"Step '{step.StepId}' condition may not read from ForEach step '{condition.SourceStepId}'.");
+            }
+        }
+
+        if (condition.Threshold < 0)
+        {
+            failures.Add($"Step '{step.StepId}' condition threshold must be non-negative.");
+        }
     }
 
     private static bool HasCycle(IReadOnlyList<WorkflowStepDefinition> steps)

--- a/src/Honua.Core/Features/Orchestration/Domain/WorkflowForEachSpec.cs
+++ b/src/Honua.Core/Features/Orchestration/Domain/WorkflowForEachSpec.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Orchestration.Domain;
+
+/// <summary>
+/// Declares that a workflow step is a ForEach/iteration template: the engine unrolls it
+/// into one concrete sub-step per item in <see cref="Items"/>, substituting the item
+/// value into the step's plan inputs. Iteration is statically declared (the collection
+/// is part of the definition) so the unroll is a pure, deterministic transform that
+/// composes with the existing DAG without introducing cycles or non-determinism.
+/// </summary>
+/// <param name="Items">
+/// The ordered collection iterated over. Each item yields one sub-step; ordering is
+/// preserved so the unroll is deterministic. Must be non-empty.
+/// </param>
+/// <param name="ItemPlaceholder">
+/// The token replaced by the current item value in the step plan's input values
+/// (default <c>${item}</c>). Allows a single plan template to fan out across items.
+/// </param>
+/// <param name="MaxIterations">
+/// Optional per-step bound on the iteration count. When set, a definition whose
+/// <see cref="Items"/> count exceeds it fails validation, guarding against an
+/// unbounded fan-out.
+/// </param>
+public sealed record WorkflowForEachSpec(
+    IReadOnlyList<string> Items,
+    string ItemPlaceholder = "${item}",
+    int? MaxIterations = null)
+{
+    /// <summary>
+    /// Absolute safety ceiling on the number of sub-steps a single ForEach may unroll
+    /// into, independent of <see cref="MaxIterations"/>. Bounds the durable run size and
+    /// the reconcile cost even if a stored definition somehow exceeds its declared bound.
+    /// </summary>
+    public const int HardIterationLimit = 1000;
+}

--- a/src/Honua.Core/Features/Orchestration/Domain/WorkflowStepCondition.cs
+++ b/src/Honua.Core/Features/Orchestration/Domain/WorkflowStepCondition.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.Core.Features.Orchestration.Domain;
+
+/// <summary>
+/// The kind of predicate a <see cref="WorkflowStepCondition"/> applies to a prior
+/// step's output. Every kind is a pure, deterministic check over already-captured
+/// state so a branch decision is reproducible and AOT-safe (no expression parsing).
+/// </summary>
+public enum WorkflowStepConditionKind
+{
+    /// <summary>The source step reached <see cref="WorkflowStepStatus.Succeeded"/>.</summary>
+    UpstreamSucceeded,
+
+    /// <summary>The source step reached <see cref="WorkflowStepStatus.Skipped"/>.</summary>
+    UpstreamSkipped,
+
+    /// <summary>The source step produced at least one output artifact (optionally matching a label).</summary>
+    HasArtifact,
+
+    /// <summary>The source step produced no output artifacts (optionally for a matching label).</summary>
+    NoArtifact,
+
+    /// <summary>The source step produced at least <see cref="WorkflowStepCondition.Threshold"/> artifacts.</summary>
+    ArtifactCountAtLeast,
+
+    /// <summary>The source step produced at most <see cref="WorkflowStepCondition.Threshold"/> artifacts.</summary>
+    ArtifactCountAtMost,
+}
+
+/// <summary>
+/// A conditional-branch predicate over a single prior step's output. The condition is
+/// evaluated once the owning step's dependencies are satisfied; when it is not met the
+/// owning step is skipped (and reported as such) rather than submitted, letting a
+/// workflow take a data-dependent path without reimplementing dependency resolution.
+/// </summary>
+/// <param name="SourceStepId">
+/// The prior step whose output the predicate reads. It must be declared in the owning
+/// step's <see cref="WorkflowStepDefinition.DependsOn"/> so it is always terminal
+/// before the predicate evaluates.
+/// </param>
+/// <param name="Kind">The predicate applied to the source step's output.</param>
+/// <param name="Threshold">
+/// The operand for the count predicates (<see cref="WorkflowStepConditionKind.ArtifactCountAtLeast"/>
+/// and <see cref="WorkflowStepConditionKind.ArtifactCountAtMost"/>); ignored otherwise.
+/// </param>
+/// <param name="ArtifactLabel">
+/// When set, the artifact predicates count only artifacts whose label matches
+/// (case-insensitive); otherwise all artifacts count.
+/// </param>
+/// <param name="Negate">When <see langword="true"/>, the predicate result is inverted.</param>
+public sealed record WorkflowStepCondition(
+    string SourceStepId,
+    WorkflowStepConditionKind Kind,
+    int Threshold = 0,
+    string? ArtifactLabel = null,
+    bool Negate = false);
+
+/// <summary>
+/// Pure evaluator for a <see cref="WorkflowStepCondition"/>. Carries no I/O so the
+/// branch decision is a deterministic function of the run's current step states; the
+/// engine and tests share this single implementation.
+/// </summary>
+public static class WorkflowStepConditionEvaluator
+{
+    /// <summary>
+    /// Evaluates the condition against the current step states. When the source step is
+    /// unknown (should not happen for a validated definition) the predicate is treated
+    /// as not met so the owning step is skipped rather than run on missing data.
+    /// </summary>
+    /// <param name="condition">The branch predicate.</param>
+    /// <param name="statesByStepId">The run's current step states, keyed by step id.</param>
+    /// <returns><see langword="true"/> when the branch should be taken.</returns>
+    public static bool Evaluate(
+        WorkflowStepCondition condition,
+        IReadOnlyDictionary<string, WorkflowStepState> statesByStepId)
+    {
+        ArgumentNullException.ThrowIfNull(condition);
+        ArgumentNullException.ThrowIfNull(statesByStepId);
+
+        if (!statesByStepId.TryGetValue(condition.SourceStepId, out var source))
+        {
+            return false;
+        }
+
+        var result = condition.Kind switch
+        {
+            WorkflowStepConditionKind.UpstreamSucceeded => source.Status == WorkflowStepStatus.Succeeded,
+            WorkflowStepConditionKind.UpstreamSkipped => source.Status == WorkflowStepStatus.Skipped,
+            WorkflowStepConditionKind.HasArtifact => CountArtifacts(source.OutputArtifacts, condition.ArtifactLabel) >= 1,
+            WorkflowStepConditionKind.NoArtifact => CountArtifacts(source.OutputArtifacts, condition.ArtifactLabel) == 0,
+            WorkflowStepConditionKind.ArtifactCountAtLeast => CountArtifacts(source.OutputArtifacts, condition.ArtifactLabel) >= condition.Threshold,
+            WorkflowStepConditionKind.ArtifactCountAtMost => CountArtifacts(source.OutputArtifacts, condition.ArtifactLabel) <= condition.Threshold,
+            _ => false
+        };
+
+        return condition.Negate ? !result : result;
+    }
+
+    private static int CountArtifacts(IReadOnlyList<ArtifactRef>? artifacts, string? label)
+    {
+        if (artifacts is null || artifacts.Count == 0)
+        {
+            return 0;
+        }
+
+        if (string.IsNullOrWhiteSpace(label))
+        {
+            return artifacts.Count;
+        }
+
+        var count = 0;
+        foreach (var artifact in artifacts)
+        {
+            if (string.Equals(artifact.Label, label, StringComparison.OrdinalIgnoreCase))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+}

--- a/src/Honua.Core/Features/Orchestration/Domain/WorkflowStepDefinition.cs
+++ b/src/Honua.Core/Features/Orchestration/Domain/WorkflowStepDefinition.cs
@@ -45,4 +45,23 @@ public sealed record WorkflowStepDefinition
     /// Optional wall-clock timeout for the step's underlying job, in seconds.
     /// </summary>
     public int? TimeoutSeconds { get; init; }
+
+    /// <summary>
+    /// Optional conditional-branch predicate evaluated over a prior step's output once
+    /// this step's dependencies are satisfied. When the predicate evaluates to
+    /// <see langword="false"/> the step is not submitted and is reported as
+    /// <see cref="WorkflowStepStatus.Skipped"/>; downstream steps that consume its
+    /// output cascade-skip exactly as they do for a skip-policy upstream. A
+    /// <see langword="null"/> condition is always taken (the existing behavior).
+    /// </summary>
+    public WorkflowStepCondition? Condition { get; init; }
+
+    /// <summary>
+    /// Optional ForEach/iteration spec. When set, this step is a template that the
+    /// engine deterministically unrolls into one concrete sub-step per item in
+    /// <see cref="WorkflowForEachSpec.Items"/> before reconciliation, substituting the
+    /// item value into the step's plan inputs. A <see langword="null"/> spec leaves the
+    /// step as an ordinary single step.
+    /// </summary>
+    public WorkflowForEachSpec? ForEach { get; init; }
 }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
@@ -910,19 +910,18 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
         },
 
         // -----------------------------------------------------------------------
-        // GeoETL sink operations (3)
-        // Terminate a workflow by writing the input FeatureCollection to an external
-        // target and emit a small result-descriptor artifact (the target location +
-        // row counts). Managed writers / Npgsql only — no GDAL.
-        // The catalog honua-layer sink (insert through honua.create_import_table /
-        // honua.insert_import_feature) is DEFERRED: unlike external-postgis (which
-        // targets a registered secure connection and therefore depends on resolver
-        // wiring outside this catalog. The catalog never accepts raw connection strings.
-        // It must reach the catalog NpgsqlDataSource. Injecting that into an executor
-        // would break the dispatcher's unconditional construction in lean
-        // deployments where Postgres is not registered, and a plan-parameter
-        // connection string would leak catalog credentials into the workflow DAG.
-        // Resolving that conditional-registration shape is a follow-on.
+        // GeoETL sink operations (4)
+        // Terminate a workflow by writing the input FeatureCollection to a target and
+        // emit a small result-descriptor artifact (the target location + row counts).
+        // Managed writers / Npgsql only — no GDAL.
+        // The catalog honua-layer sink (sink.honua-layer) loads into a named layer in the
+        // Honua catalog database. It reaches the catalog NpgsqlDataSource through the
+        // optional IHonuaLayerSink capability (#2210), which is registered only when the
+        // catalog database is present — so the geoprocessing dispatcher, constructed
+        // unconditionally including in lean Postgres-free deployments, never takes a
+        // Postgres dependency, and no catalog connection string is leaked through plan
+        // parameters. In a lean deployment the capability is absent and the node fails
+        // closed with a clear "unavailable in this deployment" message.
         // Native-format sinks (shapefile, geopackage) are deferred to the GDAL stream.
         // -----------------------------------------------------------------------
         new ProcessDefinition
@@ -969,6 +968,25 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
                 Param("schema", "Schema", "Destination schema. Defaults to public. Must match ^[A-Za-z_][A-Za-z0-9_]*$.", ProcessParameterValueType.Text, defaultValue: "public"),
                 Param("geometryColumn", "Geometry Column", "Destination geometry column. Defaults to geom. Must match ^[A-Za-z_][A-Za-z0-9_]*$.", ProcessParameterValueType.Text, defaultValue: "geom"),
                 Param("batchSize", "Batch Size", "Insert batch size. Defaults to 1000.", ProcessParameterValueType.WholeNumber, defaultValue: "1000"),
+                Param("batchId", "Batch Id", "Run batch id tagged on every row. Defaults to the operation id.", ProcessParameterValueType.Text),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer]
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "sink.honua-layer",
+            Title = "Honua Catalog Layer Sink",
+            Description = "Loads the input FeatureCollection into a named layer in the Honua catalog database via the catalog data source. Supports append/replace/upsert load modes; every row's attributes JSONB carries a reserved __pipeline_batch_id key for soft-delete rollback. Requires a configured catalog database — fails closed in lean, database-free deployments. Managed Npgsql + WKB — no GDAL.",
+            Category = "sink",
+            Parameters =
+            [
+                Param("input", "Input Features", "Input FeatureCollection as a data:application/geo+json;base64 data URI.", ProcessParameterValueType.Text, required: true),
+                Param("layer", "Layer Name", "Destination layer/table name in the catalog (created if missing). Must match ^[A-Za-z_][A-Za-z0-9_]*$.", ProcessParameterValueType.Text, required: true),
+                Param("targetSrid", "Target SRID", "Geometry SRID for the destination column.", ProcessParameterValueType.Srid, required: true),
+                Param("loadMode", "Load Mode", "How incoming rows reconcile with existing rows: append, replace, or upsert. Defaults to append.", ProcessParameterValueType.Text, defaultValue: "append"),
+                Param("keyFields", "Key Fields", "Comma-separated attribute names identifying a row for upsert. Required when loadMode is upsert.", ProcessParameterValueType.Text),
+                Param("schema", "Schema", "Destination schema. Defaults to public. Must match ^[A-Za-z_][A-Za-z0-9_]*$.", ProcessParameterValueType.Text, defaultValue: "public"),
+                Param("geometryColumn", "Geometry Column", "Destination geometry column. Defaults to geom. Must match ^[A-Za-z_][A-Za-z0-9_]*$.", ProcessParameterValueType.Text, defaultValue: "geom"),
                 Param("batchId", "Batch Id", "Run batch id tagged on every row. Defaults to the operation id.", ProcessParameterValueType.Text),
             ],
             OutputArtifactKinds = [ArtifactKind.FeatureLayer]

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/HonuaLayerSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/HonuaLayerSinkExecutor.cs
@@ -183,7 +183,7 @@ internal sealed partial class HonuaLayerSinkExecutor : IProcessExecutor
         _ => throw new TransformInputException($"loadMode '{raw}' is invalid; expected append, replace, or upsert.")
     };
 
-    private static IReadOnlyList<string> ParseKeyFields(string raw)
+    private static List<string> ParseKeyFields(string raw)
     {
         if (string.IsNullOrWhiteSpace(raw))
         {

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/HonuaLayerSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/HonuaLayerSinkExecutor.cs
@@ -1,0 +1,241 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.IO;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// <c>sink.honua-layer</c> executor. Loads the input FeatureCollection into a named layer
+/// in the Honua <em>catalog</em> database via the optional <see cref="IHonuaLayerSink"/>
+/// capability (replace/append/upsert load modes plus the reserved
+/// <c>__pipeline_batch_id</c> rollback tag). The capability is the seam that keeps the
+/// geoprocessing dispatcher decoupled from the catalog <c>NpgsqlDataSource</c>: this
+/// executor depends only on the abstraction, never on a database type.
+/// </summary>
+/// <remarks>
+/// In a lean, Postgres-free deployment the capability is not registered, so
+/// <see cref="_sink"/> resolves to <see langword="null"/> and the node fails closed with a
+/// clear "unavailable in this deployment" message — rather than forcing the dispatcher to
+/// take a Postgres dependency or leaking catalog credentials through plan parameters.
+/// </remarks>
+internal sealed partial class HonuaLayerSinkExecutor : IProcessExecutor
+{
+    internal const string HandledProcessId = "sink.honua-layer";
+
+    private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options;
+    private readonly IHonuaLayerSink? _sink;
+    private readonly ILogger<HonuaLayerSinkExecutor> _logger;
+
+    public HonuaLayerSinkExecutor(
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<HonuaLayerSinkExecutor> logger,
+        IHonuaLayerSink? sink = null)
+    {
+        _options = options;
+        _logger = logger;
+        _sink = sink;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var resolved = GeoprocessingDispatchHelper.ResolveProcessId(job.Spec.Parameters);
+        if (!string.Equals(resolved, HandledProcessId, StringComparison.Ordinal))
+        {
+            return JobExecutionResult.Failed(
+                $"Process id '{resolved ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        // Fail closed in lean deployments: the catalog-layer capability is registered only
+        // when the catalog database is present. Surface a clear, actionable message instead
+        // of a generic provider error.
+        if (_sink is null)
+        {
+            Log.SinkUnavailable(_logger, job.OperationId);
+            return JobExecutionResult.Failed(
+                $"The {HandledProcessId} sink is unavailable in this deployment: it requires a Honua catalog " +
+                "database, which is not configured here. Use sink.external-postgis or a file sink instead.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(10, "Parsing honua-layer sink inputs", cancellationToken).ConfigureAwait(false);
+
+        var inputs = new StepInputReader(job.Spec.Parameters);
+        if (!inputs.TryGetRequired("input", out var inputUri, out var inputError))
+        {
+            return JobExecutionResult.Failed($"Invalid {HandledProcessId} inputs: {inputError}");
+        }
+
+        if (!FeatureCollectionArtifact.TryParseDataUri(inputUri, out var source, out var parseError, _options.CurrentValue.MaxArtifactBytes))
+        {
+            return JobExecutionResult.Failed($"Invalid {HandledProcessId} inputs: 'input' {parseError}");
+        }
+
+        string schema;
+        string table;
+        string geometryColumn;
+        int targetSrid;
+        HonuaLayerLoadMode loadMode;
+        IReadOnlyList<string> keyFields;
+        try
+        {
+            schema = Identifier(inputs.GetOrDefault("schema", "public"));
+            table = Identifier(inputs.Require("layer"));
+            geometryColumn = Identifier(inputs.GetOrDefault("geometryColumn", "geom"));
+            targetSrid = RequireSrid(inputs, "targetSrid");
+            loadMode = ParseLoadMode(inputs.GetOrDefault("loadMode", "append"));
+            keyFields = ParseKeyFields(inputs.GetOrDefault("keyFields", string.Empty));
+
+            if (loadMode == HonuaLayerLoadMode.Upsert && keyFields.Count == 0)
+            {
+                throw new TransformInputException("loadMode 'upsert' requires a non-empty 'keyFields' list.");
+            }
+        }
+        catch (TransformInputException ex)
+        {
+            return JobExecutionResult.Failed($"Invalid {HandledProcessId} inputs: {ex.PublicMessage}");
+        }
+
+        var batchId = inputs.GetOrDefault("batchId", job.OperationId);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(40, "Encoding features", cancellationToken).ConfigureAwait(false);
+
+        var wkbWriter = new WKBWriter();
+        var rows = new List<HonuaLayerSinkRow>();
+        long rejected = 0;
+        foreach (var feature in source)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (feature.Geometry is null)
+            {
+                rejected++;
+                continue;
+            }
+
+            rows.Add(new HonuaLayerSinkRow(
+                wkbWriter.Write(feature.Geometry),
+                SinkFeatureEncoder.BuildAttributesJson(feature, batchId)));
+        }
+
+        await context.ReportProgressAsync(70, "Loading into catalog layer", cancellationToken).ConfigureAwait(false);
+
+        HonuaLayerSinkOutcome outcome;
+        try
+        {
+            outcome = await _sink.LoadAsync(
+                new HonuaLayerSinkRequest(schema, table, geometryColumn, targetSrid, loadMode, batchId, keyFields),
+                rows,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Log.SinkLoadFailed(_logger, job.OperationId, ex);
+            // The sink load is transactional, so a failure left the catalog table unchanged.
+            return JobExecutionResult.Failed($"{HandledProcessId} load failed: {ex.GetType().Name}.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.PublishArtifactAsync(
+            SinkResultArtifact.Build(
+                HandledProcessId,
+                ("schema", outcome.Schema),
+                ("layer", outcome.Table),
+                ("loadMode", loadMode.ToString()),
+                ("batchId", outcome.BatchId),
+                ("featuresWritten", outcome.FeaturesWritten),
+                ("featuresRejected", rejected)),
+            cancellationToken).ConfigureAwait(false);
+        await context.ReportProgressAsync(100, $"{HandledProcessId} completed", cancellationToken).ConfigureAwait(false);
+
+        return JobExecutionResult.Succeeded();
+    }
+
+    private static HonuaLayerLoadMode ParseLoadMode(string raw) => raw.Trim().ToLowerInvariant() switch
+    {
+        "append" => HonuaLayerLoadMode.Append,
+        "replace" => HonuaLayerLoadMode.Replace,
+        "upsert" => HonuaLayerLoadMode.Upsert,
+        _ => throw new TransformInputException($"loadMode '{raw}' is invalid; expected append, replace, or upsert.")
+    };
+
+    private static IReadOnlyList<string> ParseKeyFields(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return [];
+        }
+
+        var parts = raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var keys = new List<string>(parts.Length);
+        foreach (var part in parts)
+        {
+            // Key fields are interpolated into JSONB accessors in the sink; validate them.
+            keys.Add(Identifier(part));
+        }
+
+        return keys;
+    }
+
+    private static string Identifier(string value)
+    {
+        if (!IdentifierRegex().IsMatch(value))
+        {
+            throw new TransformInputException(
+                $"identifier '{value}' is invalid; identifiers must match ^[A-Za-z_][A-Za-z0-9_]*$ " +
+                "(they cannot be parameterized in DDL/DML).");
+        }
+
+        return value;
+    }
+
+    private static int RequireSrid(StepInputReader inputs, string key)
+    {
+        if (!inputs.TryGet(key, out var raw)
+            || !int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+            || value <= 0)
+        {
+            throw new TransformInputException($"requires a positive integer '{key}' option.");
+        }
+
+        return value;
+    }
+
+    [GeneratedRegex("^[A-Za-z_][A-Za-z0-9_]*$")]
+    private static partial Regex IdentifierRegex();
+
+    private static partial class Log
+    {
+        [LoggerMessage(9270, LogLevel.Warning,
+            "honua-layer sink refused job {OperationId}: catalog sink capability is not registered in this deployment")]
+        public static partial void SinkUnavailable(ILogger logger, string operationId);
+
+        [LoggerMessage(9271, LogLevel.Error,
+            "honua-layer sink failed job {OperationId} during catalog load")]
+        public static partial void SinkLoadFailed(ILogger logger, string operationId, Exception exception);
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/HonuaLayerSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/HonuaLayerSinkExecutor.cs
@@ -96,7 +96,7 @@ internal sealed partial class HonuaLayerSinkExecutor : IProcessExecutor
         string geometryColumn;
         int targetSrid;
         HonuaLayerLoadMode loadMode;
-        IReadOnlyList<string> keyFields;
+        List<string> keyFields;
         try
         {
             schema = Identifier(inputs.GetOrDefault("schema", "public"));

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/SinkFeatureEncoder.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/SinkFeatureEncoder.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using NetTopologySuite.Features;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// Shared encoding helper for PostGIS-family sinks: turns an NTS <see cref="IFeature"/>'s
+/// attributes into the canonical JSONB object every sink row carries, tagged with the
+/// reserved <see cref="BatchIdPropertyKey"/> for soft-delete rollback. Centralising it
+/// keeps the row wire-format identical across the external-PostGIS sink and the catalog
+/// honua-layer sink instead of duplicating the per-type JSON projection.
+/// </summary>
+internal static class SinkFeatureEncoder
+{
+    /// <summary>Reserved attribute key tagging every row with its run batch id.</summary>
+    public const string BatchIdPropertyKey = "__pipeline_batch_id";
+
+    /// <summary>
+    /// Builds the attributes JSON object for a feature, writing the reserved batch-id key
+    /// first followed by the feature's own attributes.
+    /// </summary>
+    public static string BuildAttributesJson(IFeature feature, string batchId)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString(BatchIdPropertyKey, batchId);
+
+            if (feature.Attributes is { } table)
+            {
+                var names = table.GetNames();
+                var values = table.GetValues();
+                for (var i = 0; i < names.Length; i++)
+                {
+                    WriteAttribute(writer, names[i], values[i]);
+                }
+            }
+
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static void WriteAttribute(Utf8JsonWriter writer, string name, object? value)
+    {
+        writer.WritePropertyName(name);
+        switch (value)
+        {
+            case null or DBNull:
+                writer.WriteNullValue();
+                break;
+            case JsonElement jsonElement:
+                jsonElement.WriteTo(writer);
+                break;
+            case string stringValue:
+                writer.WriteStringValue(stringValue);
+                break;
+            case bool boolValue:
+                writer.WriteBooleanValue(boolValue);
+                break;
+            case byte byteValue:
+                writer.WriteNumberValue(byteValue);
+                break;
+            case sbyte sbyteValue:
+                writer.WriteNumberValue(sbyteValue);
+                break;
+            case short shortValue:
+                writer.WriteNumberValue(shortValue);
+                break;
+            case ushort ushortValue:
+                writer.WriteNumberValue(ushortValue);
+                break;
+            case int intValue:
+                writer.WriteNumberValue(intValue);
+                break;
+            case uint uintValue:
+                writer.WriteNumberValue(uintValue);
+                break;
+            case long longValue:
+                writer.WriteNumberValue(longValue);
+                break;
+            case ulong ulongValue:
+                writer.WriteNumberValue(ulongValue);
+                break;
+            case float floatValue when float.IsFinite(floatValue):
+                writer.WriteNumberValue(floatValue);
+                break;
+            case double doubleValue when double.IsFinite(doubleValue):
+                writer.WriteNumberValue(doubleValue);
+                break;
+            case decimal decimalValue:
+                writer.WriteNumberValue(decimalValue);
+                break;
+            case DateTime dateTime:
+                writer.WriteStringValue(dateTime);
+                break;
+            case DateTimeOffset dateTimeOffset:
+                writer.WriteStringValue(dateTimeOffset);
+                break;
+            case Guid guid:
+                writer.WriteStringValue(guid);
+                break;
+            default:
+                writer.WriteStringValue(Convert.ToString(value, CultureInfo.InvariantCulture));
+                break;
+        }
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -194,6 +194,11 @@ internal static class GeoprocessingServiceCollectionExtensions
         Register<GeoJsonFileSinkExecutor>(services);
         Register<QuarantineSinkExecutor>(services);
         Register<ExternalPostgisSinkExecutor>(services);
+        // sink.honua-layer loads into a named catalog layer through the optional
+        // IHonuaLayerSink capability. The executor is always registered so the catalog
+        // advertises the node and can fail it closed with a clear message; the capability
+        // it depends on is registered only when the catalog database is present (#2210).
+        Register<HonuaLayerSinkExecutor>(services);
         Register<ImportDatasetJobExecutor>(services);
     }
 

--- a/src/Honua.Postgres/Features/Geoprocessing/PostgresHonuaLayerSink.cs
+++ b/src/Honua.Postgres/Features/Geoprocessing/PostgresHonuaLayerSink.cs
@@ -1,0 +1,241 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.Geoprocessing;
+
+/// <summary>
+/// Catalog-database implementation of <see cref="IHonuaLayerSink"/>. Loads pre-encoded
+/// feature rows into a named layer table in the Honua catalog using the catalog's own
+/// <see cref="NpgsqlDataSource"/>. This type — not the geoprocessing dispatcher — owns the
+/// dependency on the catalog data source, so it is registered only by the Postgres provider
+/// and is simply absent in lean deployments (#2210).
+/// </summary>
+/// <remarks>
+/// The load runs inside a single transaction so a failure leaves the destination table
+/// untouched; on success every row carries the reserved <c>__pipeline_batch_id</c> key in
+/// its attributes JSONB (supplied by the caller) so a completed load can be soft-deleted by
+/// batch id. Identifiers are re-validated here as defense in depth even though the executor
+/// already validates them, because they are interpolated into DDL/DML.
+/// </remarks>
+internal sealed partial class PostgresHonuaLayerSink(NpgsqlDataSource dataSource) : IHonuaLayerSink
+{
+    private const char KeyFieldSeparator = '\u001F';
+    private const int InsertChunkSize = 5000;
+
+    private readonly NpgsqlDataSource _dataSource = dataSource
+        ?? throw new ArgumentNullException(nameof(dataSource));
+
+    /// <inheritdoc />
+    public async Task<HonuaLayerSinkOutcome> LoadAsync(
+        HonuaLayerSinkRequest request,
+        IReadOnlyList<HonuaLayerSinkRow> rows,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(rows);
+
+        var schema = Identifier(request.Schema, nameof(request.Schema));
+        var table = Identifier(request.Table, nameof(request.Table));
+        var geometryColumn = Identifier(request.GeometryColumn, nameof(request.GeometryColumn));
+        foreach (var key in request.KeyFields)
+        {
+            _ = Identifier(key, "keyField");
+        }
+
+        var srid = request.TargetSrid.ToString(CultureInfo.InvariantCulture);
+
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        await EnsureTableAsync(connection, transaction, schema, table, geometryColumn, srid, cancellationToken)
+            .ConfigureAwait(false);
+
+        switch (request.LoadMode)
+        {
+            case HonuaLayerLoadMode.Replace:
+                await DeleteAllAsync(connection, transaction, schema, table, cancellationToken).ConfigureAwait(false);
+                break;
+            case HonuaLayerLoadMode.Upsert:
+                await DeleteMatchingKeysAsync(
+                    connection, transaction, schema, table, request.KeyFields, rows, cancellationToken)
+                    .ConfigureAwait(false);
+                break;
+            case HonuaLayerLoadMode.Append:
+            default:
+                break;
+        }
+
+        long written = 0;
+        for (var offset = 0; offset < rows.Count; offset += InsertChunkSize)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var count = Math.Min(InsertChunkSize, rows.Count - offset);
+            written += await InsertChunkAsync(
+                connection, transaction, schema, table, geometryColumn, srid, rows, offset, count, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+        return new HonuaLayerSinkOutcome(written, schema, table, request.BatchId);
+    }
+
+    private static async Task EnsureTableAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string schema,
+        string table,
+        string geometryColumn,
+        string srid,
+        CancellationToken cancellationToken)
+    {
+        var sql = $"""
+            CREATE SCHEMA IF NOT EXISTS "{schema}";
+            CREATE TABLE IF NOT EXISTS "{schema}"."{table}" (
+                id          BIGSERIAL PRIMARY KEY,
+                "{geometryColumn}" geometry(Geometry, {srid}),
+                attributes  JSONB NOT NULL
+            );
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task DeleteAllAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string schema,
+        string table,
+        CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand($"DELETE FROM \"{schema}\".\"{table}\"", connection, transaction);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task DeleteMatchingKeysAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string schema,
+        string table,
+        IReadOnlyList<string> keyFields,
+        IReadOnlyList<HonuaLayerSinkRow> rows,
+        CancellationToken cancellationToken)
+    {
+        var keys = BuildIncomingKeys(keyFields, rows);
+        if (keys.Count == 0)
+        {
+            return;
+        }
+
+        // Compare a deterministic composite of the key fields' JSONB text values against the
+        // incoming set, so a composite key is matched correctly with a single parameterized
+        // ANY(...) rather than per-row dynamic SQL.
+        var keyExpression = BuildKeyExpression(keyFields);
+        var sql = $"DELETE FROM \"{schema}\".\"{table}\" WHERE {keyExpression} = ANY(@keys)";
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.Add("keys", NpgsqlDbType.Array | NpgsqlDbType.Text).Value = keys.ToArray();
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string BuildKeyExpression(IReadOnlyList<string> keyFields)
+    {
+        // concat_ws(chr(31), attributes->>'k1', attributes->>'k2', ...)
+        var builder = new StringBuilder("concat_ws(chr(31)");
+        foreach (var field in keyFields)
+        {
+            builder.Append(", attributes->>'").Append(field).Append('\'');
+        }
+
+        builder.Append(')');
+        return builder.ToString();
+    }
+
+    private static HashSet<string> BuildIncomingKeys(
+        IReadOnlyList<string> keyFields,
+        IReadOnlyList<HonuaLayerSinkRow> rows)
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            using var document = JsonDocument.Parse(row.AttributesJson);
+            var root = document.RootElement;
+            var builder = new StringBuilder();
+            for (var i = 0; i < keyFields.Count; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append(KeyFieldSeparator);
+                }
+
+                if (root.TryGetProperty(keyFields[i], out var value) && value.ValueKind != JsonValueKind.Null)
+                {
+                    builder.Append(value.ValueKind == JsonValueKind.String
+                        ? value.GetString()
+                        : value.GetRawText());
+                }
+            }
+
+            keys.Add(builder.ToString());
+        }
+
+        return keys;
+    }
+
+    private static async Task<long> InsertChunkAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string schema,
+        string table,
+        string geometryColumn,
+        string srid,
+        IReadOnlyList<HonuaLayerSinkRow> rows,
+        int offset,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        var wkbs = new byte[count][];
+        var attributes = new string[count];
+        for (var i = 0; i < count; i++)
+        {
+            wkbs[i] = rows[offset + i].WellKnownBinary;
+            attributes[i] = rows[offset + i].AttributesJson;
+        }
+
+        var sql = $"""
+            INSERT INTO "{schema}"."{table}" ("{geometryColumn}", attributes)
+            SELECT ST_SetSRID(ST_GeomFromWKB(payload.wkb), {srid}), payload.attributes
+            FROM unnest(@wkbs, @attributes) AS payload(wkb, attributes)
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.Add("wkbs", NpgsqlDbType.Array | NpgsqlDbType.Bytea).Value = wkbs;
+        command.Parameters.Add("attributes", NpgsqlDbType.Array | NpgsqlDbType.Jsonb).Value = attributes;
+
+        return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string Identifier(string value, string role)
+    {
+        if (string.IsNullOrWhiteSpace(value) || !IdentifierRegex().IsMatch(value))
+        {
+            throw new ArgumentException(
+                $"{role} identifier is invalid; identifiers must match ^[A-Za-z_][A-Za-z0-9_]*$.",
+                nameof(value));
+        }
+
+        return value;
+    }
+
+    [GeneratedRegex("^[A-Za-z_][A-Za-z0-9_]*$")]
+    private static partial Regex IdentifierRegex();
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -105,6 +105,14 @@ internal static class ServiceCollectionExtensions
             return PostgresDataSourceFactory.Create(connectionString, schemaHeadersEnabled, connectionLimits, defaultSchema);
         });
 
+        // Catalog honua-layer DAG sink capability (#2210). Registered only here, with the
+        // Postgres provider, so the sink.honua-layer executor can load into a named catalog
+        // layer via the catalog NpgsqlDataSource. Absent in lean deployments, where the
+        // executor fails the node closed with a clear message.
+        services.TryAddSingleton<Honua.Core.Features.Geoprocessing.Abstractions.IHonuaLayerSink>(
+            serviceProvider => new Features.Geoprocessing.PostgresHonuaLayerSink(
+                serviceProvider.GetRequiredService<NpgsqlDataSource>()));
+
         // Register refactored feature store implementation
         services.AddRefactoredFeatureStore(configuration["Database:Schema"]);
         services.TryAddScoped<IFeatureDataProviderRegistry>(serviceProvider =>

--- a/src/Honua.Server/Features/Orchestration/WorkflowOrchestrationEngine.cs
+++ b/src/Honua.Server/Features/Orchestration/WorkflowOrchestrationEngine.cs
@@ -65,9 +65,13 @@ internal sealed class WorkflowOrchestrationEngine : IWorkflowCancellationCoordin
             throw new WorkflowDefinitionValidationException(failures);
         }
 
+        // Unroll ForEach steps deterministically so the run's durable step states match
+        // the flat DAG the reconciler will rebuild from the stored definition each tick.
+        var expanded = WorkflowDefinitionExpander.Expand(definition);
+
         var now = _clock.GetUtcNow();
         var runId = $"wf-{Guid.NewGuid():N}";
-        var stepStates = definition.Steps
+        var stepStates = expanded.Steps
             .Select(step => new WorkflowStepState
             {
                 StepId = step.StepId,
@@ -234,7 +238,11 @@ internal sealed class WorkflowOrchestrationEngine : IWorkflowCancellationCoordin
             activity?.SetTag(OrchestrationTelemetry.Tags.WorkflowId, run.WorkflowId);
             activity?.SetTag("honua.orchestration.step_count", run.StepStates.Count);
 
-            var definition = await _definitionStore.GetAsync(run.WorkflowId, reconciliationCancellation.Token).ConfigureAwait(false);
+            var rawDefinition = await _definitionStore.GetAsync(run.WorkflowId, reconciliationCancellation.Token).ConfigureAwait(false);
+            // Re-apply the deterministic ForEach unroll so the reconciler sees the same
+            // flat step-set the run's durable states were created from. The transform is
+            // pure, so both sides agree and the step-set consistency guard holds.
+            var definition = rawDefinition is null ? null : WorkflowDefinitionExpander.Expand(rawDefinition);
             if (definition is null)
             {
                 var now = _clock.GetUtcNow();
@@ -477,6 +485,24 @@ internal sealed class WorkflowOrchestrationEngine : IWorkflowCancellationCoordin
 
                         if (state.NextAttemptAt is { } nextAttempt && nextAttempt > now)
                         {
+                            continue;
+                        }
+
+                        // Conditional branch: once dependencies are terminal, evaluate the
+                        // step's predicate over prior step outputs. A not-taken branch is
+                        // skipped (and reported as such); dependents that consume its output
+                        // cascade-skip through the existing skip machinery.
+                        if (definitionStep.Condition is { } condition &&
+                            !WorkflowStepConditionEvaluator.Evaluate(condition, states))
+                        {
+                            states[state.StepId] = state with
+                            {
+                                Status = WorkflowStepStatus.Skipped,
+                                CompletedAt = now,
+                                ErrorMessage = $"Branch condition over '{condition.SourceStepId}' was not met."
+                            };
+                            OrchestrationLog.WorkflowStepSkipped(_logger, run.RunId, state.StepId, "branch condition not met");
+                            changed = true;
                             continue;
                         }
 

--- a/tests/dotnet/Honua.Core.Tests/Features/Orchestration/WorkflowDefinitionValidatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Orchestration/WorkflowDefinitionValidatorTests.cs
@@ -226,6 +226,234 @@ public sealed class WorkflowDefinitionValidatorTests
         Assert.Contains(failures, f => f.Contains("dependency cycle", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void Validate_AcceptsConditionalBranch_WhenSourceInDependsOn()
+    {
+        var definition = BuildDefinition(("a", Empty), ("b", DependsOnA));
+        definition = definition with
+        {
+            Steps =
+            [
+                definition.Steps[0],
+                definition.Steps[1] with
+                {
+                    Condition = new WorkflowStepCondition("a", WorkflowStepConditionKind.UpstreamSucceeded)
+                }
+            ]
+        };
+
+        var failures = WorkflowDefinitionValidator.Validate(definition);
+
+        Assert.Empty(failures);
+    }
+
+    [Fact]
+    public void Validate_RejectsCondition_WhenSourceNotInDependsOn()
+    {
+        var definition = BuildDefinition(("a", Empty), ("b", Empty));
+        definition = definition with
+        {
+            Steps =
+            [
+                definition.Steps[0],
+                definition.Steps[1] with
+                {
+                    Condition = new WorkflowStepCondition("a", WorkflowStepConditionKind.UpstreamSucceeded)
+                }
+            ]
+        };
+
+        var failures = WorkflowDefinitionValidator.Validate(definition);
+
+        Assert.Contains(failures, f => f.Contains("condition references source step 'a' which is not declared in DependsOn", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_RejectsCondition_WithUnknownSourceStep()
+    {
+        var definition = BuildDefinition(("a", Empty));
+        definition = definition with
+        {
+            Steps =
+            [
+                definition.Steps[0] with
+                {
+                    Condition = new WorkflowStepCondition("ghost", WorkflowStepConditionKind.UpstreamSucceeded)
+                }
+            ]
+        };
+
+        var failures = WorkflowDefinitionValidator.Validate(definition);
+
+        Assert.Contains(failures, f => f.Contains("condition references unknown source step 'ghost'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_AcceptsWellFormedForEach()
+    {
+        var definition = BuildDefinition(("a", Empty));
+        definition = definition with
+        {
+            Steps =
+            [
+                definition.Steps[0] with
+                {
+                    ForEach = new WorkflowForEachSpec(["x", "y"], MaxIterations: 5)
+                }
+            ]
+        };
+
+        var failures = WorkflowDefinitionValidator.Validate(definition);
+
+        Assert.Empty(failures);
+    }
+
+    [Fact]
+    public void Validate_RejectsForEach_WithNoItems()
+    {
+        var definition = BuildDefinition(("a", Empty));
+        definition = definition with
+        {
+            Steps =
+            [
+                definition.Steps[0] with
+                {
+                    ForEach = new WorkflowForEachSpec([])
+                }
+            ]
+        };
+
+        var failures = WorkflowDefinitionValidator.Validate(definition);
+
+        Assert.Contains(failures, f => f.Contains("ForEach must declare at least one item", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_RejectsForEach_ExceedingMaxIterations()
+    {
+        var definition = BuildDefinition(("a", Empty));
+        definition = definition with
+        {
+            Steps =
+            [
+                definition.Steps[0] with
+                {
+                    ForEach = new WorkflowForEachSpec(["x", "y", "z"], MaxIterations: 2)
+                }
+            ]
+        };
+
+        var failures = WorkflowDefinitionValidator.Validate(definition);
+
+        Assert.Contains(failures, f => f.Contains("MaxIterations is 2", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_RejectsStepId_ContainingIterationSeparator()
+    {
+        var definition = BuildDefinition(("a::0", Empty));
+
+        var failures = WorkflowDefinitionValidator.Validate(definition);
+
+        Assert.Contains(failures, f => f.Contains("reserved iteration separator", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_RejectsBinding_FromForEachStep()
+    {
+        var definition = BuildDefinition(("a", Empty), ("b", DependsOnA));
+        definition = definition with
+        {
+            Steps =
+            [
+                definition.Steps[0] with { ForEach = new WorkflowForEachSpec(["x", "y"]) },
+                definition.Steps[1] with
+                {
+                    InputBindings =
+                    [
+                        new StepInputBinding
+                        {
+                            SourceStepId = "a",
+                            SourceArtifactSelector = "artifact:0",
+                            TargetInputKey = "in"
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var failures = WorkflowDefinitionValidator.Validate(definition);
+
+        Assert.Contains(failures, f => f.Contains("may not read from ForEach step 'a'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Expand_UnrollsForEachIntoPerItemSteps_WithSubstitution()
+    {
+        var definition = BuildDefinition(("a", Empty));
+        var planStep = new AnalysisPlanStep
+        {
+            StepId = "ap",
+            Kind = AnalysisPlanStepKind.Geoprocess,
+            ProcessId = "noop",
+            Inputs = new Dictionary<string, string>(StringComparer.Ordinal) { ["region"] = "${item}" }
+        };
+        definition = definition with
+        {
+            Steps =
+            [
+                definition.Steps[0] with
+                {
+                    Plan = new AnalysisPlan { PlanId = "p", IntentId = "i", Steps = [planStep] },
+                    ForEach = new WorkflowForEachSpec(["east", "west"])
+                }
+            ]
+        };
+
+        var expanded = WorkflowDefinitionExpander.Expand(definition);
+
+        Assert.Equal(new[] { "a::0", "a::1" }, expanded.Steps.Select(s => s.StepId).ToArray());
+        Assert.All(expanded.Steps, s => Assert.Null(s.ForEach));
+        Assert.Equal("east", expanded.Steps[0].Plan.Steps[0].Inputs["region"]);
+        Assert.Equal("west", expanded.Steps[1].Plan.Steps[0].Inputs["region"]);
+    }
+
+    [Fact]
+    public void Expand_FansInDependentsOnForEachStep()
+    {
+        var definition = BuildDefinition(("a", Empty), ("b", DependsOnA));
+        definition = definition with
+        {
+            Steps =
+            [
+                definition.Steps[0] with { ForEach = new WorkflowForEachSpec(["x", "y", "z"]) },
+                definition.Steps[1]
+            ]
+        };
+
+        var expanded = WorkflowDefinitionExpander.Expand(definition);
+
+        var b = expanded.Steps.Single(s => s.StepId == "b");
+        Assert.Equal(new[] { "a::0", "a::1", "a::2" }, b.DependsOn.ToArray());
+    }
+
+    [Fact]
+    public void Expand_IsDeterministic_AcrossRepeatedCalls()
+    {
+        var definition = BuildDefinition(("a", Empty));
+        definition = definition with
+        {
+            Steps = [definition.Steps[0] with { ForEach = new WorkflowForEachSpec(["x", "y"]) }]
+        };
+
+        var first = WorkflowDefinitionExpander.Expand(definition);
+        var second = WorkflowDefinitionExpander.Expand(definition);
+
+        Assert.Equal(
+            first.Steps.Select(s => s.StepId).ToArray(),
+            second.Steps.Select(s => s.StepId).ToArray());
+    }
+
     private static WorkflowDefinition BuildDefinition(params (string StepId, string[] DependsOn)[] steps)
     {
         var now = DateTimeOffset.UtcNow;

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/HonuaLayerSinkExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/HonuaLayerSinkExecutorTests.cs
@@ -216,7 +216,7 @@ public sealed class HonuaLayerSinkExecutorTests
     }
 
     private static async Task<(ExecutionJobStatus Status, string? Uri, string Message)> RunAsync(
-        IJobExecutor executor,
+        HonuaLayerSinkExecutor executor,
         params (string Name, string Value)[] inputs)
     {
         const string processId = HonuaLayerSinkExecutor.HandledProcessId;

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/HonuaLayerSinkExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/HonuaLayerSinkExecutorTests.cs
@@ -1,0 +1,261 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Geoprocessing;
+using Honua.Geoprocessing.Execution;
+using Honua.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// In-memory unit coverage for the catalog honua-layer sink executor (#2210). Proves the
+/// seam: the node fails closed with a clear message when the optional
+/// <see cref="IHonuaLayerSink"/> capability is absent (a lean, Postgres-free deployment),
+/// and otherwise loads pre-encoded rows through the capability with the requested load mode.
+/// </summary>
+public sealed class HonuaLayerSinkExecutorTests
+{
+    private const string DataUriPrefix = "data:application/geo+json;base64,";
+
+    [UnitTest]
+    public async Task HonuaLayerSink_CapabilityAbsent_FailsClosedWithClearMessage()
+    {
+        // Lean deployment: no catalog database ⇒ IHonuaLayerSink is not registered.
+        var executor = new HonuaLayerSinkExecutor(Options(), NullLogger<HonuaLayerSinkExecutor>.Instance, sink: null);
+
+        var (status, _, message) = await RunAsync(
+            executor,
+            ("input", BuildInputUri(Feature(Point(1, 2)))),
+            ("layer", "parcels"),
+            ("targetSrid", "4326"));
+
+        status.Should().Be(ExecutionJobStatus.Failed);
+        message.Should().Contain("unavailable in this deployment");
+    }
+
+    [UnitTest]
+    public async Task HonuaLayerSink_LoadsRowsThroughCapability_AppendMode()
+    {
+        var sink = new CapturingLayerSink();
+        var executor = new HonuaLayerSinkExecutor(Options(), NullLogger<HonuaLayerSinkExecutor>.Instance, sink);
+
+        var (status, uri, _) = await RunAsync(
+            executor,
+            ("input", BuildInputUri(
+                Feature(Point(1, 2), ("name", "a")),
+                Feature(Point(3, 4), ("name", "b")))),
+            ("layer", "parcels"),
+            ("schema", "etl"),
+            ("targetSrid", "3857"),
+            ("batchId", "batch-9"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        sink.Request.Should().NotBeNull();
+        sink.Request!.Schema.Should().Be("etl");
+        sink.Request.Table.Should().Be("parcels");
+        sink.Request.TargetSrid.Should().Be(3857);
+        sink.Request.LoadMode.Should().Be(HonuaLayerLoadMode.Append);
+        sink.Request.BatchId.Should().Be("batch-9");
+        sink.Rows.Should().HaveCount(2);
+        // Every row's attributes JSON carries the reserved batch-id key for rollback.
+        sink.Rows!.Should().OnlyContain(r => r.AttributesJson.Contains("__pipeline_batch_id"));
+
+        var descriptor = DecodeDescriptor(uri!);
+        descriptor.GetProperty("loadMode").GetString().Should().Be("Append");
+        descriptor.GetProperty("featuresWritten").GetInt64().Should().Be(2);
+    }
+
+    [UnitTest]
+    public async Task HonuaLayerSink_NullGeometryRows_AreRejectedNotLoaded()
+    {
+        var sink = new CapturingLayerSink();
+        var executor = new HonuaLayerSinkExecutor(Options(), NullLogger<HonuaLayerSinkExecutor>.Instance, sink);
+
+        var (status, uri, _) = await RunAsync(
+            executor,
+            ("input", BuildInputUri(
+                Feature(Point(1, 2)),
+                new Feature(null!, new AttributesTable()))),
+            ("layer", "parcels"),
+            ("targetSrid", "4326"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        sink.Rows.Should().HaveCount(1);
+        DecodeDescriptor(uri!).GetProperty("featuresRejected").GetInt64().Should().Be(1);
+    }
+
+    [UnitTest]
+    public async Task HonuaLayerSink_UpsertWithoutKeyFields_FailsValidation()
+    {
+        var sink = new CapturingLayerSink();
+        var executor = new HonuaLayerSinkExecutor(Options(), NullLogger<HonuaLayerSinkExecutor>.Instance, sink);
+
+        var (status, _, message) = await RunAsync(
+            executor,
+            ("input", BuildInputUri(Feature(Point(1, 2)))),
+            ("layer", "parcels"),
+            ("targetSrid", "4326"),
+            ("loadMode", "upsert"));
+
+        status.Should().Be(ExecutionJobStatus.Failed);
+        message.Should().Contain("keyFields");
+        sink.Request.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task HonuaLayerSink_InvalidLoadMode_FailsValidation()
+    {
+        var sink = new CapturingLayerSink();
+        var executor = new HonuaLayerSinkExecutor(Options(), NullLogger<HonuaLayerSinkExecutor>.Instance, sink);
+
+        var (status, _, _) = await RunAsync(
+            executor,
+            ("input", BuildInputUri(Feature(Point(1, 2)))),
+            ("layer", "parcels"),
+            ("targetSrid", "4326"),
+            ("loadMode", "merge"));
+
+        status.Should().Be(ExecutionJobStatus.Failed);
+        sink.Request.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task HonuaLayerSink_UpsertWithKeyFields_PassesKeysToCapability()
+    {
+        var sink = new CapturingLayerSink();
+        var executor = new HonuaLayerSinkExecutor(Options(), NullLogger<HonuaLayerSinkExecutor>.Instance, sink);
+
+        var (status, _, _) = await RunAsync(
+            executor,
+            ("input", BuildInputUri(Feature(Point(1, 2), ("gid", "x")))),
+            ("layer", "parcels"),
+            ("targetSrid", "4326"),
+            ("loadMode", "upsert"),
+            ("keyFields", "gid, region"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        sink.Request!.LoadMode.Should().Be(HonuaLayerLoadMode.Upsert);
+        sink.Request.KeyFields.Should().Equal("gid", "region");
+    }
+
+    private sealed class CapturingLayerSink : IHonuaLayerSink
+    {
+        public HonuaLayerSinkRequest? Request { get; private set; }
+
+        public IReadOnlyList<HonuaLayerSinkRow>? Rows { get; private set; }
+
+        public Task<HonuaLayerSinkOutcome> LoadAsync(
+            HonuaLayerSinkRequest request,
+            IReadOnlyList<HonuaLayerSinkRow> rows,
+            CancellationToken cancellationToken)
+        {
+            Request = request;
+            Rows = rows;
+            return Task.FromResult(new HonuaLayerSinkOutcome(rows.Count, request.Schema, request.Table, request.BatchId));
+        }
+    }
+
+    private static JsonElement DecodeDescriptor(string uri)
+    {
+        const string prefix = "data:application/json;base64,";
+        uri.Should().StartWith(prefix);
+        var json = Encoding.UTF8.GetString(Convert.FromBase64String(uri[prefix.Length..]));
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    private static IOptionsMonitor<GeoprocessingExecutorOptions> Options()
+    {
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = 50L * 1024L * 1024L,
+            ResultRetention = TimeSpan.FromDays(7),
+            OutputRootDirectory = Path.Combine(Path.GetTempPath(), "honua-geoprocessing-outputs")
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+        return monitor;
+    }
+
+    private static Point Point(double x, double y)
+        => NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory(4326).CreatePoint(new Coordinate(x, y));
+
+    private static Feature Feature(Geometry geometry, params (string Name, object Value)[] attributes)
+    {
+        var table = new AttributesTable();
+        foreach (var (name, value) in attributes)
+        {
+            table.Add(name, value);
+        }
+
+        return new Feature(geometry, table);
+    }
+
+    private static string BuildInputUri(params IFeature[] features)
+    {
+        var collection = new FeatureCollection();
+        foreach (var feature in features)
+        {
+            collection.Add(feature);
+        }
+
+        var json = new GeoJsonWriter().Write(collection);
+        return DataUriPrefix + Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
+    }
+
+    private static async Task<(ExecutionJobStatus Status, string? Uri, string Message)> RunAsync(
+        IJobExecutor executor,
+        params (string Name, string Value)[] inputs)
+    {
+        const string processId = HonuaLayerSinkExecutor.HandledProcessId;
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-test");
+        string? publishedUri = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedUri = call.ArgAt<string>(0));
+
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId,
+            ["protocolProcessId"] = processId,
+        };
+
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+        foreach (var (name, value) in inputs)
+        {
+            parameters[prefix + name] = value;
+        }
+
+        var record = new ExecutionJobRecord
+        {
+            OperationId = "op-test",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:test",
+                Parameters = parameters
+            }
+        };
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+        return (result.Status, publishedUri, result.ErrorMessage ?? string.Empty);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Orchestration/WorkflowBranchingAndForEachTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Orchestration/WorkflowBranchingAndForEachTests.cs
@@ -20,6 +20,12 @@ public sealed class WorkflowBranchingAndForEachTests
     private static readonly ClaimsPrincipal Operator = new(
         new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "tester") }, "TestAuth"));
 
+    private static readonly string[] ForEachRegions = ["east", "west", "north"];
+    private static readonly string[] AlphaBeta = ["alpha", "beta"];
+    private static readonly string[] ExpectedRegionsSorted = ["east", "north", "west"];
+    private static readonly string[] ExpectedThreeIterationIds = ["work::0", "work::1", "work::2"];
+    private static readonly string[] ExpectedGateAndTwoIterationIds = ["gate", "work::0", "work::1"];
+
     [Fact]
     public async Task ReconcileWorkflowRun_ConditionalBranch_RunsTakenSkipsNotTaken()
     {
@@ -61,8 +67,8 @@ public sealed class WorkflowBranchingAndForEachTests
         var aJob = afterA!.StepStates.Single(s => s.StepId == "a").JobId!;
         harness.JobService.Complete(aJob, new[]
         {
-            new ArtifactRef { ArtifactId = "art-1", Kind = ArtifactKind.FeatureLayer, Uri = "s3://b/1" },
-            new ArtifactRef { ArtifactId = "art-2", Kind = ArtifactKind.FeatureLayer, Uri = "s3://b/2" }
+            new ArtifactRef { ArtifactId = "art-1", Kind = ArtifactKind.FeatureLayer, Label = "a1", Uri = "s3://b/1" },
+            new ArtifactRef { ArtifactId = "art-2", Kind = ArtifactKind.FeatureLayer, Label = "a2", Uri = "s3://b/2" }
         });
 
         // Tick 2: observe A; B taken (submitted), C not taken (Skipped) in the same pass.
@@ -90,7 +96,7 @@ public sealed class WorkflowBranchingAndForEachTests
         var harness = new Harness();
         var now = harness.Clock.GetUtcNow();
 
-        var items = new[] { "east", "west", "north" };
+        var items = ForEachRegions;
         var forEachStep = new WorkflowStepDefinition
         {
             StepId = "work",
@@ -111,7 +117,7 @@ public sealed class WorkflowBranchingAndForEachTests
 
         // The run is unrolled into one concrete step per item, deterministically ordered.
         Assert.Equal(items.Length, run.StepStates.Count);
-        Assert.Equal(new[] { "work::0", "work::1", "work::2" }, run.StepStates.Select(s => s.StepId).ToArray());
+        Assert.Equal(ExpectedThreeIterationIds, run.StepStates.Select(s => s.StepId).ToArray());
 
         // Tick 1: all three iteration jobs are submitted with the item substituted in.
         await harness.Engine.ReconcileWorkflowRunAsync(run.RunId);
@@ -119,7 +125,7 @@ public sealed class WorkflowBranchingAndForEachTests
             .Select(p => p.Steps[0].Inputs["region"])
             .OrderBy(v => v, StringComparer.Ordinal)
             .ToArray();
-        Assert.Equal(new[] { "east", "north", "west" }, submittedRegions);
+        Assert.Equal(ExpectedRegionsSorted, submittedRegions);
 
         var queued = await harness.RunStore.GetAsync(run.RunId);
         foreach (var state in queued!.StepStates)
@@ -151,7 +157,7 @@ public sealed class WorkflowBranchingAndForEachTests
             Plan = BuildPlanWithInput("plan-work", "region", "${item}"),
             DependsOn = new[] { "gate" },
             Condition = new WorkflowStepCondition("gate", WorkflowStepConditionKind.HasArtifact),
-            ForEach = new WorkflowForEachSpec(new[] { "alpha", "beta" })
+            ForEach = new WorkflowForEachSpec(AlphaBeta)
         };
 
         var definition = new WorkflowDefinition
@@ -166,7 +172,7 @@ public sealed class WorkflowBranchingAndForEachTests
         var run = await harness.Engine.CreateRunAsync(definition, WorkflowTriggerKind.Manual, Operator);
 
         // gate + two iteration sub-steps.
-        Assert.Equal(new[] { "gate", "work::0", "work::1" }, run.StepStates.Select(s => s.StepId).ToArray());
+        Assert.Equal(ExpectedGateAndTwoIterationIds, run.StepStates.Select(s => s.StepId).ToArray());
 
         // Tick 1: submit gate.
         await harness.Engine.ReconcileWorkflowRunAsync(run.RunId);
@@ -199,7 +205,7 @@ public sealed class WorkflowBranchingAndForEachTests
             Plan = BuildPlanWithInput("plan-work", "region", "${item}"),
             DependsOn = new[] { "gate" },
             Condition = new WorkflowStepCondition("gate", WorkflowStepConditionKind.HasArtifact),
-            ForEach = new WorkflowForEachSpec(new[] { "alpha", "beta" })
+            ForEach = new WorkflowForEachSpec(AlphaBeta)
         };
 
         var definition = new WorkflowDefinition
@@ -218,7 +224,7 @@ public sealed class WorkflowBranchingAndForEachTests
         var gateJob = afterGate!.StepStates.Single(s => s.StepId == "gate").JobId!;
         harness.JobService.Complete(gateJob, new[]
         {
-            new ArtifactRef { ArtifactId = "g-1", Kind = ArtifactKind.FeatureLayer, Uri = "s3://g/1" }
+            new ArtifactRef { ArtifactId = "g-1", Kind = ArtifactKind.FeatureLayer, Label = "g1", Uri = "s3://g/1" }
         });
 
         // Tick 2: gate observed Succeeded WITH an artifact; both iterations are taken.

--- a/tests/dotnet/Honua.Server.Tests/Features/Orchestration/WorkflowBranchingAndForEachTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Orchestration/WorkflowBranchingAndForEachTests.cs
@@ -1,0 +1,297 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Orchestration.Domain;
+using Honua.Server.Features.Orchestration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Features.Orchestration;
+
+/// <summary>
+/// Engine-level behavior tests for conditional branching and ForEach/iteration
+/// (issue #2146). Each test drives <see cref="WorkflowOrchestrationEngine"/> through
+/// explicit reconcile ticks with in-memory stores so the data-dependent path and the
+/// per-item fan-out are observable without background timers.
+/// </summary>
+public sealed class WorkflowBranchingAndForEachTests
+{
+    private static readonly ClaimsPrincipal Operator = new(
+        new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "tester") }, "TestAuth"));
+
+    [Fact]
+    public async Task ReconcileWorkflowRun_ConditionalBranch_RunsTakenSkipsNotTaken()
+    {
+        var harness = new Harness();
+        var now = harness.Clock.GetUtcNow();
+
+        // A produces two artifacts. B's branch (>=2 artifacts) is taken; C's branch
+        // (>=5 artifacts) is not taken and must be reported Skipped.
+        var stepA = new WorkflowStepDefinition { StepId = "a", Plan = BuildPlan("plan-a") };
+        var stepB = new WorkflowStepDefinition
+        {
+            StepId = "b",
+            Plan = BuildPlan("plan-b"),
+            DependsOn = new[] { "a" },
+            Condition = new WorkflowStepCondition("a", WorkflowStepConditionKind.ArtifactCountAtLeast, Threshold: 2)
+        };
+        var stepC = new WorkflowStepDefinition
+        {
+            StepId = "c",
+            Plan = BuildPlan("plan-c"),
+            DependsOn = new[] { "a" },
+            Condition = new WorkflowStepCondition("a", WorkflowStepConditionKind.ArtifactCountAtLeast, Threshold: 5)
+        };
+
+        var definition = new WorkflowDefinition
+        {
+            WorkflowId = "wf-branch",
+            Name = "branch",
+            Steps = new[] { stepA, stepB, stepC },
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        await harness.Definitions.TryCreateAsync(definition);
+        var run = await harness.Engine.CreateRunAsync(definition, WorkflowTriggerKind.Manual, Operator);
+
+        // Tick 1: submit A.
+        await harness.Engine.ReconcileWorkflowRunAsync(run.RunId);
+        var afterA = await harness.RunStore.GetAsync(run.RunId);
+        var aJob = afterA!.StepStates.Single(s => s.StepId == "a").JobId!;
+        harness.JobService.Complete(aJob, new[]
+        {
+            new ArtifactRef { ArtifactId = "art-1", Kind = ArtifactKind.FeatureLayer, Uri = "s3://b/1" },
+            new ArtifactRef { ArtifactId = "art-2", Kind = ArtifactKind.FeatureLayer, Uri = "s3://b/2" }
+        });
+
+        // Tick 2: observe A; B taken (submitted), C not taken (Skipped) in the same pass.
+        await harness.Engine.ReconcileWorkflowRunAsync(run.RunId);
+        var afterBranch = await harness.RunStore.GetAsync(run.RunId);
+        Assert.Equal(WorkflowStepStatus.Queued, afterBranch!.StepStates.Single(s => s.StepId == "b").Status);
+        Assert.Equal(WorkflowStepStatus.Skipped, afterBranch.StepStates.Single(s => s.StepId == "c").Status);
+        Assert.Contains("plan-b", harness.JobService.Submitted.Select(p => p.PlanId));
+        Assert.DoesNotContain("plan-c", harness.JobService.Submitted.Select(p => p.PlanId));
+
+        // Complete B; run succeeds (a skipped not-taken branch does not fail the run).
+        var bJob = afterBranch.StepStates.Single(s => s.StepId == "b").JobId!;
+        harness.JobService.Complete(bJob);
+        await harness.Engine.ReconcileWorkflowRunAsync(run.RunId);
+
+        var final = await harness.RunStore.GetAsync(run.RunId);
+        Assert.Equal(WorkflowRunStatus.Succeeded, final!.Status);
+        Assert.Equal(WorkflowStepStatus.Succeeded, final.StepStates.Single(s => s.StepId == "b").Status);
+        Assert.Equal(WorkflowStepStatus.Skipped, final.StepStates.Single(s => s.StepId == "c").Status);
+    }
+
+    [Fact]
+    public async Task ReconcileWorkflowRun_ForEach_ExecutesSubStepPerItemWithSubstitution()
+    {
+        var harness = new Harness();
+        var now = harness.Clock.GetUtcNow();
+
+        var items = new[] { "east", "west", "north" };
+        var forEachStep = new WorkflowStepDefinition
+        {
+            StepId = "work",
+            Plan = BuildPlanWithInput("plan-work", "region", "${item}"),
+            ForEach = new WorkflowForEachSpec(items)
+        };
+
+        var definition = new WorkflowDefinition
+        {
+            WorkflowId = "wf-foreach",
+            Name = "foreach",
+            Steps = new[] { forEachStep },
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        await harness.Definitions.TryCreateAsync(definition);
+        var run = await harness.Engine.CreateRunAsync(definition, WorkflowTriggerKind.Manual, Operator);
+
+        // The run is unrolled into one concrete step per item, deterministically ordered.
+        Assert.Equal(items.Length, run.StepStates.Count);
+        Assert.Equal(new[] { "work::0", "work::1", "work::2" }, run.StepStates.Select(s => s.StepId).ToArray());
+
+        // Tick 1: all three iteration jobs are submitted with the item substituted in.
+        await harness.Engine.ReconcileWorkflowRunAsync(run.RunId);
+        var submittedRegions = harness.JobService.Submitted
+            .Select(p => p.Steps[0].Inputs["region"])
+            .OrderBy(v => v, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(new[] { "east", "north", "west" }, submittedRegions);
+
+        var queued = await harness.RunStore.GetAsync(run.RunId);
+        foreach (var state in queued!.StepStates)
+        {
+            Assert.Equal(WorkflowStepStatus.Queued, state.Status);
+            harness.JobService.Complete(state.JobId!);
+        }
+
+        // Tick 2: all iterations observed Succeeded; run aggregates to Succeeded.
+        await harness.Engine.ReconcileWorkflowRunAsync(run.RunId);
+        var final = await harness.RunStore.GetAsync(run.RunId);
+        Assert.Equal(WorkflowRunStatus.Succeeded, final!.Status);
+        Assert.All(final.StepStates, s => Assert.Equal(WorkflowStepStatus.Succeeded, s.Status));
+    }
+
+    [Fact]
+    public async Task ReconcileWorkflowRun_BranchInsideForEach_GatesEveryIteration()
+    {
+        var harness = new Harness();
+        var now = harness.Clock.GetUtcNow();
+
+        // A "gate" step runs first. The ForEach body is conditioned on the gate producing
+        // an artifact; when the gate yields none, every unrolled iteration is skipped —
+        // the branch predicate composes with the per-item fan-out.
+        var gate = new WorkflowStepDefinition { StepId = "gate", Plan = BuildPlan("plan-gate") };
+        var work = new WorkflowStepDefinition
+        {
+            StepId = "work",
+            Plan = BuildPlanWithInput("plan-work", "region", "${item}"),
+            DependsOn = new[] { "gate" },
+            Condition = new WorkflowStepCondition("gate", WorkflowStepConditionKind.HasArtifact),
+            ForEach = new WorkflowForEachSpec(new[] { "alpha", "beta" })
+        };
+
+        var definition = new WorkflowDefinition
+        {
+            WorkflowId = "wf-nested",
+            Name = "nested",
+            Steps = new[] { gate, work },
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        await harness.Definitions.TryCreateAsync(definition);
+        var run = await harness.Engine.CreateRunAsync(definition, WorkflowTriggerKind.Manual, Operator);
+
+        // gate + two iteration sub-steps.
+        Assert.Equal(new[] { "gate", "work::0", "work::1" }, run.StepStates.Select(s => s.StepId).ToArray());
+
+        // Tick 1: submit gate.
+        await harness.Engine.ReconcileWorkflowRunAsync(run.RunId);
+        var afterGate = await harness.RunStore.GetAsync(run.RunId);
+        var gateJob = afterGate!.StepStates.Single(s => s.StepId == "gate").JobId!;
+        harness.JobService.Complete(gateJob); // no artifacts ⇒ branch not taken
+
+        // Tick 2: gate observed Succeeded; both iterations evaluate the branch and skip.
+        await harness.Engine.ReconcileWorkflowRunAsync(run.RunId);
+        var final = await harness.RunStore.GetAsync(run.RunId);
+
+        Assert.Equal(WorkflowStepStatus.Succeeded, final!.StepStates.Single(s => s.StepId == "gate").Status);
+        Assert.Equal(WorkflowStepStatus.Skipped, final.StepStates.Single(s => s.StepId == "work::0").Status);
+        Assert.Equal(WorkflowStepStatus.Skipped, final.StepStates.Single(s => s.StepId == "work::1").Status);
+        Assert.Equal(WorkflowRunStatus.Succeeded, final.Status);
+        // Only the gate job ran; no iteration jobs were submitted.
+        Assert.Single(harness.JobService.Submitted);
+    }
+
+    [Fact]
+    public async Task ReconcileWorkflowRun_BranchInsideForEach_RunsEveryIterationWhenTaken()
+    {
+        var harness = new Harness();
+        var now = harness.Clock.GetUtcNow();
+
+        var gate = new WorkflowStepDefinition { StepId = "gate", Plan = BuildPlan("plan-gate") };
+        var work = new WorkflowStepDefinition
+        {
+            StepId = "work",
+            Plan = BuildPlanWithInput("plan-work", "region", "${item}"),
+            DependsOn = new[] { "gate" },
+            Condition = new WorkflowStepCondition("gate", WorkflowStepConditionKind.HasArtifact),
+            ForEach = new WorkflowForEachSpec(new[] { "alpha", "beta" })
+        };
+
+        var definition = new WorkflowDefinition
+        {
+            WorkflowId = "wf-nested-taken",
+            Name = "nested-taken",
+            Steps = new[] { gate, work },
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        await harness.Definitions.TryCreateAsync(definition);
+        var run = await harness.Engine.CreateRunAsync(definition, WorkflowTriggerKind.Manual, Operator);
+
+        await harness.Engine.ReconcileWorkflowRunAsync(run.RunId);
+        var afterGate = await harness.RunStore.GetAsync(run.RunId);
+        var gateJob = afterGate!.StepStates.Single(s => s.StepId == "gate").JobId!;
+        harness.JobService.Complete(gateJob, new[]
+        {
+            new ArtifactRef { ArtifactId = "g-1", Kind = ArtifactKind.FeatureLayer, Uri = "s3://g/1" }
+        });
+
+        // Tick 2: gate observed Succeeded WITH an artifact; both iterations are taken.
+        await harness.Engine.ReconcileWorkflowRunAsync(run.RunId);
+        var afterTaken = await harness.RunStore.GetAsync(run.RunId);
+        Assert.Equal(WorkflowStepStatus.Queued, afterTaken!.StepStates.Single(s => s.StepId == "work::0").Status);
+        Assert.Equal(WorkflowStepStatus.Queued, afterTaken.StepStates.Single(s => s.StepId == "work::1").Status);
+
+        foreach (var state in afterTaken.StepStates.Where(s => s.StepId.StartsWith("work", StringComparison.Ordinal)))
+        {
+            harness.JobService.Complete(state.JobId!);
+        }
+
+        await harness.Engine.ReconcileWorkflowRunAsync(run.RunId);
+        var final = await harness.RunStore.GetAsync(run.RunId);
+        Assert.Equal(WorkflowRunStatus.Succeeded, final!.Status);
+        Assert.All(final.StepStates, s => Assert.Equal(WorkflowStepStatus.Succeeded, s.Status));
+    }
+
+    private static AnalysisPlan BuildPlan(string planId) => new()
+    {
+        PlanId = planId,
+        IntentId = $"intent-{planId}",
+        Steps = new[]
+        {
+            new AnalysisPlanStep
+            {
+                StepId = $"ap-{planId}",
+                Kind = AnalysisPlanStepKind.Geoprocess,
+                ProcessId = "noop"
+            }
+        }
+    };
+
+    private static AnalysisPlan BuildPlanWithInput(string planId, string key, string value) => new()
+    {
+        PlanId = planId,
+        IntentId = $"intent-{planId}",
+        Steps = new[]
+        {
+            new AnalysisPlanStep
+            {
+                StepId = $"ap-{planId}",
+                Kind = AnalysisPlanStepKind.Geoprocess,
+                ProcessId = "noop",
+                Inputs = new Dictionary<string, string>(StringComparer.Ordinal) { [key] = value }
+            }
+        }
+    };
+
+    private sealed class Harness
+    {
+        public Harness()
+        {
+            RunStore = new FakeWorkflowRunStore();
+            Definitions = new FakeWorkflowDefinitionStore();
+            Progress = new FakeProgressStore();
+            JobService = new FakeWorkflowJobExecutor();
+            Clock = new TestClock(new DateTimeOffset(2026, 4, 16, 12, 0, 0, TimeSpan.Zero));
+            Engine = new WorkflowOrchestrationEngine(
+                RunStore,
+                Definitions,
+                JobService,
+                Progress,
+                Clock,
+                NullLogger<WorkflowOrchestrationEngine>.Instance);
+        }
+
+        public FakeWorkflowRunStore RunStore { get; }
+        public FakeWorkflowDefinitionStore Definitions { get; }
+        public FakeProgressStore Progress { get; }
+        public FakeWorkflowJobExecutor JobService { get; }
+        public TestClock Clock { get; }
+        public WorkflowOrchestrationEngine Engine { get; }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2146
Fixes #2210

<!-- #2192 (scoped-job-token attenuate against permission grants) is NOT in this PR: it
is already fully implemented by open PR #2195 (`fix/scoped-token-grant-scoping`, which
`Closes #2192`). This branch deliberately does not touch those files to avoid conflicts. -->

## Summary
Implements two related ETL/workflow capabilities and leaves the third (#2192) to the
existing PR #2195.

- **#2146 — Workflow DAG branching + ForEach/iteration.** Extends
  `WorkflowOrchestrationEngine` with a conditional-branch predicate over prior step
  outputs (a not-taken branch is reported `Skipped` and cascades to bound dependents) and
  a statically-declared ForEach construct that deterministically unrolls into one concrete
  sub-step per item. The unroll is a pure transform applied identically at run creation and
  on every reconcile tick, so the durable step-set stays consistent with **no new persisted
  state** and acyclicity is preserved (it only duplicates nodes along existing edges).
- **#2210 — `sink.honua-layer` catalog DAG sink.** Builds the previously-deferred catalog
  layer sink behind an **optional `IHonuaLayerSink` capability** so the geoprocessing
  dispatcher — constructed unconditionally, including in lean Postgres-free deployments —
  never takes a dependency on the catalog `NpgsqlDataSource`, and no catalog connection
  string is leaked through plan parameters. When the capability is absent (lean deploy) the
  node **fails closed with a clear "unavailable in this deployment" message**. The Postgres
  implementation loads via append/replace/upsert with the reserved `__pipeline_batch_id`
  rollback tag.

## Changes Made
- Add `WorkflowStepCondition` (+ pure `WorkflowStepConditionEvaluator`), `WorkflowForEachSpec`, and `WorkflowDefinitionExpander` to `Honua.Core`; add optional `Condition`/`ForEach` to `WorkflowStepDefinition`.
- Engine: evaluate the branch predicate before submit (not-taken → `Skipped`); expand ForEach at run-create and every reconcile tick. Extend `WorkflowDefinitionValidator` to reject malformed branch/loop definitions with clear messages.
- Add `IHonuaLayerSink` capability + neutral row/request/outcome model and `HonuaLayerLoadMode` to `Honua.Core`; add always-registered `HonuaLayerSinkExecutor` (`IProcessExecutor`) that fails closed when the capability is absent; add `PostgresHonuaLayerSink` (registered only by the Postgres provider). Add the `sink.honua-layer` catalog entry and replace the deferral comment. Extract a shared `SinkFeatureEncoder` for the attributes-JSON wire format.
- Tests: branching taken/not-taken, ForEach over N, nested branch-in-ForEach (taken+skipped), validator/expander units; honua-layer fail-closed seam, load-through-capability, rejected null-geometry, load-mode/keyFields validation.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
