### PR TITLE
feat(scene): encode I3S per-field user attribute files + statistics (#1811)

### DIFF
--- a/src/Honua.Scene/Conversion/I3sAttributeBufferBuilder.cs
+++ b/src/Honua.Scene/Conversion/I3sAttributeBufferBuilder.cs
@@ -2,7 +2,10 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Buffers.Binary;
+using System.Globalization;
+using System.Text;
 using Honua.Core.Features.Scene.Conversion;
+using Honua.Core.Features.Scene.Domain;
 
 namespace Honua.Scene;
 
@@ -49,6 +52,25 @@ public static class I3sAttributeBufferBuilder
     /// <summary>The I3S Oid32 value type advertised for the OBJECTID field.</summary>
     public const string Oid32ValueType = "Oid32";
 
+    /// <summary>The I3S Float64 value type advertised for numeric user fields.</summary>
+    public const string Float64ValueType = "Float64";
+
+    /// <summary>The I3S String value type advertised for variable-length user fields.</summary>
+    public const string StringValueType = "String";
+
+    /// <summary>Bytes per <c>Float64</c> value (one little-endian double).</summary>
+    public const int Float64ValueBytes = 8;
+
+    /// <summary>Bytes per <c>attributeByteCounts</c> entry (one little-endian UInt32).</summary>
+    public const int ByteCountValueBytes = 4;
+
+    /// <summary>
+    /// Header bytes for a variable-length (string) attribute file: <c>count</c>
+    /// (UInt32) plus <c>attributeValuesByteCount</c> (UInt32), matching the I3S
+    /// string-field ordering <c>["attributeByteCounts", "attributeValues"]</c>.
+    /// </summary>
+    public const int StringHeaderBytes = 8;
+
     /// <summary>
     /// Header bytes for a fixed-width attribute file: <c>count</c> (UInt32) plus a
     /// reserved UInt32 so the value array starts on an 8-byte boundary, matching
@@ -90,6 +112,74 @@ public static class I3sAttributeBufferBuilder
 
         var ids = ReadFeatureIds(geometry);
         return PackOid32(ids);
+    }
+
+    /// <summary>
+    /// Builds the binary attribute file for one attribute-storage field directly
+    /// from the ordered scene features (the same source the geometry transcoder
+    /// consumes), or <see langword="null"/> when the field's value type is not a
+    /// servable I3S attribute layout.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Unlike the geometry-keyed overload, this path materialises <b>user
+    /// attribute values</b> from each feature's projected
+    /// <see cref="SceneFeature.Attributes"/> bag, keyed on the field's name (the
+    /// attribute key <see cref="I3sAttributeSchemaBuilder"/> assigned the field
+    /// to). The feature order is the canonical OBJECTID order the served geometry
+    /// feature section also uses, so a picked feature resolves to the same row in
+    /// every per-field file.
+    /// </para>
+    /// <para>
+    /// Three I3S value layouts are emitted: <c>Oid32</c> (object ids),
+    /// <c>Float64</c> (numeric values; a missing/non-numeric value encodes as
+    /// <c>0</c>), and <c>String</c> (UTF-8 with a per-value byte-count header; a
+    /// missing value encodes as the empty string). Any other value type returns
+    /// <see langword="null"/> so the endpoint answers an honest 404.
+    /// </para>
+    /// </remarks>
+    /// <param name="features">The ordered scene features supplying attribute values.</param>
+    /// <param name="field">The attribute-storage descriptor for the requested field.</param>
+    /// <returns>The attribute file bytes, or <see langword="null"/> for an unsupported field.</returns>
+    public static byte[]? Build(IReadOnlyList<SceneFeature> features, I3sAttributeStorageInfo field)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+        ArgumentNullException.ThrowIfNull(field);
+
+        var valueType = field.AttributeValues?.ValueType;
+
+        if (string.Equals(field.Key, ObjectIdFieldKey, StringComparison.Ordinal)
+            && string.Equals(valueType, Oid32ValueType, StringComparison.Ordinal))
+        {
+            var ids = new int[features.Count];
+            for (var i = 0; i < features.Count; i++)
+            {
+                // Oid32 narrows the 64-bit feature id to the 32-bit object-id
+                // space Esri identify uses (hosted scene object ids fit in 32 bits).
+                ids[i] = unchecked((int)features[i].Id);
+            }
+
+            return PackOid32(ids);
+        }
+
+        // User fields are keyed on the attribute name the schema builder assigned.
+        var attributeKey = field.Name;
+        if (string.IsNullOrEmpty(attributeKey))
+        {
+            return null;
+        }
+
+        if (string.Equals(valueType, Float64ValueType, StringComparison.Ordinal))
+        {
+            return PackFloat64(features, attributeKey);
+        }
+
+        if (string.Equals(valueType, StringValueType, StringComparison.Ordinal))
+        {
+            return PackStrings(features, attributeKey);
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -136,5 +226,119 @@ public static class I3sAttributeBufferBuilder
         }
 
         return buffer;
