### PR TITLE
feat: seed runtime-validated null datum-transformation pairs (#1501)

### DIFF
--- a/docs/internal/evidence/datum-transformation-parity.md
+++ b/docs/internal/evidence/datum-transformation-parity.md
@@ -39,8 +39,11 @@ later (a fixture with documented provenance) without restructuring.
 
 | From | To | Esri default | WKID | EPSG op | Tolerance (horizontal) | Notes |
 |---|---|---|---|---:|---:|---|
-| NAD83 (4269) | WGS84 (4326) | NAD_1983_To_WGS_1984_1 | 108001 | 1188 | 0.01 m | EPSG 1188 is a null transformation; pipeline is `+proj=noop` (exact identity, PROJ-version stable). Validated against the runtime. |
-| NAD27 (4267) | NAD83 (4269) | NAD_1927_To_NAD_1983_NADCON | 1241 | 1241 | 0.3 km* | Grid-based (NADCON); requires `us_noaa_conus.tif`. *When the grid is absent the transform fails explicitly (null), per the grid-data follow-up below. |
+| NAD83 (4269) | WGS84 (4326) | NAD_1983_To_WGS_1984_1 | 108001 | 1188 | 1e-9 deg | EPSG 1188 is a null transformation; pipeline is `+proj=noop` (exact identity, PROJ-version stable). Validated against the runtime. |
+| NAD83(HARN) (4152) | WGS84 (4326) | NAD_1983_HARN_To_WGS_1984_1 | — | 1580 | 1e-9 deg | EPSG 1580 is a null transformation (`+proj=noop`). Seeded under #1501; validated against the runtime in both directions. No distinct Esri WKID — ArcGIS applies no geographic transformation by default for this pair. |
+| NAD83(NSRS2007) (4759) | WGS84 (4326) | NAD_1983_NSRS2007_To_WGS_1984_1 | — | 15931 | 1e-9 deg | EPSG 15931 null transformation (`+proj=noop`). Seeded under #1501; runtime-validated. |
+| NAD83(2011) (6318) | WGS84 (4326) | NAD_1983_2011_To_WGS_1984_1 | — | 9774 | 1e-9 deg | EPSG 9774 null transformation (`+proj=noop`). Seeded under #1501; runtime-validated. |
+| NAD27 (4267) | NAD83 (4269) | NAD_1927_To_NAD_1983_NADCON | 1241 | 1241 | 0.3 km* | Grid-based (NADCON); requires `us_noaa_conus.tif`. *See the PROJ pipeline-application constraint below — a `+proj=pipeline` string cannot be forced through PostGIS' text overload, so the seeded NADCON pipeline does not apply; the explicit-failure (null) contract holds, and the 2-argument default path already resolves PROJ's NADCON-equivalent shift. |
 
 Tolerances are conservative upper bounds for the *selection* test: they prove Honua
 applies the correct pipeline, not that PROJ and EPSG agree to sub-millimeter. Tighten
@@ -49,15 +52,39 @@ them when an ArcGIS golden set is added.
 ### Seeded vs deferred pairs
 
 Only pipelines verified against the PostGIS/PROJ runtime are seeded in the table.
-Additional Esri-default pairs that use multi-step Helmert pipelines (for example
-`NAD_1983_To_NAD_1983_2011_1` / EPSG 1311, `WGS_1984_(ITRF00)_To_NAD_1983_2011` /
-EPSG 8259, and HARN realizations) are a **documented follow-up**: each Helmert PROJ
-pipeline string must be generated from the EPSG operation via `projinfo` and validated
-against the runtime before seeding, so the catalog never ships a pipeline string that
-PostGIS rejects (which would surface as a null/error result rather than a silent wrong
-answer). Until seeded, those pairs fall through to PROJ's default pipeline (no regression
-versus prior behavior) and a client-requested WKID for them returns an explicit
-"unsupported" error.
+
+Seeded under #1501: the WGS84-realization pairs **NAD83(HARN) → WGS84** (EPSG 1580),
+**NAD83(NSRS2007) → WGS84** (EPSG 15931), and **NAD83(2011) → WGS84** (EPSG 9774). EPSG
+defines all three as **null transformations** (the datums are coincident at the meter
+level, which is exactly the ArcGIS default of applying no geographic transformation). They
+are expressed as the exact-identity `+proj=noop` and validated against the runtime in both
+directions (`DatumTransformationParityTests.TransformPoint_Wgs84RealizationNullPair_SeededPipelineApplies`).
+The all-zero geocentric-translation Helmert parameters were confirmed against the runtime
+`proj.db` `helmert_transformation` table (codes 1188/1580/9774/15931).
+
+#### PROJ pipeline-application constraint (deferred non-null pairs)
+
+The remaining Esri-default pairs that resolve to a **non-identity** operation — the
+rotation-bearing Helmert pairs (e.g. `WGS_1984_(ITRF00)_To_NAD_1983` / EPSG 108190 family,
+`NAD_1983_HARN_To_WGS_1984_2` / EPSG 1901) and the grid-based NADCON/NTv2 pairs — remain a
+**documented follow-up**, but **not** because the PROJ pipeline string is unknown. The
+blocker is a PostGIS limitation: `ST_Transform`'s text overload is
+`ST_Transform(geom, from_proj text, to_srid int)`, where the middle argument is the
+**source CRS**, not a coordinate-operation pipeline. PostGIS on the current runtime
+(PostGIS 18-3.6 / PROJ 9.6) exposes **no overload that injects a `+proj=pipeline` string**;
+a pipeline string passed there fails to parse as a CRS. Only proj strings that parse as a
+CRS apply — and `+proj=noop`, which behaves as exact identity, which is why the null pairs
+can be seeded today.
+
+Consequently the `DatumTransformSql` 3-argument chokepoint can force the **identity** Esri
+default but cannot yet force a specific **non-identity** operation. Until a PostGIS
+pipeline-application mechanism is available (e.g. a custom `spatial_ref_sys` operation
+registration, a `cs2cs`-style sidecar, or a PostGIS overload that accepts a coordinate
+operation), those pairs continue to use PROJ's **default** operation selection on the
+2-argument path. PROJ's default already follows EPSG accuracy ranking, which matches Esri's
+default selection for these CONUS pairs (no regression versus prior behavior), and a
+client-requested WKID for a non-seeded pair returns an explicit "unsupported" error rather
+than a silent substitute.
 
 ## PROJ grid-data requirement (follow-up)
 
