### PR TITLE
feat(licensing): Azure Key Vault license resolver (Secrets Manager parity) (#1745)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Messaging.EventGrid" Version="5.0.0" />
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.2" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2" />

--- a/src/Honua.Aws/Features/Licensing/AwsLicenseSecretResolverServiceCollectionExtensions.cs
+++ b/src/Honua.Aws/Features/Licensing/AwsLicenseSecretResolverServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@
 using Honua.Infrastructure.Licensing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Honua.Aws.Features.Licensing;
 
@@ -35,7 +34,10 @@ public static class AwsLicenseSecretResolverServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        services.TryAddSingleton<ILicenseContentSecretResolver, AwsSecretsManagerLicenseContentResolver>();
+        // Additive (not TryAdd) so it coexists with the Azure Key Vault resolver in a multi-cloud
+        // build: the license service iterates every registered ILicenseContentSecretResolver and
+        // dispatches by reference prefix (aws:secretsmanager: here).
+        services.AddSingleton<ILicenseContentSecretResolver, AwsSecretsManagerLicenseContentResolver>();
         return services;
     }
 }

--- a/src/Honua.Azure/Features/Licensing/AzureKeyVaultLicenseContentResolver.cs
+++ b/src/Honua.Azure/Features/Licensing/AzureKeyVaultLicenseContentResolver.cs
@@ -60,14 +60,14 @@ internal sealed class AzureKeyVaultLicenseContentResolver : ILicenseContentSecre
 
     /// <inheritdoc />
     public bool CanResolve(string? secretReference)