+    }
+
+    /// <summary>
+    /// Packs a fixed-width <c>Float64</c> attribute file: an 8-byte header
+    /// (<c>count</c> + reserved, so the value array starts 8-byte aligned)
+    /// followed by <c>count</c> little-endian doubles. A missing or non-numeric
+    /// value encodes as <c>0</c>.
+    /// </summary>
+    private static byte[] PackFloat64(IReadOnlyList<SceneFeature> features, string attributeKey)
+    {
+        var buffer = new byte[HeaderBytes + (features.Count * Float64ValueBytes)];
+        var span = buffer.AsSpan();
+
+        BinaryPrimitives.WriteUInt32LittleEndian(span[..4], (uint)features.Count);
+        // span[4..8] reserved (zero) for 8-byte value-array alignment.
+
+        var offset = HeaderBytes;
+        foreach (var feature in features)
+        {
+            var value = TryGetNumeric(feature, attributeKey) ?? 0.0;
+            BinaryPrimitives.WriteDoubleLittleEndian(span.Slice(offset, Float64ValueBytes), value);
+            offset += Float64ValueBytes;
+        }
+
+        return buffer;
+    }
+
+    /// <summary>
+    /// Packs a variable-length <c>String</c> attribute file: an 8-byte header
+    /// (<c>count</c> + <c>attributeValuesByteCount</c>), then a <c>UInt32</c>
+    /// byte-count per value (UTF-8 length including the trailing NUL), then the
+    /// NUL-terminated UTF-8 value blob. A missing value encodes as the empty
+    /// string (a single NUL).
+    /// </summary>
+    private static byte[] PackStrings(IReadOnlyList<SceneFeature> features, string attributeKey)
+    {
+        var count = features.Count;
+        var utf8 = new byte[count][];
+        var valuesByteCount = 0;
+        for (var i = 0; i < count; i++)
+        {
+            var text = TryGetString(features[i], attributeKey);
+            // Each value carries a trailing NUL, so the byte-count and the blob
+            // both include the terminator (the layout ArcGIS string files use).
+            var encoded = new byte[Encoding.UTF8.GetByteCount(text) + 1];
+            Encoding.UTF8.GetBytes(text, encoded);
+            utf8[i] = encoded;
+            valuesByteCount += encoded.Length;
+        }
+
+        var byteCountsBytes = count * ByteCountValueBytes;
+        var buffer = new byte[StringHeaderBytes + byteCountsBytes + valuesByteCount];
+        var span = buffer.AsSpan();
+
+        BinaryPrimitives.WriteUInt32LittleEndian(span[..4], (uint)count);
+        BinaryPrimitives.WriteUInt32LittleEndian(span.Slice(4, 4), (uint)valuesByteCount);
+
+        var byteCountsOffset = StringHeaderBytes;
+        var valuesOffset = StringHeaderBytes + byteCountsBytes;
+        for (var i = 0; i < count; i++)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                span.Slice(byteCountsOffset, ByteCountValueBytes),
+                (uint)utf8[i].Length);
+            byteCountsOffset += ByteCountValueBytes;
+
+            utf8[i].CopyTo(span.Slice(valuesOffset, utf8[i].Length));
+            valuesOffset += utf8[i].Length;
+        }
+
+        return buffer;
+    }
+
+    /// <summary>
+    /// Reads a feature's attribute value as a double when it is present and
+    /// numeric, or <see langword="null"/> otherwise. Numeric-looking strings are
+    /// parsed invariantly so a string-typed projection of a numeric column still
+    /// resolves a value.
+    /// </summary>
+    internal static double? TryGetNumeric(SceneFeature feature, string attributeKey)
+    {
+        if (!feature.Attributes.TryGetValue(attributeKey, out var value) || value is null)
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            byte b => b,
+            sbyte b => b,
+            short s => s,
+            ushort s => s,
+            int i => i,
+            uint i => i,
+            long l => l,
+            ulong l => l,
+            float f => f,
+            double d => d,
+            decimal m => (double)m,
+            string s when double.TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => null,
+        };
+    }
+
+    private static string TryGetString(SceneFeature feature, string attributeKey)
+    {
+        if (!feature.Attributes.TryGetValue(attributeKey, out var value) || value is null)
+        {
+            return string.Empty;
+        }
+
+        return value as string
+            ?? Convert.ToString(value, CultureInfo.InvariantCulture)
+            ?? string.Empty;
     }
 }