@@ -66,10 +93,25 @@ the PostGIS image's default PROJ data path. The catalog records each pipeline's
 `requiredGrids`; when a required grid is absent the runtime must **fail explicitly**
 rather than degrade to a Helmert approximation.
 
-This PR does **not** modify the Docker image. Provisioning the PROJ grid data
-(e.g. `us_noaa_conus.tif` for NAD27↔NAD83 NADCON, and GEOID grids for vertical work) in
-the PostGIS image is a documented follow-up. Until then, grid-backed selections that hit
-a missing grid surface a PostGIS error mapped to the shared problem helper.
+Runtime observations on the test image (`postgis/postgis:18-3.6`, PROJ 9.6.0,
+`NETWORK_ENABLED=OFF`):
+
+- The seeded NADCON pipeline string is a `+proj=pipeline +step +proj=hgridshift ...`
+  expression, which — per the PROJ pipeline-application constraint above — **cannot be
+  forced through PostGIS' `ST_Transform` text overload**, so the explicit-grid path always
+  fails to apply on this runtime regardless of whether the grid is present. The
+  explicit-failure (null) contract therefore holds.
+- The **2-argument default** `ST_Transform(geom, 4267, 4269)` *does* resolve a NAD27→NAD83
+  datum shift on this image (PROJ selects its best-available NADCON-equivalent operation
+  from the data bundled with PROJ 9.6), so import/query reprojection of NAD27 data is not
+  silently identity.
+
+This PR does **not** modify the production Docker image. Provisioning explicit PROJ grid
+data (e.g. `us_noaa_conus.tif` for high-accuracy NADCON, NTv2 `.gsb` files, and GEOID
+grids for vertical work) into the image — and a pipeline-application mechanism to actually
+force them — is a documented follow-up. Until then, grid-backed *selections* that hit a
+missing grid surface a PostGIS error mapped to the shared problem helper, and the
+2-argument default path provides PROJ's best-available operation.
 
 ## Import / reprojection path
 

