### PR TITLE
feat: HA/DR recovery-objective domain and licensing entries (#356)

### DIFF
--- a/docs/guides/deploy/backup-and-restore.md
+++ b/docs/guides/deploy/backup-and-restore.md
@@ -67,6 +67,49 @@ Expected: a PostGIS version row, then `Ready`. Finish with a known feature query
 - **Startup migration failure after restore** — the restored schema is newer than the deployed image (you restored a dump taken under a later release); deploy the matching or newer application version.
 - **Attachments 404 after restore** — file-storage snapshot not restored or `FileStorage__*` settings point at a different bucket/volume.
 
+## Automated backups and RTO/RPO (Enterprise)
+
+The manual sequence above is the portable baseline every deployment can run. Enterprise
+deployments add automated, objective-driven disaster recovery (ADR-0024, #356):
+
+| Capability | Entitlement key | What it does |
+|---|---|---|
+| Backup Automation | `dr.backup-automation` | Scheduled `pg_basebackup` base backups plus continuous WAL archiving for point-in-time recovery. |
+| Failover Playbooks | `dr.failover` | Active-passive failover driven by automated health checks against the primary serving surface. |
+| Cache State Backup | `dr.cache-backup` | Backup/restore Redis cache state so warm cache contents survive a regional failover. |
+| RTO/RPO Reporting | `dr.rto-rpo-reporting` | Tracks recovery objectives and reports recovery readiness, last successful backup, and the restorable point. |
+
+### Recovery objectives (RTO/RPO)
+
+- **Recovery Time Objective (RTO)** — the maximum tolerable time to restore service after a
+  disaster. Default enterprise target: **1 hour**.
+- **Recovery Point Objective (RPO)** — the maximum tolerable data loss, measured as the age
+  of the most recent restorable point. Default enterprise target: **5 minutes**, sustained by
+  a daily base backup plus a 5-minute WAL `archive_timeout`.
+
+For the restorable point to stay inside the RPO, the WAL archive interval must be at or below
+the RPO; a base backup is always required to anchor recovery (archived WAL alone cannot
+rebuild a cluster).
+
+### Recovery readiness
+
+Readiness reporting projects recorded backups onto the objectives and reports one of:
+
+| Readiness | Meaning | Action |
+|---|---|---|
+| `not_ready` | No successful base backup exists. | Cannot recover — take a base backup immediately. |
+| `at_risk` | A base backup exists, but the restorable point is older than the RPO. | Investigate WAL archiving / backup cadence. |
+| `ready` | A base backup exists and the restorable point is within the RPO. | Recoverable inside objectives. |
+
+The shared posture rules live in `Honua.Core` (`Features/DisasterRecovery`), so the admin
+reporting surface and provider implementations agree on a single definition of recoverable.
+
+> Scope note (#356): this slice ships the licensing catalog entries, the recovery-objective /
+> backup-record / readiness domain, and this runbook. The PostgreSQL backup service that
+> executes the schedule, the Redis backup path, the failover state machine, the admin
+> endpoint, and the multi-region Terraform modules are tracked as follow-up work on the same
+> issue.
+
 ## Next steps
 
 - [Upgrade and roll back](upgrade-and-rollback.md)

--- a/src/Honua.Core/Features/DisasterRecovery/Abstractions/IBackupStatusProvider.cs
+++ b/src/Honua.Core/Features/DisasterRecovery/Abstractions/IBackupStatusProvider.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.DisasterRecovery.Domain;
+
+namespace Honua.Core.Features.DisasterRecovery.Abstractions;
+
+/// <summary>
+/// Provides recorded backup history and a recovery-readiness assessment for the disaster
+/// recovery reporting surface. Implementations (for example a PostgreSQL backup service that
+/// schedules <c>pg_basebackup</c> and WAL archiving) supply the recorded backups; readiness is
+/// derived through <see cref="Domain.RecoveryReadinessEvaluator"/> so the posture definition
+/// stays shared (#356, ADR-0024).
+/// </summary>
+public interface IBackupStatusProvider
+{
+    /// <summary>
+    /// Returns the recorded backups known to this provider, most recent first is not required.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    Task<IReadOnlyList<BackupRecord>> GetBackupHistoryAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the current recovery-readiness assessment measured against the configured
+    /// recovery objectives.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    Task<RecoveryReadiness> GetRecoveryReadinessAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/DisasterRecovery/Domain/BackupRecord.cs
+++ b/src/Honua.Core/Features/DisasterRecovery/Domain/BackupRecord.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.DisasterRecovery.Domain;
+
+/// <summary>
+/// An immutable record of a single backup attempt produced by the backup automation.
+/// Records are the evidence the recovery-readiness evaluator consumes to compute the
+/// restorable point and recovery-point compliance (#356).
+/// </summary>
+/// <param name="Id">Stable identifier for the backup artifact.</param>
+/// <param name="Kind">Category of the backup artifact.</param>
+/// <param name="CompletedAt">When the backup attempt finished.</param>
+/// <param name="Succeeded">Whether the backup completed successfully and is restorable.</param>
+/// <param name="SizeBytes">Size of the backup artifact in bytes; null when unknown or failed.</param>
+/// <param name="FailureReason">Operator-facing failure reason when <paramref name="Succeeded"/> is false.</param>
+public sealed record BackupRecord(
+    string Id,
+    BackupKind Kind,
+    DateTimeOffset CompletedAt,
+    bool Succeeded,
+    long? SizeBytes = null,
+    string? FailureReason = null)
+{
+    /// <summary>
+    /// Returns true when this record represents a PostgreSQL artifact that protects
+    /// committed data — a base backup or an archived WAL segment. Redis snapshots warm a
+    /// cache and do not extend the restorable point, so they are excluded.
+    /// </summary>
+    public bool IsDataProtecting
+        => Kind is BackupKind.PostgresBase or BackupKind.PostgresWal;
+}

--- a/src/Honua.Core/Features/DisasterRecovery/Domain/BackupSchedule.cs
+++ b/src/Honua.Core/Features/DisasterRecovery/Domain/BackupSchedule.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.DisasterRecovery.Domain;
+
+/// <summary>
+/// Backup automation cadence for a disaster-recovery plan. The schedule governs how often a
+/// full <c>pg_basebackup</c> base backup is taken and the maximum age a WAL segment may
+/// reach before it is forced to the archive (the <c>archive_timeout</c> equivalent). The
+/// WAL archive interval should be at or below the recovery point objective so the restorable
+/// point never drifts past the objective between base backups (#356).
+/// </summary>
+public sealed record BackupSchedule
+{
+    /// <summary>
+    /// Initializes a new <see cref="BackupSchedule"/>.
+    /// </summary>
+    /// <param name="baseBackupInterval">How often a full base backup is taken. Must be greater than zero.</param>
+    /// <param name="walArchiveInterval">Maximum age a WAL segment may reach before it is forced to the archive. Must be greater than zero.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when either interval is not strictly positive.</exception>
+    public BackupSchedule(TimeSpan baseBackupInterval, TimeSpan walArchiveInterval)
+    {
+        if (baseBackupInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(baseBackupInterval),
+                baseBackupInterval,
+                "Base backup interval must be greater than zero.");
+        }
+
+        if (walArchiveInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(walArchiveInterval),
+                walArchiveInterval,
+                "WAL archive interval must be greater than zero.");
+        }
+
+        BaseBackupInterval = baseBackupInterval;
+        WalArchiveInterval = walArchiveInterval;
+    }
+
+    /// <summary>
+    /// How often a full PostgreSQL base backup is taken.
+    /// </summary>
+    public TimeSpan BaseBackupInterval { get; }
+
+    /// <summary>
+    /// Maximum age a WAL segment may reach before it is forced to the archive.
+    /// </summary>
+    public TimeSpan WalArchiveInterval { get; }
+
+    /// <summary>
+    /// Default enterprise cadence: a daily base backup with a five-minute WAL archive
+    /// timeout, aligned with the default five-minute recovery point objective.
+    /// </summary>
+    public static BackupSchedule Default { get; } =
+        new(TimeSpan.FromDays(1), TimeSpan.FromMinutes(5));
+
+    /// <summary>
+    /// Returns true when the WAL archive interval is at or below the recovery point objective,
+    /// meaning continuous archiving can keep the restorable point inside the objective. A
+    /// schedule that violates this can never sustain the objective even when every backup
+    /// succeeds.
+    /// </summary>
+    public bool SatisfiesRecoveryPointObjective(RecoveryObjectives objectives)
+    {
+        ArgumentNullException.ThrowIfNull(objectives);
+        return WalArchiveInterval <= objectives.RecoveryPointObjective;
+    }
+}

--- a/src/Honua.Core/Features/DisasterRecovery/Domain/DisasterRecoveryEnums.cs
+++ b/src/Honua.Core/Features/DisasterRecovery/Domain/DisasterRecoveryEnums.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.DisasterRecovery.Domain;
+
+/// <summary>
+/// Category of a recorded backup artifact. The kinds map to the PostgreSQL backup
+/// strategy described in the backup-and-restore runbook: full base backups taken with
+/// <c>pg_basebackup</c>, continuous WAL segments archived between base backups, and Redis
+/// cache-state snapshots used to warm a failover target (#356, ADR-0024).
+/// </summary>
+public enum BackupKind
+{
+    /// <summary>
+    /// A full PostgreSQL base backup taken with <c>pg_basebackup</c>. A base backup is the
+    /// anchor from which point-in-time recovery replays archived WAL.
+    /// </summary>
+    [JsonStringEnumMemberName("postgres_base")]
+    PostgresBase = 0,
+
+    /// <summary>
+    /// An archived PostgreSQL write-ahead-log segment. WAL archives extend the restorable
+    /// point forward from the most recent base backup, shrinking the recovery-point window.
+    /// </summary>
+    [JsonStringEnumMemberName("postgres_wal")]
+    PostgresWal = 1,
+
+    /// <summary>
+    /// A Redis cache-state snapshot used to pre-warm a failover target's distributed cache.
+    /// </summary>
+    [JsonStringEnumMemberName("redis_snapshot")]
+    RedisSnapshot = 2
+}
+
+/// <summary>
+/// Overall recovery-readiness level derived from recorded backups against the configured
+/// recovery objectives. Used by the admin observability surface to render a single
+/// at-a-glance disaster-recovery posture.
+/// </summary>
+public enum RecoveryReadinessLevel
+{
+    /// <summary>
+    /// No successful base backup exists, so the system cannot be recovered. This is the
+    /// most severe state and always requires operator intervention.
+    /// </summary>
+    [JsonStringEnumMemberName("not_ready")]
+    NotReady = 0,
+
+    /// <summary>
+    /// A base backup exists, but the data-loss window exceeds the configured recovery point
+    /// objective — a recovery would lose more data than the objective allows.
+    /// </summary>
+    [JsonStringEnumMemberName("at_risk")]
+    AtRisk = 1,
+
+    /// <summary>
+    /// A base backup exists and the data-loss window is within the configured recovery point
+    /// objective. The system is recoverable inside its objectives.
+    /// </summary>
+    [JsonStringEnumMemberName("ready")]
+    Ready = 2
+}

--- a/src/Honua.Core/Features/DisasterRecovery/Domain/RecoveryObjectives.cs
+++ b/src/Honua.Core/Features/DisasterRecovery/Domain/RecoveryObjectives.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.DisasterRecovery.Domain;
+
+/// <summary>
+/// Recovery objectives that bound an active-passive disaster-recovery plan.
+/// <para>
+/// The recovery time objective (RTO) is the maximum tolerable duration to restore service
+/// after a disaster. The recovery point objective (RPO) is the maximum tolerable amount of
+/// data loss, expressed as the age of the most recent restorable point. Both are validated
+/// recovery contracts that the readiness evaluator measures recorded backups against
+/// (#356, ADR-0024).
+/// </para>
+/// </summary>
+public sealed record RecoveryObjectives
+{
+    /// <summary>
+    /// Initializes a new <see cref="RecoveryObjectives"/> with the given objectives.
+    /// </summary>
+    /// <param name="recoveryTimeObjective">Maximum tolerable time to restore service. Must be greater than zero.</param>
+    /// <param name="recoveryPointObjective">Maximum tolerable data-loss window. Must be greater than zero.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when either objective is not strictly positive.</exception>
+    public RecoveryObjectives(TimeSpan recoveryTimeObjective, TimeSpan recoveryPointObjective)
+    {
+        if (recoveryTimeObjective <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(recoveryTimeObjective),
+                recoveryTimeObjective,
+                "Recovery time objective must be greater than zero.");
+        }
+
+        if (recoveryPointObjective <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(recoveryPointObjective),
+                recoveryPointObjective,
+                "Recovery point objective must be greater than zero.");
+        }
+
+        RecoveryTimeObjective = recoveryTimeObjective;
+        RecoveryPointObjective = recoveryPointObjective;
+    }
+
+    /// <summary>
+    /// Maximum tolerable time to restore service after a disaster (RTO).
+    /// </summary>
+    public TimeSpan RecoveryTimeObjective { get; }
+
+    /// <summary>
+    /// Maximum tolerable data-loss window (RPO), measured as the age of the most recent
+    /// restorable point.
+    /// </summary>
+    public TimeSpan RecoveryPointObjective { get; }
+
+    /// <summary>
+    /// Default enterprise objectives: a one-hour recovery time objective and a five-minute
+    /// recovery point objective, matching continuous WAL archiving with a five-minute archive
+    /// timeout.
+    /// </summary>
+    public static RecoveryObjectives Default { get; } =
+        new(TimeSpan.FromHours(1), TimeSpan.FromMinutes(5));
+}

