### PR TITLE
feat: offline replica sync conformance and non-Postgres story (#2136)

### DIFF
--- a/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/ReplicaSync.cs
+++ b/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/ReplicaSync.cs
@@ -77,6 +77,14 @@ public readonly record struct ReplicaUploadLayerEdits(
 /// <param name="SyncOperationId">Optional correlation id linking produced conflicts to this call.</param>
 /// <param name="DeviceId">Optional uploading device identifier (conflict audit evidence).</param>
 /// <param name="UserId">Optional uploading user identifier (conflict audit evidence).</param>
+/// <param name="RollbackOnFailure">
+/// When true, each layer's uploaded edits are applied atomically (the shared edit pipeline wraps them
+/// in an explicit transaction) so a single failing row rolls back that layer's whole edit batch,
+/// leaving the layer's server state unchanged. Mirrors the Esri <c>rollbackOnFailure</c> sync
+/// parameter. The replica's sync cursor is only advanced when the upload succeeds, so a rolled-back
+/// upload leaves the replica re-syncable from its prior generation (#2136). Defaults to false to
+/// preserve the prior best-effort per-row behavior.
+/// </param>
 public readonly record struct ReplicaSyncRequest(
     string ReplicaId,
     string ServiceId,
@@ -86,7 +94,8 @@ public readonly record struct ReplicaSyncRequest(
     bool LastWriteWins = true,
     string? SyncOperationId = null,
     string? DeviceId = null,
-    string? UserId = null);
+    string? UserId = null,
+    bool RollbackOnFailure = false);
 
 /// <summary>
 /// A conflict detected while applying an uploaded replica edit: the client edit and a server edit to

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IReplicaEditApplier.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IReplicaEditApplier.cs
@@ -25,11 +25,17 @@ public interface IReplicaEditApplier
     /// <param name="serviceId">Service the layer belongs to.</param>
     /// <param name="publicLayerId">Service-local layer id the edits target.</param>
     /// <param name="edits">Resolved edits to apply (conflicting edits already filtered when skipped).</param>
+    /// <param name="rollbackOnFailure">
+    /// When true, the layer's edits are applied atomically so a single failing row rolls back the whole
+    /// batch (leaving the layer's server state unchanged); when false, edits apply best-effort per row
+    /// (#2136).
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The per-layer apply result.</returns>
     Task<ReplicaLayerApplyResult> ApplyAsync(
         string serviceId,
         int publicLayerId,
         ImmutableArray<ReplicaUploadEdit> edits,
+        bool rollbackOnFailure,
         CancellationToken cancellationToken = default);
 }

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IReplicaRepository.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IReplicaRepository.cs
@@ -12,6 +12,16 @@ namespace Honua.Core.Features.FeatureStore.Abstractions;
 public interface IReplicaRepository
 {
     /// <summary>
+    /// Whether this provider durably persists replica state and can therefore serve the offline
+    /// replica sync workflow (createReplica / synchronizeReplica / unRegisterReplica). True for the
+    /// Postgres-backed store; false for read-only providers (DuckDB, MySQL/MariaDB) whose replica
+    /// repository is a no-op. Protocol adapters consult this so they can return a clear, Esri-shaped
+    /// "operation not supported" response on backends that cannot persist replicas instead of
+    /// silently accepting a sync that is never durably applied (#2136).
+    /// </summary>
+    bool SupportsReplicaPersistence => true;
+
+    /// <summary>
     /// Creates or updates a replica record in persistent storage
     /// </summary>
     /// <param name="record">The replica record to persist</param>

--- a/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpReplicaRepository.cs
+++ b/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpReplicaRepository.cs
@@ -18,6 +18,14 @@ namespace Honua.Core.Features.FeatureStore.ReadOnlyProviders;
 public sealed class NoOpReplicaRepository : IReplicaRepository
 {
     /// <inheritdoc />
+    /// <remarks>
+    /// Read-only providers cannot durably persist replicas, so the offline replica sync surface is
+    /// unsupported. Protocol adapters read this to emit a conformant "operation not supported"
+    /// response instead of letting the no-op upsert silently swallow a sync (#2136).
+    /// </remarks>
+    public bool SupportsReplicaPersistence => false;
+
+    /// <inheritdoc />
     public Task UpsertAsync(ReplicaRecord record, CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 

--- a/src/Honua.Core/Features/FeatureStore/Services/ReplicaSyncService.cs
+++ b/src/Honua.Core/Features/FeatureStore/Services/ReplicaSyncService.cs
@@ -164,7 +164,7 @@ public sealed partial class ReplicaSyncService : IReplicaSyncService
             else
             {
                 applyResult = await editApplier
-                    .ApplyAsync(request.ServiceId, layer.PublicLayerId, editsToApply.ToImmutable(), cancellationToken)
+                    .ApplyAsync(request.ServiceId, layer.PublicLayerId, editsToApply.ToImmutable(), request.RollbackOnFailure, cancellationToken)
                     .ConfigureAwait(false);
             }
 

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -36,6 +36,28 @@ internal static partial class FeatureServerEndpoints
             FeatureCatalog.FieldOpsOfflineSyncKey,
             "GeoServices offline sync");
 
+    /// <summary>
+    /// Rejects replica write operations (createReplica / synchronizeReplica / unRegisterReplica) on
+    /// backends that cannot durably persist replicas — read-only providers (DuckDB, MySQL/MariaDB)
+    /// whose <see cref="IReplicaRepository"/> is a no-op. Returns a conformant Esri-shaped
+    /// <c>501 Not Implemented</c> error so an Esri client receives an explicit "operation not
+    /// supported" response instead of a silently no-op'd sync that is never durably applied (#2136).
+    /// Returns <c>null</c> when the active backend supports replica persistence.
+    /// </summary>
+    private static IResult? RequireReplicaPersistenceSupport(HttpContext context)
+    {
+        var replicaRepository = context.RequestServices.GetRequiredService<IReplicaRepository>();
+        if (replicaRepository.SupportsReplicaPersistence)
+        {
+            return null;
+        }
+
+        return StandardErrorHelpers.CreateNotImplemented(
+            context,
+            "Offline replica synchronization is not supported by this service's data store.",
+            ["The active feature provider is read-only and cannot durably persist replicas. createReplica, synchronizeReplica, and unRegisterReplica require a Postgres-backed service."]);
+    }
+
     private static async Task<IResult> HandleReplicas(
         string serviceId,
         HttpContext context)
@@ -199,6 +221,12 @@ internal static partial class FeatureServerEndpoints
         if (entitlementGate is not null)
         {
             return entitlementGate;
+        }
+
+        var unsupportedBackend = RequireReplicaPersistenceSupport(context);
+        if (unsupportedBackend is not null)
+        {
+            return unsupportedBackend;
         }
 
         var cancellationToken = GetTimeoutAwareCancellationToken(context);
@@ -839,6 +867,12 @@ internal static partial class FeatureServerEndpoints
             return entitlementGate;
         }
 
+        var unsupportedBackend = RequireReplicaPersistenceSupport(context);
+        if (unsupportedBackend is not null)
+        {
+            return unsupportedBackend;
+        }
+
         var cancellationToken = GetTimeoutAwareCancellationToken(context);
         var serviceValidationResult = await ValidateReplicationServiceV2Async(serviceId, context, cancellationToken);
         if (serviceValidationResult.ErrorResult is not null)
@@ -944,6 +978,16 @@ internal static partial class FeatureServerEndpoints
             acknowledgedServerGen = parsedServerGen;
         }
 
+        // Esri sync parameter: rollbackOnFailure=true applies each layer's uploaded edits atomically so
+        // a single failing row rolls back that layer's whole batch, leaving the server state unchanged
+        // (#2136). Defaults to false (best-effort per-row), matching the prior synchronize behavior.
+        if (!TryParseBoolValue(values, "rollbackOnFailure", false, out var rollbackOnFailure, out var rollbackError))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "Invalid rollbackOnFailure parameter",
+                [rollbackError ?? "rollbackOnFailure must be a boolean value."]);
+        }
+
         var changeTracker = context.RequestServices.GetRequiredService<IChangeTracker>();
 
         SynchronizeReplicaConflict[]? conflicts = null;