--- a/src/Honua.Core.Abstractions/Features/Infrastructure/Crs/DatumTransformationSelection.cs
+++ b/src/Honua.Core.Abstractions/Features/Infrastructure/Crs/DatumTransformationSelection.cs
@@ -7,10 +7,21 @@ namespace Honua.Core.Features.Infrastructure.Crs;
 /// A resolved datum (geographic/geodetic) transformation selected for a single
 /// source-to-target reprojection. Carries enough provenance to drive an
 /// authoritative PROJ pipeline through PostGIS' 3-argument
-/// <c>ST_Transform(geom, '&lt;pipeline&gt;', toSrid)</c> overload and to surface
+/// <c>ST_Transform(geom, '&lt;projText&gt;', toSrid)</c> overload and to surface
 /// the choice back to clients (matching ArcGIS' geotransformation metadata).
 /// </summary>
 /// <remarks>
+/// <para>
+/// PostGIS constraint: the middle argument of the text overload is the
+/// <em>source CRS</em> proj string, not a coordinate-operation pipeline. PostGIS
+/// exposes no overload that injects a <c>+proj=pipeline</c> string, so only proj
+/// strings that parse as a CRS — and the exact-identity <c>+proj=noop</c> — apply
+/// through this chokepoint on the current runtime. Selections whose
+/// <see cref="ProjPipeline"/> is a non-identity pipeline (multi-step Helmert /
+/// grid shift) cannot yet be forced this way and fall back to PROJ's default
+/// operation selection on the 2-argument path. See
+/// <c>docs/internal/evidence/datum-transformation-parity.md</c>.
+/// </para>
 /// <para>
 /// Honua keeps PostGIS/PROJ as the transformation engine; the gap addressed by
 /// this type is <em>pipeline selection</em>, not engine capability. The default

--- a/src/Honua.Core/Features/Infrastructure/Crs/Resources/esri-default-datum-transformations.json
+++ b/src/Honua.Core/Features/Infrastructure/Crs/Resources/esri-default-datum-transformations.json
@@ -15,12 +15,25 @@
     "explicitly when a listed grid is absent from the PROJ data path rather than",
     "silently degrading to a Helmert/geocentric approximation.",
     "",
