### PR TITLE
feat: harden VersionManagementServer reconcile conformance (#2135)

### DIFF
--- a/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/VersionJob.cs
+++ b/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/VersionJob.cs
@@ -56,6 +56,7 @@ public enum VersionJobStatus
 /// <param name="Status">Current lifecycle status.</param>
 /// <param name="Policy">Reconcile auto-resolution policy (ignored for post jobs).</param>
 /// <param name="CreatedAt">When the job was created.</param>
+/// <param name="ConflictDetection">Reconcile conflict-detection granularity (ignored for post jobs; #2135).</param>
 /// <param name="StartedAt">When the job acquired the lock and began, or null while pending.</param>
 /// <param name="CompletedAt">When the job reached a terminal state, or null while not terminal.</param>
 /// <param name="ConflictCount">Unresolved conflicts after a reconcile (0 for a clean reconcile or a post).</param>
@@ -73,6 +74,7 @@ public sealed record VersionJob(
     VersionJobStatus Status,
     VersionReconcilePolicy Policy,
     DateTimeOffset CreatedAt,
+    VersionConflictDetection ConflictDetection = VersionConflictDetection.ByAttribute,
     DateTimeOffset? StartedAt = null,
     DateTimeOffset? CompletedAt = null,
     int ConflictCount = 0,

--- a/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/VersionOperations.cs
+++ b/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/VersionOperations.cs
@@ -63,6 +63,32 @@ public enum VersionReconcilePolicy
 }
 
 /// <summary>
+/// Conflict-detection granularity applied by the version manager's <c>ReconcileAsync</c> when it diffs
+/// a branch version against DEFAULT (Esri <c>conflictDetection</c> conformance; #2135). Mirrors ArcGIS'
+/// <c>esriReconcileByObject</c>/<c>esriReconcileByAttribute</c> reconcile options. The two modes diverge
+/// for a feature edited on both sides on DISJOINT attribute/geometry sets: by-object flags any such
+/// object as a conflict, while by-attribute auto-merges the disjoint edits and only reports a conflict
+/// when the SAME attribute (or geometry on both sides) was changed.
+/// </summary>
+public enum VersionConflictDetection
+{
+    /// <summary>
+    /// By-attribute (column-level) detection. A feature edited in both the branch and DEFAULT on
+    /// disjoint attribute sets auto-merges; only a genuinely-overlapping field edit (or a
+    /// geometry-vs-geometry change) is reported as a conflict. This is the substrate default and keeps
+    /// the pre-#2135 reconcile behavior byte-identical.
+    /// </summary>
+    ByAttribute = 0,
+
+    /// <summary>
+    /// By-object (row-level) detection. Any feature edited in both the branch and DEFAULT since the
+    /// merge base is reported as a conflict, even when the edited attribute/geometry sets are disjoint
+    /// (no field-level auto-merge). Convergent edits (both sides deleted the same row) remain a no-op.
+    /// </summary>
+    ByObject = 1,
+}
+
+/// <summary>
 /// Operator choice for a single manually-resolved reconcile conflict (#371). Selects which side of a
 /// three-way conflict (base / DEFAULT / version) becomes the posted state for the feature. Field-level
 /// merges are produced automatically during reconcile for disjoint field edits, so the manual surface

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IVersionJobRunner.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IVersionJobRunner.cs
@@ -22,12 +22,14 @@ public interface IVersionJobRunner
     /// <param name="service">Owning service identity (lock scope).</param>
     /// <param name="versionId">Version to reconcile.</param>
     /// <param name="policy">Auto-resolution policy.</param>
+    /// <param name="detection">Conflict-detection granularity (by-attribute or by-object; #2135).</param>
     /// <param name="cancellationToken">Cancellation token for the start request (not the job).</param>
     /// <returns>The created job record.</returns>
     Task<VersionJob> StartReconcileAsync(
         string service,
         Guid versionId,
         VersionReconcilePolicy policy,
+        VersionConflictDetection detection = VersionConflictDetection.ByAttribute,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IVersionManager.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IVersionManager.cs
@@ -60,20 +60,24 @@ public interface IVersionManager
     Task<VersionContext?> ResolveAsync(string? gdbVersion, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Reconciles a version against DEFAULT, detecting conflicts since the merge base. Disjoint
-    /// field-level edits auto-merge; only genuinely-overlapping edits (overlapping fields,
-    /// geometry-vs-geometry, or update-vs-delete) become conflicts. When <paramref name="policy"/> is
-    /// a deterministic policy (#371) each conflict is auto-resolved so the version may be posted; when
-    /// <see cref="VersionReconcilePolicy.None"/> the unresolved conflicts are persisted for manual
-    /// review and block <c>Post</c>.
+    /// Reconciles a version against DEFAULT, detecting conflicts since the merge base. Under the default
+    /// <see cref="VersionConflictDetection.ByAttribute"/> detection, disjoint field-level edits auto-merge
+    /// and only genuinely-overlapping edits (overlapping fields, geometry-vs-geometry, or update-vs-delete)
+    /// become conflicts; under <see cref="VersionConflictDetection.ByObject"/> any feature edited on both
+    /// sides since the merge base is a conflict (no field-level auto-merge; #2135). When
+    /// <paramref name="policy"/> is a deterministic policy (#371) each conflict is auto-resolved so the
+    /// version may be posted; when <see cref="VersionReconcilePolicy.None"/> the unresolved conflicts are
+    /// persisted for manual review and block <c>Post</c>.
     /// </summary>
     /// <param name="versionId">Version to reconcile.</param>
     /// <param name="policy">Auto-resolution policy; <see cref="VersionReconcilePolicy.None"/> for manual review.</param>
+    /// <param name="detection">Conflict-detection granularity (by-attribute or by-object; #2135).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The reconcile result.</returns>
     Task<VersionReconcileResult> ReconcileAsync(
         Guid versionId,
         VersionReconcilePolicy policy = VersionReconcilePolicy.None,
+        VersionConflictDetection detection = VersionConflictDetection.ByAttribute,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpVersionManager.cs
+++ b/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpVersionManager.cs
@@ -51,6 +51,7 @@ public sealed class NoOpVersionManager : IVersionManager
     public Task<VersionReconcileResult> ReconcileAsync(
         Guid versionId,
         VersionReconcilePolicy policy = VersionReconcilePolicy.None,
+        VersionConflictDetection detection = VersionConflictDetection.ByAttribute,
         CancellationToken cancellationToken = default)
         => throw new NotSupportedException("Branch versioning is not supported by this data provider.");
 

--- a/src/Honua.Core/Features/FeatureStore/Services/VersionJobRunner.cs
+++ b/src/Honua.Core/Features/FeatureStore/Services/VersionJobRunner.cs
@@ -48,15 +48,18 @@ public sealed partial class VersionJobRunner : IVersionJobRunner
         string service,
         Guid versionId,
         VersionReconcilePolicy policy,
+        VersionConflictDetection detection = VersionConflictDetection.ByAttribute,
         CancellationToken cancellationToken = default)
-        => StartAsync(service, versionId, VersionJobKind.Reconcile, policy, cancellationToken);
+        => StartAsync(service, versionId, VersionJobKind.Reconcile, policy, detection, cancellationToken);
 
     /// <inheritdoc />
     public Task<VersionJob> StartPostAsync(
         string service,
         Guid versionId,
         CancellationToken cancellationToken = default)
-        => StartAsync(service, versionId, VersionJobKind.Post, VersionReconcilePolicy.None, cancellationToken);
+        => StartAsync(
+            service, versionId, VersionJobKind.Post, VersionReconcilePolicy.None,
+            VersionConflictDetection.ByAttribute, cancellationToken);
 
     /// <inheritdoc />
     public Task<VersionJob?> GetJobAsync(Guid jobId, CancellationToken cancellationToken = default)
@@ -67,6 +70,7 @@ public sealed partial class VersionJobRunner : IVersionJobRunner
         Guid versionId,
         VersionJobKind kind,
         VersionReconcilePolicy policy,
+        VersionConflictDetection detection,
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(service);
@@ -78,7 +82,8 @@ public sealed partial class VersionJobRunner : IVersionJobRunner
             Kind: kind,
             Status: VersionJobStatus.Pending,
             Policy: policy,
-            CreatedAt: DateTimeOffset.UtcNow);
+            CreatedAt: DateTimeOffset.UtcNow,
+            ConflictDetection: detection);
 
         await _jobStore.SaveAsync(job, cancellationToken).ConfigureAwait(false);
 
@@ -172,7 +177,7 @@ public sealed partial class VersionJobRunner : IVersionJobRunner
         VersionJob job,
         CancellationToken cancellationToken)
     {
-        var result = await manager.ReconcileAsync(job.VersionId, job.Policy, cancellationToken).ConfigureAwait(false);
+        var result = await manager.ReconcileAsync(job.VersionId, job.Policy, job.ConflictDetection, cancellationToken).ConfigureAwait(false);
         var conflictCount = result.Conflicts.IsDefaultOrEmpty ? 0 : result.Conflicts.Length;
         return job with
         {

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresVersionManager.ReconcilePost.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresVersionManager.ReconcilePost.cs
@@ -65,6 +65,7 @@ internal sealed partial class PostgresVersionManager
     public async Task<VersionReconcileResult> ReconcileAsync(
         Guid versionId,
         VersionReconcilePolicy policy = VersionReconcilePolicy.None,
+        VersionConflictDetection detection = VersionConflictDetection.ByAttribute,
         CancellationToken cancellationToken = default)
     {
         // The (service, version) lock serializes reconcile/post/resolve for the version (#1553); a
@@ -75,6 +76,7 @@ internal sealed partial class PostgresVersionManager
         activity?.SetTag("honua.version.id", versionId.ToString());
         activity?.SetTag("honua.version.service", _lockScope);
         activity?.SetTag("honua.version.policy", policy.ToString());
+        activity?.SetTag("honua.version.conflict_detection", detection.ToString());
 
         var version = await LoadVersionAsync(versionId, cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Version {versionId} does not exist.");
@@ -83,7 +85,7 @@ internal sealed partial class PostgresVersionManager
         try
         {
             var currentGeneration = await GetCurrentGenerationAsync(cancellationToken).ConfigureAwait(false);
-            var analysis = await AnalyzeOverlapsAsync(versionId, version.CommonAncestorGeneration, cancellationToken)
+            var analysis = await AnalyzeOverlapsAsync(versionId, version.CommonAncestorGeneration, detection, cancellationToken)
                 .ConfigureAwait(false);
 
             // Disjoint field-level edits auto-merge into the overlay so post carries both sides.
@@ -456,6 +458,7 @@ internal sealed partial class PostgresVersionManager
     private async Task<OverlapAnalysis> AnalyzeOverlapsAsync(
         Guid versionId,
         long commonAncestorGen,
+        VersionConflictDetection detection,
         CancellationToken cancellationToken)
     {
         var featuresTable = DatabaseSchema.GetFeaturesTableName(_schemaName);
@@ -538,7 +541,15 @@ internal sealed partial class PostgresVersionManager
                 && !string.Equals(baseGeom, versionGeom, StringComparison.Ordinal)
                 && !string.Equals(defaultGeom, versionGeom, StringComparison.Ordinal);
 
-            if (overlappingFields.Length == 0 && !geometryChangedOnBoth)
+            // By-attribute detection auto-merges disjoint edits and only flags genuinely-overlapping
+            // edits (overlapping fields or geometry-vs-geometry). By-object detection flags ANY feature
+            // edited on both sides since the merge base as a conflict, with no field-level auto-merge —
+            // this is the documented Esri esriReconcileByObject behavior (#2135).
+            var autoMergeable = detection == VersionConflictDetection.ByAttribute
+                && overlappingFields.Length == 0
+                && !geometryChangedOnBoth;
+
+            if (autoMergeable)
             {
                 // Disjoint edits: auto-merge DEFAULT's field changes (and a DEFAULT-only geometry change)
                 // into the overlay so a post carries both sides without a conflict.
@@ -549,8 +560,14 @@ internal sealed partial class PostgresVersionManager
                 continue;
             }
 
-            var fieldDiffs = BuildFieldDiffs(overlappingFields, baseFields, defaultFields, versionFields);
-            var conflictType = overlappingFields.Length > 0
+            // Report the overlapping fields when present; under by-object detection a disjoint edit still
+            // surfaces the union of both sides' changed fields so the conflict carries a useful three-way
+            // diff for the manual-resolution UI.
+            var reportedFields = overlappingFields.Length > 0
+                ? overlappingFields
+                : defaultChangedFields.Union(versionChangedFields, StringComparer.Ordinal).ToArray();
+            var fieldDiffs = BuildFieldDiffs(reportedFields, baseFields, defaultFields, versionFields);
+            var conflictType = reportedFields.Length > 0
                 ? ReplicaConflictType.Attribute
                 : ReplicaConflictType.Geometry;
             conflicts.Add(new OverlapConflict(layerId, objectId, conflictType,

--- a/src/Honua.Protocols.GeoServices/VersionManagementServer/Models/VersionManagementModels.cs
+++ b/src/Honua.Protocols.GeoServices/VersionManagementServer/Models/VersionManagementModels.cs
@@ -166,6 +166,18 @@ public sealed class ReconcileResponse
     /// <summary>Number of conflicts the supplied auto-resolution policy resolved.</summary>
     public int AutoResolvedCount { get; init; }
 
+    /// <summary>
+    /// True when <c>withPost=true</c> was requested and the clean reconcile posted the version in the
+    /// same operation (#2135). False when not requested or when conflicts remained (no-op-with-conflicts).
+    /// </summary>
+    public bool Posted { get; init; }
+
+    /// <summary>Net feature changes replayed onto DEFAULT when <see cref="Posted"/> is true; 0 otherwise.</summary>
+    public int AppliedChanges { get; init; }
+
+    /// <summary>DEFAULT generation produced by the <c>withPost</c> post when <see cref="Posted"/> is true; 0 otherwise.</summary>
+    public long ServerGeneration { get; init; }
+
     /// <summary>Unresolved conflicts; non-empty blocks post.</summary>
     public VersionConflictInfo[] Conflicts { get; init; } = [];
 }

--- a/src/Honua.Protocols.GeoServices/VersionManagementServer/VersionManagementServerEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/VersionManagementServer/VersionManagementServerEndpoints.cs
@@ -397,23 +397,51 @@ public static class VersionManagementServerEndpoints
             return policyError;
         }
 
+        var (detection, detectionError) = ParseConflictDetection(context, values!);
+        if (detectionError is not null)
+        {
+            return detectionError;
+        }
+
         // Async fast path: start a durable, pollable job under the version lock and return 202 with a
         // job handle. The synchronous path stays the default for small/fast versions (#1553).
         if (ParseAsyncRequested(values!))
         {
-            var job = await jobRunner.StartReconcileAsync(serviceId, versionId, policy, cancellationToken)
+            var job = await jobRunner.StartReconcileAsync(serviceId, versionId, policy, detection, cancellationToken)
                 .ConfigureAwait(false);
             return AcceptedJob(serviceId, versionGuid, job);
         }
 
+        var withPost = ParseFlag(values!, "withPost");
+
         try
         {
-            var result = await versionManager.ReconcileAsync(versionId, policy, cancellationToken).ConfigureAwait(false);
+            var result = await versionManager.ReconcileAsync(versionId, policy, detection, cancellationToken)
+                .ConfigureAwait(false);
+            var hasConflicts = !result.Conflicts.IsDefaultOrEmpty && result.Conflicts.Length > 0;
+
+            // withPost=true posts the version in the same operation after a clean reconcile (Esri
+            // conformance; #2135). When conflicts remain it is a no-op-with-conflicts response: the
+            // reconcile conflicts are returned and nothing is posted.
+            var posted = false;
+            var appliedChanges = 0;
+            long serverGeneration = 0;
+            if (withPost && result.CanPost && !hasConflicts)
+            {
+                var post = await versionManager.PostAsync(versionId, cancellationToken).ConfigureAwait(false);
+                posted = post.Posted;
+                appliedChanges = post.AppliedChanges;
+                serverGeneration = post.ServerGeneration;
+            }
+
             var response = new ReconcileResponse
             {
-                HasConflicts = !result.Conflicts.IsDefaultOrEmpty && result.Conflicts.Length > 0,
+                HasConflicts = hasConflicts,
                 CanPost = result.CanPost,
                 AutoResolvedCount = result.AutoResolvedCount,
+                Posted = posted,
+                AppliedChanges = appliedChanges,
+                ServerGeneration = serverGeneration,
                 Conflicts = result.Conflicts.IsDefaultOrEmpty
                     ? []
                     : result.Conflicts.Select(ToConflictInfo).ToArray(),
@@ -868,6 +896,44 @@ public static class VersionManagementServerEndpoints
                 "Unsupported conflictResolution policy.",
                 ["Supported policies: none, lastWriteWins, versionWins, defaultWins."])),
         };
+    }
+
+    /// <summary>
+    /// Parses the reconcile conflict-detection granularity from the <c>conflictDetection</c> parameter
+    /// (Esri conformance; #2135). Accepts Honua's short names (<c>byObject</c>/<c>byAttribute</c>), the
+    /// Esri tokens (<c>esriReconcileByObject</c>/<c>esriReconcileByAttribute</c>), and the bare
+    /// <c>object</c>/<c>attribute</c> forms. Absent or empty resolves to the
+    /// <see cref="VersionConflictDetection.ByAttribute"/> default (pre-#2135 behavior).
+    /// </summary>
+    private static (VersionConflictDetection Detection, IResult? Error) ParseConflictDetection(
+        HttpContext context,
+        IReadOnlyDictionary<string, StringValues> values)
+    {
+        var raw = GeoServicesRequestValueHelpers.GetValueString(values, "conflictDetection");
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return (VersionConflictDetection.ByAttribute, null);
+        }
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "byattribute" or "esrireconcilebyattribute" or "attribute" => (VersionConflictDetection.ByAttribute, null),
+            "byobject" or "esrireconcilebyobject" or "object" => (VersionConflictDetection.ByObject, null),
+            _ => (VersionConflictDetection.ByAttribute, StandardErrorHelpers.CreateBadRequest(
+                context,
+                "Unsupported conflictDetection mode.",
+                ["Supported modes: byObject, byAttribute."])),
+        };
+    }
+
+    /// <summary>
+    /// Whether a boolean request flag (e.g. <c>withPost</c>) is set to <c>true</c> (case-insensitive).
+    /// Absent or any other value is treated as false.
+    /// </summary>
+    private static bool ParseFlag(IReadOnlyDictionary<string, StringValues> values, string name)
+    {
+        var raw = GeoServicesRequestValueHelpers.GetValueString(values, name);
+        return string.Equals(raw?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
@@ -327,6 +327,67 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.VersionManagement)]
+    [Endpoint("POST /rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/reconcile")]
+    [InterfaceOperation(TestProtocols.VersionManagementServer, "reconcile")]
+    public async Task Reconcile_ByObjectDetection_CleanVersion_CanPost()
+    {
+        // A clean version reconciles cleanly under either detection mode; this exercises the
+        // conflictDetection=byObject parameter parsing on the reconcile endpoint (#2135).
+        var created = await CreateVersionAsync("admin.reconcile_byobject");
+        var guid = created.GetProperty("versionGuid").GetString();
+
+        var response = await PostFormAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/reconcile",
+            ("conflictDetection", "byObject"), ("f", "json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "reconcile with byObject detection should succeed; body: {0}", await response.Content.ReadAsStringAsync());
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("hasConflicts").GetBoolean().Should().BeFalse();
+        doc.RootElement.GetProperty("canPost").GetBoolean().Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.VersionManagement)]
+    [Endpoint("POST /rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/reconcile")]
+    [InterfaceOperation(TestProtocols.VersionManagementServer, "reconcile")]
+    public async Task Reconcile_UnsupportedConflictDetection_ReturnsBadRequest()
+    {
+        var created = await CreateVersionAsync("admin.reconcile_bad_detection");
+        var guid = created.GetProperty("versionGuid").GetString();
+
+        var response = await PostFormAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/reconcile",
+            ("conflictDetection", "byPlanet"), ("f", "json"));
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "an unsupported conflictDetection mode should be rejected; body: {0}", await response.Content.ReadAsStringAsync());
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.VersionManagement)]
+    [Endpoint("POST /rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/reconcile")]
+    [InterfaceOperation(TestProtocols.VersionManagementServer, "reconcile")]
+    public async Task Reconcile_WithPost_CleanVersion_PostsInline()
+    {
+        // withPost=true posts the version in the same operation after a clean reconcile; the response
+        // echoes the post outcome (#2135).
+        var created = await CreateVersionAsync("admin.reconcile_withpost");
+        var guid = created.GetProperty("versionGuid").GetString();
+
+        var response = await PostFormAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/reconcile",
+            ("withPost", "true"), ("f", "json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "reconcile withPost should succeed; body: {0}", await response.Content.ReadAsStringAsync());
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("canPost").GetBoolean().Should().BeTrue();
+        doc.RootElement.GetProperty("hasConflicts").GetBoolean().Should().BeFalse();
+        doc.RootElement.GetProperty("posted").GetBoolean().Should().BeTrue("a clean reconcile with withPost posts inline");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.VersionManagement)]
     [Endpoint("GET /rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/inspectConflicts")]
     [InterfaceOperation(TestProtocols.VersionManagementServer, "inspectConflicts")]
     public async Task InspectConflicts_CleanVersion_ReturnsNoConflicts()