--- a/src/Honua.Core/Features/DisasterRecovery/Domain/RecoveryReadiness.cs
+++ b/src/Honua.Core/Features/DisasterRecovery/Domain/RecoveryReadiness.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.DisasterRecovery.Domain;
+
+/// <summary>
+/// A point-in-time assessment of disaster-recovery readiness, derived from recorded backups
+/// against the configured <see cref="RecoveryObjectives"/>. This is the projection the admin
+/// observability surface renders for the RTO/RPO reporting capability (#356).
+/// </summary>
+/// <param name="Level">Overall readiness level.</param>
+/// <param name="Objectives">The objectives the assessment was measured against.</param>
+/// <param name="LastSuccessfulBaseBackup">When the most recent successful base backup completed; null when none exists.</param>
+/// <param name="RestorablePoint">
+/// The most recent restorable point — the latest successful data-protecting backup (base
+/// backup or archived WAL). Null when no successful base backup exists.
+/// </param>
+/// <param name="DataLossWindow">
+/// Estimated data that would be lost on recovery, measured as the age of the
+/// <paramref name="RestorablePoint"/>. Null when no restorable point exists.
+/// </param>
+/// <param name="RecoveryPointObjectiveMet">
+/// True when the <paramref name="DataLossWindow"/> is within the configured recovery point
+/// objective. False when there is no restorable point or the window exceeds the objective.
+/// </param>
+/// <param name="AssessedAt">When the assessment was computed.</param>
+public sealed record RecoveryReadiness(
+    RecoveryReadinessLevel Level,
+    RecoveryObjectives Objectives,
+    DateTimeOffset? LastSuccessfulBaseBackup,
+    DateTimeOffset? RestorablePoint,
+    TimeSpan? DataLossWindow,
+    bool RecoveryPointObjectiveMet,
+    DateTimeOffset AssessedAt);

