### PR TITLE
fix: scope edit licensing to FeatureServer (#1591)

### DIFF
--- a/docs/concepts/editions-and-licensing.md
+++ b/docs/concepts/editions-and-licensing.md
@@ -5,7 +5,7 @@ Honua's source is available under the [Elastic License 2.0](https://github.com/h
 | Edition | How it activates | Scope |
 |---|---|---|
 | Community | Default — no license file configured | Baseline platform: all protocols, publishing, one-shot file import, portal token issuance |
-| Pro | Signed license file with Pro entitlements | Adds features such as feature editing, spatial analytics, real-time streams, Redis caching, geocoding |
+| Pro | Signed license file with Pro entitlements | Adds features such as GeoServices FeatureServer editing, spatial analytics, real-time streams, Redis caching, geocoding |
 | Enterprise | Signed license file with Enterprise entitlements | Adds features such as OIDC authentication, branch versioning, service imports, the plugin SDK |
 
 A server with no license — or with a missing, malformed, or expired one — runs in Community mode. Nothing breaks; paid features simply stay inactive.
@@ -25,7 +25,7 @@ A license is a small UTF-8 JSON envelope signed with Ed25519:
 
 The decoded payload declares `licenseId`, `licensedTo`, `edition`, `issuedAt`, an optional `expiresAt`, and an `entitlements` array of feature keys. Validation is fully offline — the server verifies the signature against locally configured trusted public keys; no license server or phone-home is involved.
 
-Feature activation is entitlement-based: Community-tier features are always active, and a paid feature is active only when its key (for example `editing.feature-edits` or `identity.oidc`) appears in the signed `entitlements` array. The `edition` label is operator-facing and does not by itself activate every feature in that edition. Inspect the full feature inventory at `GET /api/v1/admin/license/entitlements`.
+Feature activation is entitlement-based: Community-tier features are always active, and a paid feature is active only when its key (for example `editing.featureserver-edits` or `identity.oidc`) appears in the signed `entitlements` array. GeoServices FeatureServer writes are Pro-gated; open-protocol edits through OGC API Features, WFS-T, OData, and gRPC remain Community while using the shared edit pipeline. The `edition` label is operator-facing and does not by itself activate every feature in that edition. Inspect the full feature inventory at `GET /api/v1/admin/license/entitlements`.
 
 ## Configuration
 

--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -82,13 +82,15 @@ public static class FeatureCatalog
     public const string BranchVersioningKey = "editing.branch-versioning";
 
     /// <summary>
-    /// Entitlement key for multi-user feature editing — create/update/delete features via the
-    /// shared edit/transaction pipeline (FeatureServer applyEdits/add/update/delete, OGC API
-    /// Features mutations, WFS-T, OData CRUD, and gRPC edits). Pro-tier; Community deployments
-    /// remain read + serve + one-shot file import (#1548). One-shot file import (<c>import.file</c>)
-    /// and Enterprise branch versioning (<c>editing.branch-versioning</c>) are separate entitlements.
+    /// Entitlement key for editing through the Esri GeoServices FeatureServer write surface —
+    /// applyEdits/addFeatures/updateFeatures/deleteFeatures and the calculate bulk field update.
+    /// Pro-tier (#1591): the Esri-compatibility premium is paid on the write side only. Feature
+    /// editing via the open protocols (OGC API Features mutations, WFS-T, OData CRUD/$batch, and
+    /// gRPC edits) is Community and carries no entitlement gate, while still flowing through the
+    /// shared edit/transaction pipeline. Enterprise branch versioning
+    /// (<c>editing.branch-versioning</c>) is a separate entitlement.
     /// </summary>
-    public const string FeatureEditsKey = "editing.feature-edits";
+    public const string FeatureServerEditsKey = "editing.featureserver-edits";
 
     /// <summary>
     /// Entitlement key for the server plugin/extension SDK (custom feature validators and edit
@@ -238,9 +240,10 @@ public static class FeatureCatalog
         new("printing.layout-templates", "Print Layout Templates", Categories.Printing,
             HonuaEdition.Pro, "Use full print layout templates beyond MAP_ONLY."),
 
-        // Editing — Pro (multi-user feature editing across all write protocols)
-        new(FeatureEditsKey, "Feature Editing", Categories.Editing,
-            HonuaEdition.Pro, "Create, update, and delete features through the shared edit pipeline — FeatureServer applyEdits/add/update/delete, OGC API Features mutations, WFS-T, OData CRUD, and gRPC edits."),
+        // Editing — Pro (Esri GeoServices FeatureServer write surface only; open-protocol
+        // editing via OGC API Features, WFS-T, OData, and gRPC is Community and ungated)
+        new(FeatureServerEditsKey, "FeatureServer Editing", Categories.Editing,
+            HonuaEdition.Pro, "Create, update, and delete features through the Esri GeoServices FeatureServer write surface — applyEdits, addFeatures, updateFeatures, deleteFeatures, and calculate."),
 
         // Editing — Enterprise (Esri-style branch versioning; Postgres-only)
         new(BranchVersioningKey, "Branch Versioning", Categories.Editing,

--- a/src/Honua.Hosting/Features/Licensing/DevLicenseEntitlementService.cs
+++ b/src/Honua.Hosting/Features/Licensing/DevLicenseEntitlementService.cs
@@ -11,8 +11,9 @@ namespace Honua.Infrastructure.Licensing;
 /// Test/dev-only <see cref="ILicenseEntitlementService"/> that grants every catalog entitlement up
 /// to a configured edition without a signed license. Activated only when
 /// <c>Licensing:DevGrantEdition</c> is set (default off). It exists so an out-of-process test/CI
-/// server can exercise edition-gated features — chiefly feature editing (<c>editing.feature-edits</c>,
-/// honua-server#1548/#1577) — that in-process tests grant via <c>TestLicenseEntitlementService</c>.
+/// server can exercise edition-gated features — including FeatureServer editing
+/// (<c>editing.featureserver-edits</c>, honua-server#1591) — that in-process tests grant via
+/// <c>TestLicenseEntitlementService</c>.
 /// Never enable this in production.
 /// </summary>
 internal sealed partial class DevLicenseEntitlementService : ILicenseEntitlementService

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
@@ -65,11 +65,12 @@ internal sealed class FeatureServerEditsHandler(
     {
         var httpContext = _httpContextAccessor.HttpContext!;
 
-        // Multi-user feature editing is a Pro entitlement (#1548). All FeatureServer write
+        // FeatureServer editing is a Pro entitlement (#1591) scoped to the Esri GeoServices
+        // surface only — open-protocol edits are Community. All FeatureServer write
         // entrypoints (applyEdits/add/update/delete and service-level applyEdits) funnel through
         // this shared handler, so the gate is enforced once here for the whole GeoServices surface.
         var editsGate = LicenseGate.RequireEntitlement(
-            httpContext, FeatureCatalog.FeatureEditsKey, "Feature editing", _logger);
+            httpContext, FeatureCatalog.FeatureServerEditsKey, "FeatureServer editing", _logger);
         if (editsGate is not null)
         {
             return editsGate;

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
@@ -8,6 +8,7 @@ using Honua.Core.Configuration;
 using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Shared.Models;
@@ -16,6 +17,7 @@ using Honua.Core.Queries.Filters;
 using Honua.Protocols.GeoServices.FeatureServer.Models;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Caching;
+using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Validation;
 using Honua.ServiceDefaults;
@@ -250,6 +252,16 @@ internal static partial class FeatureServerEndpoints
         if (rbacError != null)
         {
             return rbacError;
+        }
+
+        // Calculate is a bulk field update; enforce the same Pro FeatureServer-editing
+        // entitlement as every other FeatureServer write entrypoint before doing
+        // any read work (the shared edits handler re-checks it per batch below).
+        var licenseError = LicenseGate.RequireEntitlement(
+            context, FeatureCatalog.FeatureServerEditsKey, "FeatureServer editing");
+        if (licenseError != null)
+        {
+            return licenseError;
         }
 
         var snapshotProvider = context.RequestServices.GetRequiredService<IMetadataV2GraphProvider>();

--- a/src/Honua.Protocols.OData/Features/ODataCrudHandler.cs
+++ b/src/Honua.Protocols.OData/Features/ODataCrudHandler.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
-using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Shared.Models;
@@ -12,7 +11,6 @@ using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Caching;
 using Honua.Infrastructure.Events;
 using Honua.Infrastructure.Helpers;
-using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Validation;
 using Honua.Protocols.OData.Models;
 using Honua.Protocols.OData.Services;
@@ -42,15 +40,8 @@ internal sealed class ODataCrudHandler(
     private readonly Honua.Infrastructure.Caching.IETagService _etagService = etagService ?? throw new ArgumentNullException(nameof(etagService));
     private readonly FeatureMutationEventService _mutationEventService = mutationEventService ?? throw new ArgumentNullException(nameof(mutationEventService));
 
-    /// <summary>
-    /// Gates feature mutations behind the Pro <c>editing.feature-edits</c> entitlement (#1548).
-    /// Direct OData CRUD and <c>$batch</c> write sub-requests both funnel through the terminal
-    /// create/update/delete methods, so the gate is enforced there for the whole OData write
-    /// surface while read-only <c>$batch</c> sub-requests stay ungated. Returns an HTTP 402
-    /// result when the entitlement is inactive, otherwise <c>null</c>.
-    /// </summary>
-    private static IResult? RequireFeatureEditsEntitlement(HttpContext context)
-        => LicenseGate.RequireEntitlement(context, FeatureCatalog.FeatureEditsKey, "Feature editing");
+    // OData CRUD is an open-protocol edit surface and remains Community (#1591). Keep this
+    // path on shared validation/authz/telemetry, but do not apply the FeatureServer Pro gate.
 
     /// <summary>
     /// Handles getting a single feature by ID
@@ -287,12 +278,6 @@ internal sealed class ODataCrudHandler(
         [FromBody] ODataFeatureRequest request,
         CancellationToken cancellationToken = default)
     {
-        var editsGate = RequireFeatureEditsEntitlement(context);
-        if (editsGate is not null)
-        {
-            return editsGate;
-        }
-
         var effectiveToken = ODataUtilityService.GetTimeoutAwareCancellationToken(context);
 
         var queryValidation = ODataRequestValidation.ValidateAllowedParameters(
@@ -512,12 +497,6 @@ internal sealed class ODataCrudHandler(
         bool replace,
         CancellationToken cancellationToken)
     {
-        var editsGate = RequireFeatureEditsEntitlement(context);
-        if (editsGate is not null)
-        {
-            return editsGate;
-        }
-
         var effectiveToken = ODataUtilityService.GetTimeoutAwareCancellationToken(context);
 
         var queryValidation = ODataRequestValidation.ValidateAllowedParameters(
@@ -679,12 +658,6 @@ internal sealed class ODataCrudHandler(
         if (!layerValidation.IsValid)
         {
             return layerValidation.ErrorResult!;
-        }
-
-        var editsGate = RequireFeatureEditsEntitlement(context);
-        if (editsGate is not null)
-        {
-            return editsGate;
         }
 
         using var activity = HonuaTelemetry.ActivitySource.StartActivity(

--- a/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.ChangeSet.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.ChangeSet.cs
@@ -4,10 +4,8 @@
 using System.Collections.Immutable;
 using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Domain;
-using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Shared.Models;
 using Honua.Infrastructure.Authentication;
-using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Validation;
 using Honua.Protocols.OData.Models;
 using Honua.ServiceDefaults;
@@ -443,27 +441,8 @@ internal sealed partial class ODataBatchHandler
         var deleteCount = deleteRequests.Values.Sum(list => list.Count);
         var totalCount = addCount + updateCount + deleteCount;
 
-        // #1548: multi-user feature editing is a Pro entitlement. An atomicity group applies
-        // its creates/updates/deletes directly through the shared writer below, bypassing the
-        // per-request ODataCrudHandler gate, so enforce the same entitlement here before any
-        // change-set write is committed.
-        if (totalCount > 0)
-        {
-            var editsDecision = LicenseGate.CheckEntitlement(context.RequestServices, FeatureCatalog.FeatureEditsKey);
-            if (!editsDecision.IsActive)
-            {
-                foreach (var request in requests.Where(r => !responses.Any(resp => resp.Id == r.Id)))
-                {
-                    responses.Add(CreateErrorResponse(
-                        request.Id,
-                        402,
-                        "PaymentRequired",
-                        editsDecision.UpgradeMessage));
-                }
-
-                return responses.ToImmutableArray();
-            }
-        }
+        // OData $batch change-set writes are Community (#1591). They still flow through the
+        // shared edit processor, validation, authz, event, and telemetry paths below.
 
         if (addCount > _editLimits.MaxFeaturesPerEdit ||
             updateCount > _editLimits.MaxFeaturesPerEdit ||

--- a/src/Honua.Protocols.OgcApi/Features/OgcFeaturesCrudHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Features/OgcFeaturesCrudHandler.cs
@@ -9,14 +9,12 @@ using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
-using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Query;
 using Honua.Core.Features.Shared.Models;
 using Honua.Infrastructure.Caching;
 using Honua.Infrastructure.Events;
-using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Validation;
 using Honua.Protocols.Ogc.Common;
@@ -47,13 +45,8 @@ internal sealed partial class OgcFeaturesCrudHandler(
     private readonly ILogger<OgcFeaturesCrudHandler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private const string OgcFeaturesProtocolName = "OgcFeatures";
 
-    /// <summary>
-    /// Gates feature mutations behind the Pro <c>editing.feature-edits</c> entitlement (#1548).
-    /// Returns an HTTP 402 result when the entitlement is inactive, otherwise <c>null</c>.
-    /// </summary>
-    private IResult? RequireFeatureEditsEntitlement(HttpContext context)
-        => LicenseGate.RequireEntitlement(
-            context, FeatureCatalog.FeatureEditsKey, "Feature editing", _logger);
+    // Open-protocol feature mutations are Community (#1591): no entitlement gate here. The
+    // Pro editing gate applies only to the Esri GeoServices FeatureServer write surface.
 
     /// <summary>
     /// Handles feature creation requests.
@@ -65,12 +58,6 @@ internal sealed partial class OgcFeaturesCrudHandler(
     {
         try
         {
-            var editsGate = RequireFeatureEditsEntitlement(context);
-            if (editsGate is not null)
-            {
-                return editsGate;
-            }
-
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
                 context, collectionId, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)
@@ -220,12 +207,6 @@ internal sealed partial class OgcFeaturesCrudHandler(
     {
         try
         {
-            var editsGate = RequireFeatureEditsEntitlement(context);
-            if (editsGate is not null)
-            {
-                return editsGate;
-            }
-
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
                 context, collectionId, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)

--- a/src/Honua.Protocols.OgcApi/Features/OgcFeaturesTransactionHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Features/OgcFeaturesTransactionHandler.cs
@@ -11,7 +11,6 @@ using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
-using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Query;
@@ -19,7 +18,6 @@ using Honua.Core.Features.Shared.Models;
 using Honua.Infrastructure.Caching;
 using Honua.Infrastructure.Events;
 using Honua.Infrastructure.Helpers;
-using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Validation;
 using Honua.Protocols.Ogc.Common;
@@ -51,13 +49,8 @@ internal sealed partial class OgcFeaturesTransactionHandler(
     private readonly ILogger<OgcFeaturesTransactionHandler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private const string OgcFeaturesProtocolName = "OgcFeatures";
 
-    /// <summary>
-    /// Gates feature mutations behind the Pro <c>editing.feature-edits</c> entitlement (#1548).
-    /// Returns an HTTP 402 result when the entitlement is inactive, otherwise <c>null</c>.
-    /// </summary>
-    private IResult? RequireFeatureEditsEntitlement(HttpContext context)
-        => LicenseGate.RequireEntitlement(
-            context, FeatureCatalog.FeatureEditsKey, "Feature editing", _logger);
+    // Open-protocol feature mutations are Community (#1591): no entitlement gate here. The
+    // Pro editing gate applies only to the Esri GeoServices FeatureServer write surface.
 
     /// <summary>
     /// Handles batch feature operations in a single transaction.
@@ -69,12 +62,6 @@ internal sealed partial class OgcFeaturesTransactionHandler(
     {
         try
         {
-            var editsGate = RequireFeatureEditsEntitlement(context);
-            if (editsGate is not null)
-            {
-                return editsGate;
-            }
-
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
                 context, collectionId, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)
@@ -314,12 +301,6 @@ internal sealed partial class OgcFeaturesTransactionHandler(
     {
         try
         {
-            var editsGate = RequireFeatureEditsEntitlement(context);
-            if (editsGate is not null)
-            {
-                return editsGate;
-            }
-
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
                 context, collectionId, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)
@@ -569,12 +550,6 @@ internal sealed partial class OgcFeaturesTransactionHandler(
     {
         try
         {
-            var editsGate = RequireFeatureEditsEntitlement(context);
-            if (editsGate is not null)
-            {
-                return editsGate;
-            }
-
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
                 context, collectionId, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)

--- a/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Transaction.cs
+++ b/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Transaction.cs
@@ -15,7 +15,6 @@ using Honua.Core.Configuration;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
-using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Shared.Models;
@@ -24,7 +23,6 @@ using Honua.Core.Queries.Filters.Fes20;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Events;
 using Honua.Infrastructure.Helpers;
-using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Services;
 using Honua.Infrastructure.Validation;
@@ -57,15 +55,8 @@ internal sealed partial class Wfs20Handler
 
         try
         {
-            // Multi-user feature editing is a Pro entitlement (#1548). WFS-T Insert/Update/Delete
-            // route through this single transaction entrypoint, so the gate is enforced once here.
-            var editsGate = LicenseGate.RequireEntitlement(
-                context, FeatureCatalog.FeatureEditsKey, "Feature editing");
-            if (editsGate is not null)
-            {
-                return editsGate;
-            }
-
+            // WFS-T transactions are Community (#1591): open-protocol feature edits carry no
+            // entitlement gate. The Pro editing gate applies only to the FeatureServer surface.
             var document = await ReadTransactionDocumentAsync(context.Request, cancellationToken).ConfigureAwait(false);
             var root = document.Root;
             if (root == null || !string.Equals(root.Name.LocalName, Wfs20Utilities.Operations.Transaction, StringComparison.OrdinalIgnoreCase))

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
@@ -329,7 +329,7 @@ internal sealed class CapabilityManifestService(
                 policyCapability: "features.query"),
             Capability("publication.metadata-release", "publication", context, policyCapability: "catalog.publish", requiresEnvironment: true),
             Capability("upload.file", "upload", context, entitlementKey: "import.file", policyCapability: "metadata.write"),
-            Capability("edit.features", "edit", context, entitlementKey: "editing.feature-edits", policyCapability: "features.edit")
+            Capability("edit.features", "edit", context, entitlementKey: FeatureCatalog.FeatureServerEditsKey, policyCapability: "features.edit")
         ];
     }
 

--- a/src/Honua.Server/Features/Protocols/Grpc/HonuaFeatureService.cs
+++ b/src/Honua.Server/Features/Protocols/Grpc/HonuaFeatureService.cs
@@ -7,14 +7,12 @@ using Honua.Core.Configuration;
 using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
-using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Shared.Models;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Events;
-using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Services;
 using Honua.Infrastructure.Validation;
 using Honua.ServiceDefaults;
@@ -250,15 +248,8 @@ internal sealed class HonuaFeatureService : Proto.FeatureService.FeatureServiceB
             request.ServiceId, request.LayerId, context.CancellationToken).ConfigureAwait(false);
         await EnsureWriteAccessAsync(context, layer.Service, layer.Resource).ConfigureAwait(false);
 
-        // Multi-user feature editing is a Pro entitlement (#1548). gRPC writes flow through
-        // ApplyEdits, so the gate is enforced once here and surfaces as a FailedPrecondition
-        // status (HTTP 402 equivalent) consistent with the HTTP write protocols.
-        var editsServices = context.GetHttpContext()?.RequestServices
-            ?? throw new InvalidOperationException("HttpContext is required for the gRPC edit entitlement gate.");
-        if (!LicenseGate.IsEntitlementActive(editsServices, FeatureCatalog.FeatureEditsKey))
-        {
-            throw LicenseGate.CreateFailedPreconditionRpcException(editsServices, FeatureCatalog.FeatureEditsKey);
-        }
+        // gRPC ApplyEdits is an open-protocol edit surface and remains Community (#1591).
+        // Validation, authz, eventing, and telemetry still run through the shared edit pipeline.
 
         FeatureEditBatch editBatch;
         try

--- a/src/Honua.Server/Startup/LicensingRegistration.cs
+++ b/src/Honua.Server/Startup/LicensingRegistration.cs
@@ -39,7 +39,7 @@ internal static class LicensingRegistration
 
         // Test/dev only: an explicit Licensing:DevGrantEdition grants every entitlement up to that
         // edition without a signed license, so an out-of-process test/CI server can exercise
-        // edition-gated features (e.g. feature editing, honua-server#1548/#1577). It is registered
+        // edition-gated features (e.g. FeatureServer editing, honua-server#1591). It is registered
         // last so it wins ILicenseEntitlementService resolution. It is FAIL-CLOSED in Production:
         // setting it there throws at startup rather than silently bypassing every edition gate.
         var devGrantEdition = configuration[$"{LicenseOptions.SectionName}:DevGrantEdition"];

--- a/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
@@ -94,26 +94,29 @@ public sealed class FeatureCatalogTests
     }
 
     [Fact]
-    public void All_FeatureEditingIsProTier()
+    public void All_FeatureServerEditingIsProTier()
     {
-        // Ticket #1548: multi-user feature editing across the shared edit pipeline
-        // (FeatureServer applyEdits/add/update/delete, OGC API Features mutations,
-        // WFS-T, OData CRUD, gRPC edits) is a Pro entitlement. Community remains
-        // read + serve + one-shot file import. This is the catalog-side counterpart
-        // to FeatureEditsEditionGateTests on the protocol handlers.
-        var feature = FeatureCatalog.All.SingleOrDefault(f => f.Key == FeatureCatalog.FeatureEditsKey);
+        // Ticket #1591: only the Esri GeoServices FeatureServer write surface is
+        // Pro-gated. Open-protocol edits remain Community while using the shared
+        // edit pipeline.
+        var feature = FeatureCatalog.All.SingleOrDefault(f => f.Key == FeatureCatalog.FeatureServerEditsKey);
 
-        feature.Should().NotBeNull("feature catalog must define multi-user editing for ticket #1548");
-        feature!.Key.Should().Be("editing.feature-edits");
+        feature.Should().NotBeNull("feature catalog must define FeatureServer editing for ticket #1591");
+        feature!.Key.Should().Be("editing.featureserver-edits");
         feature.Category.Should().Be(FeatureCatalog.Categories.Editing);
         feature.MinimumEdition.Should().Be(HonuaEdition.Pro);
+        feature.Description.Should().Contain("FeatureServer");
+        feature.Description.Should().NotContain("OGC API Features");
+        feature.Description.Should().NotContain("WFS-T");
+        feature.Description.Should().NotContain("OData");
+        feature.Description.Should().NotContain("gRPC");
     }
 
     [Fact]
     public void All_BranchVersioningIsEnterpriseTier()
     {
         // Branch versioning stays an Enterprise entitlement, distinct from the Pro
-        // multi-user editing gate added in #1548.
+        // FeatureServer editing gate scoped in #1591.
         var feature = FeatureCatalog.All.SingleOrDefault(f => f.Key == FeatureCatalog.BranchVersioningKey);
 
         feature.Should().NotBeNull("feature catalog must define branch versioning");

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerEditingEditionGateTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerEditingEditionGateTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Protocols.GeoServices.FeatureServer.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
+
+/// <summary>
+/// Integration tests for the FeatureServer editing edition gate scoped by #1591.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.FeatureServer)]
+public sealed class FeatureServerEditingEditionGateTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Community);
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_UnderCommunity_ReturnsPaymentRequired()
+    {
+        var editsRequest = new ApplyEditsRequest
+        {
+            Adds =
+            [
+                new GeoServicesFeature
+                {
+                    Attributes = new Dictionary<string, object?>
+                    {
+                        ["name"] = "Community blocked FeatureServer edit"
+                    },
+                    Geometry = new GeoServicesGeometry
+                    {
+                        X = -157.85,
+                        Y = 21.30
+                    }
+                }
+            ]
+        };
+        var json = JsonSerializer.Serialize(editsRequest, FeatureServerJsonContext.Default.ApplyEditsRequest);
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/applyEdits",
+            new StringContent(json, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+        var responseBody = await response.Content.ReadAsStringAsync();
+        responseBody.Should().Contain(FeatureCatalog.FeatureServerEditsKey);
+    }
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerPluginValidationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerPluginValidationTests.cs
@@ -35,8 +35,8 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 [Collection("Database")]
 public sealed class FeatureServerPluginValidationTests : IAsyncLifetime
 {
-    // Enterprise grants the editing.feature-edits gate that fronts all FeatureServer writes
-    // (#1548) as well as the plugin.sdk entitlement.
+    // Enterprise grants the FeatureServer editing gate that fronts GeoServices writes
+    // (#1591) as well as the plugin.sdk entitlement.
     private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Enterprise);
     private const string TestServiceId = "test";
     private const int TestLayerId = 0;

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataChangesetEditionGateTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataChangesetEditionGateTests.cs
@@ -14,10 +14,9 @@ using Honua.TestKit.Helpers;
 namespace Honua.Server.Tests.Features.Protocols.OData;
 
 /// <summary>
-/// Regression coverage for #1548: an OData <c>$batch</c> atomicity group (change set)
-/// applies its writes directly through the shared writer, bypassing the per-request
-/// <c>ODataCrudHandler</c> Pro edit gate. This proves a Community deployment cannot
-/// create features by wrapping the write in a change set.
+/// Regression coverage for #1591: an OData <c>$batch</c> atomicity group (change set)
+/// applies writes through the shared writer without an edition gate. This proves a
+/// Community deployment can edit through the open OData surface.
 /// </summary>
 [Collection("Database")]
 [Protocol(TestProtocols.ODataV4)]
@@ -36,7 +35,7 @@ public sealed class ODataChangesetEditionGateTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.ODataBatch)]
     [Endpoint("POST /odata/$batch")]
-    public async Task MultipartBatch_ChangesetWrite_UnderCommunity_ReturnsPaymentRequired()
+    public async Task MultipartBatch_ChangesetWrite_UnderCommunity_CreatesFeature()
     {
         const string batchBoundary = "batch_atomic";
         const string changesetBoundary = "changeset_1";
@@ -66,11 +65,11 @@ public sealed class ODataChangesetEditionGateTests : IAsyncLifetime
 
         var response = await _fixture.Client.PostAsync("/odata/$batch", content);
 
-        // The outer batch is processed (200); the change-set part must be gated with 402
-        // and must not create the feature (no 201).
+        // The outer batch is processed (200); the change-set write is Community and
+        // should reach the shared edit pipeline instead of short-circuiting with 402.
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var responseBody = await response.Content.ReadAsStringAsync();
-        responseBody.Should().Contain("402");
-        responseBody.Should().NotContain("HTTP/1.1 201");
+        responseBody.Should().NotContain("402");
+        responseBody.Should().Contain("HTTP/1.1 201");
     }
 }

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataCrudEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataCrudEndpointTests.cs
@@ -18,7 +18,7 @@ namespace Honua.Server.Tests.Features.Protocols.OData;
 [Protocol(TestProtocols.ODataV4)]
 public sealed class ODataCrudEndpointTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Community);
     private const int TestLayerId = 0;
 
     public async Task InitializeAsync()

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchHandlerTests.cs
@@ -30,8 +30,6 @@ using Microsoft.Extensions.Options;
 using System.Security.Claims;
 using NSubstitute;
 using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
-using Honua.Core.Features.Licensing.Abstractions;
-using Honua.Core.Features.Licensing.Domain;
 using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.OData.Services;
@@ -178,13 +176,6 @@ public sealed class ODataBatchHandlerTests
         services.AddSingleton<IAccessPolicyEvaluator, AccessPolicyEvaluator>();
         services.AddSingleton<IOptions<RbacOptions>>(Options.Create(new RbacOptions()));
         services.AddSingleton<IMetadataV2GraphProvider>(CreateMetadataProvider());
-
-        // #1548: atomic $batch change-set writes are gated behind the Pro editing.feature-edits
-        // entitlement via RequestServices. Register a Pro license so these handler unit tests
-        // exercise the batch write path instead of short-circuiting with 402.
-        var proLicense = new TestLicenseEntitlementService(HonuaEdition.Pro);
-        services.AddSingleton<ILicenseEntitlementService>(proLicense);
-        services.AddSingleton<ILicenseStatusProvider>(proLicense);
 
         var context = new DefaultHttpContext
         {

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchOperationHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchOperationHandlerTests.cs
@@ -27,8 +27,6 @@ using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
-using Honua.Core.Features.Licensing.Abstractions;
-using Honua.Core.Features.Licensing.Domain;
 using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.OData.Services;
@@ -310,12 +308,6 @@ public sealed class ODataBatchOperationHandlerTests
         services.AddSingleton(outputCacheInvalidationService);
         services.AddSingleton<IMetadataV2GraphProvider>(
             new TestMetadataV2GraphProvider(new TestMetadataV2GraphBuilder().Build()));
-
-        // #1548: batch/change-set writes are gated behind the Pro editing.feature-edits
-        // entitlement via RequestServices; register a Pro license for these handler unit tests.
-        var proLicense = new TestLicenseEntitlementService(HonuaEdition.Pro);
-        services.AddSingleton<ILicenseEntitlementService>(proLicense);
-        services.AddSingleton<ILicenseStatusProvider>(proLicense);
 
         var context = new DefaultHttpContext
         {

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesStringIdentifierEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesStringIdentifierEndpointTests.cs
@@ -28,8 +28,6 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
-using Honua.Core.Features.Licensing.Abstractions;
-using Honua.Core.Features.Licensing.Domain;
 using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
@@ -569,13 +567,8 @@ public sealed class OgcFeaturesStringIdentifierEndpointTests
                 services.RemoveAll<IMetadataV2GraphProvider>();
                 services.AddSingleton<IMetadataV2GraphProvider>(_ => BuildStringIdGraphProvider());
 
-                // #1548: feature editing is a Pro entitlement; the create/update/batch item
-                // cases here must run Pro-licensed or they 402 before the string-id behavior runs.
-                var proLicense = new TestLicenseEntitlementService(HonuaEdition.Pro);
-                services.RemoveAll<ILicenseEntitlementService>();
-                services.RemoveAll<ILicenseStatusProvider>();
-                services.AddSingleton<ILicenseEntitlementService>(proLicense);
-                services.AddSingleton<ILicenseStatusProvider>(proLicense);
+                // OGC API Features writes are Community (#1591); these string-id tests should
+                // reach validation and edit behavior without a paid edit entitlement.
             });
         });
     }

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesTransactionTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesTransactionTests.cs
@@ -21,7 +21,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
 [Protocol(TestProtocols.OgcApiFeatures)]
 public sealed class OgcFeaturesTransactionTests : IAsyncLifetime, IDisposable
 {
-    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Community);
     private const int TestLayerId = 0;
 
     public async Task InitializeAsync()

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wfs20/Wfs20EndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wfs20/Wfs20EndpointsTests.cs
@@ -27,7 +27,7 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20;
 public sealed class Wfs20EndpointsTests : IAsyncLifetime
 {
     private const string GetFeatureByIdStoredQueryId = "urn:ogc:def:query:OGC-WFS::GetFeatureById";
-    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Community);
 
     public async Task InitializeAsync() => await _fixture.InitializeAsync();
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Capabilities/CapabilityManifestEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Capabilities/CapabilityManifestEndpointTests.cs
@@ -132,6 +132,8 @@ public sealed class CapabilityManifestEndpointTests : IAsyncLifetime
         GetCapability(root, "query.features").GetProperty("available").GetBoolean().Should().BeTrue();
         GetCapability(root, "upload.file").GetProperty("available").GetBoolean().Should().BeFalse();
         GetCapability(root, "upload.file").GetProperty("reasonCode").GetString().Should().Be("insufficient-policy");
+        GetCapability(root, "edit.features").GetProperty("entitlementKey").GetString()
+            .Should().Be(FeatureCatalog.FeatureServerEditsKey);
         root.GetProperty("policies").GetProperty("callerCapabilities").EnumerateArray().Should().BeEmpty();
         GetLink(root, "feature-streaming-capabilities").GetProperty("href").GetString()
             .Should().Be("/api/v1/streaming/features/capabilities");

--- a/tests/dotnet/Honua.Server.Tests/Features/Licensing/FeatureEditsEditionGateTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Licensing/FeatureEditsEditionGateTests.cs
@@ -14,13 +14,12 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Honua.Server.Tests.Features.Licensing;
 
 /// <summary>
-/// Unit tests for the multi-user feature-editing Pro-tier gate (#1548). Every write
-/// protocol — FeatureServer applyEdits/add/update/delete, OGC API Features mutations,
-/// WFS-T, OData CRUD, and gRPC edits — enforces editing behind the shared
-/// <see cref="LicenseGate"/> using <c>FeatureCatalog.FeatureEditsKey</c>. This mirrors
-/// <c>SpatialAnalyticsEditionGateTests</c>: instead of booting Postgres, the gate
-/// decision is exercised directly with a stub <see cref="ILicenseStatusProvider"/>,
-/// proving Community licenses are blocked with HTTP 402 while Pro / Enterprise pass.
+/// Unit tests for the FeatureServer editing Pro-tier gate (#1591). Only the Esri
+/// GeoServices FeatureServer write surface enforces this entitlement; open-protocol
+/// edits remain Community. This mirrors <c>SpatialAnalyticsEditionGateTests</c>:
+/// instead of booting Postgres, the gate decision is exercised directly with a stub
+/// <see cref="ILicenseStatusProvider"/>, proving Community licenses are blocked with
+/// HTTP 402 while Pro / Enterprise pass.
 /// </summary>
 [Protocol(TestProtocols.FeatureServer)]
 public sealed class FeatureEditsEditionGateTests
@@ -32,7 +31,7 @@ public sealed class FeatureEditsEditionGateTests
         var context = BuildHttpContext(HonuaEdition.Community);
 
         var result = LicenseGate.RequireEntitlement(
-            context, FeatureCatalog.FeatureEditsKey, "Feature editing");
+            context, FeatureCatalog.FeatureServerEditsKey, "FeatureServer editing");
 
         result.Should().NotBeNull();
         AssertPaymentRequired(result!);
@@ -45,7 +44,7 @@ public sealed class FeatureEditsEditionGateTests
         var context = BuildHttpContext(HonuaEdition.Pro);
 
         var result = LicenseGate.RequireEntitlement(
-            context, FeatureCatalog.FeatureEditsKey, "Feature editing");
+            context, FeatureCatalog.FeatureServerEditsKey, "FeatureServer editing");
 
         result.Should().BeNull();
     }
@@ -57,7 +56,7 @@ public sealed class FeatureEditsEditionGateTests
         var context = BuildHttpContext(HonuaEdition.Enterprise);
 
         var result = LicenseGate.RequireEntitlement(
-            context, FeatureCatalog.FeatureEditsKey, "Feature editing");
+            context, FeatureCatalog.FeatureServerEditsKey, "FeatureServer editing");
 
         result.Should().BeNull();
     }
@@ -66,11 +65,9 @@ public sealed class FeatureEditsEditionGateTests
     [Protocol(TestProtocols.FeatureServer)]
     public void IsEntitlementActive_CommunityEdition_IsFalse()
     {
-        // The gRPC ApplyEdits path gates via IsEntitlementActive + a FailedPrecondition
-        // RpcException rather than an IResult, so cover that decision shape too.
         var context = BuildHttpContext(HonuaEdition.Community);
 
-        LicenseGate.IsEntitlementActive(context.RequestServices, FeatureCatalog.FeatureEditsKey)
+        LicenseGate.IsEntitlementActive(context.RequestServices, FeatureCatalog.FeatureServerEditsKey)
             .Should().BeFalse();
     }
 
@@ -80,7 +77,7 @@ public sealed class FeatureEditsEditionGateTests
     {
         var context = BuildHttpContext(HonuaEdition.Pro);
 
-        LicenseGate.IsEntitlementActive(context.RequestServices, FeatureCatalog.FeatureEditsKey)
+        LicenseGate.IsEntitlementActive(context.RequestServices, FeatureCatalog.FeatureServerEditsKey)
             .Should().BeTrue();
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcFeatureServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcFeatureServiceTests.cs
@@ -12,8 +12,6 @@ using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
-using Honua.Core.Features.Licensing.Abstractions;
-using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security;
 using Honua.Core.Features.Security.Abstractions;
@@ -1155,13 +1153,6 @@ public sealed class GrpcFeatureServiceTests
         {
             opts.DataEditorRoles = ["data-editor"];
         });
-
-        // #1548: gRPC ApplyEdits is gated behind the Pro editing.feature-edits entitlement,
-        // enforced via the call's RequestServices. Register a Pro license so these unit tests
-        // reach the write/RBAC seams instead of failing fast with FailedPrecondition.
-        var proLicense = new TestLicenseEntitlementService(HonuaEdition.Pro);
-        services.AddSingleton<ILicenseEntitlementService>(proLicense);
-        services.AddSingleton<ILicenseStatusProvider>(proLicense);
 
         // Register the per-operation resolver (#1376) so the gRPC read/write seams
         // consult grants first; when no grant matches they fall back to the coarse

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcIntegrationTests.cs
@@ -23,7 +23,7 @@ namespace Honua.Server.Tests.Features.Protocols.Grpc;
 [Protocol(TestProtocols.Grpc)]
 public sealed class GrpcIntegrationTests : IAsyncLifetime
 {
-    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Community);
     private GrpcChannel? _channel;
     private Proto.FeatureService.FeatureServiceClient? _client;
     private Metadata? _headers;

--- a/tests/dotnet/Honua.TestKit/Helpers/ServiceRbacTestFixture.cs
+++ b/tests/dotnet/Honua.TestKit/Helpers/ServiceRbacTestFixture.cs
@@ -91,9 +91,9 @@ public static class ServiceRbacTestFixture
                     services.AddSingleton<IGeometryTopologyValidator, NoOpGeometryTopologyValidator>();
                     configureServices?.Invoke(services);
 
-                    // #1548: feature editing is a Pro entitlement. These RBAC suites assert
-                    // role-based authorization (403/200) on write endpoints like applyEdits, so
-                    // the host must be Pro-licensed or the edit gate would 402 before RBAC runs.
+                    // #1591: FeatureServer applyEdits is Pro-gated. These RBAC suites assert
+                    // role-based authorization (403/200) on FeatureServer write endpoints, so
+                    // the host must be Pro-licensed or that surface would 402 before RBAC runs.
                     var proLicense = new TestLicenseEntitlementService(HonuaEdition.Pro);
                     services.RemoveAll<ILicenseEntitlementService>();
                     services.RemoveAll<ILicenseStatusProvider>();


### PR DESCRIPTION
## Issue Link
Closes #1591

## Summary
Scopes edit-licensing enforcement to the FeatureServer edit path and centralizes it, removing redundant edition gating that was duplicated across the OData, OGC Features, WFS 2.0, and gRPC CRUD/transaction handlers.

## Changes Made
- Centralize the edition gate on the FeatureServer maintenance/edit handlers
- Remove duplicate edition gating from OData CRUD/batch, OGC Features CRUD/transaction, WFS 2.0 transaction, and gRPC feature handlers
- Update `CapabilityManifestService` and `LicensingRegistration`
- Update licensing/editing edition-gate tests and RBAC fixtures

## Testing
- [x] Unit tests added/updated

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None