--- a/src/Honua.Scene/Conversion/I3sAttributeSchemaBuilder.cs
+++ b/src/Honua.Scene/Conversion/I3sAttributeSchemaBuilder.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Conversion;
+using Honua.Core.Features.Scene.Domain;
+
+namespace Honua.Scene;
+
+/// <summary>
+/// Derives the I3S layer <c>attributeStorageInfo</c> field schema from the
+/// projected attributes of a scene's features (#1811). This is the inverse of
+/// the value encoder <see cref="I3sAttributeBufferBuilder"/>: it advertises the
+/// fields an ArcGIS SceneLayer client can identify, with the per-field binary
+/// layout (key, ordering, header, value type) the matching
+/// <c>nodes/{id}/attributes/{key}/0</c> file conforms to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The synthetic <c>OBJECTID</c> field (<c>f_0</c>, <c>Oid32</c>) every served
+/// 3D Object node carries is always emitted first, matching the merged identify
+/// slice. Each distinct user attribute key projected onto the features
+/// (<see cref="SceneFeature.Attributes"/> — the same bag the 3D Tiles
+/// <c>EXT_structural_metadata</c> property tables are baked from) is then
+/// assigned a stable <c>f_{n}</c> key in deterministic ordinal-sorted key order
+/// so the schema is byte-stable across runs for identical input.
+/// </para>
+/// <para>
+/// A field's value type is inferred from the projected values: a key whose
+/// non-null values are all numeric is advertised as <c>Float64</c>
+/// (fixed-width); any other key is advertised as a UTF-8 <c>String</c>
+/// (variable-length, with an <c>attributeByteCounts</c> buffer). This mirrors
+/// the two value layouts <see cref="I3sAttributeBufferBuilder"/> emits, so a
+/// descriptor field and its served attribute file always agree.
+/// </para>
+/// </remarks>
+public static class I3sAttributeSchemaBuilder
+{
+    /// <summary>Stable key for the synthetic <c>OBJECTID</c> field (always first).</summary>
+    public const string ObjectIdFieldKey = "f_0";
+
+    /// <summary>Prefix used for user-attribute field keys (<c>f_1</c>, <c>f_2</c>, …).</summary>
+    public const string UserFieldKeyPrefix = "f_";
+
+    /// <summary>
+    /// Builds the ordered <c>attributeStorageInfo</c> field list for a feature
+    /// set: the synthetic <c>OBJECTID</c> field followed by one typed field per
+    /// distinct projected attribute key.
+    /// </summary>
+    /// <param name="features">
+    /// The scene features whose projected <see cref="SceneFeature.Attributes"/>
+    /// define the user field set. An empty set yields the <c>OBJECTID</c> field
+    /// only.
+    /// </param>
+    /// <returns>The ordered attribute-storage descriptors.</returns>
+    public static IReadOnlyList<I3sAttributeStorageInfo> Build(IReadOnlyList<SceneFeature> features)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+
+        var fields = new List<I3sAttributeStorageInfo> { BuildObjectIdField() };
+
+        // Collect the distinct attribute keys and whether every observed value
+        // for each key is numeric, in a single deterministic pass.
+        var numericByKey = new SortedDictionary<string, bool>(StringComparer.Ordinal);
+        foreach (var feature in features)
+        {
+            foreach (var (key, value) in feature.Attributes)
+            {
+                if (string.IsNullOrEmpty(key))
+                {
+                    continue;
+                }
+
+                var valueIsNumeric = value is null || IsNumeric(value);
+                numericByKey[key] = numericByKey.TryGetValue(key, out var allNumeric)
+                    ? allNumeric && valueIsNumeric
+                    : valueIsNumeric;
+            }
+        }
+
+        var index = 1;
+        foreach (var (name, allNumeric) in numericByKey)
+        {
+            var key = UserFieldKeyPrefix + index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            fields.Add(allNumeric ? BuildNumericField(key, name) : BuildStringField(key, name));
+            index++;
+        }
+
+        return fields;
+    }
+
+    /// <summary>The synthetic <c>OBJECTID</c> (<c>f_0</c>, <c>Oid32</c>) field descriptor.</summary>
+    public static I3sAttributeStorageInfo BuildObjectIdField() => new()
+    {
+        Key = ObjectIdFieldKey,
+        Name = "OBJECTID",
+        Ordering = ["attributeValues"],
+        Header = [new I3sAttributeHeader { Property = "count", ValueType = "UInt32" }],
+        AttributeValues = new I3sAttributeValues
+        {
+            ValueType = I3sAttributeBufferBuilder.Oid32ValueType,
+            ValuesPerElement = 1,
+        },
+    };
+
+    private static I3sAttributeStorageInfo BuildNumericField(string key, string name) => new()
+    {
+        Key = key,
+        Name = name,
+        Ordering = ["attributeValues"],
+        Header = [new I3sAttributeHeader { Property = "count", ValueType = "UInt32" }],
+        AttributeValues = new I3sAttributeValues
+        {
+            ValueType = I3sAttributeBufferBuilder.Float64ValueType,
+            ValuesPerElement = 1,
+        },
+    };
+
+    private static I3sAttributeStorageInfo BuildStringField(string key, string name) => new()
+    {
+        Key = key,
+        Name = name,
+        Ordering = ["attributeByteCounts", "attributeValues"],
+        Header =
+        [
+            new I3sAttributeHeader { Property = "count", ValueType = "UInt32" },
+            new I3sAttributeHeader { Property = "attributeValuesByteCount", ValueType = "UInt32" },
+        ],
+        AttributeByteCounts = new I3sAttributeValues
+        {
+            ValueType = "UInt32",
+            ValuesPerElement = 1,
+        },
+        AttributeValues = new I3sAttributeValues
+        {
+            ValueType = I3sAttributeBufferBuilder.StringValueType,
+            Encoding = "UTF-8",
+            ValuesPerElement = 1,
+        },
+    };
+
+    /// <summary>
+    /// Whether a projected attribute value is one of the numeric CLR types the
+    /// feature projection emits (the I3S <c>Float64</c> path narrows them all to
+    /// double).
+    /// </summary>
+    internal static bool IsNumeric(object value) => value is
+        byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal;
+}