--- a/src/Honua.Core/Features/DisasterRecovery/Domain/RecoveryReadinessEvaluator.cs
+++ b/src/Honua.Core/Features/DisasterRecovery/Domain/RecoveryReadinessEvaluator.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.DisasterRecovery.Domain;
+
+/// <summary>
+/// Pure, deterministic evaluator that derives a <see cref="RecoveryReadiness"/> assessment
+/// from a set of recorded backups and the configured recovery objectives. Keeping the
+/// recovery-posture logic in Core (independent of any storage or scheduling backend) lets
+/// both the admin reporting surface and the provider implementations share one definition of
+/// "are we recoverable inside our objectives?" (#356).
+/// </summary>
+public static class RecoveryReadinessEvaluator
+{
+    /// <summary>
+    /// Evaluates recovery readiness as of <paramref name="asOf"/>.
+    /// </summary>
+    /// <param name="objectives">The recovery objectives to measure against.</param>
+    /// <param name="backups">Recorded backups; order is irrelevant and failed records are ignored for restorability.</param>
+    /// <param name="asOf">The reference time the data-loss window is measured against.</param>
+    /// <returns>A readiness assessment.</returns>
+    /// <remarks>
+    /// Readiness rules:
+    /// <list type="bullet">
+    ///   <item><description>
+    ///     No successful base backup → <see cref="RecoveryReadinessLevel.NotReady"/>; the
+    ///     system cannot be recovered at all.
+    ///   </description></item>
+    ///   <item><description>
+    ///     A base backup exists but the data-loss window (age of the latest successful
+    ///     data-protecting backup) exceeds the recovery point objective →
+    ///     <see cref="RecoveryReadinessLevel.AtRisk"/>.
+    ///   </description></item>
+    ///   <item><description>
+    ///     A base backup exists and the data-loss window is within the recovery point
+    ///     objective → <see cref="RecoveryReadinessLevel.Ready"/>.
+    ///   </description></item>
+    /// </list>
+    /// </remarks>
+    public static RecoveryReadiness Evaluate(
+        RecoveryObjectives objectives,
+        IReadOnlyList<BackupRecord> backups,
+        DateTimeOffset asOf)
+    {
+        ArgumentNullException.ThrowIfNull(objectives);
+        ArgumentNullException.ThrowIfNull(backups);
+
+        DateTimeOffset? lastBaseBackup = null;
+        DateTimeOffset? restorablePoint = null;
+
+        foreach (var backup in backups)
+        {
+            if (!backup.Succeeded)
+            {
+                continue;
+            }
+
+            if (backup.Kind == BackupKind.PostgresBase &&
+                (lastBaseBackup is null || backup.CompletedAt > lastBaseBackup.Value))
+            {
+                lastBaseBackup = backup.CompletedAt;
+            }
+
+            if (backup.IsDataProtecting &&
+                (restorablePoint is null || backup.CompletedAt > restorablePoint.Value))
+            {
+                restorablePoint = backup.CompletedAt;
+            }
+        }
+
+        // Without a base backup there is nothing to restore from — archived WAL alone cannot
+        // rebuild a cluster — so the restorable point is only meaningful with a base anchor.
+        if (lastBaseBackup is null)
+        {
+            return new RecoveryReadiness(
+                Level: RecoveryReadinessLevel.NotReady,
+                Objectives: objectives,
+                LastSuccessfulBaseBackup: null,
+                RestorablePoint: null,
+                DataLossWindow: null,
+                RecoveryPointObjectiveMet: false,
+                AssessedAt: asOf);
+        }
+
+        // The restorable point is the latest data-protecting backup; it is never older than
+        // the base backup because the base backup itself is data-protecting.
+        var dataLossWindow = asOf - restorablePoint!.Value;
+        if (dataLossWindow < TimeSpan.Zero)
+        {
+            dataLossWindow = TimeSpan.Zero;
+        }
+
+        var rpoMet = dataLossWindow <= objectives.RecoveryPointObjective;
+
+        return new RecoveryReadiness(
+            Level: rpoMet ? RecoveryReadinessLevel.Ready : RecoveryReadinessLevel.AtRisk,
+            Objectives: objectives,
+            LastSuccessfulBaseBackup: lastBaseBackup,
+            RestorablePoint: restorablePoint,
+            DataLossWindow: dataLossWindow,
+            RecoveryPointObjectiveMet: rpoMet,
+            AssessedAt: asOf);
+    }
+}