-    "Only pipelines verified against the PostGIS/PROJ runtime are seeded here. EPSG 1188",
-    "(NAD83<->WGS84) is a null transformation, expressed as +proj=noop (exact identity,",
-    "version-stable). Additional Helmert-based pairs (NAD83(2011), HARN realizations) are",
-    "a documented follow-up: each Helmert pipeline string must be generated from the EPSG",
-    "operation via projinfo and validated against the runtime before seeding, so the table",
-    "never ships a pipeline string PostGIS rejects (which would degrade to a null result)."
+    "Only pipelines verified against the PostGIS/PROJ runtime are seeded here. The seeded",
+    "WGS84-realization pairs (NAD83, NAD83(HARN), NAD83(NSRS2007), NAD83(2011)) are all",
+    "null transformations (EPSG considers the datums coincident at the meter level, which",
+    "matches the ArcGIS default of applying no geographic transformation), expressed as the",
+    "exact-identity, PROJ-version-stable +proj=noop. The Helmert parameters for these EPSG",
+    "operations (1188/1580/9774/15931) are all-zero geocentric translations, confirmed",
+    "against the runtime proj.db helmert_transformation table.",
+    "",
+    "IMPORTANT PostGIS constraint: ST_Transform's text overload is ST_Transform(geom,",
+    "from_proj_text, to_srid) -- the middle argument is the SOURCE CRS, not a coordinate",
+    "operation pipeline. PostGIS exposes no overload that injects a +proj=pipeline string,",
+    "so non-identity Helmert/grid pipelines cannot be forced through this chokepoint on the",
+    "current PostGIS/PROJ runtime; only proj strings that parse as a CRS (and +proj=noop,",
+    "which behaves as exact identity) apply. Multi-step Helmert pairs that need a specific",
+    "non-default operation (e.g. NAD83(HARN)_To_WGS_1984_2 / EPSG 1901, the rotation-bearing",
+    "WGS_1984_(ITRF00)_To_NAD_1983 family) therefore remain a documented follow-up gated on a",
+    "PostGIS pipeline-application mechanism; until then PROJ's default operation selection",
+    "(which already follows EPSG accuracy ranking, matching Esri's default for these pairs)",
+    "is used by the 2-argument path and a client WKID for them returns explicit 'unsupported'."
   ],
   "transformations": [
     {
@@ -30,6 +43,36 @@
       "toSrid": 4326,
       "areaOfUse": "North America - onshore (CONUS, Canada, Mexico, Central America)",
       "epsgOperationCode": 1188,
+      "projPipeline": "+proj=noop",
+      "requiredGrids": []
+    },
+    {
+      "wkid": null,
+      "name": "NAD_1983_HARN_To_WGS_1984_1",
+      "fromSrid": 4152,
+      "toSrid": 4326,
+      "areaOfUse": "North America - NAD83(HARN) onshore",
+      "epsgOperationCode": 1580,
+      "projPipeline": "+proj=noop",
+      "requiredGrids": []
+    },
+    {
+      "wkid": null,
+      "name": "NAD_1983_NSRS2007_To_WGS_1984_1",
+      "fromSrid": 4759,
+      "toSrid": 4326,
+      "areaOfUse": "North America - NAD83(NSRS2007) onshore",
+      "epsgOperationCode": 15931,
+      "projPipeline": "+proj=noop",
+      "requiredGrids": []
+    },
+    {
+      "wkid": null,
+      "name": "NAD_1983_2011_To_WGS_1984_1",
+      "fromSrid": 6318,
+      "toSrid": 4326,
+      "areaOfUse": "North America - NAD83(2011) onshore",
+      "epsgOperationCode": 9774,
       "projPipeline": "+proj=noop",
       "requiredGrids": []
     },

--- a/tests/dotnet/Honua.Core.Tests/Features/Infrastructure/Crs/EsriDatumTransformationCatalogTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Infrastructure/Crs/EsriDatumTransformationCatalogTests.cs
@@ -17,6 +17,8 @@ public sealed class EsriDatumTransformationCatalogTests
     private const int Nad83 = 4269;
     private const int Wgs84 = 4326;
     private const int Nad27 = 4267;
+    private const int Nad83Harn = 4152;
+    private const int Nad83Nsrs2007 = 4759;
     private const int Nad83_2011 = 6318;
 
     private readonly IDatumTransformationCatalog _catalog = EsriDatumTransformationCatalog.Create();
@@ -61,6 +63,45 @@ public sealed class EsriDatumTransformationCatalogTests
         selection.Name.Should().Be("NAD_1927_To_NAD_1983_NADCON");
         selection.RequiredGrids.Should().Contain("us_noaa_conus.tif");
         selection.ProjPipeline.Should().Contain("hgridshift");
+    }
+
+    [Theory]
+    [InlineData(Nad83Harn, 1580, "NAD_1983_HARN_To_WGS_1984_1")]
+    [InlineData(Nad83Nsrs2007, 15931, "NAD_1983_NSRS2007_To_WGS_1984_1")]
+    [InlineData(Nad83_2011, 9774, "NAD_1983_2011_To_WGS_1984_1")]
+    public void TryGetDefault_Wgs84RealizationPair_ReturnsNullTransformPipeline(int fromSrid, int epsgOp, string name)
+    {
+        // NAD83(HARN)/NSRS2007/2011 -> WGS84 are EPSG null transformations (#1501).
+        // They are seeded as the exact-identity +proj=noop, which PostGIS applies through
+        // the 3-argument ST_Transform chokepoint (validated against the runtime).
+        var found = _catalog.TryGetDefault(fromSrid, Wgs84, out var selection);
+
+        found.Should().BeTrue();
+        selection.Should().NotBeNull();
+        selection!.Name.Should().Be(name);
+        selection.FromSrid.Should().Be(fromSrid);
+        selection.ToSrid.Should().Be(Wgs84);
+        selection.EpsgOperationCode.Should().Be(epsgOp);
+        selection.ProjPipeline.Should().Be("+proj=noop");
+        selection.RequiredGrids.Should().BeEmpty();
+        selection.TransformForward.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(Nad83Harn)]
+    [InlineData(Nad83Nsrs2007)]
+    [InlineData(Nad83_2011)]
+    public void TryGetDefault_Wgs84RealizationInverse_IsSynthesizedAsInverse(int fromSrid)
+    {
+        // The inverse (WGS84 -> realization) is synthesized; for a null transform the
+        // inverse pipeline is the same exact-identity +proj=noop.
+        var found = _catalog.TryGetDefault(Wgs84, fromSrid, out var selection);
+
+        found.Should().BeTrue();
+        selection!.FromSrid.Should().Be(Wgs84);
+        selection.ToSrid.Should().Be(fromSrid);
+        selection.TransformForward.Should().BeFalse();
+        selection.ProjPipeline.Should().Be("+proj=noop");
     }
 
     [UnitTest]

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Infrastructure/Transforms/DatumTransformationParityTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Infrastructure/Transforms/DatumTransformationParityTests.cs
@@ -20,7 +20,7 @@ namespace Honua.Postgres.Tests.Features.Infrastructure.Transforms;
 /// <remarks>
 /// The oracle is currently the EPSG/PROJ reference pipeline executed by PostGIS itself.
 /// The tests are structured so an ArcGIS-generated golden coordinate set can be dropped