--- a/src/Honua.Scene/Conversion/I3sSceneLayerDocument.cs
+++ b/src/Honua.Scene/Conversion/I3sSceneLayerDocument.cs
@@ -113,6 +113,16 @@ public sealed class I3sAttributeStorageInfo
     [JsonPropertyName("header")]
     public IReadOnlyList<I3sAttributeHeader>? Header { get; set; }
 
+    /// <summary>
+    /// Per-value byte-count buffer encoding descriptor for variable-length
+    /// (string) attributes (OGC 19-008 <c>attributeByteCounts</c>). Present only
+    /// for <c>String</c> fields, whose binary file carries a
+    /// <c>UInt32</c> byte-count per value before the UTF-8 value blob so a client
+    /// can index into the variable-length values; omitted for fixed-width fields.
+    /// </summary>
+    [JsonPropertyName("attributeByteCounts")]
+    public I3sAttributeValues? AttributeByteCounts { get; set; }
+
     /// <summary>Value-buffer encoding descriptor.</summary>
     [JsonPropertyName("attributeValues")]
     public I3sAttributeValues? AttributeValues { get; set; }

--- a/src/Honua.Scene/I3sSceneStatisticsBuilder.cs
+++ b/src/Honua.Scene/I3sSceneStatisticsBuilder.cs
@@ -62,6 +62,116 @@ public static class I3sSceneStatisticsBuilder
         };
     }
 
