### PR TITLE
feat: embed governance API for keys, domains, analytics, and rate limits (#1191)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -1356,6 +1356,45 @@
       "maturity": "implemented"
     },
     {
+      "id": "get-api-v1-admin-embed-keys",
+      "route": "/api/v1/admin/embed/keys",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.EmbedGovernanceEndpointsTests.CreateListAndGetEmbedKey_ReturnsScopeAndSecretOnce"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-embed-keys-id",
+      "route": "/api/v1/admin/embed/keys/{id}",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.EmbedGovernanceEndpointsTests.CreateListAndGetEmbedKey_ReturnsScopeAndSecretOnce"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-embed-usage",
+      "route": "/api/v1/admin/embed/usage",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.EmbedGovernanceEndpointsTests.IngestAnalyticsThenQueryUsage_AggregatesEvents"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "get-api-v1-admin-feature-events-replay",
       "route": "/api/v1/admin/feature-events/replay",
       "method": "GET",
@@ -4108,6 +4147,21 @@
         "Honua.Server.Tests.Features.Protocols.Zarr.DatacubeTileEndpointTests.DatacubeTile_LayerWithoutServableCoverage_Returns404"
       ],
       "proof_ledger_surface": "datacube-tiles",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-embed-policy",
+      "route": "/api/v1/embed/policy",
+      "method": "GET",
+      "family": "uncategorized",
+      "protocol": "http-route",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.EmbedGovernanceEndpointsTests.FetchPolicy_AllowedOrigin_ReturnsPolicyWithCorsHeader",
+        "Honua.Server.Tests.Features.Admin.EmbedGovernanceEndpointsTests.FetchPolicy_DisallowedOrigin_ReturnsForbidden",
+        "Honua.Server.Tests.Features.Admin.EmbedGovernanceEndpointsTests.FetchPolicy_MissingKey_ReturnsUnauthorized"
+      ],
+      "proof_ledger_surface": "",
       "maturity": "implemented"
     },
     {
@@ -11632,6 +11686,46 @@
       "maturity": "implemented"
     },
     {
+      "id": "post-api-v1-admin-embed-keys",
+      "route": "/api/v1/admin/embed/keys",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.EmbedGovernanceEndpointsTests.CreateEmbedKey_WithoutAllowedOrigins_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.Admin.EmbedGovernanceEndpointsTests.CreateListAndGetEmbedKey_ReturnsScopeAndSecretOnce"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "post-api-v1-admin-embed-keys-id-revoke",
+      "route": "/api/v1/admin/embed/keys/{id}/revoke",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.EmbedGovernanceEndpointsTests.RevokeEmbedKey_BlocksPolicyIssuance"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "post-api-v1-admin-embed-keys-id-rotate",
+      "route": "/api/v1/admin/embed/keys/{id}/rotate",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.EmbedGovernanceEndpointsTests.RotateEmbedKey_InvalidatesOldSecret"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "post-api-v1-admin-external-services-discover",
       "route": "/api/v1/admin/external-services/discover",
       "method": "POST",
@@ -13665,6 +13759,20 @@
         "Honua.Server.Tests.Features.WorkflowPackages.WorkflowPackageEndpointsTests.WorkflowLifecycle_ValidatesDryRunsPublishesTargetsAndStampsJobProvenance"
       ],
       "proof_ledger_surface": "console-content-rbac",
+      "maturity": "implemented"
+    },
+    {
+      "id": "post-api-v1-embed-analytics",
+      "route": "/api/v1/embed/analytics",
+      "method": "POST",
+      "family": "uncategorized",
+      "protocol": "http-route",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.EmbedGovernanceEndpointsTests.IngestAnalyticsThenQueryUsage_AggregatesEvents",
+        "Honua.Server.Tests.Features.Admin.EmbedGovernanceEndpointsTests.IngestAnalytics_WithRawKeyInPayload_ReturnsBadRequest"
+      ],
+      "proof_ledger_surface": "",
       "maturity": "implemented"
     },
     {

--- a/src/Honua.Core/Features/EmbedGovernance/Abstractions/IEmbedAnalyticsStore.cs
+++ b/src/Honua.Core/Features/EmbedGovernance/Abstractions/IEmbedAnalyticsStore.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.EmbedGovernance.Domain;
+
+namespace Honua.Core.Features.EmbedGovernance.Abstractions;
+
+/// <summary>
+/// Ingestion and aggregation of redacted embed analytics events.
+/// </summary>
+public interface IEmbedAnalyticsStore
+{
+    /// <summary>Ingests a single validated, redacted analytics event.</summary>
+    /// <param name="analyticsEvent">The event to record.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task IngestAsync(EmbedAnalyticsEvent analyticsEvent, CancellationToken cancellationToken);
+
+    /// <summary>Aggregates recorded events for operator/Console reporting.</summary>
+    /// <param name="query">Filter and grouping inputs.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<EmbedUsageReport> QueryAsync(EmbedUsageQuery query, CancellationToken cancellationToken);
+}

--- a/src/Honua.Core/Features/EmbedGovernance/Abstractions/IEmbedKeyStore.cs
+++ b/src/Honua.Core/Features/EmbedGovernance/Abstractions/IEmbedKeyStore.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.EmbedGovernance.Domain;
+
+namespace Honua.Core.Features.EmbedGovernance.Abstractions;
+
+/// <summary>
+/// Result of creating or rotating an embed key, including one-time plaintext.
+/// </summary>
+/// <param name="Record">The persisted key metadata.</param>
+/// <param name="Key">The plaintext key material (returned once).</param>
+public sealed record EmbedKeyCreateResult(EmbedKeyRecord Record, string Key);
+
+/// <summary>
+/// Result of validating presented embed key material against the store.
+/// </summary>
+/// <param name="Record">The matched, still-active key record.</param>
+public sealed record EmbedKeyValidationResult(EmbedKeyRecord Record);
+
+/// <summary>
+/// Issuance, lifecycle, validation, and rate accounting for embed API keys.
+/// </summary>
+public interface IEmbedKeyStore
+{
+    /// <summary>Lists all embed keys, oldest first.</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<EmbedKeyRecord>> ListAsync(CancellationToken cancellationToken);
+
+    /// <summary>Creates a new embed key with the supplied scope.</summary>
+    /// <param name="name">Human-readable key name.</param>
+    /// <param name="scope">Authoritative key scope.</param>
+    /// <param name="expiresAt">Optional expiration.</param>
+    /// <param name="createdBy">Creating principal, when known.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<EmbedKeyCreateResult> CreateAsync(
+        string name,
+        EmbedKeyScope scope,
+        DateTimeOffset? expiresAt,
+        string? createdBy,
+        CancellationToken cancellationToken);
+
+    /// <summary>Gets a single key by id.</summary>
+    /// <param name="id">Key id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<EmbedKeyRecord?> GetAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Rotates a key, returning new plaintext and invalidating the old secret.</summary>
+    /// <param name="id">Key id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<EmbedKeyCreateResult?> RotateAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Revokes a key.</summary>
+    /// <param name="id">Key id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<EmbedKeyRecord?> RevokeAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Validates presented plaintext key material.</summary>
+    /// <param name="keyMaterial">The plaintext key from the embed request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<EmbedKeyValidationResult?> ValidateAsync(string keyMaterial, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Records a request against the key's fixed rate window and returns the
+    /// number of requests consumed in the current window, including this one.
+    /// </summary>
+    /// <param name="id">Key id.</param>
+    /// <param name="window">The fixed window length.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<int> RecordRequestAsync(Guid id, TimeSpan window, CancellationToken cancellationToken);
+}

--- a/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedAnalytics.cs
+++ b/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedAnalytics.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.EmbedGovernance.Domain;
+
+/// <summary>
+/// Category of redacted analytics event emitted by an embedded map surface.
+/// </summary>
+public enum EmbedAnalyticsEventType
+{
+    /// <summary>The embed was loaded/viewed.</summary>
+    View = 0,
+
+    /// <summary>The embed configuration changed (layers, extent, style).</summary>
+    ConfigChange = 1,
+
+    /// <summary>A search/geocode was performed in the embed.</summary>
+    Search = 2,
+
+    /// <summary>An identify/feature-info action was performed.</summary>
+    Identify = 3,
+
+    /// <summary>A policy denial was recorded for the embed.</summary>
+    PolicyDenial = 4,
+}
+
+/// <summary>
+/// A single redacted embed analytics event. By contract these events never carry
+/// raw browser API-key material; the key is identified server-side from the
+/// transport credential and surfaced here only as the issued key id.
+/// </summary>
+public sealed record EmbedAnalyticsEvent
+{
+    /// <summary>The category of event.</summary>
+    public required EmbedAnalyticsEventType EventType { get; init; }
+
+    /// <summary>Issued embed key id the event is attributed to (never the raw key).</summary>
+    public Guid? KeyId { get; init; }
+
+    /// <summary>Integration the event belongs to.</summary>
+    public string? IntegrationId { get; init; }
+
+    /// <summary>Tenant the event belongs to.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>Browser origin the event originated from.</summary>
+    public string? Origin { get; init; }
+
+    /// <summary>Service the event targeted.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>Layer/content the event targeted.</summary>
+    public string? LayerId { get; init; }
+
+    /// <summary>Deny reason when <see cref="EventType"/> is a policy denial.</summary>
+    public EmbedPolicyDenyReason? DenyReason { get; init; }
+
+    /// <summary>When the event occurred (UTC).</summary>
+    public required DateTimeOffset OccurredAt { get; init; }
+}
+
+/// <summary>
+/// Dimension to group embed usage by when querying aggregates.
+/// </summary>
+public enum EmbedUsageDimension
+{
+    /// <summary>Group by integration.</summary>
+    Integration = 0,
+
+    /// <summary>Group by tenant.</summary>
+    Tenant = 1,
+
+    /// <summary>Group by browser origin.</summary>
+    Origin = 2,
+
+    /// <summary>Group by service.</summary>
+    Service = 3,
+
+    /// <summary>Group by layer/content.</summary>
+    Layer = 4,
+
+    /// <summary>Group by event type.</summary>
+    EventType = 5,
+}
+
+/// <summary>
+/// Filter and grouping inputs for a usage aggregation query.
+/// </summary>
+public sealed record EmbedUsageQuery
+{
+    /// <summary>Dimension to group counts by.</summary>
+    public EmbedUsageDimension GroupBy { get; init; } = EmbedUsageDimension.EventType;
+
+    /// <summary>Optional integration filter.</summary>
+    public string? IntegrationId { get; init; }
+
+    /// <summary>Optional tenant filter.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>Optional origin filter.</summary>
+    public string? Origin { get; init; }
+
+    /// <summary>Optional service filter.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>Optional layer filter.</summary>
+    public string? LayerId { get; init; }
+
+    /// <summary>Optional event-type filter.</summary>
+    public EmbedAnalyticsEventType? EventType { get; init; }
+
+    /// <summary>Optional inclusive lower time bound.</summary>
+    public DateTimeOffset? From { get; init; }
+
+    /// <summary>Optional exclusive upper time bound.</summary>
+    public DateTimeOffset? To { get; init; }
+}
+
+/// <summary>
+/// A single grouped usage count.
+/// </summary>
+public sealed record EmbedUsageAggregate
+{
+    /// <summary>The grouping key value (e.g. integration id, origin, event type).</summary>
+    public required string Key { get; init; }
+
+    /// <summary>Number of events in the group.</summary>
+    public required long Count { get; init; }
+}
+
+/// <summary>
+/// Result of a usage aggregation query.
+/// </summary>
+public sealed record EmbedUsageReport
+{
+    /// <summary>The dimension counts were grouped by.</summary>
+    public required EmbedUsageDimension GroupBy { get; init; }
+
+    /// <summary>Total matching events across all groups.</summary>
+    public required long Total { get; init; }
+
+    /// <summary>Per-group counts, descending by count.</summary>
+    public IReadOnlyList<EmbedUsageAggregate> Aggregates { get; init; } = [];
+}

--- a/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedAnalyticsValidator.cs
+++ b/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedAnalyticsValidator.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.EmbedGovernance.Domain;
+
+/// <summary>
+/// Outcome of validating a redacted embed analytics event.
+/// </summary>
+public sealed record EmbedAnalyticsValidationResult
+{
+    /// <summary>Whether the event is acceptable for ingestion.</summary>
+    public required bool IsValid { get; init; }
+
+    /// <summary>Validation error when <see cref="IsValid"/> is <c>false</c>.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>A valid result singleton.</summary>
+    public static EmbedAnalyticsValidationResult Valid { get; } = new() { IsValid = true };
+
+    /// <summary>
+    /// Builds an invalid result with the supplied message.
+    /// </summary>
+    /// <param name="error">The validation error.</param>
+    /// <returns>An invalid result.</returns>
+    public static EmbedAnalyticsValidationResult Invalid(string error) => new()
+    {
+        IsValid = false,
+        Error = error,
+    };
+}
+
+/// <summary>
+/// Validates redacted embed analytics events. Enforces field bounds and, most
+/// importantly, that no field leaks raw browser API-key material.
+/// </summary>
+public static class EmbedAnalyticsValidator
+{
+    private const int MaxFieldLength = 512;
+
+    /// <summary>
+    /// Validates a single analytics event.
+    /// </summary>
+    /// <param name="analyticsEvent">The event to validate.</param>
+    /// <returns>The validation result.</returns>
+    public static EmbedAnalyticsValidationResult Validate(EmbedAnalyticsEvent analyticsEvent)
+    {
+        ArgumentNullException.ThrowIfNull(analyticsEvent);
+
+        if (!Enum.IsDefined(analyticsEvent.EventType))
+        {
+            return EmbedAnalyticsValidationResult.Invalid("eventType is not a recognized value");
+        }
+
+        foreach (var (name, value) in EnumerateFields(analyticsEvent))
+        {
+            if (value is null)
+            {
+                continue;
+            }
+
+            if (value.Length > MaxFieldLength)
+            {
+                return EmbedAnalyticsValidationResult.Invalid($"{name} exceeds the maximum length of {MaxFieldLength}");
+            }
+
+            if (EmbedKeyMaterial.LooksLikeRawKey(value))
+            {
+                return EmbedAnalyticsValidationResult.Invalid(
+                    $"{name} appears to contain raw embed key material; analytics events must be redacted");
+            }
+        }
+
+        return EmbedAnalyticsValidationResult.Valid;
+    }
+
+    private static IEnumerable<(string Name, string? Value)> EnumerateFields(EmbedAnalyticsEvent analyticsEvent)
+    {
+        yield return (nameof(analyticsEvent.IntegrationId), analyticsEvent.IntegrationId);
+        yield return (nameof(analyticsEvent.TenantId), analyticsEvent.TenantId);
+        yield return (nameof(analyticsEvent.Origin), analyticsEvent.Origin);
+        yield return (nameof(analyticsEvent.ServiceId), analyticsEvent.ServiceId);
+        yield return (nameof(analyticsEvent.LayerId), analyticsEvent.LayerId);
+    }
+}