@@ -988,7 +1032,8 @@ internal static partial class FeatureServerEndpoints
                     BaseGeneration: replica.LastSyncGeneration,
                     LayerEdits: layerEdits,
                     LastWriteWins: true,
-                    SyncOperationId: context.TraceIdentifier);
+                    SyncOperationId: context.TraceIdentifier,
+                    RollbackOnFailure: rollbackOnFailure);
 
                 var report = await syncService.ApplyUploadAsync(syncRequest, applier, cancellationToken);
                 if (!report.Success)
@@ -1475,6 +1520,12 @@ internal static partial class FeatureServerEndpoints
         if (entitlementGate is not null)
         {
             return entitlementGate;
+        }
+
+        var unsupportedBackend = RequireReplicaPersistenceSupport(context);
+        if (unsupportedBackend is not null)
+        {
+            return unsupportedBackend;
         }
 
         var cancellationToken = GetTimeoutAwareCancellationToken(context);

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
@@ -95,6 +95,7 @@ internal static partial class FeatureServerEndpoints
             HasGeometryProperties = hasGeometry,
             AllowGeometryUpdates = supportsEditing,
             SyncEnabled = ServiceSupportsSyncV2(service),
+            SyncCapabilities = ServiceSupportsSyncV2(service) ? new FeatureServerSyncCapabilities() : null,
             HasVersionedData = branchVersioningEnabled,
             IsDataVersioned = branchVersioningEnabled,
             SupportsBranchVersioning = branchVersioningEnabled,

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Models/FeatureServerJsonContext.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Models/FeatureServerJsonContext.cs
@@ -16,6 +16,7 @@ namespace Honua.Protocols.GeoServices.FeatureServer.Models;
     PropertyNameCaseInsensitive = true,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(FeatureServerResponse))]
