### PR TITLE
feat: add audit retention pruning background job (#509)

### DIFF
--- a/src/Honua.Core/Features/AuditLog/Export/IAuditRetentionPruner.cs
+++ b/src/Honua.Core/Features/AuditLog/Export/IAuditRetentionPruner.cs
@@ -14,9 +14,11 @@ namespace Honua.Core.Features.AuditLog.Export;
 /// The audit trail is append-only and tamper-evident (a Postgres
 /// <c>DO INSTEAD NOTHING</c> rule blocks ordinary deletes). The production
 /// pruner is therefore a <em>privileged</em> maintenance path that bypasses the
-/// append-only rule under controlled conditions, and is deferred to the
-/// Postgres provider wiring. This Core seam exists so the retention policy and
-/// cutoff arithmetic can be unit-tested independently of a database.
+/// append-only rule under controlled conditions; the Postgres implementation
+/// (<c>PostgresAuditLogRetentionPruner</c>) lifts the delete guard inside a
+/// transaction and removes only a contiguous head prefix of the chain so
+/// integrity verification still passes. This Core seam exists so the retention
+/// policy and cutoff arithmetic can be unit-tested independently of a database.
 /// </para>
 /// </remarks>
 public interface IAuditRetentionPruner

--- a/src/Honua.Core/Features/AuditLog/NullAuditRetentionPruner.cs
+++ b/src/Honua.Core/Features/AuditLog/NullAuditRetentionPruner.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.AuditLog.Export;
+
+namespace Honua.Core.Features.AuditLog;
+
+/// <summary>
+/// No-op <see cref="IAuditRetentionPruner"/> used when no durable audit store is
+/// configured (tests and non-database hosts). Prunes nothing and reports zero.
+/// </summary>
+/// <remarks>
+/// This is intentionally <c>sealed</c> and stateless so DI can hand out a
+/// singleton without per-call allocation, mirroring <see cref="NullAuditLog"/>.
+/// A host with a real audit store registers a provider-backed pruner (for
+/// example the Postgres implementation) ahead of this fallback.
+/// </remarks>
+public sealed class NullAuditRetentionPruner : IAuditRetentionPruner
+{
+    /// <summary>A shared, allocation-free instance.</summary>
+    public static readonly NullAuditRetentionPruner Instance = new();
+
+    /// <inheritdoc />
+    public Task<int> PruneAsync(AuditRetentionPolicy policy, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        return Task.FromResult(0);
+    }
+}

--- a/src/Honua.Postgres/Features/AuditLog/PostgresAuditLogRetentionPruner.cs
+++ b/src/Honua.Postgres/Features/AuditLog/PostgresAuditLogRetentionPruner.cs
@@ -22,37 +22,57 @@ namespace Honua.Postgres.Features.AuditLog;
 /// deletes, and migration 069 builds a hash chain over the rows. Retention is the
 /// sanctioned, privileged maintenance path the migration explicitly allows
 /// ("rotate / archive via partition swap or explicit DROP RULE in a maintenance
-/// window"). This pruner performs that rotation safely:
+/// window"). This pruner performs that rotation safely and — critically —
+/// <em>without holding a long-lived lock</em>:
 /// </para>
 /// <list type="number">
-/// <item>It lifts the delete guard inside a single transaction and restores it in
-/// the same transaction, so the append-only rule is reinstated on commit — and a
-/// rollback (on any error) restores it too, because DDL is transactional in
-/// PostgreSQL.</item>
-/// <item>It deletes only a <em>contiguous prefix</em> of the chain (rows whose
-/// <c>audit_id</c> precedes the oldest still-retained row). Because the integrity
-/// verifier treats the first surviving hashed row as the chain genesis, pruning a
-/// head prefix never breaks verification — unlike a mid-chain delete. Only expired
-/// rows are removed: any row with <c>audit_id</c> below the first non-expired row's
-/// id is, by construction, itself expired.</item>
+/// <item>It establishes a single head-prefix safety boundary up front
+/// (<c>MIN(audit_id)</c> among still-retained rows). Everything below that
+/// boundary is, by construction, an expired contiguous prefix of the chain.
+/// Because the integrity verifier treats the first surviving hashed row as the
+/// chain genesis, pruning a head prefix never breaks verification — unlike a
+/// mid-chain delete. Concurrent inserts only ever add rows <em>above</em> the
+/// boundary (higher <c>audit_id</c>, newer timestamps), so they can never be
+/// caught by the prune and the boundary stays valid for the whole sweep.</item>
+/// <item>It then deletes those expired rows in small <em>bounded chunks</em>,
+/// each in its own short transaction, looping until none remain. The
+/// append-only guard is lifted and restored <em>inside each batch transaction</em>
+/// rather than once around the entire sweep. <c>DISABLE/ENABLE RULE</c> take an
+/// <c>ACCESS EXCLUSIVE</c> lock on the table; holding that across a multi-million
+/// row first sweep would block every inline audit insert (OperationGateway,
+/// admin endpoints) for the sweep's full duration. Scoping the lift to a single
+/// small batch means the lock is held only for milliseconds at a time and is
+/// fully released between batches, so inline audit writes interleave with
+/// pruning instead of stalling.</item>
 /// </list>
+/// <para>
+/// Each batch transaction is atomic: a crash or error mid-batch rolls back and
+/// restores the rule (DDL is transactional in PostgreSQL), and between batches
+/// the committed state always has the guard enabled.
+/// </para>
 /// </remarks>
 internal sealed class PostgresAuditLogRetentionPruner : IAuditRetentionPruner
 {
+    /// <summary>Default rows deleted per batch when no explicit size is configured.</summary>
+    internal const int DefaultBatchSize = 5_000;
+
     private const string NoDeleteRule = "audit_log_no_delete";
 
     private readonly IAdoNetDatabaseConnectionProvider _connectionProvider;
     private readonly ILogger<PostgresAuditLogRetentionPruner> _logger;
     private readonly string _table;
+    private readonly int _batchSize;
 
     public PostgresAuditLogRetentionPruner(
         IAdoNetDatabaseConnectionProvider connectionProvider,
         ILogger<PostgresAuditLogRetentionPruner> logger,
-        string? schemaName = null)
+        string? schemaName = null,
+        int batchSize = DefaultBatchSize)
     {
         _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _table = SchemaSearchPath.QualifyTable("audit_log", schemaName);
+        _batchSize = batchSize > 0 ? batchSize : DefaultBatchSize;
     }
 
     public async Task<int> PruneAsync(AuditRetentionPolicy policy, CancellationToken ct)
@@ -69,10 +89,60 @@ internal sealed class PostgresAuditLogRetentionPruner : IAuditRetentionPruner
 
         await using var connection = await _connectionProvider
             .OpenNpgsqlConnectionAsync(ct).ConfigureAwait(false);
-        await using var transaction = await connection.Connection
-            .BeginTransactionAsync(ct).ConfigureAwait(false);
 
-        // Lift the append-only delete guard for the duration of this transaction.
+        // Establish the head-prefix safety boundary once, in a short read. keep_from
+        // is the smallest audit_id among still-retained (non-expired) rows; every
+        // row below it is necessarily expired and forms the chain's leading segment,
+        // so removing it keeps the surviving hash chain intact. A NULL result means
+        // no row is still retained (the whole table is expired) and everything older
+        // than the cutoff may go. Concurrent inserts only add rows above this
+        // boundary, so it remains correct for the duration of the chunked sweep.
+        var keepFrom = await ReadKeepFromAsync(connection, cutoff, ct).ConfigureAwait(false);
+
+        var totalDeleted = 0;
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var deleted = await DeleteChunkAsync(connection, cutoff, keepFrom, ct).ConfigureAwait(false);
+            totalDeleted += deleted;
+
+            // A short batch (including zero) means the expired prefix is exhausted.
+            if (deleted < _batchSize)
+            {
+                break;
+            }
+        }
+
+        if (totalDeleted > 0)
+        {
+            AuditRetentionPostgresLog.Pruned(_logger, totalDeleted, cutoff);
+        }
+
+        return totalDeleted;
+    }
+
+    private async Task<long?> ReadKeepFromAsync(NpgsqlConnection connection, DateTimeOffset cutoff, CancellationToken ct)
+    {
+        var sql = $"SELECT MIN(audit_id) FROM {_table} WHERE timestamp >= @cutoff";
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("cutoff", NpgsqlDbType.TimestampTz, cutoff);
+        var result = await command.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        return result is null or DBNull ? null : (long)result;
+    }
+
+    private async Task<int> DeleteChunkAsync(
+        NpgsqlConnection connection,
+        DateTimeOffset cutoff,
+        long? keepFrom,
+        CancellationToken ct)
+    {
+        // Each batch runs in its own short transaction so the ACCESS EXCLUSIVE lock
+        // taken by DISABLE/ENABLE RULE is held only for the few milliseconds this
+        // small delete takes, then released — letting inline audit inserts proceed
+        // between batches instead of stalling for the whole sweep.
+        await using var transaction = await connection.BeginTransactionAsync(ct).ConfigureAwait(false);
+
         // _table is schema-validated by SchemaSearchPath; the rule name is a constant.
         await ExecuteAsync(
             connection,
@@ -80,31 +150,43 @@ internal sealed class PostgresAuditLogRetentionPruner : IAuditRetentionPruner
             $"ALTER TABLE {_table} DISABLE RULE {NoDeleteRule}",
             ct).ConfigureAwait(false);
 
-        // Delete the maximal contiguous head prefix of expired rows. keep_from is
-        // the smallest audit_id among still-retained (non-expired) rows; everything
-        // before it is necessarily expired and is the chain's leading segment, so
-        // removing it keeps the surviving hash chain intact. When every row is
-        // expired (keep_from IS NULL) the whole table is cleared.
+        // Delete a bounded slice of the expired head prefix. The inner SELECT picks
+        // the oldest expired rows (ORDER BY audit_id) up to the batch size and the
+        // outer DELETE removes exactly those ctids. When keep_from is known we bound
+        // by audit_id < keep_from (the proven-expired prefix); otherwise the whole
+        // table is expired and we bound by timestamp < cutoff.
+        var boundaryPredicate = keepFrom.HasValue
+            ? "audit_id < @keepFrom"
+            : "timestamp < @cutoff";
+
         var deleteSql = $"""
-            WITH boundary AS (
-                SELECT MIN(audit_id) AS keep_from
+            DELETE FROM {_table}
+            WHERE ctid IN (
+                SELECT ctid
                 FROM {_table}
-                WHERE timestamp >= @cutoff
+                WHERE {boundaryPredicate}
+                ORDER BY audit_id
+                LIMIT @batchSize
             )
-            DELETE FROM {_table} a
-            USING boundary b
-            WHERE (b.keep_from IS NOT NULL AND a.audit_id < b.keep_from)
-               OR (b.keep_from IS NULL AND a.timestamp < @cutoff)
             """;
 
         int deleted;
         await using (var command = new NpgsqlCommand(deleteSql, connection, transaction))
         {
-            command.Parameters.AddWithValue("cutoff", NpgsqlDbType.TimestampTz, cutoff);
+            if (keepFrom.HasValue)
+            {
+                command.Parameters.AddWithValue("keepFrom", NpgsqlDbType.Bigint, keepFrom.Value);
+            }
+            else
+            {
+                command.Parameters.AddWithValue("cutoff", NpgsqlDbType.TimestampTz, cutoff);
+            }
+
+            command.Parameters.AddWithValue("batchSize", NpgsqlDbType.Integer, _batchSize);
             deleted = await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
 
-        // Restore the append-only guard before committing.
+        // Restore the append-only guard before committing this batch.
         await ExecuteAsync(
             connection,
             transaction,
@@ -112,11 +194,6 @@ internal sealed class PostgresAuditLogRetentionPruner : IAuditRetentionPruner
             ct).ConfigureAwait(false);
 
         await transaction.CommitAsync(ct).ConfigureAwait(false);
-
-        if (deleted > 0)
-        {
-            AuditRetentionPostgresLog.Pruned(_logger, deleted, cutoff);
-        }
 
         return deleted;
     }

--- a/src/Honua.Postgres/Features/AuditLog/PostgresAuditLogRetentionPruner.cs
+++ b/src/Honua.Postgres/Features/AuditLog/PostgresAuditLogRetentionPruner.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.AuditLog.Export;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.AuditLog;
+
+/// <summary>
+/// PostgreSQL implementation of <see cref="IAuditRetentionPruner"/> backing the
+/// configurable audit retention policy (#509). Removes audit records that have
+/// aged past the retention window from <c>honua.audit_log</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The audit trail is append-only and tamper-evident: migration 033 installs an
+/// <c>audit_log_no_delete</c> rule (<c>DO INSTEAD NOTHING</c>) that blocks ordinary
+/// deletes, and migration 069 builds a hash chain over the rows. Retention is the
+/// sanctioned, privileged maintenance path the migration explicitly allows
+/// ("rotate / archive via partition swap or explicit DROP RULE in a maintenance
+/// window"). This pruner performs that rotation safely:
+/// </para>
+/// <list type="number">
+/// <item>It lifts the delete guard inside a single transaction and restores it in
+/// the same transaction, so the append-only rule is reinstated on commit — and a
+/// rollback (on any error) restores it too, because DDL is transactional in
+/// PostgreSQL.</item>
+/// <item>It deletes only a <em>contiguous prefix</em> of the chain (rows whose
+/// <c>audit_id</c> precedes the oldest still-retained row). Because the integrity
+/// verifier treats the first surviving hashed row as the chain genesis, pruning a
+/// head prefix never breaks verification — unlike a mid-chain delete. Only expired
+/// rows are removed: any row with <c>audit_id</c> below the first non-expired row's
+/// id is, by construction, itself expired.</item>
+/// </list>
+/// </remarks>
+internal sealed class PostgresAuditLogRetentionPruner : IAuditRetentionPruner
+{
+    private const string NoDeleteRule = "audit_log_no_delete";
+
+    private readonly IAdoNetDatabaseConnectionProvider _connectionProvider;
+    private readonly ILogger<PostgresAuditLogRetentionPruner> _logger;
+    private readonly string _table;
+
+    public PostgresAuditLogRetentionPruner(
+        IAdoNetDatabaseConnectionProvider connectionProvider,
+        ILogger<PostgresAuditLogRetentionPruner> logger,
+        string? schemaName = null)
+    {
+        _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _table = SchemaSearchPath.QualifyTable("audit_log", schemaName);
+    }
+
+    public async Task<int> PruneAsync(AuditRetentionPolicy policy, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+
+        // Unbounded retention means "retain forever" — never remove anything.
+        if (!policy.IsBounded)
+        {
+            return 0;
+        }
+
+        var cutoff = policy.CutoffUtc(DateTimeOffset.UtcNow);
+
+        await using var connection = await _connectionProvider
+            .OpenNpgsqlConnectionAsync(ct).ConfigureAwait(false);
+        await using var transaction = await connection.Connection
+            .BeginTransactionAsync(ct).ConfigureAwait(false);
+
+        // Lift the append-only delete guard for the duration of this transaction.
+        // _table is schema-validated by SchemaSearchPath; the rule name is a constant.
+        await ExecuteAsync(
+            connection,
+            transaction,
+            $"ALTER TABLE {_table} DISABLE RULE {NoDeleteRule}",
+            ct).ConfigureAwait(false);
+
+        // Delete the maximal contiguous head prefix of expired rows. keep_from is
+        // the smallest audit_id among still-retained (non-expired) rows; everything
+        // before it is necessarily expired and is the chain's leading segment, so
+        // removing it keeps the surviving hash chain intact. When every row is
+        // expired (keep_from IS NULL) the whole table is cleared.
+        var deleteSql = $"""
+            WITH boundary AS (
+                SELECT MIN(audit_id) AS keep_from
+                FROM {_table}
+                WHERE timestamp >= @cutoff
+            )
+            DELETE FROM {_table} a
+            USING boundary b
+            WHERE (b.keep_from IS NOT NULL AND a.audit_id < b.keep_from)
+               OR (b.keep_from IS NULL AND a.timestamp < @cutoff)
+            """;
+
+        int deleted;
+        await using (var command = new NpgsqlCommand(deleteSql, connection, transaction))
+        {
+            command.Parameters.AddWithValue("cutoff", NpgsqlDbType.TimestampTz, cutoff);
+            deleted = await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
+        // Restore the append-only guard before committing.
+        await ExecuteAsync(
+            connection,
+            transaction,
+            $"ALTER TABLE {_table} ENABLE RULE {NoDeleteRule}",
+            ct).ConfigureAwait(false);
+
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
+
+        if (deleted > 0)
+        {
+            AuditRetentionPostgresLog.Pruned(_logger, deleted, cutoff);
+        }
+
+        return deleted;
+    }
+
+    private static async Task ExecuteAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string sql,
+        CancellationToken ct)
+    {
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+}
+
+internal static partial class AuditRetentionPostgresLog
+{
+    [LoggerMessage(
+        EventId = 7311,
+        Level = LogLevel.Information,
+        Message = "Pruned {DeletedCount} audit record(s) older than {Cutoff:o} under the configured retention policy.")]
+    public static partial void Pruned(ILogger logger, int deletedCount, DateTimeOffset cutoff);
+}

--- a/src/Honua.Server/Features/Infrastructure/AuditLog/Export/AuditExportOptions.cs
+++ b/src/Honua.Server/Features/Infrastructure/AuditLog/Export/AuditExportOptions.cs
@@ -28,8 +28,10 @@ public sealed class AuditExportOptions
     public AuditExportDispatcherOptions Dispatch { get; set; } = new();
 
     /// <summary>
-    /// Retention window in days. <c>0</c> (or less) means retain forever.
-    /// Consumed by the (deferred) retention pruner.
+    /// Retention window in days. <c>0</c> (or less) means retain forever. When
+    /// positive, a background sweep (<c>AuditRetentionPruneService</c>) prunes
+    /// audit records older than this window via the registered
+    /// <see cref="AuditRetentionPolicy"/> pruner (#509).
     /// </summary>
     public int RetentionDays { get; set; }
 

--- a/src/Honua.Server/Features/Infrastructure/AuditLog/Export/AuditExportOptions.cs
+++ b/src/Honua.Server/Features/Infrastructure/AuditLog/Export/AuditExportOptions.cs
@@ -35,6 +35,16 @@ public sealed class AuditExportOptions
     /// </summary>
     public int RetentionDays { get; set; }
 
+    /// <summary>
+    /// Number of expired audit rows deleted per batch by the retention sweep.
+    /// The sweep prunes in bounded chunks across short transactions so the
+    /// append-only guard's <c>ACCESS EXCLUSIVE</c> lock is held only briefly per
+    /// batch (never across an entire large first sweep), letting inline audit
+    /// inserts interleave. Values &lt;= 0 fall back to the pruner default
+    /// (<c>5000</c>).
+    /// </summary>
+    public int RetentionPruneBatchSize { get; set; } = 5000;
+
     /// <summary>Splunk HTTP Event Collector sink configuration.</summary>
     public SplunkHecSinkOptions Splunk { get; set; } = new();
 

--- a/src/Honua.Server/Features/Infrastructure/AuditLog/Export/AuditExportServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/AuditLog/Export/AuditExportServiceCollectionExtensions.cs
@@ -62,7 +62,8 @@ internal static class AuditExportServiceCollectionExtensions
         // no-op pruner keeps the sweep inert (tests / non-database hosts).
         if (options.ToRetentionPolicy().IsBounded)
         {
-            services.TryAddScoped<IAuditRetentionPruner>(static sp =>
+            var pruneBatchSize = options.RetentionPruneBatchSize;
+            services.TryAddScoped<IAuditRetentionPruner>(sp =>
             {
                 var connectionProvider = sp.GetService<IAdoNetDatabaseConnectionProvider>();
                 if (connectionProvider is null)
@@ -72,7 +73,9 @@ internal static class AuditExportServiceCollectionExtensions
 
                 return new PostgresAuditLogRetentionPruner(
                     connectionProvider,
-                    sp.GetRequiredService<ILogger<PostgresAuditLogRetentionPruner>>());
+                    sp.GetRequiredService<ILogger<PostgresAuditLogRetentionPruner>>(),
+                    schemaName: null,
+                    batchSize: pruneBatchSize);
             });
 
             services.AddHostedService<AuditRetentionPruneService>();

--- a/src/Honua.Server/Features/Infrastructure/AuditLog/Export/AuditExportServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/AuditLog/Export/AuditExportServiceCollectionExtensions.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.AuditLog;
 using Honua.Core.Features.AuditLog.Export;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.AuditLog;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -51,6 +54,29 @@ internal static class AuditExportServiceCollectionExtensions
             sp.GetRequiredService<IAuditDeadLetterStore>(),
             sp.GetRequiredService<ILogger<AuditExportDispatcher>>(),
             sp.GetRequiredService<AuditResidencyGuard>()));
+
+        // Retention is independent of the SIEM push sinks: a bounded retention
+        // window (RetentionDays > 0) schedules a background sweep that prunes
+        // expired audit records even when no export sink is enabled (#509). A
+        // Postgres-backed pruner is used when a database is wired; otherwise the
+        // no-op pruner keeps the sweep inert (tests / non-database hosts).
+        if (options.ToRetentionPolicy().IsBounded)
+        {
+            services.TryAddScoped<IAuditRetentionPruner>(static sp =>
+            {
+                var connectionProvider = sp.GetService<IAdoNetDatabaseConnectionProvider>();
+                if (connectionProvider is null)
+                {
+                    return NullAuditRetentionPruner.Instance;
+                }
+
+                return new PostgresAuditLogRetentionPruner(
+                    connectionProvider,
+                    sp.GetRequiredService<ILogger<PostgresAuditLogRetentionPruner>>());
+            });
+
+            services.AddHostedService<AuditRetentionPruneService>();
+        }
 
         if (!options.Enabled)
         {

--- a/src/Honua.Server/Features/Infrastructure/AuditLog/Export/AuditRetentionPruneService.cs
+++ b/src/Honua.Server/Features/Infrastructure/AuditLog/Export/AuditRetentionPruneService.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.AuditLog.Export;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Infrastructure.AuditLog.Export;
+
+/// <summary>
+/// Background job that enforces the configurable audit retention policy (#509):
+/// periodically removes audit records older than <c>AuditLog:Export:RetentionDays</c>
+/// from the audit store via the registered <see cref="IAuditRetentionPruner"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Only registered when a bounded retention window is configured
+/// (<c>RetentionDays &gt; 0</c>); an unbounded policy means "retain forever" and
+/// no sweep is scheduled. The sweep runs once shortly after startup and then on
+/// a fixed interval. Failures are logged and swallowed so a transient database
+/// hiccup never crashes the host — the next sweep retries.
+/// </para>
+/// <para>
+/// The pruner itself only ever deletes a contiguous head prefix of the
+/// tamper-evident chain, so retention never breaks integrity verification.
+/// </para>
+/// </remarks>
+internal sealed partial class AuditRetentionPruneService : BackgroundService
+{
+    /// <summary>How often the retention sweep runs.</summary>
+    internal static readonly TimeSpan SweepInterval = TimeSpan.FromHours(6);
+
+    /// <summary>Grace delay before the first sweep so startup work settles first.</summary>
+    internal static readonly TimeSpan InitialDelay = TimeSpan.FromMinutes(1);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly AuditRetentionPolicy _policy;
+    private readonly ILogger<AuditRetentionPruneService> _logger;
+
+    public AuditRetentionPruneService(
+        IServiceScopeFactory scopeFactory,
+        IOptions<AuditExportOptions> options,
+        ILogger<AuditRetentionPruneService> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        ArgumentNullException.ThrowIfNull(options);
+        _policy = options.Value.ToRetentionPolicy();
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Defensive: the service is only registered when bounded, but guard anyway.
+        if (!_policy.IsBounded)
+        {
+            return;
+        }
+
+        LogStarted(_logger, _policy.RetentionWindow);
+
+        try
+        {
+            await Task.Delay(InitialDelay, stoppingToken).ConfigureAwait(false);
+
+            using var timer = new PeriodicTimer(SweepInterval);
+            do
+            {
+                await PruneOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false));
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on host shutdown.
+        }
+    }
+
+    private async Task PruneOnceAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var pruner = scope.ServiceProvider.GetRequiredService<IAuditRetentionPruner>();
+            var removed = await pruner.PruneAsync(_policy, stoppingToken).ConfigureAwait(false);
+            if (removed > 0)
+            {
+                LogSweepRemoved(_logger, removed);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Never let a retention failure crash the host; the next tick retries.
+            LogSweepFailed(_logger, ex);
+        }
+    }
+
+    [LoggerMessage(
+        EventId = 7320,
+        Level = LogLevel.Information,
+        Message = "Audit retention sweep enabled (window {RetentionWindow}).")]
+    private static partial void LogStarted(ILogger logger, TimeSpan retentionWindow);
+
+    [LoggerMessage(
+        EventId = 7321,
+        Level = LogLevel.Information,
+        Message = "Audit retention sweep removed {RemovedCount} expired audit record(s).")]
+    private static partial void LogSweepRemoved(ILogger logger, int removedCount);
+
+    [LoggerMessage(
+        EventId = 7322,
+        Level = LogLevel.Warning,
+        Message = "Audit retention sweep failed; will retry on the next interval.")]
+    private static partial void LogSweepFailed(ILogger logger, Exception exception);
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/AuditLog/NullAuditRetentionPrunerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/AuditLog/NullAuditRetentionPrunerTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.AuditLog;
+using Honua.Core.Features.AuditLog.Export;
+
+namespace Honua.Core.Tests.Features.AuditLog;
+
+/// <summary>
+/// Unit tests for the no-op retention pruner fallback (#509).
+/// </summary>
+public sealed class NullAuditRetentionPrunerTests
+{
+    [Fact]
+    public async Task PruneAsync_BoundedPolicy_RemovesNothing()
+    {
+        var policy = new AuditRetentionPolicy { RetentionWindow = TimeSpan.FromDays(30) };
+
+        var removed = await NullAuditRetentionPruner.Instance.PruneAsync(policy, CancellationToken.None);
+
+        removed.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task PruneAsync_NullPolicy_Throws()
+    {
+        var act = async () => await NullAuditRetentionPruner.Instance.PruneAsync(null!, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/AuditLog/PostgresAuditLogRetentionPrunerTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/AuditLog/PostgresAuditLogRetentionPrunerTests.cs
@@ -1,0 +1,235 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using FluentAssertions;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.AuditLog.Export;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.AuditLog;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+
+namespace Honua.Postgres.Tests.Features.AuditLog;
+
+/// <summary>
+/// Integration tests for the configurable audit retention pruner (#509).
+/// Exercises real SQL against an isolated schema with the append-only rules
+/// installed, asserting that pruning removes expired head rows, retains recent
+/// rows, and leaves the tamper-evident hash chain verifiable.
+/// </summary>
+[Collection("Database")]
+public sealed class PostgresAuditLogRetentionPrunerTests(PostgresFixture fixture)
+{
+    [IntegrationTest]
+    public async Task PruneAsync_RemovesExpiredHeadRows_RetainsRecent_AndChainStillVerifies()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresAuditLogRetentionPrunerTests));
+        try
+        {
+            await EnsureAuditLogTableAsync(schema);
+            var sink = new PostgresAuditLog(Provider(schema), NullLogger<PostgresAuditLog>.Instance, schema);
+
+            var now = DateTimeOffset.UtcNow;
+            // Insert oldest-first so audit_id order matches timestamp order.
+            await sink.RecordAsync(Event("old-0") with { Timestamp = now.AddDays(-120) });
+            await sink.RecordAsync(Event("old-1") with { Timestamp = now.AddDays(-100) });
+            await sink.RecordAsync(Event("recent-0") with { Timestamp = now.AddDays(-10) });
+            await sink.RecordAsync(Event("recent-1") with { Timestamp = now.AddDays(-1) });
+
+            var pruner = new PostgresAuditLogRetentionPruner(
+                Provider(schema), NullLogger<PostgresAuditLogRetentionPruner>.Instance, schema);
+
+            var removed = await pruner.PruneAsync(
+                new AuditRetentionPolicy { RetentionWindow = TimeSpan.FromDays(90) },
+                CancellationToken.None);
+
+            removed.Should().Be(2, "the two records older than 90 days are expired");
+
+            var survivors = await ReadCorrelationIdsAsync(schema);
+            survivors.Should().ContainInOrder("recent-0", "recent-1");
+            survivors.Should().NotContain(new[] { "old-0", "old-1" });
+
+            // Pruning a contiguous head prefix must not break the hash chain: the
+            // first surviving row becomes the new genesis (its prev_hash is not
+            // checked), so verification still passes.
+            var report = await new PostgresAuditLogIntegrityVerifier(Provider(schema), schema).VerifyAsync();
+            report.Verified.Should().BeTrue("a head-prefix prune preserves chain integrity");
+            report.RowsChecked.Should().Be(2);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task PruneAsync_UnboundedPolicy_RemovesNothing()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresAuditLogRetentionPrunerTests));
+        try
+        {
+            await EnsureAuditLogTableAsync(schema);
+            var sink = new PostgresAuditLog(Provider(schema), NullLogger<PostgresAuditLog>.Instance, schema);
+            await sink.RecordAsync(Event("a") with { Timestamp = DateTimeOffset.UtcNow.AddYears(-5) });
+            await sink.RecordAsync(Event("b") with { Timestamp = DateTimeOffset.UtcNow.AddYears(-5) });
+
+            var pruner = new PostgresAuditLogRetentionPruner(
+                Provider(schema), NullLogger<PostgresAuditLogRetentionPruner>.Instance, schema);
+
+            var removed = await pruner.PruneAsync(
+                new AuditRetentionPolicy { RetentionWindow = TimeSpan.Zero },
+                CancellationToken.None);
+
+            removed.Should().Be(0, "an unbounded policy retains forever");
+            (await ReadCorrelationIdsAsync(schema)).Should().HaveCount(2);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task PruneAsync_AllRowsExpired_ClearsTable_AndRestoresAppendOnlyGuard()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresAuditLogRetentionPrunerTests));
+        try
+        {
+            await EnsureAuditLogTableAsync(schema);
+            var sink = new PostgresAuditLog(Provider(schema), NullLogger<PostgresAuditLog>.Instance, schema);
+            await sink.RecordAsync(Event("a") with { Timestamp = DateTimeOffset.UtcNow.AddDays(-200) });
+            await sink.RecordAsync(Event("b") with { Timestamp = DateTimeOffset.UtcNow.AddDays(-150) });
+
+            var pruner = new PostgresAuditLogRetentionPruner(
+                Provider(schema), NullLogger<PostgresAuditLogRetentionPruner>.Instance, schema);
+
+            var removed = await pruner.PruneAsync(
+                new AuditRetentionPolicy { RetentionWindow = TimeSpan.FromDays(90) },
+                CancellationToken.None);
+
+            removed.Should().Be(2);
+            (await ReadCorrelationIdsAsync(schema)).Should().BeEmpty();
+
+            // The append-only DELETE guard must be reinstated after the prune so a
+            // subsequent ordinary delete is once again a no-op.
+            await sink.RecordAsync(Event("c") with { Timestamp = DateTimeOffset.UtcNow });
+            await ExecuteAsync(schema, $"""DELETE FROM "{schema}".audit_log;""");
+            (await ReadCorrelationIdsAsync(schema)).Should().ContainSingle().Which.Should().Be("c");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    private static AuditEvent Event(string correlationId) => new()
+    {
+        Timestamp = DateTimeOffset.UtcNow,
+        EventType = AuditEventType.Authentication,
+        Actor = "user-1",
+        ActorType = AuditActorType.UserId,
+        ResourceType = "http",
+        ResourceId = "/api/v1/admin/x",
+        Action = "auth.success",
+        Outcome = AuditOutcome.Success,
+        CorrelationId = correlationId,
+        RemoteIp = "10.0.0.1",
+        UserAgent = "agent/1.0",
+        Details = "{}",
+    };
+
+    private TestConnectionProvider Provider(string schema) => new(fixture.DataSource, schema);
+
+    private async Task<List<string>> ReadCorrelationIdsAsync(string schema)
+    {
+        await using var conn = await fixture.GetConnectionAsync(schema);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""SELECT correlation_id FROM "{schema}".audit_log ORDER BY audit_id ASC;""";
+        await using var reader = await cmd.ExecuteReaderAsync();
+        var results = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            results.Add(reader.GetString(0));
+        }
+
+        return results;
+    }
+
+    private async Task ExecuteAsync(string schema, string sql)
+    {
+        await using var conn = await fixture.GetConnectionAsync(schema);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task EnsureAuditLogTableAsync(string schema)
+    {
+        await fixture.ExecuteAsync($"""
+            CREATE TABLE IF NOT EXISTS "{schema}".audit_log (
+                audit_id         BIGSERIAL    PRIMARY KEY,
+                timestamp        TIMESTAMPTZ  NOT NULL,
+                event_type       VARCHAR(32)  NOT NULL,
+                actor            VARCHAR(256) NOT NULL,
+                actor_type       VARCHAR(32)  NOT NULL,
+                resource_type    VARCHAR(64)  NOT NULL,
+                resource_id      VARCHAR(256),
+                action           VARCHAR(128) NOT NULL,
+                outcome          VARCHAR(16)  NOT NULL,
+                correlation_id   VARCHAR(64)  NOT NULL,
+                remote_ip        VARCHAR(64),
+                user_agent       VARCHAR(512),
+                details          TEXT         NOT NULL DEFAULT '',
+                prev_hash        CHAR(64),
+                entry_hash       CHAR(64)
+            );
+
+            DROP RULE IF EXISTS audit_log_no_update ON "{schema}".audit_log;
+            CREATE RULE audit_log_no_update AS ON UPDATE TO "{schema}".audit_log DO INSTEAD NOTHING;
+
+            DROP RULE IF EXISTS audit_log_no_delete ON "{schema}".audit_log;
+            CREATE RULE audit_log_no_delete AS ON DELETE TO "{schema}".audit_log DO INSTEAD NOTHING;
+            """);
+    }
+
+    private sealed class TestConnectionProvider(NpgsqlDataSource dataSource, string schemaName) : IAdoNetDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => dataSource.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            var conn = await dataSource.OpenConnectionAsync(cancellationToken);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SET search_path TO \"{schemaName}\", public;";
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+            return conn;
+        }
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var conn = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var tx = await conn.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (conn, tx);
+            }
+            catch
+            {
+                await conn.DisposeAsync();
+                throw;
+            }
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken = default)
+            => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(Func<Task> operation, CancellationToken cancellationToken = default)
+            => operation();
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/AuditLog/PostgresAuditLogRetentionPrunerTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/AuditLog/PostgresAuditLogRetentionPrunerTests.cs
@@ -67,6 +67,56 @@ public sealed class PostgresAuditLogRetentionPrunerTests(PostgresFixture fixture
     }
 
     [IntegrationTest]
+    public async Task PruneAsync_SmallBatchSize_DeletesExpiredPrefixAcrossMultipleBatches_AndRestoresGuard()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresAuditLogRetentionPrunerTests));
+        try
+        {
+            await EnsureAuditLogTableAsync(schema);
+            var sink = new PostgresAuditLog(Provider(schema), NullLogger<PostgresAuditLog>.Instance, schema);
+
+            var now = DateTimeOffset.UtcNow;
+            // Five expired rows force several passes when the batch size is 2.
+            for (var i = 0; i < 5; i++)
+            {
+                await sink.RecordAsync(Event($"old-{i}") with { Timestamp = now.AddDays(-200 + i) });
+            }
+
+            await sink.RecordAsync(Event("recent-0") with { Timestamp = now.AddDays(-5) });
+            await sink.RecordAsync(Event("recent-1") with { Timestamp = now.AddDays(-1) });
+
+            // batchSize = 2 -> the 5 expired rows are removed over three short
+            // transactions (2 + 2 + 1) rather than one table-locking sweep.
+            var pruner = new PostgresAuditLogRetentionPruner(
+                Provider(schema), NullLogger<PostgresAuditLogRetentionPruner>.Instance, schema, batchSize: 2);
+
+            var removed = await pruner.PruneAsync(
+                new AuditRetentionPolicy { RetentionWindow = TimeSpan.FromDays(90) },
+                CancellationToken.None);
+
+            removed.Should().Be(5, "all five records older than 90 days are expired");
+
+            var survivors = await ReadCorrelationIdsAsync(schema);
+            survivors.Should().ContainInOrder("recent-0", "recent-1");
+            survivors.Should().HaveCount(2);
+
+            // Chunked head-prefix pruning still leaves the surviving chain verifiable.
+            var report = await new PostgresAuditLogIntegrityVerifier(Provider(schema), schema).VerifyAsync();
+            report.Verified.Should().BeTrue("a chunked head-prefix prune preserves chain integrity");
+            report.RowsChecked.Should().Be(2);
+
+            // The append-only DELETE guard must be re-enabled after every batch, so
+            // an ordinary delete is once again a no-op once pruning completes.
+            await ExecuteAsync(schema, $"""DELETE FROM "{schema}".audit_log;""");
+            (await ReadCorrelationIdsAsync(schema)).Should().HaveCount(2, "the append-only guard is restored after chunked pruning");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
     public async Task PruneAsync_UnboundedPolicy_RemovesNothing()
     {
         var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresAuditLogRetentionPrunerTests));


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #509

## Summary
SIEM export and operator access (#509) was already largely implemented: the streaming JSON-Lines/CEF export endpoint (`GET /api/v1/admin/observability/audit/export`), the paginated/filterable history query surface, the tamper-evidence verifier, and the push sinks (Splunk HEC / Microsoft Sentinel / S3 / syslog) with shared retry/backoff, dead-lettering, and data-residency enforcement all landed under #2157.

The one acceptance criterion left unwired was **retention**: `AuditLog:Export:RetentionDays` existed and `AuditRetentionPolicy`/`IAuditRetentionPruner` were scaffolded, but no Postgres pruner and no background sweep were registered (the `IAuditRetentionPruner` doc and `AuditExportOptions` comment both said "deferred"). This PR implements automatic retention cleanup.

The pruner is integrity-safe by construction. The audit trail is append-only (migration 033's `audit_log_no_delete` `DO INSTEAD NOTHING` rule) and hash-chained (migration 069). The pruner lifts the delete guard inside a single transaction (restored on commit, and on rollback because DDL is transactional) and deletes only a **contiguous head prefix** of the chain. Because the integrity verifier treats the first surviving hashed row as the chain genesis (no `prev_hash` check on it), pruning the head never breaks verification — and by construction every row before the oldest non-expired row is itself expired, so no in-window row is removed.

## Changes Made
- Add `PostgresAuditLogRetentionPruner` (`IAuditRetentionPruner`) that prunes expired audit rows as a contiguous head prefix, preserving the tamper-evident chain.
- Add `AuditRetentionPruneService` background job that runs a bounded-retention sweep on a fixed interval, resolving the pruner in a scope and swallowing transient failures so a DB hiccup never crashes the host.
- Add `NullAuditRetentionPruner` no-op fallback for non-database / test hosts.
- Register the pruner + sweep in `AddHonuaAuditExport` when `RetentionDays > 0`, independent of whether SIEM push sinks are enabled.
- Update the now-accurate doc comments on `IAuditRetentionPruner` and `AuditExportOptions.RetentionDays`.
- Tests: Core no-op pruner unit tests; Postgres integration tests covering head-prefix pruning + chain re-verification, unbounded retain-forever, and append-only-guard restoration after a full clear.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Ran:
- `dotnet build src/Honua.Server/Honua.Server.csproj -c Release /p:TreatWarningsAsErrors=true` → succeeded, 0 warnings / 0 errors (also builds Core + Postgres).
- `dotnet build tests/dotnet/Honua.Postgres.Tests -c Release /p:TreatWarningsAsErrors=true` → succeeded, 0 warnings.
- `dotnet test Honua.Core.Tests --filter NullAuditRetentionPruner` → 2 passed.
- `dotnet format --verify-no-changes` on all changed files → clean.

The new Postgres integration tests (`PostgresAuditLogRetentionPrunerTests`) compile and are Testcontainers-based; Docker is unavailable in this environment, so they run in CI rather than locally.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

(No schema migration: retention reuses the existing `honua.audit_log` table and its append-only rule.)

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

## Known gaps
- Postgres integration tests could not be executed locally (no Docker); they are validated in CI.
- Retention performs deletion (rotation), not copy-to-cold-storage "archival"; archival-before-delete can be layered on the existing S3 sink in a follow-up. The remaining #509 criteria (streaming export, webhook/SIEM forwarding sinks, paginated filtered query) were already implemented under #2157, so this PR uses `Related to #509`; close #509 once archival-vs-delete is confirmed acceptable.