+    /// <summary>
+    /// Builds the statistics summary for one attribute-storage field directly
+    /// from the ordered scene features, computing real numeric ranges instead of
+    /// the node-count lower bound.
+    /// </summary>
+    /// <remarks>
+    /// For the synthetic <c>OBJECTID</c> field and any <c>Float64</c> user field
+    /// the summary carries the true <c>totalValuesCount</c> (features with a
+    /// non-null value), <c>min</c>/<c>max</c>, and distinct-value <c>count</c>
+    /// derived from the features' projected attributes. A <c>String</c> field
+    /// has no numeric range, so only <c>totalValuesCount</c> and the distinct
+    /// <c>count</c> are emitted.
+    /// </remarks>
+    /// <param name="features">The ordered scene features supplying attribute values.</param>
+    /// <param name="field">The attribute-storage descriptor for the field.</param>
+    /// <returns>The statistics document for the field.</returns>
+    public static I3sAttributeStatisticsDocument Build(
+        IReadOnlyList<SceneFeature> features,
+        I3sAttributeStorageInfo field)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+        ArgumentNullException.ThrowIfNull(field);
+
+        if (string.Equals(field.Key, ObjectIdFieldKey, StringComparison.Ordinal))
+        {
+            return BuildNumericStats(
+                features.Select(static f => (double)f.Id),
+                features.Count);
+        }
+
+        var attributeKey = field.Name;
+        if (string.IsNullOrEmpty(attributeKey))
+        {
+            return new I3sAttributeStatisticsDocument();
+        }
+
+        if (string.Equals(field.AttributeValues?.ValueType, I3sAttributeBufferBuilder.Float64ValueType, StringComparison.Ordinal))
+        {
+            var numerics = features
+                .Select(f => I3sAttributeBufferBuilder.TryGetNumeric(f, attributeKey))
+                .Where(static v => v.HasValue)
+                .Select(static v => v!.Value);
+            return BuildNumericStats(numerics, presentCountHint: null);
+        }
+
+        // Non-numeric (string) field: emit value presence + distinct count only.
+        var present = 0;
+        var distinct = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var feature in features)
+        {
+            if (feature.Attributes.TryGetValue(attributeKey, out var value) && value is not null)
+            {
+                present++;
+                distinct.Add(value as string ?? value.ToString() ?? string.Empty);
+            }
+        }
+
+        return new I3sAttributeStatisticsDocument
+        {
+            Stats = new I3sAttributeStatistics
+            {
+                TotalValuesCount = present,
+                Count = distinct.Count,
+            },
+        };
+    }
+
+    private static I3sAttributeStatisticsDocument BuildNumericStats(IEnumerable<double> values, int? presentCountHint)
+    {
+        long total = 0;
+        double min = double.PositiveInfinity;
+        double max = double.NegativeInfinity;
+        var distinct = new HashSet<double>();
+
+        foreach (var value in values)
+        {
+            total++;
+            if (value < min)
+            {
+                min = value;
+            }
+
+            if (value > max)
+            {
+                max = value;
+            }
+
+            distinct.Add(value);
+        }
+
+        if (total == 0)
+        {
+            return new I3sAttributeStatisticsDocument
+            {
+                Stats = new I3sAttributeStatistics { TotalValuesCount = presentCountHint ?? 0 },
+            };
+        }
+
+        return new I3sAttributeStatisticsDocument
+        {
+            Stats = new I3sAttributeStatistics
+            {
+                TotalValuesCount = presentCountHint ?? total,
+                Min = min,
+                Max = max,
+                Count = distinct.Count,
+            },
+        };
+    }
+
     private static long CountContentNodes(SceneDataset scene)
     {
         if (!I3sNodeStore.TryBuildNodePages(scene, out var pages))

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sAttributeBufferBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sAttributeBufferBuilderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Buffers.Binary;
+using System.Text;
 using Honua.Core.Features.Scene.Conversion;
 using Honua.Core.Features.Scene.Domain;
 using Honua.Scene;
@@ -78,6 +79,114 @@ public sealed class I3sAttributeBufferBuilderTests
 
         I3sAttributeBufferBuilder.Build(geometry, field).Should().BeNull();
     }
