### PR TITLE
Add server-side Workflows companion for Collect automations (#2121)

### DIFF
--- a/src/Honua.Core/Features/Mobile/FieldCollection/Abstractions/IFieldCollectionActionDispatcher.cs
+++ b/src/Honua.Core/Features/Mobile/FieldCollection/Abstractions/IFieldCollectionActionDispatcher.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Mobile.FieldCollection.Domain;
+
+namespace Honua.Core.Features.Mobile.FieldCollection.Abstractions;
+
+/// <summary>
+/// Hand-off boundary that enqueues a matched action invocation for asynchronous
+/// delivery (#2121). Enqueue must be fast and non-blocking so the mobile push
+/// response is never delayed by online action delivery.
+/// </summary>
+public interface IFieldCollectionActionDispatcher
+{
+    /// <summary>
+    /// Enqueues <paramref name="invocation"/> for background delivery. Returns once
+    /// the invocation is accepted; the actual handler runs out of band.
+    /// </summary>
+    ValueTask EnqueueAsync(
+        FieldCollectionActionInvocation invocation,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Mobile/FieldCollection/Abstractions/IFieldCollectionActionHandler.cs
+++ b/src/Honua.Core/Features/Mobile/FieldCollection/Abstractions/IFieldCollectionActionHandler.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Mobile.FieldCollection.Domain;
+
+namespace Honua.Core.Features.Mobile.FieldCollection.Abstractions;
+
+/// <summary>
+/// Delivers a single online action for one automation kind (#2121). One handler
+/// is registered per <see cref="FieldCollectionAutomationActionType"/>; the
+/// background dispatcher routes invocations to the handler matching the action's
+/// type.
+/// </summary>
+public interface IFieldCollectionActionHandler
+{
+    /// <summary>Gets the action kind this handler delivers.</summary>
+    FieldCollectionAutomationActionType ActionType { get; }
+
+    /// <summary>
+    /// Delivers <paramref name="invocation"/>. Implementations must not throw for
+    /// expected delivery failures; they should return a non-successful
+    /// <see cref="FieldCollectionActionResult"/> instead so the dispatcher can apply
+    /// retry policy.
+    /// </summary>
+    Task<FieldCollectionActionResult> ExecuteAsync(
+        FieldCollectionActionInvocation invocation,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Mobile/FieldCollection/Abstractions/IFieldCollectionAutomationStore.cs
+++ b/src/Honua.Core/Features/Mobile/FieldCollection/Abstractions/IFieldCollectionAutomationStore.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Mobile.FieldCollection.Domain;
+
+namespace Honua.Core.Features.Mobile.FieldCollection.Abstractions;
+
+/// <summary>
+/// Read boundary for server-side FieldCollection automation action definitions
+/// (#2121). Implementations return the enabled actions relevant to a layer so the
+/// trigger can match them against an applied change.
+/// </summary>
+public interface IFieldCollectionAutomationStore
+{
+    /// <summary>
+    /// Returns the enabled actions that may apply to changes on
+    /// <paramref name="layerId"/>. Layer-agnostic actions (those with no layer
+    /// scope) must be included alongside actions scoped to the layer. Operation
+    /// filtering is left to <see cref="FieldCollectionAutomationMatcher"/> so the
+    /// store contract stays a coarse, index-friendly query.
+    /// </summary>
+    Task<IReadOnlyList<FieldCollectionAutomationAction>> GetEnabledActionsAsync(
+        int layerId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Mobile/FieldCollection/Abstractions/IFieldCollectionAutomationTrigger.cs
+++ b/src/Honua.Core/Features/Mobile/FieldCollection/Abstractions/IFieldCollectionAutomationTrigger.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Mobile.FieldCollection.Domain;
+
+namespace Honua.Core.Features.Mobile.FieldCollection.Abstractions;
+
+/// <summary>
+/// Post-push hook that evaluates and enqueues server-side automation actions for
+/// an applied FieldCollection change (#2121). Invoked from the sync push endpoint
+/// only after a change is durably applied. Implementations are best-effort: a
+/// failure to evaluate or enqueue actions must never fail the push itself.
+/// </summary>
+public interface IFieldCollectionAutomationTrigger
+{
+    /// <summary>
+    /// Evaluates configured actions against <paramref name="automationEvent"/> and
+    /// enqueues every match for background delivery.
+    /// </summary>
+    ValueTask OnChangeAppliedAsync(
+        FieldCollectionAutomationEvent automationEvent,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Mobile/FieldCollection/Domain/FieldCollectionAutomationMatcher.cs
+++ b/src/Honua.Core/Features/Mobile/FieldCollection/Domain/FieldCollectionAutomationMatcher.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Mobile.FieldCollection.Domain;
+
+/// <summary>
+/// Pure matching logic that decides which configured automation actions fire for
+/// an applied FieldCollection change. Kept free of I/O so the trigger decision is
+/// deterministic and exhaustively unit-testable.
+/// </summary>
+public static class FieldCollectionAutomationMatcher
+{
+    /// <summary>
+    /// Returns whether <paramref name="action"/> should run for
+    /// <paramref name="automationEvent"/>. An action matches when it is enabled,
+    /// its layer scope is unset or equal to the event's layer, and its operation
+    /// filter is empty or contains the event's operation.
+    /// </summary>
+    public static bool Matches(
+        FieldCollectionAutomationAction action,
+        FieldCollectionAutomationEvent automationEvent)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        ArgumentNullException.ThrowIfNull(automationEvent);
+
+        if (!action.Enabled)
+        {
+            return false;
+        }
+
+        if (action.LayerId is int layerId && layerId != automationEvent.LayerId)
+        {
+            return false;
+        }
+
+        if (!action.Operations.IsDefaultOrEmpty
+            && !action.Operations.Contains(automationEvent.Operation))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Materializes the invocations that should be dispatched for
+    /// <paramref name="automationEvent"/> from the supplied action definitions,
+    /// preserving the order the actions were provided in.
+    /// </summary>
+    public static IReadOnlyList<FieldCollectionActionInvocation> Match(
+        IEnumerable<FieldCollectionAutomationAction> actions,
+        FieldCollectionAutomationEvent automationEvent)
+    {
+        ArgumentNullException.ThrowIfNull(actions);
+        ArgumentNullException.ThrowIfNull(automationEvent);
+
+        var matched = new List<FieldCollectionActionInvocation>();
+        foreach (var action in actions)
+        {
+            if (Matches(action, automationEvent))
+            {
+                matched.Add(FieldCollectionActionInvocation.Create(action, automationEvent));
+            }
+        }
+
+        return matched;
+    }
+}

--- a/src/Honua.Core/Features/Mobile/FieldCollection/Domain/FieldCollectionAutomationTypes.cs
+++ b/src/Honua.Core/Features/Mobile/FieldCollection/Domain/FieldCollectionAutomationTypes.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+
+namespace Honua.Core.Features.Mobile.FieldCollection.Domain;
+
+/// <summary>
+/// Online action kinds the server-side Workflows companion can run when a
+/// FieldCollection record syncs up from a device (#2121). Pairs with the
+/// device-side offline automation runtime shipped in <c>Honua.Collect.Core</c>:
+/// offline-queued HTTP replays run on the device, while these online actions run
+/// server-side once the change is durably applied.
+/// </summary>
+public enum FieldCollectionAutomationActionType
+{
+    /// <summary>Send an email notification.</summary>
+    Email = 1,
+
+    /// <summary>POST a signed JSON payload to an HTTPS webhook endpoint.</summary>
+    Webhook = 2,
+
+    /// <summary>Send an SMS notification.</summary>
+    Sms = 3,
+
+    /// <summary>Assign the synced record to a user or queue.</summary>
+    AssignRecord = 4,
+}
+
+/// <summary>
+/// A configured server-side automation action. Definitions are persisted by an
+/// <see cref="Abstractions.IFieldCollectionAutomationStore"/> and matched against
+/// applied changes by <see cref="FieldCollectionAutomationMatcher"/>.
+/// </summary>
+public sealed record FieldCollectionAutomationAction
+{
+    /// <summary>Gets the stable identifier of this action definition.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Gets the human-readable name shown in admin tooling.</summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>Gets the kind of online action to perform.</summary>
+    public required FieldCollectionAutomationActionType ActionType { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the action is active. Disabled actions are
+    /// never matched and never dispatched.
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>
+    /// Gets the layer the action is scoped to. <see langword="null"/> matches
+    /// changes on any layer.
+    /// </summary>
+    public int? LayerId { get; init; }
+
+    /// <summary>
+    /// Gets the change operations that trigger the action. An empty set matches
+    /// every operation (insert, update, delete).
+    /// </summary>
+    public ImmutableArray<FieldCollectionChangeOperation> Operations { get; init; }
+        = ImmutableArray<FieldCollectionChangeOperation>.Empty;
+
+    /// <summary>
+    /// Gets handler-specific configuration (for example <c>url</c> and <c>secret</c>
+    /// for a webhook, <c>recipients</c> for email/SMS, or <c>field</c> and
+    /// <c>value</c> for record assignment). Kept as a string map so definitions
+    /// round-trip through configuration and persistence without bespoke schemas
+    /// per action type.
+    /// </summary>
+    public ImmutableDictionary<string, string> Configuration { get; init; }
+        = ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// The applied-change signal that drives server-side automation. Produced after a
+/// FieldCollection push is durably applied so that actions never fire for
+/// conflicts or rejected writes.
+/// </summary>
+public sealed record FieldCollectionAutomationEvent
+{
+    /// <summary>Gets the identifier of the client (device) that pushed the change.</summary>
+    public required string ClientId { get; init; }
+
+    /// <summary>Gets the identifier of the change the client assigned.</summary>
+    public required string ChangeId { get; init; }
+
+    /// <summary>Gets the identifier of the feature affected by the change.</summary>
+    public required string FeatureId { get; init; }
+
+    /// <summary>Gets the identifier of the layer that contains the feature.</summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>Gets the operation that was applied.</summary>
+    public required FieldCollectionChangeOperation Operation { get; init; }
+
+    /// <summary>Gets the server-assigned version after the change was applied.</summary>
+    public required long Version { get; init; }
+
+    /// <summary>Gets the server generation the applied change belongs to.</summary>
+    public required long Generation { get; init; }
+
+    /// <summary>Gets the timestamp at which the change was recorded.</summary>
+    public required DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>
+    /// Pre-serialized JSON payload of the applied feature. Null for delete
+    /// operations, mirroring the push contract.
+    /// </summary>
+    public string? FeaturePayloadJson { get; init; }
+}
+
+/// <summary>
+/// A single matched (action, event) pair queued for delivery. The invocation id
+/// is a stable idempotency key derived from the change and action so a handler
+/// can dedupe retried deliveries.
+/// </summary>
+public sealed record FieldCollectionActionInvocation
+{
+    /// <summary>Gets the stable idempotency key for this invocation.</summary>
+    public required string InvocationId { get; init; }
+
+    /// <summary>Gets the action definition to run.</summary>
+    public required FieldCollectionAutomationAction Action { get; init; }
+
+    /// <summary>Gets the applied-change event that triggered the action.</summary>
+    public required FieldCollectionAutomationEvent Event { get; init; }
+
+    /// <summary>
+    /// Builds an invocation with a deterministic idempotency key derived from the
+    /// triggering change and the action. Replaying the same applied change for the
+    /// same action yields the same key.
+    /// </summary>
+    public static FieldCollectionActionInvocation Create(
+        FieldCollectionAutomationAction action,
+        FieldCollectionAutomationEvent automationEvent)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        ArgumentNullException.ThrowIfNull(automationEvent);
+
+        return new FieldCollectionActionInvocation
+        {
+            InvocationId = $"{automationEvent.ClientId}:{automationEvent.ChangeId}:{action.Id}",
+            Action = action,
+            Event = automationEvent,
+        };
+    }
+}
+
+/// <summary>
+/// Outcome returned by a <see cref="Abstractions.IFieldCollectionActionHandler"/>.
+/// </summary>
+public sealed record FieldCollectionActionResult
+{
+    /// <summary>Gets a value indicating whether the action delivered successfully.</summary>
+    public required bool Succeeded { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether a failed delivery is worth retrying.
+    /// Ignored when <see cref="Succeeded"/> is <see langword="true"/>.
+    /// </summary>
+    public bool Retryable { get; init; }
+
+    /// <summary>
+    /// Gets an optional, redacted error summary. Never contains stack traces,
+    /// connection strings, or destination secrets.
+    /// </summary>
+    public string? Error { get; init; }
+
+    /// <summary>Creates a successful result.</summary>
+    public static FieldCollectionActionResult Success()
+        => new() { Succeeded = true };
+
+    /// <summary>Creates a failed result.</summary>
+    public static FieldCollectionActionResult Failure(string error, bool retryable)
+        => new() { Succeeded = false, Retryable = retryable, Error = error };
+}

--- a/src/Honua.Core/Features/Mobile/FieldCollection/FieldCollectionAutomationTrigger.cs
+++ b/src/Honua.Core/Features/Mobile/FieldCollection/FieldCollectionAutomationTrigger.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Mobile.FieldCollection.Abstractions;
+using Honua.Core.Features.Mobile.FieldCollection.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.Mobile.FieldCollection;
+
+/// <summary>
+/// Default <see cref="IFieldCollectionAutomationTrigger"/>: loads enabled actions
+/// for the applied change's layer, matches them, and enqueues each match onto the
+/// dispatcher (#2121). Best-effort by design — store or dispatch failures are
+/// logged and swallowed so the originating mobile push always succeeds.
+/// </summary>
+public sealed partial class FieldCollectionAutomationTrigger : IFieldCollectionAutomationTrigger
+{
+    private readonly IFieldCollectionAutomationStore _store;
+    private readonly IFieldCollectionActionDispatcher _dispatcher;
+    private readonly ILogger<FieldCollectionAutomationTrigger> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FieldCollectionAutomationTrigger"/> class.
+    /// </summary>
+    public FieldCollectionAutomationTrigger(
+        IFieldCollectionAutomationStore store,
+        IFieldCollectionActionDispatcher dispatcher,
+        ILogger<FieldCollectionAutomationTrigger> logger)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async ValueTask OnChangeAppliedAsync(
+        FieldCollectionAutomationEvent automationEvent,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(automationEvent);
+
+        IReadOnlyList<FieldCollectionAutomationAction> actions;
+        try
+        {
+            actions = await _store
+                .GetEnabledActionsAsync(automationEvent.LayerId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Never let automation evaluation fail an already-applied push.
+            LogEvaluationFailed(_logger, automationEvent.LayerId, automationEvent.ChangeId, ex);
+            return;
+        }
+
+        if (actions.Count == 0)
+        {
+            return;
+        }
+
+        var invocations = FieldCollectionAutomationMatcher.Match(actions, automationEvent);
+        if (invocations.Count == 0)
+        {
+            return;
+        }
+
+        var enqueued = 0;
+        foreach (var invocation in invocations)
+        {
+            try
+            {
+                await _dispatcher.EnqueueAsync(invocation, cancellationToken).ConfigureAwait(false);
+                enqueued++;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                LogEnqueueFailed(_logger, invocation.Action.Id, invocation.InvocationId, ex);
+            }
+        }
+
+        LogActionsTriggered(_logger, automationEvent.LayerId, automationEvent.ChangeId, enqueued);
+    }
+
+    [LoggerMessage(
+        EventId = 21210,
+        Level = LogLevel.Information,
+        Message = "FieldCollection automation triggered. LayerId={LayerId} ChangeId={ChangeId} Enqueued={Enqueued}")]
+    private static partial void LogActionsTriggered(ILogger logger, int layerId, string changeId, int enqueued);
+
+    [LoggerMessage(
+        EventId = 21211,
+        Level = LogLevel.Warning,
+        Message = "FieldCollection automation evaluation failed. LayerId={LayerId} ChangeId={ChangeId}")]
+    private static partial void LogEvaluationFailed(ILogger logger, int layerId, string changeId, Exception exception);
+
+    [LoggerMessage(
+        EventId = 21212,
+        Level = LogLevel.Warning,
+        Message = "FieldCollection automation enqueue failed. ActionId={ActionId} InvocationId={InvocationId}")]
+    private static partial void LogEnqueueFailed(ILogger logger, string actionId, string invocationId, Exception exception);
+}

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -21,6 +21,7 @@ using Honua.Server.Features.Protocols.Zarr;
 using Honua.Protocols.GeoServices.FeatureServer;
 using Honua.Server.Features.Geocoding;
 using Honua.Server.Features.Forms;
+using Honua.Server.Features.Mobile.FieldCollection.Automations;
 using Honua.Server.Features.FieldWorkflows;
 using Honua.Server.Features.FieldWorkflows.Export;
 using Honua.Server.Features.FieldWorkflows.Review;
@@ -116,6 +117,7 @@ internal static class FeatureRegistrationExtensions
         services.AddHonuaGrpc(configuration);
         services.AddObservability(configuration);
         services.AddAlerts(configuration);
+        services.AddFieldCollectionAutomations(configuration);
         services.AddNlQuery(configuration);
         services.AddWorkflowGeneration(configuration);
         services.AddStac();

--- a/src/Honua.Server/Features/Mobile/FieldCollection/Automations/ChannelFieldCollectionActionDispatcher.cs
+++ b/src/Honua.Server/Features/Mobile/FieldCollection/Automations/ChannelFieldCollectionActionDispatcher.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Threading.Channels;
+using Honua.Core.Features.Mobile.FieldCollection.Abstractions;
+using Honua.Core.Features.Mobile.FieldCollection.Domain;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Mobile.FieldCollection.Automations;
+
+/// <summary>
+/// In-process, bounded-channel <see cref="IFieldCollectionActionDispatcher"/>
+/// (#2121). Enqueue hands the invocation to a background reader so the mobile push
+/// response is never blocked on online action delivery. The channel is bounded and
+/// uses wait back-pressure rather than dropping invocations.
+/// </summary>
+internal sealed class ChannelFieldCollectionActionDispatcher : IFieldCollectionActionDispatcher
+{
+    private readonly Channel<FieldCollectionActionInvocation> _channel;
+
+    public ChannelFieldCollectionActionDispatcher(IOptions<FieldCollectionAutomationOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var capacity = Math.Max(1, options.Value.QueueCapacity);
+        _channel = Channel.CreateBounded<FieldCollectionActionInvocation>(new BoundedChannelOptions(capacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+    }
+
+    /// <summary>Gets the reader drained by the background dispatch service.</summary>
+    public ChannelReader<FieldCollectionActionInvocation> Reader => _channel.Reader;
+
+    public ValueTask EnqueueAsync(
+        FieldCollectionActionInvocation invocation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(invocation);
+        return _channel.Writer.WriteAsync(invocation, cancellationToken);
+    }
+}

--- a/src/Honua.Server/Features/Mobile/FieldCollection/Automations/FieldCollectionAutomationDispatchBackgroundService.cs
+++ b/src/Honua.Server/Features/Mobile/FieldCollection/Automations/FieldCollectionAutomationDispatchBackgroundService.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Mobile.FieldCollection.Abstractions;
+using Honua.Core.Features.Mobile.FieldCollection.Domain;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Mobile.FieldCollection.Automations;
+
+/// <summary>
+/// Drains the in-process action queue and routes each invocation to the handler
+/// registered for its action type, applying bounded retry for retryable failures
+/// (#2121). Runs as a single-reader hosted service alongside the channel
+/// dispatcher.
+/// </summary>
+internal sealed partial class FieldCollectionAutomationDispatchBackgroundService : BackgroundService
+{
+    private readonly ChannelFieldCollectionActionDispatcher _dispatcher;
+    private readonly Dictionary<FieldCollectionAutomationActionType, IFieldCollectionActionHandler> _handlers;
+    private readonly FieldCollectionAutomationOptions _options;
+    private readonly ILogger<FieldCollectionAutomationDispatchBackgroundService> _logger;
+
+    public FieldCollectionAutomationDispatchBackgroundService(
+        ChannelFieldCollectionActionDispatcher dispatcher,
+        IEnumerable<IFieldCollectionActionHandler> handlers,
+        IOptions<FieldCollectionAutomationOptions> options,
+        ILogger<FieldCollectionAutomationDispatchBackgroundService> logger)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        ArgumentNullException.ThrowIfNull(handlers);
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var map = new Dictionary<FieldCollectionAutomationActionType, IFieldCollectionActionHandler>();
+        foreach (var handler in handlers)
+        {
+            // Last registration wins so a deployment can override a default handler.
+            map[handler.ActionType] = handler;
+        }
+
+        _handlers = map;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.Enabled)
+        {
+            LogDisabled(_logger);
+            return;
+        }
+
+        try
+        {
+            await foreach (var invocation in _dispatcher.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+            {
+                await ProcessAsync(invocation, stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Graceful shutdown.
+        }
+    }
+
+    private async Task ProcessAsync(FieldCollectionActionInvocation invocation, CancellationToken cancellationToken)
+    {
+        var actionType = invocation.Action.ActionType;
+        if (!_handlers.TryGetValue(actionType, out var handler))
+        {
+            LogNoHandler(_logger, actionType, invocation.Action.Id);
+            return;
+        }
+
+        var maxAttempts = Math.Max(1, _options.MaxAttempts);
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            FieldCollectionActionResult result;
+            try
+            {
+                result = await handler.ExecuteAsync(invocation, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                LogHandlerThrew(_logger, actionType, invocation.InvocationId, attempt, ex);
+                result = FieldCollectionActionResult.Failure("Action handler threw.", retryable: true);
+            }
+
+            if (result.Succeeded)
+            {
+                LogDelivered(_logger, actionType, invocation.InvocationId, attempt);
+                return;
+            }
+
+            if (!result.Retryable || attempt == maxAttempts)
+            {
+                LogFailed(_logger, actionType, invocation.InvocationId, attempt, result.Error ?? "delivery failed");
+                return;
+            }
+
+            try
+            {
+                await Task.Delay(ComputeBackoff(attempt), cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+        }
+    }
+
+    private static TimeSpan ComputeBackoff(int attempt)
+    {
+        // Exponential backoff capped at 30s: 1s, 2s, 4s, ...
+        var seconds = Math.Min(30d, Math.Pow(2, attempt - 1));
+        return TimeSpan.FromSeconds(seconds);
+    }
+
+    [LoggerMessage(EventId = 21220, Level = LogLevel.Information, Message = "FieldCollection automation dispatcher is disabled.")]
+    private static partial void LogDisabled(ILogger logger);
+
+    [LoggerMessage(EventId = 21221, Level = LogLevel.Debug, Message = "FieldCollection automation delivered. ActionType={ActionType} InvocationId={InvocationId} Attempt={Attempt}")]
+    private static partial void LogDelivered(ILogger logger, FieldCollectionAutomationActionType actionType, string invocationId, int attempt);
+
+    [LoggerMessage(EventId = 21222, Level = LogLevel.Warning, Message = "FieldCollection automation failed. ActionType={ActionType} InvocationId={InvocationId} Attempt={Attempt} Error={Error}")]
+    private static partial void LogFailed(ILogger logger, FieldCollectionAutomationActionType actionType, string invocationId, int attempt, string error);
+
+    [LoggerMessage(EventId = 21223, Level = LogLevel.Warning, Message = "FieldCollection automation handler threw. ActionType={ActionType} InvocationId={InvocationId} Attempt={Attempt}")]
+    private static partial void LogHandlerThrew(ILogger logger, FieldCollectionAutomationActionType actionType, string invocationId, int attempt, Exception exception);
+
+    [LoggerMessage(EventId = 21224, Level = LogLevel.Warning, Message = "No FieldCollection automation handler registered. ActionType={ActionType} ActionId={ActionId}")]
+    private static partial void LogNoHandler(ILogger logger, FieldCollectionAutomationActionType actionType, string actionId);
+}

--- a/src/Honua.Server/Features/Mobile/FieldCollection/Automations/FieldCollectionAutomationOptions.cs
+++ b/src/Honua.Server/Features/Mobile/FieldCollection/Automations/FieldCollectionAutomationOptions.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Mobile.FieldCollection.Domain;
+
+namespace Honua.Server.Features.Mobile.FieldCollection.Automations;
+
+/// <summary>
+/// Configuration for the server-side FieldCollection Workflows companion (#2121).
+/// Action definitions are bound from configuration so operators can declare
+/// online actions (email/webhook/SMS/assign) without a database migration while
+/// the persisted admin CRUD store is built out.
+/// </summary>
+public sealed class FieldCollectionAutomationOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "FieldCollectionAutomation";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether automation dispatch is active. When
+    /// false the background dispatcher idles and the trigger remains a no-op even
+    /// if actions are configured.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the bounded in-process delivery queue capacity. Enqueue waits
+    /// for room rather than dropping invocations when the queue is full.
+    /// </summary>
+    public int QueueCapacity { get; set; } = 1024;
+
+    /// <summary>
+    /// Gets or sets the maximum delivery attempts per invocation before it is
+    /// abandoned. Retries apply only to retryable handler failures.
+    /// </summary>
+    public int MaxAttempts { get; set; } = 4;
+
+    /// <summary>Gets the configured action definitions.</summary>
+    public IList<FieldCollectionAutomationActionDefinition> Actions { get; init; }
+        = new List<FieldCollectionAutomationActionDefinition>();
+}
+
+/// <summary>
+/// Configuration-bindable form of a
+/// <see cref="FieldCollectionAutomationAction"/>. Uses mutable collection types so
+/// the options binder can populate it; the store projects it to the immutable
+/// domain record.
+/// </summary>
+public sealed class FieldCollectionAutomationActionDefinition
+{
+    /// <summary>Gets or sets the stable action identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the human-readable name.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the action kind.</summary>
+    public FieldCollectionAutomationActionType ActionType { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the action is active.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Gets or sets the layer scope, or null for any layer.</summary>
+    public int? LayerId { get; set; }
+
+    /// <summary>Gets the operations that trigger the action; empty matches all.</summary>
+    public IList<FieldCollectionChangeOperation> Operations { get; init; }
+        = new List<FieldCollectionChangeOperation>();
+
+    /// <summary>Gets the handler-specific configuration values.</summary>
+    public IDictionary<string, string> Configuration { get; init; }
+        = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Honua.Server/Features/Mobile/FieldCollection/Automations/FieldCollectionAutomationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Mobile/FieldCollection/Automations/FieldCollectionAutomationServiceCollectionExtensions.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Mobile.FieldCollection;
+using Honua.Core.Features.Mobile.FieldCollection.Abstractions;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Features.Mobile.FieldCollection.Automations;
+
+/// <summary>
+/// Wires the server-side FieldCollection Workflows companion (#2121): the
+/// post-push trigger, configuration-backed action store, in-process dispatch
+/// queue, background delivery service, and online action handlers.
+/// </summary>
+internal static class FieldCollectionAutomationServiceCollectionExtensions
+{
+    public static IServiceCollection AddFieldCollectionAutomations(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services
+            .AddOptions<FieldCollectionAutomationOptions>()
+            .Bind(configuration.GetSection(FieldCollectionAutomationOptions.SectionName));
+
+        services.TryAddSingleton<IFieldCollectionAutomationStore, OptionsFieldCollectionAutomationStore>();
+
+        // The channel dispatcher is a singleton shared by the trigger (writer) and
+        // the background service (reader); register the concrete type once and
+        // expose it through the abstraction.
+        services.TryAddSingleton<ChannelFieldCollectionActionDispatcher>();
+        services.TryAddSingleton<IFieldCollectionActionDispatcher>(
+            sp => sp.GetRequiredService<ChannelFieldCollectionActionDispatcher>());
+
+        services.TryAddScoped<IFieldCollectionAutomationTrigger, FieldCollectionAutomationTrigger>();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IFieldCollectionActionHandler, WebhookFieldCollectionActionHandler>());
+
+        services.AddHostedService<FieldCollectionAutomationDispatchBackgroundService>();
+
+        return services;
+    }
+}

--- a/src/Honua.Server/Features/Mobile/FieldCollection/Automations/OptionsFieldCollectionAutomationStore.cs
+++ b/src/Honua.Server/Features/Mobile/FieldCollection/Automations/OptionsFieldCollectionAutomationStore.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.Mobile.FieldCollection.Abstractions;
+using Honua.Core.Features.Mobile.FieldCollection.Domain;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Mobile.FieldCollection.Automations;
+
+/// <summary>
+/// Configuration-backed <see cref="IFieldCollectionAutomationStore"/> (#2121).
+/// Projects <see cref="FieldCollectionAutomationOptions"/> definitions to immutable
+/// domain actions and returns the enabled ones relevant to a layer. A persisted,
+/// admin-managed store is a follow-up; this keeps the companion functional from
+/// configuration today.
+/// </summary>
+internal sealed class OptionsFieldCollectionAutomationStore : IFieldCollectionAutomationStore
+{
+    private readonly IOptionsMonitor<FieldCollectionAutomationOptions> _options;
+
+    public OptionsFieldCollectionAutomationStore(IOptionsMonitor<FieldCollectionAutomationOptions> options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public Task<IReadOnlyList<FieldCollectionAutomationAction>> GetEnabledActionsAsync(
+        int layerId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var definitions = _options.CurrentValue.Actions;
+        if (definitions is null || definitions.Count == 0)
+        {
+            return Task.FromResult<IReadOnlyList<FieldCollectionAutomationAction>>(Array.Empty<FieldCollectionAutomationAction>());
+        }
+
+        var matched = new List<FieldCollectionAutomationAction>();
+        foreach (var definition in definitions)
+        {
+            if (definition is null || !definition.Enabled)
+            {
+                continue;
+            }
+
+            // Layer-agnostic actions plus actions scoped to this layer. Operation
+            // filtering is applied later by the matcher.
+            if (definition.LayerId is int scoped && scoped != layerId)
+            {
+                continue;
+            }
+
+            matched.Add(Project(definition));
+        }
+
+        return Task.FromResult<IReadOnlyList<FieldCollectionAutomationAction>>(matched);
+    }
+
+    private static FieldCollectionAutomationAction Project(FieldCollectionAutomationActionDefinition definition)
+        => new()
+        {
+            Id = definition.Id,
+            DisplayName = string.IsNullOrWhiteSpace(definition.DisplayName) ? definition.Id : definition.DisplayName,
+            ActionType = definition.ActionType,
+            Enabled = definition.Enabled,
+            LayerId = definition.LayerId,
+            Operations = definition.Operations is { Count: > 0 }
+                ? definition.Operations.ToImmutableArray()
+                : ImmutableArray<FieldCollectionChangeOperation>.Empty,
+            Configuration = definition.Configuration is { Count: > 0 }
+                ? definition.Configuration.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase)
+                : ImmutableDictionary<string, string>.Empty,
+        };
+}

--- a/src/Honua.Server/Features/Mobile/FieldCollection/Automations/WebhookFieldCollectionActionHandler.cs
+++ b/src/Honua.Server/Features/Mobile/FieldCollection/Automations/WebhookFieldCollectionActionHandler.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers;
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.Infrastructure.Validation;
+using Honua.Core.Features.Mobile.FieldCollection.Abstractions;
+using Honua.Core.Features.Mobile.FieldCollection.Domain;
+using Honua.Infrastructure.Events;
+
+namespace Honua.Server.Features.Mobile.FieldCollection.Automations;
+
+/// <summary>
+/// Delivers FieldCollection automation webhooks (#2121). Builds a signed JSON
+/// envelope describing the applied change and POSTs it to the action's configured
+/// HTTPS endpoint, reusing the shared outbound-URL validation, HMAC signing, and
+/// header sanitization used by the alert and feature-change webhook paths.
+/// </summary>
+internal sealed class WebhookFieldCollectionActionHandler : IFieldCollectionActionHandler
+{
+    internal const string HttpClientName = "fieldcollection-automation-webhook";
+    internal const string UrlKey = "url";
+    internal const string SecretKey = "secret";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public WebhookFieldCollectionActionHandler(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+    }
+
+    public FieldCollectionAutomationActionType ActionType => FieldCollectionAutomationActionType.Webhook;
+
+    public async Task<FieldCollectionActionResult> ExecuteAsync(
+        FieldCollectionActionInvocation invocation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(invocation);
+
+        var configuration = invocation.Action.Configuration;
+        if (!configuration.TryGetValue(UrlKey, out var url) || string.IsNullOrWhiteSpace(url))
+        {
+            return FieldCollectionActionResult.Failure("Webhook 'url' is not configured.", retryable: false);
+        }
+
+        if (!configuration.TryGetValue(SecretKey, out var secret) || string.IsNullOrWhiteSpace(secret))
+        {
+            return FieldCollectionActionResult.Failure("Webhook signing 'secret' is not configured.", retryable: false);
+        }
+
+        var validation = await OutboundHttpUrlValidator
+            .ValidateAsync(url, cancellationToken)
+            .ConfigureAwait(false);
+        if (!validation.IsValid || validation.Uri is null)
+        {
+            return FieldCollectionActionResult.Failure(
+                $"Webhook destination {validation.ErrorMessage ?? "must be a valid HTTPS URL."}",
+                retryable: false);
+        }
+
+        var payload = BuildPayload(invocation.Event);
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, validation.Uri)
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+            };
+
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+            var signature = WebhookDeliveryHelper.ComputeSignature(secret, timestamp, payload);
+            WebhookDeliveryHelper.AddValidatedHeader(request.Headers, "X-Honua-FieldCollection-Action", invocation.Action.Id);
+            WebhookDeliveryHelper.AddValidatedHeader(request.Headers, "X-Honua-Event-Timestamp", timestamp);
+            WebhookDeliveryHelper.AddValidatedHeader(request.Headers, "X-Honua-Signature", $"sha256={signature}");
+            WebhookDeliveryHelper.AddValidatedHeader(request.Headers, "Idempotency-Key", invocation.InvocationId);
+
+            var client = _httpClientFactory.CreateClient(HttpClientName);
+            using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return FieldCollectionActionResult.Success();
+            }
+
+            var retryable = (int)response.StatusCode >= 500 || response.StatusCode == HttpStatusCode.TooManyRequests;
+            return FieldCollectionActionResult.Failure(
+                $"Webhook responded with {(int)response.StatusCode}.",
+                retryable);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return FieldCollectionActionResult.Failure(
+                ex is HttpRequestException ? "Webhook delivery failed." : "Webhook delivery could not be completed.",
+                retryable: true);
+        }
+    }
+
+    internal static string BuildPayload(FieldCollectionAutomationEvent automationEvent)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("changeId", automationEvent.ChangeId);
+            writer.WriteString("clientId", automationEvent.ClientId);
+            writer.WriteString("featureId", automationEvent.FeatureId);
+            writer.WriteNumber("layerId", automationEvent.LayerId);
+            writer.WriteString("operation", OperationToWire(automationEvent.Operation));
+            writer.WriteNumber("version", automationEvent.Version);
+            writer.WriteNumber("generation", automationEvent.Generation);
+            writer.WriteString("timestamp", automationEvent.Timestamp);
+
+            if (automationEvent.FeaturePayloadJson is { Length: > 0 } featureJson)
+            {
+                writer.WritePropertyName("feature");
+                using var document = JsonDocument.Parse(featureJson);
+                document.RootElement.WriteTo(writer);
+            }
+            else
+            {
+                writer.WriteNull("feature");
+            }
+
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
+    private static string OperationToWire(FieldCollectionChangeOperation operation) => operation switch
+    {
+        FieldCollectionChangeOperation.Insert => "insert",
+        FieldCollectionChangeOperation.Update => "update",
+        FieldCollectionChangeOperation.Delete => "delete",
+        _ => "update",
+    };
+}

--- a/src/Honua.Server/Features/Mobile/FieldCollection/FieldCollectionSyncEndpoints.cs
+++ b/src/Honua.Server/Features/Mobile/FieldCollection/FieldCollectionSyncEndpoints.cs
@@ -293,7 +293,8 @@ internal static class FieldCollectionSyncEndpoints
         HttpContext context,
         [FromBody] FieldCollectionPushRequestModel? body,
         [FromServices] IFieldCollectionSyncStore store,
-        [FromServices] ILoggerFactory loggerFactory)
+        [FromServices] ILoggerFactory loggerFactory,
+        [FromServices] IFieldCollectionAutomationTrigger? automationTrigger = null)
     {
         using var activity = HonuaTelemetry.ActivitySource.StartActivity("FieldCollectionSync.Push");
         activity?.SetTag("honua.protocol", ProtocolTag);
@@ -395,6 +396,29 @@ internal static class FieldCollectionSyncEndpoints
         if (result.Outcome == FieldCollectionPushOutcome.Rejected)
         {
             FieldCollectionSyncLog.PushRejected(logger, response.ChangeId, response.RejectionReason ?? string.Empty);
+        }
+
+        // Server-side Workflows companion (#2121): fan out online actions only for
+        // durably applied changes. Best-effort — the trigger swallows its own
+        // failures so automation never affects the push outcome returned above.
+        if (automationTrigger is not null
+            && result.Outcome == FieldCollectionPushOutcome.Applied
+            && result.Version is long appliedVersion)
+        {
+            var automationEvent = new FieldCollectionAutomationEvent
+            {
+                ClientId = clientId,
+                ChangeId = result.ChangeId,
+                FeatureId = pushRequest.FeatureId,
+                LayerId = pushRequest.LayerId,
+                Operation = pushRequest.Operation,
+                Version = appliedVersion,
+                Generation = result.ServerGeneration,
+                Timestamp = pushRequest.Timestamp ?? DateTimeOffset.UtcNow,
+                FeaturePayloadJson = pushRequest.FeaturePayloadJson,
+            };
+
+            await automationTrigger.OnChangeAppliedAsync(automationEvent, context.RequestAborted).ConfigureAwait(false);
         }
 
         if (logger.IsEnabled(LogLevel.Information))

--- a/tests/dotnet/Honua.Core.Tests/Features/Mobile/FieldCollection/FieldCollectionAutomationMatcherTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Mobile/FieldCollection/FieldCollectionAutomationMatcherTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.Mobile.FieldCollection.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Mobile.FieldCollection;
+
+public sealed class FieldCollectionAutomationMatcherTests
+{
+    private static FieldCollectionAutomationEvent CreateEvent(
+        int layerId = 100,
+        FieldCollectionChangeOperation operation = FieldCollectionChangeOperation.Insert)
+        => new()
+        {
+            ClientId = "device-1",
+            ChangeId = "chg-1",
+            FeatureId = "feat-1",
+            LayerId = layerId,
+            Operation = operation,
+            Version = 1,
+            Generation = 1,
+            Timestamp = DateTimeOffset.UnixEpoch,
+        };
+
+    private static FieldCollectionAutomationAction CreateAction(
+        string id = "a1",
+        bool enabled = true,
+        int? layerId = null,
+        params FieldCollectionChangeOperation[] operations)
+        => new()
+        {
+            Id = id,
+            DisplayName = id,
+            ActionType = FieldCollectionAutomationActionType.Webhook,
+            Enabled = enabled,
+            LayerId = layerId,
+            Operations = operations.Length == 0
+                ? ImmutableArray<FieldCollectionChangeOperation>.Empty
+                : operations.ToImmutableArray(),
+        };
+
+    [UnitTest]
+    public void Matches_LayerAgnosticAnyOperationEnabled_ReturnsTrue()
+    {
+        Assert.True(FieldCollectionAutomationMatcher.Matches(CreateAction(), CreateEvent()));
+    }
+
+    [UnitTest]
+    public void Matches_DisabledAction_ReturnsFalse()
+    {
+        Assert.False(FieldCollectionAutomationMatcher.Matches(CreateAction(enabled: false), CreateEvent()));
+    }
+
+    [UnitTest]
+    public void Matches_DifferentLayer_ReturnsFalse()
+    {
+        var action = CreateAction(layerId: 200);
+        Assert.False(FieldCollectionAutomationMatcher.Matches(action, CreateEvent(layerId: 100)));
+    }
+
+    [UnitTest]
+    public void Matches_SameLayer_ReturnsTrue()
+    {
+        var action = CreateAction(layerId: 100);
+        Assert.True(FieldCollectionAutomationMatcher.Matches(action, CreateEvent(layerId: 100)));
+    }
+
+    [UnitTest]
+    public void Matches_OperationNotInFilter_ReturnsFalse()
+    {
+        var action = CreateAction(operations: FieldCollectionChangeOperation.Delete);
+        Assert.False(FieldCollectionAutomationMatcher.Matches(
+            action,
+            CreateEvent(operation: FieldCollectionChangeOperation.Insert)));
+    }
+
+    [UnitTest]
+    public void Matches_OperationInFilter_ReturnsTrue()
+    {
+        var action = CreateAction(
+            operations: new[] { FieldCollectionChangeOperation.Insert, FieldCollectionChangeOperation.Update });
+        Assert.True(FieldCollectionAutomationMatcher.Matches(
+            action,
+            CreateEvent(operation: FieldCollectionChangeOperation.Update)));
+    }
+
+    [UnitTest]
+    public void Match_FiltersAndPreservesOrder_AndCreatesStableInvocationIds()
+    {
+        var actions = new[]
+        {
+            CreateAction(id: "match-1"),
+            CreateAction(id: "wrong-layer", layerId: 999),
+            CreateAction(id: "disabled", enabled: false),
+            CreateAction(id: "match-2", operations: FieldCollectionChangeOperation.Insert),
+        };
+
+        var automationEvent = CreateEvent(operation: FieldCollectionChangeOperation.Insert);
+        var invocations = FieldCollectionAutomationMatcher.Match(actions, automationEvent);
+
+        Assert.Equal(2, invocations.Count);
+        Assert.Equal("match-1", invocations[0].Action.Id);
+        Assert.Equal("match-2", invocations[1].Action.Id);
+        Assert.Equal("device-1:chg-1:match-1", invocations[0].InvocationId);
+    }
+
+    [UnitTest]
+    public void Create_IsDeterministicForSameChangeAndAction()
+    {
+        var action = CreateAction(id: "a-deterministic");
+        var automationEvent = CreateEvent();
+
+        var first = FieldCollectionActionInvocation.Create(action, automationEvent);
+        var second = FieldCollectionActionInvocation.Create(action, automationEvent);
+
+        Assert.Equal(first.InvocationId, second.InvocationId);
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Mobile/FieldCollection/FieldCollectionAutomationTriggerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Mobile/FieldCollection/FieldCollectionAutomationTriggerTests.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.Mobile.FieldCollection;
+using Honua.Core.Features.Mobile.FieldCollection.Abstractions;
+using Honua.Core.Features.Mobile.FieldCollection.Domain;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Core.Tests.Features.Mobile.FieldCollection;
+
+public sealed class FieldCollectionAutomationTriggerTests
+{
+    private static FieldCollectionAutomationEvent CreateEvent(int layerId = 100)
+        => new()
+        {
+            ClientId = "device-1",
+            ChangeId = "chg-1",
+            FeatureId = "feat-1",
+            LayerId = layerId,
+            Operation = FieldCollectionChangeOperation.Insert,
+            Version = 1,
+            Generation = 1,
+            Timestamp = DateTimeOffset.UnixEpoch,
+        };
+
+    private static FieldCollectionAutomationAction CreateAction(string id, bool enabled = true)
+        => new()
+        {
+            Id = id,
+            DisplayName = id,
+            ActionType = FieldCollectionAutomationActionType.Webhook,
+            Enabled = enabled,
+            Operations = ImmutableArray<FieldCollectionChangeOperation>.Empty,
+        };
+
+    [UnitTest]
+    public async Task OnChangeApplied_EnqueuesEveryMatchedAction()
+    {
+        var store = new FakeStore(CreateAction("a1"), CreateAction("a2"));
+        var dispatcher = new RecordingDispatcher();
+        var trigger = new FieldCollectionAutomationTrigger(
+            store,
+            dispatcher,
+            NullLogger<FieldCollectionAutomationTrigger>.Instance);
+
+        await trigger.OnChangeAppliedAsync(CreateEvent());
+
+        Assert.Equal(2, dispatcher.Enqueued.Count);
+        Assert.Equal("a1", dispatcher.Enqueued[0].Action.Id);
+        Assert.Equal("a2", dispatcher.Enqueued[1].Action.Id);
+        Assert.Equal(100, store.RequestedLayerId);
+    }
+
+    [UnitTest]
+    public async Task OnChangeApplied_NoEnabledActions_EnqueuesNothing()
+    {
+        var store = new FakeStore(CreateAction("disabled", enabled: false));
+        var dispatcher = new RecordingDispatcher();
+        var trigger = new FieldCollectionAutomationTrigger(
+            store,
+            dispatcher,
+            NullLogger<FieldCollectionAutomationTrigger>.Instance);
+
+        await trigger.OnChangeAppliedAsync(CreateEvent());
+
+        Assert.Empty(dispatcher.Enqueued);
+    }
+
+    [UnitTest]
+    public async Task OnChangeApplied_StoreThrows_DoesNotPropagate()
+    {
+        var store = new ThrowingStore();
+        var dispatcher = new RecordingDispatcher();
+        var trigger = new FieldCollectionAutomationTrigger(
+            store,
+            dispatcher,
+            NullLogger<FieldCollectionAutomationTrigger>.Instance);
+
+        // Must not throw — automation is best-effort and never fails the push.
+        await trigger.OnChangeAppliedAsync(CreateEvent());
+
+        Assert.Empty(dispatcher.Enqueued);
+    }
+
+    [UnitTest]
+    public async Task OnChangeApplied_DispatcherThrowsForOne_StillEnqueuesOthers()
+    {
+        var store = new FakeStore(CreateAction("a1"), CreateAction("a2"));
+        var dispatcher = new RecordingDispatcher { ThrowForActionId = "a1" };
+        var trigger = new FieldCollectionAutomationTrigger(
+            store,
+            dispatcher,
+            NullLogger<FieldCollectionAutomationTrigger>.Instance);
+
+        await trigger.OnChangeAppliedAsync(CreateEvent());
+
+        Assert.Single(dispatcher.Enqueued);
+        Assert.Equal("a2", dispatcher.Enqueued[0].Action.Id);
+    }
+
+    private sealed class FakeStore : IFieldCollectionAutomationStore
+    {
+        private readonly FieldCollectionAutomationAction[] _actions;
+
+        public FakeStore(params FieldCollectionAutomationAction[] actions) => _actions = actions;
+
+        public int RequestedLayerId { get; private set; }
+
+        public Task<IReadOnlyList<FieldCollectionAutomationAction>> GetEnabledActionsAsync(
+            int layerId,
+            CancellationToken cancellationToken = default)
+        {
+            RequestedLayerId = layerId;
+            return Task.FromResult<IReadOnlyList<FieldCollectionAutomationAction>>(_actions);
+        }
+    }
+
+    private sealed class ThrowingStore : IFieldCollectionAutomationStore
+    {
+        public Task<IReadOnlyList<FieldCollectionAutomationAction>> GetEnabledActionsAsync(
+            int layerId,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("store unavailable");
+    }
+
+    private sealed class RecordingDispatcher : IFieldCollectionActionDispatcher
+    {
+        public List<FieldCollectionActionInvocation> Enqueued { get; } = new();
+
+        public string? ThrowForActionId { get; init; }
+
+        public ValueTask EnqueueAsync(
+            FieldCollectionActionInvocation invocation,
+            CancellationToken cancellationToken = default)
+        {
+            if (ThrowForActionId is not null && invocation.Action.Id == ThrowForActionId)
+            {
+                throw new InvalidOperationException("queue full");
+            }
+
+            Enqueued.Add(invocation);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Mobile/FieldCollection/WebhookFieldCollectionActionHandlerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Mobile/FieldCollection/WebhookFieldCollectionActionHandlerTests.cs
@@ -1,0 +1,191 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Net;
+using System.Text.Json;
+using Honua.Core.Features.Mobile.FieldCollection.Domain;
+using Honua.Server.Features.Mobile.FieldCollection.Automations;
+using Honua.TestKit.Attributes;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Mobile.FieldCollection;
+
+public sealed class WebhookFieldCollectionActionHandlerTests
+{
+    private static FieldCollectionAutomationEvent CreateEvent(string? feature = null)
+        => new()
+        {
+            ClientId = "device-1",
+            ChangeId = "chg-1",
+            FeatureId = "feat-1",
+            LayerId = 42,
+            Operation = FieldCollectionChangeOperation.Insert,
+            Version = 3,
+            Generation = 7,
+            Timestamp = DateTimeOffset.UnixEpoch,
+            FeaturePayloadJson = feature,
+        };
+
+    private static FieldCollectionActionInvocation CreateInvocation(
+        string url = "https://example.com/hook",
+        string? secret = "signing-secret",
+        string? feature = "{\"type\":\"Feature\"}")
+    {
+        var config = ImmutableDictionary<string, string>.Empty;
+        config = config.Add(WebhookFieldCollectionActionHandler.UrlKey, url);
+        if (secret is not null)
+        {
+            config = config.Add(WebhookFieldCollectionActionHandler.SecretKey, secret);
+        }
+
+        var action = new FieldCollectionAutomationAction
+        {
+            Id = "webhook-1",
+            DisplayName = "webhook-1",
+            ActionType = FieldCollectionAutomationActionType.Webhook,
+            Configuration = config,
+        };
+
+        return FieldCollectionActionInvocation.Create(action, CreateEvent(feature));
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_PublicDestination_PostsSignedPayloadAndSucceeds()
+    {
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        var handler = new CapturingHandler();
+        httpClientFactory.CreateClient(WebhookFieldCollectionActionHandler.HttpClientName)
+            .Returns(new HttpClient(handler));
+
+        var sut = new WebhookFieldCollectionActionHandler(httpClientFactory);
+
+        var result = await sut.ExecuteAsync(CreateInvocation());
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(handler.SignatureHeader);
+        Assert.StartsWith("sha256=", handler.SignatureHeader);
+        Assert.Equal("webhook-1", handler.ActionHeader);
+        Assert.Equal("device-1:chg-1:webhook-1", handler.IdempotencyHeader);
+        Assert.NotNull(handler.Body);
+        using var doc = JsonDocument.Parse(handler.Body!);
+        Assert.Equal("chg-1", doc.RootElement.GetProperty("changeId").GetString());
+        Assert.Equal("insert", doc.RootElement.GetProperty("operation").GetString());
+        Assert.Equal(42, doc.RootElement.GetProperty("layerId").GetInt32());
+        Assert.Equal("Feature", doc.RootElement.GetProperty("feature").GetProperty("type").GetString());
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_MissingUrl_ReturnsNonRetryableFailureWithoutSending()
+    {
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        var action = new FieldCollectionAutomationAction
+        {
+            Id = "webhook-1",
+            DisplayName = "webhook-1",
+            ActionType = FieldCollectionAutomationActionType.Webhook,
+            Configuration = ImmutableDictionary<string, string>.Empty,
+        };
+        var invocation = FieldCollectionActionInvocation.Create(action, CreateEvent());
+
+        var sut = new WebhookFieldCollectionActionHandler(httpClientFactory);
+        var result = await sut.ExecuteAsync(invocation);
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.Retryable);
+        httpClientFactory.DidNotReceive().CreateClient(Arg.Any<string>());
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_MissingSecret_ReturnsNonRetryableFailure()
+    {
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        var sut = new WebhookFieldCollectionActionHandler(httpClientFactory);
+
+        var result = await sut.ExecuteAsync(CreateInvocation(secret: null));
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.Retryable);
+        Assert.Contains("secret", result.Error, StringComparison.OrdinalIgnoreCase);
+        httpClientFactory.DidNotReceive().CreateClient(Arg.Any<string>());
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_UnsafeDestination_ReturnsNonRetryableFailureWithoutSending()
+    {
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        var sut = new WebhookFieldCollectionActionHandler(httpClientFactory);
+
+        var result = await sut.ExecuteAsync(CreateInvocation(url: "https://localhost/hook"));
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.Retryable);
+        httpClientFactory.DidNotReceive().CreateClient(Arg.Any<string>());
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_ServerError_ReturnsRetryableFailure()
+    {
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        var handler = new StatusHandler(HttpStatusCode.InternalServerError);
+        httpClientFactory.CreateClient(WebhookFieldCollectionActionHandler.HttpClientName)
+            .Returns(new HttpClient(handler));
+
+        var sut = new WebhookFieldCollectionActionHandler(httpClientFactory);
+        var result = await sut.ExecuteAsync(CreateInvocation());
+
+        Assert.False(result.Succeeded);
+        Assert.True(result.Retryable);
+    }
+
+    [UnitTest]
+    public void BuildPayload_DeleteOperation_WritesNullFeature()
+    {
+        var payload = WebhookFieldCollectionActionHandler.BuildPayload(new FieldCollectionAutomationEvent
+        {
+            ClientId = "device-1",
+            ChangeId = "chg-9",
+            FeatureId = "feat-9",
+            LayerId = 1,
+            Operation = FieldCollectionChangeOperation.Delete,
+            Version = 5,
+            Generation = 5,
+            Timestamp = DateTimeOffset.UnixEpoch,
+            FeaturePayloadJson = null,
+        });
+
+        using var doc = JsonDocument.Parse(payload);
+        Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("feature").ValueKind);
+        Assert.Equal("delete", doc.RootElement.GetProperty("operation").GetString());
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public string? SignatureHeader { get; private set; }
+
+        public string? ActionHeader { get; private set; }
+
+        public string? IdempotencyHeader { get; private set; }
+
+        public string? Body { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            SignatureHeader = request.Headers.GetValues("X-Honua-Signature").Single();
+            ActionHeader = request.Headers.GetValues("X-Honua-FieldCollection-Action").Single();
+            IdempotencyHeader = request.Headers.GetValues("Idempotency-Key").Single();
+            Body = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    private sealed class StatusHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+
+        public StatusHandler(HttpStatusCode status) => _status = status;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(_status));
+    }
+}


### PR DESCRIPTION
Closes #2121

## Summary

Carve-out from the Collect automation epic: this adds the **server-side Workflows companion** for the online action half of the FieldCollection automation runtime (the offline-queued device side already shipped in `Honua.Collect.Core`). When a mobile change is durably applied through the sync push endpoint, the server now evaluates configured actions and dispatches online actions (email / webhook / SMS / assign-record).

### How it works
- After a push returns `Applied`, `FieldCollectionSyncEndpoints` invokes an optional `IFieldCollectionAutomationTrigger` with a `FieldCollectionAutomationEvent`. It fires only for durably applied changes — never for conflicts or rejections — and is best-effort: a failure to evaluate/enqueue never affects the push outcome returned to the device.
- The default trigger loads enabled actions for the change's layer from `IFieldCollectionAutomationStore`, matches them with a pure, deterministic `FieldCollectionAutomationMatcher` (enabled + layer scope + operation filter), and enqueues each match.
- `ChannelFieldCollectionActionDispatcher` is a bounded in-process queue (wait back-pressure, never drops). `FieldCollectionAutomationDispatchBackgroundService` drains it and routes each invocation to the `IFieldCollectionActionHandler` registered for its action type, applying bounded exponential-backoff retry for retryable failures.
- `WebhookFieldCollectionActionHandler` is the first concrete handler. It builds a signed JSON envelope describing the applied change and POSTs it, reusing the shared `OutboundHttpUrlValidator` (HTTPS + SSRF guards), HMAC signing, and header sanitization already used by the alert/feature-change webhook paths.
- Action definitions are bound from the `FieldCollectionAutomation` configuration section (`OptionsFieldCollectionAutomationStore`). Automation is opt-in (`Enabled=false` by default), so behavior is unchanged unless an operator configures it.

New Core contracts (reusable by a future persisted store / additional handlers): domain models + enums, `FieldCollectionAutomationMatcher`, and abstractions `IFieldCollectionAutomationStore`, `IFieldCollectionActionDispatcher`, `IFieldCollectionActionHandler`, `IFieldCollectionAutomationTrigger`.

## Testing
- `dotnet build src/Honua.Core/Honua.Core.csproj` — succeeded.
- `dotnet build src/Honua.Server/Honua.Server.csproj` — succeeded.
- `dotnet test tests/dotnet/Honua.Core.Tests` (filter `FieldCollectionAutomation`) — 12 passed. Covers matcher rules (enabled/layer/operation/order/stable ids) and the trigger (enqueues matches, no-op when none match, swallows store failures, continues past a per-invocation dispatch failure).
- `dotnet test tests/dotnet/Honua.Server.Tests` (filter `WebhookFieldCollectionActionHandler`) — 6 passed. Covers signed-payload success, missing url/secret, unsafe destination (no send), retryable 5xx, and delete-payload shape.

## Known gaps / follow-ups
- Only the **webhook** handler is implemented concretely. Email, SMS, and assign-record handlers are not yet implemented — the engine routes by action type, so they are drop-in additions (an unhandled type is logged, not dispatched). Tracked as remaining scope for this feature.
- The action store is configuration-backed (`OptionsFieldCollectionAutomationStore`). A persisted, admin-managed CRUD store + migration is a follow-up; the `IFieldCollectionAutomationStore` abstraction is the seam.
- Delivery is an in-process queue (per-instance). Durable/at-least-once delivery with a shared outbox + leader election (as in Alerts) is future work.