--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -84,7 +84,35 @@ public static class FeatureCatalog
 
         /// <summary>Server extensibility features — plugin/extension SDK.</summary>
         public const string Extensibility = "Extensibility";
+
+        /// <summary>High availability and disaster recovery — backup automation, failover, RTO/RPO reporting.</summary>
+        public const string DisasterRecovery = "DisasterRecovery";
     }
+
+    /// <summary>
+    /// Entitlement key for automated PostgreSQL backups — scheduled base backups plus
+    /// WAL archiving that enable point-in-time recovery (#356, ADR-0024). Enterprise-only.
+    /// </summary>
+    public const string BackupAutomationKey = "dr.backup-automation";
+
+    /// <summary>
+    /// Entitlement key for active-passive failover playbooks driven by automated health
+    /// checks against the primary serving surface (#356, ADR-0024). Enterprise-only.
+    /// </summary>
+    public const string FailoverPlaybooksKey = "dr.failover";
+
+    /// <summary>
+    /// Entitlement key for Redis cache-state backup and restore so warm cache contents
+    /// survive a regional failover (#356, ADR-0024). Enterprise-only.
+    /// </summary>
+    public const string CacheBackupKey = "dr.cache-backup";
+
+    /// <summary>
+    /// Entitlement key for RTO/RPO objective tracking and recovery-readiness reporting that
+    /// surfaces last-successful-backup, restorable point, and objective compliance to the
+    /// admin observability surface (#356, ADR-0024). Enterprise-only.
+    /// </summary>
+    public const string RecoveryReportingKey = "dr.rto-rpo-reporting";
 
     /// <summary>
     /// Entitlement key for agent-initiated operations under the Pro validation
