### PR TITLE
feat: add Kafka event-bus sink with idempotent producer and DLQ (#357)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,7 @@
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2" />
+    <PackageVersion Include="Confluent.Kafka" Version="2.14.2" />
     <PackageVersion Include="dbup-postgresql" Version="7.0.1" />
     <PackageVersion Include="DuckDB.NET.Data.Full" Version="1.5.0" />
     <PackageVersion Include="FlatGeobuf" Version="3.26.0" />

--- a/src/Honua.Hosting/Features/Events/FeatureChangeEventSinkMetrics.cs
+++ b/src/Honua.Hosting/Features/Events/FeatureChangeEventSinkMetrics.cs
@@ -31,4 +31,14 @@ internal static class FeatureChangeEventSinkMetrics
         "honua.event_sink.failed_total",
         "events",
         "Feature-change events whose sink publish attempt failed.");
+
+    /// <summary>
+    /// Events routed to a sink's dead-letter destination after the primary
+    /// delivery failed, tagged by sink name. A dead-lettered event is counted in
+    /// addition to (not instead of) the primary <see cref="Failed"/> increment.
+    /// </summary>
+    public static readonly Counter<long> DeadLettered = Meter.CreateCounter<long>(
+        "honua.event_sink.dead_lettered_total",
+        "events",
+        "Feature-change events routed to a sink dead-letter destination after a delivery failure.");
 }

