### PR TITLE
feat: expose usage-ranked GP tool tiering via admin API (#2144)

### DIFF
--- a/src/Honua.Server/Features/Admin/AdminLog.cs
+++ b/src/Honua.Server/Features/Admin/AdminLog.cs
@@ -126,6 +126,15 @@ internal static partial class AdminLog
     public static partial void GeocodingProviderHealthQueried(ILogger logger);
 
     /// <summary>
+    /// Log when the geoprocessing tool usage ranking is queried.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 4082,
+        Level = LogLevel.Debug,
+        Message = "Geoprocessing tool usage ranking queried, returned {Count} tools")]
+    public static partial void GeoprocessingUsageRankingQueried(ILogger logger, int count);
+
+    /// <summary>
     /// Log when feature overview is queried.
     /// </summary>
     [LoggerMessage(

--- a/src/Honua.Server/Features/Admin/GeoprocessingUsageEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/GeoprocessingUsageEndpoints.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Server.Features.Admin.Models;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Admin endpoints that expose the usage-ranked geoprocessing (GP) tool tiering
+/// view (#2144). Reads the real <see cref="IProcessUsageTelemetry"/> store the
+/// dispatcher records into and returns GP tools ranked by invocation count.
+/// </summary>
+internal static class GeoprocessingUsageEndpoints
+{
+    internal sealed class GeoprocessingUsageEndpointsLog;
+
+    public static void MapGeoprocessingUsageEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/geoprocessing")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Geoprocessing")
+            .RequireAdminAuthorization();
+
+        group.MapGet("/tools/usage-ranking", HandleGetUsageRanking)
+            .WithDisplayName("Get Geoprocessing Tool Usage Ranking")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<ApiResponse<GeoprocessingUsageRankingResponse>>();
+    }
+
+    private static IResult HandleGetUsageRanking(
+        [FromServices] IProcessUsageTelemetry usageTelemetry,
+        [FromServices] ILogger<GeoprocessingUsageEndpointsLog> logger,
+        [FromQuery] int? limit)
+    {
+        if (limit is <= 0)
+        {
+            return Results.Json(
+                ApiResponse<GeoprocessingUsageRankingResponse>.Failure("The 'limit' parameter must be a positive integer."),
+                GeoprocessingUsageJsonContext.Default.ApiResponseGeoprocessingUsageRankingResponse,
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var ranking = usageTelemetry.GetRanking(limit);
+
+        var tools = new GeoprocessingToolUsageRankEntry[ranking.Count];
+        for (var i = 0; i < ranking.Count; i++)
+        {
+            var entry = ranking[i];
+            tools[i] = new GeoprocessingToolUsageRankEntry
+            {
+                Rank = i + 1,
+                ProcessId = entry.ProcessId,
+                InvocationCount = entry.InvocationCount,
+                SuccessCount = entry.SuccessCount,
+                FailureCount = entry.FailureCount,
+                LastInvokedAt = entry.LastInvokedAt
+            };
+        }
+
+        AdminLog.GeoprocessingUsageRankingQueried(logger, tools.Length);
+
+        var response = new GeoprocessingUsageRankingResponse
+        {
+            Count = tools.Length,
+            Tools = tools
+        };
+
+        return Results.Json(
+            ApiResponse<GeoprocessingUsageRankingResponse>.CreateSuccess(response),
+            GeoprocessingUsageJsonContext.Default.ApiResponseGeoprocessingUsageRankingResponse);
+    }
+}

--- a/src/Honua.Server/Features/Admin/Models/GeoprocessingUsageJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/GeoprocessingUsageJsonContext.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Infrastructure.Models;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// JSON source generation context for geoprocessing usage-ranking admin API models.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(ApiResponse<GeoprocessingUsageRankingResponse>))]
+[JsonSerializable(typeof(ApiResponse<object>))]
+[JsonSerializable(typeof(GeoprocessingUsageRankingResponse))]
+[JsonSerializable(typeof(GeoprocessingToolUsageRankEntry))]
+[JsonSerializable(typeof(GeoprocessingToolUsageRankEntry[]))]
+internal sealed partial class GeoprocessingUsageJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Admin/Models/GeoprocessingUsageModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/GeoprocessingUsageModels.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Usage-ranked view of the geoprocessing (GP) tool catalog (#2144). Surfaces the
+/// most-invoked processes, ordered by total invocations, so operators can see
+/// which tools to prioritize and how to tier the catalog.
+/// </summary>
+public sealed class GeoprocessingUsageRankingResponse
+{
+    /// <summary>
+    /// Number of ranked tools returned in <see cref="Tools"/>.
+    /// </summary>
+    public required int Count { get; init; }
+
+    /// <summary>
+    /// Ranked GP tools, most-invoked first. Ordering is stable: descending by
+    /// invocation count, then by most-recent use, then by process id.
+    /// </summary>
+    public required GeoprocessingToolUsageRankEntry[] Tools { get; init; }
+}
+
+/// <summary>
+/// A single usage-ranked geoprocessing tool entry with its rank and recorded tallies.
+/// </summary>
+public sealed class GeoprocessingToolUsageRankEntry
+{
+    /// <summary>
+    /// One-based position of this tool within the ranking.
+    /// </summary>
+    public required int Rank { get; init; }
+
+    /// <summary>
+    /// Canonical process id of the GP tool.
+    /// </summary>
+    public required string ProcessId { get; init; }
+
+    /// <summary>
+    /// Total recorded invocations.
+    /// </summary>
+    public required long InvocationCount { get; init; }
+
+    /// <summary>
+    /// Invocations that completed successfully.
+    /// </summary>
+    public required long SuccessCount { get; init; }
+
+    /// <summary>
+    /// Invocations that failed.
+    /// </summary>
+    public required long FailureCount { get; init; }
+
+    /// <summary>
+    /// UTC timestamp of the most recent invocation.
+    /// </summary>
+    public required DateTimeOffset LastInvokedAt { get; init; }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -1377,6 +1377,7 @@ app.MapIdentityAdminEndpoints();
 app.MapAdminInfoEndpoints();
 app.MapCacheAdminEndpoints();
 app.MapGeocodingAdminEndpoints();
+app.MapGeoprocessingUsageEndpoints();
 app.MapFeatureOverviewEndpoints();
 
 // Rate limit policy administration (issue #355): CRUD + status for tenant/user/API-key

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/GeoprocessingUsageEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/GeoprocessingUsageEndpointsTests.cs
@@ -1,0 +1,127 @@
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.ProcessDiscovery)]
+public sealed class GeoprocessingUsageEndpointsTests : IAsyncLifetime
+{
+    private const string AdminPassword = "geoprocessing-usage-admin-key";
+
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public GeoprocessingUsageEndpointsTests()
+    {
+        _fixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateClient(client => client.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/geoprocessing/tools/usage-ranking")]
+    public async Task GetUsageRanking_AfterRecordingInvocations_RanksMostInvokedFirst()
+    {
+        // The endpoint reads the real singleton telemetry store the dispatcher
+        // records into, so recording here is reflected on the next read (#2144).
+        var telemetry = _fixture.Services.GetRequiredService<IProcessUsageTelemetry>();
+        var popular = $"popular-tool-{Guid.NewGuid():N}";
+        var rare = $"rare-tool-{Guid.NewGuid():N}";
+
+        telemetry.RecordInvocation(rare, succeeded: true);
+        for (var i = 0; i < 3; i++)
+        {
+            telemetry.RecordInvocation(popular, succeeded: i % 2 == 0);
+        }
+
+        var response = await _client.GetAsync("/api/v1/admin/geoprocessing/tools/usage-ranking");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+
+        var data = json.RootElement.GetProperty("data");
+        data.GetProperty("count").GetInt32().Should().BeGreaterThanOrEqualTo(2);
+
+        var tools = data.GetProperty("tools").EnumerateArray().ToArray();
+        var popularEntry = tools.Single(t => t.GetProperty("processId").GetString() == popular);
+        var rareEntry = tools.Single(t => t.GetProperty("processId").GetString() == rare);
+
+        popularEntry.GetProperty("invocationCount").GetInt64().Should().Be(3);
+        popularEntry.GetProperty("successCount").GetInt64().Should().Be(2);
+        popularEntry.GetProperty("failureCount").GetInt64().Should().Be(1);
+        rareEntry.GetProperty("invocationCount").GetInt64().Should().Be(1);
+
+        // The more-invoked tool must rank ahead of (a lower rank number than) the rarer one.
+        popularEntry.GetProperty("rank").GetInt32().Should()
+            .BeLessThan(rareEntry.GetProperty("rank").GetInt32());
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/geoprocessing/tools/usage-ranking")]
+    public async Task GetUsageRanking_WithLimit_TruncatesToRequestedCount()
+    {
+        var telemetry = _fixture.Services.GetRequiredService<IProcessUsageTelemetry>();
+        for (var i = 0; i < 4; i++)
+        {
+            telemetry.RecordInvocation($"limit-tool-{Guid.NewGuid():N}", succeeded: true);
+        }
+
+        var response = await _client.GetAsync("/api/v1/admin/geoprocessing/tools/usage-ranking?limit=1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        json.RootElement.GetProperty("data").GetProperty("count").GetInt32().Should().Be(1);
+        json.RootElement.GetProperty("data").GetProperty("tools").GetArrayLength().Should().Be(1);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/geoprocessing/tools/usage-ranking")]
+    public async Task GetUsageRanking_WithNonPositiveLimit_Returns400()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/geoprocessing/tools/usage-ranking?limit=0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/geoprocessing/tools/usage-ranking")]
+    public async Task GetUsageRanking_WithoutAdminAuth_IsUnauthorized()
+    {
+        using var anonymousClient = _fixture.CreateClient();
+
+        var response = await anonymousClient.GetAsync("/api/v1/admin/geoprocessing/tools/usage-ranking");
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2144

## Summary
Wires the existing GP usage telemetry seam into the Admin API so operators can see
geoprocessing tools ranked by usage. The dispatcher already records every process
invocation into the `IProcessUsageTelemetry` singleton (success/failure tallies +
last-used); this PR adds a read-only admin endpoint that projects that real store
into a ranked, tiered view. No new hot-path work is introduced — recording was
already in place; this only exposes the ranking.

## Changes Made
- Added `GET /api/v1/admin/geoprocessing/tools/usage-ranking` (admin-authorized),
  returning GP tools ranked by invocation count with stable tie-breaking, plus
  per-tool success/failure tallies, last-used timestamp, and one-based rank.
- Supports an optional `limit` query parameter (positive integer; non-positive
  values return `400`).
- New AOT-safe DTOs (`GeoprocessingUsageRankingResponse`,
  `GeoprocessingToolUsageRankEntry`) with a source-generated JSON context, mirroring
  the existing geocoding admin endpoint pattern.
- Registered the endpoint group in `Program.cs` and added a source-generated
  `AdminLog` entry.
- Added integration tests asserting that newly recorded invocations change ranking
  order, that `limit` truncates, that non-positive `limit` returns `400`, and that
  the endpoint requires admin auth.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

`dotnet build src/Honua.Server/Honua.Server.csproj -c Release /p:TreatWarningsAsErrors=true`
succeeds (0 warnings, 0 errors) and `dotnet format --verify-no-changes` is clean. The
new `Honua.Server.Tests` integration tests compile, but could not be executed in this
environment because the Docker daemon / Testcontainers is unavailable (fixture init fails
on `Docker.DotNet ... PingAsync`). CI runs them with Docker available.

## Known gaps
- Integration tests were not executed locally: the sandbox has no Docker daemon, so the
  Testcontainers-backed `WebAppFixture` cannot start PostGIS. The tests themselves compile
  and are expected to pass under CI. Opening as draft until CI confirms the integration
  shard is green.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