@@ -394,5 +422,15 @@ public static class FeatureCatalog
         // AI — Enterprise (approval + policy on top of the validation layer)
         new(AiApprovalWorkflowsKey, "Agent Approval Workflows", Categories.Ai,
             HonuaEdition.Enterprise, "Human-in-the-loop approval, policy-scoped agent permissions, and immutable audit for agent-initiated operations."),
+
+        // Disaster Recovery — Enterprise (HA/DR: backup automation, failover, RTO/RPO reporting)
+        new(BackupAutomationKey, "Backup Automation", Categories.DisasterRecovery,
+            HonuaEdition.Enterprise, "Scheduled PostgreSQL base backups plus WAL archiving enabling point-in-time recovery."),
+        new(FailoverPlaybooksKey, "Failover Playbooks", Categories.DisasterRecovery,
+            HonuaEdition.Enterprise, "Active-passive failover playbooks driven by automated health checks against the primary serving surface."),
+        new(CacheBackupKey, "Cache State Backup", Categories.DisasterRecovery,
+            HonuaEdition.Enterprise, "Backup and restore Redis cache state so warm cache contents survive a regional failover."),
+        new(RecoveryReportingKey, "RTO/RPO Reporting", Categories.DisasterRecovery,
+            HonuaEdition.Enterprise, "Track recovery time and recovery point objectives and report recovery readiness, last successful backup, and restorable point."),
     ];
 }