--- a/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedKeyMaterial.cs
+++ b/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedKeyMaterial.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Honua.Core.Features.EmbedGovernance.Domain;
+
+/// <summary>
+/// Generation, hashing, and recognition of embed API key material. Centralized
+/// so the issuing store and analytics validation agree on the key shape.
+/// </summary>
+public static class EmbedKeyMaterial
+{
+    /// <summary>Stable, recognizable prefix on every embed key.</summary>
+    public const string Prefix = "embk_";
+
+    private const int KeyByteCount = 32;
+    private const int DisplayPrefixLength = 14;
+
+    /// <summary>
+    /// Generates fresh, URL-safe plaintext key material.
+    /// </summary>
+    /// <returns>The plaintext key, including the recognizable prefix.</returns>
+    public static string Generate()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(KeyByteCount);
+        return Prefix + Convert.ToBase64String(bytes)
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+    }
+
+    /// <summary>
+    /// Produces the non-secret display prefix for a plaintext key.
+    /// </summary>
+    /// <param name="keyMaterial">The plaintext key.</param>
+    /// <returns>A short prefix safe to store and show operators.</returns>
+    public static string DisplayPrefix(string keyMaterial)
+    {
+        ArgumentNullException.ThrowIfNull(keyMaterial);
+        var length = Math.Min(DisplayPrefixLength, keyMaterial.Length);
+        return keyMaterial[..length];
+    }
+
+    /// <summary>
+    /// Computes the SHA-256 hash of plaintext key material.
+    /// </summary>
+    /// <param name="keyMaterial">The plaintext key.</param>
+    /// <returns>The hash bytes.</returns>
+    public static byte[] Hash(string keyMaterial)
+    {
+        ArgumentNullException.ThrowIfNull(keyMaterial);
+        return SHA256.HashData(Encoding.UTF8.GetBytes(keyMaterial));
+    }
+
+    /// <summary>
+    /// Determines whether a free-form value looks like raw embed key material.
+    /// Used to reject analytics payloads that leak the browser credential.
+    /// </summary>
+    /// <param name="value">The candidate value.</param>
+    /// <returns><c>true</c> when the value appears to embed raw key material.</returns>
+    public static bool LooksLikeRawKey(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var span = value.AsSpan().Trim();
+        var prefix = Prefix.AsSpan();
+
+        if (span.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // Catch the prefix appearing anywhere in a larger string (e.g. a URL).
+        return value.Contains(Prefix, StringComparison.Ordinal);
+    }
+}

--- a/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedKeyRecord.cs
+++ b/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedKeyRecord.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.EmbedGovernance.Domain;
+
+/// <summary>
+/// Lifecycle status of an embed API key.
+/// </summary>
+public enum EmbedKeyStatus
+{
+    /// <summary>The key can authenticate and issue policy.</summary>
+    Active = 0,
+
+    /// <summary>The key has passed its expiration time.</summary>
+    Expired = 1,
+
+    /// <summary>The key was explicitly revoked by an operator.</summary>
+    Revoked = 2,
+}
+
+/// <summary>
+/// Persisted embed API key without plaintext key material. The raw key is only
+/// ever returned once, at create and rotate time.
+/// </summary>
+public sealed record EmbedKeyRecord
+{
+    /// <summary>Stable key identifier.</summary>
+    public required Guid Id { get; init; }
+
+    /// <summary>Human-readable name used in operator list/audit views.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Non-secret key prefix used for operator recognition.</summary>
+    public required string KeyPrefix { get; init; }
+
+    /// <summary>SHA-256 hash of the plaintext key material.</summary>
+    public required byte[] KeyHash { get; init; }
+
+    /// <summary>Authoritative scope governing what the key may do.</summary>
+    public required EmbedKeyScope Scope { get; init; }
+
+    /// <summary>When the key was created.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>When the key metadata was last updated.</summary>
+    public required DateTimeOffset UpdatedAt { get; init; }
+
+    /// <summary>Optional UTC expiration time.</summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>Most recent successful policy/authentication time.</summary>
+    public DateTimeOffset? LastUsedAt { get; init; }
+
+    /// <summary>Most recent rotation time.</summary>
+    public DateTimeOffset? RotatedAt { get; init; }
+
+    /// <summary>Revocation time when revoked.</summary>
+    public DateTimeOffset? RevokedAt { get; init; }
+
+    /// <summary>Authenticated principal that created the key when available.</summary>
+    public string? CreatedBy { get; init; }
+
+    /// <summary>
+    /// Resolves the lifecycle status of the key at the supplied instant.
+    /// </summary>
+    /// <param name="now">The reference instant.</param>
+    /// <returns>The effective <see cref="EmbedKeyStatus"/>.</returns>
+    public EmbedKeyStatus GetStatus(DateTimeOffset now)
+    {
+        if (RevokedAt is not null)
+        {
+            return EmbedKeyStatus.Revoked;
+        }
+
+        if (ExpiresAt.HasValue && ExpiresAt.Value <= now)
+        {
+            return EmbedKeyStatus.Expired;
+        }
+
+        return EmbedKeyStatus.Active;
+    }
+}

--- a/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedKeyScope.cs
+++ b/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedKeyScope.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.EmbedGovernance.Domain;
+
+/// <summary>
+/// Authoritative scope attached to an embed API key. Defines the origins,
+/// services, content, tenant, and rate budget an embedded map surface may use.
+/// </summary>
+/// <remarks>
+/// Allowed-origin matching is security critical: an empty
+/// <see cref="AllowedEmbedOrigins"/> list denies every browser origin. Service
+/// and content lists narrow access when populated but allow everything when
+/// empty, so an integration can be scoped to specific origins without having to
+/// enumerate every service or content id up front.
+/// </remarks>
+public sealed record EmbedKeyScope
+{
+    /// <summary>
+    /// Browser origins (scheme + host[:port]) permitted to load the embed.
+    /// Supports an exact origin, a <c>*.example.com</c> subdomain wildcard, or
+    /// <c>*</c> for any origin. An empty list denies all origins.
+    /// </summary>
+    public IReadOnlyList<string> AllowedEmbedOrigins { get; init; } = [];
+
+    /// <summary>
+    /// Service identifiers (or service origins) the embed may call. An empty
+    /// list permits any service; <c>*</c> also permits any service.
+    /// </summary>
+    public IReadOnlyList<string> AllowedServiceOrigins { get; init; } = [];
+
+    /// <summary>
+    /// Content/item identifiers (maps, layers, scenes) the embed may render. An
+    /// empty list permits any content id; <c>*</c> also permits any content.
+    /// </summary>
+    public IReadOnlyList<string> AllowedContentIds { get; init; } = [];
+
+    /// <summary>
+    /// Tenant the key is bound to. When set, requests asserting a different
+    /// tenant are denied. <c>null</c> leaves the key tenant-agnostic.
+    /// </summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>
+    /// Integration the key represents (e.g. a customer site or app). Surfaced in
+    /// analytics and policy payloads.
+    /// </summary>
+    public string? IntegrationId { get; init; }
+
+    /// <summary>
+    /// Edition entitlement the key is issued under (e.g. <c>pro</c>,
+    /// <c>enterprise</c>). Informational; surfaced in the policy payload.
+    /// </summary>
+    public string? Edition { get; init; }
+
+    /// <summary>
+    /// Maximum embed requests allowed per <see cref="RateLimitWindow"/>. A value
+    /// of zero (the default) disables rate limiting for the key.
+    /// </summary>
+    public int RateLimitRequestsPerWindow { get; init; }
+
+    /// <summary>
+    /// Fixed window over which <see cref="RateLimitRequestsPerWindow"/> applies.
+    /// Defaults to one minute.
+    /// </summary>
+    public TimeSpan RateLimitWindow { get; init; } = TimeSpan.FromMinutes(1);
+}

--- a/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedPolicy.cs
+++ b/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedPolicy.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.EmbedGovernance.Domain;
+
+/// <summary>
+/// Rate budget advertised to an embed client. Client-side enforcement is a hint
+/// only; the authoritative limit is enforced server-side.
+/// </summary>
+public sealed record EmbedRateLimitPolicy
+{
+    /// <summary>Maximum requests allowed per window. Zero means unlimited.</summary>
+    public required int RequestsPerWindow { get; init; }
+
+    /// <summary>Length of the window in seconds.</summary>
+    public required int WindowSeconds { get; init; }
+}
+
+/// <summary>
+/// Policy payload returned to the <c>@honua-io/embed</c> remote governance
+/// adapter (consumed by <c>fetchHonuaMapEmbedPolicy</c>). It mirrors the
+/// authoritative scope of the embed key so the client can render only what the
+/// server will allow, while the server remains the security boundary.
+/// </summary>
+public sealed record EmbedPolicy
+{
+    /// <summary>Integration the key represents, when scoped.</summary>
+    public string? IntegrationId { get; init; }
+
+    /// <summary>Tenant the key is bound to, when scoped.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>Edition entitlement the key is issued under, when set.</summary>
+    public string? Edition { get; init; }
+
+    /// <summary>Browser origins the embed may load under.</summary>
+    public IReadOnlyList<string> AllowedOrigins { get; init; } = [];
+
+    /// <summary>Service identifiers/origins the embed may call.</summary>
+    public IReadOnlyList<string> AllowedServices { get; init; } = [];
+
+    /// <summary>Content identifiers the embed may render.</summary>
+    public IReadOnlyList<string> AllowedContentIds { get; init; } = [];
+
+    /// <summary>Capabilities the embed is permitted to invoke.</summary>
+    public IReadOnlyList<string> Capabilities { get; init; } = [];
+
+    /// <summary>Advertised rate budget for embed traffic.</summary>
+    public required EmbedRateLimitPolicy RateLimit { get; init; }
+}

--- a/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedPolicyEvaluation.cs
+++ b/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedPolicyEvaluation.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.EmbedGovernance.Domain;
+
+/// <summary>
+/// Reason an embed policy request was denied.
+/// </summary>
+public enum EmbedPolicyDenyReason
+{
+    /// <summary>The request was allowed.</summary>
+    None = 0,
+
+    /// <summary>The key is revoked or expired.</summary>
+    KeyInactive = 1,
+
+    /// <summary>The browser origin is not in the key's allowed-origin list.</summary>
+    OriginNotAllowed = 2,
+
+    /// <summary>The requested service is not permitted by the key scope.</summary>
+    ServiceNotAllowed = 3,
+
+    /// <summary>The requested content id is not permitted by the key scope.</summary>
+    ContentNotAllowed = 4,
+
+    /// <summary>The asserted tenant does not match the key's bound tenant.</summary>
+    TenantMismatch = 5,
+
+    /// <summary>The key has exhausted its rate budget for the current window.</summary>
+    RateLimited = 6,
+}
+
+/// <summary>
+/// Inputs the server evaluates an embed key scope against for a single request.
+/// </summary>
+public sealed record EmbedPolicyRequest
+{
+    /// <summary>Browser <c>Origin</c> header value of the embed request.</summary>
+    public string? Origin { get; init; }
+
+    /// <summary>Service identifier (or origin) the embed is requesting.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>Content/item identifier the embed is requesting.</summary>
+    public string? ContentId { get; init; }
+
+    /// <summary>Tenant the embed request asserts, when present.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>
+    /// Number of requests already consumed in the current rate window,
+    /// including this request. Zero disables the rate-limit check.
+    /// </summary>
+    public int RequestsConsumedInWindow { get; init; }
+}
+
+/// <summary>
+/// Result of evaluating an embed policy request against a key scope.
+/// </summary>
+public sealed record EmbedPolicyDecision
+{
+    /// <summary>Whether the request is permitted.</summary>
+    public required bool Allowed { get; init; }
+
+    /// <summary>The deny reason; <see cref="EmbedPolicyDenyReason.None"/> when allowed.</summary>
+    public required EmbedPolicyDenyReason Reason { get; init; }
+
+    /// <summary>Human-readable explanation suitable for audit/log surfaces.</summary>
+    public required string Message { get; init; }
+
+    /// <summary>An allowed decision singleton.</summary>
+    public static EmbedPolicyDecision Allow { get; } = new()
+    {
+        Allowed = true,
+        Reason = EmbedPolicyDenyReason.None,
+        Message = "allowed",
+    };
+
+    /// <summary>
+    /// Builds a denied decision for the supplied reason and message.
+    /// </summary>
+    /// <param name="reason">The deny reason.</param>
+    /// <param name="message">A human-readable explanation.</param>
+    /// <returns>A denied <see cref="EmbedPolicyDecision"/>.</returns>
+    public static EmbedPolicyDecision Deny(EmbedPolicyDenyReason reason, string message) => new()
+    {
+        Allowed = false,
+        Reason = reason,
+        Message = message,
+    };
+}

