### PR TITLE
test(versioning): cover 409-on-locked startEditing (#1511)

### DIFF
--- a/docs/internal/contributor/adr/0051-branch-versioning-storage-model.md
+++ b/docs/internal/contributor/adr/0051-branch-versioning-storage-model.md
@@ -246,7 +246,7 @@ only**; the durable `sync_generation` sequence as the "moment."
   such workload is in scope; the DEFAULT path is unaffected either way.
 - **Single global generation sequence serializes posts.** Accepted for v1; per-layer
   generation streams are a future option if concurrent multi-version post throughput
-  becomes a bottleneck.
+  becomes a bottleneck (tracked in #1726, revisit only on a measured bottleneck).
 - **Esri `startReading`/`stopReading`/`startEditing`/`stopEditing`** remain stateless
   acknowledgements (the overlay/moment model carries the version per-request via
   `gdbVersion`, so there is no server-held session token / edit lock to mint). They are
@@ -262,8 +262,13 @@ only**; the durable `sync_generation` sequence as the "moment."
 - #1272 — Branch-versioned editing + production offline replica/change-tracking
   (closed; this ADR decided the branch-versioning storage model, implemented across
   #1504/#1508/#1509/#1510).
-- #1511 — Branch-versioning follow-ups (post via `IFeatureWriter`, overlay-read-at-scale
-  validation, session-stateful edit, per-layer generation streams).
+- #1511 — Branch-versioning follow-ups (closed). Post via `IFeatureWriter` recorded as a
+  retained by-decision divergence; overlay-read-at-scale validated
+  (`BranchVersioningOverlayReadScaleTests`, #1533); session-stateful start/stop edit
+  resolved as moment-stateful acknowledgements (unknown → 404, locked → 409,
+  `BranchGeneration` moment) with endpoint coverage including the 409-on-locked path. The
+  per-layer generation-stream scale option is split out to #1726 (revisit only on a
+  measured concurrent multi-version post bottleneck).
 - #1270 — Epic: editing-model parity.
 - #371 — Named versions, reconcile/post, multi-user concurrent editing (owns the
   reconcile/post UX + auto-resolution policy this substrate serves).

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
@@ -232,6 +232,44 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.VersionManagement)]
+    [Endpoint("POST /rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/startEditing")]
+    [InterfaceOperation(TestProtocols.VersionManagementServer, "startEditing")]
+    public async Task StartEditing_VersionMidReconcile_Returns409Locked()
+    {
+        // A version that is mid-reconcile/post is locked (Redis-backed) for the duration of that job,
+        // so opening an edit session would be a false acknowledgement: no edit can land. Pin the
+        // version into the Reconciling state and assert startEditing refuses with a 409 in-progress
+        // (ADR-0051; the documented edit-session lock path). The read path stays open in this state.
+        var created = await CreateVersionAsync("admin.start_editing_locked");
+        var guid = created.GetProperty("versionGuid").GetString();
+
+        // VersionState.Reconciling == 1; honua.gdb_versions is the global versioning catalog and the
+        // version_id GUID targets exactly the version created above.
+        await _fixture.Postgres.ExecuteAsync(
+            $"UPDATE honua.gdb_versions SET state = 1 WHERE version_id = '{guid}'::uuid");
+
+        var editResponse = await PostFormAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/startEditing",
+            ("f", "json"));
+        editResponse.StatusCode.Should().Be(HttpStatusCode.Conflict,
+            "opening an edit session against a reconciling version must return 409; body: {0}",
+            await editResponse.Content.ReadAsStringAsync());
+
+        using (var doc = JsonDocument.Parse(await editResponse.Content.ReadAsStringAsync()))
+        {
+            doc.RootElement.TryGetProperty("error", out _).Should().BeTrue(
+                "GeoServices protocol wraps errors in an 'error' envelope");
+        }
+
+        // A read session is not gated on the lock — it reports the current moment regardless of state.
+        var readResponse = await PostFormAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/startReading",
+            ("f", "json"));
+        await AssertSuccessMomentAsync(readResponse, expectGenerationMoment: true);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.VersionManagement)]
     [Endpoint("POST /rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/stopEditing")]
     [InterfaceOperation(TestProtocols.VersionManagementServer, "stopEditing")]
     public async Task StopEditing_AcknowledgesSession()


### PR DESCRIPTION
## Issue Link
Closes #1511

## Summary
Adds test coverage for the version-management editing flow: `startEditing` against a locked version must return HTTP 409. Also clarifies the branch-versioning storage model ADR. Closes the #1511 follow-ups.

## Changes Made
- Add `VersionManagementServerEndpointTests` covering 409-on-locked `startEditing`
- Clarify ADR 0051 (branch-versioning storage model)

## Testing
- [x] Integration tests added/updated

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None