--- a/src/Honua.Hosting/Features/Events/Sinks/Kafka/ConfluentKafkaEventProducer.cs
+++ b/src/Honua.Hosting/Features/Events/Sinks/Kafka/ConfluentKafkaEventProducer.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Confluent.Kafka;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.Events;
+
+/// <summary>
+/// Confluent-backed <see cref="IKafkaEventProducer"/> that owns all
+/// idempotent-producer configuration (#357).
+/// </summary>
+/// <remarks>
+/// This is the only type that references the Confluent client. It is constructed
+/// once as a singleton; the underlying <see cref="IProducer{TKey,TValue}"/> is
+/// thread-safe and shared across all publishes. When idempotence is enabled the
+/// client enforces <c>acks=all</c>, a bounded in-flight window, and infinite
+/// retries, giving producer-side exactly-once delivery (no duplicates on retry).
+/// </remarks>
+internal sealed class ConfluentKafkaEventProducer : IKafkaEventProducer
+{
+    private static readonly TimeSpan FlushTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly IProducer<string, byte[]> _producer;
+
+    public ConfluentKafkaEventProducer(IOptions<KafkaFeatureChangeEventSinkOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var value = options.Value ?? throw new ArgumentNullException(nameof(options));
+
+        var config = new ProducerConfig
+        {
+            BootstrapServers = value.BootstrapServers,
+            EnableIdempotence = value.EnableIdempotence,
+            // Idempotence implies acks=all; set explicitly so the intent is clear
+            // even when idempotence is disabled.
+            Acks = value.EnableIdempotence ? Acks.All : Acks.Leader,
+            MessageTimeoutMs = value.MessageTimeoutMs,
+        };
+
+        if (!string.IsNullOrWhiteSpace(value.SecurityProtocol) &&
+            Enum.TryParse<SecurityProtocol>(value.SecurityProtocol, ignoreCase: true, out var protocol))
+        {
+            config.SecurityProtocol = protocol;
+        }
+
+        if (!string.IsNullOrWhiteSpace(value.SaslMechanism) &&
+            Enum.TryParse<SaslMechanism>(value.SaslMechanism, ignoreCase: true, out var mechanism))
+        {
+            config.SaslMechanism = mechanism;
+        }
+
+        if (!string.IsNullOrWhiteSpace(value.SaslUsername))
+        {
+            config.SaslUsername = value.SaslUsername;
+        }
+
+        if (!string.IsNullOrWhiteSpace(value.SaslPassword))
+        {
+            config.SaslPassword = value.SaslPassword;
+        }
+
+        _producer = new ProducerBuilder<string, byte[]>(config).Build();
+    }
+
+    /// <inheritdoc />
+    public async Task ProduceAsync(
+        string topic,
+        string key,
+        byte[] value,
+        IReadOnlyList<KeyValuePair<string, string>> headers,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+
+        var message = new Message<string, byte[]>
+        {
+            Key = key,
+            Value = value,
+            Headers = BuildHeaders(headers),
+        };
+
+        await _producer.ProduceAsync(topic, message, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Headers BuildHeaders(IReadOnlyList<KeyValuePair<string, string>> headers)
+    {
+        var kafkaHeaders = new Headers();
+        for (var i = 0; i < headers.Count; i++)
+        {
+            var header = headers[i];
+            kafkaHeaders.Add(header.Key, Encoding.UTF8.GetBytes(header.Value ?? string.Empty));
+        }
+
+        return kafkaHeaders;
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        // Flush in-flight messages so no acknowledged-but-unsent records are lost
+        // on shutdown, then release the native client handle.
+        _producer.Flush(FlushTimeout);
+        _producer.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Honua.Hosting/Features/Events/Sinks/Kafka/IKafkaEventProducer.cs
+++ b/src/Honua.Hosting/Features/Events/Sinks/Kafka/IKafkaEventProducer.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Events;
+
+/// <summary>
+/// Minimal transport abstraction over a Kafka producer (#357).
+/// </summary>
+/// <remarks>
+/// The concrete <see cref="ConfluentKafkaEventProducer"/> wraps the Confluent
+/// client and owns all idempotent-producer configuration. Keeping the sink
+/// dependent on this thin abstraction rather than the concrete client means the
+/// dead-letter routing and serialization logic in <see cref="KafkaFeatureChangeEventSink"/>
+/// can be unit-tested without a live broker.
+/// </remarks>
+internal interface IKafkaEventProducer : IAsyncDisposable
+{
+    /// <summary>
+    /// Produces a single message to <paramref name="topic"/> and awaits broker
+    /// acknowledgement. Throws when delivery cannot be confirmed (the sink turns
+    /// a throw into dead-letter routing or a metered failure).
+    /// </summary>
+    /// <param name="topic">Destination topic.</param>
+    /// <param name="key">Partition key; preserves per-feature ordering.</param>
+    /// <param name="value">Serialized event payload.</param>
+    /// <param name="headers">Message headers (event id, operation, content-type, ...).</param>
+    /// <param name="cancellationToken">Token signalling host shutdown.</param>
+    Task ProduceAsync(
+        string topic,
+        string key,
+        byte[] value,
+        IReadOnlyList<KeyValuePair<string, string>> headers,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Hosting/Features/Events/Sinks/Kafka/KafkaFeatureChangeEventSink.cs
+++ b/src/Honua.Hosting/Features/Events/Sinks/Kafka/KafkaFeatureChangeEventSink.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.Events;
+
+/// <summary>
+/// Concrete <see cref="IFeatureChangeEventSink"/> that publishes committed
+/// feature-change events to Apache Kafka (#357).
+/// </summary>
+/// <remarks>
+/// Events are serialized as JSON and keyed by <c>service/layer/feature</c> so all
+/// mutations to the same feature land on the same partition and preserve order.
+/// The underlying producer is idempotent (producer-side exactly-once) so a
+/// broker-acknowledged message is never duplicated on retry. When a delivery
+/// still fails after the producer's own retries, the event is routed to the
+/// configured dead-letter topic with diagnostic headers; if dead-lettering is
+/// disabled or itself fails, the failure surfaces to the broadcaster, which
+/// isolates and meters it without affecting durable storage or sibling sinks.
+/// </remarks>
+internal sealed partial class KafkaFeatureChangeEventSink : IFeatureChangeEventSink
+{
+    private const string ContentType = "application/json";
+
+    private readonly IKafkaEventProducer _producer;
+    private readonly KafkaFeatureChangeEventSinkOptions _options;
+    private readonly ILogger<KafkaFeatureChangeEventSink> _logger;
+
+    public KafkaFeatureChangeEventSink(
+        IKafkaEventProducer producer,
+        IOptions<KafkaFeatureChangeEventSinkOptions> options,
+        ILogger<KafkaFeatureChangeEventSink> logger)
+    {
+        _producer = producer ?? throw new ArgumentNullException(nameof(producer));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public string Name => "kafka";
+
+    /// <inheritdoc />
+    public async Task PublishAsync(FeatureChangeEvent featureEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(featureEvent);
+
+        var key = BuildKey(featureEvent);
+        var value = JsonSerializer.SerializeToUtf8Bytes(
+            featureEvent,
+            FeatureChangeEventsJsonContext.Default.FeatureChangeEvent);
+        var headers = BuildHeaders(featureEvent);
+
+        try
+        {
+            await _producer
+                .ProduceAsync(_options.Topic, key, value, headers, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            await DeadLetterAsync(featureEvent, key, value, headers, ex, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task DeadLetterAsync(
+        FeatureChangeEvent featureEvent,
+        string key,
+        byte[] value,
+        IReadOnlyList<KeyValuePair<string, string>> headers,
+        Exception failure,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_options.DeadLetterTopic))
+        {
+            // Dead-lettering disabled: surface to the broadcaster, which isolates
+            // and meters the failure without affecting durable storage or siblings.
+            throw failure;
+        }
+
+        var dlqHeaders = new List<KeyValuePair<string, string>>(headers.Count + 3);
+        dlqHeaders.AddRange(headers);
+        dlqHeaders.Add(new("x-dlq-source-topic", _options.Topic));
+        dlqHeaders.Add(new("x-dlq-error", Truncate(failure.Message, 1024)));
+        dlqHeaders.Add(new("x-dlq-failed-at", DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture)));
+
+        try
+        {
+            await _producer
+                .ProduceAsync(_options.DeadLetterTopic!, key, value, dlqHeaders, cancellationToken)
+                .ConfigureAwait(false);
+            FeatureChangeEventSinkMetrics.DeadLettered.Add(
+                1,
+                new KeyValuePair<string, object?>("sink", Name));
+            LogDeadLettered(_logger, featureEvent.EventId, _options.DeadLetterTopic!, failure);
+        }
+        catch (Exception dlqEx)
+        {
+            // Both primary and dead-letter delivery failed: surface the original
+            // failure so the broadcaster meters it. Record the DLQ failure too.
+            LogDeadLetterFailed(_logger, featureEvent.EventId, _options.DeadLetterTopic!, dlqEx);
+            throw failure;
+        }
+    }
+
+    private static string BuildKey(FeatureChangeEvent featureEvent)
+        => string.Create(
+            CultureInfo.InvariantCulture,
+            $"{featureEvent.ServiceId}/{featureEvent.LayerId}/{featureEvent.ObjectId}");
+
+    private static IReadOnlyList<KeyValuePair<string, string>> BuildHeaders(FeatureChangeEvent featureEvent)
+        =>
+        [
+            new("content-type", ContentType),
+            new("x-event-id", featureEvent.EventId),
+            new("x-event-cursor", featureEvent.Cursor.ToString(CultureInfo.InvariantCulture)),
+            new("x-service-id", featureEvent.ServiceId),
+            new("x-layer-id", featureEvent.LayerId.ToString(CultureInfo.InvariantCulture)),
+            new("x-operation", featureEvent.Operation),
+            new("x-protocol", featureEvent.Protocol),
+        ];
+
+    private static string Truncate(string value, int maxLength)
+        => value.Length <= maxLength ? value : value[..maxLength];
+
+    [LoggerMessage(
+        EventId = 9410,
+        Level = LogLevel.Warning,
+        Message = "Kafka sink dead-lettered feature-change event {EventId} to topic '{DeadLetterTopic}' after a delivery failure.")]
+    private static partial void LogDeadLettered(ILogger logger, string eventId, string deadLetterTopic, Exception failure);
+
+    [LoggerMessage(
+        EventId = 9411,
+        Level = LogLevel.Error,
+        Message = "Kafka sink failed to dead-letter feature-change event {EventId} to topic '{DeadLetterTopic}'; the original delivery failure will be surfaced.")]
+    private static partial void LogDeadLetterFailed(ILogger logger, string eventId, string deadLetterTopic, Exception failure);
+}

--- a/src/Honua.Hosting/Features/Events/Sinks/Kafka/KafkaFeatureChangeEventSinkOptions.cs
+++ b/src/Honua.Hosting/Features/Events/Sinks/Kafka/KafkaFeatureChangeEventSinkOptions.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.Events;
+
+/// <summary>
+/// Configuration for the Kafka feature-change event sink (#357).
+/// </summary>
+/// <remarks>
+/// The Kafka sink is one concrete <see cref="IFeatureChangeEventSink"/> adapter
+/// behind the broker-agnostic broadcaster. It is off by default and only wired
+/// when both the umbrella sink fan-out (<see cref="FeatureChangeEventSinkOptions.Enabled"/>)
+/// and this adapter are enabled. Committed feature-change events are published to
+/// <see cref="Topic"/> with an idempotent producer (producer-side exactly-once:
+/// no duplicates on retry) keyed by service/layer/feature so per-feature ordering
+/// is preserved within a partition. Deliveries that fail after the producer's own
+/// retries are routed to <see cref="DeadLetterTopic"/> with diagnostic headers so
+/// operators can inspect and replay them.
+/// </remarks>
+public sealed class KafkaFeatureChangeEventSinkOptions
+{
+    /// <summary>
+    /// Configuration section name bound from application configuration.
+    /// </summary>
+    public const string SectionName = "FeatureChangeEvents:Sinks:Kafka";
+
+    /// <summary>
+    /// Enables the Kafka sink adapter. Defaults to <see langword="false"/> so the
+    /// dependency is inert unless explicitly configured.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Comma-separated <c>host:port</c> list of Kafka bootstrap servers.
+    /// </summary>
+    public string? BootstrapServers { get; set; }
+
+    /// <summary>
+    /// Topic that committed feature-change events are published to.
+    /// </summary>
+    public string Topic { get; set; } = "honua.feature-changes";
+
+    /// <summary>
+    /// Topic that deliveries which fail after producer retries are routed to.
+    /// When null or empty, dead-lettering is disabled and a terminal produce
+    /// failure surfaces to the broadcaster (metered, isolated, never fatal).
+    /// </summary>
+    public string? DeadLetterTopic { get; set; } = "honua.feature-changes.dlq";
+
+    /// <summary>
+    /// Enables the idempotent producer for producer-side exactly-once semantics.
+    /// When true the underlying producer is configured with <c>acks=all</c>,
+    /// bounded in-flight requests, and infinite retries so a broker-acknowledged
+    /// message is never duplicated. Defaults to <see langword="true"/>.
+    /// </summary>
+    public bool EnableIdempotence { get; set; } = true;
+
+    /// <summary>
+    /// Per-message produce timeout in milliseconds. A produce attempt that does
+    /// not complete within this window is treated as a delivery failure and, when
+    /// configured, routed to the dead-letter topic.
+    /// </summary>
+    public int MessageTimeoutMs { get; set; } = 30_000;
+
+    /// <summary>
+    /// Optional SASL/SSL security protocol passed through to the underlying client
+    /// (for example <c>SaslSsl</c>). Null leaves the client default (PLAINTEXT).
+    /// </summary>
+    public string? SecurityProtocol { get; set; }
+
+    /// <summary>
+    /// Optional SASL mechanism (for example <c>Plain</c> or <c>ScramSha512</c>).
+    /// </summary>
+    public string? SaslMechanism { get; set; }
+
+    /// <summary>
+    /// Optional SASL username.
+    /// </summary>
+    public string? SaslUsername { get; set; }
+
+    /// <summary>
+    /// Optional SASL password.
+    /// </summary>
+    public string? SaslPassword { get; set; }
+}
+
+/// <summary>
+/// Validates <see cref="KafkaFeatureChangeEventSinkOptions"/> on startup so a
+/// misconfigured Kafka sink fails fast rather than silently dropping events.
+/// </summary>
+internal sealed class KafkaFeatureChangeEventSinkOptionsValidator
+    : IValidateOptions<KafkaFeatureChangeEventSinkOptions>
+{
+    public ValidateOptionsResult Validate(string? name, KafkaFeatureChangeEventSinkOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (!options.Enabled)
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        var failures = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(options.BootstrapServers))
+        {
+            failures.Add("Kafka sink BootstrapServers must be configured when the Kafka sink is enabled.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Topic))
+        {
+            failures.Add("Kafka sink Topic must be configured when the Kafka sink is enabled.");
+        }
+
+        if (options.MessageTimeoutMs < 1)
+        {
+            failures.Add("Kafka sink MessageTimeoutMs must be at least 1 millisecond.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.DeadLetterTopic) &&
+            string.Equals(options.DeadLetterTopic, options.Topic, StringComparison.Ordinal))
+        {
+            failures.Add("Kafka sink DeadLetterTopic must differ from Topic to avoid redelivery loops.");
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/Honua.Hosting/Honua.Hosting.csproj
+++ b/src/Honua.Hosting/Honua.Hosting.csproj
@@ -64,6 +64,15 @@
          Parquet paths. -->
     <PackageReference Include="Apache.Arrow" />
     <PackageReference Include="ParquetSharp" />
+    <!-- Confluent.Kafka backs the enterprise event-bus Kafka sink (#357):
+         the broker-agnostic IFeatureChangeEventSink Kafka adapter publishes
+         committed feature-change events to a configurable topic with an
+         idempotent producer (producer-side exactly-once) and routes failed
+         deliveries to a dead-letter topic. The dependency is isolated behind
+         the ConfluentKafkaEventProducer wrapper; the sink itself depends only
+         on the IKafkaEventProducer abstraction so it stays unit-testable
+         without a live broker. -->
+    <PackageReference Include="Confluent.Kafka" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honua.Server/Startup/FeatureEventsAndStreamingRegistration.cs
+++ b/src/Honua.Server/Startup/FeatureEventsAndStreamingRegistration.cs
@@ -88,6 +88,24 @@ internal static partial class FeatureEventsAndStreamingRegistration
         services.AddOptions<FeatureChangeEventSinkOptions>()
             .Bind(configuration.GetSection(FeatureChangeEventSinkOptions.SectionName));
         services.AddSingleton<IFeatureChangeEventSink, NoOpFeatureChangeEventSink>();
+
+        // Kafka sink adapter (#357). Bound and validated always, but the producer
+        // and sink are only registered when the adapter is enabled so deployments
+        // without Kafka never construct a broker client. The sink publishes with an
+        // idempotent producer (producer-side exactly-once) and routes failed
+        // deliveries to a dead-letter topic.
+        services.AddOptions<KafkaFeatureChangeEventSinkOptions>()
+            .Bind(configuration.GetSection(KafkaFeatureChangeEventSinkOptions.SectionName))
+            .ValidateOnStart();
+        services.AddSingleton<
+            IValidateOptions<KafkaFeatureChangeEventSinkOptions>,
+            KafkaFeatureChangeEventSinkOptionsValidator>();
+        if (configuration.GetValue<bool>($"{KafkaFeatureChangeEventSinkOptions.SectionName}:Enabled"))
+        {
+            services.AddSingleton<IKafkaEventProducer, ConfluentKafkaEventProducer>();
+            services.AddSingleton<IFeatureChangeEventSink, KafkaFeatureChangeEventSink>();
+        }
+
         services.AddSingleton<FeatureChangeEventSinkBroadcaster>();
         services.AddSingleton<IFeatureChangeEventPublisher>(sp =>
             new FeatureStreamPublisher(

--- a/tests/dotnet/Honua.Server.Tests/Features/Streaming/KafkaFeatureChangeEventSinkTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Streaming/KafkaFeatureChangeEventSinkTests.cs
@@ -1,0 +1,204 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Infrastructure.Events;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Streaming;
+
+/// <summary>
+/// Unit tests for the Kafka feature-change event sink (#357), verifying the
+/// serialized payload/key/headers, the dead-letter routing on delivery failure,
+/// and the surfaced-failure behaviour when dead-lettering is unavailable. The
+/// sink is exercised against a fake <see cref="IKafkaEventProducer"/> so no live
+/// broker is required.
+/// </summary>
+public sealed class KafkaFeatureChangeEventSinkTests
+{
+    private static FeatureChangeEvent SampleEvent(string eventId = "evt-1") => new()
+    {
+        EventId = eventId,
+        Cursor = 42,
+        Timestamp = DateTimeOffset.UnixEpoch,
+        ServiceId = "parcels",
+        LayerId = 3,
+        ObjectId = 99,
+        Operation = "update",
+        Protocol = "rest",
+        RequestId = "req-1"
+    };
+
+    private static KafkaFeatureChangeEventSink Create(
+        IKafkaEventProducer producer,
+        KafkaFeatureChangeEventSinkOptions options)
+        => new(
+            producer,
+            Options.Create(options),
+            NullLogger<KafkaFeatureChangeEventSink>.Instance);
+
+    [UnitTest]
+    public async Task PublishAsync_OnSuccess_ProducesToTopicWithKeyAndHeaders()
+    {
+        var producer = new RecordingProducer();
+        var sink = Create(producer, new KafkaFeatureChangeEventSinkOptions
+        {
+            Topic = "feature-changes",
+            DeadLetterTopic = "feature-changes.dlq",
+        });
+
+        await sink.PublishAsync(SampleEvent());
+
+        var produced = Assert.Single(producer.Produced);
+        Assert.Equal("feature-changes", produced.Topic);
+        Assert.Equal("parcels/3/99", produced.Key);
+
+        // Payload round-trips to the original event.
+        var roundTripped = JsonSerializer.Deserialize(
+            produced.Value,
+            FeatureChangeEventsJsonContext.Default.FeatureChangeEvent);
+        Assert.NotNull(roundTripped);
+        Assert.Equal("evt-1", roundTripped!.EventId);
+
+        Assert.Equal("evt-1", produced.HeaderValue("x-event-id"));
+        Assert.Equal("update", produced.HeaderValue("x-operation"));
+        Assert.Equal("application/json", produced.HeaderValue("content-type"));
+    }
+
+    [UnitTest]
+    public async Task PublishAsync_WhenPrimaryFails_RoutesToDeadLetterTopic()
+    {
+        var producer = new RecordingProducer { FailTopic = "feature-changes" };
+        var sink = Create(producer, new KafkaFeatureChangeEventSinkOptions
+        {
+            Topic = "feature-changes",
+            DeadLetterTopic = "feature-changes.dlq",
+        });
+
+        // Must not throw: a routed-to-DLQ event is handled, not a sink failure.
+        await sink.PublishAsync(SampleEvent());
+
+        var dlq = Assert.Single(producer.Produced);
+        Assert.Equal("feature-changes.dlq", dlq.Topic);
+        Assert.Equal("parcels/3/99", dlq.Key);
+        Assert.Equal("feature-changes", dlq.HeaderValue("x-dlq-source-topic"));
+        Assert.False(string.IsNullOrEmpty(dlq.HeaderValue("x-dlq-error")));
+        Assert.False(string.IsNullOrEmpty(dlq.HeaderValue("x-dlq-failed-at")));
+    }
+
+    [UnitTest]
+    public async Task PublishAsync_WhenPrimaryFails_AndDlqDisabled_SurfacesFailure()
+    {
+        var producer = new RecordingProducer { FailTopic = "feature-changes" };
+        var sink = Create(producer, new KafkaFeatureChangeEventSinkOptions
+        {
+            Topic = "feature-changes",
+            DeadLetterTopic = null,
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sink.PublishAsync(SampleEvent()));
+    }
+
+    [UnitTest]
+    public async Task PublishAsync_WhenPrimaryAndDlqFail_SurfacesOriginalFailure()
+    {
+        var producer = new RecordingProducer { FailAllTopics = true };
+        var sink = Create(producer, new KafkaFeatureChangeEventSinkOptions
+        {
+            Topic = "feature-changes",
+            DeadLetterTopic = "feature-changes.dlq",
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sink.PublishAsync(SampleEvent()));
+    }
+
+    [UnitTest]
+    public void Validate_WhenEnabledWithoutBootstrapServers_Fails()
+    {
+        var validator = new KafkaFeatureChangeEventSinkOptionsValidator();
+
+        var result = validator.Validate(null, new KafkaFeatureChangeEventSinkOptions
+        {
+            Enabled = true,
+            BootstrapServers = null,
+            Topic = "feature-changes",
+        });
+
+        Assert.True(result.Failed);
+    }
+
+    [UnitTest]
+    public void Validate_WhenDeadLetterTopicEqualsTopic_Fails()
+    {
+        var validator = new KafkaFeatureChangeEventSinkOptionsValidator();
+
+        var result = validator.Validate(null, new KafkaFeatureChangeEventSinkOptions
+        {
+            Enabled = true,
+            BootstrapServers = "localhost:9092",
+            Topic = "feature-changes",
+            DeadLetterTopic = "feature-changes",
+        });
+
+        Assert.True(result.Failed);
+    }
+
+    [UnitTest]
+    public void Validate_WhenDisabled_Succeeds()
+    {
+        var validator = new KafkaFeatureChangeEventSinkOptionsValidator();
+
+        var result = validator.Validate(null, new KafkaFeatureChangeEventSinkOptions { Enabled = false });
+
+        Assert.True(result.Succeeded);
+    }
+
+    private sealed record ProducedMessage(
+        string Topic,
+        string Key,
+        byte[] Value,
+        IReadOnlyList<KeyValuePair<string, string>> Headers)
+    {
+        public string? HeaderValue(string key)
+        {
+            foreach (var header in Headers)
+            {
+                if (string.Equals(header.Key, key, StringComparison.Ordinal))
+                {
+                    return header.Value;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    private sealed class RecordingProducer : IKafkaEventProducer
+    {
+        public List<ProducedMessage> Produced { get; } = [];
+
+        public string? FailTopic { get; set; }
+
+        public bool FailAllTopics { get; set; }
+
+        public Task ProduceAsync(
+            string topic,
+            string key,
+            byte[] value,
+            IReadOnlyList<KeyValuePair<string, string>> headers,
+            CancellationToken cancellationToken = default)
+        {
+            if (FailAllTopics || string.Equals(topic, FailTopic, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"simulated broker failure for topic '{topic}'");
+            }
+
+            Produced.Add(new ProducedMessage(topic, key, value, headers));
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #357

## Summary
Delivers the first concrete enterprise event-bus sink for the advanced event-bus
work (#357). The broker-agnostic `IFeatureChangeEventSink` abstraction, broadcaster,
metrics, and no-op default already exist on trunk (the #316 CDC foundation); this PR
adds a production-grade **Kafka** adapter behind that seam with producer-side
exactly-once delivery and a dead-letter queue path. NATS, schema registry, and the
admin DLQ viewer remain follow-up increments (see Known gaps), so this is a coherent
slice rather than a full close of the XL ticket.

## Changes Made
- Add `Confluent.Kafka` to `Directory.Packages.props` and reference it from `Honua.Hosting`.
- Add `KafkaFeatureChangeEventSink`: serializes committed feature-change events to JSON,
  keys them by `service/layer/feature` so per-feature mutations stay ordered within a
  partition, and routes deliveries that fail after producer retries to a configurable
  dead-letter topic with diagnostic headers (`x-dlq-source-topic`, `x-dlq-error`,
  `x-dlq-failed-at`). When dead-lettering is disabled or itself fails, the failure is
  surfaced to the broadcaster, which isolates and meters it without affecting durable
  storage or sibling sinks.
- Isolate the Confluent dependency behind `IKafkaEventProducer` /
  `ConfluentKafkaEventProducer`; the producer is configured idempotent (`acks=all`,
  bounded in-flight, infinite retries) for producer-side exactly-once delivery.
- Add `KafkaFeatureChangeEventSinkOptions` with startup validation and conditional
  registration in `FeatureEventsAndStreamingRegistration` (the producer and sink are only
  constructed when the adapter is enabled, so non-Kafka deployments never build a client).
- Add a `honua.event_sink.dead_lettered_total` metric and unit tests covering the success
  path, DLQ routing, surfaced-failure fallbacks, and options validation.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

What ran:
- `dotnet build src/Honua.Hosting/Honua.Hosting.csproj -c Release /p:TreatWarningsAsErrors=true` — succeeded, 0 warnings.
- `dotnet build tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj -c Release /p:TreatWarningsAsErrors=true` — succeeded, 0 warnings.
- `dotnet test ... --filter KafkaFeatureChangeEventSinkTests|FeatureChangeEventSinkBroadcasterTests` — 12 passed, 0 failed.
- `dotnet format --verify-no-changes` on the changed files — clean.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. The Kafka sink is off by default; existing deployments are unaffected unless both
`FeatureChangeEvents:Sinks:Enabled` and `FeatureChangeEvents:Sinks:Kafka:Enabled` are set.

## Known gaps
This is one slice of the XL ticket; the following remain open (issue stays open via
`Related to #357`):
- NATS JetStream sink adapter.
- Consumer-side / transactional end-to-end exactly-once (this PR covers producer-side
  idempotence; broker-acknowledged messages are not duplicated on retry).
- Event schema registry (Avro/Protobuf schema evolution).
- Admin UI: event-bus configuration, DLQ viewer, delivery metrics (honua-console).
- An integration test against a live broker (Testcontainers Kafka) — the new tests use a
  fake `IKafkaEventProducer` so they run without a broker.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