--- a/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedPolicyEvaluator.cs
+++ b/src/Honua.Core/Features/EmbedGovernance/Domain/EmbedPolicyEvaluator.cs
@@ -1,0 +1,217 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.EmbedGovernance.Domain;
+
+/// <summary>
+/// Pure evaluation of embed key scope against a request. This is the
+/// authoritative server-side decision: origin/domain (CORS), service, content,
+/// tenant, and rate-limit checks. It has no I/O so it can be unit tested in
+/// isolation and reused by every protocol surface.
+/// </summary>
+public static class EmbedPolicyEvaluator
+{
+    /// <summary>Default capabilities advertised to embeds.</summary>
+    private static readonly string[] _defaultCapabilities = ["view", "search", "identify"];
+
+    /// <summary>
+    /// Evaluates whether an embed request is permitted by a key.
+    /// </summary>
+    /// <param name="key">The embed key, including its scope.</param>
+    /// <param name="request">The request inputs.</param>
+    /// <param name="now">The reference instant for lifecycle checks.</param>
+    /// <returns>The policy decision.</returns>
+    public static EmbedPolicyDecision Evaluate(EmbedKeyRecord key, EmbedPolicyRequest request, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (key.GetStatus(now) != EmbedKeyStatus.Active)
+        {
+            return EmbedPolicyDecision.Deny(EmbedPolicyDenyReason.KeyInactive, "embed key is not active");
+        }
+
+        var scope = key.Scope;
+
+        if (!IsOriginAllowed(request.Origin, scope.AllowedEmbedOrigins))
+        {
+            return EmbedPolicyDecision.Deny(
+                EmbedPolicyDenyReason.OriginNotAllowed,
+                $"origin '{request.Origin ?? "(none)"}' is not allowed for this key");
+        }
+
+        if (!IsMemberAllowed(request.ServiceId, scope.AllowedServiceOrigins))
+        {
+            return EmbedPolicyDecision.Deny(
+                EmbedPolicyDenyReason.ServiceNotAllowed,
+                $"service '{request.ServiceId}' is not allowed for this key");
+        }
+
+        if (!IsMemberAllowed(request.ContentId, scope.AllowedContentIds))
+        {
+            return EmbedPolicyDecision.Deny(
+                EmbedPolicyDenyReason.ContentNotAllowed,
+                $"content '{request.ContentId}' is not allowed for this key");
+        }
+
+        if (!string.IsNullOrWhiteSpace(scope.TenantId)
+            && !string.IsNullOrWhiteSpace(request.TenantId)
+            && !string.Equals(scope.TenantId, request.TenantId, StringComparison.OrdinalIgnoreCase))
+        {
+            return EmbedPolicyDecision.Deny(
+                EmbedPolicyDenyReason.TenantMismatch,
+                "request tenant does not match the key's bound tenant");
+        }
+
+        if (scope.RateLimitRequestsPerWindow > 0
+            && request.RequestsConsumedInWindow > scope.RateLimitRequestsPerWindow)
+        {
+            return EmbedPolicyDecision.Deny(
+                EmbedPolicyDenyReason.RateLimited,
+                "embed key has exceeded its rate budget for the current window");
+        }
+
+        return EmbedPolicyDecision.Allow;
+    }
+
+    /// <summary>
+    /// Projects a key scope into the policy payload consumed by the embed
+    /// governance adapter.
+    /// </summary>
+    /// <param name="key">The embed key.</param>
+    /// <returns>The policy payload.</returns>
+    public static EmbedPolicy BuildPolicy(EmbedKeyRecord key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        var scope = key.Scope;
+
+        return new EmbedPolicy
+        {
+            IntegrationId = scope.IntegrationId,
+            TenantId = scope.TenantId,
+            Edition = scope.Edition,
+            AllowedOrigins = scope.AllowedEmbedOrigins,
+            AllowedServices = scope.AllowedServiceOrigins,
+            AllowedContentIds = scope.AllowedContentIds,
+            Capabilities = _defaultCapabilities,
+            RateLimit = new EmbedRateLimitPolicy
+            {
+                RequestsPerWindow = scope.RateLimitRequestsPerWindow,
+                WindowSeconds = (int)Math.Max(1, scope.RateLimitWindow.TotalSeconds),
+            },
+        };
+    }
+
+    /// <summary>
+    /// Normalizes a browser origin to a comparable lowercase scheme+host[:port]
+    /// form, stripping any path/trailing slash.
+    /// </summary>
+    /// <param name="origin">The raw origin value.</param>
+    /// <returns>The normalized origin, or <c>null</c> when blank.</returns>
+    public static string? NormalizeOrigin(string? origin)
+    {
+        if (string.IsNullOrWhiteSpace(origin))
+        {
+            return null;
+        }
+
+        var trimmed = origin.Trim().TrimEnd('/');
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+        {
+            var authority = uri.IsDefaultPort
+                ? uri.Host
+                : $"{uri.Host}:{uri.Port}";
+            return $"{uri.Scheme}://{authority}".ToLowerInvariant();
+        }
+
+        return trimmed.ToLowerInvariant();
+    }
+
+    private static bool IsOriginAllowed(string? origin, IReadOnlyList<string> allowed)
+    {
+        // Origins are security critical: an empty allow-list denies everything,
+        // and a request without an Origin header cannot satisfy a restricted key.
+        if (allowed.Count == 0)
+        {
+            return false;
+        }
+
+        var normalized = NormalizeOrigin(origin);
+        if (normalized is null)
+        {
+            return allowed.Any(static entry => entry.Trim() == "*");
+        }
+
+        var host = HostOf(normalized);
+
+        foreach (var entry in allowed)
+        {
+            var candidate = entry.Trim();
+            if (candidate.Length == 0)
+            {
+                continue;
+            }
+
+            if (candidate == "*")
+            {
+                return true;
+            }
+
+            if (candidate.StartsWith("*.", StringComparison.Ordinal))
+            {
+                var suffix = candidate[1..].ToLowerInvariant(); // ".example.com"
+                if (host is not null && host.EndsWith(suffix, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            var candidateNormalized = NormalizeOrigin(candidate);
+            if (candidateNormalized is not null
+                && string.Equals(candidateNormalized, normalized, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            // Allow a bare host entry (no scheme) to match the request host.
+            if (host is not null && string.Equals(candidate.ToLowerInvariant(), host, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsMemberAllowed(string? value, IReadOnlyList<string> allowed)
+    {
+        // Service/content lists narrow when populated, allow-all when empty.
+        if (allowed.Count == 0)
+        {
+            return true;
+        }
+
+        if (allowed.Any(static entry => entry.Trim() == "*"))
+        {
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            // A restricted list cannot be satisfied by an unspecified value.
+            return false;
+        }
+
+        return allowed.Any(entry => string.Equals(entry.Trim(), value.Trim(), StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string? HostOf(string normalizedOrigin)
+    {
+        var schemeIndex = normalizedOrigin.IndexOf("://", StringComparison.Ordinal);
+        var afterScheme = schemeIndex >= 0 ? normalizedOrigin[(schemeIndex + 3)..] : normalizedOrigin;
+        var portIndex = afterScheme.IndexOf(':', StringComparison.Ordinal);
+        return portIndex >= 0 ? afterScheme[..portIndex] : afterScheme;
+    }
+}

--- a/src/Honua.Core/Features/EmbedGovernance/InMemoryEmbedAnalyticsStore.cs
+++ b/src/Honua.Core/Features/EmbedGovernance/InMemoryEmbedAnalyticsStore.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using Honua.Core.Features.EmbedGovernance.Abstractions;
+using Honua.Core.Features.EmbedGovernance.Domain;
+
+namespace Honua.Core.Features.EmbedGovernance;
+
+/// <summary>
+/// In-memory <see cref="IEmbedAnalyticsStore"/>. Retains a bounded ring of recent
+/// events for operator reporting; a durable provider can replace it later.
+/// </summary>
+public sealed class InMemoryEmbedAnalyticsStore : IEmbedAnalyticsStore
+{
+    private const string Unknown = "(unknown)";
+    private readonly int _capacity;
+    private readonly ConcurrentQueue<EmbedAnalyticsEvent> _events = new();
+
+    /// <summary>
+    /// Creates the store.
+    /// </summary>
+    /// <param name="capacity">Maximum retained events before oldest are dropped.</param>
+    public InMemoryEmbedAnalyticsStore(int capacity = 50_000)
+    {
+        _capacity = capacity > 0 ? capacity : 50_000;
+    }
+
+    /// <inheritdoc />
+    public Task IngestAsync(EmbedAnalyticsEvent analyticsEvent, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(analyticsEvent);
+
+        _events.Enqueue(analyticsEvent);
+        while (_events.Count > _capacity && _events.TryDequeue(out _))
+        {
+            // Drop oldest to keep the buffer bounded.
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<EmbedUsageReport> QueryAsync(EmbedUsageQuery query, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(query);
+
+        var matching = _events
+            .Where(e => Matches(e, query))
+            .ToList();
+
+        var aggregates = matching
+            .GroupBy(e => DimensionKey(e, query.GroupBy))
+            .Select(g => new EmbedUsageAggregate { Key = g.Key, Count = g.LongCount() })
+            .OrderByDescending(a => a.Count)
+            .ThenBy(a => a.Key, StringComparer.Ordinal)
+            .ToList()
+            .AsReadOnly();
+
+        var report = new EmbedUsageReport
+        {
+            GroupBy = query.GroupBy,
+            Total = matching.Count,
+            Aggregates = aggregates,
+        };
+
+        return Task.FromResult(report);
+    }
+
+    private static bool Matches(EmbedAnalyticsEvent e, EmbedUsageQuery query)
+    {
+        if (query.EventType.HasValue && e.EventType != query.EventType.Value)
+        {
+            return false;
+        }
+
+        if (!FilterMatches(query.IntegrationId, e.IntegrationId)
+            || !FilterMatches(query.TenantId, e.TenantId)
+            || !FilterMatches(query.Origin, e.Origin)
+            || !FilterMatches(query.ServiceId, e.ServiceId)
+            || !FilterMatches(query.LayerId, e.LayerId))
+        {
+            return false;
+        }
+
+        if (query.From.HasValue && e.OccurredAt < query.From.Value)
+        {
+            return false;
+        }
+
+        if (query.To.HasValue && e.OccurredAt >= query.To.Value)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool FilterMatches(string? filter, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(filter))
+        {
+            return true;
+        }
+
+        return string.Equals(filter, value, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string DimensionKey(EmbedAnalyticsEvent e, EmbedUsageDimension dimension) => dimension switch
+    {
+        EmbedUsageDimension.Integration => e.IntegrationId ?? Unknown,
+        EmbedUsageDimension.Tenant => e.TenantId ?? Unknown,
+        EmbedUsageDimension.Origin => e.Origin ?? Unknown,
+        EmbedUsageDimension.Service => e.ServiceId ?? Unknown,
+        EmbedUsageDimension.Layer => e.LayerId ?? Unknown,
+        EmbedUsageDimension.EventType => e.EventType.ToString(),
+        _ => e.EventType.ToString(),
+    };
+}

--- a/src/Honua.Core/Features/EmbedGovernance/InMemoryEmbedKeyStore.cs
+++ b/src/Honua.Core/Features/EmbedGovernance/InMemoryEmbedKeyStore.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using Honua.Core.Features.EmbedGovernance.Abstractions;
+using Honua.Core.Features.EmbedGovernance.Domain;
+
+namespace Honua.Core.Features.EmbedGovernance;
+
+/// <summary>
+/// In-memory <see cref="IEmbedKeyStore"/>. Suitable as the default issuance
+/// store; a durable provider can replace it when persistence is configured.
+/// </summary>
+public sealed class InMemoryEmbedKeyStore : IEmbedKeyStore
+{
+    private readonly ConcurrentDictionary<Guid, EmbedKeyRecord> _keys = new();
+    private readonly ConcurrentDictionary<Guid, RateWindow> _windows = new();
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    /// Creates the store.
+    /// </summary>
+    /// <param name="timeProvider">Clock abstraction; defaults to system time.</param>
+    public InMemoryEmbedKeyStore(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<EmbedKeyRecord>> ListAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        IReadOnlyList<EmbedKeyRecord> result = _keys.Values
+            .OrderBy(key => key.CreatedAt)
+            .ToList()
+            .AsReadOnly();
+        return Task.FromResult(result);
+    }
+
+    /// <inheritdoc />
+    public Task<EmbedKeyCreateResult> CreateAsync(
+        string name,
+        EmbedKeyScope scope,
+        DateTimeOffset? expiresAt,
+        string? createdBy,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(scope);
+
+        var now = _timeProvider.GetUtcNow();
+        var generated = EmbedKeyMaterial.Generate();
+        var record = new EmbedKeyRecord
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            KeyPrefix = EmbedKeyMaterial.DisplayPrefix(generated),
+            KeyHash = EmbedKeyMaterial.Hash(generated),
+            Scope = scope,
+            CreatedAt = now,
+            UpdatedAt = now,
+            ExpiresAt = expiresAt,
+            CreatedBy = createdBy,
+        };
+
+        if (!_keys.TryAdd(record.Id, record))
+        {
+            throw new InvalidOperationException("Generated duplicate embed key identifier.");
+        }
+
+        return Task.FromResult(new EmbedKeyCreateResult(record, generated));
+    }
+
+    /// <inheritdoc />
+    public Task<EmbedKeyRecord?> GetAsync(Guid id, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _keys.TryGetValue(id, out var record);
+        return Task.FromResult(record);
+    }
+
+    /// <inheritdoc />
+    public Task<EmbedKeyCreateResult?> RotateAsync(Guid id, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_keys.TryGetValue(id, out var existing) || existing.RevokedAt is not null)
+        {
+            return Task.FromResult<EmbedKeyCreateResult?>(null);
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        var generated = EmbedKeyMaterial.Generate();
+        var updated = existing with
+        {
+            KeyPrefix = EmbedKeyMaterial.DisplayPrefix(generated),
+            KeyHash = EmbedKeyMaterial.Hash(generated),
+            UpdatedAt = now,
+            RotatedAt = now,
+            LastUsedAt = null,
+        };
+
+        _keys[id] = updated;
+        _windows.TryRemove(id, out _);
+        return Task.FromResult<EmbedKeyCreateResult?>(new EmbedKeyCreateResult(updated, generated));
+    }
+
+    /// <inheritdoc />
+    public Task<EmbedKeyRecord?> RevokeAsync(Guid id, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_keys.TryGetValue(id, out var existing))
+        {
+            return Task.FromResult<EmbedKeyRecord?>(null);
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        var updated = existing with
+        {
+            UpdatedAt = now,
+            RevokedAt = existing.RevokedAt ?? now,
+        };
+
+        _keys[id] = updated;
+        return Task.FromResult<EmbedKeyRecord?>(updated);
+    }
+
+    /// <inheritdoc />
+    public Task<EmbedKeyValidationResult?> ValidateAsync(string keyMaterial, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(keyMaterial))
+        {
+            return Task.FromResult<EmbedKeyValidationResult?>(null);
+        }
+
+        var providedHash = EmbedKeyMaterial.Hash(keyMaterial);
+        var now = _timeProvider.GetUtcNow();
+
+        foreach (var record in _keys.Values)
+        {
+            if (record.GetStatus(now) != EmbedKeyStatus.Active)
+            {
+                continue;
+            }
+
+            if (!CryptographicOperations.FixedTimeEquals(providedHash, record.KeyHash))
+            {
+                continue;
+            }
+
+            var updated = record with
+            {
+                LastUsedAt = now,
+                UpdatedAt = now,
+            };
+            _keys[record.Id] = updated;
+            return Task.FromResult<EmbedKeyValidationResult?>(new EmbedKeyValidationResult(updated));
+        }
+
+        return Task.FromResult<EmbedKeyValidationResult?>(null);
+    }
+
+    /// <inheritdoc />
+    public Task<int> RecordRequestAsync(Guid id, TimeSpan window, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (window <= TimeSpan.Zero)
+        {
+            window = TimeSpan.FromMinutes(1);
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        var updated = _windows.AddOrUpdate(
+            id,
+            _ => new RateWindow(now, 1),
+            (_, current) => current.WindowStart + window <= now
+                ? new RateWindow(now, 1)
+                : current with { Count = current.Count + 1 });
+
+        return Task.FromResult(updated.Count);
+    }
+
+    private sealed record RateWindow(DateTimeOffset WindowStart, int Count);
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -74,6 +74,16 @@ public static class EndpointRegistry
         new("POST", "/api/v1/admin/api-keys/{id}/revoke"),
         new("GET", "/api/v1/admin/api-keys/{id}/effective-permissions"),
 
+        // Embed governance: keys, scoping, policy, analytics, usage (#1191).
+        new("GET", "/api/v1/admin/embed/keys"),
+        new("POST", "/api/v1/admin/embed/keys"),
+        new("GET", "/api/v1/admin/embed/keys/{id}"),
+        new("POST", "/api/v1/admin/embed/keys/{id}/rotate"),
+        new("POST", "/api/v1/admin/embed/keys/{id}/revoke"),
+        new("GET", "/api/v1/admin/embed/usage"),
+        new("GET", "/api/v1/embed/policy"),
+        new("POST", "/api/v1/embed/analytics"),
+
         // OAuth2 client registry + scope catalogue (ADR-0053 Increment 2, #1888).
         new("GET", "/api/v1/admin/oauth-clients"),
         new("POST", "/api/v1/admin/oauth-clients"),

--- a/src/Honua.Server/Features/Admin/EmbedGovernance/EmbedGovernanceEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/EmbedGovernance/EmbedGovernanceEndpoints.cs
@@ -1,0 +1,374 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.EmbedGovernance.Abstractions;
+using Honua.Core.Features.EmbedGovernance.Domain;
+using Honua.Server.Features.Admin.EmbedGovernance.Models;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Models;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Admin.EmbedGovernance;
+
+/// <summary>
+/// Admin endpoints for embed API key lifecycle and embed usage reporting.
+/// </summary>
+internal static partial class EmbedGovernanceEndpoints
+{
+    internal sealed class EmbedGovernanceEndpointsLog;
+
+    /// <summary>
+    /// Registers embed governance admin endpoints.
+    /// </summary>
+    /// <param name="endpoints">The route builder.</param>
+    public static void MapEmbedGovernanceEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var keys = endpoints.MapGroup("/api/v{version:apiVersion}/admin/embed/keys")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Embed Governance")
+            .RequireAdminAuthorization();
+
+        keys.MapGet("/", HandleListKeys)
+            .WithDisplayName("List Embed Keys")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        keys.MapPost("/", HandleCreateKey)
+            .WithDisplayName("Create Embed Key")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+
+        keys.MapGet("/{id:guid}", HandleGetKey)
+            .WithDisplayName("Get Embed Key")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        keys.MapPost("/{id:guid}/rotate", HandleRotateKey)
+            .WithDisplayName("Rotate Embed Key")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+
+        keys.MapPost("/{id:guid}/revoke", HandleRevokeKey)
+            .WithDisplayName("Revoke Embed Key")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+
+        var usage = endpoints.MapGroup("/api/v{version:apiVersion}/admin/embed/usage")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Embed Governance")
+            .RequireAdminAuthorization();
+
+        usage.MapGet("/", HandleUsage)
+            .WithDisplayName("Query Embed Usage")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+    }
+
+    private static async Task<Ok<ApiResponse<IReadOnlyList<EmbedKeyResponse>>>> HandleListKeys(
+        [FromServices] IEmbedKeyStore store,
+        HttpContext context)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var records = await store.ListAsync(context.RequestAborted);
+        var response = records.Select(record => ToResponse(record, now)).ToList().AsReadOnly();
+        return TypedResults.Ok(ApiResponse<IReadOnlyList<EmbedKeyResponse>>.CreateSuccess(response));
+    }
+
+    private static async Task<Results<Created<ApiResponse<EmbedKeySecretResponse>>, BadRequest<ApiResponse<object>>>>
+        HandleCreateKey(
+            CreateEmbedKeyRequest request,
+            [FromServices] IEmbedKeyStore store,
+            [FromServices] IAuditLog auditLog,
+            [FromServices] ILogger<EmbedGovernanceEndpointsLog> logger,
+            HttpContext context)
+    {
+        if (!TryBuildScope(request, out var scope, out var validationMessage))
+        {
+            return TypedResults.BadRequest(ApiResponse<object>.Failure(validationMessage));
+        }
+
+        var creator = ResolveActor(context);
+        var result = await store.CreateAsync(request.Name.Trim(), scope, request.ExpiresAt, creator, context.RequestAborted);
+
+        LogKeyCreated(logger, result.Record.Id, result.Record.Name);
+        await EmitAuditAsync(auditLog, context, AuditEventType.AdminAction, "embed_key.create",
+            result.Record.Id.ToString(), AuditOutcome.Success, creator);
+
+        var response = new EmbedKeySecretResponse
+        {
+            EmbedKey = ToResponse(result.Record, DateTimeOffset.UtcNow),
+            Key = result.Key,
+        };
+
+        return TypedResults.Created(
+            $"/api/v1/admin/embed/keys/{result.Record.Id}",
+            ApiResponse<EmbedKeySecretResponse>.CreateSuccess(response));
+    }
+
+    private static async Task<Results<Ok<ApiResponse<EmbedKeyResponse>>, NotFound<ApiResponse<object>>>> HandleGetKey(
+        Guid id,
+        [FromServices] IEmbedKeyStore store,
+        HttpContext context)
+    {
+        var record = await store.GetAsync(id, context.RequestAborted);
+        if (record is null)
+        {
+            return TypedResults.NotFound(ApiResponse<object>.Failure("Embed key not found"));
+        }
+
+        return TypedResults.Ok(ApiResponse<EmbedKeyResponse>.CreateSuccess(ToResponse(record, DateTimeOffset.UtcNow)));
+    }
+
+    private static async Task<Results<Ok<ApiResponse<EmbedKeySecretResponse>>, NotFound<ApiResponse<object>>>>
+        HandleRotateKey(
+            Guid id,
+            [FromServices] IEmbedKeyStore store,
+            [FromServices] IAuditLog auditLog,
+            [FromServices] ILogger<EmbedGovernanceEndpointsLog> logger,
+            HttpContext context)
+    {
+        var result = await store.RotateAsync(id, context.RequestAborted);
+        if (result is null)
+        {
+            return TypedResults.NotFound(ApiResponse<object>.Failure("Embed key not found or revoked"));
+        }
+
+        LogKeyRotated(logger, id);
+        await EmitAuditAsync(auditLog, context, AuditEventType.AdminAction, "embed_key.rotate",
+            id.ToString(), AuditOutcome.Success, ResolveActor(context));
+
+        var response = new EmbedKeySecretResponse
+        {
+            EmbedKey = ToResponse(result.Record, DateTimeOffset.UtcNow),
+            Key = result.Key,
+        };
+
+        return TypedResults.Ok(ApiResponse<EmbedKeySecretResponse>.CreateSuccess(response));
+    }
+
+    private static async Task<Results<Ok<ApiResponse<EmbedKeyResponse>>, NotFound<ApiResponse<object>>>> HandleRevokeKey(
+        Guid id,
+        [FromServices] IEmbedKeyStore store,
+        [FromServices] IAuditLog auditLog,
+        [FromServices] ILogger<EmbedGovernanceEndpointsLog> logger,
+        HttpContext context)
+    {
+        var record = await store.RevokeAsync(id, context.RequestAborted);
+        if (record is null)
+        {
+            return TypedResults.NotFound(ApiResponse<object>.Failure("Embed key not found"));
+        }
+
+        LogKeyRevoked(logger, id);
+        await EmitAuditAsync(auditLog, context, AuditEventType.AdminAction, "embed_key.revoke",
+            id.ToString(), AuditOutcome.Success, ResolveActor(context));
+
+        return TypedResults.Ok(ApiResponse<EmbedKeyResponse>.CreateSuccess(ToResponse(record, DateTimeOffset.UtcNow)));
+    }
+
+    private static async Task<Results<Ok<ApiResponse<EmbedUsageResponse>>, BadRequest<ApiResponse<object>>>> HandleUsage(
+        [FromServices] IEmbedAnalyticsStore analytics,
+        [FromQuery] string? groupBy,
+        [FromQuery] string? integrationId,
+        [FromQuery] string? tenantId,
+        [FromQuery] string? origin,
+        [FromQuery] string? serviceId,
+        [FromQuery] string? layerId,
+        [FromQuery] string? eventType,
+        HttpContext context)
+    {
+        if (!TryParseDimension(groupBy, out var dimension))
+        {
+            return TypedResults.BadRequest(ApiResponse<object>.Failure($"Unknown groupBy value '{groupBy}'"));
+        }
+
+        EmbedAnalyticsEventType? eventTypeFilter = null;
+        if (!string.IsNullOrWhiteSpace(eventType))
+        {
+            if (!TryParseEventType(eventType, out var parsed))
+            {
+                return TypedResults.BadRequest(ApiResponse<object>.Failure($"Unknown eventType value '{eventType}'"));
+            }
+
+            eventTypeFilter = parsed;
+        }
+
+        var query = new EmbedUsageQuery
+        {
+            GroupBy = dimension,
+            IntegrationId = integrationId,
+            TenantId = tenantId,
+            Origin = origin,
+            ServiceId = serviceId,
+            LayerId = layerId,
+            EventType = eventTypeFilter,
+        };
+
+        var report = await analytics.QueryAsync(query, context.RequestAborted);
+        var response = new EmbedUsageResponse
+        {
+            GroupBy = report.GroupBy.ToString(),
+            Total = report.Total,
+            Aggregates = report.Aggregates
+                .Select(a => new EmbedUsageAggregateDto { Key = a.Key, Count = a.Count })
+                .ToList()
+                .AsReadOnly(),
+        };
+
+        return TypedResults.Ok(ApiResponse<EmbedUsageResponse>.CreateSuccess(response));
+    }
+
+    private static bool TryBuildScope(CreateEmbedKeyRequest request, out EmbedKeyScope scope, out string validationMessage)
+    {
+        scope = new EmbedKeyScope();
+
+        var validationResults = new List<ValidationResult>();
+        if (!Validator.TryValidateObject(request, new ValidationContext(request), validationResults, true))
+        {
+            validationMessage = $"Validation failed: {string.Join(", ", validationResults.Select(r => r.ErrorMessage))}";
+            return false;
+        }
+
+        if (request.Scope is null)
+        {
+            validationMessage = "Validation failed: scope is required";
+            return false;
+        }
+
+        var origins = Sanitize(request.Scope.AllowedEmbedOrigins);
+        if (origins.Count == 0)
+        {
+            validationMessage = "Validation failed: at least one allowed embed origin is required";
+            return false;
+        }
+
+        if (request.Scope.RateLimitRequestsPerWindow < 0)
+        {
+            validationMessage = "Validation failed: rateLimitRequestsPerWindow must be zero or greater";
+            return false;
+        }
+
+        var windowSeconds = request.Scope.RateLimitWindowSeconds <= 0 ? 60 : request.Scope.RateLimitWindowSeconds;
+
+        scope = new EmbedKeyScope
+        {
+            AllowedEmbedOrigins = origins,
+            AllowedServiceOrigins = Sanitize(request.Scope.AllowedServiceOrigins),
+            AllowedContentIds = Sanitize(request.Scope.AllowedContentIds),
+            TenantId = Trimmed(request.Scope.TenantId),
+            IntegrationId = Trimmed(request.Scope.IntegrationId),
+            Edition = Trimmed(request.Scope.Edition),
+            RateLimitRequestsPerWindow = request.Scope.RateLimitRequestsPerWindow,
+            RateLimitWindow = TimeSpan.FromSeconds(windowSeconds),
+        };
+
+        validationMessage = string.Empty;
+        return true;
+    }
+
+    private static EmbedKeyResponse ToResponse(EmbedKeyRecord record, DateTimeOffset now) => new()
+    {
+        Id = record.Id,
+        Name = record.Name,
+        KeyPrefix = record.KeyPrefix,
+        Status = record.GetStatus(now).ToString().ToLowerInvariant(),
+        Scope = new EmbedKeyScopeDto
+        {
+            AllowedEmbedOrigins = record.Scope.AllowedEmbedOrigins,
+            AllowedServiceOrigins = record.Scope.AllowedServiceOrigins,
+            AllowedContentIds = record.Scope.AllowedContentIds,
+            TenantId = record.Scope.TenantId,
+            IntegrationId = record.Scope.IntegrationId,
+            Edition = record.Scope.Edition,
+            RateLimitRequestsPerWindow = record.Scope.RateLimitRequestsPerWindow,
+            RateLimitWindowSeconds = (int)Math.Max(1, record.Scope.RateLimitWindow.TotalSeconds),
+        },
+        CreatedAt = record.CreatedAt,
+        UpdatedAt = record.UpdatedAt,
+        ExpiresAt = record.ExpiresAt,
+        LastUsedAt = record.LastUsedAt,
+        RotatedAt = record.RotatedAt,
+        RevokedAt = record.RevokedAt,
+        CreatedBy = record.CreatedBy,
+    };
+
+    private static List<string> Sanitize(IReadOnlyList<string>? values)
+    {
+        if (values is null)
+        {
+            return [];
+        }
+
+        return values
+            .Where(static v => !string.IsNullOrWhiteSpace(v))
+            .Select(static v => v.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string? Trimmed(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static bool TryParseDimension(string? value, out EmbedUsageDimension dimension)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            dimension = EmbedUsageDimension.EventType;
+            return true;
+        }
+
+        return Enum.TryParse(value, ignoreCase: true, out dimension);
+    }
+
+    private static bool TryParseEventType(string value, out EmbedAnalyticsEventType eventType) =>
+        Enum.TryParse(value, ignoreCase: true, out eventType) && Enum.IsDefined(eventType);
+
+    private static string ResolveActor(HttpContext context)
+    {
+        var apiKeyId = context.User.FindFirst("api_key_id")?.Value;
+        if (!string.IsNullOrWhiteSpace(apiKeyId))
+        {
+            return $"api-key:{apiKeyId}";
+        }
+
+        return context.User.Identity?.Name ?? AuditEvent.AnonymousActor;
+    }
+
+    private static Task EmitAuditAsync(
+        IAuditLog auditLog,
+        HttpContext context,
+        AuditEventType eventType,
+        string action,
+        string resourceId,
+        AuditOutcome outcome,
+        string actor)
+    {
+        var auditEvent = new AuditEvent
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            EventType = eventType,
+            Actor = actor,
+            ActorType = actor.StartsWith("api-key:", StringComparison.Ordinal)
+                ? AuditActorType.ApiKey
+                : AuditActorType.UserId,
+            ResourceType = "embed_key",
+            ResourceId = resourceId,
+            Action = action,
+            Outcome = outcome,
+            CorrelationId = context.TraceIdentifier,
+        };
+
+        return auditLog.RecordAsync(auditEvent, context.RequestAborted);
+    }
+
+    [LoggerMessage(EventId = 4600, Level = LogLevel.Information,
+        Message = "Created embed key {EmbedKeyId} named '{Name}'")]
+    private static partial void LogKeyCreated(ILogger logger, Guid embedKeyId, string name);
+
+    [LoggerMessage(EventId = 4601, Level = LogLevel.Information,
+        Message = "Rotated embed key {EmbedKeyId}")]
+    private static partial void LogKeyRotated(ILogger logger, Guid embedKeyId);
+
+    [LoggerMessage(EventId = 4602, Level = LogLevel.Information,
+        Message = "Revoked embed key {EmbedKeyId}")]
+    private static partial void LogKeyRevoked(ILogger logger, Guid embedKeyId);
+}

--- a/src/Honua.Server/Features/Admin/EmbedGovernance/EmbedPolicyEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/EmbedGovernance/EmbedPolicyEndpoints.cs
@@ -1,0 +1,287 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.EmbedGovernance.Abstractions;
+using Honua.Core.Features.EmbedGovernance.Domain;
+using Honua.Server.Features.Admin.EmbedGovernance.Models;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Models;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Admin.EmbedGovernance;
+
+/// <summary>
+/// Public embed governance endpoints: the policy endpoint consumed by the
+/// <c>@honua-io/embed</c> remote governance adapter, and redacted analytics
+/// ingestion. Both authenticate via the embed key presented in the
+/// <c>X-Honua-Embed-Key</c> header (or <c>key</c> query parameter); the server
+/// is the authoritative origin/domain, scope, and rate-limit boundary.
+/// </summary>
+internal static partial class EmbedPolicyEndpoints
+{
+    internal sealed class EmbedPolicyEndpointsLog;
+
+    private const string EmbedKeyHeader = "X-Honua-Embed-Key";
+
+    /// <summary>
+    /// Registers the public embed policy and analytics ingestion endpoints.
+    /// </summary>
+    /// <param name="endpoints">The route builder.</param>
+    public static void MapEmbedPolicyEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/embed")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Embed Governance")
+            .AllowAnonymous();
+
+        group.MapGet("/policy", HandlePolicy)
+            .WithDisplayName("Fetch Embed Policy")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        group.MapPost("/analytics", HandleAnalytics)
+            .WithDisplayName("Ingest Embed Analytics")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+    }
+
+    private static async Task<Results<Ok<EmbedPolicyResponse>, UnauthorizedHttpResult, JsonHttpResult<ApiResponse<object>>>>
+        HandlePolicy(
+            [FromServices] IEmbedKeyStore store,
+            [FromServices] IEmbedAnalyticsStore analytics,
+            [FromServices] IAuditLog auditLog,
+            [FromServices] ILogger<EmbedPolicyEndpointsLog> logger,
+            [FromQuery] string? serviceId,
+            [FromQuery] string? contentId,
+            [FromQuery] string? tenantId,
+            HttpContext context)
+    {
+        var validation = await ResolveKeyAsync(store, context);
+        if (validation is null)
+        {
+            return TypedResults.Unauthorized();
+        }
+
+        var key = validation.Record;
+        var origin = context.Request.Headers.Origin.ToString();
+        var consumed = await store.RecordRequestAsync(key.Id, key.Scope.RateLimitWindow, context.RequestAborted);
+
+        var request = new EmbedPolicyRequest
+        {
+            Origin = origin,
+            ServiceId = serviceId,
+            ContentId = contentId,
+            TenantId = tenantId,
+            RequestsConsumedInWindow = consumed,
+        };
+
+        var decision = EmbedPolicyEvaluator.Evaluate(key, request, DateTimeOffset.UtcNow);
+        if (!decision.Allowed)
+        {
+            LogPolicyDenied(logger, key.Id, decision.Reason);
+            await IngestDenialAsync(analytics, key, request, decision, context.RequestAborted);
+            await EmitDenialAuditAsync(auditLog, context, key.Id, decision);
+
+            var failure = ApiResponse<object>.Failure($"embed policy denied: {decision.Reason}");
+            return TypedResults.Json(failure, statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        // Authoritative server-side CORS echo for the approved origin.
+        if (!string.IsNullOrWhiteSpace(origin))
+        {
+            context.Response.Headers["Access-Control-Allow-Origin"] = origin;
+            context.Response.Headers.Append("Vary", "Origin");
+        }
+
+        var policy = EmbedPolicyEvaluator.BuildPolicy(key);
+        return TypedResults.Ok(ToResponse(policy));
+    }
+
+    private static async Task<Results<Ok<ApiResponse<EmbedAnalyticsIngestResponse>>, UnauthorizedHttpResult, BadRequest<ApiResponse<object>>>>
+        HandleAnalytics(
+            IngestEmbedAnalyticsRequest request,
+            [FromServices] IEmbedKeyStore store,
+            [FromServices] IEmbedAnalyticsStore analytics,
+            HttpContext context)
+    {
+        var validation = await ResolveKeyAsync(store, context);
+        if (validation is null)
+        {
+            return TypedResults.Unauthorized();
+        }
+
+        if (request?.Events is null || request.Events.Count == 0)
+        {
+            return TypedResults.BadRequest(ApiResponse<object>.Failure("at least one analytics event is required"));
+        }
+
+        var key = validation.Record;
+        var now = DateTimeOffset.UtcNow;
+        var accepted = 0;
+
+        foreach (var dto in request.Events)
+        {
+            if (!TryMapEvent(dto, key, now, out var analyticsEvent, out var mapError))
+            {
+                return TypedResults.BadRequest(ApiResponse<object>.Failure(mapError));
+            }
+
+            var result = EmbedAnalyticsValidator.Validate(analyticsEvent);
+            if (!result.IsValid)
+            {
+                return TypedResults.BadRequest(ApiResponse<object>.Failure(result.Error ?? "invalid analytics event"));
+            }
+
+            await analytics.IngestAsync(analyticsEvent, context.RequestAborted);
+            accepted++;
+        }
+
+        var response = new EmbedAnalyticsIngestResponse { Accepted = accepted };
+        return TypedResults.Ok(ApiResponse<EmbedAnalyticsIngestResponse>.CreateSuccess(response));
+    }
+
+    private static async Task<EmbedKeyValidationResult?> ResolveKeyAsync(IEmbedKeyStore store, HttpContext context)
+    {
+        var keyMaterial = ExtractKeyMaterial(context);
+        if (string.IsNullOrWhiteSpace(keyMaterial))
+        {
+            return null;
+        }
+
+        return await store.ValidateAsync(keyMaterial, context.RequestAborted);
+    }
+
+    private static string? ExtractKeyMaterial(HttpContext context)
+    {
+        if (context.Request.Headers.TryGetValue(EmbedKeyHeader, out var header))
+        {
+            var value = header.ToString();
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value.Trim();
+            }
+        }
+
+        var query = context.Request.Query["key"].ToString();
+        return string.IsNullOrWhiteSpace(query) ? null : query.Trim();
+    }
+
+    private static bool TryMapEvent(
+        EmbedAnalyticsEventDto dto,
+        EmbedKeyRecord key,
+        DateTimeOffset now,
+        out EmbedAnalyticsEvent analyticsEvent,
+        out string error)
+    {
+        analyticsEvent = null!;
+        error = string.Empty;
+
+        if (dto is null)
+        {
+            error = "analytics event is required";
+            return false;
+        }
+
+        if (!Enum.TryParse<EmbedAnalyticsEventType>(dto.EventType, ignoreCase: true, out var eventType)
+            || !Enum.IsDefined(eventType))
+        {
+            error = $"unknown eventType '{dto.EventType}'";
+            return false;
+        }
+
+        EmbedPolicyDenyReason? denyReason = null;
+        if (!string.IsNullOrWhiteSpace(dto.DenyReason))
+        {
+            if (!Enum.TryParse<EmbedPolicyDenyReason>(dto.DenyReason, ignoreCase: true, out var parsedReason)
+                || !Enum.IsDefined(parsedReason))
+            {
+                error = $"unknown denyReason '{dto.DenyReason}'";
+                return false;
+            }
+
+            denyReason = parsedReason;
+        }
+
+        analyticsEvent = new EmbedAnalyticsEvent
+        {
+            EventType = eventType,
+            KeyId = key.Id,
+            IntegrationId = string.IsNullOrWhiteSpace(dto.IntegrationId) ? key.Scope.IntegrationId : dto.IntegrationId.Trim(),
+            TenantId = string.IsNullOrWhiteSpace(dto.TenantId) ? key.Scope.TenantId : dto.TenantId.Trim(),
+            Origin = EmbedPolicyEvaluator.NormalizeOrigin(dto.Origin),
+            ServiceId = string.IsNullOrWhiteSpace(dto.ServiceId) ? null : dto.ServiceId.Trim(),
+            LayerId = string.IsNullOrWhiteSpace(dto.LayerId) ? null : dto.LayerId.Trim(),
+            DenyReason = denyReason,
+            OccurredAt = dto.OccurredAt ?? now,
+        };
+
+        return true;
+    }
+
+    private static Task IngestDenialAsync(
+        IEmbedAnalyticsStore analytics,
+        EmbedKeyRecord key,
+        EmbedPolicyRequest request,
+        EmbedPolicyDecision decision,
+        CancellationToken cancellationToken)
+    {
+        var analyticsEvent = new EmbedAnalyticsEvent
+        {
+            EventType = EmbedAnalyticsEventType.PolicyDenial,
+            KeyId = key.Id,
+            IntegrationId = key.Scope.IntegrationId,
+            TenantId = key.Scope.TenantId,
+            Origin = EmbedPolicyEvaluator.NormalizeOrigin(request.Origin),
+            ServiceId = string.IsNullOrWhiteSpace(request.ServiceId) ? null : request.ServiceId.Trim(),
+            LayerId = string.IsNullOrWhiteSpace(request.ContentId) ? null : request.ContentId.Trim(),
+            DenyReason = decision.Reason,
+            OccurredAt = DateTimeOffset.UtcNow,
+        };
+
+        return analytics.IngestAsync(analyticsEvent, cancellationToken);
+    }
+
+    private static Task EmitDenialAuditAsync(
+        IAuditLog auditLog,
+        HttpContext context,
+        Guid keyId,
+        EmbedPolicyDecision decision)
+    {
+        var auditEvent = new AuditEvent
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            EventType = AuditEventType.Authorization,
+            Actor = $"embed-key:{keyId}",
+            ActorType = AuditActorType.ApiKey,
+            ResourceType = "embed_policy",
+            ResourceId = keyId.ToString(),
+            Action = "embed_policy.deny",
+            Outcome = AuditOutcome.Denied,
+            CorrelationId = context.TraceIdentifier,
+            Details = decision.Reason.ToString(),
+        };
+
+        return auditLog.RecordAsync(auditEvent, context.RequestAborted);
+    }
+
+    private static EmbedPolicyResponse ToResponse(EmbedPolicy policy) => new()
+    {
+        IntegrationId = policy.IntegrationId,
+        TenantId = policy.TenantId,
+        Edition = policy.Edition,
+        AllowedOrigins = policy.AllowedOrigins,
+        AllowedServices = policy.AllowedServices,
+        AllowedContentIds = policy.AllowedContentIds,
+        Capabilities = policy.Capabilities,
+        RateLimit = new EmbedRateLimitResponse
+        {
+            RequestsPerWindow = policy.RateLimit.RequestsPerWindow,
+            WindowSeconds = policy.RateLimit.WindowSeconds,
+        },
+    };
+
+    [LoggerMessage(EventId = 4610, Level = LogLevel.Information,
+        Message = "Denied embed policy for key {EmbedKeyId}: {Reason}")]
+    private static partial void LogPolicyDenied(ILogger logger, Guid embedKeyId, EmbedPolicyDenyReason reason);
+}

--- a/src/Honua.Server/Features/Admin/EmbedGovernance/EmbedPolicyEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/EmbedGovernance/EmbedPolicyEndpoints.cs
@@ -7,6 +7,7 @@ using Honua.Core.Features.EmbedGovernance.Domain;
 using Honua.Server.Features.Admin.EmbedGovernance.Models;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Models;
+using Honua.Infrastructure.Security;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -35,7 +36,12 @@ internal static partial class EmbedPolicyEndpoints
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Embed Governance")
-            .AllowAnonymous();
+            .AllowAnonymous()
+            // Embed widgets load on arbitrary ISV origins, so the browser CORS preflight
+            // must be permitted from any origin; the per-embed-key origin allow-list is the
+            // authoritative gate enforced inside the handlers. Without this dedicated policy
+            // the global ProductionCors rejects the preflight before the handler runs (#1191).
+            .RequireCors(CorsConfiguration.EmbedPolicy);
 
         group.MapGet("/policy", HandlePolicy)
             .WithDisplayName("Fetch Embed Policy")
@@ -118,8 +124,11 @@ internal static partial class EmbedPolicyEndpoints
 
         var key = validation.Record;
         var now = DateTimeOffset.UtcNow;
-        var accepted = 0;
 
+        // Validate the ENTIRE batch before persisting anything. Persisting per-event while
+        // a later event can still reject with 400 double-counts the earlier events when the
+        // client retries the whole batch; the ingest must be all-or-nothing (#1191).
+        var mapped = new List<EmbedAnalyticsEvent>(request.Events.Count);
         foreach (var dto in request.Events)
         {
             if (!TryMapEvent(dto, key, now, out var analyticsEvent, out var mapError))
@@ -133,11 +142,15 @@ internal static partial class EmbedPolicyEndpoints
                 return TypedResults.BadRequest(ApiResponse<object>.Failure(result.Error ?? "invalid analytics event"));
             }
 
-            await analytics.IngestAsync(analyticsEvent, context.RequestAborted);
-            accepted++;
+            mapped.Add(analyticsEvent);
         }
 
-        var response = new EmbedAnalyticsIngestResponse { Accepted = accepted };
+        foreach (var analyticsEvent in mapped)
+        {
+            await analytics.IngestAsync(analyticsEvent, context.RequestAborted);
+        }
+
+        var response = new EmbedAnalyticsIngestResponse { Accepted = mapped.Count };
         return TypedResults.Ok(ApiResponse<EmbedAnalyticsIngestResponse>.CreateSuccess(response));
     }
 

--- a/src/Honua.Server/Features/Admin/EmbedGovernance/Models/EmbedGovernanceJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/EmbedGovernance/Models/EmbedGovernanceJsonContext.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Infrastructure.Models;
+
+namespace Honua.Server.Features.Admin.EmbedGovernance.Models;
+
+/// <summary>
+/// JSON source generation context for embed governance models.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(ApiResponse<IReadOnlyList<EmbedKeyResponse>>))]
+[JsonSerializable(typeof(ApiResponse<EmbedKeyResponse>))]
+[JsonSerializable(typeof(ApiResponse<EmbedKeySecretResponse>))]
+[JsonSerializable(typeof(ApiResponse<EmbedUsageResponse>))]
+[JsonSerializable(typeof(ApiResponse<EmbedAnalyticsIngestResponse>))]
+[JsonSerializable(typeof(ApiResponse<object>))]
+[JsonSerializable(typeof(CreateEmbedKeyRequest))]
+[JsonSerializable(typeof(EmbedKeyResponse))]
+[JsonSerializable(typeof(EmbedKeySecretResponse))]
+[JsonSerializable(typeof(EmbedPolicyResponse))]
+[JsonSerializable(typeof(IngestEmbedAnalyticsRequest))]
+[JsonSerializable(typeof(EmbedAnalyticsEventDto))]
+[JsonSerializable(typeof(EmbedUsageResponse))]
+internal sealed partial class EmbedGovernanceJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Admin/EmbedGovernance/Models/EmbedGovernanceModels.cs
+++ b/src/Honua.Server/Features/Admin/EmbedGovernance/Models/EmbedGovernanceModels.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Honua.Server.Features.Admin.EmbedGovernance.Models;
+
+/// <summary>
+/// Scope payload describing what an embed key may do.
+/// </summary>
+public sealed class EmbedKeyScopeDto
+{
+    /// <summary>Browser origins permitted to load the embed.</summary>
+    public IReadOnlyList<string> AllowedEmbedOrigins { get; init; } = [];
+
+    /// <summary>Service identifiers/origins the embed may call.</summary>
+    public IReadOnlyList<string> AllowedServiceOrigins { get; init; } = [];
+
+    /// <summary>Content/item identifiers the embed may render.</summary>
+    public IReadOnlyList<string> AllowedContentIds { get; init; } = [];
+
+    /// <summary>Tenant the key is bound to.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>Integration the key represents.</summary>
+    public string? IntegrationId { get; init; }
+
+    /// <summary>Edition entitlement the key is issued under.</summary>
+    public string? Edition { get; init; }
+
+    /// <summary>Maximum embed requests allowed per window; zero disables limiting.</summary>
+    public int RateLimitRequestsPerWindow { get; init; }
+
+    /// <summary>Length of the rate window in seconds; defaults to 60.</summary>
+    public int RateLimitWindowSeconds { get; init; } = 60;
+}
+
+/// <summary>
+/// Request body for creating an embed key.
+/// </summary>
+public sealed class CreateEmbedKeyRequest
+{
+    /// <summary>Human-readable key name used in operator audit and list views.</summary>
+    [Required]
+    [StringLength(120, MinimumLength = 1)]
+    public required string Name { get; init; }
+
+    /// <summary>Authoritative scope for the key.</summary>
+    [Required]
+    public required EmbedKeyScopeDto Scope { get; init; }
+
+    /// <summary>Optional UTC expiration time for the key.</summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+}
+
+/// <summary>
+/// Metadata for an embed key without plaintext key material.
+/// </summary>
+public sealed class EmbedKeyResponse
+{
+    /// <summary>Stable key identifier.</summary>
+    public Guid Id { get; init; }
+
+    /// <summary>Human-readable key name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Non-secret key prefix used for operator recognition.</summary>
+    public required string KeyPrefix { get; init; }
+
+    /// <summary>Current key lifecycle status.</summary>
+    public required string Status { get; init; }
+
+    /// <summary>Authoritative key scope.</summary>
+    public required EmbedKeyScopeDto Scope { get; init; }
+
+    /// <summary>When the key was created.</summary>
+    public DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>When the key metadata was last updated.</summary>
+    public DateTimeOffset UpdatedAt { get; init; }
+
+    /// <summary>Optional key expiration time.</summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>Most recent successful authentication time.</summary>
+    public DateTimeOffset? LastUsedAt { get; init; }
+
+    /// <summary>Most recent key rotation time.</summary>
+    public DateTimeOffset? RotatedAt { get; init; }
+
+    /// <summary>Revocation time when revoked.</summary>
+    public DateTimeOffset? RevokedAt { get; init; }
+
+    /// <summary>Authenticated principal that created the key when available.</summary>
+    public string? CreatedBy { get; init; }
+}
+
+/// <summary>
+/// Create or rotate response that includes one-time plaintext key material.
+/// </summary>
+public sealed class EmbedKeySecretResponse
+{
+    /// <summary>Key metadata without secret material.</summary>
+    public required EmbedKeyResponse EmbedKey { get; init; }
+
+    /// <summary>Plaintext key material. Returned only at create and rotate time.</summary>
+    public required string Key { get; init; }
+}
+
+/// <summary>
+/// Advertised rate budget for embed traffic.
+/// </summary>
+public sealed class EmbedRateLimitResponse
+{
+    /// <summary>Maximum requests allowed per window; zero means unlimited.</summary>
+    public int RequestsPerWindow { get; init; }
+
+    /// <summary>Length of the window in seconds.</summary>
+    public int WindowSeconds { get; init; }
+}
+
+/// <summary>
+/// Policy payload consumed by the <c>@honua-io/embed</c> governance adapter.
+/// </summary>
+public sealed class EmbedPolicyResponse
+{
+    /// <summary>Integration the key represents, when scoped.</summary>
+    public string? IntegrationId { get; init; }
+
+    /// <summary>Tenant the key is bound to, when scoped.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>Edition entitlement the key is issued under, when set.</summary>
+    public string? Edition { get; init; }
+
+    /// <summary>Browser origins the embed may load under.</summary>
+    public IReadOnlyList<string> AllowedOrigins { get; init; } = [];
+
+    /// <summary>Service identifiers/origins the embed may call.</summary>
+    public IReadOnlyList<string> AllowedServices { get; init; } = [];
+
+    /// <summary>Content identifiers the embed may render.</summary>
+    public IReadOnlyList<string> AllowedContentIds { get; init; } = [];
+
+    /// <summary>Capabilities the embed is permitted to invoke.</summary>
+    public IReadOnlyList<string> Capabilities { get; init; } = [];
+
+    /// <summary>Advertised rate budget for embed traffic.</summary>
+    public required EmbedRateLimitResponse RateLimit { get; init; }
+}
+
+/// <summary>
+/// A single redacted analytics event posted by an embed client.
+/// </summary>
+public sealed class EmbedAnalyticsEventDto
+{
+    /// <summary>Event category: view, configChange, search, identify, policyDenial.</summary>
+    [Required]
+    public required string EventType { get; init; }
+
+    /// <summary>Integration the event belongs to.</summary>
+    public string? IntegrationId { get; init; }
+
+    /// <summary>Tenant the event belongs to.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>Browser origin the event originated from.</summary>
+    public string? Origin { get; init; }
+
+    /// <summary>Service the event targeted.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>Layer/content the event targeted.</summary>
+    public string? LayerId { get; init; }
+
+    /// <summary>Deny reason when the event is a policy denial.</summary>
+    public string? DenyReason { get; init; }
+
+    /// <summary>When the event occurred (UTC). Defaults to ingest time when omitted.</summary>
+    public DateTimeOffset? OccurredAt { get; init; }
+}
+
+/// <summary>
+/// Batch of redacted analytics events. Raw browser key material must never be
+/// present in any field.
+/// </summary>
+public sealed class IngestEmbedAnalyticsRequest
+{
+    /// <summary>The events to ingest.</summary>
+    [Required]
+    public required IReadOnlyList<EmbedAnalyticsEventDto> Events { get; init; }
+}
+
+/// <summary>
+/// Result of an analytics ingestion request.
+/// </summary>
+public sealed class EmbedAnalyticsIngestResponse
+{
+    /// <summary>Number of events accepted.</summary>
+    public int Accepted { get; init; }
+}
+
+/// <summary>
+/// A single grouped usage count.
+/// </summary>
+public sealed class EmbedUsageAggregateDto
+{
+    /// <summary>The grouping key value.</summary>
+    public required string Key { get; init; }
+
+    /// <summary>Number of events in the group.</summary>
+    public long Count { get; init; }
+}
+
+/// <summary>
+/// Usage aggregation report for operator/Console reporting.
+/// </summary>
+public sealed class EmbedUsageResponse
+{
+    /// <summary>The dimension counts were grouped by.</summary>
+    public required string GroupBy { get; init; }
+
+    /// <summary>Total matching events across all groups.</summary>
+    public long Total { get; init; }
+
+    /// <summary>Per-group counts, descending by count.</summary>
+    public IReadOnlyList<EmbedUsageAggregateDto> Aggregates { get; init; } = [];
+}

--- a/src/Honua.Server/Features/Infrastructure/Security/CorsConfiguration.cs
+++ b/src/Honua.Server/Features/Infrastructure/Security/CorsConfiguration.cs
@@ -30,12 +30,23 @@ public static class CorsConfiguration
         "Content-Type", "Authorization", "X-API-Key", "X-Correlation-ID",
         "X-Grpc-Web", "X-User-Agent", "Range", "If-Range",
         "If-Match", "If-None-Match", "If-Modified-Since", "If-Unmodified-Since",
-        "Prefer"
+        "Prefer", "X-Honua-Embed-Key"
     ];
 
     public const string DevelopmentPolicy = "DevelopmentCors";
     public const string ProductionPolicy = "ProductionCors";
     public const string RestrictedPolicy = "RestrictedCors";
+
+    /// <summary>
+    /// CORS policy for the public embed governance endpoints (<c>/api/v1/embed/*</c>).
+    /// These are intentionally reachable cross-origin from arbitrary ISV sites, so the
+    /// browser preflight must be permitted from any origin — the authoritative gate is
+    /// the per-embed-key origin allow-list enforced inside the handler (which echoes
+    /// <c>Access-Control-Allow-Origin</c> only for approved origins). The global
+    /// <see cref="ProductionPolicy"/> restricts origins to the server allow-list, which
+    /// would reject the preflight before the handler ever runs (#1191).
+    /// </summary>
+    public const string EmbedPolicy = "EmbedCors";
 
     /// <summary>
     /// Configures CORS policies for different environments.
@@ -106,6 +117,13 @@ public static class CorsConfiguration
             options.AddPolicy(RestrictedPolicy, policy =>
             {
                 ConfigureRestrictedPolicy(policy, configuration);
+            });
+
+            // Embed policy - public embed governance endpoints reachable cross-origin
+            // from arbitrary ISV sites; the per-embed-key origin allow-list is the real gate.
+            options.AddPolicy(EmbedPolicy, policy =>
+            {
+                ConfigureEmbedPolicy(policy, configuration);
             });
         });
     }
@@ -212,6 +230,24 @@ public static class CorsConfiguration
             // No origins configured - explicitly deny all.
             policy.SetIsOriginAllowed(_ => false);
         }
+    }
+
+    /// <summary>
+    /// Configures the CORS policy for the public embed governance endpoints. Unlike the
+    /// production policy, this permits the cross-origin preflight from ANY origin because
+    /// embed widgets load on arbitrary ISV pages; the embed handler is the authoritative
+    /// origin gate (it validates the request origin against the per-embed-key allow-list
+    /// and echoes <c>Access-Control-Allow-Origin</c> only for approved origins). Credentials
+    /// are never enabled here — embed authentication travels in the <c>X-Honua-Embed-Key</c>
+    /// header, not cookies — so <c>AllowAnyOrigin</c> is safe.
+    /// </summary>
+    private static void ConfigureEmbedPolicy(CorsPolicyBuilder policy, IConfiguration configuration)
+    {
+        policy.AllowAnyOrigin()
+              .WithMethods("GET", "POST", "OPTIONS")
+              .WithHeaders(ResolveAllowedHeaders(configuration))
+              .WithExposedHeaders("Content-Length", "ETag")
+              .SetPreflightMaxAge(TimeSpan.FromMinutes(5));
     }
 
     /// <summary>

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -573,6 +573,13 @@ builder.Services.AddScoped<Honua.Core.Features.Authorization.Abstractions.IField
     Honua.Infrastructure.Authentication.FieldMaskSource>();
 builder.Services.AddSingleton<Honua.Infrastructure.Authentication.IAdminApiKeyStore>(sp =>
     new Honua.Infrastructure.Authentication.InMemoryAdminApiKeyStore(sp.GetService<TimeProvider>()));
+// Embed governance (#1191): authoritative embed key issuance/scoping, policy
+// evaluation, rate accounting, and redacted analytics ingestion. In-memory
+// defaults; durable providers can replace these via TryAdd later.
+builder.Services.AddSingleton<Honua.Core.Features.EmbedGovernance.Abstractions.IEmbedKeyStore>(sp =>
+    new Honua.Core.Features.EmbedGovernance.InMemoryEmbedKeyStore(sp.GetService<TimeProvider>()));
+builder.Services.AddSingleton<Honua.Core.Features.EmbedGovernance.Abstractions.IEmbedAnalyticsStore>(
+    new Honua.Core.Features.EmbedGovernance.InMemoryEmbedAnalyticsStore());
 // v1 metadata-resource / manifest-approval / gitops-watch admin surface removed in #1035 cutover.
 // V2 admin UX (epic #1046) edits the canonical MetadataV2Graph document directly via IMetadataV2GraphStore.
 
@@ -858,6 +865,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.WorkflowPackages.WorkflowPackagesJsonContext.Default,
         Honua.Server.Features.Operations.OperationsJsonContext.Default,
         Honua.Server.Features.Admin.Models.AdminApiKeyJsonContext.Default,
+        Honua.Server.Features.Admin.EmbedGovernance.Models.EmbedGovernanceJsonContext.Default,
         Honua.Server.Features.Admin.Models.OAuthClientJsonContext.Default,
         Honua.Server.Features.Admin.Models.SceneDatasetJsonContext.Default,
         Honua.Server.Features.Admin.Models.NetworkDatasetAdminJsonContext.Default,
@@ -1426,6 +1434,8 @@ app.MapOperationsEndpoints();
 Honua.Server.Features.Console.Publications.ContentPublicationEndpoints.MapContentPublicationEndpoints(app);
 Honua.Server.Features.Console.Publications.PublishedRouteEndpoints.MapPublishedRouteEndpoints(app);
 app.MapAdminApiKeyEndpoints();
+Honua.Server.Features.Admin.EmbedGovernance.EmbedGovernanceEndpoints.MapEmbedGovernanceEndpoints(app);
+Honua.Server.Features.Admin.EmbedGovernance.EmbedPolicyEndpoints.MapEmbedPolicyEndpoints(app);
 app.MapOAuthClientEndpoints();
 app.MapPackageReviewEndpoints();
 

--- a/src/Honua.Server/Startup/JsonContextRegistration.cs
+++ b/src/Honua.Server/Startup/JsonContextRegistration.cs
@@ -73,6 +73,7 @@ internal static class JsonContextRegistration
                 Honua.Server.Features.WorkflowPackages.WorkflowPackagesJsonContext.Default,
                 Honua.Server.Features.Operations.OperationsJsonContext.Default,
                 Honua.Server.Features.Admin.Models.AdminApiKeyJsonContext.Default,
+                Honua.Server.Features.Admin.EmbedGovernance.Models.EmbedGovernanceJsonContext.Default,
                 Honua.Server.Features.Admin.Models.OAuthClientJsonContext.Default,
                 Honua.Server.Features.Admin.Models.SceneDatasetJsonContext.Default,
                 Honua.Server.Features.Admin.Models.SceneGenerationJsonContext.Default,

--- a/tests/dotnet/Honua.Core.Tests/Features/EmbedGovernance/EmbedAnalyticsValidatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/EmbedGovernance/EmbedAnalyticsValidatorTests.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.EmbedGovernance.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.EmbedGovernance;
+
+/// <summary>
+/// Unit tests for <see cref="EmbedAnalyticsValidator"/> and raw-key detection.
+/// </summary>
+public sealed class EmbedAnalyticsValidatorTests
+{
+    private static readonly DateTimeOffset _now = new(2026, 6, 26, 0, 0, 0, TimeSpan.Zero);
+
+    [UnitTest]
+    public void Validate_RedactedEvent_IsValid()
+    {
+        var analyticsEvent = new EmbedAnalyticsEvent
+        {
+            EventType = EmbedAnalyticsEventType.View,
+            IntegrationId = "site-7",
+            Origin = "https://app.example.com",
+            ServiceId = "services/Roads",
+            LayerId = "0",
+            OccurredAt = _now,
+        };
+
+        var result = EmbedAnalyticsValidator.Validate(analyticsEvent);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Validate_FieldContainingRawKey_IsRejected()
+    {
+        var analyticsEvent = new EmbedAnalyticsEvent
+        {
+            EventType = EmbedAnalyticsEventType.Search,
+            IntegrationId = $"{EmbedKeyMaterial.Prefix}abc123leaked",
+            OccurredAt = _now,
+        };
+
+        var result = EmbedAnalyticsValidator.Validate(analyticsEvent);
+
+        result.IsValid.Should().BeFalse();
+        result.Error.Should().Contain("raw embed key");
+    }
+
+    [UnitTest]
+    public void Validate_RawKeyEmbeddedInUrl_IsRejected()
+    {
+        var analyticsEvent = new EmbedAnalyticsEvent
+        {
+            EventType = EmbedAnalyticsEventType.View,
+            Origin = $"https://app.example.com/?key={EmbedKeyMaterial.Prefix}leak",
+            OccurredAt = _now,
+        };
+
+        var result = EmbedAnalyticsValidator.Validate(analyticsEvent);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void Validate_OverlongField_IsRejected()
+    {
+        var analyticsEvent = new EmbedAnalyticsEvent
+        {
+            EventType = EmbedAnalyticsEventType.View,
+            LayerId = new string('x', 1000),
+            OccurredAt = _now,
+        };
+
+        var result = EmbedAnalyticsValidator.Validate(analyticsEvent);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void Validate_UndefinedEventType_IsRejected()
+    {
+        var analyticsEvent = new EmbedAnalyticsEvent
+        {
+            EventType = (EmbedAnalyticsEventType)99,
+            OccurredAt = _now,
+        };
+
+        var result = EmbedAnalyticsValidator.Validate(analyticsEvent);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void LooksLikeRawKey_DetectsPrefixedValues()
+    {
+        EmbedKeyMaterial.LooksLikeRawKey(EmbedKeyMaterial.Generate()).Should().BeTrue();
+        EmbedKeyMaterial.LooksLikeRawKey("integration-7").Should().BeFalse();
+        EmbedKeyMaterial.LooksLikeRawKey(null).Should().BeFalse();
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/EmbedGovernance/EmbedPolicyEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/EmbedGovernance/EmbedPolicyEvaluatorTests.cs
@@ -1,0 +1,227 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.EmbedGovernance.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.EmbedGovernance;
+
+/// <summary>
+/// Unit tests for <see cref="EmbedPolicyEvaluator"/> covering origin/domain,
+/// service, content, tenant, and rate-limit decisions.
+/// </summary>
+public sealed class EmbedPolicyEvaluatorTests
+{
+    private static readonly DateTimeOffset _now = new(2026, 6, 26, 0, 0, 0, TimeSpan.Zero);
+
+    private static EmbedKeyRecord Key(EmbedKeyScope scope, DateTimeOffset? expiresAt = null, DateTimeOffset? revokedAt = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = "test",
+        KeyPrefix = "embk_test",
+        KeyHash = [1, 2, 3],
+        Scope = scope,
+        CreatedAt = _now.AddDays(-1),
+        UpdatedAt = _now.AddDays(-1),
+        ExpiresAt = expiresAt,
+        RevokedAt = revokedAt,
+    };
+
+    [UnitTest]
+    public void Evaluate_AllowedOrigin_Allows()
+    {
+        var key = Key(new EmbedKeyScope { AllowedEmbedOrigins = ["https://app.example.com"] });
+        var request = new EmbedPolicyRequest { Origin = "https://app.example.com" };
+
+        var decision = EmbedPolicyEvaluator.Evaluate(key, request, _now);
+
+        decision.Allowed.Should().BeTrue();
+        decision.Reason.Should().Be(EmbedPolicyDenyReason.None);
+    }
+
+    [UnitTest]
+    public void Evaluate_OriginNotInList_DeniesOriginNotAllowed()
+    {
+        var key = Key(new EmbedKeyScope { AllowedEmbedOrigins = ["https://app.example.com"] });
+        var request = new EmbedPolicyRequest { Origin = "https://evil.example.org" };
+
+        var decision = EmbedPolicyEvaluator.Evaluate(key, request, _now);
+
+        decision.Allowed.Should().BeFalse();
+        decision.Reason.Should().Be(EmbedPolicyDenyReason.OriginNotAllowed);
+    }
+
+    [UnitTest]
+    public void Evaluate_EmptyOriginAllowList_DeniesEveryOrigin()
+    {
+        var key = Key(new EmbedKeyScope { AllowedEmbedOrigins = [] });
+        var request = new EmbedPolicyRequest { Origin = "https://app.example.com" };
+
+        var decision = EmbedPolicyEvaluator.Evaluate(key, request, _now);
+
+        decision.Allowed.Should().BeFalse();
+        decision.Reason.Should().Be(EmbedPolicyDenyReason.OriginNotAllowed);
+    }
+
+    [UnitTest]
+    public void Evaluate_SubdomainWildcard_MatchesSubdomain()
+    {
+        var key = Key(new EmbedKeyScope { AllowedEmbedOrigins = ["*.example.com"] });
+
+        var allowed = EmbedPolicyEvaluator.Evaluate(key, new EmbedPolicyRequest { Origin = "https://maps.example.com" }, _now);
+        var denied = EmbedPolicyEvaluator.Evaluate(key, new EmbedPolicyRequest { Origin = "https://example.org" }, _now);
+
+        allowed.Allowed.Should().BeTrue();
+        denied.Allowed.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void Evaluate_WildcardOrigin_AllowsAny()
+    {
+        var key = Key(new EmbedKeyScope { AllowedEmbedOrigins = ["*"] });
+
+        var decision = EmbedPolicyEvaluator.Evaluate(key, new EmbedPolicyRequest { Origin = "https://anything.test" }, _now);
+
+        decision.Allowed.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Evaluate_OriginCaseAndTrailingSlash_Normalized()
+    {
+        var key = Key(new EmbedKeyScope { AllowedEmbedOrigins = ["https://App.Example.com/"] });
+
+        var decision = EmbedPolicyEvaluator.Evaluate(key, new EmbedPolicyRequest { Origin = "https://app.example.com" }, _now);
+
+        decision.Allowed.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Evaluate_ServiceNotAllowed_Denies()
+    {
+        var key = Key(new EmbedKeyScope
+        {
+            AllowedEmbedOrigins = ["*"],
+            AllowedServiceOrigins = ["services/Roads"],
+        });
+
+        var decision = EmbedPolicyEvaluator.Evaluate(
+            key,
+            new EmbedPolicyRequest { Origin = "https://app.test", ServiceId = "services/Secret" },
+            _now);
+
+        decision.Allowed.Should().BeFalse();
+        decision.Reason.Should().Be(EmbedPolicyDenyReason.ServiceNotAllowed);
+    }
+
+    [UnitTest]
+    public void Evaluate_EmptyServiceList_AllowsAnyService()
+    {
+        var key = Key(new EmbedKeyScope { AllowedEmbedOrigins = ["*"] });
+
+        var decision = EmbedPolicyEvaluator.Evaluate(
+            key,
+            new EmbedPolicyRequest { Origin = "https://app.test", ServiceId = "services/Anything" },
+            _now);
+
+        decision.Allowed.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Evaluate_ContentNotAllowed_Denies()
+    {
+        var key = Key(new EmbedKeyScope
+        {
+            AllowedEmbedOrigins = ["*"],
+            AllowedContentIds = ["map-123"],
+        });
+
+        var decision = EmbedPolicyEvaluator.Evaluate(
+            key,
+            new EmbedPolicyRequest { Origin = "https://app.test", ContentId = "map-999" },
+            _now);
+
+        decision.Allowed.Should().BeFalse();
+        decision.Reason.Should().Be(EmbedPolicyDenyReason.ContentNotAllowed);
+    }
+
+    [UnitTest]
+    public void Evaluate_TenantMismatch_Denies()
+    {
+        var key = Key(new EmbedKeyScope { AllowedEmbedOrigins = ["*"], TenantId = "acme" });
+
+        var decision = EmbedPolicyEvaluator.Evaluate(
+            key,
+            new EmbedPolicyRequest { Origin = "https://app.test", TenantId = "globex" },
+            _now);
+
+        decision.Allowed.Should().BeFalse();
+        decision.Reason.Should().Be(EmbedPolicyDenyReason.TenantMismatch);
+    }
+
+    [UnitTest]
+    public void Evaluate_RateBudgetExceeded_DeniesRateLimited()
+    {
+        var key = Key(new EmbedKeyScope { AllowedEmbedOrigins = ["*"], RateLimitRequestsPerWindow = 5 });
+
+        var withinBudget = EmbedPolicyEvaluator.Evaluate(
+            key,
+            new EmbedPolicyRequest { Origin = "https://app.test", RequestsConsumedInWindow = 5 },
+            _now);
+        var overBudget = EmbedPolicyEvaluator.Evaluate(
+            key,
+            new EmbedPolicyRequest { Origin = "https://app.test", RequestsConsumedInWindow = 6 },
+            _now);
+
+        withinBudget.Allowed.Should().BeTrue();
+        overBudget.Allowed.Should().BeFalse();
+        overBudget.Reason.Should().Be(EmbedPolicyDenyReason.RateLimited);
+    }
+
+    [UnitTest]
+    public void Evaluate_RevokedKey_DeniesKeyInactive()
+    {
+        var key = Key(new EmbedKeyScope { AllowedEmbedOrigins = ["*"] }, revokedAt: _now.AddMinutes(-1));
+
+        var decision = EmbedPolicyEvaluator.Evaluate(key, new EmbedPolicyRequest { Origin = "https://app.test" }, _now);
+
+        decision.Allowed.Should().BeFalse();
+        decision.Reason.Should().Be(EmbedPolicyDenyReason.KeyInactive);
+    }
+
+    [UnitTest]
+    public void Evaluate_ExpiredKey_DeniesKeyInactive()
+    {
+        var key = Key(new EmbedKeyScope { AllowedEmbedOrigins = ["*"] }, expiresAt: _now.AddMinutes(-1));
+
+        var decision = EmbedPolicyEvaluator.Evaluate(key, new EmbedPolicyRequest { Origin = "https://app.test" }, _now);
+
+        decision.Allowed.Should().BeFalse();
+        decision.Reason.Should().Be(EmbedPolicyDenyReason.KeyInactive);
+    }
+
+    [UnitTest]
+    public void BuildPolicy_ProjectsScopeAndRateLimit()
+    {
+        var key = Key(new EmbedKeyScope
+        {
+            AllowedEmbedOrigins = ["https://app.example.com"],
+            AllowedServiceOrigins = ["services/Roads"],
+            AllowedContentIds = ["map-1"],
+            IntegrationId = "site-7",
+            TenantId = "acme",
+            Edition = "pro",
+            RateLimitRequestsPerWindow = 100,
+            RateLimitWindow = TimeSpan.FromSeconds(30),
+        });
+
+        var policy = EmbedPolicyEvaluator.BuildPolicy(key);
+
+        policy.AllowedOrigins.Should().ContainSingle().Which.Should().Be("https://app.example.com");
+        policy.IntegrationId.Should().Be("site-7");
+        policy.TenantId.Should().Be("acme");
+        policy.Edition.Should().Be("pro");
+        policy.RateLimit.RequestsPerWindow.Should().Be(100);
+        policy.RateLimit.WindowSeconds.Should().Be(30);
+        policy.Capabilities.Should().NotBeEmpty();
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/EmbedGovernance/InMemoryEmbedStoreTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/EmbedGovernance/InMemoryEmbedStoreTests.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.EmbedGovernance;
+using Honua.Core.Features.EmbedGovernance.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.EmbedGovernance;
+
+/// <summary>
+/// Unit tests for the in-memory embed key and analytics stores: lifecycle,
+/// validation, rate accounting, and usage aggregation.
+/// </summary>
+public sealed class InMemoryEmbedStoreTests
+{
+    private static EmbedKeyScope Scope() => new()
+    {
+        AllowedEmbedOrigins = ["https://app.example.com"],
+        IntegrationId = "site-7",
+        RateLimitRequestsPerWindow = 3,
+        RateLimitWindow = TimeSpan.FromMinutes(1),
+    };
+
+    [UnitTest]
+    public async Task CreateAndValidate_RoundTripsKeyMaterial()
+    {
+        var store = new InMemoryEmbedKeyStore();
+
+        var created = await store.CreateAsync("integration", Scope(), expiresAt: null, createdBy: "op", CancellationToken.None);
+
+        created.Key.Should().StartWith(EmbedKeyMaterial.Prefix);
+        created.Record.KeyPrefix.Should().StartWith(EmbedKeyMaterial.Prefix);
+
+        var validated = await store.ValidateAsync(created.Key, CancellationToken.None);
+        validated.Should().NotBeNull();
+        validated!.Record.Id.Should().Be(created.Record.Id);
+        validated.Record.LastUsedAt.Should().NotBeNull();
+    }
+
+    [UnitTest]
+    public async Task Validate_WrongKey_ReturnsNull()
+    {
+        var store = new InMemoryEmbedKeyStore();
+        await store.CreateAsync("integration", Scope(), null, null, CancellationToken.None);
+
+        var validated = await store.ValidateAsync($"{EmbedKeyMaterial.Prefix}not-a-real-key", CancellationToken.None);
+
+        validated.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task Revoke_PreventsValidation()
+    {
+        var store = new InMemoryEmbedKeyStore();
+        var created = await store.CreateAsync("integration", Scope(), null, null, CancellationToken.None);
+
+        await store.RevokeAsync(created.Record.Id, CancellationToken.None);
+
+        var validated = await store.ValidateAsync(created.Key, CancellationToken.None);
+        validated.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task Rotate_InvalidatesOldSecretAndIssuesNew()
+    {
+        var store = new InMemoryEmbedKeyStore();
+        var created = await store.CreateAsync("integration", Scope(), null, null, CancellationToken.None);
+
+        var rotated = await store.RotateAsync(created.Record.Id, CancellationToken.None);
+
+        rotated.Should().NotBeNull();
+        rotated!.Key.Should().NotBe(created.Key);
+
+        (await store.ValidateAsync(created.Key, CancellationToken.None)).Should().BeNull();
+        (await store.ValidateAsync(rotated.Key, CancellationToken.None)).Should().NotBeNull();
+    }
+
+    [UnitTest]
+    public async Task RecordRequest_CountsWithinWindowAndResetsAfter()
+    {
+        var clock = new MutableTimeProvider(new DateTimeOffset(2026, 6, 26, 0, 0, 0, TimeSpan.Zero));
+        var store = new InMemoryEmbedKeyStore(clock);
+        var created = await store.CreateAsync("integration", Scope(), null, null, CancellationToken.None);
+        var id = created.Record.Id;
+        var window = TimeSpan.FromMinutes(1);
+
+        (await store.RecordRequestAsync(id, window, CancellationToken.None)).Should().Be(1);
+        (await store.RecordRequestAsync(id, window, CancellationToken.None)).Should().Be(2);
+        (await store.RecordRequestAsync(id, window, CancellationToken.None)).Should().Be(3);
+
+        clock.Advance(TimeSpan.FromMinutes(2));
+
+        (await store.RecordRequestAsync(id, window, CancellationToken.None)).Should().Be(1);
+    }
+
+    [UnitTest]
+    public async Task AnalyticsStore_AggregatesByDimensionAndFilters()
+    {
+        var store = new InMemoryEmbedAnalyticsStore();
+        var now = new DateTimeOffset(2026, 6, 26, 0, 0, 0, TimeSpan.Zero);
+
+        await store.IngestAsync(Event(EmbedAnalyticsEventType.View, "site-a", "https://a.test", now), CancellationToken.None);
+        await store.IngestAsync(Event(EmbedAnalyticsEventType.View, "site-a", "https://a.test", now), CancellationToken.None);
+        await store.IngestAsync(Event(EmbedAnalyticsEventType.Search, "site-b", "https://b.test", now), CancellationToken.None);
+
+        var byEventType = await store.QueryAsync(new EmbedUsageQuery { GroupBy = EmbedUsageDimension.EventType }, CancellationToken.None);
+        byEventType.Total.Should().Be(3);
+        byEventType.Aggregates.Should().Contain(a => a.Key == "View" && a.Count == 2);
+        byEventType.Aggregates.Should().Contain(a => a.Key == "Search" && a.Count == 1);
+
+        var filtered = await store.QueryAsync(
+            new EmbedUsageQuery { GroupBy = EmbedUsageDimension.Integration, IntegrationId = "site-a" },
+            CancellationToken.None);
+        filtered.Total.Should().Be(2);
+        filtered.Aggregates.Should().ContainSingle().Which.Key.Should().Be("site-a");
+    }
+
+    private static EmbedAnalyticsEvent Event(EmbedAnalyticsEventType type, string integration, string origin, DateTimeOffset at) => new()
+    {
+        EventType = type,
+        IntegrationId = integration,
+        Origin = origin,
+        OccurredAt = at,
+    };
+
+    private sealed class MutableTimeProvider(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/EmbedGovernanceEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/EmbedGovernanceEndpointsTests.cs
@@ -1,0 +1,277 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Honua.Server.Features.Admin.EmbedGovernance.Models;
+using Honua.Infrastructure.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+/// <summary>
+/// Integration tests for embed governance: key lifecycle, scoped policy
+/// evaluation, CORS/domain enforcement, rate limiting, analytics ingestion, and
+/// usage aggregation.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.ApiKeyManagement)]
+public sealed class EmbedGovernanceEndpointsTests : IAsyncLifetime
+{
+    private const string AdminPassword = "embed-governance-admin-bootstrap-key";
+    private const string EmbedKeyHeader = "X-Honua-Embed-Key";
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public EmbedGovernanceEndpointsTests()
+    {
+        _fixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/embed/keys")]
+    [Endpoint("GET /api/v1/admin/embed/keys")]
+    [Endpoint("GET /api/v1/admin/embed/keys/{id}")]
+    public async Task CreateListAndGetEmbedKey_ReturnsScopeAndSecretOnce()
+    {
+        var created = await CreateKeyAsync("contract-key", ["https://app.example.com"]);
+
+        Assert.StartsWith("embk_", created.Key, StringComparison.Ordinal);
+        Assert.Equal("contract-key", created.EmbedKey.Name);
+        Assert.Equal("active", created.EmbedKey.Status);
+        Assert.Contains("https://app.example.com", created.EmbedKey.Scope.AllowedEmbedOrigins);
+
+        var listResponse = await _client.GetAsync("/api/v1/admin/embed/keys");
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        var listJson = await listResponse.Content.ReadAsStringAsync();
+        Assert.DoesNotContain(created.Key, listJson, StringComparison.Ordinal);
+
+        var getResponse = await _client.GetAsync($"/api/v1/admin/embed/keys/{created.EmbedKey.Id}");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        var fetched = JsonSerializer.Deserialize<ApiResponse<EmbedKeyResponse>>(
+            await getResponse.Content.ReadAsStringAsync(), _jsonOptions);
+        Assert.Equal(created.EmbedKey.Id, fetched?.Data?.Id);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/embed/keys")]
+    public async Task CreateEmbedKey_WithoutAllowedOrigins_ReturnsBadRequest()
+    {
+        var request = new CreateEmbedKeyRequest
+        {
+            Name = "no-origins",
+            Scope = new EmbedKeyScopeDto { AllowedEmbedOrigins = [] },
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/embed/keys", request, _jsonOptions);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("origin", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/embed/keys/{id}/rotate")]
+    public async Task RotateEmbedKey_InvalidatesOldSecret()
+    {
+        var created = await CreateKeyAsync("rotate-key", ["https://app.example.com"]);
+
+        var response = await _client.PostAsync($"/api/v1/admin/embed/keys/{created.EmbedKey.Id}/rotate", content: null);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var rotated = JsonSerializer.Deserialize<ApiResponse<EmbedKeySecretResponse>>(
+            await response.Content.ReadAsStringAsync(), _jsonOptions);
+
+        Assert.NotNull(rotated?.Data);
+        Assert.NotEqual(created.Key, rotated.Data.Key);
+
+        var oldKeyPolicy = await GetPolicyAsync(created.Key, "https://app.example.com");
+        Assert.Equal(HttpStatusCode.Unauthorized, oldKeyPolicy.StatusCode);
+
+        var newKeyPolicy = await GetPolicyAsync(rotated.Data.Key, "https://app.example.com");
+        Assert.Equal(HttpStatusCode.OK, newKeyPolicy.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/embed/keys/{id}/revoke")]
+    public async Task RevokeEmbedKey_BlocksPolicyIssuance()
+    {
+        var created = await CreateKeyAsync("revoke-key", ["https://app.example.com"]);
+
+        var revoke = await _client.PostAsync($"/api/v1/admin/embed/keys/{created.EmbedKey.Id}/revoke", content: null);
+        Assert.Equal(HttpStatusCode.OK, revoke.StatusCode);
+
+        var policy = await GetPolicyAsync(created.Key, "https://app.example.com");
+        Assert.Equal(HttpStatusCode.Unauthorized, policy.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/embed/policy")]
+    public async Task FetchPolicy_AllowedOrigin_ReturnsPolicyWithCorsHeader()
+    {
+        var created = await CreateKeyAsync("policy-key", ["https://app.example.com"], integrationId: "site-7");
+
+        var response = await GetPolicyAsync(created.Key, "https://app.example.com");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("https://app.example.com", response.Headers.GetValues("Access-Control-Allow-Origin").Single());
+
+        var policy = JsonSerializer.Deserialize<EmbedPolicyResponse>(
+            await response.Content.ReadAsStringAsync(), _jsonOptions);
+        Assert.NotNull(policy);
+        Assert.Equal("site-7", policy!.IntegrationId);
+        Assert.Contains("https://app.example.com", policy.AllowedOrigins);
+        Assert.NotEmpty(policy.Capabilities);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/embed/policy")]
+    public async Task FetchPolicy_DisallowedOrigin_ReturnsForbidden()
+    {
+        var created = await CreateKeyAsync("policy-deny-key", ["https://app.example.com"]);
+
+        var response = await GetPolicyAsync(created.Key, "https://evil.example.org");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("OriginNotAllowed", body, StringComparison.Ordinal);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/embed/policy")]
+    public async Task FetchPolicy_MissingKey_ReturnsUnauthorized()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/v1/embed/policy");
+        request.Headers.Add("Origin", "https://app.example.com");
+
+        using var anonymous = _fixture.CreateClient();
+        var response = await anonymous.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/embed/analytics")]
+    [Endpoint("GET /api/v1/admin/embed/usage")]
+    public async Task IngestAnalyticsThenQueryUsage_AggregatesEvents()
+    {
+        var created = await CreateKeyAsync("analytics-key", ["https://app.example.com"], integrationId: "site-analytics");
+
+        var payload = new IngestEmbedAnalyticsRequest
+        {
+            Events =
+            [
+                new EmbedAnalyticsEventDto { EventType = "view", Origin = "https://app.example.com", ServiceId = "services/Roads" },
+                new EmbedAnalyticsEventDto { EventType = "search", Origin = "https://app.example.com", ServiceId = "services/Roads" },
+            ],
+        };
+
+        var ingest = await PostAnalyticsAsync(created.Key, payload);
+        Assert.Equal(HttpStatusCode.OK, ingest.StatusCode);
+        var ingestResult = JsonSerializer.Deserialize<ApiResponse<EmbedAnalyticsIngestResponse>>(
+            await ingest.Content.ReadAsStringAsync(), _jsonOptions);
+        Assert.Equal(2, ingestResult?.Data?.Accepted);
+
+        var usage = await _client.GetAsync("/api/v1/admin/embed/usage?groupBy=eventType&integrationId=site-analytics");
+        Assert.Equal(HttpStatusCode.OK, usage.StatusCode);
+        var report = JsonSerializer.Deserialize<ApiResponse<EmbedUsageResponse>>(
+            await usage.Content.ReadAsStringAsync(), _jsonOptions);
+        Assert.NotNull(report?.Data);
+        Assert.True(report.Data.Total >= 2);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/embed/analytics")]
+    public async Task IngestAnalytics_WithRawKeyInPayload_ReturnsBadRequest()
+    {
+        var created = await CreateKeyAsync("analytics-redaction-key", ["https://app.example.com"]);
+
+        var payload = new IngestEmbedAnalyticsRequest
+        {
+            Events =
+            [
+                new EmbedAnalyticsEventDto { EventType = "view", IntegrationId = created.Key },
+            ],
+        };
+
+        var response = await PostAnalyticsAsync(created.Key, payload);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("raw embed key", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<EmbedKeySecretResponse> CreateKeyAsync(
+        string name,
+        IReadOnlyList<string> origins,
+        string? integrationId = null,
+        int rateLimit = 0)
+    {
+        var request = new CreateEmbedKeyRequest
+        {
+            Name = name,
+            Scope = new EmbedKeyScopeDto
+            {
+                AllowedEmbedOrigins = origins,
+                IntegrationId = integrationId,
+                RateLimitRequestsPerWindow = rateLimit,
+            },
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/embed/keys", request, _jsonOptions);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var result = JsonSerializer.Deserialize<ApiResponse<EmbedKeySecretResponse>>(
+            await response.Content.ReadAsStringAsync(), _jsonOptions);
+        Assert.NotNull(result?.Data);
+        return result.Data;
+    }
+
+    private async Task<HttpResponseMessage> GetPolicyAsync(string embedKey, string origin)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/v1/embed/policy");
+        request.Headers.Add(EmbedKeyHeader, embedKey);
+        request.Headers.Add("Origin", origin);
+        using var anonymous = _fixture.CreateClient();
+        return await anonymous.SendAsync(request);
+    }
+
+    private async Task<HttpResponseMessage> PostAnalyticsAsync(string embedKey, IngestEmbedAnalyticsRequest payload)
+    {
+        var json = JsonSerializer.Serialize(payload, _jsonOptions);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/embed/analytics")
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+        request.Headers.Add(EmbedKeyHeader, embedKey);
+        using var anonymous = _fixture.CreateClient();
+        return await anonymous.SendAsync(request);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/EmbedGovernanceEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/EmbedGovernanceEndpointsTests.cs
@@ -208,6 +208,77 @@ public sealed class EmbedGovernanceEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("GET /api/v1/embed/policy")]
+    public async Task FetchPolicy_CrossOriginPreflightFromArbitraryOrigin_IsAllowed()
+    {
+        var created = await CreateKeyAsync("policy-cors-key", ["https://isv.example.com"], integrationId: "site-cors");
+
+        using var anonymous = _fixture.CreateClient();
+
+        // A browser CORS preflight from an arbitrary ISV origin must be permitted; the
+        // per-embed-key origin allow-list is enforced by the handler, not by CORS.
+        using var preflight = new HttpRequestMessage(HttpMethod.Options, "/api/v1/embed/policy");
+        preflight.Headers.Add("Origin", "https://isv.example.com");
+        preflight.Headers.Add("Access-Control-Request-Method", "GET");
+        preflight.Headers.Add("Access-Control-Request-Headers", "x-honua-embed-key");
+        var preflightResponse = await anonymous.SendAsync(preflight);
+
+        Assert.True(
+            preflightResponse.StatusCode is HttpStatusCode.OK or HttpStatusCode.NoContent,
+            $"preflight returned {(int)preflightResponse.StatusCode}");
+        Assert.True(
+            preflightResponse.Headers.Contains("Access-Control-Allow-Origin"),
+            "preflight response missing Access-Control-Allow-Origin");
+
+        var allowedHeaders = preflightResponse.Headers.TryGetValues("Access-Control-Allow-Headers", out var values)
+            ? string.Join(",", values)
+            : string.Empty;
+        Assert.Contains("x-honua-embed-key", allowedHeaders, StringComparison.OrdinalIgnoreCase);
+
+        // The subsequent cross-origin GET succeeds and echoes the approved origin.
+        using var get = new HttpRequestMessage(HttpMethod.Get, "/api/v1/embed/policy");
+        get.Headers.Add(EmbedKeyHeader, created.Key);
+        get.Headers.Add("Origin", "https://isv.example.com");
+        var getResponse = await anonymous.SendAsync(get);
+
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.Equal(
+            "https://isv.example.com",
+            getResponse.Headers.GetValues("Access-Control-Allow-Origin").Single());
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/embed/analytics")]
+    [Endpoint("GET /api/v1/admin/embed/usage")]
+    public async Task IngestAnalytics_BatchWithOneInvalidEvent_PersistsZeroEvents()
+    {
+        var created = await CreateKeyAsync("analytics-atomic-key", ["https://app.example.com"], integrationId: "site-atomic");
+
+        var payload = new IngestEmbedAnalyticsRequest
+        {
+            Events =
+            [
+                // Valid event first: under the old per-event persistence this would commit
+                // before the second event rejects, double-counting on client retry.
+                new EmbedAnalyticsEventDto { EventType = "view", Origin = "https://app.example.com", ServiceId = "services/Roads" },
+                // Invalid: a raw embed key in the payload is rejected by the validator, so the
+                // entire batch must be rejected and nothing persisted.
+                new EmbedAnalyticsEventDto { EventType = "search", IntegrationId = created.Key },
+            ],
+        };
+
+        var response = await PostAnalyticsAsync(created.Key, payload);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var usage = await _client.GetAsync("/api/v1/admin/embed/usage?groupBy=eventType&integrationId=site-atomic");
+        Assert.Equal(HttpStatusCode.OK, usage.StatusCode);
+        var report = JsonSerializer.Deserialize<ApiResponse<EmbedUsageResponse>>(
+            await usage.Content.ReadAsStringAsync(), _jsonOptions);
+        Assert.NotNull(report?.Data);
+        Assert.Equal(0L, report!.Data.Total);
+    }
+
+    [IntegrationTest]
     [Endpoint("POST /api/v1/embed/analytics")]
     public async Task IngestAnalytics_WithRawKeyInPayload_ReturnsBadRequest()
     {


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1191

## Summary
Adds the backend/control-plane half of Fulcrum/Survey123-style ISV embed
governance: authoritative embed API key issuance and scoping, a policy endpoint
consumable by the `@honua-io/embed` remote governance adapter
(`fetchHonuaMapEmbedPolicy`), server-side origin/domain (CORS) enforcement,
per-key rate limiting, redacted analytics ingestion, queryable usage
aggregation, and audit events for key lifecycle and policy denials. The embed
key is the security boundary on the server; client-side policy is treated as a
hint only.

## Changes Made
- Added `Honua.Core/Features/EmbedGovernance` domain: `EmbedKeyScope`,
  `EmbedKeyRecord`, `EmbedPolicy`, `EmbedPolicyEvaluator` (origin/service/
  content/tenant/rate decisions), `EmbedAnalyticsEvent` + `EmbedAnalyticsValidator`
  (rejects payloads leaking raw key material), usage aggregation models, and
  `EmbedKeyMaterial` (generation/hash/raw-key detection).
- Added `IEmbedKeyStore`/`IEmbedAnalyticsStore` abstractions with in-memory
  implementations (key lifecycle, validation, fixed-window rate accounting,
  filtered aggregation).
- Added admin endpoints `EmbedGovernanceEndpoints` (`/api/v1/admin/embed/keys`
  CRUD + rotate/revoke, `/api/v1/admin/embed/usage`) and public
  `EmbedPolicyEndpoints` (`/api/v1/embed/policy`, `/api/v1/embed/analytics`),
  authenticated via the `X-Honua-Embed-Key` header.
- Emitted audit events for key create/rotate/revoke (AdminAction) and policy
  denials (Authorization/Denied); ingested policy denials as analytics.
- Registered DI stores, JSON source-gen context, endpoint mappings, and the new
  routes in `EndpointRegistry`.
- Added unit tests (policy evaluation, analytics validation, store lifecycle and
  rate accounting, aggregation) and integration tests for every new route.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Ran `dotnet build` on `Honua.Server` (Release, warnings-as-errors): success.
Ran `dotnet test` on `Honua.Core.Tests` filtered to `EmbedGovernance`: passed.
Ran `dotnet test` on `Honua.Architecture.Tests` (endpoint-registry drift, API
surface coverage, endpoint authorization guard, documentation coverage).
Integration tests (`Honua.Server.Tests`) require a Docker daemon
(Testcontainers + PostGIS) and so run in CI rather than this sandbox.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