-        => TryParseReference(secretReference, out _, out _);
+        => TryParseReference(secretReference, out _, out _, out _);
 
     /// <inheritdoc />
     public async Task<string?> ResolveLicenseContentAsync(
         string secretReference,
         CancellationToken cancellationToken = default)
     {
-        if (!TryParseReference(secretReference, out var vaultUri, out var secretName))
+        if (!TryParseReference(secretReference, out var vaultUri, out var secretName, out var secretVersion))
         {
             return null;
         }
@@ -76,7 +76,7 @@ internal sealed class AzureKeyVaultLicenseContentResolver : ILicenseContentSecre
         {
             var client = _clientFactory(vaultUri);
             Response<KeyVaultSecret> response = await client
-                .GetSecretAsync(secretName, cancellationToken: cancellationToken)
+                .GetSecretAsync(secretName, secretVersion, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             var value = response.Value?.Value;
@@ -98,14 +98,34 @@ internal sealed class AzureKeyVaultLicenseContentResolver : ILicenseContentSecre
     }
 
     /// <summary>
-    /// Parses an <c>azure:keyvault:&lt;vault-uri&gt;/&lt;secret&gt;</c> reference into the vault URI
-    /// and secret name. Returns <c>false</c> (rather than throwing) for any unsupported or malformed
-    /// reference so both <see cref="CanResolve"/> and the fail-safe resolution path stay non-throwing.
+    /// Parses a Key Vault license reference into the vault endpoint, secret name, and optional secret
+    /// version. Two forms are accepted:
+    /// <list type="bullet">
+    /// <item>
+    /// The canonical Azure Key Vault secret identifier,
+    /// <c>azure:keyvault:https://&lt;vault&gt;.vault.azure.net/secrets/&lt;name&gt;</c> (with an optional
+    /// trailing <c>/&lt;version&gt;</c>). This is the form Azure surfaces in the portal and CLI.
+    /// </item>
+    /// <item>
+    /// The documented shorthand,
+    /// <c>azure:keyvault:https://&lt;vault&gt;.vault.azure.net/&lt;secret&gt;</c>.
+    /// </item>
+    /// </list>
+    /// The vault endpoint is always derived from the URI scheme + authority — never by string-splitting
+    /// the path — because a naive split on the final <c>'/'</c> folds the <c>/secrets</c> segment into the
+    /// vault base, producing an endpoint that silently 404s every fetch (so Pro never activates).
+    /// Returns <c>false</c> (rather than throwing) for any unsupported or malformed reference so both
+    /// <see cref="CanResolve"/> and the fail-safe resolution path stay non-throwing.
     /// </summary>
-    private static bool TryParseReference(string? secretReference, out Uri vaultUri, out string secretName)
+    private static bool TryParseReference(
+        string? secretReference,
+        out Uri vaultUri,
+        out string secretName,
+        out string? secretVersion)
     {
         vaultUri = null!;
         secretName = string.Empty;
+        secretVersion = null;
 
         if (string.IsNullOrWhiteSpace(secretReference) ||
             !secretReference.StartsWith(KeyVaultPrefix, StringComparison.OrdinalIgnoreCase))
@@ -114,32 +134,43 @@ internal sealed class AzureKeyVaultLicenseContentResolver : ILicenseContentSecre
         }
 
         var remainder = secretReference[KeyVaultPrefix.Length..].Trim();
-        if (remainder.Length == 0)
-        {
-            return false;
-        }
-
-        // The vault URI is everything up to the final '/', the secret name is the trailing segment:
-        //   azure:keyvault:https://myvault.vault.azure.net/license-pro
-        //   -> vault = https://myvault.vault.azure.net, secret = license-pro
-        var lastSlash = remainder.LastIndexOf('/');
-        if (lastSlash <= 0 || lastSlash == remainder.Length - 1)
-        {
-            return false;
-        }
-
-        var vaultPart = remainder[..lastSlash];
-        var secretPart = remainder[(lastSlash + 1)..];
-
-        if (string.IsNullOrWhiteSpace(secretPart) ||
-            !Uri.TryCreate(vaultPart, UriKind.Absolute, out var parsedUri) ||
+        if (remainder.Length == 0 ||
+            !Uri.TryCreate(remainder, UriKind.Absolute, out var parsedUri) ||
             parsedUri.Scheme != Uri.UriSchemeHttps)
         {
             return false;
         }
 
-        vaultUri = parsedUri;
-        secretName = secretPart;
-        return true;
+        // Vault endpoint = scheme + authority only (e.g. https://myvault.vault.azure.net/). The secret
+        // name and optional version come from the path segments, NOT from a trailing-slash split.
+        var vaultEndpoint = new Uri(parsedUri.GetLeftPart(UriPartial.Authority), UriKind.Absolute);
+        var segments = parsedUri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        // Canonical identifier: /secrets/<name>[/<version>]
+        if (segments.Length >= 2 &&
+            string.Equals(segments[0], "secrets", StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrWhiteSpace(segments[1]))
+            {
+                return false;
+            }
+
+            vaultUri = vaultEndpoint;
+            secretName = segments[1];
+            secretVersion = segments.Length >= 3 && !string.IsNullOrWhiteSpace(segments[2])
+                ? segments[2]
+                : null;
+            return true;
+        }
+
+        // Shorthand: https://<vault>.vault.azure.net/<secret>
+        if (segments.Length == 1 && !string.IsNullOrWhiteSpace(segments[0]))
+        {
+            vaultUri = vaultEndpoint;
+            secretName = segments[0];
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Honua.Azure/Features/Licensing/AzureKeyVaultLicenseContentResolver.cs
+++ b/src/Honua.Azure/Features/Licensing/AzureKeyVaultLicenseContentResolver.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Azure;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using Honua.Infrastructure.Licensing;
+using Microsoft.Extensions.Logging;
+
+// NOTE: namespace deliberately omits the "Azure" segment (it uses Honua.Licensing, not
+// Honua.Azure.Features.Licensing) to match the existing Honua.Azure convention (Honua.Alerts,
+// Honua.FileStorage, Honua.ControlPlane). A Honua.Azure namespace would shadow the global Azure
+// SDK namespace for callers that reference Azure.* by its fully-qualified name.
+namespace Honua.Licensing;
+
+/// <summary>
+/// Resolves a signed license envelope from Azure Key Vault. Confined to
+/// <c>Honua.Azure</c> so the Azure.Security.KeyVault.Secrets surface stays out of the
+/// cloud-neutral <c>Honua.Hosting</c> licensing pipeline (cloud-SDK isolation
+/// contract, <c>CloudSdkIsolationTests</c>). It is the Azure-side parity of the AWS
+/// Secrets Manager resolver. Activated when
+/// <c>Licensing:LicenseContentSecretRef=azure:keyvault:&lt;vault-uri&gt;/&lt;secret&gt;</c>
+/// is configured; on Azure Functions / Container Apps this lets the ~2KB envelope be
+/// delivered via a Key Vault reference instead of an environment variable.
+/// </summary>
+internal sealed class AzureKeyVaultLicenseContentResolver : ILicenseContentSecretResolver
+{
+    private const string KeyVaultPrefix = "azure:keyvault:";
+
+    private readonly Func<Uri, SecretClient> _clientFactory;
+    private readonly ILogger<AzureKeyVaultLicenseContentResolver> _logger;
+
+    /// <summary>
+    /// Creates the resolver with the default <see cref="SecretClient"/> factory backed by
+    /// <see cref="DefaultAzureCredential"/> (managed identity, environment, workload-identity,
+    /// or developer credentials). This is the constructor the DI container selects.
+    /// </summary>
+    /// <param name="logger">The resolver logger.</param>
+    public AzureKeyVaultLicenseContentResolver(ILogger<AzureKeyVaultLicenseContentResolver> logger)
+        : this(logger, clientFactory: null)
+    {
+    }
+
+    /// <summary>
+    /// Test seam: allows injecting a <see cref="SecretClient"/> factory so the secret fetch can be
+    /// exercised without a live Key Vault.
+    /// </summary>
+    /// <param name="logger">The resolver logger.</param>
+    /// <param name="clientFactory">
+    /// Factory that builds a <see cref="SecretClient"/> for a given vault URI. When <c>null</c> the
+    /// default <see cref="DefaultAzureCredential"/>-backed client is used.
+    /// </param>
+    internal AzureKeyVaultLicenseContentResolver(
+        ILogger<AzureKeyVaultLicenseContentResolver> logger,
+        Func<Uri, SecretClient>? clientFactory)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _clientFactory = clientFactory ?? (static uri => new SecretClient(uri, new DefaultAzureCredential()));
+    }
+
+    /// <inheritdoc />
+    public bool CanResolve(string? secretReference)
+        => TryParseReference(secretReference, out _, out _);
+
+    /// <inheritdoc />
+    public async Task<string?> ResolveLicenseContentAsync(
+        string secretReference,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryParseReference(secretReference, out var vaultUri, out var secretName))
+        {
+            return null;
+        }
+
+        try
+        {
+            var client = _clientFactory(vaultUri);
+            Response<KeyVaultSecret> response = await client
+                .GetSecretAsync(secretName, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            var value = response.Value?.Value;
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                AzureLicenseLog.SecretEmpty(_logger);
+                return null;
+            }
+
+            return value;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Fail safe: the license pipeline degrades to Community when the secret cannot be
+            // fetched (missing RBAC grant, wrong vault, deleted secret, unreachable endpoint, etc.).
+            AzureLicenseLog.SecretFetchFailed(_logger, ex.GetType().Name);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Parses an <c>azure:keyvault:&lt;vault-uri&gt;/&lt;secret&gt;</c> reference into the vault URI
+    /// and secret name. Returns <c>false</c> (rather than throwing) for any unsupported or malformed
+    /// reference so both <see cref="CanResolve"/> and the fail-safe resolution path stay non-throwing.
+    /// </summary>
+    private static bool TryParseReference(string? secretReference, out Uri vaultUri, out string secretName)
+    {
+        vaultUri = null!;
+        secretName = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(secretReference) ||
+            !secretReference.StartsWith(KeyVaultPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var remainder = secretReference[KeyVaultPrefix.Length..].Trim();
+        if (remainder.Length == 0)
+        {
+            return false;
+        }
+
+        // The vault URI is everything up to the final '/', the secret name is the trailing segment:
+        //   azure:keyvault:https://myvault.vault.azure.net/license-pro
+        //   -> vault = https://myvault.vault.azure.net, secret = license-pro
+        var lastSlash = remainder.LastIndexOf('/');
+        if (lastSlash <= 0 || lastSlash == remainder.Length - 1)
+        {
+            return false;
+        }
+
+        var vaultPart = remainder[..lastSlash];
+        var secretPart = remainder[(lastSlash + 1)..];
+
+        if (string.IsNullOrWhiteSpace(secretPart) ||
+            !Uri.TryCreate(vaultPart, UriKind.Absolute, out var parsedUri) ||
+            parsedUri.Scheme != Uri.UriSchemeHttps)
+        {
+            return false;
+        }
+
+        vaultUri = parsedUri;
+        secretName = secretPart;
+        return true;
+    }
+}

--- a/src/Honua.Azure/Features/Licensing/AzureLicenseLog.cs
+++ b/src/Honua.Azure/Features/Licensing/AzureLicenseLog.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Licensing;
+
+internal static partial class AzureLicenseLog
+{
+    [LoggerMessage(
+        EventId = 10110,
+        Level = LogLevel.Warning,
+        Message = "Azure Key Vault license secret resolved to an empty value.")]
+    public static partial void SecretEmpty(ILogger logger);
+
+    [LoggerMessage(
+        EventId = 10111,
+        Level = LogLevel.Warning,
+        Message = "Failed to fetch license envelope from Azure Key Vault; the host will fall back to Community. reason={Reason}")]
+    public static partial void SecretFetchFailed(ILogger logger, string reason);
+}

--- a/src/Honua.Azure/Features/Licensing/AzureLicenseSecretResolverServiceCollectionExtensions.cs
+++ b/src/Honua.Azure/Features/Licensing/AzureLicenseSecretResolverServiceCollectionExtensions.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Infrastructure.Licensing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Licensing;
+
+/// <summary>
+/// Registers the Azure Key Vault license-content resolver. Carved out of Honua.Server per the
+/// cloud-SDK isolation contract so the Azure.Security.KeyVault.Secrets surface is confined to
+/// Honua.Azure; the cloud-neutral licensing pipeline in Honua.Hosting consumes only the
+/// <see cref="ILicenseContentSecretResolver"/> abstraction. The resolver is registered as an
+/// additive <see cref="ILicenseContentSecretResolver"/> (not via <c>TryAdd</c>) so it coexists with
+/// the AWS Secrets Manager resolver in a multi-cloud build: the license service iterates every
+/// registered resolver and dispatches by reference prefix. It is cheap and only touches the network
+/// when <c>Licensing:LicenseContentSecretRef=azure:keyvault:&lt;vault-uri&gt;/&lt;secret&gt;</c> is set.
+/// </summary>
+public static class AzureLicenseSecretResolverServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="AzureKeyVaultLicenseContentResolver"/> as an
+    /// <see cref="ILicenseContentSecretResolver"/> so the license service can load a signed envelope
+    /// from Azure Key Vault via
+    /// <c>Licensing:LicenseContentSecretRef=azure:keyvault:&lt;vault-uri&gt;/&lt;secret&gt;</c>.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The application configuration (reserved for future options).</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddAzureLicenseSecretResolver(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddSingleton<ILicenseContentSecretResolver, AzureKeyVaultLicenseContentResolver>();
+        return services;
+    }
+}

--- a/src/Honua.Azure/Honua.Azure.csproj
+++ b/src/Honua.Azure/Honua.Azure.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.Messaging.EventGrid" />
     <PackageReference Include="Azure.Messaging.EventHubs" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honua.Hosting/Features/Licensing/FileBackedLicenseService.cs
+++ b/src/Honua.Hosting/Features/Licensing/FileBackedLicenseService.cs
@@ -25,7 +25,7 @@ internal sealed class FileBackedLicenseService :
     private readonly IOptions<LicenseOptions> _options;
     private readonly IEd25519Verifier _verifier;
     private readonly ILogger<FileBackedLicenseService> _logger;
-    private readonly ILicenseContentSecretResolver? _secretResolver;
+    private readonly IReadOnlyList<ILicenseContentSecretResolver> _secretResolvers;
     private LicenseSnapshot _snapshot;
     private long _snapshotVersion;
 
@@ -33,12 +33,14 @@ internal sealed class FileBackedLicenseService :
         IOptions<LicenseOptions> options,
         IEd25519Verifier verifier,
         ILogger<FileBackedLicenseService> logger,
-        ILicenseContentSecretResolver? secretResolver = null)
+        IEnumerable<ILicenseContentSecretResolver>? secretResolvers = null)
     {
         _options = options;
         _verifier = verifier;
         _logger = logger;
-        _secretResolver = secretResolver;
+        _secretResolvers = secretResolvers as IReadOnlyList<ILicenseContentSecretResolver>
+            ?? secretResolvers?.ToArray()
+            ?? [];
         _snapshot = CreateCommunitySnapshot(
             LicenseValidationState.NoLicenseConfigured,
             isValid: true,
@@ -112,21 +114,21 @@ internal sealed class FileBackedLicenseService :
     /// When <see langword="true"/>, a valid <c>Licensing:DevGrantEdition</c> short-circuits the
     /// snapshot to that edition. Must be <see langword="false"/> in Production.
     /// </param>
-    /// <param name="secretResolver">
-    /// The same <see cref="ILicenseContentSecretResolver"/> that <c>AddHonuaLicensing</c> registers
-    /// for the per-request license service. Supplying it here lets the bootstrap snapshot honor
-    /// <c>Licensing:LicenseContentSecretRef</c> (e.g. a Secrets-Manager-only Pro license); without
-    /// it a secret-ref license degrades to Community at bootstrap and a startup gate such as the
-    /// Redis-cache probe stays off for the process lifetime (honua-server#1755). It is optional so
-    /// hosts without a secret resolver (or built with the cloud SDK excluded) still resolve file /
-    /// inline / Community licenses correctly.
+    /// <param name="secretResolvers">
+    /// The same <see cref="ILicenseContentSecretResolver"/> set that <c>AddHonuaLicensing</c> registers
+    /// for the per-request license service (e.g. AWS Secrets Manager and/or Azure Key Vault). Supplying
+    /// them here lets the bootstrap snapshot honor <c>Licensing:LicenseContentSecretRef</c> (e.g. a
+    /// secret-store-only Pro license); without them a secret-ref license degrades to Community at
+    /// bootstrap and a startup gate such as the Redis-cache probe stays off for the process lifetime
+    /// (honua-server#1755). It is optional so hosts without a secret resolver (or built with the cloud
+    /// SDK excluded) still resolve file / inline / Community licenses correctly.
     /// </param>
     /// <param name="cancellationToken">Cancellation token for the snapshot load.</param>
     internal static async Task<LicenseSnapshot> LoadBootstrapSnapshotAsync(
         IConfiguration configuration,
         ILoggerFactory loggerFactory,
         bool honorDevGrant = false,
-        ILicenseContentSecretResolver? secretResolver = null,
+        IEnumerable<ILicenseContentSecretResolver>? secretResolvers = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(configuration);
@@ -145,7 +147,7 @@ internal sealed class FileBackedLicenseService :
             Options.Create(options),
             new BouncyCastleEd25519Verifier(),
             loggerFactory.CreateLogger<FileBackedLicenseService>(),
-            secretResolver);
+            secretResolvers);
         await service.StartAsync(cancellationToken).ConfigureAwait(false);
         return service.GetSnapshot();
     }
@@ -317,10 +319,11 @@ internal sealed class FileBackedLicenseService :
     }
 
     /// <summary>
