### PR TITLE
feat: implement GML file import (reader + format detection) (#2229)

### DIFF
--- a/src/Honua.Core/Features/FileImport/Domain/SupportedFileFormat.cs
+++ b/src/Honua.Core/Features/FileImport/Domain/SupportedFileFormat.cs
@@ -45,6 +45,11 @@ public enum SupportedFileFormat
     Kml = 4,
 
     /// <summary>
+    /// Geography Markup Language (.gml)
+    /// </summary>
+    Gml = 5,
+
+    /// <summary>
     /// Well-Known Text format (.wkt)
     /// </summary>
     Wkt = 6,

--- a/src/Honua.Core/Features/FileImport/Services/FileFormatDetectionService.cs
+++ b/src/Honua.Core/Features/FileImport/Services/FileFormatDetectionService.cs
@@ -34,6 +34,7 @@ internal sealed class FileFormatDetectionService : IFileFormatDetectionService
             [".json"] = SupportedFileFormat.GeoJson,
             [".kml"] = SupportedFileFormat.Kml,
             [".kmz"] = SupportedFileFormat.Kml,
+            [".gml"] = SupportedFileFormat.Gml,
             [".wkt"] = SupportedFileFormat.Wkt,
             [".zip"] = SupportedFileFormat.Shapefile,
             [".gpkg"] = SupportedFileFormat.GeoPackage,
@@ -188,6 +189,18 @@ internal sealed class FileFormatDetectionService : IFileFormatDetectionService
         if (trimmed.StartsWith("<?xml", StringComparison.OrdinalIgnoreCase) && trimmed.Contains("<gpx"))
         {
             return SupportedFileFormat.Gpx;
+        }
+
+        // GML detection — look for the GML namespace or a FeatureCollection root element
+        if (trimmed.StartsWith("<?xml", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith('<'))
+        {
+            if (trimmed.Contains("opengis.net/gml") ||
+                trimmed.Contains("FeatureCollection") ||
+                trimmed.Contains(":FeatureCollection"))
+            {
+                return SupportedFileFormat.Gml;
+            }
         }
 
         // WKT detection (simple heuristic)

--- a/src/Honua.Geometry/Features/FileImport/Services/GmlFormatReader.cs
+++ b/src/Honua.Geometry/Features/FileImport/Services/GmlFormatReader.cs
@@ -1,0 +1,939 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Xml;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+using Honua.Core.Features.FileImport.Services;
+
+namespace Honua.Core.Features.FileImport.Services;
+
+/// <summary>
+/// Streaming GML (Geography Markup Language) format reader.
+/// Parses GML 2.x and GML 3.x feature collections into NTS features
+/// using XmlReader for memory-efficient processing.
+/// Supports common simple-feature geometry types: Point, LineString, Polygon,
+/// MultiPoint, MultiLineString, MultiPolygon, MultiSurface, MultiCurve, and
+/// MultiGeometry. Properties are read from non-geometry child elements.
+/// </summary>
+internal static class GmlFormatReader
+{
+    /// <summary>
+    /// GML 3 namespace URI.
+    /// </summary>
+    internal const string GmlNs3 = "http://www.opengis.net/gml";
+
+    /// <summary>
+    /// GML 3.2 namespace URI.
+    /// </summary>
+    internal const string GmlNs32 = "http://www.opengis.net/gml/3.2";
+
+    private static readonly char[] _coordinateSeparators = { ' ', '\n', '\r', '\t' };
+
+    /// <summary>
+    /// Tries to detect the CRS SRS name embedded in the top-level FeatureCollection element.
+    /// Returns <see langword="null"/> if no srsName is found or it cannot be parsed to an EPSG code.
+    /// </summary>
+    internal static async Task<int?> TryDetectSridAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        var settings = BuildXmlReaderSettings();
+        using var reader = XmlReader.Create(stream, settings);
+
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (reader.NodeType == XmlNodeType.Element)
+            {
+                var srsName = reader.GetAttribute("srsName");
+                if (!string.IsNullOrWhiteSpace(srsName))
+                {
+                    return ParseSrsNameToSrid(srsName);
+                }
+
+                // Only scan the root element — stop at the first feature member
+                var localName = reader.LocalName;
+                if (localName is "featureMember" or "member" or "featureMembers")
+                {
+                    break;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Streams features from a GML file using XmlReader for memory efficiency.
+    /// Recognises <c>featureMember</c> / <c>member</c> / <c>featureMembers</c>
+    /// wrapper patterns from both GML 2 and GML 3/3.2.
+    /// </summary>
+    internal static async IAsyncEnumerable<IFeature> ReadStreamingAsync(
+        Stream stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var settings = BuildXmlReaderSettings();
+        using var reader = XmlReader.Create(stream, settings);
+        var geometryFactory = GeometryFactory.Floating;
+
+        // Detect the global srsName on the FeatureCollection element so features without an
+        // explicit per-geometry srsName get the right default.
+        int? collectionSrid = null;
+
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (reader.NodeType != XmlNodeType.Element)
+            {
+                continue;
+            }
+
+            var ns = reader.NamespaceURI;
+            var localName = reader.LocalName;
+
+            // Capture the srsName from the root collection element
+            if (collectionSrid == null && (localName is "FeatureCollection" or "SimpleFeatureCollection"))
+            {
+                var srsName = reader.GetAttribute("srsName");
+                if (!string.IsNullOrWhiteSpace(srsName))
+                {
+                    collectionSrid = ParseSrsNameToSrid(srsName);
+                }
+            }
+
+            // Enter a featureMember / member / featureMembers wrapper
+            if (localName is "featureMember" or "member" or "featureMembers")
+            {
+                await foreach (var feature in ReadFeatureMemberAsync(reader, geometryFactory, collectionSrid, cancellationToken))
+                {
+                    yield return feature;
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    private static async IAsyncEnumerable<IFeature> ReadFeatureMemberAsync(
+        XmlReader reader,
+        GeometryFactory factory,
+        int? collectionSrid,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var wrapperLocalName = reader.LocalName;
+        var wrapperDepth = reader.Depth;
+
+        // Advance into the wrapper element
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (reader.NodeType == XmlNodeType.EndElement &&
+                reader.LocalName == wrapperLocalName &&
+                reader.Depth == wrapperDepth)
+            {
+                yield break;
+            }
+
+            if (reader.NodeType != XmlNodeType.Element)
+            {
+                continue;
+            }
+
+            // The first child element is the application-schema feature type
+            // (e.g. <sf:SomeFeature>, <gml:boundedBy>, etc.) Skip gml:boundedBy
+            if (reader.LocalName == "boundedBy")
+            {
+                await reader.SkipAsync();
+                continue;
+            }
+
+            var feature = await ParseFeatureElementAsync(reader, factory, collectionSrid, cancellationToken);
+            if (feature != null)
+            {
+                yield return feature;
+            }
+        }
+    }
+
+    private static async Task<IFeature?> ParseFeatureElementAsync(
+        XmlReader reader,
+        GeometryFactory factory,
+        int? collectionSrid,
+        CancellationToken cancellationToken)
+    {
+        var featureLocalName = reader.LocalName;
+        var featureDepth = reader.Depth;
+        var attributes = new AttributesTable();
+        NtsGeometry? geometry = null;
+
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (reader.NodeType == XmlNodeType.EndElement &&
+                reader.LocalName == featureLocalName &&
+                reader.Depth == featureDepth)
+            {
+                break;
+            }
+
+            if (reader.NodeType != XmlNodeType.Element)
+            {
+                continue;
+            }
+
+            var childNs = reader.NamespaceURI;
+            var childLocal = reader.LocalName;
+
+            // GML geometry elements are in the GML namespace
+            if (IsGmlNamespace(childNs))
+            {
+                var geom = await TryParseGeometryAsync(reader, factory, collectionSrid, cancellationToken);
+                if (geom != null)
+                {
+                    geometry = geom;
+                    continue;
+                }
+            }
+
+            // Property wrapper: the child of a non-GML property element may be a geometry
+            if (childLocal == "boundedBy")
+            {
+                await reader.SkipAsync();
+                continue;
+            }
+
+            // Try to read property value — may be a geometry or a text value
+            var propertyLocalName = childLocal;
+            var propertyDepth = reader.Depth;
+            var isEmptyElement = reader.IsEmptyElement;
+
+            if (isEmptyElement)
+            {
+                AddAttribute(attributes, propertyLocalName, string.Empty);
+                continue;
+            }
+
+            // Peek inside the property element
+            NtsGeometry? propertyGeom = null;
+            string? propertyText = null;
+
+            while (await reader.ReadAsync())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (reader.NodeType == XmlNodeType.EndElement &&
+                    reader.LocalName == propertyLocalName &&
+                    reader.Depth == propertyDepth)
+                {
+                    break;
+                }
+
+                if (reader.NodeType == XmlNodeType.Text || reader.NodeType == XmlNodeType.CDATA)
+                {
+                    propertyText = (propertyText ?? string.Empty) + reader.Value;
+                    continue;
+                }
+
+                if (reader.NodeType == XmlNodeType.Element && IsGmlNamespace(reader.NamespaceURI))
+                {
+                    var geom = await TryParseGeometryAsync(reader, factory, collectionSrid, cancellationToken);
+                    if (geom != null)
+                    {
+                        propertyGeom = geom;
+                        continue;
+                    }
+                }
+            }
+
+            if (propertyGeom != null)
+            {
+                geometry = propertyGeom;
+            }
+            else if (propertyText != null)
+            {
+                AddAttribute(attributes, propertyLocalName, propertyText);
+            }
+        }
+
+        if (geometry == null && attributes.Count == 0)
+        {
+            return null;
+        }
+
+        return new Feature(geometry, attributes);
+    }
+
+    private static async Task<NtsGeometry?> TryParseGeometryAsync(
+        XmlReader reader,
+        GeometryFactory factory,
+        int? collectionSrid,
+        CancellationToken cancellationToken)
+    {
+        return reader.LocalName switch
+        {
+            "Point" => await ParsePointAsync(reader, factory, collectionSrid, cancellationToken),
+            "LineString" or "Curve" => await ParseLineStringAsync(reader, factory, collectionSrid, cancellationToken),
+            "LinearRing" => await ParseLinearRingAsync(reader, factory, collectionSrid, cancellationToken),
+            "Polygon" or "Surface" => await ParsePolygonAsync(reader, factory, collectionSrid, cancellationToken),
+            "MultiPoint" => await ParseMultiPointAsync(reader, factory, collectionSrid, cancellationToken),
+            "MultiLineString" or "MultiCurve" => await ParseMultiLineStringAsync(reader, factory, collectionSrid, cancellationToken),
+            "MultiPolygon" or "MultiSurface" => await ParseMultiPolygonAsync(reader, factory, collectionSrid, cancellationToken),
+            "MultiGeometry" or "GeometryCollection" => await ParseGeometryCollectionAsync(reader, factory, collectionSrid, cancellationToken),
+            _ => null
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // Geometry parsers
+    // -----------------------------------------------------------------------
+
+    private static async Task<Point?> ParsePointAsync(
+        XmlReader reader,
+        GeometryFactory factory,
+        int? collectionSrid,
+        CancellationToken cancellationToken)
+    {
+        var elementLocalName = reader.LocalName;
+        var depth = reader.Depth;
+        int? srid = ParseSrsNameToSrid(reader.GetAttribute("srsName")) ?? collectionSrid;
+
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (reader.NodeType == XmlNodeType.EndElement &&
+                reader.LocalName == elementLocalName &&
+                reader.Depth == depth)
+            {
+                break;
+            }
+
+            if (reader.NodeType != XmlNodeType.Element)
+            {
+                continue;
+            }
+
+            if (reader.LocalName is "pos" or "coordinates")
+            {
+                var coords = await reader.ReadElementContentAsStringAsync();
+                var coordinate = ParsePos(coords);
+                if (coordinate != null)
+                {
+                    var point = factory.CreatePoint(coordinate);
+                    if (srid.HasValue)
+                    {
+                        point.SRID = srid.Value;
+                    }
+
+                    return point;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<LineString?> ParseLineStringAsync(
+        XmlReader reader,
+        GeometryFactory factory,
+        int? collectionSrid,
+        CancellationToken cancellationToken)
+    {
+        var elementLocalName = reader.LocalName;
+        var depth = reader.Depth;
+        int? srid = ParseSrsNameToSrid(reader.GetAttribute("srsName")) ?? collectionSrid;
+
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (reader.NodeType == XmlNodeType.EndElement &&
+                reader.LocalName == elementLocalName &&
+                reader.Depth == depth)
+            {
+                break;
+            }
+
+            if (reader.NodeType != XmlNodeType.Element)
+            {
+                continue;
+            }
+
+            if (reader.LocalName is "posList" or "coordinates")
+            {
+                var coords = await reader.ReadElementContentAsStringAsync();
+                var coordinates = ParsePosList(coords);
+                if (coordinates.Length >= 2)
+                {
+                    var line = factory.CreateLineString(coordinates);
+                    if (srid.HasValue)
+                    {
+                        line.SRID = srid.Value;
+                    }
+
+                    return line;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<LinearRing?> ParseLinearRingAsync(
+        XmlReader reader,
+        GeometryFactory factory,
+        int? collectionSrid,
+        CancellationToken cancellationToken)
+    {
+        var elementLocalName = reader.LocalName;
+        var depth = reader.Depth;
+        int? srid = ParseSrsNameToSrid(reader.GetAttribute("srsName")) ?? collectionSrid;
+
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (reader.NodeType == XmlNodeType.EndElement &&
+                reader.LocalName == elementLocalName &&
+                reader.Depth == depth)
+            {
+                break;
+            }
+
+            if (reader.NodeType != XmlNodeType.Element)
+            {
+                continue;
+            }
+
+            if (reader.LocalName is "posList" or "coordinates")
+            {
+                var coords = await reader.ReadElementContentAsStringAsync();
+                var coordinates = ParsePosList(coords);
+                if (coordinates.Length >= 4)
+                {
+                    var ring = factory.CreateLinearRing(coordinates);
+                    if (srid.HasValue)
+                    {
+                        ring.SRID = srid.Value;
+                    }
+
+                    return ring;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<Polygon?> ParsePolygonAsync(
+        XmlReader reader,
+        GeometryFactory factory,
+        int? collectionSrid,
+        CancellationToken cancellationToken)
+    {
+        var elementLocalName = reader.LocalName;
+        var depth = reader.Depth;
+        int? srid = ParseSrsNameToSrid(reader.GetAttribute("srsName")) ?? collectionSrid;
+        LinearRing? outerRing = null;
+        var innerRings = new List<LinearRing>();
+
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (reader.NodeType == XmlNodeType.EndElement &&
+                reader.LocalName == elementLocalName &&
+                reader.Depth == depth)
+            {
+                break;
+            }
+
+            if (reader.NodeType != XmlNodeType.Element)
+            {
+                continue;
+            }
+
+            // GML 2: <outerBoundaryIs>/<innerBoundaryIs> containing <LinearRing>
+            // GML 3: <exterior>/<interior> containing <LinearRing>
+            if (reader.LocalName is "outerBoundaryIs" or "exterior")
+            {
+                var ring = await ParseRingMemberAsync(reader, factory, srid ?? collectionSrid, cancellationToken);
+                if (ring != null)
+                {
+                    outerRing = ring;
+                }
+            }
+            else if (reader.LocalName is "innerBoundaryIs" or "interior")
+            {
+                var ring = await ParseRingMemberAsync(reader, factory, srid ?? collectionSrid, cancellationToken);
+                if (ring != null)
+                {
+                    innerRings.Add(ring);
+                }
+            }
+            else if (reader.LocalName == "LinearRing")
+            {
+                // GML 2 may nest LinearRing directly under Polygon
+                var ring = await ParseLinearRingAsync(reader, factory, srid ?? collectionSrid, cancellationToken);
+                if (ring != null && outerRing == null)
+                {
+                    outerRing = ring;
+                }
+            }
+        }
+
+        if (outerRing == null)
+        {
+            return null;
+        }
+
+        var polygon = factory.CreatePolygon(outerRing, innerRings.Count > 0 ? innerRings.ToArray() : null);
+        if (srid.HasValue)
+        {
+            polygon.SRID = srid.Value;
+        }
+
+        return polygon;
+    }
+
+    private static async Task<LinearRing?> ParseRingMemberAsync(
+        XmlReader reader,
+        GeometryFactory factory,
+        int? srid,
+        CancellationToken cancellationToken)
+    {
+        var memberLocalName = reader.LocalName;
+        var depth = reader.Depth;
+
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (reader.NodeType == XmlNodeType.EndElement &&
+                reader.LocalName == memberLocalName &&
+                reader.Depth == depth)
+            {
+                break;
+            }
+
+            if (reader.NodeType == XmlNodeType.Element && reader.LocalName == "LinearRing")
+            {
+                return await ParseLinearRingAsync(reader, factory, srid, cancellationToken);
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<MultiPoint?> ParseMultiPointAsync(
+        XmlReader reader,
+        GeometryFactory factory,
+        int? collectionSrid,
+        CancellationToken cancellationToken)
+    {
+        var elementLocalName = reader.LocalName;
+        var depth = reader.Depth;
+        int? srid = ParseSrsNameToSrid(reader.GetAttribute("srsName")) ?? collectionSrid;
+        var points = new List<Point>();
+
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (reader.NodeType == XmlNodeType.EndElement &&
+                reader.LocalName == elementLocalName &&
+                reader.Depth == depth)
+            {
+                break;
+            }
+
+            if (reader.NodeType == XmlNodeType.Element && reader.LocalName == "Point")
+            {
+                var point = await ParsePointAsync(reader, factory, srid ?? collectionSrid, cancellationToken);
+                if (point != null)
+                {
+                    points.Add(point);
+                }
+            }
+        }
+
+        if (points.Count == 0)
+        {
+            return null;
+        }
+
+        var multiPoint = factory.CreateMultiPoint(points.ToArray());
+        if (srid.HasValue)
+        {
+            multiPoint.SRID = srid.Value;
+        }
+
+        return multiPoint;
+    }
+
+    private static async Task<MultiLineString?> ParseMultiLineStringAsync(
+        XmlReader reader,
+        GeometryFactory factory,
+        int? collectionSrid,
+        CancellationToken cancellationToken)
+    {
+        var elementLocalName = reader.LocalName;
+        var depth = reader.Depth;
+        int? srid = ParseSrsNameToSrid(reader.GetAttribute("srsName")) ?? collectionSrid;
+        var lines = new List<LineString>();
+
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (reader.NodeType == XmlNodeType.EndElement &&
+                reader.LocalName == elementLocalName &&
+                reader.Depth == depth)
+            {
+                break;
+            }
+
+            if (reader.NodeType == XmlNodeType.Element &&
+                reader.LocalName is "LineString" or "Curve" or "lineStringMember" or "curveMember")
+            {
+                if (reader.LocalName is "lineStringMember" or "curveMember")
+                {
+                    // wrapper element — advance to the actual geometry inside
+                    continue;
+                }
+
+                var line = await ParseLineStringAsync(reader, factory, srid ?? collectionSrid, cancellationToken);
+                if (line != null)
+                {
+                    lines.Add(line);
+                }
+            }
+        }
+
+        if (lines.Count == 0)
+        {
+            return null;
+        }
+
+        var multiLine = factory.CreateMultiLineString(lines.ToArray());
+        if (srid.HasValue)
+        {
+            multiLine.SRID = srid.Value;
+        }
+
+        return multiLine;
+    }
+
+    private static async Task<MultiPolygon?> ParseMultiPolygonAsync(
+        XmlReader reader,
+        GeometryFactory factory,
+        int? collectionSrid,
+        CancellationToken cancellationToken)
+    {
+        var elementLocalName = reader.LocalName;
+        var depth = reader.Depth;
+        int? srid = ParseSrsNameToSrid(reader.GetAttribute("srsName")) ?? collectionSrid;
+        var polygons = new List<Polygon>();
+
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (reader.NodeType == XmlNodeType.EndElement &&
+                reader.LocalName == elementLocalName &&
+                reader.Depth == depth)
+            {
+                break;
+            }
+
+            if (reader.NodeType == XmlNodeType.Element &&
+                reader.LocalName is "Polygon" or "Surface" or "polygonMember" or "surfaceMember")
+            {
+                if (reader.LocalName is "polygonMember" or "surfaceMember")
+                {
+                    // wrapper element — advance to the actual geometry inside
+                    continue;
+                }
+
+                var polygon = await ParsePolygonAsync(reader, factory, srid ?? collectionSrid, cancellationToken);
+                if (polygon != null)
+                {
+                    polygons.Add(polygon);
+                }
+            }
+        }
+
+        if (polygons.Count == 0)
+        {
+            return null;
+        }
+
+        var multiPolygon = factory.CreateMultiPolygon(polygons.ToArray());
+        if (srid.HasValue)
+        {
+            multiPolygon.SRID = srid.Value;
+        }
+
+        return multiPolygon;
+    }
+
+    private static async Task<GeometryCollection?> ParseGeometryCollectionAsync(
+        XmlReader reader,
+        GeometryFactory factory,
+        int? collectionSrid,
+        CancellationToken cancellationToken)
+    {
+        var elementLocalName = reader.LocalName;
+        var depth = reader.Depth;
+        int? srid = ParseSrsNameToSrid(reader.GetAttribute("srsName")) ?? collectionSrid;
+        var geometries = new List<NtsGeometry>();
+
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (reader.NodeType == XmlNodeType.EndElement &&
+                reader.LocalName == elementLocalName &&
+                reader.Depth == depth)
+            {
+                break;
+            }
+
+            if (reader.NodeType != XmlNodeType.Element)
+            {
+                continue;
+            }
+
+            if (!IsGmlNamespace(reader.NamespaceURI) &&
+                reader.LocalName is not ("Point" or "LineString" or "Curve" or "Polygon" or "Surface"
+                    or "MultiPoint" or "MultiLineString" or "MultiCurve" or "MultiPolygon" or "MultiSurface"
+                    or "LinearRing"))
+            {
+                continue;
+            }
+
+            var geom = await TryParseGeometryAsync(reader, factory, srid ?? collectionSrid, cancellationToken);
+            if (geom != null)
+            {
+                geometries.Add(geom);
+            }
+        }
+
+        if (geometries.Count == 0)
+        {
+            return null;
+        }
+
+        var collection = factory.CreateGeometryCollection(geometries.ToArray());
+        if (srid.HasValue)
+        {
+            collection.SRID = srid.Value;
+        }
+
+        return collection;
+    }
+
+    // -----------------------------------------------------------------------
+    // Coordinate parsers
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Parses a GML <c>pos</c> element value (a single position).
+    /// Supports 2D and 3D coordinates in axis-order as written (typically lon/lat or lat/lon
+    /// depending on the producing system). The coordinate order is passed through as-is;
+    /// reprojection happens in the import pipeline.
+    /// </summary>
+    private static Coordinate? ParsePos(string posText)
+    {
+        var parts = posText.Trim().Split(_coordinateSeparators, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 2)
+        {
+            return null;
+        }
+
+        if (!double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var x) ||
+            !double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var y))
+        {
+            return null;
+        }
+
+        if (parts.Length >= 3 &&
+            double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var z))
+        {
+            return new CoordinateZ(x, y, z);
+        }
+
+        return new Coordinate(x, y);
+    }
+
+    /// <summary>
+    /// Parses a GML <c>posList</c> or GML 2 <c>coordinates</c> element value
+    /// into an array of coordinates.
+    /// <para>
+    /// GML 3 <c>posList</c>: space-separated flat ordinate list with implicit srsDimension
+    /// (defaults to 2). Values assumed to be grouped as x y [z] x y [z] …
+    /// </para>
+    /// <para>
+    /// GML 2 <c>coordinates</c>: comma-delimited tuples separated by space/newline
+    /// in the form "x,y[,z] x,y[,z] …".
+    /// </para>
+    /// </summary>
+    private static Coordinate[] ParsePosList(string text)
+    {
+        var trimmed = text.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            return [];
+        }
+
+        // GML 2 coordinates element uses comma-delimited tuples
+        if (trimmed.Contains(','))
+        {
+            return ParseGml2Coordinates(trimmed);
+        }
+
+        // GML 3 posList: flat space-separated ordinates
+        return ParseGml3PosList(trimmed);
+    }
+
+    private static Coordinate[] ParseGml2Coordinates(string text)
+    {
+        var coords = new List<Coordinate>();
+        var tuples = text.Split(_coordinateSeparators, StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var tuple in tuples)
+        {
+            var parts = tuple.Split(',');
+            if (parts.Length < 2)
+            {
+                continue;
+            }
+
+            if (!double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var x) ||
+                !double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var y))
+            {
+                continue;
+            }
+
+            if (parts.Length >= 3 &&
+                double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var z))
+            {
+                coords.Add(new CoordinateZ(x, y, z));
+            }
+            else
+            {
+                coords.Add(new Coordinate(x, y));
+            }
+        }
+
+        return coords.ToArray();
+    }
+
+    private static Coordinate[] ParseGml3PosList(string text)
+    {
+        var parts = text.Split(_coordinateSeparators, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 4)
+        {
+            // Not enough ordinates for even a 2D pair; treat as 2D regardless
+        }
+
+        var coords = new List<Coordinate>();
+
+        // Determine if likely 3D: if the total count is divisible by 3 but not by 2,
+        // treat as 3D. Otherwise treat as 2D (most common).
+        var is3D = parts.Length >= 3 && parts.Length % 3 == 0 && parts.Length % 2 != 0;
+
+        if (is3D)
+        {
+            for (var i = 0; i + 2 < parts.Length; i += 3)
+            {
+                if (double.TryParse(parts[i], NumberStyles.Float, CultureInfo.InvariantCulture, out var x) &&
+                    double.TryParse(parts[i + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out var y) &&
+                    double.TryParse(parts[i + 2], NumberStyles.Float, CultureInfo.InvariantCulture, out var z))
+                {
+                    coords.Add(new CoordinateZ(x, y, z));
+                }
+            }
+        }
+        else
+        {
+            for (var i = 0; i + 1 < parts.Length; i += 2)
+            {
+                if (double.TryParse(parts[i], NumberStyles.Float, CultureInfo.InvariantCulture, out var x) &&
+                    double.TryParse(parts[i + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out var y))
+                {
+                    coords.Add(new Coordinate(x, y));
+                }
+            }
+        }
+
+        return coords.ToArray();
+    }
+
+    // -----------------------------------------------------------------------
+    // SRS / namespace helpers
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Parses an SRS name attribute (e.g. <c>urn:ogc:def:crs:EPSG::4326</c>,
+    /// <c>EPSG:4326</c>, <c>http://www.opengis.net/gml/srs/epsg.xml#4326</c>)
+    /// into an integer EPSG SRID.
+    /// </summary>
+    internal static int? ParseSrsNameToSrid(string? srsName)
+    {
+        if (string.IsNullOrWhiteSpace(srsName))
+        {
+            return null;
+        }
+
+        // "EPSG:4326"
+        var colonIdx = srsName.LastIndexOf(':');
+        if (colonIdx >= 0 && int.TryParse(srsName.AsSpan(colonIdx + 1), out var srid) && srid > 0)
+        {
+            return srid;
+        }
+
+        // "http://www.opengis.net/gml/srs/epsg.xml#4326"
+        var hashIdx = srsName.LastIndexOf('#');
+        if (hashIdx >= 0 && int.TryParse(srsName.AsSpan(hashIdx + 1), out var sridHash) && sridHash > 0)
+        {
+            return sridHash;
+        }
+
+        return null;
+    }
+
+    private static bool IsGmlNamespace(string? ns)
+        => ns is GmlNs3 or GmlNs32;
+
+    private static void AddAttribute(AttributesTable attributes, string name, object? value)
+    {
+        if (!attributes.Exists(name))
+        {
+            attributes.Add(name, value);
+        }
+        else
+        {
+            attributes.DeleteAttribute(name);
+            attributes.Add(name, value);
+        }
+    }
+
+    private static XmlReaderSettings BuildXmlReaderSettings()
+        => new()
+        {
+            Async = true,
+            IgnoreWhitespace = true,
+            IgnoreComments = true,
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null
+        };
+}

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.CrsDetection.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.CrsDetection.cs
@@ -34,6 +34,7 @@ internal sealed partial class StreamingFileImportService
                 SupportedFileFormat.Kml => 4326,
                 SupportedFileFormat.Gpx => 4326,
                 SupportedFileFormat.Csv => 4326,
+                SupportedFileFormat.Gml => await GmlFormatReader.TryDetectSridAsync(stream, cancellationToken),
                 SupportedFileFormat.Wkt => await DetectWktSridAsync(stream, cancellationToken),
                 SupportedFileFormat.GeoPackage => await DetectGeoPackageSridAsync(stream, cancellationToken),
                 SupportedFileFormat.FlatGeobuf => await DetectFlatGeobufCrsAsync(stream, cancellationToken),
@@ -104,6 +105,7 @@ internal sealed partial class StreamingFileImportService
             SupportedFileFormat.Kml => 4326,
             SupportedFileFormat.Gpx => 4326,
             SupportedFileFormat.Csv => 4326,
+            SupportedFileFormat.Gml => await GmlFormatReader.TryDetectSridAsync(headerStream, cancellationToken),
             SupportedFileFormat.Wkt => await DetectWktSridAsync(headerStream, cancellationToken),
             // Defensive: currently unreachable — FlatGeobuf non-seekable paths spill to
             // a seekable temp file before reaching here (see the dedicated FlatGeobuf branch above).

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Preview.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Preview.cs
@@ -184,6 +184,7 @@ internal sealed partial class StreamingFileImportService
                 SupportedFileFormat.Wkt => WktFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
                 SupportedFileFormat.Kml => KmlFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
                 SupportedFileFormat.Gpx => GpxFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
+                SupportedFileFormat.Gml => GmlFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
                 SupportedFileFormat.Csv => CsvFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
                 SupportedFileFormat.FlatGeobuf => FlatGeobufFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
                 SupportedFileFormat.Shapefile => ReadShapefileStreamingAsync(shapefileScratch!.ShpPath, cancellationToken),

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Streaming.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Streaming.cs
@@ -104,6 +104,7 @@ internal sealed partial class StreamingFileImportService
             SupportedFileFormat.Wkt => WktFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.Kml => KmlFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.Gpx => GpxFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
+            SupportedFileFormat.Gml => GmlFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.Csv => CsvFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.FlatGeobuf => FlatGeobufFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.Shapefile => ReadShapefileStreamingAsync(shapefileScratch!.ShpPath, cancellationToken),

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/GmlFormatDetectionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/GmlFormatDetectionTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Honua.Core.Features.FileImport.Domain;
+using Honua.Core.Features.FileImport.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Core.Tests.Features.Import;
+
+public sealed class GmlFormatDetectionTests
+{
+    private readonly FileFormatDetectionService _service =
+        new(NullLogger<FileFormatDetectionService>.Instance);
+
+    // -----------------------------------------------------------------------
+    // Extension-based detection
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("rivers.gml")]
+    [InlineData("RIVERS.GML")]
+    [InlineData("parcels.GmL")]
+    public void DetectFormat_GmlExtension_ReturnsGml(string fileName)
+    {
+        _service.DetectFormat(fileName).Should().Be(SupportedFileFormat.Gml);
+    }
+
+    [Fact]
+    public void GetSupportedExtensions_IncludesGml()
+    {
+        _service.GetSupportedExtensions().Should().Contain(".gml");
+    }
+
+    // -----------------------------------------------------------------------
+    // Content-based detection
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void DetectFormatFromContent_GmlFeatureCollection_ReturnsGml()
+    {
+        var content = Encoding.UTF8.GetBytes("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+              xmlns:wfs="http://www.opengis.net/wfs"
+              xmlns:gml="http://www.opengis.net/gml">
+            </wfs:FeatureCollection>
+            """);
+
+        _service.DetectFormatFromContent(content, "unknown.xml").Should().Be(SupportedFileFormat.Gml);
+    }
+
+    [Fact]
+    public void DetectFormatFromContent_Gml32Namespace_ReturnsGml()
+    {
+        var content = Encoding.UTF8.GetBytes("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+              xmlns:wfs="http://www.opengis.net/wfs/2.0"
+              xmlns:gml="http://www.opengis.net/gml/3.2">
+            </wfs:FeatureCollection>
+            """);
+
+        _service.DetectFormatFromContent(content, "unknown.xml").Should().Be(SupportedFileFormat.Gml);
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/GmlFormatReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/GmlFormatReaderTests.cs
@@ -1,0 +1,325 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Honua.Core.Features.FileImport.Services;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Core.Tests.Features.Import;
+
+public sealed class GmlFormatReaderTests
+{
+    // -----------------------------------------------------------------------
+    // ParseSrsNameToSrid
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("EPSG:4326", 4326)]
+    [InlineData("urn:ogc:def:crs:EPSG::4326", 4326)]
+    [InlineData("urn:ogc:def:crs:EPSG::25832", 25832)]
+    [InlineData("http://www.opengis.net/gml/srs/epsg.xml#4326", 4326)]
+    [InlineData("CRS84", null)]
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    public void ParseSrsNameToSrid_ReturnsExpectedSrid(string? srsName, int? expected)
+    {
+        var result = GmlFormatReader.ParseSrsNameToSrid(srsName);
+        result.Should().Be(expected);
+    }
+
+    // -----------------------------------------------------------------------
+    // GML 3 FeatureCollection — basic geometry types
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ReadStreamingAsync_Gml3Point_ReturnsPointFeature()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+              xmlns:wfs="http://www.opengis.net/wfs"
+              xmlns:gml="http://www.opengis.net/gml"
+              xmlns:sf="http://example.com/sf"
+              srsName="EPSG:4326">
+              <gml:featureMember>
+                <sf:Road>
+                  <sf:name>Main St</sf:name>
+                  <sf:geometry>
+                    <gml:Point>
+                      <gml:pos>-122.1 37.5</gml:pos>
+                    </gml:Point>
+                  </sf:geometry>
+                </sf:Road>
+              </gml:featureMember>
+            </wfs:FeatureCollection>
+            """;
+
+        var features = await CollectAsync(gml);
+
+        features.Should().ContainSingle();
+        features[0].Geometry.Should().BeOfType<Point>();
+        var point = (Point)features[0].Geometry!;
+        point.X.Should().BeApproximately(-122.1, 0.0001);
+        point.Y.Should().BeApproximately(37.5, 0.0001);
+        features[0].Attributes["name"].Should().Be("Main St");
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_Gml3LineString_ReturnsLineStringFeature()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+              xmlns:wfs="http://www.opengis.net/wfs"
+              xmlns:gml="http://www.opengis.net/gml"
+              xmlns:sf="http://example.com/sf">
+              <gml:featureMember>
+                <sf:Road>
+                  <sf:name>Highway 1</sf:name>
+                  <sf:geom>
+                    <gml:LineString srsName="EPSG:4326">
+                      <gml:posList>-122.1 37.5 -122.2 37.6 -122.3 37.7</gml:posList>
+                    </gml:LineString>
+                  </sf:geom>
+                </sf:Road>
+              </gml:featureMember>
+            </wfs:FeatureCollection>
+            """;
+
+        var features = await CollectAsync(gml);
+
+        features.Should().ContainSingle();
+        features[0].Geometry.Should().BeOfType<LineString>();
+        var line = (LineString)features[0].Geometry!;
+        line.NumPoints.Should().Be(3);
+        features[0].Attributes["name"].Should().Be("Highway 1");
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_Gml3Polygon_ReturnsPolygonFeature()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+              xmlns:wfs="http://www.opengis.net/wfs"
+              xmlns:gml="http://www.opengis.net/gml"
+              xmlns:sf="http://example.com/sf">
+              <gml:featureMember>
+                <sf:Parcel>
+                  <sf:parcelId>P-001</sf:parcelId>
+                  <sf:shape>
+                    <gml:Polygon srsName="EPSG:4326">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>0 0 0 1 1 1 1 0 0 0</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </sf:shape>
+                </sf:Parcel>
+              </gml:featureMember>
+            </wfs:FeatureCollection>
+            """;
+
+        var features = await CollectAsync(gml);
+
+        features.Should().ContainSingle();
+        features[0].Geometry.Should().BeOfType<Polygon>();
+        features[0].Attributes["parcelId"].Should().Be("P-001");
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_Gml3PolygonWithHole_PreservesInteriorRing()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+              xmlns:wfs="http://www.opengis.net/wfs"
+              xmlns:gml="http://www.opengis.net/gml"
+              xmlns:sf="http://example.com/sf">
+              <gml:featureMember>
+                <sf:Zone>
+                  <sf:geom>
+                    <gml:Polygon>
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>0 0 0 10 10 10 10 0 0 0</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                      <gml:interior>
+                        <gml:LinearRing>
+                          <gml:posList>2 2 2 4 4 4 4 2 2 2</gml:posList>
+                        </gml:LinearRing>
+                      </gml:interior>
+                    </gml:Polygon>
+                  </sf:geom>
+                </sf:Zone>
+              </gml:featureMember>
+            </wfs:FeatureCollection>
+            """;
+
+        var features = await CollectAsync(gml);
+
+        features.Should().ContainSingle();
+        var polygon = features[0].Geometry.Should().BeOfType<Polygon>().Subject;
+        polygon.NumInteriorRings.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_MultipleFeatureMembers_ReturnsAllFeatures()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+              xmlns:wfs="http://www.opengis.net/wfs"
+              xmlns:gml="http://www.opengis.net/gml"
+              xmlns:sf="http://example.com/sf">
+              <gml:featureMember>
+                <sf:City>
+                  <sf:name>Springfield</sf:name>
+                  <sf:location>
+                    <gml:Point><gml:pos>-89.6 39.8</gml:pos></gml:Point>
+                  </sf:location>
+                </sf:City>
+              </gml:featureMember>
+              <gml:featureMember>
+                <sf:City>
+                  <sf:name>Shelbyville</sf:name>
+                  <sf:location>
+                    <gml:Point><gml:pos>-88.5 40.1</gml:pos></gml:Point>
+                  </sf:location>
+                </sf:City>
+              </gml:featureMember>
+            </wfs:FeatureCollection>
+            """;
+
+        var features = await CollectAsync(gml);
+
+        features.Should().HaveCount(2);
+        features[0].Attributes["name"].Should().Be("Springfield");
+        features[1].Attributes["name"].Should().Be("Shelbyville");
+    }
+
+    // -----------------------------------------------------------------------
+    // GML 2 coordinates element
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ReadStreamingAsync_Gml2Coordinates_ParsesTupleList()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+              xmlns:wfs="http://www.opengis.net/wfs/1.1"
+              xmlns:gml="http://www.opengis.net/gml"
+              xmlns:sf="http://example.com">
+              <gml:featureMember>
+                <sf:Road>
+                  <sf:name>Old Road</sf:name>
+                  <sf:geom>
+                    <gml:LineString srsName="EPSG:4326">
+                      <gml:coordinates>-122.1,37.5 -122.2,37.6 -122.3,37.7</gml:coordinates>
+                    </gml:LineString>
+                  </sf:geom>
+                </sf:Road>
+              </gml:featureMember>
+            </wfs:FeatureCollection>
+            """;
+
+        var features = await CollectAsync(gml);
+
+        features.Should().ContainSingle();
+        var line = features[0].Geometry.Should().BeOfType<LineString>().Subject;
+        line.NumPoints.Should().Be(3);
+        line.Coordinates[0].X.Should().BeApproximately(-122.1, 0.0001);
+        line.Coordinates[0].Y.Should().BeApproximately(37.5, 0.0001);
+    }
+
+    // -----------------------------------------------------------------------
+    // SRS detection
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task TryDetectSridAsync_SrsNameOnCollection_ReturnsEpsgCode()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+              xmlns:wfs="http://www.opengis.net/wfs"
+              xmlns:gml="http://www.opengis.net/gml"
+              srsName="urn:ogc:def:crs:EPSG::25832">
+            </wfs:FeatureCollection>
+            """;
+
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(gml));
+        var srid = await GmlFormatReader.TryDetectSridAsync(stream, CancellationToken.None);
+
+        srid.Should().Be(25832);
+    }
+
+    [Fact]
+    public async Task TryDetectSridAsync_NoSrsName_ReturnsNull()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+              xmlns:wfs="http://www.opengis.net/wfs"
+              xmlns:gml="http://www.opengis.net/gml">
+            </wfs:FeatureCollection>
+            """;
+
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(gml));
+        var srid = await GmlFormatReader.TryDetectSridAsync(stream, CancellationToken.None);
+
+        srid.Should().BeNull();
+    }
+
+    // -----------------------------------------------------------------------
+    // Multi-geometry types
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ReadStreamingAsync_MultiPoint_ReturnsMultiPoint()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+              xmlns:wfs="http://www.opengis.net/wfs"
+              xmlns:gml="http://www.opengis.net/gml"
+              xmlns:sf="http://example.com">
+              <gml:featureMember>
+                <sf:Cluster>
+                  <sf:geom>
+                    <gml:MultiPoint>
+                      <gml:Point><gml:pos>1 2</gml:pos></gml:Point>
+                      <gml:Point><gml:pos>3 4</gml:pos></gml:Point>
+                    </gml:MultiPoint>
+                  </sf:geom>
+                </sf:Cluster>
+              </gml:featureMember>
+            </wfs:FeatureCollection>
+            """;
+
+        var features = await CollectAsync(gml);
+
+        features.Should().ContainSingle();
+        var mp = features[0].Geometry.Should().BeOfType<MultiPoint>().Subject;
+        mp.NumGeometries.Should().Be(2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static async Task<List<NetTopologySuite.Features.IFeature>> CollectAsync(string gml)
+    {
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(gml));
+        var results = new List<NetTopologySuite.Features.IFeature>();
+        await foreach (var feature in GmlFormatReader.ReadStreamingAsync(stream, CancellationToken.None))
+        {
+            results.Add(feature);
+        }
+
+        return results;
+    }
+}


### PR DESCRIPTION
## Issue Link
Closes #2229

## Summary
Implements real GML file import. The earlier #1595 was resolved by removing the GML advertisement (#1605) rather than implementing it, so GML import has been absent. This adds GML detection and a streaming reader so advertised GML support is actually functional. Rebased cleanly onto current trunk.

## Changes Made
- Add `GmlFormatReader` under `Honua.Geometry/Features/FileImport/Services`
- Extend `FileFormatDetectionService` to detect GML
- Hook GML through `StreamingFileImportService` (CRS detection, preview, streaming paths)
- Add `GmlFormatDetectionTests` and `GmlFormatReaderTests`

## Testing
- [x] Unit tests added/updated

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None