--- a/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningAsyncReconcileTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningAsyncReconcileTests.cs
@@ -130,7 +130,7 @@ public sealed class BranchVersioningAsyncReconcileTests : IAsyncLifetime
             new CreateVersionRequest("AsyncJob", "sde", VersionAccess.Public), CancellationToken.None);
 
         var job = await runner.StartReconcileAsync(
-            "svc", version.VersionId, VersionReconcilePolicy.None, CancellationToken.None);
+            "svc", version.VersionId, VersionReconcilePolicy.None, cancellationToken: CancellationToken.None);
         job.Status.Should().Be(VersionJobStatus.Pending);
 
         var terminal = await PollJobAsync(runner, job.JobId);
@@ -154,7 +154,7 @@ public sealed class BranchVersioningAsyncReconcileTests : IAsyncLifetime
         held.Should().NotBeNull();
 
         var job = await runner.StartReconcileAsync(
-            "svc", version.VersionId, VersionReconcilePolicy.None, CancellationToken.None);
+            "svc", version.VersionId, VersionReconcilePolicy.None, cancellationToken: CancellationToken.None);
 
         var terminal = await PollJobAsync(runner, job.JobId);
         terminal.Status.Should().Be(VersionJobStatus.LockContended);

--- a/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningIntegrationTests.cs
@@ -348,6 +348,64 @@ public sealed class BranchVersioningIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Reconcile_ByObjectVsByAttribute_DivergeOnDisjointFieldEdits()
+    {
+        var store = CreateFeatureStore();
+        var versionManager = CreateVersionManager();
+
+        // Seed the SAME disjoint-field fixture twice (two independent features) so the two detection
+        // modes can be compared on identical edits: branch edits only "name", DEFAULT edits only
+        // "status" => the edited attribute sets are disjoint (#2135).
+        var byAttributeFeature = await store.CreateAsync(
+            PointsLayerId, BuildFeatureWithFields(13.0, 13.0, ("name", "Base"), ("status", "open")), CancellationToken.None);
+        var byObjectFeature = await store.CreateAsync(
+            PointsLayerId, BuildFeatureWithFields(13.1, 13.1, ("name", "Base"), ("status", "open")), CancellationToken.None);
+
+        var attributeVersion = await versionManager.CreateAsync(
+            new CreateVersionRequest("DivergeByAttribute", "sde", VersionAccess.Public), CancellationToken.None);
+        var objectVersion = await versionManager.CreateAsync(
+            new CreateVersionRequest("DivergeByObject", "sde", VersionAccess.Public), CancellationToken.None);
+
+        await store.ApplyEditsAsync(
+            PointsLayerId,
+            FeatureEditBatch.Create(
+                updates: ImmutableArray.Create(BuildFeatureWithFields(13.0, 13.0, byAttributeFeature.Id, ("name", "Branch"), ("status", "open"))),
+                versionContext: VersionContext.ForVersion(attributeVersion)),
+            CancellationToken.None);
+        await store.ApplyEditsAsync(
+            PointsLayerId,
+            FeatureEditBatch.Create(
+                updates: ImmutableArray.Create(BuildFeatureWithFields(13.1, 13.1, byObjectFeature.Id, ("name", "Branch"), ("status", "open"))),
+                versionContext: VersionContext.ForVersion(objectVersion)),
+            CancellationToken.None);
+
+        // DEFAULT edits only "status" on both features (disjoint from the branch's "name" edit).
+        await store.UpdateAsync(
+            PointsLayerId, BuildFeatureWithFields(13.0, 13.0, byAttributeFeature.Id, ("name", "Base"), ("status", "closed")), CancellationToken.None);
+        await store.UpdateAsync(
+            PointsLayerId, BuildFeatureWithFields(13.1, 13.1, byObjectFeature.Id, ("name", "Base"), ("status", "closed")), CancellationToken.None);
+
+        // By-attribute detection auto-merges the disjoint edits: no conflict, clear to post.
+        var byAttribute = await versionManager.ReconcileAsync(
+            attributeVersion.VersionId, VersionReconcilePolicy.None, VersionConflictDetection.ByAttribute, CancellationToken.None);
+        byAttribute.Conflicts.Should().BeEmpty("by-attribute detection auto-merges disjoint field edits");
+        byAttribute.CanPost.Should().BeTrue();
+
+        // By-object detection flags the same object as a conflict even though the field sets are disjoint.
+        var byObject = await versionManager.ReconcileAsync(
+            objectVersion.VersionId, VersionReconcilePolicy.None, VersionConflictDetection.ByObject, CancellationToken.None);
+        byObject.CanPost.Should().BeFalse("by-object detection flags any object edited on both sides");
+        var conflict = byObject.Conflicts.Should().ContainSingle(c => c.ObjectId == byObjectFeature.Id).Subject;
+        conflict.ConflictType.Should().Be(ReplicaConflictType.Attribute);
+
+        // The by-object conflict is persisted and retrievable for manual resolution; post is blocked.
+        (await versionManager.GetPendingConflictsAsync(objectVersion.VersionId, CancellationToken.None))
+            .Should().ContainSingle(c => c.ObjectId == byObjectFeature.Id);
+        var blocked = await versionManager.PostAsync(objectVersion.VersionId, CancellationToken.None);
+        blocked.BlockedByConflicts.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task Reconcile_OverlappingFieldEdits_ReportsThreeWayConflict()
     {
         var store = CreateFeatureStore();
@@ -410,7 +468,7 @@ public sealed class BranchVersioningIntegrationTests : IAsyncLifetime
         await store.UpdateAsync(
             PointsLayerId, BuildFeatureWithFields(11.0, 11.0, feature.Id, ("name", "Base"), ("status", "default")), CancellationToken.None);
 
-        var reconcile = await versionManager.ReconcileAsync(version.VersionId, policy, CancellationToken.None);
+        var reconcile = await versionManager.ReconcileAsync(version.VersionId, policy, cancellationToken: CancellationToken.None);
         reconcile.CanPost.Should().BeTrue("policy auto-resolves the conflict");
         reconcile.AutoResolvedCount.Should().Be(1);
         reconcile.Conflicts.Should().BeEmpty();


### PR DESCRIPTION
## Summary

Hardens the GeoServices VersionManagementServer reconcile surface for branch-versioned editing conformance (#2135):

- New `VersionConflictDetection` enum (`ByAttribute` default, `ByObject`); `IVersionManager.ReconcileAsync` now accepts the detection mode. By-attribute keeps the existing disjoint-field auto-merge; by-object flags **any** feature edited on both sides since the merge base as a conflict (no field-level auto-merge), so the two modes diverge on disjoint edits.
- `HandleReconcile` parses `conflictDetection` (`byObject`/`byAttribute`/`esriReconcile*`/`object`/`attribute`; unsupported → 400) and `withPost`. `withPost=true` posts the version inline after a clean reconcile and is a no-op-with-conflicts response otherwise; `ReconcileResponse` echoes `posted`/`appliedChanges`/`serverGeneration`.
- Detection threads through `IVersionJobRunner.StartReconcileAsync` and `VersionJob` so the async reconcile job honors the requested mode.

## Changes Made

- Added `VersionConflictDetection` enum and `ConflictDetection` field on `VersionJob`.
- Extended `ReconcileAsync` (interface, `PostgresVersionManager`, `NoOpVersionManager`) and `AnalyzeOverlapsAsync` to apply by-object vs by-attribute detection.
- Added `conflictDetection`/`withPost` parsing + inline post in `VersionManagementServerEndpoints`; extended `ReconcileResponse`.
- Threaded detection through `VersionJobRunner`/`IVersionJobRunner`.
- Added provider-level byObject-vs-byAttribute divergence test and endpoint conformance tests (byObject clean, invalid-mode 400, withPost inline post).

## Breaking Changes

None. `ReconcileAsync`/`StartReconcileAsync` gained an optional `detection` parameter (defaults to `ByAttribute` = prior behavior); positional `CancellationToken` call sites were updated to named arguments.

## Gate Impact

- [x] No gate-tier impact (additive protocol behavior; default preserves prior reconcile semantics)

## Testing

- [x] Built `Honua.Core.Abstractions`, `Honua.Core`, and `Honua.Protocols.GeoServices` in Release with `TreatWarningsAsErrors=true`: **0 warnings, 0 errors**.
- [ ] `Honua.Postgres` Release build and the `Honua.Server.Tests` / `Honua.Protocols.GeoServices.Tests` runs were still queued behind the shared multi-agent build lock when this PR was opened.

## Known gaps

Opened as a draft: the `Honua.Postgres` compile and the new integration/endpoint tests had not finished under the shared build lock at open time. The Postgres change is a localized signature + branch update against the already-built Core abstractions. Re-run the affected test projects before merging:

```
dotnet build src/Honua.Postgres/Honua.Postgres.csproj -c Release /p:TreatWarningsAsErrors=true
dotnet test tests/dotnet/Honua.Protocols.GeoServices.Tests/Honua.Protocols.GeoServices.Tests.csproj
dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "Tier=Fast"
```

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Closes #2135