-    /// Resolves <see cref="LicenseOptions.LicenseContentSecretRef"/> through the registered
-    /// <see cref="ILicenseContentSecretResolver"/>, if any. Never throws: a missing resolver,
-    /// an unsupported reference, or an unreachable secret returns <c>null</c> so the caller
-    /// falls through to inline content / file / Community.
+    /// Resolves <see cref="LicenseOptions.LicenseContentSecretRef"/> through the first registered
+    /// <see cref="ILicenseContentSecretResolver"/> that recognizes the reference (e.g. AWS Secrets
+    /// Manager for <c>aws:secretsmanager:</c>, Azure Key Vault for <c>azure:keyvault:</c>). Never
+    /// throws: no registered resolver, an unsupported reference, or an unreachable secret returns
+    /// <c>null</c> so the caller falls through to inline content / file / Community.
     /// </summary>
     private async Task<string?> TryResolveLicenseContentSecretAsync(
         LicenseOptions options,
@@ -332,13 +335,23 @@ internal sealed class FileBackedLicenseService :
             return null;
         }
 
-        if (_secretResolver is null)
+        if (_secretResolvers.Count == 0)
         {
             LicenseRuntimeLog.LicenseSecretResolverUnavailable(_logger);
             return null;
         }
 
-        if (!_secretResolver.CanResolve(secretRef))
+        ILicenseContentSecretResolver? resolver = null;
+        foreach (var candidate in _secretResolvers)
+        {
+            if (candidate.CanResolve(secretRef))
+            {
+                resolver = candidate;
+                break;
+            }
+        }
+
+        if (resolver is null)
         {
             LicenseRuntimeLog.LicenseSecretReferenceUnsupported(_logger);
             return null;
@@ -346,7 +359,7 @@ internal sealed class FileBackedLicenseService :
 
         try
         {
-            var content = await _secretResolver
+            var content = await resolver
                 .ResolveLicenseContentAsync(secretRef, cancellationToken)
                 .ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(content))

--- a/src/Honua.Server/Startup/LicensingRegistration.cs
+++ b/src/Honua.Server/Startup/LicensingRegistration.cs
@@ -31,15 +31,20 @@ internal static class LicensingRegistration
             configuration.GetSection(LicenseCapacityOptions.SectionName));
         services.AddSingleton<IEd25519Verifier, BouncyCastleEd25519Verifier>();
 