+[JsonSerializable(typeof(FeatureServerSyncCapabilities))]
 [JsonSerializable(typeof(LayerResponse))]
 [JsonSerializable(typeof(LayerRelationshipInfo))]
 [JsonSerializable(typeof(LayerRelationshipInfo[]))]

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Models/FeatureServerResponse.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Models/FeatureServerResponse.cs
@@ -126,6 +126,14 @@ public sealed class FeatureServerResponse
     public bool SyncEnabled { get; init; }
 
     /// <summary>
+    /// Service-level synchronization capabilities (supported sync directions, sync models,
+    /// rollbackOnFailure, and <c>supportedSyncDataOptions</c>). Emitted only when the service is
+    /// sync-enabled so Esri clients discover the offline replica behavior the server honors before they
+    /// attempt createReplica / synchronizeReplica; null (omitted) otherwise (#2136).
+    /// </summary>
+    public FeatureServerSyncCapabilities? SyncCapabilities { get; init; }
+
+    /// <summary>
     /// Whether the service exposes branch-versioned data. Emitted so Esri clients discover the
     /// VersionManagementServer surface (#1272, ADR-0051). True only when the active provider supports
     /// branch versioning (Postgres) and the Enterprise branch-versioning entitlement is active.

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Models/ReplicationModels.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Models/ReplicationModels.cs
@@ -389,10 +389,88 @@ public sealed class SynchronizeReplicaRequest
     public string? Edits { get; set; }
 
     /// <summary>
+    /// When true, each layer's uploaded edits are applied atomically: a single failing edit rolls back
+    /// that layer's whole batch, leaving the server state unchanged. Mirrors the Esri
+    /// <c>rollbackOnFailure</c> sync parameter. Defaults to false (best-effort per-row apply) (#2136).
+    /// </summary>
+    [JsonPropertyName("rollbackOnFailure")]
+    public bool RollbackOnFailure { get; set; }
+
+    /// <summary>
     /// Output format parameter.
     /// </summary>
     [JsonPropertyName("f")]
     public string? F { get; set; }