+
+    [UnitTest]
+    public void Build_FromFeatures_ObjectIdField_EmitsFeatureIdsInOrder()
+    {
+        var features = ThreeFeaturesWithAttributes();
+
+        var bytes = I3sAttributeBufferBuilder.Build(features, I3sAttributeSchemaBuilder.BuildObjectIdField());
+
+        bytes.Should().NotBeNull();
+        var span = bytes!.AsSpan();
+        BinaryPrimitives.ReadUInt32LittleEndian(span[..4]).Should().Be(3);
+        BinaryPrimitives.ReadInt32LittleEndian(span.Slice(I3sAttributeBufferBuilder.HeaderBytes, 4)).Should().Be(11);
+        BinaryPrimitives.ReadInt32LittleEndian(span.Slice(I3sAttributeBufferBuilder.HeaderBytes + 4, 4)).Should().Be(22);
+        BinaryPrimitives.ReadInt32LittleEndian(span.Slice(I3sAttributeBufferBuilder.HeaderBytes + 8, 4)).Should().Be(33);
+    }
+
+    [UnitTest]
+    public void Build_FromFeatures_Float64Field_EmitsCountHeaderAndDoubleValues()
+    {
+        var features = ThreeFeaturesWithAttributes();
+        var field = NumericField("f_1", "HEIGHT");
+
+        var bytes = I3sAttributeBufferBuilder.Build(features, field);
+
+        bytes.Should().NotBeNull();
+        var span = bytes!.AsSpan();
+        var expectedLength = I3sAttributeBufferBuilder.HeaderBytes
+            + (features.Count * I3sAttributeBufferBuilder.Float64ValueBytes);
+        bytes!.Length.Should().Be(expectedLength);
+
+        BinaryPrimitives.ReadUInt32LittleEndian(span[..4]).Should().Be(3);
+        BinaryPrimitives.ReadDoubleLittleEndian(span.Slice(I3sAttributeBufferBuilder.HeaderBytes, 8)).Should().Be(12.5);
+        BinaryPrimitives.ReadDoubleLittleEndian(span.Slice(I3sAttributeBufferBuilder.HeaderBytes + 8, 8)).Should().Be(7.0);
+        // The third feature has no HEIGHT value, so it encodes as 0.
+        BinaryPrimitives.ReadDoubleLittleEndian(span.Slice(I3sAttributeBufferBuilder.HeaderBytes + 16, 8)).Should().Be(0.0);
+    }
+
+    [UnitTest]
+    public void Build_FromFeatures_StringField_EmitsByteCountsAndNullTerminatedUtf8()
+    {
+        var features = ThreeFeaturesWithAttributes();
+        var field = StringField("f_2", "NAME");
+
+        var bytes = I3sAttributeBufferBuilder.Build(features, field);
+
+        bytes.Should().NotBeNull();
+        var span = bytes!.AsSpan();
+
+        var count = BinaryPrimitives.ReadUInt32LittleEndian(span[..4]);
+        count.Should().Be(3);
+        var valuesByteCount = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(4, 4));
+
+        // Per-value byte counts include the trailing NUL: "alpha"=6, "beta"=5, ""=1.
+        var byteCountsOffset = I3sAttributeBufferBuilder.StringHeaderBytes;
+        BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(byteCountsOffset, 4)).Should().Be(6);
+        BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(byteCountsOffset + 4, 4)).Should().Be(5);
+        BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(byteCountsOffset + 8, 4)).Should().Be(1);
+        valuesByteCount.Should().Be(6u + 5u + 1u);
+
+        var valuesOffset = byteCountsOffset + (3 * I3sAttributeBufferBuilder.ByteCountValueBytes);
+        var firstValue = Encoding.UTF8.GetString(span.Slice(valuesOffset, 5));
+        firstValue.Should().Be("alpha");
+        span[valuesOffset + 5].Should().Be(0);
+    }
+
+    [UnitTest]
+    public void Build_FromFeatures_UnsupportedValueType_ReturnsNull()
+    {
+        var features = ThreeFeaturesWithAttributes();
+        var field = new I3sAttributeStorageInfo
+        {
+            Key = "f_3",
+            Name = "GEOM",
+            AttributeValues = new I3sAttributeValues { ValueType = "Geometry" },
+        };
+
+        I3sAttributeBufferBuilder.Build(features, field).Should().BeNull();
+    }
+
+    private static IReadOnlyList<SceneFeature> ThreeFeaturesWithAttributes() =>
+    [
+        FeatureWith(11, new Dictionary<string, object?> { ["HEIGHT"] = 12.5, ["NAME"] = "alpha" }),
+        FeatureWith(22, new Dictionary<string, object?> { ["HEIGHT"] = 7, ["NAME"] = "beta" }),
+        FeatureWith(33, new Dictionary<string, object?>()),
+    ];
+
+    private static SceneFeature FeatureWith(long id, IReadOnlyDictionary<string, object?> attributes) => new()
+    {
+        Id = id,
+        Geometry = Square(id, -122.42, 37.77).Geometry,
+        Attributes = attributes,
+    };
+
+    private static I3sAttributeStorageInfo NumericField(string key, string name) => new()
+    {
+        Key = key,
+        Name = name,
+        Ordering = ["attributeValues"],
+        AttributeValues = new I3sAttributeValues { ValueType = I3sAttributeBufferBuilder.Float64ValueType, ValuesPerElement = 1 },
+    };
+
+    private static I3sAttributeStorageInfo StringField(string key, string name) => new()
+    {
+        Key = key,
+        Name = name,
+        Ordering = ["attributeByteCounts", "attributeValues"],
+        AttributeValues = new I3sAttributeValues { ValueType = I3sAttributeBufferBuilder.StringValueType, Encoding = "UTF-8", ValuesPerElement = 1 },
+    };
 
     private static I3sTranscodedGeometry TranscodeThreeFeatures()
     {

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sAttributeSchemaBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sAttributeSchemaBuilderTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Domain;
+using Honua.Scene;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.Conversion;
+
+/// <summary>
+/// Unit tests for the I3S attribute schema builder (#1811): the
+/// <c>attributeStorageInfo</c> field list an ArcGIS SceneLayer client reads to
+/// discover the identify-able fields. The schema must always lead with the
+/// synthetic OBJECTID field, assign stable <c>f_{n}</c> keys in deterministic
+/// order, and pick the value type that matches the served attribute file.
+/// </summary>
+public sealed class I3sAttributeSchemaBuilderTests
+{
+    [UnitTest]
+    public void Build_NoAttributes_EmitsObjectIdFieldOnly()
+    {
+        var features = new[] { FeatureWith(1, new Dictionary<string, object?>()) };
+
+        var schema = I3sAttributeSchemaBuilder.Build(features);
+
+        schema.Should().HaveCount(1);
+        schema[0].Key.Should().Be(I3sAttributeSchemaBuilder.ObjectIdFieldKey);
+        schema[0].Name.Should().Be("OBJECTID");
+        schema[0].AttributeValues!.ValueType.Should().Be(I3sAttributeBufferBuilder.Oid32ValueType);
+    }
+
+    [UnitTest]
+    public void Build_TypesFields_NumericAsFloat64StringAsString_InOrdinalKeyOrder()
+    {
+        var features = new[]
+        {
+            FeatureWith(1, new Dictionary<string, object?> { ["height"] = 10.0, ["name"] = "a" }),
+            FeatureWith(2, new Dictionary<string, object?> { ["name"] = "b", ["zone"] = 4 }),
+        };
+
+        var schema = I3sAttributeSchemaBuilder.Build(features);
+
+        // OBJECTID first, then user keys sorted ordinally: height, name, zone.
+        schema.Select(f => f.Name).Should().ContainInOrder("OBJECTID", "height", "name", "zone");
+        schema.Select(f => f.Key).Should().ContainInOrder("f_0", "f_1", "f_2", "f_3");
+
+        var height = schema.Single(f => f.Name == "height");
+        height.AttributeValues!.ValueType.Should().Be(I3sAttributeBufferBuilder.Float64ValueType);
+
+        var name = schema.Single(f => f.Name == "name");
+        name.AttributeValues!.ValueType.Should().Be(I3sAttributeBufferBuilder.StringValueType);
+        name.AttributeValues!.Encoding.Should().Be("UTF-8");
+        name.AttributeByteCounts!.ValueType.Should().Be("UInt32");
+
+        var zone = schema.Single(f => f.Name == "zone");
+        zone.AttributeValues!.ValueType.Should().Be(I3sAttributeBufferBuilder.Float64ValueType);
+    }
+
+    [UnitTest]
+    public void Build_MixedTypesAcrossFeatures_DemotesFieldToString()
+    {
+        // One feature reports a numeric value, another a non-numeric string for
+        // the same key: the field must serve as a String so no value is lost.
+        var features = new[]
+        {
+            FeatureWith(1, new Dictionary<string, object?> { ["code"] = 42 }),
+            FeatureWith(2, new Dictionary<string, object?> { ["code"] = "N/A" }),
+        };
+
+        var schema = I3sAttributeSchemaBuilder.Build(features);
+
+        var code = schema.Single(f => f.Name == "code");
+        code.AttributeValues!.ValueType.Should().Be(I3sAttributeBufferBuilder.StringValueType);
+    }
+
+    private static SceneFeature FeatureWith(long id, IReadOnlyDictionary<string, object?> attributes) => new()
+    {
+        Id = id,
+        Geometry = new SceneFeatureGeometry
+        {
+            Kind = SceneGeometryKind.Polygon,
+            Vertices = new[]
+            {
+                new SceneVertex(-122.42, 37.77, 0.0),
+                new SceneVertex(-122.41, 37.77, 0.0),
+                new SceneVertex(-122.41, 37.78, 0.0),
+            },
+        },
+        Attributes = attributes,
+    };
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sSceneStatisticsBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sSceneStatisticsBuilderTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Conversion;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Scene;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.Conversion;
+
+/// <summary>
+/// Unit tests for the feature-driven I3S statistics builder (#1811): the
+/// <c>statistics/f_{n}/0</c> summary an ArcGIS client reads to drive identify,
+/// classification, and renderer ranges. The summary must report real
+/// min/max/count derived from the features' projected attributes.
+/// </summary>
+public sealed class I3sSceneStatisticsBuilderTests
+{
+    [UnitTest]
+    public void Build_ObjectIdField_ReportsFeatureIdRange()
+    {
+        var features = Features();
+
+        var stats = I3sSceneStatisticsBuilder.Build(features, I3sAttributeSchemaBuilder.BuildObjectIdField());
+
+        stats.Stats.TotalValuesCount.Should().Be(3);
+        stats.Stats.Min.Should().Be(11);
+        stats.Stats.Max.Should().Be(33);
+        stats.Stats.Count.Should().Be(3);
+    }
+
+    [UnitTest]
+    public void Build_NumericField_ReportsMinMaxOverPresentValues()
+    {
+        var features = Features();
+        var field = new I3sAttributeStorageInfo
+        {
+            Key = "f_1",
+            Name = "HEIGHT",
+            AttributeValues = new I3sAttributeValues { ValueType = I3sAttributeBufferBuilder.Float64ValueType },
+        };
+
+        var stats = I3sSceneStatisticsBuilder.Build(features, field);
+
+        // Only two of three features carry HEIGHT (12.5 and 7.0).
+        stats.Stats.TotalValuesCount.Should().Be(2);
+        stats.Stats.Min.Should().Be(7.0);
+        stats.Stats.Max.Should().Be(12.5);
+        stats.Stats.Count.Should().Be(2);
+    }
+
+    [UnitTest]
+    public void Build_StringField_ReportsPresenceAndDistinctCountWithoutRange()
+    {
+        var features = Features();
+        var field = new I3sAttributeStorageInfo
+        {
+            Key = "f_2",
+            Name = "NAME",
+            AttributeValues = new I3sAttributeValues { ValueType = I3sAttributeBufferBuilder.StringValueType, Encoding = "UTF-8" },
+        };
+
+        var stats = I3sSceneStatisticsBuilder.Build(features, field);
+
+        stats.Stats.TotalValuesCount.Should().Be(2);
+        stats.Stats.Count.Should().Be(2);
+        stats.Stats.Min.Should().BeNull();
+        stats.Stats.Max.Should().BeNull();
+    }
+
+    private static IReadOnlyList<SceneFeature> Features() =>
+    [
+        FeatureWith(11, new Dictionary<string, object?> { ["HEIGHT"] = 12.5, ["NAME"] = "alpha" }),
+        FeatureWith(22, new Dictionary<string, object?> { ["HEIGHT"] = 7.0, ["NAME"] = "beta" }),
+        FeatureWith(33, new Dictionary<string, object?>()),
+    ];
+
+    private static SceneFeature FeatureWith(long id, IReadOnlyDictionary<string, object?> attributes) => new()
+    {
+        Id = id,
+        Geometry = new SceneFeatureGeometry
+        {
+            Kind = SceneGeometryKind.Polygon,
+            Vertices = new[]
+            {
+                new SceneVertex(-122.42, 37.77, 0.0),
+                new SceneVertex(-122.41, 37.77, 0.0),
+                new SceneVertex(-122.41, 37.78, 0.0),
+            },
+        },
+        Attributes = attributes,
+    };
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1811

## Summary
The merged identify slice for #1811 serves only the synthetic `OBJECTID`
(`f_0`/`Oid32`) attribute file + statistics and explicitly defers per-field
**user** attribute encoding (it returns `null`/404 for any other field). This PR
adds the reusable I3S per-field attribute engine that lane needs: derive a field
schema from a scene's projected feature attributes, encode the matching binary
attribute file per field, and compute real per-field statistics. The value
source is each `SceneFeature.Attributes` bag — the same projected attributes the
3D Tiles `EXT_structural_metadata` property tables are baked from and the same
ordered feature input `I3sGeometryTranscoder` consumes — so a descriptor field
and its served attribute file always agree on layout and order.

## Changes Made
- Add `I3sAttributeSchemaBuilder`: derives `attributeStorageInfo` (OBJECTID
  `f_0` first, then deterministic ordinal-sorted `f_n` user fields), typing a
  field `Float64` when all observed values are numeric and UTF-8 `String`
  otherwise (mixed-type keys demote to `String` so no value is lost).
- Extend `I3sAttributeBufferBuilder` with a features-based `Build` emitting three
  I3S layouts: `Oid32` object ids, `Float64` (8-byte-aligned count header +
  little-endian doubles; missing/non-numeric → 0), and `String` (count +
  `attributeValuesByteCount` header, per-value `UInt32` byte counts, NUL-
  terminated UTF-8 value blob; missing → empty string).
- Extend `I3sSceneStatisticsBuilder` with a features-based `Build` computing real
  `totalValuesCount`/`min`/`max`/distinct `count` for numeric fields and
  presence/distinct count for string fields.
- Add `attributeByteCounts` to `I3sAttributeStorageInfo` for string-field
  descriptor fidelity.
- Unit tests for schema typing/ordering, all three binary layouts, and the
  numeric/string statistics summaries.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Built `src/Honua.Scene` in Release with `TreatWarningsAsErrors=true` (0 warnings)
and ran the scene attribute/schema/statistics unit tests:
`dotnet test tests/dotnet/Honua.Core.Tests --filter "FullyQualifiedName~Scene.Conversion.I3sAttribute|FullyQualifiedName~Scene.Conversion.I3sSceneStatistics"`
→ Passed: 13, Failed: 0. `dotnet format --verify-no-changes` on the changed
files is clean.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

## Known gaps
This is one slice of the LARGE issue #1811 and is opened as a **draft** because
end-to-end ArcGIS identify of user attribute values is not yet wired:
- **Serving wiring deferred.** The new engine takes `IReadOnlyList<SceneFeature>`
  directly; the serving endpoint resolves attribute/statistics through
  `ISceneNodeGeometryProvider` → `I3sTranscodedGeometry`, which carries only the
  feature ids, not the projected attribute values. Carrying the source features
  (or a per-feature attribute carrier) through that seam, plus a production
  provider implementation, is the next step.
- **Dynamic descriptor advertisement deferred.** `I3sSceneServiceBuilder.BuildLayer`
  still advertises the static `f_0` field because no attribute schema is
  persisted on `SceneDataset`/`SceneDatasetRecord` at descriptor-build time;
  advertising `I3sAttributeSchemaBuilder.Build(...)` output requires a schema
  source (persisted at publish time).
- The acceptance criteria ("ArcGIS identify returns attribute values";
  "statistics/f_{n}/0 resolves" for user fields) are therefore not fully met
  yet — this PR lands the encoder/schema/statistics core they depend on.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