-        // Register the provider-specific license-content secret resolver so the license
-        // service can load a signed envelope from a secret store (e.g. AWS Secrets Manager)
-        // via Licensing:LicenseContentSecretRef. The AWSSDK surface stays confined to
-        // Honua.Aws (cloud-SDK isolation contract); the cloud-neutral pipeline consumes only
-        // the ILicenseContentSecretResolver abstraction and falls back to Community when none
-        // is registered.
+        // Register the provider-specific license-content secret resolvers so the license
+        // service can load a signed envelope from a secret store (AWS Secrets Manager via
+        // aws:secretsmanager:, Azure Key Vault via azure:keyvault:) using
+        // Licensing:LicenseContentSecretRef. The AWSSDK / Azure SDK surfaces stay confined to
+        // Honua.Aws / Honua.Azure (cloud-SDK isolation contract); the cloud-neutral pipeline
+        // consumes only the ILicenseContentSecretResolver abstraction, iterates every registered
+        // resolver, dispatches by reference prefix, and falls back to Community when none matches.
 #if !HONUA_EXCLUDE_AWS
         Honua.Aws.Features.Licensing.AwsLicenseSecretResolverServiceCollectionExtensions
             .AddAwsLicenseSecretResolver(services, configuration);
+#endif
+#if !HONUA_EXCLUDE_AZURE
+        Honua.Licensing.AzureLicenseSecretResolverServiceCollectionExtensions
+            .AddAzureLicenseSecretResolver(services, configuration);
 #endif
 
         services.AddSingleton<FileBackedLicenseService>();

--- a/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
+++ b/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
@@ -105,41 +105,43 @@ internal static class StartupConfigurationHelpers
         // Pro license (Licensing:LicenseContentSecretRef) resolves as Community at bootstrap, so
         // this gate sees no caching.redis entitlement and the IConnectionMultiplexer never gets
         // wired for the process lifetime even when the SM license carries it (honua-server#1755).