-/// in later (see docs/gis/datum-transformation-parity.md) without restructuring.
+/// in later (see docs/internal/evidence/datum-transformation-parity.md) without restructuring.
 /// </remarks>
 [Collection("Database")]
 public sealed class DatumTransformationParityTests : IAsyncLifetime
@@ -52,7 +52,7 @@ public sealed class DatumTransformationParityTests : IAsyncLifetime
         var result = await _service!.TransformPointAsync(-104.9903, 39.7392, 4269, 4326, selection);
 
         result.Should().NotBeNull();
-        // Tolerance per docs/gis/datum-transformation-parity.md (NAD83->WGS84_1: 0.01 m ~ 1e-7 deg).
+        // Tolerance per docs/internal/evidence/datum-transformation-parity.md (NAD83->WGS84_1: null transform, exact identity).
         result!.Value.X.Should().BeApproximately(-104.9903, 1e-5);
         result.Value.Y.Should().BeApproximately(39.7392, 1e-5);
     }
@@ -77,6 +77,30 @@ public sealed class DatumTransformationParityTests : IAsyncLifetime
         // Both should be sub-meter; ~1e-5 deg ~ 1.1 m upper bound.
         selected!.Value.X.Should().BeApproximately(oracle!.Value.X, 1e-5);
         selected.Value.Y.Should().BeApproximately(oracle.Value.Y, 1e-5);
+    }
+
+    [Theory]
+    [InlineData(4152)] // NAD83(HARN)     -> WGS84, EPSG 1580 (null)
+    [InlineData(4759)] // NAD83(NSRS2007) -> WGS84, EPSG 15931 (null)
+    [InlineData(6318)] // NAD83(2011)     -> WGS84, EPSG 9774 (null)
+    public async Task TransformPoint_Wgs84RealizationNullPair_SeededPipelineApplies(int fromSrid)
+    {
+        // The deferred Helmert/WGS84-realization pairs seeded under #1501 are EPSG null
+        // transformations (+proj=noop). This proves the seeded pipeline actually applies
+        // through PostGIS' 3-argument ST_Transform on the runtime (not hand-authored) and
+        // produces the exact-identity result the null transform mandates.
+        _catalog.TryGetDefault(fromSrid, 4326, out var selection).Should().BeTrue();
+        selection!.ProjPipeline.Should().Be("+proj=noop");
+
+        const double lon = -96.0;
+        const double lat = 41.0;
+
+        var result = await _service!.TransformPointAsync(lon, lat, fromSrid, 4326, selection);
+
+        result.Should().NotBeNull();
+        // Null transform = exact identity; allow only floating-point noise.
+        result!.Value.X.Should().BeApproximately(lon, 1e-9);
+        result.Value.Y.Should().BeApproximately(lat, 1e-9);
     }
 
     [IntegrationTest]


### PR DESCRIPTION
## Issue Link
Closes #1501

## Summary
Seeds runtime-validated null datum-transformation pairs into the Esri default datum-transformation catalog so that identity/no-op transformations are represented and validated at runtime, with refreshed parity evidence.

## Changes Made
- Extend `esri-default-datum-transformations.json` with null datum-transformation pairs
- Add runtime validation in `DatumTransformationSelection`
- Update `datum-transformation-parity.md` evidence
- Add `EsriDatumTransformationCatalogTests` and extend `DatumTransformationParityTests`

## Testing
- [x] Unit tests added/updated

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None