+}
+
+/// <summary>
+/// Service-level synchronization capabilities advertised on the FeatureServer metadata resource so
+/// Esri clients (ArcGIS API for Python, ArcGIS Pro, Maps SDKs) discover the offline replica behavior
+/// the server actually honors before they attempt createReplica / synchronizeReplica (#2136). Emitted
+/// only when the service is sync-enabled.
+/// </summary>
+public sealed class FeatureServerSyncCapabilities
+{
+    /// <summary>
+    /// Whether replica creation/synchronization runs asynchronously (replica jobs). Honua synchronizes
+    /// inline, so this is false.
+    /// </summary>
+    [JsonPropertyName("supportsAsync")]
+    public bool SupportsAsync { get; init; }
+
+    /// <summary>
+    /// Whether existing data can be registered as a replica without an extract. Not supported.
+    /// </summary>
+    [JsonPropertyName("supportsRegisteringExistingData")]
+    public bool SupportsRegisteringExistingData { get; init; }
+
+    /// <summary>
+    /// Whether the client may choose the sync direction (download / upload / bidirectional). Honua
+    /// honors <c>syncDirection</c>, so this is true.
+    /// </summary>
+    [JsonPropertyName("supportsSyncDirectionControl")]
+    public bool SupportsSyncDirectionControl { get; init; } = true;
+
+    /// <summary>
+    /// Whether per-layer sync (a replica spanning a subset of layers with per-layer generations) is
+    /// supported. Honua supports the <c>perLayer</c> sync model, so this is true.
+    /// </summary>
+    [JsonPropertyName("supportsPerLayerSync")]
+    public bool SupportsPerLayerSync { get; init; } = true;
+
+    /// <summary>
+    /// Whether per-replica sync (a single replica-wide generation) is supported. True.
+    /// </summary>
+    [JsonPropertyName("supportsPerReplicaSync")]
+    public bool SupportsPerReplicaSync { get; init; } = true;
+
+    /// <summary>
+    /// Whether the <c>none</c> sync model (snapshot replicas that never sync back) is supported. Not
+    /// supported.
+    /// </summary>
+    [JsonPropertyName("supportsSyncModelNone")]
+    public bool SupportsSyncModelNone { get; init; }
+
+    /// <summary>
+    /// Whether uploaded edits can be applied atomically via <c>rollbackOnFailure</c>. True (#2136).
+    /// </summary>
+    [JsonPropertyName("supportsRollbackOnFailure")]
+    public bool SupportsRollbackOnFailure { get; init; } = true;
+
+    /// <summary>
+    /// Whether attachment sync direction can be controlled independently. Attachment sync direction
+    /// control is not supported.
+    /// </summary>
+    [JsonPropertyName("supportsAttachmentsSyncDirection")]
+    public bool SupportsAttachmentsSyncDirection { get; init; }
+
+    /// <summary>
+    /// Bitmask of the sync data options the service supports (Esri <c>syncDataOptions</c>). Honua syncs
+    /// feature edits (bit 1, <c>esriSyncDataOptionsFeatures</c>); attachment-edit sync is not part of
+    /// the replica upload model, so the attachments bit is not advertised.
+    /// </summary>
+    [JsonPropertyName("supportedSyncDataOptions")]
+    public int SupportedSyncDataOptions { get; init; } = 1;
 }
 
 /// <summary>

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureServerReplicaEditApplier.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureServerReplicaEditApplier.cs
@@ -20,9 +20,11 @@ namespace Honua.Protocols.GeoServices.FeatureServer.Services;
 /// <remarks>
 /// The canonical <see cref="IReplicaSyncService"/> owns conflict detection and only passes the edits
 /// it decided to apply; this applier maps each <see cref="ReplicaUploadEdit"/> back to its GeoServices