-        var secretResolver = CreateBootstrapLicenseSecretResolver(loggerFactory);
+        var secretResolvers = CreateBootstrapLicenseSecretResolvers(loggerFactory);
         var snapshot = await FileBackedLicenseService
             .LoadBootstrapSnapshotAsync(
                 configuration,
                 loggerFactory,
                 honorDevGrant: !environment.IsProduction(),
-                secretResolver: secretResolver)
+                secretResolvers: secretResolvers)
             .ConfigureAwait(false);
         return snapshot.HasEntitlement("caching.redis");
     }
 
     /// <summary>
-    /// Constructs the provider-specific <see cref="ILicenseContentSecretResolver"/> for the
-    /// bootstrap entitlement probe, mirroring the resolver <c>AddHonuaLicensing</c> registers in
-    /// DI. The AWSSDK surface stays confined to <c>Honua.Aws</c> behind the same
-    /// <c>HONUA_EXCLUDE_AWS</c> guard the runtime wiring uses; when the cloud SDK is excluded the
-    /// probe falls back to file / inline / Community resolution exactly as before. Constructing the
-    /// resolver here is cheap — it only touches the network when a secret reference is configured
-    /// and resolved (its AWS client is created lazily).
+    /// Constructs the provider-specific <see cref="ILicenseContentSecretResolver"/> set for the
+    /// bootstrap entitlement probe, mirroring the resolvers <c>AddHonuaLicensing</c> registers in
+    /// DI. The AWSSDK / Azure SDK surfaces stay confined to <c>Honua.Aws</c> / <c>Honua.Azure</c>
+    /// behind the same <c>HONUA_EXCLUDE_AWS</c> / <c>HONUA_EXCLUDE_AZURE</c> guards the runtime
+    /// wiring uses; when a cloud SDK is excluded that resolver is simply omitted and the probe falls
+    /// back to file / inline / Community resolution exactly as before. Constructing the resolvers
+    /// here is cheap — each only touches the network when a matching secret reference is configured
+    /// and resolved (their cloud clients are created lazily).
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Performance",
-        "CA1859:Use concrete types when possible for improved performance",
-        Justification = "The return type must stay the cloud-neutral abstraction: in the " +
-            "HONUA_EXCLUDE_AWS build profile the concrete resolver type does not exist, so the " +
-            "method returns null typed as the interface.")]
-    private static ILicenseContentSecretResolver? CreateBootstrapLicenseSecretResolver(ILoggerFactory loggerFactory)
+    private static List<ILicenseContentSecretResolver> CreateBootstrapLicenseSecretResolvers(
+        ILoggerFactory loggerFactory)
     {
-#if HONUA_EXCLUDE_AWS
-        _ = loggerFactory;
-        return null;
-#else
-        return new Honua.Aws.Features.Licensing.AwsSecretsManagerLicenseContentResolver(
-            loggerFactory.CreateLogger<Honua.Aws.Features.Licensing.AwsSecretsManagerLicenseContentResolver>());
+        var resolvers = new List<ILicenseContentSecretResolver>(capacity: 2);
+#if !HONUA_EXCLUDE_AWS
+        resolvers.Add(new Honua.Aws.Features.Licensing.AwsSecretsManagerLicenseContentResolver(
+            loggerFactory.CreateLogger<Honua.Aws.Features.Licensing.AwsSecretsManagerLicenseContentResolver>()));
 #endif
+#if !HONUA_EXCLUDE_AZURE
+        resolvers.Add(new Honua.Licensing.AzureKeyVaultLicenseContentResolver(
+            loggerFactory.CreateLogger<Honua.Licensing.AzureKeyVaultLicenseContentResolver>()));
+#endif
+#if HONUA_EXCLUDE_AWS && HONUA_EXCLUDE_AZURE
+        _ = loggerFactory;
+#endif
+        return resolvers;
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/Licensing/AzureKeyVaultLicenseContentResolverLiveTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Licensing/AzureKeyVaultLicenseContentResolverLiveTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using FluentAssertions;
-using Honua.Aws.Features.Licensing;
+using Honua.Licensing;
 using Honua.Core.Features.Licensing.Domain;
 using Honua.Infrastructure.Licensing;
 using Honua.TestKit.Attributes;
@@ -13,39 +13,40 @@ using Microsoft.Extensions.Options;
 namespace Honua.Server.Tests.Features.Licensing;
 
 /// <summary>
-/// Opt-in live test for the AWS Secrets Manager license-content resolver. It is skipped
-/// unless the operator points it at a real secret holding a signed Pro license envelope
-/// and supplies the matching trusted public key, so CI never depends on cloud credentials.
+/// Opt-in live test for the Azure Key Vault license-content resolver. It is skipped unless the
+/// operator points it at a real Key Vault secret holding a signed Pro license envelope and supplies
+/// the matching trusted public key, so CI never depends on cloud credentials.
 ///
-/// To run against the demo Pro license:
-///   HONUA_LIVE_LICENSE_SECRET_ARN=aws:secretsmanager:&lt;arn-or-name of honua-demo-demo/license-pro&gt;
+/// To run against a Pro license stored in Key Vault:
+///   HONUA_LIVE_LICENSE_KEYVAULT_REF=azure:keyvault:https://&lt;vault&gt;.vault.azure.net/&lt;secret&gt;
 ///   HONUA_LIVE_LICENSE_KEY_ID=honuademo2026q2
 ///   HONUA_LIVE_LICENSE_PUBLIC_KEY=base64url:Y2XgDBncW5w6n7L3YG-T6HxX51DGybWazt0_gubk30k
-///   AWS_REGION=&lt;region&gt; plus credentials with secretsmanager:GetSecretValue on the secret.
+///   plus an Azure credential (managed identity / AZURE_* env / az login) with
+///   "Key Vault Secrets User" on the secret.
 /// </summary>
 [Protocol(TestProtocols.Admin)]
 [Operation(Operations.LicenseManagement)]
-public sealed class AwsSecretsManagerLicenseContentResolverLiveTests
+public sealed class AzureKeyVaultLicenseContentResolverLiveTests
 {
-    private const string SecretArnEnv = "HONUA_LIVE_LICENSE_SECRET_ARN";
+    private const string KeyVaultRefEnv = "HONUA_LIVE_LICENSE_KEYVAULT_REF";
     private const string KeyIdEnv = "HONUA_LIVE_LICENSE_KEY_ID";
     private const string PublicKeyEnv = "HONUA_LIVE_LICENSE_PUBLIC_KEY";
 
-    [EmulatorTest(SecretArnEnv, KeyIdEnv, PublicKeyEnv)]
+    [EmulatorTest(KeyVaultRefEnv, KeyIdEnv, PublicKeyEnv)]
     [Trait("Category", "Live")]
     public async Task ResolveAndValidate_LiveSecret_ActivatesPro()
     {
-        var secretRef = Environment.GetEnvironmentVariable(SecretArnEnv)!;
+        var secretRef = Environment.GetEnvironmentVariable(KeyVaultRefEnv)!;
         var keyId = Environment.GetEnvironmentVariable(KeyIdEnv)!;
         var publicKey = Environment.GetEnvironmentVariable(PublicKeyEnv)!;
 
-        var resolver = new AwsSecretsManagerLicenseContentResolver(
-            NullLogger<AwsSecretsManagerLicenseContentResolver>.Instance);
+        var resolver = new AzureKeyVaultLicenseContentResolver(
+            NullLogger<AzureKeyVaultLicenseContentResolver>.Instance);
 
         resolver.CanResolve(secretRef).Should().BeTrue();
 
-        // Feed the resolver into the real license service exactly as production does, so the
-        // test proves end-to-end that a Secrets-Manager-sourced envelope activates Pro.
+        // Feed the resolver into the real license service exactly as production does, so the test
+        // proves end-to-end that a Key-Vault-sourced envelope activates Pro.
         var service = new FileBackedLicenseService(
             Options.Create(new LicenseOptions
             {

--- a/tests/dotnet/Honua.Server.Tests/Features/Licensing/AzureKeyVaultLicenseContentResolverTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Licensing/AzureKeyVaultLicenseContentResolverTests.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Azure;
+using Azure.Security.KeyVault.Secrets;
+using FluentAssertions;
+using Honua.Licensing;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Infrastructure.Licensing;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Honua.Server.Tests.Features.Licensing;
+
+/// <summary>
+/// In-process tests for the Azure Key Vault license-content resolver. They exercise reference
+/// recognition, the fail-safe contract (never throw — degrade to Community), and end-to-end Pro
+/// activation through <see cref="FileBackedLicenseService"/> using a mocked <see cref="SecretClient"/>
+/// so no live Key Vault or Azure credentials are required.
+/// </summary>
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.LicenseManagement)]
+public sealed class AzureKeyVaultLicenseContentResolverTests
+{
+    private const string VaultUri = "https://myvault.vault.azure.net";
+    private const string SecretName = "license-pro";
+    private const string ValidRef = "azure:keyvault:https://myvault.vault.azure.net/license-pro";
+
+    private static AzureKeyVaultLicenseContentResolver CreateResolver(Func<Uri, SecretClient>? clientFactory)
+        => new(NullLogger<AzureKeyVaultLicenseContentResolver>.Instance, clientFactory);
+
+    [UnitTest]
+    public void CanResolve_ClassifiesReferencesByPrefixAndShape()
+    {
+        var resolver = CreateResolver(_ => throw new InvalidOperationException("CanResolve must not touch the network."));
+
+        var cases = new (string? Reference, bool Expected)[]
+        {
+            (ValidRef, true),
+            ("AZURE:KEYVAULT:https://myvault.vault.azure.net/license-pro", true),
+            ("azure:keyvault:https://myvault.vault.azure.net/secrets/license-pro", true),
+            ("aws:secretsmanager:arn:aws:secretsmanager:us-east-1:111122223333:secret:license", false),
+            ("azure:keyvault:", false),
+            ("azure:keyvault:license-pro", false),
+            ("azure:keyvault:https://myvault.vault.azure.net/", false),
+            ("azure:keyvault:http://myvault.vault.azure.net/license-pro", false),
+            (null, false),
+            (string.Empty, false),
+            ("   ", false),
+        };
+
+        foreach (var (reference, expected) in cases)
+        {
+            resolver.CanResolve(reference).Should().Be(
+                expected,
+                "reference '{0}' should classify as {1}",
+                reference ?? "<null>",
+                expected);
+        }
+    }
+
+    [UnitTest]
+    public async Task ResolveLicenseContentAsync_UnsupportedReference_ReturnsNullWithoutTouchingNetwork()
+    {
+        var resolver = CreateResolver(_ => throw new InvalidOperationException("must not build a client for an unsupported ref."));
+
+        var content = await resolver.ResolveLicenseContentAsync(
+            "aws:secretsmanager:honua/license-pro",
+            CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task ResolveLicenseContentAsync_SecretClientThrows_FailsSafeToNull()
+    {
+        // A missing RBAC grant / deleted secret / unreachable vault must degrade to Community,
+        // never crash the host: the resolver swallows the failure and returns null.
+        var resolver = CreateResolver(_ => throw new RequestFailedException(403, "Forbidden"));
+
+        var content = await resolver.ResolveLicenseContentAsync(ValidRef, CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task ResolveLicenseContentAsync_EmptySecretValue_ReturnsNull()
+    {
+        var resolver = CreateResolver(_ => CreateSecretClient(string.Empty));
+
+        var content = await resolver.ResolveLicenseContentAsync(ValidRef, CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task ResolveLicenseContentAsync_ResolvesSecretValue_FromMatchingSecretName()
+    {
+        const string envelope = "{\"version\":1}";
+        var resolver = CreateResolver(_ => CreateSecretClient(envelope));
+
+        var content = await resolver.ResolveLicenseContentAsync(ValidRef, CancellationToken.None);
+
+        content.Should().Be(envelope);
+    }
+
+    [UnitTest]
+    public async Task StartAsync_KeyVaultResolvedSignedLicense_ActivatesPro()
+    {
+        // End-to-end parity with the AWS Secrets Manager path: a signed Pro envelope fetched from
+        // Key Vault must activate Pro through the cloud-neutral license service.
+        const string relabeledKeyId = "honuademo2026q2";
+        var license = LicenseTestSupport.CreateSignedLicense(
+            HonuaEdition.Pro,
+            expiresAt: DateTimeOffset.UtcNow.AddDays(365),
+            entitlements: ["editing.featureserver-edits", "analytics.clustering"],
+            keyId: relabeledKeyId);
+        var envelopeJson = Encoding.UTF8.GetString(license.LicenseData);
+
+        var resolver = CreateResolver(_ => CreateSecretClient(envelopeJson));
+        var service = new FileBackedLicenseService(
+            Options.Create(new LicenseOptions
+            {
+                LicenseContentSecretRef = ValidRef,
+                TrustedKeys = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [relabeledKeyId] = license.PublicKeySetting
+                }
+            }),
+            new BouncyCastleEd25519Verifier(),
+            NullLogger<FileBackedLicenseService>.Instance,
+            [resolver]);
+
+        await service.StartAsync(CancellationToken.None);
+
+        var snapshot = service.GetSnapshot();
+        snapshot.ValidationState.Should().Be(LicenseValidationState.Valid);
+        snapshot.Edition.Should().Be(HonuaEdition.Pro);
+        snapshot.KeyId.Should().Be(relabeledKeyId);
+        snapshot.HasEntitlement("editing.featureserver-edits").Should().BeTrue();
+        service.CheckEntitlement("editing.featureserver-edits").IsActive.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public async Task StartAsync_KeyVaultFetchFails_FallsBackToCommunity()
+    {
+        var resolver = CreateResolver(_ => throw new RequestFailedException(404, "SecretNotFound"));
+        var service = new FileBackedLicenseService(
+            Options.Create(new LicenseOptions { LicenseContentSecretRef = ValidRef }),
+            new BouncyCastleEd25519Verifier(),
+            NullLogger<FileBackedLicenseService>.Instance,
+            [resolver]);
+
+        await service.StartAsync(CancellationToken.None);
+
+        var snapshot = service.GetSnapshot();
+        snapshot.Edition.Should().Be(HonuaEdition.Community);
+        snapshot.IsValid.Should().BeTrue();
+        snapshot.ValidationState.Should().Be(LicenseValidationState.NoLicenseConfigured);
+    }
+
+    private static SecretClient CreateSecretClient(string secretValue)
+    {
+        var secret = new KeyVaultSecret(SecretName, secretValue);
+        var response = Response.FromValue(secret, Mock.Of<Response>());
+
+        var client = new Mock<SecretClient>();
+        client
+            .Setup(c => c.GetSecretAsync(SecretName, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+        return client.Object;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Licensing/AzureKeyVaultLicenseContentResolverTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Licensing/AzureKeyVaultLicenseContentResolverTests.cs
@@ -43,7 +43,10 @@ public sealed class AzureKeyVaultLicenseContentResolverTests
         {
             (ValidRef, true),
             ("AZURE:KEYVAULT:https://myvault.vault.azure.net/license-pro", true),
+            // Canonical Azure secret identifier — see the dedicated resolution test for the
+            // assertion that it parses to the vault authority + "license-pro" (not a /secrets-mangled base).
             ("azure:keyvault:https://myvault.vault.azure.net/secrets/license-pro", true),
+            ("azure:keyvault:https://myvault.vault.azure.net/secrets/license-pro/abc123", true),
             ("aws:secretsmanager:arn:aws:secretsmanager:us-east-1:111122223333:secret:license", false),
             ("azure:keyvault:", false),
             ("azure:keyvault:license-pro", false),
@@ -110,6 +113,52 @@ public sealed class AzureKeyVaultLicenseContentResolverTests
     }
 
     [UnitTest]
+    public async Task ResolveLicenseContentAsync_CanonicalSecretIdentifier_UsesVaultAuthorityAndSecretName()
+    {
+        // Regression: the canonical Azure Key Vault secret identifier
+        // (https://<vault>.vault.azure.net/secrets/<name>) must parse to the vault *authority*
+        // (https://myvault.vault.azure.net/) and secret name "license-pro". A naive split on the
+        // final '/' folded "/secrets" into the vault base, which silently 404s every fetch so Pro
+        // never activates. Capture the URI the resolver hands the SecretClient factory and assert it.
+        const string canonicalRef = "azure:keyvault:https://myvault.vault.azure.net/secrets/license-pro";
+        const string envelope = "{\"version\":1}";
+
+        Uri? observedVaultUri = null;
+        var resolver = CreateResolver(uri =>
+        {
+            observedVaultUri = uri;
+            return CreateSecretClient(envelope);
+        });
+
+        var content = await resolver.ResolveLicenseContentAsync(canonicalRef, CancellationToken.None);
+
+        content.Should().Be(envelope);
+        observedVaultUri.Should().Be(new Uri("https://myvault.vault.azure.net/"));
+    }
+
+    [UnitTest]
+    public async Task ResolveLicenseContentAsync_VersionedSecretIdentifier_UsesVaultAuthorityNameAndVersion()
+    {
+        // The optional trailing version segment (.../secrets/<name>/<version>) must be peeled off the
+        // path: the vault is still the authority, the secret name is "license-pro", and the version is
+        // forwarded to GetSecretAsync rather than mangling the vault base.
+        const string versionedRef = "azure:keyvault:https://myvault.vault.azure.net/secrets/license-pro/abc123";
+        const string envelope = "{\"version\":1}";
+
+        Uri? observedVaultUri = null;
+        var resolver = CreateResolver(uri =>
+        {
+            observedVaultUri = uri;
+            return CreateSecretClient(envelope, secretVersion: "abc123");
+        });
+
+        var content = await resolver.ResolveLicenseContentAsync(versionedRef, CancellationToken.None);
+
+        content.Should().Be(envelope);
+        observedVaultUri.Should().Be(new Uri("https://myvault.vault.azure.net/"));
+    }
+
+    [UnitTest]
     public async Task StartAsync_KeyVaultResolvedSignedLicense_ActivatesPro()
     {
         // End-to-end parity with the AWS Secrets Manager path: a signed Pro envelope fetched from
@@ -164,14 +213,14 @@ public sealed class AzureKeyVaultLicenseContentResolverTests
         snapshot.ValidationState.Should().Be(LicenseValidationState.NoLicenseConfigured);
     }
 
-    private static SecretClient CreateSecretClient(string secretValue)
+    private static SecretClient CreateSecretClient(string secretValue, string? secretVersion = null)
     {
         var secret = new KeyVaultSecret(SecretName, secretValue);
         var response = Response.FromValue(secret, Mock.Of<Response>());
 
         var client = new Mock<SecretClient>();
         client
-            .Setup(c => c.GetSecretAsync(SecretName, null, It.IsAny<CancellationToken>()))
+            .Setup(c => c.GetSecretAsync(SecretName, secretVersion, It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
         return client.Object;
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Licensing/FileBackedLicenseServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Licensing/FileBackedLicenseServiceTests.cs
@@ -422,7 +422,7 @@ public sealed class FileBackedLicenseServiceTests
             configuration,
             loggerFactory,
             honorDevGrant: false,
-            secretResolver: resolver);
+            secretResolvers: [resolver]);
 
         snapshot.Edition.Should().Be(HonuaEdition.Pro);
         snapshot.IsValid.Should().BeTrue();
@@ -447,7 +447,7 @@ public sealed class FileBackedLicenseServiceTests
             configuration,
             loggerFactory,
             honorDevGrant: false,
-            secretResolver: null);
+            secretResolvers: null);
 
         snapshot.Edition.Should().Be(HonuaEdition.Community);
         snapshot.HasEntitlement("caching.redis").Should().BeFalse();
@@ -472,7 +472,7 @@ public sealed class FileBackedLicenseServiceTests
             configuration,
             loggerFactory,
             honorDevGrant: false,
-            secretResolver: resolver);
+            secretResolvers: [resolver]);
 
         snapshot.Edition.Should().Be(HonuaEdition.Community);
         snapshot.IsValid.Should().BeTrue();
@@ -521,7 +521,7 @@ public sealed class FileBackedLicenseServiceTests
             Options.Create(options),
             new BouncyCastleEd25519Verifier(),
             logger,
-            secretResolver);
+            secretResolver is null ? null : [secretResolver]);
 
     /// <summary>
     /// Stand-in for a cloud secret store (e.g. AWS Secrets Manager) that returns the


### PR DESCRIPTION
## Summary

Adds an Azure Key Vault implementation of `ILicenseContentSecretResolver` so the signed Pro license envelope can be delivered on Azure exactly the way AWS uses Secrets Manager. Activated via `Licensing:LicenseContentSecretRef=azure:keyvault:<vault-uri>/<secret>`.

The cloud-neutral interface, the `LicenseContentSecretRef` option, and the secret-before-file fail-safe resolution path already existed (shipped with the AWS resolver, #1742). This PR adds the Azure side and makes the two resolvers coexist.

## Changes Made

- Add `AzureKeyVaultLicenseContentResolver` in `Honua.Azure` (uses `Azure.Security.KeyVault.Secrets` + `DefaultAzureCredential`), confined to the Azure assembly per the cloud-SDK isolation contract. It lives in the `Honua.Licensing` namespace (matching the existing `Honua.Alerts`/`Honua.FileStorage`/`Honua.ControlPlane` convention) so it does not introduce a `Honua.Azure` namespace that would shadow the global `Azure` SDK namespace.
- Fail-safe: any unsupported/malformed reference, fetch failure, or empty secret returns `null` so the host degrades to Community and never crashes.
- Convert `FileBackedLicenseService` to consume `IEnumerable<ILicenseContentSecretResolver>` and dispatch by reference prefix, so the AWS (`aws:secretsmanager:`) and Azure (`azure:keyvault:`) resolvers coexist in a full multi-cloud build instead of one silently winning via `TryAdd`.
- Register the Azure resolver in `AddHonuaLicensing` and the bootstrap entitlement probe behind the `HONUA_EXCLUDE_AZURE` guard, mirroring the AWS wiring; switch the AWS registration to additive.
- Add `Azure.Security.KeyVault.Secrets` (4.7.0) to `Directory.Packages.props` and `Honua.Azure.csproj`.
- Tests: in-process unit tests (reference classification, fail-safe paths, empty value, end-to-end Pro activation through `FileBackedLicenseService` via a mocked `SecretClient`) plus a gated live test mirroring the AWS live test.

## Acceptance Criteria

- [x] A relabeled signed license fetched from Key Vault activates Pro — covered in CI by `StartAsync_KeyVaultResolvedSignedLicense_ActivatesPro` (mocked `SecretClient`) and by the gated live test.
- [x] Fail-safe to Community on any resolution error (never crash).
- [x] Azure SDK isolated in `Honua.Azure` (`CloudSdkIsolationTests` pass).

## Breaking Changes

None.

## Gate Impact

- [x] No gate changes / behavior-preserving for existing AWS path

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

What I ran (Release, `TreatWarningsAsErrors=true`):
- `dotnet build src/Honua.Azure/Honua.Azure.csproj` — succeeded, 0 warnings.
- `dotnet build tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj` — succeeded, 0 warnings.
- `dotnet test tests/dotnet/Honua.Server.Tests --filter FullyQualifiedName~Licensing` — Passed: 50, Skipped: 2 (AWS + Azure live tests), Failed: 0.
- `dotnet test tests/dotnet/Honua.Architecture.Tests --filter FullyQualifiedName~CloudSdkIsolation` — Passed: 4, Failed: 0.
- `dotnet format Honua.sln --verify-no-changes` on the changed files — clean.

Closes #1745