--- a/tests/dotnet/Honua.Core.Tests/Features/DisasterRecovery/RecoveryObjectivesTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/DisasterRecovery/RecoveryObjectivesTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.DisasterRecovery.Domain;
+
+namespace Honua.Core.Tests.Features.DisasterRecovery;
+
+/// <summary>
+/// Unit tests for the recovery objectives and backup schedule value objects (#356).
+/// </summary>
+public sealed class RecoveryObjectivesTests
+{
+    [Fact]
+    public void Constructor_ValidObjectives_AreStored()
+    {
+        var objectives = new RecoveryObjectives(TimeSpan.FromHours(2), TimeSpan.FromMinutes(10));
+
+        objectives.RecoveryTimeObjective.Should().Be(TimeSpan.FromHours(2));
+        objectives.RecoveryPointObjective.Should().Be(TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    public void Default_HasOneHourRtoAndFiveMinuteRpo()
+    {
+        RecoveryObjectives.Default.RecoveryTimeObjective.Should().Be(TimeSpan.FromHours(1));
+        RecoveryObjectives.Default.RecoveryPointObjective.Should().Be(TimeSpan.FromMinutes(5));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_NonPositiveRto_Throws(int seconds)
+    {
+        var act = () => new RecoveryObjectives(TimeSpan.FromSeconds(seconds), TimeSpan.FromMinutes(5));
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .Which.ParamName.Should().Be("recoveryTimeObjective");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_NonPositiveRpo_Throws(int seconds)
+    {
+        var act = () => new RecoveryObjectives(TimeSpan.FromHours(1), TimeSpan.FromSeconds(seconds));
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .Which.ParamName.Should().Be("recoveryPointObjective");
+    }
+
+    [Fact]
+    public void BackupSchedule_WalIntervalWithinRpo_SatisfiesObjective()
+    {
+        var schedule = new BackupSchedule(TimeSpan.FromDays(1), TimeSpan.FromMinutes(5));
+
+        schedule.SatisfiesRecoveryPointObjective(RecoveryObjectives.Default).Should().BeTrue();
+    }
+
+    [Fact]
+    public void BackupSchedule_WalIntervalExceedsRpo_DoesNotSatisfyObjective()
+    {
+        var schedule = new BackupSchedule(TimeSpan.FromDays(1), TimeSpan.FromMinutes(15));
+
+        schedule.SatisfiesRecoveryPointObjective(RecoveryObjectives.Default).Should().BeFalse();
+    }
+
+    [Fact]
+    public void BackupSchedule_Default_SatisfiesDefaultObjective()
+    {
+        BackupSchedule.Default.SatisfiesRecoveryPointObjective(RecoveryObjectives.Default)
+            .Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void BackupSchedule_NonPositiveBaseInterval_Throws(int seconds)
+    {
+        var act = () => new BackupSchedule(TimeSpan.FromSeconds(seconds), TimeSpan.FromMinutes(5));
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .Which.ParamName.Should().Be("baseBackupInterval");
+    }
+
+    [Fact]
+    public void BackupRecord_DataProtectingKinds_AreBaseAndWal()
+    {
+        var now = DateTimeOffset.UtcNow;
+        new BackupRecord("b", BackupKind.PostgresBase, now, true).IsDataProtecting.Should().BeTrue();
+        new BackupRecord("w", BackupKind.PostgresWal, now, true).IsDataProtecting.Should().BeTrue();
+        new BackupRecord("r", BackupKind.RedisSnapshot, now, true).IsDataProtecting.Should().BeFalse();
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/DisasterRecovery/RecoveryReadinessEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/DisasterRecovery/RecoveryReadinessEvaluatorTests.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.DisasterRecovery.Domain;
+
+namespace Honua.Core.Tests.Features.DisasterRecovery;
+
+/// <summary>
+/// Unit tests for the recovery-readiness evaluator (#356). These assert the shared
+/// RTO/RPO posture rules the admin reporting surface and provider implementations depend on.
+/// </summary>
+public sealed class RecoveryReadinessEvaluatorTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 26, 12, 0, 0, TimeSpan.Zero);
+
+    private static readonly RecoveryObjectives Objectives =
+        new(TimeSpan.FromHours(1), TimeSpan.FromMinutes(5));
+
+    [Fact]
+    public void Evaluate_NoBackups_IsNotReady()
+    {
+        var readiness = RecoveryReadinessEvaluator.Evaluate(Objectives, [], Now);
+
+        readiness.Level.Should().Be(RecoveryReadinessLevel.NotReady);
+        readiness.LastSuccessfulBaseBackup.Should().BeNull();
+        readiness.RestorablePoint.Should().BeNull();
+        readiness.DataLossWindow.Should().BeNull();
+        readiness.RecoveryPointObjectiveMet.Should().BeFalse();
+        readiness.AssessedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void Evaluate_OnlyWalArchives_IsNotReady_BecauseNoBaseAnchor()
+    {
+        // WAL alone cannot rebuild a cluster — a base backup is required to anchor recovery.
+        var backups = new[]
+        {
+            new BackupRecord("wal-1", BackupKind.PostgresWal, Now.AddMinutes(-1), Succeeded: true),
+        };
+
+        var readiness = RecoveryReadinessEvaluator.Evaluate(Objectives, backups, Now);
+
+        readiness.Level.Should().Be(RecoveryReadinessLevel.NotReady);
+        readiness.LastSuccessfulBaseBackup.Should().BeNull();
+    }
+
+    [Fact]
+    public void Evaluate_FailedBaseBackup_IsIgnored()
+    {
+        var backups = new[]
+        {
+            new BackupRecord("base-1", BackupKind.PostgresBase, Now.AddMinutes(-2), Succeeded: false, FailureReason: "disk full"),
+        };
+
+        var readiness = RecoveryReadinessEvaluator.Evaluate(Objectives, backups, Now);
+
+        readiness.Level.Should().Be(RecoveryReadinessLevel.NotReady);
+    }
+
+    [Fact]
+    public void Evaluate_RecentBaseBackupWithinRpo_IsReady()
+    {
+        var backups = new[]
+        {
+            new BackupRecord("base-1", BackupKind.PostgresBase, Now.AddMinutes(-2), Succeeded: true, SizeBytes: 1024),
+        };
+
+        var readiness = RecoveryReadinessEvaluator.Evaluate(Objectives, backups, Now);
+
+        readiness.Level.Should().Be(RecoveryReadinessLevel.Ready);
+        readiness.LastSuccessfulBaseBackup.Should().Be(Now.AddMinutes(-2));
+        readiness.RestorablePoint.Should().Be(Now.AddMinutes(-2));
+        readiness.DataLossWindow.Should().Be(TimeSpan.FromMinutes(2));
+        readiness.RecoveryPointObjectiveMet.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_WalArchiveExtendsRestorablePointInsideRpo_IsReady()
+    {
+        // Base backup is older than the RPO, but a recent WAL archive shrinks the data-loss
+        // window back inside the objective — point-in-time recovery is sustained.
+        var backups = new[]
+        {
+            new BackupRecord("base-1", BackupKind.PostgresBase, Now.AddHours(-6), Succeeded: true),
+            new BackupRecord("wal-1", BackupKind.PostgresWal, Now.AddMinutes(-3), Succeeded: true),
+        };
+
+        var readiness = RecoveryReadinessEvaluator.Evaluate(Objectives, backups, Now);
+
+        readiness.Level.Should().Be(RecoveryReadinessLevel.Ready);
+        readiness.LastSuccessfulBaseBackup.Should().Be(Now.AddHours(-6));
+        readiness.RestorablePoint.Should().Be(Now.AddMinutes(-3));
+        readiness.DataLossWindow.Should().Be(TimeSpan.FromMinutes(3));
+        readiness.RecoveryPointObjectiveMet.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_RestorablePointOlderThanRpo_IsAtRisk()
+    {
+        var backups = new[]
+        {
+            new BackupRecord("base-1", BackupKind.PostgresBase, Now.AddMinutes(-30), Succeeded: true),
+            new BackupRecord("wal-1", BackupKind.PostgresWal, Now.AddMinutes(-20), Succeeded: true),
+        };
+
+        var readiness = RecoveryReadinessEvaluator.Evaluate(Objectives, backups, Now);
+
+        readiness.Level.Should().Be(RecoveryReadinessLevel.AtRisk);
+        readiness.RestorablePoint.Should().Be(Now.AddMinutes(-20));
+        readiness.DataLossWindow.Should().Be(TimeSpan.FromMinutes(20));
+        readiness.RecoveryPointObjectiveMet.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Evaluate_RedisSnapshot_DoesNotExtendRestorablePoint()
+    {
+        // A Redis snapshot warms a cache; it does not protect committed data, so it must not
+        // count toward the restorable point.
+        var backups = new[]
+        {
+            new BackupRecord("base-1", BackupKind.PostgresBase, Now.AddMinutes(-30), Succeeded: true),
+            new BackupRecord("redis-1", BackupKind.RedisSnapshot, Now.AddMinutes(-1), Succeeded: true),
+        };
+
+        var readiness = RecoveryReadinessEvaluator.Evaluate(Objectives, backups, Now);
+
+        readiness.RestorablePoint.Should().Be(Now.AddMinutes(-30));
+        readiness.Level.Should().Be(RecoveryReadinessLevel.AtRisk);
+    }
+
+    [Fact]
+    public void Evaluate_ClampsNegativeWindowToZero_WhenBackupRecordedInFuture()
+    {
+        var backups = new[]
+        {
+            new BackupRecord("base-1", BackupKind.PostgresBase, Now.AddMinutes(5), Succeeded: true),
+        };
+
+        var readiness = RecoveryReadinessEvaluator.Evaluate(Objectives, backups, Now);
+
+        readiness.DataLossWindow.Should().Be(TimeSpan.Zero);
+        readiness.Level.Should().Be(RecoveryReadinessLevel.Ready);
+    }
+
+    [Fact]
+    public void Evaluate_NullArguments_Throw()
+    {
+        var act1 = () => RecoveryReadinessEvaluator.Evaluate(null!, [], Now);
+        var act2 = () => RecoveryReadinessEvaluator.Evaluate(Objectives, null!, Now);
+
+        act1.Should().Throw<ArgumentNullException>();
+        act2.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
@@ -56,6 +56,23 @@ public sealed class FeatureCatalogTests
         categories.Should().Contain(FeatureCatalog.Categories.Temporal);
         categories.Should().Contain(FeatureCatalog.Categories.FieldOps);
         categories.Should().Contain(FeatureCatalog.Categories.Ai);
+        categories.Should().Contain(FeatureCatalog.Categories.DisasterRecovery);
+    }
+
+    [Theory]
+    [InlineData("dr.backup-automation")]
+    [InlineData("dr.failover")]
+    [InlineData("dr.cache-backup")]
+    [InlineData("dr.rto-rpo-reporting")]
+    public void All_DisasterRecoveryFeaturesAreEnterpriseTier(string key)
+    {
+        // Ticket #356 (ADR-0024): HA/DR is an Enterprise tier capability across backup
+        // automation, failover playbooks, cache backup, and RTO/RPO reporting.
+        var feature = FeatureCatalog.All.SingleOrDefault(f => f.Key == key);
+
+        feature.Should().NotBeNull($"feature catalog must define '{key}' for ticket #356");
+        feature!.Category.Should().Be(FeatureCatalog.Categories.DisasterRecovery);
+        feature.MinimumEdition.Should().Be(HonuaEdition.Enterprise);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

First slice of HA + DR (issue #356, ADR-0024 Enterprise tier). Establishes the
shared disaster-recovery foundation in `Honua.Core` and the licensing surface so
later work (backup service, failover state machine, admin endpoint, Terraform)
adapts onto one shared RTO/RPO posture definition rather than reinventing it.

Related to #356

## Changes Made

- Add Enterprise `FeatureCatalog` entitlements + a `DisasterRecovery` category:
  `dr.backup-automation`, `dr.failover`, `dr.cache-backup`, `dr.rto-rpo-reporting`.
- Add a `Honua.Core` `DisasterRecovery` domain:
  - `RecoveryObjectives` (validated RTO/RPO value object with enterprise defaults).
  - `BackupSchedule` (base-backup + WAL-archive cadence with RPO-satisfaction check).
  - `BackupRecord` + `BackupKind` (PostgreSQL base / WAL / Redis snapshot).
  - `RecoveryReadiness` + `RecoveryReadinessLevel` projection.
  - `RecoveryReadinessEvaluator` — pure, deterministic readiness rules
    (not_ready / at_risk / ready) from recorded backups vs objectives.
  - `IBackupStatusProvider` abstraction for the deferred provider implementation.
- Add unit tests for the catalog entries, objectives/schedule validation, and the
  readiness evaluator (edge cases: no base anchor, WAL-only, RPO breach, Redis
  snapshots not extending the restorable point, future-dated backups).
- Add an RTO/RPO + recovery-readiness runbook section to
  `docs/guides/deploy/backup-and-restore.md`.

## Breaking Changes

None.

## Gate Impact

- [x] No gate-tier impact (additive Core domain + licensing entries + docs)

## Testing

- [x] Ran build + affected unit tests
- `dotnet build src/Honua.Core/Honua.Core.csproj -c Release /p:TreatWarningsAsErrors=true` — succeeded, 0 warnings.
- `dotnet test tests/dotnet/Honua.Core.Tests` (DisasterRecovery + FeatureCatalog filter) — 57 passed, 0 failed.
- `dotnet format --verify-no-changes` on the changed files — clean.

## Known gaps (deferred follow-ups on #356)

This is an intentional first slice; the following remain open on #356 and is why
the PR is a draft:

- `PostgresBackupService` that actually schedules `pg_basebackup` + WAL archiving
  and persists `BackupRecord`s (implementing `IBackupStatusProvider`).
- Redis cache-state backup/restore path.
- Active-passive failover state machine + health-check-driven trigger.
- Admin backup-status / RTO-RPO observability endpoint (+ integration tests) and
  console UI.
- Multi-region Terraform modules (honua-terraform).