-/// wire payload and dispatches a single <c>applyEdits</c> per layer. Edits are applied with
-/// <see cref="ApplyEditsRequest.RollbackOnFailure"/> set to <c>false</c> so a single bad row does not
-/// discard the rest of the upload (matching the prior synchronize behavior and Esri sync semantics).
+/// wire payload and dispatches a single <c>applyEdits</c> per layer. The synchronize adapter's
+/// <c>rollbackOnFailure</c> parameter flows through to <see cref="ApplyEditsRequest.RollbackOnFailure"/>:
+/// when true, the shared edit pipeline wraps the layer's edits in an explicit transaction so a single
+/// bad row rolls back the whole layer batch (Esri sync semantics, #2136); when false the upload is
+/// applied best-effort per row (the prior synchronize behavior).
 /// </remarks>
 internal sealed class FeatureServerReplicaEditApplier : IReplicaEditApplier
 {
@@ -39,6 +41,7 @@ internal sealed class FeatureServerReplicaEditApplier : IReplicaEditApplier
         string serviceId,
         int publicLayerId,
         ImmutableArray<ReplicaUploadEdit> edits,
+        bool rollbackOnFailure,
         CancellationToken cancellationToken = default)
     {
         if (edits.IsDefaultOrEmpty)
@@ -77,7 +80,8 @@ internal sealed class FeatureServerReplicaEditApplier : IReplicaEditApplier
             Adds = adds.Count > 0 ? adds.ToArray() : null,
             Updates = updates.Count > 0 ? updates.ToArray() : null,
             Deletes = deletes.Count > 0 ? deletes.ToArray() : null,
-            RollbackOnFailure = false,
+            RollbackOnFailure = rollbackOnFailure,
+            RollbackOnFailureExplicitlySet = true,
         };
 
         var editResult = await _editsHandler.HandleApplyEditsAsync(

--- a/tests/dotnet/Honua.Core.Tests/Features/FeatureStore/ReplicaSyncServiceUploadFilterTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/FeatureStore/ReplicaSyncServiceUploadFilterTests.cs
@@ -66,15 +66,51 @@ public sealed class ReplicaSyncServiceUploadFilterTests
         tracker.FilteredCalls.Should().Be(0, "creates use server-assigned ids and cannot conflict");
     }
 
+    [UnitTest]
+    public async Task ApplyUpload_RollbackOnFailureRequested_FlowsThroughToEditApplier()
+    {
+        // The protocol adapter's rollbackOnFailure=true must reach the edit applier so the shared edit
+        // pipeline applies each layer's batch atomically (#2136).
+        var tracker = new RecordingChangeTracker();
+        var service = CreateService(tracker);
+        var applier = new CountingEditApplier();
+        var edits = ImmutableArray.Create(
+            new ReplicaUploadEdit(FeatureEditOperationKind.Create, ObjectId: null, Payload: null));
+        var request = CreateRequest(edits, rollbackOnFailure: true);
+
+        var report = await service.ApplyUploadAsync(request, applier);
+
+        report.Success.Should().BeTrue();
+        applier.LastRollbackOnFailure.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public async Task ApplyUpload_RollbackOnFailureDefault_DoesNotRequestAtomicApply()
+    {
+        var tracker = new RecordingChangeTracker();
+        var service = CreateService(tracker);
+        var applier = new CountingEditApplier();
+        var edits = ImmutableArray.Create(
+            new ReplicaUploadEdit(FeatureEditOperationKind.Create, ObjectId: null, Payload: null));
+        var request = CreateRequest(edits);
+
+        await service.ApplyUploadAsync(request, applier);
+
+        applier.LastRollbackOnFailure.Should().BeFalse("rollbackOnFailure defaults to false (best-effort per-row)");
+    }
+
     private static ReplicaSyncService CreateService(RecordingChangeTracker tracker)
         => new(tracker, new NoReviewConflictRepository(), NullLogger<ReplicaSyncService>.Instance);
 
-    private static ReplicaSyncRequest CreateRequest(ImmutableArray<ReplicaUploadEdit> edits) => new(
+    private static ReplicaSyncRequest CreateRequest(
+        ImmutableArray<ReplicaUploadEdit> edits,
+        bool rollbackOnFailure = false) => new(
         ReplicaId: "replica-1",
         ServiceId: "svc-1",
         Direction: ReplicaSyncDirection.Upload,
         BaseGeneration: 10,
-        LayerEdits: ImmutableArray.Create(new ReplicaUploadLayerEdits(PublicLayerId: 0, StorageLayerId: 10, edits)));
+        LayerEdits: ImmutableArray.Create(new ReplicaUploadLayerEdits(PublicLayerId: 0, StorageLayerId: 10, edits)),
+        RollbackOnFailure: rollbackOnFailure);
 
     private sealed class RecordingChangeTracker : IChangeTracker
     {
@@ -112,12 +148,16 @@ public sealed class ReplicaSyncServiceUploadFilterTests
 
     private sealed class CountingEditApplier : IReplicaEditApplier
     {
+        public bool? LastRollbackOnFailure { get; private set; }
+
         public Task<ReplicaLayerApplyResult> ApplyAsync(
             string serviceId,
             int publicLayerId,
             ImmutableArray<ReplicaUploadEdit> edits,
+            bool rollbackOnFailure,
             CancellationToken cancellationToken = default)
         {
+            LastRollbackOnFailure = rollbackOnFailure;
             var result = new ReplicaLayerApplyResult(
                 publicLayerId,
                 AppliedAdds: edits.Count(edit => edit.Kind == FeatureEditOperationKind.Create),

--- a/tests/dotnet/Honua.DuckDB.Tests/ReadOnlyReplicaRepositoryTests.cs
+++ b/tests/dotnet/Honua.DuckDB.Tests/ReadOnlyReplicaRepositoryTests.cs
@@ -17,6 +17,14 @@ public sealed class ReadOnlyReplicaRepositoryTests
     private readonly NoOpReplicaRepository _repo = new();
 
     [Fact]
+    public void SupportsReplicaPersistence_IsFalse()
+    {
+        // Read-only providers cannot durably persist replicas, so the synchronize adapter emits a
+        // conformant "operation not supported" response instead of silently no-op'ing a sync (#2136).
+        Assert.False(_repo.SupportsReplicaPersistence);
+    }
+
+    [Fact]
     public async Task UpsertAsync_NoOps()
     {
         var record = new ReplicaRecord

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicaSyncTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicaSyncTests.cs
@@ -336,6 +336,131 @@ public sealed class FeatureServerReplicaSyncTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Operation(Operations.SynchronizeReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/synchronizeReplica")]
+    public async Task SynchronizeReplica_Bidirectional_AppliesUploadAndDeliversServerDelta()
+    {
+        // Conformance (#2136): a bidirectional sync uploads the client's edits AND returns the
+        // server-to-client delta in one call, excluding the client's own just-applied edits.
+        var createRoot = await CreateReplicaWithResponseAsync("BidirectionalSync", "0");
+        var replicaId = createRoot.GetProperty("replicaID").GetString()!;
+        var baseServerGen = createRoot.GetProperty("serverGen").GetInt64();
+
+        // A server-side feature committed after the replica was created — the download half must deliver it.
+        var serverObjectId = await AddFeatureAsync("server-side-bidi");
+
+        // Client uploads its own add in the same bidirectional call.
+        var edits = JsonSerializer.Serialize(new object[]
+        {
+            new { id = 0, adds = new[] { new { attributes = new { name = "client-side-bidi" } } } }
+        });
+        var payload = JsonSerializer.Serialize(new
+        {
+            replicaID = replicaId,
+            syncDirection = "bidirectional",
+            replicaServerGen = baseServerGen,
+            edits,
+            f = "json"
+        });
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/synchronizeReplica",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+        root.GetProperty("syncDirection").GetString().Should().Be("bidirectional");
+
+        // Upload half applied the client's add.
+        root.GetProperty("appliedAdds").GetInt32().Should().Be(1);
+
+        // Download half delivered the server-side feature but not the client's own just-applied add.
+        root.TryGetProperty("edits", out var deltaEdits).Should().BeTrue("a bidirectional sync must carry the download delta");
+        var layer0 = deltaEdits.EnumerateArray().Single(layer => layer.GetProperty("id").GetInt32() == 0);
+        var deliveredObjectIds = layer0.TryGetProperty("addFeatures", out var addFeatures) && addFeatures.ValueKind == JsonValueKind.Array
+            ? addFeatures.EnumerateArray().Select(f => f.GetProperty("attributes").GetProperty("objectid").GetInt64()).ToList()
+            : new List<long>();
+        deliveredObjectIds.Should().Contain(serverObjectId, "the server-side change must be delivered to the replica");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.SynchronizeReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/synchronizeReplica")]
+    public async Task SynchronizeReplica_RollbackOnFailure_AbortsUploadLeavingStateUnchanged()
+    {
+        // Conformance (#2136): with rollbackOnFailure=true, a layer batch that contains a failing edit
+        // is applied atomically — the whole batch rolls back, leaving the layer's server state unchanged.
+        var replicaId = await CreateReplicaAsync("RollbackOnFailure", "0");
+        await SynchronizeDownloadAsync(replicaId);
+
+        // One valid add plus one update targeting an object id that does not exist (which fails). Under
+        // rollbackOnFailure the valid add must NOT be persisted.
+        var edits = JsonSerializer.Serialize(new object[]
+        {
+            new
+            {
+                id = 0,
+                adds = new[] { new { attributes = new { name = "rollback-should-not-persist" } } },
+                updates = new[]
+                {
+                    new { attributes = new Dictionary<string, object?> { ["objectid"] = 999_999_999L, ["name"] = "missing" } }
+                }
+            }
+        });
+        var payload = JsonSerializer.Serialize(new
+        {
+            replicaID = replicaId,
+            syncDirection = "upload",
+            rollbackOnFailure = true,
+            edits,
+            f = "json"
+        });
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/synchronizeReplica",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+
+        // The sync is rejected because an edit failed and the batch rolled back.
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        // State unchanged: the valid add was rolled back and never persisted.
+        var matches = await CountFeaturesByNameAsync("rollback-should-not-persist");
+        matches.Should().Be(0, "rollbackOnFailure must discard the entire layer batch when any edit fails");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer")]
+    public async Task ServiceMetadata_SyncEnabled_AdvertisesSyncCapabilities()
+    {
+        // Conformance (#2136): a sync-enabled service advertises its sync capabilities (supported sync
+        // directions, sync models, rollbackOnFailure, and supportedSyncDataOptions) so Esri clients can
+        // discover the offline replica behavior before attempting createReplica / synchronizeReplica.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer?f=json");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+
+        // syncCapabilities is present exactly when the service is sync-enabled, and stays consistent
+        // with the capability flags the sync surface actually honors.
+        if (root.GetProperty("syncEnabled").GetBoolean())
+        {
+            root.TryGetProperty("syncCapabilities", out var syncCapabilities).Should().BeTrue();
+            syncCapabilities.GetProperty("supportsRollbackOnFailure").GetBoolean().Should().BeTrue();
+            syncCapabilities.GetProperty("supportsSyncDirectionControl").GetBoolean().Should().BeTrue();
+            syncCapabilities.GetProperty("supportsPerReplicaSync").GetBoolean().Should().BeTrue();
+            syncCapabilities.GetProperty("supportedSyncDataOptions").GetInt32().Should().BeGreaterThan(0);
+        }
+        else
+        {
+            root.TryGetProperty("syncCapabilities", out _).Should().BeFalse(
+                "syncCapabilities must be omitted when the service is not sync-enabled");
+        }
+    }
+
+    [IntegrationTest]
     [Operation(Operations.ListReplicas)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/replicas")]
     public async Task Replicas_AfterCreateAndUnregister_ReflectsLiveRegistryImmediately()
@@ -540,6 +665,17 @@ public sealed class FeatureServerReplicaSyncTests : IAsyncLifetime
 
         using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         doc.RootElement.GetProperty("updateResults")[0].GetProperty("success").GetBoolean().Should().BeTrue();
+    }
+
+    private async Task<int> CountFeaturesByNameAsync(string name)
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query" +
+            $"?where=name='{name}'&returnGeometry=false&f=json");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("features").GetArrayLength();
     }
 
     private async Task<string?> ReadFeatureNameAsync(long objectId)


### PR DESCRIPTION
## Summary

Brings the GeoServices offline replica sync surface to Esri conformance and defines the non-Postgres story (#2136):

- Advertises a service-level `syncCapabilities` block (supported sync directions, per-layer/per-replica sync models, `supportsRollbackOnFailure`, and `supportedSyncDataOptions`) on sync-enabled services so Esri clients discover the replica behavior before they call createReplica/synchronizeReplica.
- Honors `rollbackOnFailure=true` on `synchronizeReplica`: each layer's uploaded edits are applied atomically (the shared edit pipeline opens an explicit transaction), so a single failing edit rolls back that layer's whole batch and leaves the server state unchanged. The replica's sync cursor is only advanced when the upload succeeds.
- Returns a conformant Esri-shaped `501 Not Implemented` error when createReplica / synchronizeReplica / unRegisterReplica is invoked on a backend that cannot durably persist replicas (read-only DuckDB / MySQL providers), instead of the prior silent no-op.

Closes #2136

## Changes Made

- Added `FeatureServerSyncCapabilities` model + `FeatureServerResponse.SyncCapabilities`, populated when the service is sync-enabled; registered in the source-gen JSON context.
- Added `rollbackOnFailure` parsing to `synchronizeReplica`; plumbed it through `ReplicaSyncRequest` -> `IReplicaEditApplier.ApplyAsync` -> `FeatureServerReplicaEditApplier` (sets `ApplyEditsRequest.RollbackOnFailure`); added `rollbackOnFailure` to `SynchronizeReplicaRequest`.
- Added `IReplicaRepository.SupportsReplicaPersistence` (default `true`; `false` on `NoOpReplicaRepository`) and a `RequireReplicaPersistenceSupport` guard on the create/synchronize/unRegister handlers returning a 501 Esri error.
- Tests: unit coverage in `Honua.Core.Tests` (rollbackOnFailure flows to the applier; default false) and `Honua.DuckDB.Tests` (`SupportsReplicaPersistence` is false); integration coverage in `FeatureServerReplicaSyncTests` (bidirectional sync, rollbackOnFailure abort leaving state unchanged, syncCapabilities advertisement).

## Breaking Changes

None. `IReplicaRepository.SupportsReplicaPersistence` is a defaulted interface member (true); `rollbackOnFailure` defaults to false (prior best-effort behavior).

## Gate Impact

- [x] No gate impact / internal only

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Release-build (`/p:TreatWarningsAsErrors=true`) of `Honua.Protocols.GeoServices` and the affected test projects succeeds with 0 warnings/errors. Unit tests pass: `Honua.Core.Tests` replica-sync filter suite (4/4) and `Honua.DuckDB.Tests` read-only replica repository suite (5/5). `dotnet format --verify-no-changes` on the changed files is clean.

## Known gaps

- The three new integration tests in `FeatureServerReplicaSyncTests` (bidirectional sync, rollbackOnFailure abort, syncCapabilities advertisement) require a Postgres Testcontainer (Docker), which is unavailable in this worktree, so they were compiled but not executed locally. They run in CI. Opening as draft until CI confirms them green.
- `rollbackOnFailure` provides per-layer atomicity (the granularity the shared edit pipeline guarantees), not a single transaction spanning multiple layers. Documented in code; cross-layer atomic sync is out of scope for this slice.
